### PR TITLE
ci: add install of requirements in notebook and remove from CI

### DIFF
--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Upgrade pip
       run: |
         pip install --upgrade pip
-    - name: Install the package locally
-      run: pip install -e .
     - name: Install nbval
       run: |
         pip install nbval

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -22,6 +22,46 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "1c670f99",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: pytest<8.0 in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from -r ../requirements.txt (line 1)) (7.2.0)\n",
+      "Requirement already satisfied: filecheck<0.0.23 in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from -r ../requirements.txt (line 2)) (0.0.22)\n",
+      "Requirement already satisfied: lit<16.0.0 in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from -r ../requirements.txt (line 3)) (15.0.6)\n",
+      "Requirement already satisfied: frozenlist<1.4.* in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from -r ../requirements.txt (line 4)) (1.3.3)\n",
+      "Requirement already satisfied: coverage<8.0.0 in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from -r ../requirements.txt (line 5)) (7.0.4)\n",
+      "Requirement already satisfied: attrs>=19.2.0 in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from pytest<8.0->-r ../requirements.txt (line 1)) (22.2.0)\n",
+      "Requirement already satisfied: iniconfig in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from pytest<8.0->-r ../requirements.txt (line 1)) (2.0.0)\n",
+      "Requirement already satisfied: packaging in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from pytest<8.0->-r ../requirements.txt (line 1)) (23.0)\n",
+      "Requirement already satisfied: pluggy<2.0,>=0.12 in /Users/sasha/Develop/xdslproject/xdsl/venv/lib/python3.11/site-packages (from pytest<8.0->-r ../requirements.txt (line 1)) (1.0.0)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Install requirements if necessary\n",
+    "%pip install -r ../requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7ac54610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add the local xdsl definition to the path\n",
+    "import sys\n",
+    "sys.path.append('..')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "e86541f5-af35-4c73-9a8c-4c43e7d365d6",
    "metadata": {},
    "outputs": [],

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -496,9 +496,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -510,7 +510,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -20,7 +20,29 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "94c18ae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install requirements if necessary\n",
+    "%pip install -r ../requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
+   "id": "ec15b93c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('..')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "e86541f5-af35-4c73-9a8c-4c43e7d365d6",
    "metadata": {},
    "outputs": [],
@@ -474,9 +496,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
-   "name": "python3"
+   "name": "venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -488,7 +510,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR makes sure that the notebooks and CI both use the code in the repo, without a pip install of the framework. This lets developers iterate on the xdsl files and the notebooks at the same time.