### PR TITLE
CI: Reconfigure CI to cache built binaries

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -33,15 +33,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Checkout project
-        uses: actions/checkout@v3
-        with:
-          path: xdsl
-
-      - name: Upgrade pip
-        run: |
-          pip install --upgrade pip
-
       - name: Upgrade pip
         run: |
           pip install --upgrade pip
@@ -83,7 +74,7 @@ jobs:
         uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
       - name: Checkout MLIR
-        if: ${{ (steps.cache-binary.outputs.cache-hit != 'true') || (steps.cache-requirements.outputs.cache-hit != true) }}
+        if: ${{ (steps.cache-binary.outputs.cache-hit != 'true') || (steps.cache-requirements.outputs.cache-hit != 'true') }}
         uses: actions/checkout@v3
         with:
           repository: llvm/llvm-project.git
@@ -101,7 +92,7 @@ jobs:
           cmake -G Ninja ../llvm -DPython3_EXECUTABLE=python3 -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
 
       - name: Restore binary folder on reclone
-        if: ${{ (steps.cache-binary.outputs.cache-hit == 'true') && (steps.cache-requirements.outputs.cache-hit != true) }}
+        if: ${{ (steps.cache-binary.outputs.cache-hit == 'true') && (steps.cache-requirements.outputs.cache-hit != 'true') }}
         uses: actions/cache/restore@v3
         with:
           path: llvm-project/build

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -24,9 +24,9 @@ jobs:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
       MLIR-Version: 89996621de073e43de7bed552037b10d2a0fdf80
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: xdsl
+      - uses: actions/checkout@v3
+        with:
+          path: xdsl
 
       - name: Python Setup
         uses: actions/setup-python@v4
@@ -42,22 +42,19 @@ jobs:
         run: |
           pip install --upgrade pip
 
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade pip
+
       - name: Install the package locally
-        run: pip install -e .[extras]
+        run: |
+          # Change directory so that xdsl-opt can be found during installation.
+          cd xdsl
+          pip install -e .[extras]
 
-    - name: Upgrade pip
-      run: |
-        pip install --upgrade pip
-
-    - name: Install the package locally
-      run: |
-        # Change directory so that xdsl-opt can be found during installation.
-        cd xdsl
-        pip install -e .[extras]
-
-    - name: Install CI dependencies
-      run: |
-        pip install codecov
+      - name: Install CI dependencies
+        run: |
+          pip install codecov
 
       - name: Cache binaries
         id: cache-binary
@@ -77,14 +74,6 @@ jobs:
           restore-keys: requirements-${{ runner.os }}-${{ env.MLIR-Version }}
           append-timestamp: false
 
-<<<<<<< HEAD
-    - name: MLIR Build Setup
-      run: |
-        pip install -r ${GITHUB_WORKSPACE}/llvm-project/mlir/python/requirements.txt
-        mkdir llvm-project/build
-        cd llvm-project/build
-        cmake -G Ninja ../llvm -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-=======
       - name: Clang Setup
         if: steps.cache-binary.outputs.cache-hit != 'true'
         uses: egor-tensin/setup-clang@v1
@@ -100,7 +89,6 @@ jobs:
           repository: llvm/llvm-project.git
           path: llvm-project
           ref: ${{ env.MLIR-Version }}
->>>>>>> 42ab382 (CI: Cache binaries only)
 
       - name: Install Python Bindings Requirements
         run: pip install -r ${GITHUB_WORKSPACE}/xdsl/llvm-project/mlir/python/requirements.txt

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ["3.10", "3.11"]
 
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
@@ -28,24 +28,22 @@ jobs:
       with:
         path: xdsl
 
-    - name: Python Setup
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Python Setup
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Clang Setup
-      uses: egor-tensin/setup-clang@v1
+      - name: Checkout project
+        uses: actions/checkout@v3
+        with:
+          path: xdsl
 
-    - name: Ninja Setup
-      uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade pip
 
-    - name: CCache Setup (C++ compilation)
-      uses: hendrikmuhs/ccache-action@v1.2.5
-      with:
-        key: ${{ runner.os }}-${{ env.MLIR-Version }}
-        restore-keys: ${{ runner.os }}-${{ env.MLIR-Version }}
-        # LLVM needs serious cache size
-        max-size: 6G
+      - name: Install the package locally
+        run: pip install -e .[extras]
 
     - name: Upgrade pip
       run: |
@@ -61,55 +59,110 @@ jobs:
       run: |
         pip install codecov
 
