### PR TITLE
core: Allow using value tuples in MLIR syntax

### DIFF
--- a/tests/filecheck/mlir-conversion/value_tuple.mlir
+++ b/tests/filecheck/mlir-conversion/value_tuple.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect | xdsl-opt -f mlir -t mlir --allow-unregistered-dialect  | filecheck %s
+
+"builtin.module"() ({
+
+  %0:3 = "test.test"() : () -> (i32, i64, i32)
+  "test.test"(%0#1, %0#0) : (i64, i32) -> ()
+
+  // CHECK: %0, %1, %2 = "test.test"() : () -> (i32, i64, i32)
+  // CHECK: "test.test"(%1, %0) : (i64, i32) -> ()
+
+
+}) : () -> ()

--- a/tests/filecheck/mlir-conversion/value_tuple_access_oob.mlir
+++ b/tests/filecheck/mlir-conversion/value_tuple_access_oob.mlir
@@ -1,0 +1,9 @@
+// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect --parsing-diagnostics | filecheck %s
+
+"builtin.module"() ({
+
+  %0:3 = "test.test"() : () -> (i32, i64, i32)
+  "test.test"(%0#3) : (i32) -> ()
+  // CHECK: SSA value tuple index out of bounds. Tuple is of size 3 but tried to access element 3.
+
+}) : () -> ()

--- a/tests/filecheck/mlir-conversion/value_tuple_wrong_number.mlir
+++ b/tests/filecheck/mlir-conversion/value_tuple_wrong_number.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect --parsing-diagnostics | filecheck %s
+
+"builtin.module"() ({
+
+  %0:1 = "test.test"() : () -> (i32, i64, i32)
+  // CHECK: Operation has 3 results, but were given 1 to bind.
+
+}) : () -> ()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -141,12 +141,13 @@ def test_parse_block_name():
     assert block.args[1].name is None
 
 
-@pytest.mark.parametrize("delimiter,open_bracket,close_bracket",
-                         [(BaseParser.Delimiter.NONE, '', ''),
-                          (BaseParser.Delimiter.PAREN, '(', ')'),
-                          (BaseParser.Delimiter.SQUARE, '[', ']'),
-                          (BaseParser.Delimiter.BRACES, '{', '}'),
-                          (BaseParser.Delimiter.ANGLE, '<', '>')])
+@pytest.mark.parametrize("delimiter,open_bracket,close_bracket", [
+    (BaseParser.Delimiter.NONE, '', ''),
+    (BaseParser.Delimiter.PAREN, '(', ')'),
+    (BaseParser.Delimiter.SQUARE, '[', ']'),
+    (BaseParser.Delimiter.BRACES, '{', '}'),
+    (BaseParser.Delimiter.ANGLE, '<', '>'),
+])
 def test_parse_comma_separated_list(delimiter: BaseParser.Delimiter,
                                     open_bracket: str, close_bracket: str):
     input = open_bracket + "2, 4, 5" + close_bracket
@@ -157,11 +158,12 @@ def test_parse_comma_separated_list(delimiter: BaseParser.Delimiter,
     assert res == [2, 4, 5]
 
 
-@pytest.mark.parametrize("delimiter,open_bracket,close_bracket",
-                         [(BaseParser.Delimiter.PAREN, '(', ')'),
-                          (BaseParser.Delimiter.SQUARE, '[', ']'),
-                          (BaseParser.Delimiter.BRACES, '{', '}'),
-                          (BaseParser.Delimiter.ANGLE, '<', '>')])
+@pytest.mark.parametrize("delimiter,open_bracket,close_bracket", [
+    (BaseParser.Delimiter.PAREN, '(', ')'),
+    (BaseParser.Delimiter.SQUARE, '[', ']'),
+    (BaseParser.Delimiter.BRACES, '{', '}'),
+    (BaseParser.Delimiter.ANGLE, '<', '>'),
+])
 def test_parse_comma_separated_list_empty(delimiter: BaseParser.Delimiter,
                                           open_bracket: str,
                                           close_bracket: str):

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -873,7 +873,7 @@ class BaseParser(ABC):
             assert index_token is not None, 'Fatal error in SSA value parsing'
             self.raise_error(
                 'SSA value tuple index out of bounds. '
-                f'Tuple is of size {tuple_size} but got {index} index.',
+                f'Tuple is of size {tuple_size} but tried to access element {index}.',
                 index_token.span)
 
         self._synchronize_lexer_and_tokenizer()
@@ -1327,6 +1327,11 @@ class BaseParser(ABC):
                                     for block_name in successors
                                 ],
                                 regions=regions)
+
+        expected_results = sum(r[1] for r in results)
+        if len(op.results) != expected_results:
+            self.raise_error(f'Operation has {len(op.results)} results, '
+                             f'but were given {expected_results} to bind.')
 
         # Register the result SSA value names in the parser
         res_idx = 0

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from io import StringIO
-from typing import Any, NoReturn, TypeVar, Iterable, IO, cast, Literal
+from typing import Any, NoReturn, TypeVar, Iterable, IO, cast, Literal, Sequence
 
 from xdsl.utils.exceptions import ParseError, MultipleSpansParseError
 from xdsl.utils.lexer import Input, Lexer, Span, StringLiteral, Token
@@ -377,7 +377,7 @@ class BaseParser(ABC):
     ctx: MLContext
     """xDSL context."""
 
-    ssaValues: dict[str, SSAValue]
+    ssa_values: dict[str, tuple[SSAValue]]
     blocks: dict[str, Block]
     forward_block_references: dict[str, list[Span]]
     """
@@ -408,7 +408,7 @@ class BaseParser(ABC):
         self.lexer = Lexer(Input(input, name))
         self._current_token = self.lexer.lex()
         self.ctx = ctx
-        self.ssaValues = dict()
+        self.ssa_values = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
         self.allow_unregistered_dialect = allow_unregistered_dialect
@@ -553,11 +553,6 @@ class BaseParser(ABC):
             self.raise_error("Expected ModuleOp at top level!",
                              self.tokenizer.next_token())
 
-    def get_ssa_val(self, name: Span) -> SSAValue:
-        if name.text not in self.ssaValues:
-            self.raise_error('SSA Value used before assignment', name)
-        return self.ssaValues[name.text]
-
     def _get_block_from_name(self, block_name: Span) -> Block:
         """
         This function takes a span containing a block id (like `^42`) and returns a block.
@@ -597,7 +592,7 @@ class BaseParser(ABC):
 
         for i, (name, type) in enumerate(args):
             arg = BlockArgument(type, block, i)
-            self.ssaValues[name.text] = arg
+            self.ssa_values[name.text[1:]] = (arg, )
             # store ssa val name if valid
             if SSAValue.is_valid_name(name.text[1:]):
                 arg.name = name.text[1:]
@@ -679,19 +674,23 @@ class BaseParser(ABC):
         elif delimiter == self.Delimiter.PAREN:
             self._parse_token(Token.Kind.L_PAREN, "Expected '('" + context_msg)
             if self._parse_optional_token(Token.Kind.R_PAREN) is not None:
+                self._synchronize_lexer_and_tokenizer()
                 return []
         elif delimiter == self.Delimiter.ANGLE:
             self._parse_token(Token.Kind.LESS, "Expected '<'" + context_msg)
             if self._parse_optional_token(Token.Kind.GREATER) is not None:
+                self._synchronize_lexer_and_tokenizer()
                 return []
         elif delimiter == self.Delimiter.SQUARE:
             self._parse_token(Token.Kind.L_SQUARE,
                               "Expected '['" + context_msg)
             if self._parse_optional_token(Token.Kind.R_SQUARE) is not None:
+                self._synchronize_lexer_and_tokenizer()
                 return []
         elif delimiter == self.Delimiter.BRACES:
             self._parse_token(Token.Kind.L_BRACE, "Expected '{'" + context_msg)
             if self._parse_optional_token(Token.Kind.R_BRACE) is not None:
+                self._synchronize_lexer_and_tokenizer()
                 return []
         else:
             assert False, "Unknown delimiter"
@@ -844,16 +843,45 @@ class BaseParser(ABC):
     def try_parse_value_id(self) -> Span | None:
         return self.tokenizer.next_token_of_pattern(ParserCommons.value_id)
 
-    def try_parse_operand(self) -> SSAValue | None:
-        """Try to parse an operand with format `%<value-id>`."""
-        value_id = self.try_parse_value_id()
-        if value_id is None:
-            return None
-        return self.get_ssa_val(value_id)
+    _decimal_integer_regex = re.compile(r'[0-9]+')
 
-    def parse_operand(self, msg: str = "operand expected") -> SSAValue:
+    def parse_optional_operand(self) -> SSAValue | None:
+        """
+        Parse an operand with format `%<value-id>(#<int-literal>)?`, if present.
+        """
+        self._synchronize_lexer_and_tokenizer()
+        name_token = self._parse_optional_token(Token.Kind.PERCENT_IDENT)
+        if name_token is None:
+            return None
+        name = name_token.text[1:]
+
+        index = 0
+        index_token = self._parse_optional_token(Token.Kind.HASH_IDENT)
+        if index_token is not None:
+            if re.fullmatch(self._decimal_integer_regex,
+                            index_token.text[1:]) is None:
+                self.raise_error('Expected integer as SSA value tuple index',
+                                 index_token.span)
+            index = int(index_token.text[1:], 10)
+
+        if name not in self.ssa_values.keys():
+            self.raise_error('SSA value used before assignment',
+                             name_token.span)
+
+        tuple_size = len(self.ssa_values[name])
+        if index >= tuple_size:
+            assert index_token is not None, 'Fatal error in SSA value parsing'
+            self.raise_error(
+                'SSA value tuple index out of bounds. '
+                f'Tuple is of size {tuple_size} but got {index} index.',
+                index_token.span)
+
+        self._synchronize_lexer_and_tokenizer()
+        return self.ssa_values[name][index]
+
+    def parse_operand(self, msg: str = "Expected an operand.") -> SSAValue:
         """Parse an operand with format `%<value-id>`."""
-        return self.expect(self.try_parse_operand, msg)
+        return self.expect(self.parse_optional_operand, msg)
 
     def try_parse_suffix_id(self) -> Span | None:
         return self.tokenizer.next_token_of_pattern(ParserCommons.suffix_id)
@@ -1245,7 +1273,7 @@ class BaseParser(ABC):
 
     @abstractmethod
     def _parse_op_result_list(
-            self) -> tuple[list[Span], list[Attribute] | None]:
+            self) -> list[tuple[Span, int, Attribute | None]]:
         raise NotImplementedError()
 
     def try_parse_operation(self) -> Operation | None:
