### PR TITLE
core: add --print-op-generic to xdsl-opt, and add custom syntax for `builtin.module`

### DIFF
--- a/docs/Toy/Toy_Ch2.ipynb
+++ b/docs/Toy/Toy_Ch2.ipynb
@@ -31,7 +31,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  \"toy.func\"() ({\n",
       "    %0 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
       "    %1 = \"toy.reshape\"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64>\n",
@@ -42,7 +42,7 @@
       "    \"toy.print\"(%5) : (tensor<2x3xf64>) -> ()\n",
       "    \"toy.return\"() : () -> ()\n",
       "  }) {\"sym_name\" = \"main\", \"function_type\" = () -> ()} : () -> ()\n",
-      "}) : () -> ()"
+      "}"
      ]
     }
    ],
@@ -316,7 +316,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  \"toy.func\"() ({\n",
       "    %0 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
       "    %1 = \"toy.reshape\"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64>\n",
@@ -327,7 +327,7 @@
       "    \"toy.print\"(%5) : (tensor<2x3xf64>) -> ()\n",
       "    \"toy.return\"() : () -> ()\n",
       "  }) {\"sym_name\" = \"main\", \"function_type\" = () -> ()} : () -> ()\n",
-      "}) : () -> ()\n"
+      "}\n"
      ]
     }
    ],

--- a/docs/Toy/Toy_Ch3.ipynb
+++ b/docs/Toy/Toy_Ch3.ipynb
@@ -28,7 +28,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  \"toy.func\"() ({\n",
       "    %0 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
       "    %1 = \"toy.reshape\"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64>\n",
@@ -39,7 +39,7 @@
       "    \"toy.print\"(%5) : (tensor<2x3xf64>) -> ()\n",
       "    \"toy.return\"() : () -> ()\n",
       "  }) {\"sym_name\" = \"main\", \"function_type\" = () -> ()} : () -> ()\n",
-      "}) : () -> ()\n"
+      "}\n"
      ]
     }
    ],
@@ -81,7 +81,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  \"toy.func\"() ({\n",
       "    %0 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
       "    %1 = \"toy.reshape\"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64>\n",
@@ -92,7 +92,7 @@
       "    \"toy.print\"(%5) : (tensor<2x3xf64>) -> ()\n",
       "    \"toy.return\"() : () -> ()\n",
       "  }) {\"sym_name\" = \"main\", \"function_type\" = () -> ()} : () -> ()\n",
-      "}) : () -> ()"
+      "}"
      ]
     }
    ],
@@ -154,7 +154,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  \"toy.func\"() ({\n",
       "    %0 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
       "    %1 = \"toy.reshape\"(%0) : (tensor<2x3xf64>) -> tensor<2x3xf64>\n",
@@ -164,7 +164,7 @@
       "    \"toy.print\"(%4) : (tensor<2x3xf64>) -> ()\n",
       "    \"toy.return\"() : () -> ()\n",
       "  }) {\"sym_name\" = \"main\", \"function_type\" = () -> ()} : () -> ()\n",
-      "}) : () -> ()"
+      "}"
      ]
     }
    ],
@@ -198,7 +198,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  \"toy.func\"() ({\n",
       "    %0 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
       "    %1 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
@@ -208,7 +208,7 @@
       "    \"toy.print\"(%4) : (tensor<2x3xf64>) -> ()\n",
       "    \"toy.return\"() : () -> ()\n",
       "  }) {\"sym_name\" = \"main\", \"function_type\" = () -> ()} : () -> ()\n",
-      "}) : () -> ()"
+      "}"
      ]
     }
    ],
@@ -259,7 +259,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  \"toy.func\"() ({\n",
       "    %0 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
       "    %1 = \"toy.constant\"() {\"value\" = dense<[[1.000000e+00, 2.000000e+00, 3.000000e+00], [4.000000e+00, 5.000000e+00, 6.000000e+00]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>\n",
