### PR TITLE
core: Allow parsing of singleton unregistered attrs

### DIFF
--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -273,7 +273,7 @@ class ReturnOp(Operation):
 
     @staticmethod
     def from_input(input: SSAValue | None = None) -> ReturnOp:
-        return ReturnOp.create(operands=[input] if input is not None else [])
+        return ReturnOp.build(operands=[input])
 
 
 @irdl_op_definition

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,3 +3,5 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
+# Remember to update the CI pyright versions when updating this line
+pyright==1.1.300

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -5,7 +5,7 @@ from xdsl.dialects.arith import (Addi, Constant, DivUI, DivSI, Subi,
                                  RemSI, MinUI, MinSI, MaxUI, MaxSI, AndI, OrI,
                                  XOrI, ShLI, ShRUI, ShRSI, Cmpi, Addf, Subf,
                                  Mulf, Divf, Maxf, Minf, IndexCastOp, FPToSIOp,
-                                 SIToFPOp, ExtFOp, TruncFOp, Cmpf)
+                                 SIToFPOp, ExtFOp, TruncFOp, Cmpf, Negf)
 from xdsl.dialects.builtin import i32, i64, f32, f64, IndexType, IntegerType, Float32Type
 from xdsl.utils.exceptions import VerifyException
 
@@ -71,6 +71,17 @@ def test_cast_fp_and_si_ops():
     assert fp.result == si.input
     assert isinstance(si.result.typ, IntegerType)
     assert fp.result.typ == f32
+
+
+def test_negf_op():
+    a = Constant.from_float_and_width(1.0, f32)
+    neg_a = Negf.get(a)
+
+    b = Constant.from_float_and_width(1.0, f64)
+    neg_b = Negf.get(b)
+
+    assert neg_a.result.typ == f32
+    assert neg_b.result.typ == f64
 
 
 def test_extend_truncate_fpops():

