### PR TITLE
core: Add `GenericData` to `isa` type checks

### DIFF
--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -1,5 +1,9 @@
-from xdsl.utils.hints import isa
 from typing import Any, TypeAlias
+
+from xdsl.ir import Attribute
+from xdsl.utils.hints import isa
+
+from xdsl.dialects.builtin import ArrayAttr, IndexType, IntAttr, FloatData, IntegerAttr, IntegerType
 
 
 class Class1:
@@ -202,8 +206,6 @@ def test_dict_hint_nested():
 
 
 def test_generic_data():
-    from xdsl.dialects.builtin import ArrayAttr, IntAttr, FloatData
-
     attr = ArrayAttr([IntAttr(0)])
 
     assert isa(attr, ArrayAttr[IntAttr])
@@ -215,3 +217,12 @@ def test_generic_data():
     assert not isa(attr2, ArrayAttr[IntAttr])
     assert isa(attr2, ArrayAttr[IntAttr | FloatData])
     assert not isa(attr2, ArrayAttr[FloatData])
+
+
+def test_nested_generic_data():
+    attr = ArrayAttr([IntegerAttr.from_index_int_value(0)])
+
+    assert isa(attr, ArrayAttr[Attribute])
+    assert isa(attr, ArrayAttr[IntegerAttr[IndexType]])
+    assert isa(attr, ArrayAttr[IntegerAttr[IndexType | IntegerType]])
+    assert not isa(attr, ArrayAttr[IntegerAttr[IntegerType]])

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -1,4 +1,4 @@
-from xdsl.utils.hints import is_satisfying_hint
+from xdsl.utils.hints import isa
 from typing import Any, TypeAlias
 
 
@@ -14,179 +14,163 @@ class Class2:
     pass
 
 
-#     _
-#    / \   _ __  _   _
-#   / _ \ | '_ \| | | |
-#  / ___ \| | | | |_| |
-# /_/   \_\_| |_|\__, |
-#                |___/
-#
+################################################################################
+# Any
+################################################################################
 
 
 def test_any_hint():
     """Test that the we can check if a value is satisfying `Any`."""
-    assert is_satisfying_hint(3, Any)
-    assert is_satisfying_hint([], Any)
-    assert is_satisfying_hint([2], Any)
-    assert is_satisfying_hint(int, Any)
+    assert isa(3, Any)
+    assert isa([], Any)
+    assert isa([2], Any)
+    assert isa(int, Any)
 
 
-#   ____ _
-#  / ___| | __ _ ___ ___
-# | |   | |/ _` / __/ __|
-# | |___| | (_| \__ \__ \
-#  \____|_|\__,_|___/___/
-#
+################################################################################
+# Class
+################################################################################
 
 
 def test_class_hint_correct():
     """Test that a class hint is being satisfied by giving a class instance."""
-    assert is_satisfying_hint(Class1(), Class1)
-    assert is_satisfying_hint(SubClass1(), SubClass1)
-    assert is_satisfying_hint(Class2(), Class2)
-    assert is_satisfying_hint(True, bool)
-    assert is_satisfying_hint(10, int)
-    assert is_satisfying_hint("", str)
+    assert isa(Class1(), Class1)
+    assert isa(SubClass1(), SubClass1)
+    assert isa(Class2(), Class2)
+    assert isa(True, bool)
+    assert isa(10, int)
+    assert isa("", str)
 
 
 def test_class_hint_class():
     """Test that a class hint is not being satisfied by the class object."""
-    assert not is_satisfying_hint(Class1, Class1)
+    assert not isa(Class1, Class1)
 
 
 def test_class_hint_wrong_instance():
     """
     Test that a class hint is not being satisfied by another class instance.
     """
-    assert not is_satisfying_hint(Class2(), Class1)
-    assert not is_satisfying_hint(0, Class1)
-    assert not is_satisfying_hint("", Class1)
-    assert not is_satisfying_hint("", int)
+    assert not isa(Class2(), Class1)
+    assert not isa(0, Class1)
+    assert not isa("", Class1)
+    assert not isa("", int)
 
 
 def test_class_hint_subclass():
     """
     Test that a class hint is satisfied by a subclass.
     """
