### PR TITLE
core: add IRDLOperation with init that uses same logic as build

### DIFF
--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -37,6 +37,12 @@ class ConstantOp(Operation):
     value: OpAttr[DenseIntOrFPElementsAttr]
     res: Annotated[OpResult, TensorTypeF64]
 
+    def __init__(self, value: DenseIntOrFPElementsAttr):
+        model = ConstantOp.build_model(result_types=[value.type],
+                                       attributes={"value": value})
+        super().__init__()
+        self._update_with_model(model)
+
     @staticmethod
     def from_list(data: list[float], shape: list[int]) -> ConstantOp:
         value = DenseIntOrFPElementsAttr.tensor_from_list(data, f64, shape)
@@ -44,8 +50,7 @@ class ConstantOp(Operation):
 
     @staticmethod
     def from_value(value: DenseIntOrFPElementsAttr) -> ConstantOp:
-        return ConstantOp.create(result_types=[value.type],
-                                 attributes={"value": value})
+        return ConstantOp(value)
 
     def verify_(self) -> None:
         if not self.res.typ == self.value.type:

--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -38,9 +38,9 @@ class ConstantOp(Operation):
     res: Annotated[OpResult, TensorTypeF64]
 
     def __init__(self, value: DenseIntOrFPElementsAttr):
-        super().__init__(
+        super().__init__(**vars(
             ConstantOp.build_model(result_types=[value.type],
-                                   attributes={"value": value}))
+                                   attributes={"value": value})))
 
     @staticmethod
     def from_list(data: list[float], shape: list[int]) -> ConstantOp:
@@ -84,8 +84,8 @@ class AddOp(Operation):
             result_typ = lhs.typ
         else:
             result_typ = rhs.typ
-        super().__init__(
-            AddOp.build_model(result_types=[result_typ], operands=[lhs, rhs]))
+        super().__init__(**vars(
+            AddOp.build_model(result_types=[result_typ], operands=[lhs, rhs])))
 
     @staticmethod
     def from_summands(lhs: SSAValue, rhs: SSAValue) -> AddOp:
@@ -142,8 +142,8 @@ class FuncOp(Operation):
         if private:
             attributes["sym_visibility"] = StringAttr("private")
 
-        return super().__init__(
-            FuncOp.build_model(attributes=attributes, regions=[region]))
+        return super().__init__(**vars(
+            FuncOp.build_model(attributes=attributes, regions=[region])))
 
     @staticmethod
     def from_region(name: str,
@@ -217,10 +217,10 @@ class GenericCallOp(Operation):
         if isinstance(callee, str):
             callee = SymbolRefAttr(callee)
 
-        return super().__init__(
+        return super().__init__(**vars(
             GenericCallOp.build_model(operands=[operands],
                                       result_types=[return_types],
-                                      attributes={"callee": callee}))
+                                      attributes={"callee": callee})))
 
     @staticmethod
     def get(callee: str | SymbolRefAttr, operands: list[SSAValue | OpResult],
@@ -244,8 +244,8 @@ class MulOp(Operation):
             result_typ = lhs.typ
         else:
             result_typ = rhs.typ
-        super().__init__(
-            MulOp.build_model(result_types=[result_typ], operands=[lhs, rhs]))
+        super().__init__(**vars(
+            MulOp.build_model(result_types=[result_typ], operands=[lhs, rhs])))
 
     @staticmethod
     def from_summands(lhs: SSAValue, rhs: SSAValue) -> MulOp:
@@ -280,7 +280,7 @@ class PrintOp(Operation):
         return PrintOp(input)
 
     def __init__(self, input: SSAValue):
-        return super().__init__(PrintOp.build_model(operands=[input]))
+        return super().__init__(**vars(PrintOp.build_model(operands=[input])))
 
 
 @irdl_op_definition
@@ -306,7 +306,7 @@ class ReturnOp(Operation):
         return ReturnOp.build(operands=[input])
 
     def __init__(self, input: SSAValue | None = None):
-        return super().__init__(ReturnOp.build_model(operands=[input]))
+        return super().__init__(**vars(ReturnOp.build_model(operands=[input])))
 
 
 @irdl_op_definition
@@ -336,7 +336,7 @@ class ReshapeOp(Operation):
         element_type = arg.typ.element_type
         t = TensorTypeF64.from_type_and_list(element_type, shape)
         return super().__init__(
-            ReshapeOp.build_model(result_types=[t], operands=[arg]))
+            **vars(ReshapeOp.build_model(result_types=[t], operands=[arg])))
 
     @staticmethod
     def from_input_and_type(arg: SSAValue, t: TensorTypeF64) -> ReshapeOp:
@@ -377,9 +377,9 @@ class TransposeOp(Operation):
                 )
             output_type = input.typ
 
-        super().__init__(
+        super().__init__(**vars(
             TransposeOp.build_model(operands=[input],
-                                    result_types=[output_type]))
+                                    result_types=[output_type])))
 
 
 Toy = Dialect([

--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -44,10 +44,6 @@ class ConstantOp(IRDLOperation):
     @staticmethod
     def from_list(data: list[float], shape: list[int]) -> ConstantOp:
         value = DenseIntOrFPElementsAttr.tensor_from_list(data, f64, shape)
-        return ConstantOp.from_value(value)
-
-    @staticmethod
-    def from_value(value: DenseIntOrFPElementsAttr) -> ConstantOp:
         return ConstantOp(value)
 
     def verify_(self) -> None:
@@ -84,10 +80,6 @@ class AddOp(IRDLOperation):
         else:
             result_typ = rhs.typ
         super().__init__(result_types=[result_typ], operands=[lhs, rhs])
-
-    @staticmethod
-    def from_summands(lhs: SSAValue, rhs: SSAValue) -> AddOp:
-        return AddOp(lhs, rhs)
 
     def verify_(self):
         args = [self.lhs, self.rhs]
@@ -143,14 +135,6 @@ class FuncOp(IRDLOperation):
         return super().__init__(attributes=attributes, regions=[region])
 
     @staticmethod
-    def from_region(name: str,
-                    ftype: FunctionType,
-                    region: Region,
-                    /,
-                    private: bool = False):
-        return FuncOp(name, ftype, region, private=private)
-
-    @staticmethod
     def from_callable(name: str,
                       input_types: list[Attribute],
                       return_types: list[Attribute],
@@ -158,11 +142,10 @@ class FuncOp(IRDLOperation):
                       /,
                       private: bool = False):
         ftype = FunctionType.from_lists(input_types, return_types)
-        return FuncOp.from_region(
-            name,
-            ftype,
-            Region([Block.from_callable(input_types, func)]),
-            private=private)
+        return FuncOp(name,
+                      ftype,
+                      Region([Block.from_callable(input_types, func)]),
+                      private=private)
 
     def verify_(self):
         # Check that the returned value matches the type of the function
@@ -218,11 +201,6 @@ class GenericCallOp(IRDLOperation):
                                 result_types=[return_types],
                                 attributes={"callee": callee})
 
-    @staticmethod
-    def get(callee: str | SymbolRefAttr, operands: list[SSAValue | OpResult],
-            return_types: list[Attribute]) -> GenericCallOp:
-        return GenericCallOp(callee, operands, return_types)
-
 
 @irdl_op_definition
 class MulOp(IRDLOperation):
@@ -241,10 +219,6 @@ class MulOp(IRDLOperation):
         else:
             result_typ = rhs.typ
         super().__init__(result_types=[result_typ], operands=[lhs, rhs])
-
-    @staticmethod
-    def from_summands(lhs: SSAValue, rhs: SSAValue) -> MulOp:
-        return MulOp(lhs, rhs)
 
     def verify_(self):
         args = [self.lhs, self.rhs]
@@ -270,10 +244,6 @@ class PrintOp(IRDLOperation):
     name: str = 'toy.print'
     input: Annotated[Operand, AnyAttr()]
 
-    @staticmethod
-    def from_input(input: SSAValue) -> PrintOp:
-        return PrintOp(input)
-
     def __init__(self, input: SSAValue):
         return super().__init__(operands=[input])
 
@@ -296,10 +266,6 @@ class ReturnOp(IRDLOperation):
     name: str = 'toy.return'
     input: Annotated[OptOperand, AnyTensorTypeF64]
 
-    @staticmethod
-    def from_input(input: SSAValue | None = None) -> ReturnOp:
-        return ReturnOp.build(operands=[input])
-
     def __init__(self, input: SSAValue | None = None):
         return super().__init__(operands=[input])
 
@@ -318,10 +284,6 @@ class ReshapeOp(IRDLOperation):
     arg: Annotated[Operand, AnyTensorTypeF64]
     # We expect that the reshape operation returns a statically shaped tensor.
     res: Annotated[OpResult, TensorTypeF64]
-
-    @staticmethod
-    def from_input(arg: SSAValue, shape: list[int]) -> ReshapeOp:
-        return ReshapeOp(arg, shape)
 
     def __init__(self, arg: SSAValue, shape: list[int]):
         if not isa(arg.typ, AnyTensorTypeF64):
@@ -353,10 +315,6 @@ class TransposeOp(IRDLOperation):
     name: str = 'toy.transpose'
     arguments: Annotated[Operand, AnyTensorTypeF64]
     res: Annotated[OpResult, AnyTensorTypeF64]
-
-    @staticmethod
-    def from_input(input: SSAValue):
-        return TransposeOp(input)
 
     def __init__(self, input: SSAValue):
         output_type: TensorTypeF64 | UnrankedTensorTypeF64

--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -38,10 +38,9 @@ class ConstantOp(Operation):
     res: Annotated[OpResult, TensorTypeF64]
 
     def __init__(self, value: DenseIntOrFPElementsAttr):
-        model = ConstantOp.build_model(result_types=[value.type],
-                                       attributes={"value": value})
-        super().__init__()
-        self._update_with_model(model)
+        super().__init__(
+            ConstantOp.build_model(result_types=[value.type],
+                                   attributes={"value": value}))
 
     @staticmethod
     def from_list(data: list[float], shape: list[int]) -> ConstantOp:

--- a/docs/Toy/toy/dialect.py
+++ b/docs/Toy/toy/dialect.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 
 from typing import Annotated, TypeAlias, cast
 
-from xdsl.ir import (Dialect, SSAValue, Attribute, Block, Region, Operation,
-                     OpResult)
+from xdsl.ir import (Dialect, SSAValue, Attribute, Block, Region, OpResult)
 from xdsl.dialects.builtin import (Float64Type, FunctionType, SymbolRefAttr,
                                    TensorType, UnrankedTensorType, f64,
                                    DenseIntOrFPElementsAttr, StringAttr)

--- a/docs/Toy/toy/ir_gen.py
+++ b/docs/Toy/toy/ir_gen.py
@@ -126,8 +126,7 @@ class IRGen:
         # Arguments type are uniformly unranked tensors.
         func_type = FunctionType.from_lists(
             [self.get_type([])] * len(proto_ast.args), [self.get_type([])])
-        return self.builder.insert(
-            FuncOp.from_region(proto_ast.name, func_type, Region()))
+        return self.builder.insert(FuncOp(proto_ast.name, func_type, Region()))
 
     def ir_gen_function(self, function_ast: FunctionAST) -> FuncOp:
         'Emit a new function and add it to the MLIR module.'
@@ -165,7 +164,7 @@ class IRGen:
                     return_arg = return_op.input
                     return_types = [return_arg.typ]
         if return_op is None:
-            self.builder.insert(ReturnOp.from_input())
+            self.builder.insert(ReturnOp())
 
         input_types = [
             self.get_type([]) for _ in range(len(function_ast.proto.args))
@@ -181,10 +180,10 @@ class IRGen:
         self.builder = parent_builder
 
         func = self.builder.insert(
-            FuncOp.from_region(function_ast.proto.name,
-                               func_type,
-                               Region([block]),
-                               private=private))
+            FuncOp(function_ast.proto.name,
+                   func_type,
+                   Region([block]),
+                   private=private))
 
         return func
 
@@ -210,9 +209,9 @@ class IRGen:
         # Derive the operation name from the binary operator. At the moment we only
         # support '+' and '*'.
         if binop.op == '+':
-            op = self.builder.insert(AddOp.from_summands(lhs, rhs))
+            op = self.builder.insert(AddOp(lhs, rhs))
         elif binop.op == '*':
-            op = self.builder.insert(MulOp.from_summands(lhs, rhs))
+            op = self.builder.insert(MulOp(lhs, rhs))
         else:
             self.error(f'Unsupported binary operation `{binop.op}`')
 
@@ -241,7 +240,7 @@ class IRGen:
         else:
             expr = None
 
-        self.builder.insert(ReturnOp.from_input(expr))
+        self.builder.insert(ReturnOp(expr))
 
     def ir_gen_literal_expr(self, lit: LiteralExprAST) -> SSAValue:
         """
@@ -309,15 +308,15 @@ class IRGen:
             if len(operands) != 1:
                 self.error("MLIR codegen encountered an error: toy.transpose "
                            "does not accept multiple arguments")
-            op = self.builder.insert(TransposeOp.from_input(operands[0]))
+            op = self.builder.insert(TransposeOp(operands[0]))
             return op.res
 
         # Otherwise this is a call to a user-defined function. Calls to
         # user-defined functions are mapped to a custom call that takes the callee
         # name as an attribute.
         op = self.builder.insert(
-            GenericCallOp.get(callee, operands,
-                              [UnrankedTensorTypeF64.from_type(f64)]))
+            GenericCallOp(callee, operands,
+                          [UnrankedTensorTypeF64.from_type(f64)]))
 
         return op.res[0]
 
@@ -327,7 +326,7 @@ class IRGen:
         transpose(x) and print(x).
         """
         arg = self.ir_gen_expr(call.arg)
-        self.builder.insert(PrintOp.from_input(arg))
+        self.builder.insert(PrintOp(arg))
 
     def ir_gen_number_expr(self, num: NumberExprAST) -> SSAValue:
         'Emit a constant for a single number'
@@ -368,7 +367,7 @@ class IRGen:
         # optimized out later as needed.
         if len(vardecl.varType.shape):
             reshape_op = self.builder.insert(
-                ReshapeOp.from_input(value, vardecl.varType.shape))
+                ReshapeOp(value, vardecl.varType.shape))
 
             value = reshape_op.res
 

