### PR TITLE
builtins: Extend MemRef to cover more of the MLIR dialect

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -7,6 +7,7 @@ from xdsl.dialects.memref import (Alloc, Alloca, Dealloc, Dealloca, MemRefType,
 from xdsl.dialects import builtin, memref, func, arith
 from xdsl.printer import Printer
 
+
 def test_memreftype():
     mem1 = MemRefType.from_element_type_and_shape(i32, [1])
 
@@ -136,8 +137,10 @@ def test_memref_rank():
     assert dim_1.source is alloc0.memref
     assert isinstance(dim_1.rank.typ, IndexType)
 
+
 def test_memref_matmul():
-    memref_f64_rank2 = memref.MemRefType.from_element_type_and_shape(builtin.f64, [-1, -1])
+    memref_f64_rank2 = memref.MemRefType.from_element_type_and_shape(
+        builtin.f64, [-1, -1])
 
     module = builtin.ModuleOp.from_region_or_ops([
         func.FuncOp.from_callable(
@@ -157,7 +160,7 @@ def test_memref_matmul():
                 func.Return.get(out)
             ]
         )
-    ])
+    ])  # yapf: disable
 
     io = StringIO()
     p = Printer(target=Printer.Target.MLIR, stream=io)

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -120,8 +120,8 @@ def test_memref_dealloca():
 def test_memref_dim():
     idx = Constant.from_int_and_width(1, IndexType())
     alloc0 = Alloc.get(i32, 64, [3, 1, 2])
-    get_op = Dim.from_source_and_index(alloc0, idx)
+    dim_1 = Dim.from_source_and_index(alloc0, idx)
 
-    assert get_op.source is alloc0.memref
-    assert get_op.index is idx.result
-    assert isinstance(get_op.result.typ, IndexType)
+    assert dim_1.source is alloc0.memref
+    assert dim_1.index is idx.result
+    assert isinstance(dim_1.result.typ, IndexType)

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -132,4 +132,4 @@ def test_memref_rank():
     dim_1 = Rank.from_memref(alloc0)
 
     assert dim_1.source is alloc0.memref
-    assert isinstance(dim_1.result.typ, IndexType)
+    assert isinstance(dim_1.rank.typ, IndexType)

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -2,7 +2,7 @@ from xdsl.ir import OpResult
 from xdsl.dialects.builtin import i32, IntegerType, IndexType
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.memref import (Alloc, Alloca, Dealloc, Dealloca, MemRefType,
-                                  Load, Store, Dim)
+                                  Load, Store, Dim, Rank)
 
 
 def test_memreftype():
@@ -124,4 +124,12 @@ def test_memref_dim():
 
     assert dim_1.source is alloc0.memref
     assert dim_1.index is idx.result
+    assert isinstance(dim_1.result.typ, IndexType)
+
+
+def test_memref_rank():
+    alloc0 = Alloc.get(i32, 64, [3, 1, 2])
+    dim_1 = Rank.from_memref(alloc0)
+
+    assert dim_1.source is alloc0.memref
     assert isinstance(dim_1.result.typ, IndexType)

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -1,7 +1,8 @@
 from xdsl.ir import OpResult
 from xdsl.dialects.builtin import i32, IntegerType, IndexType
+from xdsl.dialects.arith import Constant
 from xdsl.dialects.memref import (Alloc, Alloca, Dealloc, Dealloca, MemRefType,
-                                  Load, Store)
+                                  Load, Store, Dim)
 
 
 def test_memreftype():
@@ -114,3 +115,13 @@ def test_memref_dealloca():
     dealloc0 = Dealloca.get(alloc0)
 
     assert type(dealloc0.memref) is OpResult
+
+
+def test_memref_dim():
+    idx = Constant.from_int_and_width(1, IndexType())
+    alloc0 = Alloc.get(i32, 64, [3, 1, 2])
+    get_op = Dim.from_source_and_index(alloc0, idx)
+
+    assert get_op.source is alloc0.memref
+    assert get_op.index is idx.result
+    assert isinstance(get_op.result.typ, IndexType)

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -169,9 +169,12 @@ def test_memref_matmul_verify():
                             mul := arith.Mulf.get(elem_a_i_k, elem_b_k_j),
                             out_i_j := memref.Load.get(out, [i, j]),
                             new_out_val := arith.Addf.get(out_i_j, mul),
