### PR TITLE
core: Add support for parsing dense with vector type

### DIFF
--- a/.github/workflows/ci-pyright-fails.yml
+++ b/.github/workflows/ci-pyright-fails.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Pyright
         uses: jakebailey/pyright-action@v1
         with:
-          version: 1.1.300
+          version: 1.1.301

--- a/.github/workflows/ci-pyright.yml
+++ b/.github/workflows/ci-pyright.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Pyright
         uses: jordemort/action-pyright@v1.8.0
         with:
-          version: 1.1.300
+          version: 1.1.301
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review # Change reporter.
           lib: true

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,4 +4,4 @@ pytest-cov
 coverage<8.0.0
 ipykernel
 # Remember to update the CI pyright versions when updating this line
-pyright==1.1.300
+pyright==1.1.301

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -7,6 +7,7 @@ from xdsl.dialects.memref import (Alloc, Alloca, Dealloc, Dealloca, MemRefType,
                                   Cast)
 from xdsl.dialects import builtin, memref, func, arith, scf
 from xdsl.utils.hints import isa
+from xdsl.utils.test_value import TestSSAValue
 
 
 def test_memreftype():
@@ -32,7 +33,7 @@ def test_memreftype():
 
 def test_memref_load_i32():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
     load = Load.get(memref_ssa_value, [])
 
     assert load.memref is memref_ssa_value
@@ -42,9 +43,9 @@ def test_memref_load_i32():
 
 def test_memref_load_i32_with_dimensions():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
     load = Load.get(memref_ssa_value, [index1, index2])
 
     assert load.memref is memref_ssa_value
@@ -55,8 +56,8 @@ def test_memref_load_i32_with_dimensions():
 
 def test_memref_store_i32():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-    i32_ssa_value = OpResult(i32, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
+    i32_ssa_value = TestSSAValue(i32)
     store = Store.get(i32_ssa_value, memref_ssa_value, [])
 
     assert store.memref is memref_ssa_value
@@ -66,10 +67,10 @@ def test_memref_store_i32():
 
 def test_memref_store_i32_with_dimensions():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-    i32_ssa_value = OpResult(i32, [], [])
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
+    i32_ssa_value = TestSSAValue(i32)
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
     store = Store.get(i32_ssa_value, memref_ssa_value, [index1, index2])
 
     assert store.memref is memref_ssa_value
@@ -196,7 +197,7 @@ def test_memref_matmul_verify():
 
 def test_memref_subview():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [10, 2])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
 
     res_memref_type = MemRefType.from_element_type_and_shape(i32, [1, 1])
 
@@ -263,7 +264,7 @@ def test_memref_subview_constant_parameters():
 
 def test_memref_cast():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [10, 2])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
 
     res_type = UnrankedMemrefType.from_type(i32)
 

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -1,6 +1,5 @@
 // RUN: xdsl-opt %s -t mlir -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
 
-
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
@@ -27,8 +26,7 @@
   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
-
-// CHECK-NEXT: "builtin.module"() ({
+// CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
 // CHECK-NEXT:     %2 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
@@ -40,40 +38,40 @@
 // CHECK-NEXT:     %8 = "arith.constant"() {"value" = 64 : index} : () -> index
 // CHECK-NEXT:     "scf.parallel"(%4, %4, %4, %6, %7, %8, %5, %5, %5) ({
 // CHECK-NEXT:     ^1(%9 : index, %10 : index, %11 : index):
-// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 3 : index} : () -> index
 // CHECK-NEXT:       %13 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:       %15 = "arith.addi"(%11, %12) : (index, index) -> index
+// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %15 = "arith.addi"(%9, %12) : (index, index) -> index
 // CHECK-NEXT:       %16 = "arith.addi"(%10, %13) : (index, index) -> index
-// CHECK-NEXT:       %17 = "arith.addi"(%9, %14) : (index, index) -> index
+// CHECK-NEXT:       %17 = "arith.addi"(%11, %14) : (index, index) -> index
 // CHECK-NEXT:       %18 = "memref.load"(%2, %15, %16, %17) : (memref<72x72x72xf64>, index, index, index) -> f64
-// CHECK-NEXT:       %19 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %19 = "arith.constant"() {"value" = 5 : index} : () -> index
 // CHECK-NEXT:       %20 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 5 : index} : () -> index
-// CHECK-NEXT:       %22 = "arith.addi"(%11, %19) : (index, index) -> index
+// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %22 = "arith.addi"(%9, %19) : (index, index) -> index
 // CHECK-NEXT:       %23 = "arith.addi"(%10, %20) : (index, index) -> index
-// CHECK-NEXT:       %24 = "arith.addi"(%9, %21) : (index, index) -> index
+// CHECK-NEXT:       %24 = "arith.addi"(%11, %21) : (index, index) -> index
 // CHECK-NEXT:       %25 = "memref.load"(%2, %22, %23, %24) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %26 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %27 = "arith.constant"() {"value" = 5 : index} : () -> index
 // CHECK-NEXT:       %28 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %29 = "arith.addi"(%11, %26) : (index, index) -> index
+// CHECK-NEXT:       %29 = "arith.addi"(%9, %26) : (index, index) -> index
 // CHECK-NEXT:       %30 = "arith.addi"(%10, %27) : (index, index) -> index
-// CHECK-NEXT:       %31 = "arith.addi"(%9, %28) : (index, index) -> index
+// CHECK-NEXT:       %31 = "arith.addi"(%11, %28) : (index, index) -> index
 // CHECK-NEXT:       %32 = "memref.load"(%2, %29, %30, %31) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %33 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %34 = "arith.constant"() {"value" = 3 : index} : () -> index
 // CHECK-NEXT:       %35 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %36 = "arith.addi"(%11, %33) : (index, index) -> index
+// CHECK-NEXT:       %36 = "arith.addi"(%9, %33) : (index, index) -> index
 // CHECK-NEXT:       %37 = "arith.addi"(%10, %34) : (index, index) -> index
-// CHECK-NEXT:       %38 = "arith.addi"(%9, %35) : (index, index) -> index
+// CHECK-NEXT:       %38 = "arith.addi"(%11, %35) : (index, index) -> index
 // CHECK-NEXT:       %39 = "memref.load"(%2, %36, %37, %38) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %40 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %41 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %42 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %43 = "arith.addi"(%11, %40) : (index, index) -> index
+// CHECK-NEXT:       %43 = "arith.addi"(%9, %40) : (index, index) -> index
 // CHECK-NEXT:       %44 = "arith.addi"(%10, %41) : (index, index) -> index
-// CHECK-NEXT:       %45 = "arith.addi"(%9, %42) : (index, index) -> index
+// CHECK-NEXT:       %45 = "arith.addi"(%11, %42) : (index, index) -> index
 // CHECK-NEXT:       %46 = "memref.load"(%2, %43, %44, %45) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %47 = "arith.addf"(%18, %25) : (f64, f64) -> f64
 // CHECK-NEXT:       %48 = "arith.addf"(%32, %39) : (f64, f64) -> f64
@@ -84,9 +82,9 @@
 // CHECK-NEXT:       %52 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %53 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %54 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %55 = "arith.addi"(%11, %52) : (index, index) -> index
+// CHECK-NEXT:       %55 = "arith.addi"(%9, %52) : (index, index) -> index
 // CHECK-NEXT:       %56 = "arith.addi"(%10, %53) : (index, index) -> index
-// CHECK-NEXT:       %57 = "arith.addi"(%9, %54) : (index, index) -> index
+// CHECK-NEXT:       %57 = "arith.addi"(%11, %54) : (index, index) -> index
 // CHECK-NEXT:       "memref.store"(%51, %3, %55, %56, %57) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -1,6 +1,5 @@
 // RUN: xdsl-opt %s -t mlir -p stencil-shape-inference,convert-stencil-to-gpu | filecheck %s
 
-
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
@@ -27,8 +26,7 @@
   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
-
-// CHECK-NEXT: "builtin.module"() ({
+// CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
 // CHECK-NEXT:     %2 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
