### PR TITLE
tests: Add testing for xdsl_opt_main

### DIFF
--- a/tests/xdsl_opt/README.md
+++ b/tests/xdsl_opt/README.md
@@ -1,0 +1,3 @@
+This folder contains the infrastructure to test `xdsl_opt_main` through pytest.
+The main driver sits in `test_xdsl_opt.py`, which needs the other files to read
+and reprint them.

--- a/tests/xdsl_opt/empty_program.xdsl
+++ b/tests/xdsl_opt/empty_program.xdsl
@@ -1,0 +1,1 @@
+builtin.module() {}

--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 
 def test_opt():
-    filename = 'tests/xdsl_opt/substitute_ops.xdsl'
+    filename = 'tests/xdsl_opt/empty_program.xdsl'
     opt = xDSLOptMain(args=[filename])
     assert list(opt.available_frontends.keys()) == ['xdsl', 'mlir']
     assert list(opt.available_targets.keys()) == ['xdsl', 'irdl', 'mlir']

--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -1,0 +1,18 @@
+from xdsl.xdsl_opt_main import xDSLOptMain
+from contextlib import redirect_stdout
+from io import StringIO
+
+
+def test_opt():
+    filename = 'tests/xdsl_opt/substitute_ops.xdsl'
+    opt = xDSLOptMain(args=[filename])
+    assert list(opt.available_frontends.keys()) == ['xdsl', 'mlir']
+    assert list(opt.available_targets.keys()) == ['xdsl', 'irdl', 'mlir']
+    assert list(opt.available_passes.keys()) == []
+
+    f = StringIO("")
+    with redirect_stdout(f):
+        opt.run()
+
+    expected = open(filename, 'r').read()
+    assert f.getvalue().strip() == expected.strip()

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -53,7 +53,9 @@ class xDSLOptMain:
     pipeline: List[tuple[str, Callable[[ModuleOp], None]]]
     """ The pass-pipeline to be applied. """
 
-    def __init__(self, description: str = 'xDSL modular optimizer driver'):
+    def __init__(self,
+                 description: str = 'xDSL modular optimizer driver',
+                 args=None):
         self.ctx = MLContext()
         self.register_all_dialects()
         self.register_all_frontends()
@@ -63,7 +65,7 @@ class xDSLOptMain:
         # arg handling
         arg_parser = argparse.ArgumentParser(description=description)
         self.register_all_arguments(arg_parser)
-        self.args = arg_parser.parse_args()
+        self.args = arg_parser.parse_args(args=args)
 
         self.setup_pipeline()
 


### PR DESCRIPTION
This PR hacks together a way to test xdsl_opt_main through some functionality of the arg parser.

Overall, I am feeling like the split of execution models (in a python interpreter vs from command line) will always come back to haunt us. I am not sure whether we actually can build something cleanly without reimplementing lit essentially.