### PR TITLE
core: Add SSAValue.definition property.

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -30,10 +30,10 @@ def test_ops_accessor():
 
     assert d.results[0] != c.results[0]
 
-    assert c.lhs.definition is a
-    assert c.rhs.definition is b
-    assert d.lhs.definition is a
-    assert d.rhs.definition is b
+    assert c.lhs.defining_op_or_block is a
+    assert c.rhs.defining_op_or_block is b
+    assert d.lhs.defining_op_or_block is a
+    assert d.rhs.defining_op_or_block is b
 
 
 def test_ops_accessor_II():
@@ -64,8 +64,8 @@ def test_ops_accessor_II():
 
     assert isinstance(c.lhs, ErasedSSAValue)
     assert isinstance(c.rhs, ErasedSSAValue)
-    assert c.lhs.definition is a
-    assert c.rhs.definition is b
+    assert c.lhs.defining_op_or_block is a
+    assert c.rhs.defining_op_or_block is b
 
     region2.detach_block(block0)
     region2.drop_all_references()

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,7 +1,7 @@
 from typing import cast
 import pytest
 
-from xdsl.ir import MLContext, Operation, Block, Region
+from xdsl.ir import MLContext, Operation, Block, Region, ErasedSSAValue, SSAValue
 from xdsl.dialects.arith import Addi, Subi, Constant
 from xdsl.dialects.builtin import IntegerType, i32, IntegerAttr, ModuleOp
 from xdsl.dialects.scf import If
@@ -30,6 +30,9 @@ def test_ops_accessor():
 
     assert d.results[0] != c.results[0]
 
+    assert c.lhs.definition is a and c.rhs.definition is b
+    assert d.lhs.definition is a and d.rhs.definition is b
+
 
 def test_ops_accessor_II():
     a = Constant.from_int_and_width(1, i32)
@@ -56,6 +59,11 @@ def test_ops_accessor_II():
     region2.blocks[0].erase_op(a, safe_erase=False)
     region2.blocks[0].erase_op(b, safe_erase=False)
     region2.blocks[0].erase_op(c, safe_erase=False)
+
+    assert isinstance(c.lhs, ErasedSSAValue)
+    assert isinstance(c.rhs, ErasedSSAValue)
+    assert c.lhs.definition is a
+    assert c.rhs.definition is b
 
     region2.detach_block(block0)
     region2.drop_all_references()

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -30,8 +30,10 @@ def test_ops_accessor():
 
     assert d.results[0] != c.results[0]
 
-    assert c.lhs.definition is a and c.rhs.definition is b
-    assert d.lhs.definition is a and d.rhs.definition is b
+    assert c.lhs.definition is a
+    assert c.rhs.definition is b
+    assert d.lhs.definition is a
+    assert d.rhs.definition is b
 
 
 def test_ops_accessor_II():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -30,10 +30,10 @@ def test_ops_accessor():
 
     assert d.results[0] != c.results[0]
 
-    assert c.lhs.defining_op_or_block is a
-    assert c.rhs.defining_op_or_block is b
-    assert d.lhs.defining_op_or_block is a
-    assert d.rhs.defining_op_or_block is b
+    assert c.lhs.owner is a
+    assert c.rhs.owner is b
+    assert d.lhs.owner is a
+    assert d.rhs.owner is b
 
 
 def test_ops_accessor_II():
@@ -64,8 +64,8 @@ def test_ops_accessor_II():
 
     assert isinstance(c.lhs, ErasedSSAValue)
     assert isinstance(c.rhs, ErasedSSAValue)
-    assert c.lhs.defining_op_or_block is a
-    assert c.rhs.defining_op_or_block is b
+    assert c.lhs.owner is a
+    assert c.rhs.owner is b
 
     region2.detach_block(block0)
     region2.drop_all_references()

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -131,10 +131,10 @@ class SSAValue(ABC):
 
     @property
     @abstractmethod
-    def defining_op_or_block(self) -> Operation | Block:
+    def owner(self) -> Operation | Block:
         """
         An SSA variable is either an operation result, or a basic block argument.
-        This property returns the Operation or Block that defined a specific value.
+        This property returns the Operation or Block that currently defines a specific value.
         """
         pass
 
@@ -199,7 +199,7 @@ class OpResult(SSAValue):
     """The index of the result in the defining operation."""
 
     @property
-    def defining_op_or_block(self) -> Operation:
+    def owner(self) -> Operation:
         return self.op
 
     def __repr__(self) -> str:
