### PR TITLE
xDSL/Vector: Improve tests

### DIFF
--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -212,11 +212,12 @@ def test_vector_fma_with_dimensions():
 
 
 def test_vector_fma_verify_res_lhs_type_matching():
-    i32_vector_type = VectorType.from_element_type_and_shape(i32, [1])
     i64_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
-    i32_vector_ssa_value = OpResult(i32_vector_type, [], [])
-    i64_vector_ssa_value = OpResult(i64_vector_type, [], [])
+    i32_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
+    i64_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i64, [1])
 
     fma = FMA.build(operands=[
         i32_vector_ssa_value, i64_vector_ssa_value, i64_vector_ssa_value
@@ -230,11 +231,12 @@ def test_vector_fma_verify_res_lhs_type_matching():
 
 
 def test_vector_fma_verify_res_rhs_type_matching():
-    i32_vector_type = VectorType.from_element_type_and_shape(i32, [1])
     i64_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
-    i32_vector_ssa_value = OpResult(i32_vector_type, [], [])
-    i64_vector_ssa_value = OpResult(i64_vector_type, [], [])
+    i32_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
+    i64_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i64, [1])
 
     fma = FMA.build(operands=[
         i64_vector_ssa_value, i32_vector_ssa_value, i64_vector_ssa_value
@@ -248,11 +250,12 @@ def test_vector_fma_verify_res_rhs_type_matching():
 
 
 def test_vector_fma_verify_res_acc_type_matching():
-    i32_vector_type = VectorType.from_element_type_and_shape(i32, [1])
     i64_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
-    i32_vector_ssa_value = OpResult(i32_vector_type, [], [])
-    i64_vector_ssa_value = OpResult(i64_vector_type, [], [])
+    i32_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
+    i64_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i64, [1])
 
     fma = FMA.build(operands=[
         i64_vector_ssa_value, i64_vector_ssa_value, i32_vector_ssa_value
@@ -266,11 +269,12 @@ def test_vector_fma_verify_res_acc_type_matching():
 
 
 def test_vector_fma_verify_res_lhs_shape_matching():
-    i32_vector_type1 = VectorType.from_element_type_and_shape(i32, [2, 3])
     i32_vector_type2 = VectorType.from_element_type_and_shape(i32, [4, 5])
 
-    vector_ssa_value1 = OpResult(i32_vector_type1, [], [])
-    vector_ssa_value2 = OpResult(i32_vector_type2, [], [])
+    vector_ssa_value1 = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
+    vector_ssa_value2 = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
 
     fma = FMA.build(
         operands=[vector_ssa_value1, vector_ssa_value2, vector_ssa_value2],
@@ -283,11 +287,12 @@ def test_vector_fma_verify_res_lhs_shape_matching():
 
 
 def test_vector_fma_verify_res_rhs_shape_matching():
-    i32_vector_type1 = VectorType.from_element_type_and_shape(i32, [2, 3])
     i32_vector_type2 = VectorType.from_element_type_and_shape(i32, [4, 5])
 
-    vector_ssa_value1 = OpResult(i32_vector_type1, [], [])
-    vector_ssa_value2 = OpResult(i32_vector_type2, [], [])
+    vector_ssa_value1 = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
+    vector_ssa_value2 = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
 
     fma = FMA.build(
         operands=[vector_ssa_value2, vector_ssa_value1, vector_ssa_value2],
@@ -300,11 +305,12 @@ def test_vector_fma_verify_res_rhs_shape_matching():
 
 
 def test_vector_fma_verify_res_acc_shape_matching():
-    i32_vector_type1 = VectorType.from_element_type_and_shape(i32, [2, 3])
     i32_vector_type2 = VectorType.from_element_type_and_shape(i32, [4, 5])
 
-    vector_ssa_value1 = OpResult(i32_vector_type1, [], [])
-    vector_ssa_value2 = OpResult(i32_vector_type2, [], [])
+    vector_ssa_value1 = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
+    vector_ssa_value2 = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
 
     fma = FMA.build(
         operands=[vector_ssa_value2, vector_ssa_value2, vector_ssa_value1],
@@ -523,8 +529,8 @@ def test_vector_masked_store_verify_indexing_exception():
     value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
         i32, [1])
 
-    maskedstore = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
-                                 value_to_store_vector_ssa_value)
+    maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
+                                  value_to_store_vector_ssa_value)
 
     with pytest.raises(Exception) as exc_info:
         maskedstore.verify()

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -1,26 +1,32 @@
 import pytest
 
-from typing import List
+from typing import TypeVar, List
 
-from xdsl.dialects.builtin import i1, i32, i64, IntegerType, IndexType, VectorType, _VectorTypeElems
-from xdsl.dialects.memref import MemRefType, _MemRefTypeElement, AnyIntegerAttr
+from xdsl.dialects.builtin import i1, i32, i64, IntegerType, IndexType, VectorType
+from xdsl.dialects.memref import MemRefType, AnyIntegerAttr
 from xdsl.dialects.vector import Broadcast, Load, Maskedload, Maskedstore, Store, FMA, Print, Createmask
 from xdsl.ir import OpResult
+from xdsl.irdl import Attribute
+
+_MemRefTypeElement = TypeVar("_MemRefTypeElement", bound=Attribute)
+_VectorTypeElems = TypeVar("_VectorTypeElems", bound=Attribute)
 
 
 def get_MemRef_SSAVal_from_element_type_and_shape(
-    referenced_type: _MemRefTypeElement, 
-    shape: List[int | AnyIntegerAttr]
-) -> OpResult:
-    memref_type = MemRefType.from_element_type_and_shape(referenced_type, shape)
+        referenced_type: _MemRefTypeElement,
+        shape: List[int | AnyIntegerAttr]) -> OpResult:
+    memref_type = MemRefType.from_element_type_and_shape(
+        referenced_type, shape)
     return OpResult(memref_type, [], [])
 
+
 def get_Vector_SSAVal_from_element_type_and_shape(
-    referenced_type: _VectorTypeElems, 
-    shape: List[int | AnyIntegerAttr]
-) -> OpResult:
-    vector_type = VectorType.from_element_type_and_shape(referenced_type, shape)
+        referenced_type: _VectorTypeElems,
+        shape: List[int | AnyIntegerAttr]) -> OpResult:
+    vector_type = VectorType.from_element_type_and_shape(
+        referenced_type, shape)
     return OpResult(vector_type, [], [])
+
 
 def test_vectorType():
     vec = VectorType.from_element_type_and_shape(i32, [1])
@@ -57,7 +63,8 @@ def test_vector_load_i32():
 
 
 def test_vector_load_i32_with_dimensions():
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
     load = Load.get(memref_ssa_value, [index1, index2])
@@ -71,7 +78,8 @@ def test_vector_load_i32_with_dimensions():
 def test_vector_load_verify_type_matching():
     res_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
 
     load = Load.build(operands=[memref_ssa_value, []],
                       result_types=[res_vector_type])
@@ -83,7 +91,8 @@ def test_vector_load_verify_type_matching():
 
 
 def test_vector_load_verify_indexing_exception():
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
 
     load = Load.get(memref_ssa_value, [])
 
@@ -104,8 +113,10 @@ def test_vector_store_i32():
 
 
 def test_vector_store_i32_with_dimensions():
-    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
 
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -118,8 +129,10 @@ def test_vector_store_i32_with_dimensions():
 
 
 def test_vector_store_verify_type_matching():
-    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i64, [2, 3])
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i64, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
 
@@ -130,8 +143,10 @@ def test_vector_store_verify_type_matching():
 
 
 def test_vector_store_verify_indexing_exception():
-    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
 
@@ -303,8 +318,10 @@ def test_vector_fma_verify_res_acc_shape_matching():
 
 def test_vector_masked_load():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -315,9 +332,12 @@ def test_vector_masked_load():
 
 
 def test_vector_masked_load_with_dimensions():
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -334,8 +354,10 @@ def test_vector_masked_load_with_dimensions():
 
 def test_vector_masked_load_verify_memref_res_type_matching():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     i64_res_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
@@ -353,8 +375,10 @@ def test_vector_masked_load_verify_memref_res_type_matching():
 
 def test_vector_masked_load_verify_memref_passthrough_type_matching():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i64, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i64, [1])
 
     i64_res_vector_type = VectorType.from_element_type_and_shape(i32, [1])
 
