### PR TITLE
dialects: Move stencil `CastOp` from experimental to main

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -64,7 +64,7 @@ def test_stencil_cast_op_verifier():
     cast.verify()
 
     # check that math is correct
-    with pytest.raises(VerifyException):
+    with pytest.raises(VerifyException) as ex1:
         cast = CastOp.get(
             field,
             IndexAttr.get(-2, -2, -2),
@@ -72,9 +72,10 @@ def test_stencil_cast_op_verifier():
             FieldType.from_shape((100, 100, 100), f32),
         )
         cast.verify()
+    assert "math" in ex1.value.args[0]
 
     # check that output has same dims as input and lb, ub
-    with pytest.raises(VerifyException):
+    with pytest.raises(VerifyException) as ex2:
         cast = CastOp.get(
             field,
             IndexAttr.get(-2, -2, -2),
@@ -82,9 +83,10 @@ def test_stencil_cast_op_verifier():
             FieldType.from_shape((102, 102), f32),
         )
         cast.verify()
+    assert "same dimensions" in ex2.value.args[0]
 
     # check that input has same shape as lb, ub, output
-    with pytest.raises(VerifyException):
+    with pytest.raises(VerifyException) as ex3:
         dyn_field_wrong_shape = TestSSAValue(FieldType.from_shape((-1, -1), f32))
         cast = CastOp.get(
             dyn_field_wrong_shape,
@@ -93,9 +95,10 @@ def test_stencil_cast_op_verifier():
             FieldType.from_shape((102, 102, 102), f32),
         )
         cast.verify()
+    assert "same dimensions" in ex3.value.args[0]
 
     # check that input and output have same element type
-    with pytest.raises(VerifyException):
+    with pytest.raises(VerifyException) as ex4:
         cast = CastOp.get(
             field,
             IndexAttr.get(-2, -2, -2),
@@ -103,9 +106,10 @@ def test_stencil_cast_op_verifier():
             FieldType.from_shape((102, 102, 102), f64),
         )
         cast.verify()
+    assert "element type" in ex4.value.args[0]
 
     # check that len(lb) == len(ub)
