### PR TITLE
misc: Pass SSAValue or IRNode for structural equality checking

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -45,8 +45,7 @@ class ArrayOfConstraint(AttrConstraint):
 class ArrayAttr(GenericData[tuple[AttributeCovT, ...]]):
     name: str = "array"
 
-    def __init__(self: ArrayAttr[AttributeCovT],
-                 param: Iterable[AttributeCovT]) -> None:
+    def __init__(self, param: Iterable[AttributeCovT]) -> None:
         super().__init__(tuple(param))
 
     @staticmethod

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -45,7 +45,8 @@ class ArrayOfConstraint(AttrConstraint):
 class ArrayAttr(GenericData[tuple[AttributeCovT, ...]]):
     name: str = "array"
 
-    def __init__(self, param: Iterable[AttributeCovT]) -> None:
+    def __init__(self: ArrayAttr[AttributeCovT],
+                 param: Iterable[AttributeCovT]) -> None:
         super().__init__(tuple(param))
 
     @staticmethod

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -438,9 +438,11 @@ class IRNode(ABC):
         """Check if two IR nodes are structurally equivalent."""
         ...
 
+    @abstractmethod
     def __eq__(self, other: object) -> bool:
         ...
 
+    @abstractmethod
     def __hash__(self) -> int:
         ...
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -431,10 +431,17 @@ class IRNode(ABC):
         return self.parent.get_toplevel_object()
 
     def is_structurally_equivalent(
-            self,
-            other: IRNode,
-            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
+        self,
+        other: IRNode,
+        context: dict[IRNode | SSAValue, IRNode | SSAValue] | None = None
+    ) -> bool:
         """Check if two IR nodes are structurally equivalent."""
+        ...
+
+    def __eq__(self, other: object) -> bool:
+        ...
+
+    def __hash__(self) -> int:
         ...
 
 
@@ -676,9 +683,10 @@ class Operation(IRNode):
         self.parent.detach_op(self)
 
     def is_structurally_equivalent(
-            self,
-            other: IRNode,
-            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
+        self,
+        other: IRNode,
+        context: dict[IRNode | SSAValue, IRNode | SSAValue] | None = None
+    ) -> bool:
         """
         Check if two operations are structurally equivalent.
         The context is a mapping of IR nodes to IR nodes that are already known
@@ -958,9 +966,10 @@ class Block(IRNode):
             op.erase(safe_erase=safe_erase, drop_references=False)
 
     def is_structurally_equivalent(
-            self,
-            other: IRNode,
-            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
+        self,
+        other: IRNode,
+        context: dict[IRNode | SSAValue, IRNode | SSAValue] | None = None
+    ) -> bool:
         """
         Check if two blocks are structurally equivalent.
         The context is a mapping of IR nodes to IR nodes that are already known
@@ -1194,9 +1203,10 @@ class Region(IRNode):
             block.parent = region
 
     def is_structurally_equivalent(
-            self,
-            other: IRNode,
-            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
+        self,
+        other: IRNode,
+        context: dict[IRNode | SSAValue, IRNode | SSAValue] | None = None
+    ) -> bool:
         """
         Check if two regions are structurally equivalent.
         The context is a mapping of IR nodes to IR nodes that are already known

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -113,40 +113,7 @@ class Use:
 
 
 @dataclass
-class IRNode(ABC):
-
-    parent: IRNode | None = field(init=False)
-
-    def is_ancestor(self, op: IRNode) -> bool:
-        "Returns true if the IRNode is an ancestor of another IRNode."
-        if op is self:
-            return True
-        if op.parent is None:
-            return False
-        return self.is_ancestor(op.parent)
-
-    def get_toplevel_object(self) -> IRNode:
-        """Get the operation, block, or region ancestor that has no parents."""
-        if self.parent is None:
-            return self
-        return self.parent.get_toplevel_object()
-
-    def is_structurally_equivalent(
-            self,
-            other: IRNode,
-            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
-        """Check if two IR nodes are structurally equivalent."""
-        ...
-
-    def __eq__(self, other: object) -> bool:
-        return self is other
-
-    def __hash__(self) -> int:
-        return id(self)
-
-
-@dataclass
-class SSAValue(IRNode, ABC):
+class SSAValue(ABC):
     """
     A reference to an SSA variable.
     An SSA variable is either an operation result, or a basic block argument.
