### PR TITLE
CI: Remove codecov in CI

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -44,9 +44,9 @@ jobs:
         pip install -e .[extras]
         pip install nbval
 
-    - name: Install CI dependencies
-      run: |
-        pip install codecov
+    # - name: Install CI dependencies
+    #  run: |
+    #    pip install codecov
 
     - name: Cache binaries
       id: cache-binary
@@ -118,12 +118,12 @@ jobs:
         coverage report
         coverage xml
 
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.10'
-      uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: true
-        verbose: true
-        directory: ${GITHUB_WORKSPACE}/../
-        files: coverage.xml
-        token: ${{ secrets.CODECOV_TOKEN }}
+    # - name: Upload coverage to Codecov
+    #   if: matrix.python-version == '3.10'
+    #   uses: codecov/codecov-action@v3
+    #   with:
+    #     fail_ci_if_error: true
+    #     verbose: true
+    #     directory: ${GITHUB_WORKSPACE}/../
+    #     files: coverage.xml
+    #     token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR removes codecov from our CI, as it seems they have been hacked? Or at least 
the package has been removed from PyPi: https://pypi.org/project/codecov/

I just commented the parts in the CI, so we can add them back once the situation is resolved.