### PR TITLE
xdsl: Use type annotations in PyRDL

### DIFF
--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -53,7 +53,7 @@
     "@irdl_attr_definition\n",
     "class Bag(ParametrizedAttribute):\n",
     "  name = \"sql.bag\"\n",
-    "  schema: ParameterDef[AnyAttr()]"
+    "  schema: ParameterDef[Attribute]"
    ]
   },
   {
@@ -101,7 +101,7 @@
     "@irdl_op_definition\n",
     "class Table(Operation):\n",
     "  name = \"sql.table\"\n",
-    "  table_name = AttributeDef(StringAttr)\n",
+    "  table_name: OpAttr[StringAttr]\n",
     "  result_bag: Annotated[OpResult, Bag]"
    ]
   },
@@ -155,7 +155,7 @@
     "class Selection(Operation):\n",
     "  name = \"sql.selection\"\n",
     "  input_bag: Annotated[Operand, Bag]\n",
-    "  filter = RegionDef()\n",
+    "  filter: Region\n",
     "  result_bag: Annotated[OpResult, Bag]"
    ]
   },
@@ -419,7 +419,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -433,7 +433,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "db5ef216c650b56f8eaea9067191ccc47b04eb60ad0c344e5e9f2b1a6cd0f075"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -26,6 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# xDSL should be available in the environment.\n",
+    "\n",
     "from xdsl.ir import MLContext\n",
     "from xdsl.dialects.arith import Arith\n",
     "from xdsl.dialects.builtin import Builtin\n",
@@ -715,11 +717,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "89ad8ba5",
    "metadata": {},
    "source": [
-    "Similar to parameters for `ParametrizedAttribute`, operands and results are added using fields containing `Operand` and `ResultDef`, which each contain an attribute constraint. The order correspond to the operand and result order, and the constraint applies on the SSA variable type.\n",
+    "Operands and results are added using fields containing `Operand` and `OpResult`, which each contain an attribute constraint. The order correspond to the operand and result order, and the constraint applies on the SSA variable type.\n",
     "\n",
     "Here is an example of an operation defining operands and a result:"
    ]
@@ -1054,11 +1057,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "bd06095b",
    "metadata": {},
    "source": [
-    "Attribute definitions are defined similarly to operands and results, by having `AttributeDef` static fields. The field name correspond to the expected attribute name."
+    "Attribute definitions are defined using `OpAttr`. The field name correspond to the expected attribute name."
    ]
   },
   {
@@ -1076,12 +1080,12 @@
     }
    ],
    "source": [
-    "from xdsl.irdl import AttributeDef\n",
+    "from xdsl.irdl import OpAttr\n",
     "\n",
     "@irdl_op_definition\n",
     "class StringAttrOp(Operation):\n",
     "    name: str = \"string_attr_op\"\n",
-    "    value = AttributeDef(StringAttr)\n",
+    "    value: OpAttr[StringAttr]\n",
     "    \n",
     "my_attr_op = StringAttrOp.build(attributes={\"value\": StringAttr(\"ga\")})\n",
     "my_attr_op.verify()\n",
@@ -1184,11 +1188,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5c61abd5",
    "metadata": {},
    "source": [
-    "Regions definitions are defined using `RegionDef` or `SingleBlockRegionDef`. The second definition constrains the region to contain a single block, and both definitions allows to further constraint the region by giving a constraint for the entry basic block parameters."
+    "Regions definitions are defined using `Region` or `SingleBlockRegion` annotations. The second definition constrains the region to contain a single block, and both definitions allows to further constraint the region by giving a constraint for the entry basic block parameters."
    ]
   },
   {
@@ -1213,7 +1218,7 @@
     "@irdl_op_definition\n",
     "class WhileOp(Operation):\n",
     "    name: str = \"while_op\"\n",
-    "    value = RegionDef()\n",
+    "    value: Region\n",
     "    \n",
     "region = Region.from_block_list([Block.from_arg_types([i32])])\n",
     "region_op = WhileOp.build(regions=[region])\n",
@@ -1279,19 +1284,11 @@
     "except Exception as e:\n",
     "    print(e)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "935df5ec",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -1305,7 +1302,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "db5ef216c650b56f8eaea9067191ccc47b04eb60ad0c344e5e9f2b1a6cd0f075"
+   }
   }
  },
  "nbformat": 4,

--- a/tests/test_irdl.py
+++ b/tests/test_irdl.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 import pytest
 
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
-from xdsl.irdl import AllOf, AnyAttr, AnyOf, AttrConstraint, BaseAttr, EqAttrConstraint, ParamAttrConstraint, ParameterDef, irdl_attr_definition
+from xdsl.irdl import (AllOf, AnyAttr, AnyOf, AttrConstraint, BaseAttr,
+                       EqAttrConstraint, ParamAttrConstraint, ParameterDef,
+                       irdl_attr_definition)
 from xdsl.parser import BaseParser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException

--- a/tests/test_mlir_printer.py
+++ b/tests/test_mlir_printer.py
@@ -1,10 +1,10 @@
 import re
 from io import StringIO
 from typing import Annotated
-
-from xdsl.ir import Attribute, Data, MLContext, MLIRType, Operation, ParametrizedAttribute
-from xdsl.irdl import (AnyAttr, ParameterDef, RegionDef, irdl_attr_definition,
-                       irdl_op_definition, VarOperand, VarOpResult)
+from xdsl.ir import (Attribute, Data, MLContext, MLIRType, Operation,
+                     ParametrizedAttribute, Region)
+from xdsl.irdl import (AnyAttr, ParameterDef, VarOpResult, VarOperand,
+                       irdl_attr_definition, irdl_op_definition)
 from xdsl.parser import BaseParser, XDSLParser
 from xdsl.printer import Printer
 
@@ -13,7 +13,7 @@ from xdsl.printer import Printer
 class ModuleOp(Operation):
     """Module operation. Redefined to not depend on the builtin dialect."""
     name = "module"
-    region = RegionDef()
+    region: Region
 
 
 @irdl_op_definition

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -6,13 +6,12 @@ from xdsl.dialects.builtin import (DenseIntOrFPElementsAttr, VectorType,
                                    IntegerType, Operation, StringAttr, i32)
 from xdsl.dialects.arith import Constant
 
-from xdsl.ir import Block, OpResult
-from xdsl.irdl import (OptOpResult, OptOperand, OptRegionDef,
-                       OptSingleBlockRegionDef, Operand, SingleBlockRegionDef,
-                       VarOpResult, VarRegionDef, VarSingleBlockRegionDef,
+from xdsl.ir import Block, OpResult, Region
+from xdsl.irdl import (OptOpResult, OptOperand, OptRegion,
+                       OptSingleBlockRegion, Operand, SingleBlockRegion,
+                       VarOpResult, VarRegion, VarSingleBlockRegion,
                        irdl_op_definition, AttrSizedResultSegments, VarOperand,
-                       AttrSizedOperandSegments, AttributeDef, RegionDef,
-                       OptAttributeDef, Region)
+                       AttrSizedOperandSegments, OpAttr, Region, OptOpAttr)
 
 #  ____                 _ _
 # |  _ \ ___  ___ _   _| | |_
@@ -265,7 +264,7 @@ def test_two_var_operand_builder2():
 @irdl_op_definition
 class AttrOp(Operation):
     name: str = "test.two_var_result_op"
-    attr = AttributeDef(StringAttr)
+    attr: OpAttr[StringAttr]
 
 
 def test_attr_op():
@@ -288,7 +287,7 @@ def test_attr_new_attr_op():
 class OptionalAttrOp(Operation):
     name: str = "test.opt_attr_op"
 
-    opt_attr = OptAttributeDef(StringAttr)
+    opt_attr: OptOpAttr[StringAttr]
 
 
 def test_optional_attr_op_empty():
@@ -310,7 +309,7 @@ def test_optional_attr_op_empty():
 class RegionOp(Operation):
     name: str = "test.region_op"
 
-    region = RegionDef()
+    region: Region
 
 
 def test_region_op_region():
@@ -350,7 +349,7 @@ def test_singleop_region():
 class SBRegionOp(Operation):
     name: str = "test.sbregion_op"
 
-    region = SingleBlockRegionDef()
+    region: SingleBlockRegion
 
 
 def test_sbregion_one_block():
@@ -363,7 +362,7 @@ def test_sbregion_one_block():
 class OptRegionOp(Operation):
     name: str = "test.opt_region_op"
 
-    reg = OptRegionDef()
+    reg: OptRegion
 
 
 def test_opt_region_builder():
@@ -382,7 +381,7 @@ def test_opt_region_builder_two_args():
 class OptSBRegionOp(Operation):
     name: str = "test.sbregion_op"
 
-    region = OptSingleBlockRegionDef()
+    region: OptSingleBlockRegion
 
 
 def test_opt_sbregion_one_block():
@@ -398,7 +397,7 @@ def test_opt_sbregion_one_block():
 class VarRegionOp(Operation):
     name: str = "test.var_operand_op"
 
-    regs = VarRegionDef()
+    regs: VarRegion
 
 
 def test_var_region_builder():
@@ -412,7 +411,7 @@ def test_var_region_builder():
 class VarSBRegionOp(Operation):
     name: str = "test.sbregion_op"
 
-    regs = VarSingleBlockRegionDef()
+    regs: VarSingleBlockRegion
 
 
 def test_var_sbregion_one_block():

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Annotated
 
-from xdsl.ir import OpResult, Operation, Region
+from xdsl.ir import Attribute, OpResult, Operation, Region
 from xdsl.irdl import (Operand, irdl_op_definition, OperandDef, ResultDef,
                        AttributeDef, AnyAttr, OpDef, RegionDef, OpAttr)
 
