### PR TITLE
core: Integrate parser for more complex pass pipeline specs into xdsl-opt

### DIFF
--- a/tests/test_pass_from_spec.py
+++ b/tests/test_pass_from_spec.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass, field
+
+import pytest
+
+from xdsl.dialects import builtin
+from xdsl.ir import MLContext
+
+from xdsl.passes import ModulePass
+from xdsl.utils.parse_pipeline import PipelinePassSpec
+
+
+@dataclass
+class CustomPass(ModulePass):
+    name = "custom-pass"
+
+    number: int | float
+
+    int_list: list[int]
+
+    non_init_thing: int = field(init=False)
+
+    str_thing: str
+
+    optional: str | None
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        pass
+
+
+@dataclass
+class EmptyPass(ModulePass):
+    name = "empty"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        pass
+
+
+@dataclass
+class SimplePass(ModulePass):
+    name = "simple"
+
+    a: int | float
+    b: int | None
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        pass
+
+
+def test_pass_instantiation():
+    p = CustomPass.from_pass_spec(
+        PipelinePassSpec(
+            name="custom-pass",
+            args={
+                "number": [2],
+                "int_list": [1, 2, 3],
+                "str_thing": ["hello world"],
+                # "optional" was left out here, as it is optional
+            },
+        )
+    )
+
+    assert p.number == 2
+    assert p.int_list == [1, 2, 3]
+    assert p.str_thing == "hello world"
+    assert p.optional is None
+
+    # this should just work
+    EmptyPass.from_pass_spec(PipelinePassSpec("empty", dict()))
+
+
+@pytest.mark.parametrize(
+    "spec, error_msg",
+    (
+        (PipelinePassSpec("wrong", {"a": [1]}), "Wrong pass name"),
+        (PipelinePassSpec("simple", {}), 'requires argument "a"'),
+        (
+            PipelinePassSpec("simple", {"a": [1], "no": []}),
+            'Unrecognised pass argument "no"',
+        ),
+        (PipelinePassSpec("simple", {"a": []}), "Argument must contain a value"),
+        (PipelinePassSpec("simple", {"a": ["test"]}), "Incompatible types"),
+    ),
+)
+def test_pass_instantiation_error(spec: PipelinePassSpec, error_msg: str):
+    """
+    Test all possible failure modes in pass instantiation
+    """
+    with pytest.raises(Exception, match=error_msg):
+        SimplePass.from_pass_spec(spec)

--- a/tests/test_pass_from_spec.py
+++ b/tests/test_pass_from_spec.py
@@ -52,8 +52,8 @@ def test_pass_instantiation():
             name="custom-pass",
             args={
                 "number": [2],
-                "int_list": [1, 2, 3],
-                "str_thing": ["hello world"],
+                "int-list": [1, 2, 3],
+                "str-thing": ["hello world"],
                 # "optional" was left out here, as it is optional
             },
         )

