### PR TITLE
Irdl def classes

### DIFF
--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -12,7 +12,7 @@ from frozenlist import FrozenList
 if TYPE_CHECKING:
     from xdsl.parser import Parser
     from xdsl.printer import Printer
-    from xdsl.irdl import OpDef
+    from xdsl.irdl import OpDef, ParamAttrDef
 
 OpT = TypeVar('OpT', bound='Operation')
 
@@ -229,6 +229,12 @@ class ParametrizedAttribute(Attribute):
     """An attribute parametrized by other attributes."""
 
     parameters: list[Attribute] = field(default_factory=list)
+
+    @classmethod
+    @property
+    def irdl_definition(cls) -> ParamAttrDef:
+        """Get the IRDL operation definition."""
+        ...
 
 
 @dataclass

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -468,8 +468,9 @@ class Operation:
     def __hash__(self) -> int:
         return id(self)
 
+    @classmethod
     @property
-    def get_definition(self) -> OpDef:
+    def irdl_definition(cls) -> OpDef:
         """Get the IRDL operation definition."""
         ...
 

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -233,7 +233,7 @@ class ParametrizedAttribute(Attribute):
     @classmethod
     @property
     def irdl_definition(cls) -> ParamAttrDef:
-        """Get the IRDL operation definition."""
+        """Get the IRDL attribute definition."""
         ...
 
 

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -12,6 +12,7 @@ from frozenlist import FrozenList
 if TYPE_CHECKING:
     from xdsl.parser import Parser
     from xdsl.printer import Printer
+    from xdsl.irdl import OpDef
 
 OpT = TypeVar('OpT', bound='Operation')
 
@@ -466,6 +467,11 @@ class Operation:
 
     def __hash__(self) -> int:
         return id(self)
+
+    @property
+    def get_definition(self) -> OpDef:
+        """Get the IRDL operation definition."""
+        ...
 
 
 @dataclass(eq=False)

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -417,8 +417,6 @@ class AttributeDef:
     constr: AttrConstraint
     """The attribute constraint."""
 
