### PR TITLE
dialects: Add risc-v printable interface

### DIFF
--- a/tests/test_riscv_printer.py
+++ b/tests/test_riscv_printer.py
@@ -1,0 +1,53 @@
+from io import StringIO
+from typing import Sequence
+
+from xdsl.ir import OpResult
+from xdsl.riscv_asm_writer import print_riscv_module
+from xdsl.dialects import riscv, builtin
+from xdsl.irdl import irdl_op_definition, IRDLOperation, Annotated, OpAttr
+from xdsl.ir import SSAValue
+from xdsl.dialects.builtin import IntegerType, IndexType, IntegerAttr
+from xdsl.builder import Builder
+
+
+@irdl_op_definition
+class ExternalRiscvOp(IRDLOperation, riscv.RISCVPrinterInterface):
+    name = "custom.custom_op"
+
+    rd: Annotated[OpResult, riscv.RegisterType]
+
+    imm: OpAttr[builtin.IntegerAttr[builtin.IntegerType]]
+
+    def __init__(self, rd: str, imm: int = 0):
+        super().__init__(
+            result_types=[riscv.RegisterType(riscv.Register(rd))],
+            attributes={"imm": builtin.IntegerAttr(imm, 64)},
+        )
+
+    def riscv_printed_name(self) -> str:
+        return "custom.op"
+
+    def riscv_printed_components(
+        self,
+    ) -> Sequence[
+        IntegerAttr[IntegerType | IndexType] | riscv.LabelAttr | SSAValue | str | None
+    ]:
+        return (self.rd, self.imm)
+
+
+def test_external_op_printing():
+    @builtin.ModuleOp
+    @Builder.implicit_region
+    def module():
+        riscv.LiOp(100, rd=riscv.Register("zero"))
+        ExternalRiscvOp("zero", 101)
+
+    io = StringIO()
+    print_riscv_module(module, io)
+
+    assert (
+        io.getvalue()
+        == """    li zero, 100
+    custom.op zero, 101
+"""
+    )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Annotated
+from typing import Annotated, Sequence
 
 from xdsl.ir import (
     Dialect,
@@ -28,6 +28,8 @@ from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     UnitAttr,
     IntegerAttr,
+    IntegerType,
+    IndexType,
 )
 from xdsl.utils.exceptions import VerifyException
 
@@ -157,6 +159,31 @@ class LabelAttr(Data[str]):
 
 class RISCVOp(Operation, ABC):
     pass
+
+
+class RISCVPrinterInterface(ABC):
+    """
+    This interface is used so that other dialects can extend RISC-V printing
+    without having to modify printing code or the risc-v dialect base.
+    """
+
+    @abstractmethod
+    def riscv_printed_name(self) -> str:
+        """
+        Give the name of the RISC-V instruction
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def riscv_printed_components(
+        self,
+    ) -> Sequence[
+        IntegerAttr[IntegerType | IndexType] | LabelAttr | SSAValue | str | None
+    ]:
+        """
+        Return the list of "arguments" to the operation
+        """
+        raise NotImplementedError()
 
 
 # region Base Operation classes

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass, field
-from typing import Annotated, Sequence
+from typing import Annotated
 
+from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
+    UnitAttr,
+    IntegerAttr,
+)
 from xdsl.ir import (
     Dialect,
     Operation,
@@ -12,7 +17,6 @@ from xdsl.ir import (
     OpResult,
     TypeAttribute,
 )
-
 from xdsl.irdl import (
     IRDLOperation,
     irdl_op_definition,
@@ -21,16 +25,8 @@ from xdsl.irdl import (
     OpAttr,
     OptOpAttr,
 )
-
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.dialects.builtin import (
-    AnyIntegerAttr,
-    UnitAttr,
-    IntegerAttr,
-    IntegerType,
-    IndexType,
-)
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -159,31 +155,6 @@ class LabelAttr(Data[str]):
 
 class RISCVOp(Operation, ABC):
     pass
-
-
-class RISCVPrinterInterface(ABC):
-    """
-    This interface is used so that other dialects can extend RISC-V printing
-    without having to modify printing code or the risc-v dialect base.
-    """
-
-    @abstractmethod
-    def riscv_printed_name(self) -> str:
-        """
-        Give the name of the RISC-V instruction
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def riscv_printed_components(
-        self,
-    ) -> Sequence[
-        IntegerAttr[IntegerType | IndexType] | LabelAttr | SSAValue | str | None
-    ]:
-        """
-        Return the list of "arguments" to the operation
-        """
-        raise NotImplementedError()
 
 
 # region Base Operation classes


### PR DESCRIPTION
This PR adds the `RISCVPrinterInterface` interface that allows any operation to become printable by the riscv target.

Implementing that interface requires two methods: `riscv_printed_name` and `riscv_printed_components` to print the instruction in the same format as everything else in the file.