### PR TITLE
xdsl: Add shaped array support for parsing and printing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ xdsl = py.typed
 [tool:pytest]
 python_files = *_test.py test_*.py *_example.py example_*.py
 addopts = --durations=20 --maxfail=5
-pythonpath = src
 
 [versioneer]
 VCS = git

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ xdsl = py.typed
 [tool:pytest]
 python_files = *_test.py test_*.py *_example.py example_*.py
 addopts = --durations=20 --maxfail=5
+pythonpath = src
 
 [versioneer]
 VCS = git

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -610,6 +610,32 @@ def test_parse_generic_format_attr():
     assert file.getvalue().strip() == expected.strip()
 
 
+def test_parse_dense_xdsl():
+    '''
+    Test that parsing of shaped dense tensors works.
+    '''
+    # TODO: handle nested array syntax
+    prog = """
+    %0 : !tensor<[2 : !index, 3 : !index], !f64> = arith.constant() ["value" = !dense<!tensor<[2 : !index, 3 : !index], !f64>, [1.0 : !f64, 2.0 : !f64, 3.0 : !f64, 4.0 : !f64, 5.0 : !f64, 6.0 : !f64]>]
+    """
+
+    expected = """
+    %0 : !tensor<[2 : !index, 3 : !index], !f64> = arith.constant() ["value" = !dense<!tensor<[2 : !index, 3 : !index], !f64>, [1.0 : !f64, 2.0 : !f64, 3.0 : !f64, 4.0 : !f64, 5.0 : !f64, 6.0 : !f64]>]
+    """
+
+    ctx = MLContext()
+    Builtin(ctx)
+    Arith(ctx)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file)
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()
+
+
 def test_parse_dense_mlir():
     """
     Test that we can parse attributes using generic formats.

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -608,3 +608,28 @@ def test_parse_generic_format_attr():
     printer = Printer(stream=file, print_generic_format=True)
     printer.print_op(module)
     assert file.getvalue().strip() == expected.strip()
+
+
+def test_parse_dense_mlir():
+    """
+    Test that we can parse attributes using generic formats.
+    """
+    prog = """
+    %0 = "arith.constant"() {"value" = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    """
+
+    expected = """
+    %0 = "arith.constant"() {"value" = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    """
+
+    ctx = MLContext()
+    Builtin(ctx)
+    Arith(ctx)
+
+    parser = Parser(ctx, prog, source=Parser.Source.MLIR)
+    module = parser.parse_op()
+
+    file = StringIO("")
+    printer = Printer(stream=file, target=Printer.Target.MLIR)
+    printer.print_op(module)
+    assert file.getvalue().strip() == expected.strip()

--- a/tests/printer_test.py
+++ b/tests/printer_test.py
@@ -641,11 +641,11 @@ def test_parse_dense_mlir():
     Test that we can parse attributes using generic formats.
     """
     prog = """
-    %0 = "arith.constant"() {"value" = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    %0 = "arith.constant"() {"value" = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
     """
 
     expected = """
-    %0 = "arith.constant"() {"value" = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    %0 = "arith.constant"() {"value" = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
     """
 
     ctx = MLContext()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -546,9 +546,10 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
     @builder
     def tensor_from_list(
             data: List[int] | List[float],
-            typ: IntegerType | IndexType | AnyFloat
+            typ: IntegerType | IndexType | AnyFloat,
+            shape: List[int] = []
     ) -> DenseIntOrFPElementsAttr:
-        t = AnyTensorType.from_type_and_list(typ, [len(data)])
+        t = AnyTensorType.from_type_and_list(typ, shape if len(shape) else [len(data)])
         return DenseIntOrFPElementsAttr.from_list(t, data)
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -498,7 +498,7 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
                 # Dimensions need to be greater or equal to one
                 return False
             n *= dim
-        
+
         # Product of dimensions needs to equal length
         return n == len(self.data.data)
 
@@ -564,12 +564,11 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
 
     @staticmethod
     @builder
-    def tensor_from_list(
-            data: List[int] | List[float],
-            typ: IntegerType | IndexType | AnyFloat,
-            shape: List[int] = []
-    ) -> DenseIntOrFPElementsAttr:
-        t = AnyTensorType.from_type_and_list(typ, shape if len(shape) else [len(data)])
+    def tensor_from_list(data: List[int] | List[float],
+                         typ: IntegerType | IndexType | AnyFloat,
+                         shape: List[int] = []) -> DenseIntOrFPElementsAttr:
+        t = AnyTensorType.from_type_and_list(
+            typ, shape if len(shape) else [len(data)])
         return DenseIntOrFPElementsAttr.from_list(t, data)
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -479,8 +479,28 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
     type: ParameterDef[VectorOrTensorOf[IntegerType]
                        | VectorOrTensorOf[IndexType]
                        | VectorOrTensorOf[AnyFloat]]
-    # TODO add support for multi-dimensional data
     data: ParameterDef[ArrayAttr[AnyIntegerAttr] | ArrayAttr[AnyFloatAttr]]
+
+    # The type stores the shape data
+    @property
+    def shape(self) -> List[int]:
+        return self.type.get_shape()
+
+    @property
+    def shape_is_complete(self) -> bool:
+        shape = self.shape
+        if not len(shape):
+            return False
+
+        n = 1
+        for dim in shape:
+            if dim < 1:
+                # Dimensions need to be greater or equal to one
+                return False
+            n *= dim
+        
+        # Product of dimensions needs to equal length
+        return n == len(shape)
 
     @staticmethod
     @builder

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -500,7 +500,7 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
             n *= dim
         
         # Product of dimensions needs to equal length
-        return n == len(shape)
+        return n == len(self.data.data)
 
     @staticmethod
     @builder

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -388,7 +388,7 @@ class Parser:
         Parse and flatten a list of lists. The result is a list of elements, no matter the
         rank of the input.
         '''
-        if self.parse_optional_char("["):
+        if self.parse_optional_char("[", skip_white_space=skip_white_space):
             result = [
                 el for els in self.parse_list(lambda: self.parse_nested_list(
                     parse_optional_one, delimiter, skip_white_space))

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -119,16 +119,10 @@ class Printer:
                    elems: Iterable[T],
                    print_fn: Callable[[T], None],
                    delimiter: str = ", ") -> None:
-        it = iter(elems)
-        try:
-            el = next(it)
-            print_fn(el)
-            while True:
-                el = next(it)
+        for i, elem in enumerate(elems):
+            if i:
                 self.print(delimiter)
-                print_fn(el)
-        except StopIteration:
-            return
+            print_fn(elem)
 
     def _print_new_line(self,
                         indent: int | None = None,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -10,12 +10,12 @@ from xdsl.dialects.memref import MemRefType
 from xdsl.ir import (BlockArgument, MLIRType, SSAValue, Block, Callable,
                      Attribute, Region, Operation)
 from xdsl.dialects.builtin import (
-    AnyArrayAttr, AnyIntegerAttr, AnyFloatAttr, AnyUnrankedTensorType, AnyVectorType,
-    DenseIntOrFPElementsAttr, Float16Type, Float32Type, Float64Type, FloatAttr,
-    IndexType, IntegerType, NoneAttr, OpaqueAttr, StringAttr,
-    FlatSymbolRefAttr, IntegerAttr, ArrayAttr, ParametrizedAttribute, IntAttr,
-    TensorType, UnitAttr, FunctionType, UnrankedTensorType, UnregisteredOp,
-    VectorType)
+    AnyArrayAttr, AnyIntegerAttr, AnyFloatAttr, AnyUnrankedTensorType,
+    AnyVectorType, DenseIntOrFPElementsAttr, Float16Type, Float32Type,
+    Float64Type, FloatAttr, IndexType, IntegerType, NoneAttr, OpaqueAttr,
+    StringAttr, FlatSymbolRefAttr, IntegerAttr, ArrayAttr,
+    ParametrizedAttribute, IntAttr, TensorType, UnitAttr, FunctionType,
+    UnrankedTensorType, UnregisteredOp, VectorType)
 from xdsl.irdl import Data
 from enum import Enum
 
@@ -374,7 +374,9 @@ class Printer:
         if (isinstance(attribute, DenseIntOrFPElementsAttr)
                 and self.target == self.Target.MLIR):
 
-            def print_dense_list(array: List[AnyIntegerAttr] | List[AnyFloatAttr], shape: List[int]):
+            def print_dense_list(array: List[AnyIntegerAttr]
+                                 | List[AnyFloatAttr], shape: List[int]):
+
                 def print_one_elem(val: Attribute):
                     if isinstance(val, IntegerAttr):
                         self.print(val.value.data)
@@ -388,17 +390,18 @@ class Printer:
                 self.print('[')
                 if len(shape) > 1:
                     k = len(array) // shape[0]
-                    self.print_list((
-                        array[i: i+k]
-                        for i in range(0, len(array), k)
-                    ), lambda subarray: print_dense_list(subarray, shape[1:]))
+                    self.print_list(
+                        (array[i:i + k] for i in range(0, len(array), k)),
+                        lambda subarray: print_dense_list(subarray, shape[1:]))
                 else:
                     self.print_list(array, print_one_elem)
                 self.print(']')
 
             self.print("dense<")
             data = attribute.data.data
-            shape = attribute.shape if attribute.shape_is_complete else [len(data)]
+            shape = attribute.shape if attribute.shape_is_complete else [
+                len(data)
+            ]
             print_dense_list(data, shape)
             self.print("> : ")
             self.print(attribute.type)
@@ -477,7 +480,9 @@ class Printer:
             self.print(">")
             return
 
-        assert isinstance(attribute, ParametrizedAttribute), f'{attribute}: {type(attribute)}'
+        assert isinstance(
+            attribute,
+            ParametrizedAttribute), f'{attribute}: {type(attribute)}'
 
         # Print parametrized attribute with default formatting
         if self.target == self.Target.XDSL and self.print_generic_format:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -465,7 +465,7 @@ class Printer:
             self.print(">")
             return
 
-        assert isinstance(attribute, ParametrizedAttribute)
+        assert isinstance(attribute, ParametrizedAttribute), f'{attribute}: {type(attribute)}'
 
         # Print parametrized attribute with default formatting
         if self.target == self.Target.XDSL and self.print_generic_format:


### PR DESCRIPTION
This provides a basic implementation of parsing and printing of dense tensors. One big question is what are the error scenarios and where to verify/bail for each kind of error. I added a basic test for the success case, would be nice to mirror MLIR behaviour for the error cases also, maybe as a follow-up task?