### PR TITLE
xdsl: Fix parsing of some attributes and operations

### DIFF
--- a/tests/filecheck/cmath.xdsl
+++ b/tests/filecheck/cmath.xdsl
@@ -3,34 +3,34 @@
 
 builtin.module() {
 
-    // CHECK: irdl.dialect() ["dialect_name" = "cmath"] {
-    irdl.dialect() ["dialect_name" = "cmath"] {
+    // CHECK: irdl.dialect() ["name" = "cmath"] {
+    irdl.dialect() ["name" = "cmath"] {
 
-        // CHECK: irdl.type() ["type_name" = "complex"] {
-        // CHECK: irdl.parameters() ["constraints" = [!irdl.named_type_constraint<"elementType", !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
+        // CHECK: irdl.type() ["name" = "complex"] {
+        // CHECK: irdl.parameters() ["params" = [!irdl.named_type_constraint<"elementType" : !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
         // CHECK: }
-        irdl.type() ["type_name" = "complex"] {
-            irdl.parameters() ["constraints" = [!irdl.named_type_constraint<"elementType", !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
+        irdl.type() ["name" = "complex"] {
+            irdl.parameters() ["params" = [!irdl.named_type_constraint<"elementType" : !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
         }
 
         // CHECK: irdl.operation() ["name" = "norm"] {
-        // CHECK: irdl.operands() ["constraints" = [!irdl.named_type_constraint<"c", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-        // CHECK: irdl.results() ["constraints" = [!irdl.named_type_constraint<"results", !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
+        // CHECK: irdl.operands() ["params" = [!irdl.named_type_constraint<"c" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+        // CHECK: irdl.results() ["params" = [!irdl.named_type_constraint<"results" : !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
         // CHECK: }
         irdl.operation() ["name" = "norm"] {
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"c", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-            irdl.results() ["constraints" = [!irdl.named_type_constraint<"results", !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"c" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.results() ["params" = [!irdl.named_type_constraint<"results" : !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
         }
 
         // CHECK: irdl.operation() ["name" = "mul"] {
-        // CHECK: irdl.operands() ["constraints" = [!irdl.named_type_constraint<"lhs", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]] 
-        // CHECK: irdl.operands() ["constraints" = [!irdl.named_type_constraint<"rhs", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-        // CHECK: irdl.results() ["constraints" = [!irdl.named_type_constraint<"results", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+        // CHECK: irdl.operands() ["params" = [!irdl.named_type_constraint<"lhs" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]] 
+        // CHECK: irdl.operands() ["params" = [!irdl.named_type_constraint<"rhs" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+        // CHECK: irdl.results() ["params" = [!irdl.named_type_constraint<"results" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
         // CHECK: }
         irdl.operation() ["name" = "mul"] {
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"lhs", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"rhs", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-            irdl.results() ["constraints" = [!irdl.named_type_constraint<"results", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"lhs" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"rhs" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.results() ["params" = [!irdl.named_type_constraint<"results" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
         }
     }
 }

--- a/tests/filecheck/irdl-printer/any_and_base_type.xdsl
+++ b/tests/filecheck/irdl-printer/any_and_base_type.xdsl
@@ -2,15 +2,15 @@
 
 builtin.module() {
 
-    irdl.dialect() ["dialect_name" = "test_any_dyn"] {
+    irdl.dialect() ["name" = "test_any_dyn"] {
         
-        irdl.type() ["type_name" = "complex"] {
-            irdl.parameters() ["constraints" = [!irdl.named_type_constraint<"elementType", !irdl.equality_type_constraint<!i32>>]]
+        irdl.type() ["name" = "complex"] {
+            irdl.parameters() ["params" = [!irdl.named_type_constraint<"elementType" : !irdl.equality_type_constraint<!i32>>]]
         }
 
         irdl.operation() ["name" = "foo"] {
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"any", !irdl.any_type_constraint>]]
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"basetype", !irdl.dyn_type_constraint<"complex">>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"any" : !irdl.any_type_constraint>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"basetype" : !irdl.dyn_type_constraint<"complex">>]]
         }
     }
 }

--- a/tests/filecheck/irdl-printer/cmath_program.xdsl
+++ b/tests/filecheck/irdl-printer/cmath_program.xdsl
@@ -3,21 +3,21 @@
 
 builtin.module() {
 
-    irdl.dialect() ["dialect_name" = "cmath"] {
+    irdl.dialect() ["name" = "cmath"] {
 
-        irdl.type() ["type_name" = "complex"] {
-            irdl.parameters() ["constraints" = [!irdl.named_type_constraint<"elementType", !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
+        irdl.type() ["name" = "complex"] {
+            irdl.parameters() ["params" = [!irdl.named_type_constraint<"elementType" : !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
         }
 
         irdl.operation() ["name" = "norm"] {
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"c", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-            irdl.results() ["constraints" = [!irdl.named_type_constraint<"results", !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"c" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.results() ["params" = [!irdl.named_type_constraint<"results" : !irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>>]]
         }
 
         irdl.operation() ["name" = "mul"] {
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"lhs", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"rhs", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
-            irdl.results() ["constraints" = [!irdl.named_type_constraint<"results", !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"lhs" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"rhs" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
+            irdl.results() ["params" = [!irdl.named_type_constraint<"results" : !irdl.dyn_type_params_constraint<"complex", [!irdl.any_of_type<[!irdl.equality_type_constraint<!i32>, !irdl.equality_type_constraint<!i64>]>]>>]]
         }
     }
 }

--- a/tests/filecheck/irdl_any_and_base_type.xdsl
+++ b/tests/filecheck/irdl_any_and_base_type.xdsl
@@ -2,23 +2,23 @@
 
 builtin.module() {
 
-    //CHECK: irdl.dialect() ["dialect_name" = "test_any_dyn"] {
-    irdl.dialect() ["dialect_name" = "test_any_dyn"] {
+    //CHECK: irdl.dialect() ["name" = "test_any_dyn"] {
+    irdl.dialect() ["name" = "test_any_dyn"] {
 
-        // CHECK: irdl.type() ["type_name" = "complex"] {
-        // CHECK: irdl.parameters() ["constraints" = [!irdl.named_type_constraint<"elementType", !irdl.equality_type_constraint<!i32>>]]
+        // CHECK: irdl.type() ["name" = "complex"] {
+        // CHECK: irdl.parameters() ["params" = [!irdl.named_type_constraint<"elementType" : !irdl.equality_type_constraint<!i32>>]]
         // CHECK: }
-        irdl.type() ["type_name" = "complex"] {
-            irdl.parameters() ["constraints" = [!irdl.named_type_constraint<"elementType", !irdl.equality_type_constraint<!i32>>]]
+        irdl.type() ["name" = "complex"] {
+            irdl.parameters() ["params" = [!irdl.named_type_constraint<"elementType" : !irdl.equality_type_constraint<!i32>>]]
         }
 
         //CHECK: irdl.operation() ["name" = "foo"] {
-        //CHECK: irdl.operands() ["constraints" = [!irdl.named_type_constraint<"any", !irdl.any_type_constraint>]]
-        //CHECK: irdl.operands() ["constraints" = [!irdl.named_type_constraint<"basetype", !irdl.dyn_type_constraint<"complex">>]]
+        //CHECK: irdl.operands() ["params" = [!irdl.named_type_constraint<"any" : !irdl.any_type_constraint>]]
+        //CHECK: irdl.operands() ["params" = [!irdl.named_type_constraint<"basetype" : !irdl.dyn_type_constraint<"complex">>]]
         //CHECK: }
         irdl.operation() ["name" = "foo"] {
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"any", !irdl.any_type_constraint>]]
-            irdl.operands() ["constraints" = [!irdl.named_type_constraint<"basetype", !irdl.dyn_type_constraint<"complex">>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"any" : !irdl.any_type_constraint>]]
+            irdl.operands() ["params" = [!irdl.named_type_constraint<"basetype" : !irdl.dyn_type_constraint<"complex">>]]
         }
     }
 }

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -94,8 +94,8 @@ class NamedTypeConstraintAttr(ParametrizedAttribute):
         return [StringAttr.from_str(type_name), params_constraints]
 
     def print_parameters(self, printer: Printer) -> None:
-        printer.print("<", self.type_name.data, " : ", self.params_constraints,
-                      ">")
+        printer.print("<\"", self.type_name.data, "\" : ",
+                      self.params_constraints, ">")
 
 
 @irdl_op_definition
@@ -123,7 +123,7 @@ class ParametersOp(Operation):
     Define the parameters of a type/attribute definition
     """
     name = "irdl.parameters"
-    constraints = AttributeDef(ArrayAttr)
+    params = AttributeDef(ArrayAttr)
 
 
 @irdl_op_definition
@@ -132,8 +132,17 @@ class TypeOp(Operation):
     Defines new types belonging to previously defined dialect
     """
     name = "irdl.type"
-    type_name = AttributeDef(StringAttr)
     body = SingleBlockRegionDef()
+
+    @property
+    def type_name(self) -> StringAttr:
+        return cast(StringAttr, self.attributes["name"])
+
+    def verify_(self) -> None:
+        if "name" not in self.attributes.keys():
+            raise ValueError("name attribute is required")
+        if not isinstance(self.attributes["name"], StringAttr):
+            raise ValueError("name attribute must be a string attribute")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from typing import cast
 from xdsl.dialects.builtin import ArrayAttr, StringAttr
 
 from xdsl.irdl import (ParameterDef, VarOperandDef, AnyAttr, AttributeDef,
                        SingleBlockRegionDef, VarResultDef, irdl_op_definition,
                        irdl_attr_definition)
 from xdsl.ir import ParametrizedAttribute, Operation, MLContext, Attribute
+from xdsl.parser import Parser
+from xdsl.printer import Printer
 
 
 @dataclass
@@ -81,6 +84,19 @@ class NamedTypeConstraintAttr(ParametrizedAttribute):
     type_name: ParameterDef[StringAttr]
     params_constraints: ParameterDef[Attribute]
 
+    @staticmethod
+    def parse_parameters(parser: Parser) -> list[Attribute]:
+        parser.parse_char("<")
+        type_name = parser.parse_str_literal()
+        parser.parse_char(":")
+        params_constraints = parser.parse_attribute()
+        parser.parse_char(">")
+        return [StringAttr.from_str(type_name), params_constraints]
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print("<", self.type_name.data, " : ", self.params_constraints,
+                      ">")
+
 
 @irdl_op_definition
 class DialectOp(Operation):
@@ -88,8 +104,17 @@ class DialectOp(Operation):
     Define a new dialect
     """
     name = "irdl.dialect"
-    dialect_name = AttributeDef(StringAttr)
     body = SingleBlockRegionDef()
+
+    @property
+    def dialect_name(self) -> StringAttr:
+        return cast(StringAttr, self.attributes["name"])
+
+    def verify_(self) -> None:
+        if "name" not in self.attributes.keys():
+            raise ValueError("name attribute is required")
+        if not isinstance(self.attributes["name"], StringAttr):
+            raise ValueError("name attribute must be a string attribute")
 
 
 @irdl_op_definition
@@ -128,7 +153,7 @@ class OperandsOp(Operation):
     """
     name = "irdl.operands"
     op = VarOperandDef(AnyAttr())
-    constraints = AttributeDef(AnyAttr())
+    params = AttributeDef(AnyAttr())
 
 
 @irdl_op_definition
@@ -138,7 +163,7 @@ class ResultsOp(Operation):
     """
     name = "irdl.results"
     res = VarResultDef(AnyAttr())
-    constraints = AttributeDef(AnyAttr())
+    params = AttributeDef(AnyAttr())
 
 
 @irdl_op_definition
@@ -148,3 +173,13 @@ class OperationOp(Operation):
     """
     name = "irdl.operation"
     body = SingleBlockRegionDef()
+
+    @property
+    def op_name(self) -> StringAttr:
+        return cast(StringAttr, self.attributes["name"])
+
+    def verify_(self) -> None:
+        if "name" not in self.attributes.keys():
+            raise ValueError("name attribute is required")
+        if not isinstance(self.attributes["name"], StringAttr):
+            raise ValueError("name attribute must be a string attribute")

--- a/xdsl/irdl_mlir_printer.py
+++ b/xdsl/irdl_mlir_printer.py
@@ -78,7 +78,7 @@ class IRDLPrinter:
     def print_parameters_definition(self, param_op: ParametersOp):
         self._print(f"      {ParametersOp.name}", end="(")
 
-        for param in param_op.constraints.data:
+        for param in param_op.params.data:
             self._print(f"{param.type_name.data}: ", end="")
             self.print_attr_constraint(param.params_constraints)
         self._print(")")
@@ -107,7 +107,7 @@ class IRDLPrinter:
         self._print(f"      {ResultsOp.name}", end="(")
 
         for i in range(len(res_list)):
-            for result in res_list[i].constraints.data:
+            for result in res_list[i].params.data:
                 self.print_attr_constraint(result)
                 self._print(", ", end='') if i != len(res_list) - 1 else None
         self._print(")")
@@ -116,14 +116,13 @@ class IRDLPrinter:
         self._print(f"      {OperandsOp.name}", end="(")
 
         for i in range(len(op_list)):
-            for ops in op_list[i].constraints.data:
+            for ops in op_list[i].params.data:
                 self.print_attr_constraint(ops)
                 self._print(", ", end='') if i != len(op_list) - 1 else None
         self._print(")")
 
     def print_dialect_definition(self, di: DialectOp):
-        self._print(
-            f"  {DialectOp.name} {di.attributes['dialect_name'].data} {{")
+        self._print(f"  {DialectOp.name} {di.dialect_name.data} {{")
 
         di.walk(lambda type: self.print_type_definition(type)
                 if isinstance(type, TypeOp) else None)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -707,7 +707,6 @@ class Parser:
                 return attr
 
         # Then, we parse attributes/types with the generic format.
-
         if self.parse_optional_char("!") is None:
             if self.source == self.Source.MLIR:
                 if self.parse_optional_char("#") is None:
@@ -937,7 +936,7 @@ class Parser:
 
         # Array attribute
         if self.parse_optional_char("["):
-            contents = self.parse_list(self.parse_optional_mlir_attribute)
+            contents = self.parse_list(self.parse_optional_attribute)
             self.parse_char("]")
             return ArrayAttr.from_list(contents)
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -707,6 +707,7 @@ class Parser:
                 return attr
 
         # Then, we parse attributes/types with the generic format.
+
         if self.parse_optional_char("!") is None:
             if self.source == self.Source.MLIR:
                 if self.parse_optional_char("#") is None:


### PR DESCRIPTION
Fix the parsing of some IRDL operations and attributes in IRDL, and fix the parsing of array attribute for MLIR.