### PR TITLE
core: Add HasParent trait

### DIFF
--- a/tests/filecheck/dialects/gpu/terminator_launch.mlir
+++ b/tests/filecheck/dialects/gpu/terminator_launch.mlir
@@ -21,4 +21,4 @@
         "gpu.terminator"() : () -> ()
 }) {} : () -> ()
 
-// CHECK: gpu.terminator is only meant to terminate gpu.launch
+// CHECK: 'gpu.terminator' expects parent op 'gpu.launch'

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -55,14 +55,14 @@ def test_has_parent_no_parent():
     has_parent_op = HasParentOp()
     with pytest.raises(VerifyException) as exc_info:
         has_parent_op.verify()
-    assert str(exc_info.value) == "expects parent op 'test.parent'"
+    assert str(exc_info.value) == "'test.has_parent' expects parent op 'test.parent'"
 
     has_multiple_parent_op = HasMultipleParentOp()
     with pytest.raises(VerifyException) as exc_info:
         has_multiple_parent_op.verify()
-    assert (
-        str(exc_info.value)
-        == "expects parent op to be one of 'test.parent', 'test.parent2'"
+    assert str(exc_info.value) == (
+        "'test.has_multiple_parent' expects parent op to "
+        "be one of 'test.parent', 'test.parent2'"
     )
 
 
@@ -74,14 +74,14 @@ def test_has_parent_wrong_parent():
     module = ModuleOp([HasParentOp()])
     with pytest.raises(VerifyException) as exc_info:
         module.verify()
-    assert str(exc_info.value) == "expects parent op 'test.parent'"
+    assert str(exc_info.value) == "'test.has_parent' expects parent op 'test.parent'"
 
     module = ModuleOp([HasMultipleParentOp()])
     with pytest.raises(VerifyException) as exc_info:
         module.verify()
-    assert (
-        str(exc_info.value)
-        == "expects parent op to be one of 'test.parent', 'test.parent2'"
+    assert str(exc_info.value) == (
+        "'test.has_multiple_parent' expects parent op to "
+        "be one of 'test.parent', 'test.parent2'"
     )
 
 

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -1,0 +1,64 @@
+"""
+Test the usage of builtin traits.
+"""
+
+import pytest
+
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.irdl import IRDLOperation, irdl_op_definition
+from xdsl.ir import Region
+from xdsl.traits import HasParent
+from xdsl.utils.exceptions import VerifyException
+
+
+@irdl_op_definition
+class ParentOp(IRDLOperation):
+    name = "test.parent_op"
+
+    region: Region
+
+
+@irdl_op_definition
+class HasParentOp(IRDLOperation):
+    """
+    An operation expecting a 'test.parent_op' parent.
+    """
+
+    name = "test.has_parent_op"
+
+    traits = frozenset([HasParent(ParentOp)])
+
+
+def test_has_parent_no_parent():
+    """
+    Test that an operation with an HasParentOp trait
+    fails with no parents.
+    """
+    has_parent_op = HasParentOp()
+    with pytest.raises(VerifyException) as exc_info:
+        has_parent_op.verify()
+    assert "has no parent" in str(exc_info.value)
+
+
+def test_has_parent_wrong_parent():
+    """
+    Test that an operation with an HasParentOp trait
+    fails with a wrong parent.
+    """
+    module = ModuleOp([HasParentOp()])
+    with pytest.raises(VerifyException) as exc_info:
+        module.verify()
+    assert "has a parent of type 'builtin.module'" in str(exc_info.value)
+
+
+def test_has_parent_pass():
+    """
+    Test that an operation with an HasParentOp trait
+    expects a parent operation of the right type.
+    """
+    parent_op = HasParentOp()
+    has_parent_op = ParentOp(regions=[[parent_op]])
+    has_parent_op.verify()
+
+    module = ModuleOp([has_parent_op])
+    module.verify()

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -1,3 +1,7 @@
+"""
+Test the definition and usage of traits and interfaces.
+"""
+
 from __future__ import annotations
 
 import pytest

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -20,6 +20,7 @@ from xdsl.irdl import (
     OptOpAttr,
     IRDLOperation,
 )
+from xdsl.traits import HasParent
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -194,6 +195,8 @@ class Call(IRDLOperation):
 class Return(IRDLOperation):
     name = "func.return"
     arguments: Annotated[VarOperand, AnyAttr()]
+
+    traits = frozenset([HasParent(FuncOp)])
 
     def verify_(self) -> None:
         func_op = self.parent_op()

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -29,6 +29,7 @@ from xdsl.dialects.builtin import IndexType, StringAttr, SymbolRefAttr, UnitAttr
 from xdsl.dialects import memref
 from xdsl.parser import Parser
 from xdsl.printer import Printer
+from xdsl.traits import HasParent
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -520,22 +521,19 @@ class SubgroupSizeOp(IRDLOperation):
 class TerminatorOp(IRDLOperation):
     name = "gpu.terminator"
 
+    traits = frozenset([HasParent(LaunchOp)])
+
     @staticmethod
     def get() -> TerminatorOp:
         return TerminatorOp.build()
 
     def verify_(self) -> None:
         block = self.parent_block()
-        op = self.parent_op()
         if block is not None:
             if self is not block.last_op:
                 raise VerifyException(
                     "A gpu.terminator must terminate its parent block"
                 )
-        if op is not None and not isinstance(op, LaunchOp):
-            raise VerifyException(
-                "gpu.terminator is only meant to terminate gpu.launch"
-            )
 
 
 @irdl_op_definition

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -1,5 +1,28 @@
-from xdsl.ir import OpTrait
+from dataclasses import dataclass
+from xdsl.ir import OpTrait, Operation
+from xdsl.utils.exceptions import VerifyException
 
 
 class Pure(OpTrait):
     """A trait that signals that an operation has no side effects."""
+
+
+@dataclass(frozen=True)
+class HasParent(OpTrait):
+    """Constraint the operation to have a specific parent operation."""
+
+    parameters: type[Operation]
+
+    def verify(self, op: Operation) -> None:
+        parent = op.parent_op()
+        if parent is None:
+            raise VerifyException(
+                f"Operation expects a parent of type {self.parameters.name}, "
+                "but has no parent."
+            )
+        if not isinstance(parent, self.parameters):
+            raise VerifyException(
+                f"Operation expects a parent of type '{self.parameters.name}', "
+                f"but has a parent of type '{parent.name}'."
+            )
+        return super().verify(op)

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -25,6 +25,8 @@ class HasParent(OpTrait):
         if isinstance(parent, tuple(self.parameters)):
             return
         if len(self.parameters) == 1:
-            raise VerifyException(f"expects parent op '{self.parameters[0].name}'")
+            raise VerifyException(
+                f"'{op.name}' expects parent op '{self.parameters[0].name}'"
+            )
         names = ", ".join([f"'{p.name}'" for p in self.parameters])
-        raise VerifyException(f"expects parent op to be one of {names}")
+        raise VerifyException(f"'{op.name}' expects parent op to be one of {names}")


### PR DESCRIPTION
This trait check that an operation have a specific parent operation type.
This is exactly the same trait as the MLIR one.