### PR TITLE
dialects: Implement scf.parallel

### DIFF
--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -1,7 +1,7 @@
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import Region, IndexType
 from xdsl.dialects.cf import Block
-from xdsl.dialects.scf import For
+from xdsl.dialects.scf import For, ParallelOp
 
 
 def test_for():
@@ -24,3 +24,31 @@ def test_for():
     assert f.operands == (lb.result, ub.result, step.result, carried.result)
     assert f.regions == [body]
     assert f.attributes == {}
+
+
+def test_parallel():
+    lbi = Constant.from_int_and_width(0, IndexType())
+    lbj = Constant.from_int_and_width(1, IndexType())
+    lbk = Constant.from_int_and_width(18, IndexType())
+
+    ubi = Constant.from_int_and_width(10, IndexType())
+    ubj = Constant.from_int_and_width(110, IndexType())
+    ubk = Constant.from_int_and_width(92, IndexType())
+
+    si = Constant.from_int_and_width(1, IndexType())
+    sj = Constant.from_int_and_width(3, IndexType())
+    sk = Constant.from_int_and_width(8, IndexType())
+
+    body = Region.from_block_list([])
+
+    lowerBounds = [lbi, lbj, lbk]
+    upperBounds = [ubi, ubj, ubk]
+    steps = [si, sj, sk]
+
+    p = ParallelOp.from_bounds_and_body(lowerBounds, upperBounds, steps, body)
+
+    assert isinstance(p, ParallelOp)
+    assert p.lowerBound == tuple(l.result for l in lowerBounds)
+    assert p.upperBound == tuple(l.result for l in upperBounds)
+    assert p.step == tuple(l.result for l in steps)
+    assert p.body is body

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -45,7 +45,7 @@ def test_parallel():
     upperBounds = [ubi, ubj, ubk]
     steps = [si, sj, sk]
 
-    p = ParallelOp.from_bounds_and_body(lowerBounds, upperBounds, steps, body)
+    p = ParallelOp.get(lowerBounds, upperBounds, steps, body)
 
     assert isinstance(p, ParallelOp)
     assert p.lowerBound == tuple(l.result for l in lowerBounds)

--- a/tests/filecheck/dialects/scf/parallel_bounds.mlir
+++ b/tests/filecheck/dialects/scf/parallel_bounds.mlir
@@ -1,0 +1,15 @@
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 0 : index} : () -> index
+  %1 = "arith.constant"() {"value" = 1000 : index} : () -> index
+  %2 = "arith.constant"() {"value" = 3 : index} : () -> index
+  %3 = "arith.constant"() {"value" = 0 : index} : () -> index
+  %4 = "arith.constant"() {"value" = 1000 : index} : () -> index
+  "scf.parallel"(%0, %3, %1, %4, %2) ({
+  ^bb0(%i: index):
+    "scf.yield"() : () -> ()
+  }) {"operand_segment_sizes" = array<i32: 2, 2, 1, 0>} : (index, index, index) -> ()
+}) : () -> ()
+
+// CHECK: Expected the same number of lower bounds, upper bounds, and steps for scf.parallel. Got 2, 2 and 1.

--- a/tests/filecheck/dialects/scf/parallel_iv.mlir
+++ b/tests/filecheck/dialects/scf/parallel_iv.mlir
@@ -1,0 +1,13 @@
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 0 : index} : () -> index
+  %1 = "arith.constant"() {"value" = 1000 : index} : () -> index
+  %2 = "arith.constant"() {"value" = 3 : index} : () -> index
+  "scf.parallel"(%0, %1, %2) ({
+  ^bb0(%i: index, %j: index):
+    "scf.yield"() : () -> ()
+  }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+}) : () -> ()
+
+// CHECK: Expected 1 index-typed region arguments, got ['!index', '!index']. scf.parallel's body must have an index argument for each induction variable.

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
@@ -1,0 +1,21 @@
+// RUN: xdsl-opt %s -t mlir | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 0 : index} : () -> index
+  %1 = "arith.constant"() {"value" = 1000 : index} : () -> index
+  %2 = "arith.constant"() {"value" = 3 : index} : () -> index
+  "scf.parallel"(%0, %1, %2) ({
+  ^bb0(%arg0: index):
+    "scf.yield"() : () -> ()
+  }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+}) : () -> ()
+
+// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   %{{.*}} = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:   %{{.*}} = "arith.constant"() {"value" = 1000 : index} : () -> index
+// CHECK-NEXT:   %{{.*}} = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:   "scf.parallel"(%{{.*}}, %{{.*}}, %{{.*}}) ({
+// CHECK-NEXT:   ^{{.*}}(%{{.*}}: index):
+// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -135,9 +135,10 @@ class ParallelOp(Operation):
     @staticmethod
     def get(lowerBounds: Sequence[SSAValue | Operation],
             upperBounds: Sequence[SSAValue | Operation],
-            steps: Sequence[SSAValue | Operation], body: Region):
+            steps: Sequence[SSAValue | Operation],
+            body: Region | list[Block] | list[Operation]):
         return ParallelOp.build(operands=[lowerBounds, upperBounds, steps, []],
-                                regions=[body])
+                                regions=[Region.get(body)])
 
     def verify_(self) -> None:
         if len(self.lowerBound) != len(self.upperBound) or len(

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Annotated, List
+from typing import Annotated, List, Sequence
 
 from xdsl.dialects.builtin import IndexType, IntegerType
 from xdsl.ir import Attribute, Block, Dialect, Operation, Region, SSAValue
-from xdsl.irdl import (AnyAttr, Operand, SingleBlockRegion, VarOperand,
-                       VarOpResult, irdl_op_definition)
+from xdsl.irdl import (AnyAttr, AttrSizedOperandSegments, Operand,
+                       SingleBlockRegion, VarOperand, VarOpResult,
+                       irdl_op_definition)
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -116,6 +117,43 @@ class For(Operation):
             regions=[body],
         )
         return op
