### PR TITLE
dialects: Add DimensionAttr and AllReduceOperationAttr to GPU dialect

### DIFF
--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -5,13 +5,13 @@ from xdsl.dialects.gpu import AllReduceOperationAttr, ModuleEndOp, ModuleOp, Dim
 def test_dimension():
     dim = DimensionAttr.from_dimension("x")
 
-    assert dim.value.param.data == "x"
+    assert dim.data == "x"
 
 
 def test_all_reduce_operation():
     op = AllReduceOperationAttr.from_op("add")
 
-    assert op.value.param.data == "add"
+    assert op.data == "add"
 
 
 def test_gpu_module():

--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -1,5 +1,17 @@
 from xdsl.dialects.builtin import SymbolRefAttr
-from xdsl.dialects.gpu import ModuleEndOp, ModuleOp
+from xdsl.dialects.gpu import AllReduceOperationAttr, ModuleEndOp, ModuleOp, DimensionAttr
+
+
+def test_dimension():
+    dim = DimensionAttr.from_dimension("x")
+
+    assert dim.value.param.data == "x"
+
+
+def test_all_reduce_operation():
+    op = AllReduceOperationAttr.from_op("add")
+
+    assert op.value.param.data == "add"
 
 
 def test_gpu_module():

--- a/tests/filecheck/dialects/gpu/all_reduce_operation_unknown.mlir
+++ b/tests/filecheck/dialects/gpu/all_reduce_operation_unknown.mlir
@@ -1,0 +1,6 @@
+// RUN: xdsl-opt --parsing-diagnostics %s | filecheck %s
+
+"builtin.module"() ({
+}) {"wrong_all_reduce_operation" = #gpu<all_reduce_op magic>}: () -> ()
+
+// CHECK: Unexpected op magic. A gpu all_reduce_op can only be add, and, max, min, mul, or, or xor

--- a/tests/filecheck/dialects/gpu/dimension_unknown.mlir
+++ b/tests/filecheck/dialects/gpu/dimension_unknown.mlir
@@ -1,0 +1,6 @@
+// RUN: xdsl-opt --parsing-diagnostics %s | filecheck %s
+
+"builtin.module"() ({
+}) {"wrong_dim" = #gpu<dim w>}: () -> ()
+
+// CHECK: Unexpected dim w. A gpu dim can only be x, y, or z

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/example.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/example.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
     "gpu.module"()({
-        "gpu.module_end"() : () -> ()
+        "gpu.module_end"() {"test_all_reduce_op" = #gpu<all_reduce_op add>, "test_dim" = #gpu<dim x>} : () -> ()
     }) {"sym_name" = "gpu"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:     "gpu.module"() ({
-// CHECK-NEXT:          "gpu.module_end"() : () -> ()
+// CHECK-NEXT:          "gpu.module_end"() {"test_all_reduce_op" = #gpu<all_reduce_op add>, "test_dim" = #gpu<dim x>} : () -> ()
 // CHECK-NEXT:     }) {"sym_name" = "gpu"} : () -> ()
 
 // CHECK-NEXT: }) : () -> ()

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -1,9 +1,93 @@
 from __future__ import annotations
+from typing import Generic, Type, TypeVar
 
-from xdsl.ir import Operation, Dialect
-from xdsl.irdl import irdl_op_definition, SingleBlockRegion, OpAttr
+from xdsl.ir import Attribute, Operation, Dialect, ParametrizedAttribute
+from xdsl.irdl import ParameterDef, irdl_op_definition, irdl_attr_definition, SingleBlockRegion, OpAttr
 from xdsl.dialects.builtin import StringAttr, SymbolRefAttr
+from xdsl.parser import BaseParser
+from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
+
+
+@irdl_attr_definition
+class _AllReduceOperationAttr(ParametrizedAttribute):
+    name = "all_reduce_op"
+
+    param: ParameterDef[StringAttr]
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print(f"all_reduce_op {self.param.data}")
+
+
+@irdl_attr_definition
+class _DimensionAttr(ParametrizedAttribute):
+    name = "dim"
+
+    param: ParameterDef[StringAttr]
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print(f"dim {self.param.data}")
+
+
+T = TypeVar('T',
+            bound=_AllReduceOperationAttr | _DimensionAttr,
+            covariant=True)
+
+
+@irdl_attr_definition
+class _GPUAttr(ParametrizedAttribute, Generic[T]):
+    name = "gpu"
+
+    value: ParameterDef[T]
+
+    @staticmethod
+    def parse_parameters(parser: BaseParser) -> list[Attribute]:
+        parser.parse_characters("<", f"Expected <")
+        ntok = parser.tokenizer.next_token()
+
+        if ntok.text == "dim":
+            attrtype = _DimensionAttr
+            vtok = parser.tokenizer.next_token()
+            if vtok.text not in ["x", "y", "z"]:
+                parser.raise_error(
+                    f"Unexpected dim {vtok.text}. A gpu dim can only be x, y, or z",
+                    vtok)
+
+        elif ntok.text == "all_reduce_op":
+            attrtype = _AllReduceOperationAttr
+            vtok = parser.tokenizer.next_token()
+            if vtok.text not in [
+                    "add", "and", "max", "min", "mul", "or", "xor"
+            ]:
+                parser.raise_error(
+                    f"Unexpected op {vtok.text}. A gpu all_reduce_op can only be add, "
+                    "and, max, min, mul, or, or xor ", vtok)
+        else:
+            parser.raise_error(
+                f"Unexpected token {ntok.text}. Expected dim or all_reduce_op",
+                ntok)
+        parser.parse_characters(">", f"Expected >")
+        return [attrtype([StringAttr.from_str(vtok.text)])]
+
+    @classmethod
+    def from_op(cls: Type[_GPUAttr[_AllReduceOperationAttr]],
+                value: str) -> AllReduceOperationAttr:
+        return AllReduceOperationAttr(
+            [_AllReduceOperationAttr([StringAttr(value)])])
+
+    @classmethod
+    def from_dimension(cls: Type[_GPUAttr[_DimensionAttr]],
+                       value: str) -> DimensionAttr:
+        return DimensionAttr([_DimensionAttr([StringAttr(value)])])
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print_string("<")
+        self.value.print_parameters(printer)
+        printer.print_string(">")
+
+
+DimensionAttr = _GPUAttr[_DimensionAttr]
+AllReduceOperationAttr = _GPUAttr[_AllReduceOperationAttr]
 
 
 @irdl_op_definition
@@ -33,4 +117,4 @@ class ModuleEndOp(Operation):
         return ModuleEndOp.build()
 
 
-GPU = Dialect([ModuleOp, ModuleEndOp], [])
+GPU = Dialect([ModuleOp, ModuleEndOp], [_GPUAttr])

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -42,7 +42,10 @@ class _GPUAttr(ParametrizedAttribute, Generic[T]):
 
     @staticmethod
     def parse_parameters(parser: BaseParser) -> list[Attribute]:
-        parser.parse_characters("<", f"Expected <. gpu attributes currently have the #gpu<name value> syntax.")
+        parser.parse_characters(
+            "<",
+            f"Expected <. gpu attributes currently have the #gpu<name value> syntax."
+        )
         ntok = parser.tokenizer.next_token()
 
         if ntok.text == "dim":
@@ -66,7 +69,10 @@ class _GPUAttr(ParametrizedAttribute, Generic[T]):
             parser.raise_error(
                 f"Unexpected token {ntok.text}. Expected dim or all_reduce_op",
                 ntok)
-        parser.parse_characters(">", f"Expected >. gpu attributes currently have the #gpu<name value> syntax.")
+        parser.parse_characters(
+            ">",
+            f"Expected >. gpu attributes currently have the #gpu<name value> syntax."
+        )
         return [attrtype([StringAttr.from_str(vtok.text)])]
 
     @classmethod

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -42,7 +42,7 @@ class _GPUAttr(ParametrizedAttribute, Generic[T]):
 
     @staticmethod
     def parse_parameters(parser: BaseParser) -> list[Attribute]:
-        parser.parse_characters("<", f"Expected <")
+        parser.parse_characters("<", f"Expected <. gpu attributes currently have the #gpu<name value> syntax.")
         ntok = parser.tokenizer.next_token()
 
         if ntok.text == "dim":
@@ -66,7 +66,7 @@ class _GPUAttr(ParametrizedAttribute, Generic[T]):
             parser.raise_error(
                 f"Unexpected token {ntok.text}. Expected dim or all_reduce_op",
                 ntok)
-        parser.parse_characters(">", f"Expected >")
+        parser.parse_characters(">", f"Expected >. gpu attributes currently have the #gpu<name value> syntax.")
         return [attrtype([StringAttr.from_str(vtok.text)])]
 
     @classmethod

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -75,6 +75,10 @@ class _GPUAttr(ParametrizedAttribute, Generic[T]):
         return AllReduceOperationAttr(
             [_AllReduceOperationAttr([StringAttr(value)])])
 
+    @property
+    def data(self) -> str:
+        return self.value.param.data
+
     @classmethod
     def from_dimension(cls: Type[_GPUAttr[_DimensionAttr]],
                        value: str) -> DimensionAttr:


### PR DESCRIPTION
Following #456.
The attributes definition is definitely hacky, hence the self-sufficient PR, but I can't really do better with the current MLIR syntax.

I could go for a builtin attribute, but this implies deep dependencies that I don't think we want. Work is undergoing to get the MLIR syntax fixed, so I figured it was better to have a self contained hack here in the gpu dialect, to just reimplement it cleanly in-place when fixed in MLIR, rather than expecting a deep refactor.