### PR TITLE
core: use init for creating regions, as opposed to constructor method

### DIFF
--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -147,7 +147,7 @@ class FuncOp(Operation):
         return FuncOp.from_region(
             name,
             ftype,
-            Region.from_block_list([Block.from_callable(input_types, func)]),
+            Region([Block.from_callable(input_types, func)]),
             private=private)
 
     def verify_(self):

--- a/docs/Toy/toy/ir_gen.py
+++ b/docs/Toy/toy/ir_gen.py
@@ -183,7 +183,7 @@ class IRGen:
         func = self.builder.insert(
             FuncOp.from_region(function_ast.proto.name,
                                func_type,
-                               Region.from_block_list([block]),
+                               Region([block]),
                                private=private))
 
         return func

--- a/docs/mlir_interoperation.ipynb
+++ b/docs/mlir_interoperation.ipynb
@@ -61,7 +61,7 @@
     "\n",
     "# Create Block from operations and Region from blocks\n",
     "block0 = Block.from_ops([a, b, c, d, e, f])\n",
-    "region0 = Region.from_block_list([block0])\n",
+    "region0 = Region([block0])\n",
     "\n",
     "# Create an Operation from the region\n",
     "op = ModuleOp.from_region_or_ops(region0)"

--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -18,7 +18,7 @@ def test_for_mismatch_operands_results_counts():
         "step": IntegerAttr.from_index_int_value(1)
     }
     f = For.create(operands=[],
-                   regions=[Region.from_block_list([])],
+                   regions=[Region()],
                    attributes=attributes,
                    result_types=[IndexType()])
     with pytest.raises(Exception) as e:
@@ -36,7 +36,7 @@ def test_for_mismatch_operands_results_types():
     b = Block.from_arg_types((IntegerType(32), ))
     inp = b.args[0]
     f = For.create(operands=[inp],
-                   regions=[Region.from_block_list([])],
+                   regions=[Region()],
                    attributes=attributes,
                    result_types=[IndexType()])
     with pytest.raises(Exception) as e:
@@ -53,13 +53,11 @@ def test_for_mismatch_blockargs():
     }
     b = Block.from_arg_types((IndexType(), ))
     inp = b.args[0]
