### PR TITLE
dialects: Improve Stencil TempType

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -174,7 +174,7 @@ def test_cast_op_constructor():
 def test_stencil_apply():
     result_type_val1 = TestSSAValue(ResultType.from_type(f32))
 
-    stencil_temptype = TempType.from_shape([-1] * 2, f32)
+    stencil_temptype = TempType([-1] * 2, f32)
     apply_op = ApplyOp.get([result_type_val1], Block([]), [stencil_temptype])
 
     assert len(apply_op.args) == 1
@@ -184,7 +184,7 @@ def test_stencil_apply():
 
 
 def test_stencil_apply_no_args():
-    stencil_temptype = TempType.from_shape([-1] * 1, f32)
+    stencil_temptype = TempType([-1] * 1, f32)
     apply_op = ApplyOp.get([], Block([]), [stencil_temptype, stencil_temptype])
 
     assert len(apply_op.args) == 0
@@ -294,3 +294,87 @@ def test_stencil_load_bounds():
     assert len(load.ub.array) == 2
     for my_val, load_val in zip(ub.array.data, load.ub.array):
         assert my_val.value.data == load_val.value.data
+
+
+@pytest.mark.parametrize(
+    "attr, dims",
+    (
+        (
+            i32,
+            ArrayAttr(
+                [IntegerAttr[IntegerType](1, 64), IntegerAttr[IntegerType](2, 64)]
+            ),
+        ),
+        (
+            i64,
+            ArrayAttr(
+                [
+                    IntegerAttr[IntegerType](1, 32),
+                    IntegerAttr[IntegerType](2, 32),
+                    IntegerAttr[IntegerType](3, 32),
+                ]
+            ),
+        ),
+    ),
+)
+def test_stencil_temptype_constructor_with_ArrayAttr(
+    attr: IntegerType, dims: ArrayAttr[AnyIntegerAttr]
+):
+    stencil_temptype = TempType(dims, attr)
+
+    assert stencil_temptype.element_type == attr
+    assert stencil_temptype.get_num_dims() == len(dims)
+    assert stencil_temptype.get_shape() == [
+        list(dims.data)[dim].value.data for dim in range(len(dims))
+    ]
+
+
+@pytest.mark.parametrize(
+    "attr, dims",
+    (
+        (i32, [1, 2]),
+        (i32, [1, 1, 3]),
+        (i64, [1, 1, 3]),
+    ),
+)
+def test_stencil_temptype_constructor(attr: IntegerType, dims: list[int]):
+    stencil_temptype = TempType(dims, attr)
+
+    assert stencil_temptype.element_type == attr
+    assert stencil_temptype.get_num_dims() == len(dims)
+    assert stencil_temptype.get_shape() == dims
+
+
+@pytest.mark.parametrize(
+    "attr, dims",
+    (
+        (i32, []),
+        (i64, []),
+    ),
+)
+def test_stencil_temptype_constructor_empty_list(attr: IntegerType, dims: list[int]):
+    with pytest.raises(VerifyException) as exc_info:
+        TempType(dims, attr)
+    assert (
+        exc_info.value.args[0]
+        == "Number of field dimensions must be greater than zero, got 0."
+    )
+
+
+@pytest.mark.parametrize(
+    "attr, dims",
+    (
+        (i32, [1, 2]),
+        (i32, [1, 1, 3]),
+        (i64, [1, 1, 3]),
+    ),
+)
+def test_stencil_temptype_printing(attr: IntegerType, dims: list[int]):
+    stencil_temptype = TempType(dims, attr)
+
+    expected_string: str = "stencil.Temp<["
+    for dim in dims:
+        expected_string += f"{dim} "
+    expected_string += "]>"
+
+    assert repr(stencil_temptype) == expected_string

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -105,24 +105,30 @@ class TempType(Generic[_FieldTypeElement], ParametrizedAttribute, TypeAttribute)
     shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]
     element_type: ParameterDef[_FieldTypeElement]
 
-    @staticmethod
-    def from_shape(
+    def get_num_dims(self) -> int:
+        return len(self.shape.data)
+
+    def get_shape(self) -> List[int]:
+        return [i.value.data for i in self.shape.data]
+
+    def verify(self):
+        if self.get_num_dims() <= 0:
+            raise VerifyException(
+                f"Number of field dimensions must be greater than zero, got {self.get_num_dims()}."
+            )
+
+    def __init__(
+        self,
         shape: ArrayAttr[AnyIntegerAttr] | Sequence[AnyIntegerAttr] | Sequence[int],
         typ: _FieldTypeElement,
-    ) -> TempType[_FieldTypeElement]:
-        assert len(shape) > 0
-
+    ) -> None:
         if isinstance(shape, ArrayAttr):
-            return TempType.new([shape, typ])
+            super().__init__([shape, typ])
+            return
 
         # cast to list
-        shape = cast(list[AnyIntegerAttr] | list[int], shape)
-
-        if isinstance(shape[0], IntegerAttr):
-            # the if above is a sufficient type guard, but pyright does not understand :/
-            return TempType([ArrayAttr(shape), typ])  # type: ignore
         shape = cast(list[int], shape)
-        return TempType(
+        super().__init__(
             [ArrayAttr([IntegerAttr[IntegerType](d, 64) for d in shape]), typ]
         )
 
@@ -402,7 +408,7 @@ class LoadOp(IRDLOperation):
                 "ub": ub,
             },
             result_types=[
-                TempType[Attribute].from_shape(
+                TempType[Attribute](
                     [-1] * len(field_t.shape.data), field_t.element_type
                 )
             ],

--- a/xdsl/transforms/experimental/StencilShapeInference.py
+++ b/xdsl/transforms/experimental/StencilShapeInference.py
@@ -65,7 +65,7 @@ class LoadOpShapeInference(RewritePattern):
 
         # TODO: We need to think about that. Do we want an API for this?
         # Do we just want to recreate the whole operation?
-        op.res.typ = TempType.from_shape(
+        op.res.typ = TempType(
             IndexAttr.size_from_bounds(op.lb, op.ub),
             op.res.typ.element_type,
         )
@@ -105,7 +105,7 @@ class ApplyOpShapeInference(RewritePattern):
 
         for result in op.results:
             assert isa(result.typ, TempType[Attribute])
-            result.typ = TempType.from_shape(
+            result.typ = TempType(
                 IndexAttr.size_from_bounds(op.lb, op.ub), result.typ.element_type
             )
 


### PR DESCRIPTION
Deprecate `from_shape` method in favour of `__init__()` and add helper methods to get shape and no. of dimensions. 