### PR TITLE
dialects: add ability to print comments in riscv assembly

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,7 +1,8 @@
+from xdsl.riscv_asm_writer import riscv_code
 from xdsl.utils.test_value import TestSSAValue
 from xdsl.dialects import riscv
 
-from xdsl.dialects.builtin import IntegerAttr, i32
+from xdsl.dialects.builtin import IntegerAttr, ModuleOp, i32
 
 from xdsl.utils.exceptions import VerifyException
 
@@ -77,3 +78,23 @@ def test_csr_op():
     riscv.CsrrsiOp(
         csr=csr, immediate=IntegerAttr(1, i32), rd=riscv.Registers.A2
     ).verify()
+
+
+def test_comment_op():
+    comment_op = riscv.CommentOp("my comment")
+
+    assert comment_op.comment.data == "my comment"
+
+    code = riscv_code(ModuleOp([comment_op]))
+    assert code == "    # my comment\n"
+
+
+def test_return_op():
+    return_op = riscv.EbreakOp(comment="my comment")
+
+    assert return_op.comment is not None
+
+    assert return_op.comment.data == "my comment"
+
+    code = riscv_code(ModuleOp([return_op]))
+    assert code == "    ebreak                                       # my comment\n"

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -222,7 +222,7 @@ class RdImmOperation(IRDLOperation, RISCVOp, ABC):
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr.from_int_and_width(immediate, 32)
-        if isinstance(immediate, str):
+        elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
             rd = RegisterType(Register())

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -28,6 +28,7 @@ from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     UnitAttr,
     IntegerAttr,
+    StringAttr,
 )
 from xdsl.utils.exceptions import VerifyException
 
@@ -176,6 +177,7 @@ class RdRsRsOperation(IRDLOperation, RISCVOp, ABC):
     rd: Annotated[OpResult, RegisterType]
     rs1: Annotated[Operand, RegisterType]
     rs2: Annotated[Operand, RegisterType]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
@@ -183,14 +185,20 @@ class RdRsRsOperation(IRDLOperation, RISCVOp, ABC):
         rs2: Operation | SSAValue,
         *,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
 
         super().__init__(
             operands=[rs1, rs2],
+            attributes={
+                "comment": comment,
+            },
             result_types=[rd],
         )
 
