### PR TITLE
misc: make op_type_rewrite_pattern type check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def assert_print_op(operation: Operation,
                     expected: str,
                     diagnostic: Diagnostic | None,
                     print_generic_format: bool = False,
-                    target=None):
+                    target: Printer.Target | None = None):
     """
     Utility function that helps to check the printing of an operation compared to
     some string
@@ -41,13 +41,14 @@ def assert_print_op(operation: Operation,
     """
 
     file = StringIO("")
-    if diagnostic is None and target is None:
-        printer = Printer(stream=file,
-                          print_generic_format=print_generic_format)
-    elif diagnostic is None and target is not None:
-        printer = Printer(stream=file,
-                          print_generic_format=print_generic_format,
-                          target=target)
+    if diagnostic is None:
+        if target is None:
+            printer = Printer(stream=file,
+                              print_generic_format=print_generic_format)
+        else:
+            printer = Printer(stream=file,
+                              print_generic_format=print_generic_format,
+                              target=target)
     else:
         printer = Printer(stream=file, diagnostic=diagnostic)
 

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -266,7 +266,7 @@ def test_insert_op_before_matched_op():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: None, cst: Constant,
+    def match_and_rewrite(self: AnonymousRewritePattern, cst: Constant,
                           rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_before_matched_op(new_cst)

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1,5 +1,3 @@
-from io import StringIO
-
 from xdsl.dialects.arith import Arith, Constant, Addi, Muli
 from xdsl.dialects.builtin import i32, i64, Builtin, IntegerAttr, ModuleOp
 from xdsl.dialects.scf import If, Scf
@@ -9,7 +7,6 @@ from xdsl.pattern_rewriter import (PatternRewriteWalker,
                                    PatternRewriter, AnonymousRewritePattern,
                                    GreedyRewritePatternApplier)
 from xdsl.parser import Parser
-from xdsl.printer import Printer
 
 from conftest import assert_print_op
 
@@ -129,7 +126,8 @@ def test_op_type_rewrite_pattern_static_decorator():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
+                          rewriter: PatternRewriter):
         rewriter.replace_matched_op(Constant.from_int_and_width(43, i32))
 
     rewrite_and_compare(
@@ -160,7 +158,8 @@ def test_recursive_rewriter():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
+                          rewriter: PatternRewriter):
         val = op.value.value.data
         if val == 0 or val == 1:
             return None
@@ -199,7 +198,8 @@ def test_recursive_rewriter_reversed():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
+                          rewriter: PatternRewriter):
         val = op.value.value.data
         if val == 0 or val == 1:
             return None
@@ -233,11 +233,13 @@ def test_greedy_rewrite_pattern_applier():
 }"""
 
     @op_type_rewrite_pattern
-    def constant_rewrite(op: Constant, rewriter: PatternRewriter):
+    def constant_rewrite(self: AnonymousRewritePattern, op: Constant,
+                         rewriter: PatternRewriter):
         rewriter.replace_matched_op([Constant.from_int_and_width(43, i32)])
 
     @op_type_rewrite_pattern
-    def addi_rewrite(op: Addi, rewriter: PatternRewriter):
+    def addi_rewrite(self: AnonymousRewritePattern, op: Addi,
+                     rewriter: PatternRewriter):
         rewriter.replace_matched_op([Muli.get(op.lhs, op.rhs)])
 
     rewrite_and_compare(
@@ -264,7 +266,8 @@ def test_insert_op_before_matched_op():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: None, cst: Constant,
+                          rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_before_matched_op(new_cst)
 
@@ -289,7 +292,8 @@ def test_insert_op_at_pos():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, mod: ModuleOp,
+                          rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_at_pos(new_cst, mod.regions[0].blocks[0], 0)
 
@@ -314,7 +318,8 @@ def test_insert_op_before():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, mod: ModuleOp,
+                          rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_before(new_cst, mod.ops[0])
 
@@ -339,7 +344,8 @@ def test_insert_op_after():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, mod: ModuleOp,
+                          rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_after(new_cst, mod.ops[0])
 
@@ -364,7 +370,8 @@ def test_insert_op_after_matched_op():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, cst: Constant,
+                          rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_after_matched_op(new_cst)
 
@@ -389,7 +396,8 @@ def test_insert_op_after_matched_op_reversed():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, cst: Constant,
+                          rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_after_matched_op(new_cst)
 
@@ -412,7 +420,8 @@ def test_operation_deletion():
 """builtin.module() {}"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