@@ -371,9 +395,12 @@ def test_vector_masked_load_verify_memref_passthrough_type_matching():
 
 
 def test_vector_masked_load_verify_indexing_exception():
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [2])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -386,8 +413,10 @@ def test_vector_masked_load_verify_indexing_exception():
 
 def test_vector_masked_load_verify_result_vector_rank():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     i32_res_vector_type = VectorType.from_element_type_and_shape(i32, [2, 3])
 
@@ -404,8 +433,10 @@ def test_vector_masked_load_verify_result_vector_rank():
 
 def test_vector_masked_load_verify_mask_vector_rank():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2, 3])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [2, 3])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -417,8 +448,10 @@ def test_vector_masked_load_verify_mask_vector_rank():
 
 def test_vector_masked_load_verify_mask_vector_type():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2])
-    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -430,8 +463,10 @@ def test_vector_masked_load_verify_mask_vector_type():
 
 def test_vector_masked_store():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -443,9 +478,12 @@ def test_vector_masked_store():
 
 
 def test_vector_masked_store_with_dimensions():
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -463,8 +501,10 @@ def test_vector_masked_store_with_dimensions():
 
 def test_vector_masked_store_verify_memref_value_to_store_type_matching():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i64, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i64, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -476,9 +516,12 @@ def test_vector_masked_store_verify_memref_value_to_store_type_matching():
 
 
 def test_vector_masked_store_verify_indexing_exception():
