### PR TITLE
CI: Test JupyterLite build even if not deploying.

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -84,7 +84,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -1,7 +1,12 @@
 name: Deploy JupiterLyte Page
 
 on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
   push:
+    branches:
+      - main
+  pull_request:
     branches:
       - main
 
@@ -79,6 +84,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/update_xdsl_pyodide_build.py
+++ b/.github/workflows/update_xdsl_pyodide_build.py
@@ -20,7 +20,7 @@ yaml_doc["requirements"] = {"run": ["frozenlist"]}
 
 # Find the built source distribution. This assumes it is the only thing in xdsl/dist
 xdsl_sdist = os.listdir(os.path.join(xdsl_directory, "dist"))[0]
-xdsl_sdist = os.path.join(xdsl_directory, "dist", xdsl_sdist)
+xdsl_sdist = os.path.abspath(os.path.join(xdsl_directory, "dist", xdsl_sdist))
 sha256_hash = hashlib.sha256()
 with open(xdsl_sdist, "rb") as sdist:
     # Read and update hash string value in blocks of 4K
@@ -28,6 +28,9 @@ with open(xdsl_sdist, "rb") as sdist:
         sha256_hash.update(byte_block)
 
 # Make it build the local xDSL, not the PyPi release. The pyodide build still requires the SHA256 sum.
-yaml_doc["source"] = {"url": xdsl_sdist, "sha256": sha256_hash.hexdigest()}
+yaml_doc["source"] = {
+    "url": f"file://{xdsl_sdist}",
+    "sha256": sha256_hash.hexdigest()
+}
 with open(meta_yaml_path, "w") as f:
     yaml.dump(yaml_doc, f)


### PR DESCRIPTION
Following #328. This makes the CI build the JupyterLite distribution with every other test and still deploy it only on pushes to the main branch.
Otherwise, issues affecting the JupyterLite can only be found after a merge..