### PR TITLE
Rename module to builtin.module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog 
+
+All changes should be documented in this file.
+
+## [Unreleased]
+### Added
+- Changelog file
+### Changed
+- Rename `module` to `builtin.module`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog 
-
-All changes should be documented in this file.
-
-## [Unreleased]
-### Added
-- Changelog file
-### Changed
-- Rename `module` to `builtin.module`

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -480,7 +480,7 @@ class FunctionType(ParametrizedAttribute):
 
 @irdl_op_definition
 class ModuleOp(Operation):
-    name: str = "module"
+    name: str = "builtin.module"
 
     body = SingleBlockRegionDef()
 

--- a/tests/filecheck/affine_ops.xdsl
+++ b/tests/filecheck/affine_ops.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
 
   func.func() ["sym_name" = "sum_vec", "function_type" = !fun<[!memref<[128 : !index], !i32>], [!i32]>, "sym_visibility" = "private"] {
   ^10(%ref : !memref<[128 : !index], !i32>):

--- a/tests/filecheck/arith_invalid.xdsl
+++ b/tests/filecheck/arith_invalid.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
-module () {
+builtin.module () {
     
   func.func() ["sym_name" = "wrong_types", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
     %0 : !i32 = arith.constant() ["value" = 32 : !i32]

--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
   func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"]{
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.constant() ["value" = 42 : !i32]

--- a/tests/filecheck/cf_ops.xdsl
+++ b/tests/filecheck/cf_ops.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
   
   func.func() ["sym_name" = "unconditional_br", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
     ^0:

--- a/tests/filecheck/cmath.xdsl
+++ b/tests/filecheck/cmath.xdsl
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 
-module() {
+builtin.module() {
 
     // CHECK: irdl.dialect() ["dialect_name" = "cmath"] {
     irdl.dialect() ["dialect_name" = "cmath"] {

--- a/tests/filecheck/cmath_ops.xdsl
+++ b/tests/filecheck/cmath_ops.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
 
     func.func() ["sym_name" = "conorm", "function_type" = !fun<[!cmath.complex<!f32>, !cmath.complex<!f32>], [!f32]>, "sym_visibility" = "private"] {
       ^0(%p: !cmath.complex<!f32>, %q: !cmath.complex<!f32>):

--- a/tests/filecheck/func_ops.xdsl
+++ b/tests/filecheck/func_ops.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
   
   func.func() ["sym_name" = "noarg_void", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
     func.return()

--- a/tests/filecheck/irdl-printer/any_and_base_type.xdsl
+++ b/tests/filecheck/irdl-printer/any_and_base_type.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s -t irdl | filecheck %s
 
-module() {
+builtin.module() {
 
     irdl.dialect() ["dialect_name" = "test_any_dyn"] {
         

--- a/tests/filecheck/irdl-printer/cmath_program.xdsl
+++ b/tests/filecheck/irdl-printer/cmath_program.xdsl
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s -t irdl | filecheck %s
 
 
-module() {
+builtin.module() {
 
     irdl.dialect() ["dialect_name" = "cmath"] {
 

--- a/tests/filecheck/irdl_any_and_base_type.xdsl
+++ b/tests/filecheck/irdl_any_and_base_type.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
 
     //CHECK: irdl.dialect() ["dialect_name" = "test_any_dyn"] {
     irdl.dialect() ["dialect_name" = "test_any_dyn"] {

--- a/tests/filecheck/memref_ops.xdsl
+++ b/tests/filecheck/memref_ops.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
   
   memref.global() ["sym_name" = "g", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !i64], !index>, [0 : !index]>, "sym_visibility" = "public"]
 

--- a/tests/filecheck/mlir-conversion/llvm_test.xdsl
+++ b/tests/filecheck/mlir-conversion/llvm_test.xdsl
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt -t mlir %s | filecheck %s
 
 
-module() {
+builtin.module() {
   // Type tests
   func.func() ["sym_name" = "struct_to_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
   // CHECK: func private @struct_to_struct(%arg0: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {

--- a/tests/filecheck/mlir-conversion/ops.xdsl
+++ b/tests/filecheck/mlir-conversion/ops.xdsl
@@ -3,7 +3,7 @@
 // Tests if the non generic form can be printed.
 
 // CHECK: module {
-module() {
+builtin.module() {
   func.func() ["sym_name" = "simple_ops", "function_type" = !fun<[], []>, "sym_visibility" = "private"]{
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.constant() ["value" = 42 : !i32]

--- a/tests/filecheck/parser-printer/builtin_types.xdsl
+++ b/tests/filecheck/parser-printer/builtin_types.xdsl
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 
-module() {
+builtin.module() {
   func.func() ["sym_name" = "tuple_to_tuple", "function_type" = !fun<[!tuple<[!i32]>], [!tuple<[!i32]>]>, "sym_visibility" = "private"] {
     ^0(%0 : !tuple<[!i32]>):
       func.return(%0 : !tuple<[!i32]>)

--- a/tests/filecheck/parser-printer/escaped_characters.xdsl
+++ b/tests/filecheck/parser-printer/escaped_characters.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
   func.func() ["sym_name" = "\"", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {}
   func.func() ["sym_name" = "\n", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {}
   func.func() ["sym_name" = "\t", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {}

--- a/tests/filecheck/parser-printer/float_parsing.xdsl
+++ b/tests/filecheck/parser-printer/float_parsing.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
   func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"]{
     %0 : !f32 = arith.constant() ["value" = 42.0 : !f32]
     // CHECK: %{{.*}} : !f32 = arith.constant() ["value" = 42.0 : !f32]

--- a/tests/filecheck/parser-printer/region_name_clash.xdsl
+++ b/tests/filecheck/parser-printer/region_name_clash.xdsl
@@ -2,9 +2,9 @@
 
 // Check that SSA values and blocks can reuse names across regions
 
-module() {
+builtin.module() {
 
-// CHECK: module() {
+// CHECK: builtin.module() {
 
   // Two functions that share a basic block name and a value name
   func.func() ["sym_name" = "id", "function_type" = !fun<[!i32], [!i32]>, "sym_visibility" = "private"] {

--- a/tests/filecheck/scf_ops.xdsl
+++ b/tests/filecheck/scf_ops.xdsl
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
-module() {
+builtin.module() {
   func.func() ["sym_name" = "if", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
     %0 : !i1 = arith.constant() ["value" = 1 : !i1]
     scf.if(%0 : !i1) 

--- a/tests/mlir_converter_test.py
+++ b/tests/mlir_converter_test.py
@@ -36,7 +36,7 @@ def convert_and_verify(test_prog: str):
 
 def test_func_conversion():
     test_prog = """
-module() {
+builtin.module() {
   func.func() ["sym_name" = "test", "function_type" = !fun<[], []>, "sym_visibility" = "private"]
   {
     func.return()
@@ -49,7 +49,7 @@ module() {
 
 def test_arith_conversion():
     test_prog = """
-module() {
+builtin.module() {
   func.func() ["sym_name" = "test", "function_type" = !fun<[!i32], [!i32]>, "sym_visibility" = "private"]{
   ^0(%arg : !i32):
     %0 : !i32 = arith.constant() ["value" = 0 : !i32]
@@ -63,7 +63,7 @@ module() {
 
 def test_scf_conversion():
     test_prog = """
-module() {
+builtin.module() {
   func.func() ["sym_name" = "test", "function_type" = !fun<[!i32], [!i32]>, "sym_visibility" = "private"]{
   ^0(%arg : !i32):
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
@@ -84,7 +84,7 @@ module() {
 
 def test_variadic_conversion():
     test_prog = """
-module() {
+builtin.module() {
   func.func() ["sym_name" = "test", "function_type" = !fun<[], []>, "sym_visibility" = "private"]
   {
     %1 : !memref<[1 : !i64], !i32> = memref.alloca() ["alignment" = 0 : !i64, "operand_segment_sizes" = !dense<!vector<[2 : !i64], !i32>, [0 : !i32, 0 : !i32]>]
@@ -98,7 +98,7 @@ module() {
 
 def test_memref_conversion():
     test_prog = """
-module() {
+builtin.module() {
   func.func() ["sym_name" = "sum", "function_type" = !fun<[!i32, !i32], [!i32]>, "sym_visibility" = "public"]{
   ^0(%0 : !i32, %1 : !i32):
     %2 : !index = arith.constant() ["value" = 0 : !index]
@@ -121,7 +121,7 @@ module() {
 
 def test_unit_attr_conversion():
     test_prog = """
-module() {
+builtin.module() {
   func.func() ["sym_name" = "test", "function_type" = !fun<[], []>, "sym_visibility" = "private", "llvm.emit_c_interface"]
   {
     %1 : !memref<[1 : !i64], !i32> = memref.alloca() ["alignment" = 0 : !i64, "operand_segment_sizes" = !dense<!vector<[2 : !i64], !i32>, [0 : !i32, 0 : !i32]>]

--- a/tests/pattern_rewriter_test.py
+++ b/tests/pattern_rewriter_test.py
@@ -34,13 +34,13 @@ def test_non_recursive_rewrite():
     """Test a simple non-recursive rewrite"""
 
     prog = \
-"""module() {
+"""builtin.module() {
 %0 : !i32 = arith.constant() ["value" = 42 : !i32]
 %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 43 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -61,13 +61,13 @@ def test_non_recursive_rewrite_reversed():
     """Test a simple non-recursive rewrite with reverse walk order."""
 
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i32 = arith.constant() ["value" = 42 : !i32]
 %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 43 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -90,13 +90,13 @@ def test_op_type_rewrite_pattern_method_decorator():
     """Test op_type_rewrite_pattern decorator on methods."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 43 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -116,13 +116,13 @@ def test_op_type_rewrite_pattern_static_decorator():
     """Test op_type_rewrite_pattern decorator on static functions."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 43 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -141,12 +141,12 @@ def test_recursive_rewriter():
     """Test recursive walks on operations created by rewrites."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 1 : !i64]
   %1 : !i32 = arith.constant() ["value" = 1 : !i64]
   %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
@@ -180,12 +180,12 @@ def test_recursive_rewriter_reversed():
     """Test recursive walks on operations created by rewrites, in reverse walk order."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 1 : !i64]
   %1 : !i32 = arith.constant() ["value" = 1 : !i64]
   %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
@@ -220,13 +220,13 @@ def test_greedy_rewrite_pattern_applier():
     """Test GreedyRewritePatternApplier."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 43 : !i32]
   %1 : !i32 = arith.muli(%0 : !i32, %0 : !i32)
 }"""
@@ -252,12 +252,12 @@ def test_insert_op_before_matched_op():
     """Test rewrites where operations are inserted before the matched operation."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
@@ -277,12 +277,12 @@ def test_insert_op_at_pos():
     """Test rewrites where operations are inserted with a given position."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
@@ -302,12 +302,12 @@ def test_insert_op_before():
     """Test rewrites where operations are inserted before a given operation."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
@@ -327,12 +327,12 @@ def test_insert_op_after():
     """Test rewrites where operations are inserted after a given operation."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
   %1 : !i32 = arith.constant() ["value" = 42 : !i32]
 }"""
@@ -352,12 +352,12 @@ def test_insert_op_after_matched_op():
     """Test rewrites where operations are inserted after a given operation."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
   %1 : !i32 = arith.constant() ["value" = 42 : !i32]
 }"""
@@ -377,12 +377,12 @@ def test_insert_op_after_matched_op_reversed():
     """Test rewrites where operations are inserted after a given operation."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
   %1 : !i32 = arith.constant() ["value" = 42 : !i32]
 }"""
@@ -403,12 +403,12 @@ def test_operation_deletion():
     """Test rewrites where SSA values are deleted."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {}"""
+"""builtin.module() {}"""
 
     @op_type_rewrite_pattern
     def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
@@ -426,13 +426,13 @@ def test_operation_deletion_reversed():
     """
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {}"""
+"""builtin.module() {}"""
 
     def match_and_rewrite(op: Operation, rewriter: PatternRewriter):
         if not isinstance(op, ModuleOp):
@@ -452,7 +452,7 @@ def test_operation_deletion_failure():
     arith = Arith(ctx)
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -477,13 +477,13 @@ def test_delete_inner_op():
     """Test rewrites where an operation inside a region of the matched op is deleted."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
 
     expected = \
-"""module() {}"""
+"""builtin.module() {}"""
 
     @op_type_rewrite_pattern
     def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
@@ -498,13 +498,13 @@ def test_replace_inner_op():
     """Test rewrites where an operation inside a region of the matched op is deleted."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
 }"""
 
@@ -521,7 +521,7 @@ def test_block_argument_type_change():
     """Test the modification of a block argument type."""
 
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
 ^0(%1 : !i32):
@@ -530,7 +530,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
   ^0(%1 : !i64):
@@ -553,7 +553,7 @@ def test_block_argument_erasure():
     """Test the erasure of a block argument."""
 
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
 ^0(%1 : !i32):
@@ -561,7 +561,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {} {}
 }"""
@@ -580,13 +580,13 @@ def test_block_argument_insertion():
     """Test the insertion of a block argument."""
 
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {} {}
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
   ^0(%1 : !i32):
@@ -607,7 +607,7 @@ def test_inline_block_at_pos():
     """Test the inlining of a block at a certain position."""
 
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   scf.if(%0 : !i1) {
@@ -617,7 +617,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -643,7 +643,7 @@ def test_inline_block_before_matched_op():
     """Test the inlining of a block before the matched operation."""
 
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -651,7 +651,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
   scf.if(%0 : !i1) {} {}
@@ -671,7 +671,7 @@ def test_inline_block_before():
     """Test the inlining of a block before an operation."""
 
     prog = \
-"""module() {
+"""builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   scf.if(%0 : !i1) {
@@ -681,7 +681,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -708,7 +708,7 @@ def test_inline_block_at_before_when_op_is_matched_op():
     """Test the inlining of a block before an operation, being the matched one."""
 
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -716,7 +716,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
   scf.if(%0 : !i1) {} {}
@@ -736,7 +736,7 @@ def test_inline_block_after():
     """Test the inlining of a block after an operation."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
     scf.if(%0 : !i1) {
@@ -746,7 +746,7 @@ def test_inline_block_after():
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
     scf.if(%0 : !i1) {} {}
@@ -773,7 +773,7 @@ def test_move_region_contents_to_new_regions():
     """Test moving a region outside of a region."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {
     %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -781,7 +781,7 @@ def test_move_region_contents_to_new_regions():
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   scf.if(%0 : !i1) {}
   scf.if(%0 : !i1) {

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -52,7 +52,7 @@ def test_forgotten_op_non_fail():
 
     expected = \
 """
-module() {
+builtin.module() {
   %0 : !i32 = arith.addi(%<UNKNOWN> : !i32, %<UNKNOWN> : !i32)
   -----------------------^^^^^^^^^^----------------------------------------------------------------
   | ERROR: SSAValue is not part of the IR, are you sure all operations are added before their uses?
@@ -125,14 +125,14 @@ unit_attr_op() ["parallelize", "vectorize"]
 def test_op_message():
     """Test that an operation message can be printed."""
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
     }"""
 
     expected = \
 """
-module() {
+builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Test message
@@ -159,13 +159,13 @@ module() {
 def test_two_different_op_messages():
     """Test that an operation message can be printed."""
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
     }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Test message 1
@@ -195,13 +195,13 @@ def test_two_different_op_messages():
 def test_two_same_op_messages():
     """Test that an operation message can be printed."""
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
     }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   ^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Test message 1
@@ -231,17 +231,17 @@ def test_two_same_op_messages():
 def test_op_message_with_region():
     """Test that an operation message can be printed on an operation with a region."""
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
     }"""
 
     expected = \
 """\
-module() {
-^^^^^^
+builtin.module() {
+^^^^^^^^^^^^^^
 | Test
-------
+--------------
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -267,17 +267,17 @@ def test_op_message_with_region_and_overflow():
     where the message is bigger than the operation.
     """
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
     }"""
 
     expected = \
 """\
-module() {
-^^^^^^--------
-| Test message
---------------
+builtin.module() {
+^^^^^^^^^^^^^^-----
+| Test long message
+-------------------
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -292,7 +292,7 @@ module() {
     file = StringIO("")
     diagnostic = Diagnostic()
     printer = Printer(stream=file, diagnostic=diagnostic)
-    diagnostic.add_message(module, "Test message")
+    diagnostic.add_message(module, "Test long message")
     printer.print_op(module)
     assert file.getvalue().strip() == expected.strip()
 
@@ -303,7 +303,7 @@ def test_diagnostic():
     where the message is bigger than the operation.
     """
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
     }"""
@@ -312,7 +312,7 @@ def test_diagnostic():
 """\
 Exception: test message
 
-module() {
+builtin.module() {
 ^^^^^^^^-------
 | Test message
 ---------------
@@ -348,14 +348,14 @@ def test_print_costum_name():
     Test that an SSAValue, that is a name and not a number, reserves that name
     """
     prog = \
-        """module() {
+        """builtin.module() {
     %i : !i32 = arith.constant() ["value" = 42 : !i32]
     %213 : !i32 = arith.addi(%i : !i32, %i : !i32)
     }"""
 
     expected = \
 """\
-module() {
+builtin.module() {
   %i : !i32 = arith.constant() ["value" = 42 : !i32]
   %0 : !i32 = arith.addi(%i : !i32, %i : !i32)
 }"""
@@ -407,14 +407,14 @@ def test_generic_format():
     Test that we can use generic formats in operations.
     """
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = "test.add"(%0: !i32, %0: !i32)
     }"""
 
     expected = \
 """\
-module() {
+builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = test.add %0 + %0
 }"""
@@ -438,14 +438,14 @@ def test_custom_format():
     Test that we can use custom formats in operations.
     """
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = test.add %0 + %0
     }"""
 
     expected = \
 """\
-module() {
+builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 42 : !i32]
   %1 : !i32 = test.add %0 + %0
 }"""
@@ -469,14 +469,14 @@ def test_custom_format():
     Test that we can print using generic formats.
     """
     prog = \
-        """module() {
+        """builtin.module() {
     %0 : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = test.add %0 + %0
     }"""
 
     expected = \
 """\
-"module"() {
+"builtin.module"() {
   %0 : !i32 = "arith.constant"() ["value" = 42 : !i32]
   %1 : !i32 = "test.add"(%0 : !i32, %0 : !i32)
 }"""

--- a/tests/rewriter_test.py
+++ b/tests/rewriter_test.py
@@ -34,12 +34,12 @@ def test_operation_deletion():
     """Test rewrites where SSA values are deleted."""
 
     prog = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 5 : !i32]
 }"""
 
     expected = \
-"""module() {}"""
+"""builtin.module() {}"""
 
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
         constant_op = module.ops[0]
@@ -51,13 +51,13 @@ def test_operation_deletion():
 # Test an operation replacement
 def test_replace_op_one_op():
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i32 = arith.constant() ["value" = 42 : !i32]
 %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 43 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
@@ -73,13 +73,13 @@ def test_replace_op_one_op():
 # Test an operation replacement with multiple ops
 def test_replace_op_multiple_op():
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i32 = arith.constant() ["value" = 2 : !i32]
 %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 1 : !i32]
   %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
   %2 : !i32 = arith.addi(%1 : !i32, %1 : !i32)
@@ -98,14 +98,14 @@ def test_replace_op_multiple_op():
 # Test an operation replacement with manually specified results
 def test_replace_op_new_results():
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i32 = arith.constant() ["value" = 2 : !i32]
 %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
 %2 : !i32 = arith.muli(%1 : !i32, %1 : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i32 = arith.constant() ["value" = 2 : !i32]
   %1 : !i32 = arith.muli(%0 : !i32, %0 : !i32)
 }"""
@@ -121,7 +121,7 @@ def test_replace_op_new_results():
 def test_inline_block_at_pos():
     """Test the inlining of a block at a certain position."""
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -129,7 +129,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
   scf.if(%0 : !i1) {}
@@ -148,7 +148,7 @@ scf.if(%0 : !i1) {
 def test_inline_block_before():
     """Test the inlining of a block before an operation."""
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -156,7 +156,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
   scf.if(%0 : !i1) {}
@@ -174,7 +174,7 @@ scf.if(%0 : !i1) {
 def test_inline_block_after():
     """Test the inlining of a block after an operation."""
     prog = \
-    """module() {
+    """builtin.module() {
 %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 scf.if(%0 : !i1) {
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
@@ -182,7 +182,7 @@ scf.if(%0 : !i1) {
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
   %1 : !i32 = arith.constant() ["value" = 2 : !i32]
   scf.if(%0 : !i1) {}
@@ -201,12 +201,12 @@ scf.if(%0 : !i1) {
 def test_insert_block():
     """Test the insertion of a block in a region."""
     prog = \
-    """module() {
+    """builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
 ^0:
 ^1:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
@@ -221,12 +221,12 @@ def test_insert_block():
 def test_insert_block2():
     """Test the insertion of a block in a region."""
     prog = \
-    """module() {
+    """builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
 ^0:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 ^1:
@@ -241,12 +241,12 @@ def test_insert_block2():
 def test_insert_block_before():
     """Test the insertion of a block before another block."""
     prog = \
-    """module() {
+    """builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
 ^0:
 ^1:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
@@ -261,12 +261,12 @@ def test_insert_block_before():
 def test_insert_block_after():
     """Test the insertion of a block after another block."""
     prog = \
-    """module() {
+    """builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
 ^0:
   %0 : !i1 = arith.constant() ["value" = 1 : !i1]
 ^1:
@@ -281,13 +281,13 @@ def test_insert_block_after():
 def test_preserve_naming_single_op():
     """Test the preservation of names of SSAValues"""
     prog = \
-    """module() {
+    """builtin.module() {
    %i : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%i : !i32, %i : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %i : !i32 = arith.constant() ["value" = 1 : !i32]
   %0 : !i32 = arith.addi(%i : !i32, %i : !i32)
 }"""
@@ -304,13 +304,13 @@ def test_preserve_naming_single_op():
 def test_preserve_naming_multiple_ops():
     """Test the preservation of names of SSAValues for transformations to multiple ops"""
     prog = \
-    """module() {
+    """builtin.module() {
    %i : !i32 = arith.constant() ["value" = 42 : !i32]
     %1 : !i32 = arith.addi(%i : !i32, %i : !i32)
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   %i : !i32 = arith.constant() ["value" = 1 : !i32]
   %i1 : !i32 = arith.addi(%i : !i32, %i : !i32)
   %0 : !i32 = arith.addi(%i1 : !i32, %i1 : !i32)
@@ -329,12 +329,12 @@ def test_preserve_naming_multiple_ops():
 def test_no_result_rewriter():
     """Test rewriter on ops without results"""
     prog = \
-    """module() {
+    """builtin.module() {
    func.return()
 }"""
 
     expected = \
-"""module() {
+"""builtin.module() {
   scf.yield()
 }"""
 

--- a/tests/use_test.py
+++ b/tests/use_test.py
@@ -4,7 +4,7 @@ from xdsl.parser import Parser
 from xdsl.dialects.arith import Arith
 
 test_prog = """
-module() {
+builtin.module() {
   %0 : !i1 = arith.constant() ["value" = 0 : !i1]
   %1 : !i1 = arith.andi(%0 : !i1, %0 : !i1)
 }


### PR DESCRIPTION
In MLIR, `module` real name is `builtin.module`.
It was named `module` in xDSL, but this mess up with the mlir_converter, and the MLIR printer.
This should fix it, but this will be a breaking change.