--- a/docs/Toy/toy/tests/test_interpreter.py
+++ b/docs/Toy/toy/tests/test_interpreter.py
@@ -32,23 +32,23 @@ def build_module() -> ModuleOp:
 
     def func_body(*args: BlockArgument) -> list[Operation]:
         arg0, arg1 = args
-        f0 = td.TransposeOp.from_input(arg0)
-        f1 = td.TransposeOp.from_input(arg1)
-        f2 = td.MulOp.from_summands(f0.results[0], f1.results[0])
-        f3 = td.ReturnOp.from_input(f2.results[0])
+        f0 = td.TransposeOp(arg0)
+        f1 = td.TransposeOp(arg1)
+        f2 = td.MulOp(f0.results[0], f1.results[0])
+        f3 = td.ReturnOp(f2.results[0])
         return [f0, f1, f2, f3]
 
     def main_body(*args: BlockArgument) -> list[Operation]:
         m0 = td.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [2, 3])
         [a] = m0.results
         m1 = td.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [6])
-        m2 = td.ReshapeOp.from_input(m1.results[0], [2, 3])
+        m2 = td.ReshapeOp(m1.results[0], [2, 3])
         [b] = m2.results
-        m3 = td.GenericCallOp.get('multiply_transpose', [a, b],
-                                  [unrankedf64TensorType])
+        m3 = td.GenericCallOp('multiply_transpose', [a, b],
+                              [unrankedf64TensorType])
         [c] = m3.results
