### PR TITLE
WIP: hackathon: dialects:  improvements to memref dialect for explicit cache mgmt

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -319,6 +319,12 @@ def test_dma_start():
 
     dma_start.verify()
 
+    # check if it refuses non similarly shaped memrefs when no num_elements is applied
+    with pytest.raises(
+        VerifyException, match="Expected source and dest shapes to be identical"
+    ):
+        DmaStartOp.get(src, [index], dest, [index], None, tag, [index]).verify()
+
     # check that src index count is verified
     with pytest.raises(VerifyException, match="Expected 2 source indices"):
         DmaStartOp.get(


### PR DESCRIPTION
Trying out the stuff we try to propose in an RFC to improve the memref dialect.

Things we are trying/will try out
- Make num_elements an optional attribute if shapes of attributes match exactly
- Use subviews as arguments of dma_start instead of index/stride params
- Move dma_start to async dialect, to replace tag with token?