### PR TITLE
frontend: Add basic for loop support

### DIFF
--- a/tests/filecheck/frontend/dialects/affine.py
+++ b/tests/filecheck/frontend/dialects/affine.py
@@ -1,0 +1,95 @@
+# RUN: python %s | filecheck %s
+
+from xdsl.frontend.context import CodeContext
+from xdsl.frontend.exception import CodeGenerationException
+from xdsl.frontend.program import FrontendProgram
+
+
+p = FrontendProgram()
+with CodeContext(p):
+    #      CHECK: func.func() ["sym_name" = "test_affine_for_I"
+    # CHECK-NEXT: affine.for() ["lower_bound" = 0 : !index, "upper_bound" = 100 : !index, "step" = 1 : !index] {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   affine.yield()
+    # CHECK-NEXT: }
+    def test_affine_for_I():
+        for _ in range(100):
+            pass
+
+    #      CHECK: func.func() ["sym_name" = "test_affine_for_II"
+    # CHECK-NEXT: affine.for() ["lower_bound" = 10 : !index, "upper_bound" = 30 : !index, "step" = 1 : !index] {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   affine.yield()
+    # CHECK-NEXT: }
+    def test_affine_for_II():
+        for _ in range(10, 30):
+            pass
+
+    #      CHECK: func.func() ["sym_name" = "test_affine_for_III"
+    # CHECK-NEXT: affine.for() ["lower_bound" = 1 : !index, "upper_bound" = 20 : !index, "step" = 5 : !index] {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   affine.yield()
+    # CHECK-NEXT: }
+    def test_affine_for_III():
+        for _ in range(1, 20, 5):
+            pass
+
+    #      CHECK: func.func() ["sym_name" = "test_affine_for_IV"
+    # CHECK-NEXT: affine.for() ["lower_bound" = 0 : !index, "upper_bound" = 10 : !index, "step" = 1 : !index] {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   affine.for() ["lower_bound" = 0 : !index, "upper_bound" = 20 : !index, "step" = 1 : !index] {
+    # CHECK-NEXT:   ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:     affine.for() ["lower_bound" = 0 : !index, "upper_bound" = 30 : !index, "step" = 1 : !index] {
+    # CHECK-NEXT:     ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:       affine.yield()
+    # CHECK-NEXT:     }
+    # CHECK-NEXT:     affine.yield()
+    # CHECK-NEXT:   }
+    # CHECK-NEXT:   affine.yield()
+    # CHECK-NEXT: }
+    def test_affine_for_IV():
+        for _ in range(10):
+            for _ in range(20):
+                for _ in range(30):
+                    pass
+
+
+p.compile(desymref=False)
+print(p.xdsl())
+
+
+try:
+    with CodeContext(p):
+        # CHECK: Expected integer constant for loop end, got 'float'.
+        def test_not_supported_affine_loop_I():
+            for _ in range(12.0):  # type: ignore
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Expected integer constant for loop start, got 'str'.
+        def test_not_supported_affine_loop_II():
+            for _ in range("boom", 100):  # type: ignore
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Expected integer constant for loop step, got 'float'.
+        def test_not_supported_affine_loop_III():
+            for _ in range(0, 100, 1.0):  # type: ignore
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)

--- a/tests/filecheck/frontend/dialects/invalid.py
+++ b/tests/filecheck/frontend/dialects/invalid.py
@@ -2,7 +2,7 @@
 
 from xdsl.frontend.block import block
 from xdsl.frontend.const import Const
-from xdsl.frontend.exception import FrontendProgramException
+from xdsl.frontend.exception import CodeGenerationException, FrontendProgramException
 from xdsl.frontend.program import FrontendProgram
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.dialects.builtin import i1, i32, i64
@@ -62,4 +62,54 @@ try:
     p.compile(desymref=False)
     print(p.xdsl())
 except FrontendProgramException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Else clause in for loops is not supported.
