### PR TITLE
core: remove generic attr parsing

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -518,32 +518,6 @@ builtin.module() {
     assert_print_op(module, expected, None)
 
 
-def test_parse_generic_format_attr():
-    """
-    Test that we can parse attributes using generic formats.
-    """
-    prog = \
-        """builtin.module() {
-      any() ["attr" = #"custom"<#int<0>>]
-    }"""
-
-    expected = \
-"""\
-builtin.module() {
-  any() ["attr" = !custom<zero>]
-}"""
-
-    ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_op(AnyOp)
-    ctx.register_attr(CustomFormatAttr)
-
-    parser = XDSLParser(ctx, prog)
-    module = parser.parse_op()
-
-    assert_print_op(module, expected, None)
-
-
 def test_parse_generic_format_attr_II():
     """
     Test that we can parse attributes using generic formats.

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -449,7 +449,7 @@ class BaseParser(ABC):
                  ctx: MLContext,
                  input: str,
                  name: str = '<unknown>',
-                 allow_unregistered_dialect: bool = False):
+                 allow_unregistered_ops: bool = False):
         self.tokenizer = Tokenizer(Input(input, name))
         self.lexer = Lexer(Input(input, name))
         self._current_token = self.lexer.lex()
@@ -457,7 +457,7 @@ class BaseParser(ABC):
         self.ssaValues = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
-        self.allow_unregistered_dialect = allow_unregistered_dialect
+        self.allow_unregistered_ops = allow_unregistered_ops
 
     def _synchronize_lexer_and_tokenizer(self):
         """

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -449,7 +449,7 @@ class BaseParser(ABC):
                  ctx: MLContext,
                  input: str,
                  name: str = '<unknown>',
-                 allow_unregistered_ops: bool = False):
+                 allow_unregistered_dialect: bool = False):
         self.tokenizer = Tokenizer(Input(input, name))
         self.lexer = Lexer(Input(input, name))
         self._current_token = self.lexer.lex()
@@ -457,7 +457,7 @@ class BaseParser(ABC):
         self.ssaValues = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
-        self.allow_unregistered_ops = allow_unregistered_ops
+        self.allow_unregistered_dialect = allow_unregistered_dialect
 
     def _synchronize_lexer_and_tokenizer(self):
         """


### PR DESCRIPTION
We always supported parsing attributes with `#"attr_name"<param1, param2, param3>`, which is a generic way of parsing parametrized attributes.
With the new lexer, these cannot be parsed anymore, because the lexer is unhappy about `#` not being followed by a name.

While I first felt that we should slightly tweak the lexer, I realized that I was just too attached to that feature that we never used anyway, so I think that we should remove it until we need it.
The only reason I like this feature is that it meant that  someone else could easily interact with xDSL through this. However, this feature was anyway so hidden that no one would have found it in the first place :shrug:

Depends on #638 only so I can require both features in another PR, while these are being reviewed.