@@ -267,7 +267,7 @@
       "    \"toy.print\"(%2) : (tensor<2x3xf64>) -> ()\n",
       "    \"toy.return\"() : () -> ()\n",
       "  }) {\"sym_name\" = \"main\", \"function_type\" = () -> ()} : () -> ()\n",
-      "}) : () -> ()"
+      "}"
      ]
     }
    ],

--- a/docs/Toy/examples/codegen.toy
+++ b/docs/Toy/examples/codegen.toy
@@ -13,7 +13,7 @@ def main() {
   print(d);
 }
 
-# CHECK:       "builtin.module"() ({
+# CHECK:       builtin.module {
 # CHECK-NEXT:    "toy.func"() ({
 # CHECK-NEXT:    ^0(%{{.*}} : tensor<*xf64>, %{{.*}} : tensor<*xf64>):
 # CHECK-NEXT:      %{{.*}} = "toy.transpose"(%{{.*}}) : (tensor<*xf64>) -> tensor<*xf64>
@@ -31,4 +31,4 @@ def main() {
 # CHECK-NEXT:      "toy.print"(%{{.*}}) : (tensor<*xf64>) -> ()
 # CHECK-NEXT:      "toy.return"() : () -> ()
 # CHECK-NEXT:    }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()
-# CHECK-NEXT:  }) : () -> ()
+# CHECK-NEXT:  }

--- a/docs/Toy/examples/tests/optimise_toy.mlir
+++ b/docs/Toy/examples/tests/optimise_toy.mlir
@@ -1,7 +1,7 @@
 // RUN: python -m toy %s --emit=ir-toy --opt | filecheck %s
 
 "builtin.module"() ({
-// CHECK:       "builtin.module"() ({
+// CHECK:       builtin.module {
 
   "toy.func"() ({
     %10 = "toy.constant"() {"value" = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64>} : () -> tensor<2x3xf64>

--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -383,7 +383,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  %0 = \"sql.table\"() {\"table_name\" = \"T\"} : () -> #sql.bag<i32>\n",
       "  %1 = \"sql.selection\"(%0) ({\n",
       "  ^0(%10 : i32):\n",
@@ -392,7 +392,7 @@
       "    \"scf.yield\"(%6) : (i1) -> ()\n",
       "  }) : (#sql.bag<i32>) -> #sql.bag<i32>\n",
       "  \"sql.sink\"(%1) : (#sql.bag<i32>) -> ()\n",
-      "}) : () -> ()\n"
+      "}\n"
      ]
     }
    ],
@@ -411,14 +411,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "name": "python",
-   "version": "3.11.0"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/mlir_interoperation.ipynb
+++ b/docs/mlir_interoperation.ipynb
@@ -87,14 +87,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\n",
+      "builtin.module {\n",
       "  %0 = \"arith.constant\"() {\"value\" = 1 : i32} : () -> i32\n",
       "  %1 = \"arith.constant\"() {\"value\" = 2 : i32} : () -> i32\n",
       "  %2 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\n",
       "  %3 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\n",
       "  %4 = \"arith.addi\"(%2, %3) : (i32, i32) -> i32\n",
       "  \"vector.print\"(%4) : (i32) -> ()\n",
-      "}) : () -> ()\n"
+      "}\n"
      ]
     }
    ],
@@ -203,13 +203,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"builtin.module\"() ({\r\n",
+      "builtin.module {\r\n",
       "  %0 = \"arith.constant\"() {\"value\" = 1 : i32} : () -> i32\r\n",
       "  %1 = \"arith.constant\"() {\"value\" = 2 : i32} : () -> i32\r\n",
       "  %2 = \"arith.addi\"(%0, %1) : (i32, i32) -> i32\r\n",
       "  %3 = \"arith.addi\"(%2, %2) : (i32, i32) -> i32\r\n",
       "  \"vector.print\"(%3) : (i32) -> ()\r\n",
