### PR TITLE
dialects: Improvements to stencil dialect for indexop and applyop

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -46,7 +46,8 @@ def test_stencil_return_multiple_ResultType():
 def test_stencil_apply():
     result_type_val1 = TestSSAValue(ResultType.from_type(f32))
 
-    apply_op = ApplyOp.get([result_type_val1], Block([]), f32, 2)
+    stencil_temptype = TempType.from_shape([-1] * 2, f32)
+    apply_op = ApplyOp.get([result_type_val1], Block([]), [stencil_temptype])
 
     assert len(apply_op.args) == 1
     assert len(apply_op.res) == 1
@@ -55,7 +56,8 @@ def test_stencil_apply():
 
 
 def test_stencil_apply_no_args():
-    apply_op = ApplyOp.get([], Block([]), f32, 1, result_count=2)
+    stencil_temptype = TempType.from_shape([-1] * 1, f32)
+    apply_op = ApplyOp.get([], Block([]), [stencil_temptype, stencil_temptype])
 
     assert len(apply_op.args) == 0
     assert len(apply_op.res) == 2
@@ -66,4 +68,4 @@ def test_stencil_apply_no_args():
 def test_stencil_apply_no_results():
     # Should error if there are no results expected
     with pytest.raises(AssertionError):
-        ApplyOp.get([], Block([]), f32, 0)
+        ApplyOp.get([], Block([]), [])

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -1,5 +1,6 @@
+import pytest
 from xdsl.dialects.builtin import FloatAttr, f32
-from xdsl.dialects.experimental.stencil import ReturnOp, ResultType
+from xdsl.dialects.experimental.stencil import ReturnOp, ResultType, ApplyOp
 
 from xdsl.utils.test_value import TestSSAValue
 
@@ -40,3 +41,29 @@ def test_stencil_return_multiple_ResultType():
     assert return_op.arg[0] is result_type_val1
     assert return_op.arg[1] is result_type_val2
     assert return_op.arg[2] is result_type_val3
+
+
+def test_stencil_apply():
+    result_type_val1 = TestSSAValue(ResultType.from_type(f32))
+
+    apply_op = ApplyOp.get([result_type_val1], [], f32, 2)
+
+    assert len(apply_op.args) == 1
+    assert len(apply_op.res) == 1
+    assert apply_op.res[0].typ.element_type == f32
+    assert len(apply_op.res[0].typ.shape) == 2
+
+
+def test_stencil_apply_no_args():
+    apply_op = ApplyOp.get([], [], f32, 1, result_count=2)
+
+    assert len(apply_op.args) == 0
+    assert len(apply_op.res) == 2
+    assert apply_op.res[0].typ.element_type == f32
+    assert len(apply_op.res[0].typ.shape) == 1
+
+
+def test_stencil_apply_no_results():
+    # Should error if there are no results expected
+    with pytest.raises(AssertionError):
+        apply_op = ApplyOp.get([], [], f32, 0)

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -1,7 +1,7 @@
 import pytest
 from xdsl.dialects.builtin import FloatAttr, f32
-from xdsl.dialects.experimental.stencil import ReturnOp, ResultType, ApplyOp
-
+from xdsl.dialects.experimental.stencil import ReturnOp, ResultType, ApplyOp, TempType
+from xdsl.ir import Block
 from xdsl.utils.test_value import TestSSAValue
 
 
@@ -46,24 +46,24 @@ def test_stencil_return_multiple_ResultType():
 def test_stencil_apply():
     result_type_val1 = TestSSAValue(ResultType.from_type(f32))
 
-    apply_op = ApplyOp.get([result_type_val1], [], f32, 2)
+    apply_op = ApplyOp.get([result_type_val1], Block([]), f32, 2)
 
     assert len(apply_op.args) == 1
     assert len(apply_op.res) == 1
-    assert apply_op.res[0].typ.element_type == f32
+    assert isinstance(apply_op.res[0].typ, TempType)
     assert len(apply_op.res[0].typ.shape) == 2
 
 
 def test_stencil_apply_no_args():
