### PR TITLE
CI: Rename testing job

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: CI - Python application
+name: CI - Python-based Testing
 
 on:
   # Trigger the workflow on push or pull request,
@@ -38,7 +38,7 @@ jobs:
     - name: Execute lit tests
       run: |
         export PYTHONPATH=$(pwd)
-        lit -v tests/filecheck/ 
+        lit -v tests/filecheck/
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
closes #236 

This PR renames the testing CI jobs to be more intuitive to prevent confusion.