### PR TITLE
Printer: add support to print types in MLIR style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog 
+
+All changes should be documented in this file.
+
+## [Unreleased]
+### Added
+- Changelog file
+### Changed
+- Rename `module` to `builtin.module`

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypeAlias, List, cast, Type, Sequence, Optional
 
-from xdsl.ir import (MLContext, TYPE_CHECKING, Data, ParametrizedAttribute,
-                     Operation)
+from xdsl.ir import (MLContext, TYPE_CHECKING, Data, MLIRType,
+                     ParametrizedAttribute, Operation)
 from xdsl.irdl import (irdl_attr_definition, attr_constr_coercion,
                        irdl_to_attr_constraint, irdl_op_definition, builder,
                        ParameterDef, SingleBlockRegionDef, TypeVar, Generic,
@@ -263,7 +263,7 @@ _VectorTypeElems = TypeVar("_VectorTypeElems", bound=Attribute)
 
 
 @irdl_attr_definition
-class VectorType(Generic[_VectorTypeElems], ParametrizedAttribute):
+class VectorType(Generic[_VectorTypeElems], ParametrizedAttribute, MLIRType):
     name = "vector"
 
     shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]
@@ -305,7 +305,7 @@ _TensorTypeElems = TypeVar("_TensorTypeElems", bound=Attribute, covariant=True)
 
 
 @irdl_attr_definition
-class TensorType(Generic[_TensorTypeElems], ParametrizedAttribute):
+class TensorType(Generic[_TensorTypeElems], ParametrizedAttribute, MLIRType):
     name = "tensor"
 
     shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]
@@ -389,14 +389,14 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class Float32Type(ParametrizedAttribute):
+class Float32Type(ParametrizedAttribute, MLIRType):
     name = "f32"
 
 
 f32 = Float32Type()
 
 
-class Float64Type(ParametrizedAttribute):
+class Float64Type(ParametrizedAttribute, MLIRType):
     name = "f64"
 
 
@@ -457,7 +457,7 @@ class UnitAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class FunctionType(ParametrizedAttribute):
+class FunctionType(ParametrizedAttribute, MLIRType):
     name = "fun"
 
     inputs: ParameterDef[ArrayAttr[Attribute]]

--- a/src/xdsl/dialects/cmath.py
+++ b/src/xdsl/dialects/cmath.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from xdsl.dialects.builtin import Float32Type, Float64Type
-from xdsl.ir import MLContext
+from xdsl.ir import MLContext, MLIRType
 from xdsl.irdl import (irdl_op_definition, Operation, OperandDef,
                        irdl_attr_definition, ParameterDef, ParamAttrConstraint,
                        AnyOf, ResultDef, ParametrizedAttribute,
@@ -21,7 +21,7 @@ class CMath:
 
 
 @irdl_attr_definition
-class ComplexType(ParametrizedAttribute):
+class ComplexType(ParametrizedAttribute, MLIRType):
     name = "cmath.complex"
     data: ParameterDef[Float64Type | Float32Type]
 

--- a/src/xdsl/dialects/llvm.py
+++ b/src/xdsl/dialects/llvm.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING
 from xdsl.irdl import (ParameterDef, AnyAttr, irdl_op_builder,
                        irdl_attr_definition, AttributeDef, OperandDef,
                        ResultDef, irdl_op_definition, builder)
-from xdsl.ir import (MLContext, ParametrizedAttribute, Attribute, Operation)
+from xdsl.ir import (MLContext, MLIRType, ParametrizedAttribute, Attribute,
+                     Operation)
 from xdsl.dialects.builtin import (StringAttr, ArrayOfConstraint, ArrayAttr,
                                    IntegerAttr, IntegerType)
 
@@ -27,7 +28,7 @@ class LLVM:
 
 
 @irdl_attr_definition
-class LLVMStructType(ParametrizedAttribute):
+class LLVMStructType(ParametrizedAttribute, MLIRType):
     name = "llvm.struct"
 
     # An empty string refers to a struct without a name.

--- a/src/xdsl/dialects/llvm.py
+++ b/src/xdsl/dialects/llvm.py
@@ -45,6 +45,12 @@ class LLVMStructType(ParametrizedAttribute, MLIRType):
             [StringAttr.from_str(""),
              ArrayAttr.from_list(types)])
 
+    def print_parameters_as_mlir(self, printer: Printer) -> None:
+        assert self.struct_name.data == ""
+        printer.print("<(")
+        printer.print_list(self.types.data, printer.print_attribute)
+        printer.print(")>")
+
 
 @irdl_op_definition
 class LLVMExtractValue(Operation):

