### PR TITLE
core: Add parser for more complex pass pipeline specs 

### DIFF
--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -1,11 +1,16 @@
 import pytest
 
-from xdsl.utils.parse_pipeline import tokenize_pass, Kind, PassPipelineParseError
+from xdsl.utils.parse_pipeline import (
+    tokenize_pipeline,
+    Kind,
+    PassPipelineParseError,
+    parse_pipeline,
+)
 
 
 def test_pass_lexer():
     tokens = list(
-        tokenize_pass(
+        tokenize_pipeline(
             'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12},pass-3'
         )
     )
@@ -30,7 +35,70 @@ def test_pass_lexer():
 
 def test_pass_lex_errors():
     with pytest.raises(PassPipelineParseError, match="Unknown token"):
-        list(tokenize_pass("pass-1["))
+        list(tokenize_pipeline("pass-1["))
 
     with pytest.raises(PassPipelineParseError, match="Unknown token"):
-        list(tokenize_pass("pass-1{thing$=1}"))
+        list(tokenize_pipeline("pass-1{thing$=1}"))
+
+
+def test_pass_parser():
+    passes = list(
+        parse_pipeline(
+            'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12},pass-3'
+        )
+    )
+
+    assert passes == [
+        ("pass-1", {}),
+        (
+            "pass-2",
+            {
+                "arg1": 1,
+                "arg2": "test",
+                "arg3": "test-str",
+                "arg-4": -3.44e-11,
+            },
+        ),
+        ("pass-3", {}),
+    ]
+
+
+def test_pass_parse_errors():
+    """
+    this test tries to trigger all parse errors in the parser.
+
+    In the same order they appear in the source file
+    """
+    with pytest.raises(PassPipelineParseError, match="Expected pass name here"):
+        # numbers are not valid pass names!
+        list(parse_pipeline("1"))
+
+    with pytest.raises(
+        PassPipelineParseError, match="Expected a comma or pass arguments here"
+    ):
+        list(parse_pipeline("pass-1="))
+
+    with pytest.raises(
+        PassPipelineParseError, match="Expected a comma after pass argument dict here"
+    ):
+        list(parse_pipeline("pass-1{arg1=1}="))
+
+    with pytest.raises(PassPipelineParseError, match="Expected argument name here"):
+        # numbers are not valud argument names
+        list(parse_pipeline("pass-1{1=1}"))
+
+    with pytest.raises(
+        PassPipelineParseError,
+        match="Expected equals as part of the pass argument here",
+    ):
+        # we don't support the case where there is no `=` after the arg name (yet)
+        list(parse_pipeline("pass-1{arg1 1}"))
+
+    with pytest.raises(
+        PassPipelineParseError,
+        match="Malformed pass arguments, expected either a space or `}` here",
+    ):
+        list(parse_pipeline("pass-1{arg1=1=}"))
+
+    with pytest.raises(PassPipelineParseError, match="Unknown argument value"):
+        list(parse_pipeline("pass-1{arg1={}}"))

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -19,9 +19,10 @@ def test_pass_lexer():
         Kind.IDENT, Kind.EQUALS, Kind.NUMBER,  # arg-4=-34.4e-12
         Kind.R_BRACE, Kind.COMMA,  # },
         Kind.IDENT,  # pass-3
+        Kind.EOF,
     ]  # fmt: skip
 
