### PR TITLE
dialects: Add custom syntax to stencil types

### DIFF
--- a/tests/filecheck/dialects/stencil/copy.mlir
+++ b/tests/filecheck/dialects/stencil/copy.mlir
@@ -2,34 +2,34 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
-    %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
+  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %4 = "stencil.load"(%2) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<64x64x64xf64>
     %5 = "stencil.apply"(%4) ({
-    ^1(%6 : !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>):
-      %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> f64
+    ^1(%6 : !stencil.temp<64x64x64xf64>):
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<64x64x64xf64>) -> f64
       %8 = "stencil.store_result"(%7) : (f64) -> !stencil.result<f64>
       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
-    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> ()
+    }) : (!stencil.temp<64x64x64xf64>) -> !stencil.temp<64x64x64xf64>
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<64x64x64xf64>, !stencil.field<72x72x72xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+  }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
-// CHECK-NEXT:   ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
+// CHECK-NEXT:   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<64x64x64xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^1(%6 : !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> f64
+// CHECK-NEXT:     ^1(%6 : !stencil.temp<64x64x64xf64>):
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<64x64x64xf64>) -> f64
 // CHECK-NEXT:       %8 = "stencil.store_result"(%7) : (f64) -> !stencil.result<f64>
 // CHECK-NEXT:       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[64 : i32, 64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32, 72 : i32], f64>) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<64x64x64xf64>) -> !stencil.temp<64x64x64xf64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<64x64x64xf64>, !stencil.field<72x72x72xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
-// CHECK-NEXT:   }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:   }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -2,18 +2,18 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %2 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>, %2 : !stencil.field<?x?x?xf64>):
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
     %7, %8 = "stencil.apply"(%6) ({
-    ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+    ^1(%9 : !stencil.temp<?x?x?xf64>):
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -21,10 +21,10 @@
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19, %18) : (f64, f64) -> ()
-    }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>)
-    "stencil.store"(%7, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    }) : (!stencil.temp<?x?x?xf64>) -> (!stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>)
+    "stencil.store"(%7, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+  }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -2,17 +2,17 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
-    ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+    ^1(%9 : !stencil.temp<?x?x?xf64>):
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -20,10 +20,10 @@
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+  }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/hdiff_inference.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_inference.mlir
@@ -3,17 +3,17 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
-    ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+    ^1(%9 : !stencil.temp<?x?x?xf64>):
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -21,26 +21,26 @@
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+  }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
-// CHECK-NEXT:   ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<-1, -1, 0>, "ub" = #stencil.index<65, 65, 64>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[66 : i64, 66 : i64, 64 : i64], f64>
+// CHECK-NEXT:   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<-1, -1, 0>, "ub" = #stencil.index<65, 65, 64>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<66x66x64xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^1(%6 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+// CHECK-NEXT:     ^1(%6 : !stencil.temp<?x?x?xf64>):
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
 // CHECK-NEXT:       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
 // CHECK-NEXT:       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
 // CHECK-NEXT:       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -48,8 +48,8 @@
 // CHECK-NEXT:       %15 = "arith.mulf"(%11, %cst) : (f64, f64) -> f64
 // CHECK-NEXT:       %16 = "arith.addf"(%15, %14) : (f64, f64) -> f64
 // CHECK-NEXT:       "stencil.return"(%16) : (f64) -> ()
-// CHECK-NEXT:     }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[66 : i64, 66 : i64, 64 : i64], f64>) -> !stencil.temp<[64 : i64, 64 : i64, 64 : i64], f64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[64 : i64, 64 : i64, 64 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+// CHECK-NEXT:     }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<66x66x64xf64>) -> !stencil.temp<64x64x64xf64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<64x64x64xf64>, !stencil.field<72x72x72xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
-// CHECK-NEXT:   }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+// CHECK-NEXT:   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
@@ -2,17 +2,17 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[68 : i64, 68 : i64, 68 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %6 = "stencil.load"(%3) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<68x68x68xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
-    ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+    ^1(%9 : !stencil.temp<?x?x?xf64>):
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -20,10 +20,10 @@
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+  }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
 // CHECK: The stencil computation requires a field with lower bound at least #stencil.index<-1, -1, 0>, got #stencil.index<0, 0, 0>, min: #stencil.index<-1, -1, 0>

