### PR TITLE
dialects: Add custom syntax for stencil.index

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -3,6 +3,7 @@ import pytest
 from xdsl.dialects.builtin import (
     AnyFloat,
     FloatAttr,
+    IntAttr,
     IntegerAttr,
     bf16,
     f16,
@@ -216,9 +217,9 @@ def test_stencil_apply_no_results():
         ([1, 2, 3]),
         (
             [
-                IntegerAttr[IntegerType](1, 64),
-                IntegerAttr[IntegerType](2, 64),
-                IntegerAttr[IntegerType](3, 64),
+                IntAttr(1),
+                IntAttr(2),
+                IntAttr(3),
             ]
         ),
     ),
@@ -226,10 +227,7 @@ def test_stencil_apply_no_results():
 def test_create_index_attr_from_int_list(indices: list[int]):
     stencil_index_attr = IndexAttr.get(*indices)
     expected_array_attr = ArrayAttr(
-        [
-            (IntegerAttr[IntegerType](idx, 64) if isinstance(idx, int) else idx)
-            for idx in indices
-        ]
+        [(IntAttr(idx) if isinstance(idx, int) else idx) for idx in indices]
     )
 
     assert stencil_index_attr.array == expected_array_attr
@@ -270,9 +268,7 @@ def test_index_attr_size_from_bounds(indices1: list[int], indices2: list[int]):
 def test_index_attr_neg(indices: list[int]):
     stencil_index_attr = IndexAttr.get(*indices)
     stencil_index_attr_neg = -stencil_index_attr
-    expected_array_attr = ArrayAttr(
-        [(IntegerAttr[IntegerType](-idx, 64)) for idx in indices]
-    )
+    expected_array_attr = ArrayAttr([(IntAttr(-idx)) for idx in indices])
 
     assert stencil_index_attr_neg.array == expected_array_attr
 
@@ -287,10 +283,7 @@ def test_index_attr_add(indices1: list[int], indices2: list[int]):
 
     stencil_index_attr_add = stencil_index_attr1 + stencil_index_attr2
     expected_array_attr = ArrayAttr(
-        [
-            (IntegerAttr[IntegerType](idx1 + idx2, 64))
-            for idx1, idx2 in zip(indices1, indices2)
-        ]
+        [(IntAttr(idx1 + idx2)) for idx1, idx2 in zip(indices1, indices2)]
     )
 
     assert stencil_index_attr_add.array == expected_array_attr
@@ -306,10 +299,7 @@ def test_index_attr_sub(indices1: list[int], indices2: list[int]):
 
     stencil_index_attr_sub = stencil_index_attr1 - stencil_index_attr2
     expected_array_attr = ArrayAttr(
-        [
-            (IntegerAttr[IntegerType](idx1 - idx2, 64))
-            for idx1, idx2 in zip(indices1, indices2)
-        ]
+        [(IntAttr(idx1 - idx2)) for idx1, idx2 in zip(indices1, indices2)]
     )
 
     assert stencil_index_attr_sub.array == expected_array_attr
@@ -325,10 +315,7 @@ def test_index_attr_min(indices1: list[int], indices2: list[int]):
 
     stencil_index_attr_min = IndexAttr.min(stencil_index_attr1, stencil_index_attr2)
     expected_array_attr = ArrayAttr(
-        [
-            (IntegerAttr[IntegerType](min(idx1, idx2), 64))
-            for idx1, idx2 in zip(indices1, indices2)
-        ]
+        [(IntAttr(min(idx1, idx2))) for idx1, idx2 in zip(indices1, indices2)]
     )
 
     assert stencil_index_attr_min.array == expected_array_attr
