### PR TITLE
specify pythonpath for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project includes pytest unit test and llvm-style filecheck tests. They can 
 
 ```
 # Executes pytests which are located in tests/
-pytest
+python -m pytest
 
 # Executes filecheck tests
 lit tests/filecheck

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project includes pytest unit test and llvm-style filecheck tests. They can 
 
 ```
 # Executes pytests which are located in tests/
-python -m pytest
+pytest
 
 # Executes filecheck tests
 lit tests/filecheck

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ where = src
 
 [tool:pytest]
 python_files = *_test.py test_*.py *_example.py example_*.py
+pythonpath = src


### PR DESCRIPTION
I got import errors due to running on my system version of xdsl as opposed to the local version. Specifying the `pythonpath` in the config lets pytest choose the correct xdsl. I also added `python -m pytest` since that's less likely to use a different python version to the one used to install dependencies.