--- a/tests/filecheck/dialects/stencil/heat_stencil.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil.mlir
@@ -20,28 +20,28 @@
       %t1 = "arith.remsi"(%5, %1) : (i64, i64) -> i64
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
-      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[50 : i64, 80 : i64, 40 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
+      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<50x80x40xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
-      ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+      ^2(%t0_buff : !stencil.temp<?xf32>):
+        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?xf32>) -> f32
+        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?xf32>) -> f32
+        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<?xf32>) -> f32
+        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<?xf32>) -> f32
+        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<?xf32>) -> f32
+        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<?xf32>) -> f32
+        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<?xf32>) -> f32
+        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<?xf32>) -> f32
         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -156,8 +156,8 @@
         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
-      }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
+      }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()
@@ -187,28 +187,28 @@
 // CHECK-NEXT:      %t1 = "arith.remsi"(%5, %1) : (i64, i64) -> i64
 // CHECK-NEXT:      %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:      %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-// CHECK-NEXT:      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+// CHECK-NEXT:      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
 // CHECK-NEXT:      %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:      %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-// CHECK-NEXT:      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
-// CHECK-NEXT:      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
+// CHECK-NEXT:      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+// CHECK-NEXT:      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<58x88x48xf32>) -> !stencil.temp<?x?x?xf32>
 // CHECK-NEXT:      %7 = "stencil.apply"(%6) ({
-// CHECK-NEXT:      ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-// CHECK-NEXT:        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:      ^2(%t0_buff : !stencil.temp<?xf32>):
+// CHECK-NEXT:        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<?xf32>) -> f32
 // CHECK-NEXT:        %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:        %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
 // CHECK-NEXT:        %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -323,8 +323,8 @@
 // CHECK-NEXT:        %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:        %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
 // CHECK-NEXT:        "stencil.return"(%115) : (f32) -> ()
-// CHECK-NEXT:      }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> ()
+// CHECK-NEXT:      }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
+// CHECK-NEXT:      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
 // CHECK-NEXT:      "scf.yield"() : () -> ()
 // CHECK-NEXT:    }) : (index, index, index) -> ()
 // CHECK-NEXT:    "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
@@ -20,28 +20,28 @@
       %t1 = "arith.remsi"(%5, %1) : (i64, i64) -> i64
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
-      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[50 : i64, 80 : i64, 40 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
+      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<50x80x40xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
-      ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+      ^2(%t0_buff : !stencil.temp<?xf32>):
+        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?xf32>) -> f32
+        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?xf32>) -> f32
+        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<?xf32>) -> f32
+        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<?xf32>) -> f32
+        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<?xf32>) -> f32
+        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<?xf32>) -> f32
+        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<?xf32>) -> f32
+        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<?xf32>) -> f32
         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -156,8 +156,8 @@
         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
-      }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
+      }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()
@@ -184,28 +184,28 @@
 // CHECK-NEXT:       %t1 = "arith.remsi"(%5, %1) : (i64, i64) -> i64
 // CHECK-NEXT:       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-// CHECK-NEXT:       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+// CHECK-NEXT:       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
 // CHECK-NEXT:       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-// CHECK-NEXT:       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
-// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<-2, -2, -2>, "ub" = #stencil.index<52, 82, 42>} : (!stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> !stencil.temp<[54 : i64, 84 : i64, 44 : i64], f32>
+// CHECK-NEXT:       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<-2, -2, -2>, "ub" = #stencil.index<52, 82, 42>} : (!stencil.field<58x88x48xf32>) -> !stencil.temp<54x84x44xf32>
 // CHECK-NEXT:       %7 = "stencil.apply"(%6) ({
