### PR TITLE
tests: Add the `docs/` to pytest discovery tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore = F403,E226,E731,E275,W503,F405,E722,E741,W504,W605,E402
 exclude = .github
 
 [tool:pytest]
-python_files = tests/*test_*.py
+python_files = tests/*test_*.py docs/*test_*.py
 python_classes = Test_*
 python_functions = test_*
 addopts = --durations=20 --maxfail=5


### PR DESCRIPTION
Good catch @superlopuh 