### PR TITLE
core: add OpBuilder

### DIFF
--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -150,14 +150,6 @@ class FuncOp(Operation):
             Region.from_block_list([Block.from_callable(input_types, func)]),
             private=private)
 
-    @staticmethod
-    def from_callable_region(name: str,
-                             callable_region: tuple[Region, FunctionType],
-                             /,
-                             private: bool = False):
-        region, ftype = callable_region
-        return FuncOp.from_region(name, ftype, region, private=private)
-
     def verify_(self):
         # Check that the returned value matches the type of the function
         if len(self.body.blocks) != 1:

--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -150,6 +150,14 @@ class FuncOp(Operation):
             Region.from_block_list([Block.from_callable(input_types, func)]),
             private=private)
 
+    @staticmethod
+    def from_callable_region(name: str,
+                             callable_region: tuple[Region, FunctionType],
+                             /,
+                             private: bool = False):
+        region, ftype = callable_region
+        return FuncOp.from_region(name, ftype, region, private=private)
+
     def verify_(self):
         # Check that the returned value matches the type of the function
         if len(self.body.blocks) != 1:

--- a/docs/Toy/toy/ir_gen.py
+++ b/docs/Toy/toy/ir_gen.py
@@ -5,7 +5,7 @@ from typing import Iterable
 
 from xdsl.ir import SSAValue, Block, Region
 from xdsl.dialects.builtin import ModuleOp, f64, TensorType, UnrankedTensorType
-from xdsl.builder import OpBuilder
+from xdsl.builder import Builder
 
 from toy.location import Location
 from toy.toy_ast import (LiteralExprAST, ModuleAST, NumberExprAST,
@@ -53,7 +53,7 @@ class IRGen:
     module: ModuleOp
     """A "module" matches a Toy source file: containing a list of functions."""
 
-    builder: OpBuilder
+    builder: Builder
     """
     The builder is a helper class to create IR inside a function. The builder
     is stateful, in particular it keeps an "insertion point": this is where
@@ -70,7 +70,7 @@ class IRGen:
         # We create an empty MLIR module and codegen functions one at a time and
         # add them to the module.
         self.module = ModuleOp.from_region_or_ops([])
-        self.builder = OpBuilder(self.module.body.blocks[0])
+        self.builder = Builder(self.module.body.blocks[0])
 
     def ir_gen_module(self, module_ast: ModuleAST) -> ModuleOp:
         """
@@ -144,7 +144,7 @@ class IRGen:
         block = Block.from_arg_types([
             UnrankedTensorType.from_type(f64) for _ in range(len(proto_args))
         ])
-        self.builder = OpBuilder(block)
+        self.builder = Builder(block)
 
         # Declare all the function arguments in the symbol table.
         for name, value in zip(proto_args, block.args):

--- a/docs/Toy/toy/ir_gen.py
+++ b/docs/Toy/toy/ir_gen.py
@@ -5,7 +5,7 @@ from typing import Iterable
 
 from xdsl.ir import SSAValue, Block, Region
 from xdsl.dialects.builtin import ModuleOp, f64, TensorType, UnrankedTensorType
-from xdsl.builder import Builder
+from xdsl.builder import OpBuilder
 
 from toy.location import Location
 from toy.toy_ast import (LiteralExprAST, ModuleAST, NumberExprAST,
@@ -53,7 +53,7 @@ class IRGen:
     module: ModuleOp
     """A "module" matches a Toy source file: containing a list of functions."""
 
-    builder: Builder
+    builder: OpBuilder
     """
     The builder is a helper class to create IR inside a function. The builder
     is stateful, in particular it keeps an "insertion point": this is where
@@ -70,7 +70,7 @@ class IRGen:
         # We create an empty MLIR module and codegen functions one at a time and
         # add them to the module.
         self.module = ModuleOp.from_region_or_ops([])
-        self.builder = Builder(self.module.body.blocks[0])
+        self.builder = OpBuilder(self.module.body.blocks[0])
 
     def ir_gen_module(self, module_ast: ModuleAST) -> ModuleOp:
         """
@@ -144,7 +144,7 @@ class IRGen:
         block = Block.from_arg_types([
             UnrankedTensorType.from_type(f64) for _ in range(len(proto_args))
         ])
-        self.builder = Builder(block)
+        self.builder = OpBuilder(block)
 
         # Declare all the function arguments in the symbol table.
         for name, value in zip(proto_args, block.args):

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -28,12 +28,13 @@ def test_convert_ast():
         unrankedf64TensorType = toy.UnrankedTensorType.from_type(f64)
 
         @Builder.callable_region(
-            [unrankedf64TensorType, unrankedf64TensorType],
-            [unrankedf64TensorType])
-        def multiply_transpose(builder: Builder, arg0: BlockArgument,
-                               arg1: BlockArgument) -> None:
-            a_t = builder.create(toy.TransposeOp.from_input, arg0).res
-            b_t = builder.create(toy.TransposeOp.from_input, arg1).res
+            ([unrankedf64TensorType,
+              unrankedf64TensorType], [unrankedf64TensorType]))
+        def multiply_transpose(builder: Builder, args: tuple[BlockArgument,
+                                                             ...]) -> None:
+            a, b = args
+            a_t = builder.create(toy.TransposeOp.from_input, a).res
+            b_t = builder.create(toy.TransposeOp.from_input, b).res
             prod = builder.create(toy.MulOp.from_summands, a_t, b_t).res
             builder.create(toy.ReturnOp.from_input, prod)
 
@@ -42,7 +43,7 @@ def test_convert_ast():
             return builder.create(toy.GenericCallOp.get, "multiply_transpose",
                                   [a, b], [unrankedf64TensorType]).res[0]
 
-        @Builder.callable_region([], [])
+        @Builder.callable_region
         def main(builder: Builder) -> None:
             a = builder.create(toy.ConstantOp.from_list, [1, 2, 3, 4, 5, 6],
                                [2, 3]).res

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -33,34 +33,35 @@ def test_convert_ast():
         def multiply_transpose(builder: OpBuilder, args: tuple[BlockArgument,
                                                                ...]) -> None:
             a, b = args
-            a_t = builder.create(toy.TransposeOp.from_input, a).res
-            b_t = builder.create(toy.TransposeOp.from_input, b).res
-            prod = builder.create(toy.MulOp.from_summands, a_t, b_t).res
-            builder.create(toy.ReturnOp.from_input, prod)
+            a_t = builder.insert(toy.TransposeOp.from_input(a)).res
+            b_t = builder.insert(toy.TransposeOp.from_input(b)).res
+            prod = builder.insert(toy.MulOp.from_summands(a_t, b_t)).res
+            builder.insert(toy.ReturnOp.from_input(prod))
 
         def call_multiply_transpose(builder: OpBuilder, a: SSAValue,
                                     b: SSAValue) -> OpResult:
-            return builder.create(toy.GenericCallOp.get, "multiply_transpose",
-                                  [a, b], [unrankedf64TensorType]).res[0]
+            return builder.insert(
+                toy.GenericCallOp.get("multiply_transpose", [a, b],
+                                      [unrankedf64TensorType])).res[0]
 
         @OpBuilder.callable_region
         def main(builder: OpBuilder) -> None:
-            a = builder.create(toy.ConstantOp.from_list, [1, 2, 3, 4, 5, 6],
-                               [2, 3]).res
-            b_0 = builder.create(toy.ConstantOp.from_list, [1, 2, 3, 4, 5, 6],
-                                 [6]).res
-            b = builder.create(toy.ReshapeOp.from_input, b_0, [2, 3]).res
+            a = builder.insert(
+                toy.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [2, 3])).res
+            b_0 = builder.insert(
+                toy.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [6])).res
+            b = builder.insert(toy.ReshapeOp.from_input(b_0, [2, 3])).res
             c = call_multiply_transpose(builder, a, b)
             call_multiply_transpose(builder, b, a)
             call_multiply_transpose(builder, b, c)