-    assert is_satisfying_hint(SubClass1(), Class1)
-    assert is_satisfying_hint(True, int)  # bool is a subclass of int
+    assert isa(SubClass1(), Class1)
+    assert isa(True, int)  # bool is a subclass of int
 
 
-#  _     _     _
-# | |   (_)___| |_
-# | |   | / __| __|
-# | |___| \__ \ |_
-# |_____|_|___/\__|
-#
+################################################################################
+# List
+################################################################################
 
 
 def test_list_hint_empty():
     """Test that empty lists satisfy all list hints."""
-    assert is_satisfying_hint([], list[int])
-    assert is_satisfying_hint([], list[bool])
-    assert is_satisfying_hint([], list[Class1])
+    assert isa([], list[int])
+    assert isa([], list[bool])
+    assert isa([], list[Class1])
 
 
 def test_list_hint_correct():
     """
     Test that list hints work correcly on non-empty lists of the right type.
     """
-    assert is_satisfying_hint([42], list[int])
-    assert is_satisfying_hint([0, 3, 5], list[int])
-    assert is_satisfying_hint([False], list[bool])
-    assert is_satisfying_hint([True, False], list[bool])
-    assert is_satisfying_hint([Class1(), SubClass1()], list[Class1])
+    assert isa([42], list[int])
+    assert isa([0, 3, 5], list[int])
+    assert isa([False], list[bool])
+    assert isa([True, False], list[bool])
+    assert isa([Class1(), SubClass1()], list[Class1])
 
 
 def test_list_hint_not_list_failure():
     """Test that list hints work correcly on non lists."""
-    assert not is_satisfying_hint(0, list[int])
-    assert not is_satisfying_hint(0, list[Any])
-    assert not is_satisfying_hint(True, list[bool])
-    assert not is_satisfying_hint(True, list[Any])
-    assert not is_satisfying_hint("", list[Any])
-    assert not is_satisfying_hint("", list[str])
-    assert not is_satisfying_hint(Class1(), list[Class1])
-    assert not is_satisfying_hint(Class1(), list[Any])
-    assert not is_satisfying_hint({}, list[dict[Any, Any]])
-    assert not is_satisfying_hint({}, list[Any])
+    assert not isa(0, list[int])
+    assert not isa(0, list[Any])
+    assert not isa(True, list[bool])
+    assert not isa(True, list[Any])
+    assert not isa("", list[Any])
+    assert not isa("", list[str])
+    assert not isa(Class1(), list[Class1])
+    assert not isa(Class1(), list[Any])
+    assert not isa({}, list[dict[Any, Any]])
+    assert not isa({}, list[Any])
 
 
 def test_list_hint_failure():
     """
     Test that list hints work correcly on non-empty lists of the wrong type.
     """
-    assert not is_satisfying_hint([0], list[bool])
-    assert not is_satisfying_hint([0, True], list[bool])
-    assert not is_satisfying_hint([True, 0], list[bool])
-    assert not is_satisfying_hint([True, False, True, 0], list[bool])
-    assert not is_satisfying_hint([Class2()], list[Class1])
+    assert not isa([0], list[bool])
+    assert not isa([0, True], list[bool])
+    assert not isa([True, 0], list[bool])
+    assert not isa([True, False, True, 0], list[bool])
+    assert not isa([Class2()], list[Class1])
 
 
 def test_list_hint_nested():
     """
     Test that we can check nested list hints.
     """
