### PR TITLE
core: Move unregistered operation logic to MLContext

### DIFF
--- a/tests/test_mlctx.py
+++ b/tests/test_mlctx.py
@@ -1,4 +1,5 @@
 import pytest
+from xdsl.dialects.builtin import UnregisteredOp
 
 from xdsl.ir import MLContext, ParametrizedAttribute
 from xdsl.irdl import irdl_op_definition, irdl_attr_definition, Operation
@@ -24,28 +25,44 @@ class DummyAttr2(ParametrizedAttribute):
     name = "dummy_attr2"
 
 
-def test_registration_exceptions():
+def test_get_op():
+    """Test `get_op` and `get_optional_op` methods."""
     ctx = MLContext()
     ctx.register_op(DummyOp)
-    with pytest.raises(Exception):
-        ctx.register_op(DummyOp)
 
-    ctx.register_attr(DummyAttr)
-    with pytest.raises(Exception):
-        ctx.register_attr(DummyAttr)
-
-
-def test_get_exceptions():
-    ctx = MLContext()
-    ctx.register_op(DummyOp)
-    ctx.register_attr(DummyAttr)
-
-    _ = ctx.get_op("dummy")
+    assert ctx.get_op("dummy") == DummyOp
     with pytest.raises(Exception):
         _ = ctx.get_op("dummy2")
 
-    _ = ctx.get_optional_attr("dummy_attr")
-    assert ctx.get_optional_attr("dummy_attr2") is None
+    assert ctx.get_optional_op("dummy") == DummyOp
+    assert ctx.get_optional_op("dummy2") == None
 
+
+def test_get_op_unregistered():
+    """
+    Test `get_op` and `get_optional_op`
+    methods with the `unregistered_ops` flag.
+    """
+    ctx = MLContext()
+    ctx.register_op(DummyOp)
+
+    assert ctx.get_optional_op("dummy", allow_unregistered=True) == DummyOp
+    assert isinstance(ctx.get_optional_op("dummy2", allow_unregistered=True),
+                      UnregisteredOp)
+
+    assert ctx.get_op("dummy", allow_unregistered=True) == DummyOp
+    assert isinstance(ctx.get_op("dummy2", allow_unregistered=True),
+                      UnregisteredOp)
+
+
+def test_get_attr():
+    """Test `get_attr` and `get_optional_attr` methods."""
+    ctx = MLContext()
+    ctx.register_attr(DummyAttr)
+
+    assert ctx.get_attr("dummy_attr") == DummyAttr
     with pytest.raises(Exception):
         _ = ctx.get_attr("dummy_attr2")
+
+    assert ctx.get_optional_attr("dummy_attr") == DummyAttr
+    assert ctx.get_optional_attr("dummy_attr2") == None

--- a/tests/test_mlctx.py
+++ b/tests/test_mlctx.py
@@ -47,11 +47,12 @@ def test_get_op_unregistered():
     ctx.register_op(DummyOp)
 
     assert ctx.get_optional_op("dummy", allow_unregistered=True) == DummyOp
-    assert isinstance(ctx.get_optional_op("dummy2", allow_unregistered=True),
-                      UnregisteredOp)
+    op = ctx.get_optional_op("dummy2", allow_unregistered=True)
+    assert op is not None
+    assert issubclass(op, UnregisteredOp)
 
     assert ctx.get_op("dummy", allow_unregistered=True) == DummyOp
-    assert isinstance(ctx.get_op("dummy2", allow_unregistered=True),
+    assert issubclass(ctx.get_op("dummy2", allow_unregistered=True),
                       UnregisteredOp)
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -924,9 +924,7 @@ class UnregisteredOp(Operation):
         return self.op_name__  # type: ignore
 
     @classmethod
-    def with_name(cls, name: str, ctx: MLContext) -> type[Operation]:
-        if name in ctx.registered_unregistered_ops:
-            return ctx.registered_unregistered_ops[name]  # type: ignore
+    def with_name(cls, name: str) -> type[Operation]:
 
         class UnregisteredOpWithName(UnregisteredOp):
 
@@ -942,7 +940,6 @@ class UnregisteredOp(Operation):
                 op.attributes['op_name__'] = StringAttr(name)
                 return op
 
-        ctx.registered_unregistered_ops[name] = UnregisteredOpWithName
         return UnregisteredOpWithName
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -5,9 +5,9 @@ from enum import Enum
 from typing import (Iterable, TypeAlias, List, cast, Type, Sequence,
                     TYPE_CHECKING, Any, TypeVar, overload)
 
-from xdsl.ir import (Block, Data, MLContext, MLIRType, ParametrizedAttribute,
-                     Operation, Region, Attribute, Dialect, SSAValue,
-                     AttributeCovT, AttributeInvT)
+from xdsl.ir import (Block, Data, MLIRType, ParametrizedAttribute, Operation,
+                     Region, Attribute, Dialect, SSAValue, AttributeCovT,
+                     AttributeInvT)
 
 from xdsl.irdl import (AllOf, OpAttr, VarOpResult, VarOperand, VarRegion,
                        irdl_attr_definition, attr_constr_coercion,

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -90,7 +90,7 @@ class MLContext:
             op_type = UnregisteredOp.with_name(name)
             self._registeredOps[name] = op_type
             return op_type
-        return self._registeredOps[name]
+        return None
 
     def get_op(self,
                name: str,

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -22,7 +22,7 @@ from xdsl.dialects.builtin import (
     Float64Type, FloatAttr, FunctionType, IndexType, IntegerType, Signedness,
     StringAttr, IntegerAttr, ArrayAttr, TensorType, UnrankedTensorType,
     VectorType, SymbolRefAttr, DenseArrayBase, DenseIntOrFPElementsAttr,
-    UnregisteredOp, OpaqueAttr, NoneAttr, ModuleOp, UnitAttr, i64)
+    OpaqueAttr, NoneAttr, ModuleOp, UnitAttr, i64)
 from xdsl.ir import (SSAValue, Block, Callable, Attribute, Operation, Region,
                      BlockArgument, MLContext, ParametrizedAttribute, Data)
 from xdsl.utils.hints import isa
@@ -981,13 +981,11 @@ class BaseParser(ABC):
         else:
             op_name = span.text
 
-        op_type = self.ctx.get_optional_op(op_name)
+        op_type = self.ctx.get_optional_op(
+            op_name, allow_unregistered=self.allow_unregistered_ops)
 
         if op_type is not None:
             return op_type
-
-        if self.allow_unregistered_ops:
-            return UnregisteredOp.with_name(op_name, self.ctx)
 
         self.raise_error(f'Unknown operation {op_name}!', span)
 


### PR DESCRIPTION
Previously, handling unregistered operations was done by the user.
This PR moves the unregistered operation logic to the MLContext, so `get_optional_op` and `get_op` should register `UnregisteredOp` if the corresponding flag is set.
