### PR TITLE
core: parse region properly

### DIFF
--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -260,5 +260,5 @@ def test_external_func_def():
     ext = FuncOp.external("testname", [i32, i32], [i64])
 
     assert len(ext.regions) == 1
-    assert ext.regions[0].block.is_empty
+    assert len(ext.regions[0].blocks) == 0
     assert ext.sym_name.data == "testname"

--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -33,7 +33,5 @@
     %x14 = "arith.constant"() {"value" = 0 : i64, "test" = @foo::@bar::@baz} : () -> i64
     "func.return"() : () -> ()
   }) {"function_type" = () -> (), "sym_name" = "builtin"} : () -> ()
-  "func.func"() ({
-  // CHECK: "one"=1 : i64, "two"=2 : i64, "three"="three"
-  }) {"sym_name" = "abc", "function_type" = () -> (), "value" = {"one"=1 : i64, "two"=2 : i64, "three"="three"}} : () -> ()
+  "test.op"() {"value"= {"one"=1 : i64, "two"=2 : i64, "three"="three"}} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/cf/cf_ops.mlir
+++ b/tests/filecheck/dialects/cf/cf_ops.mlir
@@ -13,13 +13,11 @@
   // CHECK-NEXT: }) {"sym_name" = "assert", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
 
   "func.func"() ({
-  ^0:
     "cf.br"() [^1] : () -> ()
   ^1:
     "cf.br"() [^1] : () -> ()
   }) {"sym_name" = "unconditional_br", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
   // CHECK: "func.func"() ({
-  // CHECK-NEXT:  ^{{.*}}:
   // CHECK-NEXT:    "cf.br"() [^{{.*}}] : () -> ()
   // CHECK-NEXT:  ^{{.*}}:
   // CHECK-NEXT:    "cf.br"() [^{{.*}}] : () -> ()

--- a/tests/filecheck/dialects/gpu/module_unterminated.mlir
+++ b/tests/filecheck/dialects/gpu/module_unterminated.mlir
@@ -2,6 +2,7 @@
 
 "builtin.module"()({
     "gpu.module"()({
+    ^0:
     }) {"sym_name" = "gpu"} : () -> ()
 }) {} : () -> ()
 

--- a/tests/filecheck/frontend/passes/desymref.mlir
+++ b/tests/filecheck/frontend/passes/desymref.mlir
@@ -16,7 +16,8 @@
     "symref.declare"() {"sym_name" = "a"} : () -> ()
   }) : () -> ()
 
-  // CHECK-NEXT:   "builtin.module"() ({
+  // CHECK-NEXT: "builtin.module"() ({
+  // CHECK-NEXT: ^{{.*}}:
   // CHECK-NEXT: }) : () -> ()
 
 
@@ -114,6 +115,7 @@
   }) : () -> ()
 
   // CHECK-NEXT: "builtin.module"() ({
+  // CHECK-NEXT: ^{{.*}}:
   // CHECK-NEXT: }) : () -> ()
 
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
@@ -1,31 +1,31 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
 
 // fastmath single flag set
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_reassoc", "sym_visibility" = "private", "fastmath" = #arith.fastmath<reassoc>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<reassoc>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<reassoc>
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_nnan", "sym_visibility" = "private", "fastmath" = #arith.fastmath<nnan>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<nnan>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<nnan>
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_ninf", "sym_visibility" = "private", "fastmath" = #arith.fastmath<ninf>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<ninf>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<ninf>
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_nsz", "sym_visibility" = "private", "fastmath" = #arith.fastmath<nsz>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<nsz>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<nsz>
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_arcp", "sym_visibility" = "private", "fastmath" = #arith.fastmath<arcp>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<arcp>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<arcp>
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_contract", "sym_visibility" = "private", "fastmath" = #arith.fastmath<contract>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<contract>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<contract>
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_afn", "sym_visibility" = "private", "fastmath" = #arith.fastmath<afn>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<afn>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<afn>
 
 // fastmath special cases
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_none", "sym_visibility" = "private", "fastmath" = #arith.fastmath<none>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<none>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<none>
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_fast", "sym_visibility" = "private", "fastmath" = #arith.fastmath<fast>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<fast>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<fast>
 
 // fastmath combination