-    assert is_satisfying_hint([[]], list[list[int]])
-    assert is_satisfying_hint([[0]], list[list[int]])
-    assert is_satisfying_hint([[0], [2, 1]], list[list[int]])
-    assert not is_satisfying_hint([[0], [2, 1], [""]], list[list[int]])
-    assert not is_satisfying_hint([[0], [2, 1], [32, ""]], list[list[int]])
-    assert is_satisfying_hint([], list[list[list[int]]])
-    assert is_satisfying_hint([[]], list[list[list[int]]])
-    assert is_satisfying_hint([[[]]], list[list[list[int]]])
-    assert is_satisfying_hint([[], [[]]], list[list[list[int]]])
-    assert is_satisfying_hint([[], [[0, 32]]], list[list[list[int]]])
+    assert isa([[]], list[list[int]])
+    assert isa([[0]], list[list[int]])
+    assert isa([[0], [2, 1]], list[list[int]])
+    assert not isa([[0], [2, 1], [""]], list[list[int]])
+    assert not isa([[0], [2, 1], [32, ""]], list[list[int]])
+    assert isa([], list[list[list[int]]])
+    assert isa([[]], list[list[list[int]]])
+    assert isa([[[]]], list[list[list[int]]])
+    assert isa([[], [[]]], list[list[list[int]]])
+    assert isa([[], [[0, 32]]], list[list[list[int]]])
 
 
-#   ____  _      _
-# |  _ \(_) ___| |_
-# | | | | |/ __| __|
-# | |_| | | (__| |_
-# |____/|_|\___|\__|
-#
+################################################################################
+# Dictionary
+################################################################################
 
 
 def test_dict_hint_empty():
     """Test that empty dicts satisfy all dict hints."""
-    assert is_satisfying_hint({}, dict[int, bool])
-    assert is_satisfying_hint({}, dict[Any, Any])
-    assert is_satisfying_hint({}, dict[Class1, Any])
-    assert is_satisfying_hint({}, dict[str, int])
+    assert isa({}, dict[int, bool])
+    assert isa({}, dict[Any, Any])
+    assert isa({}, dict[Class1, Any])
+    assert isa({}, dict[str, int])
 
 
 def test_dict_hint_correct():
     """
     Test that dict hints work correcly on non-empty dicts of the right type.
     """
-    assert is_satisfying_hint({"": 0}, dict[str, int])
-    assert is_satisfying_hint({"": 0, "a": 32}, dict[str, int])
-    assert is_satisfying_hint({0: "", 32: "a"}, dict[int, str])
-    assert is_satisfying_hint({
-        True: Class1(),
-        False: SubClass1()
-    }, dict[bool, Class1])
+    assert isa({"": 0}, dict[str, int])
+    assert isa({"": 0, "a": 32}, dict[str, int])
+    assert isa({0: "", 32: "a"}, dict[int, str])
+    assert isa({True: Class1(), False: SubClass1()}, dict[bool, Class1])
 
 
 def test_dict_hint_not_dict_failure():
     """Test that dict hints work correcly on non dicts."""
-    assert not is_satisfying_hint(0, dict[int, int])
-    assert not is_satisfying_hint(0, dict[Any, Any])
-    assert not is_satisfying_hint(True, dict[bool, bool])
-    assert not is_satisfying_hint(True, dict[Any, Any])
-    assert not is_satisfying_hint("", dict[Any, Any])
-    assert not is_satisfying_hint(Class1(), dict[Any, Any])
-    assert not is_satisfying_hint([], dict[Any, Any])
+    assert not isa(0, dict[int, int])
+    assert not isa(0, dict[Any, Any])
+    assert not isa(True, dict[bool, bool])
+    assert not isa(True, dict[Any, Any])
+    assert not isa("", dict[Any, Any])
+    assert not isa(Class1(), dict[Any, Any])
+    assert not isa([], dict[Any, Any])
 
 
 def test_dict_hint_failure():
     """
     Test that dict hints work correcly on non-empty dicts of the wrong type.
     """
-    assert not is_satisfying_hint({"": ""}, dict[int, str])
-    assert not is_satisfying_hint({0: 0}, dict[int, str])
-    assert not is_satisfying_hint({0: "0", 2: 2}, dict[int, str])
-    assert not is_satisfying_hint({0: "0", 2: "1", "2": "2"}, dict[int, str])
+    assert not isa({"": ""}, dict[int, str])
+    assert not isa({0: 0}, dict[int, str])
+    assert not isa({0: "0", 2: 2}, dict[int, str])
+    assert not isa({0: "0", 2: "1", "2": "2"}, dict[int, str])
 
 
 threeDict: TypeAlias = dict[int, dict[int, dict[int, str]]]
