### PR TITLE
misc: specify paths for pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=42", "wheel"]
 reportImportCycles = false
 reportUnnecessaryIsInstance = false
 typeCheckingMode = "strict"
-"include" = ["docs", "xdsl", "tests"]
+"include" = ["docs", "xdsl", "tests", "bench"]
 "exclude" = [
     "tests/test_frontend_op_resolver.py",
     "tests/test_frontend_python_code_check.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,11 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
+requires = ["setuptools>=42", "wheel"]
 
 [tool.pyright]
 reportImportCycles = false
 reportUnnecessaryIsInstance = false
 typeCheckingMode = "strict"
+"include" = ["docs", "xdsl", "tests"]
 "exclude" = [
     "tests/test_frontend_op_resolver.py",
     "tests/test_frontend_python_code_check.py",
@@ -29,10 +27,6 @@ typeCheckingMode = "strict"
     "tests/xdsl_opt/test_xdsl_opt.py",
 ]
 "ignore" = [
-    "venv",
-    "versioneer.py",
-    "setup.py",
-    "update_xdsl_pyodide_build.py",
     "xdsl/irdl_mlir_printer.py",
     "tests/filecheck/frontend/dialects/builtin.py",
     "tests/filecheck/frontend/dialects/invalid.py",


### PR DESCRIPTION
seems like pyright didn't ignore venv on both my machines, let's specify the paths for the time being