-            a_t = builder.create(toy.TransposeOp.from_input, a).res
+            a_t = builder.insert(toy.TransposeOp.from_input(a)).res
             call_multiply_transpose(builder, a_t, c)
-            builder.create(toy.ReturnOp.from_input)
+            builder.insert(toy.ReturnOp.from_input())
 
-        builder.create(toy.FuncOp.from_callable_region,
-                       "multiply_transpose",
-                       multiply_transpose,
-                       private=True)
-        builder.create(toy.FuncOp.from_callable_region, "main", main)
+        builder.insert(
+            toy.FuncOp.from_callable_region("multiply_transpose",
+                                            multiply_transpose,
+                                            private=True))
+        builder.insert(toy.FuncOp.from_callable_region("main", main))
 
     assert module_op.is_structurally_equivalent(generated_module_op)

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -48,7 +48,7 @@ def test_convert_ast():
 
         main_type = FunctionType.from_lists([], [])
 
-        @Builder.callable_region
+        @Builder.region
         def main(builder: Builder) -> None:
             a = builder.insert(
                 toy.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [2, 3])).res

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from xdsl.ir import OpResult, BlockArgument, SSAValue
 from xdsl.dialects.builtin import f64, ModuleOp
-from xdsl.builder import OpBuilder
+from xdsl.builder import Builder
 
 from ..parser import Parser
 from ..ir_gen import IRGen
@@ -23,29 +23,29 @@ def test_convert_ast():
     generated_module_op = ir_gen.ir_gen_module(module_ast)
 
     @ModuleOp.from_region_or_ops
