### PR TITLE
dialects: Add gpu.AllocOp

### DIFF
--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -20,7 +20,7 @@ def test_alloc():
     alloc = AllocOp.get(typ, is_async=True)
 
     assert isinstance(alloc, AllocOp)
-    assert alloc.memref.typ is typ
+    assert alloc.result.typ is typ
     assert len(alloc.asyncDependencies) == 0
     assert len(alloc.dynamicSizes) == 0
     assert alloc.asyncToken is not None
@@ -39,7 +39,7 @@ def test_alloc():
                              async_dependencies=[token])
 
     assert isinstance(full_alloc, AllocOp)
-    assert full_alloc.memref.typ is dyntyp
+    assert full_alloc.result.typ is dyntyp
     assert len(full_alloc.asyncDependencies) == 1
     assert full_alloc.asyncDependencies[0] is token
     assert len(full_alloc.dynamicSizes) == 3

--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -5,7 +5,7 @@ from xdsl.dialects.gpu import (
     LaunchOp, ModuleEndOp, ModuleOp, DimensionAttr, NumSubgroupsOp,
     SetDefaultDeviceOp, SubgroupIdOp, SubgroupSizeOp, TerminatorOp, ThreadIdOp,
     YieldOp)
-from xdsl.ir import Attribute, Block, Operation, Region, SSAValue
+from xdsl.ir import Block, Operation, Region, SSAValue
 
 
 def test_dimension():

--- a/tests/filecheck/dialects/gpu/alloc_wrong_dynamic_size.mlir
+++ b/tests/filecheck/dialects/gpu/alloc_wrong_dynamic_size.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt --verify-diagnostic %s | filecheck %s
+
+"builtin.module"() ({
+    %0 = "arith.constant"() {"value" = 10 : index} : () -> index
+    %gdmemref = "gpu.alloc"(%0, %0,%0) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: () -> memref<10x10x10xf64>
+}) : () -> ()
+
+// CHECK-NEXT: Expected 0 dynamic sizes, got 3. All dynamic sizes need to be set in the alloc operation.

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -101,7 +101,6 @@
 // CHECK-NEXT:             %gmemref = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<10x10xf64>
 // CHECK-NEXT:             %gdmemref = "gpu.alloc"(%griddimx, %griddimy, %griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>} : (index, index, index) -> memref<?x?x?xf64>
 
