### PR TITLE
core: deprecate Region.from_op_list

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -423,9 +423,9 @@
     }
    ],
    "source": [
-    "from xdsl.ir import Region\n",
+    "from xdsl.ir import Region, Block\n",
     "\n",
-    "my_region = Region.from_operation_list([const_op, add_op])\n",
+    "my_region = Region([Block([const_op, add_op])])\n",
     "printer.print_region(my_region)"
    ]
   },

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -1,6 +1,7 @@
 import pytest
 
 from conftest import assert_print_op
+from xdsl.builder import Builder
 from xdsl.dialects.func import FuncOp, Return, Call
 from xdsl.dialects.arith import Addi, Constant
 from xdsl.dialects.builtin import IntegerAttr, i32, ModuleOp, i64
@@ -19,19 +20,23 @@ def test_func():
     c = Addi.get(a, b)
 
     # Create a region to include a, b, c
-    region = Region.from_operation_list([a, b, c])
+    @Builder.region
+    def region0(builder: Builder):
+        builder.insert(a)
+        builder.insert(b)
+        builder.insert(c)
 
     # Use this region to create a func0
-    func0 = FuncOp.from_region("func0", [], [], region)
+    func0 = FuncOp.from_region("func0", [], [], region0)
 
     # Alternative generation of func0
-    func1 = FuncOp.from_region(
-        "func1", [], [],
-        Region.from_operation_list([
-            a := Constant.from_int_and_width(1, i32),
-            b := Constant.from_int_and_width(2, i32),
-            Addi.get(a, b),
-        ]))
+    @Builder.implicit_region
+    def region1():
+        a = Constant.from_int_and_width(1, i32)
+        b = Constant.from_int_and_width(2, i32)
+        Addi.get(a, b)
+
+    func1 = FuncOp.from_region("func1", [], [], region1)
 
     assert len(func0.regions[0].ops) == 3
     assert len(func1.regions[0].ops) == 3

--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -1,3 +1,4 @@
+from xdsl.builder import Builder
 from xdsl.dialects import builtin, arith, memref
 from xdsl.dialects.gpu import (
     AllocOp, AllReduceOp, AllReduceOperationAttr, AsyncTokenType, BarrierOp,
@@ -70,12 +71,10 @@ def test_all_reduce():
 
     body_block = Block(arg_types=[builtin.IndexType(), builtin.IndexType()])
 
-    ops: list[Operation] = [
-        sum := Operation.clone(arith.Addi.get(*body_block.args)),
+    @Builder.implicit_region
+    def body():
+        sum = Operation.clone(arith.Addi.get(*body_block.args))
         YieldOp.get([sum])
-    ]
-
-    body = Region.from_operation_list(ops)
 
     all_reduce_body = AllReduceOp.from_body(body, init)
 

--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -1,6 +1,6 @@
 from xdsl.dialects.builtin import AnyArrayAttr, StringAttr
 from xdsl.dialects.irdl import DialectOp, OperationOp, OperandsOp, ResultsOp, TypeOp
-from xdsl.ir import Region
+from xdsl.ir import Block, Region
 
 
 def test_dialect_accessors():
@@ -18,7 +18,7 @@ def test_dialect_accessors():
                              regions=[Region()])
     dialect = DialectOp.create(
         attributes={"name": StringAttr("test")},
-        regions=[Region.from_operation_list([type1, type2, op1, op2])])
+        regions=[Region([Block([type1, type2, op1, op2])])])
 
     assert dialect.get_op_defs() == [op1, op2]
     assert dialect.get_type_defs() == [type1, type2]
@@ -34,16 +34,15 @@ def test_operation_accessors():
     results = ResultsOp.create(attributes={"params": AnyArrayAttr([])})
 
     # Check it on an operation that has operands and results
-    op = OperationOp.create(
-        attributes={"name": StringAttr("op")},
-        regions=[Region.from_operation_list([operands, results])])
+    op = OperationOp.create(attributes={"name": StringAttr("op")},
+                            regions=[Region([Block([operands, results])])])
 
     assert op.get_operands() is operands
     assert op.get_results() is results
 
     # Check it on an operation that has no operands and results
     empty_op = OperationOp.create(attributes={"name": StringAttr("op")},
-                                  regions=[Region.from_operation_list([])])
+                                  regions=[Region([Block()])])
 
     assert empty_op.get_operands() is None
     assert empty_op.get_results() is None

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -128,8 +128,7 @@ def test_op_clone():
 def test_op_clone_with_regions():
     cond = Constant.from_int_and_width(1, 1)
     a = Constant.from_int_and_width(1, 32)
-    if_ = If.get(cond, [], Region.from_operation_list([a]),
-                 Region.from_operation_list([a.clone()]))
+    if_ = If.get(cond, [], Region([Block([a])]), Region([Block([a.clone()])]))
 
     if2 = if_.clone()
 

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -3,7 +3,7 @@ from conftest import assert_print_op
 from xdsl.dialects.arith import Arith, Constant, Addi, Muli
 from xdsl.dialects.builtin import i32, i64, Builtin, IntegerAttr, ModuleOp
 from xdsl.dialects.scf import If, Scf