@@ -1253,8 +1281,13 @@ class BaseParser(ABC):
             return self.parse_operation()
 
     def parse_operation(self) -> Operation:
-        result_list, ret_types = self._parse_op_result_list()
-        if len(result_list) > 0:
+        self._synchronize_lexer_and_tokenizer()
+        if self._current_token.kind == Token.Kind.PERCENT_IDENT:
+            results = self._parse_op_result_list()
+        else:
+            results = []
+        ret_types = [result[2] for result in results]
+        if len(results) > 0:
             self.parse_characters(
                 '=',
                 'Operation definitions expect an `=` after op-result-list!')
@@ -1265,8 +1298,8 @@ class BaseParser(ABC):
             assert isinstance(
                 self, XDSLParser
             ), "Only xDSL format currently supports custom op parsing"
-            assert ret_types is not None, "Return types must be in xDSL format"
             op_type = self._get_op_by_name(op_name)
+            ret_types = cast(list[Attribute], ret_types)
             op = op_type.parse(ret_types, self)
         else:
             # Check for basic op format
@@ -1279,32 +1312,36 @@ class BaseParser(ABC):
             args, successors, attrs, regions, func_type = self.parse_operation_details(
             )
 
-            if ret_types is None:
+            if any(res_type is None for res_type in ret_types):
                 assert func_type is not None
                 ret_types = func_type.outputs.data
+            ret_types = cast(Sequence[Attribute], ret_types)
 
             op_type = self._get_op_by_name(op_name)
 
-            op = op_type.create(
-                operands=[self.ssaValues[span.text] for span in args],
-                result_types=ret_types,
-                attributes=attrs,
-                successors=[
-                    self._get_block_from_name(block_name)
-                    for block_name in successors
-                ],
-                regions=regions)
+            op = op_type.create(operands=args,
+                                result_types=ret_types,
+                                attributes=attrs,
+                                successors=[
+                                    self._get_block_from_name(block_name)
+                                    for block_name in successors
+                                ],
+                                regions=regions)
 
         # Register the result SSA value names in the parser
-        for idx, res in enumerate(result_list):
-            ssa_val_name = res.text
-            if ssa_val_name in self.ssaValues:
+        res_idx = 0
+        for res_span, res_size, _ in results:
+            ssa_val_name = res_span.text[1:]  # Removing the leading '%'
+            if ssa_val_name in self.ssa_values:
                 self.raise_error(
-                    f"SSA value {ssa_val_name} is already defined", res)
-            self.ssaValues[ssa_val_name] = op.results[idx]
+                    f"SSA value %{ssa_val_name} is already defined", res_span)
+            self.ssa_values[ssa_val_name] = tuple(op.results[res_idx:res_idx +
+                                                             res_size])
+            res_idx += res_size
             # Carry over `ssa_val_name` for non-numeric names:
-            if SSAValue.is_valid_name(ssa_val_name[1:]):
-                self.ssaValues[ssa_val_name].name = ssa_val_name[1:]
+            if SSAValue.is_valid_name(ssa_val_name):
+                for val in self.ssa_values[ssa_val_name]:
+                    val.name = ssa_val_name
 
         return op
 
@@ -1323,7 +1360,7 @@ class BaseParser(ABC):
         self.raise_error(f'Unknown operation {op_name}!', span)
 
     def parse_region(self) -> Region:
-        oldSSAVals = self.ssaValues.copy()
+        old_ssa_values = self.ssa_values.copy()
         oldBBNames = self.blocks
         oldForwardRefs = self.forward_block_references
         self.blocks = dict()
@@ -1359,7 +1396,7 @@ class BaseParser(ABC):
 
             return region
         finally:
-            self.ssaValues = oldSSAVals
+            self.ssa_values = old_ssa_values
             self.blocks = oldBBNames
             self.forward_block_references = oldForwardRefs
 
@@ -1895,7 +1932,7 @@ class BaseParser(ABC):
     @abstractmethod
     def parse_operation_details(
         self,
-    ) -> tuple[list[Span], list[Span], dict[str, Attribute], list[Region],
+    ) -> tuple[list[SSAValue], list[Span], dict[str, Attribute], list[Region],
                FunctionType | None]:
         """
         Must return a tuple consisting of:
@@ -1910,7 +1947,7 @@ class BaseParser(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def _parse_op_args_list(self) -> list[Span]:
+    def _parse_op_args_list(self) -> list[SSAValue]:
         raise NotImplementedError()
 
     # HERE STARTS A SOMEWHAT CURSED COMPATIBILITY LAYER:
@@ -1936,20 +1973,14 @@ class BaseParser(ABC):
         args, successors, attributes, regions, _ = self.parse_operation_details(
         )
 
-        for x in args:
-            if x.text not in self.ssaValues:
-                self.raise_error(
-                    "Unknown SSAValue name, known SSA Values are: {}".format(
-                        ", ".join(self.ssaValues.keys())), x)
-
-        return op_type.create(
-            operands=[self.ssaValues[span.text] for span in args],
-            result_types=result_types,
-            attributes=attributes,
-            successors=[
-                self._get_block_from_name(span) for span in successors
-            ],
-            regions=regions)
+        return op_type.create(operands=args,
+                              result_types=result_types,
+                              attributes=attributes,
+                              successors=[
+                                  self._get_block_from_name(span)
+                                  for span in successors
+                              ],
+                              regions=regions)
 
     def parse_paramattr_parameters(self,
                                    skip_white_space: bool = True
@@ -2071,21 +2102,32 @@ class MLIRParser(BaseParser):
 
         return builtin_val
 
+    def _parse_op_result(self) -> tuple[Span, int, Attribute | None]:
+        value_token = self._parse_token(Token.Kind.PERCENT_IDENT,
+                                        'Expected result SSA value!')
+        if self._parse_optional_token(Token.Kind.COLON) is None:
+            return (value_token.span, 1, None)
+
+        size_token = self._parse_token(Token.Kind.INTEGER_LIT,
+                                       'Expected SSA value tuple size')
+        size = size_token.get_int_value()
+        return (value_token.span, size, None)
+
     def _parse_op_result_list(
-            self) -> tuple[list[Span], list[Attribute] | None]:
-        return (
-            self.parse_list_of(self.try_parse_value_id,
-                               "Expected op-result here!",
-                               allow_empty=True),
-            None,
-        )
+            self) -> list[tuple[Span, int, Attribute | None]]:
+        self._synchronize_lexer_and_tokenizer()
+        res = self.parse_comma_separated_list(self.Delimiter.NONE,
+                                              self._parse_op_result,
+                                              ' in operation result list')
+        self._synchronize_lexer_and_tokenizer()
+        return res
 
     def parse_optional_attr_dict(self) -> dict[str, Attribute]:
         return self.parse_optional_dictionary_attr_dict()
 
     def parse_operation_details(
         self,
-    ) -> tuple[list[Span], list[Span], dict[str, Attribute], list[Region],
+    ) -> tuple[list[SSAValue], list[Span], dict[str, Attribute], list[Region],
                FunctionType | None]:
         args = self._parse_op_args_list()
         succ = self._parse_optional_successor_list()
@@ -2118,15 +2160,10 @@ class MLIRParser(BaseParser):
                               "Successor list is enclosed in square brackets")
         return successors
 
-    def _parse_op_args_list(self) -> list[Span]:
-        self.parse_characters(
-            "(", "Operation args list must be enclosed by brackets!")
-        args = self.parse_list_of(self.try_parse_value_id,
-                                  "Expected another bare-id here")
-        self.parse_characters(
-            ")", "Operation args list must be closed by a closing bracket")
-        # TODO: check if type is correct here!
-        return args
+    def _parse_op_args_list(self) -> list[SSAValue]:
+        return self.parse_comma_separated_list(self.Delimiter.PAREN,
+                                               self.parse_operand,
+                                               ' in operation argument list')
 
     def parse_region_list(self) -> list[Region]:
         """
