### PR TITLE
Fix parsing of optional integer types

### DIFF
--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -34,7 +34,7 @@
 
   // CHECK: 42 : i32
 
-  "func.func"() ({}) {function_type = () -> (), value = 54 : index, sym_name = "int_attr"} : () -> ()
+  "func.func"() ({}) {function_type = () -> (), value = 54 : index, sym_name = "index_attr"} : () -> ()
 
   // CHECK: 54 : index
 

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -34,6 +34,10 @@
 
   // CHECK: 42 : i32
 
+  "func.func"() ({}) {function_type = () -> (), value = 54 : index, sym_name = "int_attr"} : () -> ()
+
+  // CHECK: 54 : index
+
 
   "func.func"() ({}) {function_type = () -> (), value = "foo", sym_name = "string_attr"} : () -> ()
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -779,9 +779,9 @@ class Parser:
             return typ
         raise ParserError(self._pos, "index type expected")
 
-    def parse_optional_mlir_integer_type(self,
-                                         skip_white_space: bool = True
-                                         ) -> IntegerType | None:
+    def parse_mlir_integer_type(self,
+                                skip_white_space: bool = True
+                                ) -> IntegerType | None:
         if (self.parse_optional_string("i", skip_white_space=skip_white_space)
                 or self.parse_optional_string(
                     "si", skip_white_space=skip_white_space)
@@ -791,15 +791,13 @@ class Parser:
             if width is not None:
                 return IntegerType.from_width(width)
             raise ParserError(self._pos, "integer type width expected")
-        return None
-
-    def parse_mlir_integer_type(self,
-                                skip_white_space: bool = True) -> IntegerType:
-        typ = self.parse_optional_mlir_integer_type(
-            skip_white_space=skip_white_space)
-        if typ is not None:
-            return typ
         raise ParserError(self._pos, "integer type expected")
+
+    def parse_optional_mlir_integer_type(self,
+                                         skip_white_space: bool = True
+                                         ) -> IntegerType | None:
+        return self.try_parse(self.parse_mlir_integer_type,
+                              skip_white_space=skip_white_space)
 
     def parse_optional_mlir_float_type(self,
                                        skip_white_space: bool = True


### PR DESCRIPTION
Parsing an optional integer type should not fail anymore when the next token starts with an `i`.