### PR TITLE
tests: Move mlir_interoperation notebook test to MLIR syntax

### DIFF
--- a/docs/mlir_interoperation.ipynb
+++ b/docs/mlir_interoperation.ipynb
@@ -68,12 +68,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "849b8140",
    "metadata": {},
    "source": [
     "Using xDSLs printer we can print this operation.\n",
-    "For convenience we provide a file called `source.xdsl` with the code printed below"
+    "For convenience we provide a file called `source.mlir` with the code printed below"
    ]
   },
   {
@@ -86,14 +87,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "builtin.module() {\n",
-      "  %0 : !i32 = arith.constant() [\"value\" = 1 : !i32]\n",
-      "  %1 : !i32 = arith.constant() [\"value\" = 2 : !i32]\n",
-      "  %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)\n",
-      "  %3 : !i32 = arith.addi(%0 : !i32, %1 : !i32)\n",
-      "  %4 : !i32 = arith.addi(%2 : !i32, %3 : !i32)\n",
-      "  vector.print(%4 : !i32)\n",
-      "}\n"
+      "\"builtin.module\"() ({\n",
+      "  %0 = \"arith.constant\"() {\"value\" = 1 : i32} : () -> i32\n",
+      "  %1 = \"arith.constant\"() {\"value\" = 2 : i32} : () -> i32\n",
+      "  %2 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\n",
+      "  %3 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\n",
+      "  %4 = \"arith.addi\"(%2, %3) : (i32, i32) -> i32\n",
+      "  \"vector.print\"(%4) : (i32) -> ()\n",
+      "}) : () -> ()\n"
      ]
     }
    ],
@@ -101,7 +102,7 @@
     "from xdsl.printer import Printer\n",
     "\n",
     "# Print in xdsl format\n",
-    "printer = Printer(target=Printer.Target.XDSL)\n",
+    "printer = Printer()\n",
     "printer.print(op)"
    ]
   },
@@ -115,57 +116,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "builtin.module() {\r\n",
-      "  %0 : !i32 = arith.constant() [\"value\" = 1 : !i32]\r\n",
-      "  %1 : !i32 = arith.constant() [\"value\" = 2 : !i32]\r\n",
-      "  %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)\r\n",
-      "  %3 : !i32 = arith.addi(%0 : !i32, %1 : !i32)\r\n",
-      "  %4 : !i32 = arith.addi(%2 : !i32, %3 : !i32)\r\n",
-      "  vector.print(%4 : !i32)\r\n",
-      "}\r\n"
+      "\"builtin.module\"() ({\r\n",
+      "  %0 = \"arith.constant\"() {value = 1 : i32} : () -> i32\r\n",
+      "  %1 = \"arith.constant\"() {value = 2 : i32} : () -> i32\r\n",
+      "  %2 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\r\n",
+      "  %3 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\r\n",
+      "  %4 = \"arith.addi\"(%2, %3) : (i32, i32) -> i32\r\n",
+      "  \"vector.print\"(%4) : (i32) -> ()\r\n",
+      "}) : () -> ()\r\n"
      ]
     }
    ],
    "source": [
     "# Cross-check file content\n",
-    "!cat source.xdsl"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "196f9723",
-   "metadata": {},
-   "source": [
-    "Then we are using the `xdsl-opt` tool provided from the repository to emit .mlir code from the .xdsl input.\n",
-    "You can see in the following cell that `xdsl-opt` can be used in various contexts such as translating back and forth from/to xdsl/mlir."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "f10b68da",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\"builtin.module\"() ({\r\n",
-      "  %0 = \"arith.constant\"() {\"value\" = 1 : i32} : () -> i32\r\n",
-      "  %1 = \"arith.constant\"() {\"value\" = 2 : i32} : () -> i32\r\n",
-      "  %2 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\r\n",
-      "  %3 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\r\n",
-      "  %4 = \"arith.addi\"(%2, %3) : (i32, i32) -> i32\r\n",
-      "  \"vector.print\"(%4) : (i32) -> ()\r\n",
-      "}) : () -> ()\r\n",
-      "\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Checkout the mlir output in generic form\n",
-    "!./../xdsl/tools/xdsl-opt -f xdsl -t mlir -o out.mlir source.xdsl\n",
-    "!cat out.mlir"
+    "!cat source.mlir"
    ]
   },
   {
@@ -189,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "142e0fa2",
    "metadata": {},
    "outputs": [
@@ -209,7 +173,7 @@
     }
    ],
    "source": [
-    "!mlir-opt out.mlir -cse --mlir-print-op-generic -o opt-out.mlir\n",
+    "!mlir-opt source.mlir -cse --mlir-print-op-generic -o opt-out.mlir\n",
     "!cat opt-out.mlir"
    ]
   },
@@ -231,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "b228d9e4",
    "metadata": {},
    "outputs": [
@@ -239,20 +203,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "builtin.module() {\r\n",
-      "  %0 : !i32 = arith.constant() [\"value\" = 1 : !i32]\r\n",
-      "  %1 : !i32 = arith.constant() [\"value\" = 2 : !i32]\r\n",
-      "  %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)\r\n",
-      "  %3 : !i32 = arith.addi(%2 : !i32, %2 : !i32)\r\n",
-      "  vector.print(%3 : !i32)\r\n",
-      "}\r\n",
+      "\"builtin.module\"() ({\r\n",
+      "  %0 = \"arith.constant\"() {\"value\" = 1 : i32} : () -> i32\r\n",
+      "  %1 = \"arith.constant\"() {\"value\" = 2 : i32} : () -> i32\r\n",
+      "  %2 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\r\n",
+      "  %3 = \"arith.addi\"(%2, %2) : (i32, i32) -> i32\r\n",
+      "  \"vector.print\"(%3) : (i32) -> ()\r\n",
+      "}) : () -> ()\r\n",
       "\r\n"
      ]
     }
    ],
    "source": [
-    "!./../xdsl/tools/xdsl-opt opt-out.mlir -f mlir -t xdsl -o ret.xdsl\n",
-    "!cat ret.xdsl"
+    "!./../xdsl/tools/xdsl-opt opt-out.mlir -f mlir -t mlir -o ret.mlir\n",
+    "!cat ret.mlir"
    ]
   },
   {
@@ -265,22 +229,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/source.mlir
+++ b/docs/source.mlir
@@ -1,0 +1,8 @@
+"builtin.module"() ({
+  %0 = "arith.constant"() {value = 1 : i32} : () -> i32
+  %1 = "arith.constant"() {value = 2 : i32} : () -> i32
+  %2 = "arith.addi"(%0, %1) : (i32, i32) -> i32
+  %3 = "arith.addi"(%0, %1) : (i32, i32) -> i32
+  %4 = "arith.addi"(%2, %3) : (i32, i32) -> i32
+  "vector.print"(%4) : (i32) -> ()
+}) : () -> ()

--- a/docs/source.xdsl
+++ b/docs/source.xdsl
@@ -1,8 +1,0 @@
-builtin.module() {
-  %0 : !i32 = arith.constant() ["value" = 1 : !i32]
-  %1 : !i32 = arith.constant() ["value" = 2 : !i32]
-  %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
-  %3 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
-  %4 : !i32 = arith.addi(%2 : !i32, %3 : !i32)
-  vector.print(%4 : !i32)
-}


### PR DESCRIPTION
I removed also a bit of the document that was talking about moving to xDSL and MLIR syntax (since there is only the MLIR syntax currently soon).