+                          rewriter: PatternRewriter):
         rewriter.erase_matched_op()
 
     rewrite_and_compare(
@@ -435,7 +444,8 @@ def test_operation_deletion_reversed():
     expected = \
 """builtin.module() {}"""
 
-    def match_and_rewrite(op: Operation, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: Operation,
+                          rewriter: PatternRewriter):
         if not isinstance(op, ModuleOp):
             rewriter.erase_matched_op()
 
@@ -459,7 +469,8 @@ def test_operation_deletion_failure():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
+                          rewriter: PatternRewriter):
         rewriter.erase_matched_op()
 
     parser = Parser(ctx, prog)
@@ -486,7 +497,8 @@ def test_delete_inner_op():
 """builtin.module() {}"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: ModuleOp,
+                          rewriter: PatternRewriter):
         rewriter.erase_op(op.ops[0])
 
     rewrite_and_compare(
@@ -508,7 +520,8 @@ def test_replace_inner_op():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: ModuleOp,
+                          rewriter: PatternRewriter):
         rewriter.replace_op(op.ops[0], [Constant.from_int_and_width(42, i32)])
 
     rewrite_and_compare(
@@ -538,7 +551,8 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         rewriter.modify_block_argument_type(op.true_region.blocks[0].args[0],
                                             i64)
 
@@ -566,7 +580,8 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         rewriter.erase_block_argument(op.true_region.blocks[0].args[0])
 
     rewrite_and_compare(
@@ -593,7 +608,8 @@ scf.if(%0 : !i1) {} {}
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         rewriter.insert_block_argument(op.true_region.blocks[0], 0, i32)
 
     rewrite_and_compare(
@@ -625,7 +641,8 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         if len(op.true_region.blocks[0].ops) > 0 and isinstance(
                 op.true_region.blocks[0].ops[0], If):
             inner_if_block = op.true_region.blocks[0].ops[
@@ -657,7 +674,8 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         rewriter.inline_block_before_matched_op(op.true_region.blocks[0])
 
     rewrite_and_compare(
@@ -689,7 +707,8 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         if len(op.true_region.blocks[0].ops) > 0 and isinstance(
                 op.true_region.blocks[0].ops[0], If):
             inner_if_block = op.true_region.blocks[0].ops[
@@ -722,7 +741,8 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         rewriter.inline_block_before(op.true_region.blocks[0], op)
 
     rewrite_and_compare(
@@ -754,7 +774,8 @@ def test_inline_block_after():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
+                          rewriter: PatternRewriter):
         if len(op.true_region.blocks[0].ops) > 0 and isinstance(
                 op.true_region.blocks[0].ops[0], If):
             inner_if_block = op.true_region.blocks[0].ops[
@@ -789,7 +810,8 @@ def test_move_region_contents_to_new_regions():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
+    def match_and_rewrite(self: AnonymousRewritePattern, op: ModuleOp,
+                          rewriter: PatternRewriter):
         new_region = rewriter.move_region_contents_to_new_regions(
             op.ops[1].regions[0])
         new_if = If.get(op.ops[1].cond, [], new_region,

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -126,8 +126,7 @@ def test_op_type_rewrite_pattern_static_decorator():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
         rewriter.replace_matched_op(Constant.from_int_and_width(43, i32))
 
     rewrite_and_compare(
@@ -158,8 +157,7 @@ def test_recursive_rewriter():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
         val = op.value.value.data
         if val == 0 or val == 1:
             return None
@@ -198,8 +196,7 @@ def test_recursive_rewriter_reversed():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
         val = op.value.value.data
         if val == 0 or val == 1:
             return None
@@ -233,13 +230,11 @@ def test_greedy_rewrite_pattern_applier():
 }"""
 
     @op_type_rewrite_pattern
