### PR TITLE
misc: add flattened_values to LiteralExprAST

### DIFF
--- a/docs/Toy/toy/toy_ast.py
+++ b/docs/Toy/toy/toy_ast.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Callable, Iterable
+from typing import Generator, List, Optional, Callable, Iterable
 from enum import Enum
 from dataclasses import dataclass
 from .location import Location
@@ -137,6 +137,16 @@ class LiteralExprAST(ExprAST):
 
     def inner_dump(self, prefix: str, dumper: Dumper):
         dumper.append('Literal:', self.__dump() + f' {self.loc}')
+
+    def iter_flattened_values(self) -> Generator[float, None, None]:
+        for value in self.values:
+            if isinstance(value, NumberExprAST):
+                yield value.val
+            else:
+                yield from value.iter_flattened_values()
+
+    def flattened_values(self) -> list[float]:
+        return list(self.iter_flattened_values())
 
 
 @dataclass


### PR DESCRIPTION
The first of a number of smaller atomic changes used in Chapter 2 of the MLIR tutorials.