### PR TITLE
core: Allow to parse comma separated undelimeted lists

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -142,7 +142,8 @@ def test_parse_block_name():
 
 
 @pytest.mark.parametrize("delimiter,open_bracket,close_bracket",
-                         [(BaseParser.Delimiter.PAREN, '(', ')'),
+                         [(BaseParser.Delimiter.NONE, '', ''),
+                          (BaseParser.Delimiter.PAREN, '(', ')'),
                           (BaseParser.Delimiter.SQUARE, '[', ']'),
                           (BaseParser.Delimiter.BRACES, '{', '}'),
                           (BaseParser.Delimiter.ANGLE, '<', '>')])
@@ -170,6 +171,13 @@ def test_parse_comma_separated_list_empty(delimiter: BaseParser.Delimiter,
                                             parser.parse_int_literal,
                                             ' in test')
     assert res == []
+
+
+def test_parse_comma_separated_list_none_delimiter_empty():
+    parser = XDSLParser(MLContext(), 'o')
+    with pytest.raises(ParseError):
+        parser.parse_comma_separated_list(BaseParser.Delimiter.NONE,
+                                          parser.parse_int_literal, ' in test')
 
 
 @pytest.mark.parametrize("delimiter,open_bracket,close_bracket",

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -661,6 +661,7 @@ class BaseParser(ABC):
         ANGLE = auto()
         SQUARE = auto()
         BRACES = auto()
+        NONE = auto()
 
     def parse_comma_separated_list(self,
                                    delimiter: Delimiter,
@@ -668,12 +669,14 @@ class BaseParser(ABC):
                                    context_msg: str = '') -> list[T_]:
         """
         Parses greedily a list of elements separated by commas, and delimited
-        by the specified delimiter.
-        The parsing stops when the delimiter is closed, or when an error is
-        produced.
+        by the specified delimiter. The parsing stops when the delimiter is
+        closed, or when an error is produced. If no delimiter is specified, at
+        least one element is expected to be parsed.
         """
         self._synchronize_lexer_and_tokenizer()
-        if delimiter == self.Delimiter.PAREN:
+        if delimiter == self.Delimiter.NONE:
+            pass
+        elif delimiter == self.Delimiter.PAREN:
             self._parse_token(Token.Kind.L_PAREN, "Expected '('" + context_msg)
             if self._parse_optional_token(Token.Kind.R_PAREN) is not None:
                 return []
@@ -701,7 +704,9 @@ class BaseParser(ABC):
             elems.append(parse())
             self._synchronize_lexer_and_tokenizer()
 
-        if delimiter == self.Delimiter.PAREN:
+        if delimiter == self.Delimiter.NONE:
+            pass
+        elif delimiter == self.Delimiter.PAREN:
             self._parse_token(Token.Kind.R_PAREN, "Expected ')'" + context_msg)
         elif delimiter == self.Delimiter.ANGLE:
             self._parse_token(Token.Kind.GREATER, "Expected '>'" + context_msg)


### PR DESCRIPTION
This allows us to specify no delimiters where parsing lists.
This require however to parse at least one element.