### PR TITLE
dialects: fix the MpiLoopInvariantCodeMotion pass

### DIFF
--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -414,7 +414,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
             GreedyRewritePatternApplier(
                 [
                     LowerHaloExchangeToMpi(HorizontalSlices2D(2)),
-                    MpiLoopInvariantCodeMotion(),
                 ]
             )
         ).rewrite_module(op)
+        MpiLoopInvariantCodeMotion().rewrite_module(op)

--- a/xdsl/transforms/experimental/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/stencil_global_to_local.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import TypeVar, Iterable, ClassVar, Callable
 from abc import ABC, abstractmethod
 from math import prod
+
 from xdsl.passes import ModulePass
 
 from xdsl.utils.hints import isa
@@ -12,6 +13,7 @@ from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import Rewriter
 from xdsl.ir import MLContext, Operation, SSAValue, Block, Region, OpResult
 from xdsl.irdl import Attribute
 from xdsl.dialects import builtin, mpi, memref, arith, scf, func
@@ -572,8 +574,16 @@ def generate_memcpy(
     ]
 
 
-class MpiLoopInvariantCodeMotion(RewritePattern):
+class MpiLoopInvariantCodeMotion:
     """
+    THIS IS NOT A REWRITE PATTERN!
+
+    This is a two-stage rewrite that modifies operations in a manner
+    that is incompatible with the PatternRewriter!
+
+    It implements a custom rewrite_module() method directly
+    on the class.
+
     This rewrite moves all memref.allo, mpi.comm.rank, mpi.allocate
     and mpi.unwrap_memref ops and moves them "up" until it hits a
     func.func, and then places them *before* the op they appear in.
@@ -586,15 +596,14 @@ class MpiLoopInvariantCodeMotion(RewritePattern):
         self.seen_ops = set()
         self.has_init = set()
 
-    @op_type_rewrite_pattern
-    def match_and_rewrite(
+    def rewrite(
         self,
         op: memref.Alloc
         | mpi.CommRank
         | mpi.AllocateTypeOp
         | mpi.UnwrapMemrefOp
         | mpi.Init,
-        rewriter: PatternRewriter,
+        rewriter: Rewriter,
         /,
     ):
         if op in self.seen_ops:
@@ -606,7 +615,7 @@ class MpiLoopInvariantCodeMotion(RewritePattern):
             op.ref.owner, memref.Alloc
         ):
             op.detach()
-            rewriter.insert_op_after(op, op.ref.owner)
+            rewriter.insert_op_after(op.ref.owner, op)
             return
 
         base = op
@@ -631,19 +640,71 @@ class MpiLoopInvariantCodeMotion(RewritePattern):
         if isinstance(op, mpi.Init):
             # ignore multiple inits
             if parent in self.has_init:
-                rewriter.erase_matched_op()
+                rewriter.erase_op(op)
                 return
             self.has_init.add(parent)
             # add a finalize() call to the end of the function
             block = parent.regions[0].blocks[-1]
             return_op = block.last_op
             assert return_op is not None
-            rewriter.insert_op_before(mpi.Finalize(), return_op)
+            rewriter.insert_op_before(return_op, mpi.Finalize())
 
         ops = list(collect_args_recursive(op))
-        for found_ops in ops:
-            found_ops.detach()
-        rewriter.insert_op_before(ops, base)
+        for found_op in ops:
+            found_op.detach()
+            rewriter.insert_op_before(base, found_op)
+
+    def get_matcher(
+        self,
+        worklist: list[
+            memref.Alloc
+            | mpi.CommRank
+            | mpi.AllocateTypeOp
+            | mpi.UnwrapMemrefOp
+            | mpi.Init
+        ],
+    ) -> Callable[[Operation], None]:
+        """
+        Returns a match() function that adds methods to a worklist
+        if they satisfy some criteria.
+        """
+
+        def match(op: Operation):
+            if isinstance(
+                op,
+                (
+                    memref.Alloc,
+                    mpi.CommRank,
+                    mpi.AllocateTypeOp,
+                    mpi.UnwrapMemrefOp,
+                    mpi.Init,
+                ),
+            ):
+                worklist.append(op)
+
+        return match
+
+    def rewrite_module(self, op: builtin.ModuleOp):
+        """
+        Apply the rewrite to a module.
+
+        We do a two-stage rewrite because we are modifying
+        the operations we loop on them, which would throw of `op.walk`.
+        """
+        # collect all ops that should be rewritten
+        worklist: list[
+            memref.Alloc
+            | mpi.CommRank
+            | mpi.AllocateTypeOp
+            | mpi.UnwrapMemrefOp
+            | mpi.Init
+        ] = list()
+        op.walk(self.get_matcher(worklist))
+
+        # rewrite ops
+        rewriter = Rewriter()
+        for matched_op in worklist:
+            self.rewrite(matched_op, rewriter)
 
 
 _LOOP_INVARIANT_OPS = (arith.Constant, arith.Addi, arith.Muli)


### PR DESCRIPTION
This moves the `MpiLoopInvariantCodeMotion` pass to a two-stage rewrite because it does nonlocal modifications