### PR TITLE
core: deprecate ModuleOp.from_region_or_ops

### DIFF
--- a/docs/Toy/Toy_Ch2.ipynb
+++ b/docs/Toy/Toy_Ch2.ipynb
@@ -378,7 +378,7 @@
     "from xdsl.builder import Builder\n",
     "\n",
     "\n",
-    "@ModuleOp.from_region_or_ops\n",
+    "@ModuleOp\n",
     "@Builder.implicit_region\n",
     "def module_op():\n",
     "    unrankedf64TensorType = toy.UnrankedTensorType.from_type(f64)\n",

--- a/docs/Toy/toy/ir_gen.py
+++ b/docs/Toy/toy/ir_gen.py
@@ -69,7 +69,7 @@ class IRGen:
     def __init__(self):
         # We create an empty MLIR module and codegen functions one at a time and
         # add them to the module.
-        self.module = ModuleOp.from_region_or_ops([])
+        self.module = ModuleOp([])
         self.builder = Builder(self.module.body.blocks[0])
 
     def ir_gen_module(self, module_ast: ModuleAST) -> ModuleOp:

--- a/docs/Toy/toy/tests/test_interpreter.py
+++ b/docs/Toy/toy/tests/test_interpreter.py
@@ -58,4 +58,4 @@ def build_module() -> ModuleOp:
         private=True)
     main = td.FuncOp.from_callable('main', [], [], main_body, private=False)
 
-    return ModuleOp.from_region_or_ops([multiply_transpose, main])
+    return ModuleOp([multiply_transpose, main])

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -22,7 +22,7 @@ def test_convert_ast():
 
     generated_module_op = ir_gen.ir_gen_module(module_ast)
 
-    @ModuleOp.from_region_or_ops
+    @ModuleOp
     @Builder.implicit_region
     def module_op():
         unrankedf64TensorType = toy.UnrankedTensorType.from_type(f64)

--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -397,7 +397,7 @@
     }
    ],
    "source": [
-    "m = ModuleOp.from_region_or_ops([t, sel, SinkOp.build(operands=[sel])])\n",
+    "m = ModuleOp([t, sel, SinkOp.build(operands=[sel])])\n",
     "printer.print(m)"
    ]
   },
@@ -411,8 +411,14 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/docs/mlir_interoperation.ipynb
+++ b/docs/mlir_interoperation.ipynb
@@ -64,7 +64,7 @@
     "region0 = Region(block0)\n",
     "\n",
     "# Create an Operation from the region\n",
