### PR TITLE
NFC: Some fixes on types and naming

### DIFF
--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -113,7 +113,7 @@ class IntegerType(ParametrizedAttribute):
 
     @staticmethod
     @builder
-    def from_width(width: int) -> Attribute:
+    def from_width(width: int) -> IntegerType:
         return IntegerType([IntAttr.from_int(width)])
 
 

--- a/src/xdsl/xdsl_opt_main.py
+++ b/src/xdsl/xdsl_opt_main.py
@@ -41,7 +41,7 @@ class xDSLOptMain:
     stream.
     """
 
-    pipeline: List[Tuple[str, Callable[[ModuleOp], None]]]
+    pipeline: List[tuple[str, Callable[[ModuleOp], None]]]
     """ The pass-pipeline to be applied. """
 
     def __init__(self, description='xDSL modular optimizer driver'):

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -112,7 +112,7 @@ class MixedResultOp(Operation):
     irdl_options = [AttrSizedResultSegments()]
 
 
-def test_two_var_result_builder():
+def test_var_mixed_builder():
     op = MixedResultOp.build(result_types=[[0, 1], 2, [3, 4]])
     op.verify()
     assert [res.typ for res in op.results] == [


### PR DESCRIPTION
This fix two types error, and also fix an error where two functions had the same names.