-    data: Any
-
     def __init__(self, typ: Attribute | type[Attribute] | AttrConstraint):
         self.constr = attr_constr_coercion(typ)
 

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -856,7 +856,10 @@ class GenericData(Data[_DataElement], ABC):
         """
 
 
-def irdl_data_verify(data: Data, typ: type) -> None:
+_DT = TypeVar("_DT")
+
+
+def irdl_data_verify(data: Data[_DT], typ: Type[_DT]) -> None:
     """Check that the Data has the expected type."""
     if isinstance(data.data, typ):
         return
@@ -869,7 +872,7 @@ T = TypeVar('T')
 
 
 def irdl_data_definition(cls: type[T]) -> type[T]:
-    new_attrs = dict()
+    new_attrs = dict[str, Any]()
 
     # Build method is added for all definitions.
     if "build" in cls.__dict__:

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -826,7 +826,7 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
                                successors, regions)
 
     new_attrs["build"] = classmethod(builder)
-    new_attrs["get_definition"] = property(lambda self: op_def)
+    new_attrs["irdl_definition"] = classmethod(property(lambda cls: op_def))
 
     return type(cls.__name__, cls.__mro__, {**cls.__dict__, **new_attrs})
 

--- a/tests/attribute_definition_test.py
+++ b/tests/attribute_definition_test.py
@@ -5,7 +5,7 @@ Test the definition of attributes and their constraints.
 from __future__ import annotations
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any, List, TypeVar, cast, Annotated, Generic, TypeAlias
+from typing import Any, TypeVar, cast, Annotated, Generic, TypeAlias
 
 import pytest
 

--- a/tests/attribute_definition_test.py
+++ b/tests/attribute_definition_test.py
@@ -12,7 +12,8 @@ import pytest
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.irdl import (AttrConstraint, GenericData, ParameterDef,
                        VerifyException, irdl_attr_definition, builder,
-                       irdl_to_attr_constraint)
+                       irdl_to_attr_constraint, AnyAttr, BaseAttr,
+                       ParamAttrDef)
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 
@@ -588,3 +589,27 @@ def test_generic_data_no_generics_wrapper_verifier():
     p.print_attribute(attr)
     assert stream.getvalue(
     ) == "!list_no_generics_wrapper<!list<[!bool<True>, !list<[!bool<False>]>]>>"
+
+
+#  ____                              _   _   _        ____        __
+# |  _ \ __ _ _ __ __ _ _ __ ___    / \ | |_| |_ _ __|  _ \  ___ / _|
+# | |_) / _` | '__/ _` | '_ ` _ \  / _ \| __| __| '__| | | |/ _ \ |_
+# |  __/ (_| | | | (_| | | | | | |/ ___ \ |_| |_| |  | |_| |  __/  _|
+# |_|   \__,_|_|  \__,_|_| |_| |_/_/   \_\__|\__|_|  |____/ \___|_|
+#
+
+
+@irdl_attr_definition
+class ParamAttrDefAttr(ParametrizedAttribute):
+    name = "test.param_attr_def_attr"
+
+    arg1: ParameterDef[Attribute]
+    arg2: ParameterDef[BoolData]
+
+
+def test_irdl_definition():
+    """Test that we can get the IRDL definition of a parametrized attribute."""
+
+    assert ParamAttrDefAttr.irdl_definition == ParamAttrDef(
+        "test.param_attr_def_attr", [("arg1", AnyAttr()),
+                                     ("arg2", BaseAttr(BoolData))])

--- a/tests/filecheck/cf_ops.xdsl
+++ b/tests/filecheck/cf_ops.xdsl
@@ -34,7 +34,7 @@ module() {
   ^4(%c : !i1, %a: !i32):
     cf.br(%c : !i1, %a : !i32)(^5)
   ^5(%cond : !i1, %arg: !i32):
-    cf.cond_br(%cond: !i1, %cond: !i1, %arg : !i32, %arg : !i32, %arg : !i32, %arg : !i32)(^5, ^6) ["operand_segment_sizes" = !dense<!vector<[3 : !i64], !i32>, [1 : !i32, 2 : !i32, 3 : !i32]>]
+    cf.cond_br(%cond: !i1, %cond: !i1, %arg : !i32, %arg : !i32, %arg : !i32, %arg : !i32)(^5, ^6) ["operand_segment_sizes" = !dense<!vector<[2 : !i64], !i32>, [2 : !i32, 3 : !i32]>]
   ^6(%24 : !i32, %25 : !i32, %26 : !i32):
     func.return(%24 : !i32)
   }
@@ -43,7 +43,7 @@ module() {
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : !i1, %{{.*}} : !i32):
   // CHECK-NEXT:   cf.br(%{{.*}} : !i1, %{{.*}} : !i32) (^{{.*}})
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : !i1, %{{.*}} : !i32):
-  // CHECK-NEXT:   cf.cond_br(%{{.*}} : !i1, %{{.*}} : !i1, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32) (^{{.*}}, ^{{.*}}) ["operand_segment_sizes" = !dense<!vector<[3 : !i64], !i32>, [1 : !i32, 2 : !i32, 3 : !i32]>]
+  // CHECK-NEXT:   cf.cond_br(%{{.*}} : !i1, %{{.*}} : !i1, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32) (^{{.*}}, ^{{.*}}) ["operand_segment_sizes" = !dense<!vector<[2 : !i64], !i32>, [2 : !i32, 3 : !i32]>]
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32):
   // CHECK-NEXT:   func.return(%{{.*}} : !i32)
   // CHECK-NEXT: }

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -123,11 +123,11 @@ def test_var_mixed_builder():
         StringAttr.from_int(4)
     ]
 
-    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [3])
+    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [2])
 
     assert op.attributes[AttrSizedResultSegments.
                          attribute_name] == DenseIntOrFPElementsAttr.from_list(
-                             dense_type, [2, 1, 2])
+                             dense_type, [2, 2])
 
 
 @irdl_op_definition

--- a/tests/operation_definition_test.py
+++ b/tests/operation_definition_test.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from xdsl.ir import Operation
+from xdsl.irdl import (irdl_op_definition, OperandDef, ResultDef, AttributeDef,
+                       RegionDef, AnyAttr, OpDef)
+
+#  ___ ____  ____  _     ____        __
+# |_ _|  _ \|  _ \| |   |  _ \  ___ / _|
+#  | || |_) | | | | |   | | | |/ _ \ |_
+#  | ||  _ <| |_| | |___| |_| |  __/  _|
+# |___|_| \_\____/|_____|____/ \___|_|
+#
+
+
+@irdl_op_definition
+class OpDefTestOp(Operation):
+    name = "test.op_def_test"
+
+    operand = OperandDef(AnyAttr())
+    result = ResultDef(AnyAttr())
+    attr = AttributeDef(AnyAttr())
+    region = RegionDef()
+
+
+def test_get_definition():
+    """Test retrieval of an IRDL definition from an operation"""
+    assert OpDefTestOp.irdl_definition == OpDef(
+        "test.op_def_test",
+        operands=[("operand", OperandDef(AnyAttr()))],
+        results=[("result", ResultDef(AnyAttr()))],
+        attributes={"attr": AttributeDef(AnyAttr())},
+        regions=[("region", RegionDef())])


### PR DESCRIPTION
Add accessors to IRDL definitions from operations and attributes. At the same time, do an overall cleaning of the `irdl.py` file.

Also fix a "bug" in IRDL where `operand_segment_sizes` was including the size of non-variadic ones.

Overall, this should allow us to more easily get the IRDL definitions of dialects, which is necessary to translate our python IRDL to MLIR IRDL.