### PR TITLE
builtin: Add as_tuple() helper to DenseArrayBase

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -900,6 +900,9 @@ class DenseArrayBase(ParametrizedAttribute):
         else:
             raise TypeError(f"Unsupported element type {type}")
 
+    def as_tuple(self) -> tuple[int] | tuple[float]:
+        return tuple(x.data for x in self.data.data)
+
 
 @irdl_attr_definition
 class FunctionType(ParametrizedAttribute, TypeAttribute):


### PR DESCRIPTION
This adds `as_tuple` to the `DenseArrayBase` class to make access easier.