### PR TITLE
misc: print operation when raising a verification error

### DIFF
--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -503,7 +503,11 @@ class Operation(IRNode):
         self.verify_()
         if verify_nested_ops:
             for region in self.regions:
-                region.verify()
+                try:
+                    region.verify()
+                except:
+                    print(f'Verification error for operation `{self}`')
+                    raise
 
     def verify_(self) -> None:
         pass


### PR DESCRIPTION
This was helpful in my debugging, otherwise there's just a verification error but not much context of where it's from.