### PR TITLE
xdsl: parse custom memref format

### DIFF
--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -124,4 +124,10 @@
 
   // CHECK: tensor<?xi32>
 
+  "func.func"() ({}) {function_type = () -> (), 
+                      memref = memref<2xf32>,
+                      sym_name = "memref"} : () -> ()
+
+  // CHECK: memref<2xf32>
+
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -136,4 +136,10 @@
 
   // CHECK: memref<*xf32>
 
+  "func.func"() ({}) {function_type = () -> (), 
+                      memref = memref<2x?xf32>,
+                      sym_name = "memref"} : () -> ()
+
+  // CHECK: memref<2x?xf32>
+
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -130,4 +130,10 @@
 
   // CHECK: memref<2xf32>
 
+  "func.func"() ({}) {function_type = () -> (), 
+                      memref = memref<*xf32>,
+                      sym_name = "memref"} : () -> ()
+
+  // CHECK: memref<*xf32>
+
 }) : () -> ()

--- a/tests/test_mlir_printer.py
+++ b/tests/test_mlir_printer.py
@@ -241,8 +241,6 @@ def test_parse_memref():
 
     test_prog = """\
     "builtin.module"() ({
-      "func.func"() ({}) {"function_type" = () -> (), "sym_name" = "dead_private_function", "sym_visibility" = "private"} : () -> ()
-      "func.func"() ({}) {"function_type" = () -> (), "sym_name" = "dead_nested_function", "sym_visibility" = "nested"} : () -> ()
       "func.func"() ({
         ^0(%0 : i1, %1 : memref<2xf32>, %2 : memref<2xf32>):
           "func.return"() : () -> ()
@@ -262,14 +260,6 @@ def test_parse_memref():
     res = StringIO()
     printer = Printer(target=Printer.Target.MLIR, stream=res)
     printer.print_op(module)
-
-    print(res.getvalue())
-    print(test_prog)
-
-    for a, b in zip(res.getvalue().split('\n'), test_prog.split('\n')):
-        print(a.strip())
-        print(b.strip())
-        print()
 
     # Remove all whitespace from the expected string.
     regex = re.compile(r'[^\S]+')

--- a/tests/test_mlir_printer.py
+++ b/tests/test_mlir_printer.py
@@ -114,7 +114,7 @@ def test_data_attr():
     """Test printing an operation with a data attribute."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !data_attr<42> ]""",
-        """"any"() {"attr" = #data_attr<42>} : () -> ()""",
+        """"any"() {attr = #data_attr<42>} : () -> ()""",
     )
 
 
@@ -130,7 +130,7 @@ def test_param_attr():
     """Test printing an operation with a parametrized attribute."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_attr ]""",
-        """"any"() {"attr" = #param_attr } : () -> ()""",
+        """"any"() {attr = #param_attr } : () -> ()""",
     )
 
 
@@ -148,13 +148,13 @@ def test_param_attr_with_param():
     """
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_attr_with_param<!param_attr> ]""",
-        """"any"() {"attr" = #param_attr_with_param<#param_attr> }
+        """"any"() {attr = #param_attr_with_param<#param_attr> }
           : () -> ()""",
     )
 
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_attr_with_param<!param_type> ]""",
-        """"any"() {"attr" = #param_attr_with_param<!param_type> }
+        """"any"() {attr = #param_attr_with_param<!param_type> }
           : () -> ()""",
     )
 
@@ -213,7 +213,7 @@ def test_op_with_attributes():
     """Test printing an operation with attributes."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !data_attr<42> ]""",
-        """"any"() {"attr" = #data_attr<42>} : () -> ()""",
+        """"any"() {attr = #data_attr<42>} : () -> ()""",
     )
 
 
@@ -221,5 +221,5 @@ def test_param_custom_format():
     """Test printing an operation with a param attribute with custom format."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_custom_format<!param_attr> ]""",
-        """"any"() {"attr" = #param_custom_format~~} : () -> ()""",
+        """"any"() {attr = #param_custom_format~~} : () -> ()""",
     )

--- a/tests/test_mlir_printer.py
+++ b/tests/test_mlir_printer.py
@@ -226,34 +226,3 @@ def test_param_custom_format():
         """any() [ "attr" = !param_custom_format<!param_attr> ]""",
         """"any"() {"attr" = #param_custom_format~~} : () -> ()""",
     )
