### PR TITLE
Testing: Improve tests for memref dialect

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -9,17 +9,20 @@ def test_memreftype():
 
     assert mem1.get_num_dims() == 1
     assert mem1.get_shape() == [1]
+    assert mem1.element_type is i32
 
     mem2 = MemRefType.from_type_and_list(i32, [3, 3, 3])
 
-    assert mem1.get_num_dims() == 1
+    assert mem2.get_num_dims() == 3
     assert mem2.get_shape() == [3, 3, 3]
+    assert mem2.element_type is i32
 
     my_i32 = IntegerType.from_width(32)
     mem3 = MemRefType.from_params(my_i32)
 
     assert mem3.get_num_dims() == 1
     assert mem3.get_shape() == [1]
+    assert mem3.element_type is my_i32
 
 
 def test_memref_load_i32():
@@ -78,8 +81,10 @@ def test_memref_alloc():
     assert alloc0.dynamic_sizes == []
     assert type(alloc0.results[0]) is OpResult
     assert alloc0.results[0].typ.get_shape() == [3, 1, 2]
+    assert type(alloc0.results[0].typ) is MemRefType
     assert type(alloc1.results[0]) is OpResult
     assert alloc1.results[0].typ.get_shape() == [1]
+    assert type(alloc1.results[0].typ) is MemRefType
 
 
 def test_memref_alloca():
@@ -87,8 +92,12 @@ def test_memref_alloca():
     alloc0 = Alloca.get(my_i32, 64, [3, 1, 2])
     alloc1 = Alloca.get(my_i32, 64)
 
+    assert type(alloc0.results[0]) is OpResult
     assert alloc0.results[0].typ.get_shape() == [3, 1, 2]
+    assert type(alloc0.results[0].typ) is MemRefType
+    assert type(alloc1.results[0]) is OpResult
     assert alloc1.results[0].typ.get_shape() == [1]
+    assert type(alloc1.results[0].typ) is MemRefType
 
 
 def test_memref_dealloc():


### PR DESCRIPTION
This PR provides minor improvements to python tests for `memref` dialect. 