### PR TITLE
Add custom format for attributes

### DIFF
--- a/src/xdsl/dialects/llvm.py
+++ b/src/xdsl/dialects/llvm.py
@@ -45,7 +45,7 @@ class LLVMStructType(ParametrizedAttribute, MLIRType):
             [StringAttr.from_str(""),
              ArrayAttr.from_list(types)])
 
-    def print_parameters_as_mlir(self, printer: Printer) -> None:
+    def print_parameters(self, printer: Printer) -> None:
         assert self.struct_name.data == ""
         printer.print("<(")
         printer.print_list(self.types.data, printer.print_attribute)

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -244,6 +244,11 @@ class ParametrizedAttribute(Attribute):
 
     parameters: list[Attribute] = field(default_factory=list)
 
+    @staticmethod
+    def parse_parameters(parser: Parser) -> list[Attribute]:
+        """Parse the attribute parameters."""
+        return parser.parse_paramattr_parameters()
+
     def print_parameters(self, printer: Printer) -> None:
         """Print the attribute parameters."""
         printer.print_paramattr_parameters(self.parameters)

--- a/src/xdsl/ir.py
+++ b/src/xdsl/ir.py
@@ -237,10 +237,6 @@ class Data(Generic[DataElement], Attribute, ABC):
     def print_parameter(data: DataElement, printer: Printer) -> None:
         """Print the attribute parameter."""
 
-    def print_parameter_as_mlir(self, printer: Printer) -> None:
-        """Print the attribute parameter in MLIR format."""
-        self.print_parameter(self.data, printer)
-
 
 @dataclass(frozen=True)
 class ParametrizedAttribute(Attribute):
@@ -248,17 +244,15 @@ class ParametrizedAttribute(Attribute):
 
     parameters: list[Attribute] = field(default_factory=list)
 
+    def print_parameters(self, printer: Printer) -> None:
+        """Print the attribute parameters."""
+        printer.print_paramattr_parameters(self.parameters)
+
     @classmethod
     @property
     def irdl_definition(cls) -> ParamAttrDef:
         """Get the IRDL attribute definition."""
         ...
-
-    def print_parameters_as_mlir(self, printer: Printer) -> None:
-        if len(self.parameters) != 0:
-            printer.print("<")
-            printer.print_list(self.parameters, printer.print_attribute)
-            printer.print(">")
 
 
 @dataclass

--- a/src/xdsl/parser.py
+++ b/src/xdsl/parser.py
@@ -595,7 +595,7 @@ class Parser:
 
         # Attribute with default format
         if parse_with_default_format:
-            if not isinstance(attr_def, ParametrizedAttribute):
+            if not issubclass(attr_def, ParametrizedAttribute):
                 raise ParserError(
                     self._pos,
                     f"{attr_def_name} is not a parameterized attribute, and "

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -269,8 +269,11 @@ class Printer:
             self._print_operand(operand)
         self.print(")")
 
-    def print_paramattr_parameters(self, params: list[Attribute]) -> None:
-        if len(params) == 0:
+    def print_paramattr_parameters(
+            self,
+            params: list[Attribute],
+            always_print_brackets: bool = False) -> None:
+        if len(params) == 0 and not always_print_brackets:
             return
         self.print("<")
         self.print_list(params, self.print_attribute)
@@ -414,6 +417,13 @@ class Printer:
             return
 
         assert isinstance(attribute, ParametrizedAttribute)
+
+        # Print parametrized attribute with default formatting
+        if self.target == self.Target.XDSL and self.print_generic_format:
+            self.print(f'!"{attribute.name}"')
+            self.print_paramattr_parameters(attribute.parameters,
+                                            always_print_brackets=True)
+            return
 
         self.print(f'!{attribute.name}')
         if len(attribute.parameters) != 0:

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -426,10 +426,7 @@ class Printer:
             return
 
         self.print(f'!{attribute.name}')
-        if len(attribute.parameters) != 0:
-            self.print("<")
-            self.print_list(attribute.parameters, self.print_attribute)
-            self.print(">")
+        attribute.print_parameters(self)
 
     def print_successors(self, successors: List[Block]):
         if len(successors) == 0:

--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -269,6 +269,13 @@ class Printer:
             self._print_operand(operand)
         self.print(")")
 
+    def print_paramattr_parameters(self, params: list[Attribute]) -> None:
+        if len(params) == 0:
+            return
+        self.print("<")
+        self.print_list(params, self.print_attribute)
+        self.print(">")
+
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, UnitAttr):
             return
@@ -391,13 +398,13 @@ class Printer:
 
             if isinstance(attribute, Data):
                 self.print("<")
-                attribute.print_parameter_as_mlir(self)
+                attribute.print_parameter(attribute.data, self)
                 self.print(">")
                 return
 
             assert isinstance(attribute, ParametrizedAttribute)
 
-            attribute.print_parameters_as_mlir(self)
+            attribute.print_parameters(self)
             return
 
         if isinstance(attribute, Data):

--- a/tests/mlir_printer_test.py
+++ b/tests/mlir_printer_test.py
@@ -68,27 +68,11 @@ class ParamType(ParametrizedAttribute, MLIRType):
 
 
 @irdl_attr_definition
-class DataAttrWithCustomFormat(Data[int]):
-    name = "data_custom_format"
-
-    @staticmethod
-    def parse_parameter(parser: Parser) -> int:
-        return parser.parse_int_literal()
-
-    @staticmethod
-    def print_parameter(data: int, printer: Printer) -> None:
-        printer.print(data)
-
-    def print_parameter_as_mlir(self, printer: Printer) -> None:
-        printer.print(f"~{self.data}~")
-
-
-@irdl_attr_definition
 class ParamAttrWithCustomFormat(ParametrizedAttribute):
     name = "param_custom_format"
     param1: ParameterDef[ParamAttr]
 
-    def print_parameters_as_mlir(self, printer: Printer) -> None:
+    def print_parameters(self, printer: Printer) -> None:
         printer.print(f"~~")
 
 
@@ -102,7 +86,6 @@ def print_as_mlir_and_compare(test_prog: str, expected: str):
     ctx.register_attr(ParamAttr)
     ctx.register_attr(ParamType)
     ctx.register_attr(ParamAttrWithParam)
-    ctx.register_attr(DataAttrWithCustomFormat)
     ctx.register_attr(ParamAttrWithCustomFormat)
 
     parser = Parser(ctx, test_prog)
@@ -230,14 +213,6 @@ def test_op_with_attributes():
     print_as_mlir_and_compare(
         """any() [ "attr" = !data_attr<42> ]""",
         """"any"() {"attr" = #data_attr<42>} : () -> ()""",
-    )
-
-
-def test_data_custom_format():
-    """Test printing an operation with a data attribute with custom format."""
-    print_as_mlir_and_compare(
-        """any() [ "attr" = !data_custom_format<42> ]""",
-        """"any"() {"attr" = #data_custom_format<~42~>} : () -> ()""",
     )
 
 


### PR DESCRIPTION
This PR adds custom format for parametrized attributes.
We can now parse attributes with two formats:
* The generic format: `!"attrname"<attr1, attr2, ...>`
* A custom format, `!attrname...`, which can be redefined for each attribute.

This is to make it easier to print/parse MLIR (which always use custom format), and make attributes more readable.
The point of using the generic format is to make it easier to parse it from outside Python for instance.