### PR TITLE
core: Reimplement shape parser with new lexer

### DIFF
--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -86,11 +86,11 @@
   // CHECK: (vector<4xf32>, vector<f32>, vector<1x12xi32>)
 
   "func.func"() ({
-    ^bb0(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<1x12xi32>, %arg3: tensor<*xf64>):
+    ^bb0(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<1x12xi32>, %arg3: tensor<*xf64>, %arg4: tensor<0xi32>):
     "func.return"() : () -> ()
-  }) {function_type = (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>, tensor<*xf64>) -> (), sym_name = "tensor_type"} : () -> ()
+  }) {function_type = (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>, tensor<*xf64>, tensor<0xi32>) -> (), sym_name = "tensor_type"} : () -> ()
 
-  // CHECK: (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>, tensor<*xf64>)
+  // CHECK: (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>, tensor<*xf64>, tensor<0xi32>)
 
   "func.func"() ({}) {function_type = () -> (),
                       value1 = dense<[0]> : tensor<1xi32>,

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1145,8 +1145,6 @@ class BaseParser(ABC):
 
     def _parse_shape(self) -> tuple[list[int] | None, Attribute]:
         """
-        """
-
         Parse a ranked or unranked shape with the following format:
         
         shape ::= ranked-shape | unranked-shape
@@ -1154,12 +1152,6 @@ class BaseParser(ABC):
         unranked-shape ::= `*`x type
         dimension ::= `?` | decimal-literal
           
-        each dimension is also required to be non-negative.
-        """
-          shape ::= ranked-shape | unranked-shape
-          ranked-shape ::= (dimension `x`)* type
-          unranked-shape ::= `*`x type
-          dimension ::= `?` | decimal-literal
         each dimension is also required to be non-negative.
         """
         self._synchronize_lexer_and_tokenizer()

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1145,7 +1145,17 @@ class BaseParser(ABC):
 
     def _parse_shape(self) -> tuple[list[int] | None, Attribute]:
         """
+        """
+
         Parse a ranked or unranked shape with the following format:
+        
+        shape ::= ranked-shape | unranked-shape
+        ranked-shape ::= (dimension `x`)* type
+        unranked-shape ::= `*`x type
+        dimension ::= `?` | decimal-literal
+          
+        each dimension is also required to be non-negative.
+        """
           shape ::= ranked-shape | unranked-shape
           ranked-shape ::= (dimension `x`)* type
           unranked-shape ::= `*`x type

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1082,6 +1082,86 @@ class BaseParser(ABC):
 
         return res
 
+    def _parse_shape_dimension(self) -> int:
+        """
+        Parse a single shape dimension, which is a decimal literal or `?`.
+        `?` is interpreted as -1. Note that if the integer literal is in
+        hexadecimal form, it will be split into multiple tokens. For example,
+        `0x10` will be split into `0` and `x10`.
+        """
+        if self._current_token.kind not in (Token.Kind.INTEGER_LIT,
+                                            Token.Kind.QUESTION):
+            self.raise_error(
+                "Expected either integer literal or '?' in shape dimension, "
+                f"got {self._current_token.kind.name}!")
+
+        if self.parse_optional_punctuation('?') is not None:
+            return -1
+
+        # If the integer literal starts with `0x`, this is decomposed into
+        # `0` and `x`.
+        int_token = self._consume_token(Token.Kind.INTEGER_LIT)
+        if int_token.text[:2] == '0x':
+            self.resume_from(int_token.span.start + 1)
+            return 0
+
+        return int_token.get_int_value()
+
+    def _parse_shape_delimiter(self) -> None:
+        """
+        Parse 'x', a shape delimiter. Note that if 'x' is followed by other
+        characters, it will split the token. For instance, 'x1' will be split
+        into 'x' and '1'.
+        """
+        if self._current_token.kind != Token.Kind.BARE_IDENT:
+            self.raise_error("Expected 'x' in shape delimiter, got "
+                             f"{self._current_token.kind.name}")
+
+        if self._current_token.text[0] != 'x':
+            self.raise_error("Expected 'x' in shape delimiter, got "
+                             f"{self._current_token.text}")
+
+        # Move the lexer to the position after 'x'.
+        self.resume_from(self._current_token.span.start + 1)
+
+    def _parse_ranked_shape(self) -> tuple[list[int], Attribute]:
+        """
+        Parse a ranked shape with the following format:
+          ranked-shape ::= (dimension `x`)* type
+          dimension ::= `?` | decimal-literal
+        each dimension is also required to be non-negative.
+        """
+        self._synchronize_lexer_and_tokenizer()
+        dims: list[int] = []
+        while self._current_token.kind in (Token.Kind.INTEGER_LIT,
+                                           Token.Kind.QUESTION):
+            dim = self._parse_shape_dimension()
+            dims.append(dim)
+            self._parse_shape_delimiter()
+
+        self._synchronize_lexer_and_tokenizer()
+        type = self.expect(self.try_parse_type, 'Expected shape type.')
+        return dims, type
+
+    def _parse_shape(self) -> tuple[list[int] | None, Attribute]:
+        """
+        Parse a ranked or unranked shape with the following format:
+          shape ::= ranked-shape | unranked-shape
+          ranked-shape ::= (dimension `x`)* type
+          unranked-shape ::= `*`x type
+          dimension ::= `?` | decimal-literal
+        each dimension is also required to be non-negative.
+        """
+        self._synchronize_lexer_and_tokenizer()
+        if self.parse_optional_punctuation('*') is not None:
+            self._parse_shape_delimiter()
+            type = self.expect(self.try_parse_type, 'Expected shape type.')
+            self._synchronize_lexer_and_tokenizer()
+            return None, type
+        res = self._parse_ranked_shape()
+        self._synchronize_lexer_and_tokenizer()
+        return res
+
     def parse_complex_attrs(self) -> ComplexType:
         element_type = self.parse_attribute()
         if not isa(element_type, IntegerType | AnyFloat):
@@ -1092,15 +1172,10 @@ class BaseParser(ABC):
 
     def parse_memref_attrs(
             self) -> MemRefType[Attribute] | UnrankedMemrefType[Attribute]:
-        dims = self._parse_tensor_or_memref_dims()
-        type = self.expect(
-            self.try_parse_type,
-            "Type cannot be nil when parsing memref attributes")
-
-        self._synchronize_lexer_and_tokenizer()
+        shape, type = self._parse_shape()
 
         # Unranked case
-        if dims is None:
+        if shape is None:
             if self.parse_optional_punctuation(',') is None:
                 self._synchronize_lexer_and_tokenizer()
                 return UnrankedMemrefType.from_type(type)
@@ -1110,7 +1185,7 @@ class BaseParser(ABC):
             return UnrankedMemrefType.from_type(type, memory_space)
 
         if self.parse_optional_punctuation(',') is None:
-            return MemRefType.from_element_type_and_shape(type, dims)
+            return MemRefType.from_element_type_and_shape(type, shape)
 
         self._synchronize_lexer_and_tokenizer()
         memory_or_layout = self.parse_attribute()
@@ -1123,7 +1198,7 @@ class BaseParser(ABC):
             memory_space = self.parse_attribute()
             self._synchronize_lexer_and_tokenizer()
             return MemRefType.from_element_type_and_shape(
-                type, dims, memory_or_layout, memory_space)
+                type, shape, memory_or_layout, memory_space)
 
         # Otherwise, there is a single argument, so we check based on the
         # attribute type. If we don't know, we return an error.
@@ -1133,14 +1208,14 @@ class BaseParser(ABC):
         # If the argument is an integer, it is a memory space
         if isa(memory_or_layout, AnyIntegerAttr):
             return MemRefType.from_element_type_and_shape(
-                type, dims, memory_space=memory_or_layout)
+                type, shape, memory_space=memory_or_layout)
 
         # We only accept strided layouts and affine_maps
         if (isa(memory_or_layout, StridedLayoutAttr)
                 or (isinstance(memory_or_layout, UnregisteredAttr)
                     and memory_or_layout.attr_name.data == "affine_map")):
             return MemRefType.from_element_type_and_shape(
-                type, dims, layout=memory_or_layout)
+                type, shape, layout=memory_or_layout)
         self.raise_error("Cannot decide if the given attribute "
                          "is a layout or a memory space!")
 
@@ -1180,22 +1255,8 @@ class BaseParser(ABC):
 
         return VectorType.from_element_type_and_shape(type, shape)
 
-    def _parse_tensor_or_memref_dims(self) -> list[int] | None:
-        # Check for unranked-ness
-        if self.tokenizer.next_token_of_pattern('*') is not None:
-            # Consume `x`
-            self.parse_characters(
-                'x', 'Unranked tensors must follow format (`<*x` type `>`)')
-        else:
-            # Parse rank:
-            return list(self.try_parse_numerical_dims(lower_bound=0))
-
     def parse_tensor_attrs(self) -> AnyTensorType | AnyUnrankedTensorType:
-        shape = self._parse_tensor_or_memref_dims()
-        type = self.try_parse_type()
-
-        if type is None:
-            self.raise_error("Expected tensor type here!")
+        shape, type = self._parse_shape()
 
         if shape is None:
             if self.parse_optional_punctuation(',') is not None:


### PR DESCRIPTION
This brings us to 3992/4121 tests passed, compare to 3988 before, because the previous parser was not handling well 0-sized dimensions.