-    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2])
-    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
+        i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [2])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedstore = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                  value_to_store_vector_ssa_value)
@@ -491,8 +534,10 @@ def test_vector_masked_store_verify_indexing_exception():
 
 def test_vector_masked_store_verify_value_to_store_vector_rank():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
-    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2, 3])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2, 3])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -504,8 +549,10 @@ def test_vector_masked_store_verify_value_to_store_vector_rank():
 
 def test_vector_masked_store_verify_mask_vector_rank():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2, 3])
-    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i1, [2, 3])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -517,8 +564,10 @@ def test_vector_masked_store_verify_mask_vector_rank():
 
 def test_vector_masked_store_verify_mask_vector_type():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
-    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2])
-    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [2])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
+        i32, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -1,10 +1,26 @@
 import pytest
 
-from xdsl.dialects.builtin import i1, i32, i64, IntegerType, IndexType, VectorType
-from xdsl.dialects.memref import MemRefType
+from typing import List
+
+from xdsl.dialects.builtin import i1, i32, i64, IntegerType, IndexType, VectorType, _VectorTypeElems
+from xdsl.dialects.memref import MemRefType, _MemRefTypeElement, AnyIntegerAttr
 from xdsl.dialects.vector import Broadcast, Load, Maskedload, Maskedstore, Store, FMA, Print, Createmask
 from xdsl.ir import OpResult
 
+
+def get_MemRef_SSAVal_from_element_type_and_shape(
+    referenced_type: _MemRefTypeElement, 
+    shape: List[int | AnyIntegerAttr]
+) -> OpResult:
+    memref_type = MemRefType.from_element_type_and_shape(referenced_type, shape)
+    return OpResult(memref_type, [], [])
+
+def get_Vector_SSAVal_from_element_type_and_shape(
+    referenced_type: _VectorTypeElems, 
+    shape: List[int | AnyIntegerAttr]
+) -> OpResult:
+    vector_type = VectorType.from_element_type_and_shape(referenced_type, shape)
+    return OpResult(vector_type, [], [])
 
 def test_vectorType():
     vec = VectorType.from_element_type_and_shape(i32, [1])
@@ -32,8 +48,7 @@ def test_vectorType_from_params():
 
 
 def test_vector_load_i32():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
     load = Load.get(memref_ssa_value, [])
 
     assert type(load.results[0]) is OpResult
@@ -42,8 +57,7 @@ def test_vector_load_i32():
 
 
 def test_vector_load_i32_with_dimensions():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [2, 3])
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
     load = Load.get(memref_ssa_value, [index1, index2])
@@ -57,8 +71,7 @@ def test_vector_load_i32_with_dimensions():
 def test_vector_load_verify_type_matching():
     res_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
 
     load = Load.build(operands=[memref_ssa_value, []],
                       result_types=[res_vector_type])