+        def test_not_supported_loop_I():
+            for i in range(10):
+                pass
+            else:
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Only range-based loops are supported.
+        def test_not_supported_loop_II():
+            for i, j in enumerate(range(10, 0, -1)):
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Range-based loop expected between 1 and 3 arguments, but got 4.
+        def test_not_supported_loop_III():
+            for i in range(0, 1, 2, 3):
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Range-based loop must take a single target variable, e.g. `for i in range(10)`.
+        def test_not_supported_loop_IV():
+            for i, j in range(100):
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
     print(e.msg)

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -1,0 +1,114 @@
+# RUN: python %s | filecheck %s
+
+from xdsl.frontend.context import CodeContext
+from xdsl.frontend.exception import CodeGenerationException
+from xdsl.frontend.program import FrontendProgram
+from xdsl.frontend.dialects.builtin import index, i32, f32
+
+
+p = FrontendProgram()
+with CodeContext(p):
+    #      CHECK: func.func() ["sym_name" = "test_for_I"
+    #      CHECK: %{{.*}} : !index = arith.constant() ["value" = 0 : !index]
+    # CHECK-NEXT: %{{.*}} : !index = symref.fetch() ["symbol" = @end]
+    # CHECK-NEXT: %{{.*}} : !index = arith.constant() ["value" = 1 : !index]
+    # CHECK-NEXT: scf.for(%{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !index) {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   scf.yield()
+    # CHECK-NEXT: }
+    def test_for_I(end: index):
+        for _ in range(end):  # type: ignore
+            pass
+
+    #      CHECK: func.func() ["sym_name" = "test_for_II"
+    #      CHECK: %{{.*}} : !index = symref.fetch() ["symbol" = @start]
+    # CHECK-NEXT: %{{.*}} : !index = symref.fetch() ["symbol" = @end]
+    # CHECK-NEXT: %{{.*}} : !index = arith.constant() ["value" = 1 : !index]
+    # CHECK-NEXT: scf.for(%{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !index) {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   scf.yield()
+    # CHECK-NEXT: }
+    def test_for_II(start: index, end: index):
+        for _ in range(start, end):  # type: ignore
+            pass
+
+    #      CHECK: func.func() ["sym_name" = "test_for_III"
+    #      CHECK: %{{.*}} : !index = symref.fetch() ["symbol" = @start]
+    # CHECK-NEXT: %{{.*}} : !index = symref.fetch() ["symbol" = @end]
+    # CHECK-NEXT: %{{.*}} : !index = symref.fetch() ["symbol" = @step]
+    # CHECK-NEXT: scf.for(%{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !index) {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   scf.yield()
+    # CHECK-NEXT: }
+    def test_for_III(start: index, end: index, step: index):
+        for _ in range(start, end, step):  # type: ignore
+            pass
+
+    #      CHECK: func.func() ["sym_name" = "test_for_IV"
+    #      CHECK: %{{.*}} : !index = arith.constant() ["value" = 0 : !index]
+    # CHECK-NEXT: %{{.*}} : !index = symref.fetch() ["symbol" = @a]
+    # CHECK-NEXT: %{{.*}} : !index = arith.constant() ["value" = 1 : !index]
+    # CHECK-NEXT: scf.for(%{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !index) {
+    # CHECK-NEXT: ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:   %{{.*}} : !index = arith.constant() ["value" = 0 : !index]
+    # CHECK-NEXT:   %{{.*}} : !index = symref.fetch() ["symbol" = @b]
+    # CHECK-NEXT:   %{{.*}} : !index = arith.constant() ["value" = 1 : !index]
+    # CHECK-NEXT:   scf.for(%{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !index) {
+    # CHECK-NEXT:   ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:     %{{.*}} : !index = arith.constant() ["value" = 0 : !index]
+    # CHECK-NEXT:     %{{.*}} : !index = symref.fetch() ["symbol" = @c]
+    # CHECK-NEXT:     %{{.*}} : !index = arith.constant() ["value" = 1 : !index]
+    # CHECK-NEXT:     scf.for(%{{.*}} : !index, %{{.*}} : !index, %{{.*}} : !index) {
+    # CHECK-NEXT:     ^{{.*}}(%{{.*}} : !index):
+    # CHECK-NEXT:       scf.yield()
+    # CHECK-NEXT:     }
+    # CHECK-NEXT:     scf.yield()
+    # CHECK-NEXT:   }
+    # CHECK-NEXT:   scf.yield()
+    # CHECK-NEXT: }
+    def test_for_IV(a: index, b: index, c: index):
+        for _ in range(a):  # type: ignore
+            for _ in range(b):  # type: ignore
+                for _ in range(c):  # type: ignore
+                    pass
+
+
+p.compile(desymref=False)
+print(p.xdsl())
+
+
+try:
+    with CodeContext(p):
+        # CHECK: Expected 'index' type for loop end, got 'i32'.
+        def test_not_supported_loop_I(end: i32):
+            for _ in range(end):  # type: ignore
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Expected 'index' type for loop start, got 'f32'.
+        def test_not_supported_loop_II(start: f32, end: index):
+            for _ in range(start, end):  # type: ignore
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)
+
+try:
+    with CodeContext(p):
+        # CHECK: Expected 'index' type for loop step, got 'f32'.
+        def test_not_supported_loop_III(start: index, end: index, step: f32):
+            for _ in range(start, end, step):  # type: ignore
+                pass
+
+    p.compile(desymref=False)
+    print(p.xdsl())
+except CodeGenerationException as e:
+    print(e.msg)


### PR DESCRIPTION
This PR adds a very basic support for range-based loops which are lowered o `affine.for` or `scf.for`.