### PR TITLE
dialects: Add strided layout attribute

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -1,9 +1,10 @@
+from typing import Sequence
 import pytest
 
 from xdsl.dialects.builtin import (DenseArrayBase, DenseIntOrFPElementsAttr,
-                                   i32, f32, FloatAttr, ArrayAttr, IntAttr,
-                                   FloatData, SymbolRefAttr,
-                                   VectorBaseTypeConstraint,
+                                   NoneAttr, StridedLayoutAttr, i32, f32,
+                                   FloatAttr, ArrayAttr, IntAttr, FloatData,
+                                   SymbolRefAttr, VectorBaseTypeConstraint,
                                    VectorRankConstraint,
                                    VectorBaseTypeAndRankConstraint)
 from xdsl.dialects.builtin import i32, i64, VectorType, UnrealizedConversionCastOp
@@ -171,3 +172,19 @@ def test_unrealized_conversion_cast():
 
     assert (conv_op2.inputs[0].typ == f32)
     assert (conv_op2.outputs[0].typ == i32)
+
+
+@pytest.mark.parametrize(
+    "strides, offset, expected_strides, expected_offset",
+    [([2], None, ArrayAttr([IntAttr(2)]), NoneAttr()),
+     ([None], 2, ArrayAttr([NoneAttr()]), IntAttr(2)),
+     ([IntAttr(2)], NoneAttr(), ArrayAttr([IntAttr(2)]), NoneAttr()),
+     ([NoneAttr()], IntAttr(2), ArrayAttr([NoneAttr()]), IntAttr(2))])
+def test_strided_constructor(strides: ArrayAttr[IntAttr | NoneAttr]
+                             | Sequence[int | None | IntAttr | NoneAttr],
+                             offset: int | None | IntAttr | NoneAttr,
+                             expected_strides: ArrayAttr[IntAttr | NoneAttr],
+                             expected_offset: IntAttr | NoneAttr):
+    strided = StridedLayoutAttr(strides, offset)
+    assert strided.strides == expected_strides
+    assert strided.offset == expected_offset

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -160,4 +160,24 @@
 
   // CHECK: "type_attr" = index
 
+  "func.func"() ({}) {function_type = () -> (),
+                      strided = strided<[1, 0x23, -23, -0x21, ?], offset: -3>,
+                      sym_name = "strided"} : () -> ()
+  // CHECK: "strided" = strided<[1, 35, -23, -33, ?], offset: -3>
+
+  "func.func"() ({}) {function_type = () -> (),
+                      strided = strided<[], offset: ?>,
+                      sym_name = "strided"} : () -> ()
+  // CHECK: "strided" = strided<[], offset: ?>
+
+  "func.func"() ({}) {function_type = () -> (),
+                      strided = strided<[], offset: 0>,
+                      sym_name = "strided"} : () -> ()
+  // CHECK: "strided" = strided<[]>
+
+  "func.func"() ({}) {function_type = () -> (),
+                      strided = strided<[]>,
+                      sym_name = "strided"} : () -> ()
+  // CHECK: "strided" = strided<[]>
+
 }) : () -> ()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -911,6 +911,44 @@ class OpaqueAttr(ParametrizedAttribute):
         return OpaqueAttr([StringAttr(name), StringAttr(value), type])
 
 
+@irdl_attr_definition
+class StridedLayoutAttr(ParametrizedAttribute):
+    """
+    An attribute representing a strided layout of a shaped type.
+    See https://mlir.llvm.org/docs/Dialects/Builtin/#stridedlayoutattr
+
+    Contrary to MLIR, we represent dynamic offsets and strides with
+    `NoneAttr`, and we do not restrict offsets and strides to 64-bits
+    integers.
+    """
+    name: str = "strided"
+
+    strides: ParameterDef[ArrayAttr[IntAttr | NoneAttr]]
+    offset: ParameterDef[IntAttr | NoneAttr]
+
+    def __init__(self,
+                 strides: ArrayAttr[IntAttr | NoneAttr]
+                 | Sequence[int | None | IntAttr | NoneAttr],
+                 offset: int | None | IntAttr | NoneAttr = 0) -> None:
+        if not isinstance(strides, ArrayAttr):
+            strides_values: list[IntAttr | NoneAttr] = []
+            for stride in strides:
+                if isinstance(stride, int):
+                    strides_values.append(IntAttr(stride))
+                elif stride is None:
+                    strides_values.append(NoneAttr())
+                else:
+                    strides_values.append(stride)
+            strides = ArrayAttr(strides_values)
+
+        if isinstance(offset, int):
+            offset = IntAttr(offset)
+        if offset is None:
+            offset = NoneAttr()
+
+        super().__init__([strides, offset])
+
+
 @irdl_op_definition
 class UnrealizedConversionCastOp(Operation):
     name: str = "builtin.unrealized_conversion_cast"

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -22,7 +22,8 @@ from xdsl.dialects.builtin import (
     Float64Type, FloatAttr, FunctionType, IndexType, IntegerType, Signedness,
     StringAttr, IntegerAttr, ArrayAttr, TensorType, UnrankedTensorType,
     UnregisteredAttr, VectorType, SymbolRefAttr, DenseArrayBase,
-    DenseIntOrFPElementsAttr, OpaqueAttr, NoneAttr, ModuleOp, UnitAttr, i64)
+    DenseIntOrFPElementsAttr, OpaqueAttr, NoneAttr, ModuleOp, UnitAttr, i64,
+    StridedLayoutAttr)
 from xdsl.ir import (SSAValue, Block, Callable, Attribute, Operation, Region,
                      BlockArgument, MLContext, ParametrizedAttribute, Data)
 from xdsl.utils.hints import isa

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from io import StringIO
-from typing import Any, NoReturn, TypeVar, Iterable, IO, cast, Literal, overload
+from typing import Any, NoReturn, TypeVar, Iterable, IO, cast, Literal
 
 from xdsl.utils.exceptions import ParseError, MultipleSpansParseError
 from xdsl.utils.lexer import Input, Lexer, Span, StringLiteral, Token

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -466,24 +466,6 @@ class BaseParser(ABC):
         This is used to allow using both the tokenizer and the lexer,
         to deprecate slowly the tokenizer.
         """
-        lexer_pos = self.lexer.pos
-        tokenizer_pos = self.tokenizer.save()
-        pos = max(lexer_pos, tokenizer_pos)
-        self.lexer.pos = pos
-        self.tokenizer.pos = pos
-        self._current_token = self.lexer.lex()
-
-    def _consume_token(self) -> None:
-        """Advance the lexer"""
-        self._current_token = self.lexer.lex()
-
-    def _synchronize_lexer_and_tokenizer(self):
-        """
-        Advance the lexer and the tokenizer to the same position,
-        which is the maximum of the two.
-        This is used to allow using both the tokenizer and the lexer,
-        to deprecate slowly the tokenizer.
-        """
         lexer_pos = self._current_token.span.start
         tokenizer_pos = self.tokenizer.save()
         pos = max(lexer_pos, tokenizer_pos)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -449,7 +449,7 @@ class BaseParser(ABC):
                  ctx: MLContext,
                  input: str,
                  name: str = '<unknown>',
-                 allow_unregistered_dialect: bool = False):
+                 allow_unregistered_ops: bool = False):
         self.tokenizer = Tokenizer(Input(input, name))
         self.lexer = Lexer(Input(input, name))
         self._current_token = self.lexer.lex()
@@ -457,7 +457,7 @@ class BaseParser(ABC):
         self.ssaValues = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
-        self.allow_unregistered_dialect = allow_unregistered_dialect
+        self.allow_unregistered_ops = allow_unregistered_ops
 
     def _synchronize_lexer_and_tokenizer(self):
         """

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1335,18 +1335,46 @@ class BaseParser(ABC):
         self.raise_error("Expected non-negative integer literal or `?`" +
                          context_msg)
 
