### PR TITLE
Renamed master to main in workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
I missed this, our main branch is called main, and not master.