### PR TITLE
dialects: Add dense_resource attribute

### DIFF
--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -143,10 +143,10 @@
   // CHECK: memref<2x?xf32>
 
   "func.func"() ({}) {function_type = () -> (), 
-                      dense_resource = dense_resource<resource_1>,
+                      dense_resource = dense_resource<resource_1> : tensor<1xi32>,
                       sym_name = "dense_resource"} : () -> ()
 
-  // CHECK: dense_resource<resource_1>
+  // CHECK: dense_resource<resource_1> : tensor<1xi32>
 
 
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -142,4 +142,11 @@
 
   // CHECK: memref<2x?xf32>
 
+  "func.func"() ({}) {function_type = () -> (), 
+                      dense_resource = dense_resource<resource_1>,
+                      sym_name = "dense_resource"} : () -> ()
+
+  // CHECK: dense_resource<resource_1>
+
+
 }) : () -> ()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -767,6 +767,7 @@ Builtin = Dialect(
         ArrayAttr,
         DictionaryAttr,
         DenseIntOrFPElementsAttr,
+        DenseResourceAttr,
         UnitAttr,
         FloatData,
         NoneAttr,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -640,6 +640,20 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
+class DenseResourceAttr(ParametrizedAttribute):
+    name = "dense_resource"
+
+    resource_handle: ParameterDef[StringAttr]
+
+    @staticmethod
+    @builder
+    def from_handle(handle: str | StringAttr) -> DenseResourceAttr:
+        if isinstance(handle, str):
+            handle = StringAttr.from_str(handle)
+        return DenseResourceAttr([handle])
+
+
+@irdl_attr_definition
 class FunctionType(ParametrizedAttribute, MLIRType):
     name = "fun"
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -645,12 +645,16 @@ class DenseResourceAttr(ParametrizedAttribute):
 
     resource_handle: ParameterDef[StringAttr]
 
+    # Should be a ShapedType, but this is not defined yet in xDSL
+    type: ParameterDef[Attribute]
+
     @staticmethod
     @builder
-    def from_handle(handle: str | StringAttr) -> DenseResourceAttr:
+    def from_params(handle: str | StringAttr,
+                    type: Attribute) -> DenseResourceAttr:
         if isinstance(handle, str):
             handle = StringAttr.from_str(handle)
-        return DenseResourceAttr([handle])
+        return DenseResourceAttr([handle, type])
 
 
 @irdl_attr_definition

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1315,7 +1315,10 @@ class BaseParser(ABC):
         self.parse_characters("<", err_msg)
         resource_handle = self.expect(self.try_parse_bare_id, err_msg)
         self.parse_characters(">", err_msg)
-        return DenseResourceAttr.from_handle(resource_handle.text)
+        self.parse_characters(":", err_msg)
+        type = self.expect(self.try_parse_type,
+                           "Dense resource attribute must be typed!")
+        return DenseResourceAttr.from_params(resource_handle.text, type)
 
     def _parse_builtin_dense_attr_args(self) -> Iterable[int | float]:
         """

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -428,7 +428,9 @@ class Printer:
 
         # Dense resources have an alias in MLIR, but not in xDSL
         if isinstance(attribute, DenseResourceAttr):
-            self.print(f"dense_resource<{attribute.resource_handle.data}>")
+            handle = attribute.resource_handle.data
+            type = attribute.type
+            self.print(f"dense_resource<{handle}> : ", type)
             return
 
         # vector types have an alias in MLIR, but not in xDSL

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -11,11 +11,11 @@ from xdsl.ir import (BlockArgument, MLIRType, SSAValue, Block, Callable,
 from xdsl.utils.diagnostic import Diagnostic
 from xdsl.dialects.builtin import (
     AnyIntegerAttr, AnyFloatAttr, AnyUnrankedTensorType, AnyVectorType,
-    DenseIntOrFPElementsAttr, Float16Type, Float32Type, Float64Type, FloatAttr,
-    IndexType, IntegerType, NoneAttr, OpaqueAttr, Signedness, StringAttr,
-    FlatSymbolRefAttr, IntegerAttr, ArrayAttr, IntAttr, TensorType, UnitAttr,
-    FunctionType, UnrankedTensorType, UnregisteredOp, VectorType,
-    DictionaryAttr)
+    DenseIntOrFPElementsAttr, DenseResourceAttr, Float16Type, Float32Type,
+    Float64Type, FloatAttr, IndexType, IntegerType, NoneAttr, OpaqueAttr,
+    Signedness, StringAttr, FlatSymbolRefAttr, IntegerAttr, ArrayAttr, IntAttr,
+    TensorType, UnitAttr, FunctionType, UnrankedTensorType, UnregisteredOp,
+    VectorType, DictionaryAttr)
 
 indentNumSpaces = 2
 
@@ -424,6 +424,11 @@ class Printer:
             print_dense_list(data, shape)
             self.print("> : ")
             self.print(attribute.type)
+            return
+
+        # Dense resources have an alias in MLIR, but not in xDSL
+        if isinstance(attribute, DenseResourceAttr):
+            self.print(f"dense_resource<{attribute.resource_handle.data}>")
             return
 
         # vector types have an alias in MLIR, but not in xDSL


### PR DESCRIPTION
This adds `dense_resource` attribute to the builtin dialect, and adds the MLIR custom parsing/printing.