### PR TITLE
core: Fix function type parsing

### DIFF
--- a/tests/filecheck/mlir-conversion/builtin_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/builtin_attrs.mlir
@@ -267,4 +267,24 @@
                       sym_name = "complex"} : () -> ()
   // CHECK: "complex" = complex<f32>
 
+  "func.func"() ({}) {function_type = () -> (),
+                      function = () -> i32,
+                      sym_name = "complex"} : () -> ()
+  // CHECK: "function" = () -> i32
+
+  "func.func"() ({}) {function_type = () -> (),
+                      function = (i1) -> (i32),
+                      sym_name = "complex"} : () -> ()
+  // CHECK: "function" = (i1) -> i32
+
+  "func.func"() ({}) {function_type = () -> (),
+                      function = (i1, i2) -> (i32, i64),
+                      sym_name = "complex"} : () -> ()
+  // CHECK: "function" = (i1, i2) -> (i32, i64)
+
+  "func.func"() ({}) {function_type = () -> (),
+                      function = () -> (() -> i32),
+                      sym_name = "complex"} : () -> ()
+  // CHECK: "function" = () -> (() -> i32)
+
 }) : () -> ()

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2367,6 +2367,12 @@ class MLIRParser(BaseParser):
         parse a builtin-type like i32, index, vector<i32> etc.
         """
         with self.backtracking("builtin type"):
+            # Check the function type separately, it is the only
+            # case of a type starting with a symbol
+            next_token = self.tokenizer.next_token(peek=True)
+            if next_token.text == '(':
+                return self.try_parse_function_type()
+
             name = self.tokenizer.next_token_of_pattern(
                 ParserCommons.builtin_type)
             if name is None:


### PR DESCRIPTION
Previously, function types were only parsed when an attribute was expected, but not when a type was expected.