### PR TITLE
[Attributes] remove call ot parent verify

### DIFF
--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -956,7 +956,12 @@ def irdl_param_attr_definition(cls: type[PA]) -> type[PA]:
     # Get the fields from the class and its parents
     clsdict = dict()
     for parent_cls in cls.mro()[::-1]:
-        clsdict = {**clsdict, **parent_cls.__dict__}
+        # We do not want the parents verifier to be called
+        filtered_dict = {
+            x: parent_cls.__dict__[x]
+            for x in parent_cls.__dict__ if x not in ["verify"]
+        }
+        clsdict = {**clsdict, **filtered_dict}
 
     param_hints = irdl_param_attr_get_param_type_hints(cls)
 

--- a/tests/attribute_builder_test.py
+++ b/tests/attribute_builder_test.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import typing
 
 from xdsl.ir import ParametrizedAttribute, Data
-from xdsl.irdl import irdl_attr_definition, builder
+from xdsl.irdl import irdl_attr_definition, builder, ParameterDef
 import pytest
 from xdsl.parser import Parser
 from xdsl.printer import Printer
+from xdsl.dialects.builtin import StringAttr
 
 
 @irdl_attr_definition
@@ -161,3 +162,27 @@ def builder_union_arg_second():
 def builder_union_arg_bad_argument():
     with pytest.raises(TypeError) as e:
         BuilderUnionArgAttr.build([])
+
+
+@irdl_attr_definition
+class A(ParametrizedAttribute):
+    name = "A"
+
+    data: ParameterDef[StringAttr]
+
+
+@irdl_attr_definition
+class B(A):
+    name = "B"
+
+    dataB: ParameterDef[StringAttr]
+
+
+def test_inheriting_attr():
+    A([StringAttr.from_str("x")])
+    B([StringAttr.from_str("x"), StringAttr.from_str("y")])
+    try:
+        B([StringAttr.from_str("x")])
+    except Exception as e:
+        return
+    assert False

--- a/tests/attribute_builder_test.py
+++ b/tests/attribute_builder_test.py
@@ -7,7 +7,6 @@ from xdsl.irdl import irdl_attr_definition, builder, ParameterDef
 import pytest
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.dialects.builtin import StringAttr
 
 
 @irdl_attr_definition
@@ -168,21 +167,21 @@ def builder_union_arg_bad_argument():
 class A(ParametrizedAttribute):
     name = "A"
 
-    data: ParameterDef[StringAttr]
+    data: ParameterDef[NoBuilderAttr]
 
 
 @irdl_attr_definition
 class B(A):
     name = "B"
 
-    dataB: ParameterDef[StringAttr]
+    dataB: ParameterDef[NoBuilderAttr]
 
 
 def test_inheriting_attr():
-    A([StringAttr.from_str("x")])
-    B([StringAttr.from_str("x"), StringAttr.from_str("y")])
+    A([NoBuilderAttr()])
+    B([NoBuilderAttr(), NoBuilderAttr()])
     try:
-        B([StringAttr.from_str("x")])
+        B([NoBuilderAttr()])
     except Exception as e:
         return
     assert False


### PR DESCRIPTION
This PR allows better handling of inheritance with `irdl_attr_defintion`. Notice that the `irdl_attr_definition` decorator would add an irdl specific verify function to check that i.e. the same number of parameters are present as required, while also taking custom verifies into account. This leads to the following issue:

```python
@irdl_attr_definition
class A(ParametrizedAttribute):
    name = "A"

    data: ParameterDef[StringAttr]


@irdl_attr_definition
class B(A):
    name = "B"

    dataB: ParameterDef[StringAttr]
```

In this case, `B([StringAttr.from_str("x"), StringAttr.from_str("y")])` gives `1 parameter expected, got 2` form A's irdl verifier, whereas `B([StringAttr.from_str("x")])` would give `2 parameters expected, got 1` from B's irdl verifier. I argue that the former is what one wants in this case, so the parents verify function is now ignored.

Notice that this also holds for custom defined verifiers of the parent, which we might want to be executed. However, this will probably require us to rename one of the verify.