### PR TITLE
tests: Move some pytest tests to MLIR syntax

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def assert_print_op(
     expected: str,
     diagnostic: Diagnostic | None,
     print_generic_format: bool = False,
-    target: Printer.Target | None = None,
+    target: Printer.Target = Printer.Target.MLIR,
 ):
     """
     Utility function that helps to check the printing of an operation compared to
@@ -45,20 +45,12 @@ def assert_print_op(
     file = StringIO("")
     if diagnostic is None:
         diagnostic = Diagnostic()
-    if target is None:
-        printer = Printer(
-            stream=file,
-            print_generic_format=print_generic_format,
-            diagnostic=diagnostic,
-            target=Printer.Target.XDSL,
-        )
-    else:
-        printer = Printer(
-            stream=file,
-            print_generic_format=print_generic_format,
-            diagnostic=diagnostic,
-            target=target,
-        )
+    printer = Printer(
+        stream=file,
+        print_generic_format=print_generic_format,
+        diagnostic=diagnostic,
+        target=target,
+    )
 
     printer.print(operation)
     assert file.getvalue().strip() == expected.strip()

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -182,16 +182,16 @@ def test_call():
     mod = ModuleOp([func0, a, b, call0])
 
     expected = """
-builtin.module() {
-  func.func() ["sym_name" = "func0", "function_type" = !fun<[!i32, !i32], [!i32]>, "sym_visibility" = "private"] {
-  ^0(%0 : !i32, %1 : !i32):
-    %2 : !i32 = arith.addi(%0 : !i32, %1 : !i32)
-    func.return(%2 : !i32)
-  }
-  %3 : !i32 = arith.constant() ["value" = 1 : !i32]
-  %4 : !i32 = arith.constant() ["value" = 2 : !i32]
-  %5 : !i32 = func.call(%3 : !i32, %4 : !i32) ["callee" = @func0]
-}
+"builtin.module"() ({
+  "func.func"() ({
+  ^0(%0 : i32, %1 : i32):
+    %2 = "arith.addi"(%0, %1) : (i32, i32) -> i32
+    "func.return"(%2) : (i32) -> ()
+  }) {"sym_name" = "func0", "function_type" = (i32, i32) -> i32, "sym_visibility" = "private"} : () -> ()
+  %3 = "arith.constant"() {"value" = 1 : i32} : () -> i32
+  %4 = "arith.constant"() {"value" = 2 : i32} : () -> i32
+  %5 = "func.call"(%3, %4) {"callee" = @func0} : (i32, i32) -> i32
+}) : () -> ()
 """  # noqa
     assert len(call0.operands) == 2
     assert len(func0.operands) == 0
@@ -228,15 +228,15 @@ def test_call_II():
     mod = ModuleOp([func0, a, call0])
 
     expected = """
-builtin.module() {
-  func.func() ["sym_name" = "func1", "function_type" = !fun<[!i32], [!i32]>, "sym_visibility" = "private"] {
-  ^0(%0 : !i32):
-    %1 : !i32 = arith.addi(%0 : !i32, %0 : !i32)
-    func.return(%1 : !i32)
-  }
-  %2 : !i32 = arith.constant() ["value" = 1 : !i32]
-  %3 : !i32 = func.call(%2 : !i32) ["callee" = @func1]
-}
+"builtin.module"() ({
+  "func.func"() ({
+  ^0(%0 : i32):
+    %1 = "arith.addi"(%0, %0) : (i32, i32) -> i32
+    "func.return"(%1) : (i32) -> ()
+  }) {"sym_name" = "func1", "function_type" = (i32) -> i32, "sym_visibility" = "private"} : () -> ()
+  %2 = "arith.constant"() {"value" = 1 : i32} : () -> i32
+  %3 = "func.call"(%2) {"callee" = @func1} : (i32) -> i32
+}) : () -> ()
 """  # noqa
     assert len(call0.operands) == 1
     assert len(func0.operands) == 0

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -23,7 +23,7 @@ from xdsl.irdl import (
     IRDLOperation,
     Operand,
 )
-from xdsl.parser import MLIRParser, Parser, BaseParser, XDSLParser
+from xdsl.parser import MLIRParser, BaseParser, XDSLParser
 from xdsl.printer import Printer
 from xdsl.utils.diagnostic import Diagnostic
 


### PR DESCRIPTION
This patch moves many tests to the MLIR syntax.
Note that 2-3 tests that were testing generic syntax were removed, as they are not supported in the MLIR syntax.