### PR TITLE
tests: make test_value hashable

### DIFF
--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -5,3 +5,10 @@ class TestSSAValue(SSAValue):
     @property
     def owner(self) -> Operation | Block:
         assert False, "Attempting to get the owner of a `TestSSAValue`"
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+    # This might be problematic, as the superclass is not hashable ...
+    def __hash__(self) -> int:  # type: ignore
+        return id(self)


### PR DESCRIPTION
Test values should be usable anywhere any of the other SSAValue subclasses could be used, so this brings the functionality to parity.