### PR TITLE
core: Create Lexer, following MLIR specification

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,150 @@
+import pytest
+
+from xdsl.utils.lexer import Input, Lexer, Token
+from xdsl.utils.exceptions import ParseError
+
+
+def assert_single_token(input: str,
+                        expected_kind: Token.Kind,
+                        expected_text: str | None = None):
+    if expected_text is None:
+        expected_text = input
+
+    file = Input(input, "<unknown>")
+    lexer = Lexer(file)
+    token = lexer.lex()
+
+    assert token.kind == expected_kind
+    assert token.span.text == expected_text
+
+
+def assert_token_fail(input: str):
+    file = Input(input, "<unknown>")
+    lexer = Lexer(file)
+    with pytest.raises(ParseError):
+        lexer.lex()
+
+
+@pytest.mark.parametrize('text,kind', [('->', Token.Kind.ARROW),
+                                       (':', Token.Kind.COLON),
+                                       (',', Token.Kind.COMMA),
+                                       ('...', Token.Kind.ELLIPSIS),
+                                       ('=', Token.Kind.EQUAL),
+                                       ('>', Token.Kind.GREATER),
+                                       ('{', Token.Kind.L_BRACE),
+                                       ('(', Token.Kind.L_PAREN),
+                                       ('[', Token.Kind.L_SQUARE),
+                                       ('<', Token.Kind.LESS),
+                                       ('-', Token.Kind.MINUS),
+                                       ('+', Token.Kind.PLUS),
+                                       ('?', Token.Kind.QUESTION),
+                                       ('}', Token.Kind.R_BRACE),
+                                       (')', Token.Kind.R_PAREN),
+                                       (']', Token.Kind.R_SQUARE),
+                                       ('*', Token.Kind.STAR),
+                                       ('|', Token.Kind.VERTICAL_BAR),
+                                       ('{-#', Token.Kind.FILE_METADATA_BEGIN),
+                                       ('#-}', Token.Kind.FILE_METADATA_END)])
+def test_punctuation(text: str, kind: Token.Kind):
+    assert_single_token(text, kind)
+
+
+@pytest.mark.parametrize(
+    'text', ['""', '"@"', '"foo"', '"\\""', '"\\n"', '"\\\\"', '"\\t"'])
+def test_str_literal(text: str):
+    assert_single_token(text, Token.Kind.STRING_LIT)
+
+
+@pytest.mark.parametrize('text',
+                         ['"', '"\\"', '"\\a"', '"\n"', '"\v"', '"\f"'])
+def test_str_literal_fail(text: str):
+    assert_token_fail(text)
+
+
+@pytest.mark.parametrize(
+    'text',
+    ['a', 'A', '_', 'a_', 'a1', 'a1_', 'a1_2', 'a1_2_3', 'a$_.', 'a$_.1'])
+def test_bare_ident(text: str):
+    '''bare-id ::= (letter|[_]) (letter|digit|[_$.])*'''
+    assert_single_token(text, Token.Kind.BARE_IDENT)
+
+
+@pytest.mark.parametrize('text', [
+    '@a', '@A', '@_', '@a_', '@a1', '@a1_', '@a1_2', '@a1_2_3', '@a$_.',
+    '@a$_.1', '@""', '@"@"', '@"foo"', '@"\\""', '@"\\n"', '@"\\\\"', '@"\\t"'
+])
+def test_at_ident(text: str):
+    '''at-ident ::= `@` (bare-id | string-literal)'''
+    assert_single_token(text, Token.Kind.AT_IDENT)
+
+
+@pytest.mark.parametrize('text', [
+    '@', '@"', '@"\\"', '@"\\a"', '@"\n"', '@"\v"', '@"\f"', '@ "a"', '@ f',
+    '@$'
+])
+def test_at_ident_fail(text: str):
+    '''at-ident ::= `@` (bare-id | string-literal)'''
+    assert_token_fail(text)
+
+
+@pytest.mark.parametrize(
+    'text',
+    ['0', '1234', 'a', 'S', '$', '_', '.', '-', 'e_.$-324', 'e5$-e_', 'foo'])
+def test_prefixed_ident(text: str):
+    '''hash-ident  ::= `#` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+    '''percent-ident  ::= `%` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+    '''caret-ident  ::= `^` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+    '''exclamation-ident  ::= `!` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+    assert_single_token('#' + text, Token.Kind.HASH_IDENT)
+    assert_single_token('%' + text, Token.Kind.PERCENT_IDENT)
+    assert_single_token('^' + text, Token.Kind.CARET_IDENT)
+    assert_single_token('!' + text, Token.Kind.EXCLAMATION_IDENT)
+
+
+@pytest.mark.parametrize('text', ['+', '""', '#', '%', '^', '!', '\n', ''])
+def test_prefixed_ident_fail(text: str):
+    '''
+    hash-ident  ::= `#` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)
+    percent-ident  ::= `%` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)
+    caret-ident  ::= `^` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)
+    exclamation-ident  ::= `!` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)
+    '''
+    assert_token_fail('#' + text)
+    assert_token_fail('%' + text)
+    assert_token_fail('^' + text)
+    assert_token_fail('!' + text)
+
+
+@pytest.mark.parametrize('text,expected', [('0x0', '0'), ('0e', '0'),
+                                           ('0$', '0'), ('0_', '0'),
+                                           ('0-', '0'), ('0.', '0')])
+def test_prefixed_ident_split(text: str, expected: str):
+    '''Check that the prefixed identifier is split at the right character.'''
+    assert_single_token('#' + text, Token.Kind.HASH_IDENT, '#' + expected)
+    assert_single_token('%' + text, Token.Kind.PERCENT_IDENT, '%' + expected)
+    assert_single_token('^' + text, Token.Kind.CARET_IDENT, '^' + expected)
+    assert_single_token('!' + text, Token.Kind.EXCLAMATION_IDENT,
+                        '!' + expected)
+
+
+@pytest.mark.parametrize('text',
+                         ['0', '01', '123456789', '99', '0x1234', '0xabcdef'])
+def test_integer_literal(text: str):
+    assert_single_token(text, Token.Kind.INTEGER_LIT)
+
+
+@pytest.mark.parametrize('text,expected', [('0a', '0'), ('0xg', '0'),
+                                           ('0xfg', '0xf'), ('0xf.', '0xf')])
+def test_integer_literal_split(text: str, expected: str):
+    assert_single_token(text, Token.Kind.INTEGER_LIT, expected)
+
+
+@pytest.mark.parametrize(
+    'text', ['0.2', '38.1243', '92.54e43', '92.5E43', '43.3e-54', '32.E+25'])
+def test_float_literal(text: str):
+    assert_single_token(text, Token.Kind.FLOAT_LIT)
+
+
+@pytest.mark.parametrize('text', ['0.', '1.', '3.9e', '4.5e+', '5.8e-'])
+def test_float_literal_fail(text: str):
+    assert_token_fail(text)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -7,17 +7,15 @@ import itertools
 import re
 import sys
 import traceback
