### PR TITLE
CI: Use mold now

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -38,9 +38,6 @@ jobs:
       uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
     - uses: rui314/setup-mold@v1
-      with:
-        mold-version: 1.1.1
-        make-default: false
 
     - name: CCache Setup (C++ compilation)
       uses: hendrikmuhs/ccache-action@v1.2.5

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Ninja Setup
       uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
+    - uses: rui314/setup-mold@v1
+      with:
+        mold-version: 1.1.1
+        make-default: false
+
     - name: CCache Setup (C++ compilation)
       uses: hendrikmuhs/ccache-action@v1.2.5
       with:
@@ -74,7 +79,7 @@ jobs:
     - name: MLIR Build
       run: |
         cd llvm-project/build
-        cmake --build . --target mlir-opt MLIRPythonModules
+        mold --run cmake --build . --target mlir-opt MLIRPythonModules
 
     - name: Test with pytest and generate code coverage
       run: |


### PR DESCRIPTION
It seems that [mold](https://github.com/rui314/setup-mold) is a faster linker than lld, which takes most of our CI time atm.