### PR TITLE
Erased value history

### DIFF
--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -106,7 +106,7 @@ class SSAValue(ABC):
         if safe_erase and len(self.uses) != 0:
             raise Exception(
                 "Attempting to delete SSA value that still has uses.")
-        self.replace_by(ErasedSSAValue(self.typ))
+        self.replace_by(ErasedSSAValue(self.typ, self))
 
 
 @dataclass
@@ -162,6 +162,8 @@ class ErasedSSAValue(SSAValue):
     An erased SSA variable.
     This is used during transformations when a SSA variable is destroyed but still used.
     """
+
+    old_value: SSAValue
 
     def __hash__(self):
         return hash(id(self))

--- a/src/xdsl/rewriter.py
+++ b/src/xdsl/rewriter.py
@@ -46,12 +46,7 @@ class Rewriter:
 
         for old_result, new_result in zip(op.results, new_results):
             if new_result is None:
-                if safe_erase:
-                    old_result.replace_by(ErasedSSAValue(old_result.typ))
-                elif len(old_result.uses) != 0:
-                    raise Exception(
-                        "SSA value was supposed to be destroyed, but still has uses."
-                    )
+                old_result.erase(safe_erase=safe_erase)
             else:
                 old_result.replace_by(new_result)
 


### PR DESCRIPTION
This commit adds a new field to ErasedSSAValue, which keeps the old ssa value that was deleted.
This is useful to get back the deleted value, in case this value was used in a dictionary for instance.

Also, this fixes a bug in the rewriter, which makes some tests fail in ChocoPy