@@ -17,9 +17,9 @@ from xdsl.irdl import (Operand, irdl_op_definition, OperandDef, ResultDef,
 class OpDefTestOp(Operation):
     name = "test.op_def_test"
 
-    operand: Annotated[Operand, AnyAttr()]
-    result: Annotated[OpResult, AnyAttr()]
-    attr: OpAttr[AnyAttr()]
+    operand: Operand
+    result: OpResult
+    attr: OpAttr[Attribute]
     region: Region
 
 

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 from typing import Annotated
 
-from xdsl.ir import OpResult, Operation
+from xdsl.ir import OpResult, Operation, Region
 from xdsl.irdl import (Operand, irdl_op_definition, OperandDef, ResultDef,
-                       AttributeDef, RegionDef, AnyAttr, OpDef)
+                       AttributeDef, AnyAttr, OpDef, RegionDef, OpAttr)
 
 #  ___ ____  ____  _     ____        __
 # |_ _|  _ \|  _ \| |   |  _ \  ___ / _|
@@ -19,8 +19,8 @@ class OpDefTestOp(Operation):
 
     operand: Annotated[Operand, AnyAttr()]
     result: Annotated[OpResult, AnyAttr()]
-    attr = AttributeDef(AnyAttr())
-    region = RegionDef()
+    attr: OpAttr[AnyAttr()]
+    region: Region
 
 
 def test_get_definition():

--- a/tests/test_ssavalue.py
+++ b/tests/test_ssavalue.py
@@ -1,10 +1,12 @@
 import pytest
 
+from typing import Annotated
+
 from xdsl.dialects.builtin import i32, StringAttr
 from xdsl.dialects.arith import Constant
 
 from xdsl.ir import Block, Operation, OpResult
-from xdsl.irdl import irdl_op_definition, ResultDef
+from xdsl.irdl import irdl_op_definition, OpResult
 
 
 def test_ssa():
@@ -23,8 +25,8 @@ def test_ssa():
 class TwoResultOp(Operation):
     name: str = "test.tworesults"
 
-    res1 = ResultDef(StringAttr)
-    res2 = ResultDef(StringAttr)
+    res1: Annotated[OpResult, StringAttr]
+    res2: Annotated[OpResult, StringAttr]
 
 
 def test_var_mixed_builder():

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from xdsl.dialects.builtin import AnyIntegerAttr, IntegerAttr, IndexType
+from xdsl.dialects.builtin import AnyIntegerAttr, IndexType, IntegerAttr
 from xdsl.ir import Operation, SSAValue, Block, Region, Dialect
-from xdsl.irdl import (VarOpResult, irdl_op_definition, AttributeDef,
-                       RegionDef, VarOperand, AnyAttr)
+from xdsl.irdl import (OpAttr, VarOpResult, irdl_op_definition, VarOperand,
+                       AnyAttr)
 
 
 @irdl_op_definition
@@ -17,11 +17,11 @@ class For(Operation):
 
     # TODO the bounds are in fact affine_maps
     # TODO support dynamic bounds as soon as maps are here
-    lower_bound = AttributeDef(IntegerAttr)
-    upper_bound = AttributeDef(IntegerAttr)
-    step = AttributeDef(IntegerAttr)
+    lower_bound: OpAttr[AnyIntegerAttr]
+    upper_bound: OpAttr[AnyIntegerAttr]
+    step: OpAttr[AnyIntegerAttr]
 
-    body = RegionDef()
+    body: Region
 
     def verify_(self) -> None:
         if len(self.operands) != len(self.results):
