### PR TITLE
dialects: Make arith.BinaryOp Generic.

### DIFF
--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -154,9 +154,7 @@ class BinaryOperation(IRDLOperation, Generic[_T]):
     result: Annotated[OpResult, _T]
 
     @classmethod
-    def get(
-        cls, operand1: Operation | SSAValue, operand2: Operation | SSAValue
-    ):
+    def get(cls, operand1: Operation | SSAValue, operand2: Operation | SSAValue):
         operand1 = SSAValue.get(operand1)
         return cls.build(operands=[operand1, operand2], result_types=[operand1.typ])
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -149,8 +149,6 @@ class BinaryOperation(IRDLOperation, Generic[_T]):
 
     They all have two operands and one result of a same type."""
 
-    traits = frozenset([Pure()])
-
     lhs: Annotated[Operand, _T]
     rhs: Annotated[Operand, _T]
     result: Annotated[OpResult, _T]
@@ -179,6 +177,8 @@ IntegerBinaryOp = BinaryOperation[IntegerType]
 @irdl_op_definition
 class Addi(SignlessIntegerBinaryOp):
     name = "arith.addi"
+
+    traits = frozenset([Pure()])
 
     def __init__(
         self,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -140,7 +140,10 @@ class Constant(IRDLOperation):
             val = FloatAttr(val, typ)
         return Constant.create(result_types=[typ], attributes={"value": val})
 
+
 _T = TypeVar("_T")
+
+
 class BinaryOperation(IRDLOperation, Generic[_T]):
     """A generic operation. Operation definitions inherit this class."""
 
@@ -152,8 +155,7 @@ class BinaryOperation(IRDLOperation, Generic[_T]):
 
     @classmethod
     def get(
-        cls,
-        operand1: Union[Operation, SSAValue], operand2: Union[Operation, SSAValue]
+        cls, operand1: Union[Operation, SSAValue], operand2: Union[Operation, SSAValue]
     ):
         operand1 = SSAValue.get(operand1)
         return cls.build(operands=[operand1, operand2], result_types=[operand1.typ])
@@ -165,6 +167,7 @@ class BinaryOperation(IRDLOperation, Generic[_T]):
 
     def __hash__(self) -> int:
         return id(self)
+
 
 SignlessIntegerBinaryOp = BinaryOperation[Annotated[Attribute, signlessIntegerLike]]
 FloatingPointLikeBinaryOp = BinaryOperation[Annotated[Attribute, floatingPointLike]]
@@ -287,6 +290,7 @@ class ShLI(IntegerBinaryOp):
     The `shli` operation shifts an integer value to the left by a variable
     amount. The low order bits are filled with zeros.
     """
+
     name = "arith.shli"
 
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -145,7 +145,9 @@ _T = TypeVar("_T", bound=Attribute)
 
 
 class BinaryOperation(IRDLOperation, Generic[_T]):
-    """A generic operation. Operation definitions inherit this class."""
+    """A generic base class for arith's binary operation.
+
+    They all have two operands and one result of a same type."""
 
     traits = frozenset([Pure()])
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -155,7 +155,7 @@ class BinaryOperation(IRDLOperation, Generic[_T]):
 
     @classmethod
     def get(
-        cls, operand1: Union[Operation, SSAValue], operand2: Union[Operation, SSAValue]
+        cls, operand1: Operation | SSAValue, operand2: Operation | SSAValue
     ):
         operand1 = SSAValue.get(operand1)
         return cls.build(operands=[operand1, operand2], result_types=[operand1.typ])

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -141,7 +141,7 @@ class Constant(IRDLOperation):
         return Constant.create(result_types=[typ], attributes={"value": val})
 
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound=Attribute)
 
 
 class BinaryOperation(IRDLOperation, Generic[_T]):


### PR DESCRIPTION
Use the new Generic Operation base class possibility brought by #979, make BinaryOperation generic, delete a third of `arith.py` :tada: 
I'm going to chop the rest of it soon!