@@ -70,8 +83,7 @@ def test_vector_load_verify_type_matching():
 
 
 def test_vector_load_verify_indexing_exception():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [2, 3])
 
     load = Load.get(memref_ssa_value, [])
 
@@ -81,11 +93,8 @@ def test_vector_load_verify_indexing_exception():
 
 
 def test_vector_store_i32():
-    i32_vector_type = VectorType.from_element_type_and_shape(i32, [1])
-    vector_ssa_value = OpResult(i32_vector_type, [], [])
-
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
 
@@ -95,11 +104,8 @@ def test_vector_store_i32():
 
 
 def test_vector_store_i32_with_dimensions():
-    i32_vector_type = VectorType.from_element_type_and_shape(i32, [2, 3])
-    vector_ssa_value = OpResult(i32_vector_type, [], [])
-
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
 
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -112,11 +118,8 @@ def test_vector_store_i32_with_dimensions():
 
 
 def test_vector_store_verify_type_matching():
-    i64_vector_type = VectorType.from_element_type_and_shape(i64, [2, 3])
-    vector_ssa_value = OpResult(i64_vector_type, [], [])
-
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i64, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
 
@@ -127,11 +130,8 @@ def test_vector_store_verify_type_matching():
 
 
 def test_vector_store_verify_indexing_exception():
-    i32_vector_type = VectorType.from_element_type_and_shape(i32, [2, 3])
-    vector_ssa_value = OpResult(i32_vector_type, [], [])
-
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2, 3])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
 
@@ -302,16 +302,9 @@ def test_vector_fma_verify_res_acc_shape_matching():
 
 
 def test_vector_masked_load():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -322,16 +315,9 @@ def test_vector_masked_load():
 
 
 def test_vector_masked_load_with_dimensions():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -347,16 +333,9 @@ def test_vector_masked_load_with_dimensions():
 
 
 def test_vector_masked_load_verify_memref_res_type_matching():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     i64_res_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
@@ -373,16 +352,9 @@ def test_vector_masked_load_verify_memref_res_type_matching():
 
 
 def test_vector_masked_load_verify_memref_passthrough_type_matching():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i64, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i64, [1])
 
     i64_res_vector_type = VectorType.from_element_type_and_shape(i32, [1])
 
@@ -399,16 +371,9 @@ def test_vector_masked_load_verify_memref_passthrough_type_matching():
 
 
 def test_vector_masked_load_verify_indexing_exception():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [2])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -420,16 +385,9 @@ def test_vector_masked_load_verify_indexing_exception():
 
 
 def test_vector_masked_load_verify_result_vector_rank():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     i32_res_vector_type = VectorType.from_element_type_and_shape(i32, [2, 3])
 
@@ -445,16 +403,9 @@ def test_vector_masked_load_verify_result_vector_rank():
 
 
 def test_vector_masked_load_verify_mask_vector_rank():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [2, 3])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2, 3])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -465,16 +416,9 @@ def test_vector_masked_load_verify_mask_vector_rank():
 
 
 def test_vector_masked_load_verify_mask_vector_type():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i32_mask_vector_type = VectorType.from_element_type_and_shape(i32, [2])