-      "}) : () -> ()\r\n",
+      "}\r\n",
       "\r\n"
      ]
     }

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -273,7 +273,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[IntegerType(parameters=[IntAttr(data=64, name='int'), SignednessAttr(data=<Signedness.SIGNLESS: 0>, name='signedness')], name='integer_type', width=IntAttr(data=64, name='int'), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>, name='signedness'))] should be of base attribute int\n"
+      "[IntegerType(parameters=[IntAttr(data=64), SignednessAttr(data=<Signedness.SIGNLESS: 0>)], width=IntAttr(data=64), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>))] should be of base attribute int\n"
      ]
     }
    ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def assert_print_op(
     operation: Operation,
     expected: str,
     diagnostic: Diagnostic | None,
-    print_generic_format: bool = False,
+    print_generic_format: bool = True,
 ):
     """
     Utility function that helps to check the printing of an operation compared to

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/affine/examples.mlir
+++ b/tests/filecheck/dialects/affine/examples.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/arith/arith_attrs.mlir
+++ b/tests/filecheck/dialects/arith/arith_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %lhsi1, %rhsi1 = "test.op"() : () -> (i1, i1)

--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 // CHECK: module
 "builtin.module"() ({

--- a/tests/filecheck/dialects/builtin/module.mlir
+++ b/tests/filecheck/dialects/builtin/module.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+
+builtin.module {
+  // CHECK: builtin.module {
+    builtin.module {}
+    // CHECK: builtin.module {
+    // CHECK-NEXT: }
+    builtin.module attributes {a = "foo", b = "bar"} {}
+    // CHECK-NEXT: builtin.module attributes {a="foo", b="bar"} {
+    // CHECK-NEXT: }
+}
+// CHECK: }

--- a/tests/filecheck/dialects/builtin/unrealized_conv_cast.mlir
+++ b/tests/filecheck/dialects/builtin/unrealized_conv_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 // CHECK: module
 "builtin.module"() ({

--- a/tests/filecheck/dialects/cf/cf_ops.mlir
+++ b/tests/filecheck/dialects/cf/cf_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/cmath/cmath_ops.mlir
+++ b/tests/filecheck/dialects/cmath/cmath_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 
 "builtin.module"() ({

--- a/tests/filecheck/dialects/func/func_ops.mlir
+++ b/tests/filecheck/dialects/func/func_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/gpu/all_reduce_body_types.mlir
+++ b/tests/filecheck/dialects/gpu/all_reduce_body_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics --print-op-generic | filecheck %s
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "gpu.module"() ({

--- a/tests/filecheck/dialects/llvm/array.mlir
+++ b/tests/filecheck/dialects/llvm/array.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 "builtin.module"() ({
   %0 = "llvm.mlir.undef"() : () -> !llvm.array<2 x i64>
   %1 = "llvm.mlir.undef"() : () -> !llvm.array<1 x i64>

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 "builtin.module"() ({
   "llvm.mlir.global"() ({
   }) {"global_type" = !llvm.array<13 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!\n", "unnamed_addr" = 0 : i64} : () -> ()

--- a/tests/filecheck/dialects/llvm/pointers.mlir
+++ b/tests/filecheck/dialects/llvm/pointers.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64
   %1 = "llvm.inttoptr"(%0) : (i64) -> !llvm.ptr<i32>

--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/dialects/mpi/memref_compat.mlir
+++ b/tests/filecheck/dialects/mpi/memref_compat.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-mpi %s
+// RUN: xdsl-opt -p lower-mpi --print-op-generic %s
 "builtin.module"() ({
     %ref = "memref.alloc"() {"alignment" = 32 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<100x14x14xf64>
     %buff, %count, %dtype = "mpi.unwrap_memref"(%ref) : (memref<100x14x14xf64>) -> (!llvm.ptr, i32, !mpi.datatype)

--- a/tests/filecheck/dialects/pdl/mlir-tests/apply_rewrite_with_no_results.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/apply_rewrite_with_no_results.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_dict.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_dict.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_loc.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/attribute_with_loc.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_operation_replace.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_operation_replace.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_0.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_0.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_1.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_1.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_2.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_2.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_3.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/infer_type_from_type_used_in_match_3.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/operations.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/operations.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_forced.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_forced.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_optimal.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/rewrite_multi_root_optimal.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/pdl/mlir-tests/rewrite_with_args.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests/rewrite_with_args.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "pdl.pattern"() ({

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 "builtin.module"() ({
   %0 = "riscv.get_register"() : () -> !riscv.reg<>
   %1 = "riscv.get_register"() : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/riscv/riscv_register_allocation.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_register_allocation.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-allocate-registers %s | filecheck %s
+// RUN: xdsl-opt -p riscv-allocate-registers %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/scf/reduce.mlir
+++ b/tests/filecheck/dialects/scf/reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 "builtin.module"() ({
   %addr = "test.op"() : () -> !riscv.reg<>
   %stream = "test.op"() : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-snitch %s | filecheck %s
+// RUN: xdsl-opt -p lower-snitch %s --print-op-generic | filecheck %s
 "builtin.module"() ({
   %addr = "test.op"() : () -> !riscv.reg<>
   %stream = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/stencil/copy.mlir
+++ b/tests/filecheck/dialects/stencil/copy.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-gpu | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-gpu --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_inference.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_inference.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference --print-op-generic | filecheck %s
 
 
 "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference --verify-diagnostic | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference --verify-diagnostic --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/heat_stencil.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/laplace.mlir
+++ b/tests/filecheck/dialects/stencil/laplace.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "func.func"() ({

--- a/tests/filecheck/dialects/vector/vector_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -82,7 +82,6 @@ with CodeContext(p):
     # CHECK-NEXT:     }) : (index, index, index) -> ()
     # CHECK-NEXT:   "func.return"() : () -> ()
     # CHECK-NEXT:   }) {"sym_name" = "test_for_IV", "function_type" = (index, index, index) -> (), "sym_visibility" = "private"} : () -> ()
-    # CHECK-NEXT: }) : () -> ()
     def test_for_IV(a: index, b: index, c: index):
         for _ in range(a):  # type: ignore
             for _ in range(b):  # type: ignore

--- a/tests/filecheck/frontend/passes/desymref.mlir
+++ b/tests/filecheck/frontend/passes/desymref.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p frontend-desymrefy | filecheck %s
+// RUN: xdsl-opt %s -p frontend-desymrefy --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 // CHECK: "builtin.module"() ({

--- a/tests/filecheck/frontend/programs/programs.py
+++ b/tests/filecheck/frontend/programs/programs.py
@@ -5,8 +5,8 @@ from xdsl.frontend.context import CodeContext
 
 p = FrontendProgram()
 with CodeContext(p):
-    # CHECK: "builtin.module"() ({
-    # CHECK-NEXT: }) : () -> ()
+    # CHECK: builtin.module {
+    # CHECK-NEXT: }
     pass
 
 p.compile(desymref=False)

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f16} : () -> f16

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/unrealized_conversion_cast.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/unrealized_conversion_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
     "gpu.module"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 "builtin.module"() ({
   "llvm.mlir.global"() ({
   }) {"global_type" = !llvm.array<12 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!", "unnamed_addr" = 0 : i64} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_mlir.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_mlir.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel_with_reduce.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel_with_reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/parser-printer/attribute_names.mlir
+++ b/tests/filecheck/parser-printer/attribute_names.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 }) {a = i32, _e = i32, "foo" = i32, _ = i32} : () -> ()

--- a/tests/filecheck/xdsl_opt/split_input.mlir
+++ b/tests/filecheck/xdsl_opt/split_input.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -split-input-file %s | xdsl-opt -split-input-file | filecheck %s
+// RUN: xdsl-opt -split-input-file %s | xdsl-opt -split-input-file --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 // CHECK: "builtin.module"() ({

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -290,18 +290,18 @@ def test_descriptions():
     assert (
         str(m)
         == """\
