### PR TITLE
core: Move block parser to lexer

### DIFF
--- a/tests/filecheck/dialects/scf/for_body_args_number_much.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_number_much.mlir
@@ -6,7 +6,7 @@
   %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step) ({
 // CHECK: Wrong number of block arguments, expected 1, got 2. The body must have the induction variable and loop-carried variables as arguments.
-  ^0(%iv : index, %carried : i8):
+  ^0(%iv : index, %carried_arg : i8):
     "scf.yield"() : () -> ()
   }) : (index, index, index) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_body_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_types.mlir
@@ -6,7 +6,7 @@
   %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Block arguments with wrong type, expected i8, got index
-  ^0(%iv : index, %carried : index):
+  ^0(%iv : index, %carried_arg : index):
     "scf.yield"() : () -> ()
   }) : (index, index, index) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_yield.mlir
+++ b/tests/filecheck/dialects/scf/for_yield.mlir
@@ -6,6 +6,6 @@
   %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: The scf.for's body does not end with a scf.yield. A scf.for loop with loop-carried variables must yield their values at the end of its body.
-  ^0(%iv : index, %carried : i8):
+  ^0(%iv : index, %carried_arg : i8):
   }) : (index, index, index) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_yield_number.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_number.mlir
@@ -6,7 +6,7 @@
   %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Expected 1 args, got 2. The scf.for must yield its carried variables.
-  ^0(%iv : index, %carried : i8):
-    "scf.yield"(%carried, %step) : () -> ()
+  ^0(%iv : index, %carried_arg : i8):
+    "scf.yield"(%carried_arg, %step) : () -> ()
   }) : (index, index, index) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_yield_types.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_types.mlir
@@ -6,7 +6,7 @@
   %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Expected i8, got index. The scf.for's scf.yield must match carried variables types.
-  ^0(%iv : index, %carried : i8):
+  ^0(%iv : index, %carried_arg : i8):
     "scf.yield"(%iv) : () -> ()
   }) : (index, index, index) -> ()
 }) : () -> ()

--- a/tests/filecheck/parser-printer/builtin_attrs.mlir
+++ b/tests/filecheck/parser-printer/builtin_attrs.mlir
@@ -31,7 +31,7 @@
   // CHECK: (ui32, ui64, ui1)
 
   "func.func"() ({
-    ^bb0(%arg0: bf16, %arg1: f16, %arg2: f32, %arg3: f64, %arg3: f80, %arg3: f128):
+    ^bb0(%arg0: bf16, %arg1: f16, %arg2: f32, %arg3: f64, %arg4: f80, %arg5: f128):
     "func.return"() : () -> ()
   }) {function_type = (bf16, f16, f32, f64, f80, f128) -> (), sym_name = "float_type"} : () -> ()
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from xdsl.parser import Parser
     from xdsl.printer import Printer
     from xdsl.irdl import ParamAttrDef
-    from xdsl.utils.lexer import Span
 
 OpT = TypeVar("OpT", bound="Operation")
 

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1030,8 +1030,6 @@ class BlockOps:
 class Block(IRNode):
     """A sequence of operations"""
 
-    declared_at: Span | None
-
     _args: tuple[BlockArgument, ...]
     """The basic block arguments."""
 
@@ -1047,10 +1045,8 @@ class Block(IRNode):
         *,
         arg_types: Iterable[Attribute] = (),
         parent: Region | None = None,
-        declared_at: Span | None = None,
     ):
         super().__init__(self)