-    mask_vector_ssa_value = OpResult(i32_mask_vector_type, [], [])
-
-    i32_passthrough_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    passthrough_vector_ssa_value = OpResult(i32_passthrough_vector_type, [],
-                                            [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2])
+    passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedload = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                 passthrough_vector_ssa_value)
@@ -485,16 +429,9 @@ def test_vector_masked_load_verify_mask_vector_type():
 
 
 def test_vector_masked_store():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_value_to_store_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    value_to_store_vector_ssa_value = OpResult(i32_value_to_store_vector_type,
-                                               [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -506,16 +443,9 @@ def test_vector_masked_store():
 
 
 def test_vector_masked_store_with_dimensions():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_value_to_store_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    value_to_store_vector_ssa_value = OpResult(i32_value_to_store_vector_type,
-                                               [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     index1 = OpResult(IndexType, [], [])
     index2 = OpResult(IndexType, [], [])
@@ -532,16 +462,9 @@ def test_vector_masked_store_with_dimensions():
 
 
 def test_vector_masked_store_verify_memref_value_to_store_type_matching():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i64_value_to_store_vector_type = VectorType.from_element_type_and_shape(
-        i64, [1])
-    value_to_store_vector_ssa_value = OpResult(i64_value_to_store_vector_type,
-                                               [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i64, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -553,16 +476,9 @@ def test_vector_masked_store_verify_memref_value_to_store_type_matching():
 
 
 def test_vector_masked_store_verify_indexing_exception():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [4, 5])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [2])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_value_to_store_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    value_to_store_vector_ssa_value = OpResult(i32_value_to_store_vector_type,
-                                               [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [4, 5])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedstore = Maskedload.get(memref_ssa_value, [], mask_vector_ssa_value,
                                  value_to_store_vector_ssa_value)
@@ -574,16 +490,9 @@ def test_vector_masked_store_verify_indexing_exception():
 
 
 def test_vector_masked_store_verify_value_to_store_vector_rank():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [1])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_value_to_store_vector_type = VectorType.from_element_type_and_shape(
-        i32, [2, 3])
-    value_to_store_vector_ssa_value = OpResult(i32_value_to_store_vector_type,
-                                               [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [1])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2, 3])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -594,16 +503,9 @@ def test_vector_masked_store_verify_value_to_store_vector_rank():
 
 
 def test_vector_masked_store_verify_mask_vector_rank():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i1_mask_vector_type = VectorType.from_element_type_and_shape(i1, [2, 3])
-    mask_vector_ssa_value = OpResult(i1_mask_vector_type, [], [])
-
-    i32_value_to_store_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    value_to_store_vector_ssa_value = OpResult(i32_value_to_store_vector_type,
-                                               [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i1, [2, 3])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -614,16 +516,9 @@ def test_vector_masked_store_verify_mask_vector_rank():
 
 
 def test_vector_masked_store_verify_mask_vector_type():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-
-    i32_mask_vector_type = VectorType.from_element_type_and_shape(i32, [2])
-    mask_vector_ssa_value = OpResult(i32_mask_vector_type, [], [])
-
-    i32_value_to_store_vector_type = VectorType.from_element_type_and_shape(
-        i32, [1])
-    value_to_store_vector_ssa_value = OpResult(i32_value_to_store_vector_type,
-                                               [], [])
+    memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(i32, [1])
+    mask_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [2])
+    value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     maskedstore = Maskedstore.get(memref_ssa_value, [], mask_vector_ssa_value,
                                   value_to_store_vector_ssa_value)
@@ -634,8 +529,7 @@ def test_vector_masked_store_verify_mask_vector_type():
 
 
 def test_vector_print():
-    i32_vector_type = VectorType.from_element_type_and_shape(i32, [1])
-    vector_ssa_value = OpResult(i32_vector_type, [], [])
+    vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(i32, [1])
 
     print = Print.get(vector_ssa_value)
 

--- a/tests/filecheck/dialects/vector/vector_ops.xdsl
+++ b/tests/filecheck/dialects/vector/vector_ops.xdsl
@@ -18,7 +18,7 @@ func.func() ["sym_name" = "vector_test", "function_type" = !fun<[!memref<[4 : !i
 
 // CHECK: builtin.module() {
 // CHECK-NEXT: func.func() ["sym_name" = "vector_test", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !vector<[true], !i1>, !index], []>, "sym_visibility" = "private"] {
-// CHECK-NEXT: ^{{.*}}(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index):
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !vector<[true], !i1>, %{{.*}} : !index):
 // CHECK-NEXT: %{{.*}} : !vector<[2 : !index], !index> = vector.load(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index)
 // CHECK-NEXT: vector.store(%{{.*}} : !vector<[2 : !index], !index>, %{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index)
 // CHECK-NEXT: %{{.*}} : !vector<[1 : !index], !index> = vector.broadcast(%{{.*}} : !index)


### PR DESCRIPTION
This PR intends to reduce code duplication in `vector` dialect python tests. It also rectifies two typos ([here](https://github.com/xdslproject/xdsl/blob/d670605e166021e632299fceb08583ef9c66f41b/tests/filecheck/dialects/vector/vector_ops.xdsl#L21) -> expected vector type and [here](https://github.com/xdslproject/xdsl/blob/d670605e166021e632299fceb08583ef9c66f41b/tests/dialects/test_vector.py#L567) -> `Maskedstore` instead of `Maskedload`)

Fixes #410 