### PR TITLE
CI: Fix Codecov token issue

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -101,7 +101,7 @@ jobs:
         coverage xml
 
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python-version }} == '3.10'
+      if: matrix.python-version == '3.10'
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -107,3 +107,4 @@ jobs:
         verbose: true
         directory: ${GITHUB_WORKSPACE}/../
         files: coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -101,6 +101,7 @@ jobs:
         coverage xml
 
     - name: Upload coverage to Codecov
+      if: ${{ env.python-version }} == '3.10'
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -101,7 +101,7 @@ jobs:
         coverage xml
 
     - name: Upload coverage to Codecov
-      if: ${{ env.python-version }} == '3.10'
+      if: ${{ matrix.python-version }} == '3.10'
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
There seems to be a number of issues with Codecov, that make it sometimes fail to upload the coverage. More details [here](https://github.com/codecov/codecov-action/issues/557) and [here](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954).

This implements the first suggested simple fix, I am not sure this will be perfect though.

Another issue I noticed is that we are now potentially uploading two coverages (after the change to also test python 3.11), which is probably not a good idea.