### PR TITLE
core: Allow to parse types where attributes are expected

### DIFF
--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -148,5 +148,16 @@
 
   // CHECK: dense_resource<resource_1> : tensor<1xi32>
 
+  "func.func"() ({}) {function_type = () -> (), 
+                      type_attr = index,
+                      sym_name = "memref"} : () -> ()
+
+  // CHECK: "type_attr" = index
+
+  "func.func"() ({}) {function_type = () -> (), 
+                      type_attr = !index,
+                      sym_name = "memref"} : () -> ()
+
+  // CHECK: "type_attr" = index
 
 }) : () -> ()

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1665,6 +1665,12 @@ class MLIRParser(BaseParser):
 
             return value
 
+        # In MLIR, a type can be parsed at any attribute location.
+        # While MLIR wraps the type in a `TypeAttr`, we do not require this
+        # in xDSL.
+        if (type := self.try_parse_type()) is not None:
+            return type
+
         # If it isn't a dialect attr, parse builtin
         builtin_val = self.try_parse_builtin_attr()
 


### PR DESCRIPTION
The new parser did not allow to parse dialect types when attributes were expected in the MLIR format.
This should fix #413 