### PR TITLE
API: Add parser methods to parse SSA values

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -356,8 +356,6 @@ class PlusCustomFormatOp(Operation):
     @classmethod
     def parse(cls, result_types: List[Attribute],
               parser: BaseParser) -> PlusCustomFormatOp:
-
-        parser.parse_operand()
         lhs = parser.parse_operand('Expected SSA Value name here!')
         parser.parse_characters("+",
                                 "Malformed operation format, expected `+`!")

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -357,17 +357,14 @@ class PlusCustomFormatOp(Operation):
     def parse(cls, result_types: List[Attribute],
               parser: BaseParser) -> PlusCustomFormatOp:
 
-        lhs = parser.expect(parser.try_parse_value_id,
-                            'Expected SSA Value name here!')
+        parser.parse_operand()
+        lhs = parser.parse_operand('Expected SSA Value name here!')
         parser.parse_characters("+",
                                 "Malformed operation format, expected `+`!")
-        rhs = parser.expect(parser.try_parse_value_id,
-                            'Expected SSA Value name here!')
+        rhs = parser.parse_operand('Expected SSA Value name here!')
 
-        return PlusCustomFormatOp.create(
-            operands=[parser.get_ssa_val(lhs),
-                      parser.get_ssa_val(rhs)],
-            result_types=result_types)
+        return PlusCustomFormatOp.create(operands=[lhs, rhs],
+                                         result_types=result_types)
 
     def print(self, printer: Printer):
         printer.print(" ", self.lhs, " + ", self.rhs)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -786,6 +786,17 @@ class BaseParser(ABC):
     def try_parse_value_id(self) -> Span | None:
         return self.tokenizer.next_token_of_pattern(ParserCommons.value_id)
 
+    def try_parse_operand(self) -> SSAValue | None:
+        '''Try to parse an operand with format `%<value-id>`'''
+        value_id = self.try_parse_value_id()
+        if value_id is None:
+            return None
+        return self.get_ssa_val(value_id)
+
+    def parse_operand(self, msg: str = "operand expected") -> SSAValue:
+        '''Parse an operand with format `%<value-id>`'''
+        return self.expect(self.try_parse_operand, msg)
+
     def try_parse_suffix_id(self) -> Span | None:
         return self.tokenizer.next_token_of_pattern(ParserCommons.suffix_id)
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -787,14 +787,14 @@ class BaseParser(ABC):
         return self.tokenizer.next_token_of_pattern(ParserCommons.value_id)
 
     def try_parse_operand(self) -> SSAValue | None:
-        '''Try to parse an operand with format `%<value-id>`'''
+        """Try to parse an operand with format `%<value-id>`."""
         value_id = self.try_parse_value_id()
         if value_id is None:
             return None
         return self.get_ssa_val(value_id)
 
     def parse_operand(self, msg: str = "operand expected") -> SSAValue:
-        '''Parse an operand with format `%<value-id>`'''
+        """Parse an operand with format `%<value-id>`."""
         return self.expect(self.try_parse_operand, msg)
 
     def try_parse_suffix_id(self) -> Span | None:


### PR DESCRIPTION
This adds `parse_operand` and `try_parse_operand` to the `Parser`.
This parse a value-id, and then converts it to an `SSAValue`.
The name comes from the MLIR parser.