### PR TITLE
xDSL/Vector: Add lit tests for verifiers

### DIFF
--- a/tests/filecheck/dialects/vector/vector_load_indexing.xdsl
+++ b/tests/filecheck/dialects/vector/vector_load_indexing.xdsl
@@ -1,0 +1,14 @@
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+
+builtin.module() {
+
+func.func() ["sym_name" = "vector_load_indexing", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index):
+    %2 : !vector<[2 : !index], !index> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index)
+
+    func.return()
+  }
+
+// CHECK: Expected an index for each dimension.
+
+}

--- a/tests/filecheck/dialects/vector/vector_load_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_load_type_matching.xdsl
@@ -1,0 +1,14 @@
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+
+builtin.module() {
+
+func.func() ["sym_name" = "vector_load_type_matching", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index):
+    %2 : !vector<[2 : !i32], !i32> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index, %1 : !index)
+
+    func.return()
+  }
+
+// CHECK: MemRef element type should match the Vector element type.
+
+}

--- a/tests/filecheck/dialects/vector/vector_store_indexing.xdsl
+++ b/tests/filecheck/dialects/vector/vector_store_indexing.xdsl
@@ -1,0 +1,14 @@
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+
+builtin.module() {
+
+func.func() ["sym_name" = "vector_store_indexing", "function_type" = !fun<[!vector<[2 : !index], !index>, !memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index):
+    vector.store(%0 : !vector<[2 : !index], !index>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index)
+
+    func.return()
+  }
+
+// CHECK: Expected an index for each dimension.
+
+}

--- a/tests/filecheck/dialects/vector/vector_store_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_store_type_matching.xdsl
@@ -1,0 +1,14 @@
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+
+builtin.module() {
+
+func.func() ["sym_name" = "vector_store_type_matching", "function_type" = !fun<[!vector<[2 : !i32], !i32>, !memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !i32], !i32>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index):
+    vector.store(%0 : !vector<[2 : !i32], !i32>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
+
+    func.return()
+  }
+
+// CHECK: MemRef element type should match the Vector element type.
+
+}


### PR DESCRIPTION
This PR intends to add `lit` tests for `vector` dialect verifiers as mentioned in [this](https://github.com/xdslproject/xdsl/pull/282#discussion_r1059927923) discussion.  