### PR TITLE
misc: Moving list to Sequence/Iterable in `xdsl/dialects`

### DIFF
--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Sequence
 
 from xdsl.dialects.builtin import AnyIntegerAttr, IndexType, IntegerAttr
 from xdsl.ir import Attribute, Operation, SSAValue, Block, Region, Dialect
@@ -49,7 +49,7 @@ class For(IRDLOperation):
 
     @staticmethod
     def from_region(
-        operands: list[Operation | SSAValue],
+        operands: Sequence[Operation | SSAValue],
         lower_bound: int | AnyIntegerAttr,
         upper_bound: int | AnyIntegerAttr,
         region: Region,
@@ -76,7 +76,7 @@ class For(IRDLOperation):
 
     @staticmethod
     def from_callable(
-        operands: list[Operation | SSAValue],
+        operands: Sequence[Operation | SSAValue],
         lower_bound: int | AnyIntegerAttr,
         upper_bound: int | AnyIntegerAttr,
         body: Block.BlockCallback,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -604,7 +604,7 @@ class VectorType(Generic[AttributeCovT], ParametrizedAttribute, TypeAttribute):
     @staticmethod
     def from_element_type_and_shape(
         referenced_type: AttributeInvT,
-        shape: Sequence[int | IntegerAttr[IndexType]],
+        shape: Iterable[int | IntegerAttr[IndexType]],
         num_scalable_dims: int | IntAttr = 0,
     ) -> VectorType[AttributeInvT]:
         if isinstance(num_scalable_dims, int):
@@ -655,7 +655,7 @@ class TensorType(Generic[AttributeCovT], ParametrizedAttribute, TypeAttribute):
     @staticmethod
     def from_type_and_list(
         referenced_type: AttributeInvT,
-        shape: Sequence[int | IntegerAttr[IndexType]] | None = None,
+        shape: Iterable[int | IntegerAttr[IndexType]] | None = None,
         encoding: Attribute = NoneAttr(),
     ) -> TensorType[AttributeInvT]:
         if shape is None:
@@ -905,20 +905,20 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
 
     @staticmethod
     def vector_from_list(
-        data: List[int] | List[float], typ: IntegerType | IndexType | AnyFloat
+        data: Sequence[int] | Sequence[float], typ: IntegerType | IndexType | AnyFloat
     ) -> DenseIntOrFPElementsAttr:
         t = VectorType.from_element_type_and_shape(typ, [len(data)])
         return DenseIntOrFPElementsAttr.from_list(t, data)
 
     @staticmethod
     def tensor_from_list(
-        data: List[int]
-        | List[float]
-        | List[IntegerAttr[IndexType]]
-        | List[IntegerAttr[IntegerType]]
-        | List[AnyFloatAttr],
+        data: Sequence[int]
+        | Sequence[float]
+        | Sequence[IntegerAttr[IndexType]]
+        | Sequence[IntegerAttr[IntegerType]]
+        | Sequence[AnyFloatAttr],
         typ: IntegerType | IndexType | AnyFloat,
-        shape: List[int] = [],
+        shape: Sequence[int] = [],
     ) -> DenseIntOrFPElementsAttr:
         t = AnyTensorType.from_type_and_list(typ, shape if len(shape) else [len(data)])
         return DenseIntOrFPElementsAttr.from_list(t, data)

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
+from collections.abc import Sequence
 
-from typing import Annotated, List, Union
+from typing import Annotated, Union, Sequence
 
 from xdsl.dialects.builtin import IntegerType, StringAttr
 from xdsl.ir import SSAValue, Operation, Block, Dialect
@@ -53,9 +54,9 @@ class ConditionalBranch(IRDLOperation):
     def get(
         cond: Union[Operation, SSAValue],
         then_block: Block,
-        then_ops: List[Union[Operation, SSAValue]],
+        then_ops: Sequence[Union[Operation, SSAValue]],
         else_block: Block,
-        else_ops: List[Union[Operation, SSAValue]],
+        else_ops: Sequence[Union[Operation, SSAValue]],
     ) -> ConditionalBranch:
         return ConditionalBranch.build(
             operands=[cond, then_ops, else_ops], successors=[then_block, else_block]

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Annotated, List, Union
+from typing import Annotated, Union, Sequence
 
 from xdsl.dialects.builtin import StringAttr, FunctionType, SymbolRefAttr
 from xdsl.ir import (
@@ -48,8 +48,8 @@ class FuncOp(IRDLOperation):
     @staticmethod
     def from_callable(
         name: str,
-        input_types: List[Attribute],
-        return_types: List[Attribute],
+        input_types: Sequence[Attribute],
+        return_types: Sequence[Attribute],
         func: Block.BlockCallback,
     ) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
@@ -66,7 +66,7 @@ class FuncOp(IRDLOperation):
 
     @staticmethod
     def external(
-        name: str, input_types: List[Attribute], return_types: List[Attribute]
+        name: str, input_types: Sequence[Attribute], return_types: Sequence[Attribute]
     ) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
         attributes: dict[str, Attribute] = {
@@ -80,8 +80,8 @@ class FuncOp(IRDLOperation):
     @staticmethod
     def from_region(
         name: str,
-        input_types: List[Attribute],
-        return_types: List[Attribute],
+        input_types: Sequence[Attribute],
+        return_types: Sequence[Attribute],
         region: Region,
     ) -> FuncOp:
         type_attr = FunctionType.from_lists(input_types, return_types)
@@ -178,8 +178,8 @@ class Call(IRDLOperation):
     @staticmethod
     def get(
         callee: Union[str, SymbolRefAttr],
-        ops: List[Union[SSAValue, Operation]],
-        return_types: List[Attribute],
+        ops: Sequence[Union[SSAValue, Operation]],
+        return_types: Sequence[Attribute],
     ) -> Call:
         if isinstance(callee, str):
             callee = SymbolRefAttr(callee)

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -339,7 +339,7 @@ class ModuleOp(IRDLOperation):
     sym_name: OpAttr[StringAttr]
 
     @staticmethod
-    def get(name: SymbolRefAttr, ops: list[Operation]) -> ModuleOp:
+    def get(name: SymbolRefAttr, ops: Sequence[Operation]) -> ModuleOp:
         op = ModuleOp.build(attributes={"sym_name": name}, regions=[ops])
         return op
 
@@ -557,7 +557,7 @@ class YieldOp(IRDLOperation):
     values: Annotated[VarOperand, Attribute]
 
     @staticmethod
-    def get(operands: list[SSAValue | Operation]) -> YieldOp:
+    def get(operands: Sequence[SSAValue | Operation]) -> YieldOp:
         return YieldOp.build([operands])
 
     def verify_(self) -> None:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Sequence
 
 from xdsl.dialects.builtin import (
     StringAttr,
@@ -65,7 +65,7 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
     #  bitmask = ParameterDef(StringAttr)
 
     @staticmethod
-    def from_type_list(types: list[Attribute]) -> LLVMStructType:
+    def from_type_list(types: Sequence[Attribute]) -> LLVMStructType:
         return LLVMStructType([StringAttr(""), ArrayAttr(types)])
 
     def print_parameters(self, printer: Printer) -> None:

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     Annotated,
+    Iterable,
     Sequence,
     TypeVar,
     Optional,
@@ -73,7 +74,7 @@ class MemRefType(Generic[_MemRefTypeElement], ParametrizedAttribute, TypeAttribu
     @staticmethod
     def from_element_type_and_shape(
         referenced_type: _MemRefTypeElement,
-        shape: Sequence[int | AnyIntegerAttr],
+        shape: Iterable[int | AnyIntegerAttr],
         layout: Attribute = NoneAttr(),
         memory_space: Attribute = NoneAttr(),
     ) -> MemRefType[_MemRefTypeElement]:
@@ -233,7 +234,7 @@ class Alloc(IRDLOperation):
     def get(
         return_type: Attribute,
         alignment: int,
-        shape: Optional[List[int | AnyIntegerAttr]] = None,
+        shape: Optional[Iterable[int | AnyIntegerAttr]] = None,
     ) -> Alloc:
         if shape is None:
             shape = [1]
@@ -262,8 +263,8 @@ class Alloca(IRDLOperation):
     def get(
         return_type: Attribute,
         alignment: int,
-        shape: Optional[List[int | AnyIntegerAttr]] = None,
-        dynamic_sizes: list[SSAValue | Operation] | None = None,
+        shape: Optional[Iterable[int | AnyIntegerAttr]] = None,
+        dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
     ) -> Alloca:
         if shape is None:
             shape = [1]

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, List, Sequence
+from typing import Annotated, Sequence
 
 from xdsl.dialects.builtin import IndexType, IntegerType
 from xdsl.ir import Attribute, Block, Dialect, Operation, Region, SSAValue
@@ -121,8 +121,8 @@ class For(IRDLOperation):
         lb: SSAValue | Operation,
         ub: SSAValue | Operation,
         step: SSAValue | Operation,
-        iter_args: List[SSAValue | Operation],
-        body: Region | List[Operation] | List[Block] | Block,
+        iter_args: Sequence[SSAValue | Operation],
+        body: Region | Sequence[Operation] | Sequence[Block] | Block,
     ) -> For:
         if isinstance(body, Block):
             body = [body]
@@ -152,7 +152,7 @@ class ParallelOp(IRDLOperation):
         lowerBounds: Sequence[SSAValue | Operation],
         upperBounds: Sequence[SSAValue | Operation],
         steps: Sequence[SSAValue | Operation],
-        body: Region | list[Block] | list[Operation],
+        body: Region | Sequence[Block] | Sequence[Operation],
         initVals: Sequence[SSAValue | Operation] = [],
     ) -> ParallelOp:
         return ParallelOp.build(
@@ -367,10 +367,10 @@ class While(IRDLOperation):
 
     @staticmethod
     def get(
-        operands: List[SSAValue | Operation],
-        result_types: List[Attribute],
-        before: Region | List[Operation] | List[Block],
-        after: Region | List[Operation] | List[Block],
+        operands: Sequence[SSAValue | Operation],
+        result_types: Sequence[Attribute],
+        before: Region | Sequence[Operation] | Sequence[Block],
+        after: Region | Sequence[Operation] | Sequence[Block],
     ) -> While:
         op = While.build(
             operands=operands, result_types=result_types, regions=[before, after]

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Annotated, List
+from typing import Annotated, Sequence
 
 from xdsl.dialects.builtin import (
     IndexType,
@@ -36,7 +36,7 @@ class Load(IRDLOperation):
             raise VerifyException("Expected an index for each dimension.")
 
     @staticmethod
-    def get(ref: SSAValue | Operation, indices: List[SSAValue | Operation]) -> Load:
+    def get(ref: SSAValue | Operation, indices: Sequence[SSAValue | Operation]) -> Load:
         ref = SSAValue.get(ref)
         assert assert_isa(ref.typ, MemRefType[Attribute])
 
@@ -71,7 +71,7 @@ class Store(IRDLOperation):
     def get(
         vector: Operation | SSAValue,
         ref: Operation | SSAValue,
-        indices: List[Operation | SSAValue],
+        indices: Sequence[Operation | SSAValue],
     ) -> Store:
         return Store.build(operands=[vector, ref, indices])
 
@@ -199,7 +199,7 @@ class Maskedload(IRDLOperation):
     @staticmethod
     def get(
         memref: SSAValue | Operation,
-        indices: List[SSAValue | Operation],
+        indices: Sequence[SSAValue | Operation],
         mask: SSAValue | Operation,
         passthrough: SSAValue | Operation,
     ) -> Maskedload:
@@ -249,7 +249,7 @@ class Maskedstore(IRDLOperation):
     @staticmethod
     def get(
         memref: SSAValue | Operation,
-        indices: List[SSAValue | Operation],
+        indices: Sequence[SSAValue | Operation],
         mask: SSAValue | Operation,
         value_to_store: SSAValue | Operation,
     ) -> Maskedstore:

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1090,7 +1090,7 @@ class Block(IRNode):
             ...
 
     @staticmethod
-    def from_callable(block_arg_types: list[Attribute], f: BlockCallback):
+    def from_callable(block_arg_types: Iterable[Attribute], f: BlockCallback):
         b = Block(arg_types=block_arg_types)
         b.add_ops(f(*b.args))
         return b


### PR DESCRIPTION
Issue #636 following pr #798 
Moving list to Sequence / Iterable in:
- xdsl/dialects/affine.py
- xdsl/dialects/builtin.py
- xdsl/dialects/cf.py
- xdsl/dialects/func.py
- xdsl/dialects/gpu.py
- xdsl/dialects/llvm.py
- xdsl/dialects/memref.py
- xdsl/dialects/scf.py
- xdsl/dialects/vector.py
- xdsl/ir.py

Also moving sequence import from `collection.abc` to `typing`