-    f = For.create(operands=[inp],
-                   regions=[
-                       Region.from_block_list(
-                           [Block.from_callable([], lambda *args: [])])
-                   ],
-                   attributes=attributes,
-                   result_types=[IndexType()])
+    f = For.create(
+        operands=[inp],
+        regions=[Region([Block.from_callable([], lambda *args: [])])],
+        attributes=attributes,
+        result_types=[IndexType()])
     with pytest.raises(Exception) as e:
         f.verify()
     assert e.value.args[

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -57,7 +57,7 @@ def test_func_II():
     # Create Blocks and Regions
     block0 = Block.from_ops([a, b, e])
     block1 = Block.from_ops([c, d, f])
-    region0 = Region.from_block_list([block0, block1])
+    region0 = Region([block0, block1])
 
     # Use this region to create a func0
     func1 = FuncOp.from_region("func1", [], [], region0)
@@ -73,8 +73,7 @@ def test_func_II():
 
 
 def test_wrong_blockarg_types():
-    r = Region.from_block_list(
-        [Block.from_callable([i32], lambda *x: [Addi.get(x[0], x[0])])])
+    r = Region([Block.from_callable([i32], lambda *x: [Addi.get(x[0], x[0])])])
     f = FuncOp.from_region("f", [i32, i32], [], r)
     with pytest.raises(VerifyException) as e:
         f.verify()
@@ -106,7 +105,7 @@ def test_call():
     ret0 = Return.get(c)
     block0.add_ops([c, ret0])
     # Create a region with the block
-    region = Region.from_block_list([block0])
+    region = Region([block0])
 
     # Create a func0 that gets the block args as arguments, returns the resulting
     # type of c and has the region as body
@@ -155,7 +154,7 @@ def test_call_II():
     ret0 = Return.get(c)
     block0.add_ops([c, ret0])
     # Create a region with the block
-    region = Region.from_block_list([block0])
+    region = Region([block0])
 
     # Create a func0 that gets the block args as arguments, returns the resulting
     # type of c and has the region as body

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -10,7 +10,7 @@ def test_for():
     step = Constant.from_int_and_width(3, IndexType())
     carried = Constant.from_int_and_width(1, IndexType())
     bodyblock = Block.from_arg_types([IndexType()])
-    body = Region.from_block_list([bodyblock])
+    body = Region([bodyblock])
     f = For.get(lb, ub, step, [carried], body)
 
     assert f.lb is lb.result
@@ -39,7 +39,7 @@ def test_parallel():
     sj = Constant.from_int_and_width(3, IndexType())
     sk = Constant.from_int_and_width(8, IndexType())
 
-    body = Region.from_block_list([])
+    body = Region()
 
     lowerBounds = [lbi, lbj, lbk]
     upperBounds = [ubi, ubj, ubk]

--- a/tests/test_frontend_op_inserter.py
+++ b/tests/test_frontend_op_inserter.py
@@ -34,14 +34,14 @@ def test_raises_exception_on_op_with_no_blocks():
 
 def test_raises_exception_on_op_with_no_blocks_II():
     inserter = OpInserter(Block())
-    empty_region = Region.from_block_list([])
+    empty_region = Region()
     with pytest.raises(FrontendProgramException) as err:
         inserter.set_insertion_point_from_region(empty_region)
     assert err.value.msg == "Trying to set the insertion point from the region without blocks."
 
 
 def test_inserts_ops():
-    region = Region.from_block_list([Block.from_ops([]), Block.from_ops([])])
+    region = Region([Block.from_ops([]), Block.from_ops([])])
     inserter = OpInserter(region.blocks[0])
 
     a = Constant.from_int_and_width(1, i32)

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -20,7 +20,7 @@ def test_ops_accessor():
 
     block0 = Block.from_ops([a, b, c])
     # Create a region to include a, b, c
-    region = Region.from_block_list([block0])
+    region = Region([block0])
 
     assert len(region.ops) == 3
     assert len(region.blocks[0].ops) == 3
@@ -44,7 +44,7 @@ def test_ops_accessor_II():
 
     block0 = Block.from_ops([a, b, c])
     # Create a region to include a, b, c
-    region = Region.from_block_list([block0])
+    region = Region([block0])
 
     assert len(region.ops) == 3
     assert len(region.blocks[0].ops) == 3
@@ -90,8 +90,8 @@ def test_ops_accessor_III():
     block1 = Block.from_ops([c, d, f])
     block2 = Block.from_ops([])
 
-    region0 = Region.from_block_list([block0, block1])
-    region1 = Region.from_block_list([block2])
+    region0 = Region([block0, block1])
+    region1 = Region([block2])
 
     with pytest.raises(ValueError):
         region0.ops

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -469,11 +469,11 @@ def test_two_var_operand_builder3():
 def test_parent_pointers():
     op = ResultOp.build(result_types=[StringAttr("0")])
     block = Block.from_ops([op])
-    reg = Region.from_block_list([block])
+    reg = Region([block])
     reg_op = RegionOp.build(regions=[reg])
 
     block_2 = Block.from_ops([reg_op])
-    reg_2 = Region.from_block_list([block_2])
+    reg_2 = Region([block_2])
     reg_op_2 = RegionOp.build(regions=[reg_2])
 
     assert op.parent_block() is block

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -50,7 +50,7 @@ class Builder:
         block = Block()
         builder = Builder(block)
         func(builder)
-        return Region.from_block_list([block])
+        return Region([block])
 
     @staticmethod
     def _region_args(
@@ -70,7 +70,7 @@ class Builder:
 
             func(builder, block.args)
 
-            region = Region.from_block_list([block])
+            region = Region([block])
             return region
 
         return wrapper
@@ -126,7 +126,7 @@ class Builder:
         with _ImplicitBuilder(builder):
             func()
 
-        return Region.from_block_list([block])
+        return Region([block])
 
     @staticmethod
     def _implicit_region_args(
@@ -147,7 +147,7 @@ class Builder:
             with _ImplicitBuilder(builder):
                 func(block.args)
 
-            region = Region.from_block_list([block])
+            region = Region([block])
             return region
 
         return wrapper

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -71,10 +71,9 @@ class For(Operation):
                       body: Block.BlockCallback,
                       step: int | AnyIntegerAttr = 1) -> For:
         arg_types = [IndexType()] + [SSAValue.get(op).typ for op in operands]
-        return For.from_region(
-            operands, lower_bound, upper_bound,
-            Region.from_block_list([Block.from_callable(arg_types, body)]),
-            step)
+        return For.from_region(operands, lower_bound, upper_bound,
+                               Region([Block.from_callable(arg_types, body)]),
+                               step)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -444,7 +444,7 @@ class ApplyOp(Operation):
 
         return ApplyOp.build(operands=[list(args)],
                              attributes=attributes,
-                             regions=[Region.from_block_list([body])],
+                             regions=[Region([body])],
                              result_types=[[
                                  TempType.from_shape([-1] * result_rank,
                                                      field_t.element_type)

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -39,11 +39,9 @@ class FuncOp(Operation):
             "function_type": type_attr,
             "sym_visibility": StringAttr("private")
         }
-        op = FuncOp.build(attributes=attributes,
-                          regions=[
-                              Region.from_block_list(
-                                  [Block.from_callable(input_types, func)])
-                          ])
+        op = FuncOp.build(
+            attributes=attributes,
+            regions=[Region([Block.from_callable(input_types, func)])])
         return op
 
     @staticmethod

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -237,7 +237,7 @@ class PatternOp(Operation):
                       sym_name: StringAttr | None,
                       callable: Block.BlockCallback) -> PatternOp:
         block = Block.from_callable([], callable)
-        region = Region.from_block_list([block])
+        region = Region([block])
         return PatternOp.get(benefit, sym_name, region)
 
 
@@ -398,7 +398,7 @@ class RewriteOp(Operation):
                       external_args: Sequence[SSAValue],
                       body: Block.BlockCallback) -> RewriteOp:
         block = Block.from_callable([], body)
-        region = Region.from_block_list([block])
+        region = Region([block])
         return RewriteOp.get(name, root, external_args, region)
 
 

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -245,7 +245,7 @@ class CodegGenerationVisitor(ast.NodeVisitor):
 
         # Create a function operation.
         entry_block = Block()
-        body_region = Region.from_block_list([entry_block])
+        body_region = Region([entry_block])
         func_op = func.FuncOp.from_region(node.name, argument_types,
                                           return_types, body_region)
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -8,6 +8,7 @@ from io import StringIO
 from itertools import chain
 from typing import (TYPE_CHECKING, Any, Callable, Generic, Iterable, Mapping,
                     Protocol, Sequence, TypeVar, cast, Iterator, ClassVar)
+from xdsl.utils.deprecation import deprecated
 
 # Used for cyclic dependencies in type hints
 if TYPE_CHECKING:
@@ -1117,15 +1118,25 @@ class Block(IRNode):
         return id(self)
 
 
-@dataclass
+@dataclass(init=False)
 class Region(IRNode):
     """A region contains a CFG of blocks. Regions are contained in operations."""
 
-    blocks: list[Block] = field(default_factory=list, init=False)
+    blocks: list[Block]
     """Blocks contained in the region. The first block is the entry block."""
 
-    parent: Operation | None = field(default=None, init=False, repr=False)
+    parent: Operation | None = field(repr=False)
     """Operation containing the region."""
+
+    def __init__(self,
+                 blocks: Iterable[Block] = (),
+                 *,
+                 parent: Operation | None = None):
+        super().__init__(self)
+        self.parent = parent
+        self.blocks = []
+        for block in blocks:
+            self.add_block(block)
 
     def parent_block(self) -> Block | None:
         return self.parent.parent if self.parent else None
@@ -1146,6 +1157,7 @@ class Region(IRNode):
         region.add_block(block)
         return region
 
+    @deprecated('Please use Region(blocks, parent=None)')
     @staticmethod
     def from_block_list(blocks: list[Block]) -> Region:
         region = Region()
@@ -1161,7 +1173,7 @@ class Region(IRNode):
             if len(arg) == 0:
                 return Region.from_operation_list([])
             if isinstance(arg[0], Block):
-                return Region.from_block_list(cast(list[Block], arg))
+                return Region(cast(list[Block], arg))
             if isinstance(arg[0], Operation):
                 return Region.from_operation_list(cast(list[Operation], arg))
         raise TypeError(f"Can't build a region with argument {arg}")

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1122,10 +1122,10 @@ class Block(IRNode):
 class Region(IRNode):
     """A region contains a CFG of blocks. Regions are contained in operations."""
 
-    blocks: list[Block]
+    blocks: list[Block] = field(default_factory=list)
     """Blocks contained in the region. The first block is the entry block."""
 
-    parent: Operation | None = field(repr=False)
+    parent: Operation | None = field(default=None, repr=False)
     """Operation containing the region."""
 
     def __init__(self,

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -443,15 +443,24 @@ class RegionDef(Region):
     An IRDL region definition.
     """
 
+    def __init__(self):
+        super().__init__(parent=None)
+
 
 @dataclass
 class VarRegionDef(RegionDef, VariadicDef):
     """An IRDL variadic region definition."""
 
+    def __init__(self):
+        super().__init__()
+
 
 @dataclass
 class OptRegionDef(RegionDef, OptionalDef):
     """An IRDL optional region definition."""
+
+    def __init__(self):
+        super().__init__()
 
 
 VarRegion: TypeAlias = list[Region]
@@ -461,6 +470,9 @@ OptRegion: TypeAlias = Region | None
 @dataclass
 class SingleBlockRegionDef(RegionDef):
     """An IRDL region definition that expects exactly one block."""
+
+    def __init__(self):
+        super().__init__()
 
 
 class VarSingleBlockRegionDef(RegionDef, VariadicDef):

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -437,30 +437,21 @@ class OptResultDef(VarResultDef, OptionalDef):
 OptOpResult: TypeAlias = OpResult | None
 
 
-@dataclass
+@dataclass(init=True)
 class RegionDef(Region):
     """
     An IRDL region definition.
     """
-
-    def __init__(self):
-        super().__init__(parent=None)
 
 
 @dataclass
 class VarRegionDef(RegionDef, VariadicDef):
     """An IRDL variadic region definition."""
 
-    def __init__(self):
-        super().__init__()
-
 
 @dataclass
 class OptRegionDef(RegionDef, OptionalDef):
     """An IRDL optional region definition."""
-
-    def __init__(self):
-        super().__init__()
 
 
 VarRegion: TypeAlias = list[Region]
@@ -470,9 +461,6 @@ OptRegion: TypeAlias = Region | None
 @dataclass
 class SingleBlockRegionDef(RegionDef):
     """An IRDL region definition that expects exactly one block."""
-
-    def __init__(self):
-        super().__init__()
 
 
 class VarSingleBlockRegionDef(RegionDef, VariadicDef):

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -182,7 +182,7 @@ class IRegion:
             # This will use the already created Block and populate it
             block.to_mutable(value_mapping=value_mapping,
                              block_mapping=block_mapping)
-        return Region.from_block_list(mutable_blocks)
+        return Region(mutable_blocks)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
In my new push to minimise surface area and simplify xDSL APIs, blocks and regions, which are little more than containers of a list of ops or blocks, get the first treatment.