### PR TITLE
Add optional attributes accessors

### DIFF
--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -590,9 +590,15 @@ def irdl_op_definition(
         new_attrs[region_name] = property(
             (lambda idx: lambda self: self.regions[idx])(region_idx))
 
-    for attribute_name, _ in attr_defs:
-        new_attrs[attribute_name] = property(
-            (lambda name: lambda self: self.attributes[name])(attribute_name))
+    for attribute_name, attr_def in attr_defs:
+        if isinstance(attr_def, OptAttributeDef):
+            new_attrs[attribute_name] = property(
+                (lambda name: lambda self: self.attributes.get(name, None)
+                 )(attribute_name))
+        else:
+            new_attrs[attribute_name] = property(
+                (lambda name: lambda self: self.attributes[name]
+                 )(attribute_name))
 
     new_attrs["irdl_operand_defs"] = operand_defs
     new_attrs["irdl_result_defs"] = result_defs

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -236,13 +236,16 @@ class OptionalAttrOp(Operation):
 def test_optional_attr_op_empty():
     op = OptionalAttrOp.build()
     op.verify()
+    assert op.opt_attr is None
 
 
 def test_optional_attr_op_non_empty_attr():
     op = OptionalAttrOp.build(attributes={"opt_attr": StringAttr.from_int(1)})
     op.verify()
+    assert op.opt_attr == StringAttr.from_int(1)
 
 
 def test_optional_attr_op_non_empty_builder():
-    op1 = OptionalAttrOp.build(attributes={"opt_attr": 1})
-    op1.verify()
+    op = OptionalAttrOp.build(attributes={"opt_attr": 1})
+    op.verify()
+    assert op.opt_attr == StringAttr.from_int(1)


### PR DESCRIPTION
This should fix the accessors for optional attributes.
They now return `None` when the attribute is not present, instead of an exception.