@@ -196,17 +180,38 @@ def test_dict_hint_nested():
     """
     Test that we can check nested dict hints.
     """
-    assert is_satisfying_hint({}, dict[int, dict[int, str]])
-    assert is_satisfying_hint({0: {}}, dict[int, dict[int, str]])
-    assert is_satisfying_hint({0: {1: ""}}, dict[int, dict[int, str]])
+    assert isa({}, dict[int, dict[int, str]])
+    assert isa({0: {}}, dict[int, dict[int, str]])
+    assert isa({0: {1: ""}}, dict[int, dict[int, str]])
 
-    assert not is_satisfying_hint({"": {}}, dict[int, dict[int, str]])
-    assert not is_satisfying_hint({0: ""}, dict[int, dict[int, str]])
-    assert not is_satisfying_hint({0: {"": ""}}, dict[int, dict[int, str]])
-    assert not is_satisfying_hint({0: {0: 0}}, dict[int, dict[int, str]])
+    assert not isa({"": {}}, dict[int, dict[int, str]])
+    assert not isa({0: ""}, dict[int, dict[int, str]])
+    assert not isa({0: {"": ""}}, dict[int, dict[int, str]])
+    assert not isa({0: {0: 0}}, dict[int, dict[int, str]])
 
-    assert is_satisfying_hint({}, threeDict)
-    assert is_satisfying_hint({0: {}}, threeDict)
-    assert is_satisfying_hint({0: {0: {}}}, threeDict)
-    assert is_satisfying_hint({0: {}, 1: {0: {}}}, threeDict)
-    assert is_satisfying_hint({0: {}, 1: {0: {0: "0", 1: "32"}}}, threeDict)
+    assert isa({}, threeDict)
+    assert isa({0: {}}, threeDict)
+    assert isa({0: {0: {}}}, threeDict)
+    assert isa({0: {}, 1: {0: {}}}, threeDict)
+    assert isa({0: {}, 1: {0: {0: "0", 1: "32"}}}, threeDict)
+
+
+################################################################################
+# GenericData
+################################################################################
+
+
+def test_generic_data():
+    from xdsl.dialects.builtin import ArrayAttr, IntAttr, FloatData
+
+    attr = ArrayAttr([IntAttr(0)])
+
+    assert isa(attr, ArrayAttr[IntAttr])
+    assert isa(attr, ArrayAttr[IntAttr | FloatData])
+    assert not isa(attr, ArrayAttr[FloatData])
+
+    attr2 = ArrayAttr([IntAttr(0), FloatData(0.0)])
+
+    assert not isa(attr2, ArrayAttr[IntAttr])
+    assert isa(attr2, ArrayAttr[IntAttr | FloatData])
+    assert not isa(attr2, ArrayAttr[FloatData])

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -1,6 +1,7 @@
-from typing import Any, TypeAlias
+from typing import Any, Generic, TypeAlias, TypeVar
 
-from xdsl.ir import Attribute
+from xdsl.ir import Attribute, ParametrizedAttribute
+from xdsl.irdl import ParameterDef, irdl_attr_definition
 from xdsl.utils.hints import isa
 
 from xdsl.dialects.builtin import ArrayAttr, IndexType, IntAttr, FloatData, IntegerAttr, IntegerType
@@ -226,3 +227,26 @@ def test_nested_generic_data():
     assert isa(attr, ArrayAttr[IntegerAttr[IndexType]])
     assert isa(attr, ArrayAttr[IntegerAttr[IndexType | IntegerType]])
     assert not isa(attr, ArrayAttr[IntegerAttr[IntegerType]])
