### PR TITLE
Minor changes to improve the type annotations

### DIFF
--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -218,7 +218,7 @@ class OptResultDef(VarResultDef, OptionalDef):
 
 
 @dataclass
-class RegionDef:
+class RegionDef(Region):
     """
     An IRDL region definition.
     If the block_args is specified, then the region expect to have the entry block with these arguments.
@@ -531,11 +531,8 @@ def irdl_op_builder(cls: typing.Type[OpT], operands: List,
                       regions=regions)
 
 
-OperationType = TypeVar("OperationType", bound=Operation)
-
-
 def irdl_op_definition(
-        cls: typing.Type[OperationType]) -> typing.Type[OperationType]:
+        cls: typing.Type[Operation]) -> typing.Type[_]:
     """Decorator used on classes to define a new operation definition."""
 
     assert issubclass(
@@ -631,7 +628,7 @@ def irdl_op_definition(
 
     new_attrs["build"] = classmethod(builder)
 
-    return type(cls.__name__, (cls, ), {**cls.__dict__, **new_attrs})
+    return type(cls.__name__, cls.__mro__, {**cls.__dict__, **new_attrs})
 
 
 @dataclass


### PR DESCRIPTION
These two changes improve the usage of xDSL in PyCharm.

1. Making `RegionDef` a subclass of `Region` allows `op` and `ops` (and other properties and methods of Regions) to show up in the autocomplete menu.
Before:
<img width="665" alt="image" src="https://user-images.githubusercontent.com/1250337/154990942-51d9aa19-206a-4dcf-be31-86f53cec1096.png">
After:
<img width="639" alt="image" src="https://user-images.githubusercontent.com/1250337/154991032-41bbf315-3a9a-4292-bbdd-83585b9516b0.png">

2. Removing the `TypeVar` in the `irdl_op_definition` significantly improves type checking experience in PyCharm. (I don't understand why!).

Before, the IDE doesn't see that `func_def` is of type `FuncDef`:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/1250337/154991315-3c468cd0-65f4-4feb-ac3e-969fe0ff9723.png">

After, it now sees this correctly:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/1250337/154991364-17a45ee2-3bd4-47cd-a420-b83e4b2abcbb.png">


