### PR TITLE
dialects: add register index and name to riscv.Register

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -3,8 +3,8 @@ from xdsl.dialects import riscv
 
 
 def test_add_op():
-    a1 = TestSSAValue(riscv.RegisterType(riscv.Register.from_name("a1")))
-    a2 = TestSSAValue(riscv.RegisterType(riscv.Register.from_name("a2")))
+    a1 = TestSSAValue(riscv.RegisterType(riscv.Register("a1")))
+    a2 = TestSSAValue(riscv.RegisterType(riscv.Register("a2")))
     add_op = riscv.AddOp(a1, a2, rd="a0")
     a0 = add_op.rd
 
@@ -13,6 +13,6 @@ def test_add_op():
     assert isinstance(a0.typ, riscv.RegisterType)
     assert isinstance(a1.typ, riscv.RegisterType)
     assert isinstance(a2.typ, riscv.RegisterType)
-    assert a0.typ.data.abi_name == "a0"
-    assert a1.typ.data.abi_name == "a1"
-    assert a2.typ.data.abi_name == "a2"
+    assert a0.typ.data.name == "a0"
+    assert a1.typ.data.name == "a1"
+    assert a2.typ.data.name == "a2"

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -3,11 +3,16 @@ from xdsl.dialects import riscv
 
 
 def test_add_op():
-    a1 = TestSSAValue(riscv.RegisterType(riscv.Register()))
-    a2 = TestSSAValue(riscv.RegisterType(riscv.Register()))
-    add_op = riscv.AddOp(a1, a2)
+    a1 = TestSSAValue(riscv.RegisterType(riscv.Register.from_name("a1")))
+    a2 = TestSSAValue(riscv.RegisterType(riscv.Register.from_name("a2")))
+    add_op = riscv.AddOp(a1, a2, rd="a0")
     a0 = add_op.rd
 
     assert a1.typ is add_op.rs1.typ
     assert a2.typ is add_op.rs2.typ
     assert isinstance(a0.typ, riscv.RegisterType)
+    assert isinstance(a1.typ, riscv.RegisterType)
+    assert isinstance(a2.typ, riscv.RegisterType)
+    assert a0.typ.data.abi_name == "a0"
+    assert a1.typ.data.abi_name == "a1"
+    assert a2.typ.data.abi_name == "a2"

--- a/tests/filecheck/dialects/riscv/riscv_allocation.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_allocation.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+"builtin.module"() ({
+  %0 = "test.op"() : () -> !riscv.reg<a1>
+  %1 = "test.op"() : () -> !riscv.reg<>
+  // add a0, a1, x?
+  %add = "riscv.add"(%0, %1) : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
+// CHECK: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
+}) : () -> ()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -33,7 +33,7 @@ class Register:
     """
 
     name: str | None = field(default=None)
-    """The register name. Should be one of `ABI_NAMES` or `None`"""
+    """The register name. Should be one of `ABI_INDEX_BY_NAME` or `None`"""
 
     ABI_INDEX_BY_NAME = {
         "zero": 0,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -32,60 +32,48 @@ class Register:
     A RISC-V register.
     """
 
-    index: int | None = field(default=None)
-    """The register index. Can be between 0 and 31."""
+    name: str | None = field(default=None)
+    """The register name. Should be one of `ABI_NAMES` or `None`"""
 
-    ABI_NAMES = [
-        "zero",
-        "ra",
-        "sp",
-        "gp",
-        "tp",
-        "t0",
-        "t1",
-        "t2",
-        "fp",
-        "s0",
-        "s1",
-        "a0",
-        "a1",
-        "a2",
-        "a3",
-        "a4",
-        "a5",
-        "a6",
-        "a7",
-        "s2",
-        "s3",
-        "s4",
-        "s5",
-        "s6",
-        "s7",
-        "s8",
-        "s9",
-        "s10",
-        "s11",
-        "t3",
-        "t4",
-        "t5",
-        "t6",
-    ]
+    ABI_INDEX_BY_NAME = {
+        "zero": 0,
+        "ra": 1,
+        "sp": 2,
+        "gp": 3,
+        "tp": 4,
+        "t0": 5,
+        "t1": 6,
+        "t2": 7,
+        "fp": 8,
+        "s0": 8,
+        "s1": 9,
+        "a0": 10,
+        "a1": 11,
+        "a2": 12,
+        "a3": 13,
+        "a4": 14,
+        "a5": 15,
+        "a6": 16,
+        "a7": 17,
+        "s2": 18,
+        "s3": 19,
+        "s4": 20,
+        "s5": 21,
+        "s6": 22,
+        "s7": 23,
+        "s8": 24,
+        "s9": 25,
+        "s10": 26,
+        "s11": 27,
+        "t3": 28,
+        "t4": 29,
+        "t5": 30,
+        "t6": 31,
+    }
 
-    ABI_INDEX_BY_NAME = {name: index for index, name in enumerate(ABI_NAMES)}
-
-    @staticmethod
-    def from_name(name: str) -> Register:
-        try:
-            index = Register.ABI_INDEX_BY_NAME[name]
-            return Register(index)
-        except KeyError:
-            raise ValueError(f"Unknown register name: {name}")
-
-    @property
-    def abi_name(self) -> str | None:
-        if self.index is None:
-            return None
-        return Register.ABI_NAMES[self.index]
+    def __post_init__(self):
+        if self.name not in Register.ABI_INDEX_BY_NAME:
+            raise ValueError(f"Unknown register name {self.name}")
 
 
 @irdl_attr_definition
@@ -102,10 +90,10 @@ class RegisterType(Data[Register], TypeAttribute):
         if name is None:
             return Register()
         text = name.text
-        return Register.from_name(text)
+        return Register(text)
 
     def print_parameter(self, printer: Printer) -> None:
-        name = self.data.abi_name
+        name = self.data.name
         if name is None:
             return
         printer.print_string(name)
@@ -133,7 +121,7 @@ class RdRsRsOperation(IRDLOperation, ABC):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, str):
-            rd = RegisterType(Register.from_name(rd))
+            rd = RegisterType(Register(rd))
 
         super().__init__(
             operands=[rs1, rs2],
@@ -159,7 +147,7 @@ class RdImmOperation(IRDLOperation, ABC):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, str):
-            rd = RegisterType(Register.from_name(rd))
+            rd = RegisterType(Register(rd))
         super().__init__(
             attributes={
                 "immediate": immediate,
@@ -190,7 +178,7 @@ class RdRsImmOperation(IRDLOperation, ABC):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, str):
-            rd = RegisterType(Register.from_name(rd))
+            rd = RegisterType(Register(rd))
         super().__init__(
             operands=[rs1],
             attributes={

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -72,7 +72,7 @@ class Register:
     }
 
     def __post_init__(self):
-        if self.name not in Register.ABI_INDEX_BY_NAME:
+        if self.name is not None and self.name not in Register.ABI_INDEX_BY_NAME:
             raise ValueError(f"Unknown register name {self.name}")
 
 


### PR DESCRIPTION
This lets us to do partial register allocation by assigning an index on the type of the SSA value. I can confirm that this "works" in the `sasha/workshop-all` branch, where code in Toy is lowered to RISC-V and runs, including things like functions & function calls, syscalls, etc. My understanding is that it works slightly differently in the ChocoPy project, but I haven't looked at that yet, so would appreciate feedback on how this approach might be better or worse than that, and other ideas.