### PR TITLE
dialects: add all rv32i/rv64i CSR instructions

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -29,29 +29,29 @@ def test_csr_op():
     zero = TestSSAValue(riscv.RegisterType(riscv.Register("zero")))
     csr = IntegerAttr(16, i32)
     # CsrrwOp
-    riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="a2").verify()
-    riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="zero").verify()
-    riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="zero").verify()
+    riscv.CsrrwOp(rs1=a1, csr=csr, rd="a2").verify()
+    riscv.CsrrwOp(rs1=a1, csr=csr, rd="zero").verify()
+    riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=True, rd="zero").verify()
     with pytest.raises(VerifyException):
-        riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="a2").verify()
+        riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=True, rd="a2").verify()
     # CsrrsOp
-    riscv.CsrrsOp(rs1=a1, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
-    riscv.CsrrsOp(rs1=zero, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
-    riscv.CsrrsOp(rs1=zero, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+    riscv.CsrrsOp(rs1=a1, csr=csr, rd="a2").verify()
+    riscv.CsrrsOp(rs1=zero, csr=csr, rd="a2").verify()
+    riscv.CsrrsOp(rs1=zero, csr=csr, readonly=True, rd="a2").verify()
     with pytest.raises(VerifyException):
-        riscv.CsrrsOp(rs1=a1, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+        riscv.CsrrsOp(rs1=a1, csr=csr, readonly=True, rd="a2").verify()
     # CsrrcOp
-    riscv.CsrrcOp(rs1=a1, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
-    riscv.CsrrcOp(rs1=zero, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
-    riscv.CsrrcOp(rs1=zero, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+    riscv.CsrrcOp(rs1=a1, csr=csr, rd="a2").verify()
+    riscv.CsrrcOp(rs1=zero, csr=csr, rd="a2").verify()
+    riscv.CsrrcOp(rs1=zero, csr=csr, readonly=True, rd="a2").verify()
     with pytest.raises(VerifyException):
-        riscv.CsrrcOp(rs1=a1, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+        riscv.CsrrcOp(rs1=a1, csr=csr, readonly=True, rd="a2").verify()
     # CsrrwiOp
-    riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(0, i32), rd="a2").verify()
-    riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(0, i32), rd="zero").verify()
-    riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(1, i32), rd="zero").verify()
+    riscv.CsrrwiOp(csr=csr, rd="a2").verify()
+    riscv.CsrrwiOp(csr=csr, rd="zero").verify()
+    riscv.CsrrwiOp(csr=csr, writeonly=True, rd="zero").verify()
     with pytest.raises(VerifyException):
-        riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(1, i32), rd="a2").verify()
+        riscv.CsrrwiOp(csr=csr, writeonly=True, rd="a2").verify()
     # CsrrsiOp
     riscv.CsrrsiOp(csr=csr, immediate=IntegerAttr(0, i32), rd="a2").verify()
     riscv.CsrrsiOp(csr=csr, immediate=IntegerAttr(1, i32), rd="a2").verify()

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,6 +1,12 @@
 from xdsl.utils.test_value import TestSSAValue
 from xdsl.dialects import riscv
 
+from xdsl.dialects.builtin import IntegerAttr, i32
+
+from xdsl.utils.exceptions import VerifyException
+
+import pytest
+
 
 def test_add_op():
     a1 = TestSSAValue(riscv.RegisterType(riscv.Register("a1")))
@@ -16,3 +22,17 @@ def test_add_op():
     assert a0.typ.data.name == "a0"
     assert a1.typ.data.name == "a1"
     assert a2.typ.data.name == "a2"
+
+
+def test_csr_op():
+    a1 = TestSSAValue(riscv.RegisterType(riscv.Register("a1")))
+    csr = IntegerAttr(16, i32)
+    op0 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="a2")
+    op0.verify()
+    op1 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="zero")
+    op1.verify()
+    op2 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="zero")
+    op2.verify()
+    op3 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="a2")
+    with pytest.raises(VerifyException):
+        op3.verify()

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -26,13 +26,35 @@ def test_add_op():
 
 def test_csr_op():
     a1 = TestSSAValue(riscv.RegisterType(riscv.Register("a1")))
+    zero = TestSSAValue(riscv.RegisterType(riscv.Register("zero")))
     csr = IntegerAttr(16, i32)
-    op0 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="a2")
-    op0.verify()
-    op1 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="zero")
-    op1.verify()
-    op2 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="zero")
-    op2.verify()
-    op3 = riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="a2")
+    # CsrrwOp
+    riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(0, i32), rd="zero").verify()
+    riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="zero").verify()
     with pytest.raises(VerifyException):