+
+
+@irdl_op_definition
+class ParallelOp(Operation):
+    name = "scf.parallel"
+    lowerBound: Annotated[VarOperand, IndexType]
+    upperBound: Annotated[VarOperand, IndexType]
+    step: Annotated[VarOperand, IndexType]
+
+    body: Region
+
+    irdl_options = [AttrSizedOperandSegments()]
+
+    @staticmethod
+    def from_bounds_and_body(lowerBounds: Sequence[SSAValue | Operation],
+                             upperBounds: Sequence[SSAValue | Operation],
+                             steps: Sequence[SSAValue | Operation],
+                             body: Region):
+        return ParallelOp.build(operands=[lowerBounds, upperBounds, steps],
+                                regions=[body])
+
+    def verify_(self) -> None:
+        if len(self.lowerBound) != len(self.upperBound) or len(
+                self.lowerBound) != len(self.step):
+            raise VerifyException(
+                "Expected the same number of lower bounds, upper "
+                "bounds, and steps for scf.parallel. Got "
+                f"{len(self.lowerBound)}, {len(self.upperBound)} and "
+                f"{len(self.lowerBound)}")
+        body_args = self.body.blocks[0].args if len(
+            self.body.blocks) != 0 else ()
+        if len(self.lowerBound) != len(body_args) or not all(
+            [a.typ is IndexType for a in body_args]):
+            raise VerifyException(
+                f"Expected {len(self.lowerBound)} region arguments, got "
+                f"{[str(a) for a in body_args]}. scf.parallel's body must have an index "
+                "argument for each induction variable. ")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -133,10 +133,9 @@ class ParallelOp(Operation):
     irdl_options = [AttrSizedOperandSegments()]
 
     @staticmethod
-    def from_bounds_and_body(lowerBounds: Sequence[SSAValue | Operation],
-                             upperBounds: Sequence[SSAValue | Operation],
-                             steps: Sequence[SSAValue | Operation],
-                             body: Region):
+    def get(lowerBounds: Sequence[SSAValue | Operation],
+            upperBounds: Sequence[SSAValue | Operation],
+            steps: Sequence[SSAValue | Operation], body: Region):
         return ParallelOp.build(operands=[lowerBounds, upperBounds, steps, []],
                                 regions=[body])
 

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -133,10 +133,12 @@ class ParallelOp(Operation):
     irdl_options = [AttrSizedOperandSegments()]
 
     @staticmethod
-    def get(lowerBounds: Sequence[SSAValue | Operation],
-            upperBounds: Sequence[SSAValue | Operation],
-            steps: Sequence[SSAValue | Operation],
-            body: Region | list[Block] | list[Operation]):
+    def get(
+        lowerBounds: Sequence[SSAValue | Operation],
+        upperBounds: Sequence[SSAValue | Operation],
+        steps: Sequence[SSAValue | Operation],
+        body: Region | list[Block] | list[Operation],
+    ):
         return ParallelOp.build(operands=[lowerBounds, upperBounds, steps, []],
                                 regions=[Region.get(body)])
 

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -147,13 +147,13 @@ class ParallelOp(Operation):
                 "Expected the same number of lower bounds, upper "
                 "bounds, and steps for scf.parallel. Got "
                 f"{len(self.lowerBound)}, {len(self.upperBound)} and "
-                f"{len(self.lowerBound)}")
+                f"{len(self.step)}.")
         body_args = self.body.blocks[0].args if len(
             self.body.blocks) != 0 else ()
         if len(self.lowerBound) != len(body_args) or not all(
             [isinstance(a.typ, IndexType) for a in body_args]):
             raise VerifyException(
-                f"Expected {len(self.lowerBound)} index typed region arguments, got "
+                f"Expected {len(self.lowerBound)} index-typed region arguments, got "
                 f"{[str(a.typ) for a in body_args]}. scf.parallel's body must have an index "
                 "argument for each induction variable. ")
         if len(self.initVals) != 0 or len(self.results) != 0:


### PR DESCRIPTION
This PR implements scf.parallel partially.
This partial implementation doesn't support reduction and loop-carried variables, which are optional in MLIR. scf.parallel can already be useful without these, so it's an opportunity to merge it progressively too!

Opening the PR as draft before the filechecks for @AntonLydike and @georgebisbas to already have a look or try at it. Not sure if @mesham is interested?

NB: scf.parallel can be translated to GPU by MLIR, so it could be used as a GPU interfacing operation too.