### PR TITLE
dialects: mpi+stencil Add a loop-invariant-code-motion pass to move allocations and mpi_comm_rank calls out of loops

### DIFF
--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -22,7 +22,8 @@ from xdsl.dialects.experimental.stencil import (AccessOp, ApplyOp, CastOp,
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
-from xdsl.transforms.experimental.stencil_global_to_local import LowerHaloExchangeToMpi, HorizontalSlices2D
+from xdsl.transforms.experimental.stencil_global_to_local import LowerHaloExchangeToMpi, HorizontalSlices2D, \
+    MpiLoopInvariantCodeMotion
 
 _TypeElement = TypeVar("_TypeElement", bound=Attribute)
 
@@ -465,5 +466,8 @@ def ConvertStencilToLLMLIR(ctx: MLContext, module: ModuleOp):
                                         apply_recursively=False,
                                         walk_reverse=True)
     the_one_pass.rewrite_module(module)
-    PatternRewriteWalker(LowerHaloExchangeToMpi(
-        HorizontalSlices2D(2))).rewrite_module(module)
+    PatternRewriteWalker(
+        GreedyRewritePatternApplier([
+            LowerHaloExchangeToMpi(HorizontalSlices2D(2)),
+            MpiLoopInvariantCodeMotion(),
+        ])).rewrite_module(module)

--- a/xdsl/transforms/experimental/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/stencil_global_to_local.py
@@ -523,8 +523,8 @@ class MpiLoopInvariantCodeMotion(RewritePattern):
             return
 
         ops = list(collect_args_recursive(op))
-        for op in ops:
-            op.detach()
+        for found_ops in ops:
+            found_ops.detach()
         rewriter.insert_op_before(ops, base)
 
 


### PR DESCRIPTION
This adds a pass to move `memref.alloc`, `mpi.comm.rank` and some others out of potential loops up to the function level.

It does some very basic loop-invariance checking, err-ing on the side of caution.