### PR TITLE
dialects: Add stencil lowerings and first lowered example.

### DIFF
--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -1,13 +1,12 @@
-// RUN: xdsl-opt %s -t mlir | filecheck %s
+// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %2 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
+  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
     %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
     %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    %7 = "stencil.load"(%4) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+    %6 = "stencil.load"(%3) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
       %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
@@ -18,13 +17,14 @@
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
-      %cst = "arith.constant"() {"value" = -4.0 : f32} : () -> f64
+      %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
-      %20 = "stencil.store_result"(%19) : (f64) -> !stencil.result<f64>
-      "stencil.return"(%20) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, "sym_name" = "stencil_hdiff"} : () -> ()
+      "stencil.return"(%19) : (!stencil.result<f64>) -> ()
+    }) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0: i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    "func.return"() : () -> ()
+  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
 

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -30,28 +30,67 @@
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
-// CHECK-NEXT:   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %2 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-// CHECK-NEXT:     %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-// CHECK-NEXT:     %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-// CHECK-NEXT:     %5 = "stencil.cast"(%2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-// CHECK-NEXT:     %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-// CHECK-NEXT:     %7 = "stencil.load"(%4) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-// CHECK-NEXT:     %8 = "stencil.apply"(%6) ({
-// CHECK-NEXT:     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-// CHECK-NEXT:       %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %12 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %13 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %14 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
-// CHECK-NEXT:       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
-// CHECK-NEXT:       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
-// CHECK-NEXT:       %cst = "arith.constant"() {"value" = -4.0 : f32} : () -> f64
-// CHECK-NEXT:       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
-// CHECK-NEXT:       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
-// CHECK-NEXT:       %20 = "stencil.store_result"(%19) : (f64) -> !stencil.result<f64>
-// CHECK-NEXT:       "stencil.return"(%20) : (!stencil.result<f64>) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-// CHECK-NEXT:   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, "sym_name" = "stencil_hdiff"} : () -> ()
+// CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
+// CHECK-NEXT:     %2 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %3 = "memref.cast"(%1) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %4 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:     %5 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:     %6 = "arith.constant"() {"value" = 64 : index} : () -> index
+// CHECK-NEXT:     %7 = "arith.constant"() {"value" = 64 : index} : () -> index
+// CHECK-NEXT:     %8 = "arith.constant"() {"value" = 64 : index} : () -> index
+// CHECK-NEXT:     "scf.parallel"(%4, %4, %4, %6, %7, %8, %5, %5, %5) ({
+// CHECK-NEXT:     ^1(%9 : index, %10 : index, %11 : index):
+// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:       %13 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %15 = "arith.addi"(%9, %12) : (index, index) -> index
+// CHECK-NEXT:       %16 = "arith.addi"(%10, %13) : (index, index) -> index
+// CHECK-NEXT:       %17 = "arith.addi"(%11, %14) : (index, index) -> index
+// CHECK-NEXT:       %18 = "memref.load"(%2, %15, %16, %17) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %19 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %20 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %22 = "arith.addi"(%9, %19) : (index, index) -> index
+// CHECK-NEXT:       %23 = "arith.addi"(%10, %20) : (index, index) -> index
+// CHECK-NEXT:       %24 = "arith.addi"(%11, %21) : (index, index) -> index
+// CHECK-NEXT:       %25 = "memref.load"(%2, %22, %23, %24) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %26 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %27 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %28 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %29 = "arith.addi"(%9, %26) : (index, index) -> index
+// CHECK-NEXT:       %30 = "arith.addi"(%10, %27) : (index, index) -> index
+// CHECK-NEXT:       %31 = "arith.addi"(%11, %28) : (index, index) -> index
+// CHECK-NEXT:       %32 = "memref.load"(%2, %29, %30, %31) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %33 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %34 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:       %35 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %36 = "arith.addi"(%9, %33) : (index, index) -> index
+// CHECK-NEXT:       %37 = "arith.addi"(%10, %34) : (index, index) -> index
+// CHECK-NEXT:       %38 = "arith.addi"(%11, %35) : (index, index) -> index
+// CHECK-NEXT:       %39 = "memref.load"(%2, %36, %37, %38) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %40 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %41 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %42 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %43 = "arith.addi"(%9, %40) : (index, index) -> index
+// CHECK-NEXT:       %44 = "arith.addi"(%10, %41) : (index, index) -> index
+// CHECK-NEXT:       %45 = "arith.addi"(%11, %42) : (index, index) -> index
+// CHECK-NEXT:       %46 = "memref.load"(%2, %43, %44, %45) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %47 = "arith.addf"(%18, %25) : (f64, f64) -> f64
+// CHECK-NEXT:       %48 = "arith.addf"(%32, %39) : (f64, f64) -> f64
+// CHECK-NEXT:       %49 = "arith.addf"(%47, %48) : (f64, f64) -> f64
+// CHECK-NEXT:       %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
+// CHECK-NEXT:       %50 = "arith.mulf"(%46, %cst) : (f64, f64) -> f64
+// CHECK-NEXT:       %51 = "arith.addf"(%50, %49) : (f64, f64) -> f64
+// CHECK-NEXT:       %52 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:       %53 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:       %54 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:       %55 = "arith.addi"(%9, %52) : (index, index) -> index
+// CHECK-NEXT:       %56 = "arith.addi"(%10, %53) : (index, index) -> index
+// CHECK-NEXT:       %57 = "arith.addi"(%11, %54) : (index, index) -> index
+// CHECK-NEXT:       "memref.store"(%51, %3, %55, %56, %57) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
+// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) {"function_type" = (memref<?x?x?xf64>, memref<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 // CHECK-NEXT: }) : () -> ()
 

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -81,9 +81,9 @@
 // CHECK-NEXT:       %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
 // CHECK-NEXT:       %50 = "arith.mulf"(%46, %cst) : (f64, f64) -> f64
 // CHECK-NEXT:       %51 = "arith.addf"(%50, %49) : (f64, f64) -> f64
