### PR TITLE
Open rewrite API on blocks

### DIFF
--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -99,8 +99,11 @@ class Printer:
             self._print("(", end='')
             self.print_list(block.args, self._print_block_arg)
             self._print(")", end='')
-        self._print(": ", end='')
-        self._print_ops(block.ops)
+        self._print(":", end='')
+        if len(block.ops) > 0:
+            self._print_ops(block.ops)
+        else:
+            self._print_new_line()
 
     def _print_block_arg(self, arg: BlockArgument) -> None:
         self._print("%", end='')

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -111,7 +111,7 @@ class Printer:
 
     def _print_region(self, region: Region) -> None:
         if len(region.blocks) == 0:
-            self._print("{}", end='')
+            self._print(" {}", end='')
             return
 
         if len(region.blocks) == 1 and len(region.blocks[0].args) == 0:
@@ -120,7 +120,7 @@ class Printer:
             self._print("}", end='')
             return
 
-        self._print("{", end='')
+        self._print(" {", end='')
         self._print_new_line()
         for block in region.blocks:
             self._print_named_block(block)

--- a/src/xdsl/rewriter.py
+++ b/src/xdsl/rewriter.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from xdsl.ir import *
 
 
@@ -105,6 +107,36 @@ class Rewriter:
         op_block = op.parent
         op_pos = op_block.get_operation_index(op)
         Rewriter.inline_block_at_pos(block, op_block, op_pos + 1)
+
+    @staticmethod
+    def insert_block_after(block: Union[Block, List[Block]], target: Block):
+        """
+        Insert one or multiple blocks after another block.
+        The blocks to insert should be detached from any region.
+        The target block should not be contained in the block to insert.
+        """
+        if target.parent is None:
+            raise Exception("Cannot move a block after a toplevel op")
+        region = target.parent
+        block_list = block if isinstance(block, list) else [block]
+        if len(block_list) == 0:
+            return
+        pos = region.get_block_index(target)
+        region.insert_block(block_list, pos + 1)
+
+    @staticmethod
+    def insert_block_before(block: Union[Block, List[Block]], target: Block):
+        """
+        Insert one or multiple block before another block.
+        The blocks to insert should be detached from any region.
+        The target block should not be contained in the block to insert.
+        """
+        if target.parent is None:
+            raise Exception("Cannot move a block after a toplevel op")
+        region = target.parent
+        block_list = block if isinstance(block, list) else [block]
+        pos = region.get_block_index(target)
+        region.insert_block(block_list, pos)
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:

--- a/tests/cf_test.py
+++ b/tests/cf_test.py
@@ -20,7 +20,7 @@ def get_example_cf_program_unconditional_noargs(ctx: MLContext, std: Std,
     f = FuncOp.from_region("test", [], [], [a, b])
 
     prog = """
-builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"]{
+builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"] {
 ^0: 
   cf.br() (^1)
 ^1: 
@@ -42,7 +42,7 @@ def get_example_cf_program_unconditional_args(ctx: MLContext, std: Std,
     f = FuncOp.from_region("test", [], [], [a, b])
 
     prog = """
-builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"]{
+builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"] {
 ^0(%0 : !i32): 
   cf.br(%0 : !i32) (^1)
 ^1(%1 : !i32): 
@@ -67,7 +67,7 @@ def get_example_cf_program_conditional_args(ctx: MLContext, std: Std,
     f = FuncOp.from_region("test", [], [], [a, b])
 
     prog = """
-builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"]{
+builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"] {
 ^0(%0 : !i32): 
   cf.br(%0 : !i32) (^1)
 ^1(%1 : !i32): 

--- a/tests/cf_test.py
+++ b/tests/cf_test.py
@@ -21,9 +21,9 @@ def get_example_cf_program_unconditional_noargs(ctx: MLContext, std: Std,
 
     prog = """
 builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"] {
-^0: 
+^0:
   cf.br() (^1)
-^1: 
+^1:
   cf.br() (^0)
 }
     """
@@ -43,9 +43,9 @@ def get_example_cf_program_unconditional_args(ctx: MLContext, std: Std,
 
     prog = """
 builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"] {
-^0(%0 : !i32): 
+^0(%0 : !i32):
   cf.br(%0 : !i32) (^1)
-^1(%1 : !i32): 
+^1(%1 : !i32):
   cf.br(%1 : !i32) (^0)
 }
     """
@@ -68,9 +68,9 @@ def get_example_cf_program_conditional_args(ctx: MLContext, std: Std,
 
     prog = """
 builtin.func() ["sym_name" = "test", "type" = !fun<[], []>, "sym_visibility" = "private"] {
-^0(%0 : !i32): 
+^0(%0 : !i32):
   cf.br(%0 : !i32) (^1)
-^1(%1 : !i32): 
+^1(%1 : !i32):
   %2 : !i1 = arith.constant() ["value" = 1 : !i1]
   cf.cond_br(%2 : !i1, %1 : !i32, %1 : !i32) (^0, ^1) ["operand_segment_sizes" = !dense<!vector<[2 : !index], !i32>, [1 : !i32, 1 : !i32]>]
 }

