### PR TITLE
dialects: riscv: Add LabelOp to riscv dialect

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -113,7 +113,7 @@ def test_label_op_with_comment():
     assert label_op.label.data == label_str
 
     code = riscv_code(ModuleOp([label_op]))
-    assert code == f"{label_str}:                                         # my label\n"
+    assert code == f"{label_str}:    # my label\n"
 
 
 def test_label_op_with_region():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -96,22 +96,25 @@ def test_comment_op():
     assert code == "    # my comment\n"
 
 
-def test_label_op():
-    # test label without comment
-    label_op0 = riscv.LabelOp("mylabel0")
+def test_label_op_without_comment():
+    label_str = "mylabel"
+    label_op = riscv.LabelOp(label_str)
 
-    assert label_op0.label.data == "mylabel0"
+    assert label_op.label.data == f"{label_str}"
 
-    code = riscv_code(ModuleOp([label_op0]))
-    assert code == "mylabel0:\n"
+    code = riscv_code(ModuleOp([label_op]))
+    assert code == f"{label_str}:\n"
 
-    # test label with comment
-    label_op1 = riscv.LabelOp("mylabel1", comment="my label too")
 
-    assert label_op1.label.data == "mylabel1"
+def test_label_op_with_comment():
+    label_str = "mylabel"
+    label_op = riscv.LabelOp(f"{label_str}", comment="my label")
 
-    code = riscv_code(ModuleOp([label_op1]))
-    assert code == "mylabel1:    # my label too\n"
+    assert label_op.label.data == "mylabel"
+    assert label_op.label.data == f"{label_str}"
+
+    code = riscv_code(ModuleOp([label_op]))
+    assert code == f"{label_str}:    # my label\n"
 
 
 def test_label_op_with_region():
@@ -121,13 +124,13 @@ def test_label_op_with_region():
         a2_reg = TestSSAValue(riscv.RegisterType(riscv.Registers.A2))
         riscv.AddOp(a1_reg, a2_reg, rd=riscv.Registers.A0)
 
-    # test label without comment
-    label_op0 = riscv.LabelOp("mylabel0", region=label_region)
+    label_str = "mylabel"
+    label_op = riscv.LabelOp(f"{label_str}", region=label_region)
 
-    assert label_op0.label.data == "mylabel0"
+    assert label_op.label.data == f"{label_str}"
 
-    code = riscv_code(ModuleOp([label_op0]))
-    assert code == "mylabel0:\n    add a0, a1, a2\n"
+    code = riscv_code(ModuleOp([label_op]))
+    assert code == f"{label_str}:\n    add a0, a1, a2\n"
 
 
 def test_return_op():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from xdsl.builder import Builder
 from xdsl.utils.test_value import TestSSAValue
 from xdsl.dialects import riscv
 
@@ -111,6 +112,22 @@ def test_label_op():
 
     code = riscv_code(ModuleOp([label_op1]))
     assert code == "mylabel1:    # my label too\n"
+
+
+def test_label_op_with_region():
+    @Builder.implicit_region
+    def label_region():
+        a1_reg = TestSSAValue(riscv.RegisterType(riscv.Registers.A1))
+        a2_reg = TestSSAValue(riscv.RegisterType(riscv.Registers.A2))
+        riscv.AddOp(a1_reg, a2_reg, rd=riscv.Registers.A0)
+
+    # test label without comment
+    label_op0 = riscv.LabelOp("mylabel0", region=label_region)
+
+    assert label_op0.label.data == "mylabel0"
+
+    code = riscv_code(ModuleOp([label_op0]))
+    assert code == "mylabel0:\n    add a0, a1, a2\n"
 
 
 def test_return_op():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -113,7 +113,7 @@ def test_label_op_with_comment():
     assert label_op.label.data == label_str
 
     code = riscv_code(ModuleOp([label_op]))
-    assert code == f"{label_str}:    # my label\n"
+    assert code == f"{label_str}:                                         # my label\n"
 
 
 def test_label_op_with_region():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -100,7 +100,7 @@ def test_label_op_without_comment():
     label_str = "mylabel"
     label_op = riscv.LabelOp(label_str)
 
-    assert label_op.label.data == f"{label_str}"
+    assert label_op.label.data == label_str
 
     code = riscv_code(ModuleOp([label_op]))
     assert code == f"{label_str}:\n"
@@ -110,8 +110,7 @@ def test_label_op_with_comment():
     label_str = "mylabel"
     label_op = riscv.LabelOp(f"{label_str}", comment="my label")
 
-    assert label_op.label.data == "mylabel"
-    assert label_op.label.data == f"{label_str}"
+    assert label_op.label.data == label_str
 
     code = riscv_code(ModuleOp([label_op]))
     assert code == f"{label_str}:    # my label\n"
@@ -127,7 +126,7 @@ def test_label_op_with_region():
     label_str = "mylabel"
     label_op = riscv.LabelOp(f"{label_str}", region=label_region)
 
-    assert label_op.label.data == f"{label_str}"
+    assert label_op.label.data == label_str
 
     code = riscv_code(ModuleOp([label_op]))
     assert code == f"{label_str}:\n    add a0, a1, a2\n"

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -95,6 +95,24 @@ def test_comment_op():
     assert code == "    # my comment\n"
 
 