@@ -344,10 +331,7 @@ def test_index_attr_max(indices1: list[int], indices2: list[int]):
 
     stencil_index_attr_max = IndexAttr.max(stencil_index_attr1, stencil_index_attr2)
     expected_array_attr = ArrayAttr(
-        [
-            (IntegerAttr[IntegerType](max(idx1, idx2), 64))
-            for idx1, idx2 in zip(indices1, indices2)
-        ]
+        [(IntAttr(max(idx1, idx2))) for idx1, idx2 in zip(indices1, indices2)]
     )
 
     assert stencil_index_attr_max.array == expected_array_attr
@@ -465,11 +449,11 @@ def test_stencil_load_bounds():
     assert isinstance(load.lb, IndexAttr)
     assert len(load.lb.array) == 2
     for my_val, load_val in zip(lb.array.data, load.lb.array):
-        assert my_val.value.data == load_val.value.data
+        assert my_val.data == load_val.data
     assert isinstance(load.ub, IndexAttr)
     assert len(load.ub.array) == 2
     for my_val, load_val in zip(ub.array.data, load.ub.array):
-        assert my_val.value.data == load_val.value.data
+        assert my_val.data == load_val.data
 
 
 @pytest.mark.parametrize(

--- a/tests/filecheck/dialects/stencil/copy.mlir
+++ b/tests/filecheck/dialects/stencil/copy.mlir
@@ -3,16 +3,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i32, -4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i32, -4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
+    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
+    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
     %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
     %5 = "stencil.apply"(%4) ({
     ^1(%6 : !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>):
-      %7 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, 0 : i32, 0 : i32]>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> f64
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> f64
       %8 = "stencil.store_result"(%7) : (f64) -> !stencil.result<f64>
       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
-    "stencil.store"(%5, %3) {"lb" = #stencil.index<[0 : i32, 0 : i32, 0 : i32]>, "ub" = #stencil.index<[64 : i32, 64 : i32, 64 : i32]>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> ()
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> ()
     "func.return"() : () -> ()
   }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
@@ -20,16 +20,16 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i32, -4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i32, -4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
 // CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
 // CHECK-NEXT:     ^1(%6 : !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, 0 : i32, 0 : i32]>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> f64
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> f64
 // CHECK-NEXT:       %8 = "stencil.store_result"(%7) : (f64) -> !stencil.result<f64>
 // CHECK-NEXT:       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<[0 : i32, 0 : i32, 0 : i32]>, "ub" = #stencil.index<[64 : i32, 64 : i32, 64 : i32]>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> ()
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -3,17 +3,17 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %2 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
     %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
     %7, %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -22,7 +22,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19, %18) : (f64, f64) -> ()
     }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>)
