### PR TITLE
core: Refactor operation creation to be __init__ based.

### DIFF
--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -267,7 +267,7 @@ class RangeOp(IRDLOperation):
                     raise VerifyException(
                         f"All arguments must have the same type or be an array  \
                           of the corresponding element type. First element type:\
-                          {elem_type}, current element type: {cur_elem_type}")
+                          {elem_type}, current element type: {cur_elem_type}"                                                                             )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -267,7 +267,7 @@ class RangeOp(IRDLOperation):
                     raise VerifyException(
                         f"All arguments must have the same type or be an array  \
                           of the corresponding element type. First element type:\
-                          {elem_type}, current element type: {cur_elem_type}"                                                                             )
+                          {elem_type}, current element type: {cur_elem_type}")
 
 
 @irdl_op_definition

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -592,7 +592,6 @@ class Operation(IRNode):
                  attributes: dict[str, Attribute] | None = None,
                  successors: Sequence[Block] | None = None,
                  regions: Sequence[Region] | None = None) -> None:
-        self.regions = []
 
         if operands is None:
             operands = []
@@ -614,6 +613,7 @@ class Operation(IRNode):
         ]
         self.attributes = attributes
         self.successors = list(successors)
+        self.regions = []
         for region in regions:
             self.add_region(region)
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -592,26 +592,31 @@ class Operation(IRNode):
                  attributes: dict[str, Attribute] | None = None,
                  successors: Sequence[Block] | None = None,
                  regions: Sequence[Region] | None = None) -> None:
-        self._operands = tuple()
-        self.results = []
-        self.successors = []
-        self.attributes = {}
         self.regions = []
 
-        if operands is not None:
-            self.operands = list(operands)
-        if result_types:
-            self.results = [
-                OpResult(typ, self, idx)
-                for (idx, typ) in enumerate(result_types)
-            ]
-        if attributes:
-            self.attributes = attributes
-        if successors:
-            self.successors = list(successors)
-        if regions:
-            for region in regions:
-                self.add_region(region)
+        if operands is None:
+            operands = []
+        if result_types is None:
+            result_types = []
+        if attributes is None:
+            attributes = {}
+        if successors is None:
+            successors = []
+        if regions is None:
+            regions = []
+
+        # This is assumed to exist by Operation.operand setter.
+        self._operands = tuple()
+        self.operands = tuple(operands)
+
+        self.results = [
+            OpResult(typ, self, idx) for (idx, typ) in enumerate(result_types)
+        ]
+        self.attributes = attributes
+        self.successors = list(successors)
+        for region in regions:
+            self.add_region(region)
+
         self.__post_init__()
 
     @classmethod

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -612,6 +612,7 @@ class Operation(IRNode):
         if regions:
             for region in regions:
                 self.add_region(region)
