### PR TITLE
Add Unranked tensor type

### DIFF
--- a/src/xdsl/printer.py
+++ b/src/xdsl/printer.py
@@ -10,11 +10,11 @@ from xdsl.dialects.memref import MemRefType
 from xdsl.ir import (BlockArgument, MLIRType, SSAValue, Block, Callable,
                      Attribute, Region, Operation)
 from xdsl.dialects.builtin import (
-    AnyArrayAttr, AnyVectorType, DenseIntOrFPElementsAttr, Float16Type,
-    Float32Type, Float64Type, FloatAttr, IndexType, IntegerType, NoneAttr,
-    OpaqueAttr, StringAttr, FlatSymbolRefAttr, IntegerAttr, ArrayAttr,
-    ParametrizedAttribute, IntAttr, TensorType, UnitAttr, FunctionType,
-    VectorType)
+    AnyArrayAttr, AnyUnrankedTensorType, AnyVectorType,
+    DenseIntOrFPElementsAttr, Float16Type, Float32Type, Float64Type, FloatAttr,
+    IndexType, IntegerType, NoneAttr, OpaqueAttr, StringAttr,
+    FlatSymbolRefAttr, IntegerAttr, ArrayAttr, ParametrizedAttribute, IntAttr,
+    TensorType, UnitAttr, FunctionType, UnrankedTensorType, VectorType)
 from xdsl.irdl import Data
 from enum import Enum
 
@@ -391,6 +391,15 @@ class Printer:
                             lambda x: self.print(x.value.data), "x")
             if len(attribute.shape.data) != 0:
                 self.print("x")
+            self.print(attribute.element_type)
+            self.print(">")
+            return
+
+        # Unranked tensors have an alias in MLIR, but not in xDSL
+        if (isinstance(attribute, UnrankedTensorType)
+                and self.target == self.Target.MLIR):
+            attribute = cast(AnyUnrankedTensorType, attribute)
+            self.print("tensor<*x")
             self.print(attribute.element_type)
             self.print(">")
             return

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -52,13 +52,12 @@
 
   // CHECK: (vector<4xf32>, vector<f32>, vector<1x12xi32>)
 
-
   "func.func"() ({
-    ^bb0(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<1x12xi32>):
+    ^bb0(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<1x12xi32>, %arg3: tensor<*xf64>):
     "func.return"() : () -> ()
-  }) {function_type = (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>) -> (), sym_name = "tensor_type"} : () -> ()
+  }) {function_type = (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>, tensor<*xf64>) -> (), sym_name = "tensor_type"} : () -> ()
 
-  // CHECK: (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>)
+  // CHECK: (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>, tensor<*xf64>)
 
   "func.func"() ({}) {function_type = () -> (),
                       value1 = dense<0> : tensor<1xi32>,


### PR DESCRIPTION
This adds the `UnrankedTensorType` type to xDSL.
`UnrankedTensorType` are parsed and printed as `tensor<*xi32>`