--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -305,6 +305,15 @@ func.func() ["function_type" = !fun<[!i32, !i32], [!i1]>, "sym_name" = "cmpi"] {
 // CHECK:   %{{.*}} !i1 = arith.cmpi(%{{.*}} : !i32, %{{.*}} : !i32)  ["predicate" = 1 : !i64]
 
 
+func.func() ["function_type" = !fun<[!f32], [!f32]>, "sym_name" = "negf"] {
+^12(%45 : !f32):
+  %46 : !f32 = arith.negf(%45 : !f32)
+  func.return(%46 : !f32)
+}
+
+// CHECK:   %{{.*}} !f32 = arith.negf(%{{.*}} : !f32)
+
+
 // fastmath single flag set
 func.func() ["function_type" = !fun<[], []>, "sym_name" = "fast_reassoc", "fastmath" = !arith.fastmath<reassoc>] {}
 // CHECK:   "fastmath" = !arith.fastmath<reassoc>

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -3,12 +3,11 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %2 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
+  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
     %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
     %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
     %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    %7, %8 = "stencil.apply"(%6) ({
+    %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
       %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
       %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
@@ -21,85 +20,76 @@
       %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
-      "stencil.return"(%19, %18) : (f64, f64) -> ()
-    }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>)
-    "stencil.store"(%7, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
-    "stencil.store"(%8, %5) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+      "stencil.return"(%19) : (!stencil.result<f64>) -> ()
+    }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0: i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
-// CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>, %2 : memref<?x?x?xf64>):
-// CHECK-NEXT:     %3 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
-// CHECK-NEXT:     %4 = "memref.cast"(%1) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
-// CHECK-NEXT:     %5 = "memref.cast"(%2) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
-// CHECK-NEXT:     %6 = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:     %7 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
+// CHECK-NEXT:     %2 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %3 = "memref.cast"(%1) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// CHECK-NEXT:     %4 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:     %5 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:     %6 = "arith.constant"() {"value" = 64 : index} : () -> index
+// CHECK-NEXT:     %7 = "arith.constant"() {"value" = 64 : index} : () -> index
 // CHECK-NEXT:     %8 = "arith.constant"() {"value" = 64 : index} : () -> index
-// CHECK-NEXT:     %9 = "arith.constant"() {"value" = 64 : index} : () -> index
-// CHECK-NEXT:     %10 = "arith.constant"() {"value" = 64 : index} : () -> index
-// CHECK-NEXT:     "scf.parallel"(%6, %6, %6, %8, %9, %10, %7, %7, %7) ({
-// CHECK-NEXT:     ^1(%11 : index, %12 : index, %13 : index):
-// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %15 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %16 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:       %17 = "arith.addi"(%13, %14) : (index, index) -> index
-// CHECK-NEXT:       %18 = "arith.addi"(%12, %15) : (index, index) -> index
-// CHECK-NEXT:       %19 = "arith.addi"(%11, %16) : (index, index) -> index
-// CHECK-NEXT:       %20 = "memref.load"(%3, %17, %18, %19) : (memref<72x72x72xf64>, index, index, index) -> f64
-// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %22 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %23 = "arith.constant"() {"value" = 5 : index} : () -> index
-// CHECK-NEXT:       %24 = "arith.addi"(%13, %21) : (index, index) -> index
-// CHECK-NEXT:       %25 = "arith.addi"(%12, %22) : (index, index) -> index
-// CHECK-NEXT:       %26 = "arith.addi"(%11, %23) : (index, index) -> index
-// CHECK-NEXT:       %27 = "memref.load"(%3, %24, %25, %26) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:     "scf.parallel"(%4, %4, %4, %6, %7, %8, %5, %5, %5) ({
+// CHECK-NEXT:     ^1(%9 : index, %10 : index, %11 : index):
+// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %13 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:       %15 = "arith.addi"(%11, %12) : (index, index) -> index
+// CHECK-NEXT:       %16 = "arith.addi"(%10, %13) : (index, index) -> index
+// CHECK-NEXT:       %17 = "arith.addi"(%9, %14) : (index, index) -> index
+// CHECK-NEXT:       %18 = "memref.load"(%2, %15, %16, %17) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %19 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %20 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %22 = "arith.addi"(%11, %19) : (index, index) -> index
+// CHECK-NEXT:       %23 = "arith.addi"(%10, %20) : (index, index) -> index
+// CHECK-NEXT:       %24 = "arith.addi"(%9, %21) : (index, index) -> index
+// CHECK-NEXT:       %25 = "memref.load"(%2, %22, %23, %24) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %26 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %27 = "arith.constant"() {"value" = 5 : index} : () -> index
 // CHECK-NEXT:       %28 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %29 = "arith.constant"() {"value" = 5 : index} : () -> index
-// CHECK-NEXT:       %30 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %31 = "arith.addi"(%13, %28) : (index, index) -> index
-// CHECK-NEXT:       %32 = "arith.addi"(%12, %29) : (index, index) -> index
-// CHECK-NEXT:       %33 = "arith.addi"(%11, %30) : (index, index) -> index
-// CHECK-NEXT:       %34 = "memref.load"(%3, %31, %32, %33) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %29 = "arith.addi"(%11, %26) : (index, index) -> index
+// CHECK-NEXT:       %30 = "arith.addi"(%10, %27) : (index, index) -> index
+// CHECK-NEXT:       %31 = "arith.addi"(%9, %28) : (index, index) -> index
+// CHECK-NEXT:       %32 = "memref.load"(%2, %29, %30, %31) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %33 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %34 = "arith.constant"() {"value" = 3 : index} : () -> index
 // CHECK-NEXT:       %35 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %36 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:       %37 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %38 = "arith.addi"(%13, %35) : (index, index) -> index
-// CHECK-NEXT:       %39 = "arith.addi"(%12, %36) : (index, index) -> index
-// CHECK-NEXT:       %40 = "arith.addi"(%11, %37) : (index, index) -> index
-// CHECK-NEXT:       %41 = "memref.load"(%3, %38, %39, %40) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %36 = "arith.addi"(%11, %33) : (index, index) -> index
+// CHECK-NEXT:       %37 = "arith.addi"(%10, %34) : (index, index) -> index
+// CHECK-NEXT:       %38 = "arith.addi"(%9, %35) : (index, index) -> index
+// CHECK-NEXT:       %39 = "memref.load"(%2, %36, %37, %38) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %40 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %41 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %42 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %43 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %44 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %45 = "arith.addi"(%13, %42) : (index, index) -> index
-// CHECK-NEXT:       %46 = "arith.addi"(%12, %43) : (index, index) -> index
-// CHECK-NEXT:       %47 = "arith.addi"(%11, %44) : (index, index) -> index
-// CHECK-NEXT:       %48 = "memref.load"(%3, %45, %46, %47) : (memref<72x72x72xf64>, index, index, index) -> f64
-// CHECK-NEXT:       %49 = "arith.addf"(%20, %27) : (f64, f64) -> f64
-// CHECK-NEXT:       %50 = "arith.addf"(%34, %41) : (f64, f64) -> f64
-// CHECK-NEXT:       %51 = "arith.addf"(%49, %50) : (f64, f64) -> f64
+// CHECK-NEXT:       %43 = "arith.addi"(%11, %40) : (index, index) -> index
+// CHECK-NEXT:       %44 = "arith.addi"(%10, %41) : (index, index) -> index
+// CHECK-NEXT:       %45 = "arith.addi"(%9, %42) : (index, index) -> index
+// CHECK-NEXT:       %46 = "memref.load"(%2, %43, %44, %45) : (memref<72x72x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %47 = "arith.addf"(%18, %25) : (f64, f64) -> f64
+// CHECK-NEXT:       %48 = "arith.addf"(%32, %39) : (f64, f64) -> f64
+// CHECK-NEXT:       %49 = "arith.addf"(%47, %48) : (f64, f64) -> f64
 // CHECK-NEXT:       %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
-// CHECK-NEXT:       %52 = "arith.mulf"(%48, %cst) : (f64, f64) -> f64
-// CHECK-NEXT:       %53 = "arith.addf"(%52, %51) : (f64, f64) -> f64
+// CHECK-NEXT:       %50 = "arith.mulf"(%46, %cst) : (f64, f64) -> f64
+// CHECK-NEXT:       %51 = "arith.addf"(%50, %49) : (f64, f64) -> f64
+// CHECK-NEXT:       %52 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %53 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %54 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %55 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %56 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %57 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %58 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %59 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %60 = "arith.addi"(%13, %54) : (index, index) -> index
-// CHECK-NEXT:       %61 = "arith.addi"(%12, %55) : (index, index) -> index
-// CHECK-NEXT:       %62 = "arith.addi"(%11, %56) : (index, index) -> index
-// CHECK-NEXT:       %63 = "arith.addi"(%13, %57) : (index, index) -> index
-// CHECK-NEXT:       %64 = "arith.addi"(%12, %58) : (index, index) -> index
-// CHECK-NEXT:       %65 = "arith.addi"(%11, %59) : (index, index) -> index
-// CHECK-NEXT:       "memref.store"(%53, %4, %60, %61, %62) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
-// CHECK-NEXT:       "memref.store"(%52, %5, %63, %64, %65) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
+// CHECK-NEXT:       %55 = "arith.addi"(%11, %52) : (index, index) -> index
+// CHECK-NEXT:       %56 = "arith.addi"(%10, %53) : (index, index) -> index
+// CHECK-NEXT:       %57 = "arith.addi"(%9, %54) : (index, index) -> index
+// CHECK-NEXT:       "memref.store"(%51, %3, %55, %56, %57) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
-// CHECK-NEXT:   }) {"function_type" = (memref<?x?x?xf64>, memref<?x?x?xf64>, memref<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+// CHECK-NEXT:   }) {"function_type" = (memref<?x?x?xf64>, memref<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/unregistered_dialect.mlir
+++ b/tests/filecheck/mlir-conversion/unregistered_dialect.mlir
@@ -5,11 +5,13 @@
   %0 = "region_op"() ({
     %y = "op_with_res"() {otherattr = #unknown_attr<b2 ...2 [] <<>>>} : () -> (i32)
     %z = "op_with_operands"(%y, %y) : (i32, i32) -> !unknown_type<{[<()>]}>
+    "op"() {ab = !unknown_singleton_type} : () -> ()
   }) {testattr = "foo"} : () -> i32
 
   // CHECK:       %{{.*}} = "region_op"() ({
   // CHECK-NEXT:   %{{.*}} = "op_with_res"() {"otherattr" = #unknown_attr<b2 ...2 [] <<>>>} : () -> i32
   // CHECK-NEXT:   %{{.*}} = "op_with_operands"(%{{.*}}, %{{.*}}) : (i32, i32) -> !unknown_type<{[<()>]}>
+  // CHECK-NEXT:   "op"() {"ab" = !unknown_singleton_type} : () -> ()
   // CHECK-NEXT:  }) {"testattr" = "foo"} : () -> i32
 
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
@@ -1,0 +1,11 @@
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
+  %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
+  %3 = "arith.negf"(%0) : (f32) -> f32
+  %4 = "arith.negf"(%1) : (f64) -> f64
+}) : ()->()
+
+// CHECK:        "arith.negf"(%0) {"fastmath" = #arith.fastmath<none>} : (f32) -> f32
+// CHECK:        "arith.negf"(%1) {"fastmath" = #arith.fastmath<none>} : (f64) -> f64

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -478,7 +478,7 @@ class ReturnOp(Operation):
       stencil.return %0 : !stencil.result<f64>
     """
     name: str = "stencil.return"
-    arg: Annotated[VarOperand, ResultType | AnyFloat]
+    arg: Annotated[Operand, ResultType | AnyFloat]
 
     @staticmethod
     def get(*res: SSAValue | Operation):

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -267,10 +267,7 @@ class DeallocOp(Operation):
             async_dependencies: Sequence[SSAValue | Operation] | None = None,
             is_async: bool = False) -> DeallocOp:
         return DeallocOp.build(
-            operands=[
-                async_dependencies if async_dependencies is not None else [],
-                buffer
-            ],
+            operands=[async_dependencies, buffer],
             result_types=[[AsyncTokenType()] if is_async else []])
 
 
@@ -292,10 +289,7 @@ class MemcpyOp(Operation):
             async_dependencies: Sequence[SSAValue | Operation] | None = None,
             is_async: bool = False) -> MemcpyOp:
         return MemcpyOp.build(
-            operands=[
-                async_dependencies if async_dependencies is not None else [],
-                source, destination
-            ],
+            operands=[async_dependencies, source, destination],
             result_types=[[AsyncTokenType()] if is_async else []])
 
     def verify_(self) -> None:

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -626,7 +626,7 @@ class Operation(IRNode):
     def build(
         cls: type[OpT],
         operands: Sequence[SSAValue | Operation
-                           | Sequence[SSAValue | Operation]]
+                           | Sequence[SSAValue | Operation] | None]
         | None = None,
         result_types: Sequence[Attribute | Sequence[Attribute]]
         | None = None,

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -899,9 +899,11 @@ class BaseParser(ABC):
         string for `<`, `(`, `[`, `{`, and may contain string literals.
         """
         self._synchronize_lexer_and_tokenizer()
