### PR TITLE
docs: add back scalar.toy filecheck

### DIFF
--- a/docs/Toy/examples/scalar.toy
+++ b/docs/Toy/examples/scalar.toy
@@ -6,7 +6,7 @@ def main() {
 }
 
 # CHECK:         "toy.func"() ({
-# CHECK-NEXT:      %0 = "toy.constant"() {"value" = dense<5.5> : tensor<f64>} : () -> tensor<4xf64>
+# CHECK-NEXT:      %0 = "toy.constant"() {"value" = dense<5.5> : tensor<f64>} : () -> tensor<f64>
 # CHECK-NEXT:      %1 = "toy.reshape"(%0) : (tensor<f64>) -> tensor<2x2xf64>
 # CHECK-NEXT:      "toy.print"(%1) : (tensor<2x2xf64>) -> ()
 # CHECK-NEXT:      "toy.return"() : () -> ()

--- a/docs/Toy/examples/scalar.toy
+++ b/docs/Toy/examples/scalar.toy
@@ -1,0 +1,13 @@
+# RUN: python -m toy %s --emit=ir | filecheck %s
+
+def main() {
+  var a<2, 2> = 5.5;
+  print(a);
+}
+
+# CHECK:         "toy.func"() ({
+# CHECK-NEXT:      %0 = "toy.constant"() {"value" = dense<5.5> : tensor<f64>} : () -> tensor<4xf64>
+# CHECK-NEXT:      %1 = "toy.reshape"(%0) : (tensor<f64>) -> tensor<2x2xf64>
+# CHECK-NEXT:      "toy.print"(%1) : (tensor<2x2xf64>) -> ()
+# CHECK-NEXT:      "toy.return"() : () -> ()
+# CHECK-NEXT:    }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()

--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -65,6 +65,10 @@ class ConstantOp(IRDLOperation):
         value = DenseIntOrFPElementsAttr.tensor_from_list(data, f64, shape)
         return ConstantOp(value)
 
+    @staticmethod
+    def from_value(value: float) -> ConstantOp:
+        return ConstantOp(DenseIntOrFPElementsAttr.tensor_from_list([value], f64, []))
+
     def verify_(self) -> None:
         if not self.res.typ == self.value.type:
             raise VerifyException(

--- a/docs/Toy/toy/frontend/parser.py
+++ b/docs/Toy/toy/frontend/parser.py
@@ -175,12 +175,15 @@ class Parser:
         numberToken = self.pop_token(NumberToken)
         return NumberExprAST(numberToken.loc, numberToken.value)
 
-    def parseTensorLiteralExpr(self):
+    def parseTensorLiteralExpr(self) -> LiteralExprAST | NumberExprAST:
         """
         Parse a literal array expression.
         tensorLiteral ::= [ literalList ] | number
         literalList ::= tensorLiteral | tensorLiteral, literalList
         """
+        if self.check(NumberToken):
+            return self.parseNumberExpr()
+
         openBracket = self.pop_pattern("[")
 
         # Hold the list of values at this nesting level.

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -1,11 +1,8 @@
-from io import StringIO
 from pathlib import Path
 
-from xdsl.ir import MLContext, OpResult, BlockArgument, SSAValue
-from xdsl.dialects.builtin import DenseIntOrFPElementsAttr, FunctionType, f64, ModuleOp
+from xdsl.ir import OpResult, BlockArgument, SSAValue
+from xdsl.dialects.builtin import FunctionType, f64, ModuleOp
 from xdsl.builder import Builder
-from xdsl.printer import Printer
-from xdsl.parser import Parser as Parser_
 
 from ..frontend.parser import Parser
 from ..frontend.ir_gen import IRGen
@@ -97,22 +94,3 @@ def test_convert_scalar():
         toy.FuncOp("main", FunctionType.from_lists([], []), main)
 
     assert module_op.is_structurally_equivalent(generated_module_op)
-
-
-def test_bla():
-    ctx = MLContext()
-
-    parser = Parser_(ctx, "dense<5.5> : tensor<f64>")
-    bla = parser.parse_attribute()
-
-    stream = StringIO()
-    printer = Printer(stream=stream)
-
-    attr = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f64, [])
-
-    assert bla == attr
-
-    printer.print_attribute(attr)
-    desc = stream.getvalue()
-
-    assert desc == "dense<5.5> : tensor<f64>"

--- a/docs/Toy/toy/tests/test_parser.py
+++ b/docs/Toy/toy/tests/test_parser.py
@@ -6,6 +6,7 @@ from ..frontend.parser import Parser, ParseError
 from ..frontend.toy_ast import (
     ModuleAST,
     FunctionAST,
+    PrintExprAST,
     PrototypeAST,
     VariableExprAST,
     ReturnExprAST,
@@ -181,3 +182,40 @@ def test_parse_error():
     parser = Parser(Path(), program)
     with pytest.raises(ParseError):
         parser.parseIdentifierExpr()
+
+
+def test_parse_scalar():
+    ast_toy = Path("docs/Toy/examples/scalar.toy")
+
+    with open(ast_toy, "r") as f:
+        parser = Parser(ast_toy, f.read())
+
+    parsed_module_ast = parser.parseModule()
+
+    def loc(line: int, col: int) -> Location:
+        return Location(ast_toy, line, col)
+
+    module_ast = ModuleAST(
+        (
+            FunctionAST(
+                loc(3, 1),
+                PrototypeAST(loc(3, 1), "main", []),
+                (
+                    VarDeclExprAST(
+                        loc(4, 3),
+                        "a",
+                        VarType([2, 2]),
+                        NumberExprAST(loc(4, 17), 5.5),
+                    ),
+                    PrintExprAST(
+                        loc(5, 3),
+                        VariableExprAST(loc(5, 9), "a"),
+                    ),
+                ),
+            ),
+        )
+    )
+
+    assert parsed_module_ast.dump() == module_ast.dump()
+
+    assert parsed_module_ast == module_ast


### PR DESCRIPTION
Also add functionality in the MLIR Toy version, of declaring a tensor with a scalar literal.