### PR TITLE
misc: Add Output folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ cython_debug/
 
 # lit tests results
 tests/filecheck/.lit_test_times.txt
+tests/**/Output/*
 
 # Mac
 .DS_Store


### PR DESCRIPTION
These are folders generated by running lit, which we probably don't want on the repo.