### PR TITLE
stencil: add global-to-local pass, halo_exchange op

### DIFF
--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -17,6 +17,7 @@ def test_opt():
         'convert-stencil-to-ll-mlir',
         'convert-stencil-to-gpu',
         'stencil-shape-inference',
+        'stencil-to-local-2d-horizontal',
         'frontend-desymrefy',
     ]
 

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -517,6 +517,19 @@ class CombineOp(Operation):
     irdl_options = [AttrSizedOperandSegments()]
 
 
+@irdl_op_definition
+class HaloSwapOp(Operation):
+    name = "stencil.halo_swap"
+
+    input_stencil: Annotated[Operand, FieldType]
+
+    @staticmethod
+    def get(input_stencil: SSAValue | Operation):
+        return HaloSwapOp.build(
+            operands=[input_stencil]
+        )
+
+
 Stencil = Dialect([
     CastOp,
     ExternalLoadOp,
@@ -531,6 +544,7 @@ Stencil = Dialect([
     StoreResultOp,
     ReturnOp,
     CombineOp,
+    HaloSwapOp,
 ], [
     FieldType,
     TempType,

--- a/xdsl/transforms/experimental/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/stencil_global_to_local.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+from typing import TypeVar
+from abc import ABC, abstractmethod
+
+from xdsl.pattern_rewriter import (PatternRewriter, PatternRewriteWalker,
+                                   RewritePattern, GreedyRewritePatternApplier,
+                                   op_type_rewrite_pattern)
+from xdsl.ir import MLContext
+from xdsl.irdl import Attribute
+from xdsl.dialects import builtin
+from xdsl.dialects.experimental import stencil
+
+_T = TypeVar('_T', bound=Attribute)
+
+
+@dataclass
+class SlicingStrategy(ABC):
+    @abstractmethod
+    def calc_resize(self, shape: tuple[int]) -> tuple[int]:
+        raise NotImplementedError("SlicingStrategy must implement calc_resize!")
+
+
+@dataclass
+class HorizontalSlices2D(SlicingStrategy):
+    slices: int
+
+    def __post_init__(self):
+        assert self.slices > 1, "must slice into at least two pieces!"
+
+    def calc_resize(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        # slice on the last dimension only
+        assert len(shape) == 2, "HorizontalSlices2D only works on 2d fields!"
+        assert shape[1] % self.slices == 0, "HorizontalSlices2D expects second dim to be divisble by number of slices!"
+
+        return shape[0], shape[1] // self.slices
+
+
+@dataclass
+class ChangeStoreOpSizes(RewritePattern):
+    strategy: SlicingStrategy
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: stencil.StoreOp, rewriter: PatternRewriter, /):
+        assert all(integer_attr.value.data == 0 for integer_attr in op.lb.array.data), "lb must be 0"
+        shape: tuple[int, ...] = tuple((integer_attr.value.data for integer_attr in op.ub.array.data))
+        new_shape = self.strategy.calc_resize(shape)
+        op.ub = stencil.IndexAttr.get(*new_shape)
+
+
+@dataclass
+class AddHaloExchangeOps(RewritePattern):
+    """
+    This rewrite adds a `stencil.halo_exchange` op after each `stencil.apply` call
+    """
+    strategy: SlicingStrategy
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: stencil.LoadOp, rewriter: PatternRewriter, /):
+        swap_op = stencil.HaloSwapOp.get(op.field)
+        rewriter.insert_op_before_matched_op(swap_op)
+
+
+def global_stencil_to_local_stencil_2d_horizontal(ctx: MLContext | None, module: builtin.ModuleOp):
+    strategy = HorizontalSlices2D(2)
+
+    gpra = GreedyRewritePatternApplier([
+        ChangeStoreOpSizes(strategy),
+        AddHaloExchangeOps(strategy)
+    ])
+
+    PatternRewriteWalker(gpra, apply_recursively=False).rewrite_module(module)
+

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -28,6 +28,7 @@ from xdsl.dialects.experimental.stencil import Stencil
 from xdsl.dialects.experimental.math import Math
 
 from xdsl.transforms.experimental.ConvertStencilToLLMLIR import ConvertStencilToLLMLIR, ConvertStencilToGPU, StencilShapeInference
+from xdsl.transforms.experimental.stencil_global_to_local import global_stencil_to_local_stencil_2d_horizontal
 
 from xdsl.irdl_mlir_printer import IRDLPrinter
 from xdsl.utils.exceptions import DiagnosticException
@@ -236,6 +237,7 @@ class xDSLOptMain:
         self.available_passes['convert-stencil-to-gpu'] = ConvertStencilToGPU
         self.available_passes[
             'stencil-shape-inference'] = StencilShapeInference
+        self.available_passes['stencil-to-local-2d-horizontal'] = global_stencil_to_local_stencil_2d_horizontal
         self.available_passes['frontend-desymrefy'] = Desymrefy
 
     def register_all_targets(self):


### PR DESCRIPTION
This adds the `stencil-to-local-2d-horizontal` pass that transforms a global stencil into a local stencil that is sliced into two parts on a horizontal axis:

```
+-------------+           +-------------+
|             |           |             |
|             |           |             |
|             |           |             |
|             |   >>>>    +-------------+
|             |           |             |
|             |           |             |
|             |           |             |
+-------------+           +-------------+
```

This pass definitely needs parametrization in the future, for now we have to make do with "static" slices per pass. Ideally, in the future we'd have something like `-p stenci-global-to-local{strategy=horizontal-2d,slices=2}` or `{strategy=grid,x=64,y=64,z=64}` something like that.