### PR TITLE
Unit Attribute Handling

### DIFF
--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -131,6 +131,11 @@ i1 = IntegerType.from_width(1)
 
 
 @irdl_attr_definition
+class UnitAttr(ParametrizedAttribute):
+    name = "unit"
+
+
+@irdl_attr_definition
 class IndexType(ParametrizedAttribute):
     name = "index"
 

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -110,7 +110,6 @@ class MLIRConverter:
             return mlir.ir.StringAttr.get(attr.parameters[0].data)
         try:
             return mlir.ir.TypeAttr.get(self.convert_type(attr))
-
         except Exception:
             raise Exception(
                 f"Unsupported attribute for mlir conversion: {attr}")

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -10,7 +10,7 @@ from xdsl.dialects.builtin import (DenseIntOrFPElementsAttr, IntegerAttr,
                                    VectorType, IntegerType, IndexType,
                                    ArrayAttr, FlatSymbolRefAttr, StringAttr,
                                    FunctionType, TupleType, ModuleOp,
-                                   Float32Type, SymbolNameAttr)
+                                   Float32Type, SymbolNameAttr, UnitAttr)
 from xdsl.dialects.memref import MemRefType
 from xdsl.dialects.llvm import LLVMStructType
 from typing import Dict
@@ -103,11 +103,14 @@ class MLIRConverter:
             )
         if isinstance(attr, FlatSymbolRefAttr):
             return mlir.ir.FlatSymbolRefAttr.get(attr.parameters[0].data)
+        if isinstance(attr, UnitAttr):
+            return mlir.ir.UnitAttr.get()
         # SymbolNameAttrs are in fact just StringAttrs
         if isinstance(attr, SymbolNameAttr):
             return mlir.ir.StringAttr.get(attr.parameters[0].data)
         try:
             return mlir.ir.TypeAttr.get(self.convert_type(attr))
+
         except Exception:
             raise Exception(
                 f"Unsupported attribute for mlir conversion: {attr}")
@@ -116,8 +119,7 @@ class MLIRConverter:
         result_types = [self.convert_type(result.typ) for result in op.results]
         operands = [self.convert_value(operand) for operand in op.operands]
         attributes = {
-            name:
-            self.convert_attribute(attr) if attr else mlir.ir.UnitAttr.get()
+            name: self.convert_attribute(attr)
             for name, attr in op.attributes.items()
         }
 

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -116,7 +116,8 @@ class MLIRConverter:
         result_types = [self.convert_type(result.typ) for result in op.results]
         operands = [self.convert_value(operand) for operand in op.operands]
         attributes = {
-            name: self.convert_attribute(attr)
+            name:
+            self.convert_attribute(attr) if attr else mlir.ir.UnitAttr.get()
             for name, attr in op.attributes.items()
         }
 

--- a/src/xdsl/parser.py
+++ b/src/xdsl/parser.py
@@ -3,7 +3,7 @@ from xdsl.ir import (SSAValue, Block, Callable, Attribute, Operation, Region,
                      BlockArgument, MLContext)
 from xdsl.dialects.builtin import (Float32Type, FloatAttr, IntegerType,
                                    StringAttr, FlatSymbolRefAttr, IntegerAttr,
-                                   ArrayAttr)
+                                   ArrayAttr, UnitAttr)
 from xdsl.irdl import Data
 from dataclasses import dataclass, field
 from typing import Any, TypeVar
@@ -596,6 +596,8 @@ class Parser:
             skip_white_space=skip_white_space)
         if attr_name is None:
             return None
+        if not self.peek_char("="):
+            return attr_name, UnitAttr([])
         self.parse_char("=")
         attr = self.parse_attribute()
         return attr_name, attr

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -309,9 +309,9 @@ class Printer:
 
     def _print_attr_string(self, attr_tuple: tuple[str, Attribute]) -> None:
         if isinstance(attr_tuple[1], UnitAttr):
-            self.print("\"%s\"" % attr_tuple[0])
+            self.print(f"\"{attr_tuple[0]}\"")
         else:
-            self.print("\"%s\" = " % attr_tuple[0])
+            self.print(f"\"{attr_tuple[0]}\" = ")
             self.print_attribute(attr_tuple[1])
 
     def _print_op_attributes(self, attributes: Dict[str, Attribute]) -> None:

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -246,6 +246,10 @@ class Printer:
         self.print(")")
 
     def print_attribute(self, attribute: Attribute) -> None:
+        if attribute is None:
+            self.print('None')
+            return
+
         if isinstance(attribute, IntegerType):
             width = attribute.parameters[0]
             assert isinstance(width, IntAttr)

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -307,15 +307,12 @@ class Printer:
         self.print_list(successors, self.print_block_name)
         self.print(")")
 
-    def _print_attr_string(self, name: str, attr: Attribute,
-                           first: bool) -> None:
-        if not first:
-            self.print(", ")
-        if isinstance(attr, UnitAttr):
-            self.print("\"%s\"" % name)
+    def _print_attr_string(self, attr_tuple: tuple[str, Attribute]) -> None:
+        if isinstance(attr_tuple[1], UnitAttr):
+            self.print("\"%s\"" % attr_tuple[0])
         else:
