### PR TITLE
docu: Make notebook use MLIR output

### DIFF
--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -74,12 +74,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "!sql.bag<!i32>"
+      "#sql.bag<i32>"
      ]
     }
    ],
    "source": [
-    "printer = Printer(target=Printer.Target.XDSL)\n",
+    "printer = Printer()\n",
     "printer.print_attribute(Bag([i32]))"
    ]
   },
@@ -127,7 +127,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%0 : !sql.bag<!i32> = sql.table() [\"table_name\" = \"T\"]"
+      "%0 = \"sql.table\"() {\"table_name\" = \"T\"} : () -> #sql.bag<i32>"
      ]
     }
    ],
@@ -197,14 +197,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%1 : !sql.bag<!i32> = sql.selection(%0 : !sql.bag<!i32>) {\n",
-      "^0(%2 : !i32):\n",
-      "  %3 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %4 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %5 : !i32 = arith.addi(%3 : !i32, %4 : !i32)\n",
-      "  %6 : !i1 = arith.cmpi(%2 : !i32, %5 : !i32) [\"predicate\" = 4 : !i64]\n",
-      "  scf.yield(%6 : !i1)\n",
-      "}"
+      "%1 = \"sql.selection\"(%0) ({\n",
+      "^0(%2 : i32):\n",
+      "  %3 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %4 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %5 = \"arith.addi\"(%3, %4) : (i32, i32) -> i32\n",
+      "  %6 = \"arith.cmpi\"(%2, %5) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
     }
    ],
@@ -267,14 +267,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%1 : !sql.bag<!i32> = sql.selection(%0 : !sql.bag<!i32>) {\n",
-      "^0(%7 : !i32):\n",
-      "  %3 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %4 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %8 : !i32 = arith.constant() [\"value\" = 10 : !i32]\n",
-      "  %6 : !i1 = arith.cmpi(%7 : !i32, %8 : !i32) [\"predicate\" = 4 : !i64]\n",
-      "  scf.yield(%6 : !i1)\n",
-      "}"
+      "%1 = \"sql.selection\"(%0) ({\n",
+      "^0(%7 : i32):\n",
+      "  %3 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %4 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%7, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
     }
    ],
@@ -331,12 +331,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%1 : !sql.bag<!i32> = sql.selection(%0 : !sql.bag<!i32>) {\n",
-      "^0(%9 : !i32):\n",
-      "  %8 : !i32 = arith.constant() [\"value\" = 10 : !i32]\n",
-      "  %6 : !i1 = arith.cmpi(%9 : !i32, %8 : !i32) [\"predicate\" = 4 : !i64]\n",
-      "  scf.yield(%6 : !i1)\n",
-      "}"
+      "%1 = \"sql.selection\"(%0) ({\n",
+      "^0(%9 : i32):\n",
+      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%9, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
     }
    ],
@@ -383,16 +383,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "builtin.module() {\n",
-      "  %0 : !sql.bag<!i32> = sql.table() [\"table_name\" = \"T\"]\n",
-      "  %1 : !sql.bag<!i32> = sql.selection(%0 : !sql.bag<!i32>) {\n",
-      "  ^0(%10 : !i32):\n",
-      "    %8 : !i32 = arith.constant() [\"value\" = 10 : !i32]\n",
-      "    %6 : !i1 = arith.cmpi(%10 : !i32, %8 : !i32) [\"predicate\" = 4 : !i64]\n",
-      "    scf.yield(%6 : !i1)\n",
-      "  }\n",
-      "  sql.sink(%1 : !sql.bag<!i32>)\n",
-      "}\n"
+      "\"builtin.module\"() ({\n",
+      "  %0 = \"sql.table\"() {\"table_name\" = \"T\"} : () -> #sql.bag<i32>\n",
+      "  %1 = \"sql.selection\"(%0) ({\n",
+      "  ^0(%10 : i32):\n",
+      "    %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "    %6 = \"arith.cmpi\"(%10, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "    \"scf.yield\"(%6) : (i1) -> ()\n",
+      "  }) : (#sql.bag<i32>) -> #sql.bag<i32>\n",
+      "  \"sql.sink\"(%1) : (#sql.bag<i32>) -> ()\n",
+      "}) : () -> ()\n"
      ]
     }
    ],

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -41,7 +41,7 @@
     "context.register_dialect(Builtin)\n",
     "\n",
     "# Printer used to pretty-print MLIR data structures\n",
-    "printer = Printer(target=Printer.Target.XDSL)"
+    "printer = Printer()"
    ]
   },
   {
@@ -695,7 +695,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "my_dialect.my_op()"
+      "\"my_dialect.my_op\"() : () -> ()"
      ]
     }
    ],