-    - name: Checkout MLIR
-      uses: actions/checkout@v3
-      with:
-        repository: llvm/llvm-project.git
-        path: llvm-project
-        ref: ${{ env.MLIR-Version }}
+      - name: Cache binaries
+        id: cache-binary
+        uses: actions/cache@v3
+        with:
+          path: llvm-project/build
+          key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
+          restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
+          append-timestamp: false
 
+      - name: Cache requirements
+        id: cache-requirements
+        uses: actions/cache@v3
+        with:
+          path: llvm-project/mlir/python/requirements.txt
+          key: requirements-${{ runner.os }}-${{ env.MLIR-Version }}
+          restore-keys: requirements-${{ runner.os }}-${{ env.MLIR-Version }}
+          append-timestamp: false
+
+<<<<<<< HEAD
     - name: MLIR Build Setup
       run: |
         pip install -r ${GITHUB_WORKSPACE}/llvm-project/mlir/python/requirements.txt
         mkdir llvm-project/build
         cd llvm-project/build
         cmake -G Ninja ../llvm -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+=======
+      - name: Clang Setup
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        uses: egor-tensin/setup-clang@v1
 
-    - name: MLIR Build
-      run: |
-        cd llvm-project/build
-        cmake --build . --target mlir-opt MLIRPythonModules
+      - name: Ninja Setup
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
-    - name: Test with pytest and generate code coverage
-      run: |
-        cd xdsl
-        # Add the MLIR Python bindings to the PYTHONPATH
-        export PYTHONPATH=$PYTHONPATH:${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
-        pytest --cov --cov-config=.coveragerc .
+      - name: Checkout MLIR
+        if: steps.cache-binary.outputs.cache-hit != 'true' || steps.cache-requirements.outputs.cache-hit != true
+        uses: actions/checkout@v3
+        with:
+          repository: llvm/llvm-project.git
+          path: llvm-project
+          ref: ${{ env.MLIR-Version }}
+>>>>>>> 42ab382 (CI: Cache binaries only)
 
-    - name: Execute lit tests
-      run: |
-        cd xdsl
-        export PYTHONPATH=$(pwd)
-        # Add mlir-opt to the path
-        export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
-        # Add the MLIR Python bindings to the PYTHONPATH
-        export PYTHONPATH=$PYTHONPATH:${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
-        lit -v tests/filecheck/ -DCOVERAGE -DEXEC_DIR=$(pwd)
+      - name: Install Python Bindings Requirements
+        run: pip install -r ${GITHUB_WORKSPACE}/xdsl/llvm-project/mlir/python/requirements.txt
 
-    - name: Combine coverage data
-      run: |
-        cd xdsl
-        coverage combine --append
-        coverage report
-        coverage xml
+      - name: MLIR Build Setup
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p llvm-project/build
+          cd llvm-project/build
+          cmake -G Ninja ../llvm -DPython3_EXECUTABLE=python3 -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
 
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.10'
-      uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
-        verbose: true
-        directory: ${GITHUB_WORKSPACE}/../
-        files: coverage.xml
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Restore binary folder on reclone
+        if: steps.cache-binary.outputs.cache-hit == 'true' && steps.cache-requirements.outputs.cache-hit != true
+        uses: actions/cache/restore@v3
+        with:
+          path: llvm-project/build
+          key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
+          restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
+
+      - name: MLIR Build
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        run: |
+          cd llvm-project/build
+          cmake --build . --target mlir-opt MLIRPythonModules
+
+      - name: diag
+        run: |
+          echo $PYTHONPATH
+          ls -R ${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
+          cat ${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core/mlir/_mlir_libs/_mlir/ir.pyi
+
+      - name: Test with pytest and generate code coverage
+        run: |
+          cd xdsl
+          # Add the MLIR Python bindings to the PYTHONPATH
+          export PYTHONPATH=${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
+          echo $PYTHONPATH
+          pytest --cov --cov-config=.coveragerc .
+
+      - name: Execute lit tests
+        run: |
+          cd xdsl
+          export PYTHONPATH=$(pwd)
+          # Add mlir-opt to the path
+          export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
+          # Add the MLIR Python bindings to the PYTHONPATH
+          export PYTHONPATH=$PYTHONPATH:${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
+          lit -v tests/filecheck/ -DCOVERAGE -DEXEC_DIR=$(pwd)
+
+      - name: Combine coverage data
+        run: |
+          cd xdsl
+          coverage combine --append
+          coverage report
+          coverage xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.10'
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          directory: ${GITHUB_WORKSPACE}/../
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -56,6 +56,7 @@ jobs:
           restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
           append-timestamp: false
 
+
       - name: Checkout MLIR
         if: steps.cache-binary.outputs.cache-hit != 'true'
         uses: actions/checkout@v3

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -75,7 +75,7 @@ jobs:
     - name: MLIR Build Setup
       if: steps.cache-binary.outputs.cache-hit != 'true'
       run: |
-        mkdir -p llvm-project/build
+        mkdir llvm-project/build
         cd llvm-project/build
         cmake -G Ninja ../llvm \
           -DLLVM_ENABLE_PROJECTS=mlir \

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -83,7 +83,7 @@ jobs:
         uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
       - name: Checkout MLIR
-        if: steps.cache-binary.outputs.cache-hit != 'true' || steps.cache-requirements.outputs.cache-hit != true
+        if: ${{ (steps.cache-binary.outputs.cache-hit != 'true') || (steps.cache-requirements.outputs.cache-hit != true) }}
         uses: actions/checkout@v3
         with:
           repository: llvm/llvm-project.git
@@ -100,9 +100,8 @@ jobs:
           cd llvm-project/build
           cmake -G Ninja ../llvm -DPython3_EXECUTABLE=python3 -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
 
-
       - name: Restore binary folder on reclone
-        if: steps.cache-binary.outputs.cache-hit == 'true' && steps.cache-requirements.outputs.cache-hit != true
+        if: ${{ (steps.cache-binary.outputs.cache-hit == 'true') && (steps.cache-requirements.outputs.cache-hit != true) }}
         uses: actions/cache/restore@v3
         with:
           path: llvm-project/build
@@ -114,12 +113,6 @@ jobs:
         run: |
           cd llvm-project/build
           cmake --build . --target mlir-opt MLIRPythonModules
-
-      - name: diag
-        run: |
-          echo $PYTHONPATH
-          ls -R ${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
-          cat ${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core/mlir/_mlir_libs/_mlir/ir.pyi
 
       - name: Test with pytest and generate code coverage
         run: |

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -47,6 +47,13 @@ jobs:
         run: |
           pip install codecov
 
+      - name: Checkout MLIR
+        uses: actions/checkout@v3
+        with:
+          repository: llvm/llvm-project.git
+          path: llvm-project
+          ref: ${{ env.MLIR-Version }}
+
       - name: Cache binaries
         id: cache-binary
         uses: actions/cache@v3
@@ -54,15 +61,6 @@ jobs:
           path: llvm-project/build
           key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
           restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
-          append-timestamp: false
-
-      - name: Cache requirements
-        id: cache-requirements
-        uses: actions/cache@v3
-        with:
-          path: llvm-project/mlir/python/requirements.txt
-          key: requirements-${{ runner.os }}-${{ env.MLIR-Version }}
-          restore-keys: requirements-${{ runner.os }}-${{ env.MLIR-Version }}
           append-timestamp: false
 
       - name: Clang Setup
@@ -73,14 +71,6 @@ jobs:
         if: steps.cache-binary.outputs.cache-hit != 'true'
         uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
-      - name: Checkout MLIR
-        if: ${{ (steps.cache-binary.outputs.cache-hit != 'true') || (steps.cache-requirements.outputs.cache-hit != 'true') }}
-        uses: actions/checkout@v3
-        with:
-          repository: llvm/llvm-project.git
-          path: llvm-project
-          ref: ${{ env.MLIR-Version }}
-
       - name: Install Python Bindings Requirements
         run: pip install -r ${GITHUB_WORKSPACE}/llvm-project/mlir/python/requirements.txt
 
@@ -90,14 +80,6 @@ jobs:
           mkdir -p llvm-project/build
           cd llvm-project/build
           cmake -G Ninja ../llvm -DPython3_EXECUTABLE=python3 -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
-
-      - name: Restore binary folder on reclone
-        if: ${{ (steps.cache-binary.outputs.cache-hit == 'true') && (steps.cache-requirements.outputs.cache-hit != 'true') }}
-        uses: actions/cache/restore@v3
-        with:
-          path: llvm-project/build
-          key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
-          restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
 
       - name: MLIR Build
         if: steps.cache-binary.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -100,6 +100,7 @@ jobs:
           cd llvm-project/build
           cmake -G Ninja ../llvm -DPython3_EXECUTABLE=python3 -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
 
+
       - name: Restore binary folder on reclone
         if: steps.cache-binary.outputs.cache-hit == 'true' && steps.cache-requirements.outputs.cache-hit != true
         uses: actions/cache/restore@v3

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -47,13 +47,6 @@ jobs:
         run: |
           pip install codecov
 
-      - name: Checkout MLIR
-        uses: actions/checkout@v3
-        with:
-          repository: llvm/llvm-project.git
-          path: llvm-project
-          ref: ${{ env.MLIR-Version }}
-
       - name: Cache binaries
         id: cache-binary
         uses: actions/cache@v3
@@ -63,6 +56,14 @@ jobs:
           restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
           append-timestamp: false
 
+      - name: Checkout MLIR
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: llvm/llvm-project.git
+          path: llvm-project
+          ref: ${{ env.MLIR-Version }}
+
       - name: Clang Setup
         if: steps.cache-binary.outputs.cache-hit != 'true'
         uses: egor-tensin/setup-clang@v1
@@ -71,21 +72,18 @@ jobs:
         if: steps.cache-binary.outputs.cache-hit != 'true'
         uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
-      - name: Install Python Bindings Requirements
-        run: pip install -r ${GITHUB_WORKSPACE}/llvm-project/mlir/python/requirements.txt
-
       - name: MLIR Build Setup
         if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |
           mkdir -p llvm-project/build
           cd llvm-project/build
-          cmake -G Ninja ../llvm -DPython3_EXECUTABLE=python3 -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+          cmake -G Ninja ../llvm -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
 
       - name: MLIR Build
         if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |
           cd llvm-project/build
-          cmake --build . --target mlir-opt MLIRPythonModules
+          cmake --build . --target mlir-opt
 
       - name: Test with pytest and generate code coverage
         run: |

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -77,7 +77,14 @@ jobs:
       run: |
         mkdir -p llvm-project/build
         cd llvm-project/build
-        cmake -G Ninja ../llvm -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+        cmake -G Ninja ../llvm \
+          -DLLVM_ENABLE_PROJECTS=mlir \
+          -DLLVM_TARGETS_TO_BUILD="X86" \
+          -DLLVM_ENABLE_LLD=ON \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DLLVM_ENABLE_ASSERTIONS=ON
 
     - name: MLIR Build
       if: steps.cache-binary.outputs.cache-hit != 'true'
@@ -90,7 +97,6 @@ jobs:
         cd xdsl
         # Add the MLIR Python bindings to the PYTHONPATH
         export PYTHONPATH=${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
-        echo $PYTHONPATH
         pytest --cov --cov-config=.coveragerc .
 
     - name: Execute lit tests

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -91,7 +91,7 @@ jobs:
           ref: ${{ env.MLIR-Version }}
 
       - name: Install Python Bindings Requirements
-        run: pip install -r ${GITHUB_WORKSPACE}/xdsl/llvm-project/mlir/python/requirements.txt
+        run: pip install -r ${GITHUB_WORKSPACE}/llvm-project/mlir/python/requirements.txt
 
       - name: MLIR Build Setup
         if: steps.cache-binary.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -18,105 +18,104 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ['3.10', '3.11']
 
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
       MLIR-Version: 89996621de073e43de7bed552037b10d2a0fdf80
     steps:
-      - uses: actions/checkout@v3
-        with:
-          path: xdsl
+    - uses: actions/checkout@v3
+      with:
+        path: xdsl
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Python Setup
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: |
-          pip install --upgrade pip
+    - name: Upgrade pip
+      run: |
+        pip install --upgrade pip
 
-      - name: Install the package locally
-        run: |
-          # Change directory so that xdsl-opt can be found during installation.
-          cd xdsl
-          pip install -e .[extras]
+    - name: Install the package locally
+      run: |
+        # Change directory so that xdsl-opt can be found during installation.
+        cd xdsl
+        pip install -e .[extras]
 
-      - name: Install CI dependencies
-        run: |
-          pip install codecov
+    - name: Install CI dependencies
+      run: |
+        pip install codecov
 
-      - name: Cache binaries
-        id: cache-binary
-        uses: actions/cache@v3
-        with:
-          path: llvm-project/build
-          key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
-          restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
-          append-timestamp: false
+    - name: Cache binaries
+      id: cache-binary
+      uses: actions/cache@v3
+      with:
+        path: llvm-project/build
+        key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
+        restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
+        append-timestamp: false
 
+    - name: Checkout MLIR
+      if: steps.cache-binary.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: llvm/llvm-project.git
+        path: llvm-project
+        ref: ${{ env.MLIR-Version }}
 
-      - name: Checkout MLIR
-        if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: llvm/llvm-project.git
-          path: llvm-project
-          ref: ${{ env.MLIR-Version }}
+    - name: Clang Setup
+      if: steps.cache-binary.outputs.cache-hit != 'true'
+      uses: egor-tensin/setup-clang@v1
 
-      - name: Clang Setup
-        if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: egor-tensin/setup-clang@v1
+    - name: Ninja Setup
+      if: steps.cache-binary.outputs.cache-hit != 'true'
+      uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
-      - name: Ninja Setup
-        if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
+    - name: MLIR Build Setup
+      if: steps.cache-binary.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p llvm-project/build
+        cd llvm-project/build
+        cmake -G Ninja ../llvm -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
 
-      - name: MLIR Build Setup
-        if: steps.cache-binary.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p llvm-project/build
-          cd llvm-project/build
-          cmake -G Ninja ../llvm -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_LLD=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+    - name: MLIR Build
+      if: steps.cache-binary.outputs.cache-hit != 'true'
+      run: |
+        cd llvm-project/build
+        cmake --build . --target mlir-opt
 
-      - name: MLIR Build
-        if: steps.cache-binary.outputs.cache-hit != 'true'
-        run: |
-          cd llvm-project/build
-          cmake --build . --target mlir-opt
+    - name: Test with pytest and generate code coverage
+      run: |
+        cd xdsl
+        # Add the MLIR Python bindings to the PYTHONPATH
+        export PYTHONPATH=${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
+        echo $PYTHONPATH
+        pytest --cov --cov-config=.coveragerc .
 
-      - name: Test with pytest and generate code coverage
-        run: |
-          cd xdsl
-          # Add the MLIR Python bindings to the PYTHONPATH
-          export PYTHONPATH=${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
-          echo $PYTHONPATH
-          pytest --cov --cov-config=.coveragerc .
+    - name: Execute lit tests
+      run: |
+        cd xdsl
+        export PYTHONPATH=$(pwd)
+        # Add mlir-opt to the path
+        export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
+        # Add the MLIR Python bindings to the PYTHONPATH
+        export PYTHONPATH=$PYTHONPATH:${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
+        lit -v tests/filecheck/ -DCOVERAGE -DEXEC_DIR=$(pwd)
 
-      - name: Execute lit tests
-        run: |
-          cd xdsl
-          export PYTHONPATH=$(pwd)
-          # Add mlir-opt to the path
-          export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
-          # Add the MLIR Python bindings to the PYTHONPATH
-          export PYTHONPATH=$PYTHONPATH:${GITHUB_WORKSPACE}/llvm-project/build/tools/mlir/python_packages/mlir_core
-          lit -v tests/filecheck/ -DCOVERAGE -DEXEC_DIR=$(pwd)
+    - name: Combine coverage data
+      run: |
+        cd xdsl
+        coverage combine --append
+        coverage report
+        coverage xml
 
-      - name: Combine coverage data
-        run: |
-          cd xdsl
-          coverage combine --append
-          coverage report
-          coverage xml
-
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.10'
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          verbose: true
-          directory: ${GITHUB_WORKSPACE}/../
-          files: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.10'
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true
+        verbose: true
+        directory: ${GITHUB_WORKSPACE}/../
+        files: coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/filecheck/mlir-conversion/with-mlir/lit.local.cfg
+++ b/tests/filecheck/mlir-conversion/with-mlir/lit.local.cfg
@@ -1,5 +1,4 @@
-try:
-    import mlir.ir
-except ImportError:
-    config.unsupported = True
+import shutil
 
+if not shutil.which("mlir-opt"):
+    config.unsupported = True


### PR DESCRIPTION
This PR changes caching of MLIR such that it caches the full build folder (because we need the PythonBindings)  and then conditionally recompiles MLIR on a cache miss.

This brings the CI execution time down to under a minute, but there is an issue atm:

It looks like the Python Bindings are not properly installed, even though I added a CI step (called `diag`) that prints the content of the respective folder, which looks in order.

Maybe @math-fehr  or @PapyChacal could take a look? I feel like I might be missing something very obvious, but I can't find it... ([Python Bindings Installation](https://mlir.llvm.org/docs/Bindings/Python/#pre-requisites)).