-"builtin.module"() ({
+builtin.module {
   %0 = "arith.constant"() {"value" = 1 : i32} : () -> i32
-}) : () -> ()"""
+}"""
     )
 
     assert (
         f"{m}"
         == """\
 ModuleOp(
-\t"builtin.module"() ({
+\tbuiltin.module {
 \t  %0 = "arith.constant"() {"value" = 1 : i32} : () -> i32
-\t}) : () -> ()
+\t}
 )"""
     )
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -404,10 +404,10 @@ def test_generic_format():
 }) : () -> ()"""
 
     expected = """\
-"builtin.module"() ({
+builtin.module {
   %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
   %1 = test.add %0 + %0 : i32
-}) : () -> ()
+}
 """
 
     ctx = MLContext()
@@ -426,17 +426,17 @@ def test_custom_format():
     Test that we can use custom formats in operations.
     """
     prog = """\
-"builtin.module"() ({
+builtin.module {
   %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
   %1 = test.add %0 + %0 : i32
-}) : () -> ()
+}
 """
 
     expected = """\
-"builtin.module"() ({
+builtin.module {
   %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
   %1 = test.add %0 + %0 : i32
-}) : () -> ()
+}
 """
 
     ctx = MLContext()

--- a/tests/xdsl_opt/empty_program.mlir
+++ b/tests/xdsl_opt/empty_program.mlir
@@ -1,2 +1,2 @@
-"builtin.module"() ({
-}) : () -> ()
+builtin.module {
+}

