### PR TITLE
tests: add a TestSSAValue object for tests

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -7,6 +7,7 @@ from xdsl.dialects.memref import (Alloc, Alloca, Dealloc, Dealloca, MemRefType,
                                   Cast)
 from xdsl.dialects import builtin, memref, func, arith, scf
 from xdsl.utils.hints import isa
+from xdsl.utils.test_value import TestSSAValue
 
 
 def test_memreftype():
@@ -32,7 +33,7 @@ def test_memreftype():
 
 def test_memref_load_i32():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
     load = Load.get(memref_ssa_value, [])
 
     assert load.memref is memref_ssa_value
@@ -42,9 +43,9 @@ def test_memref_load_i32():
 
 def test_memref_load_i32_with_dimensions():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
     load = Load.get(memref_ssa_value, [index1, index2])
 
     assert load.memref is memref_ssa_value
@@ -55,8 +56,8 @@ def test_memref_load_i32_with_dimensions():
 
 def test_memref_store_i32():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-    i32_ssa_value = OpResult(i32, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
+    i32_ssa_value = TestSSAValue(i32)
     store = Store.get(i32_ssa_value, memref_ssa_value, [])
 
     assert store.memref is memref_ssa_value
@@ -66,10 +67,10 @@ def test_memref_store_i32():
 
 def test_memref_store_i32_with_dimensions():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
-    i32_ssa_value = OpResult(i32, [], [])
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
+    i32_ssa_value = TestSSAValue(i32)
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
     store = Store.get(i32_ssa_value, memref_ssa_value, [index1, index2])
 
     assert store.memref is memref_ssa_value
@@ -196,7 +197,7 @@ def test_memref_matmul_verify():
 
 def test_memref_subview():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [10, 2])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
 
     res_memref_type = MemRefType.from_element_type_and_shape(i32, [1, 1])
 
@@ -263,7 +264,7 @@ def test_memref_subview_constant_parameters():
 
 def test_memref_cast():
     i32_memref_type = MemRefType.from_element_type_and_shape(i32, [10, 2])
-    memref_ssa_value = OpResult(i32_memref_type, [], [])
+    memref_ssa_value = TestSSAValue(i32_memref_type)
 
     res_type = UnrankedMemrefType.from_type(i32)
 

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -496,8 +496,7 @@ def test_vector_print():
 
 
 def test_vector_create_mask():
-    val = TestSSAValue(IndexType())
-    create_mask = Createmask.get(val)
+    create_mask = Createmask.get([])
 
     assert type(create_mask.results[0]) is OpResult
     assert type(create_mask.results[0].typ) is VectorType

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -1,31 +1,29 @@
 import pytest
 
-from typing import TypeVar, List
+from typing import List
 
 from xdsl.dialects.builtin import i1, i32, i64, IntegerType, IndexType, VectorType
 from xdsl.dialects.memref import MemRefType, AnyIntegerAttr
 from xdsl.dialects.vector import Broadcast, Load, Maskedload, Maskedstore, Store, FMA, Print, Createmask
 from xdsl.ir import OpResult
 from xdsl.irdl import Attribute
-
-_MemRefTypeElement = TypeVar("_MemRefTypeElement", bound=Attribute)
-_VectorTypeElems = TypeVar("_VectorTypeElems", bound=Attribute)
+from xdsl.utils.test_value import TestSSAValue
 
 
 def get_MemRef_SSAVal_from_element_type_and_shape(
-        referenced_type: _MemRefTypeElement,
-        shape: List[int | AnyIntegerAttr]) -> OpResult:
+        referenced_type: Attribute,
+        shape: List[int | AnyIntegerAttr]) -> TestSSAValue:
     memref_type = MemRefType.from_element_type_and_shape(
         referenced_type, shape)
-    return OpResult(memref_type, [], [])
+    return TestSSAValue(memref_type)
 
 
 def get_Vector_SSAVal_from_element_type_and_shape(
-        referenced_type: _VectorTypeElems,
-        shape: List[int | AnyIntegerAttr]) -> OpResult:
+        referenced_type: Attribute,
+        shape: List[int | AnyIntegerAttr]) -> TestSSAValue:
     vector_type = VectorType.from_element_type_and_shape(
         referenced_type, shape)
-    return OpResult(vector_type, [], [])
+    return TestSSAValue(vector_type)
 
 
 def test_vectorType():
@@ -65,8 +63,8 @@ def test_vector_load_i32():
 def test_vector_load_i32_with_dimensions():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
         i32, [2, 3])
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
     load = Load.get(memref_ssa_value, [index1, index2])
 
     assert type(load.results[0]) is OpResult
@@ -118,8 +116,8 @@ def test_vector_store_i32_with_dimensions():
     memref_ssa_value = get_MemRef_SSAVal_from_element_type_and_shape(
         i32, [4, 5])
 
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
     store = Store.get(vector_ssa_value, memref_ssa_value, [index1, index2])
 
     assert store.memref is memref_ssa_value
@@ -156,7 +154,7 @@ def test_vector_store_verify_indexing_exception():
 
 
 def test_vector_broadcast():
-    index1 = OpResult(IndexType, [], [])
+    index1 = TestSSAValue(IndexType())
     broadcast = Broadcast.get(index1)
 
     assert type(broadcast.results[0]) is OpResult
