### PR TITLE
compiler: Print attrs to str in a pretty format

### DIFF
--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -195,8 +195,7 @@ def test_base_constraint_fail():
     """Test the verifier of a union constraint."""
     with pytest.raises(Exception) as e:
         BoolWrapperAttr([StringData("foo")])
-    assert e.value.args[
-        0] == "StringData(data='foo') should be of base attribute bool"
+    assert e.value.args[0] == "!str<foo> should be of base attribute bool"
 
 
 #  _   _       _              ____                _             _       _
@@ -236,7 +235,7 @@ def test_union_constraint_fail():
     """Test the verifier of a union constraint."""
     with pytest.raises(Exception) as e:
         BoolOrIntParamAttr([StringData("foo")])
-    assert e.value.args[0] == "Unexpected attribute StringData(data='foo')"
+    assert e.value.args[0] == "Unexpected attribute !str<foo>"
 
 
 #     _                      _    ____                _
@@ -320,7 +319,7 @@ def test_typevar_attribute_fail():
     """Test that the verifier of an generic attribute can fail."""
     with pytest.raises(Exception) as e:
         ParamWrapperAttr([StringData("foo")])
-    assert e.value.args[0] == "Unexpected attribute StringData(data='foo')"
+    assert e.value.args[0] == "Unexpected attribute !str<foo>"
 
 
 @irdl_attr_definition
@@ -346,8 +345,7 @@ def test_param_attr_constraint_fail():
     """
     with pytest.raises(Exception) as e:
         ParamConstrAttr([ParamWrapperAttr([BoolData(True)])])
-    assert e.value.args[
-        0] == "BoolData(data=True) should be of base attribute int"
+    assert e.value.args[0] == "!bool<True> should be of base attribute int"
 
 
 _U = TypeVar("_U", bound=IntData)
@@ -380,8 +378,7 @@ def test_nested_generic_constraint_fail():
     """
     with pytest.raises(Exception) as e:
         NestedParamWrapperAttr([ParamWrapperAttr([BoolData(True)])])
-    assert e.value.args[
-        0] == "BoolData(data=True) should be of base attribute int"
+    assert e.value.args[0] == "!bool<True> should be of base attribute int"
 
 
 @irdl_attr_definition
@@ -568,7 +565,7 @@ def test_generic_data_wrapper_verifier_failure():
             [ListData([BoolData(True),
                        ListData([BoolData(False)])])])
     assert e.value.args[
-        0] == "ListData(data=[BoolData(data=False)]) should be of base attribute bool"
+        0] == "!list<[!bool<False>]> should be of base attribute bool"
 
 
 @irdl_attr_definition

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from frozenlist import FrozenList
+from io import StringIO
 from typing import (TYPE_CHECKING, Any, Callable, Generic, Protocol, Sequence,
                     TypeVar, cast, Iterator)
 import sys
@@ -264,6 +265,13 @@ class Attribute(ABC):
         Raise an exception otherwise.
         """
         pass
+
+    def __str__(self) -> str:
+        from xdsl.printer import Printer
+        res = StringIO()
+        printer = Printer(stream=res)
+        printer.print_attribute(self)
+        return res.getvalue()
 
 
 DataElement = TypeVar("DataElement")


### PR DESCRIPTION
This is the beginning of a solution for #275, in the cases for attributes.
Instead of printing them with their automatically defined "repr" format, they are directly printed with
their custom format instead.

I'll take care of operations in a separate PR to keep simple changes.