### PR TITLE
fix block erasure bug

### DIFF
--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -655,7 +655,7 @@ class Block:
         Erase the block, and remove all its references to other operations.
         If safe_erase is specified, check that no operation results are used outside the block.
         """
-        assert self.parent is not None, "Blocks with parents should first be detached before erasure."
+        assert self.parent is None, "Blocks with parents should first be detached before erasure."
         self.drop_all_references()
         for op in self.ops:
             op.erase(safe_erase=safe_erase, drop_references=False)
@@ -794,7 +794,7 @@ class Region:
             block_idx = self.get_block_index(block)
         else:
             block_idx = block
-            op = self.blocks[block_idx]
+            block = self.blocks[block_idx]
         if block.parent is not self:
             raise Exception("Cannot detach block from a different region.")
         block.parent = None


### PR DESCRIPTION
I just found a small bug in the block erasure. I wanted to clone a region (something which we should add support for as well) and ended up creating an empty Region and the cloning the Region I wanted to clone into it. This, however, meant that I had an empty block at the start of the region, which i wanted to remove again, which failed due to this bug.

In terms of code I did the following:
'''
    table = Region.from_operation_list([])
    op.table.clone_into(table)
    table.erase_block(0) # breaks with "AssertionError: Blocks with parents should first be detached before erasure."
'''