-
-
-def test_parse_memref():
-    """Test parsing and printing of memref works"""
-
-    test_prog = """\
-    "builtin.module"() ({
-      "func.func"() ({
-        ^0(%0 : i1, %1 : memref<2xf32>, %2 : memref<2xf32>):
-          "func.return"() : () -> ()
-        }) {"function_type" = (i1, memref<2xf32>, memref<2xf32>) -> (), "sym_name" = "simple1"} : () -> ()
-    }) : () -> ()
-    """
-
-    ctx = MLContext()
-
-    _ = Builtin(ctx)
-    _ = MemRef(ctx)
-    _ = Func(ctx)
-
-    parser = Parser(ctx, test_prog, source=Parser.Source.MLIR)
-    module = parser.parse_op()
-
-    res = StringIO()
-    printer = Printer(target=Printer.Target.MLIR, stream=res)
-    printer.print_op(module)
-
-    # Remove all whitespace from the expected string.
-    regex = re.compile(r'[^\S]+')
-    assert (regex.sub("", res.getvalue()).strip() == \
-            regex.sub("", test_prog).strip())

--- a/tests/test_mlir_printer.py
+++ b/tests/test_mlir_printer.py
@@ -27,14 +27,6 @@ class AnyOp(Operation):
     res: Annotated[VarOpResult, AnyAttr()]
 
 
-@irdl_op_definition
-class TestOpCrash(Operation):
-    """Operation only used for testing."""
-    name = "test.op_crash"
-    op: Annotated[VarOperand, AnyAttr()]
-    res: Annotated[VarOpResult, AnyAttr()]
-
-
 @irdl_attr_definition
 class DataAttr(Data[int]):
     """Attribute only used for testing."""

--- a/tests/test_mlir_printer.py
+++ b/tests/test_mlir_printer.py
@@ -1,5 +1,7 @@
 from io import StringIO
 from typing import Annotated
+import re
+
 from xdsl.dialects.builtin import Builtin
 from xdsl.dialects.memref import MemRef
 from xdsl.dialects.func import Func
@@ -8,8 +10,6 @@ from xdsl.irdl import (AnyAttr, ParameterDef, RegionDef, VarOpResult,
                        VarOperand, irdl_attr_definition, irdl_op_definition)
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-
-import re
 
 
 @irdl_op_definition

--- a/tests/test_mlir_printer.py
+++ b/tests/test_mlir_printer.py
@@ -125,7 +125,7 @@ def test_data_attr():
     """Test printing an operation with a data attribute."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !data_attr<42> ]""",
-        """"any"() {attr = #data_attr<42>} : () -> ()""",
+        """"any"() {"attr" = #data_attr<42>} : () -> ()""",
     )
 
 
@@ -141,7 +141,7 @@ def test_param_attr():
     """Test printing an operation with a parametrized attribute."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_attr ]""",
-        """"any"() {attr = #param_attr } : () -> ()""",
+        """"any"() {"attr" = #param_attr } : () -> ()""",
     )
 
 
