### PR TITLE
dialects: Add FastMathFlagsAttr to the Arith dialect.

### DIFF
--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -267,4 +267,32 @@ func.func() ["function_type" = !fun<[!i32, !i32], [!i32]>, "sym_name" = "shrsi"]
 }
 
 // CHECK:   %{{.*}} !i32 = arith.shrsi(%{{.*}} : !i32, %{{.*}} : !i32)
+
+// fastmath single flag set
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_reassoc", "fastmath" = !arith.fastmath<reassoc>] {}
+// CHECK:   "fastmath" = !arith.fastmath<reassoc>
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_nnan", "fastmath" = !arith.fastmath<nnan>] {}
+// CHECK:   "fastmath" = !arith.fastmath<nnan>
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_ninf", "fastmath" = !arith.fastmath<ninf>] {}
+// CHECK:   "fastmath" = !arith.fastmath<ninf>
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_nsz", "fastmath" = !arith.fastmath<nsz>] {}
+// CHECK:   "fastmath" = !arith.fastmath<nsz>
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_arcp", "fastmath" = !arith.fastmath<arcp>] {}
+// CHECK:   "fastmath" = !arith.fastmath<arcp>
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_contract", "fastmath" = !arith.fastmath<contract>] {}
+// CHECK:   "fastmath" = !arith.fastmath<contract>
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_afn", "fastmath" = !arith.fastmath<afn>] {}
+// CHECK:   "fastmath" = !arith.fastmath<afn>
+
+// fastmath special cases
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_none", "fastmath" = !arith.fastmath<none>] {}
+// CHECK:   "fastmath" = !arith.fastmath<none>
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_fast", "fastmath" = !arith.fastmath<fast>] {}
+// CHECK:   "fastmath" = !arith.fastmath<fast>
+
+// fastmath combination
+func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_two", "fastmath" = !arith.fastmath<nnan,nsz>] {}
+// CHECK:   "fastmath" = !arith.fastmath<nnan,nsz>
+
+
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
@@ -1,0 +1,31 @@
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+
+"builtin.module"() ({
+
+// fastmath single flag set
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_reassoc", "sym_visibility" = "private", "fastmath" = #arith.fastmath<reassoc>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<reassoc>
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_nnan", "sym_visibility" = "private", "fastmath" = #arith.fastmath<nnan>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<nnan>
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_ninf", "sym_visibility" = "private", "fastmath" = #arith.fastmath<ninf>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<ninf>
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_nsz", "sym_visibility" = "private", "fastmath" = #arith.fastmath<nsz>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<nsz>
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_arcp", "sym_visibility" = "private", "fastmath" = #arith.fastmath<arcp>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<arcp>
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_contract", "sym_visibility" = "private", "fastmath" = #arith.fastmath<contract>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<contract>
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_afn", "sym_visibility" = "private", "fastmath" = #arith.fastmath<afn>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<afn>
+
+// fastmath special cases
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_none", "sym_visibility" = "private", "fastmath" = #arith.fastmath<none>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<none>
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_fast", "sym_visibility" = "private", "fastmath" = #arith.fastmath<fast>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<fast>
+
+// fastmath combination
+"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_two", "sym_visibility" = "private", "fastmath" = #arith.fastmath<nnan,nsz>}: ()->()
+// CHECK:   "fastmath" = #arith.fastmath<nnan,nsz>
+
+}) : ()->()

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -663,7 +663,7 @@ class FastMathFlagsAttr(Data[FastMathFlags]):
         elif len(data.flags) == len(FastMathFlag):
             printer.print("fast")
         else:
-            # make sure we emits flags in a consistent order
+            # make sure we emit flags in a consistent order
             printer.print(",".join(flag.value for flag in FastMathFlag if flag in data))
 
     @staticmethod
@@ -717,5 +717,5 @@ Arith = Dialect([
         # Casts
         IndexCastOp,
 ], [
-        FastMathFlagsAttr
+        FastMathFlagsAttr,
 ])


### PR DESCRIPTION
I needed support for the [`arith.fastmath` attribute](https://mlir.llvm.org/docs/Dialects/ArithOps/#fastmathflagsattr), so I added it based on the code [here](https://github.com/llvm/llvm-project/blob/ee9a0f30ca8a3582d0738f7499ea902e1f713b39/mlir/include/mlir/Dialect/Arith/IR/ArithBase.td#L96-L127).

* Are PR adding small details like this to the dialects welcome?
* This is one of my first dialect additions, did I do it right?

