### PR TITLE
Irdl generic types coercions

### DIFF
--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -190,9 +190,9 @@ class ArrayAttr(Data[List[A]], IRDLGenericCoercion):
 
     @staticmethod
     def generic_constraint_coercion(args: tuple[Any]) -> AttrConstraint:
-        if len(args) == 0:
-            return ArrayOfConstraint(irdl_to_attr_constraint(args[0]))
         if len(args) == 1:
+            return ArrayOfConstraint(irdl_to_attr_constraint(args[0]))
+        if len(args) == 0:
             return ArrayOfConstraint(AnyAttr())
         raise TypeError(f"Attribute ArrayAttr expects at most type"
                         f" parameter, but {len(args)} were given")

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -176,25 +176,6 @@ class ArrayAttr(Data[List[A]]):
         return ArrayAttr(data)
 
 
-# @dataclass
-# class ArrayOfConstraint(AttrConstraint):
-#     """
-#     A constraint that enforces an ArrayData whose elements all satisfy
-#     the elem_constr.
-#     """
-#     elem_constr: AttrConstraint
-
-#     def __init__(self, constr: Attribute | Type[Attribute] | AttrConstraint):
-#         self.elem_constr = attr_constr_coercion(constr)
-
-#     def verify(self, attr: Attribute) -> None:
-#         if not isinstance(attr, Data):
-#             raise Exception(f"expected data ArrayData but got {attr}")
-
-#         for e in cast(ArrayAttr[Attribute], attr).data:
-#             self.elem_constr.verify(e)
-
-
 @irdl_attr_definition
 class VectorType(ParametrizedAttribute):
     name = "vector"

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -170,7 +170,7 @@ class ArrayOfConstraint(AttrConstraint):
 
 
 @irdl_attr_definition
-class ArrayAttr(Data[List[A]], IRDLGenericCoercion):
+class ArrayAttr(GenericData[List[A]]):
     name = "array"
 
     @staticmethod

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -196,7 +196,7 @@ DataElement = TypeVar("DataElement")
 
 
 @dataclass(frozen=True)
-class Data(Generic[DataElement], Attribute):
+class Data(Generic[DataElement], Attribute, ABC):
     """An attribute represented by a Python structure."""
 
     data: DataElement

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -167,9 +167,13 @@ class ParamAttrConstraint(AttrConstraint):
             param_constr.verify(attr.parameters[idx])
 
 
-class IRDLGenericCoercion(ABC):
+_DataElement = TypeVar("_DataElement")
+
+
+@dataclass(frozen=True)
+class GenericData(Data[_DataElement], ABC):
     """
-    Defines a coercion between a generic Attribute type and an attribute constraint.
+    A Data with type parameters.
     """
 
     @staticmethod
@@ -205,7 +209,7 @@ def irdl_to_attr_constraint(irdl: Any) -> AttrConstraint:
         return BaseAttr(irdl)
 
     origin = get_origin(irdl)
-    if issubclass(origin, IRDLGenericCoercion):
+    if issubclass(origin, GenericData):
         return origin.generic_constraint_coercion(get_args(irdl))
 
     # Union case

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -212,6 +212,12 @@ def irdl_to_attr_constraint(irdl: Any) -> AttrConstraint:
     if issubclass(origin, GenericData):
         return origin.generic_constraint_coercion(get_args(irdl))
 
+    if issubclass(origin, Data):
+        raise ValueError(
+            f"Generic `Data` type '{origin.name}' cannot be converted to "
+            "an attribute constraint. Consider making it inherit from "
+            "`GenericData` instead of `Data`")
+
     # Union case
     # This is a coercion for an `AnyOf` constraint.
     if get_origin(irdl) == types.UnionType:


### PR DESCRIPTION
This PR will detach IRDL from the different coercion definitions for generic attribute parameters. This PR does not remove nor add any functionality.

Before this PR, each generic data structure used in a `Data` should define in IRDL a way to convert their type (like `ListAttr[T]`) to a corresponding constraint (like `ArrayOf(T)`).

With this PR, each `Data` definition can extend `IRDLGenericCoercion` to provide a translation from their type to a constraint. For instance, this is the corresponding definition of `ArrayAttr`:

```python
@irdl_attr_definition
class ArrayAttr(Data[List[A]], IRDLGenericCoercion):
    ...

    @staticmethod
    def generic_constraint_coercion(args: tuple[Any]) -> AttrConstraint:
        if len(args) == 0:
            return ArrayOfConstraint(irdl_to_attr_constraint(args[0]))
        if len(args) == 1:
            return ArrayOfConstraint(AnyAttr())
        raise TypeError(f"Attribute ArrayAttr expects at most type"
                        f" parameter, but {len(args)} were given")

```