### PR TITLE
MLIRConverison: enable importing of external dialects

### DIFF
--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -6,11 +6,11 @@ from xdsl.dialects.memref import MemRefType
 
 class MLIRConverter:
 
-    def __init__(self, ctx):
+    def __init__(self, ctx, mlir_module=None):
         self.ctx = ctx
         self.op_to_mlir_ops: Dict[Operation, ir.Operation] = dict()
         self.block_to_mlir_blocks: Dict[Block, ir.Block] = dict()
-        self.mlir = ir
+        self.mlir = mlir_module if mlir_module else ir
 
     def register_external_dialects(self):
         pass

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -1,4 +1,4 @@
-import mlir.ir
+import mlir.ir as ir
 import array
 from xdsl.dialects.builtin import *
 from xdsl.dialects.memref import MemRefType
@@ -8,10 +8,14 @@ class MLIRConverter:
 
     def __init__(self, ctx):
         self.ctx = ctx
-        self.op_to_mlir_ops: Dict[Operation, mlir.ir.Operation] = dict()
-        self.block_to_mlir_blocks: Dict[Block, mlir.ir.Block] = dict()
+        self.op_to_mlir_ops: Dict[Operation, ir.Operation] = dict()
+        self.block_to_mlir_blocks: Dict[Block, ir.Block] = dict()
+        self.mlir = ir
 
-    def convert_function_type(self, typ: FunctionType) -> mlir.ir.FunctionType:
+    def register_external_dialects(self):
+        pass
+
+    def convert_function_type(self, typ: FunctionType) -> ir.FunctionType:
         input_array = typ.parameters[0]
         output_array = typ.parameters[1]
         inputs = [
@@ -22,26 +26,26 @@ class MLIRConverter:
             self.convert_type(output_type_attr)
             for output_type_attr in output_array.data
         ]
-        return mlir.ir.FunctionType.get(inputs, outputs)
+        return self.mlir.FunctionType.get(inputs, outputs)
 
-    def convert_type(self, typ: Attribute) -> mlir.ir.Type:
+    def convert_type(self, typ: Attribute) -> ir.Type:
         if isinstance(typ, Float32Type):
-            return mlir.ir.F32Type.get()
+            return self.mlir.F32Type.get()
         if isinstance(typ, IntegerType):
-            return mlir.ir.IntegerType.get_signless(typ.width.data)
+            return self.mlir.IntegerType.get_signless(typ.width.data)
         if isinstance(typ, IndexType):
-            return mlir.ir.IndexType.get()
+            return self.mlir.IndexType.get()
         if isinstance(typ, FunctionType):
             return self.convert_function_type(typ)
         if isinstance(typ, MemRefType):
-            return mlir.ir.MemRefType.get(typ.get_shape(),
-                                          self.convert_type(typ.element_type))
+            return self.mlir.MemRefType.get(
+                typ.get_shape(), self.convert_type(typ.element_type))
         if isinstance(typ, TupleType):
