### PR TITLE
dialects: Add xdsl-opt option to emit RISCV assembly

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -1,11 +1,127 @@
-// RUN: xdsl-opt -p riscv-allocate-registers -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -t riscv-asm %s | filecheck %s
 
 "builtin.module"() ({
-  %0 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<>
-  %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<>
-  %2 = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-}) : () -> ()
+  %0 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<zero>
+  // CHECK:      li zero, 6
+  %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<j1>
+  // CHECK-NEXT: li j1, 5
+  %2 = "riscv.add"(%0, %1) : (!riscv.reg<j1>, !riscv.reg<zero>) -> !riscv.reg<j2>
+  // CHECK-NEXT: add j2, zero, j1
 
-// CHECK:      li j0, 6
-// CHECK-NEXT: li j1, 5
-// CHECK-NEXT: add j2, j0, j1
+  // RV32I/RV64I: Integer Computational Instructions (Section 2.4)
+  // Integer Register-Immediate Instructions
+  %addi = "riscv.addi"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: addi j1, j1, 1
+  %slti = "riscv.slti"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: slti j1, j1, 1
+  %sltiu = "riscv.sltiu"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: sltiu j1, j1, 1
+  %andi = "riscv.andi"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: andi j1, j1, 1
+  %ori = "riscv.ori"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: ori j1, j1, 1
+  %xori = "riscv.xori"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: xori j1, j1, 1
+  %slli = "riscv.slli"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: slli j1, j1, 1
+  %srli = "riscv.srli"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: srli j1, j1, 1
+  %srai = "riscv.srai"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  // CHECK-NEXT: srai j1, j1, 1
+  %lui = "riscv.lui"() {"immediate" = 1 : i32}: () -> !riscv.reg<j0>
+  // CHECK-NEXT: lui j0, 1
+  %auipc = "riscv.auipc"() {"immediate" = 1 : i32}: () -> !riscv.reg<j0>
+  // CHECK-NEXT: auipc j0, 1
+
+  // Integer Register-Register Operations
+  %add = "riscv.add"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: add j2, j2, j1
+  %slt = "riscv.slt"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: slt j2, j2, j1
+  %sltu = "riscv.sltu"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: sltu j2, j2, j1
+  %and = "riscv.and"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: and j2, j2, j1
+  %or = "riscv.or"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: or j2, j2, j1
+  %xor = "riscv.xor"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: xor j2, j2, j1
+  %sll = "riscv.sll"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: sll j2, j2, j1
+  %srl = "riscv.srl"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: srl j2, j2, j1
+  %sub = "riscv.sub"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: sub j2, j2, j1
+  %sra = "riscv.sra"(%2, %1) : (!riscv.reg<j2>, !riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: sra j2, j2, j1
+  "riscv.nop"() : () -> ()
+  // CHECK-NEXT: nop
+
+  // Conditional Branch Instructions
+  "riscv.beq"(%2, %1) {"offset" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: beq j2, j1, 1
+  "riscv.bne"(%2, %1) {"offset" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: bne j2, j1, 1
+  "riscv.blt"(%2, %1) {"offset" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: blt j2, j1, 1
+  "riscv.bge"(%2, %1) {"offset" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: bge j2, j1, 1
+  "riscv.bltu"(%2, %1) {"offset" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: bltu j2, j1, 1
+  "riscv.bgeu"(%2, %1) {"offset" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: bgeu j2, j1, 1
+
+  // RV32I/RV64I: Load and Store Instructions (Section 2.6)
+  %lb = "riscv.lb"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: lb j2, j1, 1
+  %lbu = "riscv.lbu"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: lbu j2, j1, 1
+  %lh = "riscv.lh"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: lh j2, j1, 1
+  %lhu = "riscv.lhu"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: lhu j2, j1, 1
+  %lw = "riscv.lw"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j2>
+  // CHECK-NEXT: lw j2, j1, 1
+
+  "riscv.sb"(%2, %1) {"immediate" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: sb j2, j1, 1
+  "riscv.sh"(%2, %1) {"immediate" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: sh j2, j1, 1
+  "riscv.sw"(%2, %1) {"immediate" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
+  // CHECK-NEXT: sw j2, j1, 1
+
+  // RV32I/RV64I: Control and Status Register Instructions (Section 2.8)
+  %csrrw_rw = "riscv.csrrw"(%2) {"csr" = 1024 : i32}: (!riscv.reg<j2>) -> !riscv.reg<j1>
+  // CHECK-NEXT: csrrw j1, 1024, j2
+  %csrrw_w = "riscv.csrrw"(%2) {"csr" = 1024 : i32, "writeonly"}: (!riscv.reg<j2>) -> !riscv.reg<zero>
+  // CHECK-NEXT: csrrw zero, 1024, j2
+  %csrrs_rw = "riscv.csrrs"(%2) {"csr" = 1024 : i32}: (!riscv.reg<j2>) -> !riscv.reg<zero>
+  // CHECK-NEXT: csrrs zero, 1024, j2
+  %csrrs_r = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly"}: (!riscv.reg<zero>) -> !riscv.reg<j2>
+  // CHECK-NEXT: csrrs j2, 1024, zero
+  %csrrc_rw = "riscv.csrrc"(%2) {"csr" = 1024 : i32}: (!riscv.reg<j2>) -> !riscv.reg<j0>
+  // CHECK-NEXT: csrrc j0, 1024, j2
+  %csrrc_r = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly"}: (!riscv.reg<zero>) -> !riscv.reg<j0>
+  // CHECK-NEXT: csrrc j0, 1024, zero
+  %csrrsi_rw = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 8 : i32}: () -> !riscv.reg<j1>
+  // CHECK-NEXT: csrrsi j1, 1024, 8
+  %csrrsi_r = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<j0>
+  // CHECK-NEXT: csrrsi j0, 1024, 0
+  %csrrci_rw = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 8 : i32}: () -> !riscv.reg<j0>
+  // CHECK-NEXT: csrrci j0, 1024, 8
+  %csrrci_r = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<j1>
+  // CHECK-NEXT: csrrci j1, 1024, 0
+  %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32}: () -> !riscv.reg<j0>
+  // CHECK-NEXT: csrrwi j0, 1024
+  %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly"}: () -> !riscv.reg<zero>
+  // CHECK-NEXT: csrrwi zero, 1024
+
+  // Assembler pseudo-instructions
+  %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<j0>
+  // CHECK-NEXT: li j0, 1
+  // Environment Call and Breakpoints
+  "riscv.ecall"() : () -> ()
+  // CHECK-NEXT: ecall
+  "riscv.ebreak"() : () -> ()
+  // CHECK-NEXT: ebreak
+}) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -1,0 +1,11 @@
+// RUN: xdsl-opt -p riscv-allocate-registers -t riscv-asm %s | filecheck %s
+
+"builtin.module"() ({
+  %0 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<>
+  %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<>
+  %2 = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+}) : () -> ()
+
+// CHECK:      li j0, 6
+// CHECK-NEXT: li j1, 5
+// CHECK-NEXT: add j2, j0, j1

--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -12,7 +12,7 @@ from xdsl.xdsl_opt_main import xDSLOptMain
 def test_opt():
     opt = xDSLOptMain(args=[])
     assert list(opt.available_frontends.keys()) == ["mlir"]
-    assert list(opt.available_targets.keys()) == ["mlir"]
+    assert list(opt.available_targets.keys()) == ["mlir", "riscv-asm"]
     assert list(opt.available_passes.keys()) == [
         "lower-mpi",
         "convert-stencil-to-ll-mlir",

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -321,7 +321,7 @@ class NullaryOperation(IRDLOperation, RISCVOp, ABC):
         super().__init__()
 
 
-class CsrReadWriteOperation(IRDLOperation, ABC):
+class CsrReadWriteOperation(IRDLOperation, RISCVOp, ABC):
     """
     A base class for RISC-V operations performing a swap to/from a CSR.
 
@@ -370,7 +370,7 @@ class CsrReadWriteOperation(IRDLOperation, ABC):
             )
 
 
-class CsrBitwiseOperation(IRDLOperation, ABC):
+class CsrBitwiseOperation(IRDLOperation, RISCVOp, ABC):
     """
     A base class for RISC-V operations performing a masked bitwise operation on the
     CSR while returning the original value.
@@ -421,7 +421,7 @@ class CsrBitwiseOperation(IRDLOperation, ABC):
             )
 
 
-class CsrReadWriteImmOperation(IRDLOperation, ABC):
+class CsrReadWriteImmOperation(IRDLOperation, RISCVOp, ABC):
     """
     A base class for RISC-V operations performing a write immediate to/read from a CSR.
 
@@ -470,7 +470,7 @@ class CsrReadWriteImmOperation(IRDLOperation, ABC):
             )
 
 
-class CsrBitwiseImmOperation(IRDLOperation, ABC):
+class CsrBitwiseImmOperation(IRDLOperation, RISCVOp, ABC):
     """
     A base class for RISC-V operations performing a masked bitwise operation on the
     CSR while returning the original value. The bitmask is specified in the 'immediate'

--- a/xdsl/riscv_asm_writer.py
+++ b/xdsl/riscv_asm_writer.py
@@ -1,0 +1,56 @@
+from typing import IO
+from xdsl.ir import Operation
+from xdsl.dialects.riscv import RISCVOp, RegisterType, AnyIntegerAttr
+from xdsl.dialects.builtin import StringAttr, IntegerAttr, ModuleOp
+from xdsl.utils.hints import isa
+
+
+def print_riscv_module(module: ModuleOp, output: IO[str]):
+    for op in module.ops:
+        print_assembly_instruction(op, output)
+
+
+def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
+    # default assembly code generator
+    assert isinstance(op, RISCVOp)
+    assert op.name.startswith("riscv.")
+    instruction_name = op.name[6:]
+    components: list[str] = []
+
+    for result in op.results:
+        assert isinstance(result.typ, RegisterType)
+        assert isinstance(result.typ.data.name, str)
+        components.append(result.typ.data.name)
+
+    for operand in op.operands:
+        assert isinstance(operand.typ, RegisterType)
+        assert isinstance(operand.typ.data.name, str)
+        components.append(operand.typ.data.name)
+
+    if "offset" in op.attributes:
+        label_attr = getattr(op, "offset")
+        assert isinstance(label_attr, StringAttr)
+        components.append(label_attr.data)
+
+    if "immediate" in op.attributes:
+        immediate_attr = getattr(op, "immediate")
+        assert isinstance(immediate_attr, IntegerAttr)
+        if isa(immediate_attr, AnyIntegerAttr):
+            components.append(str(immediate_attr.value.data))
+
+    if "comment" in op.attributes:
+        comment = getattr(op, "comment")
+        assert isinstance(comment, StringAttr)
+    else:
+        comment = None
+
+    def append_comment(line: str, comment: StringAttr | None) -> str:
+        if comment is None:
+            return line
+
+        padding = " " * max(0, 48 - len(line))
+
+        return f"{line}{padding} # {comment.data}"
+
+    code = f"    {instruction_name} {', '.join(components)}"
+    print(append_comment(code, comment), file=output)

--- a/xdsl/riscv_asm_writer.py
+++ b/xdsl/riscv_asm_writer.py
@@ -1,10 +1,11 @@
 from typing import IO
 from xdsl.ir import Operation, SSAValue
 from xdsl.dialects.riscv import RISCVOp, RegisterType, AnyIntegerAttr
-from xdsl.dialects.builtin import IntegerAttr, ModuleOp
+from xdsl.dialects.builtin import ModuleOp
 from xdsl.utils.hints import isa
 
 from xdsl.dialects import riscv
+
 
 def print_riscv_module(module: ModuleOp, output: IO[str]):
     for op in module.ops:
@@ -17,54 +18,48 @@ def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
     assert op.name.startswith("riscv.")
     instruction_name = op.name[6:]
 
-
-    components: list[AnyIntegerAttr | riscv.LabelAttr | SSAValue | str] = []
+    components: list[AnyIntegerAttr | riscv.LabelAttr | SSAValue | str | None] = []
 
     match op:
         case riscv.NullaryOperation():
             pass
+        case riscv.RdRsRsOperation():
+            components = [op.rd, op.rs1, op.rs2]
+        case riscv.RdRsImmOperation():
+            components = [op.rd, op.rs1, op.immediate]
+        case riscv.RdImmOperation():
+            components = [op.rd, op.immediate]
+        case riscv.RsRsImmOperation():
+            components = [op.rs1, op.rs2, op.immediate]
+        case riscv.RsRsOffOperation():
+            components = [op.rs1, op.rs2, op.offset]
+        case riscv.CsrReadWriteImmOperation():
+            components = [op.rd, op.csr, op.immediate]
+        case riscv.CsrReadWriteOperation():
+            components = [op.rd, op.csr, op.rs1]
+        case riscv.CsrBitwiseImmOperation():
+            components = [op.rd, op.csr, op.immediate]
+        case riscv.CsrBitwiseOperation():
+            components = [op.rd, op.csr, op.rs1]
         case _:
-
-
-            for result in op.results:
-                assert isinstance(result.typ, RegisterType)
-                assert isinstance(result.typ.data.name, str)
-                components.append(result.typ.data.name)
-
-            if "csr" in op.attributes:
-                csr_attr = getattr(op, "csr")
-                assert isinstance(csr_attr, IntegerAttr)
-                components.append(str(csr_attr.value.data))
-
-            for operand in op.operands:
-                assert isinstance(operand.typ, RegisterType)
-                assert isinstance(operand.typ.data.name, str)
-                components.append(operand.typ.data.name)
-
-            if "offset" in op.attributes:
-                label_attr = getattr(op, "offset")
-                assert isinstance(label_attr, IntegerAttr)
-                components.append(str(label_attr.value.data))
-
-            if "immediate" in op.attributes:
-                immediate_attr = getattr(op, "immediate")
-                assert isinstance(immediate_attr, IntegerAttr)
-                if isa(immediate_attr, AnyIntegerAttr):
-                    components.append(str(immediate_attr.value.data))
+            raise ValueError(f"Unknown RISCV operation type :{type(op)}")
 
     component_strs: list[str] = []
 
-
     for component in components:
-        if isa(component, AnyIntegerAttr):
-            component_strs.append(f"{component.value}")
+        if component is None:
+            continue
+        elif isa(component, AnyIntegerAttr):
+            component_strs.append(f"{component.value.data}")
         elif isinstance(component, riscv.LabelAttr):
             component_strs.append(component.data)
+        elif isinstance(component, str):
+            component_strs.append(component)
         else:
             assert isinstance(component.typ, RegisterType)
             reg = component.typ.data.name
             assert reg is not None
             component_strs.append(reg)
 
-    code = f"    {instruction_name} {', '.join(components)}"
+    code = f"    {instruction_name} {', '.join(component_strs)}"
     print(code, file=output)

--- a/xdsl/riscv_asm_writer.py
+++ b/xdsl/riscv_asm_writer.py
@@ -1,7 +1,7 @@
 from typing import IO
 from xdsl.ir import Operation
 from xdsl.dialects.riscv import RISCVOp, RegisterType, AnyIntegerAttr
-from xdsl.dialects.builtin import StringAttr, IntegerAttr, ModuleOp
+from xdsl.dialects.builtin import IntegerAttr, ModuleOp
 from xdsl.utils.hints import isa
 
 
@@ -22,6 +22,11 @@ def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
         assert isinstance(result.typ.data.name, str)
         components.append(result.typ.data.name)
 
+    if "csr" in op.attributes:
+        csr_attr = getattr(op, "csr")
+        assert isinstance(csr_attr, IntegerAttr)
+        components.append(str(csr_attr.value.data))
+
     for operand in op.operands:
         assert isinstance(operand.typ, RegisterType)
         assert isinstance(operand.typ.data.name, str)
@@ -29,8 +34,8 @@ def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
 
     if "offset" in op.attributes:
         label_attr = getattr(op, "offset")
-        assert isinstance(label_attr, StringAttr)
-        components.append(label_attr.data)
+        assert isinstance(label_attr, IntegerAttr)
+        components.append(str(label_attr.value.data))
 
     if "immediate" in op.attributes:
         immediate_attr = getattr(op, "immediate")
@@ -38,19 +43,5 @@ def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
         if isa(immediate_attr, AnyIntegerAttr):
             components.append(str(immediate_attr.value.data))
 
-    if "comment" in op.attributes:
-        comment = getattr(op, "comment")
-        assert isinstance(comment, StringAttr)
-    else:
-        comment = None
-
-    def append_comment(line: str, comment: StringAttr | None) -> str:
-        if comment is None:
-            return line
-
-        padding = " " * max(0, 48 - len(line))
-
-        return f"{line}{padding} # {comment.data}"
-
     code = f"    {instruction_name} {', '.join(components)}"
-    print(append_comment(code, comment), file=output)
+    print(code, file=output)

--- a/xdsl/riscv_asm_writer.py
+++ b/xdsl/riscv_asm_writer.py
@@ -58,7 +58,8 @@ def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
         else:
             assert isinstance(component.typ, RegisterType)
             reg = component.typ.data.name
-            assert reg is not None
+            if reg is None:
+                raise ValueError("Cannot emit riscv assembly for unallocated register")
             component_strs.append(reg)
 
     code = f"    {instruction_name} {', '.join(component_strs)}"

--- a/xdsl/riscv_asm_writer.py
+++ b/xdsl/riscv_asm_writer.py
@@ -1,9 +1,10 @@
 from typing import IO
-from xdsl.ir import Operation
+from xdsl.ir import Operation, SSAValue
 from xdsl.dialects.riscv import RISCVOp, RegisterType, AnyIntegerAttr
 from xdsl.dialects.builtin import IntegerAttr, ModuleOp
 from xdsl.utils.hints import isa
 
+from xdsl.dialects import riscv
 
 def print_riscv_module(module: ModuleOp, output: IO[str]):
     for op in module.ops:
@@ -15,33 +16,55 @@ def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
     assert isinstance(op, RISCVOp)
     assert op.name.startswith("riscv.")
     instruction_name = op.name[6:]
-    components: list[str] = []
 
-    for result in op.results:
-        assert isinstance(result.typ, RegisterType)
-        assert isinstance(result.typ.data.name, str)
-        components.append(result.typ.data.name)
 
-    if "csr" in op.attributes:
-        csr_attr = getattr(op, "csr")
-        assert isinstance(csr_attr, IntegerAttr)
-        components.append(str(csr_attr.value.data))
+    components: list[AnyIntegerAttr | riscv.LabelAttr | SSAValue | str] = []
 
-    for operand in op.operands:
-        assert isinstance(operand.typ, RegisterType)
-        assert isinstance(operand.typ.data.name, str)
-        components.append(operand.typ.data.name)
+    match op:
+        case riscv.NullaryOperation():
+            pass
+        case _:
 
-    if "offset" in op.attributes:
-        label_attr = getattr(op, "offset")
-        assert isinstance(label_attr, IntegerAttr)
-        components.append(str(label_attr.value.data))
 
-    if "immediate" in op.attributes:
-        immediate_attr = getattr(op, "immediate")
-        assert isinstance(immediate_attr, IntegerAttr)
-        if isa(immediate_attr, AnyIntegerAttr):
-            components.append(str(immediate_attr.value.data))
+            for result in op.results:
+                assert isinstance(result.typ, RegisterType)
+                assert isinstance(result.typ.data.name, str)
+                components.append(result.typ.data.name)
+
+            if "csr" in op.attributes:
+                csr_attr = getattr(op, "csr")
+                assert isinstance(csr_attr, IntegerAttr)
+                components.append(str(csr_attr.value.data))
+
+            for operand in op.operands:
+                assert isinstance(operand.typ, RegisterType)
+                assert isinstance(operand.typ.data.name, str)
+                components.append(operand.typ.data.name)
+
+            if "offset" in op.attributes:
+                label_attr = getattr(op, "offset")
+                assert isinstance(label_attr, IntegerAttr)
+                components.append(str(label_attr.value.data))
+
+            if "immediate" in op.attributes:
+                immediate_attr = getattr(op, "immediate")
+                assert isinstance(immediate_attr, IntegerAttr)
+                if isa(immediate_attr, AnyIntegerAttr):
+                    components.append(str(immediate_attr.value.data))
+
+    component_strs: list[str] = []
+
+
+    for component in components:
+        if isa(component, AnyIntegerAttr):
+            component_strs.append(f"{component.value}")
+        elif isinstance(component, riscv.LabelAttr):
+            component_strs.append(component.data)
+        else:
+            assert isinstance(component.typ, RegisterType)
+            reg = component.typ.data.name
+            assert reg is not None
+            component_strs.append(reg)
 
     code = f"    {instruction_name} {', '.join(components)}"
     print(code, file=output)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -44,6 +44,7 @@ from xdsl.transforms.experimental.stencil_global_to_local import (
 from xdsl.utils.exceptions import DiagnosticException
 
 from typing import IO, Dict, Callable, List, Sequence, Type
+from xdsl.riscv_asm_writer import print_riscv_module
 
 
 class xDSLOptMain:
@@ -271,7 +272,12 @@ class xDSLOptMain:
             printer.print_op(prog)
             print("\n", file=output)
 
+        def _output_riscv_asm(prog: ModuleOp, output: IO[str]):
+            print_riscv_module(prog, output)
+            print("\n", file=output)
+
         self.available_targets["mlir"] = _output_mlir
+        self.available_targets["riscv-asm"] = _output_riscv_asm
 
     def setup_pipeline(self):
         """


### PR DESCRIPTION
Adds option to emit basic RISC-V assembly with `xdsl-opt -t riscv-asm`