### PR TITLE
Name preservation

### DIFF
--- a/src/xdsl/parser.py
+++ b/src/xdsl/parser.py
@@ -363,6 +363,9 @@ class Parser:
         self.parse_char(")")
         return res
 
+    def is_valid_name(self, name: str) -> bool:
+        return not name[-1].isnumeric()
+
     def parse_optional_op(self) -> Optional[Operation]:
         results = self.parse_optional_results()
         if results is None:
@@ -386,6 +389,8 @@ class Parser:
             if res[0] in self._ssaValues:
                 raise Exception("SSA value %s is already defined" % res[0])
             self._ssaValues[res[0]] = op.results[idx]
+            if self.is_valid_name(res[0]):
+                self._ssaValues[res[0]].name = res[0]
 
         region = self.parse_optional_region()
         while region is not None:

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -15,7 +15,8 @@ class Printer:
     print_result_types: bool = field(default=True)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
     _indent: int = field(default=0, init=False)
-    _ssa_values: Dict[SSAValue, int] = field(default_factory=dict, init=False)
+    _ssa_values: Dict[SSAValue, str] = field(default_factory=dict, init=False)
+    _ssa_names: Dict[str, int] = field(default_factory=dict, init=False)
     _block_names: Dict[Block, int] = field(default_factory=dict, init=False)
     _next_valid_name_id: int = field(default=0, init=False)
     _next_valid_block_id: int = field(default=0, init=False)
@@ -91,9 +92,9 @@ class Printer:
                 callback()
         self._print(" " * indent * indentNumSpaces)
 
-    def _get_new_valid_name_id(self) -> int:
+    def _get_new_valid_name_id(self) -> str:
         self._next_valid_name_id += 1
-        return self._next_valid_name_id - 1
+        return str(self._next_valid_name_id - 1)
 
     def _get_new_valid_block_id(self) -> int:
         self._next_valid_block_id += 1
@@ -104,6 +105,11 @@ class Printer:
         self._print("%")
         if val in self._ssa_values.keys():
             name = self._ssa_values[val]
+        elif val.name:
+            curr_ind = self._ssa_names.get(val.name, 0)
+            name = val.name + (str(curr_ind) if curr_ind != 0 else "")
+            self._ssa_values[val] = name
+            self._ssa_names[val.name] = curr_ind + 1
         else:
             name = self._get_new_valid_name_id()
             self._ssa_values[val] = name

--- a/src/xdsl/rewriter.py
+++ b/src/xdsl/rewriter.py
@@ -52,7 +52,9 @@ class Rewriter:
 
         op_idx = block.get_operation_index(op)
         block.erase_op(op_idx, safe_erase=safe_erase)
-        block.insert_op(new_ops, op_idx)
+        if len(op.results) == 0:
+            block.insert_op(new_ops, op_idx)
+        block.insert_op(new_ops, op_idx, op.results[0].name)
 
     @staticmethod
     def inline_block_at_pos(block: Block, target_block: Block, pos: int):

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -234,3 +234,33 @@ module() {
         diag.raise_exception("test message", module)
     except Exception as e:
         assert str(e)
+
+
+def test_print_costum_name():
+    """
+    Test that an SSAValue, that is a name and not a number, reserves that name
+    """
+    prog = \
+        """module() {
+    %i : !i32 = arith.constant() ["value" = 42 : !i32]
+    %213 : !i32 = arith.addi(%i : !i32, %i : !i32)
+    }"""
+
+    expected = \
+"""\
+module() {
+  %i : !i32 = arith.constant() ["value" = 42 : !i32]
+  %0 : !i32 = arith.addi(%i : !i32, %i : !i32)
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()


### PR DESCRIPTION
closes #69  This implements a feature that Mathieu and me discussed during the workshop. It adds functionality to preserve the name of an SSAValue. This makes it simpler to see which SSAValues are used where, since in hand-written SSA, the names usually mean something.

So given:
```
%i : !i32 = arith.constant() ["value" = 42 : !i32]
```
this prints:
```
%i : !i32 = arith.constant() ["value" = 42 : !i32]
```

Additionally, this gives insight in how IRs develop. If an op is rewritten to one op, the name of the SSAValue is preserved. If it is written to multiple, it gets renamed (currently old.name + str(i), where i is the index in the op list). So given a transformation that rewrites a constant to a constant and the following input:

```
   %i : !i32 = arith.constant() ["value" = 42 : !i32]
    %1 : !i32 = arith.addi(%i : !i32, %i : !i32)
```
This gives:
```
  %i0 : !i32 = arith.constant() ["value" = 1 : !i32]
  %i1 : !i32 = arith.addi(%i0 : !i32, %i0 : !i32)
  %0 : !i32 = arith.addi(%i1 : !i32, %i1 : !i32)
```

Currently, this only works of the SSAValue is names "%i". This is not a fundamental limitation, but rather a point of discussion for us: Which names de we accept such that they can be rewritten in a way that es guaranteed to preserve SSA?