### PR TITLE
[RFC] core: Phase out use of `Dialect`

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -6,10 +6,7 @@ from xdsl.dialects.arith import Addi, Subi, Constant
 from xdsl.dialects.builtin import IntegerType, i32, IntegerAttr, ModuleOp
 from xdsl.dialects.scf import If
 from xdsl.parser import XDSLParser
-from xdsl.dialects.builtin import Builtin
-from xdsl.dialects.func import Func
-from xdsl.dialects.arith import Arith
-from xdsl.dialects.cf import Cf
+from xdsl.dialects import cf, arith, func, builtin
 
 
 def test_ops_accessor():
@@ -213,10 +210,10 @@ program_successors = \
      ([program_successors, program_add], False)])
 def test_is_structurally_equivalent(args: list[str], expected_result: bool):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Func)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Cf)
+    ctx.register_dialect(builtin)
+    ctx.register_dialect(func)
+    ctx.register_dialect(arith)
+    ctx.register_dialect(cf)
 
     parser = XDSLParser(ctx, args[0])
     lhs: Operation = parser.parse_op()
@@ -241,10 +238,10 @@ def test_is_structurally_equivalent_incompatible_ir_nodes():
   }
   """
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Func)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Cf)
+    ctx.register_dialect(builtin)
+    ctx.register_dialect(func)
+    ctx.register_dialect(arith)
+    ctx.register_dialect(cf)
 
     parser = XDSLParser(ctx, program_func)
     program = parser.parse_operation()

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1,6 +1,7 @@
-from xdsl.dialects.arith import Arith, Constant, Addi, Muli
-from xdsl.dialects.builtin import i32, i64, Builtin, IntegerAttr, ModuleOp
-from xdsl.dialects.scf import If, Scf
+from xdsl.dialects.arith import Constant, Addi, Muli
+from xdsl.dialects.builtin import i32, i64, IntegerAttr, ModuleOp
+from xdsl.dialects.scf import If
+from xdsl.dialects import scf, arith, builtin
 from xdsl.ir import MLContext, Region, Operation
 from xdsl.pattern_rewriter import (PatternRewriteWalker,
                                    op_type_rewrite_pattern, RewritePattern,
@@ -14,9 +15,9 @@ from conftest import assert_print_op
 def rewrite_and_compare(prog: str, expected_prog: str,
                         walker: PatternRewriteWalker):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Scf)
+    ctx.register_dialect(builtin)
+    ctx.register_dialect(arith)
+    ctx.register_dialect(scf)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -446,8 +447,8 @@ def test_operation_deletion_failure():
     """Test rewrites where SSA values are deleted with still uses."""
 
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Arith)
+    ctx.register_dialect(builtin)
+    ctx.register_dialect(arith)
 
     prog = \
 """builtin.module() {

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -1,10 +1,10 @@
 from typing import Callable
 from conftest import assert_print_op
 
-from xdsl.dialects.arith import Arith, Constant, Addi
-from xdsl.dialects.builtin import ModuleOp, Builtin, i32
-from xdsl.dialects.scf import Scf, Yield
-from xdsl.dialects.func import Func
+from xdsl.dialects.arith import Constant, Addi
+from xdsl.dialects.builtin import ModuleOp, i32
+from xdsl.dialects.scf import Yield
+from xdsl.dialects import func, scf, builtin, arith
 from xdsl.ir import MLContext, Block
 from xdsl.parser import Parser
 from xdsl.rewriter import Rewriter
@@ -13,10 +13,10 @@ from xdsl.rewriter import Rewriter
 def rewrite_and_compare(prog: str, expected_prog: str,
                         transformation: Callable[[ModuleOp, Rewriter], None]):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Scf)