-    @OpBuilder.region
-    def module_op(builder: OpBuilder):
+    @Builder.region
+    def module_op(builder: Builder):
         unrankedf64TensorType = toy.UnrankedTensorType.from_type(f64)
 
-        @OpBuilder.callable_region(
+        @Builder.callable_region(
             ([unrankedf64TensorType,
               unrankedf64TensorType], [unrankedf64TensorType]))
-        def multiply_transpose(builder: OpBuilder, args: tuple[BlockArgument,
-                                                               ...]) -> None:
+        def multiply_transpose(builder: Builder, args: tuple[BlockArgument,
+                                                             ...]) -> None:
             a, b = args
             a_t = builder.insert(toy.TransposeOp.from_input(a)).res
             b_t = builder.insert(toy.TransposeOp.from_input(b)).res
             prod = builder.insert(toy.MulOp.from_summands(a_t, b_t)).res
             builder.insert(toy.ReturnOp.from_input(prod))
 
-        def call_multiply_transpose(builder: OpBuilder, a: SSAValue,
+        def call_multiply_transpose(builder: Builder, a: SSAValue,
                                     b: SSAValue) -> OpResult:
             return builder.insert(
                 toy.GenericCallOp.get("multiply_transpose", [a, b],
                                       [unrankedf64TensorType])).res[0]
 
-        @OpBuilder.callable_region
-        def main(builder: OpBuilder) -> None:
+        @Builder.callable_region
+        def main(builder: Builder) -> None:
             a = builder.insert(
                 toy.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [2, 3])).res
             b_0 = builder.insert(

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -31,7 +31,7 @@ def test_convert_ast():
             [unrankedf64TensorType, unrankedf64TensorType],
             [unrankedf64TensorType])
 
-        @Builder.callable_region(multiply_transpose_type.inputs)
+        @Builder.region(multiply_transpose_type.inputs)
         def multiply_transpose(builder: Builder, args: tuple[BlockArgument,
                                                              ...]) -> None:
             a, b = args

--- a/tests/dialects/test_op_builder.py
+++ b/tests/dialects/test_op_builder.py
@@ -1,0 +1,84 @@
+from xdsl.builder import OpBuilder
+from xdsl.ir import BlockArgument, Block
+from xdsl.dialects.builtin import IntAttr, ModuleOp, i32, IntegerAttr
+from xdsl.dialects.arith import Constant
+
+
+def test_builder():
+    block = Block()
+    b = OpBuilder(block)
+
+    x = Constant.from_int_and_width(1, 1)
+    y = Constant.from_int_and_width(2, 1)
+
+    b.insert(x)
+    b.insert(y)
+
+    ops = block.ops
+
+    assert len(ops) == 2
+    assert ops[0] is x
+    assert ops[1] is y
+
+
+def test_build_region():
+
+    one = IntAttr(1)
+    two = IntAttr(2)
+
+    @OpBuilder.region
+    def region(b: OpBuilder):
+        x = Constant.from_int_and_width(one, i32)
+        y = Constant.from_int_and_width(two, i32)
+
+        b.insert(x)
+        b.insert(y)
+
+    assert len(region.blocks) == 1
+
+    ops = region.ops
+
+    assert len(ops) == 2
+
+    assert isinstance(ops[0], Constant)
+    assert isinstance(ops[0].value, IntegerAttr)
+    assert ops[0].value.value is one
+
+    assert isinstance(ops[1], Constant)
+    assert isinstance(ops[1].value, IntegerAttr)
+    assert ops[1].value.value is two
+
+
+def test_build_callable_region():
+
+    one = IntAttr(1)
+    two = IntAttr(2)
+
+    @OpBuilder.callable_region(([i32], [i32]))
+    def callable_region(b: OpBuilder, args: tuple[BlockArgument, ...]):
+        assert len(args) == 1
+
+        x = Constant.from_int_and_width(one, i32)
+        y = Constant.from_int_and_width(two, i32)
+
+        b.insert(x)
+        b.insert(y)
+
+    region, ftype = callable_region
+
+    assert ftype.inputs.data == (i32, )
+    assert ftype.outputs.data == (i32, )
+
+    assert len(region.blocks) == 1
+
+    ops = region.ops
+
+    assert len(ops) == 2
+
+    assert isinstance(ops[0], Constant)
+    assert isinstance(ops[0].value, IntegerAttr)
+    assert ops[0].value.value is one
+
+    assert isinstance(ops[1], Constant)
+    assert isinstance(ops[1].value, IntegerAttr)
+    assert ops[1].value.value is two

--- a/tests/dialects/test_op_builder.py
+++ b/tests/dialects/test_op_builder.py
@@ -54,7 +54,7 @@ def test_build_callable_region():
     one = IntAttr(1)
     two = IntAttr(2)
 
-    @Builder.callable_region([i32])
+    @Builder.region([i32])
     def region(b: Builder, args: tuple[BlockArgument, ...]):
         assert len(args) == 1
 

--- a/tests/dialects/test_op_builder.py
+++ b/tests/dialects/test_op_builder.py
@@ -54,8 +54,8 @@ def test_build_callable_region():
     one = IntAttr(1)
     two = IntAttr(2)
 
-    @Builder.callable_region(([i32], [i32]))
-    def callable_region(b: Builder, args: tuple[BlockArgument, ...]):
+    @Builder.callable_region([i32])
+    def region(b: Builder, args: tuple[BlockArgument, ...]):
         assert len(args) == 1
 
         x = Constant.from_int_and_width(one, i32)
@@ -63,11 +63,6 @@ def test_build_callable_region():
 
         b.insert(x)
         b.insert(y)
-
-    region, ftype = callable_region
-
-    assert ftype.inputs.data == (i32, )
-    assert ftype.outputs.data == (i32, )
 
     assert len(region.blocks) == 1
 

--- a/tests/dialects/test_op_builder.py
+++ b/tests/dialects/test_op_builder.py
@@ -1,6 +1,6 @@
 from xdsl.builder import OpBuilder
 from xdsl.ir import BlockArgument, Block
-from xdsl.dialects.builtin import IntAttr, ModuleOp, i32, IntegerAttr
+from xdsl.dialects.builtin import IntAttr, i32, IntegerAttr
 from xdsl.dialects.arith import Constant
 
 

--- a/tests/dialects/test_op_builder.py
+++ b/tests/dialects/test_op_builder.py
@@ -1,4 +1,4 @@
-from xdsl.builder import OpBuilder
+from xdsl.builder import Builder
 from xdsl.ir import BlockArgument, Block
 from xdsl.dialects.builtin import IntAttr, i32, IntegerAttr
 from xdsl.dialects.arith import Constant
@@ -6,7 +6,7 @@ from xdsl.dialects.arith import Constant
 
 def test_builder():
     block = Block()
-    b = OpBuilder(block)
+    b = Builder(block)
 
     x = Constant.from_int_and_width(1, 1)
     y = Constant.from_int_and_width(2, 1)
@@ -26,8 +26,8 @@ def test_build_region():
     one = IntAttr(1)
     two = IntAttr(2)
 
-    @OpBuilder.region
-    def region(b: OpBuilder):
+    @Builder.region
+    def region(b: Builder):
         x = Constant.from_int_and_width(one, i32)
         y = Constant.from_int_and_width(two, i32)
 
@@ -54,8 +54,8 @@ def test_build_callable_region():
     one = IntAttr(1)
     two = IntAttr(2)
 
-    @OpBuilder.callable_region(([i32], [i32]))
-    def callable_region(b: OpBuilder, args: tuple[BlockArgument, ...]):
+    @Builder.callable_region(([i32], [i32]))
+    def callable_region(b: Builder, args: tuple[BlockArgument, ...]):
         assert len(args) == 1
 
         x = Constant.from_int_and_width(one, i32)

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -11,9 +11,10 @@ from xdsl.dialects.builtin import FunctionType
 @dataclass
 class OpBuilder:
     """
-    A helper class to construct IRs, by keeping track of where to insert an operation.
-    Currently can only append an operation to a given block, in the future will mirror the
-    API of `OpBuilder` in MLIR.
+    A helper class to construct IRs, by keeping track of where to insert an
+    operation. Currently the insertion point is always at the end of the block.
+    In the future will mirror the API of `OpBuilder` in MLIR, inserting at
+    arbitrary locations.
 
     https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder.html
     """
@@ -25,7 +26,7 @@ class OpBuilder:
 
     def insert(self, op: OperationInvT) -> OperationInvT:
         """
-        Inserts `op` in `self.block` at the current insertion point.
+        Inserts `op` in `self.block` at the end of the block.
         """
 
         self.block.add_op(op)
@@ -34,7 +35,7 @@ class OpBuilder:
     @staticmethod
     def region(func: Callable[[OpBuilder], None]) -> Region:
         """
-        Generates a region given a function.
+        Generates a single-block region.
         """
 
         block = Block()
@@ -49,9 +50,9 @@ class OpBuilder:
         types: tuple[list[Attribute], list[Attribute]]
     ) -> Callable[[_CallableRegionFuncType], tuple[Region, FunctionType]]:
         """
-        Constructs a tuple of (Region, FunctionType) for a region that takes some
-        arguments, and may return some results. The types of the arguments and results
-        are passed in the `types` parameter.
+        Constructs a tuple of (Region, FunctionType). The Region is a 
+        single-block region, containing the implementation of a function.
+        `types` specifies the input and result types of the function.
         """
 
         input_types, return_types = types

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import ParamSpec, Callable, TypeVar, Concatenate
+
+from dataclasses import dataclass, field
+
+from xdsl.ir import Operation, OperationInvT, Attribute, Region, Block
+from xdsl.dialects.builtin import FunctionType
+
+_P = ParamSpec('_P')
+_T = TypeVar('_T')
+
+
+@dataclass
+class Builder:
+    _ops: list[Operation] = field(default_factory=list)
+
+    def _get_ops(self) -> list[Operation]:
+        return self._ops
+
+    def add_op(self, op: Operation):
+        self._ops.append(op)
+
+    def create(self, func: Callable[_P, OperationInvT], *args: _P.args,
+               **kwargs: _P.kwargs) -> OperationInvT:
+        op = func(*args, **kwargs)
+        self.add_op(op)
+        return op
+
+    @staticmethod
+    def region(func: Callable[[Builder], None]) -> Region:
+
+        builder = Builder()
+
+        func(builder)
+
+        ops = builder._get_ops()
+        return Region.from_operation_list(ops)
+
+    @staticmethod
+    def callable_region(
+        input_types: list[Attribute], return_types: list[Attribute]
+    ) -> Callable[[Callable[Concatenate[Builder, _P], None]], tuple[
+            Region, FunctionType]]:
+
+        def wrapper(
+            func: Callable[Concatenate[Builder, _P], None]
+        ) -> tuple[Region, FunctionType]:
+
+            def impl(*args: _P.args, **kwargs: _P.kwargs) -> list[Operation]:
+                builder = Builder()
+
+                func(builder, *args, **kwargs)
+
+                return builder._get_ops()
+
+            region = Region.from_block_list(
+                [Block.from_callable(input_types, impl)])
+            ftype = FunctionType.from_lists(input_types, return_types)
+            return region, ftype
+
+        return wrapper

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -56,10 +56,12 @@ class Builder:
         """
 
         if isinstance(input_types, ArrayAttr):
-            input_types = list(input_types.data)
+            input_type_seq = input_types.data
+        else:
+            input_type_seq = input_types
 
         def wrapper(func: _CallableRegionFuncType) -> Region:
-            block = Block.from_arg_types(input_types)
+            block = Block.from_arg_types(input_type_seq)
             builder = Builder(block)
 
             func(builder, block.args)

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -46,13 +46,12 @@ class Builder:
         return Region.from_block_list([block])
 
     @staticmethod
-    def _callable_region_args(
+    def callable_region(
         input_types: list[Attribute] | ArrayAttr[Attribute]
     ) -> Callable[[_CallableRegionFuncType], Region]:
         """
