### PR TITLE
core: Set attributes using field name

### DIFF
--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -6,10 +6,11 @@ from xdsl.dialects.builtin import DenseArrayBase, Operation, StringAttr, i32
 from xdsl.dialects.arith import Constant
 
 from xdsl.ir import Block, OpResult, Region
-from xdsl.irdl import (OptOpResult, OptOperand, OptRegion,
-                       OptSingleBlockRegion, Operand, SingleBlockRegion,
-                       VarOpResult, VarRegion, VarSingleBlockRegion,
-                       irdl_op_definition, AttrSizedResultSegments, VarOperand,
+from xdsl.irdl import (AttrSizedRegionSegments, OptOpResult, OptOperand,
+                       OptRegion, OptSingleBlockRegion, Operand,
+                       SingleBlockRegion, VarOpResult, VarRegion,
+                       VarSingleBlockRegion, irdl_op_definition,
+                       AttrSizedResultSegments, VarOperand,
                        AttrSizedOperandSegments, OpAttr, Region, OptOpAttr)
 
 #  ____                 _ _
@@ -418,6 +419,43 @@ def test_var_sbregion_one_block():
     assert len(op2.regs) == 2  # type: ignore
     assert len(op2.regs[0].blocks) == 0  # type: ignore
     assert len(op2.regs[1].blocks) == 2  # type: ignore
+
+
+@irdl_op_definition
+class TwoVarRegionOp(Operation):
+    name: str = "test.two_var_region_op"
+
+    res1: Annotated[VarRegion, StringAttr]
+    res2: Annotated[VarRegion, StringAttr]
+    irdl_options = [AttrSizedRegionSegments()]
+
+
+def test_two_var_region_builder():
+    region1 = Region()
+    region2 = Region()
+    region3 = Region()
+    region4 = Region()
+    op2 = TwoVarRegionOp.build(
+        regions=[[region1, region2], [region3, region4]])
+    op2.verify()
+    assert op2.regions == [region1, region2, region3, region4]
+    assert op2.attributes[
+        AttrSizedRegionSegments.attribute_name] == DenseArrayBase.from_list(
+            i32, [2, 2])
+
+
+def test_two_var_operand_builder2():
+    region1 = Region()
+    region2 = Region()
+    region3 = Region()
+    region4 = Region()
+    op2 = TwoVarRegionOp.build(
+        regions=[[region1], [region2, region3, region4]])
+    op2.verify()
+    assert op2.regions == [region1, region2, region3, region4]
+    assert op2.attributes[
+        AttrSizedRegionSegments.attribute_name] == DenseArrayBase.from_list(
+            i32, [1, 3])
 
 
 #  __  __ _

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -199,3 +199,18 @@ def test_attribute_accessors():
 
     op = AttributeOp.create(attributes={"attr": StringAttr("test")})
     assert op.opt_attr is None
+
+
+def test_attribute_setters():
+    """Test setters for attributes."""
+
+    op = AttributeOp.create(attributes={"attr": StringAttr("test")})
+
+    op.attr = StringAttr("new_test")
+    assert op.attr.data == "new_test"
+
+    op.opt_attr = StringAttr("new_opt_test")
+    assert op.opt_attr.data == "new_opt_test"
+
+    op.opt_attr = None
+    assert op.opt_attr is None

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -1137,19 +1137,26 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
 
     def optional_attribute_field(attribute_name: str):
 
-        @property
-        def impl(self: _OpT):
+        def field_getter(self: _OpT):
             return self.attributes.get(attribute_name, None)
 
-        return impl
+        def field_setter(self: _OpT, value: Attribute | None):
+            if value is None:
+                self.attributes.pop(attribute_name, None)
+            else:
+                self.attributes[attribute_name] = value
+
+        return property(field_getter, field_setter)
 
     def attribute_field(attribute_name: str):
 
-        @property
-        def impl(self: _OpT):
-            return self.attributes.get(attribute_name, None)
+        def field_getter(self: _OpT):
+            return self.attributes[attribute_name]
 
-        return impl
+        def field_setter(self: _OpT, value: Attribute):
+            self.attributes[attribute_name] = value
+
+        return property(field_getter, field_setter)
 
     for attribute_name, attr_def in op_def.attributes.items():
         if isinstance(attr_def, OptAttributeDef):


### PR DESCRIPTION
Depends on #582

This allows us to simply write
```python
my_op.my_attribute = StringAttr('foo')
```
instead of
```python
my_op.attributes['my_attribute'] = StringAttr('foo')
```