-// CHECK-NEXT:       %52 = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:       %53 = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:       %54 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:       %52 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %53 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %54 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %55 = "arith.addi"(%9, %52) : (index, index) -> index
 // CHECK-NEXT:       %56 = "arith.addi"(%10, %53) : (index, index) -> index
 // CHECK-NEXT:       %57 = "arith.addi"(%11, %54) : (index, index) -> index

--- a/tests/filecheck/dialects/stencil/test_access_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering.mlir
@@ -16,7 +16,7 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>):
-// CHECK-NEXT:     %1 = "memref.cast"(%0) {"stencil_offset" = #stencil.index<[4 : i64, 4 : i64, 4 : i64]>} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %1 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
 // CHECK-NEXT:     %2 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:     %3 = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:     %4 = "arith.constant"() {"value" = 72 : index} : () -> index
@@ -31,6 +31,7 @@
 // CHECK-NEXT:       %14 = "arith.addi"(%8, %11) : (index, index) -> index
 // CHECK-NEXT:       %15 = "arith.addi"(%9, %12) : (index, index) -> index
 // CHECK-NEXT:       %16 = "memref.load"(%1, %13, %14, %15) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -15,7 +15,7 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:     "func.func"() ({
 // CHECK-NEXT:     ^0(%0 : memref<?x?x?xf64>):
-// CHECK-NEXT:         %1 = "memref.cast"(%0) {"stencil_offset" = #stencil.index<[4 : i64, 4 : i64, 4 : i64]>} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:         %1 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
 // CHECK-NEXT:         %2 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:         %3 = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:         %4 = "arith.constant"() {"value" = 72 : index} : () -> index
@@ -23,6 +23,7 @@
 // CHECK-NEXT:         %6 = "arith.constant"() {"value" = 72 : index} : () -> index
 // CHECK-NEXT:         "scf.parallel"(%2, %2, %2, %4, %5, %6, %3, %3, %3) ({
 // CHECK-NEXT:         ^1(%7 : index, %8 : index, %9 : index):
+// CHECK-NEXT:             "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:         "func.return"() : () -> ()
 // CHECK-NEXT:     }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -12,7 +12,7 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>):
