### PR TITLE
CI: Publish xDSL-enabled JupyterLite distribution on GitHub Pages.

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -1,0 +1,84 @@
+name: Deploy JupiterLyte Page
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout xDSL
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: python -m pip install jupyterlite[all] libarchive-c jupyter_server jupyterlab_server build pkginfo pyodide-build
+
+      - name: Setup EmSDK
+        # Doing this in a hacky script because the custom Action is requiring an explicit EmSDK version
+        # Pyodide is requiring a specific version too and it is changing regularly. This install the actual
+        # version required by the latest pyodide.
+
+        # Double initialization of PYODIDE_EMSCRIPTEN_VERSION: see https://github.com/pyodide/pyodide/issues/3430
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          PYODIDE_EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)
+          PYODIDE_EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)
+          ./emsdk install ${PYODIDE_EMSCRIPTEN_VERSION}
+          ./emsdk activate ${PYODIDE_EMSCRIPTEN_VERSION}
+
+      - name: Build WASM wheels for frozenlist, coverage, and xDSL
+        run: |
+          mkdir pypi
+          source emsdk/emsdk_env.sh
+          for i in frozenlist coverage
+          do
+
+          python -m pip download --no-binary :all: "$(grep $i requirements.txt)"
+          tar -xf $i-*.tar.gz
+          rm $i_*.tar.gz
+          cd $i-*
+          pyodide build
+          cd ..
+          cp $(find -path "./$i-*/dist/$i-*_wasm32.whl") pypi
+
+          done
+
+          pyodide build
+          cp $(find -path "./dist/xdsl-*.whl") pypi
+
+      - name: Build the JupyterLite site
+        run: |
+          mkdir content
+          cp README.md content
+          cp docs content -r
+          python -m jupyter lite build --contents content --output-dir jupyterlite
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./jupyterlite
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -26,6 +26,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Currently no easy way to distribute with xDSL pre-installed.\n",
+    "%pip install xdsl\n",
+    "\n",
     "from xdsl.ir import MLContext\n",
     "from xdsl.dialects.arith import Arith\n",
     "from xdsl.dialects.builtin import Builtin\n",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -25,6 +25,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Currently no easy way to distribute with xDSL pre-installed.\n",
+    "%pip install xdsl\n",
+    "\n",
     "from xdsl.ir import MLContext\n",
     "from xdsl.dialects.arith import Arith\n",
     "from xdsl.dialects.func import Func\n",


### PR DESCRIPTION
Adding a workflow hosting a JupyterLite distribution on GitHub Pages, allowing to use xDSL and the included notebooks from the web with no local installation at all.

One drawback is the necessity to have `%pip install xdsl` in the notebooks for that to work (at the moment; will probably be solved by either pyodide or jupyterlite sometime soon, as it is a problem for many use cases). This can mess things up if using the same notebook locally (where it will install the latest pypi release of xDSL)