### PR TITLE
CI: Generate proper coverage for filecheck tests

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -91,13 +91,14 @@ jobs:
         export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
         # Add the MLIR Python bindings to the PYTHONPATH
         export PYTHONPATH=$PYTHONPATH:${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
-        lit -v tests/filecheck/ -DCOVERAGE -DCOVERAGE_CONFIG=$(pwd)/.coveragerc
+        lit -v tests/filecheck/ -DCOVERAGE -DEXEC_DIR=$(pwd)
 
     - name: Combine coverage data
       run: |
-        coverage combine --append $(find xdsl/tests/filecheck -type d)
-        coverage report --data-file=xdsl/.coverage
-        coverage xml --data-file=xdsl/.coverage
+        cd xdsl
+        coverage combine --append
+        coverage report
+        coverage xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -15,7 +15,7 @@ else:
 config.environment["PATH"] = config.test_source_root + "/../../xdsl/tools/:" + os.environ["PATH"]
 
 if "COVERAGE" in lit_config.params:
-    if "COVERAGE_CONFIG" in lit_config.params:
-        config.substitutions.append(('xdsl-opt', "xdsl-opt --generate-coverage --coverage-config=" + lit_config.params["COVERAGE_CONFIG"]))
+    if "EXEC_DIR" in lit_config.params:
+        config.substitutions.append(('xdsl-opt', "xdsl-opt --generate-coverage --exec-root=" + lit_config.params["EXEC_DIR"]))
     else:
         config.substitutions.append(('xdsl-opt', "xdsl-opt --generate-coverage"))

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -71,7 +71,8 @@ class xDSLOptMain:
         Executes the different steps.
         """
         if self.args.generate_coverage:
-            os.chdir(self.args.exec_root)
+            if self.args.exec_root:
+                os.chdir(self.args.exec_root)
             cov = coverage.Coverage(check_preimported=True,
                                     config_file='.coveragerc',
                                     auto_data=True,

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -73,8 +73,7 @@ class xDSLOptMain:
         if self.args.generate_coverage:
             if self.args.exec_root:
                 os.chdir(self.args.exec_root)
-            cov = coverage.Coverage(check_preimported=True,
-                                    config_file='.coveragerc',
+            cov = coverage.Coverage(config_file='.coveragerc',
                                     auto_data=True,
                                     data_file='.coverage',
                                     data_suffix=True)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -71,7 +71,9 @@ class xDSLOptMain:
         Executes the different steps.
         """
         if self.args.generate_coverage:
-            cov = coverage.Coverage(config_file=self.args.coverage_config,
+            os.chdir(self.args.exec_root)
+            cov = coverage.Coverage(check_preimported=True,
+                                    config_file='.coveragerc',
                                     auto_data=True,
                                     data_file='.coverage',
                                     data_suffix=True)
@@ -174,12 +176,12 @@ class xDSLOptMain:
             help="Generate the xDSL code coverage for this run.")
 
         arg_parser.add_argument(
-            "--coverage-config",
+            "--exec-root",
             type=str,
             default=False,
             required=False,
             help=
-            "Link to the coverage config file. This flag only takes effect if `--generate-config` was specified."
+            "Defines the directory xdsl-opt will be run in. This flag only takes effect if `--generate-config` was specified."
         )
 
     def register_all_dialects(self):


### PR DESCRIPTION
This PR resolves an oversight in the earlier CI PR. In that version, the source directories were specified in a relative way (which is the only way it really makes sense), but since lit decides to run everything in its subdirectory, these relative paths did not exist. Therefore, all the coverages generated by the filecheck tests were basically empty (no source files) and they were not taken into account.

This is a solution to workaround this issue. The other solution I see would be to try and parametrize the config file somehow, such that an absolute source path can be defined...