@@ -159,13 +159,13 @@ def test_param_attr_with_param():
     """
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_attr_with_param<!param_attr> ]""",
-        """"any"() {attr = #param_attr_with_param<#param_attr> }
+        """"any"() {"attr" = #param_attr_with_param<#param_attr> }
           : () -> ()""",
     )
 
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_attr_with_param<!param_type> ]""",
-        """"any"() {attr = #param_attr_with_param<!param_type> }
+        """"any"() {"attr" = #param_attr_with_param<!param_type> }
           : () -> ()""",
     )
 
@@ -224,7 +224,7 @@ def test_op_with_attributes():
     """Test printing an operation with attributes."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !data_attr<42> ]""",
-        """"any"() {attr = #data_attr<42>} : () -> ()""",
+        """"any"() {"attr" = #data_attr<42>} : () -> ()""",
     )
 
 
@@ -232,7 +232,7 @@ def test_param_custom_format():
     """Test printing an operation with a param attribute with custom format."""
     print_as_mlir_and_compare(
         """any() [ "attr" = !param_custom_format<!param_attr> ]""",
-        """"any"() {attr = #param_custom_format~~} : () -> ()""",
+        """"any"() {"attr" = #param_custom_format~~} : () -> ()""",
     )
 
 
@@ -241,12 +241,12 @@ def test_parse_memref():
 
     test_prog = """\
     "builtin.module"() ({
-      "func.func"() ({}) {function_type = () -> (), sym_name = "dead_private_function", sym_visibility = "private"} : () -> ()
-      "func.func"() ({}) {function_type = () -> (), sym_name = "dead_nested_function", sym_visibility = "nested"} : () -> ()
+      "func.func"() ({}) {"function_type" = () -> (), "sym_name" = "dead_private_function", "sym_visibility" = "private"} : () -> ()
+      "func.func"() ({}) {"function_type" = () -> (), "sym_name" = "dead_nested_function", "sym_visibility" = "nested"} : () -> ()
       "func.func"() ({
         ^0(%0 : i1, %1 : memref<2xf32>, %2 : memref<2xf32>):
           "func.return"() : () -> ()
-        }) {function_type = (i1, memref<2xf32>, memref<2xf32>) -> (), sym_name = "simple1"} : () -> ()
+        }) {"function_type" = (i1, memref<2xf32>, memref<2xf32>) -> (), "sym_name" = "simple1"} : () -> ()
     }) : () -> ()
     """
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -637,7 +637,7 @@ def test_parse_dense_mlir():
     """
 
     expected = """
-    %0 = "arith.constant"() {value = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    %0 = "arith.constant"() {"value" = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
     """
 
     ctx = MLContext()

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -637,7 +637,7 @@ def test_parse_dense_mlir():
     """
 
     expected = """
-    %0 = "arith.constant"() {"value" = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
+    %0 = "arith.constant"() {value = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>
     """
 
     ctx = MLContext()

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -51,6 +51,29 @@ class MemRefType(Generic[_MemRefTypeElement], ParametrizedAttribute, MLIRType):
         return MemRefType([shape, referenced_type])
 
 
+_UnrankedMemrefTypeElems = TypeVar("_UnrankedMemrefTypeElems",
+                                   bound=Attribute,
+                                   covariant=True)
+
+
+@irdl_attr_definition
+class UnrankedMemrefType(Generic[_UnrankedMemrefTypeElems],
+                         ParametrizedAttribute, MLIRType):
+    name = "unranked_memref"
+
+    element_type: ParameterDef[_UnrankedMemrefTypeElems]
+
+    @staticmethod
+    @builder
+    def from_type(
+        referenced_type: _UnrankedMemrefTypeElems
+    ) -> UnrankedMemrefType[_UnrankedMemrefTypeElems]:
+        return UnrankedMemrefType([referenced_type])
+
+
+AnyUnrankedMemrefType: TypeAlias = UnrankedMemrefType[Attribute]
+
+
 @irdl_op_definition
 class Load(Operation):
     name = "memref.load"
@@ -243,4 +266,4 @@ class Global(Operation):
 
 
 MemRef = Dialect([Load, Store, Alloc, Alloca, Dealloc, GetGlobal, Global],
-                 [MemRefType])
+                 [MemRefType, UnrankedMemrefType])

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -897,7 +897,7 @@ class Parser:
                 return UnrankedMemrefType.from_type(typ)
             dims, typ = self.parse_shape()
             self.parse_char(">")
-            return MemRefType.from_type_and_list(typ, dims)
+            return MemRefType.from_element_type_and_shape(typ, dims)
         return None
 
     def parse_optional_mlir_index_type(self,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -5,7 +5,7 @@ from enum import Enum
 from frozenlist import FrozenList
 from typing import Iterable, TypeVar, Any, Dict, Optional, List, cast
 
-from xdsl.dialects.memref import MemRefType
+from xdsl.dialects.memref import AnyUnrankedMemrefType, MemRefType, UnrankedMemrefType
 from xdsl.ir import (BlockArgument, MLIRType, SSAValue, Block, Callable,
                      Attribute, Region, Operation, Data, ParametrizedAttribute)
 from xdsl.utils.diagnostic import Diagnostic
@@ -459,6 +459,15 @@ class Printer:
             self.print_list(attribute.shape.data,
                             lambda x: self.print(x.value.data), "x")
             self.print("x", attribute.element_type)
+            self.print(">")
+            return
+
+        # Unranked tensors have an alias in MLIR, but not in xDSL
+        if (isinstance(attribute, UnrankedMemrefType)
+                and self.target == self.Target.MLIR):
+            attribute = cast(AnyUnrankedMemrefType, attribute)
+            self.print("memref<*x")
+            self.print(attribute.element_type)
             self.print(">")
             return
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -456,8 +456,9 @@ class Printer:
                 and self.target == self.Target.MLIR):
             attribute = cast(MemRefType[Attribute], attribute)
             self.print("memref<")
-            self.print_list(attribute.shape.data,
-                            lambda x: self.print(x.value.data), "x")
+            self.print_list(
+                attribute.shape.data, lambda x: self.print(x.value.data)
+                if x.value.data != -1 else self.print("?"), "x")
             self.print("x", attribute.element_type)
             self.print(">")
             return

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -15,7 +15,7 @@ from xdsl.dialects.builtin import (
     IndexType, IntegerType, NoneAttr, OpaqueAttr, Signedness, StringAttr,
     FlatSymbolRefAttr, IntegerAttr, ArrayAttr, IntAttr, TensorType, UnitAttr,
     FunctionType, UnrankedTensorType, UnregisteredOp, VectorType,
-    DictionaryAttr, SymbolNameAttr)
+    DictionaryAttr)
 
 indentNumSpaces = 2
 
@@ -476,10 +476,6 @@ class Printer:
                 self.print(" : ", attribute.type)
             return
 
-        if isinstance(attribute, SymbolNameAttr):
-            self.print(f'"{attribute.data.data}"')
-            return
-
         if self.target == self.Target.MLIR:
             # For the MLIR target, we may print differently some attributes
             self.print("!" if isinstance(attribute, MLIRType) else "#")
@@ -526,16 +522,10 @@ class Printer:
         self.print(")" if self.target == self.Target.XDSL else "]")
 
     def _print_attr_string(self, attr_tuple: tuple[str, Attribute]) -> None:
-        if self.target == Printer.Target.XDSL:
-            self.print('"')
-
-        self.print(f"{attr_tuple[0]}")
-
-        if self.target == Printer.Target.XDSL:
-            self.print('"')
-
-        if not isinstance(attr_tuple[1], UnitAttr):
-            self.print(" = ")
+        if isinstance(attr_tuple[1], UnitAttr):
+            self.print(f"\"{attr_tuple[0]}\"")
+        else:
+            self.print(f"\"{attr_tuple[0]}\" = ")
             self.print_attribute(attr_tuple[1])
 
     def _print_op_attributes(self, attributes: Dict[str, Attribute]) -> None:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -15,7 +15,7 @@ from xdsl.dialects.builtin import (
     IndexType, IntegerType, NoneAttr, OpaqueAttr, Signedness, StringAttr,
     FlatSymbolRefAttr, IntegerAttr, ArrayAttr, IntAttr, TensorType, UnitAttr,
     FunctionType, UnrankedTensorType, UnregisteredOp, VectorType,
-    DictionaryAttr)
+    DictionaryAttr, SymbolNameAttr)
 
 indentNumSpaces = 2
 
