### PR TITLE
core: Add lexer for more complex pass pipeline specs

### DIFF
--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -1,12 +1,16 @@
 import pytest
 
-from xdsl.utils.parse_pipeline import tokenize_pass, Kind, PassPipelineParseError
+from xdsl.utils.parse_pipeline import (
+    PipelineLexer,
+    Kind,
+    PassPipelineParseError,
+)
 
 
 def test_pass_lexer():
     tokens = list(
-        tokenize_pass(
-            'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12},pass-3'
+        PipelineLexer._generator(  # type: ignore[reportPrivateUsage]
+            'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12 no-val-arg},pass-3'
         )
     )
 
@@ -16,7 +20,8 @@ def test_pass_lexer():
         Kind.IDENT, Kind.EQUALS, Kind.NUMBER, Kind.SPACE,  # arg1=1
         Kind.IDENT, Kind.EQUALS, Kind.IDENT, Kind.SPACE,  # arg2=test
         Kind.IDENT, Kind.EQUALS, Kind.STRING_LIT, Kind.SPACE,  # arg3="test-str"
-        Kind.IDENT, Kind.EQUALS, Kind.NUMBER,  # arg-4=-34.4e-12
+        Kind.IDENT, Kind.EQUALS, Kind.NUMBER, Kind.SPACE,  # arg-4=-34.4e-12
+        Kind.IDENT, # no-val-arg
         Kind.R_BRACE, Kind.COMMA,  # },
         Kind.IDENT,  # pass-3
         Kind.EOF,
@@ -30,7 +35,7 @@ def test_pass_lexer():
 
 def test_pass_lex_errors():
     with pytest.raises(PassPipelineParseError, match="Unknown token"):
-        list(tokenize_pass("pass-1["))
+        list(PipelineLexer._generator("pass-1["))  # type: ignore[reportPrivateUsage]
 
     with pytest.raises(PassPipelineParseError, match="Unknown token"):
-        list(tokenize_pass("pass-1{thing$=1}"))
+        list(PipelineLexer._generator("pass-1{thing$=1}"))  # type: ignore[reportPrivateUsage]

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -19,9 +19,10 @@ def test_pass_lexer():
         Kind.IDENT, Kind.EQUALS, Kind.NUMBER,  # arg-4=-34.4e-12
         Kind.R_BRACE, Kind.COMMA,  # },
         Kind.IDENT,  # pass-3
+        Kind.EOF,
     ]  # fmt: skip
 
-    assert tokens[-1].span.text == "pass-3"
+    assert tokens[-2].span.text == "pass-3"
     assert tokens[1].span.text == ","
     assert tokens[3].span.text == "{"
     assert tokens[18].span.text == "-34.4e-12"

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -1,0 +1,35 @@
+import pytest
+
+from xdsl.utils.parse_pipeline import tokenize_pass, Kind, PassPipelineParseError
+
+
+def test_pass_lexer():
+    tokens = list(
+        tokenize_pass(
+            'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12},pass-3'
+        )
+    )
+
+    assert [t.kind for t in tokens] == [
+        Kind.IDENT, Kind.COMMA,  # pass-1,
+        Kind.IDENT, Kind.L_BRACE,  # pass-2{
+        Kind.IDENT, Kind.EQUALS, Kind.NUMBER, Kind.SPACE,  # arg1=1
+        Kind.IDENT, Kind.EQUALS, Kind.IDENT, Kind.SPACE,  # arg2=test
+        Kind.IDENT, Kind.EQUALS, Kind.STRING_LIT, Kind.SPACE,  # arg3="test-str"
+        Kind.IDENT, Kind.EQUALS, Kind.NUMBER,  # arg-4=-34.4e-12
+        Kind.R_BRACE, Kind.COMMA,  # },
+        Kind.IDENT,  # pass-3
+    ]  # fmt: skip
+
+    assert tokens[-1].span.text == "pass-3"
+    assert tokens[1].span.text == ","
+    assert tokens[3].span.text == "{"
+    assert tokens[18].span.text == "-34.4e-12"
+
+
+def test_pass_lex_errors():
+    with pytest.raises(PassPipelineParseError, match="Unknown token"):
+        list(tokenize_pass("pass-1["))
+
+    with pytest.raises(PassPipelineParseError, match="Unknown token"):
+        list(tokenize_pass("pass-1{thing$=1}"))

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -1,10 +1,9 @@
 import pytest
 
-from xdsl.utils.parse_pipeline import (
-    PipelineLexer,
-    Kind,
-)
+from xdsl.utils.parse_pipeline import PipelineLexer, Token
 from xdsl.utils.exceptions import PassPipelineParseError
+
+Kind = Token.Kind
 
 
 def test_pass_lexer():

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -3,8 +3,8 @@ import pytest
 from xdsl.utils.parse_pipeline import (
     PipelineLexer,
     Kind,
-    PassPipelineParseError,
 )
