### PR TITLE
core: make MLIR the default syntax in xdsl-opt

### DIFF
--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/affine/examples.mlir
+++ b/tests/filecheck/dialects/affine/examples.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/arith/arith_attrs.mlir
+++ b/tests/filecheck/dialects/arith/arith_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %lhsi1, %rhsi1 = "test.op"() : () -> (i1, i1)

--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 // CHECK: module
 "builtin.module"() ({

--- a/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
+++ b/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics -t mlir | filecheck %s
+// RUN: xdsl-opt %s --parsing-diagnostics | filecheck %s
 
 "builtin.module" () {"test" = array<i32: "", 3>} ({
 })

--- a/tests/filecheck/dialects/builtin/dense_array_invalid_element.mlir
+++ b/tests/filecheck/dialects/builtin/dense_array_invalid_element.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics -t mlir | filecheck %s
+// RUN: xdsl-opt %s --parsing-diagnostics | filecheck %s
 
 "builtin.module" () {"test" = array<!fun<[],[]>: 2, 5, 2>} ({
 })

--- a/tests/filecheck/dialects/builtin/unrealized_conv_cast.mlir
+++ b/tests/filecheck/dialects/builtin/unrealized_conv_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 // CHECK: module
 "builtin.module"() ({

--- a/tests/filecheck/dialects/cf/cf_ops.mlir
+++ b/tests/filecheck/dialects/cf/cf_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -f mlir | xdsl-opt -t mlir -f mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/cmath/cmath_ops.mlir
+++ b/tests/filecheck/dialects/cmath/cmath_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 
 "builtin.module"() ({

--- a/tests/filecheck/dialects/func/func_ops.mlir
+++ b/tests/filecheck/dialects/func/func_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/gpu/all_reduce_body_types.mlir
+++ b/tests/filecheck/dialects/gpu/all_reduce_body_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/all_reduce_both.mlir
+++ b/tests/filecheck/dialects/gpu/all_reduce_both.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/all_reduce_neither.mlir
+++ b/tests/filecheck/dialects/gpu/all_reduce_neither.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/all_reduce_types.mlir
+++ b/tests/filecheck/dialects/gpu/all_reduce_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/launch_args.mlir
+++ b/tests/filecheck/dialects/gpu/launch_args.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/launch_empty.mlir
+++ b/tests/filecheck/dialects/gpu/launch_empty.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/module_unnamed.mlir
+++ b/tests/filecheck/dialects/gpu/module_unnamed.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/module_unterminated.mlir
+++ b/tests/filecheck/dialects/gpu/module_unterminated.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 
 "builtin.module"() ({
     "gpu.module"() ({

--- a/tests/filecheck/dialects/gpu/terminator_launch.mlir
+++ b/tests/filecheck/dialects/gpu/terminator_launch.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/terminator_terminate.mlir
+++ b/tests/filecheck/dialects/gpu/terminator_terminate.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/yield_terminate.mlir
+++ b/tests/filecheck/dialects/gpu/yield_terminate.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/yield_types.mlir
+++ b/tests/filecheck/dialects/gpu/yield_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/llvm/array.mlir
+++ b/tests/filecheck/dialects/llvm/array.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 "builtin.module"() ({
   %0 = "llvm.mlir.undef"() : () -> !llvm.array<2 x i64>
   %1 = "llvm.mlir.undef"() : () -> !llvm.array<1 x i64>

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 "builtin.module"() ({
   "llvm.mlir.global"() ({
   }) {"global_type" = !llvm.array<13 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!\n", "unnamed_addr" = 0 : i64} : () -> ()

--- a/tests/filecheck/dialects/llvm/pointers.mlir
+++ b/tests/filecheck/dialects/llvm/pointers.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64
   %1 = "llvm.inttoptr"(%0) : (i64) -> !llvm.ptr<i32>

--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/dialects/mpi/memref_compat.mlir
+++ b/tests/filecheck/dialects/mpi/memref_compat.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir -p lower-mpi %s
+// RUN: xdsl-opt -p lower-mpi %s
 "builtin.module"() ({
     %ref = "memref.alloc"() {"alignment" = 32 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<100x14x14xf64>
     %buff, %count, %dtype = "mpi.unwrap_memref"(%ref) : (memref<100x14x14xf64>) -> (!llvm.ptr, i32, !mpi.datatype)

--- a/tests/filecheck/dialects/pdl/mlir-tests/apply_rewrite_with_no_results.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/apply_rewrite_with_no_results.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_dict.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_dict.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_loc.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_loc.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_operation_replace.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_operation_replace.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_0.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_0.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_1.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_1.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_2.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_2.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_3.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_3.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/operations.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/operations.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_forced.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_forced.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_optimal.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_optimal.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/rewrite_with_args.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/rewrite_with_args.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/scf/reduce.mlir
+++ b/tests/filecheck/dialects/scf/reduce.mlir
@@ -17,19 +17,19 @@
     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
 }) : () -> ()
 
-// CHECK: builtin.module() {
-// CHECK-NEXT:  %0 : !index = arith.constant() ["value" = 0 : !index]
-// CHECK-NEXT:  %1 : !index = arith.constant() ["value" = 1000 : !index]
-// CHECK-NEXT:  %2 : !index = arith.constant() ["value" = 3 : !index]
-// CHECK-NEXT:  %3 : !f32 = arith.constant() ["value" = 10.2 : !f32]
-// CHECK-NEXT:  %4 : !f32 = arith.constant() ["value" = 18.1 : !f32]
-// CHECK-NEXT:  %5 : !f32 = scf.parallel(%0 : !index, %1 : !index, %2 : !index, %3 : !f32) ["operand_segment_sizes" = array<!i32: 1, 1, 1, 1>] {
-// CHECK-NEXT:  ^0(%6 : !index):
-// CHECK-NEXT:    scf.reduce(%4 : !f32) {
-// CHECK-NEXT:    ^1(%7 : !f32, %8 : !f32):
-// CHECK-NEXT:      %9 : !f32 = arith.addf(%7 : !f32, %8 : !f32)
-// CHECK-NEXT:      scf.reduce.return(%9 : !f32)
-// CHECK-NEXT:    }
-// CHECK-NEXT:    scf.yield()
-// CHECK-NEXT:  }
-// CHECK-NEXT:}
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   %0 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:   %1 = "arith.constant"() {"value" = 1000 : index} : () -> index
+// CHECK-NEXT:   %2 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:   %3 = "arith.constant"() {"value" = 10.2 : f32} : () -> f32
+// CHECK-NEXT:   %4 = "arith.constant"() {"value" = 18.1 : f32} : () -> f32
+// CHECK-NEXT:   %5 = "scf.parallel"(%0, %1, %2, %3) ({
+// CHECK-NEXT:   ^0(%6 : index):
+// CHECK-NEXT:     "scf.reduce"(%4) ({
+// CHECK-NEXT:     ^1(%7 : f32, %8 : f32):
+// CHECK-NEXT:       %9 = "arith.addf"(%7, %8) : (f32, f32) -> f32
+// CHECK-NEXT:       "scf.reduce.return"(%9) : (f32) -> ()
+// CHECK-NEXT:     }) : (f32) -> ()
+// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 
 "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/copy.mlir
+++ b/tests/filecheck/dialects/stencil/copy.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference,convert-stencil-to-gpu | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-gpu | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_inference.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_inference.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference | filecheck %s
 
 
 "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference --verify-diagnostic | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference --verify-diagnostic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/heat_stencil.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/laplace.mlir
+++ b/tests/filecheck/dialects/stencil/laplace.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | filecheck %s
+// RUN: xdsl-opt %s | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/vector/vector_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/frontend/passes/desymref.mlir
+++ b/tests/filecheck/frontend/passes/desymref.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p frontend-desymrefy -t mlir | filecheck %s
+// RUN: xdsl-opt %s -p frontend-desymrefy | filecheck %s
 
 "builtin.module"() ({
 // CHECK: "builtin.module"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f16} : () -> f16

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/unrealized_conversion_cast.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/unrealized_conversion_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/cf/assert.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/cf/assert.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | mlir-opt --mlir-print-op-generic | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = true} : () -> i1

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
     "gpu.module"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 "builtin.module"() ({
   "llvm.mlir.global"() ({
   }) {"global_type" = !llvm.array<12 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!", "unnamed_addr" = 0 : i64} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world-async.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world-async.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p lower-mpi | mlir-opt --convert-func-to-llvm --convert-memref-to-llvm --reconcile-unrealized-casts | filecheck %s
+// RUN: xdsl-opt %s -p lower-mpi | mlir-opt --convert-func-to-llvm --convert-memref-to-llvm --reconcile-unrealized-casts | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p lower-mpi | mlir-opt --convert-func-to-llvm --convert-memref-to-llvm --reconcile-unrealized-casts | filecheck %s
+// RUN: xdsl-opt %s -p lower-mpi | mlir-opt --convert-func-to-llvm --convert-memref-to-llvm --reconcile-unrealized-casts | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_mlir.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_mlir.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | mlir-opt --mlir-print-op-generic | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = false} : () -> i1

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel_with_reduce.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel_with_reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | mlir-opt --mlir-print-op-generic | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir -p convert-stencil-to-ll-mlir | mlir-opt | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | mlir-opt | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/symbol_tests.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/symbol_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt -t mlir %s | mlir-opt --mlir-print-op-generic > %t-2 && diff %t-1 %t-2
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt %s | mlir-opt --mlir-print-op-generic > %t-2 && diff %t-1 %t-2
 
 // Tests if the non generic form can be printed.
 

--- a/tests/filecheck/parser-printer/attribute_names.mlir
+++ b/tests/filecheck/parser-printer/attribute_names.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 }) {a = i32, _e = i32, "foo" = i32, _ = i32} : () -> ()

--- a/tests/filecheck/parser-printer/builtin_attrs.mlir
+++ b/tests/filecheck/parser-printer/builtin_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/parser-printer/escaped_characters.mlir
+++ b/tests/filecheck/parser-printer/escaped_characters.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/float_parsing.mlir
+++ b/tests/filecheck/parser-printer/float_parsing.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -t mlir -f mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 
 "builtin.module"() ({

--- a/tests/filecheck/parser-printer/region_name_clash.mlir
+++ b/tests/filecheck/parser-printer/region_name_clash.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir | xdsl-opt -f mlir -t mlir | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 // Check that SSA values and blocks can reuse names across regions
 

--- a/tests/filecheck/parser-printer/unregistered_affine.mlir
+++ b/tests/filecheck/parser-printer/unregistered_affine.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect | xdsl-opt -f mlir -t mlir --allow-unregistered-dialect  | filecheck %s
+// RUN: xdsl-opt %s --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect  | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/unregistered_dialect.mlir
+++ b/tests/filecheck/parser-printer/unregistered_dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect | xdsl-opt -f mlir -t mlir --allow-unregistered-dialect  | filecheck %s
+// RUN: xdsl-opt %s --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect  | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/value_tuple.mlir
+++ b/tests/filecheck/parser-printer/value_tuple.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect | xdsl-opt -f mlir -t mlir --allow-unregistered-dialect  | filecheck %s
+// RUN: xdsl-opt %s --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect  | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/value_tuple_access_oob.mlir
+++ b/tests/filecheck/parser-printer/value_tuple_access_oob.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --allow-unregistered-dialect --parsing-diagnostics | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/value_tuple_wrong_number.mlir
+++ b/tests/filecheck/parser-printer/value_tuple_wrong_number.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -t mlir --allow-unregistered-dialect --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --allow-unregistered-dialect --parsing-diagnostics | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,20 +1,20 @@
-from xdsl.dialects.arith import Arith
+from xdsl.dialects.test import Test
 from xdsl.dialects.builtin import ModuleOp, Builtin
 from xdsl.ir import MLContext, Use
 from xdsl.parser import Parser
 
 test_prog = """
-builtin.module() {
-  %0 : !i1 = arith.constant() ["value" = 0 : !i1]
-  %1 : !i1 = arith.andi(%0 : !i1, %0 : !i1)
-}
+"builtin.module"() ({
+  %0 = "test.op"() : () -> i32
+  %1 = "test.op"(%0, %0) : (i32, i32) -> i32
+}) : () -> ()
 """
 
 
 def test_main():
     ctx = MLContext()
     ctx.register_dialect(Builtin)
-    ctx.register_dialect(Arith)
+    ctx.register_dialect(Test)
 
     parser = Parser(ctx, test_prog)
     module = parser.parse_op()
@@ -22,8 +22,8 @@ def test_main():
     module.verify()
     assert isinstance(module, ModuleOp)
 
-    constant_op, andi_op = list(module.ops)
-    assert constant_op.results[0].uses == {Use(andi_op, 0), Use(andi_op, 1)}
-    assert andi_op.results[0].uses == set()
+    op1, op2 = list(module.ops)
+    assert op1.results[0].uses == {Use(op2, 0), Use(op2, 1)}
+    assert op2.results[0].uses == set()
 
     print("Done")

--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -25,7 +25,7 @@ def test_opt():
 
 def test_empty_program():
     filename = "tests/xdsl_opt/empty_program.mlir"
-    opt = xDSLOptMain(args=[filename, "-t", "mlir"])
+    opt = xDSLOptMain(args=[filename])
 
     f = StringIO("")
     with redirect_stdout(f):
@@ -84,7 +84,7 @@ def test_print_to_file():
     filename_in = "tests/xdsl_opt/empty_program.mlir"
     filename_out = "tests/xdsl_opt/empty_program.out"
 
-    opt = xDSLOptMain(args=[filename_in, "-o", filename_out, "-t", "mlir"])
+    opt = xDSLOptMain(args=[filename_in, "-o", filename_out])
     opt.run()
 
     with open(filename_in, "r") as file:
@@ -111,7 +111,7 @@ def test_operation_deletion():
 
             self.register_pass(RemoveConstantPass)
 
-    opt = xDSLOptMainPass(args=[filename_in, "-p", "remove-constant", "-t", "mlir"])
+    opt = xDSLOptMainPass(args=[filename_in, "-p", "remove-constant"])
 
     f = StringIO("")
     with redirect_stdout(f):

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2807,7 +2807,7 @@ class Source(Enum):
 def Parser(
     ctx: MLContext,
     prog: str,
-    source: Source = Source.XDSL,
+    source: Source = Source.MLIR,
     filename: str = "<unknown>",
     allow_unregistered_dialect: bool = False,
 ) -> BaseParser:

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -136,7 +136,7 @@ class xDSLOptMain:
             required=False,
             choices=targets,
             help="target",
-            default="xdsl",
+            default="mlir",
         )
 
         frontends = [name for name in self.available_frontends]
@@ -304,7 +304,7 @@ class xDSLOptMain:
         """
         if self.args.input_file is None:
             f = sys.stdin
-            file_extension = "xdsl"
+            file_extension = "mlir"
         else:
             f = open(self.args.input_file)
             _, file_extension = os.path.splitext(self.args.input_file)


### PR DESCRIPTION
This removes the need from writing `-t mlir` and `-f mlir`.
This does not remove the xDSL syntax parser and printer.