-                            memref.Store.get(new_out_val, out, [i, j])
-                        ]))
-                    ]))
+                            memref.Store.get(new_out_val, out, [i, j]),
+                            scf.Yield()
+                        ])),
+                        scf.Yield()
+                    ])),
+                    scf.Yield()
                 ])),
                 func.Return.get(out)
             ]

--- a/tests/filecheck/dialects/memref/matmul.mlir
+++ b/tests/filecheck/dialects/memref/matmul.mlir
@@ -1,0 +1,61 @@
+// RUN: xdsl-opt %s -t mlir | filecheck %s
+"builtin.module"() ({
+  "func.func"() ({
+  ^0(%0 : memref<?x?xf64>, %1 : memref<?x?xf64>):
+    %2 = "arith.constant"() {"value" = 0 : index} : () -> index
+    %3 = "arith.constant"() {"value" = 1 : index} : () -> index
+    %4 = "memref.dim"(%0, %2) : (memref<?x?xf64>, index) -> index
+    %5 = "memref.dim"(%0, %3) : (memref<?x?xf64>, index) -> index
+    %6 = "memref.dim"(%1, %2) : (memref<?x?xf64>, index) -> index
+    %7 = "memref.dim"(%1, %3) : (memref<?x?xf64>, index) -> index
+    %8 = "memref.alloca"(%4, %7) {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 2, 0>} : (index, index) -> memref<?x?xf64>
+    %9 = "arith.constant"() {"value" = 0.0 : f64} : () -> f64
+    "scf.for"(%2, %4, %3) ({
+    ^1(%10 : index):
+      "scf.for"(%2, %6, %3) ({
+      ^2(%11 : index):
+        "memref.store"(%9, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+        "scf.for"(%2, %5, %3) ({
+        ^3(%12 : index):
+          %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
+          %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
+          %15 = "arith.mulf"(%13, %14) : (f64, f64) -> f64
+          %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
+          %17 = "arith.addf"(%16, %15) : (f64, f64) -> f64
+          "memref.store"(%17, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+        }) : (index, index, index) -> ()
+      }) : (index, index, index) -> ()
+    }) : (index, index, index) -> ()
+    "func.return"(%8) : (memref<?x?xf64>) -> ()
+  }) {"sym_name" = "matmul", "function_type" = (memref<?x?xf64>, memref<?x?xf64>) -> memref<?x?xf64>, "sym_visibility" = "private"} : () -> ()
+}) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() ({
+// CHECK-NEXT:   ^0(%0 : memref<?x?xf64>, %1 : memref<?x?xf64>):
+// CHECK-NEXT:     %2 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:     %3 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:     %4 = "memref.dim"(%0, %2) : (memref<?x?xf64>, index) -> index
+// CHECK-NEXT:     %5 = "memref.dim"(%0, %3) : (memref<?x?xf64>, index) -> index
+// CHECK-NEXT:     %6 = "memref.dim"(%1, %2) : (memref<?x?xf64>, index) -> index
+// CHECK-NEXT:     %7 = "memref.dim"(%1, %3) : (memref<?x?xf64>, index) -> index
+// CHECK-NEXT:     %8 = "memref.alloca"(%4, %7) {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 2, 0>} : (index, index) -> memref<?x?xf64>
+// CHECK-NEXT:     %9 = "arith.constant"() {"value" = 0.0 : f64} : () -> f64
+// CHECK-NEXT:     "scf.for"(%2, %4, %3) ({
+// CHECK-NEXT:     ^1(%10 : index):
+// CHECK-NEXT:       "scf.for"(%2, %6, %3) ({
+// CHECK-NEXT:       ^2(%11 : index):
+// CHECK-NEXT:         "memref.store"(%9, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+// CHECK-NEXT:         "scf.for"(%2, %5, %3) ({
+// CHECK-NEXT:         ^3(%12 : index):
+// CHECK-NEXT:           %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
+// CHECK-NEXT:           %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
+// CHECK-NEXT:           %15 = "arith.mulf"(%13, %14) : (f64, f64) -> f64
+// CHECK-NEXT:           %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
+// CHECK-NEXT:           %17 = "arith.addf"(%16, %15) : (f64, f64) -> f64
+// CHECK-NEXT:           "memref.store"(%17, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+// CHECK-NEXT:         }) : (index, index, index) -> ()
+// CHECK-NEXT:       }) : (index, index, index) -> ()
+// CHECK-NEXT:     }) : (index, index, index) -> ()
+// CHECK-NEXT:     "func.return"(%8) : (memref<?x?xf64>) -> ()
+// CHECK-NEXT:   }) {"sym_name" = "matmul", "function_type" = (memref<?x?xf64>, memref<?x?xf64>) -> memref<?x?xf64>, "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -1,4 +1,5 @@
-// RUN: xdsl-opt %s -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : memref<?x?xf64>, %1 : memref<?x?xf64>):
@@ -29,6 +30,7 @@
     "func.return"(%8) : (memref<?x?xf64>) -> ()
   }) {"sym_name" = "matmul", "function_type" = (memref<?x?xf64>, memref<?x?xf64>) -> memref<?x?xf64>, "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
+
 // CHECK: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?xf64>, %1 : memref<?x?xf64>):

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -20,10 +20,8 @@
         ^3(%12 : index):
           %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
           %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
-          %15 = "arith.mulf"(%13, %14) : (f64, f64) -> f64
           %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
-          %17 = "arith.addf"(%16, %15) : (f64, f64) -> f64
-          "memref.store"(%17, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+          "memref.store"(%16, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
           "scf.yield"() : () -> ()
         }) : (index, index, index) -> ()
         "scf.yield"() : () -> ()
@@ -54,10 +52,8 @@
 // CHECK-NEXT:         ^3(%12 : index):
 // CHECK-NEXT:           %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
 // CHECK-NEXT:           %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
-// CHECK-NEXT:           %15 = "arith.mulf"(%13, %14) : (f64, f64) -> f64
 // CHECK-NEXT:           %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
-// CHECK-NEXT:           %17 = "arith.addf"(%16, %15) : (f64, f64) -> f64
-// CHECK-NEXT:           "memref.store"(%17, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+// CHECK-NEXT:           "memref.store"(%16, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
 // CHECK-NEXT:           "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) : (index, index, index) -> ()
 // CHECK-NEXT:         "scf.yield"() : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -44,7 +44,7 @@
 // CHECK-NEXT:     %6 = "memref.dim"(%1, %2) : (memref<?x?xi64>, index) -> index
 // CHECK-NEXT:     %7 = "memref.dim"(%1, %3) : (memref<?x?xi64>, index) -> index
 // CHECK-NEXT:     %8 = "memref.alloca"(%4, %7) {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 2, 0>} : (index, index) -> memref<?x?xi64>
-// CHECK-NEXT:     %9 = "arith.constant"() {"value" = 0.0 : i64} : () -> i64
+// CHECK-NEXT:     %9 = "arith.constant"() {"value" = 0 : i64} : () -> i64
 // CHECK-NEXT:     "scf.for"(%2, %4, %3) ({
 // CHECK-NEXT:     ^1(%10 : index):
 // CHECK-NEXT:       "scf.for"(%2, %6, %3) ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -2,64 +2,68 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : memref<?x?xf64>, %1 : memref<?x?xf64>):
+  ^0(%0 : memref<?x?xi64>, %1 : memref<?x?xi64>):
     %2 = "arith.constant"() {"value" = 0 : index} : () -> index
     %3 = "arith.constant"() {"value" = 1 : index} : () -> index
-    %4 = "memref.dim"(%0, %2) : (memref<?x?xf64>, index) -> index
-    %5 = "memref.dim"(%0, %3) : (memref<?x?xf64>, index) -> index
-    %6 = "memref.dim"(%1, %2) : (memref<?x?xf64>, index) -> index
-    %7 = "memref.dim"(%1, %3) : (memref<?x?xf64>, index) -> index
-    %8 = "memref.alloca"(%4, %7) {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 2, 0>} : (index, index) -> memref<?x?xf64>
-    %9 = "arith.constant"() {"value" = 0.0 : f64} : () -> f64
+    %4 = "memref.dim"(%0, %2) : (memref<?x?xi64>, index) -> index
+    %5 = "memref.dim"(%0, %3) : (memref<?x?xi64>, index) -> index
+    %6 = "memref.dim"(%1, %2) : (memref<?x?xi64>, index) -> index
+    %7 = "memref.dim"(%1, %3) : (memref<?x?xi64>, index) -> index
+    %8 = "memref.alloca"(%4, %7) {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 2, 0>} : (index, index) -> memref<?x?xi64>
+    %9 = "arith.constant"() {"value" = 0 : i64} : () -> i64
     "scf.for"(%2, %4, %3) ({
     ^1(%10 : index):
       "scf.for"(%2, %6, %3) ({
       ^2(%11 : index):
-        "memref.store"(%9, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+        "memref.store"(%9, %8, %10, %11) : (i64, memref<?x?xi64>, index, index) -> ()
         "scf.for"(%2, %5, %3) ({
         ^3(%12 : index):
-          %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
-          %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
-          %15 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
-          "memref.store"(%15, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+          %13 = "memref.load"(%0, %10, %12) : (memref<?x?xi64>, index, index) -> i64
+          %14 = "memref.load"(%1, %12, %11) : (memref<?x?xi64>, index, index) -> i64
+          %15 = "memref.load"(%8, %10, %11) : (memref<?x?xi64>, index, index) -> i64
+          %16 = "arith.muli"(%13, %14) : (i64, i64) -> i64
+          %17 = "arith.addi"(%15, %16) : (i64, i64) -> i64
+          "memref.store"(%17, %8, %10, %11) : (i64, memref<?x?xi64>, index, index) -> ()
           "scf.yield"() : () -> ()
         }) : (index, index, index) -> ()
         "scf.yield"() : () -> ()
       }) : (index, index, index) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
-    "func.return"(%8) : (memref<?x?xf64>) -> ()
-  }) {"sym_name" = "matmul", "function_type" = (memref<?x?xf64>, memref<?x?xf64>) -> memref<?x?xf64>, "sym_visibility" = "private"} : () -> ()
+    "func.return"(%8) : (memref<?x?xi64>) -> ()
+  }) {"sym_name" = "matmul", "function_type" = (memref<?x?xi64>, memref<?x?xi64>) -> memref<?x?xi64>, "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
-// CHECK-NEXT:   ^0(%0 : memref<?x?xf64>, %1 : memref<?x?xf64>):
+// CHECK-NEXT:   ^0(%0 : memref<?x?xi64>, %1 : memref<?x?xi64>):
 // CHECK-NEXT:     %2 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:     %3 = "arith.constant"() {"value" = 1 : index} : () -> index
-// CHECK-NEXT:     %4 = "memref.dim"(%0, %2) : (memref<?x?xf64>, index) -> index
-// CHECK-NEXT:     %5 = "memref.dim"(%0, %3) : (memref<?x?xf64>, index) -> index
-// CHECK-NEXT:     %6 = "memref.dim"(%1, %2) : (memref<?x?xf64>, index) -> index
-// CHECK-NEXT:     %7 = "memref.dim"(%1, %3) : (memref<?x?xf64>, index) -> index
-// CHECK-NEXT:     %8 = "memref.alloca"(%4, %7) {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 2, 0>} : (index, index) -> memref<?x?xf64>
-// CHECK-NEXT:     %9 = "arith.constant"() {"value" = 0.0 : f64} : () -> f64
+// CHECK-NEXT:     %4 = "memref.dim"(%0, %2) : (memref<?x?xi64>, index) -> index
+// CHECK-NEXT:     %5 = "memref.dim"(%0, %3) : (memref<?x?xi64>, index) -> index
+// CHECK-NEXT:     %6 = "memref.dim"(%1, %2) : (memref<?x?xi64>, index) -> index
+// CHECK-NEXT:     %7 = "memref.dim"(%1, %3) : (memref<?x?xi64>, index) -> index
+// CHECK-NEXT:     %8 = "memref.alloca"(%4, %7) {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 2, 0>} : (index, index) -> memref<?x?xi64>
+// CHECK-NEXT:     %9 = "arith.constant"() {"value" = 0.0 : i64} : () -> i64
 // CHECK-NEXT:     "scf.for"(%2, %4, %3) ({
 // CHECK-NEXT:     ^1(%10 : index):
 // CHECK-NEXT:       "scf.for"(%2, %6, %3) ({
 // CHECK-NEXT:       ^2(%11 : index):
-// CHECK-NEXT:         "memref.store"(%9, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+// CHECK-NEXT:         "memref.store"(%9, %8, %10, %11) : (i64, memref<?x?xi64>, index, index) -> ()
 // CHECK-NEXT:         "scf.for"(%2, %5, %3) ({
 // CHECK-NEXT:         ^3(%12 : index):
-// CHECK-NEXT:           %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
-// CHECK-NEXT:           %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
-// CHECK-NEXT:           %15 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
-// CHECK-NEXT:           "memref.store"(%15, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+// CHECK-NEXT:           %13 = "memref.load"(%0, %10, %12) : (memref<?x?xi64>, index, index) -> i64
+// CHECK-NEXT:           %14 = "memref.load"(%1, %12, %11) : (memref<?x?xi64>, index, index) -> i64
+// CHECK-NEXT:           %15 = "memref.load"(%8, %10, %11) : (memref<?x?xi64>, index, index) -> i64
+// CHECK-NEXT:           %16 = "arith.muli"(%13, %14) : (i64, i64) -> i64
+// CHECK-NEXT:           %17 = "arith.addi"(%15, %16) : (i64, i64) -> i64
+// CHECK-NEXT:           "memref.store"(%17, %8, %10, %11) : (i64, memref<?x?xi64>, index, index) -> ()
 // CHECK-NEXT:           "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) : (index, index, index) -> ()
 // CHECK-NEXT:         "scf.yield"() : () -> ()
 // CHECK-NEXT:       }) : (index, index, index) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "func.return"(%8) : (memref<?x?xf64>) -> ()
-// CHECK-NEXT:   }) {"sym_name" = "matmul", "function_type" = (memref<?x?xf64>, memref<?x?xf64>) -> memref<?x?xf64>, "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:     "func.return"(%8) : (memref<?x?xi64>) -> ()
+// CHECK-NEXT:   }) {"function_type" = (memref<?x?xi64>, memref<?x?xi64>) -> memref<?x?xi64>, "sym_name" = "matmul", "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -24,8 +24,11 @@
           %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
           %17 = "arith.addf"(%16, %15) : (f64, f64) -> f64
           "memref.store"(%17, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+          "scf.yield"() : () -> ()
         }) : (index, index, index) -> ()
+        "scf.yield"() : () -> ()
       }) : (index, index, index) -> ()
+      "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"(%8) : (memref<?x?xf64>) -> ()
   }) {"sym_name" = "matmul", "function_type" = (memref<?x?xf64>, memref<?x?xf64>) -> memref<?x?xf64>, "sym_visibility" = "private"} : () -> ()
