### PR TITLE
Add %pip install only in JupyterLite context.

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -59,6 +59,14 @@ jobs:
           mkdir content
           cp README.md content
           cp docs content -r
+          for f in $(find -path ./content/*.ipynb)
+          do
+          
+          echo appending to $f
+          sed -i 's/# xDSL should be available in the environment\./# xDSL should be available in the environment.\\n%pip install xdsl/g' $f
+          
+          done
+          
           python -m jupyter lite build --contents content --output-dir jupyterlite
 
       - name: Upload artifact

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -26,8 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Currently no easy way to distribute with xDSL pre-installed.\n",
-    "%pip install xdsl\n",
+    "# xDSL should be available in the environment.\n",
     "\n",
     "from xdsl.ir import MLContext\n",
     "from xdsl.dialects.arith import Arith\n",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -25,8 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Currently no easy way to distribute with xDSL pre-installed.\n",
-    "%pip install xdsl\n",
+    "# xDSL should be available in the environment.\n",
     "\n",
     "from xdsl.ir import MLContext\n",
     "from xdsl.dialects.arith import Arith\n",


### PR DESCRIPTION
This should solve the CI breaking from the `%pip install xdsl` command - and most annoyances from it.
Still necessary in Jupyter notebooks at the moment, so it's added in the CI for this context.