### PR TITLE
misc: add method to parse dictionary attr MLIR style to BaseParser

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -405,9 +405,7 @@ class DictionaryAttr(GenericData[dict[str, Attribute]]):
 
     @staticmethod
     def parse_parameter(parser: BaseParser) -> dict[str, Attribute]:
-        # force MLIR style parsing of attribute
-        from xdsl.parser import MLIRParser
-        return MLIRParser.parse_optional_attr_dict(parser)
+        return parser.parse_optional_dictionary_attr_dict()
 
     @staticmethod
     def print_parameter(data: dict[str, Attribute], printer: Printer) -> None:

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1469,8 +1469,7 @@ class BaseParser(ABC):
             return dict()
 
         self.parse_characters(
-            "{",
-            "MLIR Attribute dictionary must be enclosed in curly brackets")
+            "{", "Attribute dictionary must be enclosed in curly brackets")
 
         attrs = []
         if not self.tokenizer.starts_with('}'):
@@ -1478,8 +1477,7 @@ class BaseParser(ABC):
                                        "Expected attribute entry")
 
         self.parse_characters(
-            "}",
-            "MLIR Attribute dictionary must be enclosed in curly brackets")
+            "}", "Attribute dictionary must be enclosed in curly brackets")
 
         return self._attr_dict_from_tuple_list(attrs)
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1464,6 +1464,25 @@ class BaseParser(ABC):
     def parse_optional_attr_dict(self) -> dict[str, Attribute]:
         raise NotImplementedError()
 
+    def parse_optional_dictionary_attr_dict(self) -> dict[str, Attribute]:
+        if not self.tokenizer.starts_with("{"):
+            return dict()
+
+        self.parse_characters(
+            "{",
+            "MLIR Attribute dictionary must be enclosed in curly brackets")
+
+        attrs = []
+        if not self.tokenizer.starts_with('}'):
+            attrs = self.parse_list_of(self._parse_attribute_entry,
+                                       "Expected attribute entry")
+
+        self.parse_characters(
+            "}",
+            "MLIR Attribute dictionary must be enclosed in curly brackets")
+
+        return self._attr_dict_from_tuple_list(attrs)
+
     def _attr_dict_from_tuple_list(
             self, tuple_list: list[tuple[Span,
                                          Attribute]]) -> dict[str, Attribute]:
@@ -1727,23 +1746,7 @@ class MLIRParser(BaseParser):
         )
 
     def parse_optional_attr_dict(self) -> dict[str, Attribute]:
-        if not self.tokenizer.starts_with("{"):
-            return dict()
-
-        self.parse_characters(
-            "{",
-            "MLIR Attribute dictionary must be enclosed in curly brackets")
-
-        attrs = []
-        if not self.tokenizer.starts_with('}'):
-            attrs = self.parse_list_of(self._parse_attribute_entry,
-                                       "Expected attribute entry")
-
-        self.parse_characters(
-            "}",
-            "MLIR Attribute dictionary must be enclosed in curly brackets")
-
-        return self._attr_dict_from_tuple_list(attrs)
+        return self.parse_optional_dictionary_attr_dict()
 
     def _parse_operation_details(
         self,


### PR DESCRIPTION
Currently calls an MLIRParser method with an instance of XDSLParser, seems dangerous.