-        Constructs a tuple of (Region, FunctionType). The Region is a 
-        single-block region, containing the implementation of a function.
-        `types` specifies the input and result types of the function.
+        Constructs a single-block region, containing the implementation of a
+        function.
         """
 
         if isinstance(input_types, ArrayAttr):
@@ -70,59 +69,6 @@ class Builder:
             return region
 
         return wrapper
-
-    @staticmethod
-    def _callable_region_no_args(func: Callable[[Builder], None]) -> Region:
-        """
-        Constructs a tuple of (Region, FunctionType) for a region that takes no arguments
-        and returns no results.
-        """
-
-        @Builder._callable_region_args([])
-        def res(builder: Builder, args: tuple[BlockArgument, ...]) -> None:
-            func(builder)
-
-        return res
-
-    @overload
-    @staticmethod
-    def callable_region(
-        input: list[Attribute] | ArrayAttr[Attribute]
-    ) -> Callable[[_CallableRegionFuncType], Region]:
-        """
-        Annotation used to construct a Region tuple from a function.
-        The annotation can be used in two ways:
-
-        For regions that have inputs or outputs:
-        ```
-        @Builder.callable_region(input_types)
-        def func(builder: Builder, args: tuple[BlockArgument, ...]) -> None:
-            ...
-        ```
-
-        For regions that don't have inputs or outputs:
-        ``` python
-        @Builder.callable_region
-        def func(builder: Builder) -> None:
-            ...
-        ```
-        """
-        ...
-
-    @overload
-    @staticmethod
-    def callable_region(input: Callable[[Builder], None]) -> Region:
-        ...
-
-    @staticmethod
-    def callable_region(
-        input: list[Attribute] | ArrayAttr[Attribute]
-        | Callable[[Builder], None]
-    ) -> Callable[[_CallableRegionFuncType], Region] | Region:
-        if isinstance(input, Callable):
-            return Builder._callable_region_no_args(input)
-        else:
-            return Builder._callable_region_args(input)
 
 
 _CallableRegionFuncType: TypeAlias = Callable[

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -13,8 +13,8 @@ class OpBuilder:
     """
     A helper class to construct IRs, by keeping track of where to insert an
     operation. Currently the insertion point is always at the end of the block.
