### PR TITLE
xDSL: add immutable core IR structures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pip<24.0
 pytest<8.0
 filecheck<0.0.24
 lit<16.0.0
-frozendict<2.3.5
+immutabledict<2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pip<24.0
 pytest<8.0
 filecheck<0.0.24
 lit<16.0.0
+frozendict<2.3.5

--- a/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
+++ b/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
@@ -78,6 +78,6 @@ def test_immutable_ir(program_str: str):
     parser = XDSLParser(ctx, program_str)
     program: Operation = parser.parse_op()
     immutable_program = get_immutable_copy(program)
-    mutable_program = immutable_program.get_mutable_copy()
+    mutable_program = immutable_program.to_mutable()
 
     assert program.is_structurally_equivalent(mutable_program)

--- a/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
+++ b/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
@@ -81,3 +81,4 @@ def test_immutable_ir(program_str: str):
     mutable_program = immutable_program.to_mutable()
 
     assert program.is_structurally_equivalent(mutable_program)
+    

--- a/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
+++ b/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
@@ -81,4 +81,3 @@ def test_immutable_ir(program_str: str):
     mutable_program = immutable_program.to_mutable()
 
     assert program.is_structurally_equivalent(mutable_program)
-    

--- a/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
+++ b/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
@@ -1,0 +1,83 @@
+import pytest
+
+from xdsl.ir import MLContext, Operation
+from xdsl.parser import XDSLParser
+from xdsl.dialects.builtin import Builtin
+from xdsl.dialects.func import Func
+from xdsl.dialects.arith import Arith
+from xdsl.dialects.cf import Cf
+from xdsl.rewriting.composable_rewriting.immutable_ir.immutable_ir import get_immutable_copy
+
+program_region = \
+"""builtin.module() {
+  %0 : !i32 = arith.constant() ["value" = 1 : !i32]
+}
+"""
+program_region_2 = \
+"""builtin.module() {
+  %0 : !i32 = arith.constant() ["value" = 2 : !i32]
+}
+"""
+program_region_2_diff_name = \
+"""builtin.module() {
+  %cst : !i32 = arith.constant() ["value" = 2 : !i32]
+}
+"""
+program_region_2_diff_type = \
+"""builtin.module() {
+  %0 : !i64 = arith.constant() ["value" = 2 : !i64]
+}
+"""
+program_add = \
+"""builtin.module() {
+%0 : !i32 = arith.constant() ["value" = 1 : !i32]
+%1 : !i32 = arith.constant() ["value" = 2 : !i32]
+%2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
+}
+"""
+program_add_2 = \
+"""builtin.module() {
+%0 : !i32 = arith.constant() ["value" = 1 : !i32]
+%1 : !i32 = arith.constant() ["value" = 2 : !i32]
+%2 : !i32 = arith.addi(%1 : !i32, %0 : !i32)
+}
+"""
+program_func = \
+"""builtin.module() {
+  func.func() ["sym_name" = "test", "type" = !fun<[!i32, !i32], [!i32]>, "sym_visibility" = "private"] {
+  ^0(%0 : !i32, %1 : !i32):
+    %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
+    func.return(%2 : !i32)
+  }
+}
+"""
+program_successors = \
+"""builtin.module() {
+    func.func() ["sym_name" = "unconditional_br", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
+    ^0:
+        cf.br() (^1)
+    ^1:
+        cf.br() (^0)
+    }
+}
+"""
+
+
+@pytest.mark.parametrize("program_str", [(program_region), (program_region_2),
+                                         (program_region_2_diff_type),
+                                         (program_region_2_diff_name),
+                                         (program_add), (program_add_2),
+                                         (program_func), (program_successors)])
+def test_immutable_ir(program_str: str):
+    ctx = MLContext()
+    ctx.register_dialect(Builtin)
+    ctx.register_dialect(Func)
+    ctx.register_dialect(Arith)
+    ctx.register_dialect(Cf)
+
+    parser = XDSLParser(ctx, program_str)
+    program: Operation = parser.parse_op()
+    immutable_program = get_immutable_copy(program)
+    mutable_program = immutable_program.get_mutable_copy()
+
+    assert program.is_structurally_equivalent(mutable_program)

