### PR TITLE
core: rename some methods in parser (NFC)

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -487,7 +487,7 @@ class PlusCustomFormatOp(IRDLOperation):
         parser.parse_characters("+", "Malformed operation format, expected `+`!")
         rhs = parser.parse_operand("Expected SSA Value name here!")
         parser.parse_punctuation(":")
-        type = parser.expect(parser.try_parse_type, "Expect type here!")
+        type = parser.parse_type()
 
         return PlusCustomFormatOp.create(operands=[lhs, rhs], result_types=[type])
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -109,7 +109,7 @@ class LLVMPointerType(ParametrizedAttribute, TypeAttribute):
         if not parser.tokenizer.starts_with("<"):
             return [NoneAttr(), NoneAttr()]
         parser.parse_characters("<", "llvm.ptr parameters expected")
-        type = parser.try_parse_type()
+        type = parser.parse_optional_type()
         if type is None:
             parser.raise_error("Expected first parameter of llvm.ptr to be a type!")
         if not parser.tokenizer.starts_with(","):
@@ -158,7 +158,7 @@ class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
         parser.parse_characters(
             "x", "llvm.array size and type must be separated by `x`"
         )
-        type = parser.try_parse_type()
+        type = parser.parse_optional_type()
         if type is None:
             parser.raise_error("Expected second parameter of llvm.array to be a type!")
         parser.parse_characters(">", "End of llvm.array parameters expected!")

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1667,7 +1667,7 @@ class Parser(ABC):
         type = None
         if expect_type:
             self.parse_punctuation(":", " after block argument name!")
-            type = self.expect(self.try_parse_type, "expect argument type after `:`")
+            type = self.parse_type()
         return self.Argument(name_token.span, type)
 
     def parse_argument(self, expect_type: bool = True) -> Argument:


### PR DESCRIPTION
This renames `try_parse_type` and `try_parse_attr` to `parse_optional_type` and `parse_optional_attr`.
We should follow the `parse_optional` naming (as in MLIR), and this will require incremental changes in the parser.