### PR TITLE
xDSL: Add structural equivalence comparison for IRNode

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,9 +1,13 @@
 import pytest
 
-from xdsl.ir import Block, Region
+from xdsl.ir import MLContext, Operation, Block, Region
 from xdsl.dialects.arith import Addi, Subi, Constant
 from xdsl.dialects.builtin import i32, IntegerAttr
 from xdsl.dialects.scf import If
+from xdsl.parser import Parser
+from xdsl.dialects.builtin import Builtin
+from xdsl.dialects.func import Func
+from xdsl.dialects.arith import Arith
 
 
 def test_ops_accessor():
@@ -117,3 +121,78 @@ def test_op_clone_with_regions():
     assert len(if2.false_region.ops) == 1
     assert if2.true_region.op is not if_.true_region.op
     assert if2.false_region.op is not if_.false_region.op
+
+
+##################### Testing is_structurally_equal #####################
+
+program_region = \
+"""builtin.module() {
+  %0 : !i32 = arith.constant() ["value" = 1 : !i32]
+}
+"""
+program_region_2 = \
+"""builtin.module() {
+  %0 : !i32 = arith.constant() ["value" = 2 : !i32]
+}
+"""
+program_region_2_diff_name = \
+"""builtin.module() {
+  %cst : !i32 = arith.constant() ["value" = 2 : !i32]
+}
+"""
+program_region_2_diff_type = \
+"""builtin.module() {
+  %0 : !i64 = arith.constant() ["value" = 2 : !i64]
+}
+"""
+program_add = \
+"""builtin.module() {
+%0 : !i32 = arith.constant() ["value" = 1 : !i32]
+%1 : !i32 = arith.constant() ["value" = 2 : !i32]
+%2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
+}
+"""
+program_add_2 = \
+"""builtin.module() {
+%0 : !i32 = arith.constant() ["value" = 1 : !i32]
+%1 : !i32 = arith.constant() ["value" = 2 : !i32]
+%2 : !i32 = arith.addi(%1 : !i32, %0 : !i32)
+}
+"""
+program_func = \
+"""builtin.module() {
+  func.func() ["sym_name" = "test", "type" = !fun<[!i32, !i32], [!i32]>, "sym_visibility" = "private"] {
+  ^0(%0 : !i32, %1 : !i32):
+    %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
+    func.return(%2 : !i32)
+  }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "args, expected_result",
+    [([program_region, program_region], True),
+     ([program_region_2, program_region_2], True),
+     ([program_region_2_diff_type, program_region_2_diff_type], True),
+     ([program_region_2_diff_name, program_region_2_diff_name], True),
+     ([program_region, program_region_2], False),
+     ([program_region_2, program_region_2_diff_type], False),
+     ([program_region_2, program_region_2_diff_name], True),
+     ([program_add, program_add], True),
+     ([program_add_2, program_add_2], True),
+     ([program_add, program_add_2], False),
+     ([program_func, program_func], True)])
+def test_is_structurally_equivalent(args: list[str], expected_result: bool):
+    ctx = MLContext()
+    ctx.register_dialect(Builtin)
+    ctx.register_dialect(Func)
+    ctx.register_dialect(Arith)
+
+    parser = Parser(ctx, args[0])
+    lhs: Operation = parser.parse_op()
+
+    parser = Parser(ctx, args[1])
+    rhs: Operation = parser.parse_op()
+
+    assert lhs.is_structurally_equivalent(rhs) == expected_result

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -852,9 +852,11 @@ class Block(IRNode):
             context[arg] = other_arg
         # Add self to the context so Operations can check for identical parents
         context[self] = other
-        for op, other_op in zip(self.ops, other.ops):
-            if not op.is_structurally_equivalent(other_op, context):
-                return False
+        if not all([
+                op.is_structurally_equivalent(other_op, context)
+                for op, other_op in zip(self.ops, other.ops)
+        ]):
+            return False
 
         return True
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -585,16 +585,16 @@ class Operation(IRNode):
            len(self.successors) != len(other.successors) or \
             self.attributes != other.attributes:
             return False
+        if len(self.successors) > 0:
+            raise Exception(
+                "Checking for structural equality of ops with successors is not supported."
+            )
         if self.parent and other.parent and context.get(
                 self.parent) != other.parent:
             return False
         if not all(
                 context.get(operand) == other_operand for operand,
                 other_operand in zip(self.operands, other.operands)):
-            return False
-        if not all(
-                context.get(successor) == other_successor for successor,
-                other_successor in zip(self.successors, other.successors)):
             return False
         if not all(
                 region.is_structurally_equivalent(other_region, context)

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -852,10 +852,9 @@ class Block(IRNode):
             context[arg] = other_arg
         # Add self to the context so Operations can check for identical parents
         context[self] = other
-        if not all([
+        if not all(
                 op.is_structurally_equivalent(other_op, context)
-                for op, other_op in zip(self.ops, other.ops)
-        ]):
+                for op, other_op in zip(self.ops, other.ops)):
             return False
 
         return True


### PR DESCRIPTION
This PR adds a function to check whether two instances of `IRNode` are structurally equivalent, i.e. they share all relevant fields but don't have to be the same object.
