### PR TITLE
CI: fix pyodide-build version.

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install jupyterlite[all]==0.1.0b17 libarchive-c build pyodide-build
+          python -m pip install jupyterlite[all]==0.1.0b17 libarchive-c build pyodide-build==0.22.0
 
       - name: Build xDSL source distribution
         run: |


### PR DESCRIPTION
This (currently draft) PR intends to fix the current JupyterLite deployment failures.