### PR TITLE
testing: add nbval to requirements-optional

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -42,7 +42,6 @@ jobs:
         # Change directory so that xdsl-opt can be found during installation.
         cd xdsl
         pip install -e ".[extras]"
-        pip install nbval
 
     - name: Cache binaries
       id: cache-binary

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -32,9 +32,6 @@ jobs:
         pip install --upgrade pip
     - name: Install the package locally
       run: pip install -e ".[extras]"
-    - name: Install nbval
-      run: |
-        pip install nbval
     - name: Run examples/tutorials
       run: |
         # mlir_interoperation.ipynb is dependent on MLIR, and is tested in the MLIR-enabled workflow.

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,6 +4,7 @@ pytest-cov
 coverage<8.0.0
 ipykernel
 pytest<8.0
+nbval<0.11
 filecheck<0.0.24
 lit<17.0.0
 pre-commit==3.3.1


### PR DESCRIPTION
NB: to run these on your machine you need to pass one more parameter than in the CI:

```
python -m pytest -W error --nbval -vv docs --ignore=docs/mlir_interoperation.ipynb --nbval-current-env
```