### PR TITLE
mlir printing and parsing fix

### DIFF
--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -106,4 +106,22 @@
 
   // CHECK: "value1" = opaque<"test", "contents">, "value2" = opaque<"test", "contents"> : tensor<2xf64>
 
+  "func.func"() ({}) {function_type = () -> (),
+                      symbol = @some_symbol,
+                      sym_name = "symbol_attr"} : () -> ()
+
+  // CHECK: "symbol" = @some_symbol
+
+  "func.func"() ({}) {function_type = () -> (),
+                      value1 = dense<[0]> : tensor<?xi32>,
+                      sym_name = "unranked_tensor_type"} : () -> ()
+
+  // CHECK: tensor<?xi32>
+
+  "func.func"() ({}) {function_type = () -> (),
+                      value1 = dense<[0]> : tensor<-1xi32>,
+                      sym_name = "unranked_tensor_type_2"} : () -> ()
+
+  // CHECK: tensor<?xi32>
+
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -113,14 +113,8 @@
   // CHECK: "symbol" = @some_symbol
 
   "func.func"() ({}) {function_type = () -> (),
-                      value1 = dense<[0]> : tensor<?xi32>,
-                      sym_name = "unranked_tensor_type"} : () -> ()
-
-  // CHECK: tensor<?xi32>
-
-  "func.func"() ({}) {function_type = () -> (),
-                      value1 = dense<[0]> : tensor<-1xi32>,
-                      sym_name = "unranked_tensor_type_2"} : () -> ()
+                      value1 = tensor<?xi32>,
+                      sym_name = "non_static_shaped_tensor"} : () -> ()
 
   // CHECK: tensor<?xi32>
 

--- a/tests/filecheck/mlir-conversion/with-bindings/ops.xdsl
+++ b/tests/filecheck/mlir-conversion/with-bindings/ops.xdsl
@@ -52,5 +52,10 @@ builtin.module() {
   }
 
   memref.global() ["sym_name" = "complex_types", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !i64], !index>, [0 : !index]>, "sym_visibility" = "public"]
+  
+  func.func() ["function_type" = !fun<[], []>, "symbol" = @some_symbol, "sym_name" = "symbol_attr"] {}
 
+  func.func() ["function_type" = !fun<[], []>, "value1" = !dense<!tensor<[-1 : !index], !i32>, [0 : !i32]>, "sym_name" = "unranked_tensor_type"] {}
+  
+  func.func() ["function_type" = !fun<[], []>, "value1" = !dense<!tensor<[-1 : !index], !i32>, [0 : !i32]>, "sym_name" = "unranked_tensor_type_2"] {}
 }

--- a/tests/filecheck/mlir-conversion/with-bindings/ops.xdsl
+++ b/tests/filecheck/mlir-conversion/with-bindings/ops.xdsl
@@ -53,7 +53,4 @@ builtin.module() {
 
   memref.global() ["sym_name" = "complex_types", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !i64], !index>, [0 : !index]>, "sym_visibility" = "public"]
 
-  func.func() ["function_type" = !fun<[], []>, "symbol" = @some_symbol, "sym_name" = "symbol_attr", "sym_visibility" = "private"] {}
-
-  func.func() ["function_type" = !fun<[], []>, "value1" = !tensor<[-1 : !index], !i32>, "sym_name" = "unranked_tensor_type", "sym_visibility" = "private"] {}
 }

--- a/tests/filecheck/mlir-conversion/with-bindings/ops.xdsl
+++ b/tests/filecheck/mlir-conversion/with-bindings/ops.xdsl
@@ -52,10 +52,8 @@ builtin.module() {
   }
 
   memref.global() ["sym_name" = "complex_types", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !i64], !index>, [0 : !index]>, "sym_visibility" = "public"]
-  
-  func.func() ["function_type" = !fun<[], []>, "symbol" = @some_symbol, "sym_name" = "symbol_attr"] {}
 
-  func.func() ["function_type" = !fun<[], []>, "value1" = !dense<!tensor<[-1 : !index], !i32>, [0 : !i32]>, "sym_name" = "unranked_tensor_type"] {}
-  
-  func.func() ["function_type" = !fun<[], []>, "value1" = !dense<!tensor<[-1 : !index], !i32>, [0 : !i32]>, "sym_name" = "unranked_tensor_type_2"] {}
+  func.func() ["function_type" = !fun<[], []>, "symbol" = @some_symbol, "sym_name" = "symbol_attr", "sym_visibility" = "private"] {}
+
+  func.func() ["function_type" = !fun<[], []>, "value1" = !tensor<[-1 : !index], !i32>, "sym_name" = "unranked_tensor_type", "sym_visibility" = "private"] {}
 }

--- a/tests/filecheck/mlir-conversion/with-bindings/symbol_tests.xdsl
+++ b/tests/filecheck/mlir-conversion/with-bindings/symbol_tests.xdsl
@@ -1,0 +1,10 @@
+// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic > %t-2 && diff %t-1 %t-2
+
+// Tests if the non generic form can be printed.
+
+// CHECK: module {
+builtin.module() {
+  func.func() ["function_type" = !fun<[], []>, "symbol" = @some_symbol, "sym_name" = "symbol_attr", "sym_visibility" = "private"] {}
+
+  func.func() ["function_type" = !fun<[], []>, "value1" = !tensor<[-1 : !index], !i32>, "sym_name" = "unranked_tensor_type", "sym_visibility" = "private"] {}
+}

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -943,6 +943,11 @@ class Parser:
             self.parse_char("]")
             return ArrayAttr.from_list(contents)
 
+        # FlatSymbolRefAttr
+        if self.parse_optional_char("@"):
+            symbol_name = self.parse_alpha_num(skip_white_space=False)
+            return FlatSymbolRefAttr.from_str(symbol_name)
+
         # tensor type
         if (tensor := self.parse_optional_mlir_tensor()) is not None:
             return tensor

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -408,8 +408,9 @@ class Printer:
             attribute = cast(AnyVectorType, attribute)
             self.print(
                 "vector<" if isinstance(attribute, VectorType) else "tensor<")
-            self.print_list(attribute.shape.data,
-                            lambda x: self.print(x.value.data), "x")
+            self.print_list(
+                attribute.shape.data, lambda x: self.print(x.value.data)
+                if x.value.data != -1 else self.print("?"), "x")
             if len(attribute.shape.data) != 0:
                 self.print("x")
             self.print(attribute.element_type)


### PR DESCRIPTION
- fix mlir parsing of symbol_ref, e.g.
```
"some.mlirop"() {symbol = @some_symbol} : () -> ()
```

- fix mlir printing of tensors with unknown sizes
Now printed as `tensor<?x128xf32>` instead of `tensor<-1x128xf32>`.
This is required for reparsing with mlir-opt