+
+
+################################################################################
+# ParametrizedAttribute
+################################################################################
+
+_T = TypeVar("_T", bound=Attribute)
+
+
+@irdl_attr_definition
+class MyParamAttr(Generic[_T], ParametrizedAttribute):
+    name = "test.param"
+
+    v: ParameterDef[_T]
+
+
+def test_parametrized_attribute():
+    attr = MyParamAttr[IntAttr]([IntAttr(0)])
+
+    assert isa(attr, MyParamAttr)
+    assert isa(attr, MyParamAttr[IntAttr])
+    assert isa(attr, MyParamAttr[IntAttr | FloatData])
+    assert not isa(attr, MyParamAttr[FloatData])

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -42,7 +42,7 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
     if origin in [Union, UnionType]:
         return any(isa(arg, union_arg) for union_arg in get_args(hint))
 
-    from xdsl.dialects.builtin import GenericData
+    from xdsl.irdl import GenericData
     if (origin is not None) and issubclass(origin, GenericData):
         try:
             constraint = origin.generic_constraint_coercion(get_args(hint))

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -3,44 +3,55 @@ from types import UnionType
 from typing import (Annotated, Any, TypeGuard, TypeVar, Union, cast, get_args,
                     get_origin)
 
+from xdsl.utils.exceptions import VerifyException
+
 _T = TypeVar("_T")
 
 
-def is_satisfying_hint(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
+def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
     """
     Check if `arg` is of the type described by `hint`.
-    For now, only lists, tuples, sets, dictionaries, unions,
+    For now, only lists, dictionaries, unions,
     and non-generic classes are supported for type hints.
     """
     if hint is Any:
         return True
 
+    origin = get_origin(hint)
+
     # get_origin checks that hint is not a parametrized generic
-    if isclass(hint) and (get_origin(hint) is None):
+    if isclass(hint) and (origin is None):
         return isinstance(arg, hint)
 
-    if get_origin(hint) is list:
+    if origin is list:
         if not isinstance(arg, list):
             return False
         arg_list: list[Any] = cast(list[Any], arg)
         elem_hint, = get_args(hint)
-        return all(is_satisfying_hint(elem, elem_hint) for elem in arg_list)
+        return all(isa(elem, elem_hint) for elem in arg_list)
 
-    if get_origin(hint) is dict:
+    if origin is dict:
         if not isinstance(arg, dict):
             return False
         arg_dict: dict[Any, Any] = cast(dict[Any, Any], arg)
         key_hint, value_hint = get_args(hint)
         return all(
-            is_satisfying_hint(key, key_hint)
-            and is_satisfying_hint(value, value_hint)
+            isa(key, key_hint) and isa(value, value_hint)
             for key, value in arg_dict.items())
 
-    if get_origin(hint) in [Union, UnionType]:
-        return any(
-            is_satisfying_hint(arg, union_arg) for union_arg in get_args(hint))
+    if origin in [Union, UnionType]:
+        return any(isa(arg, union_arg) for union_arg in get_args(hint))
 
-    raise ValueError(f"is_satisfying_hint: unsupported type hint '{hint}'")
+    from xdsl.dialects.builtin import GenericData
+    if (origin is not None) and issubclass(origin, GenericData):
+        try:
+            constraint = origin.generic_constraint_coercion(get_args(hint))
+            constraint.verify(arg)
+            return True
+        except VerifyException:
+            return False
+
+    raise ValueError(f"isa: unsupported type hint '{hint}' {get_origin(hint)}")
 
 
 annotated_type = type(Annotated[int, 0])


### PR DESCRIPTION
This is an alternative implementation to #500.

Instead of defining a new function per attribute `isinstance` check, we can directly derive it from their IRDL definition! This is less error-prone, and is actually a nice use of IRDL.

This PR reuse the old `is_satisfying_hint` (which was actually completely unused), rename it to `isa` (this is what MLIR uses), and add support for `GenericData`, by reusing the `generic_constraint_coercion` function. The plan is to add more support for it with `ParametrizedAttribute` by introspecting their definitions as well.

Note that compared to #500, we don't have support for `is_array(attr)`, which we need to write as `isa(attr, AnyArrayAttr)` instead. However, this gives us support for nested checks, such as `ArrayAttr[IntegerAttr[IndexType] | FloatData]`, which would have been painful to add before. 

This also makes me realize that `isa` does the same checks as the generated `AttrConstraint` do. So I'm wondering if there wouldn't be any way to combine both, but this would be for another PR.