@@ -55,8 +58,11 @@
 // CHECK-NEXT:           %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
 // CHECK-NEXT:           %17 = "arith.addf"(%16, %15) : (f64, f64) -> f64
 // CHECK-NEXT:           "memref.store"(%17, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+// CHECK-NEXT:           "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) : (index, index, index) -> ()
+// CHECK-NEXT:         "scf.yield"() : () -> ()
 // CHECK-NEXT:       }) : (index, index, index) -> ()
+// CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) : (index, index, index) -> ()
 // CHECK-NEXT:     "func.return"(%8) : (memref<?x?xf64>) -> ()
 // CHECK-NEXT:   }) {"sym_name" = "matmul", "function_type" = (memref<?x?xf64>, memref<?x?xf64>) -> memref<?x?xf64>, "sym_visibility" = "private"} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -20,8 +20,8 @@
         ^3(%12 : index):
           %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
           %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
-          %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
-          "memref.store"(%16, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+          %15 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
+          "memref.store"(%15, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
           "scf.yield"() : () -> ()
         }) : (index, index, index) -> ()
         "scf.yield"() : () -> ()
@@ -52,8 +52,8 @@
 // CHECK-NEXT:         ^3(%12 : index):
 // CHECK-NEXT:           %13 = "memref.load"(%0, %10, %12) : (memref<?x?xf64>, index, index) -> f64
 // CHECK-NEXT:           %14 = "memref.load"(%1, %12, %11) : (memref<?x?xf64>, index, index) -> f64
