### PR TITLE
Add Region.block property for single-block Regions

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1161,7 +1161,7 @@ class ModuleOp(Operation):
 
     @property
     def ops(self) -> List[Operation]:
-        return self.regions[0].blocks[0].ops
+        return self.regions[0].block.ops
 
     @staticmethod
     def from_region_or_ops(ops: List[Operation] | Region) -> ModuleOp:

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -151,8 +151,7 @@ class ParallelOp(Operation):
                 "bounds, and steps for scf.parallel. Got "
                 f"{len(self.lowerBound)}, {len(self.upperBound)} and "
                 f"{len(self.step)}.")
-        body_args = self.body.block.args if len(
-            self.body.blocks) != 0 else ()
+        body_args = self.body.block.args if len(self.body.blocks) != 0 else ()
         if len(self.lowerBound) != len(body_args) or not all(
             [isinstance(a.typ, IndexType) for a in body_args]):
             raise VerifyException(

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -70,16 +70,16 @@ class For(Operation):
     body: SingleBlockRegion
 
     def verify_(self):
-        if (len(self.iter_args) + 1) != len(self.body.blocks[0].args):
+        if (len(self.iter_args) + 1) != len(self.body.block.args):
             raise VerifyException(
                 f"Wrong number of block arguments, expected {len(self.iter_args)+1}, got "
-                f"{len(self.body.blocks[0].args)}. The body must have the induction "
+                f"{len(self.body.block.args)}. The body must have the induction "
                 f"variable and loop-carried variables as arguments.")
         for idx, arg in enumerate(self.iter_args):
-            if self.body.blocks[0].args[idx + 1].typ != arg.typ:
+            if self.body.block.args[idx + 1].typ != arg.typ:
                 raise VerifyException(
                     f"Block arguments with wrong type, expected {arg.typ}, "
-                    f"got {self.body.blocks[0].args[idx].typ}. Arguments after the "
+                    f"got {self.body.block.args[idx].typ}. Arguments after the "
                     f"induction variable must match the carried variables.")
         if len(self.iter_args) > 0:
             if (len(self.body.ops) == 0
@@ -151,7 +151,7 @@ class ParallelOp(Operation):
                 "bounds, and steps for scf.parallel. Got "
                 f"{len(self.lowerBound)}, {len(self.upperBound)} and "
                 f"{len(self.step)}.")
-        body_args = self.body.blocks[0].args if len(
+        body_args = self.body.block.args if len(
             self.body.blocks) != 0 else ()
         if len(self.lowerBound) != len(body_args) or not all(
             [isinstance(a.typ, IndexType) for a in body_args]):
@@ -177,16 +177,16 @@ class While(Operation):
     # TODO verify dependencies between scf.condition, scf.yield and the regions
     def verify_(self):
         for idx, arg in enumerate(self.arguments):
-            if self.before_region.blocks[0].args[idx].typ != arg.typ:
+            if self.before_region.block.args[idx].typ != arg.typ:
                 raise Exception(
                     f"Block arguments with wrong type, expected {arg.typ}, "
-                    f"got {self.before_region.blocks[0].args[idx].typ}")
+                    f"got {self.before_region.block.args[idx].typ}")
 
         for idx, res in enumerate(self.res):
-            if self.after_region.blocks[0].args[idx].typ != res.typ:
+            if self.after_region.block.args[idx].typ != res.typ:
                 raise Exception(
                     f"Block arguments with wrong type, expected {res.typ}, "
-                    f"got {self.after_region.blocks[0].args[idx].typ}")
+                    f"got {self.after_region.block.args[idx].typ}")
 
     @staticmethod
     def get(operands: List[SSAValue | Operation],

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -59,7 +59,7 @@ class CodegGenerationVisitor(ast.NodeVisitor):
         self.file = file
 
         assert len(module.body.blocks) == 1
-        self.inserter = OpInserter(module.body.blocks[0])
+        self.inserter = OpInserter(module.body.block)
 
     def get_symbol(self, node: ast.Name) -> Attribute:
         assert self.symbol_table is not None

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1209,7 +1209,7 @@ class Region(IRNode):
             raise ValueError(
                 "'ops' property of Region class is only available "
                 "for single-block regions.")
-        return self.blocks[0].ops
+        return self.block.ops
 
     @property
     def op(self) -> Operation:
@@ -1220,7 +1220,18 @@ class Region(IRNode):
         if len(self.blocks) != 1 or len(self.blocks[0].ops) != 1:
             raise ValueError("'op' property of Region class is only available "
                              "for single-operation single-block regions.")
-        return self.blocks[0].ops[0]
+        return self.block.ops[0]
+
+    @property
+    def block(self) -> Operation:
+        """
+        Get the block of a single-block region.
+        Returns an exception if the region is not single-block.
+        """
+        if len(self.blocks) != 1:
+            raise ValueError("'block' property of Region class is only available "
+                             "for single-block regions.")
+        return self.blocks[0]
 
     def _attach_block(self, block: Block) -> None:
         """Attach a block to the region, and check that it has no parents."""

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1223,7 +1223,7 @@ class Region(IRNode):
         return self.block.ops[0]
 
     @property
-    def block(self) -> Operation:
+    def block(self) -> Block:
         """
         Get the block of a single-block region.
         Returns an exception if the region is not single-block.

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1229,8 +1229,9 @@ class Region(IRNode):
         Returns an exception if the region is not single-block.
         """
         if len(self.blocks) != 1:
-            raise ValueError("'block' property of Region class is only available "
-                             "for single-block regions.")
+            raise ValueError(
+                "'block' property of Region class is only available "
+                "for single-block regions.")
         return self.blocks[0]
 
     def _attach_block(self, block: Block) -> None:

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -176,7 +176,7 @@ def prepare_apply_body(op: ApplyOp, rewriter: PatternRewriter):
     # First replace all current arguments by their definition
     # and erase them from the block. (We are changing the op
     # to a loop, which has access to them either way)
-    entry = op.region.blocks[0]
+    entry = op.region.block
 
     for idx, arg in enumerate(entry.args):
         arg_uses = set(arg.uses)
@@ -197,7 +197,7 @@ class ApplyOpToParallel(RewritePattern):
         assert (op.lb is not None) and (op.ub is not None)
 
         body = prepare_apply_body(op, rewriter)
-        body.blocks[0].add_op(scf.Yield.get())
+        body.block.add_op(scf.Yield.get())
         dim = len(op.lb.array.data)
 
         # Then create the corresponding scf.parallel
@@ -273,7 +273,7 @@ class StencilTypeConversionFuncOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: FuncOp, rewriter: PatternRewriter, /):
         inputs: list[Attribute] = []
-        for arg in op.body.blocks[0].args:
+        for arg in op.body.block.args:
             if isa(arg.typ, FieldType[Attribute]):
                 memreftyp = GetMemRefFromField(arg.typ)
                 rewriter.modify_block_argument_type(arg, memreftyp)

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -740,8 +740,8 @@ class MpiAddExternalFuncDefs(RewritePattern):
         for name, types in funcs_to_emit.items():
             arg, res = types
             rewriter.insert_op_at_pos(func.FuncOp.external(name, arg, res),
-                                      module.body.blocks[0],
-                                      len(module.body.blocks[0].ops))
+                                      module.body.block,
+                                      len(module.body.block.ops))
 
 
 class LowerNullRequestOp(_MPIToLLVMRewriteBase):


### PR DESCRIPTION
This shortens the code needed to access the block in a single-block region and also documents the expectation that there is just a single block in the region.