### PR TITLE
dialects: Extend arith and func

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -4,8 +4,8 @@ from xdsl.dialects.arith import (Addi, Constant, DivUI, DivSI, Subi,
                                  FloorDivSI, CeilDivSI, CeilDivUI, RemUI,
                                  RemSI, MinUI, MinSI, MaxUI, MaxSI, AndI, OrI,
                                  XOrI, ShLI, ShRUI, ShRSI, Cmpi, Addf, Subf,
-                                 Mulf, Divf, Maxf, Minf)
-from xdsl.dialects.builtin import i32, f32
+                                 Mulf, Divf, Maxf, Minf, IndexCastOp)
+from xdsl.dialects.builtin import i32, f32, IndexType
 
 
 class Test_integer_arith_construction:
@@ -49,3 +49,12 @@ class Test_float_arith_construction:
         op = func.get(self.a, self.b)
         assert op.operands[0].op is self.a
         assert op.operands[1].op is self.b
+
+
+def test_index_cast_op():
+    a = Constant.from_int_and_width(0, 32)
+    cast = IndexCastOp.get(a, IndexType())
+
+    assert cast.result.typ == IndexType()
+    assert cast.input.typ == i32
+    assert cast.input.op == a

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -26,15 +26,12 @@ def test_func():
 
     # Alternative generation of func0
     func1 = FuncOp.from_region(
-        "func1",
-        [],
-        [],
+        "func1", [], [],
         Region.from_operation_list([
             a := Constant.from_int_and_width(1, i32),
             b := Constant.from_int_and_width(2, i32),
-            Addi.get(a, b)
-        ]))  # yapf: disable
-    # yapf disabled for structured look of this test
+            Addi.get(a, b),
+        ]))
 
     assert len(func0.regions[0].ops) == 3
     assert len(func1.regions[0].ops) == 3

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -5,7 +5,7 @@ from typing import Annotated, TypeVar, Union
 
 from xdsl.dialects.builtin import (ContainerOf, Float16Type, Float64Type, IndexType, IntAttr,
                                    IntegerType, Float32Type, IntegerAttr, FloatAttr,
-                                   Attribute, AnyFloat, AnyIntegerAttr, Signedness)
+                                   Attribute, AnyFloat, AnyIntegerAttr)
 from xdsl.ir import Operation, SSAValue, Dialect, OpResult
 from xdsl.irdl import (AnyOf, irdl_op_definition, OpAttr, AnyAttr,
                        Operand)
@@ -649,5 +649,5 @@ Arith = Dialect([
         Maxf,
 
         # Casts
-        IndexCastOp],
-        [])
+        IndexCastOp,
+], [])

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -589,6 +589,22 @@ class Minf(BinaryOperation):
         return Minf.build(operands=[operand1, operand2],
                           result_types=[operand1.typ])
 
+@irdl_op_definition
+class IndexCastOp(Operation):
+    name = "arith.index_cast"
+
+    index: Annotated[Operand, IndexType]
+
+    result: Annotated[OpResult, Attribute]
+
+    @classmethod
+    def get(cls, index: SSAValue | Operation, target_type: Attribute):
+        return cls.build(
+            operands=[index],
+            result_types=[target_type]
+        )
+
+
 Arith = Dialect([
         Constant,
 
@@ -630,5 +646,8 @@ Arith = Dialect([
 
         # Min/Max
         Minf,
-        Maxf],
+        Maxf,
+
+        # Casts
+        IndexCastOp],
         [])

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -5,7 +5,7 @@ from typing import Annotated, TypeVar, Union
 
 from xdsl.dialects.builtin import (ContainerOf, Float16Type, Float64Type, IndexType, IntAttr,
                                    IntegerType, Float32Type, IntegerAttr, FloatAttr,
-                                   Attribute, AnyFloat, AnyIntegerAttr)
+                                   Attribute, AnyFloat, AnyIntegerAttr, Signedness)
 from xdsl.ir import Operation, SSAValue, Dialect, OpResult
 from xdsl.irdl import (AnyOf, irdl_op_definition, OpAttr, AnyAttr,
                        Operand)
@@ -593,14 +593,14 @@ class Minf(BinaryOperation):
 class IndexCastOp(Operation):
     name = "arith.index_cast"
 
-    index: Annotated[Operand, IndexType]
+    input: Operand
 
-    result: Annotated[OpResult, Attribute]
+    result: OpResult
 
     @classmethod
-    def get(cls, index: SSAValue | Operation, target_type: Attribute):
+    def get(cls, input: SSAValue | Operation, target_type: Attribute):
         return cls.build(
-            operands=[index],
+            operands=[input],
             result_types=[target_type]
         )
 

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -44,6 +44,21 @@ class FuncOp(Operation):
         return op
 
     @staticmethod
+    def external(name: str, input_types: List[Attribute],
+                      return_types: List[Attribute]) -> FuncOp:
+        type_attr = FunctionType.from_lists(input_types, return_types)
+        attributes = {
+            "sym_name": StringAttr(name),
+            "function_type": type_attr,
+            "sym_visibility": StringAttr("private")
+        }
+        op = FuncOp.build(attributes=attributes,
+                          regions=[
+                              Region.from_operation_list([])
+                          ])
+        return op
+
+    @staticmethod
     def from_region(name: str, input_types: List[Attribute],
                     return_types: List[Attribute], region: Region) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -45,7 +45,7 @@ class FuncOp(Operation):
 
     @staticmethod
     def external(name: str, input_types: List[Attribute],
-                      return_types: List[Attribute]) -> FuncOp:
+                 return_types: List[Attribute]) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
         attributes = {
             "sym_name": StringAttr(name),
@@ -53,9 +53,7 @@ class FuncOp(Operation):
             "sym_visibility": StringAttr("private")
         }
         op = FuncOp.build(attributes=attributes,
-                          regions=[
-                              Region.from_operation_list([])
-                          ])
+                          regions=[Region.from_operation_list([])])
         return op
 
     @staticmethod


### PR DESCRIPTION
This PR adds the following ops:

 - `arith.index_cast`
 - `FuncOp.external` to create functions without a body that are used to inform LLVM of external function definitions.