### PR TITLE
core: add Block.insert_op(s?)_(before|after)

### DIFF
--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -990,16 +990,6 @@ class Block(IRNode):
         """The last operation in `self`"""
         return self.ops[-1] if len(self.ops) else None
 
-    def insert_op_after(self, new_op: Operation,
-                        existing_op: Operation) -> None:
-        index = self.get_operation_index(existing_op)
-        self.insert_op(new_op, index + 1)
-
-    def insert_op_before(self, new_op: Operation,
-                         existing_op: Operation) -> None:
-        index = self.get_operation_index(existing_op)
-        self.insert_op(new_op, index)
-
     def add_op(self, operation: Operation) -> None:
         """
         Add an operation at the end of the block.
@@ -1016,18 +1006,18 @@ class Block(IRNode):
         for op in ops:
             self.add_op(op)
 
-    def insert_ops_before(self, ops: list[Operation],
+    def insert_ops_before(self, ops: Sequence[Operation],
                           existing_op: Operation) -> None:
         index = self.get_operation_index(existing_op)
         self.insert_op(ops, index)
 
-    def insert_ops_after(self, ops: list[Operation],
+    def insert_ops_after(self, ops: Sequence[Operation],
                          existing_op: Operation) -> None:
         index = self.get_operation_index(existing_op)
-        self.insert_op(ops, index + 1)
+        self.insert_op(list(ops), index + 1)
 
     def insert_op(self,
-                  ops: Operation | list[Operation],
+                  ops: Operation | Sequence[Operation],
                   index: int,
                   name: str | None = None) -> None:
         """
@@ -1043,8 +1033,10 @@ class Block(IRNode):
             raise ValueError(
                 f"Can't insert operation in index {index} in a block with "
                 f"{len(self.ops)} operations.")
-        if not isinstance(ops, list):
+        if isinstance(ops, Operation):
             ops = [ops]
+        elif not isinstance(ops, list):
+            ops = list(ops)
         if name:
             for curr_op in ops:
                 for res in curr_op.results:

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -990,6 +990,16 @@ class Block(IRNode):
         """The last operation in `self`"""
         return self.ops[-1] if len(self.ops) else None
 
+    def insert_op_after(self, new_op: Operation,
+                        existing_op: Operation) -> None:
+        index = self.get_operation_index(existing_op)
+        self.insert_op(new_op, index + 1)
+
+    def insert_op_before(self, new_op: Operation,
+                         existing_op: Operation) -> None:
+        index = self.get_operation_index(existing_op)
+        self.insert_op(new_op, index)
+
     def add_op(self, operation: Operation) -> None:
         """
         Add an operation at the end of the block.
@@ -1005,6 +1015,16 @@ class Block(IRNode):
         """
         for op in ops:
             self.add_op(op)
+
+    def insert_ops_before(self, ops: list[Operation],
+                          existing_op: Operation) -> None:
+        index = self.get_operation_index(existing_op)
+        self.insert_op(ops, index)
+
+    def insert_ops_after(self, ops: list[Operation],
+                         existing_op: Operation) -> None:
+        index = self.get_operation_index(existing_op)
+        self.insert_op(ops, index + 1)
 
     def insert_op(self,
                   ops: Operation | list[Operation],

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -66,8 +66,7 @@ class PatternRewriter:
         op = op if isinstance(op, list) else [op]
         if len(op) == 0:
             return
-        op_idx = block.get_operation_index(self.current_operation)
-        block.insert_op(op, op_idx)
+        block.insert_ops_before(op, self.current_operation)
         self.added_operations_before += op
 
     def insert_op_after_matched_op(self, op: (Operation | list[Operation])):
@@ -80,8 +79,7 @@ class PatternRewriter:
         op = op if isinstance(op, list) else [op]
         if len(op) == 0:
             return
-        op_idx = block.get_operation_index(self.current_operation)
-        block.insert_op(op, op_idx + 1)
+        block.insert_ops_after(op, self.current_operation)
         self.added_operations_after += op
 
     def insert_op_at_pos(self, op: Operation | list[Operation], block: Block,
@@ -108,8 +106,7 @@ class PatternRewriter:
         op = op if isinstance(op, list) else [op]
         if len(op) == 0:
             return
-        target_op.parent.insert_op(op,
-                                   target_block.get_operation_index(target_op))
+        target_block.insert_ops_before(op, target_op)
 
     def insert_op_after(self, op: Operation | list[Operation],
                         target_op: Operation):
@@ -121,12 +118,10 @@ class PatternRewriter:
         if not self._can_modify_block(target_block):
             raise Exception("Cannot insert operations in this block.")
         self.has_done_action = True
-        op = op if isinstance(op, list) else [op]
-        if len(op) == 0:
+        ops = op if isinstance(op, list) else [op]
+        if len(ops) == 0:
             return
-        target_op.parent.insert_op(
-            op,
-            target_block.get_operation_index(target_op) + 1)
+        target_block.insert_ops_after(ops, target_op)
 
     def erase_matched_op(self, safe_erase: bool = True):
         """

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -147,7 +147,7 @@ class Rewriter:
         if op.parent is None:
             raise Exception(
                 "Cannot insert an operation after a toplevel operation")
-        op.parent.insert_op_after(new_op, op)
+        op.parent.insert_ops_after((new_op, ), op)
 
     @staticmethod
     def insert_op_before(op: Operation, new_op: Operation):
@@ -155,7 +155,7 @@ class Rewriter:
         if op.parent is None:
             raise Exception(
                 "Cannot insert an operation before a toplevel operation")
-        op.parent.insert_op_before(new_op, op)
+        op.parent.insert_ops_before((new_op, ), op)
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -147,8 +147,7 @@ class Rewriter:
         if op.parent is None:
             raise Exception(
                 "Cannot insert an operation after a toplevel operation")
-        op_idx = op.parent.get_operation_index(op)
-        op.parent.insert_op(new_op, op_idx + 1)
+        op.parent.insert_op_after(new_op, op)
 
     @staticmethod
     def insert_op_before(op: Operation, new_op: Operation):
@@ -156,8 +155,7 @@ class Rewriter:
         if op.parent is None:
             raise Exception(
                 "Cannot insert an operation before a toplevel operation")
-        op_idx = op.parent.get_operation_index(op)
-        op.parent.insert_op(new_op, op_idx)
+        op.parent.insert_op_before(new_op, op)
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:


### PR DESCRIPTION
Add APIs to block updating that are operation as opposed to index-based. Right now make it do the same thing, but will become much more efficient with linked list.