-        m4 = td.PrintOp.from_input(c)
-        m5 = td.ReturnOp.from_input()
+        m4 = td.PrintOp(c)
+        m5 = td.ReturnOp()
         return [m0, m1, m2, m3, m4, m5]
 
     multiply_transpose = td.FuncOp.from_callable(

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -53,7 +53,7 @@ def test_convert_ast():
             c = call_multiply_transpose(a, b)
             call_multiply_transpose(b, a)
             call_multiply_transpose(b, c)
-            a_t = toy.TransposeOp.from_input(a).res
+            a_t = toy.TransposeOp(a).res
             call_multiply_transpose(a_t, c)
             toy.ReturnOp()
 

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -34,14 +34,14 @@ def test_convert_ast():
         @Builder.implicit_region(multiply_transpose_type.inputs)
         def multiply_transpose(args: tuple[BlockArgument, ...]) -> None:
             a, b = args
-            a_t = toy.TransposeOp.from_input(a).res
-            b_t = toy.TransposeOp.from_input(b).res
-            prod = toy.MulOp.from_summands(a_t, b_t).res
-            toy.ReturnOp.from_input(prod)
+            a_t = toy.TransposeOp(a).res
+            b_t = toy.TransposeOp(b).res
+            prod = toy.MulOp(a_t, b_t).res
+            toy.ReturnOp(prod)
 
         def call_multiply_transpose(a: SSAValue, b: SSAValue) -> OpResult:
-            return toy.GenericCallOp.get("multiply_transpose", [a, b],
-                                         [unrankedf64TensorType]).res[0]
+            return toy.GenericCallOp("multiply_transpose", [a, b],
+                                     [unrankedf64TensorType]).res[0]
 
         main_type = FunctionType.from_lists([], [])
 
@@ -49,18 +49,18 @@ def test_convert_ast():
         def main() -> None:
             a = toy.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [2, 3]).res
             b_0 = toy.ConstantOp.from_list([1, 2, 3, 4, 5, 6], [6]).res
