### PR TITLE
misc: add pyright to requirements-optional.txt

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,4 +3,5 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
+# Remember to update the CI pyright versions when updating this line
 pyright<1.1.300

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,3 +3,4 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
+pyright<1.1.300

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,4 +4,4 @@ pytest-cov
 coverage<8.0.0
 ipykernel
 # Remember to update the CI pyright versions when updating this line
-pyright<1.1.300
+pyright==1.1.300


### PR DESCRIPTION
Will give us dependabot pings when we need to update pyright, we'll just need to remember to update CI at the same time. I added a comment to remind us of this.