### PR TITLE
dialects: Add better init for IntegerAttr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -297,6 +297,16 @@ class IntegerAttr(Generic[_IntegerAttrTyp], ParametrizedAttribute):
     value: ParameterDef[IntAttr]
     typ: ParameterDef[_IntegerAttrTyp]
 
+    @overload
+    def __init__(self: IntegerAttr[_IntegerAttrTyp], value: int | IntAttr,
+                 typ: _IntegerAttrTyp) -> None:
+        ...
+
+    @overload
+    def __init__(self: IntegerAttr[IntegerType], value: int | IntAttr,
+                 typ: int) -> None:
+        ...
+
     def __init__(self, value: int | IntAttr,
                  typ: int | IntegerType | IndexType) -> None:
         if isinstance(value, int):


### PR DESCRIPTION
This is purely a typing improvement, it doesn't change at all the implementation.

This change will make such that `IntegerAttr(value, typ)` will be correctly a `IntegerAttr[T]` when `typ` is of type `T`, and an `IntegerAttr[IntegerType]` when `typ` is of type `int`.