### PR TITLE
install: move dev imports to requirements-optional

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -34,7 +34,7 @@ jobs:
         pip install --upgrade pip
 
     - name: Install the package locally
-      run: pip install -e .
+      run: pip install -e ".[extras]"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         # Change directory so that xdsl-opt can be found during installation.
         cd xdsl
-        pip install -e .[extras]
+        pip install -e ".[extras]"
         pip install nbval
 
     - name: Cache binaries

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install --upgrade pip
     - name: Install the package locally
-      run: pip install -e .
+      run: pip install -e ".[extras]"
     - name: Install nbval
       run: |
         pip install nbval

--- a/.github/workflows/ci-pyright-fails.yml
+++ b/.github/workflows/ci-pyright-fails.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install --upgrade pip
       - name: Install the package locally
-        run: pip install -e .[extras]
+        run: pip install -e ".[extras]"
       - name: retrieve pyright version
         run: |
           python3 .github/parse_pyright_version.py

--- a/.github/workflows/ci-pyright.yml
+++ b/.github/workflows/ci-pyright.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install --upgrade pip
       - name: Install the package locally
-        run: pip install -e .[extras]
+        run: pip install -e ".[extras]"
       - name: retrieve pyright version
         run: |
           python3 .github/parse_pyright_version.py

--- a/README.md
+++ b/README.md
@@ -67,9 +67,7 @@ To contribute to the development of xDSL follow the subsequent steps.
 ```bash
 git clone https://github.com/xdslproject/xdsl.git
 cd xdsl
-pip install --editable .
-# Optional installation of extra requirements
-pip install --requirement requirements-optional.txt
+pip install --editable ".[extras]"
 ```
 
 ### Testing

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -3,6 +3,9 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
+pytest<8.0
+filecheck<0.0.24
+lit<17.0.0
 pre-commit==3.3.1
 # pyright has to be the last line and fixed with `==`. The CI parses this file
 # in `.github/parse_pyright_version.py` and installs the according version for

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 pip<24.0
-pytest<8.0
-filecheck<0.0.24
-lit<17.0.0
 immutabledict<2.2.5

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
 import versioneer
 from setuptools import find_packages, setup
 from pathlib import Path
+import re
 
 # Add README.md as long description
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
+
+git_regex = r"git\+(?P<url>https:\/\/github.com\/[\w]+\/[\w]+\.git)(@(?P<version>[\w]+))?(#egg=(?P<name>[\w]+))?"
 
 with open("requirements.txt") as f:
     required = f.read().splitlines()
@@ -35,10 +38,17 @@ for mreqs, mode in zip(
         if ";" in ir:
             entries = ir.split(";")
             extras_require[entries[1]] = entries[0]
-        # Git repos, install master
-        if ir[0:3] == "git":
-            name = ir.split("/")[-1]
-            opt_reqs += ["%s @ %s@main" % (name, ir)]
+        elif ir[0:3] == "git":
+            m = re.match(git_regex, ir)
+            assert m is not None
+            items = m.groupdict()
+            name = items["name"]
+            url = items["url"]
+            version = items.get("version")
+            if version is None:
+                version = "main"
+
+            opt_reqs += [f"{name} @ git+{url}@{version}"]
         else:
             opt_reqs += [ir]
     extras_require[mode] = opt_reqs


### PR DESCRIPTION
This PR makes the following changes:

 - moves development dependencies to requirements-optional.txt
 - imports all dependencies for CI jobs
 - updates setup.py to handle requirements in this format: 
   - `git+https://github.com/antonlydike/riscemu.git@25d059da090760862f9143478524ed6daf0ab449#egg=riscemu`

The way pip install works, is that it runs setup.py to get its dependencies. Our setup.py gives it the dependencies from requirements.txt, meaning that anyone running `pip install xdsl` would install lit along with it, which is not ideal. This PR changes that, so only the dependencies needed to run xdsl are installed.

This fixes #441 