### PR TITLE
compiler: Fix attribute builder

### DIFF
--- a/tests/test_attribute_builder.py
+++ b/tests/test_attribute_builder.py
@@ -80,12 +80,12 @@ class OneBuilderTwoArgsAttr(Data[str]):
         raise NotImplementedError()
 
 
-def test_one_builder_2_not_enough_args():
+def test_one_builder_two_args_not_enough_args():
     with pytest.raises(BuilderNotFoundException):
         OneBuilderTwoArgsAttr.build(1)
 
 
-def test_one_builder_2_too_many_args():
+def test_one_builder_two_args_too_many_args():
     with pytest.raises(BuilderNotFoundException):
         OneBuilderTwoArgsAttr.build(1, "a", "b")
 

--- a/tests/test_attribute_builder.py
+++ b/tests/test_attribute_builder.py
@@ -6,6 +6,7 @@ from xdsl.ir import ParametrizedAttribute, Data
 from xdsl.irdl import irdl_attr_definition, builder
 from xdsl.parser import Parser
 from xdsl.printer import Printer
+from xdsl.utils.exceptions import BuilderNotFoundException
 
 
 @irdl_attr_definition
@@ -19,7 +20,7 @@ def test_no_builder_default():
 
 
 def test_no_builder_exception():
-    with pytest.raises(TypeError):
+    with pytest.raises(BuilderNotFoundException):
         NoBuilderAttr.build(3)
 
 
@@ -33,12 +34,12 @@ class OneBuilderAttr(Data[str]):
         return OneBuilderAttr(str(data))
 
     @staticmethod
-    def parse_parameter(parser: Parser) -> None:
-        pass
+    def parse_parameter(parser: Parser) -> str:
+        raise NotImplementedError()
 
     @staticmethod
     def print_parameter(data: str, printer: Printer) -> None:
-        pass
+        raise NotImplementedError()
 
 
 def test_one_builder_default():
@@ -52,8 +53,41 @@ def test_one_builder_builder():
 
 
 def test_one_builder_exception():
-    with pytest.raises(TypeError):
+    with pytest.raises(BuilderNotFoundException):
         OneBuilderAttr.build("1")
+
+
+def test_one_builder_too_many_params():
+    with pytest.raises(BuilderNotFoundException):
+        OneBuilderAttr.build(1, 2)
+
+
+@irdl_attr_definition
+class OneBuilderTwoArgsAttr(Data[str]):
+    name = "test.one_builder_attr"
+
+    @staticmethod
+    @builder
+    def from_int(data1: int, data2: str) -> OneBuilderAttr:
+        return OneBuilderAttr(str(data1) + data2)
+
+    @staticmethod
+    def parse_parameter(parser: Parser) -> str:
+        raise NotImplementedError()
+
+    @staticmethod
+    def print_parameter(data: str, printer: Printer) -> None:
+        raise NotImplementedError()
+
+
+def test_one_builder_2_not_enough_args():
+    with pytest.raises(BuilderNotFoundException):
+        OneBuilderTwoArgsAttr.build(1)
+
+
+def test_one_builder_2_too_many_args():
+    with pytest.raises(BuilderNotFoundException):
+        OneBuilderTwoArgsAttr.build(1, "a", "b")
 
 
 @irdl_attr_definition