-    "stencil.store"(%7, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    "stencil.store"(%7, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -3,16 +3,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
     %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -21,7 +21,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0: i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_inference.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_inference.mlir
@@ -4,16 +4,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
     %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -22,7 +22,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0: i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
@@ -31,16 +31,16 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<[-1 : i64, -1 : i64, 0 : i64]>, "ub" = #stencil.index<[65 : i64, 65 : i64, 64 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[66 : i64, 66 : i64, 64 : i64], f64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<-1, -1, 0>, "ub" = #stencil.index<65, 65, 64>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[66 : i64, 66 : i64, 64 : i64], f64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
 // CHECK-NEXT:     ^1(%6 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
 // CHECK-NEXT:       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
 // CHECK-NEXT:       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
 // CHECK-NEXT:       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -48,8 +48,8 @@
 // CHECK-NEXT:       %15 = "arith.mulf"(%11, %cst) : (f64, f64) -> f64
 // CHECK-NEXT:       %16 = "arith.addf"(%15, %14) : (f64, f64) -> f64
 // CHECK-NEXT:       "stencil.return"(%16) : (f64) -> ()
-// CHECK-NEXT:     }) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[66 : i64, 66 : i64, 64 : i64], f64>) -> !stencil.temp<[64 : i64, 64 : i64, 64 : i64], f64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[64 : i64, 64 : i64, 64 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+// CHECK-NEXT:     }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[66 : i64, 66 : i64, 64 : i64], f64>) -> !stencil.temp<[64 : i64, 64 : i64, 64 : i64], f64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[64 : i64, 64 : i64, 64 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
@@ -3,16 +3,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[68 : i64, 68 : i64, 68 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[68 : i64, 68 : i64, 68 : i64], f64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
     %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -21,9 +21,9 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0: i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
-// CHECK: The stencil computation requires a field with lower bound at least #stencil.index<[-1 : i64, -1 : i64, 0 : i64]>, got #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, min: #stencil.index<[-1 : i64, -1 : i64, 0 : i64]>
+// CHECK: The stencil computation requires a field with lower bound at least #stencil.index<-1, -1, 0>, got #stencil.index<0, 0, 0>, min: #stencil.index<-1, -1, 0>

--- a/tests/filecheck/dialects/stencil/heat_stencil.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil.mlir
@@ -21,27 +21,27 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
       %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[50 : i64, 80 : i64, 40 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -157,7 +157,7 @@
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
       }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[50 : i64, 80 : i64, 40 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()
@@ -188,27 +188,27 @@
 // CHECK-NEXT:      %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:      %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
 // CHECK-NEXT:      %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:      %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
 // CHECK-NEXT:      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
 // CHECK-NEXT:      %7 = "stencil.apply"(%6) ({
 // CHECK-NEXT:      ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-// CHECK-NEXT:        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
 // CHECK-NEXT:        %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:        %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
 // CHECK-NEXT:        %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -324,7 +324,7 @@
 // CHECK-NEXT:        %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
 // CHECK-NEXT:        "stencil.return"(%115) : (f32) -> ()
 // CHECK-NEXT:      }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[50 : i64, 80 : i64, 40 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> ()
+// CHECK-NEXT:      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> ()
 // CHECK-NEXT:      "scf.yield"() : () -> ()
 // CHECK-NEXT:    }) : (index, index, index) -> ()
 // CHECK-NEXT:    "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
@@ -21,27 +21,27 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
       %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[50 : i64, 80 : i64, 40 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -157,7 +157,7 @@
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
       }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[50 : i64, 80 : i64, 40 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()
@@ -185,27 +185,27 @@
 // CHECK-NEXT:       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
 // CHECK-NEXT:       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
-// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<[-2 : i64, -2 : i64, -2 : i64]>, "ub" = #stencil.index<[52 : i64, 82 : i64, 42 : i64]>} : (!stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> !stencil.temp<[54 : i64, 84 : i64, 44 : i64], f32>
+// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<-2, -2, -2>, "ub" = #stencil.index<52, 82, 42>} : (!stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> !stencil.temp<[54 : i64, 84 : i64, 44 : i64], f32>
 // CHECK-NEXT:       %7 = "stencil.apply"(%6) ({
 // CHECK-NEXT:       ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-// CHECK-NEXT:         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:         %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
 // CHECK-NEXT:         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
 // CHECK-NEXT:         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -320,8 +320,8 @@
 // CHECK-NEXT:         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
 // CHECK-NEXT:         "stencil.return"(%115) : (f32) -> ()
-// CHECK-NEXT:       }) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[50 : i64, 80 : i64, 40 : i64]>} : (!stencil.temp<[54 : i64, 84 : i64, 44 : i64], f32>) -> !stencil.temp<[50 : i64, 80 : i64, 40 : i64], f32>
-// CHECK-NEXT:       "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[50 : i64, 80 : i64, 40 : i64]>} : (!stencil.temp<[50 : i64, 80 : i64, 40 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> ()
+// CHECK-NEXT:       }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[54 : i64, 84 : i64, 44 : i64], f32>) -> !stencil.temp<[50 : i64, 80 : i64, 40 : i64], f32>
+// CHECK-NEXT:       "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[50 : i64, 80 : i64, 40 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) : (index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -21,27 +21,27 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[54 : i64, 84 : i64, 44 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
       %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[50 : i64, 80 : i64, 40 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[-2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[2 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, -2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 2 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, -2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<[0 : i64, 0 : i64, 2 : i64]>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -157,7 +157,7 @@
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
       }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[50 : i64, 80 : i64, 40 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/laplace.mlir
+++ b/tests/filecheck/dialects/stencil/laplace.mlir
@@ -3,16 +3,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32], f64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
+    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
+    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
     %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32], f64>) -> !stencil.temp<[66 : i32, 66 : i32], f64>
     %5 = "stencil.apply"(%4) ({
     ^1(%6 : !stencil.temp<[66 : i32, 66 : i32], f64>):
-      %7 = "stencil.access"(%6) {"offset" = #stencil.index<[-1 : i32, 0 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %8 = "stencil.access"(%6) {"offset" = #stencil.index<[1 : i32, 0 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %9 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, 1 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %10 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, -1 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %11 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, 0 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+      %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+      %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+      %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -21,7 +21,7 @@
       %17 = "arith.mulf"(%16, %13) : (f64, f64) -> f64
       "stencil.return"(%17) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32], f64>
-    "stencil.store"(%5, %3) {"lb" = #stencil.index<[0 : i32, 0 : i32]>, "ub" = #stencil.index<[64 : i32, 64 : i32]>} : (!stencil.temp<[64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32], f64>) -> ()
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32], f64>) -> ()
     "func.return"() : () -> ()
   }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<[-1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
@@ -29,16 +29,16 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<[-1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32], f64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i32, -4 : i32]>, "ub" = #stencil.index<[68 : i32, 68 : i32]>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
 // CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32], f64>) -> !stencil.temp<[66 : i32, 66 : i32], f64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
 // CHECK-NEXT:     ^1(%6 : !stencil.temp<[66 : i32, 66 : i32], f64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<[-1 : i32, 0 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<[1 : i32, 0 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, 1 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, -1 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<[0 : i32, 0 : i32]>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
 // CHECK-NEXT:       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
 // CHECK-NEXT:       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
 // CHECK-NEXT:       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -47,7 +47,7 @@
 // CHECK-NEXT:       %17 = "arith.mulf"(%16, %13) : (f64, f64) -> f64
 // CHECK-NEXT:       "stencil.return"(%17) : (f64) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32], f64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<[0 : i32, 0 : i32]>, "ub" = #stencil.index<[64 : i32, 64 : i32]>} : (!stencil.temp<[64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32], f64>) -> ()
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32], f64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<[-1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
@@ -3,27 +3,27 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : f64, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %2 = "stencil.cast"(%1) {"lb" = #stencil.index<[-3 : i64, -3 : i64, -3 : i64]>, "ub" = #stencil.index<[67 : i64, 67 : i64, 67 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[70 : i64, 70 : i64, 70 : i64], f64>
+    %2 = "stencil.cast"(%1) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[70 : i64, 70 : i64, 70 : i64], f64>
     %3 = "stencil.apply"(%0) ({
     ^1(%4 : f64):
       %5 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
       %6 = "arith.addf"(%4, %5) : (f64, f64) -> f64
       "stencil.return"(%6) : (!stencil.result<f64>) -> ()
     }) : (f64) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%3, %2) {"lb" = #stencil.index<[1 : i64, 2 : i64, 3: i64]>, "ub" = #stencil.index<[65 : i64, 66 : i64, 63 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[64 : i64, 64 : i64, 60 : i64], f64>) -> ()
+    "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[64 : i64, 64 : i64, 60 : i64], f64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (f64, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_float64_arg"} : () -> ()
 
   "func.func"() ({
   ^2(%7 : f32, %8 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>):
-    %9 = "stencil.cast"(%8) {"lb" = #stencil.index<[-3 : i64, -3 : i64, -3 : i64]>, "ub" = #stencil.index<[67 : i64, 67 : i64, 67 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[70 : i64, 70 : i64, 70 : i64], f32>
+    %9 = "stencil.cast"(%8) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[70 : i64, 70 : i64, 70 : i64], f32>
     %10 = "stencil.apply"(%7) ({
     ^3(%11 : f32):
       %12 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
       %13 = "arith.addf"(%11, %12) : (f32, f32) -> f32
       "stencil.return"(%13) : (f32) -> ()
     }) : (f32) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-    "stencil.store"(%10, %9) {"lb" = #stencil.index<[1 : i64, 2 : i64, 3 : i64]>, "ub" = #stencil.index<[65 : i64, 66 : i64, 63 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[70 : i64, 70 : i64, 70 : i64], f32>) -> ()
+    "stencil.store"(%10, %9) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[70 : i64, 70 : i64, 70 : i64], f32>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (f32, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> (), "sym_name" = "stencil_float32_arg"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
@@ -3,12 +3,12 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64]>, "ub" = #stencil.index<[68 : i64]>} : (!stencil.field<[-1 : i64], f64>) -> !stencil.field<[72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<[-4 : i64]>, "ub" = #stencil.index<[68 : i64]>} : (!stencil.field<[72 : i64], f64>) -> !stencil.temp<[72 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<[-1 : i64], f64>) -> !stencil.field<[72 : i64], f64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<[72 : i64], f64>) -> !stencil.temp<[72 : i64], f64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[72 : i64], f64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[72 : i64], f64>) -> f64
-        }) {"lb" = #stencil.index<[0 : i64]>, "ub" = #stencil.index<[68 : i64]>} : (!stencil.temp<[72 : i64], f64>) -> ()
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64], f64>) -> f64
+        }) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<[72 : i64], f64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -3,12 +3,12 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64], f64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64], f64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[72 : i64, 72 : i64], f64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64], f64>) -> f64
-        }) {"lb" = #stencil.index<[0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 68 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64], f64>) -> ()
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64, 72 : i64], f64>) -> f64
+        }) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 68>} : (!stencil.temp<[72 : i64, 72 : i64], f64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -3,12 +3,12 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 70 : i64, 72 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 74 : i64, 76 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 70 : i64, 72 : i64]>} : (!stencil.field<[72 : i64, 74 : i64, 76 : i64], f64>) -> !stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 74 : i64, 76 : i64], f64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<[72 : i64, 74 : i64, 76 : i64], f64>) -> !stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>) -> f64
-        }) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 68 : i64]>} : (!stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>) -> ()
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>) -> f64
+        }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 68>} : (!stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -3,11 +3,11 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>):
-        }) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+        }) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64]>, "ub" = #stencil.index<[68 : i64]>} : (!stencil.field<[-1 : i64], f64>) -> !stencil.field<[72 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<[-1 : i64], f64>) -> !stencil.field<[72 : i64], f64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -3,15 +3,15 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %6 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
         %2 = "stencil.load"(%1) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
         %8 = "stencil.apply"(%2) ({
         ^b0(%4: !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>):
-            %5 = "stencil.access"(%4) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 1 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> f64
+            %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> f64
             "stencil.return"(%5) : (f64) -> ()
         }) : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>)
