### PR TITLE
stencil: Correct in-bound checks during shape inference

### DIFF
--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -136,7 +136,7 @@ class IndexAttr(ParametrizedAttribute):
     # TODO: can you have an attr and an op with the same name?
     name = "stencil.index"
 
-    array: ParameterDef[ArrayAttr[AnyIntegerAttr]]
+    array: ParameterDef[ArrayAttr[IntegerAttr[IntegerType]]]
 
     def verify(self) -> None:
         if len(self.array.data) < 1 or len(self.array.data) > 3:

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -125,10 +125,12 @@ class ReturnOpToMemref(RewritePattern):
 
 def verify_load_bounds(cast: CastOp, load: LoadOp):
 
-    if IndexAttr.min(cast.lb, load.lb) != cast.lb:
+    if [i.value.data for i in IndexAttr.min(cast.lb, load.lb).array.data
+        ] != [i.value.data for i in cast.lb.array.data]:
         raise VerifyException(
             "The stencil computation requires a field with lower bound at least "
-            f"{load.lb}, got {cast.lb}")
+            f"{load.lb}, got {cast.lb}, min: {IndexAttr.min(cast.lb, load.lb)}"
+        )
 
 
 class LoadOpToMemref(RewritePattern):


### PR DESCRIPTION
This corrects a bug, thanks @meshtag for noticing it!
Basically, shape inference final in-bounds check gave false negatives, when the bounds where correct but instanciated as different integer types.