### PR TITLE
Refactor IRDL variadic lists, and add variadic regions

### DIFF
--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -152,8 +152,8 @@ class ParamAttrConstraint(AttrConstraint):
     """The attribute parameter constraints"""
 
     def __init__(self, base_attr: type[Attribute],
-                 param_constrs: list[(Attribute | type[Attribute]
-                                      | AttrConstraint)]):
+                 param_constrs: Sequence[(Attribute | type[Attribute]
+                                          | AttrConstraint)]):
         self.base_attr = base_attr
         self.param_constrs = [
             attr_constr_coercion(constr) for constr in param_constrs
@@ -551,8 +551,8 @@ def get_attr_size_option(
 
 
 def get_variadic_sizes_from_attr(op: Operation,
-                                 defs: list[tuple[str,
-                                                  OperandDef | ResultDef]],
+                                 defs: Sequence[tuple[str,
+                                                      OperandDef | ResultDef]],
                                  arg_typ: ArgType,
                                  size_attribute_name: str) -> list[int]:
     """

--- a/src/xdsl/irdl.py
+++ b/src/xdsl/irdl.py
@@ -495,15 +495,16 @@ class ArgType(Enum):
     RESULT = 2
     REGION = 3
 
-    def get_name(self) -> str:
-        """Get the type name, this is used mostly for error messages."""
-        if self == self.OPERAND:
-            return "operand"
-        if self == self.RESULT:
-            return "result"
-        if self == self.REGION:
-            return "region"
-        assert False, "Unknown ArgType value"
+
+def get_arg_name(arg_type: ArgType) -> str:
+    """Get the type name, this is used mostly for error messages."""
+    if arg_type == ArgType.OPERAND:
+        return "operand"
+    if arg_type == ArgType.RESULT:
+        return "result"
+    if arg_type == ArgType.REGION:
+        return "region"
+    assert False, "Unknown ArgType value"
 
 
 def get_arg_defs(
@@ -583,13 +584,14 @@ def get_variadic_sizes_from_attr(op: Operation,
     for ((arg_name, arg_def), arg_size) in zip(defs, def_sizes):
         if isinstance(arg_def, OptionalDef) and arg_size > 1:
             raise VerifyException(
-                f"optional {arg_typ.get_name} {arg_name} is expected to be of "
-                f"size 0 or 1 in {size_attribute_name}, but got {arg_size}")
+                f"optional {get_arg_name(arg_typ)} {arg_name} is expected to "
+                f"be of size 0 or 1 in {size_attribute_name}, but got "
+                f"{arg_size}")
 
         if not isinstance(arg_def, VariadicDef) and arg_size != 1:
             raise VerifyException(
-                f"non-variadic {arg_typ.get_name} {arg_name} is expected to "
-                f"be of size 0 or 1 in {size_attribute_name}, but got "
+                f"non-variadic {get_arg_name(arg_typ)} {arg_name} is expected "
+                f"to be of size 0 or 1 in {size_attribute_name}, but got "
                 f"{arg_size}")
 
         if isinstance(arg_def, VariadicDef):
@@ -604,7 +606,7 @@ def get_variadic_sizes(op: Operation, op_def: OpDef,
 
     defs = get_arg_defs(op_def, typ)
     args = get_op_args(op, typ)
-    def_type_name = typ.get_name()
+    def_type_name = get_arg_name(typ)
     attribute_option = get_attr_size_option(typ)
 
     variadic_defs = [(arg_name, arg_def) for arg_name, arg_def in defs
@@ -695,9 +697,8 @@ def irdl_op_verify_arg_list(op: Operation, op_def: OpDef,
                 assert False, "Unknown ArgType value"
         except Exception as e:
             error(
-                op,
-                f"{arg_type.get_name()} at position {arg_idx} does not verify!\n{e}"
-            )
+                op, f"{get_arg_name(arg_type)} at position "
+                f"{arg_idx} does not verify!\n{e}")
 
     for def_idx, (_, arg_def) in enumerate(get_arg_defs(op_def, arg_type)):
         if isinstance(arg_def, VariadicDef):
@@ -760,7 +761,7 @@ def irdl_build_arg_list(arg_type: ArgType,
             assert False, "Unknown ArgType value"
 
     if len(args) != len(arg_defs):
-        raise ValueError(f"expected {len(arg_defs)} {arg_type.get_name()}, "
+        raise ValueError(f"expected {len(arg_defs)} {get_arg_name(arg_type)}, "
                          f"but got {len(args)}")
 
     res = list[Any]()
@@ -866,9 +867,9 @@ def irdl_op_arg_definition(new_attrs: dict[str, Any], arg_type: ArgType,
     arg_size_option = get_attr_size_option(arg_type)
     if previous_variadics > 1 and (arg_size_option is None
                                    or arg_size_option not in op_def.options):
-        raise Exception(
-            f"Operation defines more than two variadic {arg_type.get_name()}s, "
-            f"but do not define the {arg_size_option.__name__} PyRDL option.")
+        raise Exception("Operation defines more than two variadic "
+                        f"{get_arg_name(arg_type)}s, but do not define the "
+                        f"{arg_size_option.__name__} PyRDL option.")
 
 
 def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:

--- a/tests/filecheck/cf_ops.xdsl
+++ b/tests/filecheck/cf_ops.xdsl
@@ -34,7 +34,7 @@ module() {
   ^4(%c : !i1, %a: !i32):
     cf.br(%c : !i1, %a : !i32)(^5)
   ^5(%cond : !i1, %arg: !i32):
-    cf.cond_br(%cond: !i1, %cond: !i1, %arg : !i32, %arg : !i32, %arg : !i32, %arg : !i32)(^5, ^6) ["operand_segment_sizes" = !dense<!vector<[2 : !i64], !i32>, [2 : !i32, 3 : !i32]>]
+    cf.cond_br(%cond: !i1, %cond: !i1, %arg : !i32, %arg : !i32, %arg : !i32, %arg : !i32)(^5, ^6) ["operand_segment_sizes" = !dense<!vector<[3 : !i64], !i32>, [1 : !i32, 2 : !i32, 3 : !i32]>]
   ^6(%24 : !i32, %25 : !i32, %26 : !i32):
     func.return(%24 : !i32)
   }
@@ -43,7 +43,7 @@ module() {
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : !i1, %{{.*}} : !i32):
   // CHECK-NEXT:   cf.br(%{{.*}} : !i1, %{{.*}} : !i32) (^{{.*}})
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : !i1, %{{.*}} : !i32):
-  // CHECK-NEXT:   cf.cond_br(%{{.*}} : !i1, %{{.*}} : !i1, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32) (^{{.*}}, ^{{.*}}) ["operand_segment_sizes" = !dense<!vector<[2 : !i64], !i32>, [2 : !i32, 3 : !i32]>]
+  // CHECK-NEXT:   cf.cond_br(%{{.*}} : !i1, %{{.*}} : !i1, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32) (^{{.*}}, ^{{.*}}) ["operand_segment_sizes" = !dense<!vector<[3 : !i64], !i32>, [1 : !i32, 2 : !i32, 3 : !i32]>]
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : !i32, %{{.*}} : !i32, %{{.*}} : !i32):
   // CHECK-NEXT:   func.return(%{{.*}} : !i32)
   // CHECK-NEXT: }

--- a/tests/operation_builder_test.py
+++ b/tests/operation_builder_test.py
@@ -125,11 +125,11 @@ def test_var_mixed_builder():
         StringAttr.from_int(4)
     ]
 
-    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [2])
+    dense_type = VectorType.from_type_and_list(IntegerType.from_width(32), [3])
 
     assert op.attributes[AttrSizedResultSegments.
                          attribute_name] == DenseIntOrFPElementsAttr.from_list(
-                             dense_type, [2, 2])
+                             dense_type, [2, 1, 2])
 
 
 @irdl_op_definition

--- a/tests/pattern_rewriter_test.py
+++ b/tests/pattern_rewriter_test.py
@@ -526,7 +526,7 @@ def test_block_argument_type_change():
 scf.if(%0 : !i1) {
 ^0(%1 : !i32):
   %2 : !i32 = arith.addi(%1 : !i32, %1 : !i32)
-}
+} {}
 }"""
 
     expected = \
@@ -535,7 +535,7 @@ scf.if(%0 : !i1) {
   scf.if(%0 : !i1) {
   ^0(%1 : !i64):
     %2 : !i32 = arith.addi(%1 : !i64, %1 : !i64)
-  }
+  } {}
 }"""
 
     @op_type_rewrite_pattern
@@ -557,13 +557,13 @@ def test_block_argument_erasure():
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
 ^0(%1 : !i32):
-}
+} {}
 }"""
 
     expected = \
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
-  scf.if(%0 : !i1) {}
+  scf.if(%0 : !i1) {} {}
 }"""
 
     @op_type_rewrite_pattern
@@ -582,7 +582,7 @@ def test_block_argument_insertion():
     prog = \
     """module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
