### PR TITLE
API: Use typeguards to check array type

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -67,8 +67,18 @@ def test_array_len_attr():
 def test_is_array_of():
     arr = ArrayAttr([IntAttr(i) for i in range(2)])
 
-    assert ArrayAttr.is_array_of(arr)
     assert ArrayAttr.is_array_of(arr, Attribute)
     assert ArrayAttr.is_array_of(arr, IntAttr)
     assert ArrayAttr.is_array_of(arr, IntAttr | FloatAttr)
     assert not ArrayAttr.is_array_of(arr, FloatAttr)
+
+    int_arr = IntAttr(0)
+    assert not ArrayAttr.is_array_of(int_arr, Attribute)
+
+
+def test_is_array():
+    arr = ArrayAttr([IntAttr(i) for i in range(2)])
+    assert ArrayAttr.is_array(arr)
+
+    int_attr = IntAttr(0)
+    assert not ArrayAttr.is_array(int_attr)

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -3,6 +3,7 @@ import pytest
 from xdsl.dialects.builtin import (DenseArrayBase, DenseIntOrFPElementsAttr,
                                    i32, f32, FloatAttr, ArrayAttr, IntAttr,
                                    FloatData, SymbolRefAttr)
+from xdsl.ir import Attribute
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -61,3 +62,13 @@ def test_array_len_attr():
 
     assert len(arr) == 10
     assert len(arr.data) == len(arr)
+
+
+def test_is_array_of():
+    arr = ArrayAttr([IntAttr(i) for i in range(2)])
+
+    assert ArrayAttr.is_array_of(arr)
+    assert ArrayAttr.is_array_of(arr, Attribute)
+    assert ArrayAttr.is_array_of(arr, IntAttr)
+    assert ArrayAttr.is_array_of(arr, IntAttr | FloatAttr)
+    assert not ArrayAttr.is_array_of(arr, FloatAttr)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -47,31 +47,18 @@ _ArrayAttrInvT = TypeVar("_ArrayAttrInvT", bound=Attribute)
 class ArrayAttr(GenericData[List[_ArrayAttrT]]):
     name: str = "array"
 
-    @overload
     @staticmethod
-    def is_array_of(value: Any) -> TypeGuard[ArrayAttr[Attribute]]:
-        ...
+    def is_array(value: Any) -> TypeGuard[ArrayAttr[Attribute]]:
+        return isinstance(value, ArrayAttr)
 
-    @overload
     @staticmethod
     def is_array_of(
             value: Any, type: type[_ArrayAttrInvT]
-    ) -> TypeGuard[ArrayAttr[_ArrayAttrInvT]]:
-        ...
-
-    @staticmethod
-    def is_array_of(
-        value: Any,
-        type: type[_ArrayAttrInvT] = Attribute
     ) -> TypeGuard[ArrayAttr[_ArrayAttrInvT]]:
         # Check if the base type is correct
         if not isinstance(value, ArrayAttr):
             return False
         value = cast(ArrayAttr[Attribute], value)
-
-        # ArrayAttr only contains attributes
-        if type == Attribute:
-            return True
 
         # Check the element types
         return all(isinstance(e, type) for e in value.data)

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -17,14 +17,13 @@ class IntOrUnknown(AttrConstraint):
     length: int = 0
 
     def verify(self, attr: Attribute) -> None:
-        if not ArrayAttr.is_array_of(attr):
+        if not ArrayAttr.is_array(attr):
             raise VerifyException(
                 f"Expected {ArrayAttr} attribute, but got {attr.name}.")
-        if ArrayAttr.is_array_of(attr, Attribute):
-            if len(attr.data) != self.length:
-                raise VerifyException(
-                    f"Expected array of length {self.length}, got {len(attr.data)}."
-                )
+        if len(attr.data) != self.length:
+            raise VerifyException(
+                f"Expected array of length {self.length}, got {len(attr.data)}."
+            )
 
 
 @irdl_attr_definition
@@ -89,7 +88,7 @@ class ArrayLength(AttrConstraint):
     length: int = 0
 
     def verify(self, attr: Attribute) -> None:
-        if ArrayAttr.is_array_of(attr):
+        if ArrayAttr.is_array(attr):
             raise VerifyException(
                 f"Expected {ArrayAttr} attribute, but got {attr.name}.")
         attr = cast(ArrayAttr[Any], attr)

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -17,15 +17,14 @@ class IntOrUnknown(AttrConstraint):
     length: int = 0
 
     def verify(self, attr: Attribute) -> None:
-        if not isinstance(attr, ArrayAttr):
+        if not ArrayAttr.is_array_of(attr):
             raise VerifyException(
                 f"Expected {ArrayAttr} attribute, but got {attr.name}.")
-
-        attr = cast(ArrayAttr[Any], attr)
-        if len(attr.data) != self.length:
-            raise VerifyException(
-                f"Expected array of length {self.length}, got {len(attr.data)}."
-            )
+        if ArrayAttr.is_array_of(attr, Attribute):
+            if len(attr.data) != self.length:
+                raise VerifyException(
+                    f"Expected array of length {self.length}, got {len(attr.data)}."
+                )
 
 
 @irdl_attr_definition
@@ -60,9 +59,6 @@ class TempType(ParametrizedAttribute, MLIRType):
         if isinstance(shape, ArrayAttr):
             return TempType([shape])
 
-        # cast to list
-        shape = cast(list[IntAttr] | list[int], shape)
-
         if isinstance(shape[0], IntAttr):
             # the if above is a sufficient type guard, but pyright does not understand :/
             return TempType([ArrayAttr.from_list(shape)])  # type: ignore
@@ -93,7 +89,7 @@ class ArrayLength(AttrConstraint):
     length: int = 0
 
     def verify(self, attr: Attribute) -> None:
-        if not isinstance(attr, ArrayAttr):
+        if ArrayAttr.is_array_of(attr):
             raise VerifyException(
                 f"Expected {ArrayAttr} attribute, but got {attr.name}.")
         attr = cast(ArrayAttr[Any], attr)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -368,7 +368,7 @@ class Printer:
             self.print_attribute(typ)
             return
 
-        if ArrayAttr.is_array_of(attribute):
+        if ArrayAttr.is_array(attribute):
             self.print_string("[")
             self.print_list(attribute.data, self.print_attribute)
             self.print_string("]")

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -368,11 +368,9 @@ class Printer:
             self.print_attribute(typ)
             return
 
-        if isinstance(attribute, ArrayAttr):
+        if ArrayAttr.is_array_of(attribute):
             self.print_string("[")
-            self.print_list(
-                attribute.data,  # type: ignore
-                self.print_attribute)
+            self.print_list(attribute.data, self.print_attribute)
             self.print_string("]")
             return
 


### PR DESCRIPTION
Python type checking is making things difficult to check if an `attribute` is an `ArrayAttr`.
First of all, `isinstance(attribute, ArrayAttr)` will narrow `attribute` to `ArrayAttr[Unknown]`, which then requires us to use `cast(ArrayAttr[Any], attribute)` to remove pyright errors.

A solution for this is to use [`TypeGuard`](https://peps.python.org/pep-0647/), which is a user-defined function that can be used to narrow types. 

Note that the definition seems a bit weird by the use of `overload`. This is because there is a weird interaction between type variables and default types. Here is the corresponding rabbit hole discussion: https://github.com/python/mypy/issues/3737