### PR TITLE
Add support for custom printing and parsing

### DIFF
--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict, List, Callable, Optional, Any, TYPE_CHECKING, TypeVar, Set, Union
+from typing import (Dict, List, Callable, Optional, Any, TYPE_CHECKING,
+                    TypeVar, Set, Union, Tuple)
 import typing
 from frozenlist import FrozenList
 
@@ -367,6 +368,14 @@ class Operation:
 
     def verify_(self) -> None:
         pass
+
+    @classmethod
+    def parse(cls: typing.Type[OperationType], result_types: List[Attribute],
+              parser: Parser) -> OperationType:
+        return parser.parse_op_with_default_format(cls, result_types)
+
+    def print(self, printer: Printer):
+        return printer.print_op_with_default_format(self)
 
     def clone_without_regions(
             self: OperationType,

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -11,6 +11,7 @@ indentNumSpaces = 2
 class Printer:
 
     stream: Optional[Any] = field(default=None)
+    print_generic_format: bool = field(default=False)
     print_operand_types: bool = field(default=True)
     print_result_types: bool = field(default=True)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
@@ -25,7 +26,7 @@ class Printer:
     _next_line_callback: List[Callable[[], None]] = field(default_factory=list,
                                                           init=False)
 
-    def _print(self, text: Any):
+    def print(self, text: Any):
         text = str(text)
         lines = text.split('\n')
         if len(lines) != 1:
@@ -36,7 +37,7 @@ class Printer:
         print(text, end='', file=self.stream)
 
     def print_string(self, string) -> None:
-        self._print(string)
+        self.print(string)
 
     def _add_message_on_next_line(self, message: str, begin_pos: int,
                                   end_pos: int):
@@ -55,20 +56,20 @@ class Printer:
         This is expected to be called on the beginning of a new line, and expect to create a new line at the end.
         """
         indent = self._indent if indent is None else indent
-        self._print(" " * indent * indentNumSpaces)
+        self.print(" " * indent * indentNumSpaces)
         indent_size = indent * indentNumSpaces
         message_end_pos = max([len(line) for line in message.split("\n")]) + 2
         first_line = (begin_pos - indent_size) * "-" + (
             end_pos - begin_pos + 1) * "^" + (max(message_end_pos, end_pos) -
                                               end_pos) * "-"
-        self._print(first_line)
+        self.print(first_line)
         self._print_new_line(indent=indent, print_message=False)
         message_lines = message.split("\n")
         for message_line in message_lines:
-            self._print("| ")
-            self._print(message_line)
+            self.print("| ")
+            self.print(message_line)
             self._print_new_line(indent=indent, print_message=False)
-        self._print("-" * (max(message_end_pos, end_pos) - indent_size + 1))
+        self.print("-" * (max(message_end_pos, end_pos) - indent_size + 1))
         self._print_new_line(indent=0, print_message=False)
 
     T = TypeVar('T')
@@ -79,18 +80,18 @@ class Printer:
             return
         print_fn(elems[0])
         for elem in elems[1:]:
-            self._print(", ")
+            self.print(", ")
             print_fn(elem)
 
     def _print_new_line(self, indent=None, print_message=True) -> None:
         indent = self._indent if indent is None else indent
-        self._print("\n")
+        self.print("\n")
         if print_message:
             while len(self._next_line_callback) != 0:
                 callback = self._next_line_callback[0]
                 self._next_line_callback = self._next_line_callback[1:]
                 callback()
-        self._print(" " * indent * indentNumSpaces)
+        self.print(" " * indent * indentNumSpaces)
 
     def _get_new_valid_name_id(self) -> str:
         self._next_valid_name_id += 1
@@ -102,7 +103,7 @@ class Printer:
 
     def _print_result_value(self, op: Operation, idx: int) -> None:
         val = op.results[idx]
-        self._print("%")
+        self.print("%")
         if val in self._ssa_values.keys():
             name = self._ssa_values[val]
         elif val.name:
@@ -113,9 +114,9 @@ class Printer:
         else:
             name = self._get_new_valid_name_id()
             self._ssa_values[val] = name
-        self._print("%s" % name)
+        self.print("%s" % name)
         if self.print_result_types:
-            self._print(" : ")
+            self.print(" : ")
             self.print_attribute(val.typ)
 
     def _print_results(self, op: Operation) -> None:
@@ -127,28 +128,28 @@ class Printer:
         # One result
         if len(results) == 1:
             self._print_result_value(op, 0)
-            self._print(" = ")
+            self.print(" = ")
             return
 
         # Multiple results
-        self._print("(")
+        self.print("(")
         self._print_result_value(op, 0)
         for idx in range(1, len(results)):
-            self._print(", ")
+            self.print(", ")
             self._print_result_value(op, idx)
-        self._print(") = ")
+        self.print(") = ")
+
+    def print_ssa_value(self, value: SSAValue) -> None:
+        if (self._ssa_values.get(value) == None):
+            raise KeyError("SSAValue is not part of the IR, are you sure"
+                           " all operations are added before their uses?")
+        self.print(f"%{self._ssa_values[value]}")
 
     def _print_operand(self, operand: SSAValue) -> None:
-        if (self._ssa_values.get(operand) == None):
-            raise KeyError(
-                "SSAValue is not part of the IR, are you sure all operations are added before their uses?"
-            )
-        self._print("%")
-
-        self._print("%s" % self._ssa_values[operand])
+        self.print_ssa_value(operand)
 
         if self.print_operand_types:
-            self._print(" : ")
+            self.print(" : ")
             self.print_attribute(operand.typ)
 
     def _print_ops(self, ops: List[Operation]) -> None:
@@ -161,84 +162,84 @@ class Printer:
             self._print_new_line()
 
     def print_block_name(self, block: Block) -> None:
-        self._print("^")
+        self.print("^")
         if block not in self._block_names:
             self._block_names[block] = self._get_new_valid_block_id()
-        self._print(self._block_names[block])
+        self.print(self._block_names[block])
 
     def _print_named_block(self, block: Block) -> None:
         self.print_block_name(block)
         if len(block.args) > 0:
-            self._print("(")
+            self.print("(")
             self.print_list(block.args, self._print_block_arg)
-            self._print(")")
-        self._print(":")
+            self.print(")")
+        self.print(":")
         if len(block.ops) > 0:
             self._print_ops(block.ops)
         else:
             self._print_new_line()
 
     def _print_block_arg(self, arg: BlockArgument) -> None:
-        self._print("%")
+        self.print("%")
         name = self._get_new_valid_name_id()
         self._ssa_values[arg] = name
-        self._print("%s : " % name)
+        self.print("%s : " % name)
         self.print_attribute(arg.typ)
 
     def _print_region(self, region: Region) -> None:
         if len(region.blocks) == 0:
-            self._print(" {}")
+            self.print(" {}")
             return
 
         if len(region.blocks) == 1 and len(region.blocks[0].args) == 0:
-            self._print(" {")
+            self.print(" {")
             self._print_ops(region.blocks[0].ops)
-            self._print("}")
+            self.print("}")
             return
 
-        self._print(" {")
+        self.print(" {")
         self._print_new_line()
         for block in region.blocks:
             self._print_named_block(block)
-        self._print("}")
+        self.print("}")
 
     def _print_regions(self, regions: List[Region]) -> None:
         for region in regions:
             self._print_region(region)
 
-    def _print_operands(self, operands: List[SSAValue]) -> None:
+    def _print_operands(self, operands: FrozenList[SSAValue]) -> None:
         if len(operands) == 0:
-            self._print("()")
+            self.print("()")
             return
 
-        self._print("(")
+        self.print("(")
         self._print_operand(operands[0])
         for operand in operands[1:]:
-            self._print(", ")
+            self.print(", ")
             self._print_operand(operand)
-        self._print(")")
+        self.print(")")
 
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, IntegerType):
             width = attribute.parameters[0]
             assert isinstance(width, IntAttr)
-            self._print(f'!i{width.data}')
+            self.print(f'!i{width.data}')
             return
 
         if isinstance(attribute, StringAttr):
-            self._print(f'"{attribute.data}"')
+            self.print(f'"{attribute.data}"')
             return
 
         if isinstance(attribute, FlatSymbolRefAttr):
-            self._print(f'@{attribute.parameters[0].data}')
+            self.print(f'@{attribute.parameters[0].data}')
             return
 
         if isinstance(attribute, IntegerAttr):
             width = attribute.parameters[0]
             typ = attribute.parameters[1]
             assert (isinstance(width, IntAttr))
-            self._print(width.data)
-            self._print(" : ")
+            self.print(width.data)
+            self.print(" : ")
             self.print_attribute(typ)
             return
 
@@ -249,54 +250,63 @@ class Printer:
             return
 
         if isinstance(attribute, Data):
-            self._print(f'!{attribute.name}<')
+            self.print(f'!{attribute.name}<')
             attribute.print(self)
-            self._print(">")
+            self.print(">")
             return
 
         assert isinstance(attribute, ParametrizedAttribute)
 
-        self._print(f'!{attribute.name}')
+        self.print(f'!{attribute.name}')
         if len(attribute.parameters) != 0:
-            self._print("<")
+            self.print("<")
             self.print_list(attribute.parameters, self.print_attribute)
-            self._print(">")
+            self.print(">")
 
     def print_successors(self, successors: List[Block]):
         if len(successors) == 0:
             return
-        self._print(" (")
+        self.print(" (")
         self.print_list(successors, self.print_block_name)
-        self._print(")")
+        self.print(")")
 
     def _print_op_attributes(self, attributes: Dict[str, Attribute]) -> None:
         if len(attributes) == 0:
             return
 
-        self._print(" ")
-        self._print("[")
+        self.print(" ")
+        self.print("[")
 
         attribute_list = [p for p in attributes.items()]
-        self._print("\"%s\" = " % attribute_list[0][0])
+        self.print("\"%s\" = " % attribute_list[0][0])
         self.print_attribute(attribute_list[0][1])
         for (attr_name, attr) in attribute_list[1:]:
-            self._print(", \"%s\" = " % attr_name)
+            self.print(", \"%s\" = " % attr_name)
             self.print_attribute(attr)
-        self._print("]")
+        self.print("]")
+
+    def print_op_with_default_format(self, op: Operation) -> None:
+        self._print_operands(op.operands)
+        self.print_successors(op.successors)
+        self._print_op_attributes(op.attributes)
+        self._print_regions(op.regions)
 
     def _print_op(self, op: Operation) -> None:
         begin_op_pos = self._current_column
         self._print_results(op)
-        self._print(op.name)
-        self._print_operands(op.operands)
-        self.print_successors(op.successors)
-        self._print_op_attributes(op.attributes)
+        if self.print_generic_format:
+            self.print(f'"{op.name}"')
+        else:
+            self.print(op.name)
         end_op_pos = self._current_column - 1
         if op in self.diagnostic.op_messages:
             for message in self.diagnostic.op_messages[op]:
                 self._add_message_on_next_line(message, begin_op_pos,
                                                end_op_pos)
-        self._print_regions(op.regions)
+        if self.print_generic_format:
+            self.print_op_with_default_format(op)
+        else:
+            op.print(self)
 
     def print_op(self, op: Operation) -> None:
         self._print_op(op)

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -311,10 +311,7 @@ class PlusCustomFormatOp(Operation):
                                          result_types=result_types)
 
     def print(self, printer: Printer):
-        printer.print(" ")
-        printer.print_ssa_value(self.lhs)
-        printer.print(" + ")
-        printer.print_ssa_value(self.rhs)
+        printer.print(" ", self.lhs, " + ", self.rhs)
 
 
 def test_generic_format():

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import StringIO
 
 from xdsl.printer import Printer
@@ -25,6 +27,15 @@ def test_forgotten_op():
     assert False, "Exception expected"
 
 
+#  ____  _                             _   _
+# |  _ \(_) __ _  __ _ _ __   ___  ___| |_(_) ___
+# | | | | |/ _` |/ _` | '_ \ / _ \/ __| __| |/ __|
+# | |_| | | (_| | (_| | | | | (_) \__ \ |_| | (__
+# |____/|_|\__,_|\__, |_| |_|\___/|___/\__|_|\___|
+#                |___/
+#
+
+
 def test_op_message():
     """Test that an operation message can be printed."""
     prog = \
@@ -36,9 +47,9 @@ def test_op_message():
     expected = \
 """module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Test message
-  --------------------------------------------------
+  --------------------------
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
@@ -68,13 +79,13 @@ def test_two_different_op_messages():
     expected = \
 """module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Test message 1
-  --------------------------------------------------
+  --------------------------
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ^^^^^^^^^^^^^^^^^^^^^^
   | Test message 2
-  --------------------------------------------
+  ----------------------
 }"""
 
     ctx = MLContext()
@@ -104,12 +115,12 @@ def test_two_same_op_messages():
     expected = \
 """module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Test message 1
-  --------------------------------------------------
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --------------------------
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Test message 2
-  --------------------------------------------------
+  --------------------------
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
@@ -140,9 +151,9 @@ def test_op_message_with_region():
     expected = \
 """\
 module() {
-^^^^^^^^
+^^^^^^-
 | Test
---------
+-------
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -176,7 +187,7 @@ def test_op_message_with_region_and_overflow():
     expected = \
 """\
 module() {
-^^^^^^^^-------
+^^^^^^---------
 | Test message
 ---------------
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
@@ -236,6 +247,14 @@ module() {
         assert str(e)
 
 
+#  ____ ____    _    _   _
+# / ___/ ___|  / \  | \ | | __ _ _ __ ___   ___
+# \___ \___ \ / _ \ |  \| |/ _` | '_ ` _ \ / _ \
+#  ___) |__) / ___ \| |\  | (_| | | | | | |  __/
+# |____/____/_/   \_\_| \_|\__,_|_| |_| |_|\___|
+#
+
+
 def test_print_costum_name():
     """
     Test that an SSAValue, that is a name and not a number, reserves that name
@@ -262,5 +281,130 @@ module() {
 
     file = StringIO("")
     printer = Printer(stream=file)
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
+#   ____          _                  _____                          _
+#  / ___|   _ ___| |_ ___  _ __ ___ |  ___|__  _ __ _ __ ___   __ _| |_
+# | |  | | | / __| __/ _ \| '_ ` _ \| |_ / _ \| '__| '_ ` _ \ / _` | __|
+# | |__| |_| \__ \ || (_) | | | | | |  _| (_) | |  | | | | | | (_| | |_
+#  \____\__,_|___/\__\___/|_| |_| |_|_|  \___/|_|  |_| |_| |_|\__,_|\__|
+#
+
+
+@irdl_op_definition
+class PlusCustomFormatOp(Operation):
+    name = "test.add"
+    lhs = OperandDef(IntegerType)
+    rhs = OperandDef(IntegerType)
+    res = ResultDef(IntegerType)
+
+    @classmethod
+    def parse(cls, result_types: List[Attribute],
+              parser: Parser) -> PlusCustomFormatOp:
+        lhs = parser.parse_ssa_value()
+        parser.skip_white_space()
+        parser.parse_char("+")
+        rhs = parser.parse_ssa_value()
+        return PlusCustomFormatOp.create(operands=[lhs, rhs],
+                                         result_types=result_types)
+
+    def print(self, printer: Printer):
+        printer.print(" ")
+        printer.print_ssa_value(self.lhs)
+        printer.print(" + ")
+        printer.print_ssa_value(self.rhs)
+
+
+def test_generic_format():
+    """
+    Test that we can use generic formats in operations.
+    """
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = "test.add"(%0: !i32, %0: !i32)
+    }"""
+
+    expected = \
+"""\
+module() {
+  %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+  %1 : !i32 = test.add %0 + %0
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+    ctx.register_op(PlusCustomFormatOp)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
+def test_custom_format():
+    """
+    Test that we can use custom formats in operations.
+    """
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = test.add %0 + %0
+    }"""
+
+    expected = \
+"""\
+module() {
+  %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+  %1 : !i32 = test.add %0 + %0
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+    ctx.register_op(PlusCustomFormatOp)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
+def test_custom_format():
+    """
+    Test that we can print using generic formats.
+    """
+    prog = \
+        """module() {
+    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
+    %1 : !i32 = test.add %0 + %0
+    }"""
+
+    expected = \
+"""\
+"module"() {
+  %0 : !i32 = "arith.constant"() ["value" = 42 : !i32]
+  %1 : !i32 = "test.add"(%0 : !i32, %0 : !i32)
+}"""
+
+    ctx = MLContext()
+    arith = Arith(ctx)
+    builtin = Builtin(ctx)
+    ctx.register_op(PlusCustomFormatOp)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file, print_generic_format=True)
     printer.print_op(module)
     assert file.getvalue().strip() == expected.strip()


### PR DESCRIPTION
Should fix #113 

This PR allows operations to override `print` and `parse` to essentially implement custom parsing. It also open a bit the API of the printer and parser class.
This PR does not add custom format for dialects defined in xDSL, so there should not be any breaking change.

There is an example of its usage in `tests/printer_test.py`