-scf.if(%0 : !i1) {}
+scf.if(%0 : !i1) {} {}
 }"""
 
     expected = \
@@ -590,7 +590,7 @@ scf.if(%0 : !i1) {}
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
   ^0(%1 : !i32):
-  }
+  } {}
 }"""
 
     @op_type_rewrite_pattern
@@ -612,8 +612,8 @@ def test_inline_block_at_pos():
 scf.if(%0 : !i1) {
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-  }
-}
+  } {}
+} {}
 }"""
 
     expected = \
@@ -621,8 +621,8 @@ scf.if(%0 : !i1) {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-    scf.if(%0 : !i1) {}
-  }
+    scf.if(%0 : !i1) {} {}
+  } {}
 }"""
 
     @op_type_rewrite_pattern
@@ -647,14 +647,14 @@ def test_inline_block_before_matched_op():
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-}
+} {}
 }"""
 
     expected = \
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-  scf.if(%0 : !i1) {}
+  scf.if(%0 : !i1) {} {}
 }"""
 
     @op_type_rewrite_pattern
@@ -676,8 +676,8 @@ def test_inline_block_before():
 scf.if(%0 : !i1) {
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-  }
-}
+  } {}
+} {}
 }"""
 
     expected = \
@@ -685,8 +685,8 @@ scf.if(%0 : !i1) {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-    scf.if(%0 : !i1) {}
-  }
+    scf.if(%0 : !i1) {} {}
+  } {}
 }"""
 
     @op_type_rewrite_pattern
@@ -712,14 +712,14 @@ def test_inline_block_at_before_when_op_is_matched_op():
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-}
+} {}
 }"""
 
     expected = \
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-  scf.if(%0 : !i1) {}
+  scf.if(%0 : !i1) {} {}
 }"""
 
     @op_type_rewrite_pattern
@@ -741,17 +741,17 @@ def test_inline_block_after():
   scf.if(%0 : !i1) {
     scf.if(%0 : !i1) {
       %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-    }
-  }
+    } {}
+  } {}
 }"""
 
     expected = \
 """module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
-    scf.if(%0 : !i1) {}
+    scf.if(%0 : !i1) {} {}
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-  }
+  } {}
 }"""
 
     @op_type_rewrite_pattern


### PR DESCRIPTION
Since operands and results can all have optional/variadic definitions, we should not duplicate the same code everywhere.
This also adds optional and variadic regions, which are a useful concept as well (mostly optional regions).