### PR TITLE
dialects: Allow UnrankedMemrefType on relevant existing memref ops.

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -4,8 +4,9 @@ from xdsl.ir import OpResult, Block
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import i32, i64, IntegerType, IndexType, ArrayAttr, DenseArrayBase, IntegerAttr, IntAttr
 from xdsl.dialects.memref import (Alloc, Alloca, Dealloc, Dealloca, MemRefType,
-                                  Load, Store, ExtractAlignedPointerAsIndexOp,
-                                  Subview, Cast)
+                                  Load, Store, UnrankedMemrefType,
+                                  ExtractAlignedPointerAsIndexOp, Subview,
+                                  Cast)
 from xdsl.dialects import builtin, memref, func, arith, scf
 from xdsl.printer import Printer
 
@@ -248,7 +249,7 @@ def test_memref_cast():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [10, 2])
     memref_ssa_value = OpResult(i32_memref_type, [], [])
 
-    res_type = MemRefType.from_element_type_and_shape(i32, [-1, -1])
+    res_type = UnrankedMemrefType.from_type(i32)
 
     cast = Cast.build(operands=[memref_ssa_value], result_types=[res_type])
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -207,7 +207,8 @@ class Alloca(Operation):
 @irdl_op_definition
 class Dealloc(Operation):
     name = "memref.dealloc"
-    memref: Annotated[Operand, MemRefType[Attribute]]
+    memref: Annotated[Operand,
+                      MemRefType[Attribute] | UnrankedMemrefType[Attribute]]
 
     @staticmethod
     def get(operand: Operation | SSAValue) -> Dealloc:
@@ -283,7 +284,8 @@ class Global(Operation):
 class Dim(Operation):
     name = "memref.dim"
 
-    source: Annotated[Operand, MemRefType[Attribute]]
+    source: Annotated[Operand,
+                      MemRefType[Attribute] | UnrankedMemrefType[Attribute]]
     index: Annotated[Operand, IndexType]
 
     result: Annotated[OpResult, IndexType]
@@ -341,8 +343,8 @@ class Subview(Operation):
 class Cast(Operation):
     name = "memref.cast"
 
-    source: Annotated[Operand, MemRefType]
-    dest: Annotated[OpResult, MemRefType]
+    source: Annotated[Operand, MemRefType | UnrankedMemrefType]
+    dest: Annotated[OpResult, MemRefType | UnrankedMemrefType]
 
 
 MemRef = Dialect([


### PR DESCRIPTION
Tiny PR to allow unranked memrefs where it is possible in MLIR too (in the `memref` dialect).
I specifically need the `memref.cast` to unranked for the GPU demo, so I try to not do more in this one, tell me if you see something necessary though!