### PR TITLE
Rename result_index to index for OpResult class

### DIFF
--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -196,7 +196,7 @@ class OpResult(SSAValue):
     op: Operation
     """The operation defining the variable."""
 
-    result_index: int
+    index: int
     """The index of the result in the defining operation."""
 
     @property


### PR DESCRIPTION
This commit renames the result_index attribute to index for the OpResult class, as discussed in #334 (comment).

Note: This change may affect any external code that directly references the result_index attribute of the OpResult class. These codebases should be updated to reflect the new index attribute.