### PR TITLE
docs: Use JupyterLite 0.1.0b17

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install jupyterlite[all] libarchive-c build pyodide-build
+          python -m pip install jupyterlite[all]==0.1.0b17 libarchive-c build pyodide-build
           
       - name: Build xDSL source distribution
         run: |


### PR DESCRIPTION
JupyterLite 0.1.0b18 was recently released and breaks a simple behaviour we rely on (see currently [this notebook](https://xdsl.dev/xdsl/retro/notebooks/?path=Toy/Toy_Ch1.ipynb))

This PR fix the used version to 0.1.0b17 which works at the moment. Testable [there](https://papychacal.github.io/xdsl/retro/notebooks/?path=Toy/Toy_Ch1.ipynb).