### PR TITLE
dialects: streamline snitch to basic config ops

### DIFF
--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,29 +1,21 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 "builtin.module"() ({
-  %A, %B = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>) // vector {A,B}: base address
-  %n = "test.op"() : () -> !riscv.reg<> // vector {A,B}: size
-  // dm: data mover id
-  %s0 = "test.op"() : () -> !riscv.reg<>
-  %s1 = "test.op"() : () -> !riscv.reg<>
-  // bound: vector size, minus one
+  %addr = "test.op"() : () -> !riscv.reg<>
+  %stream = "test.op"() : () -> !riscv.reg<>
   %bound = "test.op"() : () -> !riscv.reg<>
-  // stride: in bytes
   %stride = "test.op"() : () -> !riscv.reg<>
-  // repetition: number of times each element will be repeated, minus one
   %rep = "test.op"() : () -> !riscv.reg<>
   // Usual SSR setup sequence:
-  "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_setup_repetition"(%s0, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_setup_repetition"(%s0, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_read"(%s0, %A) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_read"(%s0, %A) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_setup_shape"(%s1, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_setup_shape"(%s1, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_setup_repetition"(%s1, %rep) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_setup_repetition"(%s1, %rep) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_read"(%s1, %B) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: "snitch.ssr_read"(%s1, %B) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_enable"() : () -> ()
   // CHECK-NEXT: "snitch.ssr_enable"() : () -> ()
   "snitch.ssr_disable"() : () -> ()

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -8,6 +8,8 @@ that aims at generating.
 [1] https://pulp-platform.github.io/snitch/publications
 """
 
+from abc import ABC
+
 from typing import Annotated
 
 from xdsl.dialects.riscv import RegisterType
@@ -19,106 +21,90 @@ from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, Operand, OpAttr
 
 
-@irdl_op_definition
-class SsrSetupShape(IRDLOperation):
+class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
     """
-    Setup the shape (bound and stride) for an arbitrary dimension handled by a
-    specific data mover.
+    A base class for Snitch operations that set a
+    configuration value for a specific dimension handled by a streamer.
     """
 
-    name: str = "snitch.ssr_setup_shape"
-
-    datamover: Annotated[Operand, RegisterType]
-    bound: Annotated[Operand, RegisterType]
-    stride: Annotated[Operand, RegisterType]
+    stream: Annotated[Operand, RegisterType]
+    value: Annotated[Operand, RegisterType]
     dimension: OpAttr[AnyIntegerAttr]
 
     def __init__(
         self,
-        datamover: Operation | SSAValue,
-        bound: Operation | SSAValue,
-        stride: Operation | SSAValue,
+        stream: Operation | SSAValue,
+        value: Operation | SSAValue,
         dimension: AnyIntegerAttr,
     ):
         super().__init__(
-            operands=[datamover, bound, stride],
+            operands=[stream, value],
             attributes={
                 "dimension": dimension,
             },
         )
 
 
+class SsrSetStreamConfigOperation(IRDLOperation, ABC):
+    """
+    A base class for Snitch operations that set a
+    configuration value for a streamer.
+    """
+
+    stream: Annotated[Operand, RegisterType]
+    value: Annotated[Operand, RegisterType]
+
+    def __init__(self, stream: Operation | SSAValue, value: Operation | SSAValue):
+        super().__init__(operands=[stream, value])
+
+
 @irdl_op_definition
-class SsrSetupRepetition(IRDLOperation):
+class SsrSetDimensionBoundOp(SsrSetDimensionConfigOperation):
+    """
+    Set the bound for one of the dimensions handled by a
+    specific streamer.
+    """
+
+    name: str = "snitch.ssr_set_dimension_bound"
+
+
+@irdl_op_definition
+class SsrSetDimensionStrideOp(SsrSetDimensionConfigOperation):
+    """
+    Set the stride for one of the dimensions handled by a
+    specific streamer.
+    """
+
+    name: str = "snitch.ssr_set_dimension_stride"
+
+
+@irdl_op_definition
+class SsrSetDimensionSourceOp(SsrSetDimensionConfigOperation):
+    """
+    Set the data source for one of the dimensions handled by a
+    specific streamer.
+    """
+
+    name: str = "snitch.ssr_set_dimension_source"
+
+
+@irdl_op_definition
+class SsrSetDimensionDestinationOp(SsrSetDimensionConfigOperation):
+    """
+    Set the data destination for one of the dimensions handled by a
+    specific streamer.
+    """
+
+    name: str = "snitch.ssr_set_dimension_destination"
+
+
+@irdl_op_definition
+class SsrSetStreamRepetitionOp(SsrSetStreamConfigOperation):
     """
     Setup repetition count for a specific data mover.
     """
 
-    name: str = "snitch.ssr_setup_repetition"
-
-    datamover: Annotated[Operand, RegisterType]
-    repetition: Annotated[Operand, RegisterType]
-
-    def __init__(
-        self,
-        datamover: Operation | SSAValue,
-        repetition: Operation | SSAValue,
-    ):
-        super().__init__(operands=[datamover, repetition])
-
-
-@irdl_op_definition
-class SsrRead(IRDLOperation):
-    """
-    Setup a dimension for a data mover to be a read stream on a
-    specific base address.
-    """
-
-    name: str = "snitch.ssr_read"
-
-    datamover: Annotated[Operand, RegisterType]
-    address: Annotated[Operand, RegisterType]
-    dimension: OpAttr[AnyIntegerAttr]
-
-    def __init__(
-        self,
-        datamover: Operation | SSAValue,
-        address: Operation | SSAValue,
-        dimension: AnyIntegerAttr,
-    ):
-        super().__init__(
-            operands=[datamover, address],
-            attributes={
-                "dimension": dimension,
-            },
-        )
-
-
-@irdl_op_definition
-class SsrWrite(IRDLOperation):
-    """
-    Setup a dimension for a data mover to be a write stream on a
-    specific base address.
-    """
-
-    name: str = "snitch.ssr_write"
-
-    datamover: Annotated[Operand, RegisterType]
-    address: Annotated[Operand, RegisterType]
-    dimension: OpAttr[AnyIntegerAttr]
-
-    def __init__(
-        self,
-        datamover: Operation | SSAValue,
-        address: Operation | SSAValue,
-        dimension: AnyIntegerAttr,
-    ):
-        super().__init__(
-            operands=[datamover, address],
-            attributes={
-                "dimension": dimension,
-            },
-        )
+    name: str = "snitch.ssr_set_stream_repetition"
 
 
 @irdl_op_definition
@@ -147,10 +133,11 @@ class SsrDisable(IRDLOperation):
 
 Snitch = Dialect(
     [
-        SsrSetupShape,
-        SsrSetupRepetition,
-        SsrRead,
-        SsrWrite,
+        SsrSetDimensionBoundOp,
+        SsrSetDimensionStrideOp,
+        SsrSetDimensionSourceOp,
+        SsrSetDimensionDestinationOp,
+        SsrSetStreamRepetitionOp,
         SsrEnable,
         SsrDisable,
     ],


### PR DESCRIPTION
This PR is an attempt at streamlining `snitch` ops, moving away from messy LLVM pseudo-instructions that were an attempt at cramping together multiple stream configuration options just for IR convenience reasons. For instance, this former op was meant to configure both bound and stride for a specific dimension:

```mlir
"snitch.ssr_setup_shape"(%s0, %bound, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
```

This PR forces each op to take care of a single configuration parameter, for example:

```mlir
"snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
"snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
```

By breaking this up in two distinct operations, we can define clean base classes for ops that can all have the same signature.