### PR TITLE
dialects: Enable validate on func.FuncOp for external functions

### DIFF
--- a/tests/filecheck/func_ops.xdsl
+++ b/tests/filecheck/func_ops.xdsl
@@ -32,4 +32,8 @@ builtin.module() {
   // CHECK-NEXT:   func.return(%{{.*}} : !i32)
   // CHECK-NEXT: }
 
+  func.func() ["sym_name" = "external_fn", "function_type" = !fun<[!i32], [!i32]>, "sym_visibility" = "private"] { }
+
+  // CHECK: func.func() ["sym_name" = "external_fn", "function_type" = !fun<[!i32], [!i32]>, "sym_visibility" = "private"] {}
+
 }

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -20,6 +20,9 @@ class FuncOp(Operation):
     def verify_(self) -> None:
         # TODO: how to verify that there is a terminator?
         entry_block: Block = self.body.blocks[0]
+        # If this is an empty block (external function) then return
+        if len(entry_block.args) == 0 and len(entry_block.ops) == 0:
+            return
         block_arg_types = [arg.typ for arg in entry_block.args]
         if self.function_type.inputs.data != block_arg_types:
             raise VerifyException(


### PR DESCRIPTION
External functions in func.FuncOp have no body, but do have input types. The validate function fails on this because it checks the body types (which are empty) against the FuncOp input types. Therefore added a check whether the number of arguments and operations is zero and if so do not undertake this validation