### PR TITLE
dialects: Add stencil.LoadOp -> memref lowering.

### DIFF
--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -1,0 +1,19 @@
+// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+
+"builtin.module"() ({
+    "func.func"() ({
+    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
+        "func.return"() : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+}) : () -> ()
+
+// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() ({
+// CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>):
+// CHECK-NEXT:     %1 = "memref.cast"(%0) {"stencil_offset" = [4 : i64, 4 : i64, 4 : i64]} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT: }) : () -> ()
+

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -1,16 +1,17 @@
 from typing import TypeVar
+from warnings import warn
 
 from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
                                    RewritePattern, GreedyRewritePatternApplier,
                                    op_type_rewrite_pattern)
 from xdsl.ir import MLContext
 from xdsl.irdl import Attribute
-from xdsl.dialects.builtin import FunctionType, ModuleOp
+from xdsl.dialects.builtin import ArrayAttr, FunctionType, IntegerAttr, ModuleOp, i64
 from xdsl.dialects.func import FuncOp
 from xdsl.dialects.memref import MemRefType
 from xdsl.dialects import memref
 
-from xdsl.dialects.experimental.stencil import CastOp, FieldType, IndexAttr
+from xdsl.dialects.experimental.stencil import CastOp, FieldType, IndexAttr, LoadOp
 
 _TypeElement = TypeVar("_TypeElement", bound=Attribute)
 
@@ -51,6 +52,26 @@ class CastOpToMemref(RewritePattern):
         rewriter.replace_matched_op(memref.Cast.get(op.field, result_typ))
 
 
+class LoadOpToMemref(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: LoadOp, rewriter: PatternRewriter, /):
+        if op.lb is None:
+            warn("stencil.load should have a lb attribute when lowered.")
+            return
+        if not isinstance(op.field.owner, memref.Cast):
+            warn(
+                "stencil.cast should be lowered to memref.cast before the stencil.load lowering."
+            )
+            return
+        offsets: list[Attribute] = [
+            IntegerAttr(-i.value.data, i64) for i in op.lb.array.data
+        ]
+        op.field.owner.attributes["stencil_offset"] = ArrayAttr.from_list(
+            offsets)
+        rewriter.erase_matched_op()
+
+
 class StencilTypeConversionFuncOp(RewritePattern):
 
     @op_type_rewrite_pattern
@@ -62,6 +83,8 @@ class StencilTypeConversionFuncOp(RewritePattern):
                 memreftyp = GetMemRefFromField(typ)
                 rewriter.modify_block_argument_type(arg, memreftyp)
                 inputs.append(memreftyp)
+            else:
+                inputs.append(arg.typ)
 
         op.attributes["function_type"] = FunctionType.from_lists(
             inputs, list(op.function_type.outputs.data))
@@ -70,8 +93,7 @@ class StencilTypeConversionFuncOp(RewritePattern):
 def ConvertStencilToLLMLIR(ctx: MLContext, module: ModuleOp):
     walker = PatternRewriteWalker(GreedyRewritePatternApplier(
         [StencilTypeConversionFuncOp(),
-         CastOpToMemref()]),
-                                  walk_regions_first=True,
-                                  apply_recursively=False,
-                                  walk_reverse=True)
+         CastOpToMemref(),
+         LoadOpToMemref()]),
+                                  walk_regions_first=True)
     walker.rewrite_module(module)

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -69,7 +69,7 @@ class LoadOpToMemref(RewritePattern):
         ]
         op.field.owner.attributes["stencil_offset"] = ArrayAttr.from_list(
             offsets)
-        rewriter.erase_matched_op()
+        rewriter.replace_matched_op([], [op.field.owner.dest])
 
 
 class StencilTypeConversionFuncOp(RewritePattern):

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -67,6 +67,8 @@ class LoadOpToMemref(RewritePattern):
         offsets: list[Attribute] = [
             IntegerAttr(-i.value.data, i64) for i in op.lb.array.data
         ]
+
+        # TODO: handle with memref.subview or another, cleaner, approach.
         op.field.owner.attributes["stencil_offset"] = ArrayAttr.from_list(
             offsets)
         rewriter.replace_matched_op([], [op.field.owner.dest])


### PR DESCRIPTION
So to avoid implementing affine maps or strided memrefs for the moment, necessary to use memref.subview here, I'll try to use a simple annotation of the memref.cast op (lowered from the stencil.cast) to offset accesses in the stencil.access&co lowerings.