### PR TITLE
CI: Fix append-timestamp and naming

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -54,7 +54,6 @@ jobs:
         path: llvm-project/build
         key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
         restore-keys: binaries-${{ runner.os }}-${{ env.MLIR-Version }}
-        append-timestamp: false
 
     - name: Checkout MLIR
       if: steps.cache-binary.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-pyright.yml
+++ b/.github/workflows/ci-pyright.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: CI - Pyright
+name: CI - Pyright - Reviewdog
 
 on:
   # Trigger the workflow on push or pull request,


### PR DESCRIPTION
This PR removes the `append-timestamp` that was not needed anymore after removing ccache from the repo, and renames one of the pyright CIs (they had the same name).