### PR TITLE
dialects: Add memref.subview and memref.cast

### DIFF
--- a/tests/filecheck/dialects/memref/memref_ops.xdsl
+++ b/tests/filecheck/dialects/memref/memref_ops.xdsl
@@ -13,6 +13,8 @@ builtin.module() {
     %4 : !index = memref.load(%2 : !memref<[1 : !index], !index>, %1 : !index)
     %5 : !memref<[10 : !index, 2 : !index], !index> = memref.alloc() ["alignment" = 0 : !i64, "operand_segment_sizes" = array<!i32: 0, 0>]
     memref.store(%3 : !index, %5 : !memref<[10 : !index, 2 : !index], !index>, %3 : !index, %4 : !index)
+    %6 : !memref<[1 : !index, 1 : !index], !index> = memref.subview(%5 : !memref<[10 : !index, 2 : !index], !index>) ["operand_segment_sizes" = array<!i32: 1, 0, 0, 0>, "static_offsets" = array<!i64: 0, 0>, "static_sizes" = array<!i64: 1, 1>, "static_strides" = array<!i64: 1, 1>]
+    %7 : !memref<[-1 : !index, -1 : !index], !index> = memref.cast(%5 : !memref<[10 : !index, 2 : !index], !index>)
     memref.dealloc(%2 : !memref<[1 : !index], !index>)
     memref.dealloc(%5 : !memref<[10 : !index, 2 : !index], !index>)
     func.return()
@@ -28,6 +30,8 @@ builtin.module() {
   // CHECK-NEXT:  %{{.*}} : !index = memref.load(%{{.*}} : !memref<[1 : !index], !index>, %{{.*}} : !index)
   // CHECK-NEXT:  %{{.*}} : !memref<[10 : !index, 2 : !index], !index> = memref.alloc() ["alignment" = 0 : !i64, "operand_segment_sizes" = array<!i32: 0, 0>]
   // CHECK-NEXT:  memref.store(%{{.*}} : !index, %{{.*}} : !memref<[10 : !index, 2 : !index], !index>, %{{.*}} : !index, %{{.*}} : !index)
+  // CHECK-NEXT:  %{{.*}} : !memref<[1 : !index, 1 : !index], !index> = memref.subview(%{{.*}} : !memref<[10 : !index, 2 : !index], !index>) ["operand_segment_sizes" = array<!i32: 1, 0, 0, 0>, "static_offsets" = array<!i64: 0, 0>, "static_sizes" = array<!i64: 1, 1>, "static_strides" = array<!i64: 1, 1>]
+  // CHECK-NEXT:  %{{.*}} : !memref<[-1 : !index, -1 : !index], !index> = memref.cast(%{{.*}} : !memref<[10 : !index, 2 : !index], !index>)
   // CHECK-NEXT:  memref.dealloc(%{{.*}} : !memref<[1 : !index], !index>)
   // CHECK-NEXT:  memref.dealloc(%{{.*}} : !memref<[10 : !index, 2 : !index], !index>)
   // CHECK-NEXT:  func.return()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.xdsl
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.xdsl
@@ -13,6 +13,8 @@ builtin.module() {
     %4 : !index = memref.load(%2 : !memref<[1 : !index], !index>, %1 : !index)
     %5 : !memref<[10 : !index, 2 : !index], !index> = memref.alloc() ["alignment" = 0 : !i64, "operand_segment_sizes" = array<!i32: 0, 0>]
     memref.store(%3 : !index, %5 : !memref<[10 : !index, 2 : !index], !index>, %3 : !index, %4 : !index)
+    %6 : !memref<[1 : !index, 1 : !index], !index> = memref.subview(%5 : !memref<[10 : !index, 2 : !index], !index>) ["operand_segment_sizes" = array<!i32: 1, 0, 0, 0>, "static_offsets" = array<!i64: 0, 0>, "static_sizes" = array<!i64: 1, 1>, "static_strides" = array<!i64: 1, 1>]
+    %7 : !memref<[-1 : !index, -1 : !index], !index> = memref.cast(%5 : !memref<[10 : !index, 2 : !index], !index>)
     memref.dealloc(%2 : !memref<[1 : !index], !index>)
     memref.dealloc(%5 : !memref<[10 : !index, 2 : !index], !index>)
     func.return()
@@ -29,6 +31,8 @@ builtin.module() {
 // CHECK-NEXT: %4 = "memref.load"(%2, %1) : (memref<1xindex>, index) -> index
 // CHECK-NEXT: %5 = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<10x2xindex>
 // CHECK-NEXT: "memref.store"(%3, %5, %3, %4) : (index, memref<10x2xindex>, index, index) -> ()
+// CHECK-NEXT: %6 = "memref.subview"(%5) {"operand_segment_sizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
+// CHECK-NEXT: %7 = "memref.cast"(%5) : (memref<10x2xindex>) -> memref<?x?xindex>
 // CHECK-NEXT: "memref.dealloc"(%2) : (memref<1xindex>) -> ()
 // CHECK-NEXT: "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
 // CHECK-NEXT: "func.return"() : () -> ()

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Annotated, TypeVar, Optional, List, TypeAlias, cast
 
 from xdsl.dialects.builtin import (DenseIntOrFPElementsAttr, IntegerAttr,
-                                   AnyArrayAttr, DenseArrayBase, IndexType,
-                                   ArrayAttr, IntegerType, SymbolRefAttr,
-                                   StringAttr, UnitAttr)
+                                   DenseArrayBase, IndexType, ArrayAttr,
+                                   IntegerType, SymbolRefAttr, StringAttr,
+                                   UnitAttr)
 from xdsl.ir import (MLIRType, Operation, SSAValue, ParametrizedAttribute,
                      Dialect, OpResult)
 from xdsl.irdl import (irdl_attr_definition, irdl_op_definition, ParameterDef,

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -334,20 +334,6 @@ class Subview(Operation):
 
     irdl_options = [AttrSizedOperandSegments()]
 
-    @staticmethod
-    def get(source: SSAValue | Operation, offsets: SSAValue | Operation,
-            sizes: SSAValue | Operation, strides: SSAValue | Operation,
-            static_offsets: SSAValue | Attribute,
-            static_sizes: SSAValue | Attribute,
-            static_strides: SSAValue | Attribute) -> Subview:
-        return Subview.build(operands=[source, offsets, sizes, strides],
-                             attributes={
-                                 "static_offsets": static_offsets,
-                                 "static_sizes": static_sizes,
-                                 "static_strides": static_strides
-                             },
-                             result_types=[MemRefType])
-
 
 @irdl_op_definition
 class Cast(Operation):
@@ -355,10 +341,6 @@ class Cast(Operation):
 
     source: Annotated[Operand, MemRefType]
     dest: Annotated[OpResult, MemRefType]
-
-    @staticmethod
-    def get(source: SSAValue | Operation) -> Cast:
-        return Cast.build(operands=[source], result_types=[MemRefType])
 
 
 MemRef = Dialect([


### PR DESCRIPTION
This PR intends to add `memref.subview` and `memref.cast` ops in the `memref` dialect. These ops will be later utilised for lowering of some `stencil` dialect operations.