-    with pytest.raises(VerifyException):
+    with pytest.raises(VerifyException) as ex5:
         cast = CastOp.get(
             field,
             IndexAttr.get(
@@ -116,9 +120,10 @@ def test_stencil_cast_op_verifier():
             FieldType.from_shape((102, 102, 102), f32),
         )
         cast.verify()
+    assert "same dimensions" in ex5.value.args[0]
 
     # check that len(lb) == len(ub)
-    with pytest.raises(VerifyException):
+    with pytest.raises(VerifyException) as ex6:
         cast = CastOp.get(
             field,
             IndexAttr.get(-2, -2, -2),
@@ -126,9 +131,10 @@ def test_stencil_cast_op_verifier():
             FieldType.from_shape((102, 102, 102), f32),
         )
         cast.verify()
+    assert "same dimensions" in ex6.value.args[0]
 
     # check that input must be dynamic
-    with pytest.raises(VerifyException):
+    with pytest.raises(VerifyException) as ex7:
         non_dyn_field = TestSSAValue(FieldType.from_shape((102, 102, 102), f32))
         cast = CastOp.get(
             non_dyn_field,
@@ -137,6 +143,7 @@ def test_stencil_cast_op_verifier():
             FieldType.from_shape((102, 102, 102), f32),
         )
         cast.verify()
+    assert "dynamic" in ex7.value.args[0]
 
 
 def test_cast_op_constructor():

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -1,5 +1,14 @@
-from xdsl.dialects.builtin import FloatAttr, f32
-from xdsl.dialects.experimental.stencil import ReturnOp, ResultType
+import pytest
+
+from xdsl.dialects.stencil import CastOp
+from xdsl.utils.exceptions import VerifyException
+from xdsl.dialects.builtin import FloatAttr, f32, f64
+from xdsl.dialects.experimental.stencil import (
+    ReturnOp,
+    ResultType,
+    FieldType,
+    IndexAttr,
+)
 
 from xdsl.utils.test_value import TestSSAValue
 
@@ -40,3 +49,103 @@ def test_stencil_return_multiple_ResultType():
     assert return_op.arg[0] is result_type_val1
     assert return_op.arg[1] is result_type_val2
     assert return_op.arg[2] is result_type_val3
+
+
+def test_stencil_cast_op_verifier():
+    field = TestSSAValue(FieldType.from_shape((-1, -1, -1), f32))
+
+    # check that correct op verifies correctly
+    cast = CastOp.get(
+        field,
+        IndexAttr.get(-2, -2, -2),
+        IndexAttr.get(100, 100, 100),
+        FieldType.from_shape((102, 102, 102), f32),
+    )
+    cast.verify()
+
+    # check that math is correct
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((100, 100, 100), f32),
+        )
+        cast.verify()
+
+    # check that output has same dims as input and lb, ub
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102), f32),
+        )
+        cast.verify()
+
+    # check that input has same shape as lb, ub, output
+    with pytest.raises(VerifyException):
+        dyn_field_wrong_shape = TestSSAValue(FieldType.from_shape((-1, -1), f32))
+        cast = CastOp.get(
+            dyn_field_wrong_shape,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+    # check that input and output have same element type
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f64),
+        )
+        cast.verify()
+
+    # check that len(lb) == len(ub)
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(
+                -2,
+                -2,
+            ),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+    # check that len(lb) == len(ub)
+    with pytest.raises(VerifyException):
+        cast = CastOp.get(
+            field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+    # check that input must be dynamic
+    with pytest.raises(VerifyException):
+        non_dyn_field = TestSSAValue(FieldType.from_shape((102, 102, 102), f32))
+        cast = CastOp.get(
+            non_dyn_field,
+            IndexAttr.get(-2, -2, -2),
+            IndexAttr.get(100, 100, 100),
+            FieldType.from_shape((102, 102, 102), f32),
+        )
+        cast.verify()
+
+
+def test_cast_op_constructor():
+    field = TestSSAValue(FieldType.from_shape((-1, -1, -1), f32))
+
+    cast = CastOp.get(
+        field,
+        IndexAttr.get(-2, -3, -4),
+        IndexAttr.get(100, 100, 0),
+    )
+
+    assert cast.result.typ == FieldType.from_shape((102, 103, 4), f32)

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Annotated, TypeVar
+
+from xdsl.dialects.experimental.stencil import FieldType, IndexAttr
+from xdsl.ir import OpResult, SSAValue, Operation, Attribute, Dialect
+from xdsl.irdl import irdl_op_definition, IRDLOperation, Operand, OpAttr
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
+
+
+_FieldTypeVar = TypeVar("_FieldTypeVar", bound=Attribute)
+
+
+@irdl_op_definition
+class CastOp(IRDLOperation):
+    """
+    This operation casts dynamically shaped input fields to statically shaped fields.
+
+    Example:
+        %0 = stencil.cast %in ([-3, -3, 0] : [67, 67, 60]) : (!stencil.field<?x?x?xf64>) -> !stencil.field<70x70x60xf64> # noqa
+    """
+
+    name: str = "stencil.cast"
+    field: Annotated[Operand, FieldType]
+    lb: OpAttr[IndexAttr]
+    ub: OpAttr[IndexAttr]
+    result: Annotated[OpResult, FieldType]
+
+    @staticmethod
+    def get(
+        field: SSAValue | Operation,
+        lb: IndexAttr,
+        ub: IndexAttr,
+        res_type: FieldType[_FieldTypeVar] | FieldType[Attribute] | None = None,
+    ) -> CastOp:
+        """ """
+        field_ssa = SSAValue.get(field)
+        assert isa(field_ssa.typ, FieldType[Attribute])
+        if res_type is None:
+            res_type = FieldType.from_shape(
+                tuple(ub_elm - lb_elm for lb_elm, ub_elm in zip(lb, ub)),
+                field_ssa.typ.element_type,
+            )
+        return CastOp.build(
+            operands=[field],
+            attributes={"lb": lb, "ub": ub},
+            result_types=[res_type],
+        )
+
+    def verify_(self) -> None:
+        # this should be fine, verify() already checks them:
+        assert isa(self.field.typ, FieldType[Attribute])
+        assert isa(self.result.typ, FieldType[Attribute])
+
+        if self.field.typ.element_type != self.result.typ.element_type:
+            raise VerifyException(
+                "Input and output fields have different element types!"
+            )
+
+        if not len(self.lb) == len(self.ub):
+            raise VerifyException("lb and ub must have the same dimensions!")
+
+        if not len(self.field.typ.shape) == len(self.lb):
+            raise VerifyException(
+                "Input type has different dimensionality than bounds!"
+            )
+
+        if not len(self.result.typ.shape) == len(self.ub):
+            raise VerifyException(
+                "Result type has different dimensionality than bounds!"
+            )
+
+        for i, (in_attr, lb, ub, out_attr) in enumerate(
+            zip(
+                self.field.typ.shape,
+                self.lb,
+                self.ub,
+                self.result.typ.shape,
+            )
+        ):
+            in_: int = in_attr.value.data
+            out: int = out_attr.value.data
+
+            if ub - lb != out:
+                raise VerifyException(
+                    "Bound math doesn't check out in dimensions {}! {} - {} != {}".format(
+                        i, ub, lb, out
+                    )
+                )
+
+            if in_ != -1:
+                # TODO: find out if this is too strict
+                raise VerifyException("Input must be dynamically shaped!")
+
+
+Stencil = Dialect([CastOp], [])

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -55,20 +55,18 @@ class CastOp(IRDLOperation):
 
         if self.field.typ.element_type != self.result.typ.element_type:
             raise VerifyException(
-                "Input and output fields have different element types!"
+                "Input and output fields have different element types"
             )
 
         if not len(self.lb) == len(self.ub):
-            raise VerifyException("lb and ub must have the same dimensions!")
+            raise VerifyException("lb and ub must have the same dimensions")
 
         if not len(self.field.typ.shape) == len(self.lb):
-            raise VerifyException(
-                "Input type has different dimensionality than bounds!"
-            )
+            raise VerifyException("Input type and bounds must have the same dimensions")
 
         if not len(self.result.typ.shape) == len(self.ub):
             raise VerifyException(
-                "Result type has different dimensionality than bounds!"
+                "Result type and bounds must have the same dimensions"
             )
 
         for i, (in_attr, lb, ub, out_attr) in enumerate(
@@ -91,7 +89,7 @@ class CastOp(IRDLOperation):
 
             if in_ != -1:
                 # TODO: find out if this is too strict
-                raise VerifyException("Input must be dynamically shaped!")
+                raise VerifyException("Input must be dynamically shaped")
 
 
 Stencil = Dialect([CastOp], [])

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -17,6 +17,7 @@ from xdsl.dialects.func import FuncOp
 from xdsl.dialects.memref import MemRefType
 from xdsl.dialects import memref, arith, scf, builtin, gpu
 
+from xdsl.dialects.stencil import CastOp
 from xdsl.dialects.experimental.stencil import (
     AccessOp,
     ApplyOp,
@@ -29,7 +30,6 @@ from xdsl.dialects.experimental.stencil import (
     ExternalLoadOp,
     ExternalStoreOp,
 )
-from xdsl.dialects.stencil import CastOp
 from xdsl.passes import ModulePass
 
 from xdsl.utils.exceptions import VerifyException

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -20,7 +20,6 @@ from xdsl.dialects import memref, arith, scf, builtin, gpu
 from xdsl.dialects.experimental.stencil import (
     AccessOp,
     ApplyOp,
-    CastOp,
     FieldType,
     IndexAttr,
     LoadOp,
@@ -30,6 +29,7 @@ from xdsl.dialects.experimental.stencil import (
     ExternalLoadOp,
     ExternalStoreOp,
 )
+from xdsl.dialects.stencil import CastOp
 from xdsl.passes import ModulePass
 
 from xdsl.utils.exceptions import VerifyException

--- a/xdsl/transforms/experimental/StencilShapeInference.py
+++ b/xdsl/transforms/experimental/StencilShapeInference.py
@@ -3,13 +3,13 @@ from xdsl.dialects import builtin
 from xdsl.dialects.experimental.stencil import (
     AccessOp,
     ApplyOp,
-    CastOp,
     HaloSwapOp,
     IndexAttr,
     LoadOp,
     StoreOp,
     TempType,
 )
+from xdsl.dialects.stencil import CastOp
 from xdsl.ir import Attribute, BlockArgument, MLContext, Operation, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -24,9 +24,9 @@ from xdsl.dialects.mpi import MPI
 from xdsl.dialects.gpu import GPU
 from xdsl.dialects.pdl import PDL
 from xdsl.dialects.test import Test
+from xdsl.dialects.stencil import Stencil
 
 from xdsl.dialects.experimental.stencil import StencilExp
-from xdsl.dialects.stencil import Stencil
 from xdsl.dialects.experimental.math import Math
 
 from xdsl.frontend.passes.desymref import DesymrefyPass

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -25,7 +25,8 @@ from xdsl.dialects.gpu import GPU
 from xdsl.dialects.pdl import PDL
 from xdsl.dialects.test import Test
 
-from xdsl.dialects.experimental.stencil import Stencil
+from xdsl.dialects.experimental.stencil import StencilExp
+from xdsl.dialects.stencil import Stencil
 from xdsl.dialects.experimental.math import Math
 
 from xdsl.frontend.passes.desymref import DesymrefyPass
@@ -218,6 +219,7 @@ class xDSLOptMain:
         self.ctx.register_dialect(Vector)
         self.ctx.register_dialect(MPI)
         self.ctx.register_dialect(GPU)
+        self.ctx.register_dialect(StencilExp)
         self.ctx.register_dialect(Stencil)
         self.ctx.register_dialect(PDL)
         self.ctx.register_dialect(Symref)


### PR DESCRIPTION
This PR moves the `CastOp` out of experimental. The CastOp design is unlikely to change, and has full test coverage.

It might make sense to move the `IndexAttr` first, let me know if that is wanted!