### PR TITLE
dialects: cmpf operation in arith dialect

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -6,7 +6,7 @@ from xdsl.dialects.arith import (Addi, Constant, DivUI, DivSI, Subi,
                                  XOrI, ShLI, ShRUI, ShRSI, Cmpi, Addf, Subf,
                                  Mulf, Divf, Maxf, Minf, IndexCastOp, FPToSIOp,
                                  SIToFPOp, ExtFOp, TruncFOp, Cmpf)
-from xdsl.dialects.builtin import i32, f32, f64, IndexType, IntegerType, Float32Type
+from xdsl.dialects.builtin import i32, i64, f32, f64, IndexType, IntegerType, Float32Type
 
 
 class Test_integer_arith_construction:
@@ -34,7 +34,7 @@ class Test_integer_arith_construction:
         ["eq", "ne", "slt", "sle", "ult", "ule", "ugt", "uge"],
     )
     def test_Cmpi_from_mnemonic(self, input):
-        _ = Cmpi.from_mnemonic(self.a, self.b, input)
+        _ = Cmpi.get(self.a, self.b, input)
 
 
 class Test_float_arith_construction:
@@ -87,20 +87,20 @@ def test_extend_truncate_fpops():
 def test_cmpf_from_mnemonic():
     a = Constant.from_float_and_width(1.0, f64)
     b = Constant.from_float_and_width(2.0, f64)
-    cmpi_ops = [None] * 10
+    cmpf_ops = [None] * 10
 
-    cmpi_ops[0] = Cmpf.from_mnemonic(a, b, "eq")
-    cmpi_ops[1] = Cmpf.from_mnemonic(a, b, "ne")
-    cmpi_ops[2] = Cmpf.from_mnemonic(a, b, "slt")
-    cmpi_ops[3] = Cmpf.from_mnemonic(a, b, "sle")
-    cmpi_ops[4] = Cmpf.from_mnemonic(a, b, "sgt")
-    cmpi_ops[5] = Cmpf.from_mnemonic(a, b, "sge")
-    cmpi_ops[6] = Cmpf.from_mnemonic(a, b, "ult")
-    cmpi_ops[7] = Cmpf.from_mnemonic(a, b, "ule")
-    cmpi_ops[8] = Cmpf.from_mnemonic(a, b, "ugt")
-    cmpi_ops[9] = Cmpf.from_mnemonic(a, b, "uge")
+    cmpf_ops[0] = Cmpf.get(a, b, "eq")
+    cmpf_ops[1] = Cmpf.get(a, b, "ne")
+    cmpf_ops[2] = Cmpf.get(a, b, "slt")
+    cmpf_ops[3] = Cmpf.get(a, b, "sle")
+    cmpf_ops[4] = Cmpf.get(a, b, "sgt")
+    cmpf_ops[5] = Cmpf.get(a, b, "sge")
+    cmpf_ops[6] = Cmpf.get(a, b, "ult")
+    cmpf_ops[7] = Cmpf.get(a, b, "ule")
+    cmpf_ops[8] = Cmpf.get(a, b, "ugt")
+    cmpf_ops[9] = Cmpf.get(a, b, "uge")
 
-    for index, op in enumerate(cmpi_ops):
+    for index, op in enumerate(cmpf_ops):
         assert op.lhs.typ == f64
         assert op.rhs.typ == f64
         assert op.predicate.value.data == index
@@ -110,11 +110,11 @@ def test_cmpf_get():
     a = Constant.from_float_and_width(1.0, f32)
     b = Constant.from_float_and_width(2.0, f32)
 
-    cmpi_op = Cmpf.get(a, b, 1)
+    cmpf_op = Cmpf.get(a, b, 1)
 
-    assert cmpi_op.lhs.typ == f32
-    assert cmpi_op.rhs.typ == f32
-    assert cmpi_op.predicate.value.data == 1
+    assert cmpf_op.lhs.typ == f32
+    assert cmpf_op.rhs.typ == f32
+    assert cmpf_op.predicate.value.data == 1
 
 
 def test_cmpf_missmatch_type():
