### PR TITLE
minor: Remove classmethod from op constructors

### DIFF
--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -786,9 +786,9 @@ class IndexCastOp(Operation):
 
     result: OpResult
 
-    @classmethod
-    def get(cls, input: SSAValue | Operation, target_type: Attribute):
-        return cls.build(operands=[input], result_types=[target_type])
+    @staticmethod
+    def get(input_arg: SSAValue | Operation, target_type: Attribute):
+        return IndexCastOp.build(operands=[input_arg], result_types=[target_type])
 
 
 @irdl_op_definition

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -85,9 +85,8 @@ class _GPUAttr(ParametrizedAttribute, Generic[T]):
         )
         return [attrtype([StringAttr(vtok.text)])]
 
-    @classmethod
-    def from_op(cls: Type[_GPUAttr[_AllReduceOperationAttr]],
-                value: str) -> AllReduceOperationAttr:
+    @staticmethod
+    def from_op(value: str) -> AllReduceOperationAttr:
         return AllReduceOperationAttr(
             [_AllReduceOperationAttr([StringAttr(value)])])
 
@@ -95,9 +94,8 @@ class _GPUAttr(ParametrizedAttribute, Generic[T]):
     def data(self) -> str:
         return self.value.param.data
 
-    @classmethod
-    def from_dimension(cls: Type[_GPUAttr[_DimensionAttr]],
-                       value: str) -> DimensionAttr:
+    @staticmethod
+    def from_dimension(value: str) -> DimensionAttr:
         return DimensionAttr([_DimensionAttr([StringAttr(value)])])
 
     def print_parameters(self, printer: Printer) -> None:

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Annotated, Generic, Sequence, Type, TypeVar
+from typing import Annotated, Generic, Sequence, TypeVar
 
 from xdsl.ir import (Attribute, TypeAttribute, OpResult, Operation, Dialect,
                      ParametrizedAttribute, Region, SSAValue)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -329,13 +329,13 @@ class NullOp(Operation):
 
     nullptr: Annotated[OpResult, LLVMPointerType]
 
-    @classmethod
-    def get(cls, ptr_type: LLVMPointerType | None = None):
+    @staticmethod
+    def get(ptr_type: LLVMPointerType | None = None):
         if ptr_type is None:
             ptr_type = LLVMPointerType.opaque()
         assert isinstance(ptr_type, LLVMPointerType)
 
-        return cls.build(result_types=[ptr_type])
+        return NullOp.build(result_types=[ptr_type])
 
 
 @irdl_op_definition

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -330,10 +330,10 @@ class Dim(Operation):
 
     result: Annotated[OpResult, IndexType]
 
-    @classmethod
-    def from_source_and_index(cls, source: SSAValue | Operation,
+    @staticmethod
+    def from_source_and_index(source: SSAValue | Operation,
                               index: SSAValue | Operation):
-        return cls.build(operands=[source, index], result_types=[IndexType()])
+        return Dim.build(operands=[source, index], result_types=[IndexType()])
 
 
 @irdl_op_definition
@@ -344,9 +344,9 @@ class Rank(Operation):
 
     rank: Annotated[OpResult, IndexType]
 
-    @classmethod
-    def from_memref(cls, memref: Operation | SSAValue):
-        return cls.build(operands=[memref], result_types=[IndexType()])
+    @staticmethod
+    def from_memref(memref: Operation | SSAValue):
+        return Rank.build(operands=[memref], result_types=[IndexType()])
 
 
 @irdl_op_definition


### PR DESCRIPTION
As I had promised @webmiche. Sorry again for the trouble.

That should be all of them.

closes #519 