### PR TITLE
core: Add scalable dimensions to vector

### DIFF
--- a/tests/filecheck/arith_ops.xdsl
+++ b/tests/filecheck/arith_ops.xdsl
@@ -117,30 +117,30 @@ func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "maxf"] 
 
 // CHECK:   %{{.*}} : !f32 = arith.maxf(%{{.*}} : !f32, %{{.*}} : !f32)
 
-func.func() ["function_type" = !fun<[!vector<[4 : !index], !f16>, !vector<[4 : !index], !f16>], [!vector<[4 : !index], !f16>]>, "sym_name" = "maxf16_vector"] {
-^7(%21 : !vector<[4 : !index], !f16>, %22 : !vector<[4 : !index], !f16>):
-  %23 : !vector<[4 : !index], !f16> = arith.maxf(%21 : !vector<[4 : !index], !f16>, %22 : !vector<[4 : !index], !f16>)
-  func.return(%23 : !vector<[4 : !index], !f16>)
+func.func() ["function_type" = !fun<[!vector<[4 : !index], !f16, !int<0>>, !vector<[4 : !index], !f16, !int<0>>], [!vector<[4 : !index], !f16, !int<0>>]>, "sym_name" = "maxf16_vector"] {
+^7(%21 : !vector<[4 : !index], !f16, !int<0>>, %22 : !vector<[4 : !index], !f16, !int<0>>):
+  %23 : !vector<[4 : !index], !f16, !int<0>> = arith.maxf(%21 : !vector<[4 : !index], !f16, !int<0>>, %22 : !vector<[4 : !index], !f16, !int<0>>)
+  func.return(%23 : !vector<[4 : !index], !f16, !int<0>>)
 }
 
-// CHECK:   %{{.*}} : !vector<[4 : !index], !f16> = arith.maxf(%{{.*}} : !vector<[4 : !index], !f16>, %{{.*}} : !vector<[4 : !index], !f16>)
+// CHECK:   %{{.*}} : !vector<[4 : !index], !f16, !int<0>> = arith.maxf(%{{.*}} : !vector<[4 : !index], !f16, !int<0>>, %{{.*}} : !vector<[4 : !index], !f16, !int<0>>)
 
-func.func() ["function_type" = !fun<[!vector<[4 : !index], !f32>, !vector<[4 : !index], !f32>], [!vector<[4 : !index], !f32>]>, "sym_name" = "maxf32_vector"] {
-^7(%21 : !vector<[4 : !index], !f32>, %22 : !vector<[4 : !index], !f32>):
-  %23 : !vector<[4 : !index], !f32> = arith.maxf(%21 : !vector<[4 : !index], !f32>, %22 : !vector<[4 : !index], !f32>)
-  func.return(%23 : !vector<[4 : !index], !f32>)
+func.func() ["function_type" = !fun<[!vector<[4 : !index], !f32, !int<0>>, !vector<[4 : !index], !f32, !int<0>>], [!vector<[4 : !index], !f32, !int<0>>]>, "sym_name" = "maxf32_vector"] {
+^7(%21 : !vector<[4 : !index], !f32, !int<0>>, %22 : !vector<[4 : !index], !f32, !int<0>>):
+  %23 : !vector<[4 : !index], !f32, !int<0>> = arith.maxf(%21 : !vector<[4 : !index], !f32, !int<0>>, %22 : !vector<[4 : !index], !f32, !int<0>>)
+  func.return(%23 : !vector<[4 : !index], !f32, !int<0>>)
 }
 
-// CHECK:   %{{.*}} : !vector<[4 : !index], !f32> = arith.maxf(%{{.*}} : !vector<[4 : !index], !f32>, %{{.*}} : !vector<[4 : !index], !f32>)
+// CHECK:   %{{.*}} : !vector<[4 : !index], !f32, !int<0>> = arith.maxf(%{{.*}} : !vector<[4 : !index], !f32, !int<0>>, %{{.*}} : !vector<[4 : !index], !f32, !int<0>>)
 
 
-func.func() ["function_type" = !fun<[!vector<[4 : !index], !f64>, !vector<[4 : !index], !f64>], [!vector<[4 : !index], !f64>]>, "sym_name" = "maxf64_vector"] {
-^7(%21 : !vector<[4 : !index], !f64>, %22 : !vector<[4 : !index], !f64>):
-  %23 : !vector<[4 : !index], !f64> = arith.maxf(%21 : !vector<[4 : !index], !f64>, %22 : !vector<[4 : !index], !f64>)
-  func.return(%23 : !vector<[4 : !index], !f64>)
+func.func() ["function_type" = !fun<[!vector<[4 : !index], !f64, !int<0>>, !vector<[4 : !index], !f64, !int<0>>], [!vector<[4 : !index], !f64, !int<0>>]>, "sym_name" = "maxf64_vector"] {
+^7(%21 : !vector<[4 : !index], !f64, !int<0>>, %22 : !vector<[4 : !index], !f64, !int<0>>):
+  %23 : !vector<[4 : !index], !f64, !int<0>> = arith.maxf(%21 : !vector<[4 : !index], !f64, !int<0>>, %22 : !vector<[4 : !index], !f64, !int<0>>)
+  func.return(%23 : !vector<[4 : !index], !f64, !int<0>>)
 }
 
-// CHECK:   %{{.*}} : !vector<[4 : !index], !f64> = arith.maxf(%{{.*}} : !vector<[4 : !index], !f64>, %{{.*}} : !vector<[4 : !index], !f64>)
+// CHECK:   %{{.*}} : !vector<[4 : !index], !f64, !int<0>> = arith.maxf(%{{.*}} : !vector<[4 : !index], !f64, !int<0>>, %{{.*}} : !vector<[4 : !index], !f64, !int<0>>)
 
 
 func.func() ["function_type" = !fun<[!f32, !f32], [!f32]>, "sym_name" = "minf"] {

--- a/tests/filecheck/dialects/vector/vector_broadcast_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_broadcast_type_matching.xdsl
@@ -4,7 +4,7 @@ builtin.module() {
 
 func.func() ["sym_name" = "vector_broadcast_type_matching", "function_type" = !fun<[!index], []>, "sym_visibility" = "private"] {
   ^0(%0 : !index):
-    %1 : !vector<[2 : !i32], !i32> = vector.broadcast(%0 : !index)
+    %1 : !vector<[2 : !i32], !i32, !int<0>> = vector.broadcast(%0 : !index)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_createmask_indexing.xdsl
+++ b/tests/filecheck/dialects/vector/vector_createmask_indexing.xdsl
@@ -4,7 +4,7 @@ builtin.module() {
 
 func.func() ["sym_name" = "vector_createmask_indexing", "function_type" = !fun<[!index], []>, "sym_visibility" = "private"] {
   ^0(%0 : !index):
-    %1 : !vector<[2 : !i1, 2 : !i1], !i1> = vector.create_mask(%0 : !index)
+    %1 : !vector<[2 : !i1, 2 : !i1], !i1, !int<0>> = vector.create_mask(%0 : !index)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_fma_res_acc_shape_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_fma_res_acc_shape_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_fma_res_acc_shape_matching", "function_type" = !fun<[!vector<[2 : !index], !index>, !vector<[3 : !index], !index>], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !index], !index>, %1 : !vector<[3 : !index], !index>):
-    %2 : !vector<[2 : !index], !index> = vector.fma(%0 : !vector<[2 : !index], !index>, %0 : !vector<[2 : !index], !index>, %1 : !vector<[3 : !index], !index>)
+func.func() ["sym_name" = "vector_fma_res_acc_shape_matching", "function_type" = !fun<[!vector<[2 : !index], !index, !int<0>>, !vector<[3 : !index], !index, !int<0>>], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[3 : !index], !index, !int<0>>):
+    %2 : !vector<[2 : !index], !index, !int<0>> = vector.fma(%0 : !vector<[2 : !index], !index, !int<0>>, %0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[3 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_fma_res_acc_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_fma_res_acc_type_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_fma_res_acc_type_matching", "function_type" = !fun<[!vector<[2 : !index], !index>, !vector<[2 : !i32], !i32>], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !index], !index>, %1 : !vector<[2 : !i32], !i32>):
-    %2 : !vector<[2 : !i32], !i32> = vector.fma(%1 : !vector<[2 : !i32], !i32>, %1 : !vector<[2 : !i32], !i32>, %0 : !vector<[2 : !index], !index>)
+func.func() ["sym_name" = "vector_fma_res_acc_type_matching", "function_type" = !fun<[!vector<[2 : !index], !index, !int<0>>, !vector<[2 : !i32], !i32, !int<0>>], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>):
+    %2 : !vector<[2 : !i32], !i32, !int<0>> = vector.fma(%1 : !vector<[2 : !i32], !i32, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>, %0 : !vector<[2 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_fma_res_lhs_shape_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_fma_res_lhs_shape_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_fma_res_lhs_shape_matching", "function_type" = !fun<[!vector<[2 : !index], !index>, !vector<[3 : !index], !index>], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !index], !index>, %1 : !vector<[3 : !index], !index>):
-    %2 : !vector<[2 : !index], !index> = vector.fma(%1 : !vector<[3 : !index], !index>, %0 : !vector<[2 : !index], !index>, %0 : !vector<[2 : !index], !index>)
+func.func() ["sym_name" = "vector_fma_res_lhs_shape_matching", "function_type" = !fun<[!vector<[2 : !index], !index, !int<0>>, !vector<[3 : !index], !index, !int<0>>], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[3 : !index], !index, !int<0>>):
+    %2 : !vector<[2 : !index], !index, !int<0>> = vector.fma(%1 : !vector<[3 : !index], !index, !int<0>>, %0 : !vector<[2 : !index], !index, !int<0>>, %0 : !vector<[2 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_fma_res_lhs_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_fma_res_lhs_type_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_fma_res_lhs_type_matching", "function_type" = !fun<[!vector<[2 : !index], !index>, !vector<[2 : !i32], !i32>], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !index], !index>, %1 : !vector<[2 : !i32], !i32>):
-    %2 : !vector<[2 : !i32], !i32> = vector.fma(%0 : !vector<[2 : !index], !index>, %1 : !vector<[2 : !i32], !i32>, %1 : !vector<[2 : !i32], !i32>)
+func.func() ["sym_name" = "vector_fma_res_lhs_type_matching", "function_type" = !fun<[!vector<[2 : !index], !index, !int<0>>, !vector<[2 : !i32], !i32, !int<0>>], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>):
+    %2 : !vector<[2 : !i32], !i32, !int<0>> = vector.fma(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_fma_res_rhs_shape_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_fma_res_rhs_shape_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_fma_res_rhs_shape_matching", "function_type" = !fun<[!vector<[2 : !index], !index>, !vector<[3 : !index], !index>], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !index], !index>, %1 : !vector<[3 : !index], !index>):
-    %2 : !vector<[2 : !index], !index> = vector.fma(%0 : !vector<[2 : !index], !index>, %1 : !vector<[3 : !index], !index>, %0 : !vector<[2 : !index], !index>)
+func.func() ["sym_name" = "vector_fma_res_rhs_shape_matching", "function_type" = !fun<[!vector<[2 : !index], !index, !int<0>>, !vector<[3 : !index], !index, !int<0>>], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[3 : !index], !index, !int<0>>):
+    %2 : !vector<[2 : !index], !index, !int<0>> = vector.fma(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[3 : !index], !index, !int<0>>, %0 : !vector<[2 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_fma_res_rhs_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_fma_res_rhs_type_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_fma_res_rhs_type_matching", "function_type" = !fun<[!vector<[2 : !index], !index>, !vector<[2 : !i32], !i32>], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !index], !index>, %1 : !vector<[2 : !i32], !i32>):
-    %2 : !vector<[2 : !i32], !i32> = vector.fma(%1 : !vector<[2 : !i32], !i32>, %0 : !vector<[2 : !index], !index>, %1 : !vector<[2 : !i32], !i32>)
+func.func() ["sym_name" = "vector_fma_res_rhs_type_matching", "function_type" = !fun<[!vector<[2 : !index], !index, !int<0>>, !vector<[2 : !i32], !i32, !int<0>>], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>):
+    %2 : !vector<[2 : !i32], !i32, !int<0>> = vector.fma(%1 : !vector<[2 : !i32], !i32, !int<0>>, %0 : !vector<[2 : !index], !index, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_load_indexing.xdsl
+++ b/tests/filecheck/dialects/vector/vector_load_indexing.xdsl
@@ -4,7 +4,7 @@ builtin.module() {
 
 func.func() ["sym_name" = "vector_load_indexing", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
   ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index):
-    %2 : !vector<[2 : !index], !index> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index)
+    %2 : !vector<[2 : !index], !index, !int<0>> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_load_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_load_type_matching.xdsl
@@ -4,7 +4,7 @@ builtin.module() {
 
 func.func() ["sym_name" = "vector_load_type_matching", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
   ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index):
-    %2 : !vector<[2 : !i32], !i32> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index, %1 : !index)
+    %2 : !vector<[2 : !i32], !i32, !int<0>> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !index, %1 : !index)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_maskedload_indexing.xdsl
+++ b/tests/filecheck/dialects/vector/vector_maskedload_indexing.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_maskedload_indexing", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !index], !index>, !vector<[2 : !i1], !i1>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !index], !index>, %2 : !vector<[2 : !i1], !i1>, %3 : !index):
-    %4 : !vector<[2 : !index], !index> = vector.maskedload(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %2 : !vector<[2 : !i1], !i1>, %1 : !vector<[2 : !index], !index>)
+func.func() ["sym_name" = "vector_maskedload_indexing", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !index], !index, !int<0>>, !vector<[2 : !i1], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !index], !index, !int<0>>, %2 : !vector<[2 : !i1], !i1, !int<0>>, %3 : !index):
+    %4 : !vector<[2 : !index], !index, !int<0>> = vector.maskedload(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %2 : !vector<[2 : !i1], !i1, !int<0>>, %1 : !vector<[2 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_maskedload_memref_passthrough_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_maskedload_memref_passthrough_type_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_maskedload_memref_passthrough_type_matching", "function_type" = !fun<[!memref<[2 : !i32, 2 : !i32], !i32>, !vector<[2 : !index], !index>, !vector<[2 : !i1], !i1>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !memref<[2 : !i32, 2 : !i32], !i32>, %1 : !vector<[2 : !index], !index>, %2 : !vector<[2 : !i1], !i1>, %3 : !index):
-    %4 : !vector<[2 : !i32], !i32> = vector.maskedload(%0 : !memref<[2 : !i32, 2 : !i32], !i32>, %3 : !index, %3 : !index, %2 : !vector<[2 : !i1], !i1>, %1 : !vector<[2 : !index], !index>)
+func.func() ["sym_name" = "vector_maskedload_memref_passthrough_type_matching", "function_type" = !fun<[!memref<[2 : !i32, 2 : !i32], !i32>, !vector<[2 : !index], !index, !int<0>>, !vector<[2 : !i1], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[2 : !i32, 2 : !i32], !i32>, %1 : !vector<[2 : !index], !index, !int<0>>, %2 : !vector<[2 : !i1], !i1, !int<0>>, %3 : !index):
+    %4 : !vector<[2 : !i32], !i32, !int<0>> = vector.maskedload(%0 : !memref<[2 : !i32, 2 : !i32], !i32>, %3 : !index, %3 : !index, %2 : !vector<[2 : !i1], !i1, !int<0>>, %1 : !vector<[2 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_maskedload_memref_res_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_maskedload_memref_res_type_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_maskedload_memref_res_type_matching", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !index], !index>, !vector<[2 : !i1], !i1>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !index], !index>, %2 : !vector<[2 : !i1], !i1>, %3 : !index):
-    %4 : !vector<[2 : !i32], !i32> = vector.maskedload(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %3 : !index, %2 : !vector<[2 : !i1], !i1>, %1 : !vector<[2 : !index], !index>)
+func.func() ["sym_name" = "vector_maskedload_memref_res_type_matching", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !index], !index, !int<0>>, !vector<[2 : !i1], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !index], !index, !int<0>>, %2 : !vector<[2 : !i1], !i1, !int<0>>, %3 : !index):
+    %4 : !vector<[2 : !i32], !i32, !int<0>> = vector.maskedload(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %3 : !index, %2 : !vector<[2 : !i1], !i1, !int<0>>, %1 : !vector<[2 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_maskedstore_indexing.xdsl
+++ b/tests/filecheck/dialects/vector/vector_maskedstore_indexing.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_maskedstore_indexing", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !index], !index>, !vector<[2 : !i1], !i1>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !index], !index>, %2 : !vector<[2 : !i1], !i1>, %3 : !index):
-    vector.maskedstore(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %2 : !vector<[2 : !i1], !i1>, %1 : !vector<[2 : !index], !index>)
+func.func() ["sym_name" = "vector_maskedstore_indexing", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !index], !index, !int<0>>, !vector<[2 : !i1], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !index], !index, !int<0>>, %2 : !vector<[2 : !i1], !i1, !int<0>>, %3 : !index):
+    vector.maskedstore(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %2 : !vector<[2 : !i1], !i1, !int<0>>, %1 : !vector<[2 : !index], !index, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_maskedstore_memref_storevec_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_maskedstore_memref_storevec_type_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_maskedstore_memref_storevec_type_matching", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !i32], !i32>, !vector<[2 : !i1], !i1>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !i32], !i32>, %2 : !vector<[2 : !i1], !i1>, %3 : !index):
-    vector.maskedstore(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %3 : !index, %2 : !vector<[2 : !i1], !i1>, %1 : !vector<[2 : !i32], !i32>)
+func.func() ["sym_name" = "vector_maskedstore_memref_storevec_type_matching", "function_type" = !fun<[!memref<[2 : !index, 2 : !index], !index>, !vector<[2 : !i32], !i32, !int<0>>, !vector<[2 : !i1], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[2 : !index, 2 : !index], !index>, %1 : !vector<[2 : !i32], !i32, !int<0>>, %2 : !vector<[2 : !i1], !i1, !int<0>>, %3 : !index):
+    vector.maskedstore(%0 : !memref<[2 : !index, 2 : !index], !index>, %3 : !index, %3 : !index, %2 : !vector<[2 : !i1], !i1, !int<0>>, %1 : !vector<[2 : !i32], !i32, !int<0>>)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_ops.xdsl
+++ b/tests/filecheck/dialects/vector/vector_ops.xdsl
@@ -2,31 +2,31 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_test", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !vector<[1 : !i1], !i1>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !vector<[1 : !i1], !i1>, %2 : !index):
-    %3 : !vector<[2 : !index], !index> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
-    vector.store(%3 : !vector<[2 : !index], !index>, %0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
-    %4 : !vector<[1 : !index], !index> = vector.broadcast(%2 : !index)
-    %5 : !vector<[2 : !index], !index> = vector.fma(%3 : !vector<[2 : !index], !index>, %3 : !vector<[2 : !index], !index>, %3 : !vector<[2 : !index], !index>)
-    %6 : !vector<[1 : !index], !index> = vector.maskedload(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1>, %4 : !vector<[1 : !index], !index>)
-    vector.maskedstore(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1>, %6 : !vector<[1 : !index], !index>)
-    vector.print(%6 : !vector<[1 : !index], !index>)
-    %7 : !vector<[2 : !i1], !i1> = vector.create_mask(%2 : !index)
+func.func() ["sym_name" = "vector_test", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !vector<[1 : !i1], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !vector<[1 : !i1], !i1, !int<0>>, %2 : !index):
+    %3 : !vector<[2 : !index], !index, !int<0>> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
+    vector.store(%3 : !vector<[2 : !index], !index, !int<0>>, %0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
+    %4 : !vector<[1 : !index], !index, !int<0>> = vector.broadcast(%2 : !index)
+    %5 : !vector<[2 : !index], !index, !int<0>> = vector.fma(%3 : !vector<[2 : !index], !index, !int<0>>, %3 : !vector<[2 : !index], !index, !int<0>>, %3 : !vector<[2 : !index], !index, !int<0>>)
+    %6 : !vector<[1 : !index], !index, !int<0>> = vector.maskedload(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1, !int<0>>, %4 : !vector<[1 : !index], !index, !int<0>>)
+    vector.maskedstore(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1, !int<0>>, %6 : !vector<[1 : !index], !index, !int<0>>)
+    vector.print(%6 : !vector<[1 : !index], !index, !int<0>>)
+    %7 : !vector<[2 : !i1], !i1, !int<0>> = vector.create_mask(%2 : !index)
 
     func.return()
   }
 
 // CHECK: builtin.module() {
-// CHECK-NEXT: func.func() ["sym_name" = "vector_test", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !vector<[true], !i1>, !index], []>, "sym_visibility" = "private"] {
-// CHECK-NEXT: ^{{.*}}(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !vector<[true], !i1>, %{{.*}} : !index):
-// CHECK-NEXT: %{{.*}} : !vector<[2 : !index], !index> = vector.load(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index)
-// CHECK-NEXT: vector.store(%{{.*}} : !vector<[2 : !index], !index>, %{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index)
-// CHECK-NEXT: %{{.*}} : !vector<[1 : !index], !index> = vector.broadcast(%{{.*}} : !index)
-// CHECK-NEXT: %{{.*}} : !vector<[2 : !index], !index> = vector.fma(%{{.*}} : !vector<[2 : !index], !index>, %{{.*}} : !vector<[2 : !index], !index>, %{{.*}} : !vector<[2 : !index], !index>)
-// CHECK-NEXT: %{{.*}} : !vector<[1 : !index], !index> = vector.maskedload(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !vector<[true], !i1>, %{{.*}} : !vector<[1 : !index], !index>)
-// CHECK-NEXT: vector.maskedstore(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !vector<[true], !i1>, %{{.*}} : !vector<[1 : !index], !index>)
-// CHECK-NEXT: vector.print(%{{.*}} : !vector<[1 : !index], !index>)
-// CHECK-NEXT: %{{.*}} : !vector<[true], !i1> = vector.create_mask(%{{.*}} : !index)
+// CHECK-NEXT: func.func() ["sym_name" = "vector_test", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !vector<[true], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !vector<[true], !i1, !int<0>>, %{{.*}} : !index):
+// CHECK-NEXT: %{{.*}} : !vector<[2 : !index], !index, !int<0>> = vector.load(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index)
+// CHECK-NEXT: vector.store(%{{.*}} : !vector<[2 : !index], !index, !int<0>>, %{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index)
+// CHECK-NEXT: %{{.*}} : !vector<[1 : !index], !index, !int<0>> = vector.broadcast(%{{.*}} : !index)
+// CHECK-NEXT: %{{.*}} : !vector<[2 : !index], !index, !int<0>> = vector.fma(%{{.*}} : !vector<[2 : !index], !index, !int<0>>, %{{.*}} : !vector<[2 : !index], !index, !int<0>>, %{{.*}} : !vector<[2 : !index], !index, !int<0>>)
+// CHECK-NEXT: %{{.*}} : !vector<[1 : !index], !index, !int<0>> = vector.maskedload(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !vector<[true], !i1, !int<0>>, %{{.*}} : !vector<[1 : !index], !index, !int<0>>)
+// CHECK-NEXT: vector.maskedstore(%{{.*}} : !memref<[4 : !index, 4 : !index], !index>, %{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !vector<[true], !i1, !int<0>>, %{{.*}} : !vector<[1 : !index], !index, !int<0>>)
+// CHECK-NEXT: vector.print(%{{.*}} : !vector<[1 : !index], !index, !int<0>>)
+// CHECK-NEXT: %{{.*}} : !vector<[true], !i1, !int<0>> = vector.create_mask(%{{.*}} : !index)
 // CHECK-NEXT: func.return()
 // CHECK-NEXT: }
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/vector/vector_ops_mlir_conversion.xdsl
+++ b/tests/filecheck/dialects/vector/vector_ops_mlir_conversion.xdsl
@@ -2,16 +2,16 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_test_mlir_conversion", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !vector<[1 : !i1], !i1>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !vector<[1 : !i1], !i1>, %2 : !index):
-    %3 : !vector<[2 : !index], !index> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
-    vector.store(%3 : !vector<[2 : !index], !index>, %0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
-    %4 : !vector<[1 : !index], !index> = vector.broadcast(%2 : !index)
-    %5 : !vector<[2 : !index], !index> = vector.fma(%3 : !vector<[2 : !index], !index>, %3 : !vector<[2 : !index], !index>, %3 : !vector<[2 : !index], !index>)
-    %6 : !vector<[1 : !index], !index> = vector.maskedload(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1>, %4 : !vector<[1 : !index], !index>)
-    vector.maskedstore(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1>, %6 : !vector<[1 : !index], !index>)
-    vector.print(%6 : !vector<[1 : !index], !index>)
-    %7 : !vector<[2 : !i1], !i1> = vector.create_mask(%2 : !index)
+func.func() ["sym_name" = "vector_test_mlir_conversion", "function_type" = !fun<[!memref<[4 : !index, 4 : !index], !index>, !vector<[1 : !i1], !i1, !int<0>>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !memref<[4 : !index, 4 : !index], !index>, %1 : !vector<[1 : !i1], !i1, !int<0>>, %2 : !index):
+    %3 : !vector<[2 : !index], !index, !int<0>> = vector.load(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
+    vector.store(%3 : !vector<[2 : !index], !index, !int<0>>, %0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
+    %4 : !vector<[1 : !index], !index, !int<0>> = vector.broadcast(%2 : !index)
+    %5 : !vector<[2 : !index], !index, !int<0>> = vector.fma(%3 : !vector<[2 : !index], !index, !int<0>>, %3 : !vector<[2 : !index], !index, !int<0>>, %3 : !vector<[2 : !index], !index, !int<0>>)
+    %6 : !vector<[1 : !index], !index, !int<0>> = vector.maskedload(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1, !int<0>>, %4 : !vector<[1 : !index], !index, !int<0>>)
+    vector.maskedstore(%0 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index, %1 : !vector<[1 : !i1], !i1, !int<0>>, %6 : !vector<[1 : !index], !index, !int<0>>)
+    vector.print(%6 : !vector<[1 : !index], !index, !int<0>>)
+    %7 : !vector<[2 : !i1], !i1, !int<0>> = vector.create_mask(%2 : !index)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_store_indexing.xdsl
+++ b/tests/filecheck/dialects/vector/vector_store_indexing.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_store_indexing", "function_type" = !fun<[!vector<[2 : !index], !index>, !memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !index], !index>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index):
-    vector.store(%0 : !vector<[2 : !index], !index>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index)
+func.func() ["sym_name" = "vector_store_indexing", "function_type" = !fun<[!vector<[2 : !index], !index, !int<0>>, !memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index):
+    vector.store(%0 : !vector<[2 : !index], !index, !int<0>>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index)
 
     func.return()
   }

--- a/tests/filecheck/dialects/vector/vector_store_type_matching.xdsl
+++ b/tests/filecheck/dialects/vector/vector_store_type_matching.xdsl
@@ -2,9 +2,9 @@
 
 builtin.module() {
 
-func.func() ["sym_name" = "vector_store_type_matching", "function_type" = !fun<[!vector<[2 : !i32], !i32>, !memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
-  ^0(%0 : !vector<[2 : !i32], !i32>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index):
-    vector.store(%0 : !vector<[2 : !i32], !i32>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
+func.func() ["sym_name" = "vector_store_type_matching", "function_type" = !fun<[!vector<[2 : !i32], !i32, !int<0>>, !memref<[4 : !index, 4 : !index], !index>, !index], []>, "sym_visibility" = "private"] {
+  ^0(%0 : !vector<[2 : !i32], !i32, !int<0>>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index):
+    vector.store(%0 : !vector<[2 : !i32], !i32, !int<0>>, %1 : !memref<[4 : !index, 4 : !index], !index>, %2 : !index, %2 : !index)
 
     func.return()
   }

--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -98,6 +98,14 @@
   // CHECK: (vector<4xf32>, vector<f32>, vector<1x12xi32>)
 
   "func.func"() ({
+    ^bb0(%arg0: vector<[4]xf32>, %arg1: vector<[4x4]xf32>, %arg2: vector<12x[2x3]xi32>):
+    "func.return"() : () -> ()
+  }) {function_type = (vector<[4]xf32>, vector<[4x4]xf32>, vector<12x[2x3]xi32>) -> (), sym_name = "vector_type"} : () -> ()
+
+  // CHECK: (vector<[4]xf32>, vector<[4x4]xf32>, vector<12x[2x3]xi32>)
+
+
+  "func.func"() ({
     ^bb0(%arg0: tensor<4xf32>, %arg1: tensor<f32>, %arg2: tensor<1x12xi32>, %arg3: tensor<*xf64>, %arg4: tensor<0xi32>):
     "func.return"() : () -> ()
   }) {function_type = (tensor<4xf32>, tensor<f32>, tensor<1x12xi32>, tensor<*xf64>, tensor<0xi32>) -> (), sym_name = "tensor_type"} : () -> ()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -523,33 +523,53 @@ class VectorType(Generic[AttributeCovT], ParametrizedAttribute, TypeAttribute):
 
     shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]
     element_type: ParameterDef[AttributeCovT]
+    num_scalable_dims: ParameterDef[IntAttr]
 
     def get_num_dims(self) -> int:
         return len(self.shape.data)
 
+    def get_num_scalable_dims(self) -> int:
+        return self.num_scalable_dims.data
+
     def get_shape(self) -> List[int]:
         return [i.value.data for i in self.shape.data]
+
+    def verify(self):
+        if self.get_num_scalable_dims() < 0:
+            raise VerifyException(
+                f"Number of scalable dimensions {self.get_num_dims()} cannot"
+                " be negative")
+        if self.get_num_scalable_dims() > self.get_num_dims():
+            raise VerifyException(
+                f"Number of scalable dimensions {self.get_num_scalable_dims()}"
+                " cannot be larger than number of dimensions"
+                f" {self.get_num_dims()}")
 
     @staticmethod
     def from_element_type_and_shape(
         referenced_type: AttributeInvT,
-        shape: Sequence[int | IntegerAttr[IndexType]]
+        shape: Sequence[int | IntegerAttr[IndexType]],
+        num_scalable_dims: int | IntAttr = 0,
     ) -> VectorType[AttributeInvT]:
-
+        if isinstance(num_scalable_dims, int):
+            num_scalable_dims = IntAttr(num_scalable_dims)
         return VectorType([
             ArrayAttr([
                 IntegerAttr[IntegerType].from_index_int_value(d) if isinstance(
                     d, int) else d for d in shape
-            ]), referenced_type
+            ]),
+            referenced_type,
+            num_scalable_dims,
         ])
 
     @staticmethod
     def from_params(
         referenced_type: AttributeInvT,
         shape: ArrayAttr[IntegerAttr[IntegerType]] = ArrayAttr(
-            [IntegerAttr.from_int_and_width(1, 64)])
+            [IntegerAttr.from_int_and_width(1, 64)]),
+        num_scalable_dims: IntAttr = IntAttr(0),
     ) -> VectorType[AttributeInvT]:
-        return VectorType([shape, referenced_type])
+        return VectorType([shape, referenced_type, num_scalable_dims])
 
 
 AnyVectorType: TypeAlias = VectorType[Attribute]

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1127,21 +1127,27 @@ class BaseParser(ABC):
 
         return res
 
-    def _parse_shape_dimension(self) -> int:
+    def _parse_shape_dimension(self, allow_dynamic: bool = True) -> int:
         """
         Parse a single shape dimension, which is a decimal literal or `?`.
         `?` is interpreted as -1. Note that if the integer literal is in
         hexadecimal form, it will be split into multiple tokens. For example,
         `0x10` will be split into `0` and `x10`.
+        Optionally allows to not parse `?` as -1.
         """
         if self._current_token.kind not in (Token.Kind.INTEGER_LIT,
                                             Token.Kind.QUESTION):
-            self.raise_error(
-                "Expected either integer literal or '?' in shape dimension, "
-                f"got {self._current_token.kind.name}!")
+            if allow_dynamic:
+                self.raise_error(
+                    "Expected either integer literal or '?' in shape dimension, "
+                    f"got {self._current_token.kind.name}!")
+            self.raise_error("Expected integer literal in shape dimension, "
+                             f"got {self._current_token.kind.name}!")
 
         if self.parse_optional_punctuation('?') is not None:
-            return -1
+            if allow_dynamic:
+                return -1
+            self.raise_error("Unexpected dynamic dimension!")
 
         # If the integer literal starts with `0x`, this is decomposed into
         # `0` and `x`.
@@ -1279,28 +1285,38 @@ class BaseParser(ABC):
                                   "Unexpected end of dimension parameters!")
 
     def parse_vector_attrs(self) -> AnyVectorType:
-        shape = list[int](self.try_parse_numerical_dims())
-        scaling_shape: list[int] | None = None
+        self._synchronize_lexer_and_tokenizer()
 
-        if self.tokenizer.next_token_of_pattern("[") is not None:
-            # We now need to parse the scalable dimensions
-            scaling_shape = list(self.try_parse_numerical_dims())
-            self.parse_characters(
-                "]", "Expected end of scalable vector dimensions here!")
-            self.parse_characters(
-                "x", "Expected end of scalable vector dimensions here!")
+        dims: list[int] = []
+        num_scalable_dims = 0
+        # First, we parse the static dimensions
+        while self._current_token.kind == Token.Kind.INTEGER_LIT:
+            dims.append(self._parse_shape_dimension(allow_dynamic=False))
+            self._parse_shape_delimiter()
 
-        if scaling_shape is not None:
-            # TODO: handle scaling vectors!
-            self.raise_error("Warning: scaling vectors not supported!")
-            pass
+        # Then, we parse the scalable dimensions, if any
+        if self.parse_optional_punctuation('[') is not None:
 
+            # Parse the scalable dimensions
+            dims.append(self._parse_shape_dimension(allow_dynamic=False))
+            num_scalable_dims += 1
+
+            while self.parse_optional_punctuation(']') is None:
+                self._parse_shape_delimiter()
+                dims.append(self._parse_shape_dimension(allow_dynamic=False))
+                num_scalable_dims += 1
+
+            # Parse the `x` between the scalable dimensions and the type
+            self._parse_shape_delimiter()
+
+        self._synchronize_lexer_and_tokenizer()
         type = self.try_parse_type()
         if type is None:
-            self.raise_error(
-                "Expected a type at the end of the vector parameters!")
+            self.raise_error("Expected the vector element types!")
 
-        return VectorType.from_element_type_and_shape(type, shape)
+        self._synchronize_lexer_and_tokenizer()
+        return VectorType.from_element_type_and_shape(type, dims,
+                                                      num_scalable_dims)
 
     def parse_tensor_attrs(self) -> AnyTensorType | AnyUnrankedTensorType:
         shape, type = self._parse_shape()

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1289,12 +1289,12 @@ class BaseParser(ABC):
 
         dims: list[int] = []
         num_scalable_dims = 0
-        # First, we parse the static dimensions
+        # First, parse the static dimensions
         while self._current_token.kind == Token.Kind.INTEGER_LIT:
             dims.append(self._parse_shape_dimension(allow_dynamic=False))
             self._parse_shape_delimiter()
 
-        # Then, we parse the scalable dimensions, if any
+        # Then, parse the scalable dimensions, if any
         if self.parse_optional_punctuation('[') is not None:
 
             # Parse the scalable dimensions

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -495,7 +495,7 @@ class Printer:
             attribute = cast(AnyVectorType, attribute)
             shape = attribute.get_shape()
 
-            # We separate the dimensions between the static and the scalable ones
+            # Separate the dimensions between the static and the scalable ones
             if attribute.get_num_scalable_dims() == 0:
                 static_dimensions = shape
                 scalable_dimensions = []


### PR DESCRIPTION
This is a feature that was missing in our current vector implementation.
I added support for it in the parser/printer and in the type.