-    ctx.register_dialect(Func)
+    ctx.register_dialect(builtin)
+    ctx.register_dialect(arith)
+    ctx.register_dialect(scf)
+    ctx.register_dialect(func)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from xdsl.dialects.builtin import AnyIntegerAttr, IndexType, IntegerAttr
-from xdsl.ir import Operation, SSAValue, Block, Region, Dialect
+from xdsl.ir import Operation, SSAValue, Block, Region
 from xdsl.irdl import (OpAttr, VarOpResult, irdl_op_definition, VarOperand,
                        AnyAttr)
 

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -86,6 +86,3 @@ class Yield(Operation):
     def get(*operands: SSAValue | Operation) -> Yield:
         return Yield.create(
             operands=[SSAValue.get(operand) for operand in operands])
-
-
-Affine = Dialect([For, Yield], [])

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -43,7 +43,7 @@ _ArrayAttrT = TypeVar("_ArrayAttrT", bound=Attribute, covariant=True)
 
 @irdl_attr_definition
 class ArrayAttr(GenericData[List[_ArrayAttrT]]):
-    name: str = "array"
+    name: str = "array_attr"
 
     @staticmethod
     def parse_parameter(parser: BaseParser) -> List[_ArrayAttrT]:

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated, List, Union
 
 from xdsl.dialects.builtin import IntegerType
-from xdsl.ir import SSAValue, Operation, Block, Dialect
+from xdsl.ir import SSAValue, Operation, Block
 from xdsl.irdl import (irdl_op_definition, VarOperand, AnyAttr, Operand,
                        AttrSizedOperandSegments)
 

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -35,6 +35,3 @@ class ConditionalBranch(Operation):
             else_ops: List[Union[Operation, SSAValue]]) -> ConditionalBranch:
         return ConditionalBranch.build(operands=[cond, then_ops, else_ops],
                                        successors=[then_block, else_block])
-
-
-Cf = Dialect([Branch, ConditionalBranch], [])

--- a/xdsl/dialects/cmath.py
+++ b/xdsl/dialects/cmath.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 from typing import Annotated, Union
 
 from xdsl.dialects.builtin import Float32Type, Float64Type
-from xdsl.ir import (MLIRType, ParametrizedAttribute, Operation,
-                     OpResult, SSAValue)
+from xdsl.ir import (MLIRType, ParametrizedAttribute, Operation, OpResult,
+                     SSAValue)
 from xdsl.irdl import (irdl_op_definition, irdl_attr_definition, Operand,
                        ParameterDef, ParamAttrConstraint, AnyOf,
                        VerifyException)

--- a/xdsl/dialects/cmath.py
+++ b/xdsl/dialects/cmath.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Annotated, Union
 
 from xdsl.dialects.builtin import Float32Type, Float64Type