-    "op = ModuleOp.from_region_or_ops(region0)"
+    "op = ModuleOp(region0)"
    ]
   },
   {

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -170,7 +170,7 @@ def test_call():
     call0 = Call.get(func0.sym_name.data, [a, b], [ret0.arguments[0].typ])
 
     # Wrap all in a ModuleOp
-    mod = ModuleOp.from_region_or_ops([func0, a, b, call0])
+    mod = ModuleOp([func0, a, b, call0])
 
     expected = \
         """
@@ -218,7 +218,7 @@ def test_call_II():
     call0 = Call.get(func0.sym_name.data, [a], [ret0.arguments[0].typ])
 
     # Wrap all in a ModuleOp
-    mod = ModuleOp.from_region_or_ops([func0, a, call0])
+    mod = ModuleOp([func0, a, call0])
 
     expected = \
         """

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -4,7 +4,7 @@ from xdsl.dialects import llvm, builtin, arith
 
 
 def test_llvm_pointer_ops():
-    module = builtin.ModuleOp.from_region_or_ops([
+    module = builtin.ModuleOp([
         idx := arith.Constant.from_int_and_width(0, 64),
         ptr := llvm.AllocaOp.get(idx, builtin.i32),
         val := llvm.LoadOp.get(ptr),

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -152,7 +152,7 @@ def test_memref_matmul_verify():
     memref_f64_rank2 = memref.MemRefType.from_element_type_and_shape(
         builtin.f64, [-1, -1])
 
-    module = builtin.ModuleOp.from_region_or_ops([
+    module = builtin.ModuleOp([
         func.FuncOp.from_callable(
             'matmul',
             [memref_f64_rank2, memref_f64_rank2],

--- a/tests/dialects/test_mpi_lowering.py
+++ b/tests/dialects/test_mpi_lowering.py
@@ -340,7 +340,7 @@ def test_lower_mpi_allocate():
 
 
 def test_lower_mpi_vec_get():
-    mod = builtin.ModuleOp.from_region_or_ops([
+    mod = builtin.ModuleOp([
         count := CreateTestValsOp.get(i32),
         vec := mpi.AllocateTypeOp.get(mpi.RequestType, count),
         get := mpi.VectorGetOp.get(vec, count),

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -58,7 +58,7 @@ def test_parallel():
 
 def test_empty_else():
     # create if without an else block:
-    m = ModuleOp.from_region_or_ops([
+    m = ModuleOp([
         t := Constant.from_int_and_width(1, 1),
         If.get(t, [], [
             Yield.get(),

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -54,7 +54,7 @@ def test_rewrite_swap_inputs_pdl():
 
 def swap_arguments_input():
 
-    @ModuleOp.from_region_or_ops
+    @ModuleOp
     @Builder.implicit_region
     def ir_module():
 
@@ -75,7 +75,7 @@ def swap_arguments_input():
 
 def swap_arguments_output():
 
-    @ModuleOp.from_region_or_ops
+    @ModuleOp
     @Builder.implicit_region
     def ir_module():
 
@@ -125,7 +125,7 @@ def swap_arguments_pdl():
     pattern = pdl.PatternOp.get(IntegerAttr.from_int_and_width(2, 16), None,
                                 pattern_region)
 
-    pdl_module = ModuleOp.from_region_or_ops([pattern])
+    pdl_module = ModuleOp([pattern])
 
     return pdl_module
 
@@ -179,7 +179,7 @@ def test_rewrite_add_zero_pdl():
 
 def add_zero_input():
 
-    @ModuleOp.from_region_or_ops
+    @ModuleOp
     @Builder.implicit_region
     def ir_module():
 
@@ -197,7 +197,7 @@ def add_zero_input():
 
 def add_zero_output():
 
-    @ModuleOp.from_region_or_ops
+    @ModuleOp
     @Builder.implicit_region
     def ir_module():
 
@@ -248,6 +248,6 @@ def add_zero_pdl():
     pattern = pdl.PatternOp.get(IntegerAttr.from_int_and_width(2, 16), None,
                                 pattern_region)
 
-    pdl_module = ModuleOp.from_region_or_ops([pattern])
+    pdl_module = ModuleOp([pattern])
 
     return pdl_module

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -17,7 +17,7 @@ def test_import_functions():
     class B(InterpreterFunctions):
         pass
 
-    i = Interpreter(ModuleOp.from_region_or_ops([]))
+    i = Interpreter(ModuleOp([]))
 
     i.register_implementations(B())
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -273,7 +273,7 @@ def test_descriptions():
     assert str(a) == '%0 : !i32 = arith.constant() ["value" = 1 : !i32]'
     assert f'{a}' == 'Constant(%0 : !i32 = arith.constant() ["value" = 1 : !i32])'
 
-    m = ModuleOp.from_region_or_ops([a])
+    m = ModuleOp([a])
 
     assert str(m) == '''\
 builtin.module() {

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -331,7 +331,7 @@ def test_insert_op_at_pos_negative():
     Test rewrites where operations are inserted with a negative position.
     """
 
-    prog = ModuleOp.from_region_or_ops([Constant.from_int_and_width(5, 32)])
+    prog = ModuleOp([Constant.from_int_and_width(5, 32)])
 
     to_be_inserted = Constant.from_int_and_width(42, 32)
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -49,7 +49,7 @@ def test_forgotten_op_non_fail():
     lit = Constant.from_int_and_width(42, 32)
     add = Addi.get(lit, lit)
     add2 = Addi.get(add, add)
-    mod = ModuleOp.from_region_or_ops([add, add2])
+    mod = ModuleOp([add, add2])
     mod.verify()
 
     expected = \

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -16,7 +16,7 @@ from xdsl.irdl import (AllOf, OpAttr, VarOpResult, VarOperand, VarRegion,
                        irdl_op_definition, ParameterDef, SingleBlockRegion,
                        Generic, GenericData, AttrConstraint, AnyAttr,
                        IRDLOperation)
-from xdsl.utils.deprecation import deprecated_constructor
+from xdsl.utils.deprecation import deprecated, deprecated_constructor
 from xdsl.utils.exceptions import VerifyException
 
 if TYPE_CHECKING:
@@ -1160,10 +1160,18 @@ class ModuleOp(IRDLOperation):
 
     body: SingleBlockRegion
 
+    def __init__(self, ops: List[Operation] | Region):
+        if isinstance(ops, Region):
+            region = ops
+        else:
+            region = Region(Block(ops))
+        super().__init__(regions=[region])
+
     @property
     def ops(self) -> List[Operation]:
         return self.regions[0].block.ops
 
+    @deprecated("Please use ModuleOp(ops)")
     @staticmethod
     def from_region_or_ops(ops: List[Operation] | Region) -> ModuleOp:
         if isinstance(ops, list):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1171,20 +1171,6 @@ class ModuleOp(IRDLOperation):
     def ops(self) -> List[Operation]:
         return self.regions[0].block.ops
 
-    @deprecated("Please use ModuleOp(ops)")
-    @staticmethod
-    def from_region_or_ops(ops: List[Operation] | Region) -> ModuleOp:
-        if isinstance(ops, list):
-            region = Region([Block(ops)])
-        elif isinstance(ops, Region):
-            region = ops
-        else:
-            raise TypeError(
-                f"Expected region or operation list in ModuleOp.get, but got '{ops}'"
-            )
-        op = ModuleOp.create([], [], regions=[region])
-        return op
-
 
 # FloatXXType shortcuts
 bf16 = BFloat16Type()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -16,7 +16,7 @@ from xdsl.irdl import (AllOf, OpAttr, VarOpResult, VarOperand, VarRegion,
                        irdl_op_definition, ParameterDef, SingleBlockRegion,
                        Generic, GenericData, AttrConstraint, AnyAttr,
                        IRDLOperation)
-from xdsl.utils.deprecation import deprecated, deprecated_constructor
+from xdsl.utils.deprecation import deprecated_constructor
 from xdsl.utils.exceptions import VerifyException
 
 if TYPE_CHECKING:

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -20,7 +20,7 @@ class CodeGeneration:
                                 stmts: List[ast.stmt],
                                 file: str | None) -> builtin.ModuleOp:
         """Generates xDSL code and returns it encapsulated into a single module."""
-        module = builtin.ModuleOp.from_region_or_ops([])
+        module = builtin.ModuleOp([])
         visitor = CodegGenerationVisitor(type_converter, module, file)
         for stmt in stmts:
             visitor.visit(stmt)


### PR DESCRIPTION
I thought I'd deprecate instead of deleting since it's the most widely-used Operation, but I'd be ok with deleting the constructor also.