### PR TITLE
Add diagnostic engine to xDSL

### DIFF
--- a/src/xdsl/diagnostic.py
+++ b/src/xdsl/diagnostic.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from typing import Dict, List
+from dataclasses import dataclass, field
+
+from xdsl.ir import Block, Operation, Region
+from io import StringIO
+
+
+@dataclass
+class Diagnostic:
+    op_messages: Dict[Operation, List[str]] = field(default_factory=dict)
+
+    def add_message(self, op: Operation, message: str) -> None:
+        """Add a message to an operation."""
+        self.op_messages.setdefault(op, []).append(message)
+
+    def raise_exception(self,
+                        message,
+                        ir: Union[Operation, Block, Region],
+                        exception_type=Exception) -> None:
+        """Raise an exception, that will also print all messages in the IR."""
+        from xdsl.printer import Printer
+        f = StringIO()
+        p = Printer(stream=f, diagnostic=self)
+        toplevel = ir.get_toplevel_object()
+        if isinstance(toplevel, Operation):
+            p.print_op(toplevel)
+        elif isinstance(toplevel, Block):
+            p._print_named_block(toplevel)
+        elif isinstance(toplevel, Region):
+            p._print_region(toplevel)
+        else:
+            assert "xDSL internal error: get_toplevel_object returned unknown construct"
+
+        raise exception_type(message + "\n\n" + f.getvalue())

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -17,12 +17,23 @@ class Printer:
     _block_names: Dict[Block, int] = field(default_factory=dict, init=False)
     _next_valid_name_id: int = field(default=0, init=False)
     _next_valid_block_id: int = field(default=0, init=False)
+    _current_line: int = field(default=0, init=False)
+    _current_column: int = field(default=0, init=False)
+    _operation_messages: Dict[Operation, str] = field(default_factory=dict,
+                                                      init=False)
 
-    def _print(self, *args, **kwargs):
-        print(*args, **kwargs, file=self.stream)
+    def _print(self, text: Any):
+        text = str(text)
+        lines = text.split('\n')
+        if len(lines) != 1:
+            self._current_line += len(lines) - 1
+            self._current_column = len(lines[-1])
+        else:
+            self._current_column += len(lines[-1])
+        print(text, end='', file=self.stream)
 
     def print_string(self, string) -> None:
-        self._print(string, end='')
+        self._print(string)
 
     T = TypeVar('T')
 
@@ -32,12 +43,12 @@ class Printer:
             return
         print_fn(elems[0])
         for elem in elems[1:]:
-            self._print(", ", end='')
+            self._print(", ")
             print_fn(elem)
 
     def _print_new_line(self) -> None:
-        self._print("")
-        self._print(" " * self._indent * indentNumSpaces, end='')
+        self._print("\n")
+        self._print(" " * self._indent * indentNumSpaces)
 
     def _get_new_valid_name_id(self) -> int:
         self._next_valid_name_id += 1
@@ -49,15 +60,15 @@ class Printer:
 
     def _print_result_value(self, op: Operation, idx: int) -> None:
         val = op.results[idx]
-        self._print("%", end='')
+        self._print("%")
         if val in self._ssa_values.keys():
             name = self._ssa_values[val]
         else:
             name = self._get_new_valid_name_id()
             self._ssa_values[val] = name
-        self._print("%s" % name, end='')
+        self._print("%s" % name)
         if self.print_result_types:
-            self._print(" : ", end='')
+            self._print(" : ")
             self.print_attribute(val.typ)
 
     def _print_results(self, op: Operation) -> None:
@@ -69,28 +80,28 @@ class Printer:
         # One result
         if len(results) == 1:
             self._print_result_value(op, 0)
-            self._print(" = ", end='')
+            self._print(" = ")
             return
 
         # Multiple results
-        self._print("(", end='')
+        self._print("(")
         self._print_result_value(op, 0)
         for idx in range(1, len(results)):
-            self._print(", ", end='')
+            self._print(", ")
             self._print_result_value(op, idx)
