### PR TITLE
Parent pointers

### DIFF
--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -245,6 +245,15 @@ class Operation:
     parent: Optional[Block] = field(default=None, repr=False)
     """The block containing this operation."""
 
+    def parent_block(self) -> Optional[Block]:
+        return self.parent
+
+    def parent_op(self) -> Optional[Operation]:
+        return self.parent.parent.parent if self.parent and self.parent.parent else None
+
+    def parent_region(self) -> Optional[Region]:
+        return self.parent.parent if self.parent else None
+
     @property
     def operands(self) -> FrozenList[SSAValue]:
         return self._operands
@@ -418,6 +427,15 @@ class Block:
 
     parent: Optional[Region] = field(default=None, init=False, repr=False)
     """Parent region containing the block."""
+
+    def parent_op(self) -> Optional[Operation]:
+        return self.parent.parent if self.parent else None
+
+    def parent_region(self) -> Optional[Region]:
+        return self.parent
+
+    def parent_block(self) -> Optional[Block]:
+        return self.parent.parent.parent if self.parent and self.parent.parent else None
 
     def __repr__(self) -> str:
         return f"Block(_args={repr(self._args)}, num_ops={len(self.ops)})"
@@ -623,6 +641,15 @@ class Region:
 
     parent: Optional[Operation] = field(default=None, init=False, repr=False)
     """Operation containing the region."""
+
+    def parent_block(self) -> Optional[Block]:
+        return self.parent.parent if self.parent else None
+
+    def parent_op(self) -> Optional[Operation]:
+        return self.parent
+
+    def parent_region(self) -> Optional[Region]:
+        return self.parent.parent.parent if self.parent and self.parent.parent else None
 
     def __repr__(self) -> str:
         return f"Region(num_blocks={len(self.blocks)})"

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -249,3 +249,35 @@ def test_optional_attr_op_non_empty_builder():
     op = OptionalAttrOp.build(attributes={"opt_attr": 1})
     op.verify()
     assert op.opt_attr == StringAttr.from_int(1)
+
+
+def test_parent_pointers():
+    op = ResultOp.build(result_types=[0])
+    block = Block.from_ops([op])
+    reg = Region.from_block_list([block])
+    reg_op = RegionOp.build(regions=[reg])
+
+    block_2 = Block.from_ops([reg_op])
+    reg_2 = Region.from_block_list([block_2])
+    reg_op_2 = RegionOp.build(regions=[reg_2])
+
+    assert op.parent_block() is block
+    assert op.parent_region() is reg
+    assert op.parent_op() is reg_op
+
+    assert reg_op_2.parent_block() is None
+    assert reg_op_2.parent_region() is None
+    assert reg_op_2.parent_op() is None
+
+    assert reg.parent_op() is reg_op
+    assert reg.parent_block() is block_2
+    assert reg.parent_region() is reg_2
+
+    assert reg_2.parent_block() is None
+    assert reg_2.parent_region() is None
+
+    assert block.parent_region() is reg
+    assert block.parent_op() is reg_op
+    assert block.parent_block() is block_2
+
+    assert block_2.parent_block() is None


### PR DESCRIPTION
closes #68

This implements `parent_op`, `parent_region`, and `parent_block` for `Operation`, `Region`, and `Block`. This was the simplest design I could think of, feel free to suggest one if there is a simpler one.
