### PR TITLE
core: Remove parse_int_literal with parse_integer

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -539,7 +539,7 @@
     "\n",
     "    @staticmethod\n",
     "    def parse_parameter(parser: Parser) -> int:\n",
-    "        data = parser.parse_int_literal()\n",
+    "        data = parser.parse_integer()\n",
     "        return data\n",
     "\n",
     "    def print_parameter(self, printer: Printer) -> None:\n",

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -56,7 +56,7 @@ class IntData(Data[int]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> int:
-        return parser.parse_int_literal()
+        return parser.parse_integer()
 
     def print_parameter(self, printer: Printer):
         printer.print_string(str(self.data))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -195,9 +195,7 @@ def test_parse_comma_separated_list(
 ):
     input = open_bracket + "2, 4, 5" + close_bracket
     parser = Parser(MLContext(), input)
-    res = parser.parse_comma_separated_list(
-        delimiter, parser.parse_int_literal, " in test"
-    )
+    res = parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert res == [2, 4, 5]
 
 
@@ -215,9 +213,7 @@ def test_parse_comma_separated_list_empty(
 ):
     input = open_bracket + close_bracket
     parser = Parser(MLContext(), input)
-    res = parser.parse_comma_separated_list(
-        delimiter, parser.parse_int_literal, " in test"
-    )
+    res = parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert res == []
 
 
@@ -225,7 +221,7 @@ def test_parse_comma_separated_list_none_delimiter_empty():
     parser = Parser(MLContext(), "o")
     with pytest.raises(ParseError):
         parser.parse_comma_separated_list(
-            Parser.Delimiter.NONE, parser.parse_int_literal, " in test"
+            Parser.Delimiter.NONE, parser.parse_integer, " in test"
         )
 
 
@@ -244,11 +240,9 @@ def test_parse_comma_separated_list_error_element(
     input = open_bracket + "o" + close_bracket
     parser = Parser(MLContext(), input)
     with pytest.raises(ParseError) as e:
-        parser.parse_comma_separated_list(
-            delimiter, parser.parse_int_literal, " in test"
-        )
+        parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert e.value.span.text == "o"
-    assert e.value.msg == "Expected integer literal here"
+    assert e.value.msg == "Expected integer literal"
 
 
 @pytest.mark.parametrize(
@@ -266,9 +260,7 @@ def test_parse_comma_separated_list_error_delimiters(
     input = open_bracket + "2, 4 5"
     parser = Parser(MLContext(), input)
     with pytest.raises(ParseError) as e:
-        parser.parse_comma_separated_list(
-            delimiter, parser.parse_int_literal, " in test"
-        )
+        parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert e.value.span.text == "5"
     assert e.value.msg == "Expected '" + close_bracket + "' in test"
 

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -42,7 +42,7 @@ class IntData(Data[int]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> int:
-        return parser.parse_int_literal()
+        return parser.parse_integer()
 
     def print_parameter(self, printer: Printer):
         printer.print_string(str(self.data))

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -235,7 +235,7 @@ class IntAttr(Data[int]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> int:
-        data = parser.parse_int_literal()
+        data = parser.parse_integer()
         return data
 
     def print_parameter(self, printer: Printer) -> None:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -116,7 +116,7 @@ class LLVMPointerType(ParametrizedAttribute, TypeAttribute):
             parser.parse_characters(">", "End of llvm.ptr parameters expected!")
             return [type, NoneAttr()]
         parser.parse_characters(",", "llvm.ptr args must be separated by `,`")
-        addr_space = parser.parse_int_literal()
+        addr_space = parser.parse_integer()
         parser.parse_characters(">", "End of llvm.ptr parameters expected!")
         return [type, IntegerAttr.from_params(addr_space, IndexType())]
 
@@ -151,7 +151,7 @@ class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
         if not parser.tokenizer.starts_with("<"):
             return [NoneAttr(), NoneAttr()]
         parser.parse_characters("<", "llvm.array parameters expected")
-        size = IntAttr(parser.parse_int_literal())
+        size = IntAttr(parser.parse_integer())
         if not parser.tokenizer.starts_with("x"):
             parser.parse_characters(">", "End of llvm.array type expected!")
             return [size, NoneAttr()]

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2370,13 +2370,6 @@ class Parser(ABC):
     def parse_op(self) -> Operation:
         return self.parse_operation()
 
-    def parse_int_literal(self) -> int:
-        return int(
-            self.expect(
-                self.try_parse_integer_literal, "Expected integer literal here"
-            ).text
-        )
-
     def parse_builtin_dict_attr(self) -> DictionaryAttr:
         """
         Parse a dictionary attribute, with the following syntax:


### PR DESCRIPTION
parse_int_literal used the old tokenizer, while parse_integer uses the new lexer.