### PR TITLE
install: Add py.typed in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include xdsl/_version.py
 include requirements.txt requirements-optional.txt
+include xdsl/py.typed

--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,5 @@ setup(
     package_data={"xdsl": ["py.typed"]},
     install_requires=reqs,
     extras_require=extras_require,
+    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     author_email="mathieu.fehr@ed.ac.uk",
     license="MIT",
     packages=find_packages(),
+    package_data={"xdsl": ["py.typed"]},
     install_requires=reqs,
     extras_require=extras_require,
 )


### PR DESCRIPTION
It seems that the package does not have typing stubs installed with it.
According to [MyPy Documentation](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages), this change might fix it.