### PR TITLE
dialects: add snitch low-level dialect

### DIFF
--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,16 +1,16 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 "builtin.module"() ({
   %A, %B = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>) // vector {A,B}: base address
-  %n = "riscv.li"() {"immediate" = 10 : i32} : () -> !riscv.reg<> // vector {A,B}: size
+  %n = "test.op"() : () -> !riscv.reg<> // vector {A,B}: size
   // dm: data mover id
-  %s0 = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
-  %s1 = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+  %s0 = "test.op"() : () -> !riscv.reg<>
+  %s1 = "test.op"() : () -> !riscv.reg<>
   // bound: vector size, minus one
-  %bound = "riscv.li"() {"immediate" = 9 : i32} : () -> !riscv.reg<>
+  %bound = "test.op"() : () -> !riscv.reg<>
   // stride: in bytes
-  %stride = "riscv.li"() {"immediate" = 4 : i32} : () -> !riscv.reg<>
+  %stride = "test.op"() : () -> !riscv.reg<>
   // repetition: number of times each element will be repeated, minus one
-  %rep = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
+  %rep = "test.op"() : () -> !riscv.reg<>
   // Usual SSR setup sequence:
   "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -12,7 +12,7 @@
   %stride = "riscv.li"() {"immediate" = 4 : i32} : () -> !riscv.reg<>
   // repetition: number of times each element will be repeated, minus one
   %rep = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
-  
+  // Usual SSR setup sequence:
   "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_setup_repetition"(%s0, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,7 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 "builtin.module"() ({
-  %A = "test.op"() : () -> !riscv.reg<> // vector A: base address
-  %B = "test.op"() : () -> !riscv.reg<> // vector B: base address
+  %A, %B = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>) // vector {A,B}: base address
   %n = "riscv.li"() {"immediate" = 10 : i32} : () -> !riscv.reg<> // vector {A,B}: size
   // dm: data mover id
   %s0 = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -12,21 +12,19 @@
   %stride = "riscv.li"() {"immediate" = 4 : i32} : () -> !riscv.reg<>
   // repetition: number of times each element will be repeated, minus one
   %rep = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
-  // dimension: dimension index, minus one
-  %dim = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
   
-  "snitch.ssr_setup_bound_stride_1d"(%s0, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_setup_bound_stride_1d"(%s0, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_setup_repetition"(%s0, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "snitch.ssr_setup_repetition"(%s0, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_read"(%s0, %dim, %A) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_read"(%s0, %dim, %A) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_setup_bound_stride_1d"(%s1, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_setup_bound_stride_1d"(%s1, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_setup_repetition"(%s1, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_setup_repetition"(%s1, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_read"(%s1, %dim, %B) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_read"(%s1, %dim, %B) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_read"(%s0, %A) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_read"(%s0, %A) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_setup_shape"(%s1, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_setup_shape"(%s1, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_setup_repetition"(%s1, %rep) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_setup_repetition"(%s1, %rep) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_read"(%s1, %B) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_read"(%s1, %B) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_enable"() : () -> ()
   // CHECK-NEXT: "snitch.ssr_enable"() : () -> ()
   "snitch.ssr_disable"() : () -> ()

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,0 +1,34 @@
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+"builtin.module"() ({
+  %A = "test.op"() : () -> !riscv.reg<> // vector A: base address
+  %B = "test.op"() : () -> !riscv.reg<> // vector B: base address
+  %n = "riscv.li"() {"immediate" = 10 : i32} : () -> !riscv.reg<> // vector {A,B}: size
+  // dm: data mover id
+  %s0 = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
+  %s1 = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+  // bound: vector size, minus one
+  %bound = "riscv.li"() {"immediate" = 9 : i32} : () -> !riscv.reg<>
+  // stride: in bytes
+  %stride = "riscv.li"() {"immediate" = 4 : i32} : () -> !riscv.reg<>
+  // repetition: number of times each element will be repeated, minus one
+  %rep = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
+  // dimension: dimension index, minus one
+  %dim = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>
+  
+  "snitch.ssr_setup_bound_stride_1d"(%s0, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_setup_bound_stride_1d"(%s0, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_setup_repetition"(%s0, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_setup_repetition"(%s0, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_read"(%s0, %dim, %A) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_read"(%s0, %dim, %A) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_setup_bound_stride_1d"(%s1, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_setup_bound_stride_1d"(%s1, %bound, %stride) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_setup_repetition"(%s1, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_setup_repetition"(%s1, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_read"(%s1, %dim, %B) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK-NEXT: "snitch.ssr_read"(%s1, %dim, %B) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_enable"() : () -> ()
+  // CHECK-NEXT: "snitch.ssr_enable"() : () -> ()
+  "snitch.ssr_disable"() : () -> ()
+  // CHECK-NEXT: "snitch.ssr_disable"() : () -> ()
+}) : () -> ()

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -2,23 +2,26 @@ from typing import Annotated
 
 from xdsl.dialects.riscv import RegisterType
 
+from xdsl.dialects.builtin import AnyIntegerAttr
+
 from xdsl.ir import Dialect
 
-from xdsl.irdl import IRDLOperation, irdl_op_definition, Operand
+from xdsl.irdl import IRDLOperation, irdl_op_definition, Operand, OpAttr
 
 
 @irdl_op_definition
-class SsrSetupBoundStride1d(IRDLOperation):
+class SsrSetupShape(IRDLOperation):
     """
-    Setup bound and stride for the first dimension handled by a
+    Setup the shape (bound and stride) for an arbitrary dimension handled by a
     specific data mover.
     """
 
-    name: str = "snitch.ssr_setup_bound_stride_1d"
+    name: str = "snitch.ssr_setup_shape"
 
     datamover: Annotated[Operand, RegisterType]
     bound: Annotated[Operand, RegisterType]
     stride: Annotated[Operand, RegisterType]
+    dimension: OpAttr[AnyIntegerAttr]
 
 
 @irdl_op_definition
@@ -43,8 +46,8 @@ class SsrRead(IRDLOperation):
     name: str = "snitch.ssr_read"
 
     datamover: Annotated[Operand, RegisterType]
-    dimension: Annotated[Operand, RegisterType]
     address: Annotated[Operand, RegisterType]
+    dimension: OpAttr[AnyIntegerAttr]
 
 
 @irdl_op_definition
@@ -57,8 +60,8 @@ class SsrWrite(IRDLOperation):
     name: str = "snitch.ssr_write"
 
     datamover: Annotated[Operand, RegisterType]
-    dimension: Annotated[Operand, RegisterType]
     address: Annotated[Operand, RegisterType]
+    dimension: OpAttr[AnyIntegerAttr]
 
 
 @irdl_op_definition
@@ -81,7 +84,7 @@ class SsrDisable(IRDLOperation):
 
 Snitch = Dialect(
     [
-        SsrSetupBoundStride1d,
+        SsrSetupShape,
         SsrSetupRepetition,
         SsrRead,
         SsrWrite,

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -1,7 +1,8 @@
 """
-This dialect provides operations to address features of the Snitch[1]
-architecture; it works on riscv types directly as all arguments are of
-riscv.reg<> type and it is meant to be as close as possible to the asm
+This dialect provides operations to target features of the Snitch[1]
+streaming architecture based on custom extensions to the RISC-V ISA.
+This dialect works on 'riscv' types directly as all arguments are of
+'riscv.reg<>' type and it is meant to be as close as possible to the asm
 that aims at generating.
 
 [1] https://pulp-platform.github.io/snitch/publications

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -1,4 +1,5 @@
-"""This dialect provides operations to address features of the Snitch[1]
+"""
+This dialect provides operations to address features of the Snitch[1]
 architecture; it works on riscv types directly as all arguments are of
 riscv.reg<> type and it is meant to be as close as possible to the asm
 that aims at generating.

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -12,7 +12,7 @@ from xdsl.dialects.riscv import RegisterType
 
 from xdsl.dialects.builtin import AnyIntegerAttr
 
-from xdsl.ir import Dialect
+from xdsl.ir import Dialect, Operation, SSAValue
 
 from xdsl.irdl import IRDLOperation, irdl_op_definition, Operand, OpAttr
 
@@ -31,6 +31,20 @@ class SsrSetupShape(IRDLOperation):
     stride: Annotated[Operand, RegisterType]
     dimension: OpAttr[AnyIntegerAttr]
 
+    def __init__(
+        self,
+        datamover: Operation | SSAValue,
+        bound: Operation | SSAValue,
+        stride: Operation | SSAValue,
+        dimension: AnyIntegerAttr,
+    ):
+        super().__init__(
+            operands=[datamover, bound, stride],
+            attributes={
+                "dimension": dimension,
+            },
+        )
+
 
 @irdl_op_definition
 class SsrSetupRepetition(IRDLOperation):
@@ -42,6 +56,13 @@ class SsrSetupRepetition(IRDLOperation):
 
     datamover: Annotated[Operand, RegisterType]
     repetition: Annotated[Operand, RegisterType]
+
+    def __init__(
+        self,
+        datamover: Operation | SSAValue,
+        repetition: Operation | SSAValue,
+    ):
+        super().__init__(operands=[datamover, repetition])
 
 
 @irdl_op_definition
@@ -57,6 +78,19 @@ class SsrRead(IRDLOperation):
     address: Annotated[Operand, RegisterType]
     dimension: OpAttr[AnyIntegerAttr]
 
+    def __init__(
+        self,
+        datamover: Operation | SSAValue,
+        address: Operation | SSAValue,
+        dimension: AnyIntegerAttr,
+    ):
+        super().__init__(
+            operands=[datamover, address],
+            attributes={
+                "dimension": dimension,
+            },
+        )
+
 
 @irdl_op_definition
 class SsrWrite(IRDLOperation):
@@ -71,6 +105,19 @@ class SsrWrite(IRDLOperation):
     address: Annotated[Operand, RegisterType]
     dimension: OpAttr[AnyIntegerAttr]
 
+    def __init__(
+        self,
+        datamover: Operation | SSAValue,
+        address: Operation | SSAValue,
+        dimension: AnyIntegerAttr,
+    ):
+        super().__init__(
+            operands=[datamover, address],
+            attributes={
+                "dimension": dimension,
+            },
+        )
+
 
 @irdl_op_definition
 class SsrEnable(IRDLOperation):
@@ -80,6 +127,9 @@ class SsrEnable(IRDLOperation):
 
     name: str = "snitch.ssr_enable"
 
+    def __init__(self):
+        super().__init__()
+
 
 @irdl_op_definition
 class SsrDisable(IRDLOperation):
@@ -88,6 +138,9 @@ class SsrDisable(IRDLOperation):
     """
 
     name: str = "snitch.ssr_disable"
+
+    def __init__(self):
+        super().__init__()
 
 
 Snitch = Dialect(

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -1,0 +1,92 @@
+from typing import Annotated
+
+from xdsl.dialects.riscv import RegisterType
+
+from xdsl.ir import Dialect
+
+from xdsl.irdl import IRDLOperation, irdl_op_definition, Operand
+
+
+@irdl_op_definition
+class SsrSetupBoundStride1d(IRDLOperation):
+    """
+    Setup bound and stride for the first dimension handled by a
+    specific data mover.
+    """
+
+    name: str = "snitch.ssr_setup_bound_stride_1d"
+
+    datamover: Annotated[Operand, RegisterType]
+    bound: Annotated[Operand, RegisterType]
+    stride: Annotated[Operand, RegisterType]
+
+
+@irdl_op_definition
+class SsrSetupRepetition(IRDLOperation):
+    """
+    Setup repetition count for a specific data mover.
+    """
+
+    name: str = "snitch.ssr_setup_repetition"
+
+    datamover: Annotated[Operand, RegisterType]
+    repetition: Annotated[Operand, RegisterType]
+
+
+@irdl_op_definition
+class SsrRead(IRDLOperation):
+    """
+    Setup a dimension for a data mover to be a read stream on a
+    specific base address.
+    """
+
+    name: str = "snitch.ssr_read"
+
+    datamover: Annotated[Operand, RegisterType]
+    dimension: Annotated[Operand, RegisterType]
+    address: Annotated[Operand, RegisterType]
+
+
+@irdl_op_definition
+class SsrWrite(IRDLOperation):
+    """
+    Setup a dimension for a data mover to be a write stream on a
+    specific base address.
+    """
+
+    name: str = "snitch.ssr_write"
+
+    datamover: Annotated[Operand, RegisterType]
+    dimension: Annotated[Operand, RegisterType]
+    address: Annotated[Operand, RegisterType]
+
+
+@irdl_op_definition
+class SsrEnable(IRDLOperation):
+    """
+    Enable stream semantics.
+    """
+
+    name: str = "snitch.ssr_enable"
+
+
+@irdl_op_definition
+class SsrDisable(IRDLOperation):
+    """
+    Disable stream semantics.
+    """
+
+    name: str = "snitch.ssr_disable"
+
+
+Snitch = Dialect(
+    [
+        SsrSetupBoundStride1d,
+        SsrSetupRepetition,
+        SsrRead,
+        SsrWrite,
+        SsrEnable,
+        SsrDisable,
+    ],
+    [],
+)

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -1,3 +1,11 @@
+"""This dialect provides operations to address features of the Snitch[1]
+architecture; it works on riscv types directly as all arguments are of
+riscv.reg<> type and it is meant to be as close as possible to the asm
+that aims at generating.
+
+[1] https://pulp-platform.github.io/snitch/publications
+"""
+
 from typing import Annotated
 
 from xdsl.dialects.riscv import RegisterType

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -4,6 +4,7 @@ import os
 
 from io import StringIO
 from xdsl.dialects.riscv import RISCV
+from xdsl.dialects.snitch import Snitch
 from xdsl.frontend.symref import Symref
 
 from xdsl.ir import MLContext
@@ -223,6 +224,7 @@ class xDSLOptMain:
         self.ctx.register_dialect(Symref)
         self.ctx.register_dialect(Test)
         self.ctx.register_dialect(RISCV)
+        self.ctx.register_dialect(Snitch)
 
     def register_all_frontends(self):
         """


### PR DESCRIPTION
This PR adds a first draft of the Snitch dialect. Please consider that this is meant to be a *low-level dialect* in the sense that:

* It works on `riscv` types directly (e.g.: all arguments are of `riscv.reg<>` type)
* It is meant to be as close as possible to the asm that aims at generating (e.g.: each operation can be lowered as a sequence of few `riscv` instructions, potentially just one)

Edit: TODO list moved to #883 