### PR TITLE
builtin: Add SymbolRefAttr.string_value

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -2,7 +2,7 @@ import pytest
 
 from xdsl.dialects.builtin import (DenseArrayBase, DenseIntOrFPElementsAttr,
                                    i32, f32, FloatAttr, ArrayAttr, IntAttr,
-                                   FloatData)
+                                   FloatData, SymbolRefAttr)
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -45,3 +45,12 @@ def test_DenseArrayBase_verifier_failure():
         DenseArrayBase([i32, ArrayAttr.from_list([FloatData(0.0)])])
     assert err.value.args[0] == ("dense array of integer element type "
                                  "should only contain integers")
+
+
+@pytest.mark.parametrize('ref,expected', (
+    (SymbolRefAttr.from_str('test'), 'test'),
+    (SymbolRefAttr.from_str('test', ["2"]), 'test.2'),
+    (SymbolRefAttr.from_str('test', ["2", "3"]), 'test.2.3'),
+))
+def test_SymbolRefAttr_string_value(ref: SymbolRefAttr, expected: str):
+    assert ref.string_value() == expected

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -141,6 +141,12 @@ class SymbolRefAttr(ParametrizedAttribute):
                          nested: List[StringAttr] = []) -> SymbolRefAttr:
         return SymbolRefAttr([root, ArrayAttr(nested)])
 
+    def string_value(self):
+        root = self.root_reference.data
+        for ref in self.nested_references.data:
+            root += '.' + ref.data
+        return root
+
 
 @irdl_attr_definition
 class IntAttr(Data[int]):


### PR DESCRIPTION
This adds `SymbolRefAttr.string_value()` to retrieve the string value of the ref attr. For example:

 - `@func_name` -> `func_name`
 - `@func.test` -> `func.test`