-// CHECK-NEXT:       ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-// CHECK-NEXT:         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-// CHECK-NEXT:         %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+// CHECK-NEXT:       ^2(%t0_buff : !stencil.temp<?xf32>):
+// CHECK-NEXT:         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:         %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<?xf32>) -> f32
 // CHECK-NEXT:         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
 // CHECK-NEXT:         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -320,8 +320,8 @@
 // CHECK-NEXT:         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
 // CHECK-NEXT:         "stencil.return"(%115) : (f32) -> ()
-// CHECK-NEXT:       }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[54 : i64, 84 : i64, 44 : i64], f32>) -> !stencil.temp<[50 : i64, 80 : i64, 40 : i64], f32>
-// CHECK-NEXT:       "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[50 : i64, 80 : i64, 40 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>) -> ()
+// CHECK-NEXT:       }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<54x84x44xf32>) -> !stencil.temp<50x80x40xf32>
+// CHECK-NEXT:       "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<50x80x40xf32>, !stencil.field<58x88x48xf32>) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) : (index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -20,28 +20,28 @@
       %t1 = "arith.remsi"(%5, %1) : (i64, i64) -> i64
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
+      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
-      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[58 : i64, 88 : i64, 48 : i64], f32>
-      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[50 : i64, 80 : i64, 40 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
+      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<50x80x40xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
-      ^2(%t0_buff : !stencil.temp<[-1 : i64], f32>):
-        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
-        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-1 : i64], f32>) -> f32
+      ^2(%t0_buff : !stencil.temp<?xf32>):
+        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?xf32>) -> f32
+        %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?xf32>) -> f32
+        %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<?xf32>) -> f32
+        %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<?xf32>) -> f32
+        %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<?xf32>) -> f32
+        %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<?xf32>) -> f32
+        %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<?xf32>) -> f32
+        %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<?xf32>) -> f32
         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -156,8 +156,8 @@
         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
-      }) : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[58 : i64, 88 : i64, 48: i64], f32>) -> ()
+      }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/laplace.mlir
+++ b/tests/filecheck/dialects/stencil/laplace.mlir
@@ -2,17 +2,17 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32], f64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
-    %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32], f64>) -> !stencil.temp<[66 : i32, 66 : i32], f64>
+  ^0(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>):
+    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
+    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
+    %4 = "stencil.load"(%2) : (!stencil.field<72x72xf64>) -> !stencil.temp<66x66xf64>
     %5 = "stencil.apply"(%4) ({
-    ^1(%6 : !stencil.temp<[66 : i32, 66 : i32], f64>):
-      %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+    ^1(%6 : !stencil.temp<66x66xf64>):
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<66x66xf64>) -> f64
+      %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<66x66xf64>) -> f64
+      %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<66x66xf64>) -> f64
+      %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<66x66xf64>) -> f64
+      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<66x66xf64>) -> f64
       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -20,25 +20,25 @@
       %16 = "arith.mulf"(%11, %15) : (f64, f64) -> f64
       %17 = "arith.mulf"(%16, %13) : (f64, f64) -> f64
       "stencil.return"(%17) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32], f64>