--- a/tests/pattern_rewriter_test.py
+++ b/tests/pattern_rewriter_test.py
@@ -532,7 +532,7 @@ scf.if(%0 : !i1) {
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
-  ^0(%1 : !i64): 
+  ^0(%1 : !i64):
     %2 : !i32 = arith.addi(%1 : !i64, %1 : !i64)
   }
 }"""
@@ -588,7 +588,8 @@ scf.if(%0 : !i1) {}
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
-  ^0(%1 : !i32): }
+  ^0(%1 : !i32):
+  }
 }"""
 
     @op_type_rewrite_pattern

--- a/tests/pattern_rewriter_test.py
+++ b/tests/pattern_rewriter_test.py
@@ -531,7 +531,7 @@ scf.if(%0 : !i1) {
     expected = \
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
-  scf.if(%0 : !i1){
+  scf.if(%0 : !i1) {
   ^0(%1 : !i64): 
     %2 : !i32 = arith.addi(%1 : !i64, %1 : !i64)
   }
@@ -587,7 +587,7 @@ scf.if(%0 : !i1) {}
     expected = \
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
-  scf.if(%0 : !i1){
+  scf.if(%0 : !i1) {
   ^0(%1 : !i32): }
 }"""
 
@@ -781,7 +781,7 @@ def test_move_region_contents_to_new_regions():
     expected = \
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
-  scf.if(%0 : !i1){}
+  scf.if(%0 : !i1) {}
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
   } {}

--- a/tests/rewriter_test.py
+++ b/tests/rewriter_test.py
@@ -205,7 +205,8 @@ def test_insert_block():
 
     expected = \
 """module() {
-^0: ^1: 
+^0:
+^1:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 }"""
 
@@ -224,9 +225,10 @@ def test_insert_block2():
 
     expected = \
 """module() {
-^0: 
+^0:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
-^1: }"""
+^1:
+}"""
 
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
         module.regions[0].insert_block(Block(), 1)
@@ -243,7 +245,8 @@ def test_insert_block_before():
 
     expected = \
 """module() {
-^0: ^1: 
+^0:
+^1:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 }"""
 
@@ -262,9 +265,10 @@ def test_insert_block_after():
 
     expected = \
 """module() {
-^0: 
+^0:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
-^1: }"""
+^1:
+}"""
 
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
         rewriter.insert_block_after(Block(), module.regions[0].blocks[0])


### PR DESCRIPTION
Add more functionality to rewrite blocks.
It adds functions to:
* Insert new blocks in regions
* Split blocks
* Inline a block in a position inside another block

This is not ready though, since I need to first add support for insertion points I think