### PR TITLE
Fix parent attributes of ops and blocks

### DIFF
--- a/src/xdsl/dialects/affine.py
+++ b/src/xdsl/dialects/affine.py
@@ -15,8 +15,8 @@ class Affine:
 
     def for_(self, lower_bound: int, upper_bound: int,
              block: Block) -> Operation:
-        op = self.ctx.get_op("affine.for").create([], [],
-                                                  regions=[Region([block])])
+        op = self.ctx.get_op("affine.for").create(
+            [], [], regions=[Region.from_block_list([block])])
         return op
 
     def load(self, value: Union[Operation, SSAValue],

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -353,13 +353,15 @@ class FuncOp(Operation):
             return_types: List[Attribute],
             func: Callable[[BlockArgument, ...], List[Operation]]) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
-        op = FuncOp.build(
-            attributes={
-                "sym_name": name,
-                "type": type_attr,
-                "sym_visibility": "private"
-            },
-            regions=[Region([Block.from_callable(input_types, func)])])
+        op = FuncOp.build(attributes={
+            "sym_name": name,
+            "type": type_attr,
+            "sym_visibility": "private"
+        },
+                          regions=[
+                              Region.from_block_list(
+                                  [Block.from_callable(input_types, func)])
+                          ])
         return op
 
     @staticmethod
@@ -388,7 +390,7 @@ class ModuleOp(Operation):
     @staticmethod
     def from_region_or_ops(ops: Union[List[Operation], Region]) -> ModuleOp:
         if isinstance(ops, list):
-            region = Region([Block([], ops)])
+            region = Region.from_operation_list(ops)
         elif isinstance(ops, Region):
             region = ops
         else:

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -253,13 +253,13 @@ class Operation:
 class Block:
     """A sequence of operations"""
 
-    args: List[BlockArgument] = field(default_factory=list)
+    args: List[BlockArgument] = field(default_factory=list, init=False)
     """The basic block arguments."""
 
-    ops: List[Operation] = field(default_factory=list)
+    ops: List[Operation] = field(default_factory=list, init=False)
     """Ordered operations contained in the block."""
 
-    parent: Optional[Region] = field(default=None)
+    parent: Optional[Region] = field(default=None, init=False)
     """Parent region containing the block."""
 
     @staticmethod
@@ -316,15 +316,15 @@ class Block:
 class Region:
     """A region contains a CFG of blocks. Regions are contained in operations."""
 
-    blocks: List[Block] = field(default_factory=list)
+    blocks: List[Block] = field(default_factory=list, init=False)
     """Blocks contained in the region. The first block is the entry block."""
 
-    parent: Optional[Operation] = field(default=None)
+    parent: Optional[Operation] = field(default=None, init=False)
     """Operation containing the region."""
 
     @staticmethod
     def from_operation_list(ops: List[Operation]) -> Region:
-        block = Block([], ops)
+        block = Block.from_ops(ops)
         region = Region()
         region.add_block(block)
         return region


### PR DESCRIPTION
This PR ensures that all of xdsl uses region and block builders to
ensure that the parent attributes of their children are correctly set.
Furthermore, we remove all fields from their constructors to encourage the
usage of builders or getters.

Fixes #38 