-    assert tokens[-1].span.text == "pass-3"
+    assert tokens[-2].span.text == "pass-3"
     assert tokens[1].span.text == ","
     assert tokens[3].span.text == "{"
     assert tokens[18].span.text == "-34.4e-12"

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -1,0 +1,35 @@
+import pytest
+
+from xdsl.utils.parse_pipeline import tokenize_pass, Kind, PassPipelineParseError
+
+
+def test_pass_lexer():
+    tokens = list(
+        tokenize_pass(
+            'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12},pass-3'
+        )
+    )
+
+    assert [t.kind for t in tokens] == [
+        Kind.IDENT, Kind.COMMA,  # pass-1,
+        Kind.IDENT, Kind.L_BRACE,  # pass-2{
+        Kind.IDENT, Kind.EQUALS, Kind.NUMBER, Kind.SPACE,  # arg1=1
+        Kind.IDENT, Kind.EQUALS, Kind.IDENT, Kind.SPACE,  # arg2=test
+        Kind.IDENT, Kind.EQUALS, Kind.STRING_LIT, Kind.SPACE,  # arg3="test-str"
+        Kind.IDENT, Kind.EQUALS, Kind.NUMBER,  # arg-4=-34.4e-12
+        Kind.R_BRACE, Kind.COMMA,  # },
+        Kind.IDENT,  # pass-3
+    ]  # fmt: skip
+
+    assert tokens[-1].span.text == "pass-3"
+    assert tokens[1].span.text == ","
+    assert tokens[3].span.text == "{"
+    assert tokens[18].span.text == "-34.4e-12"
+
+
+def test_pass_lex_errors():
+    with pytest.raises(PassPipelineParseError, match="Unknown token"):
+        list(tokenize_pass("pass-1["))
+
+    with pytest.raises(PassPipelineParseError, match="Unknown token"):
+        list(tokenize_pass("pass-1{thing$=1}"))

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -1,0 +1,68 @@
+import re
+from dataclasses import dataclass
+from typing import Iterable
+from xdsl.utils.lexer import Input, Span
+from enum import Enum, auto
+
+
+class Kind(Enum):
+    EOF = auto()
+
+    IDENT = auto()
+    L_BRACE = auto()
+    R_BRACE = auto()
+    EQUALS = auto()
+    NUMBER = auto()
+    SPACE = auto()
+    STRING_LIT = auto()
+    COMMA = auto()
+
+
+@dataclass
+class Token:
+    span: Span
+    kind: Kind
+
+
+_lexer_rules: list[tuple[re.Pattern[str], Kind]] = [
+    (re.compile(r"[-+]?[0-9]+(\.[0-9]*([eE][-+]?[0-9]+)?)?"), Kind.NUMBER),
+    (re.compile(r"[A-Za-z0-9_-]+"), Kind.IDENT),
+    (re.compile(r'"(\\[nfvtr"\\]|[^\n\f\v\r"\\])*"'), Kind.STRING_LIT),
+    (re.compile(r"\{"), Kind.L_BRACE),
+    (re.compile(r"}"), Kind.R_BRACE),
+    (re.compile(r"="), Kind.EQUALS),
+    (re.compile(r"\s+"), Kind.SPACE),
+    (re.compile(r","), Kind.COMMA),
+]
+
+
+def tokenize_pass(input_str: str) -> Iterable[Token]:
+    """
+    This tokenizes a pass declaration string
+    """
+    input = Input(input_str, "pass-pipeline")
+    pos = 0
+    end = len(input_str)
+
+    while True:
+        token: Token | None = None
+        for pattern, kind in _lexer_rules:
+            if (match := pattern.match(input_str, pos)) is not None:
+                token = Token(Span(match.start(), match.end(), input), kind)
+                pos = match.end()
+                break
+        if token is None:
+            raise PassPipelineParseError(
+                Token(Span(pos, pos + 1, input), Kind.IDENT), "Unknown token"
+            )
+        yield token
+        if pos >= end:
+            return
+
+
+class PassPipelineParseError(BaseException):
+    def __init__(self, token: Token, msg: str):
+        super().__init__(
+            "Error parsing pass pipeline specification:\n"
+            + token.span.print_with_context(msg)
+        )

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterator
 from xdsl.utils.lexer import Input, Span
 from enum import Enum, auto
 
@@ -39,7 +39,7 @@ This is a list of lexer rules that should be tried in this specific order to get
 """
 
 
-def tokenize_pass(input_str: str) -> Iterable[Token]:
+def tokenize_pass(input_str: str) -> Iterator[Token]:
     """
     This tokenizes a pass declaration string. Pass syntax is a subset
     of MLIRs pass pipeline syntax:
@@ -70,6 +70,7 @@ def tokenize_pass(input_str: str) -> Iterable[Token]:
             )
         yield token
         if pos >= end:
+            yield Token(Span(pos, pos + 1, input), Kind.EOF)
             return
 
 

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -34,11 +34,24 @@ _lexer_rules: list[tuple[re.Pattern[str], Kind]] = [
     (re.compile(r"\s+"), Kind.SPACE),
     (re.compile(r","), Kind.COMMA),
 ]
+"""
+This is a list of lexer rules that should be tried in this specific order to get the next token.
+"""
 
 
 def tokenize_pass(input_str: str) -> Iterable[Token]:
     """
-    This tokenizes a pass declaration string
+    This tokenizes a pass declaration string. Pass syntax is a subset
+    of MLIRs pass pipeline syntax:
+
+    pipeline          ::= pipeline-element (`,` pipeline-element)*
+    pipeline-element  ::= pass-name options?
+    options           ::= `{` options-element ( ` ` options-element)* `}`
+    options-element   ::= key `=` value
+
+    key       ::= IDENT
+    pass-name ::= IDENT
+    value     :== NUMBER / IDENT / STRING_LITERAL
     """
     input = Input(input_str, "pass-pipeline")
     pos = 0


### PR DESCRIPTION
Based on top of #955 

This adds a parser for pass pipelines. This parser works as follows:

```python
list(
    parse_pipeline(
        'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12},pass-3'
    )
)
# produces:
[
    ("pass-1", {}),
    (
        "pass-2",
        {
            "arg1": 1,
            "arg2": "test",
            "arg3": "test-str",
            "arg-4": -3.44e-11,
        },
    ),
    ("pass-3", {}),
]
```