@@ -44,40 +42,40 @@
 // CHECK-NEXT:     %10 = "arith.constant"() {"value" = 64 : index} : () -> index
 // CHECK-NEXT:     "scf.parallel"(%6, %6, %6, %8, %9, %10, %7, %7, %7) ({
 // CHECK-NEXT:     ^1(%11 : index, %12 : index, %13 : index):
-// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 3 : index} : () -> index
 // CHECK-NEXT:       %15 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %16 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:       %17 = "arith.addi"(%13, %14) : (index, index) -> index
+// CHECK-NEXT:       %16 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %17 = "arith.addi"(%11, %14) : (index, index) -> index
 // CHECK-NEXT:       %18 = "arith.addi"(%12, %15) : (index, index) -> index
-// CHECK-NEXT:       %19 = "arith.addi"(%11, %16) : (index, index) -> index
+// CHECK-NEXT:       %19 = "arith.addi"(%13, %16) : (index, index) -> index
 // CHECK-NEXT:       %20 = "memref.load"(%2, %17, %18, %19) : (memref<72x72x72xf64>, index, index, index) -> f64
-// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %21 = "arith.constant"() {"value" = 5 : index} : () -> index
 // CHECK-NEXT:       %22 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %23 = "arith.constant"() {"value" = 5 : index} : () -> index
-// CHECK-NEXT:       %24 = "arith.addi"(%13, %21) : (index, index) -> index
+// CHECK-NEXT:       %23 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %24 = "arith.addi"(%11, %21) : (index, index) -> index
 // CHECK-NEXT:       %25 = "arith.addi"(%12, %22) : (index, index) -> index
-// CHECK-NEXT:       %26 = "arith.addi"(%11, %23) : (index, index) -> index
+// CHECK-NEXT:       %26 = "arith.addi"(%13, %23) : (index, index) -> index
 // CHECK-NEXT:       %27 = "memref.load"(%2, %24, %25, %26) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %28 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %29 = "arith.constant"() {"value" = 5 : index} : () -> index
 // CHECK-NEXT:       %30 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %31 = "arith.addi"(%13, %28) : (index, index) -> index
+// CHECK-NEXT:       %31 = "arith.addi"(%11, %28) : (index, index) -> index
 // CHECK-NEXT:       %32 = "arith.addi"(%12, %29) : (index, index) -> index
-// CHECK-NEXT:       %33 = "arith.addi"(%11, %30) : (index, index) -> index
+// CHECK-NEXT:       %33 = "arith.addi"(%13, %30) : (index, index) -> index
 // CHECK-NEXT:       %34 = "memref.load"(%2, %31, %32, %33) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %35 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %36 = "arith.constant"() {"value" = 3 : index} : () -> index
 // CHECK-NEXT:       %37 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %38 = "arith.addi"(%13, %35) : (index, index) -> index
+// CHECK-NEXT:       %38 = "arith.addi"(%11, %35) : (index, index) -> index
 // CHECK-NEXT:       %39 = "arith.addi"(%12, %36) : (index, index) -> index
-// CHECK-NEXT:       %40 = "arith.addi"(%11, %37) : (index, index) -> index
+// CHECK-NEXT:       %40 = "arith.addi"(%13, %37) : (index, index) -> index
 // CHECK-NEXT:       %41 = "memref.load"(%2, %38, %39, %40) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %42 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %43 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %44 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %45 = "arith.addi"(%13, %42) : (index, index) -> index
+// CHECK-NEXT:       %45 = "arith.addi"(%11, %42) : (index, index) -> index
 // CHECK-NEXT:       %46 = "arith.addi"(%12, %43) : (index, index) -> index
-// CHECK-NEXT:       %47 = "arith.addi"(%11, %44) : (index, index) -> index
+// CHECK-NEXT:       %47 = "arith.addi"(%13, %44) : (index, index) -> index
 // CHECK-NEXT:       %48 = "memref.load"(%2, %45, %46, %47) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %49 = "arith.addf"(%20, %27) : (f64, f64) -> f64
 // CHECK-NEXT:       %50 = "arith.addf"(%34, %41) : (f64, f64) -> f64
@@ -88,14 +86,12 @@
 // CHECK-NEXT:       %54 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %55 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %56 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %57 = "arith.addi"(%13, %54) : (index, index) -> index
+// CHECK-NEXT:       %57 = "arith.addi"(%11, %54) : (index, index) -> index
 // CHECK-NEXT:       %58 = "arith.addi"(%12, %55) : (index, index) -> index
-// CHECK-NEXT:       %59 = "arith.addi"(%11, %56) : (index, index) -> index
+// CHECK-NEXT:       %59 = "arith.addi"(%13, %56) : (index, index) -> index
 // CHECK-NEXT:       "memref.store"(%53, %4, %57, %58, %59) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"function_type" = (memref<?x?x?xf64>, memref<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 // CHECK-NEXT: }) : () -> ()
-
-

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -164,253 +164,252 @@
   }) {"sym_name" = "myfunc", "function_type" = (memref<2xmemref<?x?x?xf32>>) -> (), "sym_visibility" = "private", "param_names" = ["data"]} : () -> ()
 }) : () -> ()
 
