### PR TITLE
Update typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ build-backend = "setuptools.build_meta"
 include = ["src"]
 reportImportCycles = false
 reportUnnecessaryIsInstance = false
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,6 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.pyright]
+include = ["src"]
 reportImportCycles = false
 reportUnnecessaryIsInstance = false

--- a/src/tools/xdsl-opt
+++ b/src/tools/xdsl-opt
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+
 from xdsl.xdsl_opt_main import xDSLOptMain
 
 

--- a/src/xdsl/diagnostic.py
+++ b/src/xdsl/diagnostic.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from typing import Dict, List, Union, Type
+
 from dataclasses import dataclass, field
+from io import StringIO
 
 from xdsl.ir import Block, Operation, Region
-from io import StringIO
 
 
 class DiagnosticException(Exception):

--- a/src/xdsl/diagnostic.py
+++ b/src/xdsl/diagnostic.py
@@ -12,7 +12,7 @@ class DiagnosticException(Exception):
 
 @dataclass
 class Diagnostic:
-    op_messages: Dict[Operation, List[str]] = field(default_factory=dict)
+    op_messages: dict[Operation, list[str]] = field(default_factory=dict)
 
     def add_message(self, op: Operation, message: str) -> None:
         """Add a message to an operation."""
@@ -21,8 +21,8 @@ class Diagnostic:
     def raise_exception(
             self,
             message: str,
-            ir: Union[Operation, Block, Region],
-            exception_type: Type[Exception] = DiagnosticException) -> None:
+            ir: Operation | Block | Region,
+            exception_type: type[Exception] = DiagnosticException) -> None:
         """Raise an exception, that will also print all messages in the IR."""
         from xdsl.printer import Printer
         f = StringIO()

--- a/src/xdsl/dialects/affine.py
+++ b/src/xdsl/dialects/affine.py
@@ -50,11 +50,11 @@ class For(Operation):
             )
 
     @staticmethod
-    def from_region(operands: List[Union[Operation, SSAValue]],
-                    lower_bound: Union[int, IntegerAttr],
-                    upper_bound: Union[int, IntegerAttr],
+    def from_region(operands: list[Operation | SSAValue],
+                    lower_bound: int | IntegerAttr,
+                    upper_bound: int | IntegerAttr,
                     region: Region,
-                    step: Union[int, IntegerAttr] = 1) -> For:
+                    step: int | IntegerAttr = 1) -> For:
         result_types = [SSAValue.get(op).typ for op in operands]
         return For.build(operands=[[operand for operand in operands]],
                          result_types=[result_types],
@@ -66,11 +66,11 @@ class For(Operation):
                          regions=[region])
 
     @staticmethod
