### PR TITLE
Add arith ops, and make verifiers similar to the MLIR ones

### DIFF
--- a/src/xdsl/dialects/arith.py
+++ b/src/xdsl/dialects/arith.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Union
 
-from xdsl.dialects.builtin import IntegerType, Float32Type, IntegerAttr
+from xdsl.dialects.builtin import ContainerOf, Float16Type, Float64Type, IndexType, IntegerType, Float32Type, IntegerAttr
 from xdsl.ir import MLContext, Operation, SSAValue
-from xdsl.irdl import (irdl_op_definition, AttributeDef, AnyAttr, ResultDef,
-                       OperandDef, VerifyException, Attribute)
+from xdsl.irdl import (AnyOf, irdl_op_definition, AttributeDef, AnyAttr,
+                       ResultDef, OperandDef, VerifyException, Attribute)
+
+signlessIntegerLike = ContainerOf(AnyOf([IntegerType, IndexType]))
+floatingPointLike = ContainerOf(AnyOf([Float16Type, Float32Type, Float64Type]))
 
 
 @dataclass
@@ -19,8 +22,14 @@ class Arith:
         self.ctx.register_op(Addi)
         self.ctx.register_op(Muli)
         self.ctx.register_op(Subi)
-        self.ctx.register_op(FloorDiviSI)
+        self.ctx.register_op(FloorDivSI)
+        self.ctx.register_op(CeilDivSI)
+        self.ctx.register_op(CeilDivUI)
         self.ctx.register_op(RemSI)
+        self.ctx.register_op(MinSI)
+        self.ctx.register_op(MaxSI)
+        self.ctx.register_op(MinUI)
+        self.ctx.register_op(MaxUI)
 
         self.ctx.register_op(Addf)
         self.ctx.register_op(Mulf)
@@ -30,6 +39,8 @@ class Arith:
         self.ctx.register_op(AndI)
         self.ctx.register_op(OrI)
         self.ctx.register_op(XOrI)
+        self.ctx.register_op(Minf)
+        self.ctx.register_op(Maxf)
 
 
 @irdl_op_definition
@@ -57,9 +68,9 @@ class Constant(Operation):
 @irdl_op_definition
 class Addi(Operation):
     name: str = "arith.addi"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -70,16 +81,17 @@ class Addi(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> Addi:
+        operand1 = SSAValue.get(operand1)
         return Addi.build(operands=[operand1, operand2],
-                          result_types=[IntegerType.from_width(32)])
+                          result_types=[operand1.typ])
 
 
 @irdl_op_definition
 class Muli(Operation):
     name: str = "arith.muli"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -90,16 +102,17 @@ class Muli(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> Muli:
+        operand1 = SSAValue.get(operand1)
         return Muli.build(operands=[operand1, operand2],
-                          result_types=[IntegerType.from_width(32)])
+                          result_types=[operand1.typ])
 
 
 @irdl_op_definition
 class Subi(Operation):
     name: str = "arith.subi"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -110,16 +123,17 @@ class Subi(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> Subi:
+        operand1 = SSAValue.get(operand1)
         return Subi.build(operands=[operand1, operand2],
-                          result_types=[IntegerType.from_width(32)])
+                          result_types=[operand1.typ])
 
 
 @irdl_op_definition