-        self._print(") = ", end='')
+        self._print(") = ")
 
     def _print_operand(self, operand: SSAValue) -> None:
         if (self._ssa_values.get(operand) == None):
             raise KeyError(
                 "SSAValue is not part of the IR, are you sure all operations are added before their uses?"
             )
-        self._print("%", end='')
+        self._print("%")
 
-        self._print("%s" % self._ssa_values[operand], end='')
+        self._print("%s" % self._ssa_values[operand])
 
         if self.print_operand_types:
-            self._print(" : ", end='')
+            self._print(" : ")
             self.print_attribute(operand.typ)
 
     def _print_ops(self, ops: List[Operation]) -> None:
@@ -103,46 +114,46 @@ class Printer:
             self._print_new_line()
 
     def print_block_name(self, block: Block) -> None:
-        self._print("^", end='')
+        self._print("^")
         if block not in self._block_names:
             self._block_names[block] = self._get_new_valid_block_id()
-        self._print(self._block_names[block], end='')
+        self._print(self._block_names[block])
 
     def _print_named_block(self, block: Block) -> None:
         self.print_block_name(block)
         if len(block.args) > 0:
-            self._print("(", end='')
+            self._print("(")
             self.print_list(block.args, self._print_block_arg)
-            self._print(")", end='')
-        self._print(":", end='')
+            self._print(")")
+        self._print(":")
         if len(block.ops) > 0:
             self._print_ops(block.ops)
         else:
             self._print_new_line()
 
     def _print_block_arg(self, arg: BlockArgument) -> None:
-        self._print("%", end='')
+        self._print("%")
         name = self._get_new_valid_name_id()
         self._ssa_values[arg] = name
-        self._print("%s : " % name, end='')
+        self._print("%s : " % name)
         self.print_attribute(arg.typ)
 
     def _print_region(self, region: Region) -> None:
         if len(region.blocks) == 0:
-            self._print(" {}", end='')
+            self._print(" {}")
             return
 
         if len(region.blocks) == 1 and len(region.blocks[0].args) == 0:
-            self._print(" {", end='')
+            self._print(" {")
             self._print_ops(region.blocks[0].ops)
-            self._print("}", end='')
+            self._print("}")
             return
 
-        self._print(" {", end='')
+        self._print(" {")
         self._print_new_line()
         for block in region.blocks:
             self._print_named_block(block)
-        self._print("}", end='')
+        self._print("}")
 
     def _print_regions(self, regions: List[Region]) -> None:
         for region in regions:
@@ -150,37 +161,37 @@ class Printer:
 
     def _print_operands(self, operands: List[SSAValue]) -> None:
         if len(operands) == 0:
-            self._print("()", end='')
+            self._print("()")
             return
 
-        self._print("(", end='')
+        self._print("(")
         self._print_operand(operands[0])
         for operand in operands[1:]:
-            self._print(", ", end='')
+            self._print(", ")
             self._print_operand(operand)
-        self._print(")", end='')
+        self._print(")")
 
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, IntegerType):
             width = attribute.parameters[0]
             assert isinstance(width, IntAttr)
-            self._print(f'!i{width.data}', end='')
+            self._print(f'!i{width.data}')
             return
 
         if isinstance(attribute, StringAttr):
-            self._print(f'"{attribute.data}"', end='')
+            self._print(f'"{attribute.data}"')
             return
 
         if isinstance(attribute, FlatSymbolRefAttr):
-            self._print(f'@{attribute.parameters[0].data}', end='')
+            self._print(f'@{attribute.parameters[0].data}')
             return
 
         if isinstance(attribute, IntegerAttr):
             width = attribute.parameters[0]
             typ = attribute.parameters[1]
             assert (isinstance(width, IntAttr))
-            self._print(width.data, end='')
-            self._print(" : ", end='')
+            self._print(width.data)
+            self._print(" : ")
             self.print_attribute(typ)
             return
 
@@ -191,44 +202,44 @@ class Printer:
             return
 
         if isinstance(attribute, Data):
-            self._print(f'!{attribute.name}<', end='')
+            self._print(f'!{attribute.name}<')
             attribute.print(self)
-            self._print(">", end='')
+            self._print(">")
             return
 
         assert isinstance(attribute, ParametrizedAttribute)
 