-    def from_callable(operands: List[Union[Operation, SSAValue]],
-                      lower_bound: Union[int, IntegerAttr],
-                      upper_bound: Union[int, IntegerAttr],
+    def from_callable(operands: list[Operation | SSAValue],
+                      lower_bound: int | IntegerAttr,
+                      upper_bound: int | IntegerAttr,
                       body: Block.BlockCallback,
-                      step: Union[int, IntegerAttr] = 1) -> For:
+                      step: int | IntegerAttr = 1) -> For:
         arg_types = [IndexType()] + [SSAValue.get(op).typ for op in operands]
         return For.from_region(
             operands, lower_bound, upper_bound,

--- a/src/xdsl/dialects/affine.py
+++ b/src/xdsl/dialects/affine.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Union, List
 from dataclasses import dataclass
 
-from xdsl.ir import Operation, SSAValue, MLContext, Block, Region
-from xdsl.dialects.builtin import IntegerAttr, IndexType, IndexType
-from xdsl.irdl import irdl_op_definition, AttributeDef, RegionDef, VarResultDef, VarOperandDef, AnyAttr
+from xdsl.dialects.builtin import IndexType, IntegerAttr
+from xdsl.ir import Block, MLContext, Operation, Region, SSAValue
+from xdsl.irdl import (AnyAttr, AttributeDef, RegionDef, VarOperandDef,
+                       VarResultDef, irdl_op_definition)
 
 
 @dataclass

--- a/src/xdsl/dialects/arith.py
+++ b/src/xdsl/dialects/arith.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+
+from xdsl.dialects.builtin import Float32Type, IntegerAttr, IntegerType
 from xdsl.ir import *
 from xdsl.irdl import *
 from xdsl.util import *
-from xdsl.dialects.builtin import IntegerType, Float32Type, IntegerAttr
 
 
 @dataclass
@@ -41,8 +42,8 @@ class Constant(Operation):
         return Constant.create(result_types=[typ], attributes={"value": attr})
 
     @staticmethod
-    def from_int_constant(val: Union[int, Attribute],
-                          typ: Union[int, Attribute]) -> Constant:
+    def from_int_constant(val: int | Attribute,
+                          typ: int | Attribute) -> Constant:
         if isinstance(typ, int):
             typ = IntegerType.from_width(typ)
         return Constant.create(
@@ -64,8 +65,8 @@ class Addi(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> Addi:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> Addi:
         return Addi.build(operands=[operand1, operand2],
                           result_types=[IntegerType.from_width(32)])
 
@@ -84,8 +85,8 @@ class Muli(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> Muli:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> Muli:
         return Muli.build(operands=[operand1, operand2],
                           result_types=[IntegerType.from_width(32)])
 
@@ -104,8 +105,8 @@ class Subi(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> Subi:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> Subi:
         return Subi.build(operands=[operand1, operand2],
                           result_types=[IntegerType.from_width(32)])
 
@@ -124,8 +125,8 @@ class FloorDiviSI(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> FloorDiviSI:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> FloorDiviSI:
         return FloorDiviSI.build(operands=[operand1, operand2],
                                  result_types=[IntegerType.from_width(32)])
 
@@ -144,8 +145,8 @@ class RemSI(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> RemSI:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> RemSI:
         return RemSI.build(operands=[operand1, operand2],
                            result_types=[IntegerType.from_width(32)])
 
@@ -164,8 +165,8 @@ class AndI(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> AndI:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> AndI:
         return AndI.build(operands=[operand1, operand2],
                           result_types=[SSAValue.get(operand1).typ])
 
@@ -184,8 +185,8 @@ class OrI(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> OrI:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> OrI:
 
         return OrI.build(operands=[operand1, operand2],
                          result_types=[SSAValue.get(operand1).typ])
@@ -205,8 +206,8 @@ class XOrI(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> XOrI:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> XOrI:
         return XOrI.build(operands=[operand1, operand2],
                           result_types=[SSAValue.get(operand1).typ])
 
@@ -220,8 +221,8 @@ class Cmpi(Operation):
     output = ResultDef(IntegerType.from_width(1))
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue], arg: int) -> Cmpi:
+    def get(operand1: Operation | SSAValue, operand2: Operation | SSAValue,
+            arg: int) -> Cmpi:
         return Cmpi.build(
             operands=[operand1, operand2],
             result_types=[IntegerType.from_width(1)],
@@ -242,8 +243,8 @@ class Addf(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> Addf:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> Addf:
         return Addf.build(operands=[operand1, operand2],
                           result_types=[Float32Type()])
 
@@ -262,7 +263,7 @@ class Mulf(Operation):
                 "expect all input and output types to be equal")
 
     @staticmethod
-    def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> Mulf:
+    def get(operand1: Operation | SSAValue,
+            operand2: Operation | SSAValue) -> Mulf:
         return Mulf.build(operands=[operand1, operand2],
                           result_types=[Float32Type()])

--- a/src/xdsl/dialects/cf.py
+++ b/src/xdsl/dialects/cf.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+
+from xdsl.dialects.builtin import IntegerType
 from xdsl.ir import *
 from xdsl.irdl import *
 from xdsl.util import *
-from xdsl.dialects.builtin import IntegerType
 
 
 @dataclass
@@ -21,7 +22,7 @@ class Branch(Operation):
     arguments = VarOperandDef(AnyAttr())
 
     @staticmethod
-    def get(block: Block, *ops: Union[Operation, SSAValue]) -> Branch:
+    def get(block: Block, *ops: Operation | SSAValue) -> Branch:
         return Branch.build(operands=[[op for op in ops]], successors=[block])
 
 
@@ -36,8 +37,8 @@ class ConditionalBranch(Operation):
     irdl_options = [AttrSizedOperandSegments()]
 
     @staticmethod
-    def get(cond: Union[Operation, SSAValue], then_block: Block,
-            then_ops: List[Union[Operation, SSAValue]], else_block: Block,
-            else_ops: List[Union[Operation, SSAValue]]) -> ConditionalBranch:
+    def get(cond: Operation | SSAValue, then_block: Block,
+            then_ops: list[Operation | SSAValue], else_block: Block,
+            else_ops: list[Operation | SSAValue]) -> ConditionalBranch:
         return ConditionalBranch.build(operands=[cond, then_ops, else_ops],
                                        successors=[then_block, else_block])

--- a/src/xdsl/dialects/func.py
+++ b/src/xdsl/dialects/func.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 
-from xdsl.irdl import *
-from xdsl.ir import *
 from xdsl.dialects.builtin import *
+from xdsl.ir import *
+from xdsl.irdl import *
 
 
 @dataclass
@@ -26,8 +27,8 @@ class FuncOp(Operation):
     sym_visibility = AttributeDef(StringAttr)
 
     @staticmethod
-    def from_callable(name: str, input_types: List[Attribute],
-                      return_types: List[Attribute],
+    def from_callable(name: str, input_types: list[Attribute],
+                      return_types: list[Attribute],
                       func: Block.BlockCallback) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
         op = FuncOp.build(attributes={
@@ -42,8 +43,8 @@ class FuncOp(Operation):
         return op
 
     @staticmethod
-    def from_region(name: str, input_types: List[Attribute],
-                    return_types: List[Attribute], region: Region) -> FuncOp:
+    def from_region(name: str, input_types: list[Attribute],
+                    return_types: list[Attribute], region: Region) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
         op = FuncOp.build(attributes={
             "sym_name": name,
@@ -65,9 +66,9 @@ class Call(Operation):
     # TODO how do we verify that the types are correct?
 
     @staticmethod
-    def get(callee: Union[str, FlatSymbolRefAttr],
-            operands: List[Union[SSAValue, Operation]],
-            return_types: List[Attribute]) -> Call:
+    def get(callee: str | FlatSymbolRefAttr,
+            operands: list[SSAValue | Operation],
+            return_types: list[Attribute]) -> Call:
         return Call.build(operands=operands,
                           result_types=return_types,
                           attributes={"callee": callee})
@@ -79,5 +80,5 @@ class Return(Operation):
     arguments = VarOperandDef(AnyAttr())
 
     @staticmethod
-    def get(*ops: Union[Operation, SSAValue]) -> Return:
+    def get(*ops: Operation | SSAValue) -> Return:
         return Return.build(operands=[[op for op in ops]])

--- a/src/xdsl/dialects/memref.py
+++ b/src/xdsl/dialects/memref.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
-from xdsl.ir import *
+
 from xdsl.dialects.builtin import *
+from xdsl.ir import *
 from xdsl.irdl import *
 
 
@@ -35,14 +37,14 @@ class MemRefType(Generic[_MemRefTypeElement], ParametrizedAttribute):
     def get_num_dims(self) -> int:
         return len(self.shape.data)
 
-    def get_shape(self) -> List[int]:
+    def get_shape(self) -> list[int]:
         return [i.value.data for i in self.shape.data]
 
     @staticmethod
     @builder
     def from_type_and_list(
         referenced_type: _MemRefTypeElement,
-        shape: Optional[List[int | AnyIntegerAttr]] = None
+        shape: list[int | AnyIntegerAttr] | None = None
     ) -> MemRefType[_MemRefTypeElement]:
         if shape is None:
             shape = [1]
@@ -81,7 +83,7 @@ class Load(Operation):
 
     @staticmethod
     def get(ref: SSAValue | Operation,
-            indices: List[SSAValue | Operation]) -> Load:
+            indices: list[SSAValue | Operation]) -> Load:
         return Load.build(operands=[ref, indices],
                           result_types=[SSAValue.get(ref).typ.element_type])
 
@@ -103,7 +105,7 @@ class Store(Operation):
 
     @staticmethod
     def get(value: Operation | SSAValue, ref: Operation | SSAValue,
-            indices: List[Operation | SSAValue]) -> Store:
+            indices: list[Operation | SSAValue]) -> Store:
         return Store.build(operands=[value, ref, indices])
 
 
@@ -124,7 +126,7 @@ class Alloc(Operation):
     @staticmethod
     def get(return_type: Attribute,
             alignment: int,
-            shape: Optional[List[int | AnyIntegerAttr]] = None) -> Alloc:
+            shape: list[int | AnyIntegerAttr] | None = None) -> Alloc:
         if shape is None:
             shape = [1]
         return Alloc.build(
@@ -152,7 +154,7 @@ class Alloca(Operation):
     @staticmethod
     def get(return_type: Attribute,
             alignment: int,
-            shape: Optional[List[int | AnyIntegerAttr]] = None) -> Alloca:
+            shape: list[int | AnyIntegerAttr] | None = None) -> Alloca:
         if shape is None:
             shape = [1]
         return Alloca.build(
@@ -223,7 +225,7 @@ class Global(Operation):
     @staticmethod
     def get(sym_name: str | StringAttr,
             typ: Attribute,
-            initial_value: Optional[Attribute],
+            initial_value: Attribute | None,
             sym_visibility: str = "private") -> Global:
         return Global.build(
             attributes={

--- a/src/xdsl/dialects/scf.py
+++ b/src/xdsl/dialects/scf.py
@@ -70,13 +70,13 @@ class While(Operation):
         for (idx, arg) in enumerate(self.arguments):
             if self.before_region.blocks[0].args[idx].typ != arg.typ:
                 raise Exception(
-                    f"Block arguments with wrong type, expected {arg.typ}, got {self.before_region.block[0].args[idx].typ}"
+                    f"Block arguments with wrong type, expected {arg.typ}, got {self.before_region.blocks[0].args[idx].typ}"
                 )
 
         for (idx, res) in enumerate(self.res):
             if self.after_region.blocks[0].args[idx].typ != res.typ:
                 raise Exception(
-                    f"Block arguments with wrong type, expected {res.typ}, got {self.after_region.block[0].args[idx].typ}"
+                    f"Block arguments with wrong type, expected {res.typ}, got {self.after_region.blocks[0].args[idx].typ}"
                 )
 
     @staticmethod

--- a/src/xdsl/dialects/scf.py
+++ b/src/xdsl/dialects/scf.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from xdsl.dialects.builtin import *
 
 
@@ -24,9 +25,9 @@ class If(Operation):
     false_region = RegionDef()
 
     @staticmethod
-    def get(cond: SSAValue | Operation, return_types: List[Attribute],
-            true_region: Region | List[Block] | List[Operation],
-            false_region: Region | List[Block] | List[Operation]):
+    def get(cond: SSAValue | Operation, return_types: list[Attribute],
+            true_region: Region | list[Block] | list[Operation],
+            false_region: Region | list[Block] | list[Operation]):
         return If.build(operands=[cond],
                         result_types=[return_types],
                         regions=[true_region, false_region])
@@ -80,10 +81,10 @@ class While(Operation):
                 )
 
     @staticmethod
-    def get(operands: List[SSAValue | Operation],
-            result_types: List[Attribute],
-            before: Region | List[Operation] | List[Block],
-            after: Region | List[Operation] | List[Block]) -> While:
+    def get(operands: list[SSAValue | Operation],
+            result_types: list[Attribute],
+            before: Region | list[Operation] | list[Block],
+            after: Region | list[Operation] | list[Block]) -> While:
         op = While.build(operands=operands,
                          result_types=result_types,
                          regions=[before, after])

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -644,9 +644,7 @@ class Block:
         self.ops = self.ops[:op_idx] + self.ops[op_idx + 1:]
         return op
 
-    def erase_op(self,
-                 op: int | Operation,
-                 safe_erase: bool = True) -> None:
+    def erase_op(self, op: int | Operation, safe_erase: bool = True) -> None:
         """
         Erase an operation from the block.
         If safe_erase is True, check that the operation has no uses.
@@ -786,8 +784,7 @@ class Region:
         self._attach_block(block)
         self.blocks.append(block)
 
-    def insert_block(self, blocks: Block | list[Block],
-                     index: int) -> None:
+    def insert_block(self, blocks: Block | list[Block], index: int) -> None:
         """
         Insert one or multiple blocks at a given index in the region.
         The blocks should not be attached to another region.
@@ -827,9 +824,7 @@ class Region:
         self.blocks = self.blocks[:block_idx] + self.blocks[block_idx + 1:]
         return block
 
-    def erase_block(self,
-                    block: int | Block,
-                    safe_erase: bool = True) -> None:
+    def erase_block(self, block: int | Block, safe_erase: bool = True) -> None:
         """
         Erase a block from the region.
         If safe_erase is True, check that the block has no uses.

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Generic, List,
-                    Protocol, Optional, Sequence, Set, Type, TypeVar, Union,
-                    cast)
-import typing
+from typing import (TYPE_CHECKING, Any, Callable, Generic, Protocol, Sequence,
+                    TypeVar, cast)
+
 from frozenlist import FrozenList
 
 # Used for cyclic dependencies in type hints

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -19,29 +19,29 @@ OpT = TypeVar('OpT', bound='Operation')
 @dataclass
 class MLContext:
     """Contains structures for operations/attributes registration."""
-    _registeredOps: Dict[str, Type[Operation]] = field(default_factory=dict)
-    _registeredAttrs: Dict[str, Type[Attribute]] = field(default_factory=dict)
+    _registeredOps: dict[str, type[Operation]] = field(default_factory=dict)
+    _registeredAttrs: dict[str, type[Attribute]] = field(default_factory=dict)
 
-    def register_op(self, op: Type[Operation]) -> None:
+    def register_op(self, op: type[Operation]) -> None:
         """Register an operation definition. Operation names should be unique."""
         if op.name in self._registeredOps:
             raise Exception(f"Operation {op.name} has already been registered")
         self._registeredOps[op.name] = op
 
-    def register_attr(self, attr: Type[Attribute]) -> None:
+    def register_attr(self, attr: type[Attribute]) -> None:
         """Register an attribute definition. Attribute names should be unique."""
         if attr.name in self._registeredAttrs:
             raise Exception(
                 f"Attribute {attr.name} has already been registered")
         self._registeredAttrs[attr.name] = attr
 
-    def get_op(self, name: str) -> Type[Operation]:
+    def get_op(self, name: str) -> type[Operation]:
         """Get an operation class from its name."""
         if name not in self._registeredOps:
             raise Exception(f"Operation {name} is not registered")
         return self._registeredOps[name]
 
-    def get_attr(self, name: str) -> Type[Attribute]:
+    def get_attr(self, name: str) -> type[Attribute]:
         """Get an attribute class from its name."""
         if name not in self._registeredAttrs:
             raise Exception(f"Attribute {name} is not registered")
@@ -67,10 +67,10 @@ class SSAValue(ABC):
     typ: Attribute
     """Each SSA variable is associated to a type."""
 
-    uses: Set[Use] = field(init=False, default_factory=set, repr=False)
+    uses: set[Use] = field(init=False, default_factory=set, repr=False)
     """All uses of the value."""
 
-    name: Optional[str] = field(init=False, default=None)
+    name: str | None = field(init=False, default=None)
 
     @staticmethod
     def get(arg: SSAValue | Operation) -> SSAValue:
@@ -187,7 +187,7 @@ class Attribute(ABC):
     """The attribute name should be a static field in the attribute classes."""
 
     @classmethod
-    def build(cls: Type[A], *args: Any) -> A:
+    def build(cls: type[A], *args: Any) -> A:
         """Create a new attribute using one of the builder defined in IRDL."""
         assert False
 
@@ -226,7 +226,7 @@ class Data(Generic[DataElement], Attribute, ABC):
 class ParametrizedAttribute(Attribute):
     """An attribute parametrized by other attributes."""
 
-    parameters: List[Attribute] = field(default_factory=list)
+    parameters: list[Attribute] = field(default_factory=list)
 
 
 @dataclass
@@ -239,31 +239,31 @@ class Operation:
     _operands: FrozenList[SSAValue] = field(default_factory=FrozenList)
     """The operation operands."""
 
-    results: List[OpResult] = field(default_factory=list)
+    results: list[OpResult] = field(default_factory=list)
     """The results created by the operation."""
 
-    successors: List[Block] = field(default_factory=list)
+    successors: list[Block] = field(default_factory=list)
     """
     The basic blocks that the operation may give control to.
     This list should be empty for non-terminator operations.
     """
 
-    attributes: Dict[str, Attribute] = field(default_factory=dict)
+    attributes: dict[str, Attribute] = field(default_factory=dict)
     """The attributes attached to the operation."""
 
-    regions: List[Region] = field(default_factory=list)
+    regions: list[Region] = field(default_factory=list)
     """Regions arguments of the operation."""
 
-    parent: Optional[Block] = field(default=None, repr=False)
+    parent: Block | None = field(default=None, repr=False)
     """The block containing this operation."""
 
-    def parent_block(self) -> Optional[Block]:
+    def parent_block(self) -> Block | None:
         return self.parent
 
-    def parent_op(self) -> Optional[Operation]:
+    def parent_op(self) -> Operation | None:
         return self.parent.parent.parent if self.parent and self.parent.parent else None
 
-    def parent_region(self) -> Optional[Region]:
+    def parent_region(self) -> Region | None:
         return self.parent.parent if self.parent else None
 
     @property
@@ -271,7 +271,7 @@ class Operation:
         return self._operands
 
     @operands.setter
-    def operands(self, new: Union[List[SSAValue], FrozenList[SSAValue]]):
+    def operands(self, new: list[SSAValue] | FrozenList[SSAValue]):
         if isinstance(new, list):
             new = FrozenList(new)
         for idx, operand in enumerate(self._operands):
@@ -288,11 +288,11 @@ class Operation:
     @staticmethod
     def with_result_types(
             op: Any,
-            operands: Optional[Sequence[SSAValue]] = None,
-            result_types: Optional[Sequence[Attribute]] = None,
-            attributes: Optional[Dict[str, Attribute]] = None,
-            successors: Optional[Sequence[Block]] = None,
-            regions: Optional[Sequence[Region]] = None) -> Operation:
+            operands: Sequence[SSAValue] | None = None,
+            result_types: Sequence[Attribute] | None = None,
+            attributes: dict[str, Attribute] | None = None,
+            successors: Sequence[Block] | None = None,
+            regions: Sequence[Region] | None = None) -> Operation:
 
         operation = op()
         if operands is not None:
@@ -315,23 +315,23 @@ class Operation:
         return operation
 
     @classmethod
-    def create(cls: Type[OpT],
-               operands: Optional[Sequence[SSAValue]] = None,
-               result_types: Optional[Sequence[Attribute]] = None,
-               attributes: Optional[Dict[str, Attribute]] = None,
-               successors: Optional[Sequence[Block]] = None,
-               regions: Optional[Sequence[Region]] = None) -> OpT:
+    def create(cls: type[OpT],
+               operands: Sequence[SSAValue] | None = None,
+               result_types: Sequence[Attribute] | None = None,
+               attributes: dict[str, Attribute] | None = None,
+               successors: Sequence[Block] | None = None,
+               regions: Sequence[Region] | None = None) -> OpT:
         op = Operation.with_result_types(cls, operands, result_types,
                                          attributes, successors, regions)
         return cast(OpT, op)
 
     @classmethod
-    def build(cls: Type[OpT],
-              operands: Optional[List[Any]] = None,
-              result_types: Optional[List[Any]] = None,
-              attributes: Optional[Dict[str, Any]] = None,
-              successors: Optional[List[Any]] = None,
-              regions: Optional[List[Any]] = None) -> OpT:
+    def build(cls: type[OpT],
+              operands: list[Any] | None = None,
+              result_types: list[Any] | None = None,
+              attributes: dict[str, Any] | None = None,
+              successors: list[Any] | None = None,
+              regions: list[Any] | None = None) -> OpT:
         """Create a new operation using builders."""
         ...
 
@@ -379,7 +379,7 @@ class Operation:
         pass
 
     @classmethod
-    def parse(cls: typing.Type[Parser._OperationType], result_types: List[Attribute],
+    def parse(cls: type[Parser._OperationType], result_types: list[Attribute],
               parser: Parser) -> Parser._OperationType:
         return parser.parse_op_with_default_format(cls, result_types)
 
@@ -388,8 +388,8 @@ class Operation:
 
     def clone_without_regions(
             self: OpT,
-            value_mapper: Optional[Dict[SSAValue, SSAValue]] = None,
-            block_mapper: Optional[Dict[Block, Block]] = None) -> OpT:
+            value_mapper: dict[SSAValue, SSAValue] | None = None,
+            block_mapper: dict[Block, Block] | None = None) -> OpT:
         """Clone an operation, with empty regions instead."""
         if value_mapper is None:
             value_mapper = {}
@@ -415,8 +415,8 @@ class Operation:
         return cloned_op
 
     def clone(self: OpT,
-              value_mapper: Optional[Dict[SSAValue, SSAValue]] = None,
-              block_mapper: Optional[Dict[Block, Block]] = None) -> OpT:
+              value_mapper: dict[SSAValue, SSAValue] | None = None,
+              block_mapper: dict[Block, Block] | None = None) -> OpT:
         """Clone an operation with all its regions and operations in them."""
         if value_mapper is None:
             value_mapper = {}
@@ -446,13 +446,13 @@ class Operation:
             raise Exception("Cannot detach a toplevel operation.")
         self.parent.detach_op(self)
 
-    def get_toplevel_object(self) -> Union[Operation, Block, Region]:
+    def get_toplevel_object(self) -> Operation | Block | Region:
         """Get the operation, block, or region ancestor that has no parents."""
         if self.parent is None:
             return self
         return self.parent.get_toplevel_object()
 
-    def is_ancestor(self, op: Union[Operation, Block, Region]) -> bool:
+    def is_ancestor(self, op: Operation | Block | Region) -> bool:
         """Returns true if the operation is an ancestor of the operation, block, or region."""
         if op is self:
             return True
@@ -475,19 +475,19 @@ class Block:
                                              init=False)
     """The basic block arguments."""
 
-    ops: List[Operation] = field(default_factory=list, init=False)
+    ops: list[Operation] = field(default_factory=list, init=False)
     """Ordered operations contained in the block."""
 
-    parent: Optional[Region] = field(default=None, init=False, repr=False)
+    parent: Region | None = field(default=None, init=False, repr=False)
     """Parent region containing the block."""
 
-    def parent_op(self) -> Optional[Operation]:
+    def parent_op(self) -> Operation | None:
         return self.parent.parent if self.parent else None
 
-    def parent_region(self) -> Optional[Region]:
+    def parent_region(self) -> Region | None:
         return self.parent
 
-    def parent_block(self) -> Optional[Block]:
+    def parent_block(self) -> Block | None:
         return self.parent.parent.parent if self.parent and self.parent.parent else None
 
     def __repr__(self) -> str:
@@ -499,7 +499,7 @@ class Block:
         return self._args
 
     @staticmethod
-    def from_arg_types(arg_types: List[Attribute]) -> Block:
+    def from_arg_types(arg_types: list[Attribute]) -> Block:
         b = Block()
         b._args = FrozenList([
             BlockArgument(typ, b, index) for index, typ in enumerate(arg_types)
@@ -508,8 +508,8 @@ class Block:
         return b
 
     @staticmethod
-    def from_ops(ops: List[Operation],
-                 arg_types: Optional[List[Attribute]] = None):
+    def from_ops(ops: list[Operation],
+                 arg_types: list[Attribute] | None = None):
         b = Block()
         if arg_types is not None:
             b._args = FrozenList([
@@ -522,16 +522,16 @@ class Block:
 
     class BlockCallback(Protocol):
 
-        def __call__(self, *args: BlockArgument) -> List[Operation]:
+        def __call__(self, *args: BlockArgument) -> list[Operation]:
             ...
 
     @staticmethod
-    def from_callable(block_arg_types: List[Attribute], f: BlockCallback):
+    def from_callable(block_arg_types: list[Attribute], f: BlockCallback):
         b = Block.from_arg_types(block_arg_types)
         b.add_ops(f(*b.args))
         return b
 
-    def is_ancestor(self, op: Union[Operation, Block, Region]) -> bool:
+    def is_ancestor(self, op: Operation | Block | Region) -> bool:
         """Returns true if the block is an ancestor of the operation, block, or region."""
         if op is self:
             return True
@@ -589,7 +589,7 @@ class Block:
         self._attach_op(operation)
         self.ops.append(operation)
 
-    def add_ops(self, ops: List[Operation]) -> None:
+    def add_ops(self, ops: list[Operation]) -> None:
         """
         Add operations at the end of the block.
         The operations should not be attached to another block.
@@ -598,9 +598,9 @@ class Block:
             self.add_op(op)
 
     def insert_op(self,
-                  ops: Union[Operation, List[Operation]],
+                  ops: Operation | list[Operation],
                   index: int,
-                  name: Optional[str] = None) -> None:
+                  name: str | None = None) -> None:
         """
         Insert one or multiple operations at a given index in the block.
         The operations should not be attached to another block.
@@ -628,7 +628,7 @@ class Block:
                 return idx
         assert False, "Unexpected xdsl error"
 
-    def detach_op(self, op: Union[int, Operation]) -> Operation:
+    def detach_op(self, op: int | Operation) -> Operation:
         """
         Detach an operation from the block.
         Returns the detached operation.
@@ -645,7 +645,7 @@ class Block:
         return op
 
     def erase_op(self,
-                 op: Union[int, Operation],
+                 op: int | Operation,
                  safe_erase: bool = True) -> None:
         """
         Erase an operation from the block.
@@ -686,7 +686,7 @@ class Block:
         for op in self.ops:
             op.erase(safe_erase=safe_erase, drop_references=False)
 
-    def get_toplevel_object(self) -> Union[Operation, Block, Region]:
+    def get_toplevel_object(self) -> Operation | Block | Region:
         """Get the operation, block, or region ancestor that has no parents."""
         if self.parent is None:
             return self
@@ -703,53 +703,53 @@ class Block:
 class Region:
     """A region contains a CFG of blocks. Regions are contained in operations."""
 
-    blocks: List[Block] = field(default_factory=list, init=False)
+    blocks: list[Block] = field(default_factory=list, init=False)
     """Blocks contained in the region. The first block is the entry block."""
 
-    parent: Optional[Operation] = field(default=None, init=False, repr=False)
+    parent: Operation | None = field(default=None, init=False, repr=False)
     """Operation containing the region."""
 
-    def parent_block(self) -> Optional[Block]:
+    def parent_block(self) -> Block | None:
         return self.parent.parent if self.parent else None
 
-    def parent_op(self) -> Optional[Operation]:
+    def parent_op(self) -> Operation | None:
         return self.parent
 
-    def parent_region(self) -> Optional[Region]:
+    def parent_region(self) -> Region | None:
         return self.parent.parent.parent if self.parent and self.parent.parent else None
 
     def __repr__(self) -> str:
         return f"Region(num_blocks={len(self.blocks)})"
 
     @staticmethod
-    def from_operation_list(ops: List[Operation]) -> Region:
+    def from_operation_list(ops: list[Operation]) -> Region:
         block = Block.from_ops(ops)
         region = Region()
         region.add_block(block)
         return region
 
     @staticmethod
-    def from_block_list(blocks: List[Block]) -> Region:
+    def from_block_list(blocks: list[Block]) -> Region:
         region = Region()
         for block in blocks:
             region.add_block(block)
         return region
 
     @staticmethod
-    def get(arg: Region | List[Block] | List[Operation]) -> Region:
+    def get(arg: Region | list[Block] | list[Operation]) -> Region:
         if isinstance(arg, Region):
             return arg
         if isinstance(arg, list):
             if len(arg) == 0:
                 return Region.from_operation_list([])
             if isinstance(arg[0], Block):
-                return Region.from_block_list(cast(List[Block], arg))
+                return Region.from_block_list(cast(list[Block], arg))
             if isinstance(arg[0], Operation):
-                return Region.from_operation_list(cast(List[Operation], arg))
+                return Region.from_operation_list(cast(list[Operation], arg))
         raise TypeError(f"Can't build a region with argument {arg}")
 
     @property
-    def ops(self) -> List[Operation]:
+    def ops(self) -> list[Operation]:
         """
         Get the operations of a single-block region.
         Returns an exception if the region is not single-block.
@@ -786,7 +786,7 @@ class Region:
         self._attach_block(block)
         self.blocks.append(block)
 
-    def insert_block(self, blocks: Union[Block, List[Block]],
+    def insert_block(self, blocks: Block | list[Block],
                      index: int) -> None:
         """
         Insert one or multiple blocks at a given index in the region.
@@ -811,7 +811,7 @@ class Region:
                 return idx
         assert False, "Unexpected xdsl error"
 
-    def detach_block(self, block: Union[int, Block]) -> Block:
+    def detach_block(self, block: int | Block) -> Block:
         """
         Detach a block from the region.
         Returns the detached block.
@@ -828,7 +828,7 @@ class Region:
         return block
 
     def erase_block(self,
-                    block: Union[int, Block],
+                    block: int | Block,
                     safe_erase: bool = True) -> None:
         """
         Erase a block from the region.
@@ -839,9 +839,9 @@ class Region:
 
     def clone_into(self,
                    dest: Region,
-                   insert_index: Optional[int] = None,
-                   value_mapper: Optional[Dict[SSAValue, SSAValue]] = None,
-                   block_mapper: Optional[Dict[Block, Block]] = None):
+                   insert_index: int | None = None,
+                   value_mapper: dict[SSAValue, SSAValue] | None = None,
+                   block_mapper: dict[Block, Block] | None = None):
         """
         Clone all block of this region into `dest` to position `insert_index`
         """
@@ -901,13 +901,13 @@ class Region:
         for block in region.blocks:
             block.parent = region
 
-    def get_toplevel_object(self) -> Union[Operation, Block, Region]:
+    def get_toplevel_object(self) -> Operation | Block | Region:
         """Get the operation, block, or region ancestor that has no parents."""
         if self.parent is None:
             return self
         return self.parent.get_toplevel_object()
 
-    def is_ancestor(self, op: Union[Operation, Block, Region]) -> bool:
+    def is_ancestor(self, op: Operation | Block | Region) -> bool:
         """Returns true if the region is an ancestor of the operation, block, or region."""
         if op is self:
             return True

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -379,8 +379,8 @@ class Operation:
         pass
 
     @classmethod
-    def parse(cls: typing.Type[OperationType], result_types: List[Attribute],
-              parser: Parser) -> OperationType:
+    def parse(cls: typing.Type[Parser._OperationType], result_types: List[Attribute],
+              parser: Parser) -> Parser._OperationType:
         return parser.parse_op_with_default_format(cls, result_types)
 
     def print(self, printer: Printer):

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -6,9 +6,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from inspect import isclass
-from typing import (Annotated, Any, Callable, Dict, Generic, List, Optional,
-                    Sequence, Tuple, Type, TypeAlias, TypeVar, Union, cast,
-                    get_args, get_origin, get_type_hints)
+from typing import (Annotated, Any, Callable, Generic, Sequence, TypeAlias,
+                    TypeVar, Union, cast, get_args, get_origin, get_type_hints)
 
 from xdsl import util
 from xdsl.diagnostic import Diagnostic, DiagnosticException
@@ -282,7 +281,7 @@ def irdl_to_attr_constraint(
 
     # Union case
     # This is a coercion for an `AnyOf` constraint.
-    if origin == types.UnionType or origin == Union:
+    if origin is types.UnionType or origin is Union:
         constraints: list[AttrConstraint] = []
         for arg in get_args(irdl):
             # We should not try to convert IRDL annotations, which do not

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -69,9 +69,8 @@ class BaseAttr(AttrConstraint):
                 f"{attr} should be of base attribute {self.attr.name}")
 
 
-def attr_constr_coercion(
-        attr: (Attribute | type[Attribute] |
-                    AttrConstraint)) -> AttrConstraint:
+def attr_constr_coercion(attr: (Attribute | type[Attribute]
+                                | AttrConstraint)) -> AttrConstraint:
     """
     Attributes are coerced into EqAttrConstraints,
     and Attribute types are coerced into BaseAttr.
@@ -144,8 +143,8 @@ class ParamAttrConstraint(AttrConstraint):
     """The attribute parameter constraints"""
 
     def __init__(self, base_attr: type[Attribute],
-                 param_constrs: list[(Attribute | type[Attribute] |
-                                           AttrConstraint)]):
+                 param_constrs: list[(Attribute | type[Attribute]
+                                      | AttrConstraint)]):
         self.base_attr = base_attr
         self.param_constrs = [
             attr_constr_coercion(constr) for constr in param_constrs
@@ -490,8 +489,7 @@ def get_variadic_sizes(op: Operation, is_operand: bool) -> list[int]:
 
 def get_operand_or_result(
         op: Operation, arg_def_idx: int, previous_var_args: int,
-        is_operand: bool
-) -> SSAValue | SSAValue | None | list[SSAValue]:
+        is_operand: bool) -> SSAValue | None | list[SSAValue]:
     """
     Get an operand or a result.
     In the case of a variadic operand or result definition, return a list of operand or results.

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -60,7 +60,7 @@ class EqAttrConstraint(AttrConstraint):
 class BaseAttr(AttrConstraint):
     """Constrain an attribute to be of a given base type."""
 
-    attr: Type[Attribute]
+    attr: type[Attribute]
     """The expected attribute base type."""
 
     def verify(self, attr: Attribute) -> None:
@@ -70,8 +70,8 @@ class BaseAttr(AttrConstraint):
 
 
 def attr_constr_coercion(
-        attr: Union[Attribute, Type[Attribute],
-                    AttrConstraint]) -> AttrConstraint:
+        attr: (Attribute | type[Attribute] |
+                    AttrConstraint)) -> AttrConstraint:
     """
     Attributes are coerced into EqAttrConstraints,
     and Attribute types are coerced into BaseAttr.
@@ -97,10 +97,10 @@ class AnyAttr(AttrConstraint):
 class AnyOf(AttrConstraint):
     """Ensure that an attribute satisfies one of the given constraints."""
 
-    attr_constrs: List[AttrConstraint]
+    attr_constrs: list[AttrConstraint]
     """The list of constraints that are checked."""
 
-    def __init__(self, attr_constrs: Sequence[Attribute | Type[Attribute]
+    def __init__(self, attr_constrs: Sequence[Attribute | type[Attribute]
                                               | AttrConstraint]):
         self.attr_constrs = [
             attr_constr_coercion(constr) for constr in attr_constrs
@@ -122,7 +122,7 @@ class AnyOf(AttrConstraint):
 class AllOf(AttrConstraint):
     """Ensure that an attribute satisfies all the given constraints."""
 
-    attr_constrs: List[AttrConstraint]
+    attr_constrs: list[AttrConstraint]
     """The list of constraints that are checked."""
 
     def verify(self, attr: Attribute) -> None:
@@ -137,15 +137,15 @@ class ParamAttrConstraint(AttrConstraint):
     and also constrain its parameters with additional constraints.
     """
 
-    base_attr: Type[Attribute]
+    base_attr: type[Attribute]
     """The base attribute type."""
 
-    param_constrs: List[AttrConstraint]
+    param_constrs: list[AttrConstraint]
     """The attribute parameter constraints"""
 
-    def __init__(self, base_attr: Type[Attribute],
-                 param_constrs: List[Union[Attribute, Type[Attribute],
-                                           AttrConstraint]]):
+    def __init__(self, base_attr: type[Attribute],
+                 param_constrs: list[(Attribute | type[Attribute] |
+                                           AttrConstraint)]):
         self.base_attr = base_attr
         self.param_constrs = [
             attr_constr_coercion(constr) for constr in param_constrs
@@ -189,7 +189,7 @@ def irdl_to_attr_constraint(
     irdl: Any,
     *,
     allow_type_var: bool = False,
-    type_var_mapping: Optional[Dict[TypeVar, AttrConstraint]] = None
+    type_var_mapping: dict[TypeVar, AttrConstraint] | None = None
 ) -> AttrConstraint:
     if isinstance(irdl, AttrConstraint):
         return irdl
@@ -197,7 +197,7 @@ def irdl_to_attr_constraint(
     # Annotated case
     # Each argument of the Annotated type correspond to a constraint to satisfy.
     if get_origin(irdl) == Annotated:
-        constraints: List[AttrConstraint] = []
+        constraints: list[AttrConstraint] = []
         for arg in get_args(irdl):
             # We should not try to convert IRDL annotations, which do not
             # correspond to constraints
@@ -271,7 +271,7 @@ def irdl_to_attr_constraint(
         }
 
         origin_parameters = irdl_param_attr_get_param_type_hints(origin)
-        origin_constraints: List[Attribute | Type[Attribute]
+        origin_constraints: list[Attribute | type[Attribute]
                                  | AttrConstraint] = [
                                      irdl_to_attr_constraint(
                                          param,
@@ -284,7 +284,7 @@ def irdl_to_attr_constraint(
     # Union case
     # This is a coercion for an `AnyOf` constraint.
     if origin == types.UnionType or origin == Union:
-        constraints: List[AttrConstraint] = []
+        constraints: list[AttrConstraint] = []
         for arg in get_args(irdl):
             # We should not try to convert IRDL annotations, which do not
             # correspond to constraints
@@ -355,7 +355,7 @@ class OperandDef(OperandOrResultDef):
     constr: AttrConstraint
     """The operand constraint."""
 
-    def __init__(self, typ: Attribute | Type[Attribute] | AttrConstraint):
+    def __init__(self, typ: Attribute | type[Attribute] | AttrConstraint):
         self.constr = attr_constr_coercion(typ)
 
 
@@ -376,7 +376,7 @@ class ResultDef(OperandOrResultDef):
     constr: AttrConstraint
     """The result constraint."""
 
-    def __init__(self, typ: Attribute | Type[Attribute] | AttrConstraint):
+    def __init__(self, typ: Attribute | type[Attribute] | AttrConstraint):
         self.constr = attr_constr_coercion(typ)
 
 
@@ -396,8 +396,8 @@ class RegionDef(Region):
     An IRDL region definition.
     If the block_args is specified, then the region expect to have the entry block with these arguments.
     """
-    block_args: Optional[List[Attribute]] = None
-    blocks: List[Block] = field(default_factory=list)
+    block_args: list[Attribute] | None = None
+    blocks: list[Block] = field(default_factory=list)
 
 
 @dataclass
@@ -415,7 +415,7 @@ class AttributeDef:
 
     data: Any
 
-    def __init__(self, typ: Union[Attribute, Type[Attribute], AttrConstraint]):
+    def __init__(self, typ: Attribute | type[Attribute] | AttrConstraint):
         self.constr = attr_constr_coercion(typ)
 
 
@@ -423,11 +423,11 @@ class AttributeDef:
 class OptAttributeDef(AttributeDef):
     """An IRDL attribute definition for an optional attribute."""
 
-    def __init__(self, typ: Union[Attribute, Type[Attribute], AttrConstraint]):
+    def __init__(self, typ: Attribute | type[Attribute] | AttrConstraint):
         super().__init__(typ)
 
 
-def get_variadic_sizes(op: Operation, is_operand: bool) -> List[int]:
+def get_variadic_sizes(op: Operation, is_operand: bool) -> list[int]:
     """Get variadic sizes of operands or results."""
 
     # We need irdl to define DenseIntOrFPElementsAttr, but here we need
@@ -491,7 +491,7 @@ def get_variadic_sizes(op: Operation, is_operand: bool) -> List[int]:
 def get_operand_or_result(
         op: Operation, arg_def_idx: int, previous_var_args: int,
         is_operand: bool
-) -> Union[SSAValue, Optional[SSAValue], List[SSAValue]]:
+) -> SSAValue | SSAValue | None | list[SSAValue]:
     """
     Get an operand or a result.
     In the case of a variadic operand or result definition, return a list of operand or results.
@@ -521,10 +521,10 @@ def get_operand_or_result(
         return op_arguments[begin_arg]
 
 
-def irdl_op_verify(op: Operation, operands: List[Tuple[str, OperandDef]],
-                   results: List[Tuple[str, ResultDef]],
-                   regions: List[Tuple[str, RegionDef]],
-                   attributes: List[Tuple[str, AttributeDef]]) -> None:
+def irdl_op_verify(op: Operation, operands: list[tuple[str, OperandDef]],
+                   results: list[tuple[str, ResultDef]],
+                   regions: list[tuple[str, RegionDef]],
+                   attributes: list[tuple[str, AttributeDef]]) -> None:
     """Given an IRDL definition, verify that an operation satisfies its invariants."""
 
     # Verify operands.
@@ -602,7 +602,7 @@ def irdl_op_verify(op: Operation, operands: List[Tuple[str, OperandDef]],
 
 def irdl_build_attribute(irdl_def: AttrConstraint, result) -> Attribute:
     if isinstance(irdl_def, BaseAttr):
-        if isinstance(result, Tuple):
+        if isinstance(result, tuple):
             return irdl_def.attr.build(*result)
         return irdl_def.attr.build(result)
     if isinstance(result, Attribute):
@@ -613,11 +613,11 @@ def irdl_build_attribute(irdl_def: AttrConstraint, result) -> Attribute:
 OpT = TypeVar('OpT', bound=Operation)
 
 
-def irdl_op_builder(cls: Type[OpT], operands: List[Any],
-                    operand_defs: List[Tuple[str, OperandDef]],
-                    res_types: List[Any], res_defs: List[Tuple[str,
+def irdl_op_builder(cls: type[OpT], operands: list[Any],
+                    operand_defs: list[tuple[str, OperandDef]],
+                    res_types: list[Any], res_defs: list[tuple[str,
                                                                ResultDef]],
-                    attributes: Dict[str, Any], attr_defs: Dict[str,
+                    attributes: dict[str, Any], attr_defs: dict[str,
                                                                 AttributeDef],
                     successors, regions, options) -> OpT:
     """Builder for an irdl operation."""
@@ -702,7 +702,7 @@ def irdl_op_builder(cls: Type[OpT], operands: List[Any],
                       regions=regions)
 
 
-def irdl_op_definition(cls: Type[OpT]) -> Type[OpT]:
+def irdl_op_definition(cls: type[OpT]) -> type[OpT]:
     """Decorator used on classes to define a new operation definition."""
 
     assert issubclass(
@@ -807,7 +807,7 @@ ParameterDef: TypeAlias = Annotated[_A, IRDLAnnotations.ParamDefAnnot]
 
 
 def irdl_attr_verify(attr: ParametrizedAttribute,
-                     parameters: List[AttrConstraint]):
+                     parameters: list[AttrConstraint]):
     """Given an IRDL definition, verify that an attribute satisfies its invariants."""
 
     if len(attr.parameters) != len(parameters):
@@ -831,7 +831,7 @@ def builder(f: C) -> C:
     return f
 
 
-def irdl_get_builders(cls) -> List[Callable[..., Any]]:
+def irdl_get_builders(cls) -> list[Callable[..., Any]]:
     builders = []
     for field_name in cls.__dict__:
         field_ = cls.__dict__[field_name]
@@ -868,7 +868,7 @@ def irdl_attr_builder(cls, builders, *args):
         f"No available {cls.__name__} builders for arguments {args}")
 
 
-def irdl_data_verify(data: Data, typ: Type) -> None:
+def irdl_data_verify(data: Data, typ: type) -> None:
     """Check that the Data has the expected type."""
     if isinstance(data.data, typ):
         return
@@ -880,7 +880,7 @@ def irdl_data_verify(data: Data, typ: Type) -> None:
 T = TypeVar('T')
 
 
-def irdl_data_definition(cls: Type[T]) -> Type[T]:
+def irdl_data_definition(cls: type[T]) -> type[T]:
     new_attrs = dict()
 
     # Build method is added for all definitions.
@@ -920,7 +920,7 @@ def irdl_data_definition(cls: Type[T]) -> Type[T]:
 
 
 def irdl_param_attr_get_param_type_hints(
-        cls: Type[ParametrizedAttribute]) -> List[Tuple[str, Any]]:
+        cls: type[ParametrizedAttribute]) -> list[tuple[str, Any]]:
     """Get the type hints of an IRDL parameter definitions."""
     res = []
     for field_name, field_type in get_type_hints(cls,
@@ -943,7 +943,7 @@ def irdl_param_attr_get_param_type_hints(
 PA = TypeVar("PA", bound=ParametrizedAttribute)
 
 
-def irdl_param_attr_definition(cls: Type[PA]) -> Type[PA]:
+def irdl_param_attr_definition(cls: type[PA]) -> type[PA]:
     """Decorator used on classes to define a new attribute definition."""
 
     # Get the fields from the class and its parents
@@ -990,7 +990,7 @@ def irdl_param_attr_definition(cls: Type[PA]) -> Type[PA]:
     }))
 
 
-def irdl_attr_definition(cls: Type[T]) -> Type[T]:
+def irdl_attr_definition(cls: type[T]) -> type[T]:
     if issubclass(cls, ParametrizedAttribute):
         return irdl_param_attr_definition(cls)
     if issubclass(cls, Data):

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -2,8 +2,9 @@ from xdsl import ensure_mlir_module_loaded
 
 ensure_mlir_module_loaded()
 
-from xdsl import _mlir_module as mlir
 import array
+
+from xdsl import _mlir_module as mlir
 from xdsl.dialects.builtin import *
 from xdsl.dialects.memref import MemRefType
 
@@ -12,8 +13,8 @@ class MLIRConverter:
 
     def __init__(self, ctx):
         self.ctx = ctx
-        self.op_to_mlir_ops: Dict[Operation, mlir.ir.Operation] = dict()
-        self.block_to_mlir_blocks: Dict[Block, mlir.ir.Block] = dict()
+        self.op_to_mlir_ops: dict[Operation, mlir.ir.Operation] = dict()
+        self.block_to_mlir_blocks: dict[Block, mlir.ir.Block] = dict()
 
     def register_external_dialects(self):
         pass

--- a/src/xdsl/parser.py
+++ b/src/xdsl/parser.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
-from xdsl.dialects.builtin import *
+
 from typing import TypeVar
+
+from xdsl.dialects.builtin import *
 
 indentNumSpaces = 2
 
@@ -11,8 +13,8 @@ class Parser:
         self._ctx: MLContext = ctx
         self._str: str = _str
         self._idx: int = 0
-        self._ssaValues: Dict[str, SSAValue] = dict()
-        self._blocks: Dict[str, Block] = dict()
+        self._ssaValues: dict[str, SSAValue] = dict()
+        self._blocks: dict[str, Block] = dict()
 
     def skip_white_space(self) -> None:
         while self._idx < len(self._str):
@@ -40,7 +42,7 @@ class Parser:
         return self._str[start_idx:]
 
     # TODO why two different functions, no nums in ident?
-    def parse_optional_ident(self, skip_white_space=True) -> Optional[str]:
+    def parse_optional_ident(self, skip_white_space=True) -> str | None:
         res = self.parse_while(lambda x: x.isalpha() or x == "_" or x == ".",
                                skip_white_space=skip_white_space)
         if len(res) == 0:
@@ -53,7 +55,7 @@ class Parser:
             raise Exception("ident expected")
         return res
 
-    def parse_optional_alpha_num(self, skip_white_space=True) -> Optional[str]:
+    def parse_optional_alpha_num(self, skip_white_space=True) -> str | None:
         res = self.parse_while(lambda x: x.isalnum() or x == "_" or x == ".",
                                skip_white_space=skip_white_space)
         if len(res) == 0:
@@ -66,7 +68,7 @@ class Parser:
             raise Exception("alphanum expected")
         return res
 
-    def parse_optional_str_literal(self) -> Optional[str]:
+    def parse_optional_str_literal(self) -> str | None:
         parsed = self.parse_optional_char('"')
         if parsed is None:
             return None
@@ -96,7 +98,7 @@ class Parser:
             raise Exception("string literal expected")
         return res
 
-    def parse_optional_int_literal(self) -> Optional[int]:
+    def parse_optional_int_literal(self) -> int | None:
         is_negative = self.parse_optional_char("-")
         res = self.parse_while(lambda char: char.isnumeric())
         if len(res) == 0:
@@ -111,7 +113,7 @@ class Parser:
             raise Exception("int literal expected")
         return res
 
-    def peek_char(self, char: str) -> Optional[bool]:
+    def peek_char(self, char: str) -> bool | None:
         self.skip_white_space()
         if self._idx == len(self._str):
             return None
@@ -119,7 +121,7 @@ class Parser:
             return True
         return None
 
-    def parse_optional_char(self, char: str) -> Optional[bool]:
+    def parse_optional_char(self, char: str) -> bool | None:
         assert (len(char) == 1)
         res = self.peek_char(char)
         if res:
@@ -133,7 +135,7 @@ class Parser:
             raise Exception("'%s' expected" % char)
         return True
 
-    def parse_string(self, contents: List[str]) -> bool:
+    def parse_string(self, contents: list[str]) -> bool:
         self.skip_white_space()
         for char in contents:
             if self._idx >= len(self._str):
@@ -146,8 +148,8 @@ class Parser:
     T = TypeVar('T')
 
     def parse_list(self,
-                   parse_optional_one: Callable[[], Optional[T]],
-                   delimiter: str = ",") -> List[T]:
+                   parse_optional_one: Callable[[], T | None],
+                   delimiter: str = ",") -> list[T]:
         assert (len(delimiter) <= 1)
         res = []
         one = parse_optional_one()
@@ -162,7 +164,7 @@ class Parser:
         return res
 
     def parse_optional_block_argument(
-            self) -> Optional[Tuple[str, BlockArgument]]:
+            self) -> tuple[str, BlockArgument] | None:
         name = self.parse_optional_ssa_name()
         if name is None:
             return None
@@ -171,7 +173,7 @@ class Parser:
         # TODO how to get the id?
         return name, BlockArgument(typ, None, 0)
 
-    def parse_optional_named_block(self) -> Optional[Block]:
+    def parse_optional_named_block(self) -> Block | None:
         if self.parse_optional_char("^") is None:
             return None
         block_name = self.parse_alpha_num(skip_white_space=False)
@@ -201,7 +203,7 @@ class Parser:
             block.add_op(op)
         return block
 
-    def parse_optional_region(self) -> Optional[Region]:
+    def parse_optional_region(self) -> Region | None:
         if not self.parse_optional_char("{"):
             return None
         region = Region()
@@ -217,13 +219,13 @@ class Parser:
         self.parse_char("}")
         return region
 
-    def parse_optional_ssa_name(self) -> Optional[str]:
+    def parse_optional_ssa_name(self) -> str | None:
         if self.parse_optional_char("%") is None:
             return None
         name = self.parse_alpha_num()
         return name
 
-    def parse_optional_ssa_value(self) -> Optional[SSAValue]:
+    def parse_optional_ssa_value(self) -> SSAValue | None:
         name = self.parse_optional_ssa_name()
         if name is None:
             return None
@@ -237,7 +239,7 @@ class Parser:
             raise Exception("Expected SSA value")
         return res
 
-    def parse_optional_result(self) -> Optional[Tuple[str, Attribute]]:
+    def parse_optional_result(self) -> tuple[str, Attribute] | None:
         name = self.parse_optional_ssa_name()
         if name is None:
             return None
@@ -245,7 +247,7 @@ class Parser:
         typ = self.parse_attribute()
         return name, typ
 
-    def parse_optional_results(self) -> Optional[List[Tuple[str, Attribute]]]:
+    def parse_optional_results(self) -> list[tuple[str, Attribute]] | None:
         # One argument
         res = self.parse_optional_result()
         if res is not None:
@@ -262,7 +264,7 @@ class Parser:
         self.parse_char("=")
         return res
 
-    def parse_optional_operand(self) -> Optional[SSAValue]:
+    def parse_optional_operand(self) -> SSAValue | None:
         value = self.parse_optional_ssa_value()
         if value is None:
             return None
@@ -273,13 +275,13 @@ class Parser:
                             (typ, value.typ))
         return value
 
-    def parse_operands(self) -> List[Optional[SSAValue]]:
+    def parse_operands(self) -> list[SSAValue | None]:
         self.parse_char("(")
         res = self.parse_list(lambda: self.parse_optional_operand())
         self.parse_char(")")
         return res
 
-    def parse_optional_attribute(self) -> Optional[Attribute]:
+    def parse_optional_attribute(self) -> Attribute | None:
         # Shorthand for StringAttr
         string_lit = self.parse_optional_str_literal()
         if string_lit is not None:
@@ -342,8 +344,7 @@ class Parser:
             raise Exception("attribute expected")
         return res
 
-    def parse_optional_named_attribute(
-            self) -> Optional[Tuple[str, Attribute]]:
+    def parse_optional_named_attribute(self) -> tuple[str, Attribute] | None:
         attr_name = self.parse_optional_str_literal()
         if attr_name is None:
             return None
@@ -351,14 +352,14 @@ class Parser:
         attr = self.parse_attribute()
         return attr_name, attr
 
-    def parse_op_attributes(self) -> Dict[str, Attribute]:
+    def parse_op_attributes(self) -> dict[str, Attribute]:
         if not self.parse_optional_char("["):
             return dict()
         attrs_with_names = self.parse_list(self.parse_optional_named_attribute)
         self.parse_char("]")
         return {name: attr for (name, attr) in attrs_with_names}
 
-    def parse_optional_successor(self) -> Optional[Block]:
+    def parse_optional_successor(self) -> Block | None:
         parsed = self.parse_optional_char("^")
         if parsed is None:
             return None
@@ -371,7 +372,7 @@ class Parser:
             self._blocks[bb_name] = block
         return block
 
-    def parse_successors(self) -> List[Block]:
+    def parse_successors(self) -> list[Block]:
         parsed = self.parse_optional_char("(")
         if parsed is None:
             return None
@@ -386,7 +387,7 @@ class Parser:
 
     def parse_op_with_default_format(
             self, op_type: type[_OperationType],
-            result_types: List[Attribute]) -> _OperationType:
+            result_types: list[Attribute]) -> _OperationType:
         operands = self.parse_operands()
         successors = self.parse_successors()
         attributes = self.parse_op_attributes()
@@ -402,7 +403,7 @@ class Parser:
                               successors=successors,
                               regions=regions)
 
-    def _parse_optional_op_name(self) -> Optional[Tuple[str, bool]]:
+    def _parse_optional_op_name(self) -> tuple[str, bool] | None:
         op_name = self.parse_optional_alpha_num()
         if op_name is not None:
             return op_name, False
@@ -411,13 +412,13 @@ class Parser:
             return op_name, True
         return None
 
-    def _parse_op_name(self) -> Tuple[str, bool]:
+    def _parse_op_name(self) -> tuple[str, bool]:
         op_name = self._parse_optional_op_name()
         if op_name is None:
             raise Exception("Expected operation name")
         return op_name
 
-    def parse_optional_op(self) -> Optional[Operation]:
+    def parse_optional_op(self) -> Operation | None:
         results = self.parse_optional_results()
         if results is None:
             op_name_and_generic = self._parse_optional_op_name()

--- a/src/xdsl/parser.py
+++ b/src/xdsl/parser.py
@@ -385,7 +385,7 @@ class Parser:
     _OperationType = TypeVar('_OperationType', bound='Operation')
 
     def parse_op_with_default_format(
-            self, op_type: typing.Type[_OperationType],
+            self, op_type: type[_OperationType],
             result_types: List[Attribute]) -> _OperationType:
         operands = self.parse_operands()
         successors = self.parse_successors()

--- a/src/xdsl/pattern_rewriter.py
+++ b/src/xdsl/pattern_rewriter.py
@@ -22,11 +22,11 @@ class PatternRewriter:
     has_erased_matched_operation: bool = field(default=False, init=False)
     """Was the matched operation erased."""
 
-    added_operations_before: List[Operation] = field(default_factory=list,
+    added_operations_before: list[Operation] = field(default_factory=list,
                                                      init=False)
     """The operations added directly before the matched operation."""
 
-    added_operations_after: List[Operation] = field(default_factory=list,
+    added_operations_after: list[Operation] = field(default_factory=list,
                                                     init=False)
     """The operations added directly after the matched operation."""
 
@@ -53,8 +53,8 @@ class PatternRewriter:
             return True  # Toplevel operation of current_operation is always a ModuleOp
         return self._can_modify_op(region.parent)
 
-    def insert_op_before_matched_op(self, op: Union[Operation,
-                                                    List[Operation]]):
+    def insert_op_before_matched_op(self, op: (Operation |
+                                                    list[Operation])):
         """Insert operations before the matched operation."""
         if self.current_operation.parent is None:
             raise Exception(
@@ -68,8 +68,8 @@ class PatternRewriter:
         block.insert_op(op, op_idx)
         self.added_operations_before += op
 
-    def insert_op_after_matched_op(self, op: Union[Operation,
-                                                   List[Operation]]):
+    def insert_op_after_matched_op(self, op: (Operation |
+                                                   list[Operation])):
         """Insert operations after the matched operation."""
         if self.current_operation.parent is None:
             raise Exception(
@@ -83,7 +83,7 @@ class PatternRewriter:
         block.insert_op(op, op_idx + 1)
         self.added_operations_after += op
 
-    def insert_op_at_pos(self, op: Union[Operation, List[Operation]],
+    def insert_op_at_pos(self, op: Operation | list[Operation],
                          block: Block, pos: int):
         """Insert operations in a block contained in the matched operation."""
         if not self._can_modify_block(block):
@@ -94,7 +94,7 @@ class PatternRewriter:
             return
         block.insert_op(op, pos)
 
-    def insert_op_before(self, op: Union[Operation, List[Operation]],
+    def insert_op_before(self, op: Operation | list[Operation],
                          target_op: Operation):
         """Insert operations before an operation contained in the matched operation."""
         if target_op.parent is None:
@@ -110,7 +110,7 @@ class PatternRewriter:
         target_op.parent.insert_op(op,
                                    target_block.get_operation_index(target_op))
 
-    def insert_op_after(self, op: Union[Operation, List[Operation]],
+    def insert_op_after(self, op: Operation | list[Operation],
                         target_op: Operation):
         """Insert operations after an operation contained in the matched operation."""
         if target_op.parent is None:
@@ -154,8 +154,8 @@ class PatternRewriter:
 
     def replace_matched_op(
             self,
-            new_ops: Union[Operation, List[Operation]],
-            new_results: Optional[List[Optional[OpResult]]] = None,
+            new_ops: Operation | list[Operation],
+            new_results: list[OpResult | None] | None = None,
             safe_erase: bool = True):
         """
         Replace the matched operation with new operations.
@@ -175,8 +175,8 @@ class PatternRewriter:
 
     def replace_op(self,
                    op: Operation,
-                   new_ops: Union[Operation, List[Operation]],
-                   new_results: Optional[List[Optional[OpResult]]] = None,
+                   new_ops: Operation | list[Operation],
+                   new_results: list[OpResult | None] | None = None,
                    safe_erase: bool = True):
         """
         Replace an operation with new operations.
@@ -387,7 +387,7 @@ def op_type_rewrite_pattern(func):
 class GreedyRewritePatternApplier(RewritePattern):
     """Apply a list of patterns in order until one pattern matches, and then use this rewrite."""
 
-    rewrite_patterns: List[RewritePattern]
+    rewrite_patterns: list[RewritePattern]
     """The list of rewrites to apply in order."""
 
     def match_and_rewrite(self, op: Operation,

--- a/src/xdsl/pattern_rewriter.py
+++ b/src/xdsl/pattern_rewriter.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Optional, Callable, Union, Tuple
+from typing import Callable
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import Operation, OpResult, Region, Block, BlockArgument, Attribute
+from xdsl.ir import (Attribute, Block, BlockArgument, Operation, OpResult,
+                     Region)
 from xdsl.rewriter import Rewriter
 
 

--- a/src/xdsl/pattern_rewriter.py
+++ b/src/xdsl/pattern_rewriter.py
@@ -53,8 +53,7 @@ class PatternRewriter:
             return True  # Toplevel operation of current_operation is always a ModuleOp
         return self._can_modify_op(region.parent)
 
-    def insert_op_before_matched_op(self, op: (Operation |
-                                                    list[Operation])):
+    def insert_op_before_matched_op(self, op: (Operation | list[Operation])):
         """Insert operations before the matched operation."""
         if self.current_operation.parent is None:
             raise Exception(
@@ -68,8 +67,7 @@ class PatternRewriter:
         block.insert_op(op, op_idx)
         self.added_operations_before += op
 
-    def insert_op_after_matched_op(self, op: (Operation |
-                                                   list[Operation])):
+    def insert_op_after_matched_op(self, op: (Operation | list[Operation])):
         """Insert operations after the matched operation."""
         if self.current_operation.parent is None:
             raise Exception(
@@ -83,8 +81,8 @@ class PatternRewriter:
         block.insert_op(op, op_idx + 1)
         self.added_operations_after += op
 
-    def insert_op_at_pos(self, op: Operation | list[Operation],
-                         block: Block, pos: int):
+    def insert_op_at_pos(self, op: Operation | list[Operation], block: Block,
+                         pos: int):
         """Insert operations in a block contained in the matched operation."""
         if not self._can_modify_block(block):
             raise Exception("Cannot insert operations in block.")
@@ -152,11 +150,10 @@ class PatternRewriter:
                 ", or that are contained in the matched operation.")
         Rewriter.erase_op(op, safe_erase=safe_erase)
 
-    def replace_matched_op(
-            self,
-            new_ops: Operation | list[Operation],
-            new_results: list[OpResult | None] | None = None,
-            safe_erase: bool = True):
+    def replace_matched_op(self,
+                           new_ops: Operation | list[Operation],
+                           new_results: list[OpResult | None] | None = None,
+                           safe_erase: bool = True):
         """
         Replace the matched operation with new operations.
         Also, optionally specify SSA values to replace the operation results.

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -74,7 +74,7 @@ class Printer:
         indent = self._indent if indent is None else indent
         self.print(" " * indent * indentNumSpaces)
         indent_size = indent * indentNumSpaces
-        message_end_pos = max([len(line) for line in message.split("\n")]) + 2
+        message_end_pos = max(len(line) for line in message.split("\n")) + 2
         first_line = (begin_pos - indent_size) * "-" + (
             end_pos - begin_pos + 1) * "^" + (max(message_end_pos, end_pos) -
                                               end_pos) * "-"

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
-from xdsl.dialects.builtin import *
-from xdsl.diagnostic import *
-from typing import TypeVar
+
 from dataclasses import dataclass
+from typing import TypeVar
+
+from xdsl.diagnostic import *
+from xdsl.dialects.builtin import *
 
 indentNumSpaces = 2
 
@@ -10,20 +12,20 @@ indentNumSpaces = 2
 @dataclass(eq=False, repr=False)
 class Printer:
 
-    stream: Optional[Any] = field(default=None)
+    stream: Any | None = field(default=None)
     print_generic_format: bool = field(default=False)
     print_operand_types: bool = field(default=True)
     print_result_types: bool = field(default=True)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
     _indent: int = field(default=0, init=False)
-    _ssa_values: Dict[SSAValue, str] = field(default_factory=dict, init=False)
-    _ssa_names: Dict[str, int] = field(default_factory=dict, init=False)
-    _block_names: Dict[Block, int] = field(default_factory=dict, init=False)
+    _ssa_values: dict[SSAValue, str] = field(default_factory=dict, init=False)
+    _ssa_names: dict[str, int] = field(default_factory=dict, init=False)
+    _block_names: dict[Block, int] = field(default_factory=dict, init=False)
     _next_valid_name_id: int = field(default=0, init=False)
     _next_valid_block_id: int = field(default=0, init=False)
     _current_line: int = field(default=0, init=False)
     _current_column: int = field(default=0, init=False)
-    _next_line_callback: List[Callable[[], None]] = field(default_factory=list,
+    _next_line_callback: list[Callable[[], None]] = field(default_factory=list,
                                                           init=False)
 
     def print(self, *argv) -> None:
@@ -90,7 +92,7 @@ class Printer:
 
     T = TypeVar('T')
 
-    def print_list(self, elems: List[T], print_fn: Callable[[T],
+    def print_list(self, elems: list[T], print_fn: Callable[[T],
                                                             None]) -> None:
         if len(elems) == 0:
             return
@@ -168,7 +170,7 @@ class Printer:
             self.print(" : ")
             self.print_attribute(operand.typ)
 
-    def _print_ops(self, ops: List[Operation]) -> None:
+    def _print_ops(self, ops: list[Operation]) -> None:
         self._indent += 1
         for op in ops:
             self._print_new_line()
@@ -219,7 +221,7 @@ class Printer:
             self._print_named_block(block)
         self.print("}")
 
-    def print_regions(self, regions: List[Region]) -> None:
+    def print_regions(self, regions: list[Region]) -> None:
         for region in regions:
             self.print_region(region)
 
@@ -279,14 +281,14 @@ class Printer:
             self.print_list(attribute.parameters, self.print_attribute)
             self.print(">")
 
-    def print_successors(self, successors: List[Block]):
+    def print_successors(self, successors: list[Block]):
         if len(successors) == 0:
             return
         self.print(" (")
         self.print_list(successors, self.print_block_name)
         self.print(")")
 
-    def _print_op_attributes(self, attributes: Dict[str, Attribute]) -> None:
+    def _print_op_attributes(self, attributes: dict[str, Attribute]) -> None:
         if len(attributes) == 0:
             return
 

--- a/src/xdsl/rewriter.py
+++ b/src/xdsl/rewriter.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Union
 
 from xdsl.ir import *
 
@@ -20,7 +20,7 @@ class Rewriter:
 
     @staticmethod
     def replace_op(op: Operation,
-                   new_ops: Union[Operation, List[Operation]],
+                   new_ops: Operation | List[Operation],
                    new_results: Optional[List[Optional[SSAValue]]] = None,
                    safe_erase: bool = True):
         """
@@ -107,7 +107,7 @@ class Rewriter:
         Rewriter.inline_block_at_pos(block, op_block, op_pos + 1)
 
     @staticmethod
-    def insert_block_after(block: Union[Block, List[Block]], target: Block):
+    def insert_block_after(block: Block | List[Block], target: Block):
         """
         Insert one or multiple blocks after another block.
         The blocks to insert should be detached from any region.
@@ -123,7 +123,7 @@ class Rewriter:
         region.insert_block(block_list, pos + 1)
 
     @staticmethod
-    def insert_block_before(block: Union[Block, List[Block]], target: Block):
+    def insert_block_before(block: Block | List[Block], target: Block):
         """
         Insert one or multiple block before another block.
         The blocks to insert should be detached from any region.

--- a/src/xdsl/rewriter.py
+++ b/src/xdsl/rewriter.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Union
-
 from xdsl.ir import *
 
 
@@ -20,8 +18,8 @@ class Rewriter:
 
     @staticmethod
     def replace_op(op: Operation,
-                   new_ops: Operation | List[Operation],
-                   new_results: Optional[List[Optional[SSAValue]]] = None,
+                   new_ops: Operation | list[Operation],
+                   new_results: list[SSAValue | None] | None = None,
                    safe_erase: bool = True):
         """
         Replace an operation with multiple new ones.
@@ -107,7 +105,7 @@ class Rewriter:
         Rewriter.inline_block_at_pos(block, op_block, op_pos + 1)
 
     @staticmethod
-    def insert_block_after(block: Block | List[Block], target: Block):
+    def insert_block_after(block: Block | list[Block], target: Block):
         """
         Insert one or multiple blocks after another block.
         The blocks to insert should be detached from any region.
@@ -123,7 +121,7 @@ class Rewriter:
         region.insert_block(block_list, pos + 1)
 
     @staticmethod
-    def insert_block_before(block: Block | List[Block], target: Block):
+    def insert_block_before(block: Block | list[Block], target: Block):
         """
         Insert one or multiple block before another block.
         The blocks to insert should be detached from any region.

--- a/src/xdsl/util.py
+++ b/src/xdsl/util.py
@@ -7,7 +7,7 @@ from xdsl.ir import Operation, SSAValue, BlockArgument, Block, Region, Attribute
 
 
 def new_op(op_name, num_results, num_operands,
-           num_regions) -> typing.Type[Operation]:
+           num_regions) -> type[Operation]:
 
     @dataclass(eq=False)
     class OpBase(Operation):

--- a/src/xdsl/util.py
+++ b/src/xdsl/util.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 from xdsl.ir import Operation, SSAValue, BlockArgument, Block, Region, Attribute
 
 
-def new_op(op_name, num_results, num_operands,
-           num_regions) -> type[Operation]:
+def new_op(op_name, num_results, num_operands, num_regions) -> type[Operation]:
 
     @dataclass(eq=False)
     class OpBase(Operation):

--- a/src/xdsl/util.py
+++ b/src/xdsl/util.py
@@ -1,9 +1,11 @@
 import inspect
-from inspect import signature
-from typing import Annotated, Any, TypeGuard, Union, NoReturn, Callable, List
 import typing
 from dataclasses import dataclass
-from xdsl.ir import Operation, SSAValue, BlockArgument, Block, Region, Attribute
+from inspect import signature
+from typing import Annotated, Any, Callable, NoReturn, TypeGuard
+
+from xdsl.ir import (Attribute, Block, BlockArgument, Operation, Region,
+                     SSAValue)
 
 
 def new_op(op_name, num_results, num_operands, num_regions) -> type[Operation]:

--- a/src/xdsl/xdsl_opt_main.py
+++ b/src/xdsl/xdsl_opt_main.py
@@ -225,7 +225,7 @@ class xDSLOptMain:
             f = sys.stdin
             file_extension = 'xdsl'
         else:
-            f = open(self.args.input_file, mode='r')
+            f = open(self.args.input_file)
             _, file_extension = os.path.splitext(self.args.input_file)
             file_extension = file_extension.replace(".", "")
 

--- a/src/xdsl/xdsl_opt_main.py
+++ b/src/xdsl/xdsl_opt_main.py
@@ -1,17 +1,18 @@
 import argparse
-import sys
 import os
+import sys
 from io import IOBase
+
+from xdsl.dialects.affine import *
+from xdsl.dialects.arith import *
+from xdsl.dialects.builtin import *
+from xdsl.dialects.cf import *
+from xdsl.dialects.func import *
+from xdsl.dialects.memref import *
+from xdsl.dialects.scf import *
 from xdsl.ir import *
 from xdsl.parser import *
 from xdsl.printer import *
-from xdsl.dialects.func import *
-from xdsl.dialects.scf import *
-from xdsl.dialects.arith import *
-from xdsl.dialects.affine import *
-from xdsl.dialects.memref import *
-from xdsl.dialects.builtin import *
-from xdsl.dialects.cf import *
 
 
 class xDSLOptMain:
@@ -22,24 +23,24 @@ class xDSLOptMain:
     attributes.
     """
 
-    available_frontends: Dict[str, Callable[[IOBase], ModuleOp]] = {}
+    available_frontends: dict[str, Callable[[IOBase], ModuleOp]] = {}
     """
     A mapping from file extension to a frontend that can handle this 
     file type.
     """
 
-    available_passes: Dict[str, Callable[[MLContext, ModuleOp], None]] = {}
+    available_passes: dict[str, Callable[[MLContext, ModuleOp], None]] = {}
     """
     A mapping from pass names to functions that apply the pass to a  ModuleOp.
     """
 
-    available_targets: Dict[str, Callable[[ModuleOp, IOBase], None]] = {}
+    available_targets: dict[str, Callable[[ModuleOp, IOBase], None]] = {}
     """
     A mapping from target names to functions that serialize a ModuleOp into a 
     stream.
     """
 
-    pipeline: List[Tuple[str, Callable[[ModuleOp], None]]]
+    pipeline: list[tuple[str, Callable[[ModuleOp], None]]]
     """ The pass-pipeline to be applied. """
 
     def __init__(self, description='xDSL modular optimizer driver'):

--- a/tests/attribute_builder_test.py
+++ b/tests/attribute_builder_test.py
@@ -136,7 +136,7 @@ class BuilderUnionArgAttr(Data[str]):
 
     @staticmethod
     @builder
-    def from_int(i: typing.Union[str, int]) -> BuilderUnionArgAttr:
+    def from_int(i: str | int) -> BuilderUnionArgAttr:
         return BuilderUnionArgAttr(str(i))
 
     @staticmethod

--- a/tests/attribute_builder_test.py
+++ b/tests/attribute_builder_test.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import typing
 
-from xdsl.ir import ParametrizedAttribute, Data
-from xdsl.irdl import irdl_attr_definition, builder
 import pytest
+
+from xdsl.ir import Data, ParametrizedAttribute
+from xdsl.irdl import builder, irdl_attr_definition
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 

--- a/tests/attribute_definition_test.py
+++ b/tests/attribute_definition_test.py
@@ -3,15 +3,16 @@ Test the definition of attributes and their constraints.
 """
 
 from __future__ import annotations
+
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any, List, TypeVar, cast, Annotated, Generic, TypeAlias
+from typing import Annotated, Any, Generic, TypeAlias, TypeVar, cast
 
 import pytest
 
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.irdl import (AttrConstraint, GenericData, ParameterDef,
-                       VerifyException, irdl_attr_definition, builder,
+                       VerifyException, builder, irdl_attr_definition,
                        irdl_to_attr_constraint)
 from xdsl.parser import Parser
 from xdsl.printer import Printer

--- a/tests/attribute_definition_test.py
+++ b/tests/attribute_definition_test.py
@@ -92,7 +92,7 @@ def test_simple_data_verifier_failure():
                                "<class 'bool'>, but <class 'int'> given.")
 
 
-class IntListMissingVerifierData(Data[List[int]]):
+class IntListMissingVerifierData(Data[list[int]]):
     """
     An attribute holding a list of integers.
     The definition should fail, since no verifier is provided, and the Data
@@ -101,11 +101,11 @@ class IntListMissingVerifierData(Data[List[int]]):
     name = "missing_verifier_data"
 
     @staticmethod
-    def parse_parameter(parser: Parser) -> List[int]:
+    def parse_parameter(parser: Parser) -> list[int]:
         raise NotImplementedError()
 
     @staticmethod
-    def print_parameter(data: List[int], printer: Printer) -> None:
+    def print_parameter(data: list[int], printer: Printer) -> None:
         raise NotImplementedError()
 
 
@@ -121,18 +121,18 @@ def test_data_with_non_class_param_missing_verifier_failure():
 
 
 @irdl_attr_definition
-class IntListData(Data[List[int]]):
+class IntListData(Data[list[int]]):
     """
     An attribute holding a list of integers.
     """
     name = "int_list"
 
     @staticmethod
-    def parse_parameter(parser: Parser) -> List[int]:
+    def parse_parameter(parser: Parser) -> list[int]:
         raise NotImplementedError()
 
     @staticmethod
-    def print_parameter(data: List[int], printer: Printer) -> None:
+    def print_parameter(data: list[int], printer: Printer) -> None:
         printer.print_string("[")
         printer.print_list(data, lambda x: printer.print_string(str(x)))
         printer.print_string("]")
@@ -477,15 +477,15 @@ class DataListAttr(AttrConstraint):
 
 
 @irdl_attr_definition
-class ListData(GenericData[List[A]]):
+class ListData(GenericData[list[A]]):
     name = "list"
 
     @staticmethod
-    def parse_parameter(parser: Parser) -> List[A]:
+    def parse_parameter(parser: Parser) -> list[A]:
         raise NotImplementedError()
 
     @staticmethod
-    def print_parameter(data: List[A], printer: Printer) -> None:
+    def print_parameter(data: list[A], printer: Printer) -> None:
         printer.print_string("[")
         printer.print_list(data, printer.print_attribute)
         printer.print_string("]")
@@ -497,7 +497,7 @@ class ListData(GenericData[List[A]]):
 
     @staticmethod
     @builder
-    def from_list(data: List[A]) -> ListData[A]:
+    def from_list(data: list[A]) -> ListData[A]:
         return ListData(data)
 
     def verify(self) -> None:

--- a/tests/mlir_converter_test.py
+++ b/tests/mlir_converter_test.py
@@ -1,12 +1,12 @@
 import pytest
 
 docutils = pytest.importorskip("mlir")
-from xdsl.mlir_converter import *
-from xdsl.dialects.scf import Scf
-from xdsl.dialects.func import Func
-from xdsl.dialects.memref import MemRef
 from xdsl.dialects.affine import Affine
 from xdsl.dialects.arith import Arith
+from xdsl.dialects.func import Func
+from xdsl.dialects.memref import MemRef
+from xdsl.dialects.scf import Scf
+from xdsl.mlir_converter import *
 from xdsl.parser import Parser
 
 

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import typing
 
-from xdsl.ir import ParametrizedAttribute, Data, Block
-from xdsl.irdl import *
 import pytest
+
+from xdsl.dialects.builtin import (DenseIntOrFPElementsAttr, IntegerAttr,
+                                   IntegerType, VectorType)
+from xdsl.ir import Block, Data, ParametrizedAttribute
+from xdsl.irdl import *
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.dialects.builtin import DenseIntOrFPElementsAttr, IntegerAttr, VectorType, IntegerType
 
 
 @irdl_attr_definition

--- a/tests/pattern_rewriter_test.py
+++ b/tests/pattern_rewriter_test.py
@@ -1,12 +1,12 @@
-from xdsl.dialects.scf import Scf, If
-
-from xdsl.printer import Printer
-from xdsl.dialects.builtin import Builtin, IntegerAttr, i32, i64
-from xdsl.parser import Parser
-from xdsl.dialects.arith import Arith, Constant, Addi, Muli
-from xdsl.ir import MLContext
-from xdsl.pattern_rewriter import *
 from io import StringIO
+
+from xdsl.dialects.arith import Addi, Arith, Constant, Muli
+from xdsl.dialects.builtin import Builtin, IntegerAttr, i32, i64
+from xdsl.dialects.scf import If, Scf
+from xdsl.ir import MLContext
+from xdsl.parser import Parser
+from xdsl.pattern_rewriter import *
+from xdsl.printer import Printer
 
 
 def rewrite_and_compare(prog: str, expected_prog: str,

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from io import StringIO
 
-from xdsl.printer import Printer
-from xdsl.parser import Parser
-from xdsl.dialects.builtin import Builtin
-from xdsl.dialects.arith import *
 from xdsl.diagnostic import Diagnostic
+from xdsl.dialects.arith import *
+from xdsl.dialects.builtin import Builtin
+from xdsl.parser import Parser
+from xdsl.printer import Printer
 
 
 def test_forgotten_op():

--- a/tests/rewriter_test.py
+++ b/tests/rewriter_test.py
@@ -1,11 +1,11 @@
 from io import StringIO
 from typing import Callable
 
-from xdsl.dialects.arith import Arith, Constant, Addi
-from xdsl.dialects.builtin import ModuleOp, Builtin, i32
-from xdsl.dialects.scf import Scf, Yield
+from xdsl.dialects.arith import Addi, Arith, Constant
+from xdsl.dialects.builtin import Builtin, ModuleOp, i32
 from xdsl.dialects.func import Func
-from xdsl.ir import MLContext, Block
+from xdsl.dialects.scf import Scf, Yield
+from xdsl.ir import Block, MLContext
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.rewriter import Rewriter

--- a/tests/use_test.py
+++ b/tests/use_test.py
@@ -1,7 +1,7 @@
+from xdsl.dialects.arith import *
 from xdsl.dialects.builtin import *
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.dialects.arith import *
 
 test_prog = """
 module() {


### PR DESCRIPTION
Fix some error found by pyright type checker.

Replace typing.{Dict,List,Set,Type,Union,Optional} as they are deprecated since 3.9