### PR TITLE
dialects: Clean up type vars for Attribute types

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -487,7 +487,7 @@ class VectorType(Generic[AttributeInvT], ParametrizedAttribute, MLIRType):
     @staticmethod
     def from_element_type_and_shape(
         referenced_type: AttributeInvT,
-        shape: List[int | IntegerAttr[IndexType]]
+        shape: Sequence[int | IntegerAttr[IndexType]]
     ) -> VectorType[AttributeInvT]:
 
         return VectorType([

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -317,6 +317,9 @@ DataElement = TypeVar("DataElement", covariant=True)
 
 _D = TypeVar("_D", bound="Data[Any]")
 
+AttributeTCov = TypeVar("AttributeTCov", bound=Attribute, covariant=True)
+AttributeT = TypeVar("AttributeT", bound=Attribute)
+
 
 @dataclass(frozen=True)
 class Data(Generic[DataElement], Attribute, ABC):

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -317,8 +317,8 @@ DataElement = TypeVar("DataElement", covariant=True)
 
 _D = TypeVar("_D", bound="Data[Any]")
 
-AttributeTCov = TypeVar("AttributeTCov", bound=Attribute, covariant=True)
-AttributeT = TypeVar("AttributeT", bound=Attribute)
+AttributeCovT = TypeVar("AttributeCovT", bound=Attribute, covariant=True)
+AttributeInvT = TypeVar("AttributeInvT", bound=Attribute)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Fixing issue #515 by creating a common type for Attributes in the ir.py folder. 