### PR TITLE
dialects: Add HostRegisterOp to GPU

### DIFF
--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -1,6 +1,9 @@
-from typing import List
 from xdsl.dialects import builtin, arith, memref
-from xdsl.dialects.gpu import AllReduceOp, AllReduceOperationAttr, AsyncTokenType, BarrierOp, BlockDimOp, BlockIdOp, GlobalIdOp, GridDimOp, HostRegisterOp, LaneIdOp, LaunchOp, ModuleEndOp, ModuleOp, DimensionAttr, NumSubgroupsOp, SetDefaultDeviceOp, SubgroupIdOp, SubgroupSizeOp, TerminatorOp, ThreadIdOp, YieldOp
+from xdsl.dialects.gpu import (
+    AllReduceOp, AllReduceOperationAttr, AsyncTokenType, BarrierOp, BlockDimOp,
+    BlockIdOp, GlobalIdOp, GridDimOp, HostRegisterOp, LaneIdOp, LaunchOp,
+    ModuleEndOp, ModuleOp, DimensionAttr, NumSubgroupsOp, SetDefaultDeviceOp,
+    SubgroupIdOp, SubgroupSizeOp, TerminatorOp, ThreadIdOp, YieldOp)
 from xdsl.ir import Block, Operation, Region, SSAValue
 
 

--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -1,6 +1,6 @@
 from typing import List
-from xdsl.dialects import builtin, arith
-from xdsl.dialects.gpu import AllReduceOp, AllReduceOperationAttr, AsyncTokenType, BarrierOp, BlockDimOp, BlockIdOp, GlobalIdOp, GridDimOp, LaneIdOp, LaunchOp, ModuleEndOp, ModuleOp, DimensionAttr, NumSubgroupsOp, SetDefaultDeviceOp, SubgroupIdOp, SubgroupSizeOp, TerminatorOp, ThreadIdOp, YieldOp
+from xdsl.dialects import builtin, arith, memref
+from xdsl.dialects.gpu import AllReduceOp, AllReduceOperationAttr, AsyncTokenType, BarrierOp, BlockDimOp, BlockIdOp, GlobalIdOp, GridDimOp, HostRegisterOp, LaneIdOp, LaunchOp, ModuleEndOp, ModuleOp, DimensionAttr, NumSubgroupsOp, SetDefaultDeviceOp, SubgroupIdOp, SubgroupSizeOp, TerminatorOp, ThreadIdOp, YieldOp
 from xdsl.ir import Block, Operation, Region, SSAValue
 
 
@@ -106,6 +106,21 @@ def test_grid_dim():
 
     assert isinstance(grid_dim, GridDimOp)
     assert grid_dim.dimension is dim
+
+
+def test_host_register():
+    memref_type = memref.MemRefType.from_element_type_and_shape(
+        builtin.i32, [10, 10])
+    ref = memref.Alloca.get(memref_type, 0)
+
+    unranked = memref.Cast.build(
+        operands=[ref],
+        result_types=[memref.UnrankedMemrefType.from_type(builtin.i32)])
+
+    register = HostRegisterOp.from_memref(unranked)
+
+    assert isinstance(register, HostRegisterOp)
+    assert register.value is unranked.results[0]
 
 
 def test_lane_id():

--- a/tests/filecheck/dialects/gpu/example.mlir
+++ b/tests/filecheck/dialects/gpu/example.mlir
@@ -6,6 +6,10 @@
             %n = "arith.constant"() {"value" = 13 : index} : () -> index
             %one = "arith.constant"() {"value" = 1 : index} : () -> index
 
