### PR TITLE
Add optional attributes to IRDL

### DIFF
--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -24,6 +24,7 @@ class Builtin:
         self.ctx.register_attr(VectorType)
         self.ctx.register_attr(TensorType)
         self.ctx.register_attr(DenseIntOrFPElementsAttr)
+        self.ctx.register_attr(UnitAttr)
 
         self.ctx.register_attr(FunctionType)
         self.ctx.register_attr(Float32Type)
@@ -315,6 +316,11 @@ class Float32Type(ParametrizedAttribute):
 
 
 f32 = Float32Type()
+
+
+@irdl_op_definition
+class UnitAttr(ParametrizedAttribute):
+    name: str = "unit"
 
 
 @irdl_attr_definition

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -318,7 +318,7 @@ class Float32Type(ParametrizedAttribute):
 f32 = Float32Type()
 
 
-@irdl_op_definition
+@irdl_attr_definition
 class UnitAttr(ParametrizedAttribute):
     name: str = "unit"
 

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -240,11 +240,20 @@ class AttributeDef:
     constr: AttrConstraint
     """The attribute constraint."""
 
-    data: Any
+    data: typing.Any
 
     def __init__(self, typ: Union[Attribute, typing.Type[Attribute],
                                   AttrConstraint]):
         self.constr = attr_constr_coercion(typ)
+
+
+@dataclass(init=False)
+class OptAttributeDef(AttributeDef):
+    """An IRDL attribute definition for an optional attribute."""
+
+    def __init__(self, typ: Union[Attribute, typing.Type[Attribute],
+                                  AttrConstraint]):
+        super().__init__(typ)
 
 
 def get_variadic_sizes(op: Operation, is_operand: bool) -> List[int]:
@@ -412,6 +421,8 @@ def irdl_op_verify(op: Operation, operands: List[Tuple[str, OperandDef]],
 
     for attr_name, attr_def in attributes:
         if attr_name not in op.attributes:
+            if isinstance(attr_def, OptAttributeDef):
+                continue
             raise Exception(f"attribute {attr_name} expected")
         attr_def.constr.verify(op.attributes[attr_name])
 

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -224,3 +224,25 @@ def test_region_op_ops():
     op.verify()
     assert len(op.region.blocks) == 1
     assert len(op.region.blocks[0].ops) == 2
+
+
+@irdl_op_definition
+class OptionalAttrOp(Operation):
+    name: str = "test.opt_attr_op"
+
+    opt_attr = OptAttributeDef(StringAttr)
+
+
+def test_optional_attr_op_empty():
+    op = OptionalAttrOp.build()
+    op.verify()
+
+
+def test_optional_attr_op_non_empty_attr():
+    op = OptionalAttrOp.build(attributes={"opt_attr": StringAttr.from_int(1)})
+    op.verify()
+
+
+def test_optional_attr_op_non_empty_builder():
+    op1 = OptionalAttrOp.build(attributes={"opt_attr": 1})
+    op1.verify()


### PR DESCRIPTION
This allows to have attributes that can be omitted in operations.