-            b = toy.ReshapeOp.from_input(b_0, [2, 3]).res
+            b = toy.ReshapeOp(b_0, [2, 3]).res
             c = call_multiply_transpose(a, b)
             call_multiply_transpose(b, a)
             call_multiply_transpose(b, c)
             a_t = toy.TransposeOp.from_input(a).res
             call_multiply_transpose(a_t, c)
-            toy.ReturnOp.from_input()
+            toy.ReturnOp()
 
-        toy.FuncOp.from_region("multiply_transpose",
-                               multiply_transpose_type,
-                               multiply_transpose,
-                               private=True)
-        toy.FuncOp.from_region("main", main_type, main)
+        toy.FuncOp("multiply_transpose",
+                   multiply_transpose_type,
+                   multiply_transpose,
+                   private=True)
+        toy.FuncOp("main", main_type, main)
 
     assert module_op.is_structurally_equivalent(generated_module_op)

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -180,11 +180,11 @@ def test_memref_matmul_verify():
                             out_i_j := memref.Load.get(out, [i, j]),
                             new_out_val := arith.Addf.get(out_i_j, mul),
                             memref.Store.get(new_out_val, out, [i, j]),
-                            scf.Yield()
+                            scf.Yield.get()
                         ])),
-                        scf.Yield()
+                        scf.Yield.get()
                     ])),
