### PR TITLE
parser: Fix parsing of multiple regions

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
@@ -1,0 +1,10 @@
+// RUN: xdsl-opt %s -t mlir | mlir-opt --mlir-print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = false} : () -> i1
+  "scf.if"(%0) ({}, {}) : (i1) -> ()
+}) : () -> ()
+
+// CHECK: "scf.if"({{%\d+}}) ({}, {}) : (i1) -> ()
+
+

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
@@ -2,9 +2,17 @@
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = false} : () -> i1
-  "scf.if"(%0) ({}, {}) : (i1) -> ()
+  "scf.if"(%0) ({
+    "scf.yield"() : () -> ()
+  }, {
+    "scf.yield"() : () -> ()
+  }) : (i1) -> ()
 }) : () -> ()
 
-// CHECK: "scf.if"({{%\d+}}) ({}, {}) : (i1) -> ()
+// CHECK:        "scf.if"(%{{\d+}}) ({
+// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:   }) : (i1) -> ()
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -95,9 +95,7 @@ def test_parse_multi_region_mlir():
 
     op_str = """
     "test.multi_region" () ({
-        ^bb0:
     }, {
-        ^bb1:
     }) : () -> ()
     """
 
@@ -114,9 +112,7 @@ def test_parse_multi_region_xdsl():
 
     op_str = """
     "test.multi_region" () {
-        ^bb0:
     } {
-        ^bb1:
     }
     """
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,12 +2,11 @@ from io import StringIO
 
 import pytest
 
-from xdsl.dialects.builtin import IntAttr, DictionaryAttr, StringAttr, ArrayAttr, Builtin
-from xdsl.dialects.builtin import SymbolRefAttr
-from xdsl.ir import MLContext, Attribute, Operation, Region
-from xdsl.ir import ParametrizedAttribute
-from xdsl.irdl import irdl_attr_definition
-from xdsl.irdl import irdl_op_definition
+from xdsl.dialects.builtin import (IntAttr, DictionaryAttr, StringAttr,
+                                   ArrayAttr, Builtin, SymbolRefAttr)
+from xdsl.ir import (MLContext, Attribute, Operation, Region,
+                     ParametrizedAttribute)
+from xdsl.irdl import irdl_attr_definition, irdl_op_definition
 from xdsl.parser import XDSLParser, MLIRParser
 from xdsl.printer import Printer
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1798,8 +1798,10 @@ class MLIRParser(BaseParser):
         while not self.tokenizer.is_eof() and self.tokenizer.starts_with("{"):
             regions.append(self.parse_region())
             if self.tokenizer.starts_with(','):
-                self.parse_characters(',',
-                                      msg='This error should never be printed')
+                self.parse_characters(
+                    ',',
+                    msg='This error should never be printed, please open '
+                    'an issue at github.com/xdslproject/xdsl')
                 if not self.tokenizer.starts_with('{'):
                     self.raise_error(
                         "Expected next region (because of `,` after region end)!"

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1540,7 +1540,7 @@ class BaseParser(ABC):
         """
         Parses a sequence of regions for as long as there is a `{` in the input.
         """
-        regions = []
+        regions: list[Region] = []
         while not self.tokenizer.is_eof() and self.tokenizer.starts_with("{"):
             regions.append(self.parse_region())
         return regions
@@ -1794,7 +1794,7 @@ class MLIRParser(BaseParser):
         """
         Parses a sequence of regions for as long as there is a `{` in the input.
         """
-        regions = []
+        regions: list[Region] = []
         while not self.tokenizer.is_eof() and self.tokenizer.starts_with("{"):
             regions.append(self.parse_region())
             if self.tokenizer.starts_with(','):

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1543,13 +1543,6 @@ class BaseParser(ABC):
         regions = []
         while not self.tokenizer.is_eof() and self.tokenizer.starts_with("{"):
             regions.append(self.parse_region())
-            if self.tokenizer.starts_with(','):
-                self.parse_characters(',',
-                                      msg='This error should never be printed')
-                if not self.tokenizer.starts_with('{'):
-                    self.raise_error(
-                        "Expected next region (because of `,` after region end)!"
-                    )
         return regions
 
     def _parse_builtin_type_with_name(self, name: Span):
@@ -1796,6 +1789,22 @@ class MLIRParser(BaseParser):
             ")", "Operation args list must be closed by a closing bracket")
         # TODO: check if type is correct here!
         return args
+
+    def parse_region_list(self) -> list[Region]:
+        """
+        Parses a sequence of regions for as long as there is a `{` in the input.
+        """
+        regions = []
+        while not self.tokenizer.is_eof() and self.tokenizer.starts_with("{"):
+            regions.append(self.parse_region())
+            if self.tokenizer.starts_with(','):
+                self.parse_characters(',',
+                                      msg='This error should never be printed')
+                if not self.tokenizer.starts_with('{'):
+                    self.raise_error(
+                        "Expected next region (because of `,` after region end)!"
+                    )
+        return regions
 
 
 class XDSLParser(BaseParser):

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1543,6 +1543,13 @@ class BaseParser(ABC):
         regions = []
         while not self.tokenizer.is_eof() and self.tokenizer.starts_with("{"):
             regions.append(self.parse_region())
+            if self.tokenizer.starts_with(','):
+                self.parse_characters(',',
+                                      msg='This error should never be printed')
+                if not self.tokenizer.starts_with('{'):
+                    self.raise_error(
+                        "Expected next region (because of `,` after region end)!"
+                    )
         return regions
 
     def _parse_builtin_type_with_name(self, name: Span):


### PR DESCRIPTION
I noticed that parsing of multiple regions is currently broken in the parser. This fixes it.