### PR TITLE
dialects: Move `stencil.CastOp` out of experimental

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -1,5 +1,14 @@
-from xdsl.dialects.builtin import FloatAttr, f32
-from xdsl.dialects.experimental.stencil import ReturnOp, ResultType
+import pytest
+
+from xdsl.dialects.stencil import CastOp
+from xdsl.utils.exceptions import VerifyException
+from xdsl.dialects.builtin import FloatAttr, f32, f64
+from xdsl.dialects.experimental.stencil import (
+    ReturnOp,
+    ResultType,
+    FieldType,
+    IndexAttr,
+)
 
 from xdsl.utils.test_value import TestSSAValue
 
@@ -40,3 +49,103 @@ def test_stencil_return_multiple_ResultType():
     assert return_op.arg[0] is result_type_val1
     assert return_op.arg[1] is result_type_val2
     assert return_op.arg[2] is result_type_val3
+
+
+def test_stencil_cast_op_verifier():
+    field = TestSSAValue(FieldType.from_shape((-1, -1, -1), f32))
+
+    # check that correct op verifies correctly
+    cast = CastOp.get(
+        field,
+        IndexAttr.get(-2, -2, -2),
+        IndexAttr.get(100, 100, 100),
+        FieldType.from_shape((102, 102, 102), f32),
+    )
+    cast.verify()
+
+    # check that math is correct
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((100, 100, 100), f32),
+        )
+        cast.verify()
+
+    # check that output has same dims as input and lb, ub
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102), f32),
+        )
+        cast.verify()
+
+    # check that input has same shape as lb, ub, output
+    with pytest.raises(VerifyException):
+        dyn_field_wrong_shape = TestSSAValue(FieldType.from_shape((-1, -1), f32))
+        cast = CastOp.get(
+            dyn_field_wrong_shape,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+    # check that input and output have same element type
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f64),
+        )
+        cast.verify()
+
+    # check that len(lb) == len(ub)
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(
+                -2,
+                -2,
+            ),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+    # check that len(lb) == len(ub)
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+    # check that input must be dynamic
+    with pytest.raises(VerifyException):
+        non_dyn_field = TestSSAValue(FieldType.from_shape((102, 102, 102), f32))
+        cast = CastOp.get(
+            non_dyn_field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+
+def test_cast_op_constructor():
+    field = TestSSAValue(FieldType.from_shape((-1, -1, -1), f32))
+
+    cast = CastOp.get(
+        field,
+        IndexAttr.get(-2, -3, -4),
+        IndexAttr.get(100, 100, 0),
+    )
+
+    assert cast.result.typ == FieldType.from_shape((102, 103, 4), f32)

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -20,7 +20,6 @@ from xdsl.dialects import memref, arith, scf, builtin, gpu
 from xdsl.dialects.experimental.stencil import (
     AccessOp,
     ApplyOp,
-    CastOp,
     FieldType,
     IndexAttr,
     LoadOp,
@@ -30,6 +29,7 @@ from xdsl.dialects.experimental.stencil import (
     ExternalLoadOp,
     ExternalStoreOp,
 )
+from xdsl.dialects.stencil import CastOp
 from xdsl.passes import ModulePass
 
 from xdsl.utils.exceptions import VerifyException

--- a/xdsl/transforms/experimental/StencilShapeInference.py
+++ b/xdsl/transforms/experimental/StencilShapeInference.py
@@ -3,13 +3,13 @@ from xdsl.dialects import builtin
 from xdsl.dialects.experimental.stencil import (
     AccessOp,
     ApplyOp,
-    CastOp,
     HaloSwapOp,
     IndexAttr,
     LoadOp,
     StoreOp,
     TempType,
 )
+from xdsl.dialects.stencil import CastOp
 from xdsl.ir import Attribute, BlockArgument, MLContext, Operation, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -25,7 +25,8 @@ from xdsl.dialects.gpu import GPU
 from xdsl.dialects.pdl import PDL
 from xdsl.dialects.test import Test
 
-from xdsl.dialects.experimental.stencil import Stencil
+from xdsl.dialects.experimental.stencil import StencilExp
+from xdsl.dialects.stencil import Stencil
 from xdsl.dialects.experimental.math import Math
 
 from xdsl.frontend.passes.desymref import DesymrefyPass
@@ -218,6 +219,7 @@ class xDSLOptMain:
         self.ctx.register_dialect(Vector)
         self.ctx.register_dialect(MPI)
         self.ctx.register_dialect(GPU)
+        self.ctx.register_dialect(StencilExp)
         self.ctx.register_dialect(Stencil)
         self.ctx.register_dialect(PDL)
         self.ctx.register_dialect(Symref)


### PR DESCRIPTION
This moves the stencil `CastOp` out of experimental. It has a proper verifier and is thoroughly tested. We also consider this operation to be stable enough to be moved out.