### PR TITLE
bug: Fix error message on missing Operands in the context of variadic Operands

### DIFF
--- a/tests/filecheck/irdl_missing_operand.xdsl
+++ b/tests/filecheck/irdl_missing_operand.xdsl
@@ -1,0 +1,9 @@
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+
+builtin.module() {
+  func.func() ["sym_name" = "arg_rec", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
+    ^0():
+     cf.cond_br() (^0) ["operand_segment_sizes" = array<!i32: 0, 0, 0>]
+     //CHECK: non-variadic operand then is expected to be of size 1 in operand_segment_sizes, but got 0
+  }
+}

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -780,8 +780,7 @@ def get_variadic_sizes_from_attr(op: Operation,
         if not isinstance(arg_def, VariadicDef) and arg_size != 1:
             raise VerifyException(
                 f"non-variadic {get_construct_name(construct)} {arg_name} is expected "
-                f"to be of size 1 in {size_attribute_name}, but got "
-                f"{arg_size}")
+                f"to be of size 1 in {size_attribute_name}, but got {arg_size}")
 
         if isinstance(arg_def, VariadicDef):
             variadic_sizes.append(arg_size)

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -780,7 +780,7 @@ def get_variadic_sizes_from_attr(op: Operation,
         if not isinstance(arg_def, VariadicDef) and arg_size != 1:
             raise VerifyException(
                 f"non-variadic {get_construct_name(construct)} {arg_name} is expected "
-                f"to be of size 0 or 1 in {size_attribute_name}, but got "
+                f"to be of size 1 in {size_attribute_name}, but got "
                 f"{arg_size}")
 
         if isinstance(arg_def, VariadicDef):

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -780,7 +780,8 @@ def get_variadic_sizes_from_attr(op: Operation,
         if not isinstance(arg_def, VariadicDef) and arg_size != 1:
             raise VerifyException(
                 f"non-variadic {get_construct_name(construct)} {arg_name} is expected "
-                f"to be of size 1 in {size_attribute_name}, but got {arg_size}")
+                f"to be of size 1 in {size_attribute_name}, but got {arg_size}"
+            )
 
         if isinstance(arg_def, VariadicDef):
             variadic_sizes.append(arg_size)


### PR DESCRIPTION
closes #493 

I argue that the `0 or` is not even needed here, as we know that if something is not a VariadicDef, it has to be a normal def (optionalDefs are also VariadicDefs), so only saying 1 is enough.