### PR TITLE
core: move backtracking from tokenizer to parser

### DIFF
--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -399,7 +399,7 @@ class BaseParser(ABC):
                  ctx: MLContext,
                  input: str,
                  name: str = '<unknown>',
-                 allow_unregistered_ops: bool = False):
+                 allow_unregistered_dialect: bool = False):
         self.tokenizer = Tokenizer(Input(input, name))
         self.lexer = Lexer(Input(input, name))
         self._current_token = self.lexer.lex()
@@ -407,7 +407,7 @@ class BaseParser(ABC):
         self.ssaValues = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
-        self.allow_unregistered_ops = allow_unregistered_ops
+        self.allow_unregistered_dialect = allow_unregistered_dialect
 
     def resume_from(self, pos: int):
         """

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -399,7 +399,7 @@ class BaseParser(ABC):
                  ctx: MLContext,
                  input: str,
                  name: str = '<unknown>',
-                 allow_unregistered_dialect: bool = False):
+                 allow_unregistered_ops: bool = False):
         self.tokenizer = Tokenizer(Input(input, name))
         self.lexer = Lexer(Input(input, name))
         self._current_token = self.lexer.lex()
@@ -407,7 +407,7 @@ class BaseParser(ABC):
         self.ssaValues = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
-        self.allow_unregistered_dialect = allow_unregistered_dialect
+        self.allow_unregistered_ops = allow_unregistered_ops
 
     def resume_from(self, pos: int):
         """


### PR DESCRIPTION
This is necessary to allow the tokenizer and the lexer to be
used at the same time. Otherwise, when the tokenizer backtrack,
it is moved forward by the lexer/tokenizer synchronization.