-    apply_op = ApplyOp.get([], [], f32, 1, result_count=2)
+    apply_op = ApplyOp.get([], Block([]), f32, 1, result_count=2)
 
     assert len(apply_op.args) == 0
     assert len(apply_op.res) == 2
-    assert apply_op.res[0].typ.element_type == f32
+    assert isinstance(apply_op.res[0].typ, TempType)
     assert len(apply_op.res[0].typ.shape) == 1
 
 
 def test_stencil_apply_no_results():
     # Should error if there are no results expected
     with pytest.raises(AssertionError):
-        apply_op = ApplyOp.get([], [], f32, 0)
+        ApplyOp.get([], Block([]), f32, 0)

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -324,7 +324,7 @@ class IndexOp(IRDLOperation):
     """
 
     name: str = "stencil.index"
-    dim: OpAttr[IntegerType]
+    dim: OpAttr[IntegerAttr]
     offset: OpAttr[IndexAttr]
     idx: Annotated[OpResult, builtin.IndexType]
 
@@ -481,16 +481,13 @@ class ApplyOp(IRDLOperation):
     def get(
         args: Sequence[SSAValue] | Sequence[Operation],
         body: Block,
+        result_type,
+        result_rank: int,
         lb: IndexAttr | None = None,
         ub: IndexAttr | None = None,
         result_count: int = 1,
     ):
-        assert len(args) > 0
-        field_t = SSAValue.get(args[0]).typ
-        assert isinstance(field_t, TempType)
-        field_t = cast(FieldType[Attribute], field_t)
-
-        result_rank = len(field_t.shape.data)
+        assert result_rank > 0
 
         attributes = {}
         if lb is not None:
@@ -504,7 +501,7 @@ class ApplyOp(IRDLOperation):
             regions=[Region(body)],
             result_types=[
                 [
-                    TempType.from_shape([-1] * result_rank, field_t.element_type)
+                    TempType.from_shape([-1] * result_rank, result_type)
                     for _ in range(result_count)
                 ]
             ],

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -457,6 +457,9 @@ class StoreOp(IRDLOperation):
         return StoreOp.build(operands=[temp, field], attributes={"lb": lb, "ub": ub})
 
 
+from typing import TypeVar, Generic
+
+
 @irdl_op_definition
 class ApplyOp(IRDLOperation):
     """
@@ -481,13 +484,11 @@ class ApplyOp(IRDLOperation):
     def get(
         args: Sequence[SSAValue] | Sequence[Operation],
         body: Block,
-        result_type: AnyFloat,
-        result_rank: int,
+        result_types: Sequence[TempType[_FieldTypeElement]],
         lb: IndexAttr | None = None,
         ub: IndexAttr | None = None,
-        result_count: int = 1,
     ):
-        assert result_rank > 0
+        assert len(result_types) > 0
 
         attributes = {}
         if lb is not None:
@@ -499,12 +500,7 @@ class ApplyOp(IRDLOperation):
             operands=[list(args)],
             attributes=attributes,
             regions=[Region(body)],
-            result_types=[
-                [
-                    TempType.from_shape([-1] * result_rank, result_type)
-                    for _ in range(result_count)
-                ]
-            ],
+            result_types=[result_types],
         )
 
 

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -324,7 +324,7 @@ class IndexOp(IRDLOperation):
     """
 
     name: str = "stencil.index"
-    dim: OpAttr[IntegerAttr]
+    dim: OpAttr[AnyIntegerAttr]
     offset: OpAttr[IndexAttr]
     idx: Annotated[OpResult, builtin.IndexType]
 
@@ -481,7 +481,7 @@ class ApplyOp(IRDLOperation):
     def get(
         args: Sequence[SSAValue] | Sequence[Operation],
         body: Block,
-        result_type,
+        result_type: AnyFloat,
         result_rank: int,
         lb: IndexAttr | None = None,
         ub: IndexAttr | None = None,


### PR DESCRIPTION
Moved dims field from OpAttr IntegerType to IntegerAttr as this was incorrect before. Also can now have zero arguments to the apply op, with the result type provided explicitly now and the number of results too (was previously derived from the first argument)