### PR TITLE
compiler: Fix tensor_from_list method of DenseIntOrFPElementsAttr to properly handle f32 input values

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -1,0 +1,31 @@
+from xdsl.dialects.builtin import DenseIntOrFPElementsAttr, f32, FloatAttr
+
+
+def test_DenseIntOrFPElementsAttr_fp_type_conversion():
+    check1 = DenseIntOrFPElementsAttr.tensor_from_list([4, 5], f32)
+
+    value1 = check1.data.data[0].value.data
+    value2 = check1.data.data[1].value.data
+
+    # Ensure type conversion happened properly during attribute construction.
+    assert type(value1) == float
+    assert value1 == 4.0
+    assert type(value2) == float
+    assert value2 == 5.0
+
+    t1 = FloatAttr.from_value(4.0, f32)
+    t2 = FloatAttr.from_value(5.0, f32)
+
+    check2 = DenseIntOrFPElementsAttr.tensor_from_list([t1, t2], f32)
+
+    value3 = check2.data.data[0].value.data
+    value4 = check2.data.data[1].value.data
+
+    # Ensure type conversion happened properly during attribute construction.
+    assert type(value3) == float
+    assert value3 == 4.0
+    assert type(value4) == float
+    assert value4 == 5.0
+
+
+#TODO: Add more tests for the builtin dialect.

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -551,7 +551,7 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
 
     @staticmethod
     @builder
-    def from_index_list(
+    def create_dense_index(
             type: VectorOrTensorOf[IndexType],
             data: List[int | IntegerAttr[IndexType]]
     ) -> DenseIntOrFPElementsAttr:
@@ -563,7 +563,7 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
 
     @staticmethod
     @builder
-    def from_int_list(
+    def create_dense_int(
         type: VectorOrTensorOf[IntegerType],
         data: List[int | IntegerAttr[IntegerType]]
     ) -> DenseIntOrFPElementsAttr:
@@ -575,28 +575,28 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
 
     @staticmethod
     @builder
-    def from_float_list(
+    def create_dense_float(
             type: VectorOrTensorOf[AnyFloat],
-            data: List[float | AnyFloatAttr]) -> DenseIntOrFPElementsAttr:
+            data: List[int | float | AnyFloatAttr]
+    ) -> DenseIntOrFPElementsAttr:
         data_attr = [
-            FloatAttr.from_value(d, type.element_type)
-            if isinstance(d, float) else d for d in data
+            FloatAttr.from_value(float(d), type.element_type)
+            if not isinstance(d, FloatAttr) else d for d in data
         ]
         return DenseIntOrFPElementsAttr([type, ArrayAttr.from_list(data_attr)])
 
     @staticmethod
     @builder
     def from_list(
-        type: VectorOrTensorOf[Attribute],
-        data: List[int | IntegerAttr[IntegerType]]
-        | List[int | IntegerAttr[IndexType]] | List[float | AnyFloatAttr]
+        type: VectorOrTensorOf[Attribute], data: List[int | AnyIntegerAttr]
+        | List[int | float | AnyFloatAttr]
     ) -> DenseIntOrFPElementsAttr:
         if isinstance(type.element_type, IntegerType):
-            return DenseIntOrFPElementsAttr.from_int_list(type, data)
+            return DenseIntOrFPElementsAttr.create_dense_int(type, data)
         elif isinstance(type.element_type, IndexType):
-            return DenseIntOrFPElementsAttr.from_index_list(type, data)
+            return DenseIntOrFPElementsAttr.create_dense_index(type, data)
         elif isinstance(type.element_type, AnyFloat):
-            return DenseIntOrFPElementsAttr.from_float_list(type, data)
+            return DenseIntOrFPElementsAttr.create_dense_float(type, data)
         else:
             raise TypeError(f"Unsupported element type {type.element_type}")
 


### PR DESCRIPTION
Fixes #179 

The following program can be used to verify that the proposed changes work as expected : 
```
from xdsl.dialects.builtin import *

def test_DenseIntOrFPElementsAttr():
    check1 = DenseIntOrFPElementsAttr.tensor_from_list([4, 5], f32)

    value1 = check1.data.data[0].value.data
    value2 = check1.data.data[1].value.data

    # Ensure type conversion happened properly during attribute construction.
    res1 = type(value1) == float and value1 == 4.0 and type(
        value2) == float and value2 == 5.0
    assert (res1)

    t1 = FloatAttr.from_value(4.0, f32)
    t2 = FloatAttr.from_value(5.0, f32)

    check2 = DenseIntOrFPElementsAttr.tensor_from_list([t1, t2], f32)

    value3 = check2.data.data[0].value.data
    value4 = check2.data.data[1].value.data

    # Ensure type conversion happened properly during attribute construction.
    res2 = type(value3) == float and value3 == 4.0 and type(
        value4) == float and value4 == 5.0
    assert (res2)


if __name__ == '__main__':
    test_DenseIntOrFPElementsAttr()
```