@@ -122,6 +122,16 @@ def test_cmpf_missmatch_type():
     b = Constant.from_float_and_width(2.0, f64)
 
     with pytest.raises(TypeError) as e:
-        cmpi_op = Cmpf.get(a, b, 1)
+        cmpf_op = Cmpf.get(a, b, 1)
     assert e.value.args[
-        0] == "Cmpf operands must have same type, but provided !f32 and !f64"
+        0] == "Comparison operands must have same type, but provided !f32 and !f64"
+
+
+def test_cmpi_missmatch_type():
+    a = Constant.from_float_and_width(1, i32)
+    b = Constant.from_float_and_width(2, i64)
+
+    with pytest.raises(TypeError) as e:
+        cmpi_op = Cmpi.get(a, b, 1)
+    assert e.value.args[
+        0] == "Comparison operands must have same type, but provided !i32 and !i64"

--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -287,6 +287,15 @@ func.func() ["function_type" = !fun<[!f64], [!f32]>, "sym_name" = "truncfop"] {
 // CHECK:   %{{.*}} !f32 = arith.truncf(%{{.*}} : !f64)
 
 
+func.func() ["function_type" = !fun<[!f64, !f64], [!i1]>, "sym_name" = "cmpf"] {
+^12(%39 : !f64, %40 : !f64):
+  %41 : !i1 = arith.cmpf(%39 : !f64, %40 : !f64) ["predicate" = 2 : !i64]
+  func.return(%41 : !i1)
+}
+
+// CHECK:   %{{.*}} !i1 = arith.cmpf(%{{.*}} : !f64, %{{.*}} : !f64)  ["predicate" = 2 : !i64]
+
+
 // fastmath single flag set
 func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_reassoc", "fastmath" = !arith.fastmath<reassoc>] {}
 // CHECK:   "fastmath" = !arith.fastmath<reassoc>

--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -296,6 +296,15 @@ func.func() ["function_type" = !fun<[!f64, !f64], [!i1]>, "sym_name" = "cmpf"] {
 // CHECK:   %{{.*}} !i1 = arith.cmpf(%{{.*}} : !f64, %{{.*}} : !f64)  ["predicate" = 2 : !i64]
 
 
+func.func() ["function_type" = !fun<[!i32, !i32], [!i1]>, "sym_name" = "cmpi"] {
+^12(%42 : !i32, %43 : !i32):
+  %44 : !i1 = arith.cmpi(%42 : !f64, %43 : !f64) ["predicate" = 1 : !i64]
+  func.return(%44 : !i1)
+}
+
+// CHECK:   %{{.*}} !i1 = arith.cmpi(%{{.*}} : !i32, %{{.*}} : !i32)  ["predicate" = 1 : !i64]
+
+
 // fastmath single flag set
 func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_reassoc", "fastmath" = !arith.fastmath<reassoc>] {}
 // CHECK:   "fastmath" = !arith.fastmath<reassoc>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -3,9 +3,15 @@
 "builtin.module"() ({
   %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
   %2 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %3 = "arith.cmpf"(%1, %2) {"predicate" = 2 : i64} : (f64, f64) -> i1
-  %4 = "arith.select"(%3, %1, %2) : (i1, f64, f64) -> f64
+  %3 = "arith.constant"() {"value" = 1 : i32} : () -> i32
+  %4 = "arith.constant"() {"value" = 2 : i32} : () -> i32
+  %5 = "arith.cmpf"(%1, %2) {"predicate" = 2 : i64} : (f64, f64) -> i1
+  %6 = "arith.select"(%5, %1, %2) : (i1, f64, f64) -> f64
+  %7 = "arith.cmpi"(%3, %4) {"predicate" = 1 : i64} : (i32, i32) -> i1
+  %8 = "arith.select"(%7, %3, %4) : (i1, i32, i32) -> i32
 }) : ()->()
 
 // CHECK:        "arith.cmpf"(%0, %1) {"predicate" = 2 : i64} : (f64, f64) -> i1
-// CHECK:        "arith.select"(%2, %0, %1) : (i1, f64, f64) -> f64
+// CHECK:        "arith.select"(%4, %0, %1) : (i1, f64, f64) -> f64
+// CHECK:        "arith.cmpi"(%2, %3) {"predicate" = 1 : i64} : (i32, i32) -> i1
+// CHECK:        "arith.select"(%6, %2, %3) : (i1, i32, i32) -> i32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -1,0 +1,11 @@
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+
+"builtin.module"() ({
+  %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
+  %2 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
+  %3 = "arith.cmpf"(%1, %2) {"predicate" = 2 : i64} : (f64, f64) -> i1
+  %4 = "arith.select"(%3, %1, %2) : (i1, f64, f64) -> f64
+}) : ()->()
+
+// CHECK:        "arith.cmpf"(%0, %1) {"predicate" = 2 : i64} : (f64, f64) -> i1
+// CHECK:        "arith.select"(%2, %0, %1) : (i1, f64, f64) -> f64

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -434,20 +434,8 @@ class ComparisonOperation():
     """
 
     @staticmethod
-    def _get_comparison_predicate(mnemonic: str) -> int:
-        comparison_operations = {
-            "eq": 0,
-            "ne": 1,
-            "slt": 2,
-            "sle": 3,
-            "sgt": 4,
-            "sge": 5,
-            "ult": 6,
-            "ule": 7,
-            "ugt": 8,
-            "uge": 9
-        }
-
+    def _get_comparison_predicate(
+            mnemonic: str, comparison_operations: dict[str, int]) -> int:
         if mnemonic in comparison_operations:
             return comparison_operations[mnemonic]
         else:
@@ -500,9 +488,22 @@ class Cmpi(Operation, ComparisonOperation):
         operand1 = SSAValue.get(operand1)
         operand2 = SSAValue.get(operand2)
         Cmpi._validate_operand_types(operand1, operand2)
-        
+
         if isinstance(arg, str):
-          arg = Cmpi._get_comparison_predicate(arg)
+            cmpi_comparison_operations = {
+                "eq": 0,
+                "ne": 1,
+                "slt": 2,
+                "sle": 3,
+                "sgt": 4,
+                "sge": 5,
+                "ult": 6,
+                "ule": 7,
+                "ugt": 8,
+                "uge": 9
+            }
+            arg = Cmpi._get_comparison_predicate(arg,
+                                                 cmpi_comparison_operations)
 
         return Cmpi.build(
             operands=[operand1, operand2],
@@ -548,9 +549,28 @@ class Cmpf(Operation, ComparisonOperation):
         operand2 = SSAValue.get(operand2)
 
         Cmpf._validate_operand_types(operand1, operand2)
-        
+
         if isinstance(arg, str):
-          arg = Cmpf._get_comparison_predicate(arg)
+            cmpf_comparison_operations = {
+                "false": 0,
+                "oeq": 1,
+                "ogt": 2,
+                "oge": 3,
+                "olt": 4,
+                "ole": 5,
+                "one": 6,
+                "ord": 7,
+                "ueq": 8,
+                "ugt": 9,
+                "uge": 10,
+                "ult": 11,
+                "ule": 12,
+                "une": 13,
+                "uno": 14,
+                "true": 15
+            }
+            arg = Cmpf._get_comparison_predicate(arg,
+                                                 cmpf_comparison_operations)
 
         return Cmpf.build(
             operands=[operand1, operand2],

--- a/xdsl/frontend/dialects/arith.py
+++ b/xdsl/frontend/dialects/arith.py
@@ -28,7 +28,7 @@ def cmpi(lhs: _Int, rhs: _Int, mnemonic: str) -> i1:
 
 
 def resolve_cmpi() -> Callable[..., Operation]:
-    return arith.Cmpi.from_mnemonic
+    return arith.Cmpi.get
 
 
 def muli(lhs: _Int, rhs: _Int) -> _Int:


### PR DESCRIPTION
Added cmpf operation in arith dialect, which is a comparison for floating point numbers. I have based this on the structure of the existing cmpi operation. Associated tests included.