--- a/tests/test_immutable_list.py
+++ b/tests/test_immutable_list.py
@@ -1,0 +1,166 @@
+import pytest
+from xdsl.utils.immutable_list import IList
+
+
+def test_append():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j])
+    list.append(k)
+    assert list == IList([i, j, k])
+
+
+def test_append_to_frozen():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j])
+    list.freeze()
+    with pytest.raises(Exception):
+        list.append(k)
+
+
+def test_extend():
+    i, j, k = 1, 2, 3
+    list0: IList[int] = IList([i, j, k])
+    list1: IList[int] = IList([i, j, k])
+    list0.extend(list1)
+    assert list0 == IList([i, j, k, i, j, k])
+
+
+def test_extend_frozen():
+    i, j, k = 1, 2, 3
+    list0: IList[int] = IList([i, j, k])
+    list1: IList[int] = IList([i, j, k])
+    list0.freeze()
+    with pytest.raises(Exception):
+        list0.extend(list1)
+
+
+def test_insert():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j])
+    list.insert(1, k)
+    assert list == IList([i, k, j])
+
+
+def test_insert_frozen():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j])
+    list.freeze()
+    with pytest.raises(Exception):
+        list.insert(1, k)
+
+
+def test_remove():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list.remove(k)
+    assert list == IList([i, j])
+
+
+def test_remove_frozen():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list.freeze()
+    with pytest.raises(Exception):
+        list.remove(k)
+
+
+def test_pop():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    assert list.pop(-1) == k
+    assert list == IList([i, j])
+
+
+def test_pop_frozen():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list.freeze()
+    with pytest.raises(Exception):
+        list.pop(-1)
+
+
+def test_clear():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list.clear()
+    assert list == IList([])
+
+
+def test_clear_frozen():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list.freeze()
+    with pytest.raises(Exception):
+        list.clear()
+
+
+def test_setitem():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list[1] = 4
+    assert list == IList([i, 4, k])
+
+
+def test_setitem_frozen():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list.freeze()
+    with pytest.raises(Exception):
+        list[1] = 4
+
+
+def test_delitem():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    del list[1]
+    assert list == IList([i, k])
+
+
+def test_delitem_frozen():
+    i, j, k = 1, 2, 3
+    list: IList[int] = IList([i, j, k])
+    list.freeze()
+    with pytest.raises(Exception):
+        del list[1]
+
+
+def test_add():
+    i, j, k = 1, 2, 3
+    list0: IList[int] = IList([i, j])
+    list1: IList[int] = IList([k])
+    list2 = list0 + list1
+    assert list2 == IList([i, j, k])
+
+
+def test_add_frozen():
+    i, j, k = 1, 2, 3
+    list0: IList[int] = IList([i, j])
+    list1: IList[int] = IList([k])
+    list0.freeze()
+    list1.freeze()
+    list2 = list0 + list1
+    assert list2 == IList([i, j, k])
+
+
+def test_iadd():
+    i, j, k = 1, 2, 3
+    list0: IList[int] = IList([i, j])
+    list1: IList[int] = IList([k])
+    list0 += list1
+    assert list0 == IList([i, j, k])
+
+
+def test_iadd_frozen():
+    i, j, k = 1, 2, 3
+    list0: IList[int] = IList([i, j])
+    list1: IList[int] = IList([k])
+    list0.freeze()
+    with pytest.raises(Exception):
+        list0 += list1
+
+
+def test_eq():
+    i, j, k = 1, 2, 3
+    list0: IList[int] = IList([i, j, k])
+    list1: IList[int] = IList([i, j, k])
+    assert list0 == list1

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -10,6 +10,7 @@ from xdsl.dialects.builtin import Builtin
 from xdsl.dialects.func import Func
 from xdsl.dialects.arith import Arith
 from xdsl.dialects.cf import Cf
+from xdsl.rewriting.composable_rewriting.immutable_ir.immutable_ir import get_immutable_copy
 
 
 def test_ops_accessor():
@@ -257,11 +258,32 @@ def test_is_structurally_equivalent_incompatible_ir_nodes():
     assert program.regions[0].is_structurally_equivalent(program) == False
     assert program.regions[0].blocks[0].is_structurally_equivalent(
         program) == False
-    assert program.ops[0].regions[0].blocks[0].ops[
-        0].is_structurally_equivalent(
-            program.ops[0].regions[0].blocks[0].ops[1]) == False
-    assert program.ops[0].regions[0].blocks[0].is_structurally_equivalent(
-        program.ops[0].regions[0].blocks[1]) == False
+    if isinstance(program, ModuleOp):
+        assert program.ops[0].regions[0].blocks[0].ops[
+            0].is_structurally_equivalent(
+                program.ops[0].regions[0].blocks[0].ops[1]) == False
+        assert program.ops[0].regions[0].blocks[0].is_structurally_equivalent(
+            program.ops[0].regions[0].blocks[1]) == False
+
+
+@pytest.mark.parametrize("program_str", [(program_region), (program_region_2),
+                                         (program_region_2_diff_type),
+                                         (program_region_2_diff_name),
+                                         (program_add), (program_add_2),
+                                         (program_func), (program_successors)])
+def test_immutable_ir(program_str: str):
+    ctx = MLContext()
+    ctx.register_dialect(Builtin)
+    ctx.register_dialect(Func)
+    ctx.register_dialect(Arith)
+    ctx.register_dialect(Cf)
+
+    parser = Parser(ctx, program_str)
+    program: Operation = parser.parse_op()
+    immutable_program = get_immutable_copy(program)
+    mutable_program = immutable_program.get_mutable_copy()
+
+    assert program.is_structurally_equivalent(mutable_program)
 
 
 def test_descriptions():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -257,12 +257,11 @@ def test_is_structurally_equivalent_incompatible_ir_nodes():
     assert program.regions[0].is_structurally_equivalent(program) == False
     assert program.regions[0].blocks[0].is_structurally_equivalent(
         program) == False
-    if isinstance(program, ModuleOp):
-        assert program.ops[0].regions[0].blocks[0].ops[
-            0].is_structurally_equivalent(
-                program.ops[0].regions[0].blocks[0].ops[1]) == False
-        assert program.ops[0].regions[0].blocks[0].is_structurally_equivalent(
-            program.ops[0].regions[0].blocks[1]) == False
+    assert program.ops[0].regions[0].blocks[0].ops[
+        0].is_structurally_equivalent(
+            program.ops[0].regions[0].blocks[0].ops[1]) == False
+    assert program.ops[0].regions[0].blocks[0].is_structurally_equivalent(
+        program.ops[0].regions[0].blocks[1]) == False
 
 
 def test_descriptions():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -10,7 +10,6 @@ from xdsl.dialects.builtin import Builtin
 from xdsl.dialects.func import Func
 from xdsl.dialects.arith import Arith
 from xdsl.dialects.cf import Cf