-
-// CHECK-NEXT:"builtin.module"() ({
-// CHECK-NEXT:  "func.func"() ({
-// CHECK-NEXT:  ^0(%data : memref<2xmemref<?x?x?xf32>>):
-// CHECK-NEXT:    %time_m = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:    %time_M = "arith.constant"() {"value" = 1000 : index} : () -> index
-// CHECK-NEXT:    %step = "arith.constant"() {"value" = 1 : index} : () -> index
-// CHECK-NEXT:    %0 = "arith.constant"() {"value" = 1 : index} : () -> index
-// CHECK-NEXT:    %time_M_1 = "arith.addi"(%time_M, %0) : (index, index) -> index
-// CHECK-NEXT:    "scf.for"(%time_m, %time_M_1, %step) ({
-// CHECK-NEXT:    ^1(%time : index):
-// CHECK-NEXT:      %time_1 = "arith.index_cast"(%time) : (index) -> i64
-// CHECK-NEXT:      %1 = "arith.constant"() {"value" = 2 : i64} : () -> i64
-// CHECK-NEXT:      %2 = "arith.constant"() {"value" = 0 : i64} : () -> i64
-// CHECK-NEXT:      %3 = "arith.addi"(%time_1, %2) : (i64, i64) -> i64
-// CHECK-NEXT:      %t0 = "arith.remsi"(%3, %1) : (i64, i64) -> i64
-// CHECK-NEXT:      %4 = "arith.constant"() {"value" = 1 : i64} : () -> i64
-// CHECK-NEXT:      %5 = "arith.addi"(%time_1, %4) : (i64, i64) -> i64
-// CHECK-NEXT:      %t1 = "arith.remsi"(%5, %1) : (i64, i64) -> i64
-// CHECK-NEXT:      %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
-// CHECK-NEXT:      %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-// CHECK-NEXT:      %t0_w_size_3 = "memref.cast"(%t0_w_size_1) : (memref<?x?x?xf32>) -> memref<48x88x58xf32>
-// CHECK-NEXT:      %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
-// CHECK-NEXT:      %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-// CHECK-NEXT:      %t1_w_size_3 = "memref.cast"(%t1_w_size_1) : (memref<?x?x?xf32>) -> memref<48x88x58xf32>
-// CHECK-NEXT:      %6 = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:      %7 = "arith.constant"() {"value" = 1 : index} : () -> index
-// CHECK-NEXT:      %8 = "arith.constant"() {"value" = 50 : index} : () -> index
-// CHECK-NEXT:      %9 = "arith.constant"() {"value" = 80 : index} : () -> index
-// CHECK-NEXT:      %10 = "arith.constant"() {"value" = 40 : index} : () -> index
-// CHECK-NEXT:      "scf.parallel"(%6, %6, %6, %8, %9, %10, %7, %7, %7) ({
-// CHECK-NEXT:      ^2(%11 : index, %12 : index, %13 : index):
-// CHECK-NEXT:        %14 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %15 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %16 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %17 = "arith.addi"(%13, %14) : (index, index) -> index
-// CHECK-NEXT:        %18 = "arith.addi"(%12, %15) : (index, index) -> index
-// CHECK-NEXT:        %19 = "arith.addi"(%11, %16) : (index, index) -> index
-// CHECK-NEXT:        %20 = "memref.load"(%t0_w_size_3, %17, %18, %19) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %21 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %22 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %23 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:        %24 = "arith.addi"(%13, %21) : (index, index) -> index
-// CHECK-NEXT:        %25 = "arith.addi"(%12, %22) : (index, index) -> index
-// CHECK-NEXT:        %26 = "arith.addi"(%11, %23) : (index, index) -> index
-// CHECK-NEXT:        %27 = "memref.load"(%t0_w_size_3, %24, %25, %26) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %28 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %29 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %30 = "arith.constant"() {"value" = 5 : index} : () -> index
-// CHECK-NEXT:        %31 = "arith.addi"(%13, %28) : (index, index) -> index
-// CHECK-NEXT:        %32 = "arith.addi"(%12, %29) : (index, index) -> index
-// CHECK-NEXT:        %33 = "arith.addi"(%11, %30) : (index, index) -> index
-// CHECK-NEXT:        %34 = "memref.load"(%t0_w_size_3, %31, %32, %33) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %35 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %36 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %37 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:        %38 = "arith.addi"(%13, %35) : (index, index) -> index
-// CHECK-NEXT:        %39 = "arith.addi"(%12, %36) : (index, index) -> index
-// CHECK-NEXT:        %40 = "arith.addi"(%11, %37) : (index, index) -> index
-// CHECK-NEXT:        %41 = "memref.load"(%t0_w_size_3, %38, %39, %40) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %42 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %43 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %44 = "arith.constant"() {"value" = 6 : index} : () -> index
-// CHECK-NEXT:        %45 = "arith.addi"(%13, %42) : (index, index) -> index
-// CHECK-NEXT:        %46 = "arith.addi"(%12, %43) : (index, index) -> index
-// CHECK-NEXT:        %47 = "arith.addi"(%11, %44) : (index, index) -> index
-// CHECK-NEXT:        %48 = "memref.load"(%t0_w_size_3, %45, %46, %47) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %49 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %50 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:        %51 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %52 = "arith.addi"(%13, %49) : (index, index) -> index
-// CHECK-NEXT:        %53 = "arith.addi"(%12, %50) : (index, index) -> index
-// CHECK-NEXT:        %54 = "arith.addi"(%11, %51) : (index, index) -> index
-// CHECK-NEXT:        %55 = "memref.load"(%t0_w_size_3, %52, %53, %54) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %56 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %57 = "arith.constant"() {"value" = 5 : index} : () -> index
-// CHECK-NEXT:        %58 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %59 = "arith.addi"(%13, %56) : (index, index) -> index
-// CHECK-NEXT:        %60 = "arith.addi"(%12, %57) : (index, index) -> index
-// CHECK-NEXT:        %61 = "arith.addi"(%11, %58) : (index, index) -> index
-// CHECK-NEXT:        %62 = "memref.load"(%t0_w_size_3, %59, %60, %61) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %63 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %64 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:        %65 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %66 = "arith.addi"(%13, %63) : (index, index) -> index
-// CHECK-NEXT:        %67 = "arith.addi"(%12, %64) : (index, index) -> index
-// CHECK-NEXT:        %68 = "arith.addi"(%11, %65) : (index, index) -> index
-// CHECK-NEXT:        %69 = "memref.load"(%t0_w_size_3, %66, %67, %68) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %70 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %71 = "arith.constant"() {"value" = 6 : index} : () -> index
-// CHECK-NEXT:        %72 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %73 = "arith.addi"(%13, %70) : (index, index) -> index
-// CHECK-NEXT:        %74 = "arith.addi"(%12, %71) : (index, index) -> index
-// CHECK-NEXT:        %75 = "arith.addi"(%11, %72) : (index, index) -> index
-// CHECK-NEXT:        %76 = "memref.load"(%t0_w_size_3, %73, %74, %75) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %77 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:        %78 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %79 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %80 = "arith.addi"(%13, %77) : (index, index) -> index
-// CHECK-NEXT:        %81 = "arith.addi"(%12, %78) : (index, index) -> index
-// CHECK-NEXT:        %82 = "arith.addi"(%11, %79) : (index, index) -> index
-// CHECK-NEXT:        %83 = "memref.load"(%t0_w_size_3, %80, %81, %82) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %84 = "arith.constant"() {"value" = 5 : index} : () -> index
-// CHECK-NEXT:        %85 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %86 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %87 = "arith.addi"(%13, %84) : (index, index) -> index
-// CHECK-NEXT:        %88 = "arith.addi"(%12, %85) : (index, index) -> index
-// CHECK-NEXT:        %89 = "arith.addi"(%11, %86) : (index, index) -> index
-// CHECK-NEXT:        %90 = "memref.load"(%t0_w_size_3, %87, %88, %89) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %91 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:        %92 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %93 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %94 = "arith.addi"(%13, %91) : (index, index) -> index
-// CHECK-NEXT:        %95 = "arith.addi"(%12, %92) : (index, index) -> index
-// CHECK-NEXT:        %96 = "arith.addi"(%11, %93) : (index, index) -> index
-// CHECK-NEXT:        %97 = "memref.load"(%t0_w_size_3, %94, %95, %96) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %98 = "arith.constant"() {"value" = 6 : index} : () -> index
-// CHECK-NEXT:        %99 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %100 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %101 = "arith.addi"(%13, %98) : (index, index) -> index
-// CHECK-NEXT:        %102 = "arith.addi"(%12, %99) : (index, index) -> index
-// CHECK-NEXT:        %103 = "arith.addi"(%11, %100) : (index, index) -> index
-// CHECK-NEXT:        %104 = "memref.load"(%t0_w_size_3, %101, %102, %103) : (memref<48x88x58xf32>, index, index, index) -> f32
-// CHECK-NEXT:        %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
-// CHECK-NEXT:        %105 = "arith.constant"() {"value" = -1 : i64} : () -> i64
-// CHECK-NEXT:        %106 = "math.fpowi"(%dt, %105) : (f32, i64) -> f32
-// CHECK-NEXT:        %107 = "arith.mulf"(%106, %20) : (f32, f32) -> f32
-// CHECK-NEXT:        %108 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
-// CHECK-NEXT:        %h_x = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %109 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %110 = "math.fpowi"(%h_x, %109) : (f32, i64) -> f32
-// CHECK-NEXT:        %111 = "arith.mulf"(%108, %110) : (f32, f32) -> f32
-// CHECK-NEXT:        %112 = "arith.mulf"(%111, %27) : (f32, f32) -> f32
-// CHECK-NEXT:        %113 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
-// CHECK-NEXT:        %h_x_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %114 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %115 = "math.fpowi"(%h_x_1, %114) : (f32, i64) -> f32
-// CHECK-NEXT:        %116 = "arith.mulf"(%113, %115) : (f32, f32) -> f32
-// CHECK-NEXT:        %117 = "arith.mulf"(%116, %34) : (f32, f32) -> f32
-// CHECK-NEXT:        %118 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
-// CHECK-NEXT:        %h_x_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %119 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %120 = "math.fpowi"(%h_x_2, %119) : (f32, i64) -> f32
-// CHECK-NEXT:        %121 = "arith.mulf"(%118, %120) : (f32, f32) -> f32
-// CHECK-NEXT:        %122 = "arith.mulf"(%121, %20) : (f32, f32) -> f32
-// CHECK-NEXT:        %123 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
-// CHECK-NEXT:        %h_x_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %124 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %125 = "math.fpowi"(%h_x_3, %124) : (f32, i64) -> f32
-// CHECK-NEXT:        %126 = "arith.mulf"(%123, %125) : (f32, f32) -> f32
-// CHECK-NEXT:        %127 = "arith.mulf"(%126, %41) : (f32, f32) -> f32
-// CHECK-NEXT:        %128 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
-// CHECK-NEXT:        %h_x_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %129 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %130 = "math.fpowi"(%h_x_4, %129) : (f32, i64) -> f32
-// CHECK-NEXT:        %131 = "arith.mulf"(%128, %130) : (f32, f32) -> f32
-// CHECK-NEXT:        %132 = "arith.mulf"(%131, %48) : (f32, f32) -> f32
-// CHECK-NEXT:        %133 = "arith.addf"(%112, %117) : (f32, f32) -> f32
-// CHECK-NEXT:        %134 = "arith.addf"(%133, %122) : (f32, f32) -> f32
-// CHECK-NEXT:        %135 = "arith.addf"(%134, %127) : (f32, f32) -> f32
-// CHECK-NEXT:        %136 = "arith.addf"(%135, %132) : (f32, f32) -> f32
-// CHECK-NEXT:        %137 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
-// CHECK-NEXT:        %h_y = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %138 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %139 = "math.fpowi"(%h_y, %138) : (f32, i64) -> f32
-// CHECK-NEXT:        %140 = "arith.mulf"(%137, %139) : (f32, f32) -> f32
-// CHECK-NEXT:        %141 = "arith.mulf"(%140, %55) : (f32, f32) -> f32
-// CHECK-NEXT:        %142 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
-// CHECK-NEXT:        %h_y_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %143 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %144 = "math.fpowi"(%h_y_1, %143) : (f32, i64) -> f32
-// CHECK-NEXT:        %145 = "arith.mulf"(%142, %144) : (f32, f32) -> f32
-// CHECK-NEXT:        %146 = "arith.mulf"(%145, %62) : (f32, f32) -> f32
-// CHECK-NEXT:        %147 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
-// CHECK-NEXT:        %h_y_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %148 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %149 = "math.fpowi"(%h_y_2, %148) : (f32, i64) -> f32
-// CHECK-NEXT:        %150 = "arith.mulf"(%147, %149) : (f32, f32) -> f32
-// CHECK-NEXT:        %151 = "arith.mulf"(%150, %20) : (f32, f32) -> f32
-// CHECK-NEXT:        %152 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
-// CHECK-NEXT:        %h_y_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %153 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %154 = "math.fpowi"(%h_y_3, %153) : (f32, i64) -> f32
-// CHECK-NEXT:        %155 = "arith.mulf"(%152, %154) : (f32, f32) -> f32
-// CHECK-NEXT:        %156 = "arith.mulf"(%155, %69) : (f32, f32) -> f32
-// CHECK-NEXT:        %157 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
-// CHECK-NEXT:        %h_y_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %158 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %159 = "math.fpowi"(%h_y_4, %158) : (f32, i64) -> f32
-// CHECK-NEXT:        %160 = "arith.mulf"(%157, %159) : (f32, f32) -> f32
-// CHECK-NEXT:        %161 = "arith.mulf"(%160, %76) : (f32, f32) -> f32
-// CHECK-NEXT:        %162 = "arith.addf"(%141, %146) : (f32, f32) -> f32
-// CHECK-NEXT:        %163 = "arith.addf"(%162, %151) : (f32, f32) -> f32
-// CHECK-NEXT:        %164 = "arith.addf"(%163, %156) : (f32, f32) -> f32
-// CHECK-NEXT:        %165 = "arith.addf"(%164, %161) : (f32, f32) -> f32
-// CHECK-NEXT:        %166 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
-// CHECK-NEXT:        %h_z = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %167 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %168 = "math.fpowi"(%h_z, %167) : (f32, i64) -> f32
-// CHECK-NEXT:        %169 = "arith.mulf"(%166, %168) : (f32, f32) -> f32
-// CHECK-NEXT:        %170 = "arith.mulf"(%169, %83) : (f32, f32) -> f32
-// CHECK-NEXT:        %171 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
-// CHECK-NEXT:        %h_z_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %172 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %173 = "math.fpowi"(%h_z_1, %172) : (f32, i64) -> f32
-// CHECK-NEXT:        %174 = "arith.mulf"(%171, %173) : (f32, f32) -> f32
-// CHECK-NEXT:        %175 = "arith.mulf"(%174, %90) : (f32, f32) -> f32
-// CHECK-NEXT:        %176 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
-// CHECK-NEXT:        %h_z_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %177 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %178 = "math.fpowi"(%h_z_2, %177) : (f32, i64) -> f32
-// CHECK-NEXT:        %179 = "arith.mulf"(%176, %178) : (f32, f32) -> f32
-// CHECK-NEXT:        %180 = "arith.mulf"(%179, %20) : (f32, f32) -> f32
-// CHECK-NEXT:        %181 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
-// CHECK-NEXT:        %h_z_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %182 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %183 = "math.fpowi"(%h_z_3, %182) : (f32, i64) -> f32
-// CHECK-NEXT:        %184 = "arith.mulf"(%181, %183) : (f32, f32) -> f32
-// CHECK-NEXT:        %185 = "arith.mulf"(%184, %97) : (f32, f32) -> f32
-// CHECK-NEXT:        %186 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
-// CHECK-NEXT:        %h_z_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:        %187 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:        %188 = "math.fpowi"(%h_z_4, %187) : (f32, i64) -> f32
-// CHECK-NEXT:        %189 = "arith.mulf"(%186, %188) : (f32, f32) -> f32
-// CHECK-NEXT:        %190 = "arith.mulf"(%189, %104) : (f32, f32) -> f32
-// CHECK-NEXT:        %191 = "arith.addf"(%170, %175) : (f32, f32) -> f32
-// CHECK-NEXT:        %192 = "arith.addf"(%191, %180) : (f32, f32) -> f32
-// CHECK-NEXT:        %193 = "arith.addf"(%192, %185) : (f32, f32) -> f32
-// CHECK-NEXT:        %194 = "arith.addf"(%193, %190) : (f32, f32) -> f32
-// CHECK-NEXT:        %195 = "arith.addf"(%136, %165) : (f32, f32) -> f32
-// CHECK-NEXT:        %196 = "arith.addf"(%195, %194) : (f32, f32) -> f32
-// CHECK-NEXT:        %a = "arith.constant"() {"value" = 0.5 : f32} : () -> f32
-// CHECK-NEXT:        %197 = "arith.mulf"(%196, %a) : (f32, f32) -> f32
-// CHECK-NEXT:        %198 = "arith.addf"(%107, %197) : (f32, f32) -> f32
-// CHECK-NEXT:        %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
-// CHECK-NEXT:        %199 = "arith.mulf"(%198, %dt_1) : (f32, f32) -> f32
-// CHECK-NEXT:        %200 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %201 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %202 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:        %203 = "arith.addi"(%13, %200) : (index, index) -> index
-// CHECK-NEXT:        %204 = "arith.addi"(%12, %201) : (index, index) -> index
-// CHECK-NEXT:        %205 = "arith.addi"(%11, %202) : (index, index) -> index
-// CHECK-NEXT:        "memref.store"(%199, %t1_w_size_3, %203, %204, %205) : (f32, memref<48x88x58xf32>, index, index, index) -> ()
-// CHECK-NEXT:        "scf.yield"() : () -> ()
-// CHECK-NEXT:      }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
-// CHECK-NEXT:      "scf.yield"() : () -> ()
-// CHECK-NEXT:    }) : (index, index, index) -> ()
-// CHECK-NEXT:    "func.return"() : () -> ()
-// CHECK-NEXT:  }) {"sym_name" = "myfunc", "function_type" = (memref<2xmemref<?x?x?xf32>>) -> (), "sym_visibility" = "private", "param_names" = ["data"]} : () -> ()
-// CHECK-NEXT:}) : () -> ()
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() ({
+// CHECK-NEXT:   ^0(%data : memref<2xmemref<?x?x?xf32>>):
+// CHECK-NEXT:     %time_m = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:     %time_M = "arith.constant"() {"value" = 1000 : index} : () -> index
+// CHECK-NEXT:     %step = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:     %0 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:     %time_M_1 = "arith.addi"(%time_M, %0) : (index, index) -> index
+// CHECK-NEXT:     "scf.for"(%time_m, %time_M_1, %step) ({
+// CHECK-NEXT:     ^1(%time : index):
+// CHECK-NEXT:       %time_1 = "arith.index_cast"(%time) : (index) -> i64
+// CHECK-NEXT:       %1 = "arith.constant"() {"value" = 2 : i64} : () -> i64
+// CHECK-NEXT:       %2 = "arith.constant"() {"value" = 0 : i64} : () -> i64
+// CHECK-NEXT:       %3 = "arith.addi"(%time_1, %2) : (i64, i64) -> i64
+// CHECK-NEXT:       %t0 = "arith.remsi"(%3, %1) : (i64, i64) -> i64
+// CHECK-NEXT:       %4 = "arith.constant"() {"value" = 1 : i64} : () -> i64
+// CHECK-NEXT:       %5 = "arith.addi"(%time_1, %4) : (i64, i64) -> i64
+// CHECK-NEXT:       %t1 = "arith.remsi"(%5, %1) : (i64, i64) -> i64
+// CHECK-NEXT:       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
+// CHECK-NEXT:       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
+// CHECK-NEXT:       %t0_w_size_3 = "memref.cast"(%t0_w_size_1) : (memref<?x?x?xf32>) -> memref<58x88x48xf32>
+// CHECK-NEXT:       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
+// CHECK-NEXT:       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
+// CHECK-NEXT:       %t1_w_size_3 = "memref.cast"(%t1_w_size_1) : (memref<?x?x?xf32>) -> memref<58x88x48xf32>
+// CHECK-NEXT:       %6 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:       %7 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:       %8 = "arith.constant"() {"value" = 50 : index} : () -> index
+// CHECK-NEXT:       %9 = "arith.constant"() {"value" = 80 : index} : () -> index
+// CHECK-NEXT:       %10 = "arith.constant"() {"value" = 40 : index} : () -> index
+// CHECK-NEXT:       "scf.parallel"(%6, %6, %6, %8, %9, %10, %7, %7, %7) ({
+// CHECK-NEXT:       ^2(%11 : index, %12 : index, %13 : index):
+// CHECK-NEXT:         %14 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %15 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %16 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %17 = "arith.addi"(%11, %14) : (index, index) -> index
+// CHECK-NEXT:         %18 = "arith.addi"(%12, %15) : (index, index) -> index
+// CHECK-NEXT:         %19 = "arith.addi"(%13, %16) : (index, index) -> index
+// CHECK-NEXT:         %20 = "memref.load"(%t0_w_size_3, %17, %18, %19) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %21 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:         %22 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %23 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %24 = "arith.addi"(%11, %21) : (index, index) -> index
+// CHECK-NEXT:         %25 = "arith.addi"(%12, %22) : (index, index) -> index
+// CHECK-NEXT:         %26 = "arith.addi"(%13, %23) : (index, index) -> index
+// CHECK-NEXT:         %27 = "memref.load"(%t0_w_size_3, %24, %25, %26) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %28 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:         %29 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %30 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %31 = "arith.addi"(%11, %28) : (index, index) -> index
+// CHECK-NEXT:         %32 = "arith.addi"(%12, %29) : (index, index) -> index
+// CHECK-NEXT:         %33 = "arith.addi"(%13, %30) : (index, index) -> index
+// CHECK-NEXT:         %34 = "memref.load"(%t0_w_size_3, %31, %32, %33) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %35 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:         %36 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %37 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %38 = "arith.addi"(%11, %35) : (index, index) -> index
+// CHECK-NEXT:         %39 = "arith.addi"(%12, %36) : (index, index) -> index
+// CHECK-NEXT:         %40 = "arith.addi"(%13, %37) : (index, index) -> index
+// CHECK-NEXT:         %41 = "memref.load"(%t0_w_size_3, %38, %39, %40) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %42 = "arith.constant"() {"value" = 6 : index} : () -> index
+// CHECK-NEXT:         %43 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %44 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %45 = "arith.addi"(%11, %42) : (index, index) -> index
+// CHECK-NEXT:         %46 = "arith.addi"(%12, %43) : (index, index) -> index
+// CHECK-NEXT:         %47 = "arith.addi"(%13, %44) : (index, index) -> index
+// CHECK-NEXT:         %48 = "memref.load"(%t0_w_size_3, %45, %46, %47) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %49 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %50 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:         %51 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %52 = "arith.addi"(%11, %49) : (index, index) -> index
+// CHECK-NEXT:         %53 = "arith.addi"(%12, %50) : (index, index) -> index
+// CHECK-NEXT:         %54 = "arith.addi"(%13, %51) : (index, index) -> index
+// CHECK-NEXT:         %55 = "memref.load"(%t0_w_size_3, %52, %53, %54) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %56 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %57 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:         %58 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %59 = "arith.addi"(%11, %56) : (index, index) -> index
+// CHECK-NEXT:         %60 = "arith.addi"(%12, %57) : (index, index) -> index
+// CHECK-NEXT:         %61 = "arith.addi"(%13, %58) : (index, index) -> index
+// CHECK-NEXT:         %62 = "memref.load"(%t0_w_size_3, %59, %60, %61) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %63 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %64 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:         %65 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %66 = "arith.addi"(%11, %63) : (index, index) -> index
+// CHECK-NEXT:         %67 = "arith.addi"(%12, %64) : (index, index) -> index
+// CHECK-NEXT:         %68 = "arith.addi"(%13, %65) : (index, index) -> index
+// CHECK-NEXT:         %69 = "memref.load"(%t0_w_size_3, %66, %67, %68) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %70 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %71 = "arith.constant"() {"value" = 6 : index} : () -> index
+// CHECK-NEXT:         %72 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %73 = "arith.addi"(%11, %70) : (index, index) -> index
+// CHECK-NEXT:         %74 = "arith.addi"(%12, %71) : (index, index) -> index
+// CHECK-NEXT:         %75 = "arith.addi"(%13, %72) : (index, index) -> index
+// CHECK-NEXT:         %76 = "memref.load"(%t0_w_size_3, %73, %74, %75) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %77 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %78 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %79 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:         %80 = "arith.addi"(%11, %77) : (index, index) -> index
+// CHECK-NEXT:         %81 = "arith.addi"(%12, %78) : (index, index) -> index
+// CHECK-NEXT:         %82 = "arith.addi"(%13, %79) : (index, index) -> index
+// CHECK-NEXT:         %83 = "memref.load"(%t0_w_size_3, %80, %81, %82) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %84 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %85 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %86 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:         %87 = "arith.addi"(%11, %84) : (index, index) -> index
+// CHECK-NEXT:         %88 = "arith.addi"(%12, %85) : (index, index) -> index
+// CHECK-NEXT:         %89 = "arith.addi"(%13, %86) : (index, index) -> index
+// CHECK-NEXT:         %90 = "memref.load"(%t0_w_size_3, %87, %88, %89) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %91 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %92 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %93 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:         %94 = "arith.addi"(%11, %91) : (index, index) -> index
+// CHECK-NEXT:         %95 = "arith.addi"(%12, %92) : (index, index) -> index
+// CHECK-NEXT:         %96 = "arith.addi"(%13, %93) : (index, index) -> index
+// CHECK-NEXT:         %97 = "memref.load"(%t0_w_size_3, %94, %95, %96) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %98 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %99 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %100 = "arith.constant"() {"value" = 6 : index} : () -> index
+// CHECK-NEXT:         %101 = "arith.addi"(%11, %98) : (index, index) -> index
+// CHECK-NEXT:         %102 = "arith.addi"(%12, %99) : (index, index) -> index
+// CHECK-NEXT:         %103 = "arith.addi"(%13, %100) : (index, index) -> index
+// CHECK-NEXT:         %104 = "memref.load"(%t0_w_size_3, %101, %102, %103) : (memref<58x88x48xf32>, index, index, index) -> f32
+// CHECK-NEXT:         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
+// CHECK-NEXT:         %105 = "arith.constant"() {"value" = -1 : i64} : () -> i64
+// CHECK-NEXT:         %106 = "math.fpowi"(%dt, %105) : (f32, i64) -> f32
+// CHECK-NEXT:         %107 = "arith.mulf"(%106, %20) : (f32, f32) -> f32
+// CHECK-NEXT:         %108 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:         %h_x = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %109 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %110 = "math.fpowi"(%h_x, %109) : (f32, i64) -> f32
+// CHECK-NEXT:         %111 = "arith.mulf"(%108, %110) : (f32, f32) -> f32
+// CHECK-NEXT:         %112 = "arith.mulf"(%111, %27) : (f32, f32) -> f32
+// CHECK-NEXT:         %113 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:         %h_x_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %114 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %115 = "math.fpowi"(%h_x_1, %114) : (f32, i64) -> f32
+// CHECK-NEXT:         %116 = "arith.mulf"(%113, %115) : (f32, f32) -> f32
+// CHECK-NEXT:         %117 = "arith.mulf"(%116, %34) : (f32, f32) -> f32
+// CHECK-NEXT:         %118 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
+// CHECK-NEXT:         %h_x_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %119 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %120 = "math.fpowi"(%h_x_2, %119) : (f32, i64) -> f32
+// CHECK-NEXT:         %121 = "arith.mulf"(%118, %120) : (f32, f32) -> f32
+// CHECK-NEXT:         %122 = "arith.mulf"(%121, %20) : (f32, f32) -> f32
+// CHECK-NEXT:         %123 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:         %h_x_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %124 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %125 = "math.fpowi"(%h_x_3, %124) : (f32, i64) -> f32
+// CHECK-NEXT:         %126 = "arith.mulf"(%123, %125) : (f32, f32) -> f32
+// CHECK-NEXT:         %127 = "arith.mulf"(%126, %41) : (f32, f32) -> f32
+// CHECK-NEXT:         %128 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:         %h_x_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %129 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %130 = "math.fpowi"(%h_x_4, %129) : (f32, i64) -> f32
+// CHECK-NEXT:         %131 = "arith.mulf"(%128, %130) : (f32, f32) -> f32
+// CHECK-NEXT:         %132 = "arith.mulf"(%131, %48) : (f32, f32) -> f32
+// CHECK-NEXT:         %133 = "arith.addf"(%112, %117) : (f32, f32) -> f32
+// CHECK-NEXT:         %134 = "arith.addf"(%133, %122) : (f32, f32) -> f32
+// CHECK-NEXT:         %135 = "arith.addf"(%134, %127) : (f32, f32) -> f32
+// CHECK-NEXT:         %136 = "arith.addf"(%135, %132) : (f32, f32) -> f32
+// CHECK-NEXT:         %137 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:         %h_y = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %138 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %139 = "math.fpowi"(%h_y, %138) : (f32, i64) -> f32
+// CHECK-NEXT:         %140 = "arith.mulf"(%137, %139) : (f32, f32) -> f32
+// CHECK-NEXT:         %141 = "arith.mulf"(%140, %55) : (f32, f32) -> f32
+// CHECK-NEXT:         %142 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:         %h_y_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %143 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %144 = "math.fpowi"(%h_y_1, %143) : (f32, i64) -> f32
+// CHECK-NEXT:         %145 = "arith.mulf"(%142, %144) : (f32, f32) -> f32
+// CHECK-NEXT:         %146 = "arith.mulf"(%145, %62) : (f32, f32) -> f32
+// CHECK-NEXT:         %147 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
+// CHECK-NEXT:         %h_y_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %148 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %149 = "math.fpowi"(%h_y_2, %148) : (f32, i64) -> f32
+// CHECK-NEXT:         %150 = "arith.mulf"(%147, %149) : (f32, f32) -> f32
+// CHECK-NEXT:         %151 = "arith.mulf"(%150, %20) : (f32, f32) -> f32
+// CHECK-NEXT:         %152 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:         %h_y_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %153 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %154 = "math.fpowi"(%h_y_3, %153) : (f32, i64) -> f32
+// CHECK-NEXT:         %155 = "arith.mulf"(%152, %154) : (f32, f32) -> f32
+// CHECK-NEXT:         %156 = "arith.mulf"(%155, %69) : (f32, f32) -> f32
+// CHECK-NEXT:         %157 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:         %h_y_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %158 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %159 = "math.fpowi"(%h_y_4, %158) : (f32, i64) -> f32
+// CHECK-NEXT:         %160 = "arith.mulf"(%157, %159) : (f32, f32) -> f32
+// CHECK-NEXT:         %161 = "arith.mulf"(%160, %76) : (f32, f32) -> f32
+// CHECK-NEXT:         %162 = "arith.addf"(%141, %146) : (f32, f32) -> f32
+// CHECK-NEXT:         %163 = "arith.addf"(%162, %151) : (f32, f32) -> f32
+// CHECK-NEXT:         %164 = "arith.addf"(%163, %156) : (f32, f32) -> f32
+// CHECK-NEXT:         %165 = "arith.addf"(%164, %161) : (f32, f32) -> f32
+// CHECK-NEXT:         %166 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:         %h_z = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %167 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %168 = "math.fpowi"(%h_z, %167) : (f32, i64) -> f32
+// CHECK-NEXT:         %169 = "arith.mulf"(%166, %168) : (f32, f32) -> f32
+// CHECK-NEXT:         %170 = "arith.mulf"(%169, %83) : (f32, f32) -> f32
+// CHECK-NEXT:         %171 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:         %h_z_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %172 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %173 = "math.fpowi"(%h_z_1, %172) : (f32, i64) -> f32
+// CHECK-NEXT:         %174 = "arith.mulf"(%171, %173) : (f32, f32) -> f32
+// CHECK-NEXT:         %175 = "arith.mulf"(%174, %90) : (f32, f32) -> f32
+// CHECK-NEXT:         %176 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
+// CHECK-NEXT:         %h_z_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %177 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %178 = "math.fpowi"(%h_z_2, %177) : (f32, i64) -> f32
+// CHECK-NEXT:         %179 = "arith.mulf"(%176, %178) : (f32, f32) -> f32
+// CHECK-NEXT:         %180 = "arith.mulf"(%179, %20) : (f32, f32) -> f32
+// CHECK-NEXT:         %181 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:         %h_z_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %182 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %183 = "math.fpowi"(%h_z_3, %182) : (f32, i64) -> f32
+// CHECK-NEXT:         %184 = "arith.mulf"(%181, %183) : (f32, f32) -> f32
+// CHECK-NEXT:         %185 = "arith.mulf"(%184, %97) : (f32, f32) -> f32
+// CHECK-NEXT:         %186 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:         %h_z_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
+// CHECK-NEXT:         %187 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:         %188 = "math.fpowi"(%h_z_4, %187) : (f32, i64) -> f32
+// CHECK-NEXT:         %189 = "arith.mulf"(%186, %188) : (f32, f32) -> f32
+// CHECK-NEXT:         %190 = "arith.mulf"(%189, %104) : (f32, f32) -> f32
+// CHECK-NEXT:         %191 = "arith.addf"(%170, %175) : (f32, f32) -> f32
+// CHECK-NEXT:         %192 = "arith.addf"(%191, %180) : (f32, f32) -> f32
+// CHECK-NEXT:         %193 = "arith.addf"(%192, %185) : (f32, f32) -> f32
+// CHECK-NEXT:         %194 = "arith.addf"(%193, %190) : (f32, f32) -> f32
+// CHECK-NEXT:         %195 = "arith.addf"(%136, %165) : (f32, f32) -> f32
+// CHECK-NEXT:         %196 = "arith.addf"(%195, %194) : (f32, f32) -> f32
+// CHECK-NEXT:         %a = "arith.constant"() {"value" = 0.5 : f32} : () -> f32
+// CHECK-NEXT:         %197 = "arith.mulf"(%196, %a) : (f32, f32) -> f32
+// CHECK-NEXT:         %198 = "arith.addf"(%107, %197) : (f32, f32) -> f32
+// CHECK-NEXT:         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
+// CHECK-NEXT:         %199 = "arith.mulf"(%198, %dt_1) : (f32, f32) -> f32
+// CHECK-NEXT:         %200 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %201 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %202 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:         %203 = "arith.addi"(%11, %200) : (index, index) -> index
+// CHECK-NEXT:         %204 = "arith.addi"(%12, %201) : (index, index) -> index
+// CHECK-NEXT:         %205 = "arith.addi"(%13, %202) : (index, index) -> index
+// CHECK-NEXT:         "memref.store"(%199, %t1_w_size_3, %203, %204, %205) : (f32, memref<58x88x48xf32>, index, index, index) -> ()
+// CHECK-NEXT:         "scf.yield"() : () -> ()
+// CHECK-NEXT:       }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
+// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:     }) : (index, index, index) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) {"sym_name" = "myfunc", "function_type" = (memref<2xmemref<?x?x?xf32>>) -> (), "sym_visibility" = "private", "param_names" = ["data"]} : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -13,7 +13,7 @@
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
-// CHECK-NEXT: "builtin.module"() ({
+// CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?xf64>):
 // CHECK-NEXT:     %1 = "memref.cast"(%0) : (memref<?x?xf64>) -> memref<72x72xf64>
@@ -23,10 +23,10 @@
 // CHECK-NEXT:     %5 = "arith.constant"() {"value" = 68 : index} : () -> index
 // CHECK-NEXT:     "scf.parallel"(%2, %2, %4, %5, %3, %3) ({
 // CHECK-NEXT:     ^1(%6 : index, %7 : index):
-// CHECK-NEXT:       %8 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %9 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:       %10 = "arith.addi"(%7, %8) : (index, index) -> index
-// CHECK-NEXT:       %11 = "arith.addi"(%6, %9) : (index, index) -> index
+// CHECK-NEXT:       %8 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:       %9 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:       %10 = "arith.addi"(%6, %8) : (index, index) -> index
+// CHECK-NEXT:       %11 = "arith.addi"(%7, %9) : (index, index) -> index
 // CHECK-NEXT:       %12 = "memref.load"(%1, %10, %11) : (memref<72x72xf64>, index, index) -> f64
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 2, 2, 2, 0>} : (index, index, index, index, index, index) -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -13,10 +13,10 @@
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
-// CHECK-NEXT: "builtin.module"() ({
+// CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>):
-// CHECK-NEXT:     %1 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<76x74x72xf64>
+// CHECK-NEXT:     %1 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x74x76xf64>
 // CHECK-NEXT:     %2 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:     %3 = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:     %4 = "arith.constant"() {"value" = 64 : index} : () -> index
@@ -24,13 +24,13 @@
 // CHECK-NEXT:     %6 = "arith.constant"() {"value" = 68 : index} : () -> index
 // CHECK-NEXT:     "scf.parallel"(%2, %2, %2, %4, %5, %6, %3, %3, %3) ({
 // CHECK-NEXT:     ^1(%7 : index, %8 : index, %9 : index):
-// CHECK-NEXT:       %10 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %10 = "arith.constant"() {"value" = 3 : index} : () -> index
 // CHECK-NEXT:       %11 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:       %13 = "arith.addi"(%9, %10) : (index, index) -> index
+// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %13 = "arith.addi"(%7, %10) : (index, index) -> index
 // CHECK-NEXT:       %14 = "arith.addi"(%8, %11) : (index, index) -> index
-// CHECK-NEXT:       %15 = "arith.addi"(%7, %12) : (index, index) -> index
-// CHECK-NEXT:       %16 = "memref.load"(%1, %13, %14, %15) : (memref<76x74x72xf64>, index, index, index) -> f64
+// CHECK-NEXT:       %15 = "arith.addi"(%9, %12) : (index, index) -> index
+// CHECK-NEXT:       %16 = "memref.load"(%1, %13, %14, %15) : (memref<72x74x76xf64>, index, index, index) -> f64
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -16,7 +16,7 @@
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
-// CHECK-NEXT: "builtin.module"() ({
+// CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
 // CHECK-NEXT:     %2 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
@@ -28,19 +28,19 @@
 // CHECK-NEXT:     %8 = "arith.constant"() {"value" = 64 : index} : () -> index
 // CHECK-NEXT:     "scf.parallel"(%4, %4, %4, %6, %7, %8, %5, %5, %5) ({
 // CHECK-NEXT:     ^1(%9 : index, %10 : index, %11 : index):
-// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %12 = "arith.constant"() {"value" = 3 : index} : () -> index
 // CHECK-NEXT:       %13 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:       %15 = "arith.addi"(%11, %12) : (index, index) -> index
+// CHECK-NEXT:       %14 = "arith.constant"() {"value" = 5 : index} : () -> index
+// CHECK-NEXT:       %15 = "arith.addi"(%9, %12) : (index, index) -> index
 // CHECK-NEXT:       %16 = "arith.addi"(%10, %13) : (index, index) -> index
-// CHECK-NEXT:       %17 = "arith.addi"(%9, %14) : (index, index) -> index
+// CHECK-NEXT:       %17 = "arith.addi"(%11, %14) : (index, index) -> index
 // CHECK-NEXT:       %18 = "memref.load"(%2, %15, %16, %17) : (memref<72x72x72xf64>, index, index, index) -> f64
 // CHECK-NEXT:       %19 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %20 = "arith.constant"() {"value" = 4 : index} : () -> index
 // CHECK-NEXT:       %21 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:       %22 = "arith.addi"(%11, %19) : (index, index) -> index
+// CHECK-NEXT:       %22 = "arith.addi"(%9, %19) : (index, index) -> index
 // CHECK-NEXT:       %23 = "arith.addi"(%10, %20) : (index, index) -> index
-// CHECK-NEXT:       %24 = "arith.addi"(%9, %21) : (index, index) -> index
+// CHECK-NEXT:       %24 = "arith.addi"(%11, %21) : (index, index) -> index
 // CHECK-NEXT:       "memref.store"(%18, %3, %22, %23, %24) : (f64, memref<72x72x72xf64>, index, index, index) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -100,6 +100,13 @@
   // CHECK: "value1" = dense<[0]> : tensor<1xi32>, "value2" = dense<[0.0, 1.0]> : tensor<2xf64>
 
   "func.func"() ({}) {function_type = () -> (),
+                      value1 = dense<[0]> : vector<1xi32>,
+                      value2 = dense<[0.0, 1.0]> : vector<2xf64>,
+                      sym_name = "dense_attr"} : () -> ()
+
+  // CHECK: "value1" = dense<[0]> : vector<1xi32>, "value2" = dense<[0.0, 1.0]> : vector<2xf64>
+
+  "func.func"() ({}) {function_type = () -> (),
                       value1 = opaque<"test", "contents">,
                       value2 = opaque<"test", "contents"> : tensor<2xf64>,
                       sym_name = "dense_attr"} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -1,6 +1,5 @@
 // RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | mlir-opt | filecheck %s
 
-
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
@@ -38,40 +37,40 @@
 // CHECK-NEXT:     %c64_1 = arith.constant 64 : index
 // CHECK-NEXT:     %c64_2 = arith.constant 64 : index
 // CHECK-NEXT:     scf.parallel (%arg2, %arg3, %arg4) = (%c0, %c0, %c0) to (%c64, %c64_1, %c64_2) step (%c1, %c1, %c1) {
+// CHECK-NEXT:       %c3 = arith.constant 3 : index
 // CHECK-NEXT:       %c4 = arith.constant 4 : index
 // CHECK-NEXT:       %c4_3 = arith.constant 4 : index
-// CHECK-NEXT:       %c3 = arith.constant 3 : index
-// CHECK-NEXT:       %0 = arith.addi %arg4, %c4 : index
-// CHECK-NEXT:       %1 = arith.addi %arg3, %c4_3 : index
-// CHECK-NEXT:       %2 = arith.addi %arg2, %c3 : index
+// CHECK-NEXT:       %0 = arith.addi %arg2, %c3 : index
+// CHECK-NEXT:       %1 = arith.addi %arg3, %c4 : index
+// CHECK-NEXT:       %2 = arith.addi %arg4, %c4_3 : index
 // CHECK-NEXT:       %3 = memref.load %cast[%0, %1, %2] : memref<72x72x72xf64>
+// CHECK-NEXT:       %c5 = arith.constant 5 : index
 // CHECK-NEXT:       %c4_4 = arith.constant 4 : index
 // CHECK-NEXT:       %c4_5 = arith.constant 4 : index
-// CHECK-NEXT:       %c5 = arith.constant 5 : index
-// CHECK-NEXT:       %4 = arith.addi %arg4, %c4_4 : index
-// CHECK-NEXT:       %5 = arith.addi %arg3, %c4_5 : index
-// CHECK-NEXT:       %6 = arith.addi %arg2, %c5 : index
+// CHECK-NEXT:       %4 = arith.addi %arg2, %c5 : index
+// CHECK-NEXT:       %5 = arith.addi %arg3, %c4_4 : index
+// CHECK-NEXT:       %6 = arith.addi %arg4, %c4_5 : index
 // CHECK-NEXT:       %7 = memref.load %cast[%4, %5, %6] : memref<72x72x72xf64>
 // CHECK-NEXT:       %c4_6 = arith.constant 4 : index
 // CHECK-NEXT:       %c5_7 = arith.constant 5 : index
 // CHECK-NEXT:       %c4_8 = arith.constant 4 : index
-// CHECK-NEXT:       %8 = arith.addi %arg4, %c4_6 : index
+// CHECK-NEXT:       %8 = arith.addi %arg2, %c4_6 : index
 // CHECK-NEXT:       %9 = arith.addi %arg3, %c5_7 : index
-// CHECK-NEXT:       %10 = arith.addi %arg2, %c4_8 : index
+// CHECK-NEXT:       %10 = arith.addi %arg4, %c4_8 : index
 // CHECK-NEXT:       %11 = memref.load %cast[%8, %9, %10] : memref<72x72x72xf64>
 // CHECK-NEXT:       %c4_9 = arith.constant 4 : index
 // CHECK-NEXT:       %c3_10 = arith.constant 3 : index
 // CHECK-NEXT:       %c4_11 = arith.constant 4 : index
-// CHECK-NEXT:       %12 = arith.addi %arg4, %c4_9 : index
+// CHECK-NEXT:       %12 = arith.addi %arg2, %c4_9 : index
 // CHECK-NEXT:       %13 = arith.addi %arg3, %c3_10 : index
-// CHECK-NEXT:       %14 = arith.addi %arg2, %c4_11 : index
+// CHECK-NEXT:       %14 = arith.addi %arg4, %c4_11 : index
 // CHECK-NEXT:       %15 = memref.load %cast[%12, %13, %14] : memref<72x72x72xf64>
 // CHECK-NEXT:       %c4_12 = arith.constant 4 : index
 // CHECK-NEXT:       %c4_13 = arith.constant 4 : index
 // CHECK-NEXT:       %c4_14 = arith.constant 4 : index
-// CHECK-NEXT:       %16 = arith.addi %arg4, %c4_12 : index
+// CHECK-NEXT:       %16 = arith.addi %arg2, %c4_12 : index
 // CHECK-NEXT:       %17 = arith.addi %arg3, %c4_13 : index
-// CHECK-NEXT:       %18 = arith.addi %arg2, %c4_14 : index
+// CHECK-NEXT:       %18 = arith.addi %arg4, %c4_14 : index
 // CHECK-NEXT:       %19 = memref.load %cast[%16, %17, %18] : memref<72x72x72xf64>
 // CHECK-NEXT:       %20 = arith.addf %3, %7 : f64
 // CHECK-NEXT:       %21 = arith.addf %11, %15 : f64
@@ -82,9 +81,9 @@
 // CHECK-NEXT:       %c4_15 = arith.constant 4 : index
 // CHECK-NEXT:       %c4_16 = arith.constant 4 : index
 // CHECK-NEXT:       %c4_17 = arith.constant 4 : index
-// CHECK-NEXT:       %25 = arith.addi %arg4, %c4_15 : index
+// CHECK-NEXT:       %25 = arith.addi %arg2, %c4_15 : index
 // CHECK-NEXT:       %26 = arith.addi %arg3, %c4_16 : index
-// CHECK-NEXT:       %27 = arith.addi %arg2, %c4_17 : index
+// CHECK-NEXT:       %27 = arith.addi %arg4, %c4_17 : index
 // CHECK-NEXT:       memref.store %24, %cast_0[%25, %26, %27] : memref<72x72x72xf64>
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -9,6 +9,7 @@ from xdsl.ir import OpResult, OpTrait, Operation
 from xdsl.irdl import Operand, irdl_op_definition
 from xdsl.utils.exceptions import VerifyException
 from xdsl.dialects.builtin import IntegerType, i1, i32, i64
+from xdsl.utils.test_value import TestSSAValue
 
 
 @dataclass(frozen=True)
@@ -97,9 +98,9 @@ def test_verifier():
     """
     Check that the traits verifier are correctly called.
     """
-    operand64 = OpResult(i64, [], [])  # type: ignore
-    operand32 = OpResult(i32, [], [])  # type: ignore
-    operand1 = OpResult(i1, [], [])  # type: ignore
+    operand64 = TestSSAValue(i64)
+    operand32 = TestSSAValue(i32)
+    operand1 = TestSSAValue(i1)
     op = TestOp.create(operands=[operand1], result_types=[i32])
     with pytest.raises(VerifyException) as e:
         op.verify()

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -21,9 +21,9 @@ from xdsl.dialects.builtin import (
     AnyVectorType, DenseResourceAttr, DictionaryAttr, Float16Type, Float32Type,
     Float64Type, FloatAttr, FunctionType, IndexType, IntegerType, Signedness,
     StringAttr, IntegerAttr, ArrayAttr, TensorType, UnrankedTensorType,
-    UnregisteredAttr, VectorType, SymbolRefAttr, DenseArrayBase,
-    DenseIntOrFPElementsAttr, OpaqueAttr, NoneAttr, ModuleOp, UnitAttr, i64,
-    StridedLayoutAttr)
+    UnregisteredAttr, VectorOrTensorOf, VectorType, SymbolRefAttr,
+    DenseArrayBase, DenseIntOrFPElementsAttr, OpaqueAttr, NoneAttr, ModuleOp,
+    UnitAttr, i64, StridedLayoutAttr)
 from xdsl.ir import (SSAValue, Block, Callable, Attribute, Operation, Region,
                      BlockArgument, MLContext, ParametrizedAttribute, Data)
 from xdsl.utils.hints import isa