@@ -203,26 +211,32 @@ class RdImmOperation(IRDLOperation, RISCVOp, ABC):
 
     rd: Annotated[OpResult, RegisterType]
     immediate: OpAttr[AnyIntegerAttr | LabelAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr.from_int_and_width(immediate, 32)
-        elif isinstance(immediate, str):
+        if isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
         super().__init__(
+            result_types=[rd],
             attributes={
                 "immediate": immediate,
+                "comment": comment,
             },
-            result_types=[rd],
         )
 
 
@@ -237,6 +251,7 @@ class RdRsImmOperation(IRDLOperation, RISCVOp, ABC):
     rd: Annotated[OpResult, RegisterType]
     rs1: Annotated[Operand, RegisterType]
     immediate: OpAttr[AnyIntegerAttr | LabelAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
@@ -244,6 +259,7 @@ class RdRsImmOperation(IRDLOperation, RISCVOp, ABC):
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(immediate, 32)
@@ -254,12 +270,15 @@ class RdRsImmOperation(IRDLOperation, RISCVOp, ABC):
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
         super().__init__(
             operands=[rs1],
+            result_types=[rd],
             attributes={
                 "immediate": immediate,
+                "comment": comment,
             },
-            result_types=[rd],
         )
 
 
@@ -271,20 +290,25 @@ class RdRsOperation(IRDLOperation, RISCVOp, ABC):
 
     rd: Annotated[OpResult, RegisterType]
     rs: Annotated[Operand, RegisterType]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
-        rs1: Operation | SSAValue,
+        rs: Operation | SSAValue,
         *,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
         super().__init__(
-            operands=[rs1],
+            operands=[rs],
             result_types=[rd],
+            attributes={"comment": comment},
         )
 
 
@@ -298,18 +322,29 @@ class RsRsOffOperation(IRDLOperation, RISCVOp, ABC):
 
     rs1: Annotated[Operand, RegisterType]
     rs2: Annotated[Operand, RegisterType]
-    offset: OpAttr[AnyIntegerAttr]
+    offset: OpAttr[AnyIntegerAttr | LabelAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
-        offset: AnyIntegerAttr,
+        offset: int | AnyIntegerAttr | LabelAttr,
+        *,
+        comment: str | StringAttr | None = None,
     ):
+        if isinstance(offset, int):
+            offset = IntegerAttr.from_int_and_width(offset, 32)
+        if isinstance(offset, str):
+            offset = LabelAttr(offset)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
         super().__init__(
             operands=[rs1, rs2],
             attributes={
                 "offset": offset,
+                "comment": comment,
             },
         )
 
@@ -325,17 +360,28 @@ class RsRsImmOperation(IRDLOperation, RISCVOp, ABC):
     rs1: Annotated[Operand, RegisterType]
     rs2: Annotated[Operand, RegisterType]
     immediate: OpAttr[AnyIntegerAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
-        immediate: AnyIntegerAttr,
+        immediate: int | AnyIntegerAttr | str | LabelAttr,
+        *,
+        comment: str | StringAttr | None = None,
     ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr.from_int_and_width(immediate, 32)
+        elif isinstance(immediate, str):
+            immediate = LabelAttr(immediate)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
         super().__init__(
             operands=[rs1, rs2],
             attributes={
                 "immediate": immediate,
+                "comment": comment,
             },
         )
 
@@ -360,8 +406,21 @@ class NullaryOperation(IRDLOperation, RISCVOp, ABC):
     A base class for RISC-V operations that have neither sources nor destinations.
     """
 
-    def __init__(self):
-        super().__init__()
+    comment: OptOpAttr[StringAttr]
+
+    def __init__(
+        self,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            attributes={
+                "comment": comment,
+            },
+        )
 
 
 class CsrReadWriteOperation(IRDLOperation, RISCVOp, ABC):
@@ -379,6 +438,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVOp, ABC):
     rs1: Annotated[Operand, RegisterType]
     csr: OpAttr[AnyIntegerAttr]
     writeonly: OptOpAttr[UnitAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
@@ -387,16 +447,20 @@ class CsrReadWriteOperation(IRDLOperation, RISCVOp, ABC):
         *,
         writeonly: bool = False,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
         super().__init__(
             operands=[rs1],
             attributes={
                 "csr": csr,
                 "writeonly": UnitAttr() if writeonly else None,
+                "comment": comment,
             },
             result_types=[rd],
         )
@@ -430,6 +494,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVOp, ABC):
     rs1: Annotated[Operand, RegisterType]
     csr: OpAttr[AnyIntegerAttr]
     readonly: OptOpAttr[UnitAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
@@ -438,16 +503,20 @@ class CsrBitwiseOperation(IRDLOperation, RISCVOp, ABC):
         *,
         readonly: bool = False,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
         super().__init__(
             operands=[rs1],
             attributes={
                 "csr": csr,
                 "readonly": UnitAttr() if readonly else None,
+                "comment": comment,
             },
             result_types=[rd],
         )
@@ -479,6 +548,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVOp, ABC):
     csr: OpAttr[AnyIntegerAttr]
     writeonly: OptOpAttr[UnitAttr]
     immediate: OptOpAttr[AnyIntegerAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
@@ -487,16 +557,20 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVOp, ABC):
         *,
         writeonly: bool = False,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
         super().__init__(
             attributes={
                 "csr": csr,
                 "immediate": immediate,
                 "writeonly": UnitAttr() if writeonly else None,
+                "comment": comment,
             },
             result_types=[rd],
         )
@@ -529,6 +603,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVOp, ABC):
     rd: Annotated[OpResult, RegisterType]
     csr: OpAttr[AnyIntegerAttr]
     immediate: OpAttr[AnyIntegerAttr]
+    comment: OptOpAttr[StringAttr]
 
     def __init__(
         self,
@@ -536,15 +611,19 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVOp, ABC):
         immediate: AnyIntegerAttr,
         *,
         rd: RegisterType | Register | None = None,
+        comment: str | StringAttr | None = None,
     ):
         if rd is None:
             rd = RegisterType(Register())
         elif isinstance(rd, Register):
             rd = RegisterType(rd)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
         super().__init__(
             attributes={
                 "csr": csr,
                 "immediate": immediate,
+                "comment": comment,
             },
             result_types=[rd],
         )
@@ -1410,6 +1489,25 @@ class EcallOp(NullaryOperation):
 
 
 @irdl_op_definition
+class CommentOp(IRDLOperation, RISCVOp):
+    name = "riscv.comment"
+    comment: OpAttr[StringAttr]
+
+    def __init__(self, comment: str | StringAttr):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            attributes={
+                "comment": comment,
+            },
+        )
+
+    def assembly_instruction(self) -> str | None:
+        return f"    # {self.comment.data}"
+
+
+@irdl_op_definition
 class EbreakOp(NullaryOperation):
     """
     The EBREAK instruction is used by debuggers to cause control to be
@@ -1554,6 +1652,7 @@ RISCV = Dialect(
         EcallOp,
         EbreakOp,
         WfiOp,
+        CommentOp,
         GetRegisterOp,
         ScfgwOp,
     ],

--- a/xdsl/riscv_asm_writer.py
+++ b/xdsl/riscv_asm_writer.py
@@ -1,7 +1,8 @@
+from io import StringIO
 from typing import IO
 from xdsl.ir import Operation, SSAValue
 from xdsl.dialects.riscv import RISCVOp, RegisterType, AnyIntegerAttr
-from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.builtin import ModuleOp, StringAttr
 from xdsl.utils.hints import isa
 
 from xdsl.dialects import riscv
@@ -12,40 +13,65 @@ def print_riscv_module(module: ModuleOp, output: IO[str]):
         print_assembly_instruction(op, output)
 
 
+def append_comment(line: str, comment: StringAttr | None) -> str:
+    if comment is None:
+        return line
+
+    padding = " " * max(0, 48 - len(line))
+
+    return f"{line}{padding} # {comment.data}"
+
+
 def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
     # default assembly code generator
     assert isinstance(op, RISCVOp)
     assert op.name.startswith("riscv.")
     instruction_name = op.name[6:]
 
-    components: list[AnyIntegerAttr | riscv.LabelAttr | SSAValue | str | None] = []
+    components: list[AnyIntegerAttr | riscv.LabelAttr | SSAValue | str | None]
+    comment: StringAttr | None
 
     match op:
         case riscv.GetRegisterOp():
             # Don't print assembly for creating a SSA value representing register
             return
+        case riscv.CommentOp():
+            desc = f"    # {op.comment.data}"
+            print(desc, file=output)
+            return
         case riscv.NullaryOperation():
-            pass
+            components = []
+            comment = op.comment
         case riscv.RdRsRsOperation():
             components = [op.rd, op.rs1, op.rs2]
+            comment = op.comment
         case riscv.RdRsImmOperation():
             components = [op.rd, op.rs1, op.immediate]
+            comment = op.comment
         case riscv.RdImmOperation():
             components = [op.rd, op.immediate]
+            comment = op.comment
         case riscv.RsRsImmOperation():
             components = [op.rs1, op.rs2, op.immediate]
+            comment = op.comment
         case riscv.RsRsOffOperation():
             components = [op.rs1, op.rs2, op.offset]
+            comment = op.comment
         case riscv.RdRsOperation():
             components = [op.rd, op.rs]
+            comment = op.comment
         case riscv.CsrReadWriteImmOperation():
             components = [op.rd, op.csr, op.immediate]
+            comment = op.comment
         case riscv.CsrReadWriteOperation():
             components = [op.rd, op.csr, op.rs1]
+            comment = op.comment
         case riscv.CsrBitwiseImmOperation():
             components = [op.rd, op.csr, op.immediate]
+            comment = op.comment
         case riscv.CsrBitwiseOperation():
             components = [op.rd, op.csr, op.rs1]
+            comment = op.comment
         case _:
             raise ValueError(f"Unknown RISCV operation type :{type(op)}")
 
@@ -65,5 +91,14 @@ def print_assembly_instruction(op: Operation, output: IO[str]) -> None:
             reg = component.typ.register_name
             component_strs.append(reg)
 
-    code = f"    {instruction_name} {', '.join(component_strs)}"
+    code = f"    {instruction_name}"
+    if len(component_strs):
+        code += f" {', '.join(component_strs)}"
+    code = append_comment(code, comment)
     print(code, file=output)
+
+
+def riscv_code(module: ModuleOp) -> str:
+    stream = StringIO()
+    print_riscv_module(module, stream)
+    return stream.getvalue()


### PR DESCRIPTION
This PR adds inline comments, that are aligned to column 50 when possible, and a comment on their own line when not.

This PR has orthogonal functionality but has a conflict in the implementation with #906, some code will need to be moved around depending on which is merged first, but that change should be pretty trivial.