-        "stencil.store"(%8, %7) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+        "stencil.store"(%8, %7) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -3,16 +3,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %6 = "stencil.load"(%3) {"lb" = #stencil.index<[-4 : i64, -4 : i64, -4 : i64]>, "ub" = #stencil.index<[68 : i64, 68 : i64, 68 : i64]>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    %6 = "stencil.load"(%3) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<[-1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<[1 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, -1 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -20,8 +20,8 @@
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
-    }) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0 : i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<[0 : i64, 0 : i64, 0: i64]>, "ub" = #stencil.index<[64 : i64, 64 : i64, 64 : i64]>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -34,6 +34,8 @@ from xdsl.irdl import (
     Block,
     IRDLOperation,
 )
+from xdsl.parser import Parser
+from xdsl.printer import Printer
 from xdsl.utils.hints import isa
 
 
@@ -132,6 +134,17 @@ class IndexAttr(ParametrizedAttribute, Iterable[int]):
     name = "stencil.index"
 
     array: ParameterDef[ArrayAttr[IntAttr]]
+
+    @staticmethod
+    def parse_parameters(parser: Parser) -> list[Attribute]:
+        """Parse the attribute parameters."""
+        ints = parser.parse_comma_separated_list(
+            parser.Delimiter.ANGLE, lambda: parser.parse_integer(allow_boolean=False)
+        )
+        return [ArrayAttr((IntAttr(i) for i in ints))]
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print(f'<{", ".join((str(e.data) for e in self.array.data))}>')
 
     def verify(self) -> None:
         if len(self.array.data) < 1 or len(self.array.data) > 3:

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -145,8 +145,8 @@ class ReturnOpToMemref(RewritePattern):
 
 
 def verify_load_bounds(cast: CastOp, load: LoadOp):
