### PR TITLE
core: Add operation custom format

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 
 import re
 from io import StringIO
+from typing import Annotated
 
 from xdsl.dialects.arith import Arith, Addi, Constant
-from xdsl.dialects.builtin import Builtin, IntAttr, ModuleOp, UnitAttr, i32
+from xdsl.dialects.builtin import Builtin, IntAttr, IntegerType, ModuleOp, UnitAttr, i32
 from xdsl.dialects.func import Func
 from xdsl.ir import (
     Attribute,
     MLContext,
+    OpResult,
     Operation,
     ParametrizedAttribute,
     Block,
 )
 from xdsl.irdl import (
+    Operand,
     OptOpAttr,
     ParameterDef,
     irdl_attr_definition,
@@ -363,6 +366,113 @@ def test_print_custom_block_arg_name():
 # | |__| |_| \__ \ || (_) | | | | | |  _| (_) | |  | | | | | | (_| | |_
 #  \____\__,_|___/\__\___/|_| |_| |_|_|  \___/|_|  |_| |_| |_|\__,_|\__|
 #
+
+
+@irdl_op_definition
+class PlusCustomFormatOp(IRDLOperation):
+    name = "test.add"
+    lhs: Annotated[Operand, IntegerType]
+    rhs: Annotated[Operand, IntegerType]
+    res: Annotated[OpResult, IntegerType]
+
+    @classmethod
+    def parse(cls, parser: Parser) -> PlusCustomFormatOp:
+        lhs = parser.parse_operand("Expected SSA Value name here!")
+        parser.parse_characters("+", "Malformed operation format, expected `+`!")
+        rhs = parser.parse_operand("Expected SSA Value name here!")
+        parser.parse_punctuation(":")
+        type = parser.expect(parser.try_parse_type, "Expect type here!")
+
+        return PlusCustomFormatOp.create(operands=[lhs, rhs], result_types=[type])
+
+    def print(self, printer: Printer):
+        printer.print(" ", self.lhs, " + ", self.rhs, " : ", self.res.typ)
+
+
+def test_generic_format():
+    """
+    Test that we can use generic formats in operations.
+    """
+    prog = """
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+  %1 = "test.add"(%0, %0) : (i32, i32) -> i32
+}) : () -> ()"""
+
+    expected = """\
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+  %1 = test.add %0 + %0 : i32
+}) : () -> ()
+"""
+
+    ctx = MLContext()
+    ctx.register_dialect(Arith)
+    ctx.register_dialect(Builtin)
+    ctx.register_op(PlusCustomFormatOp)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    assert_print_op(module, expected, None, False)
+
+
+def test_custom_format():
+    """
+    Test that we can use custom formats in operations.
+    """
+    prog = """\
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+  %1 = test.add %0 + %0 : i32
+}) : () -> ()
+"""
+
+    expected = """\
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+  %1 = test.add %0 + %0 : i32
+}) : () -> ()
+"""
+
+    ctx = MLContext()
+    ctx.register_dialect(Arith)
+    ctx.register_dialect(Builtin)
+    ctx.register_op(PlusCustomFormatOp)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    assert_print_op(module, expected, None, False)
+
+
+def test_custom_format_II():
+    """
+    Test that we can print using generic formats.
+    """
+    prog = """\
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+  %1 = test.add %0 + %0 : i32
+}) : () -> ()
+"""
+
+    expected = """\
+"builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+  %1 = "test.add"(%0, %0) : (i32, i32) -> i32
+}) : () -> ()
+"""
+
+    ctx = MLContext()
+    ctx.register_dialect(Arith)
+    ctx.register_dialect(Builtin)
+    ctx.register_op(PlusCustomFormatOp)
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_op()
+
+    assert_print_op(module, expected, None, print_generic_format=True)
 
 
 @irdl_attr_definition

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -786,10 +786,8 @@ class Operation(IRNode):
     _OperationType = TypeVar("_OperationType", bound="Operation")
 
     @classmethod
-    def parse(
-        cls: type[_OperationType], result_types: list[Attribute], parser: Parser
-    ) -> _OperationType:
-        parser.raise_error(f"Parsing not implemented for operation {cls.name}")
+    def parse(cls: type[_OperationType], parser: Parser) -> _OperationType:
+        parser.raise_error(f"Operation {cls.name} does not have a custom format.")
 
     def print(self, printer: Printer):
         return printer.print_op_with_default_format(self)

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1520,7 +1520,8 @@ class Parser(ABC):
         # Check for custom op format
         op_name = self.try_parse_bare_id()
         if op_name is not None:
-            self.raise_error("Custom op parsing not yet implemented.")
+            op_type = self._get_op_by_name(op_name)
+            return op_type.parse(self)
         else:
             # Check for basic op format
             op_name = self.try_parse_string_literal()

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -673,6 +673,8 @@ class Printer:
         use_custom_format = False
         if isinstance(op, UnregisteredOp):
             self.print(f'"{op.op_name.data}"')
+        # If we print with the generic format, or the operation does not have a custom
+        # format
         elif self.print_generic_format or Operation.print is type(op).print:
             self.print(f'"{op.name}"')
         else:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -670,10 +670,14 @@ class Printer:
             raise TypeError("Expected an Operation; got %s" % type(op).__name__)
         begin_op_pos = self._current_column
         self._print_results(op)
+        use_custom_format = False
         if isinstance(op, UnregisteredOp):
             self.print(f'"{op.op_name.data}"')
-        else:
+        elif self.print_generic_format or Operation.print is type(op).print:
             self.print(f'"{op.name}"')
+        else:
+            self.print(f"{op.name}")
+            use_custom_format = True
         end_op_pos = self._current_column
         if op in self.diagnostic.op_messages:
             for message in self.diagnostic.op_messages[op]:
@@ -683,5 +687,7 @@ class Printer:
             del op.attributes["op_name__"]
             self.print_op_with_default_format(op)
             op.attributes["op_name__"] = op_name
+        elif use_custom_format:
+            op.print(self)
         else:
             self.print_op_with_default_format(op)


### PR DESCRIPTION
This PRs adds back support for operation custom format.
This means that we can add custom printing and parsing functions to our operations, so they are printed in a more concise and readable way.