### PR TITLE
dialects: Factoring out some mpi passes, adding support for pass args

### DIFF
--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -18,12 +18,13 @@ def test_opt():
         "convert-stencil-to-ll-mlir",
         "convert-stencil-to-gpu",
         "stencil-shape-inference",
-        "stencil-to-local-2d-horizontal",
+        "dmp-decompose-2d",
         "frontend-desymrefy",
         "dce",
         "lower-snitch",
         "riscv-allocate-registers",
         "lower-riscv-func",
+        "dmp-to-mpi",
     ]
 
 

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -320,9 +320,7 @@ class AccessOp(IRDLOperation):
             attributes={
                 "offset": IndexAttr(
                     [
-                        ArrayAttr(
-                            IntegerAttr[IntegerType](value, 64) for value in offset
-                        ),
+                        ArrayAttr(IntAttr(value) for value in offset),
                     ]
                 ),
             },
@@ -506,7 +504,7 @@ class ReturnOp(IRDLOperation):
 class HaloSwapOp(IRDLOperation):
     name = "stencil.halo_swap"
 
-    input_stencil: Annotated[Operand, TempType]
+    input_stencil: Annotated[Operand, TempType | memref.MemRefType]
 
     buff_lb: OptOpAttr[IndexAttr]
     buff_ub: OptOpAttr[IndexAttr]

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -36,12 +36,6 @@ from xdsl.passes import ModulePass
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
-from xdsl.transforms.experimental.stencil_global_to_local import (
-    LowerHaloExchangeToMpi,
-    HorizontalSlices2D,
-    MpiLoopInvariantCodeMotion,
-)
-
 _TypeElement = TypeVar("_TypeElement", bound=Attribute)
 
 # TODO docstrings and comments
@@ -430,11 +424,3 @@ class ConvertStencilToLLMLIRPass(ModulePass):
             walk_reverse=True,
         )
         the_one_pass.rewrite_module(op)
-        PatternRewriteWalker(
-            GreedyRewritePatternApplier(
-                [
-                    LowerHaloExchangeToMpi(HorizontalSlices2D(2)),
-                ]
-            )
-        ).rewrite_module(op)
-        MpiLoopInvariantCodeMotion().rewrite_module(op)

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -799,8 +799,6 @@ class LowerNullRequestOp(_MPIToLLVMRewriteBase):
 class LowerMPIPass(ModulePass):
     name = "lower-mpi"
 
-    # lower to func.call
-
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         # TODO: how to get the lib info in here?
         lib_info = MpiLibraryInfo()

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -45,6 +45,7 @@ from xdsl.transforms.experimental.ConvertStencilToLLMLIR import (
 from xdsl.transforms.experimental.StencilShapeInference import StencilShapeInferencePass
 from xdsl.transforms.experimental.stencil_global_to_local import (
     GlobalStencilToLocalStencil2DHorizontal,
+    LowerHaloToMPI,
 )
 
 from xdsl.utils.exceptions import DiagnosticException
@@ -289,6 +290,7 @@ class xDSLOptMain:
         self.register_pass(LowerSnitchPass)
         self.register_pass(RISCVRegisterAllocation)
         self.register_pass(LowerRISCVFunc)
+        self.register_pass(LowerHaloToMPI)
 
     def register_all_targets(self):
         """


### PR DESCRIPTION
This makes it so that stencil no longer loweres the MPI stuff itself, but now there's a separate pass `dmp-to-mpi{slices=4}`.

This also names the decomposition pass `dmp-decompose-2d{slices=4}`. Names are still open to discussion