### PR TITLE
core: add block init with all the fields

### DIFF
--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -871,7 +871,7 @@ class Block(IRNode):
     """Parent region containing the block."""
 
     def __init__(self,
-                 *ops: Operation,
+                 ops: Iterable[Operation] = (),
                  arg_types: tuple[Attribute, ...] = (),
                  parent: Region | None = None,
                  declared_at: Span | None = None):

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -872,6 +872,7 @@ class Block(IRNode):
 
     def __init__(self,
                  ops: Iterable[Operation] = (),
+                 *,
                  arg_types: tuple[Attribute, ...] = (),
                  parent: Region | None = None,
                  declared_at: Span | None = None):

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -6,8 +6,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from io import StringIO
 from itertools import chain
-from typing import (TYPE_CHECKING, Any, Callable, Generic, Mapping, Protocol,
-                    Sequence, TypeVar, cast, Iterator, ClassVar)
+from typing import (TYPE_CHECKING, Any, Callable, Generic, Iterable, Mapping,
+                    Protocol, Sequence, TypeVar, cast, Iterator, ClassVar)
 
 # Used for cyclic dependencies in type hints
 if TYPE_CHECKING:
@@ -855,21 +855,35 @@ class Operation(IRNode):
 OperationInvT = TypeVar('OperationInvT', bound=Operation)
 
 
-@dataclass()
+@dataclass(init=False)
 class Block(IRNode):
     """A sequence of operations"""
 
-    declared_at: Span | None = None
+    declared_at: Span | None
 
-    _args: tuple[BlockArgument, ...] = field(default_factory=lambda: (),
-                                             init=False)
+    _args: tuple[BlockArgument, ...]
     """The basic block arguments."""
 
-    ops: list[Operation] = field(default_factory=list, init=False)
+    ops: list[Operation]
     """Ordered operations contained in the block."""
 
-    parent: Region | None = field(default=None, init=False, repr=False)
+    parent: Region | None
     """Parent region containing the block."""
+
+    def __init__(self,
+                 *ops: Operation,
+                 arg_types: tuple[Attribute, ...] = (),
+                 parent: Region | None = None,
+                 declared_at: Span | None = None):
+        super().__init__(self)
+        self.declared_at = declared_at
+        self._args = tuple(
+            BlockArgument(typ, self, index)
+            for index, typ in enumerate(arg_types))
+        self.ops = []
+        self.parent = parent
+
+        self.add_ops(ops)
 
     def parent_op(self) -> Operation | None:
         return self.parent.parent if self.parent else None
@@ -967,7 +981,7 @@ class Block(IRNode):
         self._attach_op(operation)
         self.ops.append(operation)
 
-    def add_ops(self, ops: list[Operation]) -> None:
+    def add_ops(self, ops: Iterable[Operation]) -> None:
         """
         Add operations at the end of the block.
         The operations should not be attached to another block.

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -571,7 +571,7 @@ class BaseParser(ABC):
         block_id, args = self._parse_optional_block_label()
 
         if block_id is None:
-            block = Block(self.tokenizer.last_token)
+            block = Block(declared_at=self.tokenizer.last_token)
         elif self.forward_block_references.pop(block_id.text,
                                                None) is not None:
             block = self.blocks[block_id.text]
@@ -587,7 +587,7 @@ class BaseParser(ABC):
                     [(block.declared_at, None)],
                     self.tokenizer.history,
                 )
-            block = Block(block_id)
+            block = Block(declared_at=block_id)
             self.blocks[block_id.text] = block
 
         block_args: list[BlockArgument] = []


### PR DESCRIPTION
This gives an alternative to the builder methods. A subsequent PR will deprecate the other buidlers and migrate existing code to the API we settle on.

One alternative to consider is passing a list of ops as opposed to a vararg. I'm happy with either.