### PR TITLE
dialects: Minor bug fix for stencil transformation

### DIFF
--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -170,10 +170,10 @@ def prepare_apply_body(op: ApplyOp, rewriter: PatternRewriter):
     # to a loop, which has access to them either way)
     entry = op.region.blocks[0]
 
-    for arg in entry.args:
+    for idx, arg in enumerate(entry.args):
         arg_uses = set(arg.uses)
         for use in arg_uses:
-            use.operation.replace_operand(use.index, op.args[use.index])
+            use.operation.replace_operand(use.index, op.args[idx])
         entry.erase_arg(arg)
 
     dim = len(op.lb.array.data)


### PR DESCRIPTION
When replacing stencil.apply with scf.parallel, the transformation removes the block and updates operations to point to the operation that originated each block argument. However, there was a bug as it was replacing the block arguments of an operation based upon the field index in that operation, rather than the index in the block arguments