-
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from io import StringIO
-from string import hexdigits
 from typing import Any, TypeVar, Iterable, IO, cast
 
 from xdsl.utils.exceptions import ParseError, MultipleSpansParseError
-from xdsl.utils.lexer import Input, Span, Token
+from xdsl.utils.lexer import Input, Span
 from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
 from xdsl.dialects.builtin import (
     AnyArrayAttr, AnyFloat, AnyFloatAttr, AnyTensorType, AnyUnrankedTensorType,
@@ -279,12 +277,6 @@ class Tokenizer:
             pos,
         )
 
-    def skip_whitespace(self):
-        """
-        Skip over whitespace
-        """
-        self.pos = self.next_pos()
-
     def next_token(self, peek: bool = False) -> Span:
         """
         Return a Span of the next token, according to the self.break_on rules.
@@ -295,316 +287,16 @@ class Tokenizer:
         This will skip over line comments. Meaning it will skip the entire line if
         it encounters '//'
         """
-        self.skip_whitespace()
-        start_pos = self.pos
-        # Construct the token, and extract its span
-        span = self.lex(start_pos).span
-        assert span.end == self.pos, "Token lexing did not advance the position"
+        i = self.next_pos()
+        # Construct the span:
+        span = Span(i, self._find_token_end(i), self.input)
         # Advance pointer if not peeking
-        if peek:
-            self.pos = start_pos
+        if not peek:
+            self.pos = span.end
 
         # Save last token
         self.last_token = span
         return span
