### PR TITLE
Fehr/fix parser parametric attr

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,10 @@
 from io import StringIO
 
 import pytest
+from xdsl.irdl import irdl_attr_definition
 
 from xdsl.printer import Printer
-from xdsl.ir import MLContext, Attribute
+from xdsl.ir import MLContext, Attribute, ParametrizedAttribute
 from xdsl.parser import XDSLParser
 from xdsl.dialects.builtin import IntAttr, DictionaryAttr, StringAttr, ArrayAttr, Builtin
 
@@ -41,3 +42,23 @@ def test_dictionary_attr(data: dict[str, Attribute]):
     attr = XDSLParser(ctx, text).parse_attribute()
 
     assert attr.data == data
+
+
+@irdl_attr_definition
+class TestAttr(ParametrizedAttribute):
+    name = 'test.attr'
+
+
+def test_parsing():
+    """
+    Test that the default attribute parser does not try to
+    parse attribute arguments without the delimiters.
+    """
+    ctx = MLContext()
+    ctx.register_attr(TestAttr)
+
+    prog = '#test.attr "foo"'
+    parser = XDSLParser(ctx, prog)
+
+    r = parser.parse_attribute()
+    assert r == TestAttr()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,10 +1,10 @@
 from io import StringIO
 
 import pytest
-from xdsl.irdl import irdl_attr_definition
 
 from xdsl.printer import Printer
 from xdsl.ir import MLContext, Attribute, ParametrizedAttribute
+from xdsl.irdl import irdl_attr_definition
 from xdsl.parser import XDSLParser
 from xdsl.dialects.builtin import IntAttr, DictionaryAttr, StringAttr, ArrayAttr, Builtin
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1628,19 +1628,17 @@ class BaseParser(ABC):
             ],
             regions=regions)
 
-    def parse_paramattr_parameters(
-            self,
-            expect_brackets: bool = False,
-            skip_white_space: bool = True) -> list[Attribute]:
+    def parse_paramattr_parameters(self,
+                                   skip_white_space: bool = True
+                                   ) -> list[Attribute]:
         opening_brackets = self.tokenizer.next_token_of_pattern('<')
-        if expect_brackets and opening_brackets is None:
-            self.raise_error("Expected start attribute parameters here (`<`)!")
+        if opening_brackets is None:
+            return []
 
         res = self.parse_list_of(self.try_parse_attribute,
                                  'Expected another attribute here!')
 
-        if opening_brackets is not None and self.tokenizer.next_token_of_pattern(
-                '>') is None:
+        if self.tokenizer.next_token_of_pattern('>') is None:
             self.raise_error(
                 "Malformed parameter list, expected either another parameter or `>`!"
             )


### PR DESCRIPTION
Fix #425
The issue was that in the new parser, the default parser for parametrized attributes would allow parameters without brackets.