### PR TITLE
dialects: Add helpers to FuncOp to make rewriting easier

### DIFF
--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -111,6 +111,12 @@ def test_func_rewriting_helpers():
     with pytest.raises(IndexError):
         func.replace_argument_type(-4, i64)
 
+    decl = FuncOp.external('external_func', [], [])
+    assert decl.is_declaration
+
+    with pytest.raises(AssertionError):
+        decl.args
+
 
 def test_func_get_return_op():
     # pyright complains about lambda arg types unknown

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -117,10 +117,10 @@ def test_func_get_return_op():
     # honestly don't know how to fix
     func_w_ret = FuncOp.from_callable(
         'test', [i32, i32, i32], [i32],
-        lambda x, y, z: [Return.get(y)])  # type: ignore
+        lambda *args: [Return.get(args[1])])  # type: ignore
 
     func = FuncOp.from_callable('test', [i32, i32, i32], [],
-                                lambda x, y, z: [])  # type: ignore
+                                lambda *args: [])  # type: ignore
 
     assert func_w_ret.get_return_op() is not None
     assert func.get_return_op() is None

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -121,12 +121,10 @@ def test_func_rewriting_helpers():
 def test_func_get_return_op():
     # pyright complains about lambda arg types unknown
     # honestly don't know how to fix
-    func_w_ret = FuncOp.from_callable(
-        'test', [i32, i32, i32], [i32],
-        lambda *args: [Return.get(args[1])])
+    func_w_ret = FuncOp.from_callable('test', [i32, i32, i32], [i32],
+                                      lambda *args: [Return.get(args[1])])
 
-    func = FuncOp.from_callable('test', [i32, i32, i32], [],
-                                lambda *args: [])
+    func = FuncOp.from_callable('test', [i32, i32, i32], [], lambda *args: [])
 
     assert func_w_ret.get_return_op() is not None
     assert func.get_return_op() is None

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -89,7 +89,7 @@ def test_func_rewriting_helpers():
     :return:
     """
     func = FuncOp.from_callable('test', [i32, i32, i32], [],
-                                lambda x, y, z: [Return.get()])  # type: ignore
+                                lambda *args: [Return.get()])
 
     func.replace_argument_type(2, i64)
     assert func.function_type.inputs.data[2] is i64
@@ -117,10 +117,10 @@ def test_func_get_return_op():
     # honestly don't know how to fix
     func_w_ret = FuncOp.from_callable(
         'test', [i32, i32, i32], [i32],
-        lambda *args: [Return.get(args[1])])  # type: ignore
+        lambda *args: [Return.get(args[1])])
 
     func = FuncOp.from_callable('test', [i32, i32, i32], [],
-                                lambda *args: [])  # type: ignore
+                                lambda *args: [])
 
     assert func_w_ret.get_return_op() is not None
     assert func.get_return_op() is None

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -3,7 +3,7 @@ import pytest
 from conftest import assert_print_op
 from xdsl.dialects.func import FuncOp, Return, Call
 from xdsl.dialects.arith import Addi, Constant
-from xdsl.dialects.builtin import IntegerAttr, i32, ModuleOp, i64
+from xdsl.dialects.builtin import IntegerAttr, i32, ModuleOp, i64, IntegerType
 from xdsl.ir import Block, Region
 from xdsl.utils.exceptions import VerifyException
 
@@ -99,8 +99,17 @@ def test_func_rewriting_helpers():
     assert func.function_type.inputs.data[0] is i64
     assert func.args[0].typ is i64
 
+    # check negaitve index
+    i8 = IntegerType(8)
+    func.replace_argument_type(-2, i8)
+    assert func.function_type.inputs.data[1] is i8
+    assert func.args[1].typ is i8
+
     with pytest.raises(IndexError):
         func.replace_argument_type(3, i64)
+
+    with pytest.raises(IndexError):
+        func.replace_argument_type(-4, i64)
 
 
 def test_func_get_return_op():

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -83,6 +83,26 @@ def test_wrong_blockarg_types():
         "types as the function input types")
 
 
+def test_func_rewriting_helpers():
+    """
+    test replace_argument_type and update_function_type (implicitly)
+    :return:
+    """
+    func = FuncOp.from_callable('test', [i32, i32, i32], [],
+                                lambda x, y, z: [Return.get()])
+
+    func.replace_argument_type(2, i64)
+    assert func.function_type.inputs.data[2] is i64
+    assert func.body.blocks[0].args[2].typ is i64
+
+    func.replace_argument_type(func.body.blocks[0].args[0], i64)
+    assert func.function_type.inputs.data[0] is i64
+    assert func.body.blocks[0].args[0].typ is i64
+
+    with pytest.raises(IndexError):
+        func.replace_argument_type(3, i64)
+
+
 def test_callable_constructor():
     f = FuncOp.from_callable("f", [], [], lambda *args: [])
     assert f.sym_name.data == "f"

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -89,18 +89,32 @@ def test_func_rewriting_helpers():
     :return:
     """
     func = FuncOp.from_callable('test', [i32, i32, i32], [],
-                                lambda x, y, z: [Return.get()])
+                                lambda x, y, z: [Return.get()])  # type: ignore
 
     func.replace_argument_type(2, i64)
     assert func.function_type.inputs.data[2] is i64
