### PR TITLE
Builtin: add TupleType to MLIRConverter

### DIFF
--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -36,6 +36,9 @@ class MLIRConverter:
         if isinstance(typ, MemRefType):
             return mlir.ir.MemRefType.get(typ.get_shape(),
                                           self.convert_type(typ.element_type))
+        if isinstance(typ, TupleType):
+            return mlir.ir.TupleType.get_tuple(
+                [self.convert_type(t) for t in typ.types.data])
         raise Exception(f"Unsupported type for mlir conversion: {typ}")
 
     def convert_value(self, value: SSAValue) -> mlir.ir.Value:


### PR DESCRIPTION
This PR adds the TupleType to the MLIRConverter. Feel free to check whether it works on your machines, not having testing for that in the CI is a bit of a pain.