### PR TITLE
core: Allow op_type_rewrite_pattern to use unions

### DIFF
--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1,5 +1,5 @@
 from xdsl.dialects.arith import Arith, Constant, Addi, Muli
-from xdsl.dialects.builtin import StringAttr, i32, i64, Builtin, IntegerAttr, ModuleOp
+from xdsl.dialects.builtin import i32, i64, Builtin, IntegerAttr, ModuleOp
 from xdsl.dialects.scf import If, Scf
 from xdsl.ir import MLContext, Region, Operation
 from xdsl.pattern_rewriter import (PatternRewriteWalker,

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -10,7 +10,6 @@ from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import (Operation, Region, Block, BlockArgument, Attribute,
                      SSAValue)
 from xdsl.rewriter import Rewriter
-from xdsl.utils.hints import isa
 
 
 @dataclass(eq=False)


### PR DESCRIPTION
This allows us to factor more code when a rewrite should allow multiple input operation types.