### PR TITLE
CI: Remove CI dependencies from requirements

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -23,18 +23,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Upgrade pip
       run: |
         pip install --upgrade pip
+
     - name: Install the package locally
-      run: pip install -e .[extras]
+      run: pip install -e .
+
     - name: Test with pytest
       run: |
         pytest
+
     - name: Execute lit tests
       run: |
         export PYTHONPATH=$(pwd)

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -56,7 +56,6 @@ jobs:
 
     - name: Install CI dependencies
       run: |
-        pip install nbval
         pip install codecov
 
     - name: Checkout MLIR

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -25,6 +25,8 @@ jobs:
       MLIR-Version: 74992f4a5bb79e2084abdef406ef2e5aa2024368
     steps:
     - uses: actions/checkout@v3
+      with:
+        path: xdsl
 
     - name: Python Setup
       uses: actions/setup-python@v4
@@ -45,10 +47,17 @@ jobs:
         # LLVM needs serious cache size
         max-size: 6G
 
-    - name: Checkout project
-      uses: actions/checkout@v3
-      with:
-        path: xdsl
+    - name: Upgrade pip
+      run: |
+        pip install --upgrade pip
+
+    - name: Install the package locally
+      run: pip install -e xdsl[extras]
+
+    - name: Install CI dependencies
+      run: |
+        pip install nbval
+        pip install codecov
 
     - name: Checkout MLIR
       uses: actions/checkout@v3
@@ -56,13 +65,6 @@ jobs:
         repository: llvm/llvm-project.git
         path: llvm-project
         ref: ${{ env.MLIR-Version }}
-
-    - name: Upgrade pip
-      run: |
-        pip install --upgrade pip
-
-    - name: Install the package locally
-      run: pip install -e .[extras]
 
     - name: MLIR Build Setup
       run: |

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,5 @@
 yapf<0.33
 toml<0.11
-codecov
 pytest-cov
 ipykernel
+coverage<8.0.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,4 +2,3 @@ yapf<0.33
 toml<0.11
 pytest-cov
 ipykernel
-coverage<8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pip<24.0
 pytest<8.0
 filecheck<0.0.24
 lit<16.0.0
+coverage<8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pip<24.0
 pytest<8.0
 filecheck<0.0.24
 lit<16.0.0
-coverage<8.0.0


### PR DESCRIPTION
This PR fixes the MLIR CI to not clone twice and moves some dependencies of the CI from the requirements to the actual CI.