### PR TITLE
dialects: arith.constant from_float_and_width accepts integer as width

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -6,7 +6,7 @@ from xdsl.dialects.arith import (Addi, Constant, DivUI, DivSI, Subi,
                                  XOrI, ShLI, ShRUI, ShRSI, Cmpi, Addf, Subf,
                                  Mulf, Divf, Maxf, Minf, IndexCastOp, FPToSIOp,
                                  SIToFPOp, ExtFOp, TruncFOp)
-from xdsl.dialects.builtin import i32, f32, f64, IndexType, IntegerType, Float32Type
+from xdsl.dialects.builtin import i32, f32, f64, IndexType, IntegerType, Float32Type, FloatAttr
 
 
 class Test_integer_arith_construction:
@@ -50,6 +50,43 @@ class Test_float_arith_construction:
         op = func.get(self.a, self.b)
         assert op.operands[0].op is self.a
         assert op.operands[1].op is self.b
+
+
+def test_float_arith_construction_int_width():
+    a = Constant.from_float_and_width(1.1, 32)
+    b = Constant.from_float_and_width(1.1, 64)
+
+    assert a.result.typ == f32
+    assert a.value.type == f32
+    assert b.result.typ == f64
+    assert b.value.type == f64
+
+
+def test_float_arith_construction_int_width_illegal():
+    try:
+        a = Constant.from_float_and_width(1.1, 48)
+        # This should raise ValueError as 48 is an illegal float width
+        assert False
+    except ValueError:
+        pass
+
+
+def test_float_arith_construction_int_width_missmatch():
+    try:
+        a = Constant.from_float_and_width(FloatAttr(1.4, 64), 32)
+        # This should raise TypeError as the type width in FloatAttr is
+        # mismatched against the integer width provided
+        assert False
+    except TypeError:
+        pass
+
+    try:
+        a = Constant.from_float_and_width(FloatAttr(1.4, 64), i32)
+        # This should raise TypeError as the type width in FloatAttr is
+        # mismatched against the float type provided
+        assert False
+    except TypeError:
+        pass
 
 
 def test_index_cast_op():

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -40,12 +40,23 @@ class Constant(Operation):
             result_types=[typ],
             attributes={"value": IntegerAttr.from_params(val, typ)})
 
-    # To add tests for this constructor
     @staticmethod
     def from_float_and_width(val: float | FloatAttr[_FloatTypeT],
-                             typ: _FloatTypeT) -> Constant:
+                             typ: int | _FloatTypeT) -> Constant:
         if isinstance(val, float):
             val = FloatAttr(val, typ)
+            if isinstance(typ, int):
+                typ = val.type
+        else:
+            # Check provided width matches that of the FloatAttr passed
+            if isinstance(typ, int):
+                # We create a dummy FloatAttr for the type, this
+                # provides error checking on the width
+                typ=FloatAttr(0.0, typ).type
+            if val.type != typ:
+                raise TypeError(f"Provided float is of type {val.type}"
+                                f" but provided width type is {typ}")
+
         return Constant.create(
             result_types=[typ],
             attributes={"value": val})


### PR DESCRIPTION
The Constant operation of arith dialect has a method from_float_and_width, this now accepts an integer as the float width. We use the FloatAttr to construct the underlying type, so that will raise a value exception if the width is illegal for a float.

If a floatattr is provided as value then will check the type of that against the provided type, if there is a missmatch it will  raise a type exception.

Also added some tests for these