### PR TITLE
CI: Fix Pyright CI to v1.1.299

### DIFF
--- a/.github/workflows/ci-pyright-fails.yml
+++ b/.github/workflows/ci-pyright-fails.yml
@@ -33,3 +33,4 @@ jobs:
         run: pip install -e .[extras]
       - name: Pyright
         uses: jakebailey/pyright-action@v1
+          version: 1.1.299

--- a/.github/workflows/ci-pyright.yml
+++ b/.github/workflows/ci-pyright.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Pyright
         uses: jordemort/action-pyright@v1.8.0
         with:
+          version: 1.1.299
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review # Change reporter.
           lib: true


### PR DESCRIPTION
This PR fixes the pyright version to 1.1.299 s.t. we can work on actually fixing the error introduced by v1.1.300