### PR TITLE
dialects: add LowerNullRequestOp to lower-mpi pass

### DIFF
--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -825,6 +825,7 @@ class LowerMPIPass(ModulePass):
                     LowerMpiUnwrapMemrefOp(lib_info),
                     LowerMpiGetDtype(lib_info),
                     LowerMpiAllocateType(lib_info),
+                    LowerNullRequestOp(lib_info),
                     LowerMpiVectorGet(lib_info),
                 ]
             ),


### PR DESCRIPTION
This just adds `LowerNullRequestOp` to the `lower-mpi` pass, apparently I forgot that previously.