### PR TITLE
Error: print proper error on missing SSAValue

### DIFF
--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -74,6 +74,10 @@ class Printer:
         self._print(") = ", end='')
 
     def _print_operand(self, operand: SSAValue) -> None:
+        if (self._ssaValues.get(operand) == None):
+            raise KeyError(
+                "SSAValue is not part of the IR, are you sure all operations are added before their uses?"
+            )
         self._print("%", end='')
         self._print("%s : " % self._ssaValues[operand], end='')
         self.print_attribute(operand.typ)

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -1,0 +1,19 @@
+from xdsl.printer import Printer
+from xdsl.dialects.arith import *
+
+
+def test_forgotten_op():
+    ctx = MLContext()
+    arith = Arith(ctx)
+
+    lit = Constant.from_int_constant(42, 32)
+    add = Addi.get(lit, lit)
+
+    add.verify()
+    try:
+        printer = Printer()
+        printer.print_op(add)
+    except KeyError:
+        return
+
+    assert False, "Exception expected"


### PR DESCRIPTION
Closes #59 

This gives a bit better error message, when one forgets to add an operation to the IR. This helps in cases like: https://github.com/compiling-techniques/ChocoPyCompiler/pull/297