### PR TITLE
CI: Remove coverage from the pyodide/JupyterLite deployment.

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -55,11 +55,10 @@ jobs:
           cd pyodide
           git fetch --all
           git checkout 0.22.0a3
-          python -m pip install -r requirements.txt
+          python -m pip install -U -r requirements.txt
           sudo apt update && sudo apt install f2c
           
-          rm packages/xdsl -rf
-          pyodide skeleton pypi xdsl
+          pyodide skeleton pypi --update xdsl
           
           ../xdsl/.github/workflows/update_xdsl_pyodide_build.py packages/xdsl/meta.yaml ../xdsl
           

--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -62,7 +62,7 @@ jobs:
           
           ../xdsl/.github/workflows/update_xdsl_pyodide_build.py packages/xdsl/meta.yaml ../xdsl
           
-          PYODIDE_PACKAGES="coverage,xdsl" make
+          PYODIDE_PACKAGES="xdsl" make
 
       - name: Build the JupyterLite site
         run: |


### PR DESCRIPTION
This PR stops building and deploying `coverage` in the custom pyodide distribution, that was necessary to ship with until #433.

This saves a tiny bit of CI time, just makes it simpler, and maybe more importantly, make all JupyterLite stuff run a bit more smoothly!

This doesn't touch anything out of JupyterLite build and deploy.