@@ -226,7 +226,7 @@ class BlockArgument(SSAValue):
     """The index of the variable in the block arguments."""
 
     @property
-    def defining_op_or_block(self) -> Block:
+    def owner(self) -> Block:
         return self.block
 
     def __repr__(self) -> str:
@@ -255,8 +255,8 @@ class ErasedSSAValue(SSAValue):
     old_value: SSAValue
 
     @property
-    def defining_op_or_block(self) -> Operation | Block:
-        return self.old_value.defining_op_or_block
+    def owner(self) -> Operation | Block:
+        return self.old_value.owner
 
     def __hash__(self) -> int:  # type: ignore
         return hash(id(self))

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -130,6 +130,11 @@ class SSAValue(ABC):
         r'[A-Za-z0-9._$-]*[A-Za-z._$-]')
 
     @property
+    @abstractmethod
+    def definition(self) -> Operation | Block:
+        pass
+
+    @property
     def name(self) -> str | None:
         return self._name
 
@@ -189,6 +194,10 @@ class OpResult(SSAValue):
     result_index: int
     """The index of the result in the defining operation."""
 
+    @property
+    def definition(self) -> Operation:
+        return self.op
+
     def __repr__(self) -> str:
         return f"OpResult(typ={repr(self.typ)}, num_uses={repr(len(self.uses))}, " + \
                f"op_name={repr(self.op.name)}, " + \
@@ -211,6 +220,10 @@ class BlockArgument(SSAValue):
 
     index: int
     """The index of the variable in the block arguments."""
+
+    @property
+    def definition(self) -> Block:
+        return self.block
 
     def __repr__(self) -> str:
         if isinstance(self.block, Block):
@@ -236,6 +249,10 @@ class ErasedSSAValue(SSAValue):
     """
 
     old_value: SSAValue
+
+    @property
+    def definition(self) -> Operation | Block:
+        return self.old_value.definition
 
     def __hash__(self) -> int:  # type: ignore
         return hash(id(self))

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -132,6 +132,10 @@ class SSAValue(ABC):
     @property
     @abstractmethod
     def definition(self) -> Operation | Block:
+        """
+        An SSA variable is either an operation result, or a basic block argument.
+        This property returns the Operation or Block that defined a specific value.
+        """
         pass
 
     @property

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -131,7 +131,7 @@ class SSAValue(ABC):
 
     @property
     @abstractmethod
-    def definition(self) -> Operation | Block:
+    def defining_op_or_block(self) -> Operation | Block:
         """
         An SSA variable is either an operation result, or a basic block argument.
         This property returns the Operation or Block that defined a specific value.
@@ -199,7 +199,7 @@ class OpResult(SSAValue):
     """The index of the result in the defining operation."""
 
     @property
-    def definition(self) -> Operation:
+    def defining_op_or_block(self) -> Operation:
         return self.op
 
     def __repr__(self) -> str:
@@ -226,7 +226,7 @@ class BlockArgument(SSAValue):
     """The index of the variable in the block arguments."""
 
     @property
-    def definition(self) -> Block:
+    def defining_op_or_block(self) -> Block:
         return self.block
 
     def __repr__(self) -> str:
@@ -255,8 +255,8 @@ class ErasedSSAValue(SSAValue):
     old_value: SSAValue
 
     @property
-    def definition(self) -> Operation | Block:
-        return self.old_value.definition
+    def defining_op_or_block(self) -> Operation | Block:
+        return self.old_value.defining_op_or_block
 
     def __hash__(self) -> int:  # type: ignore
         return hash(id(self))


### PR DESCRIPTION
Hi, this minor PR just add a `definition` property to `SSAValue`, usable e.g. to get the `Operation` or `Block`that defined a generic `Operand`.

Motivating example:

```python3
@irdl_op_definition
class OpOp(Operation):
    name = "dialect.op"
    operand: Annotated[Operand, SomeType]

    def verify_(self):
        # OpOp requires its operand to be defined by a WantedOp
        if isinstance(self.operand, OpResult):
            if isinstance(self.operand.op, WantedOp):
                # All good
```

Can just be:

```python3
@irdl_op_definition
class OpOp(Operation):
    name = "dialect.op"
    operand: Annotated[Operand, SomeType]

    def verify_(self):
        # OpOp requires its operand to be defined by a WantedOp
        if isinstance(self.operand.definition, WantedOp):
            # All good
```