### PR TITLE
Add __post_init__ method to Operation class

### DIFF
--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -503,8 +503,9 @@ class Operation(IRNode):
         self._operands = new
 
     def __post_init__(self):
-        assert (self.name != "")
-        assert (isinstance(self.name, str))
+    if self.parent is not None:
+        raise ValueError("Can't instantiate Operation with parent argument. "
+                         "Use the static methods of the class instead.")
 
     @staticmethod
     def with_result_types(


### PR DESCRIPTION
This commit adds a `__post_init__` method to the `Operation` class to address an issue with misleading error messages when constructing operations incorrectly. The method checks if the `parent` attribute is not None, and raises a `ValueError` with a more informative error message that explains the correct way to instantiate an `Operation`.