-    In the future will mirror the API of `OpBuilder` in MLIR, inserting at
-    arbitrary locations.
+    In the future will closely follow the API of `OpBuilder` in MLIR, inserting 
+    at arbitrary locations.
 
     https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder.html
     """

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -11,7 +11,7 @@ _P = ParamSpec('_P')
 
 
 @dataclass
-class Builder:
+class OpBuilder:
     """
     A helper class to construct IRs, by keeping track of where to insert an operation.
     Currently can only append an operation to a given block, in the future will mirror the
@@ -32,10 +32,10 @@ class Builder:
         return op
 
     @staticmethod
-    def region(func: Callable[[Builder], None]) -> Region:
+    def region(func: Callable[[OpBuilder], None]) -> Region:
 
         block = Block()
-        builder = Builder(block)
+        builder = OpBuilder(block)
 
         func(builder)
 
@@ -52,7 +52,7 @@ class Builder:
                 func: _CallableRegionFuncType) -> tuple[Region, FunctionType]:
 
             block = Block.from_arg_types(input_types)
-            builder = Builder(block)
+            builder = OpBuilder(block)
 
             func(builder, block.args)
 
@@ -64,10 +64,10 @@ class Builder:
 
     @staticmethod
     def _callable_region_no_args(
-            func: Callable[[Builder], None]) -> tuple[Region, FunctionType]:
+            func: Callable[[OpBuilder], None]) -> tuple[Region, FunctionType]:
 
