### PR TITLE
tests: drop test code from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,3 +21,7 @@ coverage:
 
 ignore:
   - "**/*.ipynb"
+  # https://about.codecov.io/blog/should-i-include-test-files-in-code-coverage-calculations/
+  - tests
+  - .github
+  - .git


### PR DESCRIPTION
There are several approaches to whether tests should be included in the coverage.
There are pros and cons.
In order to motivate better coverage for our core code, I think we could drop.

- https://about.codecov.io/blog/should-i-include-test-files-in-code-coverage-calculations/#:~:text=As%20mentioned%20above%2C%20tests%20are,run%20all%20of%20your%20tests.
- https://softwareengineering.stackexchange.com/questions/309015/when-does-it-make-sense-to-include-test-code-in-coverage