### PR TITLE
dialects: Remove unused constraint from stencil dialect

### DIFF
--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -43,23 +43,6 @@ from xdsl.irdl import (
 from xdsl.utils.hints import isa
 
 
-@dataclass
-class IntOrUnknown(AttrConstraint):
-    length: int = 0
-
-    def verify(self, attr: Attribute) -> None:
-        if not isinstance(attr, ArrayAttr):
-            raise VerifyException(
-                f"Expected {ArrayAttr} attribute, but got {attr.name}."
-            )
-
-        attr = cast(ArrayAttr[Any], attr)
-        if len(attr.data) != self.length:
-            raise VerifyException(
-                f"Expected array of length {self.length}, got {len(attr.data)}."
-            )
-
-
 _FieldTypeElement = TypeVar("_FieldTypeElement", bound=Attribute)
 
 


### PR DESCRIPTION
I couldn't find any use for `IntOrUnknown` in the `stencil` dialect, so I think we should clean things a bit and remove it. 
(/cc @PapyChacal @mesham )