### PR TITLE
math: Add a math dialect and register it to xdsl-opt

### DIFF
--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated, Union
 
 from xdsl.dialects.builtin import IntegerType, AnyFloat, Attribute
-from xdsl.ir import Operation, SSAValue, OpResult
+from xdsl.ir import Operation, SSAValue, OpResult, Dialect
 from xdsl.irdl import irdl_op_definition, OptOpAttr, Operand
 from xdsl.dialects.arith import FastMathFlagsAttr
 
@@ -171,3 +171,12 @@ class SqrtOp(Operation):
         return SqrtOp.build(attributes=attributes,
                             operands=[operand],
                             result_types=[operand.typ])
+
+
+Math = Dialect([
+    FPowIOp,
+    IPowIOp,
+    PowFOp,
+    RsqrtOp,
+    SqrtOp,
+])

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -23,6 +23,7 @@ from xdsl.dialects.gpu import GPU
 from xdsl.dialects.pdl import PDL
 
 from xdsl.dialects.experimental.stencil import Stencil
+from xdsl.dialects.experimental.math import Math
 
 from xdsl.transforms.experimental.ConvertStencilToLLMLIR import ConvertStencilToLLMLIR, ConvertStencilToGPU
 
@@ -191,6 +192,7 @@ class xDSLOptMain:
         self.ctx.register_dialect(Scf)
         self.ctx.register_dialect(Cf)
         self.ctx.register_dialect(CMath)
+        self.ctx.register_dialect(Math)
         self.ctx.register_dialect(IRDL)
         self.ctx.register_dialect(LLVM)
         self.ctx.register_dialect(Vector)


### PR DESCRIPTION
As it says on the tin, I add the math dialect declaration and register it in `xdsl-opt`