@@ -739,8 +739,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%0 : !i32 = arith.constant() [\"value\" = 62 : !i32]\n",
-      "%1 : !i32 = arith.addi32(%0 : !i32, %0 : !i32)"
+      "%0 = \"arith.constant\"() {\"value\" = 62 : i32} : () -> i32\n",
+      "%1 = \"arith.addi32\"(%0, %0) : (i32, i32) -> i32"
      ]
     }
    ],
@@ -907,8 +907,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%2 : !i32 = arith.constant() [\"value\" = 62 : !i32]\n",
-      "%3 : !i32 = add_variadic(%2 : !i32, %2 : !i32, %2 : !i32)"
+      "%2 = \"arith.constant\"() {\"value\" = 62 : i32} : () -> i32\n",
+      "%3 = \"add_variadic\"(%2, %2, %2) : (i32, i32, i32) -> i32"
      ]
     }
    ],
@@ -1064,7 +1064,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "string_attr_op() [\"value\" = \"ga\"]"
+      "\"string_attr_op\"() {\"value\" = \"ga\"} : () -> ()"
      ]
     }
    ],
@@ -1150,7 +1150,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "string_attr_op() [\"value\" = \"ga\", \"other_attr\" = !int<42>]"
+      "\"string_attr_op\"() {\"value\" = \"ga\", \"other_attr\" = #int<42>} : () -> ()"
      ]
     }
    ],
@@ -1187,9 +1187,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "while_op() {\n",
-      "^0(%4 : !i32):\n",
-      "}"
+      "\"while_op\"() ({\n",
+      "^0(%4 : i32):\n",
+      "}) : () -> ()"
      ]
     }
    ],

--- a/docs/xdsl-introduction.ipynb
+++ b/docs/xdsl-introduction.ipynb
@@ -560,14 +560,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%0 : !sql.bag = sql.select() [\"table_name\" = \"T\"]%1 : !sql.bag = sql.filter(%0 : !sql.bag) {\n",
-      "^0(%2 : !i32):\n",
-      "  %3 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %4 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %5 : !i32 = arith.addi(%3 : !i32, %4 : !i32)\n",
-      "  %6 : !i1 = arith.cmpi(%2 : !i32, %5 : !i32) [\"predicate\" = 4 : !i64]\n",
-      "  scf.yield(%6 : !i1)\n",
-      "}"
+      "%0 = \"sql.select\"() {\"table_name\" = \"T\"} : () -> #sql.bag%1 = \"sql.filter\"(%0) ({\n",
+      "^0(%2 : i32):\n",
+      "  %3 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %4 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %5 = \"arith.addi\"(%3, %4) : (i32, i32) -> i32\n",
+      "  %6 = \"arith.cmpi\"(%2, %5) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "}) : (#sql.bag) -> #sql.bag"
      ]
     }
    ],
@@ -580,7 +580,7 @@
     "# from xdsl.dialects.arith import Constant, Addi, Cmpi\n",
     "# from xdsl.dialects.scf import Yield\n",
     "\n",
-    "printer = Printer(target=Printer.Target.XDSL)\n",
+    "printer = Printer()\n",
     "\n",
     "# initialises a \"Select\" operation: \n",
     "# select(\"T\")\n",
@@ -711,14 +711,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%1 : !sql.bag = sql.filter(%0 : !sql.bag) {\n",
-      "^0(%7 : !i32):\n",
-      "  %3 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %4 : !i32 = arith.constant() [\"value\" = 5 : !i32]\n",
-      "  %8 : !i32 = arith.constant() [\"value\" = 10 : !i32]\n",
-      "  %6 : !i1 = arith.cmpi(%7 : !i32, %8 : !i32) [\"predicate\" = 4 : !i64]\n",
-      "  scf.yield(%6 : !i1)\n",
-      "}"
+      "%1 = \"sql.filter\"(%0) ({\n",
+      "^0(%7 : i32):\n",
+      "  %3 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %4 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
+      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%7, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "}) : (#sql.bag) -> #sql.bag"
      ]
     }
    ],
@@ -752,12 +752,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%1 : !sql.bag = sql.filter(%0 : !sql.bag) {\n",
-      "^0(%9 : !i32):\n",
-      "  %8 : !i32 = arith.constant() [\"value\" = 10 : !i32]\n",
-      "  %6 : !i1 = arith.cmpi(%9 : !i32, %8 : !i32) [\"predicate\" = 4 : !i64]\n",
-      "  scf.yield(%6 : !i1)\n",
-      "}"
+      "%1 = \"sql.filter\"(%0) ({\n",
+      "^0(%9 : i32):\n",
+      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%9, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "}) : (#sql.bag) -> #sql.bag"
      ]
     }
    ],


### PR DESCRIPTION
Given that we now support MLIR output well, our public documentation should also use MLIR output.