### PR TITLE
dialects: Improve MemRefType.from_type_list() constructor

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -5,13 +5,13 @@ from xdsl.dialects.memref import (Alloc, Alloca, Dealloc, Dealloca, MemRefType,
 
 
 def test_memreftype():
-    mem1 = MemRefType.from_type_and_list(i32)
+    mem1 = MemRefType.from_element_type_and_shape(i32, [1])
 
     assert mem1.get_num_dims() == 1
     assert mem1.get_shape() == [1]
     assert mem1.element_type is i32
 
-    mem2 = MemRefType.from_type_and_list(i32, [3, 3, 3])
+    mem2 = MemRefType.from_element_type_and_shape(i32, [3, 3, 3])
 
     assert mem2.get_num_dims() == 3
     assert mem2.get_shape() == [3, 3, 3]
@@ -26,7 +26,7 @@ def test_memreftype():
 
 
 def test_memref_load_i32():
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
     load = Load.get(memref_ssa_value, [])
 
@@ -36,7 +36,7 @@ def test_memref_load_i32():
 
 
 def test_memref_load_i32_with_dimensions():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [2, 3])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -49,7 +49,7 @@ def test_memref_load_i32_with_dimensions():
 
 
 def test_memref_store_i32():
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
     i32_ssa_value = OpResult(i32, [], [])
     store = Store.get(i32_ssa_value, memref_ssa_value, [])
@@ -60,7 +60,7 @@ def test_memref_store_i32():
 
 
 def test_memref_store_i32_with_dimensions():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [2, 3])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
     i32_ssa_value = OpResult(i32, [], [])
     index1 = OpResult(IndexType, [], [])

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -32,7 +32,7 @@ def test_vectorType_from_params():
 
 
 def test_vector_load_i32():
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
     load = Load.get(memref_ssa_value, [])
 
@@ -42,7 +42,7 @@ def test_vector_load_i32():
 
 
 def test_vector_load_i32_with_dimensions():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [2, 3])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -57,7 +57,7 @@ def test_vector_load_i32_with_dimensions():
 def test_vector_load_verify_type_matching():
     res_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
-    i32_memref_type = MemRefType.from_type_and_list(i32, [4, 5])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     load = Load.build(operands=[memref_ssa_value, []],
@@ -70,7 +70,7 @@ def test_vector_load_verify_type_matching():
 
 
 def test_vector_load_verify_indexing_exception():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [2, 3])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     load = Load.get(memref_ssa_value, [])
@@ -84,7 +84,7 @@ def test_vector_store_i32():
     i32_vector_type = VectorType.from_element_type_and_shape(i32, [1])
     vector_ssa_value = OpResult(i32_vector_type, [], [])
 
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
@@ -98,7 +98,7 @@ def test_vector_store_i32_with_dimensions():
     i32_vector_type = VectorType.from_element_type_and_shape(i32, [2, 3])
     vector_ssa_value = OpResult(i32_vector_type, [], [])
 
-    i32_memref_type = MemRefType.from_type_and_list(i32, [4, 5])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     index1 = OpResult(IndexType, [], [])
@@ -115,7 +115,7 @@ def test_vector_store_verify_type_matching():
     i64_vector_type = VectorType.from_element_type_and_shape(i64, [2, 3])
     vector_ssa_value = OpResult(i64_vector_type, [], [])
 
-    i32_memref_type = MemRefType.from_type_and_list(i32, [4, 5])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
@@ -130,7 +130,7 @@ def test_vector_store_verify_indexing_exception():
     i32_vector_type = VectorType.from_element_type_and_shape(i32, [2, 3])
     vector_ssa_value = OpResult(i32_vector_type, [], [])
 
