### PR TITLE
dialects: add llvm.cconv attribute

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -154,6 +154,18 @@ def test_linkage_attr_unknown_str():
         llvm.LinkageAttr("unknown")
 
 
+def test_cconv_attr():
+    cconv = llvm.CConvAttr("c 999")
+
+    assert isinstance(cconv.cconv, builtin.StringAttr)
+    assert cconv.cconv.data == "c 999"
+
+
+def test_cconv_attr_unknown_str():
+    with pytest.raises(VerifyException):
+        llvm.CConvAttr("unknown")
+
+
 def test_global_op():
     global_op = llvm.GlobalOp.get(
         builtin.i32,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -222,7 +222,6 @@ class LinkageAttr(ParametrizedAttribute):
             raise VerifyException(f"Specified linkage '{self.linkage.data}' is unknown")
 
 
-
 _ALLOWED_CCONV_RE = re.compile(
     "|".join(
         [


### PR DESCRIPTION
This PR adds the [`llvm.cconv`](https://llvm.org/docs/LangRef.html#calling-conventions) attribute to the LLVM dialect.

**WIP**: this is a first step towards having xDSL lowering (extern) function calls down to LLVM.