-class FloorDiviSI(Operation):
+class FloorDivSI(Operation):
     name: str = "arith.floordivsi"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -129,17 +143,60 @@ class FloorDiviSI(Operation):
 
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
-            operand2: Union[Operation, SSAValue]) -> FloorDiviSI:
-        return FloorDiviSI.build(operands=[operand1, operand2],
-                                 result_types=[IntegerType.from_width(32)])
+            operand2: Union[Operation, SSAValue]) -> FloorDivSI:
+        operand1 = SSAValue.get(operand1)
+        return FloorDivSI.build(operands=[operand1, operand2],
+                                result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class CeilDivSI(Operation):
+    name: str = "arith.ceildivsi"
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> CeilDivSI:
+        operand1 = SSAValue.get(operand1)
+        return CeilDivSI.build(operands=[operand1, operand2],
+                               result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class CeilDivUI(Operation):
+    name: str = "arith.ceildivui"
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> CeilDivUI:
+        operand1 = SSAValue.get(operand1)
+        return CeilDivUI.build(operands=[operand1, operand2],
+                               result_types=[operand1.typ])
 
 
 @irdl_op_definition
 class RemSI(Operation):
     name: str = "arith.remsi"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -150,16 +207,101 @@ class RemSI(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> RemSI:
+        operand1 = SSAValue.get(operand1)
         return RemSI.build(operands=[operand1, operand2],
-                           result_types=[IntegerType.from_width(32)])
+                           result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class MinUI(Operation):
+    name: str = "arith.minui"
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> MinUI:
+        operand1 = SSAValue.get(operand1)
+        return MinUI.build(operands=[operand1, operand2],
+                           result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class MaxUI(Operation):
+    name: str = "arith.maxui"
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> MaxUI:
+        operand1 = SSAValue.get(operand1)
+        return MaxUI.build(operands=[operand1, operand2],
+                           result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class MinSI(Operation):
+    name: str = "arith.minsi"
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> MinSI:
+        operand1 = SSAValue.get(operand1)
+        return MinSI.build(operands=[operand1, operand2],
+                           result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class MaxSI(Operation):
+    name: str = "arith.maxsi"
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> MaxSI:
+        operand1 = SSAValue.get(operand1)
+        return MaxSI.build(operands=[operand1, operand2],
+                           result_types=[operand1.typ])
 
 
 @irdl_op_definition
 class AndI(Operation):
     name: str = "arith.andi"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -170,16 +312,17 @@ class AndI(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> AndI:
+        operand1 = SSAValue.get(operand1)
         return AndI.build(operands=[operand1, operand2],
-                          result_types=[SSAValue.get(operand1).typ])
+                          result_types=[operand1.typ])
 
 
 @irdl_op_definition
 class OrI(Operation):
     name: str = "arith.ori"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -190,17 +333,17 @@ class OrI(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> OrI:
-
+        operand1 = SSAValue.get(operand1)
         return OrI.build(operands=[operand1, operand2],
-                         result_types=[SSAValue.get(operand1).typ])
+                         result_types=[operand1.typ])
 
 
 @irdl_op_definition
 class XOrI(Operation):
     name: str = "arith.xori"
-    input1 = OperandDef(IntegerType)
-    input2 = OperandDef(IntegerType)
-    output = ResultDef(IntegerType)
+    input1 = OperandDef(signlessIntegerLike)
+    input2 = OperandDef(signlessIntegerLike)
+    output = ResultDef(signlessIntegerLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -211,8 +354,9 @@ class XOrI(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> XOrI:
+        operand1 = SSAValue.get(operand1)
         return XOrI.build(operands=[operand1, operand2],
-                          result_types=[SSAValue.get(operand1).typ])
+                          result_types=[operand1.typ])
 
 
 @irdl_op_definition
@@ -235,9 +379,9 @@ class Cmpi(Operation):
 @irdl_op_definition
 class Addf(Operation):
     name: str = "arith.addf"
-    input1 = OperandDef(Float32Type)
-    input2 = OperandDef(Float32Type)
-    output = ResultDef(Float32Type)
+    input1 = OperandDef(floatingPointLike)
+    input2 = OperandDef(floatingPointLike)
+    output = ResultDef(floatingPointLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -248,16 +392,17 @@ class Addf(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> Addf:
+        operand1 = SSAValue.get(operand1)
         return Addf.build(operands=[operand1, operand2],
-                          result_types=[Float32Type()])
+                          result_types=[operand1.typ])
 
 
 @irdl_op_definition
 class Mulf(Operation):
     name: str = "arith.mulf"
-    input1 = OperandDef(Float32Type)
-    input2 = OperandDef(Float32Type)
-    output = ResultDef(Float32Type)
+    input1 = OperandDef(floatingPointLike)
+    input2 = OperandDef(floatingPointLike)
+    output = ResultDef(floatingPointLike)
 
     # TODO replace with trait
     def verify_(self) -> None:
@@ -268,5 +413,48 @@ class Mulf(Operation):
     @staticmethod
     def get(operand1: Union[Operation, SSAValue],
             operand2: Union[Operation, SSAValue]) -> Mulf:
+        operand1 = SSAValue.get(operand1)
         return Mulf.build(operands=[operand1, operand2],
-                          result_types=[Float32Type()])
+                          result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class Maxf(Operation):
+    name: str = "arith.maxf"
+    input1 = OperandDef(floatingPointLike)
+    input2 = OperandDef(floatingPointLike)
+    output = ResultDef(floatingPointLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> Maxf:
+        operand1 = SSAValue.get(operand1)
+        return Maxf.build(operands=[operand1, operand2],
+                          result_types=[operand1.typ])
+
+
+@irdl_op_definition
+class Minf(Operation):
+    name: str = "arith.minf"
+    input1 = OperandDef(floatingPointLike)
+    input2 = OperandDef(floatingPointLike)
+    output = ResultDef(floatingPointLike)
+
+    # TODO replace with trait
+    def verify_(self) -> None:
+        if self.input1.typ != self.input2.typ or self.input2.typ != self.output.typ:
+            raise VerifyException(
+                "expect all input and output types to be equal")
+
+    @staticmethod
+    def get(operand1: Union[Operation, SSAValue],
+            operand2: Union[Operation, SSAValue]) -> Minf:
+        operand1 = SSAValue.get(operand1)
+        return Minf.build(operands=[operand1, operand2],
+                          result_types=[operand1.typ])

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -34,6 +34,7 @@ class Builtin:
         self.ctx.register_attr(TupleType)
 
         self.ctx.register_attr(FunctionType)
+        self.ctx.register_attr(Float16Type)
         self.ctx.register_attr(Float32Type)
         self.ctx.register_attr(Float64Type)
         self.ctx.register_attr(FloatData)
@@ -386,6 +387,13 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
             typ: IntegerType | IndexType) -> DenseIntOrFPElementsAttr:
         t = AnyTensorType.from_type_and_list(typ, [len(data)])
         return DenseIntOrFPElementsAttr.from_list(t, data)
+
+
+class Float16Type(ParametrizedAttribute, MLIRType):
+    name = "f16"
+
+
+f16 = Float16Type()
 
 
 @irdl_attr_definition

--- a/src/xdsl/dialects/builtin.py
+++ b/src/xdsl/dialects/builtin.py
@@ -345,6 +345,25 @@ class TensorType(Generic[_TensorTypeElems], ParametrizedAttribute, MLIRType):
 AnyTensorType: TypeAlias = TensorType[Attribute]
 
 
+@dataclass(init=False)
+class ContainerOf(AttrConstraint):
+    """A type constraint that can be nested once in a vector or a tensor."""
+    elem_constr: AttrConstraint
+
+    def __init__(
+            self,
+            elem_constr: Attribute | type[Attribute] | AttrConstraint) -> None:
+        self.elem_constr = attr_constr_coercion(elem_constr)
+
+    def verify(self, attr: Attribute) -> None:
+        if isinstance(attr, VectorType):
+            self.elem_constr.verify(attr.element_type)  # type: ignore
+        elif isinstance(attr, TensorType):
+            self.elem_constr.verify(attr.element_type)  # type: ignore
+        else:
+            self.elem_constr.verify(attr)
+
+
 @irdl_attr_definition
 class DenseIntOrFPElementsAttr(ParametrizedAttribute):
     name = "dense"

--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -1,24 +1,171 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 builtin.module() {
-  func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"]{
-    %0 : !i32 = arith.constant() ["value" = 42 : !i32]
-    %1 : !i32 = arith.constant() ["value" = 42 : !i32]
-    %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32) 
-    %3 : !i32 = arith.subi(%0 : !i32, %1 : !i32) 
-    %4 : !i32 = arith.muli(%0 : !i32, %1 : !i32) 
-    %5 : !i32 = arith.floordivsi(%0 : !i32, %1 : !i32) 
-    %6 : !i32 = arith.remsi(%0 : !i32, %1 : !i32) 
-    func.return()
-  }
+func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "ceildivi"] {
+^0(%0 : !i32, %1 : !i32):
+  %2 : !i32 = arith.ceildivsi(%0 : !i32, %1 : !i32)
+  func.return(%2 : !i32)
 }
 
-// CHECK: func.func() ["sym_name" = "main"
-// CHECK-NEXT: %{{.*}} : !i32 = arith.constant() ["value" = 42 : !i32] 
-// CHECK-NEXT: %{{.*}} : !i32 = arith.constant() ["value" = 42 : !i32]
-// CHECK-NEXT: %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32) 
-// CHECK-NEXT: %{{.*}} : !i32 = arith.subi(%{{.*}} : !i32, %{{.*}} : !i32) 
-// CHECK-NEXT: %{{.*}} : !i32 = arith.muli(%{{.*}} : !i32, %{{.*}} : !i32) 
-// CHECK-NEXT: %{{.*}} : !i32 = arith.floordivsi(%{{.*}} : !i32, %{{.*}} : !i32)
-// CHECK-NEXT: %{{.*}} : !i32 = arith.remsi(%{{.*}} : !i32, %{{.*}} : !i32) 
+//CHECK:      func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "ceildivi"] {
+//CHECK-NEXT: ^0(%0 : !i32, %1 : !i32):
+//CHECK-NEXT:   %2 : !i32 = arith.ceildivsi(%0 : !i32, %1 : !i32)
+//CHECK-NEXT:   func.return(%2 : !i32)
+//CHECK-NEXT: }
 
+
+func.func() ["function_type" = !fun<[!index, !index], [!index]>, "sym_name" = "ceildivi_index"] {
+^1(%3 : !index, %4 : !index):
+  %5 : !index = arith.ceildivsi(%3 : !index, %4 : !index)
+  func.return(%5 : !index)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!index, !index], [!index]>, "sym_name" = "ceildivi_index"] {
+// CHECK-NEXT: ^1(%3 : !index, %4 : !index):
+// CHECK-NEXT:   %5 : !index = arith.ceildivsi(%3 : !index, %4 : !index)
+// CHECK-NEXT:   func.return(%5 : !index)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "floordivi"] {
+^2(%6 : !i32, %7 : !i32):
+  %8 : !i32 = arith.floordivsi(%6 : !i32, %7 : !i32)
+  func.return(%8 : !i32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "floordivi"] {
+// CHECK-NEXT: ^2(%6 : !i32, %7 : !i32):
+// CHECK-NEXT:   %8 : !i32 = arith.floordivsi(%6 : !i32, %7 : !i32)
+// CHECK-NEXT:   func.return(%8 : !i32)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!index, !index], [!index]>, "sym_name" = "floordivi_index"] {
+^3(%9 : !index, %10 : !index):
+  %11 : !index = arith.floordivsi(%9 : !index, %10 : !index)
+  func.return(%11 : !index)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!index, !index], [!index]>, "sym_name" = "floordivi_index"] {
+// CHECK-NEXT: ^3(%9 : !index, %10 : !index):
+// CHECK-NEXT:   %11 : !index = arith.floordivsi(%9 : !index, %10 : !index)
+// CHECK-NEXT:   func.return(%11 : !index)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "ceildivui"] {
+^4(%12 : !i32, %13 : !i32):
+  %14 : !i32 = arith.ceildivui(%12 : !i32, %13 : !i32)
+  func.return(%14 : !i32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "ceildivui"] {
+// CHECK-NEXT: ^4(%12 : !i32, %13 : !i32):
+// CHECK-NEXT:   %14 : !i32 = arith.ceildivui(%12 : !i32, %13 : !i32)
+// CHECK-NEXT:   func.return(%14 : !i32)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!index, !index], [!index]>, "sym_name" = "ceildivui_index"] {
+^5(%15 : !index, %16 : !index):
+  %17 : !index = arith.ceildivui(%15 : !index, %16 : !index)
+  func.return(%17 : !index)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!index, !index], [!index]>, "sym_name" = "ceildivui_index"] {
+// CHECK-NEXT: ^5(%15 : !index, %16 : !index):
+// CHECK-NEXT:   %17 : !index = arith.ceildivui(%15 : !index, %16 : !index)
+// CHECK-NEXT:   func.return(%17 : !index)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "maxf"] {
+^6(%18 : !f32, %19 : !f32):
+  %20 : !f32 = arith.maxf(%18 : !f32, %19 : !f32)
+  func.return(%20 : !f32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "maxf"] {
+// CHECK-NEXT: ^6(%18 : !f32, %19 : !f32):
+// CHECK-NEXT:   %20 : !f32 = arith.maxf(%18 : !f32, %19 : !f32)
+// CHECK-NEXT:   func.return(%20 : !f32)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!vector<[4 : !index], !f32>, !vector<[4 : !index], !f32>], [!vector<[4 : !index], !f32>]>, "sym_name" = "maxf_vector"] {
+^7(%21 : !vector<[4 : !index], !f32>, %22 : !vector<[4 : !index], !f32>):
+  %23 : !vector<[4 : !index], !f32> = arith.maxf(%21 : !vector<[4 : !index], !f32>, %22 : !vector<[4 : !index], !f32>)
+  func.return(%23 : !vector<[4 : !index], !f32>)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!vector<[4 : !index], !f32>, !vector<[4 : !index], !f32>], [!vector<[4 : !index], !f32>]>, "sym_name" = "maxf_vector"] {
+// CHECK-NEXT: ^7(%21 : !vector<[4 : !index], !f32>, %22 : !vector<[4 : !index], !f32>):
+// CHECK-NEXT:   %23 : !vector<[4 : !index], !f32> = arith.maxf(%21 : !vector<[4 : !index], !f32>, %22 : !vector<[4 : !index], !f32>)
+// CHECK-NEXT:   func.return(%23 : !vector<[4 : !index], !f32>)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "minf"] {
+^8(%24 : !f32, %25 : !f32):
+  %26 : !f32 = arith.minf(%24 : !f32, %25 : !f32)
+  func.return(%26 : !f32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "minf"] {
+// CHECK-NEXT: ^8(%24 : !f32, %25 : !f32):
+// CHECK-NEXT:   %26 : !f32 = arith.minf(%24 : !f32, %25 : !f32)
+// CHECK-NEXT:   func.return(%26 : !f32)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "maxsi"] {
+^9(%27 : !i32, %28 : !i32):
+  %29 : !i32 = arith.maxsi(%27 : !i32, %28 : !i32)
+  func.return(%29 : !i32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "maxsi"] {
+// CHECK-NEXT: ^9(%27 : !i32, %28 : !i32):
+// CHECK-NEXT:   %29 : !i32 = arith.maxsi(%27 : !i32, %28 : !i32)
+// CHECK-NEXT:   func.return(%29 : !i32)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "minsi"] {
+^10(%30 : !i32, %31 : !i32):
+  %32 : !i32 = arith.minsi(%30 : !i32, %31 : !i32)
+  func.return(%32 : !i32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "minsi"] {
+// CHECK-NEXT: ^10(%30 : !i32, %31 : !i32):
+// CHECK-NEXT:   %32 : !i32 = arith.minsi(%30 : !i32, %31 : !i32)
+// CHECK-NEXT:   func.return(%32 : !i32)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "maxui"] {
+^11(%33 : !i32, %34 : !i32):
+  %35 : !i32 = arith.maxui(%33 : !i32, %34 : !i32)
+  func.return(%35 : !i32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "maxui"] {
+// CHECK-NEXT: ^11(%33 : !i32, %34 : !i32):
+// CHECK-NEXT:   %35 : !i32 = arith.maxui(%33 : !i32, %34 : !i32)
+// CHECK-NEXT:   func.return(%35 : !i32)
+// CHECK-NEXT: }
+
+
+func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "minui"] {
+^12(%36 : !i32, %37 : !i32):
+  %38 : !i32 = arith.minui(%36 : !i32, %37 : !i32)
+  func.return(%38 : !i32)
+}
+
+// CHECK: func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "minui"] {
+// CHECK-NEXT: ^12(%36 : !i32, %37 : !i32):
+// CHECK-NEXT:   %38 : !i32 = arith.minui(%36 : !i32, %37 : !i32)
+// CHECK-NEXT:   func.return(%38 : !i32)
+// CHECK-NEXT: }
+}


### PR DESCRIPTION
This PR adds some missing operations to arith, and make their verifiers the same as in MLIR.
This also adds float16 to xDSL