### PR TITLE
core: Fix is_structurally_equivalent

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -7,10 +7,12 @@ from xdsl.dialects.builtin import Builtin, IntegerType, i32, i64, IntegerAttr, M
 from xdsl.dialects.func import Func
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.scf import If
+from xdsl.dialects.test import TestOp
 
 from xdsl.ir import MLContext, Operation, Block, Region, ErasedSSAValue, SSAValue
 from xdsl.parser import Parser
 from xdsl.irdl import IRDLOperation, VarRegion, irdl_op_definition, Operand
+from xdsl.utils.test_value import TestSSAValue
 
 
 def test_ops_accessor():
@@ -236,6 +238,22 @@ def test_is_structurally_equivalent(args: list[str], expected_result: bool):
     rhs: Operation = parser.parse_op()
 
     assert lhs.is_structurally_equivalent(rhs) == expected_result
+
+
+def test_is_structurally_equivalent_free_operands():
+    val1 = TestSSAValue(i32)
+    val2 = TestSSAValue(i64)
+    op1 = TestOp.create(operands=[val1, val2])
+    op2 = TestOp.create(operands=[val1, val2])
+    assert op1.is_structurally_equivalent(op2)
+
+
+def test_is_structurally_equivalent_free_operands_fail():
+    val1 = TestSSAValue(i32)
+    val2 = TestSSAValue(i32)
+    op1 = TestOp.create(operands=[val1])
+    op2 = TestOp.create(operands=[val2])
+    assert not op1.is_structurally_equivalent(op2)
 
 
 def test_is_structurally_equivalent_incompatible_ir_nodes():

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -918,12 +918,12 @@ class Operation(IRNode):
         if self.parent and other.parent and context.get(self.parent) != other.parent:
             return False
         if not all(
-            context.get(operand) == other_operand
+            context.get(operand, operand) == other_operand
             for operand, other_operand in zip(self.operands, other.operands)
         ):
             return False
         if not all(
-            context.get(successor) == other_successor
+            context.get(successor, successor) == other_successor
             for successor, other_successor in zip(self.successors, other.successors)
         ):
             return False


### PR DESCRIPTION
Comparing two operations that have operands that are not in
the context would fail.
Now, when operands and successors are not in the context, we
compare operands and successors by equality.