### PR TITLE
llvm: Add `ptr.is_typed()` method to check if pointer is typed

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -35,8 +35,6 @@ def test_llvm_pointer_ops():
 
 
 def test_llvm_pointer_type():
-
-
     assert llvm.LLVMPointerType.typed(builtin.i64).is_typed()
     assert llvm.LLVMPointerType.typed(builtin.i64).type is builtin.i64
     assert isinstance(

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -36,10 +36,13 @@ def test_llvm_pointer_ops():
 
 def test_llvm_pointer_type():
 
+
+    assert llvm.LLVMPointerType.typed(builtin.i64).is_typed()
     assert llvm.LLVMPointerType.typed(builtin.i64).type is builtin.i64
     assert isinstance(
         llvm.LLVMPointerType.typed(builtin.i64).addr_space, builtin.NoneAttr)
 
+    assert not llvm.LLVMPointerType.opaque().is_typed()
     assert isinstance(llvm.LLVMPointerType.opaque().type, builtin.NoneAttr)
     assert isinstance(llvm.LLVMPointerType.opaque().addr_space,
                       builtin.NoneAttr)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -91,6 +91,9 @@ class LLVMPointerType(ParametrizedAttribute, MLIRType):
     def typed(type: Attribute):
         return LLVMPointerType([type, NoneAttr()])
 
+    def is_typed(self):
+        return not isinstance(self.type, NoneAttr)
+
 
 @irdl_op_definition
 class AllocaOp(Operation):


### PR DESCRIPTION
This is a quick helper method that is probably useful for anyone who interacts with pointers and cares about their wrapped type