### PR TITLE
docs: sync toy dialect from workshop repo

### DIFF
--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -38,7 +38,7 @@ class ConstantOp(Operation):
     res: Annotated[OpResult, TensorTypeF64]
 
     @staticmethod
-    def from_list(data: List[float], shape: List[int]):
+    def from_list(data: List[float], shape: List[int]) -> ConstantOp:
         value = DenseIntOrFPElementsAttr.tensor_from_list(data, f64, shape)
         return ConstantOp.from_value(value)
 

--- a/docs/Toy/toy/parser.py
+++ b/docs/Toy/toy/parser.py
@@ -447,5 +447,5 @@ class Parser:
         Location is retrieved from the lexer to enrich the error message.
         """
         token = self.getToken()
-        line = self.program.splitlines()[token.line]
+        line = self.program.splitlines()[token.line - 1]
         raise ParseError(self.getToken(), expected, context, line)

--- a/docs/Toy/toy/tests/test_toy.py
+++ b/docs/Toy/toy/tests/test_toy.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from ..parser import Parser
+import pytest
+
+from ..parser import Parser, ParseError
 from ..toy_ast import ModuleAST, FunctionAST, PrototypeAST, VariableExprAST, ReturnExprAST, BinaryExprAST, CallExprAST, VarDeclExprAST, VarType, LiteralExprAST, NumberExprAST
 from ..location import Location
 
@@ -84,3 +86,10 @@ def test_parse_ast():
     ))
 
     assert parsed_module_ast == module_ast
+
+
+def test_parse_error():
+    program = "def("
+    parser = Parser(Path(), program)
+    with pytest.raises(ParseError):
+        parser.parseIdentifierExpr()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ reportImportCycles = false
 reportUnnecessaryIsInstance = false
 typeCheckingMode = "strict"
 "exclude" = [
-    "docs/Toy/toy/dialect.py",
     "tests/test_frontend_op_resolver.py",
     "tests/test_frontend_python_code_check.py",
     "tests/test_ir.py",


### PR DESCRIPTION
I'm using the Toy dialect as a testbed for xDSL features in the workshop repo, and would like to migrate some of them over into this one. This PR is the first of the migration from the workshop, syncing over the existing files.

Three main changes:
1. fix a bug in the parser
2. update the dialect file with fixes from the other repo
3. remove dialect file from pyright exclude list