### PR TITLE
Rewriter: print operation on invalid erase

### DIFF
--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -108,7 +108,8 @@ class SSAValue(ABC):
         """
         if safe_erase and len(self.uses) != 0:
             raise Exception(
-                "Attempting to delete SSA value that still has uses.")
+                "Attempting to delete SSA value that still has uses of operation:\n"
+                f"{self.op}")
         self.replace_by(ErasedSSAValue(self.typ, self))
 
 


### PR DESCRIPTION
closes #101 

This changes the print of an SSAValue that still has uses from 

```
Attempting to delete SSA value that still has uses.
```

to (with the right operation printed):

```
Attempting to delete SSA value that still has uses of operation:
Constant(name='arith.constant', _operands=<FrozenList(frozen=True, [])>, results=[OpResult(typ=IntegerType(parameters=[IntAttr(data=32)], width=IntAttr(data=32)), num_uses=2, op_name='arith.constant', result_index=0, name=None)], successors=[], attributes={'value': IntegerAttr(parameters=[IntAttr(data=5), IntegerType(parameters=[IntAttr(data=32)], width=IntAttr(data=32))], value=IntAttr(data=5), typ=IntegerType(parameters=[IntAttr(data=32)], width=IntAttr(data=32)))}, regions=[])
```