### PR TITLE
Compiler: fix mlir module loading

### DIFF
--- a/xdsl/__init__.py
+++ b/xdsl/__init__.py
@@ -19,7 +19,7 @@ def load_mlir_module(mlir_module: _xdsl_init_types.ModuleType) -> None:
     _REQUIRED_MLIR_MODULES by the caller prior to calling this function.
     """
     global _mlir_module
-    if _mlir_module != mlir_module:
+    if _mlir_module and _mlir_module != mlir_module:
         raise RuntimeError('Different modules already loaded previously.')
     for submodule in _REQUIRED_MLIR_MODULES:
         if not hasattr(mlir_module, submodule):

--- a/xdsl/__init__.py
+++ b/xdsl/__init__.py
@@ -16,7 +16,11 @@ def load_mlir_module(mlir_module: _xdsl_init_types.ModuleType) -> None:
     Otherwise, `mlir` is used. Subsequent calls to this function are only
     allowed if they are made with the same argument. Furthermore, the provided
     module needs to be imported including all submodules specified in
-    _REQUIRED_MLIR_MODULES by the caller prior to calling this function.
+    _REQUIRED_MLIR_MODULES by the caller prior to calling this function. If we
+    load_mlir_module is called the first time (i.e. when _mlir_module is still
+    None), the given argument is written into _mlir_module (given that the
+    required submodules are loaded). If the function is called again, the given
+    mlir_module argument needs to be the same each time.
     """
     global _mlir_module
     if _mlir_module and _mlir_module != mlir_module:


### PR DESCRIPTION
This PR fixes loading of MLIR modules. The behavior we want here is that, if we call `load_mlir_module` the first time (i.e. when `_mlir_module` is still None), the given argument is written into `_mlir_module` (given that the required submodules are loaded). If the function is called again, the given `mlir_module` argument needs to be the same each time.