### PR TITLE
dialects: Add a stencil.CastOp -> memref.Cast lowering.

### DIFF
--- a/tests/filecheck/dialects/stencil/test_castop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering.mlir
@@ -1,0 +1,17 @@
+// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+
+"builtin.module"() ({
+    "func.func"() ({
+    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        "func.return"() : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+}) : () -> ()
+
+// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:     "func.func"() ({
+// CHECK-NEXT:     ^0(%0 : memref<?x?x?xf64>):
+// CHECK-NEXT:         %1 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -149,8 +149,8 @@ class CastOp(Operation):
     """
     name: str = "stencil.cast"
     field: Annotated[Operand, FieldType]
-    lb: OptOpAttr[IndexAttr]
-    ub: OptOpAttr[IndexAttr]
+    lb: OpAttr[IndexAttr]
+    ub: OpAttr[IndexAttr]
     result: Annotated[OpResult, FieldType]
 
 

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -8,10 +8,10 @@ from xdsl.dialects.builtin import (AnyIntegerAttr, ParametrizedAttribute,
                                    AnyFloat)
 from xdsl.dialects import builtin
 from xdsl.ir import Operation, Dialect, MLIRType
-from xdsl.irdl import (irdl_attr_definition, irdl_op_definition, ParameterDef,
-                       AttrConstraint, Attribute, Region, VerifyException,
-                       Generic, AnyOf, Annotated, Operand, OpAttr, OpResult,
-                       VarOperand, VarOpResult, OptOpAttr,
+from xdsl.irdl import (AnyAttr, irdl_attr_definition, irdl_op_definition,
+                       ParameterDef, AttrConstraint, Attribute, Region,
+                       VerifyException, Generic, AnyOf, Annotated, Operand,
+                       OpAttr, OpResult, VarOperand, VarOpResult, OptOpAttr,
                        AttrSizedOperandSegments)
 
 
@@ -289,7 +289,7 @@ class ApplyOp(Operation):
       }
     """
     name: str = "stencil.apply"
-    args: Annotated[VarOperand, TempType]
+    args: Annotated[VarOperand, AnyAttr()]
     lb: OptOpAttr[IndexAttr]
     ub: OptOpAttr[IndexAttr]
     region: Region

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -1,8 +1,9 @@
 from typing import TypeVar
 
 from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
-                                   RewritePattern, GreedyRewritePatternApplier)
-from xdsl.ir import MLContext, Operation
+                                   RewritePattern, GreedyRewritePatternApplier,
+                                   op_type_rewrite_pattern)
+from xdsl.ir import MLContext
 from xdsl.irdl import Attribute
 from xdsl.dialects.builtin import FunctionType, ModuleOp
 from xdsl.dialects.func import FuncOp
@@ -35,9 +36,8 @@ def GetMemRefFromFieldWithLBAndUB(memref_element_type: _TypeElement,
 
 class CastOpToMemref(RewritePattern):
 
-    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
-        if not isinstance(op, CastOp):
-            return
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: CastOp, rewriter: PatternRewriter, /):
         if not isinstance(op.field.typ, FieldType):
             return
 
@@ -51,9 +51,8 @@ class CastOpToMemref(RewritePattern):
 
 class StencilTypeConversionFuncOp(RewritePattern):
 
-    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
-        if not isinstance(op, FuncOp):
-            return
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: FuncOp, rewriter: PatternRewriter, /):
         inputs: list[Attribute] = []
         for arg in op.body.blocks[0].args:
             if isinstance(arg.typ, FieldType):

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -26,6 +26,8 @@ def GetMemRefFromField(
 def GetMemRefFromFieldWithLBAndUB(memref_element_type: _TypeElement,
                                   lb: IndexAttr,
                                   ub: IndexAttr) -> MemRefType[_TypeElement]:
+    # lb and ub defines the minimum and maximum coordinates of the resulting memref,
+    # so its shape is simply ub - lb, computed here.
     dims = [
         ub.value.data - lb.value.data
         for lb, ub in zip(lb.array.data, ub.array.data)

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -4,7 +4,7 @@ from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
                                    RewritePattern, GreedyRewritePatternApplier)
 from xdsl.ir import MLContext, Operation
 from xdsl.irdl import Attribute
-from xdsl.dialects.builtin import ArrayAttr, FunctionType, IntegerAttr, ModuleOp, AnyIntegerAttr, IndexType
+from xdsl.dialects.builtin import FunctionType, ModuleOp
 from xdsl.dialects.func import FuncOp
 from xdsl.dialects.memref import MemRefType
 from xdsl.dialects import memref


### PR DESCRIPTION
There will be PyRight issues, but I'm opening to get advice: I'm confused by this new typechecking error on ArrayAttr.__new__, and can't remember how to make pyright happy with the type parameter of a MemRefType :thinking: 