-    i32_memref_type = MemRefType.from_type_and_list(i32, [4, 5])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
@@ -302,7 +302,7 @@ def test_vector_fma_verify_res_acc_shape_matching():
 
 
 def test_vector_masked_load():
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
@@ -322,7 +322,7 @@ def test_vector_masked_load():
 
 
 def test_vector_masked_load_with_dimensions():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [4, 5])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
@@ -347,7 +347,7 @@ def test_vector_masked_load_with_dimensions():
 
 
 def test_vector_masked_load_verify_memref_res_type_matching():
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
@@ -373,7 +373,7 @@ def test_vector_masked_load_verify_memref_res_type_matching():
 
 
 def test_vector_masked_load_verify_memref_passthrough_type_matching():
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
@@ -399,7 +399,7 @@ def test_vector_masked_load_verify_memref_passthrough_type_matching():
 
 
 def test_vector_masked_load_verify_indexing_exception():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [4, 5])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [2])
@@ -420,7 +420,7 @@ def test_vector_masked_load_verify_indexing_exception():
 
 
 def test_vector_masked_load_verify_result_vector_rank():
-    i32_memref_type = MemRefType.from_type_and_list(i32)
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
@@ -445,7 +445,7 @@ def test_vector_masked_load_verify_result_vector_rank():
 
 
 def test_vector_masked_load_verify_mask_vector_rank():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [2, 3])
@@ -465,7 +465,7 @@ def test_vector_masked_load_verify_mask_vector_rank():
 
 
 def test_vector_masked_load_verify_mask_vector_type():
-    i32_memref_type = MemRefType.from_type_and_list(i32, [])
+    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
     i32_mask_vector_type = VectorType.from_element_type_and_shape(i32, [2])

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -32,12 +32,10 @@ class MemRefType(Generic[_MemRefTypeElement], ParametrizedAttribute, MLIRType):
 
     @staticmethod
     @builder
-    def from_type_and_list(
-        referenced_type: _MemRefTypeElement,
-        shape: Optional[List[int | AnyIntegerAttr]] = None
+    def from_element_type_and_shape(
+            referenced_type: _MemRefTypeElement,
+            shape: List[int | AnyIntegerAttr]
     ) -> MemRefType[_MemRefTypeElement]:
-        if shape is None:
-            shape = [1]
         return MemRefType([
             ArrayAttr[AnyIntegerAttr].from_list(
                 [IntegerAttr.build(d) for d in shape]), referenced_type
@@ -120,12 +118,15 @@ class Alloc(Operation):
             shape: Optional[List[int | AnyIntegerAttr]] = None) -> Alloc:
         if shape is None:
             shape = [1]
-        return Alloc.build(
-            operands=[[], []],
-            result_types=[MemRefType.from_type_and_list(return_type, shape)],
-            attributes={
-                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
-            })
+        return Alloc.build(operands=[[], []],
+                           result_types=[
+                               MemRefType.from_element_type_and_shape(
+                                   return_type, shape)
+                           ],
+                           attributes={
+                               "alignment":
+                               IntegerAttr.from_int_and_width(alignment, 64)
+                           })
 
 
 @irdl_op_definition
@@ -148,12 +149,15 @@ class Alloca(Operation):
             shape: Optional[List[int | AnyIntegerAttr]] = None) -> Alloca:
         if shape is None:
             shape = [1]
-        return Alloca.build(
-            operands=[[], []],
-            result_types=[MemRefType.from_type_and_list(return_type, shape)],
-            attributes={
-                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
-            })
+        return Alloca.build(operands=[[], []],
+                            result_types=[
+                                MemRefType.from_element_type_and_shape(
+                                    return_type, shape)
+                            ],
+                            attributes={
+                                "alignment":
+                                IntegerAttr.from_int_and_width(alignment, 64)
+                            })
 
 
 @irdl_op_definition


### PR DESCRIPTION
This PR intends to modify the `MemRefType.from_type_and_list()` constructor in accordance with [this](https://github.com/xdslproject/xdsl/pull/300#discussion_r1066818410) discussion. 