-        op3.verify()
+        riscv.CsrrwOp(rs1=a1, csr=csr, writeonly=IntegerAttr(1, i32), rd="a2").verify()
+    # CsrrsOp
+    riscv.CsrrsOp(rs1=a1, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrsOp(rs1=zero, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrsOp(rs1=zero, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+    with pytest.raises(VerifyException):
+        riscv.CsrrsOp(rs1=a1, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+    # CsrrcOp
+    riscv.CsrrcOp(rs1=a1, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrcOp(rs1=zero, csr=csr, readonly=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrcOp(rs1=zero, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+    with pytest.raises(VerifyException):
+        riscv.CsrrcOp(rs1=a1, csr=csr, readonly=IntegerAttr(1, i32), rd="a2").verify()
+    # CsrrwiOp
+    riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(0, i32), rd="zero").verify()
+    riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(1, i32), rd="zero").verify()
+    with pytest.raises(VerifyException):
+        riscv.CsrrwiOp(csr=csr, writeonly=IntegerAttr(1, i32), rd="a2").verify()
+    # CsrrsiOp
+    riscv.CsrrsiOp(csr=csr, immediate=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrsiOp(csr=csr, immediate=IntegerAttr(1, i32), rd="a2").verify()
+    # CsrrciOp
+    riscv.CsrrciOp(csr=csr, immediate=IntegerAttr(0, i32), rd="a2").verify()
+    riscv.CsrrsiOp(csr=csr, immediate=IntegerAttr(1, i32), rd="a2").verify()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -79,6 +79,11 @@
   // CHECK-NEXT: "riscv.sh"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   "riscv.sw"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.sw"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // RV32I/RV64I: Control and Status Register Instructions (Section 2.8)
+  %csrrw_rw = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 0 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrw_w = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   // Assembler pseudo-insgtructions
   %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -92,6 +92,14 @@
   // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %csrrc_r = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrsi_rw = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 8 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg<>
+  %csrrsi_r = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg<>
+  %csrrci_rw = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 8 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg<>
+  %csrrci_r = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg<>
   // Assembler pseudo-insgtructions
   %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -84,6 +84,14 @@
   // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %csrrw_w = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrs_rw = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrs_r = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrc_rw = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrc_r = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   // Assembler pseudo-insgtructions
   %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -100,6 +100,10 @@
   // CHECK-NEXT: %{{.*}} = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg<>
   %csrrci_r = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg<>
+  %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 0 : i32, "immediate" = 1 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 0 : i32, "immediate" = 1 : i32} : () -> !riscv.reg<>
+  %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 1 : i32, "immediate" = 1 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 1 : i32, "immediate" = 1 : i32} : () -> !riscv.reg<>
   // Assembler pseudo-insgtructions
   %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -80,18 +80,18 @@
   "riscv.sw"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.sw"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // RV32I/RV64I: Control and Status Register Instructions (Section 2.8)
-  %csrrw_rw = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 0 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  %csrrw_w = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  %csrrs_rw = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  %csrrs_r = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  %csrrc_rw = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 0 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  %csrrc_r = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrw_rw = "riscv.csrrw"(%0) {"csr" = 1024 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrw_w = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly"}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly"} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrs_rw = "riscv.csrrs"(%0) {"csr" = 1024 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrs"(%0) {"csr" = 1024 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrs_r = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly"}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly"} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrc_rw = "riscv.csrrc"(%0) {"csr" = 1024 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32} : (!riscv.reg<>) -> !riscv.reg<>
+  %csrrc_r = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly"}: (!riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly"} : (!riscv.reg<>) -> !riscv.reg<>
   %csrrsi_rw = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 8 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg<>
   %csrrsi_r = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<>
@@ -100,11 +100,11 @@
   // CHECK-NEXT: %{{.*}} = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg<>
   %csrrci_r = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg<>
-  %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 0 : i32, "immediate" = 1 : i32}: () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 0 : i32, "immediate" = 1 : i32} : () -> !riscv.reg<>
-  %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 1 : i32, "immediate" = 1 : i32}: () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly" = 1 : i32, "immediate" = 1 : i32} : () -> !riscv.reg<>
-  // Assembler pseudo-insgtructions
+  %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 1 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 1 : i32} : () -> !riscv.reg<>
+  %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly", "immediate" = 1 : i32}: () -> !riscv.reg<>
+  // CHECK-NEXT: %{{.*}} = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly", "immediate" = 1 : i32} : () -> !riscv.reg<>
+  // Assembler pseudo-instructions
   %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
   // Environment Call and Breakpoints

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -371,7 +371,6 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
 
     def __init__(
         self,
-        rs1: Operation | SSAValue,
         csr: AnyIntegerAttr,
         writeonly: AnyIntegerAttr,
         *,
@@ -382,7 +381,6 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
         elif isinstance(rd, str):
             rd = RegisterType(Register(rd))
         super().__init__(
-            operands=[rs1],
             attributes={
                 "csr": csr,
                 "writeonly": writeonly,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -275,8 +275,13 @@ class CsrReadWriteOperation(IRDLOperation, ABC):
         rs1: Operation | SSAValue,
         csr: AnyIntegerAttr,
         writeonly: AnyIntegerAttr,
+        *,
+        rd: RegisterType | str | None = None,
     ):
-        rd = RegisterType(Register())
+        if rd is None:
+            rd = RegisterType(Register())
+        elif isinstance(rd, str):
+            rd = RegisterType(Register(rd))
         super().__init__(
             operands=[rs1],
             attributes={
@@ -321,8 +326,13 @@ class CsrBitwiseOperation(IRDLOperation, ABC):
         rs1: Operation | SSAValue,
         csr: AnyIntegerAttr,
         readonly: AnyIntegerAttr,
+        *,
+        rd: RegisterType | str | None = None,
     ):
-        rd = RegisterType(Register())
+        if rd is None:
+            rd = RegisterType(Register())
+        elif isinstance(rd, str):
+            rd = RegisterType(Register(rd))
         super().__init__(
             operands=[rs1],
             attributes={
@@ -364,8 +374,13 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
         rs1: Operation | SSAValue,
         csr: AnyIntegerAttr,
         writeonly: AnyIntegerAttr,
+        *,
+        rd: RegisterType | str | None = None,
     ):
-        rd = RegisterType(Register())
+        if rd is None:
+            rd = RegisterType(Register())
+        elif isinstance(rd, str):
+            rd = RegisterType(Register(rd))
         super().__init__(
             operands=[rs1],
             attributes={
@@ -408,8 +423,13 @@ class CsrBitwiseImmOperation(IRDLOperation, ABC):
         self,
         csr: AnyIntegerAttr,
         immediate: AnyIntegerAttr,
+        *,
+        rd: RegisterType | str | None = None,
     ):
-        rd = RegisterType(Register())
+        if rd is None:
+            rd = RegisterType(Register())
+        elif isinstance(rd, str):
+            rd = RegisterType(Register(rd))
         super().__init__(
             attributes={
                 "csr": csr,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -284,12 +284,12 @@ class CsrReadWriteOperation(IRDLOperation, ABC):
             rd = RegisterType(Register())
         elif isinstance(rd, str):
             rd = RegisterType(Register(rd))
-        attributes: dict[str, Attribute] = {"csr": csr}
-        if writeonly:
-            attributes["writeonly"] = UnitAttr()
         super().__init__(
             operands=[rs1],
-            attributes=attributes,
+            attributes={
+                "csr": csr,
+                "writeonly": UnitAttr() if writeonly else None,
+            },
             result_types=[rd],
         )
 
@@ -335,12 +335,12 @@ class CsrBitwiseOperation(IRDLOperation, ABC):
             rd = RegisterType(Register())
         elif isinstance(rd, str):
             rd = RegisterType(Register(rd))
-        attributes: dict[str, Attribute] = {"csr": csr}
-        if readonly:
-            attributes["readonly"] = UnitAttr()
         super().__init__(
             operands=[rs1],
-            attributes=attributes,
+            attributes={
+                "csr": csr,
+                "readonly": UnitAttr() if readonly else None,
+            },
             result_types=[rd],
         )
 
@@ -382,11 +382,11 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
             rd = RegisterType(Register())
         elif isinstance(rd, str):
             rd = RegisterType(Register(rd))
-        attributes: dict[str, Attribute] = {"csr": csr}
-        if writeonly:
-            attributes["writeonly"] = UnitAttr()
         super().__init__(
-            attributes=attributes,
+            attributes={
+                "csr": csr,
+                "writeonly": UnitAttr() if writeonly else None,
+            },
             result_types=[rd],
         )
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -391,7 +391,7 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
         )
 
     def verify_(self) -> None:
-        if not self.writeonly:
+        if self.writeonly is None:
             return
         if not isinstance(self.rd.typ, RegisterType):
             return

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -282,7 +282,7 @@ class CsrReadWriteOperation(IRDLOperation, ABC):
         )
 
 
-class CsrReadAndBitwiseOperation(IRDLOperation, ABC):
+class CsrBitwiseOperation(IRDLOperation, ABC):
     """
     A base class for RISC-V operations performing a masked bitwise operation on the
     CSR while returning the original value.
@@ -907,7 +907,7 @@ class CsrrwOp(CsrReadWriteOperation):
 
 
 @irdl_op_definition
-class CsrrsOp(CsrReadAndBitwiseOperation):
+class CsrrsOp(CsrBitwiseOperation):
     """
     Reads the value of the CSR, zero-extends the value to XLEN bits, and writes
     it to integer register rd. The initial value in integer register rs1 is treated
@@ -932,7 +932,7 @@ class CsrrsOp(CsrReadAndBitwiseOperation):
 
 
 @irdl_op_definition
-class CsrrcOp(CsrReadAndBitwiseOperation):
+class CsrrcOp(CsrBitwiseOperation):
     """
     Reads the value of the CSR, zero-extends the value to XLEN bits, and writes
     it to integer register rd. The initial value in integer register rs1 is treated

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -249,7 +249,7 @@ class NullaryOperation(IRDLOperation, ABC):
         super().__init__()
 
 
-class CsrSwapOperation(IRDLOperation, ABC):
+class CsrReadWriteOperation(IRDLOperation, ABC):
     """
     A base class for RISC-V operations performing a swap to/from a CSR.
 
@@ -889,7 +889,7 @@ class SwOp(RsRsImmOperation):
 
 
 @irdl_op_definition
-class CsrrwOp(CsrSwapOperation):
+class CsrrwOp(CsrReadWriteOperation):
     """
     Atomically swaps values in the CSRs and integer registers.
     CSRRW reads the old value of the CSR, zero-extends the value to XLEN bits,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -349,7 +349,7 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
         )
 
 
-class CsrReadAndBitwiseImmOperation(IRDLOperation, ABC):
+class CsrBitwiseImmOperation(IRDLOperation, ABC):
     """
     A base class for RISC-V operations performing a masked bitwise operation on the
     CSR while returning the original value. The bitmask is specified in the 'immediate'
@@ -974,7 +974,7 @@ class CsrrwiOp(CsrReadWriteImmOperation):
 
 
 @irdl_op_definition
-class CsrrsiOp(CsrReadAndBitwiseImmOperation):
+class CsrrsiOp(CsrBitwiseImmOperation):
     """
     Reads the value of the CSR, zero-extends the value to XLEN bits, and writes
     it to integer register rd. The value in the 'immediate' attribute is treated
@@ -997,7 +997,7 @@ class CsrrsiOp(CsrReadAndBitwiseImmOperation):
 
 
 @irdl_op_definition
-class CsrrciOp(CsrReadAndBitwiseImmOperation):
+class CsrrciOp(CsrBitwiseImmOperation):
     """
     Reads the value of the CSR, zero-extends the value to XLEN bits, and writes
     it to integer register rd.  The value in the 'immediate' attribute is treated

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -11,6 +11,7 @@ from xdsl.ir import (
     Data,
     OpResult,
     TypeAttribute,
+    Attribute,
 )
 
 from xdsl.irdl import (
@@ -283,7 +284,7 @@ class CsrReadWriteOperation(IRDLOperation, ABC):
             rd = RegisterType(Register())
         elif isinstance(rd, str):
             rd = RegisterType(Register(rd))
-        attributes = {"csr": csr}
+        attributes: dict[str, Attribute] = {"csr": csr}
         if writeonly:
             attributes["writeonly"] = UnitAttr()
         super().__init__(
@@ -334,7 +335,7 @@ class CsrBitwiseOperation(IRDLOperation, ABC):
             rd = RegisterType(Register())
         elif isinstance(rd, str):
             rd = RegisterType(Register(rd))
-        attributes = {"csr": csr}
+        attributes: dict[str, Attribute] = {"csr": csr}
         if readonly:
             attributes["readonly"] = UnitAttr()
         super().__init__(
@@ -381,7 +382,7 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
             rd = RegisterType(Register())
         elif isinstance(rd, str):
             rd = RegisterType(Register(rd))
-        attributes = {"csr": csr}
+        attributes: dict[str, Attribute] = {"csr": csr}
         if writeonly:
             attributes["writeonly"] = UnitAttr()
         super().__init__(

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -11,7 +11,6 @@ from xdsl.ir import (
     Data,
     OpResult,
     TypeAttribute,
-    Attribute,
 )
 
 from xdsl.irdl import (


### PR DESCRIPTION
This PR adds all the instructions in the RV32I/RV64I Section 2.8 (Control and Status Register Instructions) of the spec.

WIP: this section of the spec defines instructions with weird behavior, like:

> Atomically swaps values in the CSRs and integer registers. CSRRW reads the old value of the CSR, zero-extends the value to XLEN bits, then writes it to integer register rd. The initial value in rs1 is written to the CSR. The initial value in rs1 is written to the CSR. **If rd=x0, then the instruction shall not read the CSR and shall not cause any of the side-effects that might occur on a CSR read.**

In order to expose this *full* (e.g.: *read/write*) VS *limited* (e.g.: *write only*) behavior the idea is to treat instructions like regular ones by taking into account their *full* behaviour and then use an attribute to switch on the *limited* mode. When, for example,  we have a `riscv.csrrw` in *limited mode*, rd **must be allocated to x0**.