-    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32], f64>) -> ()
+    }) : (!stencil.temp<66x66xf64>) -> !stencil.temp<64x64xf64>
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<64x64xf64>, !stencil.field<72x72xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<[-1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+  }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<?x?xf64>, !stencil.field<?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
-// CHECK-NEXT:   ^0(%0 : !stencil.field<[-1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32], f64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i32, -1 : i32], f64>) -> !stencil.field<[72 : i32, 72 : i32], f64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[72 : i32, 72 : i32], f64>) -> !stencil.temp<[66 : i32, 66 : i32], f64>
+// CHECK-NEXT:   ^0(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>):
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<72x72xf64>) -> !stencil.temp<66x66xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^1(%6 : !stencil.temp<[66 : i32, 66 : i32], f64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> f64
+// CHECK-NEXT:     ^1(%6 : !stencil.temp<66x66xf64>):
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<66x66xf64>) -> f64
+// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<66x66xf64>) -> f64
+// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<66x66xf64>) -> f64
+// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<66x66xf64>) -> f64
+// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<66x66xf64>) -> f64
 // CHECK-NEXT:       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
 // CHECK-NEXT:       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
 // CHECK-NEXT:       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -46,8 +46,8 @@
 // CHECK-NEXT:       %16 = "arith.mulf"(%11, %15) : (f64, f64) -> f64
 // CHECK-NEXT:       %17 = "arith.mulf"(%16, %13) : (f64, f64) -> f64
 // CHECK-NEXT:       "stencil.return"(%17) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<[66 : i32, 66 : i32], f64>) -> !stencil.temp<[64 : i32, 64 : i32], f64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[64 : i32, 64 : i32], f64>, !stencil.field<[72 : i32, 72 : i32], f64>) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<66x66xf64>) -> !stencil.temp<64x64xf64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<64x64xf64>, !stencil.field<72x72xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
