### PR TITLE
API: Fix pyright issues in xdsl-opt-main

### DIFF
--- a/xdsl/irdl_mlir_printer.py
+++ b/xdsl/irdl_mlir_printer.py
@@ -1,4 +1,4 @@
-from io import IOBase
+from typing import IO
 from dataclasses import dataclass
 
 from xdsl.dialects.builtin import ModuleOp
@@ -16,7 +16,7 @@ from xdsl.dialects.irdl import (
 @dataclass(frozen=True, eq=False)
 class IRDLPrinter:
 
-    stream: IOBase
+    stream: IO[str]
 
     def _print(self, s: str, end: str | None = None):
         print(s, file=self.stream, end=end)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 import os
-from io import IOBase, StringIO
+from io import StringIO
 import coverage
 
 from xdsl.ir import MLContext


### PR DESCRIPTION
Fix two pyright issues in xdsl_opt_main.
In particular, we should use `IO[str]` instead of `IOBase` when requiring a stream for printing.