### PR TITLE
IRDL: fix operand_segment_sizes types

### DIFF
--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -286,7 +286,10 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
     def from_list(
             type: Union[VectorType, TensorType],
             data: List[Union[int, IntegerAttr]]) -> DenseIntOrFPElementsAttr:
-        data_attr = [IntegerAttr.build(d) for d in data]
+        element_type = type.element_type
+        # Only use the element_type if the passed data is an int, o/w use the IntegerAttr
+        data_attr = [(IntegerAttr.from_params(d, element_type) if isinstance(
+            d, int) else d) for d in data]
         return DenseIntOrFPElementsAttr([type, ArrayAttr.from_list(data_attr)])
 
     @staticmethod

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -437,7 +437,7 @@ def irdl_op_builder(cls: typing.Type[OpT], operands: List,
     # We need irdl to define DenseIntOrFPElementsAttr, but here we need
     # DenseIntOrFPElementsAttr.
     # So we have a circular dependency that we solve by importing in this function.
-    from xdsl.dialects.builtin import DenseIntOrFPElementsAttr, IntegerAttr, VectorType, IntegerType, i64
+    from xdsl.dialects.builtin import DenseIntOrFPElementsAttr, IntegerAttr, VectorType, IntegerType, i32
 
     # Build operands by forwarding the values to SSAValue.get
     if len(operand_defs) != len(operands):
@@ -496,7 +496,7 @@ def irdl_op_builder(cls: typing.Type[OpT], operands: List,
             if isinstance(operand_def, VarOperandDef)
         ]
         built_attributes[AttrSizedOperandSegments.attribute_name] =\
-            DenseIntOrFPElementsAttr.vector_from_list(sizes, i64)
+            DenseIntOrFPElementsAttr.vector_from_list(sizes, i32)
 
     if AttrSizedResultSegments() in options:
         sizes = [
@@ -505,7 +505,7 @@ def irdl_op_builder(cls: typing.Type[OpT], operands: List,
             if isinstance(result_def, VarResultDef)
         ]
         built_attributes[AttrSizedResultSegments.attribute_name] =\
-            DenseIntOrFPElementsAttr.vector_from_list(sizes, i64)
+            DenseIntOrFPElementsAttr.vector_from_list(sizes, i32)
 
     # Build regions using `Region.get`.
     regions = [Region.get(region) for region in regions]

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -80,15 +80,11 @@ def test_two_var_result_builder():
         StringAttr.from_int(3)
     ]
 
-    dense_type = VectorType.from_type_and_list(IntegerType.from_width(64), [2])
+    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [2])
 
     assert op.attributes[AttrSizedResultSegments.
                          attribute_name] == DenseIntOrFPElementsAttr.from_list(
-                             dense_type,
-                             [IntegerAttr.from_index_int_value(2)] * 2)
-
-
-test_two_var_result_builder()
+                             dense_type, [2, 2])
 
 
 def test_two_var_result_builder2():
@@ -100,13 +96,10 @@ def test_two_var_result_builder2():
         StringAttr.from_int(2),
         StringAttr.from_int(3)
     ]
-    dense_type = VectorType.from_type_and_list(IntegerType.from_width(64), [2])
+    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [2])
     assert op.attributes[AttrSizedResultSegments.
                          attribute_name] == DenseIntOrFPElementsAttr.from_list(
-                             dense_type, [
-                                 IntegerAttr.from_index_int_value(1),
-                                 IntegerAttr.from_index_int_value(3)
-                             ])
+                             dense_type, [1, 3])
 
 
 @irdl_op_definition
@@ -163,11 +156,11 @@ def test_two_var_operand_builder():
     op2 = TwoVarOperandOp.build(operands=[[op1, op1], [op1, op1]])
     op2.verify()
     assert op2.operands == [op1.res] * 4
-    dense_type = VectorType.from_type_and_list(IntegerType.from_width(64), [2])
+    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [2])
     assert op2.attributes[
         AttrSizedOperandSegments.
         attribute_name] == DenseIntOrFPElementsAttr.from_list(
-            dense_type, [IntegerAttr.from_index_int_value(2)] * 2)
+            dense_type, [2, 2])
 
 
 def test_two_var_operand_builder2():
@@ -175,14 +168,11 @@ def test_two_var_operand_builder2():
     op2 = TwoVarOperandOp.build(operands=[[op1], [op1, op1, op1]])
     op2.verify()
     assert op2.operands == [op1.res] * 4
-    dense_type = VectorType.from_type_and_list(IntegerType.from_width(64), [2])
+    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [2])
     assert op2.attributes[
         AttrSizedOperandSegments.
         attribute_name] == DenseIntOrFPElementsAttr.from_list(
-            dense_type, [
-                IntegerAttr.from_index_int_value(1),
-                IntegerAttr.from_index_int_value(3)
-            ])
+            dense_type, [1, 3])
 
 
 @irdl_op_definition


### PR DESCRIPTION
This PR changes the types of the operand segment sizes to the ones MLIR uses. Furthermore, it changes a builder for the `DenseIntOrFPElementAttrs` to actually respect the type passed as a vector or tensor type. 