-        @Builder._callable_region_args(([], []))
-        def res(builder: Builder, args: tuple[BlockArgument, ...]) -> None:
+        @OpBuilder._callable_region_args(([], []))
+        def res(builder: OpBuilder, args: tuple[BlockArgument, ...]) -> None:
             func(builder)
 
         return res
@@ -82,13 +82,13 @@ class Builder:
     @overload
     @staticmethod
     def callable_region(
-            input: Callable[[Builder], None]) -> tuple[Region, FunctionType]:
+            input: Callable[[OpBuilder], None]) -> tuple[Region, FunctionType]:
         ...
 
     @staticmethod
     def callable_region(
         input: tuple[list[Attribute], list[Attribute]]
-        | Callable[[Builder], None]
+        | Callable[[OpBuilder], None]
     ) -> Callable[[_CallableRegionFuncType],
                   tuple[Region, FunctionType]] | tuple[Region, FunctionType]:
         """
@@ -97,23 +97,23 @@ class Builder:
 
         For regions that have inputs or outputs:
         ```
-        @Builder.callable_region((input_types, output_types))
-        def func(builder: Builder, args: tuple[BlockArgument, ...]) -> None:
+        @OpBuilder.callable_region((input_types, output_types))
+        def func(builder: OpBuilder, args: tuple[BlockArgument, ...]) -> None:
             ...
         ```
 
         For regions that don't have inputs or outputs:
         ``` python
-        @Builder.callable_region
-        def func(builder: Builder) -> None:
+        @OpBuilder.callable_region
+        def func(builder: OpBuilder) -> None:
             ...
         ```
         """
         if isinstance(input, tuple):
-            return Builder._callable_region_args(input)
+            return OpBuilder._callable_region_args(input)
         else:
-            return Builder._callable_region_no_args(input)
+            return OpBuilder._callable_region_no_args(input)
 
 
 _CallableRegionFuncType: TypeAlias = Callable[
-    [Builder, tuple[BlockArgument, ...]], None]
+    [OpBuilder, tuple[BlockArgument, ...]], None]

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -37,12 +37,9 @@ class Builder:
         """
         Generates a single-block region.
         """
-
         block = Block()
         builder = Builder(block)
-
         func(builder)
-
         return Region.from_block_list([block])
 
     @staticmethod
@@ -50,9 +47,8 @@ class Builder:
         input_types: list[Attribute] | ArrayAttr[Attribute]
     ) -> Callable[[_CallableRegionFuncType], Region]:
         """
-        Constructs a tuple of (Region, FunctionType). The Region is a 
-        single-block region, containing the implementation of a function.
-        `types` specifies the input and result types of the function.
+        Constructs a single-block region, containing the implementation of a
+        function with some input arguments.
         """
 
         if isinstance(input_types, ArrayAttr):
@@ -82,14 +78,14 @@ class Builder:
 
         For regions that have inputs or outputs:
         ```
-        @Builder.callable_region(input_types)
+        @Builder.region(input_types)
         def func(builder: Builder, args: tuple[BlockArgument, ...]) -> None:
             ...
         ```
 
         For regions that don't have inputs or outputs:
         ``` python
-        @Builder.callable_region
+        @Builder.region
         def func(builder: Builder) -> None:
             ...
         ```

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -33,7 +33,7 @@ class Builder:
         return op
 
     @staticmethod
