### PR TITLE
core: unify builder arg building

### DIFF
--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -383,6 +383,7 @@ def test_opt_sbregion_one_block():
     op2 = OptSBRegionOp.build(regions=[[]])
     op1.verify()
     op2.verify()
+    assert op1.region is not None
     assert len(op1.region.blocks) == 1
     assert op2.region is None
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -545,7 +545,8 @@ class Operation(IRNode):
         attributes: dict[str, Attribute] | None = None,
         successors: Sequence[Block] | None = None,
         regions: Sequence[Region | Sequence[Operation] | Sequence[Block]
-                          | Sequence[Region]]
+                          | Sequence[Region | Sequence[Operation]
+                                     | Sequence[Block]]]
         | None = None
     ) -> OpT:
         """Create a new operation using builders."""
@@ -1031,7 +1032,7 @@ class Region(IRNode):
         return region
 
     @staticmethod
-    def get(arg: Region | list[Block] | list[Operation]) -> Region:
+    def get(arg: Region | Sequence[Block] | Sequence[Operation]) -> Region:
         if isinstance(arg, Region):
             return arg
         if isinstance(arg, list):

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass, field
 from enum import Enum
 from functools import reduce
 from inspect import isclass
-from typing import (Annotated, Any, Generic, Sequence, TypeAlias, TypeVar,
-                    Union, cast, get_args, get_origin, get_type_hints)
+from typing import (Annotated, Any, Generic, Literal, Sequence, TypeAlias,
+                    TypeVar, Union, cast, get_args, get_origin, get_type_hints,
+                    overload)
 from types import UnionType, GenericAlias, FunctionType
 
 from xdsl.ir import (Attribute, Block, Data, OpResult, Operation,
@@ -903,6 +904,31 @@ def irdl_op_verify_arg_list(op: Operation, op_def: OpDef,
             arg_idx += 1
 
 
+@overload
+def irdl_build_arg_list(construct: Literal[VarIRConstruct.OPERAND],
+                        args: Sequence[SSAValue | Sequence[SSAValue]],
+                        arg_defs: Sequence[tuple[str, OperandDef]],
+                        error_prefix: str) -> tuple[list[SSAValue], list[int]]:
+    ...
+
+
+@overload
+def irdl_build_arg_list(
+        construct: Literal[VarIRConstruct.RESULT],
+        args: Sequence[Attribute | Sequence[Attribute]],
+        arg_defs: Sequence[tuple[str, ResultDef]],
+        error_prefix: str) -> tuple[list[Attribute], list[int]]:
+    ...
+
+
+@overload
+def irdl_build_arg_list(construct: Literal[VarIRConstruct.REGION],
+                        args: Sequence[Region | Sequence[Region]],
+                        arg_defs: Sequence[tuple[str, RegionDef]],
+                        error_prefix: str) -> tuple[list[Region], list[int]]:
+    ...
+
+
 def irdl_build_arg_list(construct: VarIRConstruct,
                         args: Sequence[Any],
                         arg_defs: Sequence[tuple[str, Any]],
@@ -950,7 +976,7 @@ def irdl_op_builder(
     operands: Sequence[SSAValue | Operation
                        | Sequence[SSAValue | Operation]
                        | None],
-    res_types: Sequence[Attribute | Sequence[Attribute] | None],
+    res_types: Sequence[Attribute | Sequence[Attribute]],
     attributes: dict[str, Attribute], successors: Sequence[Block],
     regions: Sequence[Region | Sequence[Operation] | Sequence[Block]
                       | Sequence[Region | Sequence[Operation]

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -909,23 +909,6 @@ def irdl_build_arg_list(construct: VarIRConstruct,
                         error_prefix: str = "") -> tuple[list[Any], list[int]]:
     """Build a list of arguments (operands, results, regions)"""
 
-    def build_arg(arg_def: Any, arg: Any) -> Any:
-        """Build a single argument."""
-        if construct == VarIRConstruct.OPERAND:
-            assert isinstance(arg, SSAValue)
-            return arg
-        elif construct == VarIRConstruct.RESULT:
-            if not isinstance(arg, Attribute):
-                raise ValueError(error_prefix +
-                                 f"expected Attribute, but got {type(arg)}")
-            return arg
-        elif construct == VarIRConstruct.REGION:
-            assert isinstance(arg_def, RegionDef)
-            assert isinstance(arg, Region)
-            return arg
-        else:
-            assert False, "Unknown ArgType value"
-
     if len(args) != len(arg_defs):
         raise ValueError(
             f"Expected {len(arg_defs)} {get_construct_name(construct)}, "
@@ -951,10 +934,10 @@ def irdl_build_arg_list(construct: VarIRConstruct,
                     "expects a list of size at most 1, but "
                     f"got a list of size {len(arg)}")
 
-            res.extend([build_arg(arg_def, arg_arg) for arg_arg in arg])
+            res.extend(arg)
             arg_sizes.append(len(arg))
         else:
-            res.append(build_arg(arg_def, arg))
+            res.append(arg)
             arg_sizes.append(1)
     return res, arg_sizes
 


### PR DESCRIPTION
While working on the PDL dialect, I found that our type annotation for region building didn't support optional regions. This PR adds a bit more typing to reflect the fact that we do accept variadic of regions.

Another change is to support passing `None` to the `irdl_op_builder` (note, not the `build` method on the Operation, yet), which correctly translates to the expected `[]`. This was already annotated as supported by the type annotations, but I don't think actually worked. The nice thing about that is that we can pass the optional values directly to the builder now, and have it work correctly. This would simplify quite a lot of getters and make it easier for us to transition to plain `dataclass` inits in the future.