### PR TITLE
core: Allow generic operations

### DIFF
--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -693,12 +693,19 @@ class OpDef:
         # Check that all fields of the operation definition are either already
         # in Operation, or are class functions or methods.
         for field_name, value in clsdict.items():
+            # Fields that are already in Operation (i.e. operands, results, ...)
             if field_name in opdict:
                 continue
+            # IRDLOperation ClassVar fields are allowed
             if field_name in ["irdl_options", "traits", "name"]:
                 continue
+            # Dunder fields are allowed (i.e. __orig_bases__, __annotations__, ...)
+            # They are used by Python to store information about the class, so they
+            # should not be considered as part of the operation definition.
+            # Also, they can provide a possiblea escape hatch.
             if field_name[:2] == "__" and field_name[-2:] == "__":
                 continue
+            # Methods, properties, and functions are allowed
             if isinstance(
                 value, (FunctionType, PropertyType, classmethod, staticmethod)
             ):

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -719,8 +719,7 @@ class OpDef:
         if issubclass(pyrdl_def, Generic):
             type_var_mapping = {
                 k: irdl_to_attr_constraint(v)
-                for var_mapping in get_type_var_mapping(pyrdl_def).values()
-                for k, v in var_mapping.items()
+                for k, v in get_type_var_mapping(pyrdl_def)[1].items()
             }
 
         op_def = OpDef(clsdict["name"])

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -129,7 +129,8 @@ def get_type_var_mapping(
         raise ValueError(f"{cls} does not specialize a generic class.")
 
     # Get the generic parent
-    orig_bases: Sequence[Any] = cls.__orig_bases__  # type: ignore
+    orig_bases = cls.__orig_bases__  # type: ignore
+    orig_bases = cast(Sequence[Any], orig_bases)
     orig_bases = [
         orig_base for orig_base in orig_bases if get_origin(orig_base) is not Generic
     ]


### PR DESCRIPTION
Allow to create Generic operations, to factor some code.

For instance, this will let us write a generic `BinaryOperation`, that is parametrizable.
```python
class BinaryOperation(Generic[_T], Operation, ABC):
  lhs: Annotated[Operand, _T]
  rhs: Annotated[Operand, _T]
  res: Annotated[OpResult, _T]
  
  def verify():
      ...
``` 
And we can then use it with inheritance.
```python
@irdl_op_definition
class Addi(BinaryOperation[Annotated[IntegerType, i32]):
   name = "arith.addi"
```