### PR TITLE
WIP: Load mlir module based on configurable module name.

### DIFF
--- a/src/xdsl/__init__.py
+++ b/src/xdsl/__init__.py
@@ -1,0 +1,33 @@
+import sys
+from importlib.abc import MetaPathFinder as _xdsl_importlib_MetaPathFinder
+from importlib import util as _xdsl_importlib_util
+
+# Name of the mlir Python module that should be loaded as alias for `mlir_xdsl`.
+mlir_module_name = 'mlir'
+
+
+def _register_mlir_finder():
+    # This class acts as a 'finder' in the module find_spec phase of Python's
+    # import process. It only handles the case where the module to be imported
+    # is called `mlir_xdsl` and returns None otherwise (which means that the
+    # next finder is tried). In the former case, it uses the default find_spec
+    # implementation to find the module with the name defined in
+    # mlir_module_name, effectively aliasing that module as `mlir_xdsl`.
+    # See also:
+    #   - https://www.sobyte.net/post/2021-10/python-import/
+    #   - https://docs.python.org/3/library/importlib.html#importlib.util.find_spec
+    class MlirModuleFinder(_xdsl_importlib_MetaPathFinder):
+        def find_spec(self, fullname, path, target=None):
+            if fullname == 'mlir_xdsl':
+                # Call default find_spec implementation with `mlir_module_name`
+                spec = _xdsl_importlib_util.find_spec(mlir_module_name)
+                # Override the module name to be sure it is loaded under the
+                # alias
+                spec.name = 'mlir_xdsl'
+                return spec
+
+    # Register our finder
+    sys.meta_path += [MlirModuleFinder()]
+
+
+_register_mlir_finder()

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -1,4 +1,5 @@
-import mlir.ir
+import mlir_xdsl as mlir
+import mlir_xdsl.ir
 import array
 from xdsl.dialects.builtin import *
 from xdsl.dialects.memref import MemRefType

--- a/tests/filecheck/mlir-conversion/lit.local.cfg
+++ b/tests/filecheck/mlir-conversion/lit.local.cfg
@@ -1,5 +1,5 @@
 try:
-    import mlir.ir
+    import mlir_xdsl.ir
 except ImportError:
     config.unsupported = True
 

--- a/tests/mlir_converter_test.py
+++ b/tests/mlir_converter_test.py
@@ -1,5 +1,8 @@
 import pytest
 
+import xdsl
+xdsl.mlir_module_name = 'mlir'
+
 docutils = pytest.importorskip("mlir")
 from xdsl.mlir_converter import *
 from xdsl.dialects.scf import Scf
@@ -9,8 +12,10 @@ from xdsl.dialects.affine import Affine
 from xdsl.dialects.arith import Arith
 from xdsl.parser import Parser
 
-
 def convert_and_verify(test_prog: str):
+    print("Imported mlir.\n  Path: ", mlir.__path__)
+    print("Imported mlir.ir.\n  File: ", mlir.ir.__file__)
+
     ctx = MLContext()
     builtin = Builtin(ctx)
     func = Func(ctx)


### PR DESCRIPTION
This is an attempt to fix #111.

- [ ] Remove debug code.
- [ ] Test whether lit tests still work.
- [x] Tests whether we can `import xdsl_mlir as mlir`.