### PR TITLE
misc: add type annotations to build function

### DIFF
--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from xdsl.dialects.builtin import AnyIntegerAttr, IndexType, IntegerAttr
-from xdsl.ir import Operation, SSAValue, Block, Region, Dialect
+from xdsl.ir import Attribute, Operation, SSAValue, Block, Region, Dialect
 from xdsl.irdl import (OpAttr, VarOpResult, irdl_op_definition, VarOperand,
                        AnyAttr)
 
@@ -54,7 +54,7 @@ class For(Operation):
         if isinstance(step, int):
             step = IntegerAttr.from_index_int_value(step)
         result_types = [SSAValue.get(op).typ for op in operands]
-        attributes = {
+        attributes: dict[str, Attribute] = {
             "lower_bound": lower_bound,
             "upper_bound": upper_bound,
             "step": step,

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -31,7 +31,7 @@ class FuncOp(Operation):
                       return_types: List[Attribute],
                       func: Block.BlockCallback) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
-        attributes = {
+        attributes: dict[str, Attribute] = {
             "sym_name": StringAttr(name),
             "function_type": type_attr,
             "sym_visibility": StringAttr("private")
@@ -47,7 +47,7 @@ class FuncOp(Operation):
     def external(name: str, input_types: List[Attribute],
                  return_types: List[Attribute]) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
-        attributes = {
+        attributes: dict[str, Attribute] = {
             "sym_name": StringAttr(name),
             "function_type": type_attr,
             "sym_visibility": StringAttr("private")
@@ -60,7 +60,7 @@ class FuncOp(Operation):
     def from_region(name: str, input_types: List[Attribute],
                     return_types: List[Attribute], region: Region) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
-        attributes = {
+        attributes: dict[str, Attribute] = {
             "sym_name": StringAttr(name),
             "function_type": type_attr,
             "sym_visibility": StringAttr("private")

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -118,12 +118,13 @@ class AllReduceOp(Operation):
     def from_op(op: AllReduceOperationAttr,
                 operand: SSAValue | Operation,
                 uniform: UnitAttr | None = None):
+        attributes: dict[str, Attribute] = {"op": op}
+        if uniform is not None:
+            attributes["uniform"] = uniform
+
         return AllReduceOp.build(operands=[operand],
                                  result_types=[SSAValue.get(operand).typ],
-                                 attributes={"op": op}
-                                 | ({
-                                     "uniform": uniform
-                                 } if uniform is not None else {}),
+                                 attributes=attributes,
                                  regions=[Region()])
 
     @staticmethod

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -283,8 +283,8 @@ class LaunchOp(Operation):
         operands = [[] if asyncDependencies is None else
                     [SSAValue.get(a) for a in asyncDependencies]]
 
-        operands += [gs for gs in gridSize]
-        operands += [bs for bs in blockSize]
+        operands += [SSAValue.get(gs) for gs in gridSize]
+        operands += [SSAValue.get(bs) for bs in blockSize]
         operands += [[] if dynamicSharedMemorySize is None else
                      [SSAValue.get(dynamicSharedMemorySize)]]
         return LaunchOp.build(

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -263,10 +263,12 @@ class Global(Operation):
                             "dense type or an unit attribute")
 
     @staticmethod
-    def get(sym_name: str | StringAttr,
-            typ: Attribute,
-            initial_value: Optional[Attribute],
-            sym_visibility: str = "private") -> Global:
+    def get(
+        sym_name: StringAttr,
+        typ: Attribute,
+        initial_value: Attribute,
+        sym_visibility: StringAttr = StringAttr("private")
+    ) -> Global:
         return Global.build(
             attributes={
                 "sym_name": sym_name,

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -520,12 +520,14 @@ class Operation(IRNode):
         return cast(OpT, op)
 
     @classmethod
-    def build(cls: type[OpT],
-              operands: list[Any] | None = None,
-              result_types: list[Any] | None = None,
-              attributes: dict[str, Any] | None = None,
-              successors: list[Any] | None = None,
-              regions: list[Any] | None = None) -> OpT:
+    def build(
+        cls: type[OpT],
+        operands: list[Any] | None = None,
+        result_types: list[Any] | None = None,
+        attributes: dict[str, Any] | None = None,
+        successors: list[Any] | None = None,
+        regions: list[Region | list[Operation] | list[Block]] | None = None
+    ) -> OpT:
         """Create a new operation using builders."""
         ...
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -522,10 +522,14 @@ class Operation(IRNode):
     @classmethod
     def build(
         cls: type[OpT],
-        operands: list[Any] | None = None,
-        result_types: list[Any] | None = None,
+        operands: list[SSAValue | Operation
+                       | list[SSAValue | Operation]]
+        | list[SSAValue | Operation] | None = None,
+        result_types: list[Attribute | list[Attribute]] | list[list[Attribute]]
+        | list[Attribute]
+        | None = None,
         attributes: dict[str, Any] | None = None,
-        successors: list[Any] | None = None,
+        successors: list[Block] | None = None,
         regions: list[Region | list[Operation] | list[Block]] | None = None
     ) -> OpT:
         """Create a new operation using builders."""

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -528,7 +528,7 @@ class Operation(IRNode):
         result_types: list[Attribute | list[Attribute]] | list[list[Attribute]]
         | list[Attribute]
         | None = None,
-        attributes: dict[str, Any] | None = None,
+        attributes: dict[str, Attribute] | None = None,
         successors: list[Block] | None = None,
         regions: list[Region | list[Operation] | list[Block]] | None = None
     ) -> OpT:

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -524,7 +524,8 @@ class Operation(IRNode):
         cls: type[OpT],
         operands: list[SSAValue | Operation
                        | list[SSAValue | Operation]]
-        | list[SSAValue | Operation] | None = None,
+        | list[SSAValue | Operation] | list[SSAValue | list[SSAValue]]
+        | None = None,
         result_types: list[Attribute | list[Attribute]] | list[list[Attribute]]
         | list[Attribute]
         | None = None,

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -522,16 +522,15 @@ class Operation(IRNode):
     @classmethod
     def build(
         cls: type[OpT],
-        operands: list[SSAValue | Operation
-                       | list[SSAValue | Operation]]
-        | list[SSAValue | Operation] | list[SSAValue | list[SSAValue]]
+        operands: Sequence[SSAValue | Operation
+                           | Sequence[SSAValue | Operation]]
         | None = None,
-        result_types: list[Attribute | list[Attribute]] | list[list[Attribute]]
-        | list[Attribute]
+        result_types: Sequence[Attribute | Sequence[Attribute]]
         | None = None,
         attributes: dict[str, Attribute] | None = None,
-        successors: list[Block] | None = None,
-        regions: list[Region | list[Operation] | list[Block]] | None = None
+        successors: Sequence[Block] | None = None,
+        regions: Sequence[Region | Sequence[Operation] | Sequence[Block]]
+        | None = None
     ) -> OpT:
         """Create a new operation using builders."""
         ...

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -737,7 +737,8 @@ def get_attr_size_option(
 
 def get_variadic_sizes_from_attr(op: Operation,
                                  defs: Sequence[tuple[str,
-                                                      OperandDef | ResultDef]],
+                                                      OperandDef | ResultDef
+                                                      | RegionDef]],
                                  construct: VarIRConstruct,
                                  size_attribute_name: str) -> list[int]:
     """
@@ -955,12 +956,13 @@ def irdl_build_arg_list(construct: VarIRConstruct,
     return res, arg_sizes
 
 
-def irdl_op_builder(cls: type[_OpT], op_def: OpDef,
-                    operands: Sequence[SSAValue | Operation
-                                       | list[SSAValue | Operation] | None],
-                    res_types: Sequence[Any | list[Any] | None],
-                    attributes: dict[str, Any], successors: Sequence[Block],
-                    regions: Sequence[Any | None]) -> _OpT:
+def irdl_op_builder(
+        cls: type[_OpT], op_def: OpDef,
+        operands: Sequence[SSAValue | Operation
+                           | list[SSAValue | Operation] | None],
+        res_types: Sequence[Any | list[Any] | None],
+        attributes: dict[str, Any], successors: Sequence[Block],
+        regions: Sequence[Region | list[Operation] | list[Block]]) -> _OpT:
     """Builder for an irdl operation."""
 
     # We need irdl to define DenseArrayBase, but here we need
@@ -1072,12 +1074,14 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
             new_attrs[attribute_name] = property(
                 lambda self, name=attribute_name: self.attributes[name])
 
-    def builder(cls: type[_OpT],
-                operands: list[Any] | None = None,
-                result_types: list[Any] | None = None,
-                attributes: dict[str, Any] | None = None,
-                successors: list[Any] | None = None,
-                regions: list[Any] | None = None) -> _OpT:
+    def builder(
+        cls: type[_OpT],
+        operands: list[Any] | None = None,
+        result_types: list[Any] | None = None,
+        attributes: dict[str, Any] | None = None,
+        successors: list[Any] | None = None,
+        regions: list[Region | list[Operation] | list[Block]] | None = None
+    ) -> _OpT:
         if operands is None:
             operands = []
         if result_types is None:

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -961,7 +961,7 @@ def irdl_op_builder(
         operands: Sequence[SSAValue | Operation
                            | list[SSAValue | Operation] | None],
         res_types: Sequence[Any | list[Any] | None],
-        attributes: dict[str, Any], successors: Sequence[Block],
+        attributes: dict[str, Attribute], successors: Sequence[Block],
         regions: Sequence[Region | list[Operation] | list[Block]]) -> _OpT:
     """Builder for an irdl operation."""
 
@@ -1080,7 +1080,7 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
                        | list[SSAValue | Operation]] | None = None,
         result_types: list[Attribute | list[Attribute]] | list[Attribute]
         | None = None,
-        attributes: dict[str, Any] | None = None,
+        attributes: dict[str, Attribute] | None = None,
         successors: list[Block] | None = None,
         regions: list[Region | list[Operation] | list[Block]] | None = None
     ) -> _OpT:

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -959,11 +959,12 @@ def irdl_build_arg_list(construct: VarIRConstruct,
 def irdl_op_builder(
         cls: type[_OpT], op_def: OpDef,
         operands: Sequence[SSAValue | Operation
-                           | list[SSAValue | Operation] | list[SSAValue]
+                           | Sequence[SSAValue | Operation]
                            | None],
         res_types: Sequence[Any | list[Any] | None],
         attributes: dict[str, Attribute], successors: Sequence[Block],
-        regions: Sequence[Region | list[Operation] | list[Block]]) -> _OpT:
+        regions: Sequence[Region | Sequence[Operation] | Sequence[Block]]
+) -> _OpT:
     """Builder for an irdl operation."""
 
     # We need irdl to define DenseArrayBase, but here we need
@@ -1077,14 +1078,14 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
 
     def builder(
         cls: type[_OpT],
-        operands: list[SSAValue | Operation
-                       | list[SSAValue | Operation]]
-        | list[SSAValue | list[SSAValue]] | None = None,
-        result_types: list[Attribute | list[Attribute]] | list[Attribute]
+        operands: Sequence[SSAValue | Operation
+                           | Sequence[SSAValue | Operation]] | None = None,
+        result_types: Sequence[Attribute | Sequence[Attribute]]
         | None = None,
         attributes: dict[str, Attribute] | None = None,
-        successors: list[Block] | None = None,
-        regions: list[Region | list[Operation] | list[Block]] | None = None
+        successors: Sequence[Block] | None = None,
+        regions: Sequence[Region | Sequence[Operation] | Sequence[Block]]
+        | None = None
     ) -> _OpT:
         if operands is None:
             operands = []

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -1076,10 +1076,12 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
 
     def builder(
         cls: type[_OpT],
-        operands: list[Any] | None = None,
-        result_types: list[Any] | None = None,
+        operands: list[SSAValue | Operation
+                       | list[SSAValue | Operation]] | None = None,
+        result_types: list[Attribute | list[Attribute]] | list[Attribute]
+        | None = None,
         attributes: dict[str, Any] | None = None,
-        successors: list[Any] | None = None,
+        successors: list[Block] | None = None,
         regions: list[Region | list[Operation] | list[Block]] | None = None
     ) -> _OpT:
         if operands is None:

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -1072,12 +1072,22 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
             new_attrs[attribute_name] = property(
                 lambda self, name=attribute_name: self.attributes[name])
 
-    def builder(cls,
-                operands=[],
-                result_types=[],
-                attributes=dict(),
-                successors=[],
-                regions=[]):
+    def builder(cls: type[_OpT],
+                operands: list[Any] | None = None,
+                result_types: list[Any] | None = None,
+                attributes: dict[str, Any] | None = None,
+                successors: list[Any] | None = None,
+                regions: list[Any] | None = None) -> _OpT:
+        if operands is None:
+            operands = []
+        if result_types is None:
+            result_types = []
+        if attributes is None:
+            attributes = {}
+        if successors is None:
+            successors = []
+        if regions is None:
+            regions = []
         return irdl_op_builder(cls, op_def, operands, result_types, attributes,
                                successors, regions)
 

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -959,7 +959,8 @@ def irdl_build_arg_list(construct: VarIRConstruct,
 def irdl_op_builder(
         cls: type[_OpT], op_def: OpDef,
         operands: Sequence[SSAValue | Operation
-                           | list[SSAValue | Operation] | None],
+                           | list[SSAValue | Operation] | list[SSAValue]
+                           | None],
         res_types: Sequence[Any | list[Any] | None],
         attributes: dict[str, Attribute], successors: Sequence[Block],
         regions: Sequence[Region | list[Operation] | list[Block]]) -> _OpT:
@@ -1077,7 +1078,8 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
     def builder(
         cls: type[_OpT],
         operands: list[SSAValue | Operation
-                       | list[SSAValue | Operation]] | None = None,
+                       | list[SSAValue | Operation]]
+        | list[SSAValue | list[SSAValue]] | None = None,
         result_types: list[Attribute | list[Attribute]] | list[Attribute]
         | None = None,
         attributes: dict[str, Attribute] | None = None,


### PR DESCRIPTION
Currently it's a lot of Any | None, which doesn't match the signature of the function defined in the `irdl_op_definition` annotation. The types reflect the types of the objects currently accepted by the build function.