### PR TITLE
compiler: Add verifiers to func.func and func.return

### DIFF
--- a/tests/filecheck/affine_ops.xdsl
+++ b/tests/filecheck/affine_ops.xdsl
@@ -27,7 +27,7 @@ builtin.module() {
 // CHECK-NEXT: }
 
 
-  func.func() ["sym_name" = "affine_mm", "function_type" = !fun<[!memref<[256 : !index, 256 : !index], !f32>, !memref<[256 : !index, 256 : !index], !f32>, !memref<[256 : !index, 256 : !index], !f32>], [!f32]>, "sym_visibility" = "private"] {
+  func.func() ["sym_name" = "affine_mm", "function_type" = !fun<[!memref<[256 : !index, 256 : !index], !f32>, !memref<[256 : !index, 256 : !index], !f32>, !memref<[256 : !index, 256 : !index], !f32>], [!memref<[256 : !index, 256 : !index], !f32>]>, "sym_visibility" = "private"] {
   ^0(%0 : !memref<[256 : !index, 256 : !index], !f32>, %1 : !memref<[256 : !index, 256 : !index], !f32>, %2 : !memref<[256 : !index, 256 : !index], !f32>):
     affine.for() ["lower_bound" = 0 : !index, "upper_bound" = 256 : !index, "step" = 1 : !index] {
     ^1(%3 : !index):

--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -224,22 +224,22 @@ func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "divf"] 
 // CHECK:   %{{.*}} : !f32 = arith.divf(%{{.*}} : !f32, %{{.*}} : !f32)
 
 
-func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "select_int"] {
+func.func() ["function_type" = !fun<[!i1, !i32, !i32], [!i32]>, "sym_name" = "select_int"] {
 ^6(%0 : !i1, %18 : !i32, %19 : !i32):
   %8 : !i32 = arith.select(%0 : !i1, %18 : !i32, %19 : !i32)
   func.return(%8 : !i32)
 }
 
-// CHECK:   %{{.*}} : !i32 = arith.select(%{{.*}} : !i32, %{{.*}} : !i32)
+// CHECK:   %{{.*}} : !i32 = arith.select(%{{.*}} : !i1, %{{.*}} : !i32, %{{.*}} : !i32)
 
 
-func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "select_float"] {
+func.func() ["function_type" = !fun<[!i1, !f32, !f32], [!f32]>, "sym_name" = "select_float"] {
 ^6(%0 : !i1, %18 : !f32, %19 : !f32):
   %8 : !f32 = arith.select(%0 : !i1, %18 : !f32, %19 : !f32)
   func.return(%8 : !f32)
 }
 
-// CHECK:   %{{.*}} : !f32 = arith.select(%{{.*}} : !f32, %{{.*}} : !f32)
+// CHECK:   %{{.*}} : !f32 = arith.select(%{{.*}} : !i1, %{{.*}} : !f32, %{{.*}} : !f32)
 
 
 func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "shli"] {

--- a/tests/filecheck/builtin_attrs.xdsl
+++ b/tests/filecheck/builtin_attrs.xdsl
@@ -4,8 +4,7 @@
 // CHECK: module
 builtin.module() {
 
-  func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "builtin"] {
-    
+  func.func() ["function_type" = !fun<[], []>, "sym_name" = "builtin"] {
     // CHECK: "test" = !dense<!tensor<[1 : !index], !i32>, [0 : !i32]>
     %x1 : !i64 = arith.constant() ["value" = 0 : !i64, "test" = !dense<!tensor<[1 : !index], !i32>, [0 : !i32]>]
 
@@ -24,6 +23,7 @@ builtin.module() {
     // CHECK: "test" = false
     %x6 : !i64 = arith.constant() ["value" = 0 : !i64, "test" = 0 : !i1]
 
+    func.return()
   }
 
 }

--- a/tests/filecheck/cmath_ops.xdsl
+++ b/tests/filecheck/cmath_ops.xdsl
@@ -18,7 +18,7 @@ builtin.module() {
     // CHECK-NEXT: func.return(%{{.*}} : !f32)
     // CHECK-NEXT: }
 
-    func.func() ["sym_name" = "conorm2", "function_type" = !fun<[!cmath.complex<!f32>], [!f32]>, "sym_visibility" = "private"] {
+    func.func() ["sym_name" = "conorm2", "function_type" = !fun<[!cmath.complex<!f32>, !cmath.complex<!f32>], [!f32]>, "sym_visibility" = "private"] {
       ^1(%a: !cmath.complex<!f32>, %b: !cmath.complex<!f32>):
         %ab : !cmath.complex<!f32> = cmath.mul(%a : !cmath.complex<!f32>, %b : !cmath.complex<!f32>)
         %conorm : !f32 = cmath.norm(%ab : !cmath.complex<!f32>)

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -24,7 +24,7 @@
   // CHECK: (si32, si64, si1)
 
   "func.func"() ({
-    ^bb0(%arg0: ui32, %arg1: ui64, %arg2: si1):
+    ^bb0(%arg0: ui32, %arg1: ui64, %arg2: ui1):
     "func.return"() : () -> ()
   }) {function_type = (ui32, ui64, ui1) -> (), sym_name = "unsigned_int_type"} : () -> ()
 


### PR DESCRIPTION
Previously, there was no verification of `func.func` and `func.return` ops. This PR adds a basic function signature check and fixes wrong xDSL filecheck tests.