### PR TITLE
[MLIR]: Conversion with ctx and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,9 @@ lit tests/filecheck
 ## Generating executables through MLIR
 
 xDSL can generate executables using MLIR as the backend. To use this
-functionality, make sure to install the [MLIR Python
-Bindings](https://mlir.llvm.org/docs/Bindings/Python/). Given an input file
-`input.xdsl`, that contains IR with only the mirrored dialects found in
-`src/xdsl/dialects` (arith, builtin, cf, func, irdl, llvm, memref, and scf),
-run:
+functionality, make sure to installed clang. Given an input file `input.xdsl`,
+that contains IR with only the mirrored dialects found in `src/xdsl/dialects`
+(arith, builtin, cf, func, irdl, llvm, memref, and scf), run:
 
 ```bash
 ### Prints MLIR generic from to tmp.mlir

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ lit tests/filecheck
 ## Generating executables through MLIR
 
 xDSL can generate executables using MLIR as the backend. To use this
-functionality, make sure to installed clang. Given an input file `input.xdsl`,
-that contains IR with only the mirrored dialects found in `src/xdsl/dialects`
-(arith, builtin, cf, func, irdl, llvm, memref, and scf), run:
+functionality, make sure to have clang, mlir-opt and mlir-translate installed
+and in the PATH. Clang can be installed by standard package managers (apt, pacman...), for MLIR
+follow [this](https://mlir.llvm.org/getting_started/) and run `ninja install`
+afterward. Given an input file `input.xdsl`, that contains IR with only the
+mirrored dialects found in `src/xdsl/dialects` (arith, builtin, cf, func, irdl,
+llvm, memref, and scf), run:
 
 ```bash
 ### Prints MLIR generic from to tmp.mlir

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ lit tests/filecheck
 
 xDSL can generate executables using MLIR as the backend. To use this
 functionality, make sure to have clang, mlir-opt and mlir-translate installed
-and in the PATH. Clang can be installed by standard package managers (apt, pacman...), for MLIR
-follow [this](https://mlir.llvm.org/getting_started/) and run `ninja install`
-afterward. Given an input file `input.xdsl`, that contains IR with only the
-mirrored dialects found in `src/xdsl/dialects` (arith, builtin, cf, func, irdl,
-llvm, memref, and scf), run:
+and in the PATH. Clang can be installed by standard package managers (apt,
+pacman...), for MLIR follow [this](https://mlir.llvm.org/getting_started/) and
+run `ninja install` afterward. Given an input file `input.xdsl`, that contains
+IR with only the mirrored dialects found in `src/xdsl/dialects` (arith, builtin,
+cf, func, irdl, llvm, memref, and scf), run:
 
 ```bash
 ### Prints MLIR generic from to tmp.mlir

--- a/src/xdsl/mlir_converter.py
+++ b/src/xdsl/mlir_converter.py
@@ -160,18 +160,22 @@ class MLIRConverter:
             mlir_block = self.block_to_mlir_blocks[block]
             self.convert_block(block, mlir_block)
 
+    def convert_module_with_ctx(self, op: Operation,
+                                mlir_ctx: mlir.ir.Context) -> mlir.ir.Module:
+        with mlir.ir.Location.unknown(mlir_ctx):
+            if not isinstance(op, ModuleOp):
+                raise Exception("top-level operation should be a ModuleOp")
+            mlir_module = mlir.ir.Module.create()
+            mlir_block = mlir_module.operation.regions[0].blocks[0]
+            block = op.regions[0].blocks[0]
+
+            ip = mlir.ir.InsertionPoint.at_block_begin(mlir_block)
+            for op in block.ops:
+                ip.insert(self.convert_op(op))
+            return mlir_module
+
     def convert_module(self, op: Operation) -> mlir.ir.Module:
         with mlir.ir.Context() as mlir_ctx:
             mlir_ctx.allow_unregistered_dialects = True
             self.register_external_dialects()
-            with mlir.ir.Location.unknown(mlir_ctx):
-                if not isinstance(op, ModuleOp):
-                    raise Exception("top-level operation should be a ModuleOp")
-                mlir_module = mlir.ir.Module.create()
-                mlir_block = mlir_module.operation.regions[0].blocks[0]
-                block = op.regions[0].blocks[0]
-
-                ip = mlir.ir.InsertionPoint.at_block_begin(mlir_block)
-                for op in block.ops:
-                    ip.insert(self.convert_op(op))
-                return mlir_module
+            return self.convert_module_with_ctx(op, mlir_ctx)


### PR DESCRIPTION
This PR adds a function to the mlir_converter that takes a ctx as an argument. With this, I can use things like the PassManager with the same module as returned here and not print and reparse it.

This also fixes the README in that it removes the requirement for the MLIR Python Bindings.