### PR TITLE
core: Make `break_on` in the `Lexer` private

### DIFF
--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -814,7 +814,6 @@ class BaseParser(ABC):
                                   "Unexpected end of dimension parameters!")
 
     def parse_vector_attrs(self) -> AnyVectorType:
-        # Also break on 'x' characters as they are separators in dimension parameters
         shape = list[int](self.try_parse_numerical_dims())
         scaling_shape: list[int] | None = None
 


### PR DESCRIPTION
This PR starts the cleanup of the Lexer, to try to incrementally go towards an MLIR-like lexer.
This change is in preparation of a token system, rather than having the Lexer rely on untyped `Span`.

This PR makes the `break_on` field private, and removes the `configured` function, which used to modify `break_on`.