### PR TITLE
Changed typing to improve type checking in PyCharm

### DIFF
--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from xdsl.irdl import *
 from xdsl.ir import *
 

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -185,7 +185,7 @@ class FunctionType:
 
 
 @irdl_op_definition
-class FuncOp:
+class FuncOp(Operation):
     name: str = "builtin.func"
 
     body = RegionDef()
@@ -195,7 +195,7 @@ class FuncOp:
 
 
 @irdl_op_definition
-class ModuleOp:
+class ModuleOp(Operation):
     name: str = "module"
 
     body = SingleBlockRegionDef()

--- a/src/xdsl/dialects/memref.py
+++ b/src/xdsl/dialects/memref.py
@@ -108,7 +108,7 @@ class MemRefType:
 
 
 @irdl_op_definition
-class Load:
+class Load(Operation):
     name = "memref.load"
     memref = OperandDef(MemRefType)
     indices = VarOperandDef(IndexType)
@@ -127,7 +127,7 @@ class Load:
 
 
 @irdl_op_definition
-class Store:
+class Store(Operation):
     name = "memref.store"
     value = OperandDef(AnyAttr())
     memref = OperandDef(MemRefType)
@@ -143,7 +143,7 @@ class Store:
 
 
 @irdl_op_definition
-class Alloc:
+class Alloc(Operation):
     name = "memref.alloc"
 
     dynamic_sizes = VarOperandDef(IndexType)
@@ -158,7 +158,7 @@ class Alloc:
 
 
 @irdl_op_definition
-class Alloca:
+class Alloca(Operation):
     name = "memref.alloca"
 
     dynamic_sizes = VarOperandDef(IndexType)
@@ -173,7 +173,7 @@ class Alloca:
 
 
 @irdl_op_definition
-class Dealloc:
+class Dealloc(Operation):
     name = "memref.dealloc"
     memref = OperandDef(MemRefType)
 
@@ -197,7 +197,7 @@ class GetGlobal(Operation):
 
 
 @irdl_op_definition
-class Global:
+class Global(Operation):
     name = "memref.global"
     sym_name = AttributeDef(SymbolNameAttr)
     sym_visibility = AttributeDef(StringAttr)

--- a/src/xdsl/dialects/scf.py
+++ b/src/xdsl/dialects/scf.py
@@ -35,7 +35,7 @@ class Scf:
 
 
 @irdl_op_definition
-class If:
+class If(Operation):
     name: str = "scf.if"
     output = VarResultDef(AnyAttr())
     cond = OperandDef(IntegerType.get(1))
@@ -46,20 +46,20 @@ class If:
 
 
 @irdl_op_definition
-class Yield:
+class Yield(Operation):
     name: str = "scf.yield"
     arguments = VarOperandDef(AnyAttr())
 
 
 @irdl_op_definition
-class Condition:
+class Condition(Operation):
     name: str = "scf.condition"
     cond = OperandDef(IntegerType.get(1))
     arguments = VarOperandDef(AnyAttr())
 
 
 @irdl_op_definition
-class While:
+class While(Operation):
     name: str = "scf.while"
     arguments = VarOperandDef(AnyAttr())
 

--- a/src/xdsl/dialects/std.py
+++ b/src/xdsl/dialects/std.py
@@ -93,7 +93,7 @@ class Std:
 
 
 @irdl_op_definition
-class Constant:
+class Constant(Operation):
     name: str = "std.constant"
     output = ResultDef(AnyAttr())
     value = AttributeDef(AnyAttr())
@@ -105,7 +105,7 @@ class Constant:
 
 
 @irdl_op_definition
-class Addi:
+class Addi(Operation):
     name: str = "std.addi"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -118,7 +118,7 @@ class Addi:
 
 
 @irdl_op_definition
-class Muli:
+class Muli(Operation):
     name: str = "std.muli"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -131,7 +131,7 @@ class Muli:
 
 
 @irdl_op_definition
-class Subi:
+class Subi(Operation):
     name: str = "std.subi"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -144,7 +144,7 @@ class Subi:
 
 
 @irdl_op_definition
-class FloordiviSigned:
+class FloordiviSigned(Operation):
     name: str = "std.floordivi_signed"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -157,7 +157,7 @@ class FloordiviSigned:
 
 
 @irdl_op_definition
