### PR TITLE
core: Add lexer in parser

### DIFF
--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -640,20 +640,20 @@ class BaseParser(ABC):
         produced.
         """
         self._synchronize_lexer_and_tokenizer()
-        if delimiter == BaseParser.Delimiter.PAREN:
+        if delimiter == self.Delimiter.PAREN:
             self._parse_token(Token.Kind.L_PAREN, "Expected '('" + context_msg)
             if self._consume_if(Token.Kind.R_PAREN) is not None:
                 return []
-        elif delimiter == BaseParser.Delimiter.ANGLE:
+        elif delimiter == self.Delimiter.ANGLE:
             self._parse_token(Token.Kind.LESS, "Expected '<'" + context_msg)
             if self._consume_if(Token.Kind.GREATER) is not None:
                 return []
-        elif delimiter == BaseParser.Delimiter.SQUARE:
+        elif delimiter == self.Delimiter.SQUARE:
             self._parse_token(Token.Kind.L_SQUARE,
                               "Expected '['" + context_msg)
             if self._consume_if(Token.Kind.R_SQUARE) is not None:
                 return []
-        elif delimiter == BaseParser.Delimiter.BRACES:
+        elif delimiter == self.Delimiter.BRACES:
             self._parse_token(Token.Kind.L_BRACE, "Expected '{'" + context_msg)
             if self._consume_if(Token.Kind.R_BRACE) is not None:
                 return []
@@ -668,14 +668,14 @@ class BaseParser(ABC):
             elems.append(parse())
             self._synchronize_lexer_and_tokenizer()
 
-        if delimiter == BaseParser.Delimiter.PAREN:
+        if delimiter == self.Delimiter.PAREN:
             self._parse_token(Token.Kind.R_PAREN, "Expected ')'" + context_msg)
-        elif delimiter == BaseParser.Delimiter.ANGLE:
+        elif delimiter == self.Delimiter.ANGLE:
             self._parse_token(Token.Kind.GREATER, "Expected '>'" + context_msg)
-        elif delimiter == BaseParser.Delimiter.SQUARE:
+        elif delimiter == self.Delimiter.SQUARE:
             self._parse_token(Token.Kind.R_SQUARE,
                               "Expected ']'" + context_msg)
-        elif delimiter == BaseParser.Delimiter.BRACES:
+        elif delimiter == self.Delimiter.BRACES:
             self._parse_token(Token.Kind.R_BRACE, "Expected '}'" + context_msg)
         else:
             assert False, "Unknown delimiter"

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -472,6 +472,10 @@ class BaseParser(ABC):
         self.lexer.pos = pos
         self.tokenizer.pos = pos
         self._current_token = self.lexer.lex()
+        # Make sure both point to the same position,
+        # to avoid having problems with `backtracking`.
+        if self._current_token.span.start > self.tokenizer.pos:
+            self.tokenizer.pos = self._current_token.span.start
 
     def _consume_token(self, expected_kind: Token.Kind | None) -> None:
         """
@@ -1018,6 +1022,7 @@ class BaseParser(ABC):
 
         This will, for example, include backtracking errors, if any occurred previously.
         """
+        self._synchronize_lexer_and_tokenizer()
         if at_position is None:
             at_position = self.tokenizer.next_token(peek=True)
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -485,7 +485,7 @@ class BaseParser(ABC):
             assert self._current_token.kind == expected_kind, "Consumed an unexpected token!"
         self._current_token = self.lexer.lex()
 
-    def _consume_if(self, expected_kind: Token.Kind) -> Token | None:
+    def _parse_optional_token(self, expected_kind: Token.Kind) -> Token | None:
         """
         If the current token is of the expected kind, consume it and return it.
         Otherwise, return False.
@@ -642,20 +642,20 @@ class BaseParser(ABC):
         self._synchronize_lexer_and_tokenizer()
         if delimiter == self.Delimiter.PAREN:
             self._parse_token(Token.Kind.L_PAREN, "Expected '('" + context_msg)
-            if self._consume_if(Token.Kind.R_PAREN) is not None:
+            if self._parse_optional_token(Token.Kind.R_PAREN) is not None:
                 return []
         elif delimiter == self.Delimiter.ANGLE:
             self._parse_token(Token.Kind.LESS, "Expected '<'" + context_msg)
-            if self._consume_if(Token.Kind.GREATER) is not None:
+            if self._parse_optional_token(Token.Kind.GREATER) is not None:
                 return []
         elif delimiter == self.Delimiter.SQUARE:
             self._parse_token(Token.Kind.L_SQUARE,
                               "Expected '['" + context_msg)
-            if self._consume_if(Token.Kind.R_SQUARE) is not None:
+            if self._parse_optional_token(Token.Kind.R_SQUARE) is not None:
                 return []
         elif delimiter == self.Delimiter.BRACES:
             self._parse_token(Token.Kind.L_BRACE, "Expected '{'" + context_msg)
-            if self._consume_if(Token.Kind.R_BRACE) is not None:
+            if self._parse_optional_token(Token.Kind.R_BRACE) is not None:
                 return []
         else:
             assert False, "Unknown delimiter"
@@ -663,7 +663,7 @@ class BaseParser(ABC):
         self._synchronize_lexer_and_tokenizer()
         elems = [parse()]
         self._synchronize_lexer_and_tokenizer()
-        while self._consume_if(Token.Kind.COMMA) is not None:
+        while self._parse_optional_token(Token.Kind.COMMA) is not None:
             self._synchronize_lexer_and_tokenizer()
             elems.append(parse())
             self._synchronize_lexer_and_tokenizer()

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -449,7 +449,7 @@ class BaseParser(ABC):
                  ctx: MLContext,
                  input: str,
                  name: str = '<unknown>',
-                 allow_unregistered_dialect: bool = False):
+                 allow_unregistered_ops: bool = False):
         self.tokenizer = Tokenizer(Input(input, name))
         self.lexer = Lexer(Input(input, name))
         self._current_token = self.lexer.lex()
@@ -457,7 +457,7 @@ class BaseParser(ABC):
         self.ssaValues = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
-        self.allow_unregistered_dialect = allow_unregistered_dialect
+        self.allow_unregistered_ops = allow_unregistered_ops
 
     def _synchronize_lexer_and_tokenizer(self):
         """


### PR DESCRIPTION
This is the strategy I'd like to use to slowly deprecate the tokenizer in favor of the lexer.
The parser has both the lexer and the tokenizer, and we expect the tokenizer to always be up to date.
Once we want to use the lexer, we first synchronize both, to advance the lexer to the last tokenizer position, then
after parsing we advance the tokenizer back to the end of the lexer position.