-        self._print(f'!{attribute.name}', end='')
+        self._print(f'!{attribute.name}')
         if len(attribute.parameters) != 0:
-            self._print("<", end='')
+            self._print("<")
             self.print_list(attribute.parameters, self.print_attribute)
-            self._print(">", end='')
+            self._print(">")
 
     def print_successors(self, successors: List[Block]):
         if len(successors) == 0:
             return
-        self._print(" (", end='')
+        self._print(" (")
         self.print_list(successors, self.print_block_name)
-        self._print(")", end='')
+        self._print(")")
 
     def _print_op_attributes(self, attributes: Dict[str, Attribute]) -> None:
         if len(attributes) == 0:
             return
 
-        self._print(" ", end='')
-        self._print("[", end='')
+        self._print(" ")
+        self._print("[")
 
         attribute_list = [p for p in attributes.items()]
-        self._print("\"%s\" = " % attribute_list[0][0], end='')
+        self._print("\"%s\" = " % attribute_list[0][0])
         self.print_attribute(attribute_list[0][1])
         for (attr_name, attr) in attribute_list[1:]:
-            self._print(", \"%s\" = " % attr_name, end='')
+            self._print(", \"%s\" = " % attr_name)
             self.print_attribute(attr)
-        self._print("]", end='')
+        self._print("]")
 
     def _print_op(self, op: Operation) -> None:
         self._print_results(op)
-        self._print(op.name, end='')
+        self._print(op.name)
         self._print_operands(op.operands)
         self.print_successors(op.successors)
         self._print_op_attributes(op.attributes)

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -1,8 +1,13 @@
+from io import StringIO
+
 from xdsl.printer import Printer
+from xdsl.parser import Parser
+from xdsl.dialects.builtin import Builtin
 from xdsl.dialects.arith import *
 
 
 def test_forgotten_op():
+    """Test that the parsing of an undefined operand raises an exception."""
     ctx = MLContext()
     arith = Arith(ctx)
 
@@ -17,3 +22,101 @@ def test_forgotten_op():
         return
 
     assert False, "Exception expected"
+
+
+def test_op_message():
+    """Test that an operation message can be printed."""
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+    }"""
+
+    expected = \
+"""module() {
+  %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | Test message
+  --------------------------------------------------
+  %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.add_operation_message(module.ops[0], "Test message")
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
+def test_op_message_with_region():
+    """Test that an operation message can be printed on an operation with a region."""
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+    }"""
+
+    expected = \
+"""\
+module() {
+^^^^^^^^
+| Test
+--------
+  %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+  %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.add_operation_message(module, "Test")
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
+def test_op_message_with_region_and_overflow():
+    """
+    Test that an operation message can be printed on an operation with a region,
+    where the message is bigger than the operation.
+    """
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+    }"""
+
+    expected = \
+"""\
+module() {
+^^^^^^^^-------
+| Test message
+---------------
+  %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+  %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.add_operation_message(module, "Test message")
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -55,6 +55,76 @@ def test_op_message():
     assert file.getvalue().strip() == expected.strip()
 
 
+def test_two_different_op_messages():
+    """Test that an operation message can be printed."""
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+    }"""
+
+    expected = \
+"""module() {
+  %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | Test message 1
+  --------------------------------------------------
+  %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | Test message 2
+  --------------------------------------------
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.add_operation_message(module.ops[0], "Test message 1")
+    printer.add_operation_message(module.ops[1], "Test message 2")
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
+def test_two_same_op_messages():
+    """Test that an operation message can be printed."""
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+    }"""
+
+    expected = \
+"""module() {
+  %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | Test message 1
+  --------------------------------------------------
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | Test message 2
+  --------------------------------------------------
+  %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.add_operation_message(module.ops[0], "Test message 1")
+    printer.add_operation_message(module.ops[0], "Test message 2")
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
 def test_op_message_with_region():
     """Test that an operation message can be printed on an operation with a region."""
     prog = \


### PR DESCRIPTION
This PR adds a diagnostic class to xDSL, that can be used to print errors in the code.
This can be used in the verifiers, the rewriter, or the IR methods.