-    def region(func: Callable[[Builder], None]) -> Region:
+    def _region_no_args(func: Callable[[Builder], None]) -> Region:
         """
         Generates a single-block region.
         """
@@ -46,12 +46,13 @@ class Builder:
         return Region.from_block_list([block])
 
     @staticmethod
-    def callable_region(
+    def _region_args(
         input_types: list[Attribute] | ArrayAttr[Attribute]
     ) -> Callable[[_CallableRegionFuncType], Region]:
         """
-        Constructs a single-block region, containing the implementation of a
-        function.
+        Constructs a tuple of (Region, FunctionType). The Region is a 
+        single-block region, containing the implementation of a function.
+        `types` specifies the input and result types of the function.
         """
 
         if isinstance(input_types, ArrayAttr):
@@ -69,6 +70,46 @@ class Builder:
             return region
 
         return wrapper
+
+    @overload
+    @staticmethod
+    def region(
+        input: list[Attribute] | ArrayAttr[Attribute]
+    ) -> Callable[[_CallableRegionFuncType], Region]:
+        """
+        Annotation used to construct a Region tuple from a function.
+        The annotation can be used in two ways:
+
+        For regions that have inputs or outputs:
+        ```
+        @Builder.callable_region(input_types)
+        def func(builder: Builder, args: tuple[BlockArgument, ...]) -> None:
+            ...
+        ```
+
+        For regions that don't have inputs or outputs:
+        ``` python
+        @Builder.callable_region
+        def func(builder: Builder) -> None:
+            ...
+        ```
+        """
+        ...
+
+    @overload
+    @staticmethod
+    def region(input: Callable[[Builder], None]) -> Region:
+        ...
+
+    @staticmethod
+    def region(
+        input: list[Attribute] | ArrayAttr[Attribute]
+        | Callable[[Builder], None]
+    ) -> Callable[[_CallableRegionFuncType], Region] | Region:
+        if isinstance(input, Callable):
+            return Builder._region_no_args(input)
+        else:
+            return Builder._region_args(input)
 
 
 _CallableRegionFuncType: TypeAlias = Callable[

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -22,13 +22,13 @@ class OpBuilder:
 
     block: Block
 
-    def add_op(self, op: Operation):
+    def insert(self, op: Operation):
         self.block.add_op(op)
 
     def create(self, func: Callable[_P, OperationInvT], *args: _P.args,
                **kwargs: _P.kwargs) -> OperationInvT:
         op = func(*args, **kwargs)
-        self.add_op(op)
+        self.insert(op)
         return op
 
     @staticmethod

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import ParamSpec, Callable, TypeAlias, overload
+from typing import Callable, TypeAlias, overload
 
 from dataclasses import dataclass
 
 from xdsl.ir import Operation, OperationInvT, Attribute, Region, Block, BlockArgument
 from xdsl.dialects.builtin import FunctionType
-
-_P = ParamSpec('_P')
 
 
 @dataclass
@@ -22,13 +20,8 @@ class OpBuilder:
 
     block: Block
 
-    def insert(self, op: Operation):
+    def insert(self, op: OperationInvT) -> OperationInvT:
         self.block.add_op(op)
-
-    def create(self, func: Callable[_P, OperationInvT], *args: _P.args,
-               **kwargs: _P.kwargs) -> OperationInvT:
-        op = func(*args, **kwargs)
-        self.insert(op)
         return op
 
     @staticmethod

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -12,6 +12,14 @@ _P = ParamSpec('_P')
 
 @dataclass
 class Builder:
+    """
+    A helper class to construct IRs, by keeping track of where to insert an operation.
+    Currently can only append an operation to a given block, in the future will mirror the
+    API of `OpBuilder` in MLIR.
+
+    https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder.html
+    """
+
     block: Block
 
     def add_op(self, op: Operation):
@@ -83,6 +91,24 @@ class Builder:
         | Callable[[Builder], None]
     ) -> Callable[[_CallableRegionFuncType],
                   tuple[Region, FunctionType]] | tuple[Region, FunctionType]:
+        """
+        Annotation used to construct a (Region, FunctionType) tuple from a function.
+        The annotation can be used in two ways:
+
+        For regions that have inputs or outputs:
+        ```
+        @Builder.callable_region((input_types, output_types))
+        def func(builder: Builder, args: tuple[BlockArgument, ...]) -> None:
+            ...
+        ```
+
+        For regions that don't have inputs or outputs:
+        ``` python
+        @Builder.callable_region
+        def func(builder: Builder) -> None:
+            ...
+        ```
+        """
         if isinstance(input, tuple):
             return Builder._callable_region_args(input)
         else:

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -4,7 +4,7 @@ from typing import Callable, TypeAlias, overload
 
 from dataclasses import dataclass
 
-from xdsl.ir import Operation, OperationInvT, Attribute, Region, Block, BlockArgument
+from xdsl.ir import OperationInvT, Attribute, Region, Block, BlockArgument
 from xdsl.dialects.builtin import FunctionType
 
 

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -47,7 +47,7 @@ class Builder:
         input_types: list[Attribute] | ArrayAttr[Attribute]
     ) -> Callable[[_CallableRegionFuncType], Region]:
         """
-        Constructs a single-block region, containing the implementation of a
+        Decorator for constructing a single-block region, containing the implementation of a
         function with some input arguments.
         """
 

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -15,7 +15,7 @@ class Builder:
     block: Block
 
     def add_op(self, op: Operation):