-
 // CHECK-NEXT:             %{{.*}} = "gpu.lane_id"() : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.num_subgroups"() : () -> index
 

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt -t mlir %s | filecheck %s
 
 "builtin.module"() ({
     "gpu.module"() ({
@@ -29,6 +29,9 @@
             %griddimx = "gpu.grid_dim"() {"dimension" = #gpu<dim x>} : () -> index
             %griddimy = "gpu.grid_dim"() {"dimension" = #gpu<dim y>} : () -> index
             %griddimz = "gpu.grid_dim"() {"dimension" = #gpu<dim z>} : () -> index
+
+            %gmemref = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>}: () -> memref<10x10xf64>
+            %gdmemref = "gpu.alloc"(%griddimx, %griddimy,%griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: () -> memref<?x?x?xf64>
 
             %laneid = "gpu.lane_id"() : () -> index
             %numsubgroups = "gpu.num_subgroups"() : () -> index
@@ -95,6 +98,10 @@
 // CHECK-NEXT:             %{{.*}} = "gpu.grid_dim"() {"dimension" = #gpu<dim y>} : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.grid_dim"() {"dimension" = #gpu<dim z>} : () -> index
 
+// CHECK-NEXT:             %gmemref = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<10x10xf64>
+// CHECK-NEXT:             %gdmemref = "gpu.alloc"(%griddimx, %griddimy, %griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>} : (index, index, index) -> memref<?x?x?xf64>
+
+
 // CHECK-NEXT:             %{{.*}} = "gpu.lane_id"() : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.num_subgroups"() : () -> index
 
@@ -119,7 +126,7 @@
 // CHECK-SAME:                 %{{.*}} : index, %{{.*}} : index, %{{.*}} : index,
 // CHECK-SAME:                 %{{.*}} : index, %{{.*}} : index, %{{.*}} : index):
 // CHECK-NEXT:                 %{{.*}} = "gpu.all_reduce"(%{{.*}}) ({
-// CHECK-NEXT:             }) {"op" = #gpu<all_reduce_op add>} : (index) -> index
+// CHECK-NEXT:                 }) {"op" = #gpu<all_reduce_op add>} : (index) -> index
 // CHECK-NEXT:                 %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (index, index) -> index    
 // CHECK-NEXT:                 "gpu.terminator"() : () -> ()
 // CHECK-NEXT:             }) {"operand_segment_sizes" = array<i32: 0, 1, 1, 1, 1, 1, 1, 0>} : (index, index, index, index, index, index) -> () 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | filecheck %s
+// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
 
 "builtin.module"() ({
     "gpu.module"() ({
@@ -29,6 +29,9 @@
             %griddimx = "gpu.grid_dim"() {"dimension" = #gpu<dim x>} : () -> index
             %griddimy = "gpu.grid_dim"() {"dimension" = #gpu<dim y>} : () -> index
             %griddimz = "gpu.grid_dim"() {"dimension" = #gpu<dim z>} : () -> index
+
+            %gmemref = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>}: () -> memref<10x10xf64>
+            %gdmemref = "gpu.alloc"(%griddimx, %griddimy,%griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: () -> memref<?x?x?xf64>
 
             %laneid = "gpu.lane_id"() : () -> index
             %numsubgroups = "gpu.num_subgroups"() : () -> index
@@ -95,6 +98,9 @@
 // CHECK-NEXT:             %{{.*}} = "gpu.grid_dim"() {"dimension" = #gpu<dim y>} : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.grid_dim"() {"dimension" = #gpu<dim z>} : () -> index
 
+// CHECK-NEXT:             %{{.*}} = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<10x10xf64>
+// CHECK-NEXT:             %{{.*}} = "gpu.alloc"(%{{.*}}, %{{.*}}, %{{.*}}) {"operand_segment_sizes" = array<i32: 0, 3, 0>} : (index, index, index) -> memref<?x?x?xf64>
+
 // CHECK-NEXT:             %{{.*}} = "gpu.lane_id"() : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.num_subgroups"() : () -> index
 
@@ -119,7 +125,7 @@
 // CHECK-SAME:                 %{{.*}} : index, %{{.*}} : index, %{{.*}} : index,
 // CHECK-SAME:                 %{{.*}} : index, %{{.*}} : index, %{{.*}} : index):
 // CHECK-NEXT:                 %{{.*}} = "gpu.all_reduce"(%{{.*}}) ({
-// CHECK-NEXT:                 }) {"op" = #gpu<all_reduce_op add>} : (index) -> index
+// CHECK-NEXT:             }) {"op" = #gpu<all_reduce_op add>} : (index) -> index
 // CHECK-NEXT:                 %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (index, index) -> index    
 // CHECK-NEXT:                 "gpu.terminator"() : () -> ()
 // CHECK-NEXT:             }) {"operand_segment_sizes" = array<i32: 0, 1, 1, 1, 1, 1, 1, 0>} : (index, index, index, index, index, index) -> () 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import Annotated, Generic, Sequence, Type, TypeVar
-from xdsl.dialects import builtin
 
 from xdsl.ir import (Attribute, MLIRType, OpResult, Operation, Dialect,
                      ParametrizedAttribute, Region, SSAValue)

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -122,13 +122,13 @@ class AllocOp(Operation):
 
     irdl_options = [AttrSizedOperandSegments()]
 
-    memref: Annotated[OpResult, memref.MemRefType[Attribute]]
+    result: Annotated[OpResult, memref.MemRefType[Attribute]]
     asyncToken: Annotated[OptOpResult, AsyncTokenType]
 
     def verify_(self) -> None:
         ndyn = len(self.dynamicSizes)
-        assert isinstance(self.memref.typ, memref.MemRefType)
-        typ: memref.MemRefType[Attribute] = self.memref.typ
+        assert isinstance(self.result.typ, memref.MemRefType)
+        typ: memref.MemRefType[Attribute] = self.result.typ
         ndyn_typ = len([i for i in typ.shape.data if i.value.data == -1])
         if ndyn != ndyn_typ:
             raise VerifyException(

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -143,13 +143,12 @@ class AllocOp(Operation):
             async_dependencies: Sequence[SSAValue | Operation] | None = None,
             is_async: bool = False) -> AllocOp:
         token_return = [AsyncTokenType()] if is_async else []
-        dynamic_sizes_vals: list[SSAValue] = [] if dynamic_sizes is None else [
+        dynamic_sizes_vals: list[SSAValue] = [
             SSAValue.get(e) for e in dynamic_sizes
-        ]
-        async_dependencies_vals: list[
-            SSAValue] = [] if async_dependencies is None else [
-                SSAValue.get(e) for e in async_dependencies
-            ]
+        ] if dynamic_sizes else []
+        async_dependencies_vals: list[SSAValue] = [
+            SSAValue.get(e) for e in async_dependencies
+        ] if async_dependencies else []
         attributes: dict[str, Attribute] = {
             "hostShared": UnitAttr()
         } if host_shared else {}


### PR DESCRIPTION
This adds a GPU-specific memref-allocation operation, intended to be used in the next stencil lowerings.