@@ -72,11 +106,11 @@ class TwoBuildersAttr(Data[str]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> str:
-        pass
+        raise NotImplementedError()
 
     @staticmethod
     def print_parameter(data: str, printer: Printer) -> None:
-        pass
+        raise NotImplementedError()
 
 
 def test_two_builders_default():
@@ -95,43 +129,58 @@ def test_two_builders_second_builder():
 
 
 def test_two_builders_bad_args():
-    with pytest.raises(TypeError):
+    with pytest.raises(BuilderNotFoundException):
         TwoBuildersAttr.build([])
 
 
 @irdl_attr_definition
 class BuilderDefaultArgAttr(Data[str]):
     name = "test.builder_default_arg_attr"
-    param: str
 
     @staticmethod
     @builder
-    def from_int(data: int) -> BuilderDefaultArgAttr:
-        return BuilderDefaultArgAttr(str(data))
+    def from_int(data1: int,
+                 data2: int = 42,
+                 data3: int = 17) -> BuilderDefaultArgAttr:
+        return BuilderDefaultArgAttr(f"{data1}, {data2}, {data3}")
 
     @staticmethod
-    def parse_parameter(parser: Parser) -> None:
-        pass
+    def parse_parameter(parser: Parser) -> str:
+        raise NotImplementedError()
 
     @staticmethod
     def print_parameter(data: str, printer: Printer) -> None:
-        pass
+        raise NotImplementedError()
 
 
-def builder_default_arg_default():
+def test_builder_default_args_too_few_args():
+    with pytest.raises(BuilderNotFoundException):
+        BuilderDefaultArgAttr.build()
+
+
+def test_builder_default_args_only_required_args():
     attr = BuilderDefaultArgAttr.build(4)
-    assert attr == BuilderDefaultArgAttr("40")
+    assert attr == BuilderDefaultArgAttr("4, 42, 17")
 
 
-def builder_default_arg_arg():
-    attr = BuilderDefaultArgAttr.build(4, 2)
-    assert attr == BuilderDefaultArgAttr("42")
+def test_builder_default_args_only_required_args_and_one():
+    attr = BuilderDefaultArgAttr.build(4, 5)
+    assert attr == BuilderDefaultArgAttr("4, 5, 17")
+
+
+def test_builder_default_args_all_args():
+    attr = BuilderDefaultArgAttr.build(4, 5, 6)
+    assert attr == BuilderDefaultArgAttr("4, 5, 6")
+
+
+def test_builder_default_args_too_many_args():
+    with pytest.raises(BuilderNotFoundException):
+        BuilderDefaultArgAttr.build(4, 5, 6, 7)
 
 
 @irdl_attr_definition
 class BuilderUnionArgAttr(Data[str]):
     name = "test.builder_union_arg_attr"
-    param: str
 
     @staticmethod
     @builder
@@ -139,24 +188,24 @@ class BuilderUnionArgAttr(Data[str]):
         return BuilderUnionArgAttr(str(data))
 
     @staticmethod
-    def parse_parameter(parser: Parser) -> None:
-        pass
+    def parse_parameter(parser: Parser) -> str:
+        raise NotImplementedError()
 
     @staticmethod
     def print_parameter(data: str, printer: Printer) -> None:
-        pass
+        raise NotImplementedError()
 
 
-def builder_union_arg_first():
+def test_builder_union_arg_first():
     attr = BuilderUnionArgAttr.build(4)
     assert attr == BuilderUnionArgAttr("4")
 
 
-def builder_union_arg_second():
+def test_builder_union_arg_second():
     attr = BuilderUnionArgAttr.build("4")
     assert attr == BuilderUnionArgAttr("4")
 
 
-def builder_union_arg_bad_argument():
-    with pytest.raises(TypeError):
+def test_builder_union_arg_bad_argument():
+    with pytest.raises(BuilderNotFoundException):
         BuilderUnionArgAttr.build([])

--- a/tests/test_attribute_builder.py
+++ b/tests/test_attribute_builder.py
@@ -57,7 +57,7 @@ def test_one_builder_exception():
         OneBuilderAttr.build("1")
 
 
-def test_one_builder_too_many_params():
+def test_one_builder_extra_params():
     with pytest.raises(BuilderNotFoundException):
         OneBuilderAttr.build(1, 2)
 
@@ -85,7 +85,7 @@ def test_one_builder_two_args_not_enough_args():
         OneBuilderTwoArgsAttr.build(1)
 
 
-def test_one_builder_two_args_too_many_args():
+def test_one_builder_two_args_extra_args():
     with pytest.raises(BuilderNotFoundException):
         OneBuilderTwoArgsAttr.build(1, "a", "b")
 
@@ -153,7 +153,7 @@ class BuilderDefaultArgAttr(Data[str]):
         raise NotImplementedError()
 
 
-def test_builder_default_args_too_few_args():
+def test_builder_default_args_missing_args():
     with pytest.raises(BuilderNotFoundException):
         BuilderDefaultArgAttr.build()
 
@@ -173,7 +173,7 @@ def test_builder_default_args_all_args():
     assert attr == BuilderDefaultArgAttr("4, 5, 6")
 
 
-def test_builder_default_args_too_many_args():
+def test_builder_default_args_extra_args():
     with pytest.raises(BuilderNotFoundException):
         BuilderDefaultArgAttr.build(4, 5, 6, 7)
 

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -19,7 +19,7 @@ class VerifyException(DiagnosticException):
 @dataclass
 class BuilderNotFoundException(Exception):
     """
-    Exception raised when no builders are not found for a given attribute type
+    Exception raised when no builders are found for a given attribute type
     and a given tuple of arguments.
     """
     attribute: type[Attribute]

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -1,6 +1,30 @@
+"""Custom xDSL exceptions.
+
+This module contains all custom exceptions used by xDSL.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+from xdsl.ir import Attribute
+
+
 class DiagnosticException(Exception):
-    ...
+    pass
 
 
 class VerifyException(DiagnosticException):
-    ...
+    pass
+
+
+@dataclass
+class BuilderNotFoundException(Exception):
+    """
+    Exception raised when no builders are not found for a given attribute type
+    and a given tuple of arguments.
+    """
+    attribute: type[Attribute]
+    args: tuple[Any]
+
+    def __str__(self) -> str:
+        return f"No builder found for attribute {self.attribute} with " \
+               f"arguments {self.args}"

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -1,4 +1,5 @@
 from inspect import isclass
+from types import UnionType
 from typing import (Annotated, Any, TypeGuard, TypeVar, Union, cast, get_args,
                     get_origin)
 
@@ -35,7 +36,7 @@ def is_satisfying_hint(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
             and is_satisfying_hint(value, value_hint)
             for key, value in arg_dict.items())
 
-    if get_origin(hint) is Union:
+    if get_origin(hint) is Union or get_origin(hint) is UnionType:
         return any(
             is_satisfying_hint(arg, union_arg) for union_arg in get_args(hint))
 

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -36,7 +36,7 @@ def is_satisfying_hint(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
             and is_satisfying_hint(value, value_hint)
             for key, value in arg_dict.items())
 
-    if get_origin(hint) is Union or get_origin(hint) is UnionType:
+    if get_origin(hint) in [Union, UnionType]:
         return any(
             is_satisfying_hint(arg, union_arg) for union_arg in get_args(hint))
 


### PR DESCRIPTION
Fix `Attribute.build`, which failed if too many arguments were given.
It also failed when using `|` rather than `Union`.

Also update the builder tests, and fix obviously wrong ones.