-// CHECK-NEXT:   }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<[-1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:   }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<?x?xf64>, !stencil.field<?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
@@ -2,30 +2,30 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : f64, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %2 = "stencil.cast"(%1) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[70 : i64, 70 : i64, 70 : i64], f64>
+  ^0(%0 : f64, %1 : !stencil.field<?x?x?xf64>):
+    %2 = "stencil.cast"(%1) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<70x70x70xf64>
     %3 = "stencil.apply"(%0) ({
     ^1(%4 : f64):
       %5 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
       %6 = "arith.addf"(%4, %5) : (f64, f64) -> f64
       "stencil.return"(%6) : (!stencil.result<f64>) -> ()
-    }) : (f64) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[64 : i64, 64 : i64, 60 : i64], f64>) -> ()
+    }) : (f64) -> !stencil.temp<?x?x?xf64>
+    "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<?x?x?xf64>, !stencil.field<64x64x60xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (f64, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_float64_arg"} : () -> ()
+  }) {"function_type" = (f64, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_float64_arg"} : () -> ()
 
   "func.func"() ({
-  ^2(%7 : f32, %8 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>):
-    %9 = "stencil.cast"(%8) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> !stencil.field<[70 : i64, 70 : i64, 70 : i64], f32>
+  ^2(%7 : f32, %8 : !stencil.field<?x?x?xf32>):
+    %9 = "stencil.cast"(%8) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<70x70x70xf32>
     %10 = "stencil.apply"(%7) ({
     ^3(%11 : f32):
       %12 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
       %13 = "arith.addf"(%11, %12) : (f32, f32) -> f32
       "stencil.return"(%13) : (f32) -> ()
-    }) : (f32) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>
-    "stencil.store"(%10, %9) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f32>, !stencil.field<[70 : i64, 70 : i64, 70 : i64], f32>) -> ()
+    }) : (f32) -> !stencil.temp<?x?x?xf32>
+    "stencil.store"(%10, %9) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<?x?x?xf32>, !stencil.field<70x70x70xf32>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (f32, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f32>) -> (), "sym_name" = "stencil_float32_arg"} : () -> ()
+  }) {"function_type" = (f32, !stencil.field<?x?x?xf32>) -> (), "sym_name" = "stencil_float32_arg"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<[-1 : i64], f64>) -> !stencil.field<[72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<[72 : i64], f64>) -> !stencil.temp<[72 : i64], f64>
+    ^0(%0 : !stencil.field<?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<72xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.temp<72xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<[72 : i64], f64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64], f64>) -> f64
-        }) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<[72 : i64], f64>) -> ()
+        ^b0(%3: !stencil.temp<72xf64>):
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72xf64>) -> f64
+        }) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<72xf64>) -> ()
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64], f64>
+    ^0(%0 : !stencil.field<?x?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<72x72xf64>) -> !stencil.temp<72x72xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<[72 : i64, 72 : i64], f64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64, 72 : i64], f64>) -> f64
-        }) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 68>} : (!stencil.temp<[72 : i64, 72 : i64], f64>) -> ()
+        ^b0(%3: !stencil.temp<72x72xf64>):
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72x72xf64>) -> f64
+        }) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 68>} : (!stencil.temp<72x72xf64>) -> ()
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 74 : i64, 76 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<[72 : i64, 74 : i64, 76 : i64], f64>) -> !stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>
+    ^0(%0 : !stencil.field<?x?x?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x74x76xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<72x74x76xf64>) -> !stencil.temp<72x74x76xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>) -> f64
-        }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 68>} : (!stencil.temp<[72 : i64, 74 : i64, 76 : i64], f64>) -> ()
+        ^b0(%3: !stencil.temp<72x74x76xf64>):
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72x74x76xf64>) -> f64
+        }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 68>} : (!stencil.temp<72x74x76xf64>) -> ()
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
+    ^0(%0 : !stencil.field<?x?x?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<72x72x72xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>):
-        }) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+        ^b0(%3: !stencil.temp<72x72x72xf64>):
+        }) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.temp<72x72x72xf64>) -> ()
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<[-1 : i64], f64>) -> !stencil.field<[72 : i64], f64>
+    ^0(%0 : !stencil.field<?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<72xf64>
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
+    ^0(%0 : !stencil.field<?x?x?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %1 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
+  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
     "func.return"() : () -> ()
-  }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+  }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
+    ^0(%0 : !stencil.field<?x?x?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<72x72x72xf64>
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -2,18 +2,18 @@
 
 "builtin.module"() ({
     "func.func"() ({
-    ^0(%0 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, %6 : !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-        %2 = "stencil.load"(%1) : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>
+    ^0(%0 : !stencil.field<?x?x?xf64>, %6 : !stencil.field<?x?x?xf64>):
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+        %2 = "stencil.load"(%1) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<72x72x72xf64>
         %8 = "stencil.apply"(%2) ({
-        ^b0(%4: !stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>):
-            %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> f64
+        ^b0(%4: !stencil.temp<72x72x72xf64>):
+            %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72x72x72xf64>) -> f64
             "stencil.return"(%5) : (f64) -> ()
-        }) : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>) -> (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>)
-        "stencil.store"(%8, %7) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[72 : i64, 72 : i64, 72 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+        }) : (!stencil.temp<72x72x72xf64>) -> (!stencil.temp<72x72x72xf64>)
+        "stencil.store"(%8, %7) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<72x72x72xf64>, !stencil.field<72x72x72xf64>) -> ()
         "func.return"() : () -> ()
-    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>, !stencil.field<[-1 : i32, -1 : i32, -1 : i32], f64>) -> (), "sym_visibility" = "private"} : () -> ()
+    }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -2,17 +2,17 @@
 
 "builtin.module"() ({
   "func.func"() ({
-  ^0(%0 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, %1 : !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>
-    %6 = "stencil.load"(%3) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
+  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+    %6 = "stencil.load"(%3) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
-    ^1(%9 : !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> f64
+    ^1(%9 : !stencil.temp<?x?x?xf64>):
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -20,10 +20,10 @@
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
-    }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>) -> !stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[72 : i64, 72 : i64, 72 : i64], f64>) -> ()
+    }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (!stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>, !stencil.field<[-1 : i64, -1 : i64, -1 : i64], f64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
+  }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: module {

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -8,7 +8,6 @@ from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     IntAttr,
     IntegerAttr,
-    NoneAttr,
     ParametrizedAttribute,
     ArrayAttr,
     IntegerType,

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -65,16 +65,9 @@ class FieldType(Generic[_FieldTypeElement], ParametrizedAttribute, TypeAttribute
     @staticmethod
     def parse_parameters(parser: Parser) -> list[Attribute]:
         parser.parse_char("<")
-        attribute = parser.parse_memref_attrs()
-        if not isa(attribute, memref.MemRefType[Attribute]):
-            parser.raise_error(f"stencil.field must be ranked.")
-        if not isinstance(attribute.layout, NoneAttr) or not isinstance(
-            attribute.memory_space, NoneAttr
-        ):
-            parser.raise_error("Expected '>' here!")
-
+        dims, element_type = parser.parse_ranked_shape()
         parser.parse_char(">")
-        return [attribute.shape, attribute.element_type]
+        return [ArrayAttr([IntegerAttr(d, 64) for d in dims]), element_type]
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print("<")
@@ -125,16 +118,9 @@ class TempType(Generic[_FieldTypeElement], ParametrizedAttribute, TypeAttribute)
     @staticmethod
     def parse_parameters(parser: Parser) -> list[Attribute]:
         parser.parse_char("<")
-        attribute = parser.parse_memref_attrs()
-        if not isa(attribute, memref.MemRefType[Attribute]):
-            parser.raise_error(f"stencil.field must be ranked.")
-        if not isinstance(attribute.layout, NoneAttr) or not isinstance(
-            attribute.memory_space, NoneAttr
-        ):
-            parser.raise_error("Expected '>' here!")
-
+        dims, element_type = parser.parse_ranked_shape()
         parser.parse_char(">")
-        return [attribute.shape, attribute.element_type]
+        return [ArrayAttr([IntegerAttr(d, 64) for d in dims]), element_type]
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print("<")

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1306,7 +1306,7 @@ class Parser(ABC):
         # Move the lexer to the position after 'x'.
         self.resume_from(self._current_token.span.start + 1)
 
-    def _parse_ranked_shape(self) -> tuple[list[int], Attribute]:
+    def parse_ranked_shape(self) -> tuple[list[int], Attribute]:
         """
         Parse a ranked shape with the following format:
           ranked-shape ::= (dimension `x`)* type
@@ -1324,7 +1324,7 @@ class Parser(ABC):
         type = self.expect(self.try_parse_type, "Expected shape type.")
         return dims, type
 
-    def _parse_shape(self) -> tuple[list[int] | None, Attribute]:
+    def parse_shape(self) -> tuple[list[int] | None, Attribute]:
         """
         Parse a ranked or unranked shape with the following format:
 
@@ -1341,7 +1341,7 @@ class Parser(ABC):
             type = self.expect(self.try_parse_type, "Expected shape type.")
             self._synchronize_lexer_and_tokenizer()
             return None, type
-        res = self._parse_ranked_shape()
+        res = self.parse_ranked_shape()
         self._synchronize_lexer_and_tokenizer()
         return res
 
@@ -1356,7 +1356,7 @@ class Parser(ABC):
     def parse_memref_attrs(
         self,
     ) -> MemRefType[Attribute] | UnrankedMemrefType[Attribute]:
-        shape, type = self._parse_shape()
+        shape, type = self.parse_shape()
 
         # Unranked case
         if shape is None:
@@ -1451,7 +1451,7 @@ class Parser(ABC):
         return VectorType.from_element_type_and_shape(type, dims, num_scalable_dims)
 
     def parse_tensor_attrs(self) -> AnyTensorType | AnyUnrankedTensorType:
-        shape, type = self._parse_shape()
+        shape, type = self.parse_shape()
 
         if shape is None:
             if self.parse_optional_punctuation(",") is not None:


### PR DESCRIPTION
This PR adds custom syntax to the stencil types (`stencil.temp` and `stencil.field`) for readability.
The meaningful change is in `xdsl/`, the rest is just filechecks updates!
Stacked on #975