### PR TITLE
CI: Add a container build workflow.

### DIFF
--- a/.github/workflows/Dockerfile-MLIR
+++ b/.github/workflows/Dockerfile-MLIR
@@ -1,0 +1,32 @@
+ARG MLIR_VERSION
+
+FROM ubuntu:22.04 as build
+
+ARG MLIR_VERSION
+
+# Install dependencies
+RUN apt update \
+ && apt install --yes --no-install-recommends git cmake build-essential ca-certificates ninja-build clang lld python3.10-dev pip
+RUN mkdir llvm-project \
+ && cd llvm-project \
+ && git init \
+ && git remote add origin https://github.com/llvm/llvm-project.git \
+ && git fetch --depth 1 origin ${MLIR_VERSION} \
+ && git checkout FETCH_HEAD
+RUN mkdir llvm-project/build \
+ && cd llvm-project/build \
+ && cmake -G Ninja ../llvm \
+      -DLLVM_ENABLE_PROJECTS=mlir \
+      -DLLVM_TARGETS_TO_BUILD="X86" \
+      -DLLVM_ENABLE_LLD=ON \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLLVM_ENABLE_ASSERTIONS=ON \
+      -DCMAKE_INSTALL_PREFIX=install
+RUN cd llvm-project/build \
+ && cmake --build . --target install
+
+FROM ubuntu:22.04 as install
+RUN --mount=from=build,target=install,source=llvm-project/build/install,rw \
+    cp -R install/* /usr/local

--- a/.github/workflows/ci-mlir-docker.yml
+++ b/.github/workflows/ci-mlir-docker.yml
@@ -1,0 +1,43 @@
+name: Build MLIR container
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+        IMAGE: ghcr.io/xdslproject/xdsl/MLIR
+        CACHE: ghcr.io/xdslproject/xdsl/MLIR-cache
+        MLIR_VERSION: 89996621de073e43de7bed552037b10d2a0fdf80
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile-MLIR
+          build-args: |
+            MLIR_VERSION=${{env.MLIR_VERSION}}
+          push: true
+          tags: "${{env.IMAGE}}:${{env.MLIR_VERSION}}"
+          cache-from: type=registry,ref=${{env.CACHE}}:${{env.MLIR_VERSION}}
+          cache-to: type=registry,ref=${{env.CACHE}}:${{env.MLIR_VERSION}},mode=max


### PR DESCRIPTION
This **draft** PR is to test things out with building a cached MLIR docker container, to replace our usage of the GitHub Actions cache with it if it works well for us. I'm currently just after testing the CI myself, no need to review for now, but feel free to give opinions on the approach!

Pros:

- No more cache invalidation struggles
- Easier usage of MLIR in different CI workflows (As in, not having a specific MLIR workflow that does all what the other workflows do for the MLIR-needing cases)

Cons:

- Handling a container, instead of a cache.