@@ -49,9 +49,9 @@ class For(Operation):
                     step: int | AnyIntegerAttr = 1) -> For:
         result_types = [SSAValue.get(op).typ for op in operands]
         attributes = {
-            "lower_bound": lower_bound,
-            "upper_bound": upper_bound,
-            "step": step,
+            "lower_bound": IntegerAttr.from_index_int_value(lower_bound),
+            "upper_bound": IntegerAttr.from_index_int_value(upper_bound),
+            "step": IntegerAttr.from_index_int_value(step),
         }
         return For.build(operands=[[operand for operand in operands]],
                          result_types=[result_types],

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -7,7 +7,7 @@ from xdsl.dialects.builtin import (ContainerOf, Float16Type, Float64Type, IndexT
                                    IntegerType, Float32Type, IntegerAttr, FloatAttr,
                                    Attribute, AnyFloat)
 from xdsl.ir import Operation, SSAValue, Dialect, OpResult
-from xdsl.irdl import (AnyOf, irdl_op_definition, AttributeDef, AnyAttr,
+from xdsl.irdl import (AnyOf, irdl_op_definition, OpAttr, AnyAttr,
                        Operand)
 from xdsl.utils.exceptions import VerifyException
 
@@ -20,7 +20,7 @@ floatingPointLike = ContainerOf(AnyOf([Float16Type, Float32Type, Float64Type]))
 class Constant(Operation):
     name: str = "arith.constant"
     result: Annotated[OpResult, AnyAttr()]
-    value = AttributeDef(AnyAttr())
+    value: OpAttr[Attribute]
 
     @staticmethod
     def from_attr(attr: Attribute, typ: Attribute) -> Constant:
@@ -423,7 +423,7 @@ class Cmpi(Operation):
     -   unsigned greater than or equal (mnemonic: `"uge"`; integer value: `9`)
     """
     name: str = "arith.cmpi"
-    predicate = AttributeDef(IntegerAttr)
+    predicate: OpAttr[IntegerAttr]
     lhs: Annotated[Operand, IntegerType]
     rhs: Annotated[Operand, IntegerType]
     result: Annotated[OpResult, IntegerType.from_width(1)]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import (Annotated, Callable, TypeAlias, List, cast, Type, Sequence,
-                    TYPE_CHECKING, Any, TypeVar)
+from typing import (TypeAlias, List, cast, Type, Sequence, TYPE_CHECKING, Any,
+                    TypeVar)
 
-from xdsl.ir import (Data, MLIRType, ParametrizedAttribute, Operation,
-                     SSAValue, Region, Attribute, Dialect, MLContext)
-from xdsl.irdl import (AttributeDef, VarOpResult, VarOperand, VarRegionDef,
+from xdsl.ir import (Data, MLIRType, ParametrizedAttribute, Operation, Region,
+                     Attribute, Dialect)
+from xdsl.irdl import (OpAttr, VarOpResult, VarOperand, VarRegion,
                        irdl_attr_definition, attr_constr_coercion,
                        irdl_data_definition, irdl_to_attr_constraint,
                        irdl_op_definition, builder, ParameterDef,
-                       SingleBlockRegionDef, Generic, GenericData,
-                       AttrConstraint, AnyAttr)
+                       SingleBlockRegion, Generic, GenericData, AttrConstraint,
+                       AnyAttr)
 from xdsl.utils.exceptions import VerifyException
 
 if TYPE_CHECKING:
@@ -686,10 +686,10 @@ class OpaqueAttr(ParametrizedAttribute):
 class UnregisteredOp(Operation):
     name: str = "builtin.unregistered"
 
-    op_name__ = AttributeDef(StringAttr)
-    args: Annotated[VarOperand, AnyAttr()]
-    res: Annotated[VarOpResult, AnyAttr()]
-    regs = VarRegionDef()
+    op_name__: OpAttr[StringAttr]
+    args: VarOperand
+    res: VarOpResult
+    regs: VarRegion
 
     @property
     def op_name(self) -> StringAttr:
@@ -716,7 +716,7 @@ class UnregisteredOp(Operation):
 class ModuleOp(Operation):
     name: str = "builtin.module"
 
-    body = SingleBlockRegionDef()
+    body: SingleBlockRegion
 
     @property
     def ops(self) -> List[Operation]:

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -3,8 +3,8 @@ from typing import Annotated, List, Union
 
 from xdsl.dialects.builtin import StringAttr, FunctionType, FlatSymbolRefAttr
 from xdsl.ir import SSAValue, Operation, Block, Region, Attribute, Dialect
-from xdsl.irdl import (OptAttributeDef, VarOpResult, irdl_op_definition,
-                       VarOperand, AnyAttr, RegionDef, AttributeDef)
+from xdsl.irdl import (VarOpResult, irdl_op_definition, VarOperand, AnyAttr,
+                       OpAttr, OptOpAttr)
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -12,10 +12,10 @@ from xdsl.utils.exceptions import VerifyException
 class FuncOp(Operation):
     name: str = "func.func"
 
-    body = RegionDef()
-    sym_name = AttributeDef(StringAttr)
-    function_type = AttributeDef(FunctionType)
-    sym_visibility = OptAttributeDef(StringAttr)
+    body: Region
+    sym_name: OpAttr[StringAttr]
+    function_type: OpAttr[FunctionType]
+    sym_visibility: OptOpAttr[StringAttr]
 
     def verify_(self) -> None:
         # TODO: how to verify that there is a terminator?
@@ -60,7 +60,7 @@ class FuncOp(Operation):
 class Call(Operation):
     name: str = "func.call"
     arguments: Annotated[VarOperand, AnyAttr()]
-    callee = AttributeDef(FlatSymbolRefAttr)
+    callee: OpAttr[FlatSymbolRefAttr]
 
     # Note: naming this results triggers an ArgumentError
     res: Annotated[VarOpResult, AnyAttr()]

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -3,7 +3,8 @@ from typing import cast
 
 from xdsl.dialects.builtin import AnyArrayAttr, ArrayAttr, StringAttr
 from xdsl.ir import (ParametrizedAttribute, Operation, Attribute, Dialect)
-from xdsl.irdl import (ParameterDef, irdl_op_definition, irdl_attr_definition)
+from xdsl.irdl import (ParameterDef, irdl_op_definition, irdl_attr_definition,
+                       SingleBlockRegion, OpAttr)
 from xdsl.parser import BaseParser
 from xdsl.printer import Printer
 

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 from typing import cast
 
 from xdsl.dialects.builtin import AnyArrayAttr, ArrayAttr, StringAttr
-from xdsl.ir import ParametrizedAttribute, Operation, Attribute, Dialect
-from xdsl.irdl import (ParameterDef, AnyAttr, AttributeDef,
-                       SingleBlockRegionDef, irdl_op_definition,
-                       irdl_attr_definition)
+from xdsl.ir import (ParametrizedAttribute, Operation, Attribute, Dialect)
+from xdsl.irdl import (ParameterDef, irdl_op_definition, irdl_attr_definition)
 from xdsl.parser import BaseParser
 from xdsl.printer import Printer
 
@@ -80,7 +78,7 @@ class DialectOp(Operation):
     Define a new dialect
     """
     name = "irdl.dialect"
-    body = SingleBlockRegionDef()
+    body: SingleBlockRegion
 
     @property
     def dialect_name(self) -> StringAttr:
@@ -107,7 +105,7 @@ class ParametersOp(Operation):
     Define the parameters of a type/attribute definition
     """
     name = "irdl.parameters"
-    params = AttributeDef(ArrayAttr)
+    params: OpAttr[AnyArrayAttr]
 
 
 @irdl_op_definition
@@ -116,7 +114,7 @@ class TypeOp(Operation):
     Defines new types belonging to previously defined dialect
     """
     name = "irdl.type"
-    body = SingleBlockRegionDef()
+    body: SingleBlockRegion
 
     @property
     def type_name(self) -> StringAttr:
@@ -136,7 +134,7 @@ class ConstraintVarsOp(Operation):
     current region
     """
     name = "irdl.constraint_vars"
-    constraints = AttributeDef(AnyAttr())
+    constraints: OpAttr[Attribute]
 
 
 @irdl_op_definition
@@ -145,7 +143,7 @@ class OperandsOp(Operation):
     Define the operands of a parent operation
     """
     name = "irdl.operands"
-    params = AttributeDef(AnyAttr())
+    params: OpAttr[Attribute]
 
 
 @irdl_op_definition
@@ -154,7 +152,7 @@ class ResultsOp(Operation):
     Define results of parent operation
     """
     name = "irdl.results"
-    params = AttributeDef(AnyAttr())
+    params: OpAttr[Attribute]
 
 
 @irdl_op_definition
@@ -163,7 +161,7 @@ class OperationOp(Operation):
     Define a new operation belonging to previously defined dialect
     """
     name = "irdl.operation"
-    body = SingleBlockRegionDef()
+    body: SingleBlockRegion
 
     @property
     def op_name(self) -> StringAttr:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING, Annotated
 
 from xdsl.ir import (MLIRType, ParametrizedAttribute, Attribute, Dialect,
                      Operation)
-from xdsl.irdl import (Operand, ParameterDef, AnyAttr, irdl_attr_definition,
-                       AttributeDef, irdl_op_definition, builder)
+from xdsl.irdl import (OpAttr, Operand, ParameterDef, AnyAttr,
+                       irdl_attr_definition, irdl_op_definition, builder)
 from xdsl.ir import OpResult, Attribute
-from xdsl.dialects.builtin import StringAttr, ArrayOfConstraint, ArrayAttr
+from xdsl.dialects.builtin import AnyArrayAttr, StringAttr, ArrayOfConstraint, ArrayAttr
 
 if TYPE_CHECKING:
     from xdsl.parser import BaseParser
@@ -52,7 +52,7 @@ class LLVMStructType(ParametrizedAttribute, MLIRType):
 class LLVMExtractValue(Operation):
     name = "llvm.extractvalue"
 
-    position = AttributeDef(ArrayOfConstraint(AnyAttr()))
+    position: OpAttr[AnyArrayAttr]
     container: Annotated[Operand, AnyAttr()]
 
     res: Annotated[OpResult, AnyAttr()]
@@ -62,7 +62,7 @@ class LLVMExtractValue(Operation):
 class LLVMInsertValue(Operation):
     name = "llvm.insertvalue"
 
-    position = AttributeDef(ArrayOfConstraint(AnyAttr()))
+    position: OpAttr[AnyArrayAttr]
     container: Annotated[Operand, AnyAttr()]
     value: Annotated[Operand, AnyAttr()]
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -7,10 +7,9 @@ from xdsl.dialects.builtin import (IntegerAttr, IndexType, ArrayAttr,
                                    DenseIntOrFPElementsAttr)
 from xdsl.ir import (MLIRType, Operation, SSAValue, ParametrizedAttribute,
                      Dialect, OpResult)
-from xdsl.irdl import (irdl_attr_definition, irdl_op_definition, builder,
-                       ParameterDef, Generic, Attribute, AnyAttr, Operand,
-                       VarOperand, AttributeDef, AttrSizedOperandSegments,
-                       OptAttributeDef)
+from xdsl.irdl import (OptOpAttr, irdl_attr_definition, irdl_op_definition,
+                       builder, ParameterDef, Generic, Attribute, AnyAttr,
+                       Operand, VarOperand, AttrSizedOperandSegments, OpAttr)
 
 _MemRefTypeElement = TypeVar("_MemRefTypeElement", bound=Attribute)
 
@@ -131,7 +130,7 @@ class Alloc(Operation):
     memref: Annotated[OpResult, MemRefType]
 
     # TODO how to constraint the IntegerAttr type?
-    alignment = AttributeDef(IntegerAttr)
+    alignment: OpAttr[AnyIntegerAttr]
 
     irdl_options = [AttrSizedOperandSegments()]
 
@@ -162,7 +161,7 @@ class Alloca(Operation):
     memref: Annotated[OpResult, MemRefType]
 
     # TODO how to constraint the IntegerAttr type?
-    alignment = AttributeDef(IntegerAttr)
+    alignment: OpAttr[AnyIntegerAttr]
 
     irdl_options = [AttrSizedOperandSegments()]
 
@@ -206,8 +205,6 @@ class Dealloca(Operation):
 @irdl_op_definition
 class GetGlobal(Operation):
     name = "memref.get_global"
-    # name = AttributeDef(FlatSymbolRefAttr)
-
     memref: Annotated[OpResult, MemRefType]
 
     def verify_(self) -> None:
@@ -231,15 +228,11 @@ class GetGlobal(Operation):
 @irdl_op_definition
 class Global(Operation):
     name = "memref.global"
-    sym_name = AttributeDef(StringAttr)
 
-    sym_visibility = AttributeDef(StringAttr)
-    type = AttributeDef(AnyAttr())
-
-    initial_value = OptAttributeDef(AnyAttr())
-
-    # TODO how do we represent these in MLIR-Lite
-    # constant = AttributeDef(UnitAttr)
+    sym_name: OpAttr[StringAttr]
+    sym_visibility: OpAttr[StringAttr]
+    type: OpAttr[Attribute]
+    initial_value: OptOpAttr[Attribute]
 
     def verify_(self) -> None:
         if not isinstance(self.type, MemRefType):

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -4,7 +4,7 @@ from typing import Annotated, List
 
 from xdsl.ir import SSAValue, Block, Region, Operation, Attribute, Dialect
 from xdsl.irdl import (VarOpResult, VarOperand, irdl_op_definition, Operand,
-                       RegionDef, AnyAttr)
+                       AnyAttr)
 from xdsl.dialects.builtin import IntegerType
 
 
@@ -14,9 +14,9 @@ class If(Operation):
     output: Annotated[VarOpResult, AnyAttr()]
     cond: Annotated[Operand, IntegerType.from_width(1)]
 
-    true_region = RegionDef()
+    true_region: Region
     # TODO this should be optional under certain conditions
-    false_region = RegionDef()
+    false_region: Region
 
     @staticmethod
     def get(cond: SSAValue | Operation, return_types: List[Attribute],
@@ -57,8 +57,8 @@ class While(Operation):
     arguments: Annotated[VarOperand, AnyAttr()]
 
     res: Annotated[VarOpResult, AnyAttr()]
-    before_region = RegionDef()
-    after_region = RegionDef()
+    before_region: Region
+    after_region: Region
 
     # TODO verify dependencies between scf.condition, scf.yield and the regions
     def verify_(self):

--- a/xdsl/frontend/symref.py
+++ b/xdsl/frontend/symref.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 from typing import Annotated
 from xdsl.ir import Attribute, Dialect, OpResult, SSAValue
-from xdsl.irdl import Operand, irdl_op_definition, AttributeDef, AnyAttr, Operation
+from xdsl.irdl import Operand, irdl_op_definition, OpAttr, AnyAttr, Operation
 from xdsl.dialects.builtin import StringAttr, FlatSymbolRefAttr
 
 
 @irdl_op_definition
 class Declare(Operation):
     name: str = "symref.declare"
-    sym_name = AttributeDef(StringAttr)
+    sym_name: OpAttr[StringAttr]
 
     @staticmethod
     def get(sym_name: str | StringAttr) -> Declare:
@@ -19,7 +19,7 @@ class Declare(Operation):
 class Fetch(Operation):
     name: str = "symref.fetch"
     value: Annotated[OpResult, AnyAttr()]
-    symbol = AttributeDef(FlatSymbolRefAttr)
+    symbol: OpAttr[FlatSymbolRefAttr]
 
     @staticmethod
     def get(symbol: str | FlatSymbolRefAttr, result_type: Attribute) -> Fetch:
@@ -31,7 +31,7 @@ class Fetch(Operation):
 class Update(Operation):
     name: str = "symref.update"
     value: Annotated[Operand, AnyAttr()]
-    symbol = AttributeDef(FlatSymbolRefAttr)
+    symbol: OpAttr[FlatSymbolRefAttr]
 
     @staticmethod
     def get(symbol: str | FlatSymbolRefAttr,

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from frozenlist import FrozenList
+from functools import reduce
 from inspect import isclass
 from typing import (Annotated, Any, Callable, Generic, Sequence, TypeAlias,
                     TypeVar, Union, cast, get_args, get_origin, get_type_hints)
@@ -27,6 +28,11 @@ def error(op: Operation, msg: str):
 
 class IRDLAnnotations(Enum):
     ParamDefAnnot = 1
+
+    AttributeDefAnnot = 2
+    OptAttributeDefAnnot = 3
+
+    SingleBlockRegionAnnot = 4
 
 
 #   ____                _             _       _
@@ -174,6 +180,9 @@ def irdl_to_attr_constraint(
 ) -> AttrConstraint:
     if isinstance(irdl, AttrConstraint):
         return irdl
+
+    if isinstance(irdl, Attribute):
+        return EqAttrConstraint(irdl)
 
     # Annotated case
     # Each argument of the Annotated type corresponds to a constraint to satisfy.
@@ -353,7 +362,7 @@ class OperandDef(OperandOrResultDef):
         self.constr = attr_constr_coercion(typ)
 
 
-Operand = Annotated[SSAValue, OperandDef]
+Operand: TypeAlias = SSAValue
 
 
 @dataclass(init=False)
@@ -361,7 +370,7 @@ class VarOperandDef(OperandDef, VariadicDef):
     """An IRDL variadic operand definition."""
 
 
-VarOperand = Annotated[list[SSAValue], VarOperandDef]
+VarOperand: TypeAlias = list[SSAValue]
 
 
 @dataclass(init=False)
@@ -369,7 +378,7 @@ class OptOperandDef(VarOperandDef, OptionalDef):
     """An IRDL optional operand definition."""
 
 
-OptOperand = Annotated[SSAValue | None, OptOperandDef]
+OptOperand: TypeAlias = SSAValue | None
 
 
 @dataclass(init=False)
@@ -388,7 +397,7 @@ class VarResultDef(ResultDef, VariadicDef):
     """An IRDL variadic result definition."""
 
 
-VarOpResult = Annotated[OpResult, VarResultDef]
+VarOpResult = list[OpResult]
 
 
 @dataclass(init=False)
@@ -396,7 +405,7 @@ class OptResultDef(VarResultDef, OptionalDef):
     """An IRDL optional result definition."""
 
 
-OptOpResult = Annotated[OpResult | None, OptResultDef]
+OptOpResult = OpResult | None
 
 
 @dataclass
@@ -416,6 +425,10 @@ class OptRegionDef(RegionDef, OptionalDef):
     """An IRDL optional region definition."""
 
 
+VarRegion: TypeAlias = list[Region]
+OptRegion: TypeAlias = Region | None
+
+
 @dataclass
 class SingleBlockRegionDef(RegionDef):
     """An IRDL region definition that expects exactly one block."""
@@ -427,6 +440,14 @@ class VarSingleBlockRegionDef(RegionDef, VariadicDef):
 
 class OptSingleBlockRegionDef(RegionDef, OptionalDef):
     """An IRDL optional region definition that expects exactly one block."""
+
+
+SingleBlockRegion: TypeAlias = Annotated[
+    Region, IRDLAnnotations.SingleBlockRegionAnnot]
+VarSingleBlockRegion: TypeAlias = Annotated[
+    list[Region], IRDLAnnotations.SingleBlockRegionAnnot]
+OptSingleBlockRegion: TypeAlias = Annotated[
+    Region | None, IRDLAnnotations.SingleBlockRegionAnnot]
 
 
 @dataclass(init=False)
@@ -446,6 +467,13 @@ class OptAttributeDef(AttributeDef):
 
     def __init__(self, typ: Attribute | type[Attribute] | AttrConstraint):
         super().__init__(typ)
+
+
+_OpAttrT = TypeVar("_OpAttrT", bound=Attribute)
+
+OpAttr: TypeAlias = Annotated[_OpAttrT, IRDLAnnotations.AttributeDefAnnot]
+OptOpAttr: TypeAlias = Annotated[_OpAttrT | None,
+                                 IRDLAnnotations.OptAttributeDefAnnot]
 
 
 @dataclass(kw_only=True)
@@ -476,49 +504,84 @@ class OpDef:
         op_def = OpDef(clsdict["name"])
         for field_name, field_type in get_type_hints(
                 pyrdl_def, include_extras=True).items():
-            origin = get_origin(field_type)
-            if origin != Annotated:
+
+            if field_name in get_type_hints(Operation).keys():
                 continue
-            args = get_args(field_type)
 
-            fail = False
-            if len(args) == 3:
-                if args[1] is OperandDef:
-                    op_def.operands.append((field_name, OperandDef(args[-1])))
-                elif args[1] is VarOperandDef:
-                    op_def.operands.append(
-                        (field_name, VarOperandDef(args[-1])))
-                elif args[1] is OptOperandDef:
-                    op_def.operands.append(
-                        (field_name, OptOperandDef(args[-1])))
-                elif args[1] is VarResultDef:
-                    op_def.results.append((field_name, VarResultDef(args[-1])))
-                elif args[1] is OptResultDef:
-                    op_def.results.append((field_name, OptResultDef(args[-1])))
-                else:
-                    fail = True
-            elif len(args) == 2:
-                if args[0] is OpResult:
-                    op_def.results.append((field_name, ResultDef(args[-1])))
-                else:
-                    fail = True
+            origin = get_origin(field_type)
+            args: tuple[Any, ...]
+            if origin is None:
+                args = (field_type, )
+            elif origin == Annotated:
+                args = get_args(field_type)
             else:
-                fail = True
+                args = (field_type, )
+            args = cast(tuple[Any, ...], args)
 
-            if fail:
-                raise ValueError(f'''
-                    Unsupported type annotation {args} in {pyrdl_def.__name__}.
-                    ''')
+            # Get attribute constraints from a list of pyrdl constraints
+            def get_constraint(
+                    pyrdl_constrs: tuple[Any, ...]) -> AttrConstraint:
+                constraints = [
+                    irdl_to_attr_constraint(pyrdl_constr)
+                    for pyrdl_constr in pyrdl_constrs
+                    if not isinstance(pyrdl_constr, IRDLAnnotations)
+                ]
+                if len(constraints) == 0:
+                    return AnyAttr()
+                if len(constraints) == 1:
+                    return constraints[0]
+                return AllOf(constraints)
 
-        for field_name, field_value in clsdict.items():
-            if isinstance(field_value, OperandDef):
-                op_def.operands.append((field_name, field_value))
-            elif isinstance(field_value, ResultDef):
-                op_def.results.append((field_name, field_value))
-            elif isinstance(field_value, RegionDef):
-                op_def.regions.append((field_name, field_value))
-            elif isinstance(field_value, AttributeDef):
-                op_def.attributes[field_name] = field_value
+            if args[0] == Operand:
+                constraint = get_constraint(args[1:])
+                op_def.operands.append((field_name, OperandDef(constraint)))
+            elif args[0] == list[Operand]:
+                constraint = get_constraint(args[1:])
+                op_def.operands.append((field_name, VarOperandDef(constraint)))
+            elif args[0] == (Operand | None):
+                constraint = get_constraint(args[1:])
+                op_def.operands.append((field_name, OptOperandDef(constraint)))
+
+            elif args[0] == OpResult:
+                constraint = get_constraint(args[1:])
+                op_def.results.append((field_name, ResultDef(constraint)))
+            elif args[0] == list[OpResult]:
+                constraint = get_constraint(args[1:])
+                op_def.results.append((field_name, VarResultDef(constraint)))
+            elif args[0] == (OpResult | None):
+                constraint = get_constraint(args[1:])
+                op_def.results.append((field_name, OptResultDef(constraint)))
+
+            elif IRDLAnnotations.AttributeDefAnnot in args:
+                constraint = get_constraint(args)
+                op_def.attributes[field_name] = AttributeDef(constraint)
+            elif IRDLAnnotations.OptAttributeDefAnnot in args:
+                assert get_origin(args[0]) in [UnionType, Union]
+                args = (reduce(lambda x, y: x | y,
+                               get_args(args[0])[:-1]), *args[1:])
+                constraint = get_constraint(args)
+                op_def.attributes[field_name] = OptAttributeDef(constraint)
+
+            elif args[0] == Region:
+                if (len(args) > 1
+                        and args[1] == IRDLAnnotations.SingleBlockRegionAnnot):
+                    op_def.regions.append((field_name, SingleBlockRegionDef()))
+                else:
+                    op_def.regions.append((field_name, RegionDef()))
+            elif args[0] == VarRegion:
+                if (len(args) > 1
+                        and args[1] == IRDLAnnotations.SingleBlockRegionAnnot):
+                    op_def.regions.append(
+                        (field_name, VarSingleBlockRegionDef()))
+                else:
+                    op_def.regions.append((field_name, VarRegionDef()))
+            elif args[0] == OptRegion:
+                if (len(args) > 1
+                        and args[1] == IRDLAnnotations.SingleBlockRegionAnnot):
+                    op_def.regions.append(
+                        (field_name, OptSingleBlockRegionDef()))
+                else:
+                    op_def.regions.append((field_name, OptRegionDef()))
 
         op_def.options = clsdict.get("irdl_options", [])
 

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -28,10 +28,8 @@ def error(op: Operation, msg: str):
 
 class IRDLAnnotations(Enum):
     ParamDefAnnot = 1
-
     AttributeDefAnnot = 2
     OptAttributeDefAnnot = 3
-
     SingleBlockRegionAnnot = 4
 
 


### PR DESCRIPTION
This PR updates PyRDL to use type annotations.
This should greatly reduce the amount of PyRight type checking errors.