-// CHECK-NEXT:           %16 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
-// CHECK-NEXT:           "memref.store"(%16, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
+// CHECK-NEXT:           %15 = "memref.load"(%8, %10, %11) : (memref<?x?xf64>, index, index) -> f64
+// CHECK-NEXT:           "memref.store"(%15, %8, %10, %11) : (f64, memref<?x?xf64>, index, index) -> ()
 // CHECK-NEXT:           "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) : (index, index, index) -> ()
 // CHECK-NEXT:         "scf.yield"() : () -> ()

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -281,9 +281,22 @@ class Dim(Operation):
     result: Annotated[OpResult, IndexType]
 
     @classmethod
-    def from_source_and_index(cls, source: Operand | Operation,
+    def from_source_and_index(cls, source: SSAValue | Operation,
                               index: Operand | Operation):
         return cls.build(operands=[source, index], result_types=[IndexType()])
+
+
+@irdl_op_definition
+class Rank(Operation):
+    name = "memref.rank"
+
+    source: Annotated[Operand, MemRefType]
+
+    rank: Annotated[OpResult, IndexType]
+
+    @classmethod
+    def from_memref(cls, memref: Operation | SSAValue):
+        return cls.build(operands=[memref], result_types=[IndexType()])
 
 
 MemRef = Dialect([Load, Store, Alloc, Alloca, Dealloc, GetGlobal, Global, Dim],

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -184,10 +184,15 @@ class Alloca(Operation):
     @staticmethod
     def get(return_type: Attribute,
             alignment: int,
-            shape: Optional[List[int | AnyIntegerAttr]] = None) -> Alloca:
+            shape: Optional[List[int | AnyIntegerAttr]] = None,
+            dynamic_sizes: list[SSAValue, Operation] = None) -> Alloca:
         if shape is None:
             shape = [1]
-        return Alloca.build(operands=[[], []],
+
+        if dynamic_sizes is None:
+            dynamic_sizes = []
+
+        return Alloca.build(operands=[dynamic_sizes, []],
                             result_types=[
                                 MemRefType.from_element_type_and_shape(
                                     return_type, shape)

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -185,7 +185,7 @@ class Alloca(Operation):
     def get(return_type: Attribute,
             alignment: int,
             shape: Optional[List[int | AnyIntegerAttr]] = None,
-            dynamic_sizes: list[SSAValue, Operation] = None) -> Alloca:
+            dynamic_sizes: list[SSAValue | Operation] | None = None) -> Alloca:
         if shape is None:
             shape = [1]
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -287,7 +287,7 @@ class Dim(Operation):
 
     @classmethod
     def from_source_and_index(cls, source: SSAValue | Operation,
-                              index: Operand | Operation):
+                              index: SSAValue | Operation):
         return cls.build(operands=[source, index], result_types=[IndexType()])
 
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -271,5 +271,20 @@ class Global(Operation):
             })
 
 
