### PR TITLE
dialects: Fix PDL definitions, and lint it with latest xDSL features

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -539,7 +539,7 @@
     "\n",
     "    @staticmethod\n",
     "    def parse_parameter(parser: Parser) -> int:\n",
-    "        data = parser.parse_int_literal()\n",
+    "        data = parser.parse_integer()\n",
     "        return data\n",
     "\n",
     "    def print_parameter(self, printer: Printer) -> None:\n",

--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -39,9 +39,7 @@ def test_build_anr():
 
 
 def test_build_rewrite():
-    r = pdl.RewriteOp(
-        StringAttr("r"), root=None, external_args=[type_val, attr_val], body=None
-    )
+    r = pdl.RewriteOp("r", root=None, external_args=[type_val, attr_val], body=None)
 
     assert r.attributes["name"] == StringAttr("r")
     assert r.external_args == (type_val, attr_val)
@@ -50,7 +48,7 @@ def test_build_rewrite():
 
 def test_build_operation_replace():
     operation = pdl.OperationOp(
-        op_name=StringAttr("operation"),
+        op_name="operation",
         attribute_value_names=ArrayAttr([StringAttr("name")]),
         operand_values=[val_val],
         attribute_values=[attr_val],

--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -23,14 +23,14 @@ type_val, attr_val, val_val, op_val = block.args
 
 
 def test_build_anc():
-    anc = pdl.ApplyNativeConstraintOp.get("anc", [type_val])
+    anc = pdl.ApplyNativeConstraintOp("anc", [type_val])
 
     assert anc.attributes["name"] == StringAttr("anc")
     assert anc.args == (type_val,)
 
 
 def test_build_anr():
-    anr = pdl.ApplyNativeRewriteOp.get("anr", [type_val], [attribute_type])
+    anr = pdl.ApplyNativeRewriteOp("anr", [type_val], [attribute_type])
 
     assert anr.attributes["name"] == StringAttr("anr")
     assert anr.args == (type_val,)
@@ -39,63 +39,63 @@ def test_build_anr():
 
 
 def test_build_rewrite():
-    r = pdl.RewriteOp.get(
+    r = pdl.RewriteOp(
         StringAttr("r"), root=None, external_args=[type_val, attr_val], body=None
     )
 
     assert r.attributes["name"] == StringAttr("r")
-    assert r.externalArgs == (type_val, attr_val)
+    assert r.external_args == (type_val, attr_val)
     assert len(r.results) == 0
 
 
 def test_build_operation_replace():
-    operation = pdl.OperationOp.get(
-        opName=StringAttr("operation"),
-        attributeValueNames=ArrayAttr([StringAttr("name")]),
-        operandValues=[val_val],
-        attributeValues=[attr_val],
-        typeValues=[type_val],
+    operation = pdl.OperationOp(
+        op_name=StringAttr("operation"),
+        attribute_value_names=ArrayAttr([StringAttr("name")]),
+        operand_values=[val_val],
+        attribute_values=[attr_val],
+        type_values=[type_val],
     )
 
     assert operation.opName == StringAttr("operation")
     assert operation.attributeValueNames == ArrayAttr([StringAttr("name")])
-    assert operation.operandValues == (val_val,)
-    assert operation.attributeValues == (attr_val,)
-    assert operation.typeValues == (type_val,)
+    assert operation.operand_values == (val_val,)
+    assert operation.attribute_values == (attr_val,)
+    assert operation.type_values == (type_val,)
 
-    replace = pdl.ReplaceOp.get(opValue=op_val, replOperation=operation.results[0])
+    replace = pdl.ReplaceOp(op_value=op_val, repl_operation=operation.results[0])
     replace.verify()
 
-    assert replace.opValue == op_val
-    assert replace.replOperation == operation.results[0]
-    assert replace.replValues == ()
+    assert replace.op_value == op_val
+    assert replace.repl_operation == operation.results[0]
+    assert replace.repl_values == ()
 
-    replace = pdl.ReplaceOp.get(opValue=op_val, replValues=[val_val])
+    replace = pdl.ReplaceOp(op_value=op_val, repl_values=[val_val])
     replace.verify()
 
-    assert replace.opValue == op_val
-    assert replace.replOperation == None
-    assert replace.replValues == (val_val,)
+    assert replace.op_value == op_val
+    assert replace.repl_operation == None
+    assert replace.repl_values == (val_val,)
 
     with pytest.raises(VerifyException):
-        replace = pdl.ReplaceOp.get(opValue=op_val)
+        replace = pdl.ReplaceOp(op_value=op_val)
         replace.verify()
 
     with pytest.raises(VerifyException):
-        replace = pdl.ReplaceOp.get(
-            opValue=op_val, replOperation=operation.results[0], replValues=[val_val]
+        replace = pdl.ReplaceOp(
+            op_value=op_val, repl_operation=operation.results[0], repl_values=[val_val]
         )
         replace.verify()
 
 
 def test_build_result():
-    res = pdl.ResultOp.get(IntegerAttr.from_int_and_width(1, 32), parent=op_val)
+    res = pdl.ResultOp(IntegerAttr.from_int_and_width(1, 32), parent=op_val)
 
     assert res.index == IntegerAttr.from_int_and_width(1, 32)
     assert res.parent_ == op_val
 
 
 def test_build_operand():
-    operand = pdl.OperandOp.get(val_val)
+    operand = pdl.OperandOp(val_val)
 
-    assert operand.valueType == val_val
+    assert operand.value_type == val_val

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -96,31 +96,29 @@ def swap_arguments_pdl():
 
     @Builder.implicit_region
     def pattern_region():
-        x = pdl.OperandOp.get().value
-        y = pdl.OperandOp.get().value
-        typ = pdl.TypeOp.get().result
+        x = pdl.OperandOp().value
+        y = pdl.OperandOp().value
+        typ = pdl.TypeOp().result
 
-        x_y_op = pdl.OperationOp.get(
-            StringAttr("arith.addi"), operandValues=[x, y], typeValues=[typ]
+        x_y_op = pdl.OperationOp(
+            StringAttr("arith.addi"), operand_values=[x, y], type_values=[typ]
         ).op
-        x_y = pdl.ResultOp.get(IntegerAttr.from_int_and_width(0, 32), parent=x_y_op).val
-        z = pdl.OperandOp.get().value
-        x_y_z_op = pdl.OperationOp.get(
-            opName=StringAttr("arith.addi"), operandValues=[x_y, z], typeValues=[typ]
+        x_y = pdl.ResultOp(IntegerAttr.from_int_and_width(0, 32), parent=x_y_op).val
+        z = pdl.OperandOp().value
+        x_y_z_op = pdl.OperationOp(
+            op_name=StringAttr("arith.addi"), operand_values=[x_y, z], type_values=[typ]
         ).op
 
         @Builder.implicit_region
         def rewrite_region():
-            z_x_y_op = pdl.OperationOp.get(
-                StringAttr("arith.addi"), operandValues=[z, x_y], typeValues=[typ]
+            z_x_y_op = pdl.OperationOp(
+                StringAttr("arith.addi"), operand_values=[z, x_y], type_values=[typ]
             ).op
-            pdl.ReplaceOp.get(x_y_z_op, z_x_y_op)
+            pdl.ReplaceOp(x_y_z_op, z_x_y_op)
 
-        pdl.RewriteOp.get(None, x_y_z_op, [], rewrite_region)
+        pdl.RewriteOp(None, x_y_z_op, [], rewrite_region)
 
-    pattern = pdl.PatternOp.get(
-        IntegerAttr.from_int_and_width(2, 16), None, pattern_region
-    )
+    pattern = pdl.PatternOp(IntegerAttr.from_int_and_width(2, 16), None, pattern_region)
 
     pdl_module = ModuleOp([pattern])
 
@@ -211,37 +209,33 @@ def add_zero_pdl():
     @Builder.implicit_region
     def pattern_region():
         # Type i32
-        pdl_i32 = pdl.TypeOp.get().result
+        pdl_i32 = pdl.TypeOp().result
 
         # LHS: i32
-        lhs = pdl.OperandOp.get().results[0]
+        lhs = pdl.OperandOp().results[0]
 
         # Constant 0: i32
-        zero = pdl.AttributeOp.get(
-            value=IntegerAttr.from_int_and_width(0, 32), valueType=pdl_i32
-        ).results[0]
-        rhs_op = pdl.OperationOp.get(
-            opName=StringAttr("arith.constant"),
-            attributeValueNames=ArrayAttr([StringAttr("value")]),
-            attributeValues=[zero],
-            typeValues=[pdl_i32],
+        zero = pdl.AttributeOp(value=IntegerAttr.from_int_and_width(0, 32)).results[0]
+        rhs_op = pdl.OperationOp(
+            op_name=StringAttr("arith.constant"),
+            attribute_value_names=ArrayAttr([StringAttr("value")]),
+            attribute_values=[zero],
+            type_values=[pdl_i32],
         ).op
-        rhs = pdl.ResultOp.get(IntegerAttr.from_int_and_width(0, 32), parent=rhs_op).val
+        rhs = pdl.ResultOp(IntegerAttr.from_int_and_width(0, 32), parent=rhs_op).val
 
         # LHS + 0
-        sum = pdl.OperationOp.get(
-            StringAttr("arith.addi"), operandValues=[lhs, rhs], typeValues=[pdl_i32]
+        sum = pdl.OperationOp(
+            StringAttr("arith.addi"), operand_values=[lhs, rhs], type_values=[pdl_i32]
         ).op
 
         @Builder.implicit_region
         def rewrite_region():
-            pdl.ReplaceOp.get(sum, replValues=[lhs])
+            pdl.ReplaceOp(sum, repl_values=[lhs])
 
-        pdl.RewriteOp.get(None, sum, [], rewrite_region)
+        pdl.RewriteOp(None, sum, [], rewrite_region)
 
-    pattern = pdl.PatternOp.get(
-        IntegerAttr.from_int_and_width(2, 16), None, pattern_region
-    )
+    pattern = pdl.PatternOp(IntegerAttr.from_int_and_width(2, 16), None, pattern_region)
 
     pdl_module = ModuleOp([pattern])
 

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -56,7 +56,7 @@ class IntData(Data[int]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> int:
-        return parser.parse_int_literal()
+        return parser.parse_integer()
 
     def print_parameter(self, printer: Printer):
         printer.print_string(str(self.data))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -195,9 +195,7 @@ def test_parse_comma_separated_list(
 ):
     input = open_bracket + "2, 4, 5" + close_bracket
     parser = Parser(MLContext(), input)
-    res = parser.parse_comma_separated_list(
-        delimiter, parser.parse_int_literal, " in test"
-    )
+    res = parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert res == [2, 4, 5]
 
 
@@ -215,9 +213,7 @@ def test_parse_comma_separated_list_empty(
 ):
     input = open_bracket + close_bracket
     parser = Parser(MLContext(), input)
-    res = parser.parse_comma_separated_list(
-        delimiter, parser.parse_int_literal, " in test"
-    )
+    res = parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert res == []
 
 
@@ -225,7 +221,7 @@ def test_parse_comma_separated_list_none_delimiter_empty():
     parser = Parser(MLContext(), "o")
     with pytest.raises(ParseError):
         parser.parse_comma_separated_list(
-            Parser.Delimiter.NONE, parser.parse_int_literal, " in test"
+            Parser.Delimiter.NONE, parser.parse_integer, " in test"
         )
 
 
@@ -244,11 +240,9 @@ def test_parse_comma_separated_list_error_element(
     input = open_bracket + "o" + close_bracket
     parser = Parser(MLContext(), input)
     with pytest.raises(ParseError) as e:
-        parser.parse_comma_separated_list(
-            delimiter, parser.parse_int_literal, " in test"
-        )
+        parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert e.value.span.text == "o"
-    assert e.value.msg == "Expected integer literal here"
+    assert e.value.msg == "Expected integer literal"
 
 
 @pytest.mark.parametrize(
@@ -266,9 +260,7 @@ def test_parse_comma_separated_list_error_delimiters(
     input = open_bracket + "2, 4 5"
     parser = Parser(MLContext(), input)
     with pytest.raises(ParseError) as e:
-        parser.parse_comma_separated_list(
-            delimiter, parser.parse_int_literal, " in test"
-        )
+        parser.parse_comma_separated_list(delimiter, parser.parse_integer, " in test")
     assert e.value.span.text == "5"
     assert e.value.msg == "Expected '" + close_bracket + "' in test"
 

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -42,7 +42,7 @@ class IntData(Data[int]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> int:
-        return parser.parse_int_literal()
+        return parser.parse_integer()
 
     def print_parameter(self, printer: Printer):
         printer.print_string(str(self.data))

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -235,7 +235,7 @@ class IntAttr(Data[int]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> int:
-        data = parser.parse_int_literal()
+        data = parser.parse_integer()
         return data
 
     def print_parameter(self, printer: Printer) -> None:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -116,7 +116,7 @@ class LLVMPointerType(ParametrizedAttribute, TypeAttribute):
             parser.parse_characters(">", "End of llvm.ptr parameters expected!")
             return [type, NoneAttr()]
         parser.parse_characters(",", "llvm.ptr args must be separated by `,`")
-        addr_space = parser.parse_int_literal()
+        addr_space = parser.parse_integer()
         parser.parse_characters(">", "End of llvm.ptr parameters expected!")
         return [type, IntegerAttr.from_params(addr_space, IndexType())]
 
@@ -151,7 +151,7 @@ class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
         if not parser.tokenizer.starts_with("<"):
             return [NoneAttr(), NoneAttr()]
         parser.parse_characters("<", "llvm.array parameters expected")
-        size = IntAttr(parser.parse_int_literal())
+        size = IntAttr(parser.parse_integer())
         if not parser.tokenizer.starts_with("x"):
             parser.parse_characters(">", "End of llvm.array type expected!")
             return [size, NoneAttr()]

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
-from typing import Annotated, Generic, Sequence, TypeVar
+from typing import Annotated, Generic, Iterable, Sequence, TypeVar
 
-from xdsl.dialects.builtin import ArrayAttr, IntegerAttr, IntegerType, StringAttr
+from xdsl.dialects.builtin import (
+    AnyArrayAttr,
+    ArrayAttr,
+    IntegerAttr,
+    IntegerType,
+    StringAttr,
+    i32,
+)
 from xdsl.ir import (
     Attribute,
     Block,
@@ -63,7 +70,10 @@ _RangeT = TypeVar(
 @irdl_attr_definition
 class RangeType(Generic[_RangeT], ParametrizedAttribute, TypeAttribute):
     name = "pdl.range"
-    elementType: ParameterDef[_RangeT]
+    element_type: ParameterDef[_RangeT]
+
+    def __init__(self, element_type: _RangeT):
+        super().__init__([element_type])
 
 
 @irdl_op_definition
@@ -77,6 +87,19 @@ class ApplyNativeConstraintOp(IRDLOperation):
     # name: OpAttr[StringAttr]
     args: Annotated[VarOperand, AnyPDLType]
 
+    @property
+    def constraint_name(self) -> StringAttr:
+        name = self.attributes.get("name", None)
+        if not isinstance(name, StringAttr):
+            raise VerifyException(
+                f"Operation {self.name} requires a StringAttr 'name' attribute"
+            )
+        return name
+
+    @constraint_name.setter
+    def constraint_name(self, name: StringAttr) -> None:
+        self.attributes["name"] = name
+
     def verify_(self) -> None:
         if "name" not in self.attributes:
             raise VerifyException("ApplyNativeConstraintOp requires a 'name' attribute")
@@ -84,11 +107,10 @@ class ApplyNativeConstraintOp(IRDLOperation):
         if not isinstance(self.attributes["name"], StringAttr):
             raise VerifyException("expected 'name' attribute to be a StringAttr")
 
-    @staticmethod
-    def get(name: str, args: Sequence[SSAValue]) -> ApplyNativeConstraintOp:
-        return ApplyNativeConstraintOp.build(
-            result_types=[], operands=[args], attributes={"name": StringAttr(name)}
-        )
+    def __init__(self, name: str | StringAttr, args: Sequence[SSAValue]) -> None:
+        if isinstance(name, str):
+            name = StringAttr(name)
+        super().__init__(operands=[args], attributes={"name": name})
 
 
 @irdl_op_definition
@@ -103,21 +125,31 @@ class ApplyNativeRewriteOp(IRDLOperation):
     args: Annotated[VarOperand, AnyPDLType]
     res: Annotated[VarOpResult, AnyPDLType]
 
-    def verify_(self) -> None:
-        if "name" not in self.attributes:
-            raise VerifyException("ApplyNativeRewriteOp requires a 'name' attribute")
+    @property
+    def constraint_name(self) -> StringAttr:
+        name = self.attributes.get("name", None)
+        if not isinstance(name, StringAttr):
+            raise VerifyException(
+                f"Operation {self.name} requires a StringAttr 'name' attribute"
+            )
+        return name
 
-        if not isinstance(self.attributes["name"], StringAttr):
-            raise VerifyException("expected 'name' attribute to be a StringAttr")
+    @constraint_name.setter
+    def constraint_name(self, name: StringAttr) -> None:
+        self.attributes["name"] = name
 
-    @staticmethod
-    def get(
-        name: str, args: Sequence[SSAValue], result_types: Sequence[Attribute]
-    ) -> ApplyNativeRewriteOp:
-        return ApplyNativeRewriteOp.build(
+    def __init__(
+        self,
+        name: str | StringAttr,
+        args: Sequence[SSAValue],
+        result_types: Sequence[Attribute],
+    ) -> None:
+        if isinstance(name, str):
+            name = StringAttr(name)
+        super().__init__(
             result_types=[result_types],
             operands=[args],
-            attributes={"name": StringAttr(name)},
+            attributes={"name": name},
         )
 
 
@@ -129,24 +161,30 @@ class AttributeOp(IRDLOperation):
 
     name: str = "pdl.attribute"
     value: OptOpAttr[Attribute]
-    valueType: Annotated[OptOperand, TypeType]
+    value_type: Annotated[OptOperand, TypeType]
     output: Annotated[OpResult, AttributeType]
 
-    @staticmethod
-    def get(
-        value: Attribute | None = None, valueType: SSAValue | None = None
-    ) -> AttributeOp:
+    def verify_(self):
+        if self.value is not None and self.value_type is not None:
+            raise VerifyException(
+                f"{self.name} cannot both specify an expected attribute "
+                "via a constant value and an expected type."
+            )
+
+    def __init__(self, value: Attribute | SSAValue | None = None) -> None:
+        """
+        The given value is either the expected attribute, if given an attribute, or the
+        expected attribute type, if given an SSAValue.
+        """
         attributes: dict[str, Attribute] = {}
-        if value is not None:
+        operands: list[SSAValue | None] = [None]
+        if isinstance(value, Attribute):
             attributes["value"] = value
+        elif isinstance(value, SSAValue):
+            operands = [value]
 
-        if valueType is None:
-            value_type = []
-        else:
-            value_type = [valueType]
-
-        return AttributeOp.build(
-            operands=[value_type], attributes=attributes, result_types=[AttributeType()]
+        super().__init__(
+            operands=operands, attributes=attributes, result_types=[AttributeType()]
         )
 
 
@@ -157,11 +195,10 @@ class EraseOp(IRDLOperation):
     """
 
     name: str = "pdl.erase"
-    opValue: Annotated[Operand, OperationType]
+    op_value: Annotated[Operand, OperationType]
 
-    @staticmethod
-    def get(opValue: SSAValue) -> EraseOp:
-        return EraseOp.build(operands=[opValue], result_types=[])
+    def __init__(self, op_value: SSAValue) -> None:
+        super().__init__(operands=[op_value])
 
 
 @irdl_op_definition
@@ -171,16 +208,11 @@ class OperandOp(IRDLOperation):
     """
 
     name: str = "pdl.operand"
-    valueType: Annotated[OptOperand, TypeType]
+    value_type: Annotated[OptOperand, TypeType]
     value: Annotated[OpResult, ValueType]
 
-    @staticmethod
-    def get(valueType: SSAValue | None = None) -> OperandOp:
-        if valueType is None:
-            value_type = []
-        else:
-            value_type = [valueType]
-        return OperandOp.build(operands=[value_type], result_types=[ValueType()])
+    def __init__(self, value_type: SSAValue | None = None) -> None:
+        super().__init__(operands=[value_type], result_types=[ValueType()])
 
 
 @irdl_op_definition
@@ -190,8 +222,11 @@ class OperandsOp(IRDLOperation):
     """
 
     name: str = "pdl.operands"
-    valueType: Annotated[Operand, RangeType[TypeType]]
+    value_type: Annotated[OptOperand, RangeType[TypeType]]
     value: Annotated[OpResult, RangeType[ValueType]]
+
+    def __init__(self, value_type: SSAValue | None) -> None:
+        super().__init__(operands=[value_type], result_types=[RangeType(ValueType())])
 
 
 @irdl_op_definition
@@ -204,34 +239,39 @@ class OperationOp(IRDLOperation):
     opName: OptOpAttr[StringAttr]
     attributeValueNames: OpAttr[ArrayAttr[StringAttr]]
 
-    operandValues: Annotated[VarOperand, ValueType | RangeType[ValueType]]
-    attributeValues: Annotated[VarOperand, AttributeType]
-    typeValues: Annotated[VarOperand, TypeType | RangeType[TypeType]]
+    operand_values: Annotated[VarOperand, ValueType | RangeType[ValueType]]
+    attribute_values: Annotated[VarOperand, AttributeType]
+    type_values: Annotated[VarOperand, TypeType | RangeType[TypeType]]
     op: Annotated[OpResult, OperationType]
 
     irdl_options = [AttrSizedOperandSegments()]
 
-    @staticmethod
-    def get(
-        opName: StringAttr | None,
-        attributeValueNames: ArrayAttr[StringAttr] | None = None,
-        operandValues: Sequence[SSAValue] | None = None,
-        attributeValues: Sequence[SSAValue] | None = None,
-        typeValues: Sequence[SSAValue] | None = None,
+    def __init__(
+        self,
+        op_name: str | StringAttr | None,
+        attribute_value_names: ArrayAttr[StringAttr] | None = None,
+        operand_values: Sequence[SSAValue] | None = None,
+        attribute_values: Sequence[SSAValue] | None = None,
+        type_values: Sequence[SSAValue] | None = None,
     ):
-        if attributeValueNames is None:
-            attributeValueNames = ArrayAttr([])
-        if operandValues is None:
-            operandValues = []
-        if attributeValues is None:
-            attributeValues = []
-        if typeValues is None:
-            typeValues = []
+        if isinstance(op_name, str):
+            op_name = StringAttr(op_name)
+        if attribute_value_names is None:
+            attribute_value_names = ArrayAttr([])
+        if operand_values is None:
+            operand_values = []
+        if attribute_values is None:
+            attribute_values = []
+        if type_values is None:
+            type_values = []
 
-        return OperationOp.build(
-            operands=[operandValues, attributeValues, typeValues],
+        super().__init__(
+            operands=[operand_values, attribute_values, type_values],
             result_types=[OperationType()],
-            attributes={"attributeValueNames": attributeValueNames, "opName": opName},
+            attributes={
+                "attributeValueNames": attribute_value_names,
+                "opName": op_name,
+            },
         )
 
 
@@ -242,15 +282,23 @@ class PatternOp(IRDLOperation):
     """
 
     name: str = "pdl.pattern"
-    benefit: OpAttr[IntegerAttr[IntegerType]]
+    benefit: OpAttr[IntegerAttr[Annotated[IntegerType, IntegerType(16)]]]
     sym_name: OptOpAttr[StringAttr]
     body: Region
 
-    @staticmethod
-    def get(
-        benefit: IntegerAttr[IntegerType], sym_name: StringAttr | None, body: Region
-    ) -> PatternOp:
-        return PatternOp.build(
+    def __init__(
+        self,
+        benefit: int | IntegerAttr[IntegerType],
+        sym_name: str | StringAttr | None,
+        body: Region | Block.BlockCallback,
+    ):
+        if isinstance(benefit, int):
+            benefit = IntegerAttr(benefit, 16)
+        if isinstance(sym_name, str):
+            sym_name = StringAttr(sym_name)
+        if not isinstance(body, Region):
+            body = Region(Block.from_callable([], body))
+        super().__init__(
             attributes={
                 "benefit": benefit,
                 "sym_name": sym_name,
@@ -258,16 +306,6 @@ class PatternOp(IRDLOperation):
             regions=[body],
             result_types=[],
         )
-
-    @staticmethod
-    def from_callable(
-        benefit: IntegerAttr[IntegerType],
-        sym_name: StringAttr | None,
-        callable: Block.BlockCallback,
-    ) -> PatternOp:
-        block = Block.from_callable([], callable)
-        region = Region(block)
-        return PatternOp.get(benefit, sym_name, region)
 
 
 @irdl_op_definition
@@ -283,7 +321,7 @@ class RangeOp(IRDLOperation):
     def verify_(self) -> None:
         def get_type_or_elem_type(arg: SSAValue) -> Attribute:
             if isa(arg.typ, RangeType[AnyPDLType]):
-                return arg.typ.elementType
+                return arg.typ.element_type
             else:
                 return arg.typ
 
@@ -297,6 +335,26 @@ class RangeOp(IRDLOperation):
                           of the corresponding element type. First element type:\
                           {elem_type}, current element type: {cur_elem_type}"
                     )
+
+    def __init__(
+        self,
+        arguments: Sequence[SSAValue],
+        result_type: RangeType[AnyPDLType] | None = None,
+    ) -> None:
+        if result_type is None:
+            if len(arguments) == 0:
+                raise ValueError("Empty range constructions require a return type.")
+
+            if isa(arguments[0].typ, RangeType[AnyPDLType]):
+                result_type = RangeType(arguments[0].typ.element_type)
+            elif isa(arguments[0].typ, AnyPDLType):
+                result_type = RangeType(arguments[0].typ)
+            else:
+                raise ValueError(
+                    f"Arguments of {self.name} are expected to be PDL types"
+                )
+
+        super().__init__(operands=arguments, result_types=[result_type])
 
 
 @irdl_op_definition
@@ -315,37 +373,37 @@ class ReplaceOp(IRDLOperation):
     """
 
     name: str = "pdl.replace"
-    opValue: Annotated[Operand, OperationType]
-    replOperation: Annotated[OptOperand, OperationType]
-    replValues: Annotated[VarOperand, ValueType | ArrayAttr[ValueType]]
+    op_value: Annotated[Operand, OperationType]
+    repl_operation: Annotated[OptOperand, OperationType]
+    repl_values: Annotated[VarOperand, ValueType | ArrayAttr[ValueType]]
 
     irdl_options = [AttrSizedOperandSegments()]
 
-    @staticmethod
-    def get(
-        opValue: SSAValue,
-        replOperation: SSAValue | None = None,
-        replValues: Sequence[SSAValue] | None = None,
-    ) -> ReplaceOp:
-        operands: list[SSAValue | Sequence[SSAValue]] = [opValue]
-        if replOperation is None:
+    def __init__(
+        self,
+        op_value: SSAValue,
+        repl_operation: SSAValue | None = None,
+        repl_values: Sequence[SSAValue] | None = None,
+    ) -> None:
+        operands: list[SSAValue | Sequence[SSAValue]] = [op_value]
+        if repl_operation is None:
             operands.append([])
         else:
-            operands.append([replOperation])
-        if replValues is None:
-            replValues = []
-        operands.append(replValues)
-        return ReplaceOp.build(operands=operands)
+            operands.append([repl_operation])
+        if repl_values is None:
+            repl_values = []
+        operands.append(repl_values)
+        super().__init__(operands=operands)
 
     def verify_(self) -> None:
-        if self.replOperation is None:
-            if not len(self.replValues):
+        if self.repl_operation is None:
+            if not len(self.repl_values):
                 raise VerifyException(
                     "Exactly one of `replOperation` or "
                     "`replValues` must be set in `ReplaceOp`"
                     ", both are empty"
                 )
-        elif len(self.replValues):
+        elif len(self.repl_values):
             raise VerifyException(
                 "Exactly one of `replOperation` or `replValues` must be set in "
                 "`ReplaceOp`, both are set"
@@ -359,13 +417,14 @@ class ResultOp(IRDLOperation):
     """
 
     name: str = "pdl.result"
-    index: OpAttr[IntegerAttr[IntegerType]]
+    index: OpAttr[IntegerAttr[Annotated[IntegerType, i32]]]
     parent_: Annotated[Operand, OperationType]
     val: Annotated[OpResult, ValueType]
 
-    @staticmethod
-    def get(index: IntegerAttr[IntegerType], parent: SSAValue) -> ResultOp:
-        return ResultOp.build(
+    def __init__(self, index: int | IntegerAttr[IntegerType], parent: SSAValue) -> None:
+        if isinstance(index, int):
+            index = IntegerAttr(index, 32)
+        super().__init__(
             operands=[parent], attributes={"index": index}, result_types=[ValueType()]
         )
 
@@ -377,9 +436,21 @@ class ResultsOp(IRDLOperation):
     """
 
     name: str = "pdl.results"
-    index: OpAttr[IntegerAttr[IntegerType]]
+    index: OpAttr[IntegerAttr[Annotated[IntegerType, i32]]]
     parent_: Annotated[Operand, OperationType]
     val: Annotated[OpResult, ValueType | ArrayAttr[ValueType]]
+
+    def __init__(
+        self,
+        index: int | IntegerAttr[IntegerType],
+        parent: SSAValue,
+        result_type: ValueType | ArrayAttr[ValueType],
+    ) -> None:
+        if isinstance(index, int):
+            index = IntegerAttr(index, 32)
+        super().__init__(
+            operands=[parent], result_types=[result_type], attributes={"index": index}
+        )
 
 
 @irdl_op_definition
@@ -394,7 +465,7 @@ class RewriteOp(IRDLOperation):
     # https://github.com/xdslproject/xdsl/issues/98
     # name: OptOpAttr[StringAttr]
     # parameters of external rewriter function
-    externalArgs: Annotated[VarOperand, AnyPDLType]
+    external_args: Annotated[VarOperand, AnyPDLType]
     # body of inline rewriter function
     body: OptRegion
 
@@ -405,13 +476,16 @@ class RewriteOp(IRDLOperation):
             if not isinstance(self.attributes["name"], StringAttr):
                 raise Exception("expected 'name' attribute to be a StringAttr")
 
-    @staticmethod
-    def get(
-        name: StringAttr | None,
+    def __init__(
+        self,
+        name: str | StringAttr | None,
         root: SSAValue | None,
         external_args: Sequence[SSAValue],
-        body: Region | None,
-    ) -> RewriteOp:
+        body: Region | Block.BlockCallback | None,
+    ) -> None:
+        if isinstance(name, str):
+            name = StringAttr(name)
+
         operands: list[SSAValue | Sequence[SSAValue]] = []
         if root is not None:
             operands.append([root])
@@ -420,8 +494,10 @@ class RewriteOp(IRDLOperation):
         operands.append(external_args)
 
         regions: list[Region | list[Region]] = []
-        if body is not None:
+        if isinstance(body, Region):
             regions.append([body])
+        elif body is not None:
+            regions.append(Region(Block.from_callable([], body)))
         else:
             regions.append([])
 
@@ -429,20 +505,12 @@ class RewriteOp(IRDLOperation):
         if name is not None:
             attributes["name"] = name
 
-        return RewriteOp.build(
-            result_types=[], operands=operands, attributes=attributes, regions=regions
+        super().__init__(
+            result_types=[],
+            operands=operands,
+            attributes=attributes,
+            regions=regions,
         )
-
-    @staticmethod
-    def from_callable(
-        name: StringAttr | None,
-        root: SSAValue | None,
-        external_args: Sequence[SSAValue],
-        body: Block.BlockCallback,
-    ) -> RewriteOp:
-        block = Block.from_callable([], body)
-        region = Region(block)
-        return RewriteOp.get(name, root, external_args, region)
 
 
 @irdl_op_definition
@@ -455,10 +523,9 @@ class TypeOp(IRDLOperation):
     constantType: OptOpAttr[Attribute]
     result: Annotated[OpResult, TypeType]
 
-    @staticmethod
-    def get(constantType: TypeType | None = None) -> TypeOp:
-        return TypeOp.build(
-            attributes={"constantType": constantType}, result_types=[TypeType()]
+    def __init__(self, constant_type: TypeType | None = None) -> None:
+        super().__init__(
+            attributes={"constantType": constant_type}, result_types=[TypeType()]
         )
 
 
@@ -469,8 +536,14 @@ class TypesOp(IRDLOperation):
     """
 
     name: str = "pdl.types"
-    constantTypes: Annotated[OptOperand, ArrayAttr[TypeType]]
+    constantTypes: OptOpAttr[AnyArrayAttr]
     result: Annotated[OpResult, RangeType[TypeType]]
+
+    def __init__(self, constant_types: Iterable[TypeType] = ()) -> None:
+        super().__init__(
+            attributes={"constantType": ArrayAttr(constant_types)},
+            result_types=[RangeType(TypeType())],
+        )
 
 
 PDL = Dialect(

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -36,11 +36,13 @@ class PDLMatcher:
         if ssa_val in self.matching_context:
             return True
 
-        if pdl_op.valueType is not None:
-            assert isinstance(pdl_op.valueType, OpResult)
-            assert isinstance(pdl_op.valueType.op, pdl.TypeOp)
+        if pdl_op.value_type is not None:
+            assert isinstance(pdl_op.value_type, OpResult)
+            assert isinstance(pdl_op.value_type.op, pdl.TypeOp)
 
-            if not self.match_type(pdl_op.valueType, pdl_op.valueType.op, xdsl_val.typ):
+            if not self.match_type(
+                pdl_op.value_type, pdl_op.value_type.op, xdsl_val.typ
+            ):
                 return False
 
         self.matching_context[ssa_val] = xdsl_val
@@ -98,16 +100,16 @@ class PDLMatcher:
             if pdl_op.value != xdsl_attr:
                 return False
 
-        if pdl_op.valueType is not None:
-            assert isinstance(pdl_op.valueType, OpResult)
-            assert isinstance(pdl_op.valueType.op, pdl.TypeOp)
+        if pdl_op.value_type is not None:
+            assert isinstance(pdl_op.value_type, OpResult)
+            assert isinstance(pdl_op.value_type.op, pdl.TypeOp)
 
             assert isa(
                 xdsl_attr, IntegerAttr[IntegerType]
             ), "Only handle integer types for now"
 
             if not self.match_type(
-                pdl_op.valueType, pdl_op.valueType.op, xdsl_attr.typ
+                pdl_op.value_type, pdl_op.value_type.op, xdsl_attr.typ
             ):
                 return False
 
@@ -127,7 +129,7 @@ class PDLMatcher:
 
         attribute_value_names = [avn.data for avn in pdl_op.attributeValueNames.data]
 
-        for avn, av in zip(attribute_value_names, pdl_op.attributeValues):
+        for avn, av in zip(attribute_value_names, pdl_op.attribute_values):
             assert isinstance(av, OpResult)
             assert isinstance(av.op, pdl.AttributeOp)
             if avn not in xdsl_op.attributes:
@@ -136,7 +138,7 @@ class PDLMatcher:
             if not self.match_attribute(av, av.op, avn, xdsl_op.attributes[avn]):
                 return False
 
-        pdl_operands = pdl_op.operandValues
+        pdl_operands = pdl_op.operand_values
         xdsl_operands = xdsl_op.operands
 
         if len(pdl_operands) != len(xdsl_operands):
@@ -152,7 +154,7 @@ class PDLMatcher:
                 if not self.match_result(pdl_operand, pdl_operand.op, xdsl_operand):
                     return False
 
-        pdl_results = pdl_op.typeValues
+        pdl_results = pdl_op.type_values
         xdsl_results = xdsl_op.results
 
         if len(pdl_results) != len(xdsl_results):
@@ -281,16 +283,16 @@ class PDLFunctions(InterpreterFunctions):
         # How to deal with operand_segment_sizes?
         # operand_values, attribute_values, type_values = args
 
-        operand_values = interpreter.get_values(op.operandValues)
+        operand_values = interpreter.get_values(op.operand_values)
         for operand in operand_values:
             assert isinstance(operand, SSAValue)
 
-        attribute_values = interpreter.get_values(op.attributeValues)
+        attribute_values = interpreter.get_values(op.attribute_values)
 
         for attribute in attribute_values:
             assert isinstance(attribute, Attribute)
 
-        type_values = interpreter.get_values(op.typeValues)
+        type_values = interpreter.get_values(op.type_values)
 
         for type_value in type_values:
             assert isinstance(type_value, TypeAttribute)
@@ -309,13 +311,13 @@ class PDLFunctions(InterpreterFunctions):
     ) -> tuple[Any, ...]:
         rewriter = self.rewriter
 
-        (old,) = interpreter.get_values((op.opValue,))
+        (old,) = interpreter.get_values((op.op_value,))
 
-        if op.replOperation is not None:
-            (new_op,) = interpreter.get_values((op.replOperation,))
+        if op.repl_operation is not None:
+            (new_op,) = interpreter.get_values((op.repl_operation,))
             rewriter.replace_op(old, new_op)
-        elif len(op.replValues):
-            new_vals = interpreter.get_values(op.replValues)
+        elif len(op.repl_values):
+            new_vals = interpreter.get_values(op.repl_values)
             rewriter.replace_op(old, new_ops=[], new_results=list(new_vals))
         else:
             assert False, "Unexpected ReplaceOp"

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2370,13 +2370,6 @@ class Parser(ABC):
     def parse_op(self) -> Operation:
         return self.parse_operation()
 
-    def parse_int_literal(self) -> int:
-        return int(
-            self.expect(
-                self.try_parse_integer_literal, "Expected integer literal here"
-            ).text
-        )
-
     def parse_builtin_dict_attr(self) -> DictionaryAttr:
         """
         Parse a dictionary attribute, with the following syntax:

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -600,6 +600,11 @@ class Parser(ABC):
         if self._current_token.span.start > self.tokenizer.pos:
             self.tokenizer.pos = self._current_token.span.start
 
+    @property
+    def pos(self) -> Position:
+        """Get the position of the next token."""
+        return self._current_token.span.start
+
     def _consume_token(self, expected_kind: Token.Kind | None = None) -> Token:
         """
         Advance the lexer to the next token.


### PR DESCRIPTION
This PR lint PDL operations by making use of `__init__`, and fix 1-2 inconsistencies I found compared to the MLIR dialect.