+def test_label_op():
+    # test label without comment
+    label_op0 = riscv.LabelOp("mylabel0")
+
+    assert label_op0.label.data == "mylabel0"
+
+    code = riscv_code(ModuleOp([label_op0]))
+    assert code == "mylabel0:\n"
+
+    # test label with comment
+    label_op1 = riscv.LabelOp("mylabel1", comment="my label too")
+
+    assert label_op1.label.data == "mylabel1"
+
+    code = riscv_code(ModuleOp([label_op1]))
+    assert code == "mylabel1:    # my label too\n"
+
+
 def test_return_op():
     return_op = riscv.EbreakOp(comment="my comment")
 

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -160,4 +160,11 @@
   }) {"directive" = ".text"} : () -> ()
   // CHECK-NEXT:  .text
   // CHECK-NEXT:  addi j1, j1, 1
+  "riscv.label"() {"label" = #riscv.label<"label0">} : () -> ()
+  // CHECK-NEXT: label0:
+  "riscv.label"() ({
+    %nested_addi = "riscv.addi"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j1>
+  }) {"label" = #riscv.label<"label1">} : () -> ()
+  // CHECK-NEXT: label1:
+  // CHECK-NEXT: addi j1, j1, 1
 }) : () -> ()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1722,6 +1722,13 @@ class EcallOp(NullaryOperation):
 
 @irdl_op_definition
 class LabelOp(IRDLOperation, RISCVOp):
+    """
+    The label operation is used to emit text labels (e.g. loop:) that are used
+    as branch, unconditional jump targets and symbol offsets.
+
+    https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#labels
+    """
+
     name = "riscv.label"
     label: OpAttr[LabelAttr]
     comment: OptOpAttr[StringAttr]

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1749,6 +1749,13 @@ class LabelOp(IRDLOperation, RISCVOp):
             regions=[region],
         )
 
+    def assembly_line(self) -> str | None:
+        comment = ""
+        if self.comment is not None and self.comment.data:
+            comment = f"    # {self.comment.data}"
+
+        return f"{self.label.data}:{comment}"
+
 
 @irdl_op_definition
 class DirectiveOp(IRDLOperation, RISCVOp):

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1740,6 +1740,7 @@ class LabelOp(IRDLOperation, RISCVOp):
     One needs to do the following:
 
     ``` python
+    @Builder.implicit_region
     def my_add():
         a1_reg = TestSSAValue(riscv.RegisterType(riscv.Registers.A1))
         a2_reg = TestSSAValue(riscv.RegisterType(riscv.Registers.A2))

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1725,10 +1725,12 @@ class LabelOp(IRDLOperation, RISCVOp):
     name = "riscv.label"
     label: OpAttr[LabelAttr]
     comment: OptOpAttr[StringAttr]
+    data: OptSingleBlockRegion
 
     def __init__(
         self,
         label: str | LabelAttr,
+        region: OptSingleBlockRegion = None,
         *,
         comment: str | StringAttr | None = None,
     ):
@@ -1736,12 +1738,15 @@ class LabelOp(IRDLOperation, RISCVOp):
             label = LabelAttr(label)
         if isinstance(comment, str):
             comment = StringAttr(comment)
+        if region is None:
+            region = Region()
 
         super().__init__(
             attributes={
                 "label": label,
                 "comment": comment,
-            }
+            },
+            regions=[region],
         )
 
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1721,6 +1721,31 @@ class EcallOp(NullaryOperation):
 
 
 @irdl_op_definition
+class LabelOp(IRDLOperation, RISCVOp):
+    name = "riscv.label"
+    label: OpAttr[LabelAttr]
+    comment: OptOpAttr[StringAttr]
+
+    def __init__(
+        self,
+        label: str | LabelAttr,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(label, str):
+            label = LabelAttr(label)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            attributes={
+                "label": label,
+                "comment": comment,
+            }
+        )
+
+
+@irdl_op_definition
 class DirectiveOp(IRDLOperation, RISCVOp):
     """
     The directive operation is used to emit assembler directives (e.g. .word; .text; .data; etc.)
@@ -1930,6 +1955,7 @@ RISCV = Dialect(
         RemuOp,
         LiOp,
         EcallOp,
+        LabelOp,
         DirectiveOp,
         EbreakOp,
         WfiOp,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1727,6 +1727,26 @@ class LabelOp(IRDLOperation, RISCVOp):
     as branch, unconditional jump targets and symbol offsets.
 
     https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#labels
+
+    Optionally, a label can be associated with a single-block region, since
+    that is a common target for jump instructions.
+
+    For example, to generate this assembly:
+    ```
+    label1:
+        add a0, a1, a2
+    ```
+
+    One needs to do the following:
+
+    ``` python
+    def my_add():
+        a1_reg = TestSSAValue(riscv.RegisterType(riscv.Registers.A1))
+        a2_reg = TestSSAValue(riscv.RegisterType(riscv.Registers.A2))
+        riscv.AddOp(a1_reg, a2_reg, rd=riscv.Registers.A0)
+
+    label_op = riscv.LabelOp("label1", my_add)
+    ```
     """
 
     name = "riscv.label"


### PR DESCRIPTION
This PR adds the LabelOp in the riscv dialect (based on the current version found in `sasha/workshop-all` branch).
[Labels][1] can be used as targets for branches, unconditional jumps and symbol offsets, e.g.,

```
loop:
    j loop
```

A label can also be associated with a region, e.g.:

```
mylabel:
    add a0, a1, a2
```

[1]: https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#labels