### PR TITLE
[LLVM] introduce and convert the LLVMStructType

### DIFF
--- a/src/xdsl/dialects/llvm.py
+++ b/src/xdsl/dialects/llvm.py
@@ -29,7 +29,7 @@ class LLVMStructType(ParametrizedAttribute):
 
     # An empty string refers to a struct without a name.
     struct_name: ParameterDef[StringAttr]
-    types: ParameterDef[ArrayAttr[AnyAttr()]]
+    types: ParameterDef[ArrayAttr[Attribute]]
 
     # TODO: Add this parameter once xDSL supports the necessary capabilities.
     #  bitmask = ParameterDef(StringAttr)

--- a/src/xdsl/dialects/llvm.py
+++ b/src/xdsl/dialects/llvm.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 from dataclasses import dataclass
 
-from xdsl.irdl import ParameterDef, AnyAttr, irdl_op_builder, irdl_attr_definition, AttributeDef, OperandDef, ResultDef, irdl_op_definition
+from xdsl.irdl import (ParameterDef, AnyAttr, irdl_op_builder,
+                       irdl_attr_definition, AttributeDef, OperandDef,
+                       ResultDef, irdl_op_definition, builder)
 from xdsl.ir import MLContext, ParametrizedAttribute, TYPE_CHECKING, Attribute, Operation
-from typing import overload
 from xdsl.dialects.builtin import StringAttr, ArrayOfConstraint, ArrayAttr
 
 if TYPE_CHECKING:
@@ -26,11 +27,15 @@ class LLVM:
 class LLVMStructType(ParametrizedAttribute):
     name = "llvm.struct"
 
+    # An empty string refers to a struct without a name.
     struct_name: ParameterDef[StringAttr]
     types: ParameterDef[ArrayAttr[AnyAttr()]]
 
-    # bitmask = ParameterDef(StringAttr)
+    # TODO: Add this parameter once xDSL supports the necessary capabilities.
+    #  bitmask = ParameterDef(StringAttr)
 