-from xdsl.ir import MLContext, Region, Operation
+from xdsl.ir import Block, MLContext, Region, Operation
 from xdsl.pattern_rewriter import (PatternRewriteWalker,
                                    op_type_rewrite_pattern, RewritePattern,
                                    PatternRewriter, AnonymousRewritePattern,
@@ -871,8 +871,7 @@ def test_move_region_contents_to_new_regions():
         assert isinstance(old_if, If)
         new_region = rewriter.move_region_contents_to_new_regions(
             old_if.regions[0])
-        new_if = If.get(old_if.cond, [], new_region,
-                        Region.from_operation_list([]))
+        new_if = If.get(old_if.cond, [], new_region, Region([Block()]))
         rewriter.insert_op_after(new_if, op.ops[1])
 
     rewrite_and_compare(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1044,7 +1044,7 @@ class UnrealizedConversionCastOp(Operation):
 class UnregisteredOp(Operation, ABC):
     """
     An unregistered operation.
-    
+
     Each unregistered op is registered as a subclass of `UnregisteredOp`,
     and op with different names have distinct subclasses.
     """
@@ -1088,11 +1088,11 @@ class UnregisteredOp(Operation, ABC):
 class UnregisteredAttr(ParametrizedAttribute, ABC):
     """
     An unregistered attribute or type.
-    
+
     Each unregistered attribute is registered as a subclass of
-    `UnregisteredAttr`, and attribute with different names have 
+    `UnregisteredAttr`, and attribute with different names have
     distinct subclasses.
-    
+
     Since attributes do not have a generic format, unregistered
     attributes represent their original parameters as a string,
     which is exactly the content parsed from the textual
@@ -1121,7 +1121,7 @@ class UnregisteredAttr(ParametrizedAttribute, ABC):
     def with_name_and_type(cls, name: str,
                            is_type: bool) -> type[UnregisteredAttr]:
         """
-        Return a new unregistered attribute type given a name and a 
+        Return a new unregistered attribute type given a name and a
         boolean indicating if the attribute can be a type.
         This function should not be called directly. Use methods from
         `MLContext` to get an `UnregisteredAttr` type.
@@ -1166,7 +1166,7 @@ class ModuleOp(Operation):
     @staticmethod
     def from_region_or_ops(ops: List[Operation] | Region) -> ModuleOp:
         if isinstance(ops, list):
-            region = Region.from_operation_list(ops)
+            region = Region([Block(ops)])
         elif isinstance(ops, Region):
             region = ops
         else:

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -53,8 +53,7 @@ class FuncOp(Operation):
             "function_type": type_attr,
             "sym_visibility": StringAttr("private")
         }
-        op = FuncOp.build(attributes=attributes,
-                          regions=[Region.from_operation_list([])])
+        op = FuncOp.build(attributes=attributes, regions=[Region([Block()])])
         return op
 
     @staticmethod

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1158,19 +1158,14 @@ class Region(IRNode):
         return f"Region(num_blocks={len(self.blocks)})"
 
     @staticmethod
+    @deprecated('Please use Region([Block(ops)])')
     def from_operation_list(ops: list[Operation]) -> Region:
-        block = Block(ops)
-        region = Region()
-        region.add_block(block)
-        return region
+        return Region([Block(ops)])
 
     @deprecated('Please use Region(blocks, parent=None)')
     @staticmethod
     def from_block_list(blocks: list[Block]) -> Region:
-        region = Region()
-        for block in blocks:
-            region.add_block(block)
-        return region
+        return Region(blocks)
 
     @deprecated('Please use Region(blocks) or Region([Block(ops)])')
     @staticmethod
@@ -1179,11 +1174,11 @@ class Region(IRNode):
             return arg
         if isinstance(arg, list):
             if len(arg) == 0:
-                return Region.from_operation_list([])
+                return Region([Block()])
             if isinstance(arg[0], Block):
                 return Region(cast(list[Block], arg))
             if isinstance(arg[0], Operation):
-                return Region.from_operation_list(cast(list[Operation], arg))
+                return Region([Block(cast(list[Operation], arg))])
         raise TypeError(f"Can't build a region with argument {arg}")
 
     @property

--- a/xdsl/transforms/experimental/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/stencil_global_to_local.py
@@ -405,8 +405,8 @@ def generate_mpi_calls_for(
         yield scf.If.get(
             cond_val,
             [],
-            Region.from_operation_list(list(then())),
-            Region.from_operation_list(list(else_())),
+            Region([Block(then())]),
+            Region([Block(else_())]),
         )
 
     # wait for all calls to complete
@@ -417,15 +417,17 @@ def generate_mpi_calls_for(
         yield scf.If.get(
             cond_val,
             [],
-            Region.from_operation_list(
-                list(
-                    generate_memcpy(
-                        source,
-                        ex.source_area(),
-                        buffer.memref,
-                        reverse=True,
-                    )) + [scf.Yield.get()]),
-            Region.from_operation_list([scf.Yield.get()]),
+            Region([
+                Block(
+                    list(
+                        generate_memcpy(
+                            source,
+                            ex.source_area(),
+                            buffer.memref,
+                            reverse=True,
+                        )) + [scf.Yield.get()])
+            ]),
+            Region([Block([scf.Yield.get()])]),
         )
 
 


### PR DESCRIPTION
This is the last deprecation in favour of `Region.__init__` one thing to watch out for is that `Region.get([])` produces a region with a single empty block, and `Region([])` produces a region with no blocks. In the now closed variadic init PR, this meant that the new way to spell `Region.get([])` was `Region(Block())` I wonder if we want to make `Region()` create an empty single block region? Or maybe that would be more confusing? If so, maybe this would be the PR to add it.

I look forward to your feedback!