--- a/tests/test_pass_from_spec.py
+++ b/tests/test_pass_from_spec.py
@@ -71,11 +71,11 @@ def test_pass_instantiation():
 @pytest.mark.parametrize(
     "spec, error_msg",
     (
-        (PipelinePassSpec("wrong", {"a": [1]}), "Wrong pass name"),
+        (PipelinePassSpec("wrong", {"a": [1]}), "Cannot create Pass simple"),
         (PipelinePassSpec("simple", {}), 'requires argument "a"'),
         (
             PipelinePassSpec("simple", {"a": [1], "no": []}),
-            'Unrecognised pass argument "no"',
+            'Unrecognised pass arguments "no"',
         ),
         (PipelinePassSpec("simple", {"a": []}), "Argument must contain a value"),
         (PipelinePassSpec("simple", {"a": ["test"]}), "Incompatible types"),

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -61,7 +61,8 @@ class ModulePass(ABC):
             # convert pass arg to the correct type:
             arg_dict[field.name] = _convert_pass_arg_to_type(
                 # we use default value [] here, this makes handling optionals easier
-                spec.args.pop(field.name, []), field.type
+                spec.args.pop(field.name, []),
+                field.type,
             )
             # we use .pop here to also remove the arg from the dict
 

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -1,16 +1,28 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, Field
+from types import UnionType, NoneType
+
+from xdsl.utils.hints import isa
 from xdsl.dialects import builtin
 from xdsl.ir import MLContext
-from typing import ClassVar
+from typing import ClassVar, TypeVar, get_origin, Any, Union, get_args
+from xdsl.utils.parse_pipeline import (
+    PipelinePassSpec,
+    PassArgListType,
+    PassArgElementType,
+)
+
+_T = TypeVar("_T", bound="ModulePass")
 
 
+@dataclass
 class ModulePass(ABC):
     """
     A Pass is a named rewrite pass over an IR module.
 
     All passes are expected to leave the IR in a valid state after application.
     That is, the IR verifies. In turn, all passes can expect the IR they are
-    applied to to be in a valid state.
+    applied to be in a valid state.
     """
 
     name: ClassVar[str]
@@ -18,3 +30,56 @@ class ModulePass(ABC):
     @abstractmethod
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         ...
+
+    @classmethod
+    def from_pass_spec(cls: type[_T], spec: PipelinePassSpec) -> _T:
+        assert issubclass(cls, ModulePass), f"{cls} must be subclass of ModulePass"
+        assert hasattr(cls, "__dataclass_fields__"), f"{cls} must be a dataclass"
+
+        assert spec.name == cls.name, "Wrong pass name provided"
+
+        fields: dict[str, Field[_T]] = cls.__dataclass_fields__
+
+        arg_dict = dict[str, PassArgListType | PassArgElementType | None]()
+
+        for field in fields.values():
+            if field.name == "name" or not field.init:
+                continue
+            if field.name not in spec.args and not _is_optional(field.type):
+                raise Exception(f'Pass {cls.name} requires argument "{field.name}"')
+
+            arg_dict[field.name] = _convert_pass_type(
+                spec.args.pop(field.name, []), field.type
+            )
+
+        if len(spec.args) != 0:
+            raise Exception(f'Unrecognised pass argument "{list(spec.args)[0]}"')
+
+        return cls(**arg_dict)
+
+
+def _convert_pass_type(
+    value: PassArgListType, dest_type: Any
+) -> PassArgListType | PassArgElementType | None:
+    origin = get_origin(dest_type)
+
+    # we need to special case optionals as [] means no option given
+    if origin in [Union, UnionType]:
+        if len(value) == 0:
+            if NoneType in get_args(dest_type):
+                return None
+            else:
+                raise Exception("Argument must contain a value")
+
+    if len(value) == 1 and isa(value[0], dest_type):
+        return value[0]
+
+    if isa(value, dest_type):
+        return value
+    raise Exception(f"Incompatible types: given {value}, expected {dest_type}")
+
+
+def _is_optional(field_type: Any):
+    return get_origin(field_type) in [Union, UnionType] and NoneType in get_args(
+        field_type
+    )

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -28,7 +28,7 @@ class ModulePass(ABC):
     applied.
 
     In order to make a pass accept arguments, it must be a dataclass. Furthermore,
-    only the these types are supported as argument types:
+    only the following types are supported as argument types:
 
     Base types:             int | float | bool | string
     Lists of base types:    list[int], list[int|float], list[int] | list[float]

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -33,34 +33,61 @@ class ModulePass(ABC):
 
     @classmethod
     def from_pass_spec(cls: type[_T], spec: PipelinePassSpec) -> _T:
+        """
+        This method takes a PipelinePassSpec, does type checking on the
+        arguments, and then instantiates an instance of the ModulePass
+        from the spec.
+        """
+        # some sanity checks here
         assert issubclass(cls, ModulePass), f"{cls} must be subclass of ModulePass"
         assert hasattr(cls, "__dataclass_fields__"), f"{cls} must be a dataclass"
-
         assert spec.name == cls.name, "Wrong pass name provided"
 
+        # get all dataclass fields
         fields: dict[str, Field[_T]] = cls.__dataclass_fields__
 
+        # start constructing the argument dict for the dataclass
         arg_dict = dict[str, PassArgListType | PassArgElementType | None]()
 
+        # iterate over all fields of the dataclass
         for field in fields.values():
+            # ignore the name field and everything that's not used by __init__
             if field.name == "name" or not field.init:
                 continue
+            # check that non-optional fields are present
             if field.name not in spec.args and not _is_optional(field.type):
                 raise Exception(f'Pass {cls.name} requires argument "{field.name}"')
 
-            arg_dict[field.name] = _convert_pass_type(
+            # convert pass arg to the correct type:
+            arg_dict[field.name] = _convert_pass_arg_to_type(
+                # we use default value [] here, this makes handling optionals easier
                 spec.args.pop(field.name, []), field.type
             )
+            # we use .pop here to also remove the arg from the dict
 
+        # if not all args were removed we raise an error
         if len(spec.args) != 0:
             raise Exception(f'Unrecognised pass argument "{list(spec.args)[0]}"')
 
+        # instantiate the dataclass using kwargs
         return cls(**arg_dict)
 
 
-def _convert_pass_type(
+def _convert_pass_arg_to_type(
     value: PassArgListType, dest_type: Any
 ) -> PassArgListType | PassArgElementType | None:
+    """
+    Takes in a list of pass args, and converts them to the required type.
+
+    value,      dest_type,      result
+    []          int | None      None
+    [1]         int | None      1
+    [1,2]       list[int]       [1,2]
+    [1,2]       int | None      Error
+    []          int             Error
+
+    And so on
+    """
     origin = get_origin(dest_type)
 
     # we need to special case optionals as [] means no option given
@@ -71,15 +98,22 @@ def _convert_pass_type(
             else:
                 raise Exception("Argument must contain a value")
 
+    # first check if an individual value passes the type check
     if len(value) == 1 and isa(value[0], dest_type):
         return value[0]
 
+    # then check if array value is okay
     if isa(value, dest_type):
         return value
+
+    # at this point we exhausted all possibilities
     raise Exception(f"Incompatible types: given {value}, expected {dest_type}")
 
 
 def _is_optional(field_type: Any):
+    """
+    Shorthand to check if the given type allows "None" as a value.
+    """
     return get_origin(field_type) in [Union, UnionType] and NoneType in get_args(
         field_type
     )

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -19,11 +19,13 @@ ModulePassT = TypeVar("ModulePassT", bound="ModulePass")
 @dataclass
 class ModulePass(ABC):
     """
-    A Pass is a named rewrite pass over an IR module, that can accept arguments.
+    A Pass is a named rewrite pass over an IR module that can accept arguments.
 
-    All passes are expected to leave the IR in a valid state after application.
-    That is, the IR verifies. In turn, all passes can expect that the IR they are
-    applied to is in a valid state.
+    All passes are expected to leave the IR in a valid state *after* application,
+    meaning that a call to .verify() succeeds on the whole module. In turn, all
+    passes can expect that the IR they are applied to is in a valid state. It
+    is not required that the IR verifies at any point while the pass is being
+    applied.
 
     In order to make a pass accept arguments, it must be a dataclass. Furthermore,
     only the these types are supported as argument types:

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -64,7 +64,7 @@ class ModulePass(ABC):
         spec.normalize_arg_names()
 
         # get all dataclass fields
-        fields: tuple[Field, ...] = dataclasses.fields(cls)
+        fields: tuple[Field[Any], ...] = dataclasses.fields(cls)
 
         # start constructing the argument dict for the dataclass
         arg_dict = dict[str, PassArgListType | PassArgElementType | None]()
@@ -88,7 +88,7 @@ class ModulePass(ABC):
 
         # if not all args were removed we raise an error
         if len(spec.args) != 0:
-            raise ValueError(f'Unrecognised pass arguments "{list(spec.args)}"')
+            raise ValueError(f'Unrecognised pass arguments "{", ".join(spec.args)}"')
 
         # instantiate the dataclass using kwargs
         return cls(**arg_dict)

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -43,6 +43,9 @@ class ModulePass(ABC):
         assert hasattr(cls, "__dataclass_fields__"), f"{cls} must be a dataclass"
         assert spec.name == cls.name, "Wrong pass name provided"
 
+        # normalize spec arg names:
+        spec.normalize_arg_names()
+
         # get all dataclass fields
         fields: dict[str, Field[_T]] = cls.__dataclass_fields__
 

--- a/xdsl/transforms/experimental/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/stencil_global_to_local.py
@@ -299,8 +299,11 @@ class AddHaloExchangeOps(RewritePattern):
         rewriter.insert_op_after_matched_op(swap_op)
 
 
+@dataclass
 class GlobalStencilToLocalStencil2DHorizontal(ModulePass):
     name = "stencil-to-local-2d-horizontal"
+
+    nodes: int
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         strategy = HorizontalSlices2D(2)

--- a/xdsl/transforms/experimental/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/stencil_global_to_local.py
@@ -303,8 +303,6 @@ class AddHaloExchangeOps(RewritePattern):
 class GlobalStencilToLocalStencil2DHorizontal(ModulePass):
     name = "stencil-to-local-2d-horizontal"
 
-    nodes: int
-
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         strategy = HorizontalSlices2D(2)
 

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -112,6 +112,14 @@ class PipelinePassSpec:
     name: str
     args: dict[str, PassArgListType]
 
+    def normalize_arg_names(self):
+        """
+        This normalized all arg names by replacing `-` with `_`
+        """
+        for k, v in list(self.args.items()):
+            del self.args[k]
+            self.args[k.replace("-", "_")] = v
+
 
 def parse_pipeline(
     pipeline_spec: str,

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -47,6 +47,7 @@ from xdsl.transforms.experimental.stencil_global_to_local import (
 )
 
 from xdsl.utils.exceptions import DiagnosticException
+from xdsl.utils.parse_pipeline import parse_pipeline
 
 from typing import IO, Dict, Callable, List, Sequence, Type
 from xdsl.riscv_asm_writer import print_riscv_module
@@ -312,15 +313,17 @@ class xDSLOptMain:
         """
         Creates a pipeline that consists of all the passes specified.
 
-        Failes, if not all passes are registered.
+        Fails, if not all passes are registered.
         """
-        pipeline = [str(item) for item in self.args.passes.split(",") if len(item) > 0]
+        pipeline = list(parse_pipeline(self.args.passes))
 
         for p in pipeline:
-            if p not in self.available_passes:
-                raise Exception(f"Unrecognized pass: {p}")
+            if p.name not in self.available_passes:
+                raise Exception(f"Unrecognized pass: {p.name}")
 
-        self.pipeline = [self.available_passes[p]() for p in pipeline]
+        self.pipeline = [
+            self.available_passes[p.name].from_pass_spec(p) for p in pipeline
+        ]
 
     def parse_input(self) -> List[ModuleOp]:
         """


### PR DESCRIPTION
This is the final stage of the pass pipeline parser.

This PR hooks up the parser to xdsl-opt. A pass is now a dataclass that can have fields:

```python
@dataclass
class CustomPass(ModulePass):
    name = "custom-pass"

    number: int | float

    int_list: list[int]

    non_init_thing: int = field(init=False)

    str_thing: str

    optional: str | None
```

Which can then be called from the command line as `custom-pass{number=1 int_list=1,2,3 str_thing=hello}`.

Optional fields are not required to be present.

*A note on edge cases:*

Due to the nature of the syntax, we can't know if `x=3` means `3` or `[3]`. So if we see an annotation like `int | list[int]` we cannot know how to convert. This implementation will always resort to non-lists in cases like this.