+            %memref = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<10x10xi32>
+            %unranked = "memref.cast"(%memref) : (memref<10x10xi32>) -> memref<*xi32>
+            "gpu.host_register"(%unranked) : (memref<*xi32>) -> ()
+
             %threadidx = "gpu.thread_id"() {"dimension" = #gpu<dim x>} : () -> index
             %threadidy = "gpu.thread_id"() {"dimension" = #gpu<dim y>} : () -> index
             %threadidz = "gpu.thread_id"() {"dimension" = #gpu<dim z>} : () -> index
@@ -64,6 +68,10 @@
 // CHECK-NEXT:         "func.func"() ({
 // CHECK-NEXT:             %{{.*}} = "arith.constant"() {"value" = 13 : index} : () -> index
 // CHECK-NEXT:             %{{.*}} = "arith.constant"() {"value" = 1 : index} : () -> index
+
+// CHECK-NEXT:             %{{.*}} = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<10x10xi32>
+// CHECK-NEXT:             %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x10xi32>) -> memref<*xi32>
+// CHECK-NEXT:             "gpu.host_register"(%{{.*}}) : (memref<*xi32>) -> ()
 
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() {"dimension" = #gpu<dim x>} : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() {"dimension" = #gpu<dim y>} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/example.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/example.mlir
@@ -6,6 +6,10 @@
             %n = "arith.constant"() {"value" = 13 : index} : () -> index
             %one = "arith.constant"() {"value" = 1 : index} : () -> index
 
+            %memref = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<10x10xi32>
+            %unranked = "memref.cast"(%memref) : (memref<10x10xi32>) -> memref<*xi32>
+            "gpu.host_register"(%unranked) : (memref<*xi32>) -> ()
+
             %threadidx = "gpu.thread_id"() {"dimension" = #gpu<dim x>} : () -> index
             %threadidy = "gpu.thread_id"() {"dimension" = #gpu<dim y>} : () -> index
             %threadidz = "gpu.thread_id"() {"dimension" = #gpu<dim z>} : () -> index
@@ -64,6 +68,10 @@
 // CHECK-NEXT:         "func.func"() ({
 // CHECK-NEXT:             %{{.*}} = "arith.constant"() {"value" = 13 : index} : () -> index
 // CHECK-NEXT:             %{{.*}} = "arith.constant"() {"value" = 1 : index} : () -> index
+
+// CHECK-NEXT:             %{{.*}} = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<10x10xi32>
+// CHECK-NEXT:             %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x10xi32>) -> memref<*xi32>
+// CHECK-NEXT:             "gpu.host_register"(%{{.*}}) : (memref<*xi32>) -> ()
 
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() {"dimension" = #gpu<dim x>} : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() {"dimension" = #gpu<dim y>} : () -> index

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -4,6 +4,7 @@ from typing import Annotated, Generic, Type, TypeVar
 from xdsl.ir import Attribute, MLIRType, OpResult, Operation, Dialect, ParametrizedAttribute, Region, SSAValue
 from xdsl.irdl import AttrSizedOperandSegments, Operand, OptOpAttr, OptOpResult, OptOperand, ParameterDef, VarOperand, irdl_op_definition, irdl_attr_definition, SingleBlockRegion, OpAttr
 from xdsl.dialects.builtin import IndexType, StringAttr, SymbolRefAttr, UnitAttr, i32
+from xdsl.dialects import memref
 from xdsl.parser import BaseParser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
@@ -241,6 +242,17 @@ class GridDimOp(Operation):
 
 
 @irdl_op_definition
+class HostRegisterOp(Operation):
+    name = "gpu.host_register"
+
+    value: Annotated[Operand, memref.UnrankedMemrefType]
+
+    @staticmethod
+    def from_memref(memref: SSAValue | Operation):
+        return HostRegisterOp.build(operands=[SSAValue.get(memref)])
+
+
+@irdl_op_definition
 class LaneIdOp(Operation):
     name = "gpu.lane_id"
     result: Annotated[OpResult, IndexType]
@@ -423,6 +435,7 @@ GPU = Dialect([
     BlockIdOp,
     GlobalIdOp,
     GridDimOp,
+    HostRegisterOp,
     LaneIdOp,
     LaunchOp,
     ModuleOp,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -243,6 +243,15 @@ class GridDimOp(Operation):
 
 @irdl_op_definition
 class HostRegisterOp(Operation):
+    """
+    This op maps the provided host buffer into the device address space.
+
+    This operation may not be supported in every environment, there is not yet a way to
+    check at runtime whether this feature is supported.
+    Writes from the host are guaranteed to be visible to device kernels that are launched
+    afterwards. Writes from the device are guaranteed to be visible on the host after
+    synchronizing with the device kernel completion.
+    """
     name = "gpu.host_register"
 
     value: Annotated[Operand, memref.UnrankedMemrefType]

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 from typing import Annotated, Generic, Type, TypeVar
 
-from xdsl.ir import Attribute, MLIRType, OpResult, Operation, Dialect, ParametrizedAttribute, Region, SSAValue
-from xdsl.irdl import AttrSizedOperandSegments, Operand, OptOpAttr, OptOpResult, OptOperand, ParameterDef, VarOperand, irdl_op_definition, irdl_attr_definition, SingleBlockRegion, OpAttr
+from xdsl.ir import (Attribute, MLIRType, OpResult, Operation, Dialect,
+                     ParametrizedAttribute, Region, SSAValue)
+from xdsl.irdl import (AttrSizedOperandSegments, Operand, OptOpAttr,
+                       OptOpResult, OptOperand, ParameterDef, VarOperand,
+                       irdl_op_definition, irdl_attr_definition,
+                       SingleBlockRegion, OpAttr)
 from xdsl.dialects.builtin import IndexType, StringAttr, SymbolRefAttr, UnitAttr, i32
 from xdsl.dialects import memref
 from xdsl.parser import BaseParser


### PR DESCRIPTION
This small PR just adds the HostRegisterOp to the GPU dialect.
(It makes a host memref accessible from the device/GPU)