### PR TITLE
tests: Make scf.for test roundtrip

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_mlir.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_mlir.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
 
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index


### PR DESCRIPTION
A tiny PR to make scf.for interop test round-trip to and from MLIR.