-        self.block.ops.append(op)
+        self.block.add_op(op)
 
     def create(self, func: Callable[_P, OperationInvT], *args: _P.args,
                **kwargs: _P.kwargs) -> OperationInvT:

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -19,13 +19,23 @@ class OpBuilder:
     """
 
     block: Block
+    """
+    Operations will be inserted in this block.
+    """
 
     def insert(self, op: OperationInvT) -> OperationInvT:
+        """
+        Inserts `op` in `self.block` at the current insertion point.
+        """
+
         self.block.add_op(op)
         return op
 
     @staticmethod
     def region(func: Callable[[OpBuilder], None]) -> Region:
+        """
+        Generates a region given a function.
+        """
 
         block = Block()
         builder = OpBuilder(block)
@@ -38,6 +48,11 @@ class OpBuilder:
     def _callable_region_args(
         types: tuple[list[Attribute], list[Attribute]]
     ) -> Callable[[_CallableRegionFuncType], tuple[Region, FunctionType]]:
+        """
+        Constructs a tuple of (Region, FunctionType) for a region that takes some
+        arguments, and may return some results. The types of the arguments and results
+        are passed in the `types` parameter.
+        """
 
         input_types, return_types = types
 
@@ -58,6 +73,10 @@ class OpBuilder:
     @staticmethod
     def _callable_region_no_args(
             func: Callable[[OpBuilder], None]) -> tuple[Region, FunctionType]:
+        """
+        Constructs a tuple of (Region, FunctionType) for a region that takes no arguments
+        and returns no results.
+        """
 
         @OpBuilder._callable_region_args(([], []))
         def res(builder: OpBuilder, args: tuple[BlockArgument, ...]) -> None:
@@ -70,20 +89,6 @@ class OpBuilder:
     def callable_region(
         input: tuple[list[Attribute], list[Attribute]]
     ) -> Callable[[_CallableRegionFuncType], tuple[Region, FunctionType]]:
-        ...
-
-    @overload
-    @staticmethod
-    def callable_region(
-            input: Callable[[OpBuilder], None]) -> tuple[Region, FunctionType]:
-        ...
-
-    @staticmethod
-    def callable_region(
-        input: tuple[list[Attribute], list[Attribute]]
-        | Callable[[OpBuilder], None]
-    ) -> Callable[[_CallableRegionFuncType],
-                  tuple[Region, FunctionType]] | tuple[Region, FunctionType]:
         """
         Annotation used to construct a (Region, FunctionType) tuple from a function.
         The annotation can be used in two ways:
@@ -102,6 +107,20 @@ class OpBuilder:
             ...
         ```
         """
+        ...
+
+    @overload
+    @staticmethod
+    def callable_region(
+            input: Callable[[OpBuilder], None]) -> tuple[Region, FunctionType]:
+        ...
+
+    @staticmethod
+    def callable_region(
+        input: tuple[list[Attribute], list[Attribute]]
+        | Callable[[OpBuilder], None]
+    ) -> Callable[[_CallableRegionFuncType],
+                  tuple[Region, FunctionType]] | tuple[Region, FunctionType]:
         if isinstance(input, tuple):
             return OpBuilder._callable_region_args(input)
         else:

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -844,7 +844,7 @@ class Block(IRNode):
         return self._args
 
     @staticmethod
-    def from_arg_types(arg_types: list[Attribute]) -> Block:
+    def from_arg_types(arg_types: Sequence[Attribute]) -> Block:
         b = Block()
         b._args = tuple(
             BlockArgument(typ, b, index)


### PR DESCRIPTION
I'm writing a bit more IR as part of the PDL work, and thought I'd get this in to make it all a bit neater. I carry on from where we left off in the discussion in the xdsl-workshop repo.

This is a purely additive change, the current code and APIs are fine, although I'd expect that we'll want to transition to being more Builder-based to make the code more similar to MLIR.