### PR TITLE
core: Change ssa val `__repr__`

### DIFF
--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -204,10 +204,10 @@ class OpResult(SSAValue):
         return self.op
 
     def __repr__(self) -> str:
-        return "<{}[{}: {}] from {} with {} uses>".format(
+        return "<{}[{}] index: {}, operation: {}, uses: {}>".format(
             self.__class__.__name__,
-            self.result_index,
             self.typ,
+            self.result_index,
             self.op.name,
             len(self.uses),
         )
@@ -235,10 +235,10 @@ class BlockArgument(SSAValue):
         return self.block
 
     def __repr__(self) -> str:
-        return "<{}[{}: {}] with {} uses>".format(
+        return "<{}[{}] index: {}, uses: {}>".format(
             self.__class__.__name__,
-            self.index,
             self.typ,
+            self.index,
             len(self.uses),
         )
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -204,12 +204,12 @@ class OpResult(SSAValue):
         return self.op
 
     def __repr__(self) -> str:
-        return "{}<%{}: {}>(num_uses={}, op_name={})".format(
+        return "<{}[{}: {}] from {} with {} uses>".format(
             self.__class__.__name__,
-            self.name or self.result_index,
+            self.result_index,
             self.typ,
-            len(self.uses),
             self.op.name,
+            len(self.uses),
         )
 
     def __eq__(self, other: object) -> bool:
@@ -235,7 +235,7 @@ class BlockArgument(SSAValue):
         return self.block
 
     def __repr__(self) -> str:
-        return "{}<%{}: {}>(num_uses={})".format(
+        return "<{}[{}: {}] with {} uses>".format(
             self.__class__.__name__,
             self.index,
             self.typ,

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -231,13 +231,7 @@ class BlockArgument(SSAValue):
         return self.block
 
     def __repr__(self) -> str:
-        if isinstance(self.block, Block):
-            block_repr = f"Block(num_arguments={len(self.block.args)}, " + \
-                         f"num_blocks={len(self.block.ops)} ops)"
-        else:
-            block_repr = repr(self.block)
-        return f"OpResult(typ={repr(self.typ)}, num_uses={repr(len(self.uses))}" + \
-               f", block={block_repr}, index={repr(self.index)}"
+        return "{}<%{}: {}>(num_uses={})".format(self.__class__.__name__, self.index, self.typ, len(self.uses))
 
     def __eq__(self, other: object) -> bool:
         return self is other

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -204,9 +204,13 @@ class OpResult(SSAValue):
         return self.op
 
     def __repr__(self) -> str:
-        return f"OpResult(typ={repr(self.typ)}, num_uses={repr(len(self.uses))}, " + \
-               f"op_name={repr(self.op.name)}, " + \
-               f"result_index={repr(self.result_index)}, name={repr(self.name)})"
+        return "{}<%{}: {}>(num_uses={}, op_name={})".format(
+            self.__class__.__name__,
+            self.name or self.result_index,
+            self.typ,
+            len(self.uses),
+            self.op.name,
+        )
 
     def __eq__(self, other: object) -> bool:
         return self is other
@@ -231,7 +235,12 @@ class BlockArgument(SSAValue):
         return self.block
 
     def __repr__(self) -> str:
-        return "{}<%{}: {}>(num_uses={})".format(self.__class__.__name__, self.index, self.typ, len(self.uses))
+        return "{}<%{}: {}>(num_uses={})".format(
+            self.__class__.__name__,
+            self.index,
+            self.typ,
+            len(self.uses),
+        )
 
     def __eq__(self, other: object) -> bool:
         return self is other


### PR DESCRIPTION
Change how SSA Values are printed to cli:

 - Block arguments: `BlockArgument<%0: !i32>(num_uses=0)`
 - Operation result: `OpResult<%0: !i32>(num_uses=0, op_name=arith.constant)` or `OpResult<%const: !i32>(num_uses=0, op_name=arith.constant)` if it has a `.name` attribute