### PR TITLE
core: Add successors to IRDL

### DIFF
--- a/tests/dialects/test_cf.py
+++ b/tests/dialects/test_cf.py
@@ -26,7 +26,7 @@ def test_branch():
     br0 = Branch.get(block0)
     ops = list(br0.successors[0].ops)
 
-    assert br0.successors[0] is block0
+    assert br0.successor is block0
     assert ops[0] is a
     assert ops[1] is b
     assert ops[2] is c
@@ -47,5 +47,5 @@ def test_condbranch():
     assert branch0.cond is c.results[0]
     assert branch0.then_arguments[0] is d.results[0]
     assert branch0.else_arguments[0] is e.results[0]
-    assert branch0.successors[0] is block0
-    assert branch0.successors[1] is block1
+    assert branch0.then_block is block0
+    assert branch0.then_block is block1

--- a/tests/dialects/test_cf.py
+++ b/tests/dialects/test_cf.py
@@ -48,4 +48,4 @@ def test_condbranch():
     assert branch0.then_arguments[0] is d.results[0]
     assert branch0.else_arguments[0] is e.results[0]
     assert branch0.then_block is block0
-    assert branch0.then_block is block1
+    assert branch0.else_block is block1

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -10,15 +10,19 @@ from xdsl.dialects.arith import Constant
 from xdsl.ir import Block, OpResult, Region
 from xdsl.irdl import (
     AttrSizedRegionSegments,
+    AttrSizedSuccessorSegments,
     OptOpResult,
     OptOperand,
     OptRegion,
     OptSingleBlockRegion,
     Operand,
+    OptSuccessor,
     SingleBlockRegion,
+    Successor,
     VarOpResult,
     VarRegion,
     VarSingleBlockRegion,
+    VarSuccessor,
     irdl_op_definition,
     AttrSizedResultSegments,
     VarOperand,
@@ -474,6 +478,92 @@ def test_two_var_operand_builder3():
     assert op2.regions == [region1, region2, region3, region4]
     assert op2.attributes[
         AttrSizedRegionSegments.attribute_name
+    ] == DenseArrayBase.from_list(i32, [1, 3])
+
+
+#  ____
+# / ___| _   _  ___ ___ ___  ___ ___  ___  _ __
+# \___ \| | | |/ __/ __/ _ \/ __/ __|/ _ \| '__|
+#  ___) | |_| | (_| (_|  __/\__ \__ \ (_) | |
+# |____/ \__,_|\___\___\___||___/___/\___/|_|
+#
+
+
+@irdl_op_definition
+class SuccessorOp(IRDLOperation):
+    name: str = "test.successor_op"
+
+    successor: Successor
+
+
+def test_successor_op_successor():
+    block = Block()
+    op = SuccessorOp.build(successors=[block])
+    op.verify()
+    assert len(op.successors) == 1
+
+
+@irdl_op_definition
+class OptSuccessorOp(IRDLOperation):
+    name: str = "test.opt_successora_op"
+
+    successor: OptSuccessor
+
+
+def test_opt_successor_builder():
+    block = Block()
+    op1 = OptSuccessorOp.build(successors=[block])
+    op2 = OptSuccessorOp.build(successors=[None])
+    op1.verify()
+    op2.verify()
+
+
+@irdl_op_definition
+class VarSuccessorOp(IRDLOperation):
+    name: str = "test.var_succesor_op"
+
+    successor: VarSuccessor
+
+
+def test_var_successor_builder():
+    block = Block()
+    op = VarSuccessorOp.build(successors=[[block, block, block]])
+    op.verify()
+    assert len(op.successors) == 3
+
+
+@irdl_op_definition
+class TwoVarSuccessorOp(IRDLOperation):
+    name: str = "test.two_var_successor_op"
+
+    res1: VarSuccessor
+    res2: VarSuccessor
+    irdl_options = [AttrSizedSuccessorSegments()]
+
+
+def test_two_var_successor_builder():
+    block1 = Block()
+    block2 = Block()
+    block3 = Block()
+    block4 = Block()
+    op2 = TwoVarSuccessorOp.build(successors=[[block1, block2], [block3, block4]])
+    op2.verify()
+    assert op2.successors == [block1, block2, block3, block4]
+    assert op2.attributes[
+        AttrSizedSuccessorSegments.attribute_name
+    ] == DenseArrayBase.from_list(i32, [2, 2])
+
+
+def test_two_var_successor_builder2():
+    block1 = Block()
+    block2 = Block()
+    block3 = Block()
+    block4 = Block()
+    op2 = TwoVarSuccessorOp.build(successors=[[block1], [block2, block3, block4]])
+    op2.verify()
+    assert op2.successors == [block1, block2, block3, block4]
+    assert op2.attributes[
+        AttrSizedSuccessorSegments.attribute_name
     ] == DenseArrayBase.from_list(i32, [1, 3])
 
 

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -491,7 +491,7 @@ def test_two_var_operand_builder3():
 
 @irdl_op_definition
 class SuccessorOp(IRDLOperation):
-    name: str = "test.successor_op"
+    name = "test.successor_op"
 
     successor: Successor
 
@@ -505,7 +505,7 @@ def test_successor_op_successor():
 
 @irdl_op_definition
 class OptSuccessorOp(IRDLOperation):
-    name: str = "test.opt_successora_op"
+    name = "test.opt_successora_op"
 
     successor: OptSuccessor
 
@@ -520,7 +520,7 @@ def test_opt_successor_builder():
 
 @irdl_op_definition
 class VarSuccessorOp(IRDLOperation):
-    name: str = "test.var_succesor_op"
+    name = "test.var_succesor_op"
 
     successor: VarSuccessor
 
@@ -534,7 +534,7 @@ def test_var_successor_builder():
 
 @irdl_op_definition
 class TwoVarSuccessorOp(IRDLOperation):
-    name: str = "test.two_var_successor_op"
+    name = "test.two_var_successor_op"
 
     res1: VarSuccessor
     res2: VarSuccessor

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -12,7 +12,7 @@ from xdsl.irdl import (
     AnyAttr,
     Operand,
     AttrSizedOperandSegments,
-    IRDLOperation,
+    IRDLOperation, Successor,
 )
 
 
@@ -34,10 +34,11 @@ class Branch(IRDLOperation):
     name = "cf.br"
 
     arguments: Annotated[VarOperand, AnyAttr()]
+    successor: Successor
 
     @staticmethod
-    def get(block: Block, *ops: Union[Operation, SSAValue]) -> Branch:
-        return Branch.build(operands=[[op for op in ops]], successors=[block])
+    def get(dest: Block, *ops: Union[Operation, SSAValue]) -> Branch:
+        return Branch.build(operands=[[op for op in ops]], successors=[dest])
 
 
 @irdl_op_definition
@@ -49,6 +50,9 @@ class ConditionalBranch(IRDLOperation):
     else_arguments: Annotated[VarOperand, AnyAttr()]
 
     irdl_options = [AttrSizedOperandSegments()]
+
+    then_block: Successor
+    else_block: Successor
 
     @staticmethod
     def get(

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -12,7 +12,8 @@ from xdsl.irdl import (
     AnyAttr,
     Operand,
     AttrSizedOperandSegments,
-    IRDLOperation, Successor,
+    IRDLOperation,
+    Successor,
 )
 
 


### PR DESCRIPTION
This PR adds successors to IRDL, with the current syntax:
```
class MyOp(IRDLOperation):
   successor1: Successor
   opt_succ: OptSuccessor
   var_succ: VarSuccessor
```