### PR TITLE
install: Remove PyPi update script

### DIFF
--- a/update_pypi.sh
+++ b/update_pypi.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-rm -rf ${SCRIPT_DIR}/dist
-python3 -m build
-python3 -m twine upload ${SCRIPT_DIR}/dist/*


### PR DESCRIPTION
Remove script that used to update the PyPi package.
Now that this is done in the CI, we do not need to manually do it.