--- a/src/xdsl/dialects/memref.py
+++ b/src/xdsl/dialects/memref.py
@@ -6,7 +6,7 @@ from typing import TypeVar, Optional, List, TypeAlias
 from xdsl.dialects.builtin import (IntegerAttr, IndexType, ArrayAttr,
                                    IntegerType, FlatSymbolRefAttr, StringAttr,
                                    DenseIntOrFPElementsAttr)
-from xdsl.ir import Operation, SSAValue, MLContext
+from xdsl.ir import MLIRType, Operation, SSAValue, MLContext
 from xdsl.irdl import (irdl_attr_definition, irdl_op_definition, builder,
                        ParameterDef, Generic, Attribute, ParametrizedAttribute,
                        AnyAttr, OperandDef, VarOperandDef, ResultDef,
@@ -36,7 +36,7 @@ AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
 
 @irdl_attr_definition
-class MemRefType(Generic[_MemRefTypeElement], ParametrizedAttribute):
+class MemRefType(Generic[_MemRefTypeElement], ParametrizedAttribute, MLIRType):
     name = "memref"
 
     shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -217,11 +217,6 @@ class Attribute(ABC):
         """
         pass
 
-    @abstractmethod
-    def print_as_mlir(self, printer: Printer) -> None:
-        """Print the attribute in MLIR format."""
-        ...
-
 
 DataElement = TypeVar("DataElement")
 
@@ -242,11 +237,9 @@ class Data(Generic[DataElement], Attribute, ABC):
     def print_parameter(data: DataElement, printer: Printer) -> None:
         """Print the attribute parameter."""
 
-    def print_as_mlir(self, printer: Printer) -> None:
-        printer.print("!" if isinstance(self, MLIRType) else "#")
-        printer.print(f"{self.name}<")
+    def print_parameter_as_mlir(self, printer: Printer) -> None:
+        """Print the attribute parameter in MLIR format."""
         self.print_parameter(self.data, printer)
-        printer.print(">")
 
 
 @dataclass(frozen=True)
@@ -261,9 +254,7 @@ class ParametrizedAttribute(Attribute):
         """Get the IRDL attribute definition."""
         ...
 
-    def print_as_mlir(self, printer: Printer) -> None:
-        printer.print("!" if isinstance(self, MLIRType) else "#")
-        printer.print(f'{self.name}')
+    def print_parameters_as_mlir(self, printer: Printer) -> None:
         if len(self.parameters) != 0:
             printer.print("<")
             printer.print_list(self.parameters, printer.print_attribute)

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -146,7 +146,7 @@ class Printer:
             name = self._get_new_valid_name_id()
             self._ssa_values[val] = name
         self.print("%s" % name)
-        if self.target == self.Target.MLIR:
+        if self.target == self.Target.XDSL:
             self.print(" : ")
             self.print_attribute(val.typ)
 
@@ -354,7 +354,7 @@ class Printer:
             self.print_list(op.operands,
                             lambda operand: self.print_attribute(operand.typ))
             self.print(") -> (")
-            self.print_list(op.operands,
+            self.print_list(op.results,
                             lambda result: self.print_attribute(result.typ))
             self.print(")")
 

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -262,7 +262,10 @@ class Printer:
         if isinstance(attribute, IntegerType):
             width = attribute.parameters[0]
             assert isinstance(width, IntAttr)
-            self.print(f'!i{width.data}')
+            if self.target == self.Target.MLIR:
+                self.print(f'i{width.data}')
+            else:
+                self.print(f'!i{width.data}')
             return
 
         if isinstance(attribute, StringAttr):
@@ -294,6 +297,10 @@ class Printer:
             self.print_string("[")
             self.print_list(attribute.data, self.print_attribute)
             self.print_string("]")
+            return
+
+        if self.target == self.Target.MLIR:
+            attribute.print_as_mlir(self)
             return
 
         if isinstance(attribute, Data):
@@ -354,7 +361,7 @@ class Printer:
     def _print_op(self, op: Operation) -> None:
         begin_op_pos = self._current_column
         self._print_results(op)
-        if self.print_generic_format:
+        if self.print_generic_format or self.target == self.Target.MLIR:
             self.print(f'"{op.name}"')
         else:
             self.print(op.name)
@@ -363,7 +370,7 @@ class Printer:
             for message in self.diagnostic.op_messages[op]:
                 self._add_message_on_next_line(message, begin_op_pos,
                                                end_op_pos)
-        if self.print_generic_format:
+        if self.print_generic_format or self.target == self.Target.MLIR:
             self.print_op_with_default_format(op)
         else:
             op.print(self)

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from frozenlist import FrozenList
+
 from xdsl.diagnostic import Diagnostic
 from typing import TypeVar, Any, Dict, Optional, List
 
@@ -27,6 +29,7 @@ class Printer:
     print_operand_types: TypeLocation = field(default=TypeLocation.INLINE)
     print_result_types: TypeLocation = field(default=TypeLocation.INLINE)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
+
     _indent: int = field(default=0, init=False)
     _ssa_values: Dict[SSAValue, str] = field(default_factory=dict, init=False)
     _ssa_names: Dict[str, int] = field(default_factory=dict, init=False)
@@ -102,8 +105,8 @@ class Printer:
 
     T = TypeVar('T')
 
-    def print_list(self, elems: List[T], print_fn: Callable[[T],
-                                                            None]) -> None:
+    def print_list(self, elems: FrozenList[T] | List[T],
+                   print_fn: Callable[[T], None]) -> None:
         if len(elems) == 0:
             return
         print_fn(elems[0])
@@ -341,21 +344,11 @@ class Printer:
         if (self.print_operand_types == Printer.TypeLocation.AFTER
                 and self.print_result_types == Printer.TypeLocation.AFTER):
             self.print(" : (")
-            first = True
-            for operand in op.operands:
-                if first:
-                    first = False
-                else:
-                    self.print(", ")
-                self.print_attribute(operand.typ)
+            self.print_list(op.operands,
+                            lambda operand: self.print_attribute(operand.typ))
             self.print(") -> (")
-            first = True
-            for result in op.results:
-                if first:
-                    first = False
-                else:
-                    self.print(", ")
-                self.print_attribute(result.typ)
+            self.print_list(op.operands,
+                            lambda result: self.print_attribute(result.typ))
             self.print(")")
 
     def _print_op(self, op: Operation) -> None:

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -9,6 +9,7 @@ from xdsl.dialects.builtin import (FloatAttr, IntegerType, StringAttr,
                                    FlatSymbolRefAttr, IntegerAttr, ArrayAttr,
                                    ParametrizedAttribute, IntAttr, UnitAttr)
 from xdsl.irdl import Data
+from enum import Enum
 
 indentNumSpaces = 2
 
@@ -16,10 +17,15 @@ indentNumSpaces = 2
 @dataclass(eq=False, repr=False)
 class Printer:
 
+    class TypeLocation(Enum):
+        NONE = 1
+        INLINE = 2
+        AFTER = 3
+
     stream: Optional[Any] = field(default=None)
     print_generic_format: bool = field(default=False)
-    print_operand_types: bool = field(default=True)
-    print_result_types: bool = field(default=True)
+    print_operand_types: TypeLocation = field(default=TypeLocation.INLINE)
+    print_result_types: TypeLocation = field(default=TypeLocation.INLINE)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
     _indent: int = field(default=0, init=False)
     _ssa_values: Dict[SSAValue, str] = field(default_factory=dict, init=False)
@@ -32,7 +38,7 @@ class Printer:
     _next_line_callback: List[Callable[[], None]] = field(default_factory=list,
                                                           init=False)
 
-    def print(self, *argv) -> None:
+    def print(self, *argv: Any) -> None:
         for arg in argv:
             if isinstance(arg, str):
                 self.print_string(arg)
@@ -136,7 +142,7 @@ class Printer:
             name = self._get_new_valid_name_id()
             self._ssa_values[val] = name
         self.print("%s" % name)
-        if self.print_result_types:
+        if self.print_result_types == Printer.TypeLocation.INLINE:
             self.print(" : ")
             self.print_attribute(val.typ)
 
@@ -174,7 +180,7 @@ class Printer:
     def _print_operand(self, operand: SSAValue) -> None:
         self.print_ssa_value(operand)
 
-        if self.print_operand_types:
+        if self.print_operand_types == Printer.TypeLocation.INLINE:
             self.print(" : ")
             self.print_attribute(operand.typ)
 
@@ -331,6 +337,26 @@ class Printer:
         self.print_successors(op.successors)
         self._print_op_attributes(op.attributes)
         self.print_regions(op.regions)
+
+        if (self.print_operand_types == Printer.TypeLocation.AFTER
+                and self.print_result_types == Printer.TypeLocation.AFTER):
+            self.print(" : (")
+            first = True
+            for operand in op.operands:
+                if first:
+                    first = False
+                else:
+                    self.print(", ")
+                self.print_attribute(operand.typ)
+            self.print(") -> (")
+            first = True
+            for result in op.results:
+                if first:
+                    first = False
+                else:
+                    self.print(", ")
+                self.print_attribute(result.typ)
+            self.print(")")
 
     def _print_op(self, op: Operation) -> None:
         begin_op_pos = self._current_column

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -24,11 +24,16 @@ class Printer:
         INLINE = 2
         AFTER = 3
 
+    class Target(Enum):
+        XDSL = 1
+        MLIR = 2
+
     stream: Optional[Any] = field(default=None)
     print_generic_format: bool = field(default=False)
     print_operand_types: TypeLocation = field(default=TypeLocation.INLINE)
     print_result_types: TypeLocation = field(default=TypeLocation.INLINE)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
+    target: Target = field(default=Target.XDSL)
 
     _indent: int = field(default=0, init=False)
     _ssa_values: Dict[SSAValue, str] = field(default_factory=dict, init=False)
@@ -223,20 +228,20 @@ class Printer:
 
     def print_region(self, region: Region) -> None:
         if len(region.blocks) == 0:
-            self.print(" {}")
+            self.print(" {}" if self.target == self.Target.XDSL else " ({})")
             return
 
         if len(region.blocks) == 1 and len(region.blocks[0].args) == 0:
-            self.print(" {")
+            self.print(" {" if self.target == self.Target.XDSL else " ({")
             self._print_ops(region.blocks[0].ops)
-            self.print("}")
+            self.print("}" if self.target == self.Target.XDSL else "})")
             return
 
-        self.print(" {")
+        self.print(" {" if self.target == self.Target.XDSL else " ({")
         self._print_new_line()
         for block in region.blocks:
             self._print_named_block(block)
-        self.print("}")
+        self.print("}" if self.target == self.Target.XDSL else "})")
 
     def print_regions(self, regions: List[Region]) -> None:
         for region in regions:
@@ -328,12 +333,12 @@ class Printer:
             return
 
         self.print(" ")
-        self.print("[")
+        self.print("[" if self.target == Printer.Target.XDSL else "{")
 
         attribute_list = [p for p in attributes.items()]
         self.print_list(attribute_list, self._print_attr_string)
 
-        self.print("]")
+        self.print("]" if self.target == Printer.Target.XDSL else "}")
 
     def print_op_with_default_format(self, op: Operation) -> None:
         self._print_operands(op.operands)

--- a/src/xdsl/xdsl_opt_main.py
+++ b/src/xdsl/xdsl_opt_main.py
@@ -142,6 +142,13 @@ class xDSLOptMain:
                                 help="Prints the content of a triggered "
                                 "exception and exits with code 0")
 
+        arg_parser.add_argument(
+            "--use-mlir-bindings",
+            default=False,
+            action='store_true',
+            help="Use the MLIR bindings for printing MLIR. "
+            "This requires the MLIR Python bindings to be installed.")
+
     def register_all_dialects(self):
         """
         Register all dialects that can be used.
@@ -213,13 +220,12 @@ class xDSLOptMain:
 
         self.available_targets['xdsl'] = _output_xdsl
         self.available_targets['irdl'] = _output_irdl
-        self.available_targets['xdsl-mlir'] = _output_xdsl_mlir
-        try:
+
+        if self.args.use_mlir_bindings:
             from xdsl.mlir_converter import MLIRConverter
             self.available_targets['mlir'] = _output_mlir
-        except ImportError:
-            # do not add mlir as target if import does not work
-            pass
+        else:
+            self.available_targets['mlir'] = _output_xdsl_mlir
 
     def setup_pipeline(self):
         """

--- a/src/xdsl/xdsl_opt_main.py
+++ b/src/xdsl/xdsl_opt_main.py
@@ -196,6 +196,12 @@ class xDSLOptMain:
             printer = Printer(stream=output)
             printer.print_op(prog)
 
+        def _output_xdsl_mlir(prog: ModuleOp, output: IOBase):
+            printer = Printer(stream=output,
+                              print_operand_types=Printer.TypeLocation.AFTER,
+                              print_result_types=Printer.TypeLocation.AFTER)
+            printer.print_op(prog)
+
         def _output_mlir(prog: ModuleOp, output: IOBase):
             converter = MLIRConverter(self.ctx)
             mlir_module = converter.convert_module(prog)
@@ -207,7 +213,7 @@ class xDSLOptMain:
 
         self.available_targets['xdsl'] = _output_xdsl
         self.available_targets['irdl'] = _output_irdl
-
+        self.available_targets['xdsl-mlir'] = _output_xdsl_mlir
         try:
             from xdsl.mlir_converter import MLIRConverter
             self.available_targets['mlir'] = _output_mlir

--- a/tests/filecheck/mlir-conversion/llvm_test.xdsl
+++ b/tests/filecheck/mlir-conversion/llvm_test.xdsl
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | filecheck %s
+// RUN: xdsl-opt -t mlir --use-mlir-bindings %s | filecheck %s
 
 
 builtin.module() {

--- a/tests/filecheck/mlir-conversion/ops.xdsl
+++ b/tests/filecheck/mlir-conversion/ops.xdsl
@@ -1,4 +1,5 @@
 // RUN: xdsl-opt -t mlir --use-mlir-bindings %s | filecheck %s
+// RUN: xdsl-opt -t mlir --use-mlir-bindings %s | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic > %t-2 | diff %t-1 %t-2
 
 // Tests if the non generic form can be printed.
 

--- a/tests/filecheck/mlir-conversion/ops.xdsl
+++ b/tests/filecheck/mlir-conversion/ops.xdsl
@@ -1,5 +1,5 @@
 // RUN: xdsl-opt -t mlir --use-mlir-bindings %s | filecheck %s
-// RUN: xdsl-opt -t mlir --use-mlir-bindings %s | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic > %t-2 | diff %t-1 %t-2
+// RUN: xdsl-opt -t mlir --use-mlir-bindings %s | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic > %t-2 && diff %t-1 %t-2
 
 // Tests if the non generic form can be printed.
 

--- a/tests/filecheck/mlir-conversion/ops.xdsl
+++ b/tests/filecheck/mlir-conversion/ops.xdsl
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | filecheck %s
+// RUN: xdsl-opt -t mlir --use-mlir-bindings %s | filecheck %s
 
 // Tests if the non generic form can be printed.
 

--- a/tests/filecheck/parser-printer/llvm_mlir_printer.xdsl
+++ b/tests/filecheck/parser-printer/llvm_mlir_printer.xdsl
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt -t mlir %s | filecheck %s
 
 
-"module"() {
+"builtin.module"() {
   func.func() ["sym_name" = "struct_to_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
     ^0(%0 : !llvm.struct<"", [!i32]>):
       func.return(%0 : !llvm.struct<"", [!i32]>)
@@ -9,7 +9,7 @@
 }
 
 
-// CHECK:     "module"() ({
+// CHECK:     "builtin.module"() ({
 // CHECK-NEXT:  "func.func"() ({
 // CHECK-NEXT:  ^0(%0 : !llvm.struct<(i32)>):
 // CHECK-NEXT:    "func.return"(%0) : (!llvm.struct<(i32)>) -> ()

--- a/tests/filecheck/parser-printer/llvm_mlir_printer.xdsl
+++ b/tests/filecheck/parser-printer/llvm_mlir_printer.xdsl
@@ -1,0 +1,17 @@
+// RUN: xdsl-opt -t mlir %s | filecheck %s
+
+
+"module"() {
+  func.func() ["sym_name" = "struct_to_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
+    ^0(%0 : !llvm.struct<"", [!i32]>):
+      func.return(%0 : !llvm.struct<"", [!i32]>)
+  }
+}
+
+
+// CHECK:     "module"() ({
+// CHECK-NEXT:  "func.func"() {"sym_name" = "struct_to_struct", "function_type" = !fun<[!llvm.struct<(i32)>], [!llvm.struct<(i32)>]>, "sym_visibility" = "private"} ({
+// CHECK-NEXT:  ^0(%0 : !llvm.struct<(i32)>):
+// CHECK-NEXT:    "func.return"(%0) : (!llvm.struct<(i32)>) -> ()
+// CHECK-NEXT:  }) : () -> ()
+// CHECK-NEXT:}) : () -> ()

--- a/tests/filecheck/parser-printer/llvm_mlir_printer.xdsl
+++ b/tests/filecheck/parser-printer/llvm_mlir_printer.xdsl
@@ -10,8 +10,8 @@
 
 
 // CHECK:     "module"() ({
-// CHECK-NEXT:  "func.func"() {"sym_name" = "struct_to_struct", "function_type" = !fun<[!llvm.struct<(i32)>], [!llvm.struct<(i32)>]>, "sym_visibility" = "private"} ({
+// CHECK-NEXT:  "func.func"() ({
 // CHECK-NEXT:  ^0(%0 : !llvm.struct<(i32)>):
 // CHECK-NEXT:    "func.return"(%0) : (!llvm.struct<(i32)>) -> ()
-// CHECK-NEXT:  }) : () -> ()
+// CHECK-NEXT:  }) {"sym_name" = "struct_to_struct", "function_type" = (!llvm.struct<(i32)>) -> !llvm.struct<(i32)>, "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT:}) : () -> ()

--- a/tests/mlir_printer_test.py
+++ b/tests/mlir_printer_test.py
@@ -1,8 +1,7 @@
 from io import StringIO
 from xdsl.ir import Attribute, Data, MLContext, MLIRType, Operation, ParametrizedAttribute
-from xdsl.irdl import (AnyAttr, AttributeDef, ParameterDef, RegionDef,
-                       VarOperandDef, VarResultDef, irdl_attr_definition,
-                       irdl_op_definition)
+from xdsl.irdl import (AnyAttr, ParameterDef, RegionDef, VarOperandDef,
+                       VarResultDef, irdl_attr_definition, irdl_op_definition)
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 
@@ -17,9 +16,9 @@ class ModuleOp(Operation):
 
 
 @irdl_op_definition
-class TestOp(Operation):
+class AnyOp(Operation):
     """Operation only used for testing."""
-    name = "test"
+    name = "any"
     op = VarOperandDef(AnyAttr())
     res = VarResultDef(AnyAttr())
 
@@ -97,7 +96,7 @@ def print_as_mlir_and_compare(test_prog: str, expected: str):
     ctx = MLContext()
 
     ctx.register_op(ModuleOp)
-    ctx.register_op(TestOp)
+    ctx.register_op(AnyOp)
     ctx.register_attr(DataAttr)
     ctx.register_attr(DataType)
     ctx.register_attr(ParamAttr)
@@ -122,40 +121,40 @@ def print_as_mlir_and_compare(test_prog: str, expected: str):
 def test_empty_op():
     """Test printing an empty operation."""
     print_as_mlir_and_compare(
-        """test()""",
-        """"test"() : () -> ()""",
+        """any()""",
+        """"any"() : () -> ()""",
     )
 
 
 def test_data_attr():
     """Test printing an operation with a data attribute."""
     print_as_mlir_and_compare(
-        """test() [ "attr" = !data_attr<42> ]""",
-        """"test"() {"attr" = #data_attr<42>} : () -> ()""",
+        """any() [ "attr" = !data_attr<42> ]""",
+        """"any"() {"attr" = #data_attr<42>} : () -> ()""",
     )
 
 
 def test_data_type():
     """Test printing an operation with a data type."""
     print_as_mlir_and_compare(
-        """%0 : !data_type<42> = test()""",
-        """%0 = "test"() : () -> !data_type<42>""",
+        """%0 : !data_type<42> = any()""",
+        """%0 = "any"() : () -> !data_type<42>""",
     )
 
 
 def test_param_attr():
     """Test printing an operation with a parametrized attribute."""
     print_as_mlir_and_compare(
-        """test() [ "attr" = !param_attr ]""",
-        """"test"() {"attr" = #param_attr } : () -> ()""",
+        """any() [ "attr" = !param_attr ]""",
+        """"any"() {"attr" = #param_attr } : () -> ()""",
     )
 
 
 def test_param_type():
     """Test printing an operation with a parametrized type."""
     print_as_mlir_and_compare(
-        """%0 : !param_type = test()""",
-        """%0 = "test"() : () -> !param_type""",
+        """%0 : !param_type = any()""",
+        """%0 = "any"() : () -> !param_type""",
     )
 
 
@@ -164,14 +163,14 @@ def test_param_attr_with_param():
     Test printing an operation with a parametrized attribute with parameters.
     """
     print_as_mlir_and_compare(
-        """test() [ "attr" = !param_attr_with_param<!param_attr> ]""",
-        """"test"() {"attr" = #param_attr_with_param<#param_attr> }
+        """any() [ "attr" = !param_attr_with_param<!param_attr> ]""",
+        """"any"() {"attr" = #param_attr_with_param<#param_attr> }
           : () -> ()""",
     )
 
     print_as_mlir_and_compare(
-        """test() [ "attr" = !param_attr_with_param<!param_type> ]""",
-        """"test"() {"attr" = #param_attr_with_param<!param_type> }
+        """any() [ "attr" = !param_attr_with_param<!param_type> ]""",
+        """"any"() {"attr" = #param_attr_with_param<!param_type> }
           : () -> ()""",
     )
 
@@ -189,13 +188,13 @@ def test_op_with_results():
     """Test printing an operation with results."""
 
     print_as_mlir_and_compare(
-        """%0 : !param_attr = test()""",
-        """%0 = "test"() : () -> #param_attr""",
+        """%0 : !param_attr = any()""",
+        """%0 = "any"() : () -> #param_attr""",
     )
 
     print_as_mlir_and_compare(
-        """(%0 : !param_attr, %1 : !param_type) = test()""",
-        """(%0, %1) = "test"() : () -> (#param_attr, !param_type)""",
+        """(%0 : !param_attr, %1 : !param_type) = any()""",
+        """(%0, %1) = "any"() : () -> (#param_attr, !param_type)""",
     )
 
 
@@ -203,24 +202,24 @@ def test_op_with_operands():
     """Test printing an operation with operands."""
     print_as_mlir_and_compare(
         """module() {
-           %0 : !param_attr = test()
-           test(%0 : !param_attr)
+           %0 : !param_attr = any()
+           any(%0 : !param_attr)
         }""",
         """"module"() ({
-              %0 = "test"() : () -> #param_attr
-              "test"(%0) : (#param_attr) -> ()
+              %0 = "any"() : () -> #param_attr
+              "any"(%0) : (#param_attr) -> ()
             }) : () -> ()
         """,
     )
 
     print_as_mlir_and_compare(
         """module() {
-           %0 : !param_attr = test()
-           test(%0 : !param_attr, %0 : !param_attr)
+           %0 : !param_attr = any()
+           any(%0 : !param_attr, %0 : !param_attr)
         }""",
         """"module"() ({
-              %0 = "test"() : () -> #param_attr
-              "test"(%0, %0) : (#param_attr, #param_attr) -> ()
+              %0 = "any"() : () -> #param_attr
+              "any"(%0, %0) : (#param_attr, #param_attr) -> ()
             }) : () -> ()
         """,
     )
@@ -229,22 +228,22 @@ def test_op_with_operands():
 def test_op_with_attributes():
     """Test printing an operation with attributes."""
     print_as_mlir_and_compare(
-        """test() [ "attr" = !data_attr<42> ]""",
-        """"test"() {"attr" = #data_attr<42>} : () -> ()""",
+        """any() [ "attr" = !data_attr<42> ]""",
+        """"any"() {"attr" = #data_attr<42>} : () -> ()""",
     )
 
 
 def test_data_custom_format():
     """Test printing an operation with a data attribute with custom format."""
     print_as_mlir_and_compare(
-        """test() [ "attr" = !data_custom_format<42> ]""",
-        """"test"() {"attr" = #data_custom_format<~42~>} : () -> ()""",
+        """any() [ "attr" = !data_custom_format<42> ]""",
+        """"any"() {"attr" = #data_custom_format<~42~>} : () -> ()""",
     )
 
 
 def test_param_custom_format():
     """Test printing an operation with a param attribute with custom format."""
     print_as_mlir_and_compare(
-        """test() [ "attr" = !param_custom_format<!param_attr> ]""",
-        """"test"() {"attr" = #param_custom_format~~} : () -> ()""",
+        """any() [ "attr" = !param_custom_format<!param_attr> ]""",
+        """"any"() {"attr" = #param_custom_format~~} : () -> ()""",
     )

--- a/tests/mlir_printer_test.py
+++ b/tests/mlir_printer_test.py
@@ -1,0 +1,250 @@
+from io import StringIO
+from xdsl.ir import Attribute, Data, MLContext, MLIRType, Operation, ParametrizedAttribute
+from xdsl.irdl import (AnyAttr, AttributeDef, ParameterDef, RegionDef,
+                       VarOperandDef, VarResultDef, irdl_attr_definition,
+                       irdl_op_definition)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+
+import re
+
+
+@irdl_op_definition
+class ModuleOp(Operation):
+    """Module operation. Redefined to not depend on the builtin dialect."""
+    name = "module"
+    region = RegionDef()
+
+
+@irdl_op_definition
+class TestOp(Operation):
+    """Operation only used for testing."""
+    name = "test"
+    op = VarOperandDef(AnyAttr())
+    res = VarResultDef(AnyAttr())
+
+
+@irdl_attr_definition
+class DataAttr(Data[int]):
+    """Attribute only used for testing."""
+    name = "data_attr"
+
+    @staticmethod
+    def parse_parameter(parser: Parser) -> int:
+        return parser.parse_int_literal()
+
+    @staticmethod
+    def print_parameter(data: int, printer: Printer) -> None:
+        printer.print(data)
+
+
+@irdl_attr_definition
+class DataType(Data[int], MLIRType):
+    """Attribute only used for testing."""
+    name = "data_type"
+
+    @staticmethod
+    def parse_parameter(parser: Parser) -> int:
+        return parser.parse_int_literal()
+
+    @staticmethod
+    def print_parameter(data: int, printer: Printer) -> None:
+        printer.print(data)
+
+
+@irdl_attr_definition
+class ParamAttr(ParametrizedAttribute):
+    name = "param_attr"
+
+
+@irdl_attr_definition
+class ParamAttrWithParam(ParametrizedAttribute):
+    name = "param_attr_with_param"
+    data: ParameterDef[Attribute]
+
+
+@irdl_attr_definition
+class ParamType(ParametrizedAttribute, MLIRType):
+    name = "param_type"
+
+
+@irdl_attr_definition
+class DataAttrWithCustomFormat(Data[int]):
+    name = "data_custom_format"
+
+    @staticmethod
+    def parse_parameter(parser: Parser) -> int:
+        return parser.parse_int_literal()
+
+    @staticmethod
+    def print_parameter(data: int, printer: Printer) -> None:
+        printer.print(data)
+
+    def print_parameter_as_mlir(self, printer: Printer) -> None:
+        printer.print(f"~{self.data}~")
+
+
+@irdl_attr_definition
+class ParamAttrWithCustomFormat(ParametrizedAttribute):
+    name = "param_custom_format"
+    param1: ParameterDef[ParamAttr]
+
+    def print_parameters_as_mlir(self, printer: Printer) -> None:
+        printer.print(f"~~")
+
+
+def print_as_mlir_and_compare(test_prog: str, expected: str):
+    ctx = MLContext()
+
+    ctx.register_op(ModuleOp)
+    ctx.register_op(TestOp)
+    ctx.register_attr(DataAttr)
+    ctx.register_attr(DataType)
+    ctx.register_attr(ParamAttr)
+    ctx.register_attr(ParamType)
+    ctx.register_attr(ParamAttrWithParam)
+    ctx.register_attr(DataAttrWithCustomFormat)
+    ctx.register_attr(ParamAttrWithCustomFormat)
+
+    parser = Parser(ctx, test_prog)
+    module = parser.parse_op()
+
+    res = StringIO()
+    printer = Printer(target=Printer.Target.MLIR, stream=res)
+    printer.print_op(module)
+
+    # Remove all whitespace from the expected string.
+    regex = re.compile(r'[^\S]+')
+    assert (regex.sub("", res.getvalue()).strip() == \
+            regex.sub("", expected).strip())
+
+
+def test_empty_op():
+    """Test printing an empty operation."""
+    print_as_mlir_and_compare(
+        """test()""",
+        """"test"() : () -> ()""",
+    )
+
+
+def test_data_attr():
+    """Test printing an operation with a data attribute."""
+    print_as_mlir_and_compare(
+        """test() [ "attr" = !data_attr<42> ]""",
+        """"test"() {"attr" = #data_attr<42>} : () -> ()""",
+    )
+
+
+def test_data_type():
+    """Test printing an operation with a data type."""
+    print_as_mlir_and_compare(
+        """%0 : !data_type<42> = test()""",
+        """%0 = "test"() : () -> !data_type<42>""",
+    )
+
+
+def test_param_attr():
+    """Test printing an operation with a parametrized attribute."""
+    print_as_mlir_and_compare(
+        """test() [ "attr" = !param_attr ]""",
+        """"test"() {"attr" = #param_attr } : () -> ()""",
+    )
+
+
+def test_param_type():
+    """Test printing an operation with a parametrized type."""
+    print_as_mlir_and_compare(
+        """%0 : !param_type = test()""",
+        """%0 = "test"() : () -> !param_type""",
+    )
+
+
+def test_param_attr_with_param():
+    """
+    Test printing an operation with a parametrized attribute with parameters.
+    """
+    print_as_mlir_and_compare(
+        """test() [ "attr" = !param_attr_with_param<!param_attr> ]""",
+        """"test"() {"attr" = #param_attr_with_param<#param_attr> }
+          : () -> ()""",
+    )
+
+    print_as_mlir_and_compare(
+        """test() [ "attr" = !param_attr_with_param<!param_type> ]""",
+        """"test"() {"attr" = #param_attr_with_param<!param_type> }
+          : () -> ()""",
+    )
+
+
+def test_op_with_region():
+    """Test printing an operation with a region."""
+
+    print_as_mlir_and_compare(
+        """module() {}""",
+        """"module"() ({}) : () -> ()""",
+    )
+
+
+def test_op_with_results():
+    """Test printing an operation with results."""
+
+    print_as_mlir_and_compare(
+        """%0 : !param_attr = test()""",
+        """%0 = "test"() : () -> #param_attr""",
+    )
+
+    print_as_mlir_and_compare(
+        """(%0 : !param_attr, %1 : !param_type) = test()""",
+        """(%0, %1) = "test"() : () -> (#param_attr, !param_type)""",
+    )
+
+
+def test_op_with_operands():
+    """Test printing an operation with operands."""
+    print_as_mlir_and_compare(
+        """module() {
+           %0 : !param_attr = test()
+           test(%0 : !param_attr)
+        }""",
+        """"module"() ({
+              %0 = "test"() : () -> #param_attr
+              "test"(%0) : (#param_attr) -> ()
+            }) : () -> ()
+        """,
+    )
+
+    print_as_mlir_and_compare(
+        """module() {
+           %0 : !param_attr = test()
+           test(%0 : !param_attr, %0 : !param_attr)
+        }""",
+        """"module"() ({
+              %0 = "test"() : () -> #param_attr
+              "test"(%0, %0) : (#param_attr, #param_attr) -> ()
+            }) : () -> ()
+        """,
+    )
+
+
+def test_op_with_attributes():
+    """Test printing an operation with attributes."""
+    print_as_mlir_and_compare(
+        """test() [ "attr" = !data_attr<42> ]""",
+        """"test"() {"attr" = #data_attr<42>} : () -> ()""",
+    )
+
+
+def test_data_custom_format():
+    """Test printing an operation with a data attribute with custom format."""
+    print_as_mlir_and_compare(
+        """test() [ "attr" = !data_custom_format<42> ]""",
+        """"test"() {"attr" = #data_custom_format<~42~>} : () -> ()""",
+    )
+
+
+def test_param_custom_format():
+    """Test printing an operation with a param attribute with custom format."""
+    print_as_mlir_and_compare(
+        """test() [ "attr" = !param_custom_format<!param_attr> ]""",
+        """"test"() {"attr" = #param_custom_format~~} : () -> ()""",
+    )


### PR DESCRIPTION
This brings the xDSL output closer to the syntax MLIR is using.