### PR TITLE
API: Fix pyright issue in printer.py

### DIFF
--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -446,8 +446,8 @@ class Printer:
         # Dense resources have an alias in MLIR, but not in xDSL
         if isinstance(attribute, DenseResourceAttr):
             handle = attribute.resource_handle.data
-            type = attribute.type
-            self.print(f"dense_resource<{handle}> : ", type)
+            attr_type = attribute.type
+            self.print(f"dense_resource<{handle}> : ", attr_type)
             return
 
         # vector types have an alias in MLIR, but not in xDSL

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -446,8 +446,7 @@ class Printer:
         # Dense resources have an alias in MLIR, but not in xDSL
         if isinstance(attribute, DenseResourceAttr):
             handle = attribute.resource_handle.data
-            attr_type = attribute.type
-            self.print(f"dense_resource<{handle}> : ", attr_type)
+            self.print(f"dense_resource<{handle}> : ", attribute.type)
             return
 
         # vector types have an alias in MLIR, but not in xDSL


### PR DESCRIPTION
`type` was used as a variable, which made the use of `type(...)` BEFORE its creation invalid.