-// CHECK-NEXT:     %1 = "memref.cast"(%0) {"stencil_offset" = #stencil.index<[4 : i64, 4 : i64, 4 : i64]>} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %1 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -1,0 +1,49 @@
+// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+
+"builtin.module"() ({
+    "func.func"() ({
+    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %6 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
+        %8 = "stencil.apply"(%2) ({
+        ^b0(%4: !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>):
+            %5 = "stencil.access"(%4) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> f64
+            "stencil.return"(%5) : (f64) -> ()
+        }) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>)
+        "stencil.store"(%8, %7) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+        "func.return"() : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+}) : () -> ()
+
+// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() ({
+// CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
+// CHECK-NEXT:     %2 = "memref.cast"(%0) {"stencil_offset" = #stencil.index<[4 : i64, 4 : i64, 4 : i64]>} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %3 = "memref.cast"(%1) {"stencil_offset" = #stencil.index<[4 : i64, 4 : i64, 4 : i64]>} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %4 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:     %5 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:     %6 = "arith.constant"() {"value" = 72 : index} : () -> index
+// CHECK-NEXT:     %7 = "arith.constant"() {"value" = 72 : index} : () -> index
+// CHECK-NEXT:     %8 = "arith.constant"() {"value" = 72 : index} : () -> index
+// CHECK-NEXT:     "scf.parallel"(%4, %4, %4, %6, %7, %8, %5, %5, %5) ({
+// CHECK-NEXT:     ^1(%9 : index, %10 : index, %11 : index):
+// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:       %13 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %15 = "arith.addi"(%9, %12) : (index, index) -> index
+// CHECK-NEXT:       %16 = "arith.addi"(%10, %13) : (index, index) -> index
+// CHECK-NEXT:       %17 = "arith.addi"(%11, %14) : (index, index) -> index
+// CHECK-NEXT:       %18 = "memref.load"(%2, %15, %16, %17) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %19 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %20 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %22 = "arith.addi"(%9, %19) : (index, index) -> index
+// CHECK-NEXT:       %23 = "arith.addi"(%10, %20) : (index, index) -> index
+// CHECK-NEXT:       %24 = "arith.addi"(%11, %21) : (index, index) -> index
+// CHECK-NEXT:       "memref.store"(%18, %3, %22, %23, %24) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
+// CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>, memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT: 

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -19,8 +19,8 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
-// CHECK-NEXT:     %2 = "memref.cast"(%0) {"stencil_offset" = #stencil.index<[4 : i64, 4 : i64, 4 : i64]>} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
-// CHECK-NEXT:     %3 = "memref.cast"(%1) {"stencil_offset" = #stencil.index<[4 : i64, 4 : i64, 4 : i64]>} : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %2 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %3 = "memref.cast"(%1) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
 // CHECK-NEXT:     %4 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:     %5 = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:     %6 = "arith.constant"() {"value" = 72 : index} : () -> index
@@ -42,6 +42,7 @@
 // CHECK-NEXT:       %23 = "arith.addi"(%10, %20) : (index, index) -> index
 // CHECK-NEXT:       %24 = "arith.addi"(%11, %21) : (index, index) -> index
 // CHECK-NEXT:       "memref.store"(%18, %3, %22, %23, %24) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
+// CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>, memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -1,0 +1,94 @@
+// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | mlir-opt | filecheck %s
+
+
+"builtin.module"() ({
+  "func.func"() ({
+  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %6 = "stencil.load"(%3) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+    %8 = "stencil.apply"(%6) ({
+    ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
+      %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
+      %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
+      %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
+      %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
+      %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
+      "stencil.return"(%19) : (!stencil.result<f64>) -> ()
+    }) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0: i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    "func.return"() : () -> ()
+  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+}) : () -> ()
+
+
+// CHECK-NEXT: module {
+// CHECK-NEXT:   func.func @stencil_hdiff(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>) {
+// CHECK-NEXT:     %cast = memref.cast %arg0 : memref<?x?x?xf64> to memref<72x72x72xf64>
+// CHECK-NEXT:     %cast_0 = memref.cast %arg1 : memref<?x?x?xf64> to memref<72x72x72xf64>
+// CHECK-NEXT:     %c0 = arith.constant 0 : index
+// CHECK-NEXT:     %c1 = arith.constant 1 : index
+// CHECK-NEXT:     %c64 = arith.constant 64 : index
+// CHECK-NEXT:     %c64_1 = arith.constant 64 : index
+// CHECK-NEXT:     %c64_2 = arith.constant 64 : index
+// CHECK-NEXT:     scf.parallel (%arg2, %arg3, %arg4) = (%c0, %c0, %c0) to (%c64, %c64_1, %c64_2) step (%c1, %c1, %c1) {
+// CHECK-NEXT:       %c3 = arith.constant 3 : index
+// CHECK-NEXT:       %c4 = arith.constant 4 : index
+// CHECK-NEXT:       %c4_3 = arith.constant 4 : index
+// CHECK-NEXT:       %0 = arith.addi %arg2, %c3 : index
+// CHECK-NEXT:       %1 = arith.addi %arg3, %c4 : index
+// CHECK-NEXT:       %2 = arith.addi %arg4, %c4_3 : index
+// CHECK-NEXT:       %3 = memref.load %cast[%0, %1, %2] : memref<72x72x72xf64>
+// CHECK-NEXT:       %c5 = arith.constant 5 : index
+// CHECK-NEXT:       %c4_4 = arith.constant 4 : index
+// CHECK-NEXT:       %c4_5 = arith.constant 4 : index
+// CHECK-NEXT:       %4 = arith.addi %arg2, %c5 : index
+// CHECK-NEXT:       %5 = arith.addi %arg3, %c4_4 : index
+// CHECK-NEXT:       %6 = arith.addi %arg4, %c4_5 : index
+// CHECK-NEXT:       %7 = memref.load %cast[%4, %5, %6] : memref<72x72x72xf64>
+// CHECK-NEXT:       %c4_6 = arith.constant 4 : index
+// CHECK-NEXT:       %c5_7 = arith.constant 5 : index
+// CHECK-NEXT:       %c4_8 = arith.constant 4 : index
+// CHECK-NEXT:       %8 = arith.addi %arg2, %c4_6 : index
+// CHECK-NEXT:       %9 = arith.addi %arg3, %c5_7 : index
+// CHECK-NEXT:       %10 = arith.addi %arg4, %c4_8 : index
+// CHECK-NEXT:       %11 = memref.load %cast[%8, %9, %10] : memref<72x72x72xf64>
+// CHECK-NEXT:       %c4_9 = arith.constant 4 : index
+// CHECK-NEXT:       %c3_10 = arith.constant 3 : index
+// CHECK-NEXT:       %c4_11 = arith.constant 4 : index
+// CHECK-NEXT:       %12 = arith.addi %arg2, %c4_9 : index
+// CHECK-NEXT:       %13 = arith.addi %arg3, %c3_10 : index
+// CHECK-NEXT:       %14 = arith.addi %arg4, %c4_11 : index
+// CHECK-NEXT:       %15 = memref.load %cast[%12, %13, %14] : memref<72x72x72xf64>
+// CHECK-NEXT:       %c4_12 = arith.constant 4 : index
+// CHECK-NEXT:       %c4_13 = arith.constant 4 : index
+// CHECK-NEXT:       %c4_14 = arith.constant 4 : index
+// CHECK-NEXT:       %16 = arith.addi %arg2, %c4_12 : index
+// CHECK-NEXT:       %17 = arith.addi %arg3, %c4_13 : index
+// CHECK-NEXT:       %18 = arith.addi %arg4, %c4_14 : index
+// CHECK-NEXT:       %19 = memref.load %cast[%16, %17, %18] : memref<72x72x72xf64>
+// CHECK-NEXT:       %20 = arith.addf %3, %7 : f64
+// CHECK-NEXT:       %21 = arith.addf %11, %15 : f64
+// CHECK-NEXT:       %22 = arith.addf %20, %21 : f64
+// CHECK-NEXT:       %cst = arith.constant -4.000000e+00 : f64
+// CHECK-NEXT:       %23 = arith.mulf %19, %cst : f64
+// CHECK-NEXT:       %24 = arith.addf %23, %22 : f64
+// CHECK-NEXT:       %c0_15 = arith.constant 0 : index
+// CHECK-NEXT:       %c0_16 = arith.constant 0 : index
+// CHECK-NEXT:       %c0_17 = arith.constant 0 : index
+// CHECK-NEXT:       %25 = arith.addi %arg2, %c0_15 : index
+// CHECK-NEXT:       %26 = arith.addi %arg3, %c0_16 : index
+// CHECK-NEXT:       %27 = arith.addi %arg4, %c0_17 : index
+// CHECK-NEXT:       memref.store %24, %cast_0[%25, %26, %27] : memref<72x72x72xf64>
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -79,12 +79,12 @@
 // CHECK-NEXT:       %cst = arith.constant -4.000000e+00 : f64
 // CHECK-NEXT:       %23 = arith.mulf %19, %cst : f64
 // CHECK-NEXT:       %24 = arith.addf %23, %22 : f64
-// CHECK-NEXT:       %c0_15 = arith.constant 0 : index
-// CHECK-NEXT:       %c0_16 = arith.constant 0 : index
-// CHECK-NEXT:       %c0_17 = arith.constant 0 : index
-// CHECK-NEXT:       %25 = arith.addi %arg2, %c0_15 : index
-// CHECK-NEXT:       %26 = arith.addi %arg3, %c0_16 : index
-// CHECK-NEXT:       %27 = arith.addi %arg4, %c0_17 : index
+// CHECK-NEXT:       %c4_15 = arith.constant 4 : index
+// CHECK-NEXT:       %c4_16 = arith.constant 4 : index
+// CHECK-NEXT:       %c4_17 = arith.constant 4 : index
+// CHECK-NEXT:       %25 = arith.addi %arg2, %c4_15 : index
+// CHECK-NEXT:       %26 = arith.addi %arg3, %c4_16 : index
+// CHECK-NEXT:       %27 = arith.addi %arg4, %c4_17 : index
 // CHECK-NEXT:       memref.store %24, %cast_0[%25, %26, %27] : memref<72x72x72xf64>
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -332,7 +332,7 @@ class ReturnOp(Operation):
       stencil.return %0 : !stencil.result<f64>
     """
     name: str = "stencil.return"
-    args: Annotated[VarOperand, ResultType]
+    arg: Annotated[Operand, ResultType | AnyFloat]
 
 
 @irdl_op_definition

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -133,7 +133,7 @@ class Store(Operation):
 
     @staticmethod
     def get(value: Operation | SSAValue, ref: Operation | SSAValue,
-            indices: List[Operation | SSAValue]) -> Store:
+            indices: Sequence[Operation | SSAValue]) -> Store:
         return Store.build(operands=[value, ref, indices])
 
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -105,7 +105,6 @@ class Load(Operation):
             indices: Sequence[SSAValue | Operation]) -> Load:
         ssa_value = SSAValue.get(ref)
         typ = ssa_value.typ
-        assert isinstance(typ, MemRefType)
         typ = cast(MemRefType[Attribute], typ)
         return Load.build(operands=[ref, indices],
                           result_types=[typ.element_type])

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -126,7 +126,7 @@ class ParallelOp(Operation):
     upperBound: Annotated[VarOperand, IndexType]
     step: Annotated[VarOperand, IndexType]
     initVals: Annotated[VarOperand, AnyAttr()]
-    results: Annotated[VarOpResult, AnyAttr()]
+    res: Annotated[VarOpResult, AnyAttr()]
 
     body: Region
 
@@ -140,7 +140,8 @@ class ParallelOp(Operation):
         body: Region | list[Block] | list[Operation],
     ):
         return ParallelOp.build(operands=[lowerBounds, upperBounds, steps, []],
-                                regions=[Region.get(body)])
+                                regions=[Region.get(body)],
+                                result_types=[[]])
 
     def verify_(self) -> None:
         if len(self.lowerBound) != len(self.upperBound) or len(
@@ -158,7 +159,7 @@ class ParallelOp(Operation):
                 f"Expected {len(self.lowerBound)} index-typed region arguments, got "
                 f"{[str(a.typ) for a in body_args]}. scf.parallel's body must have an index "
                 "argument for each induction variable. ")
-        if len(self.initVals) != 0 or len(self.results) != 0:
+        if len(self.initVals) != 0 or len(self.res) != 0:
             raise VerifyException(
                 "scf.parallel loop-carried variables and reduction are not implemented yet."
             )

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -117,13 +117,6 @@ class LoadOpToMemref(RewritePattern):
         rewriter.replace_matched_op([], list(op.field.owner.results))
 
 
-class ApplyOpInsertInductionVariables(RewritePattern):
-
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
-        pass
-
-
 class ApplyOpToParallel(RewritePattern):
 
     @op_type_rewrite_pattern

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -4,14 +4,14 @@ from warnings import warn
 from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
                                    RewritePattern, GreedyRewritePatternApplier,
                                    op_type_rewrite_pattern)
-from xdsl.ir import MLContext
+from xdsl.ir import BlockArgument, MLContext
 from xdsl.irdl import Attribute
 from xdsl.dialects.builtin import ArrayAttr, FunctionType, IntegerAttr, ModuleOp, i64
 from xdsl.dialects.func import FuncOp
 from xdsl.dialects.memref import MemRefType
 from xdsl.dialects import memref, arith, scf, builtin
 
-from xdsl.dialects.experimental.stencil import AccessOp, ApplyOp, CastOp, FieldType, IndexAttr, LoadOp, TempType
+from xdsl.dialects.experimental.stencil import AccessOp, ApplyOp, CastOp, FieldType, IndexAttr, LoadOp, ReturnOp, StoreOp, TempType
 
 _TypeElement = TypeVar("_TypeElement", bound=Attribute)
 
@@ -50,6 +50,73 @@ class CastOpToMemref(RewritePattern):
         rewriter.replace_matched_op(memref.Cast.get(op.field, result_typ))
 
 
+class StoreOpPrepare(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: StoreOp, rewriter: PatternRewriter, /):
+        if op.lb is None:
+            warn("stencil.store should have a lb attribute when lowered.")
+            return
+        if not isinstance(op.field.owner, memref.Cast):
+            warn(
+                "stencil.cast should be lowered to memref.cast before the stencil.store lowering."
+            )
+            return
+        offsets: list[Attribute] = [
+            IntegerAttr(-i.value.data, i64) for i in op.lb.array.data
+        ]
+
+        # TODO: handle with memref.subview or another, cleaner, approach.
+        op.field.owner.attributes["stencil_offset"] = IndexAttr(
+            [ArrayAttr.from_list(offsets)])
+
+
+class StoreOpCleanup(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: StoreOp, rewriter: PatternRewriter, /):
+        rewriter.erase_matched_op()
+        pass
+
+
+class ReturnOpToMemref(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ReturnOp, rewriter: PatternRewriter, /):
+
+        apply = op.parent_op()
+        assert isinstance(apply, ApplyOp)
+
+        res = list(apply.res)[0]
+
+        if (len(res.uses) > 1) or (not isinstance(
+            (store := list(res.uses)[0].operation), StoreOp)):
+            warn("Only single store result atm")
+            return
+
+        cast = store.field.owner
+        assert isinstance(cast, memref.Cast)
+
+        offsets = cast.attributes['stencil_offset']
+        assert isinstance(offsets, IndexAttr)
+
+        block = apply.region.blocks[0]
+
+        off_const_ops = [
+            arith.Constant.from_int_and_width(x.value.data,
+                                              builtin.IndexType())
+            for x in offsets.array.data
+        ]
+
+        off_sum_ops = [
+            arith.Addi.get(i, x) for i, x in zip(block.args, off_const_ops)
+        ]
+
+        load = memref.Store.get(op.arg, cast.dest, off_sum_ops)
+
+        rewriter.replace_matched_op([*off_const_ops, *off_sum_ops, load])
+
+
 class LoadOpToMemref(RewritePattern):
 
     @op_type_rewrite_pattern
@@ -72,6 +139,21 @@ class LoadOpToMemref(RewritePattern):
         rewriter.replace_matched_op([], [op.field.owner.dest])
 
 
+class ApplyOpInsertInductionVariables(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
+        if 'done' in op.attributes.keys():
+            return
+        rewriter.insert_block_argument(op.region.blocks[0], 0,
+                                       builtin.IndexType())
+        rewriter.insert_block_argument(op.region.blocks[0], 0,
+                                       builtin.IndexType())
+        rewriter.insert_block_argument(op.region.blocks[0], 0,
+                                       builtin.IndexType())
+        op.attributes['done'] = builtin.UnitAttr()
+
+
 class ApplyOpToParallel(RewritePattern):
 
     @op_type_rewrite_pattern
@@ -88,16 +170,11 @@ class ApplyOpToParallel(RewritePattern):
         # to a loop, which has access to them either way)
         entry = op.region.blocks[0]
 
-        for arg in entry.args:
+        for arg in entry.args[3:]:
             arg_uses = set(arg.uses)
             for use in arg_uses:
                 use.operation.replace_operand(use.index, op.args[use.index])
             entry.erase_arg(arg)
-
-        # Define index args for the parallel loop induction variables.
-        entry.insert_arg(builtin.IndexType(), 0)
-        entry.insert_arg(builtin.IndexType(), 0)
-        entry.insert_arg(builtin.IndexType(), 0)
 
         #Then create the corresponding scf.parallel
         dims = IndexAttr.size_from_bounds(op.lb, op.ub)
@@ -116,14 +193,22 @@ class ApplyOpToParallel(RewritePattern):
                                body=body)
 
         # Replace with the loop and necessary constants.
-        rewriter.replace_matched_op([zero, one, *upperBounds, p])
+        rewriter.insert_op_before_matched_op([zero, one, *upperBounds, p])
+        rewriter.erase_matched_op(False)
 
 
 class AccessOpToMemref(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: AccessOp, rewriter: PatternRewriter, /):
-        if not isinstance(op.temp.owner, memref.Cast):
+        arg = op.temp
+        assert isinstance(arg, BlockArgument)
+        apply = op.parent_op()
+        assert isinstance(apply, ApplyOp)
+
+        cast = apply.args[arg.index - 3].owner
+        if not isinstance(cast, memref.Cast):
+            print(cast)
             warn(
                 "stencil.load should have been lowered before lowering related "
                 "stencil.access")
@@ -133,15 +218,14 @@ class AccessOpToMemref(RewritePattern):
         # a block.
         assert (block := op.parent_block()) is not None
 
-        if not isinstance(op.temp.owner.attributes["stencil_offset"],
-                          IndexAttr):
+        if not isinstance(cast.attributes["stencil_offset"], IndexAttr):
             warn(
-                f"Expected IndexAttr-typed stencil_offset, got {op.temp.owner.attributes['stencil_offset']}"
+                f"Expected IndexAttr-typed stencil_offset, got {cast.attributes['stencil_offset']}"
             )
             return
 
         access_offset = op.offset.array.data
-        memref_offset = op.temp.owner.attributes["stencil_offset"].array.data
+        memref_offset = cast.attributes["stencil_offset"].array.data
 
         offsets = [
             a.value.data + m.value.data
@@ -157,7 +241,7 @@ class AccessOpToMemref(RewritePattern):
             arith.Addi.get(i, x) for i, x in zip(block.args, off_const_ops)
         ]
 
-        load = memref.Load.get(op.temp, off_sum_ops)
+        load = memref.Load.get(cast.dest, off_sum_ops)
 
         rewriter.replace_matched_op([*off_const_ops, *off_sum_ops, load],
                                     [load.res])
@@ -182,12 +266,29 @@ class StencilTypeConversionFuncOp(RewritePattern):
 
 
 def ConvertStencilToLLMLIR(ctx: MLContext, module: ModuleOp):
-    walker = PatternRewriteWalker(GreedyRewritePatternApplier([
+    preparation = PatternRewriteWalker(GreedyRewritePatternApplier([
+        ApplyOpInsertInductionVariables(),
         StencilTypeConversionFuncOp(),
         CastOpToMemref(),
         LoadOpToMemref(),
-        ApplyOpToParallel(),
-        AccessOpToMemref()
+        StoreOpPrepare(),
     ]),
-                                  walk_regions_first=True)
-    walker.rewrite_module(module)
+                                       walk_regions_first=True)
+
+    lowering = PatternRewriteWalker(GreedyRewritePatternApplier([
+        AccessOpToMemref(),
+        ReturnOpToMemref(),
+    ]),
+                                    walk_regions_first=True)
+
+    lowering2 = PatternRewriteWalker(
+        GreedyRewritePatternApplier([
+            ApplyOpToParallel(),
+        ]))
+
+    cleanup = PatternRewriteWalker(
+        GreedyRewritePatternApplier([StoreOpCleanup()]))
+    preparation.rewrite_module(module)
+    lowering.rewrite_module(module)
+    lowering2.rewrite_module(module)
+    cleanup.rewrite_module(module)

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -116,9 +116,6 @@ class LoadOpToMemref(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: LoadOp, rewriter: PatternRewriter, /):
-        if op.lb is None:
-            warn("stencil.load should have a lb attribute when lowered.")
-            return
         if not isinstance(op.field.owner, memref.Cast):
             warn(
                 "stencil.cast should be lowered to memref.cast before the stencil.load lowering."

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -83,7 +83,8 @@ class StencilOffsetCleanup(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.Cast, rewriter: PatternRewriter, /):
-        op.attributes.pop('stencil_offset')
+        if 'stencil_offset' in op.attributes:
+            op.attributes.pop('stencil_offset')
 
 
 class ReturnOpToMemref(RewritePattern):

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -151,15 +151,13 @@ class ApplyOpInsertInductionVariables(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
-        if 'done' in op.attributes.keys():
-            return
+
         rewriter.insert_block_argument(op.region.blocks[0], 0,
                                        builtin.IndexType())
         rewriter.insert_block_argument(op.region.blocks[0], 0,
                                        builtin.IndexType())
         rewriter.insert_block_argument(op.region.blocks[0], 0,
                                        builtin.IndexType())
-        op.attributes['done'] = builtin.UnitAttr()
 
 
 class ApplyOpToParallel(RewritePattern):
@@ -281,7 +279,8 @@ def ConvertStencilToLLMLIR(ctx: MLContext, module: ModuleOp):
         LoadOpToMemref(),
         StoreOpPrepare(),
     ]),
-                                       walk_regions_first=True)
+                                       walk_regions_first=True,
+                                       apply_recursively=False)
 
     lowering = PatternRewriteWalker(GreedyRewritePatternApplier([
         AccessOpToMemref(),

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import TypeVar
 from warnings import warn
 
@@ -35,14 +36,10 @@ def GetMemRefFromFieldWithLBAndUB(memref_element_type: _TypeElement,
     return MemRefType.from_element_type_and_shape(memref_element_type, dims)
 
 
+@dataclass
 class CastOpToMemref(RewritePattern):
 
     return_target: dict[ReturnOp, CastOp | memref.Cast]
-
-    def __init__(self, return_target: dict[ReturnOp,
-                                           CastOp | memref.Cast]) -> None:
-        super().__init__()
-        self.return_target = return_target
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: CastOp, rewriter: PatternRewriter, /):
@@ -70,14 +67,10 @@ class StoreOpCleanup(RewritePattern):
         pass
 
 
+@dataclass
 class ReturnOpToMemref(RewritePattern):
 
     return_target: dict[ReturnOp, CastOp | memref.Cast]
-
-    def __init__(self, return_target: dict[ReturnOp,
-                                           CastOp | memref.Cast]) -> None:
-        super().__init__()
-        self.return_target = return_target
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ReturnOp, rewriter: PatternRewriter, /):

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -4,7 +4,7 @@ from warnings import warn
 from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
                                    RewritePattern, GreedyRewritePatternApplier,
                                    op_type_rewrite_pattern)
-from xdsl.ir import BlockArgument, MLContext, Operation
+from xdsl.ir import MLContext, Operation
 from xdsl.irdl import Attribute
 from xdsl.dialects.builtin import ArrayAttr, FunctionType, IntegerAttr, ModuleOp
 from xdsl.dialects.func import FuncOp
@@ -290,7 +290,9 @@ def ConvertStencilToLLMLIR(ctx: MLContext, module: ModuleOp):
                                       apply_recursively=False)
 
     second_pass = PatternRewriteWalker(
-        GreedyRewritePatternApplier([StencilOffsetCleanup()]))
+        GreedyRewritePatternApplier([
+            StencilOffsetCleanup(),
+        ]))
 
     first_pass.rewrite_module(module)
     second_pass.rewrite_module(module)


### PR DESCRIPTION
This PR adds `stencil.store` and `stencil.return` lowerings, and slightly re"organize" existing lowerings. It now includes a cleanup pass (So we don't have those 'stencil_offset' attributes on the output anymore.)

[tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir](https://github.com/xdslproject/xdsl/compare/emilien/stencil-store-lowering?expand=1#diff-9f450a143c8d386ca1315c78dc7d7a684d434964b838916c8513d1876899dcb4) is a quickly scrapped test showing a lowering to standard MLIR.

I tried on my machine and it seems compilable simply through `|mlir-opt --test-lower-to-llvm | mlir-translate --mlir-to-llvmir | clang -x ir -`. I stopped at the `undefined reference to main`, I'm exhausted by this PR and will get back to that tomorrow!

I expect this lowering to blow up on maaany variations. it's super hacky, the idea was to have a minimum working thingy and see what's next to enhance from here. So try it, blow it up, and tell me what you don't want to blow up exactly :slightly_smiling_face: