### PR TITLE
xdsl: fix some type issues with DictionaryAttr printing and parsing

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,7 +7,7 @@ from xdsl.parser import Parser
 @pytest.mark.parametrize("input,expected", [("0, 1, 1", [0, 1, 1]),
                                             ("1, 0, 1", [1, 0, 1]),
                                             ("1, 1, 0", [1, 1, 0])])
-def test_int_list_parser(input, expected):
+def test_int_list_parser(input: str, expected: list[int]):
     ctx = MLContext()
     parser = Parser(ctx, input)
 
@@ -28,10 +28,10 @@ def test_int_list_parser(input, expected):
     "VV": 12,
     "AA": -8
 })])
-def test_int_dictionary_parser(input, expected):
+def test_int_dictionary_parser(input: str, expected: dict[str, int]):
     ctx = MLContext()
     parser = Parser(ctx, input)
 
-    int_dict = parser.parse_dictionary(parser.parse_str_literal,
-                                       parser.parse_int_literal)
+    int_dict = parser.parse_dictionary(parser.parse_optional_str_literal,
+                                       parser.parse_optional_int_literal)
     assert int_dict == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -32,5 +32,6 @@ def test_int_dictionary_parser(input, expected):
     ctx = MLContext()
     parser = Parser(ctx, input)
 
-    int_dict = parser.parse_dictionary(parser.parse_int_literal)
+    int_dict = parser.parse_dictionary(parser.parse_str_literal,
+                                       parser.parse_int_literal)
     assert int_dict == expected

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import (Annotated, Callable, TypeAlias, List, cast, Type, Sequence,
-                    Optional, TYPE_CHECKING, Any, TypeVar)
+                    TYPE_CHECKING, Any, TypeVar)
 
 from xdsl.ir import (Data, MLIRType, ParametrizedAttribute, Operation,
                      SSAValue, Region, Attribute, Dialect)
@@ -480,7 +480,7 @@ class TensorType(Generic[_TensorTypeElems], ParametrizedAttribute, MLIRType):
     @builder
     def from_type_and_list(
         referenced_type: _TensorTypeElems,
-        shape: Optional[Sequence[int | IntegerAttr[IndexType]]] = None
+        shape: Sequence[int | IntegerAttr[IndexType]] | None = None
     ) -> TensorType[_TensorTypeElems]:
         if shape is None:
             shape = [1]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -346,7 +346,7 @@ _DictionaryAttrT = TypeVar("_DictionaryAttrT", bound=Attribute, covariant=True)
 
 
 @irdl_attr_definition
-class DictionaryAttr(GenericData[dict[str, _DictionaryAttrT]]):
+class DictionaryAttr(GenericData[dict[StringAttr, _DictionaryAttrT]]):
     name = "dictionary"
 
     @staticmethod
@@ -355,7 +355,14 @@ class DictionaryAttr(GenericData[dict[str, _DictionaryAttrT]]):
         parse_optional_attribute: Callable[[], _DictionaryAttrT | None]
     ) -> dict[str, _DictionaryAttrT]:
         parser.parse_char("{")
-        data = parser.parse_dictionary(parser.parse_str_literal,
+
+        def parse_optional_string_attr():
+            literal = parser.parse_optional_str_literal()
+            if literal is None:
+                return None
+            return StringAttr.from_str(literal)
+
+        data = parser.parse_dictionary(parse_optional_string_attr,
                                        parse_optional_attribute)
         parser.parse_char("}")
         return data

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -709,7 +709,7 @@ class Parser:
         # Shorthand for DictionaryAttr
         parse_bracket = self.parse_optional_char("{")
         if parse_bracket:
-            dictionary = self.parse_dictionary(self.parse_str_literal,
+            dictionary = self.parse_dictionary(self.parse_optional_str_literal,
                                                self.parse_optional_attribute)
             self.parse_char("}")
             return DictionaryAttr.from_dict(dictionary)
@@ -987,7 +987,7 @@ class Parser:
 
         # Shorthand for DictionaryAttr
         if self.parse_optional_char("{"):
-            contents = self.parse_dictionary(self.parse_str_literal,
+            contents = self.parse_dictionary(self.parse_optional_str_literal,
                                              self.parse_optional_attribute)
             self.parse_char("}")
             return DictionaryAttr.from_dict(contents)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -386,8 +386,6 @@ class Parser:
         return None
 
     T = TypeVar('T')
-    K = TypeVar('K')
-    V = TypeVar('V')
 
     def parse_optional_nested_list(
             self,
@@ -462,6 +460,9 @@ class Parser:
             res.append(one)
         return res
 
+    K = TypeVar('K')
+    V = TypeVar('V')
+
     def parse_dictionary(self,
                          parse_optional_key: Callable[[], K | None],
                          parse_optional_value: Callable[[], V | None],
@@ -488,10 +489,13 @@ class Parser:
         parse_optional_key: Callable[[], K | None],
         parse_optional_value: Callable[[], V | None],
     ) -> dict[K, V] | None:
-        if not ((key := parse_optional_key()) is not None
-                and self.parse_optional_char("=") and
-                (value := parse_optional_value()) is not None):
+        if (key := parse_optional_key()) is None:
             return None
+        self.parse_char("=")
+        if (value := parse_optional_value()) is None:
+            raise ParserError(self._pos,
+                              'Expected dictionary value after `key=`')
+
         return {key: value}
 
     def parse_optional_block_argument(

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -471,16 +471,17 @@ class Parser:
         if skip_white_space:
             self.skip_white_space()
         assert (len(delimiter) <= 1)
-        res = self.parse_optional_dict_entry(parse_optional_key,
-                                             parse_optional_value)
-        if res is None:
+        entry = self.parse_optional_dict_entry(parse_optional_key,
+                                               parse_optional_value)
+        if entry is None:
             return {}
+        res = dict([entry])
         while (self.parse_optional_char(delimiter)
                if len(delimiter) == 1 else True):
             entry = self.parse_optional_dict_entry(parse_optional_key,
                                                    parse_optional_value)
             if entry is not None:
-                res = res | entry
+                res[entry[0]] = entry[1]
 
         return res
 
@@ -488,7 +489,7 @@ class Parser:
         self,
         parse_optional_key: Callable[[], K | None],
         parse_optional_value: Callable[[], V | None],
-    ) -> dict[K, V] | None:
+    ) -> tuple[K, V] | None:
         if (key := parse_optional_key()) is None:
             return None
         self.parse_char("=")
@@ -496,7 +497,7 @@ class Parser:
             raise ParserError(self._pos,
                               'Expected dictionary value after `key=`')
 
-        return {key: value}
+        return key, value
 
     def parse_optional_block_argument(
             self,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -295,6 +295,9 @@ class Printer:
         self.print_list(params, self.print_attribute)
         self.print(">")
 
+    def print_string_literal(self, string: str):
+        self.print(f'"{string}"')
+
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, UnitAttr):
             return
@@ -323,7 +326,7 @@ class Printer:
                 return
 
         if isinstance(attribute, StringAttr):
-            self.print(f'"{attribute.data}"')
+            self.print_string_literal(attribute.data)
             return
 
         if isinstance(attribute, FlatSymbolRefAttr):
@@ -365,9 +368,8 @@ class Printer:
             return
 
         if isinstance(attribute, DictionaryAttr):
-            data = cast(DictionaryAttr[Attribute], attribute).data
             self.print_string("{")
-            self.print_dictionary(data, self.print_attribute,
+            self.print_dictionary(attribute.data, self.print_string_literal,
                                   self.print_attribute)
             self.print_string("}")
             return

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -367,7 +367,6 @@ class Printer:
         if isinstance(attribute, DictionaryAttr):
             data = cast(DictionaryAttr[Attribute], attribute).data
             self.print_string("{")
-            # The keys are attributes, even if type is annotated as dict[str, Attribute]
             self.print_dictionary(data, self.print_attribute,
                                   self.print_attribute)
             self.print_string("}")

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -78,12 +78,11 @@ class Printer:
     def _add_message_on_next_line(self, message: str, begin_pos: int,
                                   end_pos: int):
         """Add a message that will be displayed on the next line."""
-        # Python does not have a way to specify the type of an optional
-        # argument.
-        callback: Callable[[int], None] = (
-            lambda indent=self._indent: self._print_message(
-                message, begin_pos, end_pos, indent))
-        self._next_line_callback.append(cast(Callable[[], None], callback))
+
+        def callback(indent: int = self._indent):
+            self._print_message(message, begin_pos, end_pos, indent)
+
+        self._next_line_callback.append(callback)
 
     def _print_message(self,
                        message: str,
@@ -113,6 +112,8 @@ class Printer:
         self._print_new_line(indent=0, print_message=False)
 
     T = TypeVar('T')
+    K = TypeVar('K')
+    V = TypeVar('V')
 
     def print_list(self,
                    elems: Iterable[T],
@@ -124,15 +125,16 @@ class Printer:
             print_fn(elem)
 
     def print_dictionary(self,
-                         elems: dict,
-                         print_fn: Callable[[T], None],
+                         elems: dict[K, V],
+                         print_key: Callable[[K], None],
+                         print_value: Callable[[V], None],
                          delimiter: str = ", ") -> None:
         for i, (key, value) in enumerate(elems.items()):
             if i:
                 self.print(delimiter)
-            print_fn(key)
+            print_key(key)
             self.print("=")
-            print_fn(value)
+            print_value(value)
 
     def _print_new_line(self,
                         indent: int | None = None,
@@ -347,7 +349,8 @@ class Printer:
 
         if isinstance(attribute, FloatAttr):
             value = attribute.value
-            typ = attribute.type
+            typ = cast(FloatAttr[Float16Type | Float32Type | Float64Type],
+                       attribute).type
             self.print(value.data)
             self.print(" : ")
             self.print_attribute(typ)
@@ -362,10 +365,11 @@ class Printer:
             return
 
         if isinstance(attribute, DictionaryAttr):
+            data = cast(DictionaryAttr[Attribute], attribute).data
             self.print_string("{")
-            self.print_dictionary(
-                attribute.data,  # type: ignore
-                self.print_attribute)
+            # The keys are attributes, even if type is annotated as dict[str, Attribute]
+            self.print_dictionary(data, self.print_attribute,
+                                  self.print_attribute)
             self.print_string("}")
             return
 
@@ -530,7 +534,7 @@ class Printer:
         self.print(" ")
         self.print("[" if self.target == Printer.Target.XDSL else "{")
 
-        attribute_list = [p for p in attributes.items()]
+        attribute_list = list(attributes.items())
         self.print_list(attribute_list, self._print_attr_string)
 
         self.print("]" if self.target == Printer.Target.XDSL else "}")


### PR DESCRIPTION
Pyright wasn't happy about some of the printing and parsing code, and while fixing the pyright issues I found that the DictionaryAttr types are ambiguous. Bits of code expect the key type to be `StringAttribute`, but the parser constructs it as `str`. The implementation of `DictionaryAttr` declares the data parameter to have type `dict[str, A]`, but the `verify_` function checks that keys are of type `StringAttr`.

This PR is mostly tricks to make the type checker happy, the code functionality should be pretty much the same, modulo the key printing/parsing functions being passed in separately from the value printing/parsing functions.

Happy to add the code that would realign the key types in this PR, or in a follow-up