+    def parse_keyword(self, keyword: str, context_msg: str = "") -> str:
+        """Parse a specific identifier."""
+
+        error_msg = f"Expected '{keyword}'" + context_msg
+        if self.parse_optional_keyword(keyword) is not None:
+            return keyword
+        self.raise_error(error_msg)
+
+    def parse_optional_keyword(self, keyword: str) -> str | None:
+        """Parse a specific identifier if it is present"""
+
+        if (self._current_token.kind == Token.Kind.BARE_IDENT
+                and self._current_token.text == keyword):
+            self._consume_token(Token.Kind.BARE_IDENT)
+            return keyword
+        return None
+
     def parse_strided_layout_attr(self) -> Attribute:
-        # Consume `strided` keyword
-        self._consume_token(Token.Kind.BARE_IDENT)
+        """
+        Parse a strided layout attribute.
+        | `strided` `<` `[` comma-separated-int-or-question `]`
+          (`,` `offset` `:` integer-literal)? `>`
+        """
+        # Parse `strided` keyword
+        self.parse_keyword("strided")
 
+        # Parse stride list
         self._parse_token(Token.Kind.LESS, "Expected `<` after `strided`")
-        self._parse_token(Token.Kind.L_SQUARE,
-                          "Expected `[` in strided attribute ")
-
-        self.parse_comma_separated_list(
+        strides = self.parse_comma_separated_list(
             self.Delimiter.SQUARE,
             lambda: self.parse_int_or_question(" in stride list"),
             " in stride list")
+
+        if self._consume_if(Token.Kind.GREATER)
+
+        # Parse the optional offset
+        if self._consume_if(Token.Kind.COMMA) is not None:
+            self.parse_keyword("offset", " after comma")
+            self._parse_token(Token.Kind.COLON, "Expected ':' after 'offset'")
+            pass
 
     def try_parse_builtin_named_attr(self) -> Attribute | None:
         name = self.tokenizer.next_token(peek=True)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1313,7 +1313,9 @@ class BaseParser(ABC):
 
         self._synchronize_lexer_and_tokenizer()
         if self._current_token.text == "strided":
-            return self.parse_strided_layout_attr()
+            strided = self.parse_strided_layout_attr()
+            self._synchronize_lexer_and_tokenizer()
+            return strided
 
         return None
 
@@ -1372,7 +1374,6 @@ class BaseParser(ABC):
 
         # Case without offset
         if self._parse_optional_token(Token.Kind.GREATER) is not None:
-            self._synchronize_lexer_and_tokenizer()
             return StridedLayoutAttr(strides)
 
         # Parse the optional offset
@@ -1384,7 +1385,6 @@ class BaseParser(ABC):
         offset = self._parse_int_or_question(" in stride offset")
         self._parse_token(Token.Kind.GREATER,
                           "Expected '>' in end of stride attribute")
-        self._synchronize_lexer_and_tokenizer()
         return StridedLayoutAttr(strides, None if offset == '?' else offset)
 
     def try_parse_builtin_named_attr(self) -> Attribute | None:


### PR DESCRIPTION
This PR adds the strided layout attribute (https://mlir.llvm.org/docs/Dialects/Builtin/#stridedlayoutattr),
as well as its parsing.

The parsing for the attribute inside a `memref` will be added in a later PR.

This PR depends on #639