### PR TITLE
[WIP] dialects: riscv: remove SectionOp and use DirectiveOp instead

### DIFF
--- a/docs/Toy/toy/rewrites/lower_llvm.py
+++ b/docs/Toy/toy/rewrites/lower_llvm.py
@@ -30,7 +30,6 @@ class AddSections(RewritePattern):
         heap_section = riscv.DirectiveOp(
             ".bss",
             None,
-            
             Region(
                 Block(
                     [
@@ -132,7 +131,7 @@ class DataDirectiveRewritePattern(RewritePattern):
 
     def data_directive(self, op: Operation) -> riscv.DirectiveOp:
         """
-        Relies on the data directive being inserted earlier 
+        Relies on the data directive being inserted earlier
         """
         if self._data_directive is None:
             module_op = op.get_toplevel_object()

--- a/docs/Toy/toy/tests/test_end_to_end.py
+++ b/docs/Toy/toy/tests/test_end_to_end.py
@@ -265,7 +265,7 @@ def risc_0():
         riscv.LabelOp("heap")
         riscv.DirectiveOp(".space", "1024")
 
-    riscv_func.SectionOp(".bss", bss_region)
+    riscv.DirectiveOp(".bss", None, bss_region)
 
     @Builder.implicit_region
     def data_region():
@@ -281,7 +281,7 @@ def risc_0():
         riscv.DirectiveOp(".word", "0x6, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6")
         pass
 
-    riscv_func.SectionOp(".data", data_region)
+    riscv.DirectiveOp(".data", None, data_region)
 
     @Builder.implicit_region
     def text_region():
@@ -330,7 +330,7 @@ def risc_0():
 
         riscv_func.FuncOp("main", main)
 
-    riscv_func.SectionOp(".text", text_region)
+    riscv.DirectiveOp(".text", None, text_region)
 
 
 riscv_asm = """.bss

--- a/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
+++ b/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
@@ -18,16 +18,6 @@
 // CHECK-NEXT:     %{{.+}} = "riscv.li"() {"immediate" = 93 : i32} : () -> !riscv.reg<a7>
 // CHECK-NEXT:     "riscv.ecall"() : () -> ()
 
-
-    "riscv_func.section"() ({
-        "riscv.label"() {"label" = #riscv.label<"main">} : () -> ()
-        "riscv_func.syscall"() {"syscall_num" = 93 : i32} : () -> ()
-    }) {"directive" = "text"} : () -> ()
-// CHECK-NEXT:     "riscv.directive"() {"directive" = "text"} : () -> ()
-// CHECK-NEXT:     "riscv.label"() {"label" = #riscv.label<"main">} : () -> ()
-// CHECK-NEXT:     %{{.*}} = "riscv.li"() {"immediate" = 93 : i32} : () -> !riscv.reg<a7>
-// CHECK-NEXT:     "riscv.ecall"() : () -> ()
-
     "riscv_func.func"() ({
         %0 = "riscv_func.call"() {"func_name" = "get_one"} : () -> !riscv.reg<>
         %1 = "riscv_func.call"() {"func_name" = "get_one"} : () -> !riscv.reg<>

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1618,7 +1618,12 @@ class DirectiveOp(IRDLOperation, RISCVOp):
     value: OptOpAttr[StringAttr]
     data: OptSingleBlockRegion
 
-    def __init__(self, directive: str | StringAttr, value: str | StringAttr | None, region: OptSingleBlockRegion = None):
+    def __init__(
+        self,
+        directive: str | StringAttr,
+        value: str | StringAttr | None,
+        region: OptSingleBlockRegion = None,
+    ):
         if isinstance(directive, str):
             directive = StringAttr(directive)
         if isinstance(value, str):
@@ -1630,8 +1635,8 @@ class DirectiveOp(IRDLOperation, RISCVOp):
             attributes={
                 "directive": directive,
                 "value": value,
-            }, 
-            regions=[region] 
+            },
+            regions=[region],
         )
 
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -7,6 +7,7 @@ from typing import Annotated, Sequence
 from xdsl.ir import (
     Dialect,
     Operation,
+    Region,
     SSAValue,
     Attribute,
     Data,
@@ -16,6 +17,7 @@ from xdsl.ir import (
 
 from xdsl.irdl import (
     IRDLOperation,
+    OptSingleBlockRegion,
     VarOpResult,
     irdl_op_definition,
     irdl_attr_definition,
@@ -1614,18 +1616,22 @@ class DirectiveOp(IRDLOperation, RISCVOp):
     name = "riscv.directive"
     directive: OpAttr[StringAttr]
     value: OptOpAttr[StringAttr]
+    data: OptSingleBlockRegion
 
-    def __init__(self, directive: str | StringAttr, value: str | StringAttr | None):
+    def __init__(self, directive: str | StringAttr, value: str | StringAttr | None, region: OptSingleBlockRegion = None):
         if isinstance(directive, str):
             directive = StringAttr(directive)
         if isinstance(value, str):
             value = StringAttr(value)
+        if region is None:
+            region = Region()
 
         super().__init__(
             attributes={
                 "directive": directive,
                 "value": value,
-            }
+            }, 
+            regions=[region] 
         )
 
 

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -52,24 +52,6 @@ class SyscallOp(IRDLOperation):
 
 
 @irdl_op_definition
-class SectionOp(IRDLOperation):
-    """
-    This instruction corresponds to a section. Its block can be added to during
-    the lowering process.
-    """
-
-    name = "riscv_func.section"
-
-    directive: OpAttr[StringAttr]
-    data: SingleBlockRegion
-
-    def __init__(self, directive: str | StringAttr, region: Region):
-        if isinstance(directive, str):
-            directive = StringAttr(directive)
-        super().__init__(attributes={"directive": directive}, regions=[region])
-
-
-@irdl_op_definition
 class CallOp(IRDLOperation):
     name = "riscv_func.call"
     args: Annotated[VarOperand, riscv.RegisterType]
@@ -167,7 +149,6 @@ class ReturnOp(IRDLOperation):
 RISCV_Func = Dialect(
     [
         SyscallOp,
-        SectionOp,
         CallOp,
         FuncOp,
         ReturnOp,

--- a/xdsl/riscv_asm_writer.py
+++ b/xdsl/riscv_asm_writer.py
@@ -9,8 +9,9 @@ from xdsl.dialects import riscv
 
 
 def print_riscv_module(module: ModuleOp, output: IO[str]):
-    for op in module.ops:
-        print_assembly_instruction(op, output)
+    for op in module.walk():
+        if isa(op, RISCVOp):
+            print_assembly_instruction(op, output)
 
 
 def append_comment(line: str, comment: StringAttr | None) -> str:

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -59,13 +59,6 @@ class LowerSyscallOp(RewritePattern):
         rewriter.replace_matched_op(ops, new_results=new_results)
 
 
-class LowerSectionOp(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: riscv_func.SectionOp, rewriter: PatternRewriter):
-        rewriter.inline_block_after(op.data.block, op)
-        rewriter.replace_matched_op(riscv.DirectiveOp(op.directive, None))
-
-
 SCALL_EXIT = 93
 """
 93 is the number of the `exit` syscall on RISCV.
@@ -145,7 +138,6 @@ class LowerRISCVFunc(ModulePass):
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
         PatternRewriteWalker(LowerRISCVFuncReturnOp()).rewrite_module(op)
-        PatternRewriteWalker(LowerSectionOp()).rewrite_module(op)
         PatternRewriteWalker(LowerSyscallOp()).rewrite_module(op)
         PatternRewriteWalker(LowerRISCVFuncOp()).rewrite_module(op)
         PatternRewriteWalker(LowerRISCVCallOp()).rewrite_module(op)


### PR DESCRIPTION
Since SectionOp is not useful in the current state of things for the riscv dialect (and optimized later) remove it to use directly DirectiveOp instead.