-"func.func"() ({}) {"function_type" = ()->(), "sym_name" = "fast_two", "sym_visibility" = "private", "fastmath" = #arith.fastmath<nnan,nsz>}: ()->()
+"test.op"() {"fastmath" = #arith.fastmath<nnan,nsz>}: ()->()
 // CHECK:   "fastmath" = #arith.fastmath<nnan,nsz>
 
 }) : ()->()

--- a/tests/filecheck/parser-printer/attribute_names.mlir
+++ b/tests/filecheck/parser-printer/attribute_names.mlir
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 
-"builtin.module"() ({
-}) {a = i32, _e = i32, "foo" = i32, _ = i32} : () -> ()
+builtin.module attributes {a = i32, _e = i32, "foo" = i32, _ = i32} {
+}
 
 // CHECK: "a" = i32, "_e" = i32, "foo" = i32, "_" = i32

--- a/tests/filecheck/parser-printer/region_name_clash.mlir
+++ b/tests/filecheck/parser-printer/region_name_clash.mlir
@@ -41,7 +41,9 @@
   // CHECK:      "test.op"() ({
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : i1):
   // CHECK-NEXT:   "test.op"(%{{.*}}) ({
+  // CHECK-NEXT:   ^{{.*}}:
   // CHECK-NEXT:   }, {
+  // CHECK-NEXT:   ^{{.*}}:
   // CHECK-NEXT:   }) : (i1) -> ()
   // CHECK-NEXT:   "test.op"(%{{.*}}) : (i1) -> ()
   // CHECK-NEXT: }) : () -> ()
@@ -53,6 +55,7 @@
     "test.op"(%0) ({
       %1 = "test.op"() : () -> i32
     }, {
+    ^1:
     }) : (i1) -> ()
     %1 = "test.op"() : () -> i32
     "test.op"(%0) : (i1) -> ()
@@ -64,6 +67,7 @@
   // CHECK-NEXT:   "test.op"(%{{.*}}) ({
   // CHECK-NEXT:     %{{.*}} = "test.op"() : () -> i32
   // CHECK-NEXT:   }, {
+  // CHECK-NEXT:   ^{{.*}}:
   // CHECK-NEXT:   }) : (i1) -> ()
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
   // CHECK-NEXT:   "test.op"(%{{.*}}) : (i1) -> ()

--- a/tests/filecheck/xdsl_opt/split_input.mlir
+++ b/tests/filecheck/xdsl_opt/split_input.mlir
@@ -1,6 +1,7 @@
 // RUN: xdsl-opt --split-input-file %s | xdsl-opt --split-input-file --print-op-generic | filecheck %s
 
 "builtin.module"() ({
+  ^0:
 // CHECK: "builtin.module"() ({
 }) : () -> ()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -301,7 +301,7 @@ def test_parse_block_name():
 
     ctx = MLContext()
     parser = Parser(ctx, block_str)
-    block = parser._parse_block()  # type: ignore
+    block = parser._parse_block()  # pyright: ignore[reportPrivateUsage]
 
     assert block.args[0].name_hint == "name"
     assert block.args[1].name_hint is None

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -472,6 +472,7 @@ def test_operation_deletion():
 }) : () -> ()"""
 
     expected = """"builtin.module"() ({
+^0:
 }) : () -> ()"""
 
     @op_type_rewrite_pattern
@@ -495,6 +496,7 @@ def test_operation_deletion_reversed():
 }) : () -> ()"""
 
     expected = """"builtin.module"() ({
+^0:
 }) : () -> ()"""
 
     def match_and_rewrite(op: Operation, rewriter: PatternRewriter):
@@ -546,6 +548,7 @@ def test_delete_inner_op():
 }) : () -> ()"""
 
     expected = """"builtin.module"() ({
+^0:
 }) : () -> ()"""
 
     @op_type_rewrite_pattern
@@ -622,13 +625,16 @@ def test_block_argument_erasure():
   "scf.if"(%0) ({
   ^0(%1 : i32):
   }, {
+  ^0:
   }) : (i1) -> ()
 }) : () -> ()"""
 
     expected = """"builtin.module"() ({
   %0 = "arith.constant"() {"value" = true} : () -> i1
   "scf.if"(%0) ({
+  ^0:
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()"""
 
