### PR TITLE
Disable the timestamp on MLIR's build cache key.

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -44,6 +44,7 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ env.MLIR-Version }}
         # LLVM needs serious cache size
         max-size: 6G
+        append-timestamp: false
 
     - name: Checkout project
       uses: actions/checkout@v3


### PR DESCRIPTION
Currently, a new cache is created for **every** rebuild of MLIR, even if it was mainly fetched from an existing cache.
This PR solves this by only creating caches according to platform and MLIR commit.