-        self.declared_at = declared_at
         self._args = tuple(
             BlockArgument(typ, self, index) for index, typ in enumerate(arg_types)
         )

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -72,7 +72,6 @@ from xdsl.ir import (
     Attribute,
     Operation,
     Region,
-    BlockArgument,
     MLContext,
     ParametrizedAttribute,
     Data,
@@ -473,7 +472,7 @@ class Parser(ABC):
     """xDSL context."""
 
     ssa_values: dict[str, tuple[SSAValue]]
-    blocks: dict[str, Block]
+    blocks: dict[str, tuple[Block, Span | None]]
     forward_block_references: dict[str, list[Span]]
     """
     Blocks we encountered references to before the definition (must be empty after
@@ -669,78 +668,103 @@ class Parser(ABC):
 
         If the block definition was not seen yet, we create a forward declaration.
         """
-        name = block_name.text
+        name = block_name.text[1:]
         if name not in self.blocks:
             self.forward_block_references[name].append(block_name)
-            self.blocks[name] = Block()
-        return self.blocks[name]
+            self.blocks[name] = (Block(), None)
+        return self.blocks[name][0]
 
-    def parse_block(self) -> Block:
-        block_id, args = self._parse_optional_block_label()
+    def _parse_ssa_definition(self) -> str:
+        """
+        Parse an SSA definition, with the format `%ident`. Returns the value name.
+        If a value with the same name is already in scope, return an error.
+        """
+        name_token = self._parse_token(
+            Token.Kind.PERCENT_IDENT, "Expected result SSA value!"
+        )
+        name = name_token.text[1:]
+        if name in self.ssa_values:
+            self.raise_error(
+                f"a value with name '{name}' is already defined", name_token.span
+            )
+        return name
 
-        if block_id is None:
-            block = Block(declared_at=self.tokenizer.last_token)
-        elif self.forward_block_references.pop(block_id.text, None) is not None:
-            block = self.blocks[block_id.text]
-            block.declared_at = block_id
-        else:
-            if block_id.text in self.blocks:
-                block = self.blocks[block_id.text]
-                assert block.declared_at is not None, "Parsed block must have a span"
-                raise MultipleSpansParseError(
-                    block_id,
-                    "Re-declaration of block {}".format(block_id.text),
-                    "Originally declared here:",
-                    [(block.declared_at, None)],
-                    self.tokenizer.history,
-                )
-            block = Block(declared_at=block_id)
-            self.blocks[block_id.text] = block
+    def _parse_optional_block_arg_list(self, block: Block):
+        """
+        Parse a block argument list, if present, and add them to the block.
 
-        block_args: list[BlockArgument] = []
+            value-id-and-type-list ::= value-id-and-type (`,` ssa-id-and-type)*
+            block-arg-list ::= `(` value-id-and-type-list? `)`
+        """
+        if self._current_token.kind != Token.Kind.L_PAREN:
+            return None
 
-        for i, (name, type) in enumerate(args):
-            arg = BlockArgument(type, block, i)
-            self.ssa_values[name.text[1:]] = (arg,)
-            # store ssa val name if valid
-            if SSAValue.is_valid_name(name.text[1:]):
-                arg.name_hint = name.text[1:]
-            block_args.append(arg)
+        def parse_argument() -> None:
+            """Parse a single block argument with its type."""
+            arg_name = self._parse_ssa_definition()
+            self.parse_punctuation(":")
+            self._synchronize_lexer_and_tokenizer()
+            arg_type = self.parse_attribute()
+            self._synchronize_lexer_and_tokenizer()
 
-        block._args = tuple(block_args)  # type: ignore
+            # Insert the block argument in the block, and set its name.
+            block_arg = block.insert_arg(arg_type, len(block.args))
+            if SSAValue.is_valid_name(arg_name):
+                block_arg.name_hint = arg_name
 
-        while (next_op := self.try_parse_operation()) is not None:
-            block.add_op(next_op)
+            # Register the value name in the parser
+            self.ssa_values[arg_name] = (block_arg,)
 
+        self.parse_comma_separated_list(self.Delimiter.PAREN, parse_argument)
         return block
 
-    def _parse_optional_block_label(
-        self,
-    ) -> tuple[Span | None, list[tuple[Span, Attribute]]]:
+    def parse_block_body(self, block: Block):
         """
-        A block label consists of block-id ( `(` block-arg `,` ... `)` )?
+        Parse a block body, which consist of a list of operations.
+        The operations are added at the end of the block.
         """
-        block_id = self.try_parse_block_id()
-        arg_list = list[tuple[Span, Attribute]]()
+        self._synchronize_lexer_and_tokenizer()
+        while (op := self.try_parse_operation()) is not None:
+            self._synchronize_lexer_and_tokenizer()
+            block.add_op(op)
 
-        if block_id is not None:
-            if self.tokenizer.starts_with("("):
-                arg_list = self._parse_block_arg_list()
+    def parse_block(self) -> Block:
+        """
+        Parse a block with the following format:
+          block ::= block-label? operation*
+          block-label    ::= block-id block-arg-list? `:`
+          block-id       ::= caret-id
+          block-arg-list ::= `(` ssa-id-and-type-list? `)`
+        """
+        self._synchronize_lexer_and_tokenizer()
+        name_token = self._parse_optional_token(Token.Kind.CARET_IDENT)
 
-            self.parse_characters(":", "Block label must end in a `:`!")
+        # Case where the block does not have a name (entry block)
+        if name_token is None:
+            block = Block()
+            self.parse_block_body(block)
+            return block
 
-        return block_id, arg_list
+        name = name_token.text[1:]
+        if name not in self.blocks:
+            block = Block()
+            self.blocks[name] = (block, name_token.span)
+        else:
+            block, original_definition = self.blocks[name]
+            if original_definition is not None:
+                raise MultipleSpansParseError(
+                    name_token.span,
+                    f"re-declaration of block '{name}'",
+                    "originally declared here:",
+                    [(original_definition, None)],
+                )
+            self.forward_block_references.pop(name)
 
-    def _parse_block_arg_list(self) -> list[tuple[Span, Attribute]]:
-        self.parse_characters("(", "Block arguments must start with `(`")
-
-        args = self.parse_list_of(
-            self.try_parse_value_id_and_type, "Expected value-id and type here!"
-        )
-
-        self.parse_characters(")", "Expected closing of block arguments!")
-
-        return args
+        self._parse_optional_block_arg_list(block)
+        self.parse_punctuation(":")
+        self.parse_block_body(block)
+        self._synchronize_lexer_and_tokenizer()
+        return block
 
     def try_parse_single_reference(self) -> Span | None:
         with self.backtracking("part of a reference"):


### PR DESCRIPTION
Move the block parser to the lexer.
This doesn't change any functionality, besides fixing a bug in multiple tests.

It also removes the `declared-at` from the block, which was a hack in my opinion.