### PR TITLE
CI: Add MLIR-based CI

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -1,0 +1,86 @@
+# This workflow will install MLIR, Python dependencies, run tests and lint with a single version of Python
+
+name: CI - MLIR-based Testing
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.10']
+
+    env:
+      LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
+      MLIR-Version: 74992f4a5bb79e2084abdef406ef2e5aa2024368
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Python Setup
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Clang Setup
+      uses: egor-tensin/setup-clang@v1
+
+    - name: Ninja Setup
+      uses: llvm/actions/install-ninja@main
+
+    - name: CCache Setup (C++ compilation)
+      uses: hendrikmuhs/ccache-action@v1.2.5
+      with:
+        key: ${{ runner.os }}-${{ env.MLIR-Version }}
+        restore-keys: ${{ runner.os }}-${{ env.MLIR-Version }}
+        # LLVM needs serious cache size
+        max-size: 6G
+
+    - name: Checkout project
+      uses: actions/checkout@v3
+      with:
+        path: xdsl
+
+    - name: Checkout MLIR
+      uses: actions/checkout@v3
+      with:
+        repository: llvm/llvm-project.git
+        path: llvm-project
+        ref: ${{ env.MLIR-Version }}
+
+    - name: Upgrade pip
+      run: |
+        pip install --upgrade pip
+
+    - name: Install the package locally
+      run: |
+        pip install -e ${GITHUB_WORKSPACE}/xdsl
+
+    - name: MLIR Build Setup
+      run: |
+        pip install -r ${GITHUB_WORKSPACE}/llvm-project/mlir/python/requirements.txt
+        mkdir llvm-project/build
+        cd llvm-project/build
+        cmake -G Ninja ../llvm -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: MLIR Build
+      run: |
+        cd llvm-project/build
+        cmake --build . --target mlir-opt MLIRPythonModules
+
+    - name: Test
+      run: |
+        # Add the Python Bindings to the pythonpath
+        export PYTHONPATH=$PYTHONPATH:${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
+        # Add mlir-opt to the path
+        export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
+        lit -v ${GITHUB_WORKSPACE}/xdsl/tests/filecheck/mlir-conversion/with-bindings/


### PR DESCRIPTION
This PR adds a CI for our MLIR-based tests. There are a couple of things to mention here:
- On PRs/Pushes on main, this workflow is triggered.
- From the MLIR repo, only the commit we want is cloned (no history, no branches). This commit is hardcoded in the `Clone MLIR` part of the workflow.
- The workflow uses [CCache](https://github.com/hendrikmuhs/ccache-action) for gh actions to cache compiled files. This cache is saved on the github action cache and restored each time before trying to rebuild. This way, I managed to get the execution time down from around 2h ([here](https://github.com/xdslproject/xdsl/actions/runs/3566592241)) to 10min.
-  If we need to, this cache can be cleaned by following [this](https://github.com/hendrikmuhs/ccache-action/issues/28). 
- Notice that the compiled files need to be linked again for each execution. I moved to clang with [LLD](https://lld.llvm.org/) to speed this up.
- If we want to speed this CI job up further, we could pre-compile the mlir-opt executable and pull it in each time. Though notice that this will need manual recompilation if we decide to update the commit hash for the CI, whereas the current version does this fully automatically.
- Another potential timesave is that only `mlir-opt` is compiled. This reduces the amount of files needed to be cached and linked for each execution.  
- Notice that this CI job __only__ runs the tests in `tests/filecheck/mir-conversion/with-bindings` as all others are already run in the Python-based Testing job. Please indicate if anyone wants this to be different.
- Currently, the ninja installation seems to have issues with nodes that are deprecated. I am piggyback off of some of googles repos, so I am assuming that they will update this, when it becomes really necessary. Still, we should keep this in mind.