### PR TITLE
core: Add parse_integer function

### DIFF
--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1449,13 +1449,8 @@ class BaseParser(ABC):
         self._synchronize_lexer_and_tokenizer()
         if self._parse_optional_token(Token.Kind.QUESTION) is not None:
             return '?'
-        negative = False
-        if self._parse_optional_token(Token.Kind.MINUS) is not None:
-            negative = True
-        if (token := self._parse_optional_token(
-                Token.Kind.INTEGER_LIT)) is not None:
-            value = token.get_int_value()
-            return -value if negative else value
+        if (v := self.parse_optional_integer(allow_boolean=False)) is not None:
+            return v
         self.raise_error("Expected an integer literal or `?`" + context_msg)
 
     def parse_keyword(self, keyword: str, context_msg: str = "") -> str:

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -763,6 +763,11 @@ class BaseParser(ABC):
     def parse_optional_integer(self,
                                allow_boolean: bool = True,
                                allow_negative: bool = True) -> int | None:
+        """
+        Parse an (possible negative) integer. The integer can either be
+        decimal or hexadecimal.
+        Optionally allow parsing of 'true' or 'false' into 1 and 0.
+        """
         self._synchronize_lexer_and_tokenizer()
         # Parse true and false if needed
         if allow_boolean:
@@ -802,6 +807,12 @@ class BaseParser(ABC):
                       allow_boolean: bool = True,
                       allow_negative: bool = True,
                       context_msg: str = '') -> int:
+        """
+        Parse an (possible negative) integer, if present. The integer can
+        either be decimal or hexadecimal.
+        Optionally allow parsing of 'true' or 'false' into 1 and 0.
+        """
+
         return self.expect(
             lambda: self.parse_optional_integer(allow_boolean, allow_negative),
             'Expected integer literal' + context_msg)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -276,7 +276,9 @@ class Tokenizer:
                 lambda x: x >= 0,
                 (self.input.content.find(part, i) for part in self._break_on),
             ))
-        return min(min(break_pos), self.input.len)
+        # Make sure that we break at some point
+        break_pos.append(self.input.len)
+        return min(break_pos)
 
     def next_pos(self, i: int | None = None) -> int:
         """

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -276,9 +276,7 @@ class Tokenizer:
                 lambda x: x >= 0,
                 (self.input.content.find(part, i) for part in self._break_on),
             ))
-        # Make sure that we break at some point
-        break_pos.append(self.input.len)
-        return min(break_pos)
+        return min(min(break_pos), self.input.len)
 
     def next_pos(self, i: int | None = None) -> int:
         """

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -271,11 +271,14 @@ class Tokenizer:
             if self.input.content.startswith(part, i):
                 return i + len(part)
         # Otherwise return the start of the next break
-        return min(
+        break_pos = list(
             filter(
                 lambda x: x >= 0,
                 (self.input.content.find(part, i) for part in self._break_on),
             ))
+        # Make sure that we break at some point
+        break_pos.append(self.input.len)
+        return min(break_pos)
 
     def next_pos(self, i: int | None = None) -> int:
         """
@@ -756,6 +759,52 @@ class BaseParser(ABC):
             items.append(next_item)
 
         return items
+
+    def parse_optional_integer(self,
+                               allow_boolean: bool = True,
+                               allow_negative: bool = True) -> int | None:
+        self._synchronize_lexer_and_tokenizer()
+        # Parse true and false if needed
+        if allow_boolean:
+            if self._current_token.kind == Token.Kind.BARE_IDENT:
+                if self._current_token.text == 'true':
+                    self._consume_token(Token.Kind.BARE_IDENT)
+                    self._synchronize_lexer_and_tokenizer()
+                    return 1
+                elif self._current_token.text == 'false':
+                    self._consume_token(Token.Kind.BARE_IDENT)
+                    self._synchronize_lexer_and_tokenizer()
+                    return 0
+                return None
+
+        # Parse negative numbers if required
+        is_negative = False
+        if allow_negative:
+            is_negative = self._parse_optional_token(
+                Token.Kind.MINUS) is not None
+
+        # Parse the actual number
+        if (int_token := self._parse_optional_token(
+                Token.Kind.INTEGER_LIT)) is None:
+            if is_negative:
+                self.raise_error("Expected integer literal after '-'")
+            self._synchronize_lexer_and_tokenizer()
+            return None
+
+        # Get the value and optionally negate it
+        value = int_token.get_int_value()
+        if is_negative:
+            value = -value
+        self._synchronize_lexer_and_tokenizer()
+        return value
+
+    def parse_integer(self,
+                      allow_boolean: bool = True,
+                      allow_negative: bool = True,
+                      context_msg: str = '') -> int:
+        return self.expect(
+            lambda: self.parse_optional_integer(allow_boolean, allow_negative),
+            'Expected integer literal' + context_msg)
 
     def try_parse_integer_literal(self) -> Span | None:
         return self.tokenizer.next_token_of_pattern(


### PR DESCRIPTION
This adds a useful function to parse integers.
This one exists in MLIR, though it doesn't have the option to deactivate booleans or integers.
I feel this option is quite useful, to improve code reuse.