@@ -165,7 +163,7 @@ def test_vector_broadcast():
 
 
 def test_vector_broadcast_verify_type_matching():
-    index1 = OpResult(IndexType, [], [])
+    index1 = TestSSAValue(IndexType())
     res_vector_type = VectorType.from_element_type_and_shape(i64, [1])
 
     broadcast = Broadcast.build(operands=[index1],
@@ -180,9 +178,9 @@ def test_vector_broadcast_verify_type_matching():
 def test_vector_fma():
     i32_vector_type = VectorType.from_element_type_and_shape(i32, [1])
 
-    lhs_vector_ssa_value = OpResult(i32_vector_type, [], [])
-    rhs_vector_ssa_value = OpResult(i32_vector_type, [], [])
-    acc_vector_ssa_value = OpResult(i32_vector_type, [], [])
+    lhs_vector_ssa_value = TestSSAValue(i32_vector_type)
+    rhs_vector_ssa_value = TestSSAValue(i32_vector_type)
+    acc_vector_ssa_value = TestSSAValue(i32_vector_type)
 
     fma = FMA.get(lhs_vector_ssa_value, rhs_vector_ssa_value,
                   acc_vector_ssa_value)
@@ -197,9 +195,9 @@ def test_vector_fma():
 def test_vector_fma_with_dimensions():
     i32_vector_type = VectorType.from_element_type_and_shape(i32, [2, 3])
 
-    lhs_vector_ssa_value = OpResult(i32_vector_type, [], [])
-    rhs_vector_ssa_value = OpResult(i32_vector_type, [], [])
-    acc_vector_ssa_value = OpResult(i32_vector_type, [], [])
+    lhs_vector_ssa_value = TestSSAValue(i32_vector_type)
+    rhs_vector_ssa_value = TestSSAValue(i32_vector_type)
+    acc_vector_ssa_value = TestSSAValue(i32_vector_type)
 
     fma = FMA.get(lhs_vector_ssa_value, rhs_vector_ssa_value,
                   acc_vector_ssa_value)
@@ -345,8 +343,8 @@ def test_vector_masked_load_with_dimensions():
     passthrough_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
         i32, [1])
 
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
 
     maskedload = Maskedload.get(memref_ssa_value, [index1, index2],
                                 mask_vector_ssa_value,
@@ -441,8 +439,8 @@ def test_vector_masked_store_with_dimensions():
     value_to_store_vector_ssa_value = get_Vector_SSAVal_from_element_type_and_shape(
         i32, [1])
 
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
 
     maskedstore = Maskedstore.get(memref_ssa_value, [index1, index2],
                                   mask_vector_ssa_value,
@@ -498,7 +496,8 @@ def test_vector_print():
 
 
 def test_vector_create_mask():
-    create_mask = Createmask.get([])
+    val = TestSSAValue(IndexType())
+    create_mask = Createmask.get(val)
 
     assert type(create_mask.results[0]) is OpResult
     assert type(create_mask.results[0].typ) is VectorType
@@ -506,8 +505,8 @@ def test_vector_create_mask():
 
 
 def test_vector_create_mask_with_dimensions():
-    index1 = OpResult(IndexType, [], [])
-    index2 = OpResult(IndexType, [], [])
+    index1 = TestSSAValue(IndexType())
+    index2 = TestSSAValue(IndexType())
 
     create_mask = Createmask.get([index1, index2])
 

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -9,6 +9,7 @@ from xdsl.ir import OpResult, OpTrait, Operation
 from xdsl.irdl import Operand, irdl_op_definition
 from xdsl.utils.exceptions import VerifyException
 from xdsl.dialects.builtin import IntegerType, i1, i32, i64
+from xdsl.utils.test_value import TestSSAValue
 
 
 @dataclass(frozen=True)
@@ -97,9 +98,9 @@ def test_verifier():
     """
     Check that the traits verifier are correctly called.
     """
-    operand64 = OpResult(i64, [], [])  # type: ignore
-    operand32 = OpResult(i32, [], [])  # type: ignore
-    operand1 = OpResult(i1, [], [])  # type: ignore
+    operand64 = TestSSAValue(i64)
+    operand32 = TestSSAValue(i32)
+    operand1 = TestSSAValue(i1)
     op = TestOp.create(operands=[operand1], result_types=[i32])
     with pytest.raises(VerifyException) as e:
         op.verify()

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -5,4 +5,4 @@ class TestSSAValue(SSAValue):
 
     @property
     def owner(self) -> Operation | Block:
-        assert False
+        assert False, 'Attempting to get the owner of a `TestSSAValue`'

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -1,0 +1,8 @@
+from xdsl.ir import Block, Operation, SSAValue
+
+
+class TestSSAValue(SSAValue):
+
+    @property
+    def owner(self) -> Operation | Block:
+        assert False


### PR DESCRIPTION
There's quite a lot of `OpResult(typ, [], [])` in the tests, which is not ideal, as `[]` is neither an `Operation` nor an `int`, which makes the type checking unhappy. Adding a test value with no owner made it clear that sometimes we were passing the Python class of the xDSL type, as opposed to an instance of the type, and I'm not sure how that ever worked :) There are a few other bugs that surfaced after this change, for future PRs.