-class RemiSigned:
+class RemiSigned(Operation):
     name: str = "std.remi_signed"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -170,7 +170,7 @@ class RemiSigned:
 
 
 @irdl_op_definition
-class Call:
+class Call(Operation):
     name: str = "std.call"
     arguments = VarOperandDef(AnyAttr())
     callee = AttributeDef(FlatSymbolRefAttr)
@@ -181,13 +181,13 @@ class Call:
 
 
 @irdl_op_definition
-class Return:
+class Return(Operation):
     name: str = "std.return"
     arguments = VarOperandDef(AnyAttr())
 
 
 @irdl_op_definition
-class And:
+class And(Operation):
     name: str = "std.and"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -200,7 +200,7 @@ class And:
 
 
 @irdl_op_definition
-class Or:
+class Or(Operation):
     name: str = "std.or"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -213,7 +213,7 @@ class Or:
 
 
 @irdl_op_definition
-class Xor:
+class Xor(Operation):
     name: str = "std.xor"
     input1 = OperandDef(IntegerType)
     input2 = OperandDef(IntegerType)
@@ -226,7 +226,7 @@ class Xor:
 
 
 @irdl_op_definition
-class Cmpi:
+class Cmpi(Operation):
     name: str = "std.cmpi"
     predicate = AttributeDef(IntegerAttr)
     input1 = OperandDef(IntegerType)
@@ -235,7 +235,7 @@ class Cmpi:
 
 
 @irdl_op_definition
-class Addf:
+class Addf(Operation):
     name: str = "std.addf"
     input1 = OperandDef(Float32Type)
     input2 = OperandDef(Float32Type)
@@ -248,7 +248,7 @@ class Addf:
 
 
 @irdl_op_definition
-class Mulf:
+class Mulf(Operation):
     name: str = "std.mulf"
     input1 = OperandDef(Float32Type)
     input2 = OperandDef(Float32Type)

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     from xdsl.parser import Parser
     from xdsl.printer import Printer
 
+OperationType = TypeVar('OperationType', bound='Operation')
+
 
 @dataclass
 class MLContext:
@@ -18,7 +20,7 @@ class MLContext:
     _registeredAttrs: Dict[str, typing.Type[Attribute]] = field(
         default_factory=dict)
 
-    def register_op(self, op: typing.Type[Operation]) -> None:
+    def register_op(self, op: OperationType) -> None:
         """Register an operation definition. Operation names should be unique."""
         if op.name in self._registeredOps:
             raise Exception(f"Operation {op.name} has already been registered")
@@ -118,9 +120,6 @@ class ParametrizedAttribute(Attribute):
         ...
 
 
-T = TypeVar('T', bound='Operation')
-
-
 @dataclass
 class Operation(ABC):
     """A generic operation. Operation definitions inherit this class."""
@@ -177,12 +176,12 @@ class Operation(ABC):
         return operation
 
     @classmethod
-    def create(cls: typing.Type[T],
+    def create(cls: typing.Type[OperationType],
                operands: Optional[List[SSAValue]] = None,
                result_types: Optional[List[Attribute]] = None,
                attributes: Optional[Dict[str, Attribute]] = None,
                successors: Optional[List[Block]] = None,
-               regions: Optional[List[Region]] = None) -> T:
+               regions: Optional[List[Region]] = None) -> OperationType:
         return Operation.with_result_types(cls, operands, result_types,
                                            attributes, successors, regions)
 

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from xdsl.parser import Parser
     from xdsl.printer import Printer
 
-OperationType = TypeVar('OperationType', bound='Operation')
+OperationType = TypeVar('OperationType', bound='Operation', covariant=True)
 
 
 @dataclass
@@ -20,7 +20,7 @@ class MLContext:
     _registeredAttrs: Dict[str, typing.Type[Attribute]] = field(
         default_factory=dict)
 
-    def register_op(self, op: OperationType) -> None:
+    def register_op(self, op: typing.Type[Operation]) -> None:
         """Register an operation definition. Operation names should be unique."""
         if op.name in self._registeredOps:
             raise Exception(f"Operation {op.name} has already been registered")

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -121,7 +121,7 @@ class ParametrizedAttribute(Attribute):
 
 
 @dataclass