+from xdsl.utils.exceptions import PassPipelineParseError
 
 
 def test_pass_lexer():

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from io import StringIO
 from typing import Any, IO
 
+from utils.parse_pipeline import Token
+
 if typing.TYPE_CHECKING:
     from xdsl.parser import Span, BacktrackingHistory
     from xdsl.ir import Attribute
@@ -158,3 +160,11 @@ class MultipleSpansParseError(ParseError):
         print(self.ref_text or "With respect to:", file=file)
         for span, msg in self.refs:
             print(span.print_with_context(msg), file=file)
+
+
+class PassPipelineParseError(BaseException):
+    def __init__(self, token: Token, msg: str):
+        super().__init__(
+            "Error parsing pass pipeline specification:\n"
+            + token.span.print_with_context(msg)
+        )

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -10,11 +10,10 @@ from dataclasses import dataclass
 from io import StringIO
 from typing import Any, IO
 
-from utils.parse_pipeline import Token
-
 if typing.TYPE_CHECKING:
     from xdsl.parser import Span, BacktrackingHistory
     from xdsl.ir import Attribute
+    from xdsl.utils.parse_pipeline import Token
 
 
 class DiagnosticException(Exception):

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -1,0 +1,68 @@
+import re
+from dataclasses import dataclass
+from typing import Iterable
+from xdsl.utils.lexer import Input, Span
+from enum import Enum, auto
+
+
+class Kind(Enum):
+    EOF = auto()
+
+    IDENT = auto()
+    L_BRACE = auto()
+    R_BRACE = auto()
+    EQUALS = auto()
+    NUMBER = auto()
+    SPACE = auto()
+    STRING_LIT = auto()
+    COMMA = auto()
+
+
+@dataclass
+class Token:
+    span: Span
+    kind: Kind
+
+
+_lexer_rules: list[tuple[re.Pattern[str], Kind]] = [
+    (re.compile(r"[-+]?[0-9]+(\.[0-9]*([eE][-+]?[0-9]+)?)?"), Kind.NUMBER),
+    (re.compile(r"[A-Za-z0-9_-]+"), Kind.IDENT),
+    (re.compile(r'"(\\[nfvtr"\\]|[^\n\f\v\r"\\])*"'), Kind.STRING_LIT),
+    (re.compile(r"\{"), Kind.L_BRACE),
+    (re.compile(r"}"), Kind.R_BRACE),
+    (re.compile(r"="), Kind.EQUALS),
+    (re.compile(r"\s+"), Kind.SPACE),
+    (re.compile(r","), Kind.COMMA),
+]
+
+
+def tokenize_pass(input_str: str) -> Iterable[Token]:
+    """
+    This tokenizes a pass declaration string
+    """
+    input = Input(input_str, "pass-pipeline")
+    pos = 0
+    end = len(input_str)
+
+    while True:
+        token: Token | None = None
+        for pattern, kind in _lexer_rules:
+            if (match := pattern.match(input_str, pos)) is not None:
+                token = Token(Span(match.start(), match.end(), input), kind)
+                pos = match.end()
+                break
+        if token is None:
+            raise PassPipelineParseError(
+                Token(Span(pos, pos + 1, input), Kind.IDENT), "Unknown token"
+            )
+        yield token
+        if pos >= end:
+            return
+
+
+class PassPipelineParseError(BaseException):
+    def __init__(self, token: Token, msg: str):
+        super().__init__(
+            "Error parsing pass pipeline specification:\n"
+            + token.span.print_with_context(msg)
+        )

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterator
 from xdsl.utils.lexer import Input, Span
 from enum import Enum, auto
 
@@ -39,7 +39,7 @@ This is a list of lexer rules that should be tried in this specific order to get
 """
 
 
-def tokenize_pass(input_str: str) -> Iterable[Token]:
+def tokenize_pass(input_str: str) -> Iterator[Token]:
     """
     This tokenizes a pass declaration string. Pass syntax is a subset
     of MLIRs pass pipeline syntax:
@@ -70,6 +70,7 @@ def tokenize_pass(input_str: str) -> Iterable[Token]:
             )
         yield token
         if pos >= end:
+            yield Token(Span(pos, pos + 1, input), Kind.EOF)
             return
 
 

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -34,11 +34,24 @@ _lexer_rules: list[tuple[re.Pattern[str], Kind]] = [
     (re.compile(r"\s+"), Kind.SPACE),
     (re.compile(r","), Kind.COMMA),
 ]