@@ -441,6 +408,33 @@ class ParametrizedAttribute(Attribute):
     @property
     def irdl_definition(cls) -> ParamAttrDef:
         """Get the IRDL attribute definition."""
+        ...
+
+
+@dataclass
+class IRNode(ABC):
+
+    parent: IRNode | None
+
+    def is_ancestor(self, op: IRNode) -> bool:
+        "Returns true if the IRNode is an ancestor of another IRNode."
+        if op is self:
+            return True
+        if op.parent is None:
+            return False
+        return self.is_ancestor(op.parent)
+
+    def get_toplevel_object(self) -> IRNode:
+        """Get the operation, block, or region ancestor that has no parents."""
+        if self.parent is None:
+            return self
+        return self.parent.get_toplevel_object()
+
+    def is_structurally_equivalent(
+            self,
+            other: IRNode,
+            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
+        """Check if two IR nodes are structurally equivalent."""
         ...
 
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -6,8 +6,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from io import StringIO
 from itertools import chain
-from typing import (TYPE_CHECKING, Any, Callable, Generic, Optional, Protocol,
-                    Sequence, TypeVar, cast, Iterator, ClassVar)
+from typing import (TYPE_CHECKING, Any, Callable, Generic, Protocol, Sequence,
+                    TypeVar, cast, Iterator, ClassVar)
 
 # Used for cyclic dependencies in type hints
 if TYPE_CHECKING:

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -113,7 +113,40 @@ class Use:
 
 
 @dataclass
-class SSAValue(ABC):
+class IRNode(ABC):
+
+    parent: IRNode | None = field(init=False)
+
+    def is_ancestor(self, op: IRNode) -> bool:
+        "Returns true if the IRNode is an ancestor of another IRNode."
+        if op is self:
+            return True
+        if op.parent is None:
+            return False
+        return self.is_ancestor(op.parent)
+
+    def get_toplevel_object(self) -> IRNode:
+        """Get the operation, block, or region ancestor that has no parents."""
+        if self.parent is None:
+            return self
+        return self.parent.get_toplevel_object()
+
+    def is_structurally_equivalent(
+            self,
+            other: IRNode,
+            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
+        """Check if two IR nodes are structurally equivalent."""
+        ...
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+@dataclass
+class SSAValue(IRNode, ABC):
     """
     A reference to an SSA variable.
     An SSA variable is either an operation result, or a basic block argument.
@@ -408,33 +441,6 @@ class ParametrizedAttribute(Attribute):
     @property
     def irdl_definition(cls) -> ParamAttrDef:
         """Get the IRDL attribute definition."""
-        ...
-
-
-@dataclass
-class IRNode(ABC):
-
-    parent: IRNode | None
-
-    def is_ancestor(self, op: IRNode) -> bool:
-        "Returns true if the IRNode is an ancestor of another IRNode."
-        if op is self:
-            return True
-        if op.parent is None:
-            return False
-        return self.is_ancestor(op.parent)
-
-    def get_toplevel_object(self) -> IRNode:
-        """Get the operation, block, or region ancestor that has no parents."""
-        if self.parent is None:
-            return self
-        return self.parent.get_toplevel_object()
-
-    def is_structurally_equivalent(
-            self,
-            other: IRNode,
-            context: Optional[dict[IRNode, IRNode]] = None) -> bool:
-        """Check if two IR nodes are structurally equivalent."""
         ...
 
 


### PR DESCRIPTION
This was actually kind of assumed by the code checking for structural equivalence. The parent is currently `None`, which feels about right. We could probably make it the same as `owner`, although I'm not sure it's worth doing if everything works.