### PR TITLE
installation: Add xdsl-opt location to known paths

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -53,8 +53,9 @@ jobs:
 
     - name: Install the package locally
       run: |
+        # Change directory so that xdsl-opt can be found during installation.
         cd xdsl
-        pip install -e xdsl[extras]
+        pip install -e .[extras]
 
     - name: Install CI dependencies
       run: |

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -52,7 +52,9 @@ jobs:
         pip install --upgrade pip
 
     - name: Install the package locally
-      run: pip install -e xdsl[extras]
+      run: |
+        cd xdsl
+        pip install -e xdsl[extras]
 
     - name: Install CI dependencies
       run: |

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     description="xDSL",
     long_description=long_description,
     long_description_content_type='text/markdown',
+    scripts=['xdsl/tools/xdsl-opt'],
     project_urls={
         "Source Code": "https://github.com/xdslproject/xdsl",
         "Issue Tracker": "https://github.com/xdslproject/xdsl/issues",


### PR DESCRIPTION
This PR intends to make `xdsl-opt` available from anywhere after running `pip install -e . `