-                    scf.Yield()
+                    scf.Yield.get()
                 ])),
                 func.Return.get(out)
             ]

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -14,7 +14,7 @@ from xdsl.utils.deprecation import deprecated
 if TYPE_CHECKING:
     from xdsl.parser import BaseParser
     from xdsl.printer import Printer
-    from xdsl.irdl import OpDef, ParamAttrDef
+    from xdsl.irdl import OpDef, ParamAttrDef, OperationModel
     from xdsl.utils.lexer import Span
 
 OpT = TypeVar('OpT', bound='Operation')
@@ -518,16 +518,6 @@ class OpTrait():
     def verify(self, op: Operation) -> None:
         """Check that the operation satisfies the trait requirements."""
         pass
-
-
-@dataclass
-class OperationModel:
-
-    operands: tuple[SSAValue, ...] = field(default_factory=lambda: ())
-    result_types: list[Attribute] = field(default_factory=list)
-    attributes: dict[str, Attribute] = field(default_factory=dict)
-    successors: list[Block] = field(default_factory=list)
-    regions: list[Region] = field(default_factory=list)
 
 
 @dataclass(init=False)

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -596,24 +596,42 @@ class Operation(IRNode):
         assert (self.name != "")
         assert (isinstance(self.name, str))
 
-    def __init__(self, model: OperationModel):
+    def __init__(self,
+                 operands: Sequence[SSAValue] | None = None,
+                 result_types: Sequence[Attribute] | None = None,
+                 attributes: dict[str, Attribute] | None = None,
+                 successors: Sequence[Block] | None = None,
+                 regions: Sequence[Region] | None = None):
         super().__init__(parent=None)
 
         self._operands = ()
-        self.operands = tuple(model.operands)
 
-        self.results = [
-            OpResult(typ, self, idx)
-            for (idx, typ) in enumerate(model.result_types)
-        ]
+        if operands is not None:
+            self.operands = tuple(operands)
 
-        self.attributes = model.attributes
-        self.successors = model.successors
+        if result_types is None:
+            self.results = []
+        else:
+            self.results = [
+                OpResult(typ, self, idx)
+                for (idx, typ) in enumerate(result_types)
+            ]
+
+        if attributes is None:
+            self.attributes = {}
+        else:
+            self.attributes = attributes
+
+        if successors is None:
+            self.successors = []
+        else:
+            self.successors = list(successors)
 
         self.regions = []
 
-        for region in model.regions:
-            self.add_region(region)
+        if regions is not None:
+            for region in regions:
+                self.add_region(region)
 
         self.__post_init__()
 
@@ -624,34 +642,10 @@ class Operation(IRNode):
                attributes: dict[str, Attribute] | None = None,
                successors: Sequence[Block] | None = None,
                regions: Sequence[Region] | None = None) -> OpT:
-        if operands is None:
-            operands = ()
-        else:
-            operands = tuple(operands)
-
-        if result_types is None:
-            result_types = []
-        else:
-            result_types = list(result_types)
-
-        if attributes is None:
-            attributes = {}
-
-        if successors is None:
-            successors = []
-        else:
-            successors = list(successors)
-
-        if regions is None:
-            regions = []
-        else:
-            regions = list(regions)
-
-        model = OperationModel(operands, result_types, attributes, successors,
-                               regions)
 
         op = cls.__new__(cls)
-        Operation.__init__(op, model)
+        Operation.__init__(op, operands, result_types, attributes, successors,
+                           regions)
         return op
 
     @classmethod

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -11,7 +11,7 @@ from typing import (Annotated, Any, Generic, Literal, Mapping, Sequence,
 from types import UnionType, GenericAlias, FunctionType
 
 from xdsl.ir import (Attribute, Block, Data, OpResult, OpTrait, Operation,
-                     OperationModel, ParametrizedAttribute, Region, SSAValue)
+                     ParametrizedAttribute, Region, SSAValue)
 from xdsl.utils.diagnostic import Diagnostic
 from xdsl.utils.exceptions import (PyRDLAttrDefinitionError,
                                    PyRDLOpDefinitionError, VerifyException)
