### PR TITLE
core: allow block.insert_op to take negative positions

### DIFF
--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -326,6 +326,26 @@ def test_insert_op_at_pos():
                              apply_recursively=False))
 
 
+def test_insert_op_at_pos_negative():
+    """
+    Test rewrites where operations are inserted with a negative position.
+    """
+
+    prog = ModuleOp.from_region_or_ops([Constant.from_int_and_width(5, 32)])
+
+    to_be_inserted = Constant.from_int_and_width(42, 32)
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
+        rewriter.insert_op_at_pos(to_be_inserted, mod.regions[0].blocks[0], -1)
+
+    PatternRewriteWalker(AnonymousRewritePattern(match_and_rewrite),
+                         apply_recursively=False).rewrite_module(prog)
+
+    assert to_be_inserted in prog.ops
+    assert prog.ops.index(to_be_inserted) == 1
+
+
 def test_insert_op_before():
     """Test rewrites where operations are inserted before a given operation."""
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1000,7 +1000,12 @@ class Block(IRNode):
         Insert one or multiple operations at a given index in the block.
         The operations should not be attached to another block.
         """
-        if index < 0 or index > len(self.ops):
+        # allow negative indices to specify a position from the back of the array
+        # -1 inserts in the last position
+        if index < 0:
+            index = len(self.ops) + index + 1
+
+        if index > len(self.ops):
             raise ValueError(
                 f"Can't insert operation in index {index} in a block with "
                 f"{len(self.ops)} operations.")


### PR DESCRIPTION
This patch will allow `insert_at` to accept negative positions, which are then calculated as offsets from the back of the ops list.

Note that the test for this doesn't print/parse a whole module, reducing test time by an order of magnitude.

part of #557 