+"""
+This is a list of lexer rules that should be tried in this specific order to get the next token.
+"""
 
 
 def tokenize_pass(input_str: str) -> Iterable[Token]:
     """
-    This tokenizes a pass declaration string
+    This tokenizes a pass declaration string. Pass syntax is a subset
+    of MLIRs pass pipeline syntax:
+
+    pipeline          ::= pipeline-element (`,` pipeline-element)*
+    pipeline-element  ::= pass-name options?
+    options           ::= `{` options-element ( ` ` options-element)* `}`
+    options-element   ::= key `=` value
+
+    key       ::= IDENT
+    pass-name ::= IDENT
+    value     :== NUMBER / IDENT / STRING_LITERAL
     """
     input = Input(input_str, "pass-pipeline")
     pos = 0

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -1,23 +1,11 @@
+from __future__ import annotations
 import re
 from dataclasses import dataclass
 from typing import Iterator
 
 from xdsl.utils.exceptions import PassPipelineParseError
 from xdsl.utils.lexer import Input, Span
-from enum import Enum, auto
-
-
-class Kind(Enum):
-    EOF = auto()
-
-    IDENT = auto()
-    L_BRACE = auto()
-    R_BRACE = auto()
-    EQUALS = auto()
-    NUMBER = auto()
-    SPACE = auto()
-    STRING_LIT = auto()
-    COMMA = auto()
+from enum import Enum
 
 
 @dataclass
@@ -25,16 +13,28 @@ class Token:
     span: Span
     kind: Kind
 
+    class Kind(Enum):
+        EOF = object()
 
-_lexer_rules: list[tuple[re.Pattern[str], Kind]] = [
-    (re.compile(r"[-+]?[0-9]+(\.[0-9]*([eE][-+]?[0-9]+)?)?"), Kind.NUMBER),
-    (re.compile(r"[A-Za-z0-9_-]+"), Kind.IDENT),
-    (re.compile(r'"(\\[nfvtr"\\]|[^\n\f\v\r"\\])*"'), Kind.STRING_LIT),
-    (re.compile(r"\{"), Kind.L_BRACE),
-    (re.compile(r"}"), Kind.R_BRACE),
-    (re.compile(r"="), Kind.EQUALS),
-    (re.compile(r"\s+"), Kind.SPACE),
-    (re.compile(r","), Kind.COMMA),
+        IDENT = object()
+        L_BRACE = "{"
+        R_BRACE = "}"
+        EQUALS = "="
+        NUMBER = object()
+        SPACE = object()
+        STRING_LIT = object()
+        COMMA = ","
+
+
+_lexer_rules: list[tuple[re.Pattern[str], Token.Kind]] = [
+    (re.compile(r"[-+]?[0-9]+(\.[0-9]*([eE][-+]?[0-9]+)?)?"), Token.Kind.NUMBER),
+    (re.compile(r"[A-Za-z0-9_-]+"), Token.Kind.IDENT),
+    (re.compile(r'"(\\[nfvtr"\\]|[^\n\f\v\r"\\])*"'), Token.Kind.STRING_LIT),
+    (re.compile(r"\{"), Token.Kind.L_BRACE),
+    (re.compile(r"}"), Token.Kind.R_BRACE),
+    (re.compile(r"="), Token.Kind.EQUALS),
+    (re.compile(r"\s+"), Token.Kind.SPACE),
+    (re.compile(r","), Token.Kind.COMMA),
 ]
 """
 This is a list of lexer rules that should be tried in this specific order to get the next token.
@@ -76,11 +76,11 @@ class PipelineLexer:
                     break
             if token is None:
                 raise PassPipelineParseError(
-                    Token(Span(pos, pos + 1, input), Kind.IDENT), "Unknown token"
+                    Token(Span(pos, pos + 1, input), Token.Kind.IDENT), "Unknown token"
                 )
             yield token
             if pos >= end:
-                yield Token(Span(pos, pos + 1, input), Kind.EOF)
+                yield Token(Span(pos, pos + 1, input), Token.Kind.EOF)
                 return
 
     def lex(self) -> Token:

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -1,6 +1,8 @@
 import re
 from dataclasses import dataclass
 from typing import Iterator
+
+from xdsl.utils.exceptions import PassPipelineParseError
 from xdsl.utils.lexer import Input, Span
 from enum import Enum, auto
 
@@ -49,7 +51,7 @@ class PipelineLexer:
     options-element   ::= key (`=` value (`,` value)* )?
     key       ::= IDENT
     pass-name ::= IDENT
-    value     :== NUMBER / BOOL / IDENT / STRING_LITERAL
+    value     ::= NUMBER | BOOL | IDENT | STRING_LITERAL
     """
 
     _stream: Iterator[Token]
@@ -90,11 +92,3 @@ class PipelineLexer:
         if self._peeked is None:
             self._peeked = next(self._stream)
         return self._peeked
-
-
-class PassPipelineParseError(BaseException):
-    def __init__(self, token: Token, msg: str):
-        super().__init__(
-            "Error parsing pass pipeline specification:\n"
-            + token.span.print_with_context(msg)
-        )


### PR DESCRIPTION
This PR starts to add pass arguments. We first provide a very simple tokenizer for the syntax of passes. We implement a subset of MLIRs pass syntax here.

This is needed to get passes such as domain slicing for MPI going.