@@ -651,7 +657,9 @@ def test_block_argument_insertion():
     prog = """"builtin.module"() ({
   %0 = "arith.constant"() {"value" = true} : () -> i1
   "scf.if"(%0) ({
+  ^0:
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()"""
 
@@ -660,6 +668,7 @@ def test_block_argument_insertion():
   "scf.if"(%0) ({
   ^0(%1 : i32):
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()"""
 
@@ -684,6 +693,7 @@ def test_inline_block_before_matched_op():
   "scf.if"(%0) ({
     %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()"""
 
@@ -691,7 +701,9 @@ def test_inline_block_before_matched_op():
   %0 = "arith.constant"() {"value" = true} : () -> i1
   %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   "scf.if"(%0) ({
+  ^0:
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()"""
 
@@ -717,8 +729,10 @@ def test_inline_block_before():
     "scf.if"(%0) ({
       %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
     }, {
+    ^1:
     }) : (i1) -> ()
   }, {
+  ^2:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -728,9 +742,12 @@ def test_inline_block_before():
   "scf.if"(%0) ({
     %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
     "scf.if"(%0) ({
+    ^0:
     }, {
+    ^1:
     }) : (i1) -> ()
   }, {
+  ^2:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -759,6 +776,7 @@ def test_inline_block_at_before_when_op_is_matched_op():
   "scf.if"(%0) ({
     %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -767,7 +785,9 @@ def test_inline_block_at_before_when_op_is_matched_op():
   %0 = "arith.constant"() {"value" = true} : () -> i1
   %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   "scf.if"(%0) ({
+  ^0:
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -794,8 +814,10 @@ def test_inline_block_after():
     "scf.if"(%0) ({
       %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
     }, {
+      ^1:
     }) : (i1) -> ()
   }, {
+  ^2:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -804,10 +826,13 @@ def test_inline_block_after():
   %0 = "arith.constant"() {"value" = true} : () -> i1
   "scf.if"(%0) ({
     "scf.if"(%0) ({
+    ^0:
     }, {
+    ^1:
     }) : (i1) -> ()
     %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   }, {
+  ^2:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -837,8 +862,10 @@ def test_inline_block_after_matched():
     "scf.if"(%0) ({
       %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
     }, {
+    ^0:
     }) : (i1) -> ()
   }, {
+  ^1:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -847,9 +874,12 @@ def test_inline_block_after_matched():
   %0 = "arith.constant"() {"value" = true} : () -> i1
   "scf.if"(%0) ({
     "scf.if"(%0) ({
+    ^0:
     }, {
+    ^1:
     }) : (i1) -> ()
   }, {
+  ^2:
   }) : (i1) -> ()
   %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
 }) : () -> ()
@@ -889,6 +919,7 @@ def test_move_region_contents_to_new_regions():
   "scf.if"(%0) ({
     %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   }, {
+  ^0:
   }) : (i1) -> ()
 }) : () -> ()
 """

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -39,6 +39,7 @@ def test_operation_deletion():
 
     expected = """\
 "builtin.module"() ({
+^0:
 }) : () -> ()"""
 
     def transformation(module: ModuleOp, rewriter: Rewriter) -> None:
@@ -145,6 +146,7 @@ def test_inline_block_at_end():
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = true} : () -> i1
   "scf.if"(%0) ({
+  ^0:
   }) : (i1) -> ()
   %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
 }) : () -> ()
@@ -178,6 +180,7 @@ def test_inline_block_before():
   %0 = "arith.constant"() {"value" = true} : () -> i1
   %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   "scf.if"(%0) ({
+  ^0:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -209,6 +212,7 @@ def test_inline_block_after():
   %0 = "arith.constant"() {"value" = true} : () -> i1
   %1 = "arith.constant"() {"value" = 2 : i32} : () -> i32
   "scf.if"(%0) ({
+  ^0:
   }) : (i1) -> ()
 }) : () -> ()
 """
@@ -256,9 +260,8 @@ def test_insert_block2():
 
     expected = """\
 "builtin.module"() ({
-^0:
   %0 = "arith.constant"() {"value" = true} : () -> i1
-^1:
+^0:
 }) : () -> ()
 """
 
@@ -302,9 +305,8 @@ def test_insert_block_after():
 
     expected = """\
 "builtin.module"() ({
-^0:
   %0 = "arith.constant"() {"value" = true} : () -> i1
-^1:
+^0:
 }) : () -> ()
 """
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1260,6 +1260,11 @@ class ModuleOp(IRDLOperation):
         if attributes is not None:
             attributes = attributes.data
         region = parser.parse_region()
+
+        # Add a block if the region is empty
+        if len(region.blocks) == 0:
+            region.add_block(Block())
+
         return ModuleOp(region, attributes)
 
     def print(self, printer: Printer) -> None:
@@ -1267,7 +1272,13 @@ class ModuleOp(IRDLOperation):
             printer.print(" attributes {")
             printer.print_dictionary(self.attributes, printer.print, printer.print)
             printer.print("}")
-        printer.print(" ", self.body)
+
+        if self.body.block.is_empty:
+            # Do not print the entry block if the region has an empty block
+            printer.print(" {\n")
+            printer.print("}")
+        else:
+            printer.print(" ", self.body)
 
 
 # FloatXXType shortcuts

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -161,9 +161,10 @@ class FuncOp(IRDLOperation):
     @property
     def is_declaration(self) -> bool:
         """
-        A helper to identify functions that are external declarations (have an empty function body)
+        A helper to identify functions that are external declarations (have an empty
+        function body)
         """
-        return self.body.block.is_empty
+        return len(self.body.blocks) == 0
 
 
 @irdl_op_definition

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -33,11 +33,12 @@ class FuncOp(IRDLOperation):
     sym_visibility: OptOpAttr[StringAttr]
 
     def verify_(self) -> None:
+        # If this is an empty region (external function), then return
+        if len(self.body.blocks) == 0:
+            return
+
         # TODO: how to verify that there is a terminator?
         entry_block: Block = self.body.blocks[0]
-        # If this is an empty block (external function) then return
-        if len(entry_block.args) == 0 and entry_block.is_empty:
-            return
         block_arg_types = [arg.typ for arg in entry_block.args]
         if self.function_type.inputs.data != tuple(block_arg_types):
             raise VerifyException(
@@ -74,7 +75,7 @@ class FuncOp(IRDLOperation):
             "function_type": type_attr,
             "sym_visibility": StringAttr("private"),
         }
-        op = FuncOp.build(attributes=attributes, regions=[Region([Block()])])
+        op = FuncOp.build(attributes=attributes, regions=[Region()])
         return op
 
     @staticmethod

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -265,6 +265,10 @@ class Printer:
         if not isinstance(block, Block):
             raise TypeError("Expected a Block; got %s" % type(block).__name__)
 
+        # Print block name if it is empty
+        if block.is_empty:
+            print_block_name = True
+
         print_block_args = len(block.args) > 0
         if print_block_args or print_block_name:
             self._print_new_line()
@@ -297,11 +301,9 @@ class Printer:
         if not isinstance(region, Region):
             raise TypeError("Expected a Region; got %s" % type(region).__name__)
 
-        print_block_name = len(region.blocks) != 1
-
         self.print("{")
-        for block in region.blocks:
-            self.print_block(block, print_block_name=print_block_name)
+        for idx, block in enumerate(region.blocks):
+            self.print_block(block, print_block_name=(idx != 0))
         self._print_new_line()
         self.print("}")
 


### PR DESCRIPTION
Previously, both empty regions and regions with an empty block were parsed and printed the same.
I rewrote the region  parser with the lexer, and now follow the same syntax as MLIR.
Additionally, I fixed a bug in `func` that was relying on the printing of empty regions.

Empty region:
```
{}
```

Region with empty block:
```
{
^bb0:
}
```

Region with a non-empty block:
```
{
  "test.op"() : () -> ()
}
```