### PR TITLE
CI: Update the environment PYTHONPATH with the users

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -42,5 +42,4 @@ jobs:
 
     - name: Execute lit tests
       run: |
-        export PYTHONPATH=$(pwd)
         lit -v tests/filecheck/

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -4,6 +4,8 @@ import os
 config.test_source_root = os.path.dirname(__file__)
 xdsl_src = os.path.dirname(os.path.dirname(config.test_source_root))
 
+config.environment["PYTHONPATH"] = os.environ.get("PYTHONPATH")
+
 config.name = "xDSL"
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {xdsl_src}"])
 config.suffixes = ['.test', '.xdsl', '.mlir', '.py']

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -4,7 +4,7 @@ import os
 config.test_source_root = os.path.dirname(__file__)
 xdsl_src = os.path.dirname(os.path.dirname(config.test_source_root))
 
-config.environment["PYTHONPATH"] = if p := os.environ.get("PYTHONPATH") then p else ""
+config.environment["PYTHONPATH"] = p if (p := os.environ.get("PYTHONPATH")) else ""
 
 config.name = "xDSL"
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {xdsl_src}"])

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -4,7 +4,7 @@ import os
 config.test_source_root = os.path.dirname(__file__)
 xdsl_src = os.path.dirname(os.path.dirname(config.test_source_root))
 
-config.environment["PYTHONPATH"] = os.environ.get("PYTHONPATH")
+config.environment["PYTHONPATH"] = if p := os.environ.get("PYTHONPATH") then p else ""
 
 config.name = "xDSL"
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {xdsl_src}"])


### PR DESCRIPTION
This readds the PYTHONPATH configuration for the runners environment in lit with the one configured by the user.

This is pretty much a cheat for lazy people like me who do not install xdsl through `pip install .` (and then run `pip install -U .` each time a change is made), but rather have the PYTHONPATH setup to discover the xdsl sources directly.