### PR TITLE
dialects: register allocation always starts at 0

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_register_allocation.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_register_allocation.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   %0 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<>
-  %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<>
+  %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<s0>
   %2 = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<j0>
-// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<j1>
-// CHECK-NEXT:  %{{\d+}} = "riscv.add"(%{{\d+}}, %{{\d+}}) : (!riscv.reg<j0>, !riscv.reg<j1>) -> !riscv.reg<j2>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<s0>
+// CHECK-NEXT:  %{{\d+}} = "riscv.add"(%{{\d+}}, %{{\d+}}) : (!riscv.reg<j0>, !riscv.reg<s0>) -> !riscv.reg<j1>
 // CHECK-NEXT: }) : () -> ()

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -4,18 +4,31 @@ from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
 
 
+def allocate_registers(op: ModuleOp) -> None:
+    """
+    Allocates unallocated registers in the module. Currently sets them to an infinite set
+    of `j` registers.
+    """
+    idx: int = 0
+    for operation in op.ops:
+        # Don't perform register allocations on non-RISCV-ops
+        if not isinstance(operation, RISCVOp):
+            continue
+        else:
+            for result in operation.results:
+                assert isinstance(result.typ, RegisterType)
+                if result.typ.data.name is None:
+                    result.typ = RegisterType(Register(f"j{idx}"))
+                    idx += 1
+
+
 class RISCVRegisterAllocation(ModulePass):
+    """
+    Allocates unallocated registers in the module. Currently sets them to an infinite set
+    of `j` registers.
+    """
+
     name = "riscv-allocate-registers"
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
-        idx: int = 0
-        for operation in op.ops:
-            # Don't perform register allocations on non-RISCV-ops
-            if not isinstance(operation, RISCVOp):
-                continue
-            else:
-                for result in operation.results:
-                    assert isinstance(result.typ, RegisterType)
-                    if result.typ.data.name is None:
-                        result.typ = RegisterType(Register(f"j{idx}"))
-                idx += 1
+        allocate_registers(op)


### PR DESCRIPTION
Small usability issue with the infinite register allocation. Not a bug per se, but the register allocation would skip indices, which makes it a bit less readable when debugging.