### PR TITLE
misc: add Makefile and add pyright to requirements-optional.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# define the name of the virtual environment directory
+VENV := venv
+
+# default target, when make executed without arguments
+all: venv
+
+install: FORCE
+	pip install --upgrade pip
+	pip install -r requirements.txt --require-venv
+	pip install -r requirements-optional.txt --require-venv
+	pip install --editable . --require-venv
+
+requirements.txt:
+	pip install -r requirements.txt --require-venv
+
+# update is a shortcut target
+update: requirements.txt
+
+test: update
+	# Executes pytests which are located in tests/
+	pytest
+	# Executes filecheck tests
+	lit tests/filecheck
+
+format:
+	yapf -ir xdsl
+
+lint:
+	pyright
+
+lint-ci: pyright-ci.json
+	pyright -p pyright-ci.json
+
+clean:
+	rm -r $(VENV)
+	find . -type f -name '*.pyc' -delete
+
+.PHONY: all install update venv test clean
+
+FORCE: ;

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ To contribute to the development of xDSL follow the subsequent steps.
 
 ```bash
 git clone https://github.com/xdslproject/xdsl.git
-pip install --editable .
-# Optional installation of extra requirements
-pip install --requirement requirements-optional.txt
+# We currently support Python 3.10 and 3.11
+python3.10 -m venv venv
+source venv/bin/activate
+make install
 ```
 
 ### Testing
@@ -73,17 +74,19 @@ The xDSL project uses pytest unit tests and LLVM-style filecheck tests. They can
 be executed from the root directory:
 
 ```bash
-# Executes pytests which are located in tests/
-pytest
-
-# Executes filecheck tests
-lit tests/filecheck
+make test
 ```
 
 ### Formatting
 
 All python code used in xDSL uses [yapf](https://github.com/google/yapf) to
 format the code in a uniform manner.
+
+To format manually, run:
+
+```bash
+make format
+```
 
 To automate the formatting within vim, one can use
 https://github.com/vim-autoformat/vim-autoformat and trigger a `:Autoformat` on

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,3 +3,4 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
+pyright


### PR DESCRIPTION
This should make it easier for new contributors to get set up. I couldn't figure out how to get the venv part in there, I just require venv to be activated for the pip commands.