### PR TITLE
printer: Fix printing of named block arguments

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -5,11 +5,11 @@ from io import StringIO
 from typing import List, Annotated
 
 from xdsl.dialects.arith import Arith, Addi, Constant
-from xdsl.dialects.builtin import Builtin, IntAttr, ModuleOp, IntegerType, UnitAttr
+from xdsl.dialects.builtin import Builtin, IntAttr, ModuleOp, IntegerType, UnitAttr, i32
 from xdsl.dialects.func import Func
-from xdsl.ir import Attribute, MLContext, OpResult, ParametrizedAttribute
+from xdsl.ir import Attribute, MLContext, OpResult, ParametrizedAttribute, Block
 from xdsl.irdl import (OptOpAttr, ParameterDef, irdl_attr_definition,
-                       irdl_op_definition, Operation, Operand, OptAttributeDef)
+                       irdl_op_definition, Operation, Operand)
 from xdsl.parser import Parser, BaseParser, XDSLParser
 from xdsl.printer import Printer
 from xdsl.utils.diagnostic import Diagnostic
@@ -336,6 +336,17 @@ builtin.module() {
     module = parser.parse_op()
 
     assert_print_op(module, expected, None)
+
+
+def test_print_custom_block_arg_name():
+    block = Block.from_arg_types([i32, i32])
+    block.args[0].name = "test"
+    block.args[1].name = "test"
+
+    io = StringIO()
+    p = Printer(target=Printer.Target.MLIR, stream=io)
+    p.print_block(block)
+    assert io.getvalue() == """\n^0(%test : i32, %0 : i32):"""
 
 
 #   ____          _                  _____                          _

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -241,7 +241,7 @@ class Printer:
 
     def _print_block_arg(self, arg: BlockArgument) -> None:
         self.print("%")
-        if arg.name and arg not in self._ssa_values:
+        if arg.name and arg.name not in self._ssa_values.values():
             name = arg.name
         else:
             name = self._get_new_valid_name_id()

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -241,7 +241,10 @@ class Printer:
 
     def _print_block_arg(self, arg: BlockArgument) -> None:
         self.print("%")
-        name = self._get_new_valid_name_id()
+        if arg.name and arg not in self._ssa_values:
+            name = arg.name
+        else:
+            name = self._get_new_valid_name_id()
         self._ssa_values[arg] = name
         self.print("%s : " % name)
         self.print_attribute(arg.typ)


### PR DESCRIPTION
I think this fixes printing of named `BlockArgument` SSA Values. We used them in devito to make SSA much more readable. Feel free to proof-read!