### PR TITLE
xdsl: parse dictionary as non-optional

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,15 +15,15 @@ def test_int_list_parser(input: str, expected: list[int]):
     assert int_list == expected
 
 
-@pytest.mark.parametrize("input,expected", [('"A"=0, "B"=1, "C"=2', {
+@pytest.mark.parametrize("input,expected", [('{"A"=0, "B"=1, "C"=2}', {
     "A": 0,
     "B": 1,
     "C": 2
-}), ('"MA"=10, "BR"=7, "Z"=3', {
+}), ('{"MA"=10, "BR"=7, "Z"=3}', {
     "MA": 10,
     "BR": 7,
     "Z": 3
-}), ('"Q"=77, "VV"=12, "AA"=-8', {
+}), ('{"Q"=77, "VV"=12, "AA"=-8}', {
     "Q": 77,
     "VV": 12,
     "AA": -8
@@ -32,6 +32,6 @@ def test_int_dictionary_parser(input: str, expected: dict[str, int]):
     ctx = MLContext()
     parser = Parser(ctx, input)
 
-    int_dict = parser.parse_dictionary(parser.parse_optional_str_literal,
-                                       parser.parse_optional_int_literal)
+    int_dict = parser.parse_dictionary(parser.parse_str_literal,
+                                       parser.parse_int_literal)
     assert int_dict == expected

--- a/tests/test_parser_error.py
+++ b/tests/test_parser_error.py
@@ -39,7 +39,7 @@ unknown() {
   %0 : !i32 unknown()
 }
 """
-    check_error(prog, 3, 13, "'=' expected")
+    check_error(prog, 3, 13, "'=' expected, got u")
 
 
 def test_parser_redefined_value():

--- a/tests/test_parser_error.py
+++ b/tests/test_parser_error.py
@@ -39,7 +39,7 @@ unknown() {
   %0 : !i32 unknown()
 }
 """
-    check_error(prog, 3, 13, "'=' expected, got u")
+    check_error(prog, 3, 13, "'=' expected, got 'u'")
 
 
 def test_parser_redefined_value():

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -349,11 +349,8 @@ class DictionaryAttr(GenericData[dict[str, Attribute]]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> dict[str, Attribute]:
-        parser.parse_char("{")
-
-        data = parser.parse_dictionary(parser.parse_optional_str_literal,
-                                       parser.parse_optional_attribute)
-        parser.parse_char("}")
+        data = parser.parse_dictionary(parser.parse_str_literal,
+                                       parser.parse_attribute)
         return data
 
     @staticmethod

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -482,12 +482,12 @@ class Parser:
         if self.peek_char("}"):
             return {}
 
-        entry = self.parse_dict_entry(parse_key, parse_value)
-        res = dict((entry, ))
+        key, value = self.parse_dict_entry(parse_key, parse_value)
+        res = {key: value}
         while not self.peek_char("}"):
             parse_delimiter()
-            entry = self.parse_dict_entry(parse_key, parse_value)
-            res[entry[0]] = entry[1]
+            key, value = self.parse_dict_entry(parse_key, parse_value)
+            res[key] = value
 
         self.parse_char("}")
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -360,7 +360,7 @@ class Parser:
         res = self.parse_optional_char(char, skip_white_space=skip_white_space)
         if res is None:
             raise ParserError(self._pos,
-                              f"'{char}' expected, got {current_char}")
+                              f"'{char}' expected, got '{current_char}'")
         return True
 
     def parse_string(self,


### PR DESCRIPTION
Parse the whole dictionary, including opening and closing braces. This makes a number of things easier to implement, and lets us pass non-optional parsing functions for key and value