-            return mlir.ir.TupleType.get_tuple(
+            return self.mlir.TupleType.get_tuple(
                 [self.convert_type(t) for t in typ.types.data])
         raise Exception(f"Unsupported type for mlir conversion: {typ}")
 
-    def convert_value(self, value: SSAValue) -> mlir.ir.Value:
+    def convert_value(self, value: SSAValue) -> ir.Value:
         if isinstance(value, OpResult):
             mlir_op = self.op_to_mlir_ops[value.op]
             return mlir_op.results[value.result_index]
@@ -50,14 +54,14 @@ class MLIRConverter:
             return mlir_block.arguments[value.index]
         raise Exception("Unknown value")
 
-    def convert_attribute(self, attr: Attribute) -> mlir.ir.Attribute:
+    def convert_attribute(self, attr: Attribute) -> ir.Attribute:
         if isinstance(attr, StringAttr):
-            return mlir.ir.StringAttr.get(attr.data)
+            return self.mlir.StringAttr.get(attr.data)
         if isinstance(attr, IntegerAttr):
-            return mlir.ir.IntegerAttr.get(
+            return self.mlir.IntegerAttr.get(
                 self.convert_type(attr.parameters[1]), attr.parameters[0].data)
         if isinstance(attr, ArrayAttr):
-            return mlir.ir.ArrayAttr.get(
+            return self.mlir.ArrayAttr.get(
                 [self.convert_attribute(sub_attr) for sub_attr in attr.data])
         if isinstance(attr, DenseIntOrFPElementsAttr):
             # TODO fix this as soon as DEneIntElementsAttr allow us to pass
@@ -66,21 +70,21 @@ class MLIRConverter:
             element_type = self.convert_type(attr.type.element_type)
             typ = "vector" if isinstance(attr.type, VectorType) else "tensor"
 
-            return mlir.ir.DenseIntElementsAttr.parse(
+            return self.mlir.DenseIntElementsAttr.parse(
                 f"dense<{[d.parameters[0].data for d in attr.data.data]}> : {typ}<{len(attr.data.data)}x{element_type}>"
             )
         if isinstance(attr, FlatSymbolRefAttr):
-            return mlir.ir.FlatSymbolRefAttr.get(attr.parameters[0].data)
+            return self.mlir.FlatSymbolRefAttr.get(attr.parameters[0].data)
         # SymbolNameAttrs are in fact just StringAttrs
         if isinstance(attr, SymbolNameAttr):
-            return mlir.ir.StringAttr.get(attr.parameters[0].data)
+            return self.mlir.StringAttr.get(attr.parameters[0].data)
         try:
-            return mlir.ir.TypeAttr.get(self.convert_type(attr))
+            return self.mlir.TypeAttr.get(self.convert_type(attr))
         except Exception:
             raise Exception(
                 f"Unsupported attribute for mlir conversion: {attr}")
 
-    def convert_op(self, op: Operation) -> mlir.ir.Operation:
+    def convert_op(self, op: Operation) -> ir.Operation:
         result_types = [self.convert_type(result.typ) for result in op.results]
         operands = [self.convert_value(operand) for operand in op.operands]
         attributes = {
@@ -92,12 +96,12 @@ class MLIRConverter:
             self.block_to_mlir_blocks[succ] for succ in op.successors
         ]
 
-        mlir_op = mlir.ir.Operation.create(op.name,
-                                           results=result_types,
-                                           operands=operands,
-                                           attributes=attributes,
-                                           successors=successors,
-                                           regions=len(op.regions))
+        mlir_op = self.mlir.Operation.create(op.name,
+                                             results=result_types,
+                                             operands=operands,
+                                             attributes=attributes,
+                                             successors=successors,
+                                             regions=len(op.regions))
         self.op_to_mlir_ops[op] = mlir_op
 
         for region_idx in range(len(op.regions)):
@@ -105,14 +109,13 @@ class MLIRConverter:
                                 mlir_op.regions[region_idx])
         return mlir_op
 
-    def convert_block(self, block: Block, mlir_block: mlir.ir.Block) -> None:
-        ip = mlir.ir.InsertionPoint.at_block_begin(mlir_block)
+    def convert_block(self, block: Block, mlir_block: ir.Block) -> None:
+        ip = self.mlir.InsertionPoint.at_block_begin(mlir_block)
         for op in block.ops:
             ip.insert(self.convert_op(op))
         return mlir_block
 
-    def convert_region(self, region: Region,
-                       mlir_region: mlir.ir.Region) -> None:
+    def convert_region(self, region: Region, mlir_region: ir.Region) -> None:
         assert (len(mlir_region.blocks) == 0)
         for block in region.blocks:
             mlir_block_args = [
@@ -126,17 +129,18 @@ class MLIRConverter:
             mlir_block = self.block_to_mlir_blocks[block]
             self.convert_block(block, mlir_block)
 
-    def convert_module(self, op: Operation) -> mlir.ir.Module:
-        with mlir.ir.Context() as mlir_ctx:
+    def convert_module(self, op: Operation) -> ir.Module:
+        with self.mlir.Context() as mlir_ctx:
             mlir_ctx.allow_unregistered_dialects = True
-            with mlir.ir.Location.unknown(mlir_ctx):
+            self.register_external_dialects()
+            with self.mlir.Location.unknown(mlir_ctx):
                 if not isinstance(op, ModuleOp):
                     raise Exception("top-level operation should be a ModuleOp")
-                mlir_module = mlir.ir.Module.create()
+                mlir_module = self.mlir.Module.create()
                 mlir_block = mlir_module.operation.regions[0].blocks[0]
                 block = op.regions[0].blocks[0]
 
-                ip = mlir.ir.InsertionPoint.at_block_begin(mlir_block)
+                ip = self.mlir.InsertionPoint.at_block_begin(mlir_block)
                 for op in block.ops:
                     ip.insert(self.convert_op(op))
                 return mlir_module


### PR DESCRIPTION
There are some problems with the python bindings and how they have to be imported. In essence, when building the python bindings for a dialect that is not defined within MLIR (so not `cf`, `arith`, ...), you have to rename the folder where the python bindings are and to build an IR, the same version of the bindings has to used for all objects.

So I bascially made the imported package a field of the Converter. That means on one hand, the typechecking works using the standard python bindings, while when creating objects, we use the field of the package to always have the same bindings.

How I used it in the Converter with the new dialects can be seen here: [PR](https://github.com/google/iree-llvm-sandbox/pull/474/files?file-filters%5B%5D=.py&show-viewed-files=true#diff-4f0d1cfdc11bdaf8d1df2c201015be533134ec8afde132b866de7dbd73b9f256)
I am not sure about this design, in particular, having the imported library as a field of the converter feels extremely hacky, but it seems to work. Comments are welcome!