@@ -476,6 +476,10 @@ class Printer:
                 self.print(" : ", attribute.type)
             return
 
+        if isinstance(attribute, SymbolNameAttr):
+            self.print(f'"{attribute.data.data}"')
+            return
+
         if self.target == self.Target.MLIR:
             # For the MLIR target, we may print differently some attributes
             self.print("!" if isinstance(attribute, MLIRType) else "#")
@@ -522,10 +526,16 @@ class Printer:
         self.print(")" if self.target == self.Target.XDSL else "]")
 
     def _print_attr_string(self, attr_tuple: tuple[str, Attribute]) -> None:
-        if isinstance(attr_tuple[1], UnitAttr):
-            self.print(f"\"{attr_tuple[0]}\"")
-        else:
-            self.print(f"\"{attr_tuple[0]}\" = ")
+        if self.target == Printer.Target.XDSL:
+            self.print('"')
+
+        self.print(f"{attr_tuple[0]}")
+
+        if self.target == Printer.Target.XDSL:
+            self.print('"')
+
+        if not isinstance(attr_tuple[1], UnitAttr):
+            self.print(" = ")
             self.print_attribute(attr_tuple[1])
 
     def _print_op_attributes(self, attributes: Dict[str, Attribute]) -> None:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -471,7 +471,7 @@ class Printer:
             self.print(">")
             return
 
-        # index type have an alias in MLIR, but not in xDSL
+        # IndexType has an alias in MLIR, but not in xDSL
         if (isinstance(attribute, IndexType)
                 and self.target == self.Target.MLIR):
             self.print("index")


### PR DESCRIPTION
Currently adds memref as if it was a builtin, which feels a little wrong. Would love some input on how to make it better. Should we add custom formats? Is builtin style ok for now?

The number of tests successfully parsed went from 90 to 97 with current changes.