### PR TITLE
dialects: add all rv32i/rv64i register-immediate instructions

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -20,4 +20,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.xori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %ori = "riscv.ori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.ori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %andi = "riscv.andi"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.andi"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -30,4 +30,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.srai"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %lui = "riscv.lui"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.lui"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+  %auipc = "riscv.auipc"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.auipc"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -18,4 +18,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.sltiu"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %xori = "riscv.xori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.xori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %ori = "riscv.ori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.ori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -14,4 +14,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.addi"(%{{.*}}) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %slti = "riscv.slti"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.slti"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %sltiu = "riscv.sltiu"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.sltiu"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -2,26 +2,20 @@
 "builtin.module"() ({
   %0 = "test.op"() : () -> !riscv.reg<>
   %1 = "test.op"() : () -> !riscv.reg<>
-  %add = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  // CHECK: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  %sub = "riscv.sub"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
-  %xor = "riscv.xor"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.xor"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // RV32I/RV64I: Integer Computational Instructions (Section 2.4)
+  // Integer Register-Immediate Instructions
   %addi = "riscv.addi"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.addi"(%{{.*}}) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK: %{{.*}} = "riscv.addi"(%{{.*}}) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %slti = "riscv.slti"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.slti"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %sltiu = "riscv.sltiu"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.sltiu"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  %xori = "riscv.xori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.xori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  %ori = "riscv.ori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.ori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %andi = "riscv.andi"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.andi"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %ori = "riscv.ori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.ori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %xori = "riscv.xori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.xori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %slli = "riscv.slli"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.slli"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %srli = "riscv.srli"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
@@ -32,4 +26,14 @@
   // CHECK-NEXT: %{{.*}} = "riscv.lui"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
   %auipc = "riscv.auipc"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.auipc"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+  // Integer Register-Register Operations
+  %add = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  %sub = "riscv.sub"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  %xor = "riscv.xor"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.xor"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // Assembler pseudo-insgtructions
+  %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -24,4 +24,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.andi"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %slli = "riscv.slli"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.slli"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %srli = "riscv.srli"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.srli"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -28,4 +28,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.srli"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %srai = "riscv.srai"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.srai"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %lui = "riscv.lui"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.lui"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -16,4 +16,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.slti"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %sltiu = "riscv.sltiu"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.sltiu"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %xori = "riscv.xori"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.xori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -26,4 +26,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.slli"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %srli = "riscv.srli"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.srli"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %srai = "riscv.srai"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.srai"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -12,4 +12,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.xor"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   %addi = "riscv.addi"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.addi"(%{{.*}}) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %slti = "riscv.slti"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.slti"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -22,4 +22,6 @@
   // CHECK-NEXT: %{{.*}} = "riscv.ori"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %andi = "riscv.andi"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.andi"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %slli = "riscv.slli"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.slli"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -278,6 +278,19 @@ class SrliOp(RdRsImmOperation):
 
     name = "riscv.srli"
 
+@irdl_op_definition
+class SraiOp(RdRsImmOperation):
+    """
+    Performs arithmetic right shift on the value in register rs1 by the shift amount
+    held in the lower 5 bits of the immediate
+
+    x[rd] = x[rs1] >>s shamt
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srai
+    """
+
+    name = "riscv.srai"
+
 
 @irdl_op_definition
 class XorOp(RdRsRsOperation):
@@ -306,6 +319,7 @@ RISCV = Dialect(
         AndiOp,
         SlliOp,
         SrliOp,
+        SraiOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -181,6 +181,20 @@ class AddiOp(RdRsImmOperation):
     name = "riscv.addi"
 
 
+@irdl_op_definition
+class SltiOp(RdRsImmOperation):
+    """
+    Place the value 1 in register rd if register rs1 is less than the sign-extended
+    immediate when both are treated as signed numbers, else 0 is written to rd.
+
+    x[rd] = x[rs1] <s sext(immediate)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slti
+    """
+
+    name = "riscv.slti"
+
+
 # Logical
 
 
@@ -204,6 +218,7 @@ RISCV = Dialect(
         LiOp,
         XorOp,
         AddiOp,
+        SltiOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -266,6 +266,20 @@ class SlliOp(RdRsImmOperation):
 
 
 @irdl_op_definition
+class SrliOp(RdRsImmOperation):
+    """
+    Performs logical right shift on the value in register rs1 by the shift amount held
+    in the lower 5 bits of the immediate.
+
+    x[rd] = x[rs1] >>u shamt
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srli
+    """
+
+    name = "riscv.srli"
+
+
+@irdl_op_definition
 class XorOp(RdRsRsOperation):
     """
     Performs bitwise XOR on registers rs1 and rs2 and place the result in rd.
@@ -291,6 +305,7 @@ RISCV = Dialect(
         OriOp,
         AndiOp,
         SlliOp,
+        SrliOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -194,6 +194,7 @@ class SltiOp(RdRsImmOperation):
 
     name = "riscv.slti"
 
+
 @irdl_op_definition
 class SltiuOp(RdRsImmOperation):
     """
@@ -207,7 +208,19 @@ class SltiuOp(RdRsImmOperation):
 
     name = "riscv.sltiu"
 
-# Logical
+
+@irdl_op_definition
+class XoriOp(RdRsImmOperation):
+    """
+    Performs bitwise XOR on register rs1 and the sign-extended 12-bit immediate and place
+    the result in rd.
+
+    x[rd] = x[rs1] ^ sext(immediate)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#xori
+    """
+
+    name = "riscv.xori"
 
 
 @irdl_op_definition
@@ -232,6 +245,7 @@ RISCV = Dialect(
         AddiOp,
         SltiOp,
         SltiuOp,
+        XoriOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -308,6 +308,21 @@ class LuiOp(RdImmOperation):
 
 
 @irdl_op_definition
+class AuipcOp(RdImmOperation):
+    """
+    Build pc-relative addresses and uses the U-type format. AUIPC forms a 32-bit offset
+    from the 20-bit U-immediate, filling in the lowest 12 bits with zeros, adds this
+    offset to the pc, then places the result in register rd.
+
+    x[rd] = pc + sext(immediate[31:12] << 12)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#auipc
+    """
+
+    name = "riscv.auipc"
+
+
+@irdl_op_definition
 class XorOp(RdRsRsOperation):
     """
     Performs bitwise XOR on registers rs1 and rs2 and place the result in rd.
@@ -336,6 +351,7 @@ RISCV = Dialect(
         SrliOp,
         SraiOp,
         LuiOp,
+        AuipcOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -194,6 +194,18 @@ class SltiOp(RdRsImmOperation):
 
     name = "riscv.slti"
 
+@irdl_op_definition
+class SltiuOp(RdRsImmOperation):
+    """
+    Place the value 1 in register rd if register rs1 is less than the immediate when
+    both are treated as unsigned numbers, else 0 is written to rd.
+
+    x[rd] = x[rs1] <u sext(immediate)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sltiu
+    """
+
+    name = "riscv.sltiu"
 
 # Logical
 
@@ -219,6 +231,7 @@ RISCV = Dialect(
         XorOp,
         AddiOp,
         SltiOp,
+        SltiuOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -224,6 +224,20 @@ class XoriOp(RdRsImmOperation):
 
 
 @irdl_op_definition
+class OriOp(RdRsImmOperation):
+    """
+    Performs bitwise OR on register rs1 and the sign-extended 12-bit immediate and place
+    the result in rd.
+
+    x[rd] = x[rs1] | sext(immediate)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#ori
+    """
+
+    name = "riscv.ori"
+
+
+@irdl_op_definition
 class XorOp(RdRsRsOperation):
     """
     Performs bitwise XOR on registers rs1 and rs2 and place the result in rd.
@@ -246,6 +260,7 @@ RISCV = Dialect(
         SltiOp,
         SltiuOp,
         XoriOp,
+        OriOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -238,6 +238,20 @@ class OriOp(RdRsImmOperation):
 
 
 @irdl_op_definition
+class AndiOp(RdRsImmOperation):
+    """
+    Performs bitwise AND on register rs1 and the sign-extended 12-bit
+    immediate and place the result in rd.
+
+    x[rd] = x[rs1] & sext(immediate)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#andi
+    """
+
+    name = "riscv.andi"
+
+
+@irdl_op_definition
 class XorOp(RdRsRsOperation):
     """
     Performs bitwise XOR on registers rs1 and rs2 and place the result in rd.
@@ -261,6 +275,7 @@ RISCV = Dialect(
         SltiuOp,
         XoriOp,
         OriOp,
+        AndiOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -123,48 +123,9 @@ class RdRsImmOperation(IRDLOperation, ABC):
         )
 
 
-# Arithmetic
+# RV32I/RV64I: Integer Computational Instructions (Section 2.4)
 
-
-@irdl_op_definition
-class AddOp(RdRsRsOperation):
-    """
-    Adds the registers rs1 and rs2 and stores the result in rd.
-    Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.
-
-    x[rd] = x[rs1] + x[rs2]
-
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#add
-    """
-
-    name = "riscv.add"
-
-
-@irdl_op_definition
-class SubOp(RdRsRsOperation):
-    """
-    Subtracts the registers rs1 and rs2 and stores the result in rd.
-    Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.
-
-    x[rd] = x[rs1] - x[rs2]
-
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sub
-    """
-
-    name = "riscv.sub"
-
-
-@irdl_op_definition
-class LiOp(RdImmOperation):
-    """
-    Loads an immediate into rd.
-
-    This is an assembler pseudo-instruction.
-
-    https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#load-immediate
-    """
-
-    name = "riscv.li"
+## Integer Register-Immediate Instructions
 
 
 @irdl_op_definition
@@ -210,17 +171,17 @@ class SltiuOp(RdRsImmOperation):
 
 
 @irdl_op_definition
-class XoriOp(RdRsImmOperation):
+class AndiOp(RdRsImmOperation):
     """
-    Performs bitwise XOR on register rs1 and the sign-extended 12-bit immediate and place
-    the result in rd.
+    Performs bitwise AND on register rs1 and the sign-extended 12-bit
+    immediate and place the result in rd.
 
-    x[rd] = x[rs1] ^ sext(immediate)
+    x[rd] = x[rs1] & sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#xori
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#andi
     """
 
-    name = "riscv.xori"
+    name = "riscv.andi"
 
 
 @irdl_op_definition
@@ -238,17 +199,17 @@ class OriOp(RdRsImmOperation):
 
 
 @irdl_op_definition
-class AndiOp(RdRsImmOperation):
+class XoriOp(RdRsImmOperation):
     """
-    Performs bitwise AND on register rs1 and the sign-extended 12-bit
-    immediate and place the result in rd.
+    Performs bitwise XOR on register rs1 and the sign-extended 12-bit immediate and place
+    the result in rd.
 
-    x[rd] = x[rs1] & sext(immediate)
+    x[rd] = x[rs1] ^ sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#andi
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#xori
     """
 
-    name = "riscv.andi"
+    name = "riscv.xori"
 
 
 @irdl_op_definition
@@ -322,6 +283,37 @@ class AuipcOp(RdImmOperation):
     name = "riscv.auipc"
 
 
+## Integer Register-Register Operations
+
+
+@irdl_op_definition
+class AddOp(RdRsRsOperation):
+    """
+    Adds the registers rs1 and rs2 and stores the result in rd.
+    Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.
+
+    x[rd] = x[rs1] + x[rs2]
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#add
+    """
+
+    name = "riscv.add"
+
+
+@irdl_op_definition
+class SubOp(RdRsRsOperation):
+    """
+    Subtracts the registers rs1 and rs2 and stores the result in rd.
+    Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.
+
+    x[rd] = x[rs1] - x[rs2]
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sub
+    """
+
+    name = "riscv.sub"
+
+
 @irdl_op_definition
 class XorOp(RdRsRsOperation):
     """
@@ -335,23 +327,40 @@ class XorOp(RdRsRsOperation):
     name = "riscv.xor"
 
 
+## Assembler pseudo-insgtructions
+## https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md
+
+
+@irdl_op_definition
+class LiOp(RdImmOperation):
+    """
+    Loads an immediate into rd.
+
+    This is an assembler pseudo-instruction.
+
+    https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#load-immediate
+    """
+
+    name = "riscv.li"
+
+
 RISCV = Dialect(
     [
-        AddOp,
-        SubOp,
-        LiOp,
-        XorOp,
         AddiOp,
         SltiOp,
         SltiuOp,
-        XoriOp,
-        OriOp,
         AndiOp,
+        OriOp,
+        XoriOp,
         SlliOp,
         SrliOp,
         SraiOp,
         LuiOp,
         AuipcOp,
+        AddOp,
+        SubOp,
+        XorOp,
+        LiOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -278,11 +278,12 @@ class SrliOp(RdRsImmOperation):
 
     name = "riscv.srli"
 
+
 @irdl_op_definition
 class SraiOp(RdRsImmOperation):
     """
     Performs arithmetic right shift on the value in register rs1 by the shift amount
-    held in the lower 5 bits of the immediate
+    held in the lower 5 bits of the immediate.
 
     x[rd] = x[rs1] >>s shamt
 
@@ -290,6 +291,20 @@ class SraiOp(RdRsImmOperation):
     """
 
     name = "riscv.srai"
+
+
+@irdl_op_definition
+class LuiOp(RdImmOperation):
+    """
+    Build 32-bit constants and uses the U-type format. LUI places the U-immediate value
+    in the top 20 bits of the destination register rd, filling in the lowest 12 bits with zeros.
+
+    x[rd] = sext(immediate[31:12] << 12)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lui
+    """
+
+    name = "riscv.lui"
 
 
 @irdl_op_definition
@@ -320,6 +335,7 @@ RISCV = Dialect(
         SlliOp,
         SrliOp,
         SraiOp,
+        LuiOp,
     ],
     [RegisterType],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -252,6 +252,20 @@ class AndiOp(RdRsImmOperation):
 
 
 @irdl_op_definition
+class SlliOp(RdRsImmOperation):
+    """
+    Performs logical left shift on the value in register rs1 by the shift amount
+    held in the lower 5 bits of the immediate.
+
+    x[rd] = x[rs1] << shamt
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slli
+    """
+
+    name = "riscv.slli"
+
+
+@irdl_op_definition
 class XorOp(RdRsRsOperation):
     """
     Performs bitwise XOR on registers rs1 and rs2 and place the result in rd.
@@ -276,6 +290,7 @@ RISCV = Dialect(
         XoriOp,
         OriOp,
         AndiOp,
+        SlliOp,
     ],
     [RegisterType],
 )


### PR DESCRIPTION
This PR adds all the instructions in the RV32I/RV64I Section 2.4 (Integer Register-Immediate Instructions) of the spec. It also reorders all of the previously existing instructions according to the spec sections.