@@ -1478,7 +1478,9 @@ class BaseParser(ABC):
         type = self.expect(self.try_parse_type,
                            "Dense attribute must be typed!")
 
-        assert isa(type, AnyTensorType)
+        if not isa(type, VectorOrTensorOf[Attribute]):
+            self.raise_error(
+                "Expected vector or tensor type for dense attribute")
 
         return DenseIntOrFPElementsAttr.from_list(type, info)
 

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -40,7 +40,6 @@ def GetMemRefFromFieldWithLBAndUB(memref_element_type: _TypeElement,
     # lb and ub defines the minimum and maximum coordinates of the resulting memref,
     # so its shape is simply ub - lb, computed here.
     dims = IndexAttr.size_from_bounds(lb, ub)
-    dims.reverse()
 
     return MemRefType.from_element_type_and_shape(memref_element_type, dims)
 
@@ -121,10 +120,8 @@ class ReturnOpToMemref(RewritePattern):
                                               builtin.IndexType())
             for x in offsets.array.data
         ]
-        off_const_ops.reverse()
 
         args = list(block.args)
-        args.reverse()
 
         off_sum_ops = [
             arith.Addi.get(i, x) for i, x in zip(args, off_const_ops)
@@ -281,10 +278,8 @@ class AccessOpToMemref(RewritePattern):
                                               builtin.IndexType())
             for x in memref_offset
         ]
-        off_const_ops.reverse()
 
         args = list(block.args)
-        args.reverse()
 
         off_sum_ops = [
             arith.Addi.get(i, x) for i, x in zip(args, off_const_ops)

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -1,0 +1,8 @@
+from xdsl.ir import Block, Operation, SSAValue
+
+
+class TestSSAValue(SSAValue):
+
+    @property
+    def owner(self) -> Operation | Block:
+        assert False, 'Attempting to get the owner of a `TestSSAValue`'


### PR DESCRIPTION
There was a check in the parser that was preventing this.