-    if [i.value.data for i in IndexAttr.min(cast.lb, load.lb).array.data] != [
-        i.value.data for i in cast.lb.array.data
+    if [i.data for i in IndexAttr.min(cast.lb, load.lb).array.data] != [
+        i.data for i in cast.lb.array.data
     ]:  # noqa
         raise VerifyException(
             "The stencil computation requires a field with lower bound at least "
@@ -194,8 +194,8 @@ class LoadOpToMemref(RewritePattern):
         element_type = cast.result.typ.element_type
         shape = [i.value.data for i in cast.result.typ.shape.data]
 
-        offsets = [i.value.data for i in (op.lb - cast.lb).array.data]
-        sizes = [i.value.data for i in (op.ub - op.lb).array.data]
+        offsets = [i.data for i in (op.lb - cast.lb).array.data]
+        sizes = [i.data for i in (op.ub - op.lb).array.data]
         strides = [1] * len(sizes)
 
         subview = memref.Subview.from_static_parameters(
@@ -279,7 +279,7 @@ class AccessOpToMemref(RewritePattern):
 
         memref_offset = (op.offset - load.lb).array.data
         off_const_ops = [
-            arith.Constant.from_int_and_width(x.value.data, builtin.IndexType())
+            arith.Constant.from_int_and_width(x.data, builtin.IndexType())
             for x in memref_offset
         ]
 
@@ -319,8 +319,8 @@ class StencilTypeConversionFuncOp(RewritePattern):
             assert isa(cast.result.typ, FieldType[Attribute])
             new_cast = cast.clone()
             source_shape = [i.value.data for i in cast.result.typ.shape.data]
-            offsets = [i.value.data for i in (store.lb - cast.lb).array.data]
-            sizes = [i.value.data for i in (store.ub - store.lb).array.data]
+            offsets = [i.data for i in (store.lb - cast.lb).array.data]
+            sizes = [i.data for i in (store.ub - store.lb).array.data]
             subview = memref.Subview.from_static_parameters(
                 new_cast.result,
                 cast.result.typ.element_type,

--- a/xdsl/transforms/experimental/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/stencil_global_to_local.py
@@ -276,10 +276,10 @@ class ChangeStoreOpSizes(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: stencil.StoreOp, rewriter: PatternRewriter, /):
         assert all(
-            integer_attr.value.data == 0 for integer_attr in op.lb.array.data
+            integer_attr.data == 0 for integer_attr in op.lb.array.data
         ), "lb must be 0"
         shape: tuple[int, ...] = tuple(
-            (integer_attr.value.data for integer_attr in op.ub.array.data)
+            (integer_attr.data for integer_attr in op.ub.array.data)
         )
         new_shape = self.strategy.calc_resize(shape)
         op.ub = stencil.IndexAttr.get(*new_shape)


### PR DESCRIPTION
This PR adds custom syntax to `stencil.index` for readability (and switch it to using IntAttr).
The meaningful changes are in`xdsl/`, the rest is all filechecks and pytests updates!