### PR TITLE
misc: Remove usage of coverage in xdsl-opt.

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,5 @@
 yapf<0.33
 toml<0.11
 pytest-cov
+coverage<8.0.0
 ipykernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pip<24.0
 pytest<8.0
 filecheck<0.0.24
 lit<16.0.0
-coverage<8.0.0

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -14,8 +14,10 @@ else:
 
 config.environment["PATH"] = config.test_source_root + "/../../xdsl/tools/:" + os.environ["PATH"]
 
+xdsl_opt = config.test_source_root + "/../../xdsl/tools/xdsl-opt"
+
 if "COVERAGE" in lit_config.params:
     if "EXEC_DIR" in lit_config.params:
-        config.substitutions.append(('xdsl-opt', "xdsl-opt --generate-coverage --exec-root=" + lit_config.params["EXEC_DIR"]))
+        config.substitutions.append(('xdsl-opt', f"coverage run -p {xdsl_opt} --exec-root=" + lit_config.params["EXEC_DIR"]))
     else:
-        config.substitutions.append(('xdsl-opt', "xdsl-opt --generate-coverage"))
+        config.substitutions.append(('xdsl-opt', f"coverage run -p {xdsl_opt}"))

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 import os
 from io import StringIO
-import coverage
 
 from xdsl.ir import MLContext
 from xdsl.parser import XDSLParser, MLIRParser, ParseError
@@ -77,16 +76,6 @@ class xDSLOptMain:
         """
         Executes the different steps.
         """
-        if self.args.generate_coverage:
-            if self.args.exec_root:
-                os.chdir(self.args.exec_root)
-            cov = coverage.Coverage(config_file='.coveragerc',
-                                    auto_data=True,
-                                    data_file='.coverage',
-                                    data_suffix=True)
-
-            cov.start()
-
         if not self.args.parsing_diagnostics:
             module = self.parse_input()
         else:
@@ -107,9 +96,6 @@ class xDSLOptMain:
 
         contents = self.output_resulting_program(module)
         self.print_to_output_stream(contents)
-
-        if self.args.generate_coverage:
-            cov.stop()  # type: ignore (reportUnboundVariable)
 
     def register_all_arguments(self, arg_parser: argparse.ArgumentParser):
         """
@@ -182,12 +168,6 @@ class xDSLOptMain:
             default=False,
             action='store_true',
             help="Allow the parsing of unregistered operations.")
-
-        arg_parser.add_argument(
-            "--generate-coverage",
-            default=False,
-            action='store_true',
-            help="Generate the xDSL code coverage for this run.")
 
         arg_parser.add_argument(
             "--exec-root",


### PR DESCRIPTION
Use coverage CLI to get coverage from filechecks instead. I open this PR as a draft to make sure codecov report is still working properly first.

This removes the need to have coverage installed to just run xDSL.
Bonus: coverage is the only non-pure dependency left, so if we remove it, xDSL can be used as a pure-Python tool. This means that only a Python distribution is needed to run it, not even some precompiled wheels for some dependencies! This is nice for e.g. JupyterLite, or other exotic platforms.