### PR TITLE
install: Switch to using entry_points for xdsl-opt script.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     description="xDSL",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    scripts=['xdsl/tools/xdsl-opt'],
+    entry_points={"console_scripts": ["xdsl-opt = xdsl.tools.xdsl_opt:main"]},
     project_urls={
         "Source Code": "https://github.com/xdslproject/xdsl",
         "Issue Tracker": "https://github.com/xdslproject/xdsl/issues",

--- a/xdsl/tools/xdsl_opt.py
+++ b/xdsl/tools/xdsl_opt.py
@@ -1,0 +1,5 @@
+from xdsl.xdsl_opt_main import xDSLOptMain
+
+
+def main():
+    xDSLOptMain().run()


### PR DESCRIPTION
This makes the script automatically work on all platforms, the previous method only worked on linux.