-        self._parse_token(Token.Kind.LESS, "Expected '<' for attribute body!")
+        start_token = self._parse_optional_token(Token.Kind.LESS)
+        if start_token is None:
+            return ""
 
-        start_pos = self._current_token.span.start
+        start_pos = start_token.span.start
         end_pos: int = start_pos
 
         symbols_stack = [Token.Kind.LESS]
@@ -935,8 +937,8 @@ class BaseParser(ABC):
                         self._current_token.span)
                 symbols_stack.pop()
                 if len(symbols_stack) == 0:
+                    end_pos = token.span.end
                     break
-                end_pos = self._current_token.span.start
                 continue
 
             # Checking for unexpected EOF
@@ -945,7 +947,6 @@ class BaseParser(ABC):
                     "Unexpected end of file before closing of attribute body!")
 
             # Other tokens
-            end_pos = self._current_token.span.end
             self._consume_token()
 
         body = self.lexer.input.slice(start_pos, end_pos)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -539,8 +539,7 @@ class Printer:
 
         if isinstance(attribute, UnregisteredAttr):
             self.print('!' if attribute.is_type.data else '#')
-            self.print(attribute.attr_name.data, '<', attribute.value.data,
-                       '>')
+            self.print(attribute.attr_name.data, attribute.value.data)
             return
 
         if self.target == self.Target.MLIR:


### PR DESCRIPTION
This allows us to parse `!singleton`, a type or attribute with no parameters.
This requires us to include the `<` and `>` in the values of unregistered attributes.

This allows us to parse from  2764 to 3040 files (over 4799)