### PR TITLE
xdsl: provide custom __str__ and __format__ functions for attrs and ops

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -105,9 +105,8 @@ def test_op_clone():
     a = Constant.from_int_and_width(1, 32)
     b = a.clone()
 
-    b_value = b.value
-    assert isinstance(b_value, IntegerAttr)
-    b_value = cast(IntegerAttr[Any], b_value)
+    assert isinstance(b.value, IntegerAttr)
+    b_value = cast(IntegerAttr[Any], b.value)
 
     assert a is not b
     assert b_value.value.data == 1

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -258,7 +258,7 @@ def test_descriptions():
     a = Constant.from_int_and_width(1, 32)
 
     assert str(a.value) == '1 : !i32'
-    assert f'{a.value}' == 'IntegerAttr(1 : !i32)'
+    assert f'{a.value}' == '1 : !i32'
 
     assert str(a) == '%0 : !i32 = arith.constant() ["value" = 1 : !i32]'
     assert f'{a}' == 'Constant(%0 : !i32 = arith.constant() ["value" = 1 : !i32])'

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -291,6 +291,9 @@ class Attribute(ABC):
         printer.print_attribute(self)
         return res.getvalue()
 
+    def __format__(self, __format_spec: str) -> str:
+        return f'{self.__class__.__qualname__}({str(self)})'
+
 
 DataElement = TypeVar("DataElement")
 
@@ -629,6 +632,29 @@ class Operation(IRNode):
 
     def __hash__(self) -> int:
         return id(self)
+
+    def __str__(self) -> str:
+        from xdsl.printer import Printer
+        res = StringIO()
+        printer = Printer(stream=res)
+        printer.print_op(self)
+        desc = res.getvalue()
+        # Printer currently prints a new line when printing an operation.
+        # We don't want this behaviour when printing ops inline, so remove
+        # the trailing newline for now
+        last_char_is_newline = not desc or desc[-1] == "\n"
+        assert last_char_is_newline, "If the format changes, update this function"
+        desc = desc[:-1]
+        return desc
+
+    def __format__(self, __format_spec: str) -> str:
+        desc = str(self)
+        if '\n' in desc:
+            # Description is multi-line, indent each line
+            desc = '\n'.join('\t' + line for line in desc.splitlines())
+            # Add newline before and after
+            desc = f'\n{desc}\n'
+        return f'{self.__class__.__qualname__}({desc})'
 
     @classmethod
     @property

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -291,9 +291,6 @@ class Attribute(ABC):
         printer.print_attribute(self)
         return res.getvalue()
 
-    def __format__(self, __format_spec: str) -> str:
-        return f'{self.__class__.__qualname__}({str(self)})'
-
 
 DataElement = TypeVar("DataElement")
 


### PR DESCRIPTION
This test shows the new output, I think this would be useful for debugging, and not much information lost since the printed output is supposed to be unambiguous anyway.

``` python
def test_descriptions():
    a = Constant.from_int_and_width(1, 32)

    assert str(a.value) == '1 : !i32'
    assert f'{a.value}' == 'IntegerAttr(1 : !i32)'

    assert str(a) == '%0 : !i32 = arith.constant() ["value" = 1 : !i32]'
    assert f'{a}' == 'Constant(%0 : !i32 = arith.constant() ["value" = 1 : !i32])'

    m = ModuleOp.from_region_or_ops([a])

    assert str(m) == '''\
builtin.module() {
  %0 : !i32 = arith.constant() ["value" = 1 : !i32]
}'''

    assert f'{m}' == '''\
ModuleOp(
\tbuiltin.module() {
\t  %0 : !i32 = arith.constant() ["value" = 1 : !i32]
\t}
)'''

```

Would there be any downsides to printing like this?