### PR TITLE
frontend: Add initial skeleton

### DIFF
--- a/tests/filecheck/frontend/programs/invalid.py
+++ b/tests/filecheck/frontend/programs/invalid.py
@@ -1,0 +1,31 @@
+# RUN: python %s | filecheck %s
+
+from xdsl.frontend.program import FrontendProgram, FrontendProgramException
+from xdsl.frontend.context import CodeContext
+
+p = FrontendProgram()
+
+#      CHECK: Cannot compile program without the code context
+# CHECK-NEXT:     p = FrontendProgram()
+# CHECK-NEXT:     with CodeContext(p):
+# CHECK-NEXT:         # Your code here.
+try:
+    p.compile(desymref=False)
+except FrontendProgramException as e:
+    print(e.msg)
+
+#      CHECK: Cannot print the program IR without compiling it first. Make sure to use:
+# CHECK-NEXT:     p = FrontendProgram()
+# CHECK-NEXT:     with CodeContext(p):
+# CHECK-NEXT:         # Your code here.
+# CHECK-NEXT:     p.compile()
+with CodeContext(p):
+
+    def foo():
+        return
+
+
+try:
+    print(p.xdsl())
+except FrontendProgramException as e:
+    print(e.msg)

--- a/tests/filecheck/frontend/programs/programs.py
+++ b/tests/filecheck/frontend/programs/programs.py
@@ -1,0 +1,12 @@
+# RUN: python %s | filecheck %s
+
+from xdsl.frontend.program import FrontendProgram
+from xdsl.frontend.context import CodeContext
+
+p = FrontendProgram()
+with CodeContext(p):
+    # CHECK: builtin.module() {}
+    pass
+
+p.compile(desymref=False)
+print(p.xdsl())

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -3,7 +3,7 @@ import os
 
 config.name = "xDSL"
 config.test_format = lit.formats.ShTest()
-config.suffixes = ['.test', '.xdsl', '.mlir']
+config.suffixes = ['.test', '.xdsl', '.mlir', '.py']
 
 config.test_source_root = os.path.dirname(__file__)
 

--- a/xdsl/frontend/context.py
+++ b/xdsl/frontend/context.py
@@ -1,0 +1,42 @@
+import ast
+
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from inspect import getsource
+from sys import _getframe
+from typing import Any, Dict
+from xdsl.frontend.program import FrontendProgram
+
+
+@dataclass
+class CodeContext(AbstractContextManager):
+    """
+    The CodeContext with block marks the scope in which the code in the custom DSL
+    can be written. This code will be translated to xDSL/MLIR.
+    """
+
+    program: FrontendProgram
+    """
+    Underlying front-end program which can be compiled and translated to xDSL/MLIR.
+    """
+
+    def __enter__(self) -> None:
+        # First, get the Python AST from the code.
+        frame = _getframe(1)
+        src = getsource(frame)
+        python_ast = ast.parse(src)
+
+        # Get all the global information and record it as well. In particular,
+        # this contains all the imports.
+        self.program.globals: Dict[str, Any] = frame.f_globals
+
+        # Find where the program starts.
+        for node in ast.walk(python_ast):
+            if isinstance(node, ast.With) and \
+               node.lineno == frame.f_lineno - frame.f_code.co_firstlineno + 1:
+
+                # Found the program AST. Store it for later compilation or execution.
+                self.program.stmts = node.body
+
+    def __exit__(self, *args):
+        pass

--- a/xdsl/frontend/program.py
+++ b/xdsl/frontend/program.py
@@ -97,12 +97,3 @@ Cannot print the program IR without compiling it first. Make sure to use:
 
     def xdsl(self) -> str:
         return self._print(Printer.Target.XDSL)
-
-    def mlir_roundtrip(self, mlir_opt_path, mlir_opt_args=[]) -> str:
-        """
-        Runs 'mlir-opt' on the generated IR with specified arguments and returns the output as a string.
-        """
-        cmd = [mlir_opt_path] + mlir_opt_args
-        ip = self._print(Printer.Target.MLIR).encode("utf-8")
-        result = subprocess.run(cmd, stdout=subprocess.PIPE, input=ip)
-        return result.stdout.decode("utf-8").strip()

--- a/xdsl/frontend/program.py
+++ b/xdsl/frontend/program.py
@@ -1,0 +1,108 @@
+import ast
+import subprocess
+
+from dataclasses import dataclass, field
+from io import StringIO
+from typing import Any, Dict, List
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.printer import Printer
+
+
+@dataclass
+class FrontendProgramException(Exception):
+    """
+    Exception type used when something goes wrong with `FrontendProgram`.
+    """
+
+    msg: str
+
+    def __init__(self, msg):
+        super().__init__()
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return f"{self.msg}"
+
+
+@dataclass
+class FrontendProgram:
+    """
+    Class to store the Python AST of a program written in the frontend. This
+    program can be compiled and translated to xDSL or MLIR.
+    """
+
+    stmts: List[ast.stmt] = field(default=None)
+    """AST nodes stored for compilation to xDSL."""
+
+    globals: Dict[str, Any] = field(default=None)
+    """Global information for this program, including all the imports."""
+
+    xdsl_program: ModuleOp = field(default=None)
+    """Generated xDSL program when AST is compiled."""
+
+    def _check_can_compile(self):
+        if self.stmts is None or self.globals is None:
+            msg = \
+"""
+Cannot compile program without the code context. Try to use:
+    p = FrontendProgram()
+    with CodeContext(p):
+        # Your code here."""
+            raise FrontendProgramException(msg)
+
+    def compile(self, desymref=True) -> None:
+        """Generates xDSL from the source program."""
+
+        # Both statements and globals msut be initialized from within the `CodeContext`.
+        self._check_can_compile()
+
+        # TODO: Land basic code generation in the next patch.
+        self.xdsl_program = ModuleOp.from_region_or_ops([])
+        self.xdsl_program.verify()
+
+        # Optionally run desymrefication pass to produce actual SSA.
+        if desymref:
+            self.desymref()
+
+    def desymref(self) -> None:
+        """Desymrefy the generated xDSL."""
+
+        # TODO: Land desymref in the next patch.
+        raise FrontendProgramException(
+            "Running desymref pass is not supported.")
+
+        self.xdsl_program.verify()
+
+    def _check_can_print(self):
+        if self.xdsl_program is None:
+            msg = \
+"""
+Cannot print the program IR without compiling it first. Make sure to use:
+    p = FrontendProgram()
+    with CodeContext(p):
+        # Your code here.
+    p.compile()"""
+            raise FrontendProgramException(msg)
+
+    def _print(self, target) -> str:
+        self._check_can_print()
+
+        file = StringIO("")
+        printer = Printer(stream=file, target=target)
+        printer.print_op(self.xdsl_program)
+        return file.getvalue().strip()
+
+    def mlir(self) -> str:
+        return self._print(Printer.Target.MLIR)
+
+    def xdsl(self) -> str:
+        return self._print(Printer.Target.XDSL)
+
+    def mlir_roundtrip(self, mlir_opt_path, mlir_opt_args=[]) -> str:
+        """
+        Runs 'mlir-opt' on the generated IR with specified arguments and returns the output as a string.
+        """
+        cmd = [mlir_opt_path] + mlir_opt_args
+        ip = self._print(Printer.Target.MLIR).encode("utf-8")
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, input=ip)
+        return result.stdout.decode("utf-8").strip()


### PR DESCRIPTION
This is a first patch to support Python front-ends for xDSL. At the moment, only empty module is generated.