### PR TITLE
core: Allow replace_operand to take SSAValue or index

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -286,3 +286,15 @@ ModuleOp(
 \t  %0 : !i32 = arith.constant() ["value" = 1 : !i32]
 \t}
 )'''
+
+
+def test_replace_operand():
+    cst0 = Constant.from_int_and_width(0, 32).result
+    cst1 = Constant.from_int_and_width(1, 32).result
+    add = Addi.get(cst0, cst1)
+
+    new_cst = Constant.from_int_and_width(2, 32).result
+    add.replace_operand(cst0, new_cst)
+
+    assert new_cst in add.operands
+    assert cst0 not in add.operands

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -298,3 +298,6 @@ def test_replace_operand():
 
     assert new_cst in add.operands
     assert cst0 not in add.operands
+
+    with pytest.raises(ValueError):
+        add.replace_operand(cst0, new_cst)

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -645,7 +645,12 @@ class Operation(IRNode):
                         new_operand: SSAValue) -> None:
         """Replace an operand with another operand."""
         if isinstance(operand, SSAValue):
-            operand_idx = self._operands.index(operand)
+            try:
+                operand_idx = self._operands.index(operand)
+            except ValueError as err:
+                raise ValueError("{} is not an operand of {}!".format(
+                    operand, self
+                )) from err
         else:
             operand_idx = operand
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -641,8 +641,14 @@ class Operation(IRNode):
         """Create a new operation using builders."""
         ...
 
-    def replace_operand(self, operand_idx: int, new_operand: SSAValue) -> None:
+    def replace_operand(self, operand: int | SSAValue,
+                        new_operand: SSAValue) -> None:
         """Replace an operand with another operand."""
+        if isinstance(operand, SSAValue):
+            operand_idx = self._operands.index(operand)
+        else:
+            operand_idx = operand
+
         self.operands = list(self._operands[:operand_idx]) + [
             new_operand
         ] + list(self._operands[operand_idx + 1:])


### PR DESCRIPTION
This patch allows one to call `add.replace_operand(old_operand, new_operand)` instead of `add.replace_operand(add.operands.index(old_operand), new_operand)`.

An `IndexError` will be raised when `old_operand` is not an operand of the operation.

Part of #557 