-from xdsl.ir import (MLIRType, ParametrizedAttribute, Operation, Dialect,
+from xdsl.ir import (MLIRType, ParametrizedAttribute, Operation,
                      OpResult, SSAValue)
 from xdsl.irdl import (irdl_op_definition, irdl_attr_definition, Operand,
                        ParameterDef, ParamAttrConstraint, AnyOf,

--- a/xdsl/dialects/cmath.py
+++ b/xdsl/dialects/cmath.py
@@ -59,6 +59,3 @@ class Mul(Operation):
         operand1 = SSAValue.get(operand1)
         return Mul.build(operands=[operand1, operand2],
                          result_types=[operand1.typ])
-
-
-CMath = Dialect([Norm, Mul], [ComplexType])

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -343,27 +343,3 @@ class Combine(Operation):
     res: VarOpResult
 
     irdl_options = [AttrSizedOperandSegments()]
-
-
-Dialect([
-    Cast,
-    External_Load,
-    External_Store,
-    Index,
-    Access,
-    DynAccess,
-    Load,
-    Buffer,
-    Store,
-    Apply,
-    StoreResult,
-    Return,
-    Combine,
-], [
-    FieldType,
-    TempType,
-    ResultType,
-    Stencil_Element,
-    Stencil_Index,
-    Stencil_Loop,
-])

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -5,7 +5,7 @@ from typing import cast, Any
 
 from xdsl.dialects.builtin import (ParametrizedAttribute, ArrayAttr, f32, f64,
                                    IntegerType, IndexType, IntAttr, AnyFloat)
-from xdsl.ir import Operation, Dialect, MLIRType
+from xdsl.ir import Operation, MLIRType
 from xdsl.irdl import (irdl_attr_definition, irdl_op_definition, ParameterDef,
                        AttrConstraint, Attribute, Region, VerifyException,
                        AnyOf, Annotated, Operand, OpAttr, OpResult, VarOperand,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Generic, Type, TypeVar
 
-from xdsl.ir import Attribute, Operation, Dialect, ParametrizedAttribute
+from xdsl.ir import Attribute, Operation, ParametrizedAttribute
 from xdsl.irdl import ParameterDef, irdl_op_definition, irdl_attr_definition, SingleBlockRegion, OpAttr
 from xdsl.dialects.builtin import StringAttr, SymbolRefAttr
 from xdsl.parser import BaseParser

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -125,6 +125,3 @@ class ModuleEndOp(Operation):
     @staticmethod
     def get() -> ModuleEndOp:
         return ModuleEndOp.build()
-
-
-GPU = Dialect([ModuleOp, ModuleEndOp], [_GPUAttr])

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -187,25 +187,3 @@ class OperationOp(Operation):
             if isinstance(op, ResultsOp):
                 return op
         return None
-
-
-IRDL = Dialect(
-    [
-        DialectOp,
-        ParametersOp,
-        TypeOp,
-        ConstraintVarsOp,
-        OperandsOp,
-        ResultsOp,
-        OperationOp,
-    ],
-    [
-        AnyTypeConstraintAttr,
-        AnyOfTypeConstraintAttr,  #
-        EqTypeConstraintAttr,
-        VarTypeConstraintAttr,
-        TypeParamsConstraintAttr,
-        NamedTypeConstraintAttr,
-        DynTypeBaseConstraintAttr,
-        DynTypeParamsConstraintAttr
-    ])

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import cast
 
 from xdsl.dialects.builtin import AnyArrayAttr, ArrayAttr, StringAttr
-from xdsl.ir import (ParametrizedAttribute, Operation, Attribute, Dialect)
+from xdsl.ir import (ParametrizedAttribute, Operation, Attribute)
 from xdsl.irdl import (ParameterDef, irdl_op_definition, irdl_attr_definition,
                        SingleBlockRegion, OpAttr)
 from xdsl.parser import BaseParser

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Annotated
 from xdsl.dialects.builtin import (StringAttr, ArrayAttr, DenseArrayBase,
                                    IntAttr, NoneAttr, IntegerType, IntegerAttr,
                                    AnyIntegerAttr, IndexType)
-from xdsl.ir import (MLIRType, ParametrizedAttribute, Attribute, Dialect,
+from xdsl.ir import (MLIRType, ParametrizedAttribute, Attribute,
                      OpResult, Operation, SSAValue)
 from xdsl.irdl import (OpAttr, Operand, ParameterDef, AnyAttr,
                        irdl_attr_definition, irdl_op_definition)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Annotated
 from xdsl.dialects.builtin import (StringAttr, ArrayAttr, DenseArrayBase,
                                    IntAttr, NoneAttr, IntegerType, IntegerAttr,
                                    AnyIntegerAttr, IndexType)
-from xdsl.ir import (MLIRType, ParametrizedAttribute, Attribute,
-                     OpResult, Operation, SSAValue)
+from xdsl.ir import (MLIRType, ParametrizedAttribute, Attribute, OpResult,
+                     Operation, SSAValue)
 from xdsl.irdl import (OpAttr, Operand, ParameterDef, AnyAttr,
                        irdl_attr_definition, irdl_op_definition)
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -209,14 +209,3 @@ class LLVMMLIRUndef(Operation):
     name = "llvm.mlir.undef"
 
     res: Annotated[OpResult, AnyAttr()]
-
-
-LLVM = Dialect([
-    LLVMExtractValue,
-    LLVMInsertValue,
-    LLVMMLIRUndef,
-    AllocaOp,
-    IntToPtrOp,
-    NullOp,
-    LoadOp,
-], [LLVMStructType, LLVMPointerType])

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -316,16 +316,3 @@ class ExtractAlignedPointerAsIndexOp(Operation):
     def get(source: SSAValue | Operation):
         return ExtractAlignedPointerAsIndexOp.build(operands=[source],
                                                     result_types=[IndexType()])
-
-
-MemRef = Dialect([
-    Load,
-    Store,
-    Alloc,
-    Alloca,
-    Dealloc,
-    GetGlobal,
-    Global,
-    Dim,
-    ExtractAlignedPointerAsIndexOp,
-], [MemRefType, UnrankedMemrefType])

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -6,7 +6,7 @@ from xdsl.dialects.builtin import (DenseIntOrFPElementsAttr, IntegerAttr,
                                    IndexType, ArrayAttr, IntegerType,
                                    SymbolRefAttr, StringAttr, UnitAttr)
 from xdsl.ir import (MLIRType, Operation, SSAValue, ParametrizedAttribute,
-                    OpResult)
+                     OpResult)
 from xdsl.irdl import (irdl_attr_definition, irdl_op_definition, ParameterDef,
                        Generic, Attribute, AnyAttr, Operand, VarOperand,
                        AttrSizedOperandSegments, OpAttr)

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -6,7 +6,7 @@ from xdsl.dialects.builtin import (DenseIntOrFPElementsAttr, IntegerAttr,
                                    IndexType, ArrayAttr, IntegerType,
                                    SymbolRefAttr, StringAttr, UnitAttr)
 from xdsl.ir import (MLIRType, Operation, SSAValue, ParametrizedAttribute,
-                     Dialect, OpResult)
+                    OpResult)
 from xdsl.irdl import (irdl_attr_definition, irdl_op_definition, ParameterDef,
                        Generic, Attribute, AnyAttr, Operand, VarOperand,
                        AttrSizedOperandSegments, OpAttr)

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -6,7 +6,7 @@ from enum import Enum
 from xdsl.dialects.builtin import (IntegerType, Signedness, IntegerAttr,
                                    AnyFloatAttr, AnyIntegerAttr, StringAttr)
 from xdsl.dialects.memref import MemRefType
-from xdsl.ir import Operation, Attribute, SSAValue, OpResult, ParametrizedAttribute, Dialect, MLIRType
+from xdsl.ir import Operation, Attribute, SSAValue, OpResult, ParametrizedAttribute, MLIRType
 from xdsl.irdl import (Operand, Annotated, irdl_op_definition,
                        irdl_attr_definition, OpAttr, OptOpResult)
 

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -340,16 +340,3 @@ class Init(MPIBaseOp):
 @irdl_op_definition
 class Finalize(MPIBaseOp):
     name = "mpi.finalize"
-
-
-MPI = Dialect([
-    ISend,
-    IRecv,
-    Test,
-    Recv,
-    Send,
-    GetStatusField,
-    Init,
-    Finalize,
-    CommRank,
-], [RequestType, StatusType])

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated, List
 
 from xdsl.dialects.builtin import IndexType, IntegerType
-from xdsl.ir import Attribute, Block, Dialect, Operation, Region, SSAValue
+from xdsl.ir import Attribute, Block, Operation, Region, SSAValue
 from xdsl.irdl import (AnyAttr, Operand, SingleBlockRegion, VarOperand,
                        VarOpResult, irdl_op_definition)
 from xdsl.utils.exceptions import VerifyException

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -150,6 +150,3 @@ class While(Operation):
                          result_types=result_types,
                          regions=[before, after])
         return op
-
-
-Scf = Dialect([If, For, Yield, Condition, While], [])

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -3,7 +3,7 @@ from typing import Annotated, List, cast
 
 from xdsl.dialects.builtin import IndexType, VectorType, i1
 from xdsl.dialects.memref import MemRefType
-from xdsl.ir import Attribute, Operation, SSAValue, Dialect, OpResult
+from xdsl.ir import Attribute, Operation, SSAValue, OpResult
 from xdsl.irdl import AnyAttr, irdl_op_definition, Operand, VarOperand
 from xdsl.utils.exceptions import VerifyException
 

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -262,8 +262,3 @@ class Createmask(Operation):
         return Createmask.build(
             operands=[mask_operands],
             result_types=[VectorType.from_element_type_and_shape(i1, [1])])
-
-
-Vector = Dialect(
-    [Load, Store, Broadcast, FMA, Maskedload, Maskedstore, Print, Createmask],
-    [])

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -65,9 +65,6 @@ class MLContext:
             # skip stuff not defined in this module
             if val.__module__ != dialect.__name__:
                 continue
-            # skip private stuff
-            if name.startswith('_'):
-                continue
             # register all operations
             if issubclass(val, Operation):
                 self.register_op(val)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -6,18 +6,8 @@ from io import StringIO
 from xdsl.ir import MLContext
 from xdsl.parser import XDSLParser, MLIRParser, ParseError
 from xdsl.printer import Printer
-from xdsl.dialects.func import Func
-from xdsl.dialects.scf import Scf
-from xdsl.dialects.affine import Affine
-from xdsl.dialects.arith import Arith
-from xdsl.dialects.builtin import ModuleOp, Builtin
-from xdsl.dialects.cmath import CMath
-from xdsl.dialects.cf import Cf
-from xdsl.dialects.vector import Vector
-from xdsl.dialects.memref import MemRef
-from xdsl.dialects.llvm import LLVM
-from xdsl.dialects.irdl import IRDL
-from xdsl.dialects.gpu import GPU
+from xdsl.dialects import affine, arith, builtin, cf, cmath, func, gpu, irdl, llvm, memref, scf, vector
+from xdsl.dialects.builtin import ModuleOp
 
 from xdsl.irdl_mlir_printer import IRDLPrinter
 from xdsl.utils.exceptions import DiagnosticException
@@ -176,18 +166,18 @@ class xDSLOptMain:
 
         Add other/additional dialects by overloading this function.
         """
-        self.ctx.register_dialect(Builtin)
-        self.ctx.register_dialect(Func)
-        self.ctx.register_dialect(Arith)
-        self.ctx.register_dialect(MemRef)
-        self.ctx.register_dialect(Affine)
-        self.ctx.register_dialect(Scf)
-        self.ctx.register_dialect(Cf)
-        self.ctx.register_dialect(CMath)
-        self.ctx.register_dialect(IRDL)
-        self.ctx.register_dialect(LLVM)
-        self.ctx.register_dialect(Vector)
-        self.ctx.register_dialect(GPU)
+        self.ctx.register_dialect(builtin)
+        self.ctx.register_dialect(func)
+        self.ctx.register_dialect(arith)
+        self.ctx.register_dialect(memref)
+        self.ctx.register_dialect(affine)
+        self.ctx.register_dialect(scf)
+        self.ctx.register_dialect(cf)
+        self.ctx.register_dialect(cmath)
+        self.ctx.register_dialect(irdl)
+        self.ctx.register_dialect(llvm)
+        self.ctx.register_dialect(vector)
+        self.ctx.register_dialect(gpu)
 
     def register_all_frontends(self):
         """


### PR DESCRIPTION
I wanted to try and remove the `Dialect` class from xDSL, just to see how it would affect the code. I switched over to have a module containing a bunch of `Operation` and `Attribute` classes to be a dialect. I did not remove all the uses of dialect, there's a bunch of small stuff still left, mainly in tests.

Why i did that:

 - `Dialect` is just a thin wrapper around two lists, and only used to register them with the `MLContext`
 - I always forget to add stuff to the dialect definition, which then breaks stuff
 - It reduces LOC, and imo the Lines were not doing anything useful

Comments welcome! I get that this is pretty insane, so be gentle. I hope that this isn't going to become a huge discussion, just looking for some honest feedback.


Some info:

 - only classes defined in the package are added to the dialect
 - only non ABC classes will be added to the dialect

Note that I renamed the `ArrayAttr` to `array_attr` because the name clashed with `DenseArrayBase`, so that needs to be looked at I guess.