### PR TITLE
Printer: improve indentation

### DIFF
--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -81,9 +81,9 @@ class Printer:
         self._indent += 1
         for op in ops:
             self._print_new_line()
-            self.print_op(op)
+            self._print_op(op)
         self._indent -= 1
-        if len(ops) != 0:
+        if len(ops) > 0:
             self._print_new_line()
 
     def print_block_name(self, block: Block) -> None:
@@ -114,9 +114,9 @@ class Printer:
             return
 
         if len(region.blocks) == 1 and len(region.blocks[0].args) == 0:
-            self._print("{", end='')
+            self._print(" {", end='')
             self._print_ops(region.blocks[0].ops)
-            self._print("}")
+            self._print("}", end='')
             return
 
         self._print("{", end='')
@@ -128,7 +128,6 @@ class Printer:
     def _print_regions(self, regions: List[Region]) -> None:
         for region in regions:
             self._print_region(region)
-            self._print(" ", end='')
 
     def _print_operands(self, operands: List[SSAValue]) -> None:
         if len(operands) == 0:
@@ -197,6 +196,7 @@ class Printer:
         if len(attributes) == 0:
             return
 
+        self._print(" ", end='')
         self._print("[", end='')
         attribute_list = [p for p in attributes.items()]
         self._print("\"%s\" = " % attribute_list[0][0], end='')
@@ -206,11 +206,14 @@ class Printer:
             self.print_attribute(attr)
         self._print("]", end='')
 
-    def print_op(self, op: Operation) -> None:
+    def _print_op(self, op: Operation) -> None:
         self._print_results(op)
         self._print(op.name, end='')
         self._print_operands(op.operands)
         self.print_successors(op.successors)
-        self._print(" ", end='')
         self._print_op_attributes(op.attributes)
         self._print_regions(op.regions)
+
+    def print_op(self, op: Operation) -> None:
+        self._print_op(op)
+        self._print_new_line()

--- a/tests/rewriter_test.py
+++ b/tests/rewriter_test.py
@@ -34,7 +34,7 @@ def test_non_recursive_rewrite():
     expected = \
 """module() {
   %0 : !i32 = std.constant() ["value" = 43 : !i64]
-  %1 : !i32 = std.addi(%0 : !i32, %0 : !i32) 
+  %1 : !i32 = std.addi(%0 : !i32, %0 : !i32)
 }"""
 
     class RewriteConst(RewritePattern):
@@ -66,7 +66,7 @@ def test_op_type_rewrite_pattern_method_decorator():
     expected = \
 """module() {
   %0 : !i32 = std.constant() ["value" = 43 : !i64]
-  %1 : !i32 = std.addi(%0 : !i32, %0 : !i32) 
+  %1 : !i32 = std.addi(%0 : !i32, %0 : !i32)
 }"""
 
     class RewriteConst(RewritePattern):
@@ -97,7 +97,7 @@ def test_op_type_rewrite_pattern_static_decorator():
     expected = \
 """module() {
   %0 : !i32 = std.constant() ["value" = 43 : !i64]
-  %1 : !i32 = std.addi(%0 : !i32, %0 : !i32) 
+  %1 : !i32 = std.addi(%0 : !i32, %0 : !i32)
 }"""
 
     @op_type_rewrite_pattern
@@ -128,13 +128,13 @@ def test_recursive_rewriter():
 """module() {
   %0 : !i32 = std.constant() ["value" = 1 : !i64]
   %1 : !i32 = std.constant() ["value" = 1 : !i64]
-  %2 : !i32 = std.addi(%0 : !i32, %1 : !i32) 
+  %2 : !i32 = std.addi(%0 : !i32, %1 : !i32)
   %3 : !i32 = std.constant() ["value" = 1 : !i64]
-  %4 : !i32 = std.addi(%2 : !i32, %3 : !i32) 
+  %4 : !i32 = std.addi(%2 : !i32, %3 : !i32)
   %5 : !i32 = std.constant() ["value" = 1 : !i64]
-  %6 : !i32 = std.addi(%4 : !i32, %5 : !i32) 
+  %6 : !i32 = std.addi(%4 : !i32, %5 : !i32)
   %7 : !i32 = std.constant() ["value" = 1 : !i64]
-  %8 : !i32 = std.addi(%6 : !i32, %7 : !i32) 
+  %8 : !i32 = std.addi(%6 : !i32, %7 : !i32)
 }"""
 
     @op_type_rewrite_pattern
@@ -170,7 +170,7 @@ def test_greedy_rewrite_pattern_applier():
     expected = \
 """module() {
   %0 : !i32 = std.constant() ["value" = 43 : !i64]
-  %1 : !i32 = std.muli(%0 : !i32, %0 : !i32) 
+  %1 : !i32 = std.muli(%0 : !i32, %0 : !i32)
 }"""
 
     @op_type_rewrite_pattern


### PR DESCRIPTION
Before this patch we print nested regions as:

```
choco.ast.program() {}
 {
  choco.ast.call_expr() {
    choco.ast.id_expr() ["id" = "print"]
  }
 {
    choco.ast.binary_expr() ["op" = "+"]{
      choco.ast.binary_expr() ["op" = "+"]{
        choco.ast.literal() ["value" = !int<42>]
      }
 {
        choco.ast.literal() ["value" = !int<43>]
      }
 
    }
 {
      choco.ast.literal() ["value" = !int<44>]
    }
 
  }
 
}
```

after this patch we print them as:
```
choco.ast.program() {} {
  choco.ast.call_expr() {
    choco.ast.id_expr() ["id" = "print"]
  } {
    choco.ast.binary_expr() ["op" = "+"] {
      choco.ast.binary_expr() ["op" = "+"] {
        choco.ast.literal() ["value" = !int<42>]
      } {
        choco.ast.literal() ["value" = !int<43>]
      }
    } {
      choco.ast.literal() ["value" = !int<44>]
    }
  }
}

```