### PR TITLE
core: Remove build from Attribute

### DIFF
--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -314,7 +314,7 @@ class GetGlobal(IRDLOperation):
     @staticmethod
     def get(name: str, return_type: Attribute) -> GetGlobal:
         return GetGlobal.build(
-            result_types=[return_type], attributes={"name": SymbolRefAttr.build(name)}
+            result_types=[return_type], attributes={"name": SymbolRefAttr(name)}
         )
 
     # TODO how to verify the types, as the global might be defined in another

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -358,11 +358,6 @@ class Attribute(ABC):
     name: str = field(default="", init=False)
     """The attribute name should be a static field in the attribute classes."""
 
-    @classmethod
-    def build(cls: type[A], *args: Any) -> A:
-        """Create a new attribute using one of the builder defined in IRDL."""
-        assert False
-
     def __post_init__(self):
         self._verify()
 


### PR DESCRIPTION
Remove build from Attribute as proposed in #752 - this PR also replaces one remaining use with a constructor call.