-    def constant_rewrite(self: AnonymousRewritePattern, op: Constant,
-                         rewriter: PatternRewriter):
+    def constant_rewrite(op: Constant, rewriter: PatternRewriter):
         rewriter.replace_matched_op([Constant.from_int_and_width(43, i32)])
 
     @op_type_rewrite_pattern
-    def addi_rewrite(self: AnonymousRewritePattern, op: Addi,
-                     rewriter: PatternRewriter):
+    def addi_rewrite(op: Addi, rewriter: PatternRewriter):
         rewriter.replace_matched_op([Muli.get(op.lhs, op.rhs)])
 
     rewrite_and_compare(
@@ -266,8 +261,7 @@ def test_insert_op_before_matched_op():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, cst: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_before_matched_op(new_cst)
 
@@ -292,8 +286,7 @@ def test_insert_op_at_pos():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, mod: ModuleOp,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_at_pos(new_cst, mod.regions[0].blocks[0], 0)
 
@@ -318,8 +311,7 @@ def test_insert_op_before():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, mod: ModuleOp,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_before(new_cst, mod.ops[0])
 
@@ -344,8 +336,7 @@ def test_insert_op_after():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, mod: ModuleOp,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_after(new_cst, mod.ops[0])
 
@@ -370,8 +361,7 @@ def test_insert_op_after_matched_op():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, cst: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_after_matched_op(new_cst)
 
@@ -396,8 +386,7 @@ def test_insert_op_after_matched_op_reversed():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, cst: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
         new_cst = Constant.from_int_and_width(42, i32)
         rewriter.insert_op_after_matched_op(new_cst)
 
@@ -420,8 +409,7 @@ def test_operation_deletion():
 """builtin.module() {}"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
         rewriter.erase_matched_op()
 
     rewrite_and_compare(
@@ -444,8 +432,8 @@ def test_operation_deletion_reversed():
     expected = \
 """builtin.module() {}"""
 
-    def match_and_rewrite(self: AnonymousRewritePattern, op: Operation,
-                          rewriter: PatternRewriter):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(op: Operation, rewriter: PatternRewriter):
         if not isinstance(op, ModuleOp):
             rewriter.erase_matched_op()
 
@@ -469,8 +457,7 @@ def test_operation_deletion_failure():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: Constant,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
         rewriter.erase_matched_op()
 
     parser = Parser(ctx, prog)
@@ -497,8 +484,7 @@ def test_delete_inner_op():
 """builtin.module() {}"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: ModuleOp,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
         rewriter.erase_op(op.ops[0])
 
     rewrite_and_compare(
@@ -520,8 +506,7 @@ def test_replace_inner_op():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: ModuleOp,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
         rewriter.replace_op(op.ops[0], [Constant.from_int_and_width(42, i32)])
 
     rewrite_and_compare(
@@ -551,8 +536,7 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         rewriter.modify_block_argument_type(op.true_region.blocks[0].args[0],
                                             i64)
 
@@ -580,8 +564,7 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         rewriter.erase_block_argument(op.true_region.blocks[0].args[0])
 
     rewrite_and_compare(
@@ -608,8 +591,7 @@ scf.if(%0 : !i1) {} {}
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         rewriter.insert_block_argument(op.true_region.blocks[0], 0, i32)
 
     rewrite_and_compare(
@@ -641,8 +623,7 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         if len(op.true_region.blocks[0].ops) > 0 and isinstance(
                 op.true_region.blocks[0].ops[0], If):
             inner_if_block = op.true_region.blocks[0].ops[
@@ -674,8 +655,7 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         rewriter.inline_block_before_matched_op(op.true_region.blocks[0])
 
     rewrite_and_compare(
@@ -707,8 +687,7 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         if len(op.true_region.blocks[0].ops) > 0 and isinstance(
                 op.true_region.blocks[0].ops[0], If):
             inner_if_block = op.true_region.blocks[0].ops[
@@ -741,8 +720,7 @@ scf.if(%0 : !i1) {
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         rewriter.inline_block_before(op.true_region.blocks[0], op)
 
     rewrite_and_compare(
@@ -774,8 +752,7 @@ def test_inline_block_after():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: If,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: If, rewriter: PatternRewriter):
         if len(op.true_region.blocks[0].ops) > 0 and isinstance(
                 op.true_region.blocks[0].ops[0], If):
             inner_if_block = op.true_region.blocks[0].ops[
@@ -810,8 +787,7 @@ def test_move_region_contents_to_new_regions():
 }"""
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self: AnonymousRewritePattern, op: ModuleOp,
-                          rewriter: PatternRewriter):
+    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
         new_region = rewriter.move_region_contents_to_new_regions(
             op.ops[1].regions[0])
         new_if = If.get(op.ops[1].cond, [], new_region,

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -432,7 +432,6 @@ def test_operation_deletion_reversed():
     expected = \
 """builtin.module() {}"""
 
-    @op_type_rewrite_pattern
     def match_and_rewrite(op: Operation, rewriter: PatternRewriter):
         if not isinstance(op, ModuleOp):
             rewriter.erase_matched_op()

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -422,7 +422,7 @@ class Cmpi(Operation):
     -   unsigned greater than or equal (mnemonic: `"uge"`; integer value: `9`)
     """
     name: str = "arith.cmpi"
-    predicate: OpAttr[IntegerAttr]
+    predicate: OpAttr[IntegerAttr[IntegerType]]
     lhs: Annotated[Operand, IntegerType]
     rhs: Annotated[Operand, IntegerType]
     result: Annotated[OpResult, IntegerType.from_width(1)]

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -422,7 +422,7 @@ class Cmpi(Operation):
     -   unsigned greater than or equal (mnemonic: `"uge"`; integer value: `9`)
     """
     name: str = "arith.cmpi"
-    predicate: OpAttr[IntegerAttr[IntegerType]]
+    predicate: OpAttr[IntegerAttr]
     lhs: Annotated[Operand, IntegerType]
     rhs: Annotated[Operand, IntegerType]
     result: Annotated[OpResult, IntegerType.from_width(1)]

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Callable, TypeVar
 
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import (Operation, Region, Block, BlockArgument, Attribute,
@@ -319,11 +319,14 @@ class RewritePattern(ABC):
     """
 
     @abstractmethod
-    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
         """
         Match an operation, and optionally perform a rewrite using the rewriter.
         """
         ...
+
+
+_OperationT = TypeVar("_OperationT", bound=Operation)
 
 
 @dataclass(eq=False, repr=False)
@@ -331,16 +334,20 @@ class AnonymousRewritePattern(RewritePattern):
     """
     A rewrite pattern encoded by an anonymous function.
     """
-    func: Callable[[Operation, PatternRewriter], None]
+    func: Callable[[AnonymousRewritePattern, Operation, PatternRewriter], None]
 
     def match_and_rewrite(self, op: Operation,
                           rewriter: PatternRewriter) -> None:
-        self.func(op, rewriter)
+        self.func(self, op, rewriter)
+
+
+_RewritePatternT = TypeVar("_RewritePatternT", bound=RewritePattern)
+_OperationT = TypeVar("_OperationT", bound=Operation)
 
 
 def op_type_rewrite_pattern(
-    func: Callable[..., None]
-) -> Callable[[Any, Any], None] | Callable[[Any, Any, Any], None]:
+    func: Callable[[_RewritePatternT, _OperationT, PatternRewriter], None]
+) -> Callable[[_RewritePatternT, Operation, PatternRewriter], None]:
     """
     This function is intended to be used as a decorator on a RewritePatter method.
     It uses type hints to match on a specific operation type before calling the decorated
@@ -348,46 +355,27 @@ def op_type_rewrite_pattern(
     """
     # Get the operation argument and check that it is a subclass of Operation
     params = [param for param in inspect.signature(func).parameters.values()]
-    if len(params) < 2:
+    if len(params) != 3:
         raise Exception(
             "op_type_rewrite_pattern expects the decorated function to "
-            "have two non-self arguments.")
-    is_method = params[0].name == "self"
-    if is_method:
-        if len(params) != 3:
-            raise Exception(
-                "op_type_rewrite_pattern expects the decorated method to "
-                "have two non-self arguments.")
-    else:
-        if len(params) != 2:
-            raise Exception(
-                "op_type_rewrite_pattern expects the decorated function to "
-                "have two arguments.")
-    expected_type = params[-2].annotation
-    if not issubclass(expected_type, Operation):
+            "have three arguments.")
+    if params[0].name != "self":
         raise Exception(
-            "op_type_rewrite_pattern expects the first non-self argument"
-            "type hint to be an Operation subclass")
+            "op_type_rewrite_pattern expects the decorated method to "
+            "have self as the first argument.")
 
-    if not is_method:
-
-        def op_type_rewrite_pattern_static_wrapper(
-                op: Operation, rewriter: PatternRewriter) -> None:
-            if not isinstance(op, expected_type):
-                return None
-            func(op, rewriter)
-
-        return op_type_rewrite_pattern_static_wrapper
+    expected_type: type[_OperationT] = params[1].annotation
+    if not issubclass(expected_type, Operation):
+        raise Exception("op_type_rewrite_pattern expects the second argument"
+                        "type hint to be an Operation subclass")
 
     def op_type_rewrite_pattern_method_wrapper(
-            self,  # type: ignore
-            op: Operation,
+            self: _RewritePatternT, op: Operation,
             rewriter: PatternRewriter) -> None:
-        if not isinstance(op, expected_type):
-            return None
-        func(self, op, rewriter)
+        if isinstance(op, expected_type):
+            func(self, op, rewriter)
 
-    return op_type_rewrite_pattern_method_wrapper  # type: ignore
+    return op_type_rewrite_pattern_method_wrapper
 
 
 @dataclass(eq=False, repr=False)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -333,6 +333,23 @@ class AnonymousRewritePattern(RewritePattern):
     """
     func: Callable[[RewritePattern, Operation, PatternRewriter], None]
 
+    def __init__(
+        self,
+        func: Callable[[RewritePattern, Operation, PatternRewriter], None]
+        | Callable[[Operation, PatternRewriter], None]):
+        params = [
+            param for param in inspect.signature(func).parameters.values()
+        ]
+        if len(params) == 2:
+
+            def new_func(self: RewritePattern, op: Operation,
+                         rewriter: PatternRewriter):
+                func(op, rewriter)  # type: ignore
+
+            self.func = new_func
+        else:
+            self.func = func  # type: ignore
+
     def match_and_rewrite(self, op: Operation,
                           rewriter: PatternRewriter) -> None:
         self.func(self, op, rewriter)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -319,7 +319,7 @@ class RewritePattern(ABC):
     """
 
     @abstractmethod
-    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
         """
         Match an operation, and optionally perform a rewrite using the rewriter.
         """

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -326,9 +326,6 @@ class RewritePattern(ABC):
         ...
 
 
-_OperationT = TypeVar("_OperationT", bound=Operation)
-
-
 @dataclass(eq=False, repr=False)
 class AnonymousRewritePattern(RewritePattern):
     """

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -318,6 +318,9 @@ class RewritePattern(ABC):
     A side-effect free rewrite pattern matching on a DAG.
     """
 
+    # The / in the function signature makes the previous arguments positional, see
+    # https://peps.python.org/pep-0570/
+    # This is used by the op_type_rewrite_pattern
     @abstractmethod
     def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
         """


### PR DESCRIPTION
In my quest of fewer squiggly lines, I nerd-sniped myself into resolving this. The main problem with the type checking is that methods take `self` as the first parameters, and functions in general don't. The decorator as it is in the code today handles both, but then the type checker complains that it doesn't know which it is, a 2 or 3 argument method. The 2-argument version is useful for the anonymous case, the 3-argument version is useful for the custom class case.

There are three possible ways to solve this:
1. two decorators
2. decorator that only ever takes 3 arguments, including a dummy self for the anonymous case
3. no decorator for anonymous, determine from type of function passed in whether it needs a check at runtime

I went for 2 in this PR, but maybe 3 is worth a go, will have a quick pass to see how I feel.