+    @staticmethod
+    @builder
     def from_type_list(types: list[Attribute]) -> LLVMStructType:
         return LLVMStructType(
             [StringAttr.from_str(""),

--- a/src/xdsl/dialects/llvm.py
+++ b/src/xdsl/dialects/llvm.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+from xdsl.irdl import ParameterDef, AnyAttr, irdl_op_builder, irdl_attr_definition, AttributeDef, OperandDef, ResultDef, irdl_op_definition
+from xdsl.ir import MLContext, ParametrizedAttribute, TYPE_CHECKING, Attribute, Operation
+from typing import overload
+from xdsl.dialects.builtin import StringAttr, ArrayOfConstraint, ArrayAttr
+
+if TYPE_CHECKING:
+    from xdsl.parser import Parser
+    from xdsl.printer import Printer
+
+
+@dataclass
+class LLVM:
+    ctx: MLContext
+
+    def __post_init__(self):
+        self.ctx.register_attr(LLVMStructType)
+
+        self.ctx.register_op(LLVMExtractValue)
+        self.ctx.register_op(LLVMInsertValue)
+
+
+@irdl_attr_definition
+class LLVMStructType(ParametrizedAttribute):
+    name = "llvm.struct"
+
+    struct_name: ParameterDef[StringAttr]
+    types: ParameterDef[ArrayAttr[AnyAttr()]]
+
+    # bitmask = ParameterDef(StringAttr)
+
+    def from_type_list(types: list[Attribute]) -> LLVMStructType:
+        return LLVMStructType(
+            [StringAttr.from_str(""),
+             ArrayAttr.from_list(types)])
+
+
+@irdl_op_definition
+class LLVMExtractValue(Operation):
+    name = "llvm.extractvalue"
+
+    position = AttributeDef(ArrayOfConstraint(AnyAttr()))
+    container = OperandDef(AnyAttr())
+
+    res = ResultDef(AnyAttr())
+
+
+@irdl_op_definition
+class LLVMInsertValue(Operation):
+    name = "llvm.insertvalue"
+
+    position = AttributeDef(ArrayOfConstraint(AnyAttr()))
+    container = OperandDef(AnyAttr())
+    value = OperandDef(AnyAttr())
+
+    res = ResultDef(AnyAttr())

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -6,6 +6,7 @@ from xdsl import _mlir_module as mlir
 import array
 from xdsl.dialects.builtin import *
 from xdsl.dialects.memref import MemRefType
+from xdsl.dialects.llvm import LLVMStructType
 
 
 class MLIRConverter:
@@ -46,6 +47,26 @@ class MLIRConverter:
         if isinstance(typ, TupleType):
             return mlir.ir.TupleType.get_tuple(
                 [self.convert_type(t) for t in typ.types.data])
+        if isinstance(typ, LLVMStructType):
+            from xdsl.printer import Printer
+            from io import StringIO
+            types = []
+            for t in typ.types.data:
+                file = StringIO("")
+                p = Printer(stream=file)
+                p.print_attribute(t)
+                types.append(file.getvalue()[1:])
+            type_string = "(" + ", ".join(types) + ")"
+
+            if typ.struct_name.data != "":
+                mlir_module = mlir.ir.Module.parse(
+                    "%0 = llvm.mlir.undef : !llvm.struct<" +
+                    typ.struct_name.data + ", " + type_string + ">")
+            else:
+                mlir_module = mlir.ir.Module.parse(
+                    "%0 = llvm.mlir.undef : !llvm.struct<" + type_string + ">")
+            return mlir_module.body.operations.__getitem__(
+                0).operation.result.type
         raise Exception(f"Unsupported type for mlir conversion: {typ}")
 
     def convert_value(self, value: SSAValue) -> mlir.ir.Value:

--- a/src/xdsl/xdsl_opt_main.py
+++ b/src/xdsl/xdsl_opt_main.py
@@ -14,6 +14,7 @@ from xdsl.dialects.builtin import *
 from xdsl.dialects.cmath import *
 from xdsl.dialects.cf import *
 from xdsl.dialects.irdl import *
+from xdsl.dialects.llvm import LLVM
 
 
 class xDSLOptMain:
@@ -151,6 +152,7 @@ class xDSLOptMain:
         cf = Cf(self.ctx)
         cmath = CMath(self.ctx)
         irdl = IRDL(self.ctx)
+        llvm = LLVM(self.ctx)
 
     def register_all_frontends(self):
         """

--- a/tests/filecheck/mlir-conversion/llvm_types.xdsl
+++ b/tests/filecheck/mlir-conversion/llvm_types.xdsl
@@ -1,0 +1,21 @@
+// RUN: xdsl-opt -t mlir %s | filecheck %s
+
+
+module() {
+  func.func() ["sym_name" = "struct_to_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
+    ^0(%0 : !llvm.struct<"", [!i32]>):
+      func.return(%0 : !llvm.struct<"", [!i32]>)
+  }
+  func.func() ["sym_name" = "struct_to_struct2", "function_type" = !fun<[!llvm.struct<"", [!i32, !i32]>], [!llvm.struct<"", [!i32, !i32]>]>, "sym_visibility" = "private"] {
+    ^1(%1 : !llvm.struct<"", [!i32, !i32]>):
+      func.return(%1 : !llvm.struct<"", [!i32, !i32]>)
+  }
+}
+
+
+//      CHECK: func.func private @struct_to_struct(%{{.*}}: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+// CHECK-NEXT:     return %{{.*}} : !llvm.struct<(i32)>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func private @struct_to_struct2(%{{.*}}: !llvm.struct<(i32, i32)>) -> !llvm.struct<(i32, i32)> {
+// CHECK-NEXT:     return %{{.*}} : !llvm.struct<(i32, i32)>
+// CHECK-NEXT: }


### PR DESCRIPTION
So I need the `llvm.struct<(i32)>` type for my project. Turns out: the llvm dialect is not exposed in the python bindings so I cannot go the usual route. For that reason, I came up with a really mad hack IMO. Feel free to comment if you see any way this could be improved.