-MemRef = Dialect([Load, Store, Alloc, Alloca, Dealloc, GetGlobal, Global],
+@irdl_op_definition
+class Dim(Operation):
+    name = "memref.dim"
+
+    source: Annotated[Operand, MemRefType]
+    index: Annotated[Operand, IndexType]
+
+    result: Annotated[OpResult, IndexType]
+
+    @classmethod
+    def from_source_and_index(cls, source: Operand | Operation,
+                              index: Operand | Operation):
+        return cls.build(operands=[source, index], result_types=[IndexType()])
+
+
+MemRef = Dialect([Load, Store, Alloc, Alloca, Dealloc, GetGlobal, Global, Dim],
                  [MemRefType, UnrankedMemrefType])

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -78,7 +78,7 @@ AnyUnrankedMemrefType: TypeAlias = UnrankedMemrefType[Attribute]
 @irdl_op_definition
 class Load(Operation):
     name = "memref.load"
-    memref: Annotated[Operand, MemRefType]
+    memref: Annotated[Operand, MemRefType[Attribute]]
     indices: Annotated[VarOperand, IndexType]
     res: Annotated[OpResult, AnyAttr()]
 
@@ -114,7 +114,7 @@ class Load(Operation):
 class Store(Operation):
     name = "memref.store"
     value: Annotated[Operand, AnyAttr()]
-    memref: Annotated[Operand, MemRefType]
+    memref: Annotated[Operand, MemRefType[Attribute]]
     indices: Annotated[VarOperand, IndexType]
 
     def verify_(self):
@@ -143,7 +143,7 @@ class Alloc(Operation):
     dynamic_sizes: Annotated[VarOperand, IndexType]
     symbol_operands: Annotated[VarOperand, IndexType]
 
-    memref: Annotated[OpResult, MemRefType]
+    memref: Annotated[OpResult, MemRefType[Attribute]]
 
     # TODO how to constraint the IntegerAttr type?
     alignment: OpAttr[AnyIntegerAttr]
@@ -174,7 +174,7 @@ class Alloca(Operation):
     dynamic_sizes: Annotated[VarOperand, IndexType]
     symbol_operands: Annotated[VarOperand, IndexType]
 
-    memref: Annotated[OpResult, MemRefType]
+    memref: Annotated[OpResult, MemRefType[Attribute]]
 
     # TODO how to constraint the IntegerAttr type?
     alignment: OpAttr[AnyIntegerAttr]
@@ -206,7 +206,7 @@ class Alloca(Operation):
 @irdl_op_definition
 class Dealloc(Operation):
     name = "memref.dealloc"
-    memref: Annotated[Operand, MemRefType]
+    memref: Annotated[Operand, MemRefType[Attribute]]
 
     @staticmethod
     def get(operand: Operation | SSAValue) -> Dealloc:
@@ -216,7 +216,7 @@ class Dealloc(Operation):
 @irdl_op_definition
 class Dealloca(Operation):
     name = "memref.dealloca"
-    memref: Annotated[Operand, MemRefType]
+    memref: Annotated[Operand, MemRefType[Attribute]]
 
     @staticmethod
     def get(operand: Operation | SSAValue) -> Dealloca:
@@ -226,7 +226,7 @@ class Dealloca(Operation):
 @irdl_op_definition
 class GetGlobal(Operation):
     name = "memref.get_global"
-    memref: Annotated[OpResult, MemRefType]
+    memref: Annotated[OpResult, MemRefType[Attribute]]
 
     def verify_(self) -> None:
         if 'name' not in self.attributes:
@@ -280,7 +280,7 @@ class Global(Operation):
 class Dim(Operation):
     name = "memref.dim"
 
-    source: Annotated[Operand, MemRefType]
+    source: Annotated[Operand, MemRefType[Attribute]]
     index: Annotated[Operand, IndexType]
 
     result: Annotated[OpResult, IndexType]
@@ -295,7 +295,7 @@ class Dim(Operation):
 class Rank(Operation):
     name = "memref.rank"
 
-    source: Annotated[Operand, MemRefType]
+    source: Annotated[Operand, MemRefType[Attribute]]
 
     rank: Annotated[OpResult, IndexType]
 


### PR DESCRIPTION
This PR aims to get better memref support into xDSL

I want to implement with this PR:

 - `memref.dim`
 - `memref.rank`

Not added in this PR, but might be of interest in the future.
 - `memref.view`and `memref.subview`
 - `memref.reshape`
 - `memref.realloc`
