### PR TITLE
core: Start with adding an MLIR bytecode parser

### DIFF
--- a/tests/test_bytecode_parser.py
+++ b/tests/test_bytecode_parser.py
@@ -15,9 +15,4 @@ from xdsl.bytecode_parser import BytecodeParser
     ),
 )
 def test_single_bit_varint(input: int, result: int):
-    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
-    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
-    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
-    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
-    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
-    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
+    assert BytecodeParser(input.to_bytes(1, "little")).parse_varint() == result

--- a/tests/test_bytecode_parser.py
+++ b/tests/test_bytecode_parser.py
@@ -16,3 +16,44 @@ from xdsl.bytecode_parser import BytecodeParser
 )
 def test_single_bit_varint(input: int, result: int):
     assert BytecodeParser(input.to_bytes(1, "little")).parse_varint() == result
+
+
+@pytest.mark.parametrize(
+    "input, result",
+    (
+        ((0b00000010, 0), 0),
+        ((0b00000010, 1), 0),
+        ((0b00000010, 0b11), -1),
+        ((0b11111110, 0b11111110), 8191),
+        (
+            (
+                0b00000000,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111110,
+            ),
+            2**63 - 1,
+        ),
+        (
+            (
+                0b00000000,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+                0b11111111,
+            ),
+            -(2**63 - 1),
+        ),
+    ),
+)
+def test_multi_bit_varint(input: tuple[int], result: int):
+    assert BytecodeParser(bytes(input)).parse_varint() == result

--- a/tests/test_bytecode_parser.py
+++ b/tests/test_bytecode_parser.py
@@ -1,0 +1,23 @@
+import pytest
+
+from xdsl.bytecode_parser import BytecodeParser
+
+
+@pytest.mark.parametrize(
+    "input, result",
+    (
+        (0b00000001, 0),
+        (0b00000011, 0),
+        (0b00000111, -1),
+        (0b00000101, 1),
+        (0b11111101, 0b111111),
+        (0b11111111, -0b111111),
+    ),
+)
+def test_single_bit_varint(input: int, result: int):
+    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
+    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
+    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
+    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
+    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result
+    assert BytecodeParser(input.to_bytes(1, "big")).parse_varint() == result

--- a/xdsl/bytecode_parser.py
+++ b/xdsl/bytecode_parser.py
@@ -26,9 +26,10 @@ class BytecodeParser:
             additional_bytes += 1
 
         leading_bits = first_byte >> (additional_bytes + 1)
-        assert additional_bytes == 0
 
         value_bits = leading_bits
+        for byte in self._pop_bytes(additional_bytes):
+            value_bits = (value_bits << 8) + byte
 
         sign = -1 if value_bits & 1 else 1
         value = value_bits >> 1

--- a/xdsl/bytecode_parser.py
+++ b/xdsl/bytecode_parser.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BytecodeParser:
+    _bytes: bytes
+    _pos: int = 0
+
+    def _pop_bytes(self, len: int = 1) -> bytes:
+        b = self._bytes[self._pos : self._pos + len]
+        self._pos += len
+        return b
+
+    def _peek_bytes(self, len: int = 1) -> bytes:
+        return self._bytes[self._pos : self._pos + len]
+
+    def parse_varint(self):
+        """
+        Parse a varint as per the spec:
+        https://mlir.llvm.org/docs/BytecodeFormat/#variable-width-integers
+        """
+        first_byte = self._pop_bytes()[0]
+
+        additional_bytes = 0
+        while first_byte & (1 << additional_bytes) == 0 and additional_bytes < 8:
+            additional_bytes += 1
+
+        leading_bits = first_byte >> (additional_bytes + 1)
+        assert additional_bytes == 0
+
+        value_bits = leading_bits
+
+        sign = -1 if value_bits & 1 else 1
+        value = value_bits >> 1
+        return sign * value


### PR DESCRIPTION
This PR starts an effort to add support for the MLIR bytecode format. I start with a simple wrapper around some bytes, a peek, a consume, and a method to parse the variable int: https://mlir.llvm.org/docs/BytecodeFormat/#variable-width-integers