-from xdsl.rewriting.composable_rewriting.immutable_ir.immutable_ir import get_immutable_copy
 
 
 def test_ops_accessor():
@@ -264,26 +263,6 @@ def test_is_structurally_equivalent_incompatible_ir_nodes():
                 program.ops[0].regions[0].blocks[0].ops[1]) == False
         assert program.ops[0].regions[0].blocks[0].is_structurally_equivalent(
             program.ops[0].regions[0].blocks[1]) == False
-
-
-@pytest.mark.parametrize("program_str", [(program_region), (program_region_2),
-                                         (program_region_2_diff_type),
-                                         (program_region_2_diff_name),
-                                         (program_add), (program_add_2),
-                                         (program_func), (program_successors)])
-def test_immutable_ir(program_str: str):
-    ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Func)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Cf)
-
-    parser = XDSLParser(ctx, program_str)
-    program: Operation = parser.parse_op()
-    immutable_program = get_immutable_copy(program)
-    mutable_program = immutable_program.get_mutable_copy()
-
-    assert program.is_structurally_equivalent(mutable_program)
 
 
 def test_descriptions():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -278,7 +278,7 @@ def test_immutable_ir(program_str: str):
     ctx.register_dialect(Arith)
     ctx.register_dialect(Cf)
 
-    parser = Parser(ctx, program_str)
+    parser = XDSLParser(ctx, program_str)
     program: Operation = parser.parse_op()
     immutable_program = get_immutable_copy(program)
     mutable_program = immutable_program.get_mutable_copy()

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -1,76 +1,9 @@
 from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
-from typing import Iterable, Sequence, SupportsIndex, Type, TypeGuard, Any, TypeVar, List
+from typing import Sequence, Type, TypeGuard, Any
 from xdsl.ir import Attribute, Block, BlockArgument, OpResult, Operation, Region, SSAValue
-
-_T = TypeVar('_T')
-
-
-class IList(List[_T]):
-    """
-    A list that can be frozen. Once frozen, it can not be modified. 
-    In comparison to FrozenList this supports pattern matching.
-    """
-    _frozen: bool = False
-
-    def freeze(self):
-        self._frozen = True
-
-    def _unfreeze(self):
-        self._frozen = False
-
-    def append(self, __object: _T) -> None:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().append(__object)
-
-    def extend(self, __iterable: Iterable[_T]) -> None:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().extend(__iterable)
-
-    def insert(self, __index: SupportsIndex, __object: _T) -> None:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().insert(__index, __object)
-
-    def remove(self, __value: _T) -> None:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().remove(__value)
-
-    def pop(self, __index: SupportsIndex = ...) -> _T:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().pop(__index)
-
-    def clear(self) -> None:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().clear()
-
-    def __setitem__(self, __index: SupportsIndex, __object: _T) -> None:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().__setitem__(__index, __object)
-
-    def __add__(self, __x: Iterable[_T]) -> IList[_T]:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        if isinstance(__x, IList) and __x._frozen:
-            raise Exception("frozen list can not be modified")
-        return IList(super().__add__(__x))  # type: ignore
-
-    def __iadd__(self, __x: Iterable[_T]) -> IList[_T]:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        return super().__iadd__(__x)  # type: ignore
-
-    def __eq__(self, __o: object) -> bool:
-        if isinstance(__o, IList):
-            return super().__eq__(__o)  # type: ignore
-        return False
+from xdsl.utils.immutable_list import IList
 
 
 @dataclass(frozen=True)
@@ -127,7 +60,8 @@ class IBlockArg(ISSAValue):
 
     def __repr__(self) -> str:
         return "BlockArg(type:" + self.typ.name + (
-            "attached" if self.block is not None else "unattached") + ")"
+            "attached"
+            if self.block is not None else "unattached") + ")"  # type: ignore
 
 
 @dataclass(frozen=True)

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -65,6 +65,11 @@ class IList(List[_T]):
             raise Exception("frozen list can not be modified")
         return IList(super().__add__(__x))  # type: ignore
 
+    def __iadd__(self, __x: Iterable[_T]) -> IList[_T]:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().__iadd__(__x)  # type: ignore
+
     def __eq__(self, __o: object) -> bool:
         if isinstance(__o, IList):
             return super().__eq__(__o)  # type: ignore

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
-from typing import Sequence, Type, TypeGuard, Any
+from typing import Sequence, TypeGuard, Any
 from xdsl.ir import Attribute, Block, BlockArgument, OpResult, Operation, Region, SSAValue
 from xdsl.utils.exceptions import InvalidIRException
 from xdsl.utils.immutable_list import IList

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -439,7 +439,7 @@ class IOperation:
         new_op: Operation = self.op_type.create(
             operands=mutable_operands,
             result_types=[result.typ for result in self.results],
-            attributes=self.attributes.copy(),
+            attributes=dict(self.attributes),
             successors=mutable_successors,
             regions=mutable_regions)
 
@@ -523,4 +523,4 @@ class IOperation:
         return self.attributes[name]
 
     def get_attributes_copy(self) -> dict[str, Attribute]:
-        return self.attributes.copy()
+        return dict(self.attributes)

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 from typing import Sequence, TypeGuard, Any
-from frozendict import frozendict
+from immutabledict import immutabledict
 from xdsl.ir import Attribute, Block, BlockArgument, OpResult, Operation, Region, SSAValue
 from xdsl.utils.exceptions import InvalidIRException
 from xdsl.utils.immutable_list import IList
@@ -319,14 +319,15 @@ class IOperation:
                       "regions")
     name: str
     op_type: type[Operation]
-    attributes: frozendict
+    attributes: immutabledict[str, Attribute]
     operands: IList[ISSAValue]
     results: IList[IOpResult]
     successors: IList[IBlock]
     regions: IList[IRegion]
 
     def __init__(self, name: str, op_type: type[Operation],
-                 attributes: frozendict, operands: Sequence[ISSAValue],
+                 attributes: immutabledict[str, Attribute],
+                 operands: Sequence[ISSAValue],
                  result_types: Sequence[Attribute],
                  successors: Sequence[IBlock],
                  regions: Sequence[IRegion]) -> None:
@@ -353,7 +354,8 @@ class IOperation:
     @classmethod
     def get(cls, name: str, op_type: type[Operation],
             operands: Sequence[ISSAValue], result_types: Sequence[Attribute],
-            attributes: frozendict, successors: Sequence[IBlock],
+            attributes: immutabledict[str,
+                                      Attribute], successors: Sequence[IBlock],
             regions: Sequence[IRegion]) -> IOperation:
         return cls(name, op_type, attributes, operands, result_types,
                    successors, regions)
@@ -491,7 +493,8 @@ class IOperation:
         else:
             operands.extend(existing_operands)
 
-        attributes: frozendict = frozendict(op.attributes)
+        attributes: immutabledict[str,
+                                  Attribute] = immutabledict(op.attributes)
 
         successors: list[IBlock] = []
         for successor in op.successors:
@@ -517,7 +520,7 @@ class IOperation:
         return immutable_op
 
     def get_attribute(self, name: str) -> Attribute:
-        return self.attributes[name]  # type: ignore
+        return self.attributes[name]
 
     def get_attributes_copy(self) -> dict[str, Attribute]:
         return self.attributes.copy()

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass
 from typing import Sequence, TypeGuard, Any
+from frozendict import frozendict
 from xdsl.ir import Attribute, Block, BlockArgument, OpResult, Operation, Region, SSAValue
 from xdsl.utils.exceptions import InvalidIRException
 from xdsl.utils.immutable_list import IList
@@ -318,15 +319,14 @@ class IOperation:
                       "regions")
     name: str
     op_type: type[Operation]
-    attributes: dict[str, Attribute]
+    attributes: frozendict
     operands: IList[ISSAValue]
     results: IList[IOpResult]
     successors: IList[IBlock]
     regions: IList[IRegion]
 
     def __init__(self, name: str, op_type: type[Operation],
-                 attributes: dict[str,
-                                  Attribute], operands: Sequence[ISSAValue],
+                 attributes: frozendict, operands: Sequence[ISSAValue],
                  result_types: Sequence[Attribute],
                  successors: Sequence[IBlock],
                  regions: Sequence[IRegion]) -> None:
@@ -353,7 +353,7 @@ class IOperation:
     @classmethod
     def get(cls, name: str, op_type: type[Operation],
             operands: Sequence[ISSAValue], result_types: Sequence[Attribute],
-            attributes: dict[str, Attribute], successors: Sequence[IBlock],
+            attributes: frozendict, successors: Sequence[IBlock],
             regions: Sequence[IRegion]) -> IOperation:
         return cls(name, op_type, attributes, operands, result_types,
                    successors, regions)
@@ -491,7 +491,7 @@ class IOperation:
         else:
             operands.extend(existing_operands)
 
-        attributes: dict[str, Attribute] = op.attributes.copy()
+        attributes: frozendict = frozendict(op.attributes)
 
         successors: list[IBlock] = []
         for successor in op.successors:
@@ -517,7 +517,7 @@ class IOperation:
         return immutable_op
 
     def get_attribute(self, name: str) -> Attribute:
-        return self.attributes[name]
+        return self.attributes[name]  # type: ignore
 
     def get_attributes_copy(self) -> dict[str, Attribute]:
         return self.attributes.copy()

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -203,8 +203,8 @@ class IBlock:
         return self is __o
 
     def __repr__(self) -> str:
-        return "block of" + str(len(self.ops)) + " operations with args: " + str(
-            self.args)
+        return "block of" + str(len(
+            self.ops)) + " operations with args: " + str(self.args)
 
     def __post_init__(self):
         for arg in self.args:

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+from abc import ABC
+from typing import Iterable, Sequence, SupportsIndex, Type, TypeGuard, Any
+from xdsl.ir import *
+from xdsl.dialects.builtin import *
+from xdsl.dialects.arith import *
+
+
+_T = TypeVar('_T')
+class IList(List[_T]):
+    """
+    A list that can be frozen. Once frozen, it can not be modified. 
+    In comparison to FrozenList this supports pattern matching.
+    """
+    _frozen: bool = False
+
+    def freeze(self):
+        self._frozen = True
+
+    def _unfreeze(self):
+        self._frozen = False
+
+    def append(self, __object: _T) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().append(__object)
+
+    def extend(self, __iterable: Iterable[_T]) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().extend(__iterable)
+
+    def insert(self, __index: SupportsIndex, __object: _T) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().insert(__index, __object)
+
+    def remove(self, __value: _T) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().remove(__value)
+
+    def pop(self, __index: SupportsIndex = ...) -> _T:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().pop(__index)
+
+    def clear(self) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().clear()
+
+
+@dataclass(frozen=True)
+class ISSAValue(ABC):
+    """
+    Represents an immutable SSA variable. An immutable SSA variable is either an operation result
+    or a basic block argument.
+    """
+    typ: Attribute
+    users: IList[IOp]
+
+    def _add_user(self, op: IOp):
+        self.users._unfreeze() # type: ignore
+        self.users.append(op)
+        self.users.freeze()
+
+    def _remove_user(self, op: IOp):
+        if op not in self.users:
+            raise Exception(f"Trying to remove a user ({op.name}) that is not an actual user of this value!")
+
+        self.users._unfreeze() # type: ignore
+        self.users.remove(op)
+        self.users.freeze()
+
+
+@dataclass(frozen=True)
+class IResult(ISSAValue):
+    """Represents an immutable SSA variable defined by an operation result."""
+    op: IOp
+    result_index: int
+
+    def __hash__(self) -> int:
+        return hash(id(self.op)) + hash(self.result_index)
+
+    def __eq__(self, __o: IResult) -> bool:
+        if isinstance(__o, IResult):
+            return self.op == __o.op and self.result_index == __o.result_index
+        return False
+
+
+@dataclass(frozen=True)
+class IBlockArg(ISSAValue):
+    """Represents an immutable SSA variable defined by a basic block."""
+    block: IBlock
+    index: int
+
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+    def __eq__(self, __o: IBlockArg) -> bool:
+        return self is __o
+
+    def __repr__(self) -> str:
+        return "BlockArg(type:" + self.typ.name + (
+            "attached" if self.block is not None else "unattached") + ")"
+
+
+@dataclass(frozen=True)
+class IRegion:
+    """An immutable region contains a CFG of immutable blocks. IRegions are contained in operations."""
+
+    blocks: IList[IBlock]
+    """Immutable blocks contained in the IRegion. The first block is the entry block."""
+
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+    def __eq__(self, __o: object) -> bool:
+        return self is __o
+
+    @property
+    def block(self) -> Optional[IBlock]:
+        """Returns the entry block of this region."""
+
+        if len(self.blocks) > 0:
+            return self.blocks[0]
+        return None
+
+    @property
+    def ops(self) -> IList[IOp]:
+        """Returns a list of all operations in this region."""
+
+        return IList([op for block in self.blocks for op in block.ops])
+         
+        
+    def __init__(self, blocks: Sequence[IBlock]):
+        """Creates a new immutable region from a sequence of immutable blocks."""
+
+        object.__setattr__(self, "blocks", IList(blocks))
+        self.blocks.freeze()
+
+    @classmethod
+    def from_mutable(
+        cls,
+        blocks: Sequence[Block],
+        value_map: Optional[dict[SSAValue, ISSAValue]] = None,
+        block_map: Optional[dict[Block, IBlock]] = None,
+    ) -> IRegion:
+        """
+        Creates a new immutable region from a sequence of mutable blocks.
+        The value_map and block_map are used to map already known correspondings
+        of mutable values to immutable values and mutable blocks to immutable blocks.
+        """
+        if value_map is None:
+            value_map = {}
+        if block_map is None:
+            block_map = {}
+
+        # adding dummy block mappings so that ops have a successor to reference
+        # when the actual block is created all successor references will be moved
+        # to the correct block
+        for block in blocks:
+            block_map[block] = IBlock([],[])
+
+        immutable_blocks = [
+            IBlock.from_mutable(block, value_map, block_map)
+            for block in blocks
+        ]
+
+        assert (blocks[0].parent is not None)
+        region = IRegion(immutable_blocks)
+
+        # clean up successor references to blocks for ops inside this region
+        for block, imm_block in zip(blocks, region.blocks):
+            dummy_block = block_map[block]
+            for op in region.ops:
+                try:
+                    dummy_index = op.successors.index(dummy_block)
+                except ValueError:
+                    continue
+                # replace dummy successor with actual successor
+                object.__setattr__(op, "successors", IList(op.successors[:dummy_index]+[imm_block]+op.successors[dummy_index+1:]))
+
+        return region
+
+    def get_mutable_copy(
+            self,
+            value_mapping: Optional[dict[ISSAValue, SSAValue]] = None,
+            block_mapping: Optional[dict[IBlock, Block]] = None) -> Region:
+        """
+        Returns a mutable region that is a copy of this immutable region.
+        The value_mapping and block_mapping are used to map already known correspondings
+        of immutable values to mutable values and immutable blocks to mutable blocks.
+        """
+        if value_mapping is None:
+            value_mapping = {}
+        if block_mapping is None:
+            block_mapping = {}
+        mutable_blocks: List[Block] = []
+        # All mutable blocks have to be initialized first so that ops can
+        # refer to them in their successor lists.
+        for block in self.blocks:
+            mutable_blocks.append(mutable_block := Block.from_arg_types(block.arg_types))
+            block_mapping[block] = mutable_block
+        for block in self.blocks:
+            # This will use the already created Block and populate it
+            block.get_mutable_copy(value_mapping=value_mapping, block_mapping=block_mapping)
+        return Region.from_block_list(mutable_blocks)
+
+
+@dataclass(frozen=True)
+class IBlock:
+    """An immutable block contains a list of immutable operations. IBlocks are contained in IRegions."""
+    args: IList[IBlockArg]
+    ops: IList[IOp]
+
+    @property
+    def arg_types(self) -> List[Attribute]:
+        frozen_arg_types = [arg.typ for arg in self.args]
+        return frozen_arg_types
+
+    def __hash__(self) -> int:
+        return (id(self))
+
+    def __eq__(self, __o: object) -> bool:
+        return self is __o
+
+    def __repr__(self) -> str:
+        return "block of" + str(len(self.ops)) + " with args: " + str(
+            self.args)
+
+    def __post_init__(self):
+        for arg in self.args:
+            object.__setattr__(arg, "block", self)
+
+    def __init__(self, args: Sequence[Attribute] | Sequence[IBlockArg],
+                 ops: Sequence[IOp]):
+        """Creates a new immutable block."""
+
+        # Type Guards:
+        def is_iblock_arg_seq(
+                list: Sequence[Any]) -> TypeGuard[Sequence[IBlockArg]]:
+            if len(list) == 0:
+                return False
+            return all([isinstance(elem, IBlockArg) for elem in list])
+
+        def is_type_seq(list: Sequence[Any]) -> TypeGuard[Sequence[Attribute]]:
+            return all([isinstance(elem, Attribute) for elem in list])
+
+        if is_type_seq(args):
+            block_args: Sequence[IBlockArg] = [
+                IBlockArg(type, IList([]), self, idx) for idx, type in enumerate(args)
+            ]
+        elif is_iblock_arg_seq(args):
+            block_args: Sequence[IBlockArg] = args
+            for block_arg in block_args:
+                object.__setattr__(block_arg, "block", self)
+        else:
+            raise Exception("args for IBlock ill structured")
+
+        object.__setattr__(self, "args", IList(block_args))
+        object.__setattr__(self, "ops", IList(ops))
+
+        self.args.freeze()
+        self.ops.freeze()
+
+    @classmethod
+    def from_mutable(
+        cls,
+        block: Block,
+        value_map: Optional[dict[SSAValue, ISSAValue]] = None,
+        block_map: Optional[dict[Block, IBlock]] = None,
+    ) -> IBlock:
+        """
+        Creates an immutable block from a mutable block. 
+        The value_map and block_map are used to map already known correspondings
+        of mutable values to immutable values and mutable blocks to immutable blocks.
+        """
+        if value_map is None:
+            value_map = {}
+        if block_map is None:
+            block_map = {}
+
+        args: List[IBlockArg] = []
+        for arg in block.args:
+            # The IBlock that will house this IBlockArg is not constructed yet.
+            # After construction the block field will be set by the IBlock.
+            immutable_arg = IBlockArg(arg.typ, IList([]), None, arg.index)  # type: ignore
+            args.append(immutable_arg)
+            value_map[arg] = immutable_arg
+
+        immutable_ops = [
+            IOp.from_mutable(op, value_map=value_map, block_map=block_map, existing_operands=None)
+            for op in block.ops
+        ]
+
+        return IBlock(args, immutable_ops)
+
+    def get_mutable_copy(
+            self,
+            value_mapping: Optional[dict[ISSAValue, SSAValue]] = None,
+            block_mapping: Optional[dict[IBlock, Block]] = None) -> Block:
+        """
+        Returns a mutable block that is a copy of this immutable block.
+        The value_mapping and block_mapping are used to map already known correspondings
+        of immutable values to mutable values and immutable blocks to mutable blocks.
+        """
+        if value_mapping is None:
+            value_mapping = {}
+        if block_mapping is None:
+            block_mapping = {}
+
+
+        # Block might already have been created by the Region, look it up
+        if self in block_mapping:
+            mutable_block = block_mapping[self]
+        else:
+            mutable_block = Block.from_arg_types(self.arg_types)
+        for idx, arg in enumerate(self.args):
+            value_mapping[arg] = mutable_block.args[idx]
+        block_mapping[self] = mutable_block
+
+        for immutable_op in self.ops:
+            mutable_block.add_op(
+                immutable_op.get_mutable_copy(value_mapping=value_mapping,
+                                              block_mapping=block_mapping))
+        return mutable_block
+
+
+def get_immutable_copy(op: Operation) -> IOp:
+    return IOp.from_mutable(op, {})
+
+
+@dataclass(frozen=True)
+class OpData:
+    """
+    Represents split off fields of IOp to its own class because they are
+    often preserved during rewriting. A new operation of the same type, e.g.
+    with changed operands can still use the same OpData instance. This design
+    increases sharing in the IR.
+    """
+    name: str
+    op_type: type[Operation]
+    attributes: dict[str, Attribute]
+
+
+@dataclass(frozen=True)
+class IOp:
+    """Represents an immutable operation."""
+    
+    __match_args__ = ("op_type", "operands", "results", "successors",
+                      "regions")
+    _op_data: OpData
+    operands: IList[ISSAValue]
+    results: IList[IResult]
+    successors: IList[IBlock]
+    regions: IList[IRegion]
+
+    def __init__(self, op_data: OpData, operands: Sequence[ISSAValue],
+                 result_types: Sequence[Attribute],
+                 successors: Sequence[IBlock],
+                 regions: Sequence[IRegion]) -> None:
+        object.__setattr__(self, "_op_data", op_data)
+        object.__setattr__(self, "operands", IList(operands))
+        for operand in operands:
+            operand._add_user(self) # type: ignore
+        object.__setattr__(
+            self, "results",
+            IList([
+                IResult(type, IList([]), self, idx)
+                for idx, type in enumerate(result_types)
+            ]))
+        object.__setattr__(self, "successors", IList(successors))
+        object.__setattr__(self, "regions", IList(regions))
+
+        self.operands.freeze()
+        self.results.freeze()
+        self.successors.freeze()
+        self.regions.freeze()
+
+    @classmethod
+    def get(cls, name: str, op_type: type[Operation],
+            operands: Sequence[ISSAValue], result_types: Sequence[Attribute],
+            attributes: dict[str, Attribute], successors: Sequence[IBlock],
+            regions: Sequence[IRegion]) -> IOp:
+        return cls(OpData(name, op_type, attributes), operands, result_types,
+                   successors, regions)
+
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+    def __eq__(self, __o: object) -> bool:
+        return self is __o
+
+    @property
+    def name(self) -> str:
+        return self._op_data.name
+
+    @property
+    def op_type(self) -> Type[Operation]:
+        return self._op_data.op_type
+
+    @property
+    def attributes(self) -> dict[str, Attribute]:
+        return self._op_data.attributes
+
+    @property
+    def result(self) -> IResult | None:
+        if len(self.results) > 0:
+            return self.results[0]
+        return None
+
+    @property
+    def region(self) -> IRegion | None:
+        if len(self.regions) > 0:
+            return self.regions[0]
+        return None
+
+    @property
+    def result_types(self) -> List[Attribute]:
+        return [result.typ for result in self.results]
+
+    def get_mutable_copy(
+            self,
+            value_mapping: Optional[dict[ISSAValue, SSAValue]] = None,
+            block_mapping: Optional[dict[IBlock, Block]] = None) -> Operation:
+        """
+        Returns a mutable operation that is a copy of this immutable operation.
+        The value_mapping and block_mapping are used to map already known correspondings
+        of immutable values to mutable values and immutable blocks to mutable blocks.
+        """
+        if value_mapping is None:
+            value_mapping = {}
+        if block_mapping is None:
+            block_mapping = {}
+
+        mutable_operands: List[SSAValue] = []
+        for operand in self.operands:
+            if operand in value_mapping:
+                mutable_operands.append(value_mapping[operand])
+            else:
+                print(f"ERROR: op {self.name} uses SSAValue before definition")
+                # Continuing to enable printing the IR including missing
+                # operands for investigation
+                mutable_operands.append(
+                    OpResult(
+                        operand.typ,
+                        None,  # type: ignore
+                        0))
+
+        mutable_successors: List[Block] = []
+        for successor in self.successors:
+            if successor in block_mapping:
+                mutable_successors.append(block_mapping[successor])
+            else:
+                raise Exception("Block used before definition")
+
+        mutable_regions: List[Region] = []
+        for region in self.regions:
+            mutable_regions.append(
+                region.get_mutable_copy(value_mapping=value_mapping,
+                                        block_mapping=block_mapping))
+
+        new_op: Operation = self.op_type.create(
+            operands=mutable_operands,
+            result_types=[result.typ for result in self.results],
+            attributes=self.attributes.copy(),
+            successors=mutable_successors,
+            regions=mutable_regions)
+
+        for idx, result in enumerate(self.results):
+            m_result = new_op.results[idx]
+            value_mapping[result] = m_result
+
+        return new_op
+
+    @classmethod
+    def from_mutable(
+            cls,
+            op: Operation,
+            value_map: Optional[dict[SSAValue, ISSAValue]] = None,
+            block_map: Optional[dict[Block, IBlock]] = None,
+            existing_operands: Optional[Sequence[ISSAValue]] = None) -> IOp:
+        """
+        Returns an immutable operation that is a copy of the given mutable operation.
+        The value_map and block_map are used to map already known correspondings
+        of mutable values to immutable values and mutable blocks to immutable blocks.
+        """
+        assert isinstance(op, Operation)
+        op_type = op.__class__
+
+        if value_map is None:
+            value_map = {}
+        if block_map is None:
+            block_map = {}
+
+        operands: List[ISSAValue] = []
+        if existing_operands is None:
+            for operand in op.operands:
+                match operand:
+                    case OpResult():
+                        if operand in value_map:
+                            operands.append(value_map[operand])
+                        else:
+                            raise Exception("Operand used before definition")
+                    case BlockArgument():
+                        if operand not in value_map:
+                            raise Exception(
+                                "Block argument expected in mapping for op: " +
+                                op.name)
+                        operands.append(value_map[operand])
+                    case _:
+                        raise Exception(
+                            "Operand is expected to be either OpResult or BlockArgument"
+                        )
+        else:
+            operands.extend(existing_operands)
+
+        attributes: dict[str, Attribute] = op.attributes.copy()
+
+        successors: List[IBlock] = []
+        for successor in op.successors:
+            if successor in block_map:
+                successors.append(block_map[successor])
+            else:
+                # TODO: I think this is not right, build tests with successors
+                newImmutableSuccessor = IBlock.from_mutable(successor)
+                block_map[successor] = newImmutableSuccessor
+                successors.append(newImmutableSuccessor)
+
+        regions: List[IRegion] = []
+        for region in op.regions:
+            regions.append(
+                IRegion.from_mutable(region.blocks, value_map, block_map))
+
+        immutable_op = IOp.get(op.name, op_type, operands,
+                               [result.typ for result in op.results],
+                               attributes, successors, regions)
+
+        for idx, result in enumerate(op.results):
+            value_map[result] = immutable_op.results[idx]
+
+        return immutable_op
+
+    def get_attribute(self, name: str) -> Attribute:
+        return self.attributes[name]
+
+    def get_attributes_copy(self) -> dict[str, Attribute]:
+        return self.attributes.copy()

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -203,7 +203,7 @@ class IBlock:
         return self is __o
 
     def __repr__(self) -> str:
-        return "block of" + str(len(self.ops)) + " with args: " + str(
+        return "block of" + str(len(self.ops)) + " operations with args: " + str(
             self.args)
 
     def __post_init__(self):

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -35,6 +35,10 @@ class PyRDLAttrDefinitionError(Exception):
     pass
 
 
+class InvalidIRException(Exception):
+    pass
+
+
 @dataclass
 class BuilderNotFoundException(Exception):
     """

--- a/xdsl/utils/immutable_list.py
+++ b/xdsl/utils/immutable_list.py
@@ -52,6 +52,11 @@ class IList(List[_T]):
             raise Exception("frozen list can not be modified")
         return super().__setitem__(__index, __object)
 
+    def __delitem__(self, __index: SupportsIndex | slice) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().__delitem__(__index)
+
     def __add__(self, __x: Iterable[_T]) -> IList[_T]:
         return IList(super().__add__(__x))  # type: ignore
 

--- a/xdsl/utils/immutable_list.py
+++ b/xdsl/utils/immutable_list.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from typing import TypeVar, Iterable, SupportsIndex, List
+
+_T = TypeVar('_T')
+
+
+class IList(List[_T]):
+    """
+    A list that can be frozen. Once frozen, it can not be modified. 
+    In comparison to FrozenList this supports pattern matching.
+    """
+    _frozen: bool = False
+
+    def freeze(self):
+        self._frozen = True
+
+    def _unfreeze(self):
+        self._frozen = False
+
+    def append(self, __object: _T) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().append(__object)
+
+    def extend(self, __iterable: Iterable[_T]) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().extend(__iterable)
+
+    def insert(self, __index: SupportsIndex, __object: _T) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().insert(__index, __object)
+
+    def remove(self, __value: _T) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().remove(__value)
+
+    def pop(self, __index: SupportsIndex = ...) -> _T:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().pop(__index)
+
+    def clear(self) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().clear()
+
+    def __setitem__(self, __index: SupportsIndex, __object: _T) -> None:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().__setitem__(__index, __object)
+
+    def __add__(self, __x: Iterable[_T]) -> IList[_T]:
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        if isinstance(__x, IList) and __x._frozen:
+            raise Exception("frozen list can not be modified")
+        return IList(super().__add__(__x))  # type: ignore
+
+    def __iadd__(self, __x: Iterable[_T]):
+        if self._frozen:
+            raise Exception("frozen list can not be modified")
+        return super().__iadd__(__x)  # type: ignore
+
+    def __eq__(self, __o: object) -> bool:
+        if isinstance(__o, IList):
+            return super().__eq__(__o)  # type: ignore
+        return False

--- a/xdsl/utils/immutable_list.py
+++ b/xdsl/utils/immutable_list.py
@@ -53,10 +53,6 @@ class IList(List[_T]):
         return super().__setitem__(__index, __object)
 
     def __add__(self, __x: Iterable[_T]) -> IList[_T]:
-        if self._frozen:
-            raise Exception("frozen list can not be modified")
-        if isinstance(__x, IList) and __x._frozen:
-            raise Exception("frozen list can not be modified")
         return IList(super().__add__(__x))  # type: ignore
 
     def __iadd__(self, __x: Iterable[_T]):


### PR DESCRIPTION
This PR adds an alternative core infrastructure that provides immutability.
Immutability is especially useful for building rewriting systems that support backtracking.

This introduces immutable versions of these core IR constructs:
Operation -> [IOp](https://github.com/xdslproject/xdsl/blob/7987690229bdb16bf528eddf2e8eb78e1b3348db/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py#L349)
Block -> [IBlock](https://github.com/xdslproject/xdsl/blob/7987690229bdb16bf528eddf2e8eb78e1b3348db/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py#L213)
Region -> [IRegion](https://github.com/xdslproject/xdsl/blob/7987690229bdb16bf528eddf2e8eb78e1b3348db/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py#L110)
SSAValue -> [ISSAValue](https://github.com/xdslproject/xdsl/blob/7987690229bdb16bf528eddf2e8eb78e1b3348db/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py#L55)
OpResult -> [IResult](https://github.com/xdslproject/xdsl/blob/7987690229bdb16bf528eddf2e8eb78e1b3348db/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py#L78)
BlockArg -> [IBlockArg](https://github.com/xdslproject/xdsl/blob/7987690229bdb16bf528eddf2e8eb78e1b3348db/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py#L93)

Some implementation decisions are taken to increase the amount of sharing of IR constructs for rewriting. A specific example for this is the splitting off of some fields from `IOp` to [OpData](https://github.com/xdslproject/xdsl/blob/7987690229bdb16bf528eddf2e8eb78e1b3348db/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py#L336)


The immutable IR is designed to enable Python pattern matching on it in a non verbose, pythonic way. 
For this reason some of the names of IR constructs are shortened. 