--- a/tests/xdsl_opt/empty_program.wrong
+++ b/tests/xdsl_opt/empty_program.wrong
@@ -1,2 +1,2 @@
-"builtin.module"() ({
-}) : () -> ()
+builtin.module {
+}

--- a/tests/xdsl_opt/simple_program.mlir
+++ b/tests/xdsl_opt/simple_program.mlir
@@ -1,3 +1,3 @@
-"builtin.module"() ({
+builtin.module {
   "test.op"() : () -> ()
-}) : () -> ()
+}

--- a/tests/xdsl_opt/split_input_file.mlir
+++ b/tests/xdsl_opt/split_input_file.mlir
@@ -1,17 +1,17 @@
-"builtin.module"() ({
-}) : () -> ()
+builtin.module {
+}
 
 // -----
-"builtin.module"() ({
+builtin.module {
   "test.op"() : () -> ()
-}) : () -> ()
+}
 
 // -----
-"builtin.module"() ({
+builtin.module {
   %x = "test.op"() : () -> i1
-}) : () -> ()
+}
 
 // -----
-"builtin.module"() ({
+builtin.module {
   %x = "test.op"() : () -> i2
-}) : () -> ()
+}

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -214,7 +214,7 @@ class xDSLOptMain:
         )
 
         arg_parser.add_argument(
-            "--print-generic-op",
+            "--print-op-generic",
             default=False,
             action="store_true",
             help="Print operations with the generic format",
@@ -292,7 +292,7 @@ class xDSLOptMain:
 
         def _output_mlir(prog: ModuleOp, output: IO[str]):
             printer = Printer(
-                stream=output, print_generic_format=self.args.print_generic_op
+                stream=output, print_generic_format=self.args.print_op_generic
             )
             printer.print_op(prog)
             print("\n", file=output)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -213,6 +213,13 @@ class xDSLOptMain:
             " using `// -----`",
         )
 
+        arg_parser.add_argument(
+            "--print-generic-op",
+            default=False,
+            action="store_true",
+            help="Print operations with the generic format",
+        )
+
     def register_all_dialects(self):
         """
         Register all dialects that can be used.
@@ -284,7 +291,9 @@ class xDSLOptMain:
         """
 
         def _output_mlir(prog: ModuleOp, output: IO[str]):
-            printer = Printer(stream=output)
+            printer = Printer(
+                stream=output, print_generic_format=self.args.print_generic_op
+            )
             printer.print_op(prog)
             print("\n", file=output)
 


### PR DESCRIPTION
To make things simpler, I added `--print-op-generic` to all tests that were printing `module.builtin`.
So we will be able to move to custom syntax in those tests all at once, rather than adding things one by one.