### PR TITLE
dialects: Add mlir conversion test for memref ops

### DIFF
--- a/tests/filecheck/dialects/memref/memref_ops.xdsl
+++ b/tests/filecheck/dialects/memref/memref_ops.xdsl
@@ -2,7 +2,7 @@
 
 builtin.module() {
   
-  memref.global() ["sym_name" = "g", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !index], !i32>, [0 : !i64]>, "sym_visibility" = "public"]
+  memref.global() ["sym_name" = "g", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !index], !index>, [0 : !i64]>, "sym_visibility" = "public"]
 
   func.func() ["sym_name" = "memref_test", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
     %0 : !memref<[1 : !i64], !index> = memref.get_global() ["name" = @g]
@@ -18,7 +18,7 @@ builtin.module() {
     func.return()
   }
 
-  // CHECK: memref.global() ["sym_name" = "g", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !index], !i32>, [0 : !i64]>, "sym_visibility" = "public"]
+  // CHECK: memref.global() ["sym_name" = "g", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !index], !index>, [0 : !i64]>, "sym_visibility" = "public"]
   // CHECK-NEXT: func.func() ["sym_name" = "memref_test"
   // CHECK-NEXT:  %{{.*}} : !memref<[1 : !i64], !index> = memref.get_global() ["name" = @g]
   // CHECK-NEXT:  %{{.*}} : !index = arith.constant() ["value" = 0 : !index]

--- a/tests/filecheck/dialects/memref/memref_ops_mlir_conversion.xdsl
+++ b/tests/filecheck/dialects/memref/memref_ops_mlir_conversion.xdsl
@@ -1,0 +1,38 @@
+// RUN: xdsl-opt -t mlir %s | filecheck %s
+
+builtin.module() {
+  
+  memref.global() ["sym_name" = "g", "type" = !memref<[1 : !i64], !index>, "initial_value" = !dense<!tensor<[1 : !index], !index>, [0 : !i64]>, "sym_visibility" = "public"]
+
+  func.func() ["sym_name" = "memref_test", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
+    %0 : !memref<[1 : !i64], !index> = memref.get_global() ["name" = @g]
+    %1 : !index = arith.constant() ["value" = 0 : !index]
+    %2 : !memref<[1 : !index], !index> = memref.alloca() ["alignment" = 0 : !i64, "operand_segment_sizes" = array<!i32: 0, 0>]
+    %3 : !index = arith.constant() ["value" = 42 : !index]
+    memref.store(%3 : !index, %2 : !memref<[1 : !index], !index>, %1 : !index)
+    %4 : !index = memref.load(%2 : !memref<[1 : !index], !index>, %1 : !index)
+    %5 : !memref<[10 : !index, 2 : !index], !index> = memref.alloc() ["alignment" = 0 : !i64, "operand_segment_sizes" = array<!i32: 0, 0>]
+    memref.store(%3 : !index, %5 : !memref<[10 : !index, 2 : !index], !index>, %3 : !index, %4 : !index)
+    memref.dealloc(%2 : !memref<[1 : !index], !index>)
+    memref.dealloc(%5 : !memref<[10 : !index, 2 : !index], !index>)
+    func.return()
+  }
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT: "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<[0]> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
+// CHECK-NEXT: "func.func"() ({
+// CHECK-NEXT: %0 = "memref.get_global"() {"name" = @g} : () -> memref<1xindex>
+// CHECK-NEXT: %1 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT: %2 = "memref.alloca"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
+// CHECK-NEXT: %3 = "arith.constant"() {"value" = 42 : index} : () -> index
+// CHECK-NEXT: "memref.store"(%3, %2, %1) : (index, memref<1xindex>, index) -> ()
+// CHECK-NEXT: %4 = "memref.load"(%2, %1) : (memref<1xindex>, index) -> index
+// CHECK-NEXT: %5 = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<10x2xindex>
+// CHECK-NEXT: "memref.store"(%3, %5, %3, %4) : (index, memref<10x2xindex>, index, index) -> ()
+// CHECK-NEXT: "memref.dealloc"(%2) : (memref<1xindex>) -> ()
+// CHECK-NEXT: "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
+// CHECK-NEXT: "func.return"() : () -> ()
+// CHECK-NEXT: }) {"sym_name" = "memref_test", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT: }) : () -> ()
+
+}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.xdsl
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.xdsl
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | filecheck %s
+// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
 
 builtin.module() {
   
@@ -19,7 +19,7 @@ builtin.module() {
   }
 
 // CHECK: "builtin.module"() ({
-// CHECK-NEXT: "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<[0]> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
+// CHECK-NEXT: "memref.global"() {"initial_value" = dense<[0]> : tensor<1xindex>, "sym_name" = "g", "sym_visibility" = "public", "type" = memref<1xindex>} : () -> ()
 // CHECK-NEXT: "func.func"() ({
 // CHECK-NEXT: %0 = "memref.get_global"() {"name" = @g} : () -> memref<1xindex>
 // CHECK-NEXT: %1 = "arith.constant"() {"value" = 0 : index} : () -> index
@@ -32,7 +32,7 @@ builtin.module() {
 // CHECK-NEXT: "memref.dealloc"(%2) : (memref<1xindex>) -> ()
 // CHECK-NEXT: "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
 // CHECK-NEXT: "func.return"() : () -> ()
-// CHECK-NEXT: }) {"sym_name" = "memref_test", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT: }) {"function_type" = () -> (), "sym_name" = "memref_test", "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()
 
 }


### PR DESCRIPTION
This PR intends to fix the lowering of memref ops to llvm ir and also add a corresponding mlir conversion test (inspired from vector dialect). 

When we try to lower the current memref ir from [here](https://github.com/xdslproject/xdsl/blob/main/tests/filecheck/memref_ops.xdsl), we get the following error 
```
error: 'memref.global' op initial value expected to be of type 'tensor<1xindex>', but was of type 'tensor<1xi32>'
  "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<[0]> : tensor<1xi32>, "sym_visibility" = "public"} : () -> ()
  ^
```
Lowering was done as follows: 
```
./xdsl/tools/xdsl-opt -t mlir ./tests/filecheck/memref_ops.xdsl > mlir_memref_check.mlir
``` 
and then 
```
<path-to-mlir-opt> --convert-scf-to-cf --convert-cf-to-llvm --convert-func-to-llvm --convert-arith-to-llvm --convert-memref-to-llvm --convert-vector-to-llvm --reconcile-unrealized-casts mlir_memref_check.mlir | <path-to-mlir-translate> --mlir-to-llvmir > tmp.ll
```
This PR should fix this behaviour. 