-
-    def form_token(self, kind: Token.Kind, start_pos: int) -> Token:
-        """
-        Return a token with the given kind, and the start position.
-        """
-        return Token(kind, Span(start_pos, self.pos, self.input))
-
-    def lex(self, start_pos: int) -> Token:
-        start_pos = self.pos
-        # Handle end of file
-        if start_pos > self.input.len:
-            return self.form_token(Token.Kind.EOF, start_pos)
-
-        current_char = self.input.at(start_pos)
-        self.pos += 1
-
-        # bare identifier
-        if current_char.isalpha() or current_char == '_':
-            return self.lex_bare_identifier(start_pos)
-
-        # single-char punctuation that are not part of a multi-char token
-        single_char_punctuation = {
-            ':': Token.Kind.COLON,
-            ',': Token.Kind.COMMA,
-            '(': Token.Kind.L_PAREN,
-            ')': Token.Kind.R_PAREN,
-            '}': Token.Kind.R_BRACE,
-            '[': Token.Kind.L_SQUARE,
-            ']': Token.Kind.R_SQUARE,
-            '<': Token.Kind.LESS,
-            '>': Token.Kind.GREATER,
-            '=': Token.Kind.EQUAL,
-            '+': Token.Kind.PLUS,
-            '*': Token.Kind.STAR,
-            '?': Token.Kind.QUESTION,
-            '|': Token.Kind.VERTICAL_BAR
-        }
-        if current_char in single_char_punctuation:
-            return self.form_token(single_char_punctuation[current_char],
-                                   start_pos)
-
-        # '...'
-        if current_char == '.':
-            if (start_pos + 2 >= self.input.len
-                    or self.input.slice(start_pos, start_pos + 3) != '...'):
-                raise ParseError(
-                    Span(start_pos, start_pos + 1, self.input),
-                    'Expected three consecutive dots for an ellipsis',
-                )
-            self.pos += 2
-            return self.form_token(Token.Kind.ELLIPSIS, start_pos)
-
-        # '-' and '->'
-        if current_char == '-':
-            if (start_pos + 1 < self.input.len
-                    and self.input.at(start_pos + 1) == '>'):
-                self.pos += 1
-                return self.form_token(Token.Kind.ARROW, start_pos)
-            return self.form_token(Token.Kind.MINUS, start_pos)
-
-        # '{' and '{-#'
-        if current_char == '{':
-            if (start_pos + 2 < self.input.len and self.input.slice(
-                    start_pos + 1, start_pos + 2) == '-#'):
-                self.pos += 2
-                return self.form_token(Token.Kind.FILE_METADATA_BEGIN,
-                                       start_pos)
-            return self.form_token(Token.Kind.L_BRACE, start_pos)
-
-        # '#-}'
-        if (start_pos + 2 < self.input.len
-                and self.input.slice(start_pos, start_pos + 2) == '#-}'):
-            self.pos += 2
-            return self.form_token(Token.Kind.FILE_METADATA_END, start_pos)
-
-        # '@' and at-identifier
-        if current_char == '@':
-            return self.lex_at_ident(start_pos)
-
-        # '#', '!', '^', '%' identifiers
-        if current_char in ['#', '!', '^', '%']:
-            return self.lex_prefixed_ident(start_pos)
-
-        if current_char == '"':
-            return self.lex_string_literal(start_pos)
-
-        if current_char.isnumeric():
-            return self.lex_number(start_pos)
-
-        raise ParseError(
-            Span(start_pos, start_pos + 1, self.input),
-            'Unexpected character: {}'.format(current_char),
-        )
-
-    def lex_bare_identifier(self, start_pos: int) -> Token:
-        """
-        Lex a bare identifier with the following grammar:
-        `bare-id ::= (letter|[_]) (letter|digit|[_$.])*`
-
-        The first character is expected to have already been parsed.
-        """
-        assert self.pos != 0, "First identifier character must have been parsed"
-        first_char = self.input.at(self.pos - 1)
-        assert first_char.isalpha() or first_char == '_', \
-            "First identifier character must have been parsed correctly"
-
-        while self.pos < self.input.len:
-            current_char = self.input.at(self.pos)
-            if not (current_char.isalnum() or current_char in ['_', '$', '.']):
-                break
-            self.pos += 1
-
-        return self.form_token(Token.Kind.BARE_IDENT, start_pos)
-
-    def lex_at_ident(self, start_pos: int) -> Token:
-        """
-        Lex an at-identifier with the following grammar:
-        `at-id ::= `@` (bare-id | string-literal)`
-
-        The first character `@` is expected to have already been parsed.
-        """
-        assert self.pos != 0, "First identifier character must have been parsed"
-        assert self.input.at(self.pos - 1) == '@', \
-            "First at-identifier character must have been parsed correctly"
-
-        next_char = self.input.at(self.pos)
-
-        # bare identifier case
-        if next_char.isalpha() or next_char == '_':
-            self.pos += 1
-            token = self.lex_bare_identifier(start_pos)
-            return self.form_token(Token.Kind.AT_IDENT, token.span.start)
-
-        # literal string case
-        if next_char == '"':
-            self.pos += 1
-            token = self.lex_string_literal(start_pos)
-            return self.form_token(Token.Kind.AT_IDENT, token.span.start)
-
-        raise ParseError(
-            Span(start_pos, self.pos, self.input),
-            "@ identifier expected to start with letter, '_', or '\"'.")
-
-    def lex_prefixed_ident(self, start_pos: int) -> Token:
-        """
-        Parsed the following prefixed identifiers:
-        ```
-        hash-ident  ::= `#` suffix-id
-        percent-ident  ::= `%` suffix-id
-        caret-ident  ::= `^` suffix-id
-        exclamation-ident  ::= `!` suffix-id
-        ```
-        with 
-        ```
-        suffix-id = (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
-        ```
-        """
-        assert self.pos != 0, "First prefixed identifier character must have been parsed"
-        first_char = self.input.at(self.pos - 1)
-        if first_char == '#':
-            kind = Token.Kind.HASH_IDENT
-        elif first_char == '!':
-            kind = Token.Kind.EXCLAMATION_IDENT
-        elif first_char == '^':
-            kind = Token.Kind.CARET_IDENT
-        elif first_char == '%':
-            kind = Token.Kind.PERCENT_IDENT
-        else:
-            assert False, "First prefixed identifier character must have been parsed correctly"
-
-        punctuation = ['$', '.', '_', '-']
-
-        if self.pos >= self.input.len:
-            raise ParseError(
-                Span(start_pos, self.pos, self.input),
-                "Character expected to follow with an identifier.")
-        current_char = self.input.at(self.pos)
-        self.pos += 1
-
-        if current_char.isdigit():
-            # digit+ case
-            while self.pos < self.input.len:
-                current_char = self.input.at(self.pos)
-                if not current_char.isdigit():
-                    break
-                self.pos += 1
-        elif current_char.isalpha() or current_char in punctuation:
-            # (letter|[$._-]) (letter|[$._-]|digit)* case
-            while self.pos < self.input.len:
-                current_char = self.input.at(self.pos)
-                if not (current_char.isalnum() or current_char in punctuation):
-                    break
-                self.pos += 1
-        else:
-            raise ParseError(
-                Span(start_pos, self.pos - 1, self.input),
-                "Character expected to follow with an identifier.")
-
-        return self.form_token(kind, start_pos)
-
-    def lex_string_literal(self, start_pos: int) -> Token:
-        """Lex a string literal."""
-        assert self.pos != 0, "First string literal character `\"` must have been parsed"
-        assert self.input.at(self.pos - 1) == '"', \
-            "First string literal character `\"` must have been parsed correctly"
-
-        while self.pos < self.input.len:
-            current_char = self.input.at(self.pos)
-            self.pos += 1
-
-            # end of string literal
-            if current_char == '"':
-                return self.form_token(Token.Kind.STRING_LIT, start_pos)
-
-            # newline character in string literal (not allowed)
-            if current_char in ['\n', '\v', '\f']:
-                raise ParseError(
-                    Span(start_pos, self.pos, self.input),
-                    "Newline character not allowed in string literal.")
-
-            # escape character
-            # TODO: handle unicode escape
-            if current_char == '\\':
-                if self.pos >= self.input.len:
-                    raise ParseError(
-                        Span(start_pos, self.pos, self.input),
-                        "Escape character expected to follow with a character."
-                    )
-                escaped_char = self.input.at(self.pos)
-                self.pos += 1
-                if escaped_char not in ['"', '\\', 'n', 't']:
-                    raise ParseError(Span(self.pos - 1, self.pos, self.input),
-                                     "Unknown espace in string literal.")
-
-        raise ParseError(Span(start_pos, self.pos, self.input),
-                         "End of file reached before closing string literal.")
-
-    def lex_number(self, start_pos: int) -> Token:
-        assert self.pos != 0, "First numeric character must have been parsed"
-        first_digit = self.input.at(self.pos - 1)
-        assert first_digit.isdigit(), \
-            "First numeric character must have been parsed correctly"
-
-        # Hexadecimal case, we only parse it if we see the first '0x' characters,
-        # and then a first digit.
-        # Otherwise, a string like '0xi32' would not be parsed correctly.
-        if self.pos + 1 < self.input.len and self.input.slice(
-                self.pos - 1,
-                self.pos) == '0x' and self.input.at(self.pos + 1) in hexdigits:
-            self.pos += 2
-            while self.pos < self.input.len:
-                current_char = self.input.at(self.pos)
-                if current_char not in hexdigits:
-                    break
-                self.pos += 1
-            return self.form_token(Token.Kind.INTEGER_LIT, start_pos)
-
-        def consume_digits():
-            while self.pos < self.input.len:
-                current_char = self.input.at(self.pos)
-                if not current_char.isdigit():
-                    break
-                self.pos += 1
-
-        # Decimal case
-        consume_digits()
-
-        # Fractional part
-        if self.pos >= self.input.len or self.input.at(self.pos) != '.':
-            return self.form_token(Token.Kind.INTEGER_LIT, start_pos)
-        self.pos += 1
-
-        if self.pos >= self.input.len:
-            raise ParseError(Span(start_pos, self.pos, self.input),
-                             "Decimal '.' expected to follow with a digit.")
-
-        consume_digits()
-
-        # Exponent part
-        if self.pos + 1 < self.input.len and self.input.at(
-                self.pos) in ['e', 'E']:
-            self.pos += 1
-            if self.pos >= self.input.len:
-                raise ParseError(
-                    Span(start_pos, self.pos, self.input),
-                    "Exponent expected to follow with a digit or a sign.")
-
-            # Parse optionally a sign
-            if self.input.at(self.pos) in ['+', '-']:
-                self.pos += 1
-                if self.pos >= self.input.len:
-                    raise ParseError(
-                        Span(start_pos, self.pos, self.input),
-                        "Sign expected to be followed with a digit.")
-
-            consume_digits()
-
-        return self.form_token(Token.Kind.FLOAT_LIT, start_pos)
 
     def next_token_of_pattern(self,
                               pattern: re.Pattern[str] | str,
@@ -667,8 +359,10 @@ class Tokenizer:
         """
         i = self.pos if i is None else i
         # Skip whitespaces
-        while self.input.at(i).isspace():
+        while (c := self.input.at(i)) is not None and c.isspace():
             i += 1
+        if c is None:
+            raise EOFError()
 
         # Skip comments as well
         if self.input.content.startswith("//", i):

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -7,15 +7,17 @@ import itertools
 import re
 import sys
 import traceback
+
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from io import StringIO
+from string import hexdigits
 from typing import Any, TypeVar, Iterable, IO, cast
 
 from xdsl.utils.exceptions import ParseError, MultipleSpansParseError
-from xdsl.utils.lexer import Input, Span
+from xdsl.utils.lexer import Input, Span, Token
 from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
 from xdsl.dialects.builtin import (
     AnyArrayAttr, AnyFloat, AnyFloatAttr, AnyTensorType, AnyUnrankedTensorType,
@@ -277,6 +279,12 @@ class Tokenizer:
             pos,
         )
 
+    def skip_whitespace(self):
+        """
+        Skip over whitespace
+        """
+        self.pos = self.next_pos()
+
     def next_token(self, peek: bool = False) -> Span:
         """
         Return a Span of the next token, according to the self.break_on rules.
@@ -287,16 +295,316 @@ class Tokenizer:
         This will skip over line comments. Meaning it will skip the entire line if
         it encounters '//'
         """
-        i = self.next_pos()
-        # Construct the span:
-        span = Span(i, self._find_token_end(i), self.input)
+        self.skip_whitespace()
+        start_pos = self.pos
+        # Construct the token, and extract its span
+        span = self.lex(start_pos).span
+        assert span.end == self.pos, "Token lexing did not advance the position"
         # Advance pointer if not peeking
-        if not peek:
-            self.pos = span.end
+        if peek:
+            self.pos = start_pos
 
         # Save last token
         self.last_token = span
         return span
+
+    def form_token(self, kind: Token.Kind, start_pos: int) -> Token:
+        """
+        Return a token with the given kind, and the start position.
+        """
+        return Token(kind, Span(start_pos, self.pos, self.input))
+
+    def lex(self, start_pos: int) -> Token:
+        start_pos = self.pos
+        # Handle end of file
+        if start_pos > self.input.len:
+            return self.form_token(Token.Kind.EOF, start_pos)
+
+        current_char = self.input.at(start_pos)
+        self.pos += 1
+
+        # bare identifier
+        if current_char.isalpha() or current_char == '_':
+            return self.lex_bare_identifier(start_pos)
+
+        # single-char punctuation that are not part of a multi-char token
+        single_char_punctuation = {
+            ':': Token.Kind.COLON,
+            ',': Token.Kind.COMMA,
+            '(': Token.Kind.L_PAREN,
+            ')': Token.Kind.R_PAREN,
+            '}': Token.Kind.R_BRACE,
+            '[': Token.Kind.L_SQUARE,
+            ']': Token.Kind.R_SQUARE,
+            '<': Token.Kind.LESS,
+            '>': Token.Kind.GREATER,
+            '=': Token.Kind.EQUAL,
+            '+': Token.Kind.PLUS,
+            '*': Token.Kind.STAR,
+            '?': Token.Kind.QUESTION,
+            '|': Token.Kind.VERTICAL_BAR
+        }
+        if current_char in single_char_punctuation:
+            return self.form_token(single_char_punctuation[current_char],
+                                   start_pos)
+
+        # '...'
+        if current_char == '.':
+            if (start_pos + 2 >= self.input.len
+                    or self.input.slice(start_pos, start_pos + 3) != '...'):
+                raise ParseError(
+                    Span(start_pos, start_pos + 1, self.input),
+                    'Expected three consecutive dots for an ellipsis',
+                )
+            self.pos += 2
+            return self.form_token(Token.Kind.ELLIPSIS, start_pos)
+
+        # '-' and '->'
+        if current_char == '-':
+            if (start_pos + 1 < self.input.len
+                    and self.input.at(start_pos + 1) == '>'):
+                self.pos += 1
+                return self.form_token(Token.Kind.ARROW, start_pos)
+            return self.form_token(Token.Kind.MINUS, start_pos)
+
+        # '{' and '{-#'
+        if current_char == '{':
+            if (start_pos + 2 < self.input.len and self.input.slice(
+                    start_pos + 1, start_pos + 2) == '-#'):
+                self.pos += 2
+                return self.form_token(Token.Kind.FILE_METADATA_BEGIN,
+                                       start_pos)
+            return self.form_token(Token.Kind.L_BRACE, start_pos)
+
+        # '#-}'
+        if (start_pos + 2 < self.input.len
+                and self.input.slice(start_pos, start_pos + 2) == '#-}'):
+            self.pos += 2
+            return self.form_token(Token.Kind.FILE_METADATA_END, start_pos)
+
+        # '@' and at-identifier
+        if current_char == '@':
+            return self.lex_at_ident(start_pos)
+
+        # '#', '!', '^', '%' identifiers
+        if current_char in ['#', '!', '^', '%']:
+            return self.lex_prefixed_ident(start_pos)
+
+        if current_char == '"':
+            return self.lex_string_literal(start_pos)
+
+        if current_char.isnumeric():
+            return self.lex_number(start_pos)
+
+        raise ParseError(
+            Span(start_pos, start_pos + 1, self.input),
+            'Unexpected character: {}'.format(current_char),
+        )
+
+    def lex_bare_identifier(self, start_pos: int) -> Token:
+        """
+        Lex a bare identifier with the following grammar:
+        `bare-id ::= (letter|[_]) (letter|digit|[_$.])*`
+
+        The first character is expected to have already been parsed.
+        """
+        assert self.pos != 0, "First identifier character must have been parsed"
+        first_char = self.input.at(self.pos - 1)
+        assert first_char.isalpha() or first_char == '_', \
+            "First identifier character must have been parsed correctly"
+
+        while self.pos < self.input.len:
+            current_char = self.input.at(self.pos)
+            if not (current_char.isalnum() or current_char in ['_', '$', '.']):
+                break
+            self.pos += 1
+
+        return self.form_token(Token.Kind.BARE_IDENT, start_pos)
+
+    def lex_at_ident(self, start_pos: int) -> Token:
+        """
+        Lex an at-identifier with the following grammar:
+        `at-id ::= `@` (bare-id | string-literal)`
+
+        The first character `@` is expected to have already been parsed.
+        """
+        assert self.pos != 0, "First identifier character must have been parsed"
+        assert self.input.at(self.pos - 1) == '@', \
+            "First at-identifier character must have been parsed correctly"
+
+        next_char = self.input.at(self.pos)
+
+        # bare identifier case
+        if next_char.isalpha() or next_char == '_':
+            self.pos += 1
+            token = self.lex_bare_identifier(start_pos)
+            return self.form_token(Token.Kind.AT_IDENT, token.span.start)
+
+        # literal string case
+        if next_char == '"':
+            self.pos += 1
+            token = self.lex_string_literal(start_pos)
+            return self.form_token(Token.Kind.AT_IDENT, token.span.start)
+
+        raise ParseError(
+            Span(start_pos, self.pos, self.input),
+            "@ identifier expected to start with letter, '_', or '\"'.")
+
+    def lex_prefixed_ident(self, start_pos: int) -> Token:
+        """
+        Parsed the following prefixed identifiers:
+        ```
+        hash-ident  ::= `#` suffix-id
+        percent-ident  ::= `%` suffix-id
+        caret-ident  ::= `^` suffix-id
+        exclamation-ident  ::= `!` suffix-id
+        ```
+        with 
+        ```
+        suffix-id = (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+        ```
+        """
+        assert self.pos != 0, "First prefixed identifier character must have been parsed"
+        first_char = self.input.at(self.pos - 1)
+        if first_char == '#':
+            kind = Token.Kind.HASH_IDENT
+        elif first_char == '!':
+            kind = Token.Kind.EXCLAMATION_IDENT
+        elif first_char == '^':
+            kind = Token.Kind.CARET_IDENT
+        elif first_char == '%':
+            kind = Token.Kind.PERCENT_IDENT
+        else:
+            assert False, "First prefixed identifier character must have been parsed correctly"
+
+        punctuation = ['$', '.', '_', '-']
+
+        if self.pos >= self.input.len:
+            raise ParseError(
+                Span(start_pos, self.pos, self.input),
+                "Character expected to follow with an identifier.")
+        current_char = self.input.at(self.pos)
+        self.pos += 1
+
+        if current_char.isdigit():
+            # digit+ case
+            while self.pos < self.input.len:
+                current_char = self.input.at(self.pos)
+                if not current_char.isdigit():
+                    break
+                self.pos += 1
+        elif current_char.isalpha() or current_char in punctuation:
+            # (letter|[$._-]) (letter|[$._-]|digit)* case
+            while self.pos < self.input.len:
+                current_char = self.input.at(self.pos)
+                if not (current_char.isalnum() or current_char in punctuation):
+                    break
+                self.pos += 1
+        else:
+            raise ParseError(
+                Span(start_pos, self.pos - 1, self.input),
+                "Character expected to follow with an identifier.")
+
+        return self.form_token(kind, start_pos)
+
+    def lex_string_literal(self, start_pos: int) -> Token:
+        """Lex a string literal."""
+        assert self.pos != 0, "First string literal character `\"` must have been parsed"
+        assert self.input.at(self.pos - 1) == '"', \
+            "First string literal character `\"` must have been parsed correctly"
+
+        while self.pos < self.input.len:
+            current_char = self.input.at(self.pos)
+            self.pos += 1
+
+            # end of string literal
+            if current_char == '"':
+                return self.form_token(Token.Kind.STRING_LIT, start_pos)
+
+            # newline character in string literal (not allowed)
+            if current_char in ['\n', '\v', '\f']:
+                raise ParseError(
+                    Span(start_pos, self.pos, self.input),
+                    "Newline character not allowed in string literal.")
+
+            # escape character
+            # TODO: handle unicode escape
+            if current_char == '\\':
+                if self.pos >= self.input.len:
+                    raise ParseError(
+                        Span(start_pos, self.pos, self.input),
+                        "Escape character expected to follow with a character."
+                    )
+                escaped_char = self.input.at(self.pos)
+                self.pos += 1
+                if escaped_char not in ['"', '\\', 'n', 't']:
+                    raise ParseError(Span(self.pos - 1, self.pos, self.input),
+                                     "Unknown espace in string literal.")
+
+        raise ParseError(Span(start_pos, self.pos, self.input),
+                         "End of file reached before closing string literal.")
+
+    def lex_number(self, start_pos: int) -> Token:
+        assert self.pos != 0, "First numeric character must have been parsed"
+        first_digit = self.input.at(self.pos - 1)
+        assert first_digit.isdigit(), \
+            "First numeric character must have been parsed correctly"
+
+        # Hexadecimal case, we only parse it if we see the first '0x' characters,
+        # and then a first digit.
+        # Otherwise, a string like '0xi32' would not be parsed correctly.
+        if self.pos + 1 < self.input.len and self.input.slice(
+                self.pos - 1,
+                self.pos) == '0x' and self.input.at(self.pos + 1) in hexdigits:
+            self.pos += 2
+            while self.pos < self.input.len:
+                current_char = self.input.at(self.pos)
+                if current_char not in hexdigits:
+                    break
+                self.pos += 1
+            return self.form_token(Token.Kind.INTEGER_LIT, start_pos)
+
+        def consume_digits():
+            while self.pos < self.input.len:
+                current_char = self.input.at(self.pos)
+                if not current_char.isdigit():
+                    break
+                self.pos += 1
+
+        # Decimal case
+        consume_digits()
+
+        # Fractional part
+        if self.pos >= self.input.len or self.input.at(self.pos) != '.':
+            return self.form_token(Token.Kind.INTEGER_LIT, start_pos)
+        self.pos += 1
+
+        if self.pos >= self.input.len:
+            raise ParseError(Span(start_pos, self.pos, self.input),
+                             "Decimal '.' expected to follow with a digit.")
+
+        consume_digits()
+
+        # Exponent part
+        if self.pos + 1 < self.input.len and self.input.at(
+                self.pos) in ['e', 'E']:
+            self.pos += 1
+            if self.pos >= self.input.len:
+                raise ParseError(
+                    Span(start_pos, self.pos, self.input),
+                    "Exponent expected to follow with a digit or a sign.")
+
+            # Parse optionally a sign
+            if self.input.at(self.pos) in ['+', '-']:
+                self.pos += 1
+                if self.pos >= self.input.len:
+                    raise ParseError(
+                        Span(start_pos, self.pos, self.input),
+                        "Sign expected to be followed with a digit.")
+
+            consume_digits()
+
+        return self.form_token(Token.Kind.FLOAT_LIT, start_pos)
 
     def next_token_of_pattern(self,
                               pattern: re.Pattern[str] | str,

--- a/xdsl/utils/lexer.py
+++ b/xdsl/utils/lexer.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from io import StringIO
 from enum import Enum, auto
+from typing import Callable, cast
+from string import hexdigits
+
+from xdsl.utils.exceptions import ParseError
 
 
 @dataclass(frozen=True)
@@ -43,16 +47,18 @@ class Input:
                 return [source[start:next_start]], start, line_no
             while next_start < span.end:
                 next_start = source.find('\n', next_start + 1)
+                if next_start == -1:
+                    next_start = span.end
             return source[start:next_start].split('\n'), start, line_no
 
-    def at(self, i: int) -> str:
+    def at(self, i: int) -> str | None:
         if i >= self.len:
-            raise EOFError()
+            return None
         return self.content[i]
 
-    def slice(self, start: int, end: int) -> str:
-        if end >= self.len:
-            raise EOFError()
+    def slice(self, start: int, end: int) -> str | None:
+        if end > self.len or start < 0:
+            return None
         return self.content[start:end]
 
 
@@ -158,7 +164,6 @@ class Token:
 
         # Punctuation
         ARROW = auto()  # ->
-        AT = auto()  # @
         COLON = auto()  # :
         COMMA = auto()  # ,
         ELLIPSIS = auto()  # ...
@@ -182,3 +187,334 @@ class Token:
     kind: Kind
 
     span: Span
+
+
+@dataclass
+class Lexer:
+    input: Input
+    """Input that is currently being lexed."""
+
+    pos: int = field(init=False, default=0)
+    """
+    Current position in the input.
+    The position can be out of bounds, in which case the lexer is in EOF state.
+    """
+
+    def _is_in_bounds(self, size: int = 1) -> bool:
+        """
+        Check if the current position is within the bounds of the input.
+        """
+        return self.pos + size - 1 < len(self.input.content)
+
+    def _get_chars(self, size: int = 1) -> str | None:
+        """
+        Get the character at the current location, or multiple characters ahead.
+        Return None if the position is out of bounds.
+        """
+        res = self.input.slice(self.pos, self.pos + size)
+        self._consume_chars(size)
+        return res
+
+    def _peek_chars(self, size: int = 1) -> str | None:
+        """
+        Peek at the character at the current location, or multiple characters ahead.
+        Return None if the position is out of bounds.
+        """
+        return self.input.slice(self.pos, self.pos + size)
+
+    def _consume_chars(self, size: int = 1) -> None:
+        """
+        Advance the lexer position in the input by the given amount.
+        """
+        self.pos = min(self.pos + size, len(self.input))
+
+    def _consume_while(self, predicate: Callable[[str], bool]) -> None:
+        """
+        Advance the lexer position as long as the current character satisfies the
+        given predicate.
+        Returns the number of characters consumed.
+        """
+        while ((current := self._peek_chars()) is not None
+               and predicate(current)):
+            self._consume_chars()
+
+    def _consume_whitespace(self) -> None:
+        """
+        Consume whitespace and comments.
+        """
+        while (current := self._peek_chars()) is not None:
+            # Whitespace
+            if current.isspace():
+                self._consume_chars()
+                continue
+
+            # Comments
+            if current == '/':
+                if self._peek_chars(2) == '//':
+                    self._consume_chars(2)
+                    self._consume_while(lambda c: c != '\n')
+                    continue
+
+            return
+
+    def _form_token(self, kind: Token.Kind, start_pos: int) -> Token:
+        """
+        Return a token with the given kind, and the start position.
+        """
+        return Token(kind, Span(start_pos, self.pos, self.input))
+
+    def lex(self) -> Token:
+        """
+        Lex a token from the input, and returns it.
+        """
+        # First, skip whitespaces
+        self._consume_whitespace()
+
+        start_pos = self.pos
+        current_char = self._get_chars()
+
+        # Handle end of file
+        if current_char is None:
+            return self._form_token(Token.Kind.EOF, start_pos)
+
+        # bare identifier
+        if current_char.isalpha() or current_char == '_':
+            return self._lex_bare_identifier(start_pos)
+
+        # single-char punctuation that are not part of a multi-char token
+        single_char_punctuation = {
+            ':': Token.Kind.COLON,
+            ',': Token.Kind.COMMA,
+            '(': Token.Kind.L_PAREN,
+            ')': Token.Kind.R_PAREN,
+            '}': Token.Kind.R_BRACE,
+            '[': Token.Kind.L_SQUARE,
+            ']': Token.Kind.R_SQUARE,
+            '<': Token.Kind.LESS,
+            '>': Token.Kind.GREATER,
+            '=': Token.Kind.EQUAL,
+            '+': Token.Kind.PLUS,
+            '*': Token.Kind.STAR,
+            '?': Token.Kind.QUESTION,
+            '|': Token.Kind.VERTICAL_BAR
+        }
+        if current_char in single_char_punctuation:
+            return self._form_token(single_char_punctuation[current_char],
+                                    start_pos)
+
+        # '...'
+        if current_char == '.':
+            if (self._get_chars(2) != '..'):
+                raise ParseError(
+                    Span(start_pos, start_pos + 1, self.input),
+                    "Expected three consecutive '.' for an ellipsis",
+                )
+            return self._form_token(Token.Kind.ELLIPSIS, start_pos)
+
+        # '-' and '->'
+        if current_char == '-':
+            if self._peek_chars() == '>':
+                self._consume_chars()
+                return self._form_token(Token.Kind.ARROW, start_pos)
+            return self._form_token(Token.Kind.MINUS, start_pos)
+
+        # '{' and '{-#'
+        if current_char == '{':
+            if (self._peek_chars(2) == '-#'):
+                self._consume_chars(2)
+                return self._form_token(Token.Kind.FILE_METADATA_BEGIN,
+                                        start_pos)
+            return self._form_token(Token.Kind.L_BRACE, start_pos)
+
+        # '#-}'
+        if (current_char == '#' and self._peek_chars(2) == '-}'):
+            self._consume_chars(2)
+            return self._form_token(Token.Kind.FILE_METADATA_END, start_pos)
+
+        # '@' and at-identifier
+        if current_char == '@':
+            return self._lex_at_ident(start_pos)
+
+        # '#', '!', '^', '%' identifiers
+        if current_char in ['#', '!', '^', '%']:
+            return self._lex_prefixed_ident(start_pos)
+
+        if current_char == '"':
+            return self._lex_string_literal(start_pos)
+
+        if current_char.isnumeric():
+            return self._lex_number(start_pos)
+
+        raise ParseError(
+            Span(start_pos, start_pos + 1, self.input),
+            'Unexpected character: {}'.format(current_char),
+        )
+
+    def _lex_bare_identifier(self, start_pos: int) -> Token:
+        """
+        Lex a bare identifier with the following grammar:
+        `bare-id ::= (letter|[_]) (letter|digit|[_$.])*`
+
+        The first character is expected to have already been parsed.
+        """
+        self._consume_while(lambda c: c.isalnum() or c in ['_', '$', '.'])
+
+        return self._form_token(Token.Kind.BARE_IDENT, start_pos)
+
+    def _lex_at_ident(self, start_pos: int) -> Token:
+        """
+        Lex an at-identifier with the following grammar:
+        `at-id ::= `@` (bare-id | string-literal)`
+
+        The first character `@` is expected to have already been parsed.
+        """
+        current_char = self._get_chars()
+
+        if current_char is None:
+            raise ParseError(Span(start_pos, start_pos + 1, self.input),
+                             "Unexpected end of file after @.")
+
+        # bare identifier case
+        if current_char.isalpha() or current_char == '_':
+            token = self._lex_bare_identifier(start_pos)
+            return self._form_token(Token.Kind.AT_IDENT, token.span.start)
+
+        # literal string case
+        if current_char == '"':
+            token = self._lex_string_literal(start_pos)
+            return self._form_token(Token.Kind.AT_IDENT, token.span.start)
+
+        raise ParseError(
+            Span(start_pos, self.pos, self.input),
+            "@ identifier expected to start with letter, '_', or '\"'.")
+
+    def _lex_prefixed_ident(self, start_pos: int) -> Token:
+        """
+        Parsed the following prefixed identifiers:
+        ```
+        hash-ident  ::= `#` suffix-id
+        percent-ident  ::= `%` suffix-id
+        caret-ident  ::= `^` suffix-id
+        exclamation-ident  ::= `!` suffix-id
+        ```
+        with 
+        ```
+        suffix-id = (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+        ```
+
+        The first character is expected to have already been parsed.
+        """
+        assert self.pos != 0, "First prefixed identifier character must have been parsed"
+        first_char = self.input.at(self.pos - 1)
+        if first_char == '#':
+            kind = Token.Kind.HASH_IDENT
+        elif first_char == '!':
+            kind = Token.Kind.EXCLAMATION_IDENT
+        elif first_char == '^':
+            kind = Token.Kind.CARET_IDENT
+        elif first_char == '%':
+            kind = Token.Kind.PERCENT_IDENT
+        else:
+            assert False, "First prefixed identifier character must have been parsed correctly"
+
+        punctuation = ['$', '.', '_', '-']
+
+        current_char = self._get_chars()
+        if current_char is None:
+            raise ParseError(
+                Span(start_pos, start_pos + 1, self.input),
+                "'first_char' is expected to follow with an identifier.")
+
+        if current_char.isdigit():
+            # digit+ case
+            self._consume_while(lambda c: c.isdigit())
+        elif current_char.isalpha() or current_char in punctuation:
+            # (letter|[$._-]) (letter|[$._-]|digit)* case
+            self._consume_while(lambda c: c.isalnum() or c in punctuation)
+        else:
+            raise ParseError(
+                Span(start_pos, start_pos + 1, self.input),
+                "Character expected to follow with an identifier.")
+
+        return self._form_token(kind, start_pos)
+
+    def _lex_string_literal(self, start_pos: int) -> Token:
+        """
+        Lex a string literal.
+        The first character `"` is expected to have already been parsed.
+        """
+
+        while self._is_in_bounds():
+            current_char = self._get_chars()
+
+            # end of string literal
+            if current_char == '"':
+                return self._form_token(Token.Kind.STRING_LIT, start_pos)
+
+            # newline character in string literal (not allowed)
+            if current_char in ['\n', '\v', '\f']:
+                raise ParseError(
+                    Span(start_pos, self.pos, self.input),
+                    "Newline character not allowed in string literal.")
+
+            # escape character
+            # TODO: handle unicode escape
+            if current_char == '\\':
+                escaped_char = self._get_chars()
+                if escaped_char not in ['"', '\\', 'n', 't']:
+                    raise ParseError(Span(self.pos - 1, self.pos, self.input),
+                                     "Unknown escape in string literal.")
+
+        raise ParseError(Span(start_pos, self.pos, self.input),
+                         "End of file reached before closing string literal.")
+
+    def _lex_number(self, start_pos: int) -> Token:
+        """
+        Lex a number literal, which is either a decimal or an hexadecimal.
+        The first character is expected to have already been parsed.
+        """
+        first_digit = self.input.at(self.pos - 1)
+
+        # Hexadecimal case, we only parse it if we see the first '0x' characters,
+        # and then a first digit.
+        # Otherwise, a string like '0xi32' would not be parsed correctly.
+        if (first_digit == '0' and self._peek_chars() == 'x'
+                and self._is_in_bounds(2)
+                and cast(str, self.input.at(self.pos + 1)) in hexdigits):
+            self._consume_chars(2)
+            self._consume_while(lambda c: c in hexdigits)
+            return self._form_token(Token.Kind.INTEGER_LIT, start_pos)
+
+        # Decimal case
+        self._consume_while(lambda c: c.isdigit())
+
+        # Fractional part
+        if self._peek_chars() != '.':
+            return self._form_token(Token.Kind.INTEGER_LIT, start_pos)
+        self._consume_chars()
+
+        if not self._is_in_bounds():
+            raise ParseError(Span(start_pos, self.pos, self.input),
+                             "Decimal '.' expected to follow with a digit.")
+
+        self._consume_while(lambda c: c.isdigit())
+
+        # Exponent part
+        if self._peek_chars() in ['e', 'E']:
+            self._consume_chars()
+            if not self._is_in_bounds():
+                raise ParseError(
+                    Span(start_pos, self.pos, self.input),
+                    "Exponent expected to follow with a digit or a sign.")
+
+            # Parse optionally a sign
+            if self._peek_chars() in ['+', '-']:
+                self._consume_chars()
+                if not self._is_in_bounds():
+                    raise ParseError(
+                        Span(start_pos, self.pos, self.input),
+                        "Sign expected to be followed with a digit.")
+
+            self._consume_while(lambda c: c.isdigit())
+
+        return self._form_token(Token.Kind.FLOAT_LIT, start_pos)

--- a/xdsl/utils/lexer.py
+++ b/xdsl/utils/lexer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from io import StringIO
+from enum import Enum, auto
 
 
 @dataclass(frozen=True)
@@ -44,10 +45,15 @@ class Input:
                 next_start = source.find('\n', next_start + 1)
             return source[start:next_start].split('\n'), start, line_no
 
-    def at(self, i: int):
+    def at(self, i: int) -> str:
         if i >= self.len:
             raise EOFError()
         return self.content[i]
+
+    def slice(self, start: int, end: int) -> str:
+        if end >= self.len:
+            raise EOFError()
+        return self.content[start:end]
 
 
 @dataclass(frozen=True)
@@ -122,3 +128,57 @@ class Span:
     def __repr__(self):
         return "{}[{}:{}](text='{}')".format(self.__class__.__name__,
                                              self.start, self.end, self.text)
+
+
+@dataclass
+class Token:
+
+    class Kind(Enum):
+        # Markers
+        EOF = auto()
+
+        # Identifiers
+        BARE_IDENT = auto()
+        '''bare-id ::= (letter|[_]) (letter|digit|[_$.])*'''
+        AT_IDENT = auto()  # @foo
+        '''at-ident ::= `@` (bare-id | string-literal)'''
+        HASH_IDENT = auto()  # #foo
+        '''hash-ident  ::= `#` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+        PERCENT_IDENT = auto()  # %foo
+        '''percent-ident  ::= `%` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+        CARET_IDENT = auto()  # ^foo
+        '''caret-ident  ::= `^` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+        EXCLAMATION_IDENT = auto()  # !foo
+        '''exclamation-ident  ::= `!` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)'''
+
+        # Literals
+        FLOAT_LIT = auto()  # 1.0
+        INTEGER_LIT = auto()  # 1
+        STRING_LIT = auto()  # "foo"
+
+        # Punctuation
+        ARROW = auto()  # ->
+        AT = auto()  # @
+        COLON = auto()  # :
+        COMMA = auto()  # ,
+        ELLIPSIS = auto()  # ...
+        EQUAL = auto()  # =
+        GREATER = auto()  # >
+        L_BRACE = auto()  # {
+        L_PAREN = auto()  # (
+        L_SQUARE = auto()  # [
+        LESS = auto()  # <
+        MINUS = auto()  # -
+        PLUS = auto()  # +
+        QUESTION = auto()  # ?
+        R_BRACE = auto()  # }
+        R_PAREN = auto()  # )
+        R_SQUARE = auto()  # ]
+        STAR = auto()  # *
+        VERTICAL_BAR = auto()  # |
+        FILE_METADATA_BEGIN = auto()  # {-#
+        FILE_METADATA_END = auto()  # #-}
+
+    kind: Kind
+
+    span: Span


### PR DESCRIPTION
This depends on #543

This is a reimplementation of the MLIR lexer, that should follow MLIR specification.
The only difference is that we do not have tokens for each possible keywords. The reason for this is that I'm still unsure
why MLIR has keyword tokens. It doesn't change any functionality otherwise.

The lexer is tested, but not included in the current parser. This is the work for another PR.