@@ -1063,17 +1063,42 @@ def irdl_build_regions_arg(r: _RegionArg | Sequence[_RegionArg]
         ]
 
 
+@dataclass
+class OperationModel:
+
+    operands: tuple[SSAValue, ...] = field(default_factory=lambda: ())
+    result_types: list[Attribute] = field(default_factory=list)
+    attributes: dict[str, Attribute] = field(default_factory=dict)
+    successors: list[Block] = field(default_factory=list)
+    regions: list[Region] = field(default_factory=list)
+
+
 def irdl_op_model_builder(
-    op_def: OpDef, operands: Sequence[SSAValue | Operation
-                                      | Sequence[SSAValue | Operation]
-                                      | None],
-    res_types: Sequence[Attribute | Sequence[Attribute] | None],
-    attributes: Mapping[str, Attribute | None], successors: Sequence[Block],
+    op_def: OpDef,
+    operands: Sequence[SSAValue | Operation
+                       | Sequence[SSAValue | Operation] | None]
+    | None = None,
+    res_types: Sequence[Attribute | Sequence[Attribute] | None]
+    | None = None,
+    attributes: Mapping[str, Attribute | None] | None = None,
+    successors: Sequence[Block] | None = None,
     regions: Sequence[Region | Sequence[Operation] | Sequence[Block]
                       | Sequence[Region | Sequence[Operation]
                                  | Sequence[Block]] | None]
+    | None = None
 ) -> OperationModel:
     """Builder for an irdl operation."""
+
+    if operands is None:
+        operands = []
+    if res_types is None:
+        res_types = []
+    if attributes is None:
+        attributes = {}
+    if successors is None:
+        successors = []
+    if regions is None:
+        regions = []
 
     # We need irdl to define DenseArrayBase, but here we need
     # DenseArrayBase.

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -1274,16 +1274,6 @@ def irdl_op_definition(cls: type[_OpT]) -> type[_OpT]:
         | None = None
     ) -> OperationModel:
         """Create a new operation model using builder."""
-        if operands is None:
-            operands = []
-        if result_types is None:
-            result_types = []
-        if attributes is None:
-            attributes = {}
-        if successors is None:
-            successors = []
-        if regions is None:
-            regions = []
         return irdl_op_model_builder(op_def, operands, result_types,
                                      attributes, successors, regions)
 

--- a/xdsl/irdl_op.py
+++ b/xdsl/irdl_op.py
@@ -1,0 +1,28 @@
+from typing import Sequence, Mapping
+
+from .ir import SSAValue, Attribute, Block, Region, Operation
+from .irdl import irdl_op_model_builder
+
+
+class IRDLOperation(Operation):
+
+    def __init__(
+        self,
+        operands: Sequence[SSAValue | Operation
+                           | Sequence[SSAValue | Operation] | None]
+        | None = None,
+        result_types: Sequence[Attribute | Sequence[Attribute]]
+        | None = None,
+        attributes: Mapping[str, Attribute | None] | None = None,
+        successors: Sequence[Block] | None = None,
+        regions: Sequence[Region | Sequence[Operation] | Sequence[Block]
+                          | Sequence[Region | Sequence[Operation]
+                                     | Sequence[Block]]]
+        | None = None):
+
+        op_def = type(self).irdl_definition
+        assert op_def is not None
+
+        model = irdl_op_model_builder(op_def, operands, result_types,
+                                      attributes, successors, regions)
+        super().__init__(**vars(model))


### PR DESCRIPTION
Got inspired to explore this route, was surprisingly fast to get to a working solution, so I thought I'd push a PR to discuss pros and cons vs other potential approaches. I migrated the Toy dialect, and it does look a little neater now. I'd love to one day get to automatically generated inits but this approach would not make it any harder to get there, I don't think.