@@ -2186,17 +2223,15 @@ class XDSLParser(BaseParser):
         return value
 
     def _parse_op_result_list(
-            self) -> tuple[list[Span], list[Attribute] | None]:
+            self) -> list[tuple[Span, int, Attribute | None]]:
         if not self.tokenizer.starts_with("%"):
-            return list(), list()
+            return []
         results = self.parse_list_of(
             self.try_parse_value_id_and_type,
             "Expected (value-id `:` type) here!",
             allow_empty=False,
         )
-        # TODO: this is hideous, make it cleaner
-        # zip(*results) works, but is barely readable :/
-        return [name for name, _ in results], [type for _, type in results]
+        return [(name, 1, type) for name, type in results]
 
     def try_parse_builtin_attr(self) -> Attribute | None:
         """
@@ -2231,7 +2266,7 @@ class XDSLParser(BaseParser):
 
     def parse_operation_details(
         self,
-    ) -> tuple[list[Span], list[Span], dict[str, Attribute], list[Region],
+    ) -> tuple[list[SSAValue], list[Span], dict[str, Attribute], list[Region],
                FunctionType | None]:
         """
         Must return a tuple consisting of:
@@ -2287,15 +2322,14 @@ class XDSLParser(BaseParser):
             '>', 'Malformed attribute arguments, reached end of args list!')
         return attr(args)
 
-    def _parse_op_args_list(self) -> list[Span]:
+    def _parse_op_args_list(self) -> list[SSAValue]:
         self.parse_characters(
             "(", "Operation args list must be enclosed by brackets!")
         args = self.parse_list_of(self.try_parse_value_id_and_type,
                                   "Expected another bare-id here")
         self.parse_characters(
             ")", "Operation args list must be closed by a closing bracket")
-        # TODO: check if type is correct here!
-        return [name for name, _ in args]
+        return [self.ssa_values[arg.text[1:]][0] for arg, _ in args]
 
     def try_parse_type(self) -> Attribute | None:
         return self.try_parse_attribute()


### PR DESCRIPTION
This PR allows us to parse value tuples (not sure what their exact names are in MLIR).
This means we can now parse 3913 tests compared to 3754 before (over 4121 total).