+        self.__post_init__()
 
     @classmethod
     def create(cls: type[OpT],
@@ -623,7 +624,6 @@ class Operation(IRNode):
         op = cls.__new__(cls)
         Operation.__init__(op, operands, result_types, attributes, successors,
                            regions)
-        Operation.__post_init__(op)
         return op
 
     def replace_operand(self, operand: int | SSAValue,

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -325,10 +325,6 @@ _OpT = TypeVar('_OpT', bound='IRDLOperation')
 
 class IRDLOperation(Operation):
 
-    @staticmethod
-    def get_def() -> OpDef:
-        ...
-
     def __init__(
         self: IRDLOperation,
         operands: Sequence[SSAValue | Operation
@@ -352,8 +348,8 @@ class IRDLOperation(Operation):
             successors = []
         if regions is None:
             regions = []
-        irdl_op_init(self, self.get_def(), operands, result_types, attributes,
-                     successors, regions)
+        irdl_op_init(self, self.irdl_definition, operands, result_types,
+                     attributes, successors, regions)
 
     @classmethod
     def build(
@@ -379,6 +375,12 @@ class IRDLOperation(Operation):
                                successors=successors,
                                regions=regions)
         return op
+
+    @classmethod
+    @property
+    def irdl_definition(cls) -> OpDef:
+        """Get the IRDL operation definition."""
+        ...
 
 
 @dataclass
@@ -1233,11 +1235,6 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
 
     op_def = OpDef.from_pyrdl(cls)
     new_attrs = dict[str, Any]()
-
-    def get_def(self):
-        return op_def
-
-    new_attrs["get_def"] = get_def
 
     # Add operand access fields
     irdl_op_arg_definition(new_attrs, VarIRConstruct.OPERAND, op_def)

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -378,7 +378,6 @@ class IRDLOperation(Operation):
                                attributes=attributes,
                                successors=successors,
                                regions=regions)
-        op.__post_init__()
         return op
 
 

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -329,22 +329,6 @@ class IRDLOperation(Operation):
     def get_def() -> OpDef:
         ...
 
-    def irdl_init(
-        self,
-        operands: Sequence[SSAValue | Operation
-                           | Sequence[SSAValue | Operation] | None]
-        | None = None,
-        result_types: Sequence[Attribute | Sequence[Attribute]]
-        | None = None,
-        attributes: Mapping[str, Attribute | None] | None = None,
-        successors: Sequence[Block] | None = None,
-        regions: Sequence[Region | Sequence[Operation] | Sequence[Block]
-                          | Sequence[Region | Sequence[Operation]
-                                     | Sequence[Block]]]
-        | None = None):
-        """Initialize a new operation using builders."""
-        ...
-
     def __init__(
         self: IRDLOperation,
         operands: Sequence[SSAValue | Operation
@@ -388,11 +372,12 @@ class IRDLOperation(Operation):
     ) -> _OpT:
         """Create a new operation using builders."""
         op = cls.__new__(cls)
-        op.irdl_init(operands=operands,
-                     result_types=result_types,
-                     attributes=attributes,
-                     successors=successors,
-                     regions=regions)
+        IRDLOperation.__init__(op,
+                               operands=operands,
+                               result_types=result_types,
+                               attributes=attributes,
+                               successors=successors,
+                               regions=regions)
         op.__post_init__()
         return op
 
@@ -1295,32 +1280,6 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
             new_attrs[attribute_name] = attribute_field(attribute_name)
 
     new_attrs["traits"] = op_def.traits
-
-    def init(self: cls,
-             operands: Sequence[SSAValue | Operation
-                                | Sequence[SSAValue | Operation]]
-             | None = None,
-             result_types: Sequence[Attribute | Sequence[Attribute]]
-             | None = None,
-             attributes: dict[str, Attribute] | None = None,
-             successors: Sequence[Block] | None = None,
-             regions: Sequence[Region | Sequence[Operation] | Sequence[Block]]
-             | None = None):
-        if operands is None:
-            operands = []
-        if result_types is None:
-            result_types = []
-        if attributes is None:
-            attributes = {}
-        if successors is None:
-            successors = []
-        if regions is None:
-            regions = []
-
-        irdl_op_init(self, op_def, operands, result_types, attributes,
-                     successors, regions)
-
-    new_attrs["irdl_init"] = init
 
     @classmethod
     @property

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -325,6 +325,10 @@ _OpT = TypeVar('_OpT', bound='IRDLOperation')
 
 class IRDLOperation(Operation):
 
+    @staticmethod
+    def get_def() -> OpDef:
+        ...
+
     def irdl_init(
         self,
         operands: Sequence[SSAValue | Operation
@@ -340,6 +344,32 @@ class IRDLOperation(Operation):
         | None = None):
         """Initialize a new operation using builders."""
         ...
+
+    def __init__(
+        self: IRDLOperation,
+        operands: Sequence[SSAValue | Operation
+                           | Sequence[SSAValue | Operation] | None]
+        | None = None,
+        result_types: Sequence[Attribute | Sequence[Attribute]]
+        | None = None,
+        attributes: Mapping[str, Attribute | None] | None = None,
+        successors: Sequence[Block] | None = None,
+        regions: Sequence[Region | Sequence[Operation] | Sequence[Block]
+                          | Sequence[Region | Sequence[Operation]
+                                     | Sequence[Block]]]
+        | None = None):
+        if operands is None:
+            operands = []
+        if result_types is None:
+            result_types = []
+        if attributes is None:
+            attributes = {}
+        if successors is None:
+            successors = []
+        if regions is None:
+            regions = []
+        irdl_op_init(self, self.get_def(), operands, result_types, attributes,
+                     successors, regions)
 
     @classmethod
     def build(
@@ -1219,6 +1249,11 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
 
     op_def = OpDef.from_pyrdl(cls)
     new_attrs = dict[str, Any]()
+
+    def get_def(self):
+        return op_def
+
+    new_attrs["get_def"] = get_def
 
     # Add operand access fields
     irdl_op_arg_definition(new_attrs, VarIRConstruct.OPERAND, op_def)


### PR DESCRIPTION
EDIT: This PR refactors Operation creation on top of the IRDLOperation split.
Now, `Operation` and `IRDLOperation` factories (respectively, `create` and `build`) are based on those type's `__init__`s.
The main impact being that all subclasses can now "standardly" define custom `__init__`s, leveraging the new `IRDLOperation`'s `__init__`, just as `get` was leveraging `build` up until now.

This is a kind of second breath for this PR. I would say the discussion about the current proposal starts at [this comment](https://github.com/xdslproject/xdsl/pull/700#issuecomment-1508710769)