-            self.print("\"%s\" = " % name)
-            self.print_attribute(attr)
+            self.print("\"%s\" = " % attr_tuple[0])
+            self.print_attribute(attr_tuple[1])
 
     def _print_op_attributes(self, attributes: Dict[str, Attribute]) -> None:
         if len(attributes) == 0:
@@ -325,10 +322,8 @@ class Printer:
         self.print("[")
 
         attribute_list = [p for p in attributes.items()]
-        self._print_attr_string(attribute_list[0][0], attribute_list[0][1],
-                                True)
-        for (attr_name, attr) in attribute_list[1:]:
-            self._print_attr_string(attr_name, attr, False)
+        self.print_list(attribute_list, self._print_attr_string)
+
         self.print("]")
 
     def print_op_with_default_format(self, op: Operation) -> None:

--- a/tests/mlir_converter_test.py
+++ b/tests/mlir_converter_test.py
@@ -2,13 +2,14 @@ import pytest
 
 docutils = pytest.importorskip("mlir")
 
-from xdsl.mlir_converter import MLContext, Builtin, MLIRConverter, mlir
+from xdsl.mlir_converter import MLIRConverter, mlir
 from xdsl.dialects.scf import Scf
 from xdsl.dialects.func import Func
 from xdsl.dialects.memref import MemRef
 from xdsl.dialects.affine import Affine
 from xdsl.dialects.arith import Arith
 from xdsl.parser import Parser
+from xdsl.dialects.builtin import Builtin, MLContext
 
 
 def convert_and_verify(test_prog: str):
@@ -112,6 +113,20 @@ module() {
     %9 : !i32 = memref.load(%5 : !memref<[1 : !index], !i32>, %8 : !index)
     %10 : !i32 = arith.addi(%7 : !i32, %9 : !i32)
     func.return(%10 : !i32)
+  }
+}
+    """
+    convert_and_verify(test_prog)
+
+
+def test_unit_attr_conversion():
+    test_prog = """
+module() {
+  func.func() ["sym_name" = "test", "function_type" = !fun<[], []>, "sym_visibility" = "private", "llvm.emit_c_interface"]
+  {
+    %1 : !memref<[1 : !i64], !i32> = memref.alloca() ["alignment" = 0 : !i64, "operand_segment_sizes" = !dense<!vector<[2 : !i64], !i32>, [0 : !i32, 0 : !i32]>]
+
+    func.return()
   }
 }
     """

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from io import StringIO
 
-from xdsl.dialects.builtin import Builtin, ModuleOp, IntegerType
+from xdsl.dialects.builtin import Builtin, ModuleOp, IntegerType, UnitAttr
 from xdsl.dialects.arith import Arith, Addi, Constant
 from xdsl.diagnostic import Diagnostic
 from xdsl.ir import MLContext
-from xdsl.irdl import irdl_op_definition, Operation, OperandDef, ResultDef
+from xdsl.irdl import irdl_op_definition, Operation, OperandDef, ResultDef, OptAttributeDef
 from xdsl.printer import Printer
 from xdsl.parser import Parser
 
@@ -68,6 +68,48 @@ module() {
     printer = Printer(stream=file)
     printer.print_op(mod)
 
+    assert file.getvalue().strip() == expected.strip()
+
+
+@irdl_op_definition
+class UnitAttrOp(Operation):
+    name = "unit_attr_op"
+
+    parallelize = OptAttributeDef(UnitAttr)
+
+
+def test_unit_attr():
+    """Test that a UnitAttr can be defined and printed"""
+
+    expected = \
+"""
+unit_attr_op() ["parallelize"]
+"""
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+
+    unit_op = UnitAttrOp.build(attributes={"parallelize": UnitAttr([])})
+
+    printer.print_op(unit_op)
+    assert file.getvalue().strip() == expected.strip()
+
+
+def test_added_unit_attr():
+    """Test that a UnitAttr can be added to an op, even if its not defined as a field."""
+
+    expected = \
+"""
+unit_attr_op() ["parallelize", "vectorize"]
+"""
+    file = StringIO("")
+    printer = Printer(stream=file)
+    unitop = UnitAttrOp.build(attributes={
+        "parallelize": UnitAttr([]),
+        "vectorize": UnitAttr([])
+    })
+
+    printer.print_op(unitop)
     assert file.getvalue().strip() == expected.strip()
 
 


### PR DESCRIPTION
This PR concerns UnitAttrs and how to handle them as I need it to add a `llvm.emit_c_interface` to a function operation.

Currently, this is primarily a hack that I used to get UnitAttrs through the MLIRConverter, but I think this nicely opens the can of worms that is design decisions around UnitAttrs. 

The approach of this PR is an implicit one. Anything that maps a str to `None` is just a UnitAttr with that name.

Obviously, this does not add any functionality to `AttributeDef` and just hacks around in the attributes dictionary currently. However, I feel that this might not be too bad, at least not the spirit of it. In my understanding, UnitAttrs are not really something you want to define in an AttributeDef (unless it is as part of an OptAttr), but rather information you want to pass down by just adding some attribute.

On the user-side I have this code:

```python
f = FuncOp.from_region("main", batches, [],
                         Region.from_block_list([body_block]))
f.attributes['llvm.emit_c_interface'] = None
```