-    assert func.body.blocks[0].args[2].typ is i64
+    assert func.args[2].typ is i64
 
-    func.replace_argument_type(func.body.blocks[0].args[0], i64)
+    func.replace_argument_type(func.args[0], i64)
     assert func.function_type.inputs.data[0] is i64
-    assert func.body.blocks[0].args[0].typ is i64
+    assert func.args[0].typ is i64
 
     with pytest.raises(IndexError):
         func.replace_argument_type(3, i64)
+
+
+def test_func_get_return_op():
+    # pyright complains about lambda arg types unknown
+    # honestly don't know how to fix
+    func_w_ret = FuncOp.from_callable(
+        'test', [i32, i32, i32], [i32],
+        lambda x, y, z: [Return.get(y)])  # type: ignore
+
+    func = FuncOp.from_callable('test', [i32, i32, i32], [],
+                                lambda x, y, z: [])  # type: ignore
+
+    assert func_w_ret.get_return_op() is not None
+    assert func.get_return_op() is None
 
 
 def test_callable_constructor():

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -85,7 +85,7 @@ class FuncOp(Operation):
 
         if arg not in self.args:
             raise ValueError(
-                "Arg {} does not belong to this function!".format(arg))
+                "Arg {} does not belong to this function".format(arg))
 
         arg.typ = new_type
         self.update_function_type()

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -86,7 +86,8 @@ class FuncOp(Operation):
             arg = self.body.blocks[0].args[arg]
 
         if arg not in self.args:
-            raise ValueError("Arg {} does not belong to this function!".format(arg))
+            raise ValueError(
+                "Arg {} does not belong to this function!".format(arg))
 
         arg.typ = new_type
         self.update_function_type()

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -76,14 +76,12 @@ class FuncOp(Operation):
         or the BlockArgument object itself) with new_type. This also takes care of updating
         the function_type attribute.
         """
-
         if isinstance(arg, int):
-            if arg < 0:
-                arg = len(self.args) + arg
-            if not (0 <= arg < len(self.body.blocks[0].args)):
-                raise IndexError("Block {} does not have argument #{}!".format(
+            try:
+                arg = self.body.blocks[0].args[arg]
+            except IndexError:
+                raise IndexError("Block {} does not have argument #{}".format(
                     self.body.blocks[0], arg))
-            arg = self.body.blocks[0].args[arg]
 
         if arg not in self.args:
             raise ValueError(

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -76,7 +76,9 @@ class FuncOp(Operation):
         """
 
         if isinstance(arg, int):
-            if len(self.body.blocks[0].args) <= arg:
+            if arg < 0:
+                arg = len(self.args) + arg
+            if not (0 <= arg < len(self.body.blocks[0].args)):
                 raise IndexError("Block {} does not have argument #{}!".format(
                     self.body.blocks[0], arg))
             arg = self.body.blocks[0].args[arg]

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -89,7 +89,7 @@ class FuncOp(Operation):
         Update the function_type attribute to reflect changes in the
         block argument types.
         """
-        return_op = self.body.blocks[-1].ops[-1]
+        return_op = self.get_return_op()
         return_type: tuple[Attribute] = tuple()
 
         if return_op is not None:

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -96,7 +96,7 @@ class FuncOp(Operation):
             return_type = tuple(arg.typ for arg in return_op.operands)
 
         self.attributes['function_type'] = FunctionType.from_lists(
-            [arg.typ for arg in self.body.blocks[0].args],
+            [arg.typ for arg in self.args],
             return_type,
         )
 
@@ -109,6 +109,10 @@ class FuncOp(Operation):
         if not isinstance(self.body.blocks[-1].ops[-1], Return):
             return
         return self.body.blocks[-1].ops[-1]
+
+    @property
+    def args(self) -> tuple[BlockArgument, ...]:
+        return self.body.blocks[0].args
 
 
 @irdl_op_definition

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -91,8 +91,12 @@ class FuncOp(Operation):
         Update the function_type attribute to reflect changes in the
         block argument types.
         """
+        if len(self.function_type.inputs) != len(self.args):
+            raise NotImplementedError(
+                "UpdateFunctionType currently not implemented for external function definitions"
+            )
         return_op = self.get_return_op()
-        return_type: tuple[Attribute] = tuple()
+        return_type: tuple[Attribute] = self.function_type.outputs.data
 
         if return_op is not None:
             return_type = tuple(arg.typ for arg in return_op.operands)

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -91,6 +91,7 @@ class FuncOp(Operation):
         Update the function_type attribute to reflect changes in the
         block argument types.
         """
+        # Refuse to work with external function definitions, as they don't have block args
         if len(self.function_type.inputs) != len(self.args):
             raise NotImplementedError(
                 "UpdateFunctionType currently not implemented for external function definitions"


### PR DESCRIPTION
Inspired by #557 

This adds:

 - `get_return_op()` to get the Return statement
 - `args` property to return the block arguments as a tuple
 - `update_function_type` to update the `function_type` attribute according to block argument types and return op argument types
 - `replace_argument_type(idx | arg, new_type)` to change the type of an argument and immediately update the function type attribute

Not sure if this is too big in one, let's see. Am happy to split this if needed!