### PR TITLE
core: Fix isa to not assert

### DIFF
--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -179,6 +179,7 @@ def test_tuple_hint_failure():
     """
     assert not isa((0, ), tuple[bool])
     assert not isa((0, True), tuple[bool, bool])
+    assert not isa((0, True), tuple[int])
     assert not isa((True, 0), tuple[bool, bool])
     assert not isa((True, False, True, 0), tuple[bool, ...])
     assert not isa((Class2(), ), tuple[Class1])

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -39,8 +39,7 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
         if len(elem_hints) == 2 and elem_hints[1] is ...:
             return all(isa(elem, elem_hints[0]) for elem in arg_tuple)
         else:
-            assert len(elem_hints) == len(arg_tuple)
-            return all(
+            return len(elem_hints) == len(arg_tuple) and all(
                 isa(elem, hint) for elem, hint in zip(arg_tuple, elem_hints))
 
     if origin is dict:


### PR DESCRIPTION
Small fix for my last PR on `isa` tuple support