-class Operation(ABC):
+class Operation:
     """A generic operation. Operation definitions inherit this class."""
 
     name: str = field(default="", init=False)
@@ -200,9 +200,8 @@ class Operation(ABC):
         for region in self.regions:
             region.verify()
 
-    @abstractmethod
     def verify_(self) -> None:
-        ...
+        pass
 
     def __eq__(self, other: Operation) -> bool:
         return self is other

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -401,7 +401,7 @@ def irdl_op_verify(op: Operation, operands: List[Tuple[str, OperandDef]],
         attr_def.constr.verify(op.attributes[attr_name])
 
 
-def irdl_op_definition(cls: xdsl.ir.OperationType) -> xdsl.ir.OperationType:
+def irdl_op_definition(cls: typing.Type[xdsl.ir.OperationType]) -> typing.Type[xdsl.ir.OperationType]:
     """Decorator used on classes to define a new operation definition."""
     operands = [(field_name, field)
                 for field_name, field in cls.__dict__.items()

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from abc import ABC, abstractmethod
 
 from xdsl.ir import Operation, Attribute, ParametrizedAttribute, SSAValue
-from typing import List, Tuple, Optional, Union
+from typing import List, Tuple, Optional, Union, TypeVar
 from inspect import isclass
 import typing
 
@@ -401,9 +401,11 @@ def irdl_op_verify(op: Operation, operands: List[Tuple[str, OperandDef]],
         attr_def.constr.verify(op.attributes[attr_name])
 
 
+OperationType = TypeVar("OperationType", bound=Operation)
+
+
 def irdl_op_definition(
-    cls: typing.Type[xdsl.ir.OperationType]
-) -> typing.Type[xdsl.ir.OperationType]:
+        cls: typing.Type[OperationType]) -> typing.Type[OperationType]:
     """Decorator used on classes to define a new operation definition."""
     operands = [(field_name, field)
                 for field_name, field in cls.__dict__.items()
@@ -497,7 +499,11 @@ def irdl_attr_verify(attr: ParametrizedAttribute,
         param_def.constr.verify(attr.parameters[idx])
 
 
-def irdl_attr_definition(cls) -> typing.Type[Attribute]:
+AttributeType = TypeVar("AttributeType", bound=ParametrizedAttribute)
+
+
+def irdl_attr_definition(
+        cls: typing.Type[AttributeType]) -> typing.Type[AttributeType]:
     """Decorator used on classes to define a new attribute definition."""
 
     parameters = []

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -401,7 +401,9 @@ def irdl_op_verify(op: Operation, operands: List[Tuple[str, OperandDef]],
         attr_def.constr.verify(op.attributes[attr_name])
 
 
-def irdl_op_definition(cls: typing.Type[xdsl.ir.OperationType]) -> typing.Type[xdsl.ir.OperationType]:
+def irdl_op_definition(
+    cls: typing.Type[xdsl.ir.OperationType]
+) -> typing.Type[xdsl.ir.OperationType]:
     """Decorator used on classes to define a new operation definition."""
     operands = [(field_name, field)
                 for field_name, field in cls.__dict__.items()

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -401,7 +401,7 @@ def irdl_op_verify(op: Operation, operands: List[Tuple[str, OperandDef]],
         attr_def.constr.verify(op.attributes[attr_name])
 
 
-def irdl_op_definition(cls) -> typing.Type[Operation]:
+def irdl_op_definition(cls: xdsl.ir.OperationType) -> xdsl.ir.OperationType:
     """Decorator used on classes to define a new operation definition."""
     operands = [(field_name, field)
                 for field_name, field in cls.__dict__.items()


### PR DESCRIPTION
This change no longer highlights code such as:
```python
def translate_def(ctx: Ctx, op: Operation) -> [Operation]:
    if isinstance(op, choco_ast.FuncDef):
        return translate_fun_def(ctx, op)

def translate_fun_def(ctx: Ctx, fun_def: choco_ast.FuncDef) -> Operation:
...
```
as a typing error.

With this change PyCharm (and I assume mypy) correctly assumes that the type of `op` in the branch is `choco_ast.FuncDef` and not `Operation`),