### PR TITLE
Allow rewriters to delete SSA values

### DIFF
--- a/src/xdsl/rewriter.py
+++ b/src/xdsl/rewriter.py
@@ -40,7 +40,7 @@ class RewritePattern(ABC):
     @abstractmethod
     def match_and_rewrite(
             self, op: Operation,
-            new_operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
+            new_operands: List[Optional[SSAValue]]) -> Optional[RewriteAction]:
         """
         Match an operation, and optionally returns a rewrite to be performed.
         `op` is the operation to match, and `new_operands` are the potential new values of the operands.
@@ -55,12 +55,12 @@ class AnonymousRewritePattern(RewritePattern):
     """
     A rewrite pattern encoded by an anonymous function.
     """
-    func: Callable[[Operation, Optional[List[SSAValue]]],
+    func: Callable[[Operation, List[Optional[SSAValue]]],
                    Optional[RewriteAction]]
 
     def match_and_rewrite(
             self, op: Operation,
-            new_operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
+            new_operands: List[Optional[SSAValue]]) -> Optional[RewriteAction]:
         return self.func(op, new_operands)
 
 
@@ -96,7 +96,7 @@ def op_type_rewrite_pattern(func):
 
         def op_type_rewrite_pattern_static_wrapper(
                 op: Operation,
-                operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
+                operands: List[Optional[SSAValue]]) -> Optional[RewriteAction]:
             if not isinstance(op, expected_type):
                 return None
             return func(op, operands)
@@ -105,7 +105,7 @@ def op_type_rewrite_pattern(func):
 
     def op_type_rewrite_pattern_method_wrapper(
             self, op: Operation,
-            operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
+            operands: List[Optional[SSAValue]]) -> Optional[RewriteAction]:
         if not isinstance(op, expected_type):
             return None
         return func(self, op, operands)
@@ -150,11 +150,11 @@ class OperandUpdater:
         for (old_res, new_res) in zip(old_op.results, action.new_results):
             self.result_mapping[old_res] = new_res
 
-    def get_new_value(self, value: SSAValue) -> SSAValue:
+    def get_new_value(self, value: SSAValue) -> Optional[SSAValue]:
         """Get the updated value, if it exists, or returns the same one."""
         return self.result_mapping.get(value, value)
 
-    def get_new_operands(self, op: Operation) -> [SSAValue]:
+    def get_new_operands(self, op: Operation) -> [Optional[SSAValue]]:
         """Get the new operation updated operands"""
         return [self.get_new_value(operand) for operand in op.operands]
 

--- a/src/xdsl/rewriter.py
+++ b/src/xdsl/rewriter.py
@@ -19,8 +19,8 @@ class RewriteAction:
     new_ops: List[Operation]
     """New operations that replace the one matched."""
 
-    new_results: List[SSAValue]
-    """SSA values that replace the matched operation results."""
+    new_results: List[Optional[SSAValue]]
+    """SSA values that replace the matched operation results. None values are deleted SSA Values."""
     @staticmethod
     def from_op_list(new_ops: List[Operation]) -> RewriteAction:
         """
@@ -157,7 +157,10 @@ class OperandUpdater:
 
     def update_operands(self, op: Operation) -> None:
         """Update an operation operands with the new operands."""
-        op.operands = self.get_new_operands(op)
+        new_operands = self.get_new_operands(op)
+        if None in new_operands:
+            raise Exception("Use of deleted SSA Value")
+        op.operands = new_operands
 
 
 @dataclass(eq=False, repr=False)

--- a/tests/rewriter_test.py
+++ b/tests/rewriter_test.py
@@ -39,8 +39,8 @@ def test_non_recursive_rewrite():
 
     class RewriteConst(RewritePattern):
         def match_and_rewrite(
-                self, op: Operation,
-                new_operands: List[SSAValue]) -> Optional[RewriteAction]:
+                self, op: Operation, new_operands: Optional[List[SSAValue]]
+        ) -> Optional[RewriteAction]:
             if isinstance(op, Constant):
                 return RewriteAction.from_op_list(
                     [std.constant_from_attr(IntegerAttr.get(43), std.i32)])
@@ -72,8 +72,8 @@ def test_op_type_rewrite_pattern_method_decorator():
     class RewriteConst(RewritePattern):
         @op_type_rewrite_pattern
         def match_and_rewrite(
-                self, op: Constant,
-                new_operands: List[SSAValue]) -> Optional[RewriteAction]:
+                self, op: Constant, new_operands: Optional[List[SSAValue]]
+        ) -> Optional[RewriteAction]:
             return RewriteAction.from_op_list(
                 [std.constant_from_attr(IntegerAttr.get(43), std.i32)])
 
@@ -103,7 +103,7 @@ def test_op_type_rewrite_pattern_static_decorator():
     @op_type_rewrite_pattern
     def match_and_rewrite(
             op: Constant,
-            new_operands: List[SSAValue]) -> Optional[RewriteAction]:
+            new_operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
         return RewriteAction.from_op_list(
             [std.constant_from_attr(IntegerAttr.get(43), std.i32)])
 
@@ -140,7 +140,7 @@ def test_recursive_rewriter():
     @op_type_rewrite_pattern
     def match_and_rewrite(
             op: Constant,
-            new_operands: List[SSAValue]) -> Optional[RewriteAction]:
+            new_operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
         val = op.value.value.data
         if val == 0 or val == 1:
             return None
@@ -212,7 +212,7 @@ def test_operation_deletion():
     @op_type_rewrite_pattern
     def match_and_rewrite(
             op: Constant,
-            new_operands: List[SSAValue]) -> Optional[RewriteAction]:
+            new_operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
         return RewriteAction([], [None])
 
     rewrite_and_compare(
@@ -235,7 +235,7 @@ def test_operation_deletion_failure():
     @op_type_rewrite_pattern
     def match_and_rewrite(
             op: Constant,
-            new_operands: List[SSAValue]) -> Optional[RewriteAction]:
+            new_operands: Optional[List[SSAValue]]) -> Optional[RewriteAction]:
         return RewriteAction([], [None])
 
     parser = Parser(ctx, prog)


### PR DESCRIPTION
Rewriters can now delete SSA values, by mapping them to None it the updater.
This can be used to delete operations for instance.
During the walk, it is checked that no operations are created with the deleted operands, and thus those rewrites are safe to use. 