### PR TITLE
dialects: Change RewriteOp constructor

### DIFF
--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -39,7 +39,9 @@ def test_build_anr():
 
 
 def test_build_rewrite():
-    r = pdl.RewriteOp("r", root=None, external_args=[type_val, attr_val], body=None)
+    r = pdl.RewriteOp(
+        name="r", root=None, external_args=[type_val, attr_val], body=None
+    )
 
     assert r.attributes["name"] == StringAttr("r")
     assert r.external_args == (type_val, attr_val)

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -116,7 +116,7 @@ def swap_arguments_pdl():
             ).op
             pdl.ReplaceOp(x_y_z_op, z_x_y_op)
 
-        pdl.RewriteOp(None, x_y_z_op, [], rewrite_region)
+        pdl.RewriteOp(x_y_z_op, rewrite_region)
 
     pattern = pdl.PatternOp(IntegerAttr.from_int_and_width(2, 16), None, pattern_region)
 
@@ -233,7 +233,7 @@ def add_zero_pdl():
         def rewrite_region():
             pdl.ReplaceOp(sum, repl_values=[lhs])
 
-        pdl.RewriteOp(None, sum, [], rewrite_region)
+        pdl.RewriteOp(sum, rewrite_region)
 
     pattern = pdl.PatternOp(IntegerAttr.from_int_and_width(2, 16), None, pattern_region)
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -478,10 +478,10 @@ class RewriteOp(IRDLOperation):
 
     def __init__(
         self,
-        name: str | StringAttr | None,
         root: SSAValue | None,
-        external_args: Sequence[SSAValue],
-        body: Region | Block.BlockCallback | None,
+        body: Region | Block.BlockCallback | None = None,
+        name: str | StringAttr | None = None,
+        external_args: Sequence[SSAValue] = (),
     ) -> None:
         if isinstance(name, str):
             name = StringAttr(name)


### PR DESCRIPTION
Reorder the RewriteOp constructor, to add more optional arguments to the end.