### PR TITLE
core: Add PyRDL constraint variables

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1426,7 +1426,7 @@
      "text": [
       "arith.addi operation does not verify\n",
       "\n",
-      "%0 = \"arith.addi\"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i64\n",
+      "%0 = arith.addi %<UNKNOWN>, %<UNKNOWN> : i64\n",
       "\n",
       "\n"
      ]

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8df70eb6",
    "metadata": {},
@@ -10,6 +11,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "48013c49",
    "metadata": {
@@ -28,7 +30,7 @@
    "source": [
     "# xDSL should be available in the environment.\n",
     "\n",
-    "from xdsl.ir import MLContext\n",
+    "from xdsl.ir import MLContext, Attribute\n",
     "from xdsl.dialects.arith import Arith\n",
     "from xdsl.dialects.builtin import Builtin\n",
     "from xdsl.printer import Printer\n",
@@ -45,6 +47,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2a2a8564",
    "metadata": {},
@@ -53,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d0b62875",
    "metadata": {},
@@ -62,6 +66,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "11f19f3a",
    "metadata": {
@@ -72,14 +77,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ab6a12ad",
    "metadata": {},
    "source": [
-    "Attribute constraints represent invariants over attributes, and are an important concept for defining new attributes and operations. In practice, an attribute constraint is a child class of `AttrConstraint` that implements a `verify` method. The method takes an attribute as parameter, and raises an exception if the invariant is not respected."
+    "Attribute constraints represent invariants over attributes, and are an important concept for defining new attributes and operations. In practice, an attribute constraint is a child class of `AttrConstraint` that implements a `verify` method. The method takes an attribute to verify as parameter, and a dictionary associating constraint variables to attributes. `verify` does not return anything, but raises an exception if the invariant is not respected."
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4edaf649",
    "metadata": {},
@@ -88,6 +95,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5c94f21c",
    "metadata": {},
@@ -105,17 +113,18 @@
     "# NBVAL_CHECK_OUTPUT\n",
     "\n",
     "from xdsl.irdl import AnyAttr\n",
-    "from xdsl.dialects.builtin import i64, StringAttr\n",
+    "from xdsl.dialects.builtin import i64, StringAttr, IndexType, IntegerType\n",
     "\n",
     "# Construct the constraint\n",
     "any_constraint = AnyAttr()\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "any_constraint.verify(i64)\n",
-    "any_constraint.verify(StringAttr(\"ga\"))"
+    "any_constraint.verify(i64, {})\n",
+    "any_constraint.verify(StringAttr(\"ga\"), {})"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b44e60b8",
    "metadata": {},
@@ -124,6 +133,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4c95e2c9",
    "metadata": {},
@@ -153,16 +163,17 @@
     "eq_constraint = EqAttrConstraint(i64)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "eq_constraint.verify(i64)\n",
+    "eq_constraint.verify(i64, {})\n",
     "\n",
     "# This will trigger an exception\n",
     "try:\n",
-    "    eq_constraint.verify(i32)\n",
+    "    eq_constraint.verify(i32, {})\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "94a595c1",
    "metadata": {},
@@ -171,6 +182,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d7a772ce",
    "metadata": {},
@@ -201,12 +213,12 @@
     "base_constraint = BaseAttr(StringAttr)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "base_constraint.verify(StringAttr(\"ga\"))\n",
-    "base_constraint.verify(StringAttr(\"bu\"))\n",
+    "base_constraint.verify(StringAttr(\"ga\"), {})\n",
+    "base_constraint.verify(StringAttr(\"bu\"), {})\n",
     "\n",
     "# This will trigger an exception\n",
     "try:\n",
-    "    base_constraint.verify(i32)\n",
+    "    base_constraint.verify(i32, {})\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -228,12 +240,13 @@
    "source": [
     "# This too\n",
     "try:\n",
-    "    base_constraint.verify(IntAttr(3))\n",
+    "    base_constraint.verify(IntAttr(3), {})\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "33af66e2",
    "metadata": {},
@@ -242,6 +255,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "afab9d0c",
    "metadata": {},
@@ -266,6 +280,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2552bb9e",
    "metadata": {},
@@ -274,6 +289,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9f08d8e6",
    "metadata": {},
@@ -300,20 +316,21 @@
     "or_constraint = AnyOf([i32, StringAttr])\n",
     "\n",
     "# This will pass without triggering an exception, since the first constraint is satisfied\n",
-    "or_constraint.verify(i32)\n",
+    "or_constraint.verify(i32, {})\n",
     "\n",
     "# This will pass without triggering an exception, since the second constraint is satisfied\n",
-    "or_constraint.verify(StringAttr(\"ga\"))\n",
-    "or_constraint.verify(StringAttr(\"bu\"))\n",
+    "or_constraint.verify(StringAttr(\"ga\"), {})\n",
+    "or_constraint.verify(StringAttr(\"bu\"), {})\n",
     "\n",
     "# This will trigger an exception, since none of the constraints are satisfied\n",
     "try:\n",
-    "    or_constraint.verify(i64)\n",
+    "    or_constraint.verify(i64, {})\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d3d0bcac",
    "metadata": {},
@@ -322,6 +339,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8f5349a5",
    "metadata": {},
@@ -351,12 +369,12 @@
     "param_constraint = ParamAttrConstraint(IntegerAttr, [IntAttr, i32])\n",
     "\n",
     "# This will pass without triggering an exception.\n",
-    "param_constraint.verify(IntegerAttr(IntAttr(42), i32))\n",
-    "param_constraint.verify(IntegerAttr(IntAttr(23), i32))\n",
+    "param_constraint.verify(IntegerAttr(IntAttr(42), i32), {})\n",
+    "param_constraint.verify(IntegerAttr(IntAttr(23), i32), {})\n",
     "\n",
     "# This will trigger an exception, since the attribute type is not the expected one\n",
     "try:\n",
-    "    param_constraint.verify(i64)\n",
+    "    param_constraint.verify(i64, {})\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -379,12 +397,101 @@
     "# This will trigger an exception, since the second parameter constraint is not satisfied\n",
     "\n",
     "try:\n",
-    "    param_constraint.verify(IntegerAttr(IntAttr(42), i64))\n",
+    "    param_constraint.verify(IntegerAttr(IntAttr(42), i64), {})\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "95b9b8d0",
+   "metadata": {},
+   "source": [
+    "### Constraint variables"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "41f9cdb2",
+   "metadata": {},
+   "source": [
+    "Constraint variables are used to specify equality between attributes in operation and attribute definitions. They also contain a constraint that must be satisfied.\n",
+    "The first time a contraint variable is used, it will check that the constraint is satisfied. If it is satisfied, it sets the variable to the given attribute. If a constraint variable is already set, it will check that the given attribute is equal to the one already set. Two constraint variables with the same name are considered equal, and are expected to carry the same contraint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0f810106",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "index should be of base attribute integer_type\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.irdl import VarConstraint\n",
+    "\n",
+    "var_constraint = VarConstraint(\"T\", BaseAttr(IntegerType))\n",
+    "constraint_variables: dict[str, Attribute] = {}\n",
+    "\n",
+    "# The underlying constraint is not satisfied by the given attribute\n",
+    "try:\n",
+    "    var_constraint.verify(IndexType(), constraint_variables)\n",
+    "except VerifyException as e:\n",
+    "    print(e)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b13019cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "i32\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The constraint sets the constraint variable if the attribute verifies\n",
+    "var_constraint.verify(i32, constraint_variables)\n",
+    "print(constraint_variables[\"T\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "915a0bb0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "attribute i32 expected from variable 'T', but got i64\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Since the variable is set, the constraint can now only be satisfied by the same attribute\n",
+    "try:\n",
+    "    var_constraint.verify(i64, constraint_variables)\n",
+    "except VerifyException as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4c826817",
    "metadata": {},
@@ -393,6 +500,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9229e1b1",
    "metadata": {},
@@ -402,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "d223e7ef",
    "metadata": {},
    "outputs": [],
@@ -430,25 +538,25 @@
     "        self.elem_constr = attr_constr_coercion(constr)\n",
     "\n",
     "    # Check that an attribute satisfies the constraints\n",
-    "    def verify(self, attr: Attribute) -> None:\n",
+    "    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:\n",
     "        # We first check that the attribute is an ArrayAttr\n",
     "        if not isa(attr, ArrayAttr[Attribute]):\n",
     "            raise VerifyException(f\"expected attribute ArrayData but got {attr}\")\n",
     "\n",
     "        # We check the constraint for all elements in the array\n",
     "        for e in attr.data:\n",
-    "            self.elem_constr.verify(e)\n",
+    "            self.elem_constr.verify(e, constraint_vars)\n",
     "\n",
     "array_constraint = ArrayOfConstraint(IntAttr)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "array_constraint.verify(ArrayAttr([IntAttr(42)]))\n",
-    "array_constraint.verify(ArrayAttr([IntAttr(3), IntAttr(7)]))"
+    "array_constraint.verify(ArrayAttr([IntAttr(42)]), {})\n",
+    "array_constraint.verify(ArrayAttr([IntAttr(3), IntAttr(7)]), {})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "de0c5c5a",
    "metadata": {},
    "outputs": [
@@ -463,14 +571,14 @@
    "source": [
     "# This will trigger an exception, since the attribute is not an array\n",
     "try:\n",
-    "    array_constraint.verify(i32)\n",
+    "    array_constraint.verify(i32, {})\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "ad57e07b",
    "metadata": {},
    "outputs": [
@@ -485,12 +593,13 @@
    "source": [
     "# This will trigger an exception, since the array contains attribute that do not satisfies the constraint\n",
     "try:\n",
-    "    array_constraint.verify(ArrayAttr([IntAttr(42), StringAttr(\"ga\")]))\n",
+    "    array_constraint.verify(ArrayAttr([IntAttr(42), StringAttr(\"ga\")]), {})\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fa7462d5",
    "metadata": {},
@@ -499,6 +608,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6700817f",
    "metadata": {},
@@ -507,6 +617,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6fc72e3f",
    "metadata": {},
@@ -516,7 +627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "124e32cd",
    "metadata": {},
    "outputs": [
@@ -550,6 +661,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "331478d4",
    "metadata": {},
@@ -558,6 +670,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "36c28f4c",
    "metadata": {},
@@ -569,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "71235913",
    "metadata": {},
    "outputs": [
@@ -612,6 +725,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a12379ed",
    "metadata": {},
@@ -621,7 +735,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "37d898dd",
    "metadata": {},
    "outputs": [
@@ -631,7 +745,7 @@
        "[IntAttr(data=32)]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -641,6 +755,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b12eac71",
    "metadata": {},
@@ -650,7 +765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "839f1113",
    "metadata": {},
    "outputs": [
@@ -660,7 +775,7 @@
        "IntAttr(data=32)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -670,6 +785,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f64eeac0",
    "metadata": {},
@@ -678,6 +794,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "565c0893",
    "metadata": {},
@@ -687,7 +804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "37cd98f4",
    "metadata": {},
    "outputs": [
@@ -711,6 +828,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cf6f57b1",
    "metadata": {},
@@ -731,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "ab101eee",
    "metadata": {},
    "outputs": [
@@ -769,6 +887,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "63bdbb95",
    "metadata": {},
@@ -778,7 +897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "40f730fa",
    "metadata": {},
    "outputs": [],
@@ -789,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "c10a416c",
    "metadata": {},
    "outputs": [
@@ -811,7 +930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "id": "6bfa01b3",
    "metadata": {},
    "outputs": [
@@ -833,7 +952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "id": "789669c1",
    "metadata": {},
    "outputs": [
@@ -860,6 +979,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4e91b76e",
    "metadata": {},
@@ -869,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "id": "237cab4b",
    "metadata": {},
    "outputs": [],
@@ -880,6 +1000,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7ca2d81f",
    "metadata": {
@@ -890,6 +1011,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "df3363f0",
    "metadata": {},
@@ -899,7 +1021,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "id": "4114ad65",
    "metadata": {},
    "outputs": [
@@ -929,6 +1051,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "af200030",
    "metadata": {},
@@ -938,7 +1061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "id": "fb78943b",
    "metadata": {},
    "outputs": [
@@ -955,6 +1078,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c244d389",
    "metadata": {},
@@ -964,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "id": "cd39869a",
    "metadata": {},
    "outputs": [
@@ -998,6 +1122,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "750648d5",
    "metadata": {},
@@ -1007,7 +1132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "id": "568bea3c",
    "metadata": {},
    "outputs": [
@@ -1038,6 +1163,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "40a5df55",
    "metadata": {},
@@ -1056,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "38f82633",
    "metadata": {},
    "outputs": [
@@ -1082,6 +1208,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "60359257",
    "metadata": {},
@@ -1091,7 +1218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "id": "51bc29d5",
    "metadata": {},
    "outputs": [
@@ -1112,6 +1239,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d7475215",
    "metadata": {},
@@ -1121,7 +1249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "id": "d256e75f",
    "metadata": {},
    "outputs": [],
@@ -1133,6 +1261,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a9c0a907",
    "metadata": {},
@@ -1142,7 +1271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "id": "de32620d",
    "metadata": {},
    "outputs": [
@@ -1161,6 +1290,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ed9d8538",
    "metadata": {},
@@ -1179,7 +1309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "id": "e7a363f9",
    "metadata": {},
    "outputs": [
@@ -1208,6 +1338,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4dbea4ba",
    "metadata": {},
@@ -1216,6 +1347,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "46890068",
    "metadata": {},
@@ -1225,7 +1357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "id": "207fa9c9",
    "metadata": {},
    "outputs": [
@@ -1233,7 +1365,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "expect all input and result types to be equal\n"
+      "arith.addi operation does not verify\n",
+      "\n",
+      "%0 = \"arith.addi\"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i64\n",
+      "\n",
+      "\n"
      ]
     }
    ],

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1002,6 +1002,65 @@
   {
    "attachments": {},
    "cell_type": "markdown",
+   "id": "850ee366",
+   "metadata": {},
+   "source": [
+    "### Constraint variables"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "7cd6baec",
+   "metadata": {},
+   "source": [
+    "Constraint variables can directly be used in Operation and Attribute definitions by using a `TypeAlias` annotated with a `ConstraintVar`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "477d309e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "binary_op operation does not verify\n",
+      "\n",
+      "%0 = \"binary_op\"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i64\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.irdl import ConstraintVar\n",
+    "\n",
+    "@irdl_op_definition\n",
+    "class BinaryOp(IRDLOperation):\n",
+    "    name: str = \"binary_op\"\n",
+    "\n",
+    "    T = Annotated[IntegerType, ConstraintVar(\"T\")]\n",
+    "\n",
+    "    lhs: Annotated[Operand, T]\n",
+    "    rhs: Annotated[Operand, T]\n",
+    "    result: Annotated[OpResult, T]\n",
+    "\n",
+    "op = BinaryOp.build(operands=[i32_ssa_var, i32_ssa_var], result_types=[i32])\n",
+    "op.verify()\n",
+    "\n",
+    "op_incorrect = BinaryOp.build(operands=[i32_ssa_var, i32_ssa_var], result_types=[i64])\n",
+    "try:\n",
+    "    op_incorrect.verify()\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
    "id": "7ca2d81f",
    "metadata": {
     "tags": []
@@ -1021,7 +1080,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "4114ad65",
    "metadata": {},
    "outputs": [
@@ -1061,7 +1120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "fb78943b",
    "metadata": {},
    "outputs": [
@@ -1088,7 +1147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "cd39869a",
    "metadata": {},
    "outputs": [
@@ -1132,7 +1191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "id": "568bea3c",
    "metadata": {},
    "outputs": [
@@ -1182,7 +1241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "id": "38f82633",
    "metadata": {},
    "outputs": [
@@ -1218,7 +1277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "id": "51bc29d5",
    "metadata": {},
    "outputs": [
@@ -1249,7 +1308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "id": "d256e75f",
    "metadata": {},
    "outputs": [],
@@ -1271,7 +1330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "id": "de32620d",
    "metadata": {},
    "outputs": [
@@ -1309,7 +1368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "id": "e7a363f9",
    "metadata": {},
    "outputs": [
@@ -1357,7 +1416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "id": "207fa9c9",
    "metadata": {},
    "outputs": [

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -136,7 +136,7 @@ def test_vector_rank_constraint_verify():
     vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
     constraint = VectorRankConstraint(2)
 
-    constraint.verify(vector_type)
+    constraint.verify(vector_type, {})
 
 
 def test_vector_rank_constraint_rank_mismatch():
@@ -144,7 +144,7 @@ def test_vector_rank_constraint_rank_mismatch():
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, {})
     assert e.value.args[0] == "Expected vector rank to be 3, got 2."
 
 
@@ -153,7 +153,7 @@ def test_vector_rank_constraint_attr_mismatch():
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type)
+        constraint.verify(memref_type, {})
     assert e.value.args[0] == "memref<1x2xi32> should be of type VectorType."
 
 
@@ -161,7 +161,7 @@ def test_vector_base_type_constraint_verify():
     vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
     constraint = VectorBaseTypeConstraint(i32)
 
-    constraint.verify(vector_type)
+    constraint.verify(vector_type, {})
 
 
 def test_vector_base_type_constraint_type_mismatch():
@@ -169,7 +169,7 @@ def test_vector_base_type_constraint_type_mismatch():
     constraint = VectorBaseTypeConstraint(i64)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, {})
     assert e.value.args[0] == "Expected vector type to be i64, got i32."
 
 
@@ -178,7 +178,7 @@ def test_vector_base_type_constraint_attr_mismatch():
     constraint = VectorBaseTypeConstraint(i32)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type)
+        constraint.verify(memref_type, {})
     assert e.value.args[0] == "memref<1x2xi32> should be of type VectorType."
 
 
@@ -186,7 +186,7 @@ def test_vector_base_type_and_rank_constraint_verify():
     vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i32, 2)
 
-    constraint.verify(vector_type)
+    constraint.verify(vector_type, {})
 
 
 def test_vector_base_type_and_rank_constraint_base_type_mismatch():
@@ -194,7 +194,7 @@ def test_vector_base_type_and_rank_constraint_base_type_mismatch():
     constraint = VectorBaseTypeAndRankConstraint(i64, 2)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, {})
     assert e.value.args[0] == "Expected vector type to be i64, got i32."
 
 
@@ -203,7 +203,7 @@ def test_vector_base_type_and_rank_constraint_rank_mismatch():
     constraint = VectorBaseTypeAndRankConstraint(i32, 3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, {})
     assert e.value.args[0] == "Expected vector rank to be 3, got 2."
 
 
@@ -216,7 +216,7 @@ memref<1x2xi32> should be of type VectorType.
 memref<1x2xi32> should be of type VectorType."""
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type)
+        constraint.verify(memref_type, {})
     assert e.value.args[0] == error_msg
 
 

--- a/tests/filecheck/dialects/arith/arith_invalid.mlir
+++ b/tests/filecheck/dialects/arith/arith_invalid.mlir
@@ -5,5 +5,5 @@
   %lhs, %rhs = "test.op"() : () -> (i32, i64)
   %res = "arith.addi"(%lhs, %rhs) : (i32, i64) -> i32
 
-  // CHECK: expect all input and result types to be equal
+  // CHECK: attribute i32 expected from variable 'T', but got i64
 }) : () -> ()

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -245,7 +245,7 @@ def test_union_constraint_fail():
 
 
 class PositiveIntConstr(AttrConstraint):
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(
                 f"Expected {IntData.name} attribute, but got {attr.name}."
@@ -462,10 +462,10 @@ class DataListAttr(AttrConstraint):
 
     elem_constr: AttrConstraint
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         attr = cast(ListData[Any], attr)
         for e in attr.data:
-            self.elem_constr.verify(e)
+            self.elem_constr.verify(e, constraint_vars)
 
 
 @irdl_attr_definition

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -223,7 +223,7 @@ def test_region_accessors():
 
 @irdl_op_definition
 class OperandOp(IRDLOperation):
-    name = "test.o  perand_op"
+    name = "test.operand_op"
 
     irdl_options = [AttrSizedOperandSegments()]
 

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -62,7 +62,7 @@ def test_eq_attr_verify():
     """Check that an EqAttrConstraint verifies the expected attribute"""
     bool_true = BoolData(True)
     eq_true_constraint = EqAttrConstraint(bool_true)
-    eq_true_constraint.verify(bool_true)
+    eq_true_constraint.verify(bool_true, {})
 
 
 def test_eq_attr_verify_wrong_parameters_fail():
@@ -74,7 +74,7 @@ def test_eq_attr_verify_wrong_parameters_fail():
     bool_false = BoolData(False)
     eq_true_constraint = EqAttrConstraint(bool_true)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(bool_false)
+        eq_true_constraint.verify(bool_false, {})
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {bool_false}")
 
 
@@ -87,7 +87,7 @@ def test_eq_attr_verify_wrong_base_fail():
     int_zero = IntData(0)
     eq_true_constraint = EqAttrConstraint(bool_true)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(int_zero)
+        eq_true_constraint.verify(int_zero, {})
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {int_zero}")
 
 
@@ -97,8 +97,8 @@ def test_base_attr_verify():
     base attribute.
     """
     eq_true_constraint = BaseAttr(BoolData)
-    eq_true_constraint.verify(BoolData(True))
-    eq_true_constraint.verify(BoolData(False))
+    eq_true_constraint.verify(BoolData(True), {})
+    eq_true_constraint.verify(BoolData(False), {})
 
 
 def test_base_attr_verify_wrong_base_fail():
@@ -109,7 +109,7 @@ def test_base_attr_verify_wrong_base_fail():
     eq_true_constraint = BaseAttr(BoolData)
     int_zero = IntData(0)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(int_zero)
+        eq_true_constraint.verify(int_zero, {})
     assert e.value.args[0] == (
         f"{int_zero} should be of base attribute {BoolData.name}"
     )
@@ -118,16 +118,16 @@ def test_base_attr_verify_wrong_base_fail():
 def test_any_attr_verify():
     """Check that an AnyAttr verifies any attribute."""
     any_constraint = AnyAttr()
-    any_constraint.verify(BoolData(True))
-    any_constraint.verify(BoolData(False))
-    any_constraint.verify(IntData(0))
+    any_constraint.verify(BoolData(True), {})
+    any_constraint.verify(BoolData(False), {})
+    any_constraint.verify(IntData(0), {})
 
 
 @dataclass
 class LessThan(AttrConstraint):
     bound: int
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
         if attr.data >= self.bound:
@@ -138,7 +138,7 @@ class LessThan(AttrConstraint):
 class GreaterThan(AttrConstraint):
     bound: int
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
         if attr.data <= self.bound:
@@ -153,10 +153,10 @@ def test_anyof_verify():
     verify.
     """
     constraint = AnyOf([LessThan(0), GreaterThan(10)])
-    constraint.verify(IntData(-1))
-    constraint.verify(IntData(-10))
-    constraint.verify(IntData(11))
-    constraint.verify(IntData(100))
+    constraint.verify(IntData(-1), {})
+    constraint.verify(IntData(-10), {})
+    constraint.verify(IntData(11), {})
+    constraint.verify(IntData(100), {})
 
 
 def test_anyof_verify_fail():
@@ -170,11 +170,11 @@ def test_anyof_verify_fail():
     ten = IntData(10)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(zero)
+        constraint.verify(zero, {})
     assert e.value.args[0] == f"Unexpected attribute {zero}"
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(ten)
+        constraint.verify(ten, {})
     assert e.value.args[0] == f"Unexpected attribute {ten}"
 
 
@@ -184,9 +184,9 @@ def test_allof_verify():
     verify.
     """
     constraint = AllOf([LessThan(10), GreaterThan(0)])
-    constraint.verify(IntData(1))
-    constraint.verify(IntData(9))
-    constraint.verify(IntData(5))
+    constraint.verify(IntData(1), {})
+    constraint.verify(IntData(9), {})
+    constraint.verify(IntData(5), {})
 
 
 def test_allof_verify_fail():
@@ -197,11 +197,11 @@ def test_allof_verify_fail():
     constraint = AllOf([LessThan(10), GreaterThan(0)])
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(10))
+        constraint.verify(IntData(10), {})
     assert e.value.args[0] == f"{IntData(10)} should hold a value less than 10"
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(0))
+        constraint.verify(IntData(0), {})
     assert e.value.args[0] == f"{IntData(0)} should hold a value greater than 0"
 
 
@@ -213,7 +213,7 @@ def test_allof_verify_multiple_failures():
     constraint = AllOf([LessThan(5), GreaterThan(8)])
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(7))
+        constraint.verify(IntData(7), {})
     assert (
         e.value.args[0]
         == f"The following constraints were not satisfied:\n{IntData(7)} should hold a value less than 5\n{IntData(7)} should hold a value greater than 8"
@@ -225,8 +225,8 @@ def test_param_attr_verify():
     constraint = ParamAttrConstraint(
         DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
     )
-    constraint.verify(DoubleParamAttr([bool_true, IntData(0)]))
-    constraint.verify(DoubleParamAttr([bool_true, IntData(42)]))
+    constraint.verify(DoubleParamAttr([bool_true, IntData(0)]), {})
+    constraint.verify(DoubleParamAttr([bool_true, IntData(42)]), {})
 
 
 def test_param_attr_verify_base_fail():
@@ -235,7 +235,7 @@ def test_param_attr_verify_base_fail():
         DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
     )
     with pytest.raises(VerifyException) as e:
-        constraint.verify(bool_true)
+        constraint.verify(bool_true, {})
     assert e.value.args[0] == (
         f"{bool_true} should be of base attribute {DoubleParamAttr.name}"
     )
@@ -246,7 +246,7 @@ def test_param_attr_verify_params_num_params_fail():
     constraint = ParamAttrConstraint(DoubleParamAttr, [EqAttrConstraint(bool_true)])
     attr = DoubleParamAttr([bool_true, IntData(0)])
     with pytest.raises(VerifyException) as e:
-        constraint.verify(attr)
+        constraint.verify(attr, {})
     assert e.value.args[0] == (f"1 parameters expected, but got 2")
 
 
@@ -258,11 +258,11 @@ def test_param_attr_verify_params_fail():
     )
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(DoubleParamAttr([bool_true, bool_false]))
+        constraint.verify(DoubleParamAttr([bool_true, bool_false]), {})
     assert e.value.args[0] == (
         f"{bool_false} should be of base attribute {IntData.name}"
     )
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(DoubleParamAttr([bool_false, IntData(0)]))
+        constraint.verify(DoubleParamAttr([bool_false, IntData(0)]), {})
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {bool_false}")

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -13,6 +13,7 @@ from xdsl.irdl import (
     EqAttrConstraint,
     ParamAttrConstraint,
     ParameterDef,
+    VarConstraint,
     irdl_attr_definition,
 )
 from xdsl.parser import Parser
@@ -266,3 +267,41 @@ def test_param_attr_verify_params_fail():
     with pytest.raises(VerifyException) as e:
         constraint.verify(DoubleParamAttr([bool_false, IntData(0)]), {})
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {bool_false}")
+
+
+def test_constraint_vars_success():
+    """Test that VarConstraint verifier succeed when given the same attributes."""
+
+    constraint = VarConstraint("T", AnyOf([BoolData(False), IntData(0)]))
+
+    constraint_vars = {}
+    constraint.verify(BoolData(False), constraint_vars)
+    constraint.verify(BoolData(False), constraint_vars)
+
+    constraint_vars = {}
+    constraint.verify(IntData(0), constraint_vars)
+    constraint.verify(IntData(0), constraint_vars)
+
+
+def test_constraint_vars_fail_different():
+    """Test that VarConstraint verifier fails when given different attributes."""
+
+    constraint = VarConstraint("T", AnyOf([BoolData(False), IntData(0)]))
+
+    constraint_vars = {}
+    constraint.verify(IntData(0), constraint_vars)
+
+    with pytest.raises(VerifyException):
+        constraint.verify(BoolData(False), constraint_vars)
+
+
+def test_constraint_vars_fail_underlying_constraint():
+    """
+    Test that VarConstraint verifier fails when given
+    attributes that fail the underlying constraint.
+    """
+
+    constraint = VarConstraint("T", AnyOf([BoolData(False), IntData(0)]))
+
+    with pytest.raises(VerifyException):
+        constraint.verify(IntData(1), {})

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -183,11 +183,6 @@ class BinaryOperation(IRDLOperation, Generic[_T]):
         printer.print(" : ")
         printer.print_attribute(self.result.typ)
 
-    # TODO replace with trait
-    def verify_(self) -> None:
-        if not (self.operands[0].typ == self.operands[1].typ == self.results[0].typ):
-            raise VerifyException("expect all input and result types to be equal")
-
     def __hash__(self) -> int:
         return id(self)
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -22,6 +22,7 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Operation, SSAValue, Dialect, OpResult, Data
 from xdsl.irdl import (
     AnyOf,
+    ConstraintVar,
     irdl_op_definition,
     OpAttr,
     AnyAttr,
@@ -149,9 +150,11 @@ class BinaryOperation(IRDLOperation, Generic[_T]):
 
     They all have two operands and one result of a same type."""
 
-    lhs: Annotated[Operand, _T]
-    rhs: Annotated[Operand, _T]
-    result: Annotated[OpResult, _T]
+    T = Annotated[Attribute, ConstraintVar("T"), _T]
+
+    lhs: Annotated[Operand, T]
+    rhs: Annotated[Operand, T]
+    result: Annotated[OpResult, T]
 
     def __init__(
         self,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -80,11 +80,11 @@ class ArrayOfConstraint(AttrConstraint):
     def __init__(self, constr: Attribute | Type[Attribute] | AttrConstraint):
         self.elem_constr = attr_constr_coercion(constr)
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, Data):
             raise Exception(f"expected data ArrayData but got {attr}")
         for e in cast(ArrayAttr[Attribute], attr).data:
-            self.elem_constr.verify(e)
+            self.elem_constr.verify(e, constraint_vars)
 
 
 @irdl_attr_definition
@@ -723,11 +723,11 @@ class ContainerOf(AttrConstraint):
     ) -> None:
         self.elem_constr = attr_constr_coercion(elem_constr)
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if isinstance(attr, VectorType) or isinstance(attr, TensorType):
-            self.elem_constr.verify(attr.element_type)  # type: ignore
+            self.elem_constr.verify(attr.element_type, constraint_vars)  # type: ignore
         else:
-            self.elem_constr.verify(attr)
+            self.elem_constr.verify(attr, constraint_vars)
 
 
 VectorOrTensorOf: TypeAlias = (
@@ -750,7 +750,7 @@ class VectorRankConstraint(AttrConstraint):
     expected_rank: int
     """The expected vector rank."""
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, VectorType):
             raise VerifyException(f"{attr} should be of type VectorType.")
         if attr.get_num_dims() != self.expected_rank:
@@ -768,7 +768,7 @@ class VectorBaseTypeConstraint(AttrConstraint):
     expected_type: Attribute
     """The expected vector base type."""
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, VectorType):
             raise VerifyException(f"{attr} should be of type VectorType.")
         if attr.element_type != self.expected_type:  # type: ignore
@@ -789,14 +789,14 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
     expected_rank: int
     """The expected vector rank."""
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         constraint = AllOf(
             [
                 VectorBaseTypeConstraint(self.expected_type),
                 VectorRankConstraint(self.expected_rank),
             ]
         )
-        constraint.verify(attr)
+        constraint.verify(attr, constraint_vars)
 
 
 @irdl_attr_definition

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -87,7 +87,7 @@ class AttrConstraint(ABC):
 @dataclass
 class VarConstraint(AttrConstraint):
     """
-    Constraint variable. If the variable is already set, this will constraint
+    Constraint variable. If the variable is already set, this will constrain
     the attribute to be equal to the variable. Otherwise, it will first check that the
     variable satisfies the variable constraint, then set the variable with the
     attribute.

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -60,6 +60,7 @@ class IRDLAnnotations(Enum):
     AttributeDefAnnot = 2
     OptAttributeDefAnnot = 3
     SingleBlockRegionAnnot = 4
+    ConstraintVarAnnot = 5
 
 
 #   ____                _             _       _
@@ -75,12 +76,54 @@ class AttrConstraint(ABC):
     """Constrain an attribute to a certain value."""
 
     @abstractmethod
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         """
         Check if the attribute satisfies the constraint,
         or raise an exception otherwise.
         """
         ...
+
+
+@dataclass
+class VarConstraint(AttrConstraint):
+    """
+    Constraint variable. If the variable is already set, this will constraint
+    the attribute to be equal to the variable. Otherwise, it will first check that the
+    variable satisfies the variable constraint, then set the variable with the
+    attribute.
+    """
+
+    name: str
+    """The variable name. All uses of that name refer to the same variable."""
+
+    constraint: AttrConstraint
+    """The constraint that the variable must satisfy."""
+
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+        if self.name in constraint_vars:
+            if attr != constraint_vars[self.name]:
+                raise VerifyException(
+                    f"attribute {constraint_vars[self.name]} expected from variable "
+                    f"'{self.name}' but got {attr}"
+                )
+        else:
+            self.constraint.verify(attr, constraint_vars)
+            constraint_vars[self.name] = attr
+
+
+@dataclass
+class ConstraintVar:
+    """
+    Annotation used in PyRDL to define a constraint variable.
+    For instance, the following code defines a constraint variable T,
+    that can then be used in PyRDL:
+    ```python
+    T = Annotated[PyRDLConstraint, ConstraintVar("T")]
+    ```
+    """
+
+    name: str
+    """The variable name. All uses of that name refer to the same variable."""
 
 
 @dataclass
@@ -90,7 +133,7 @@ class EqAttrConstraint(AttrConstraint):
     attr: Attribute
     """The attribute we want to check equality with."""
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if attr != self.attr:
             raise VerifyException(f"Expected attribute {self.attr} but got {attr}")
 
@@ -102,7 +145,7 @@ class BaseAttr(AttrConstraint):
     attr: type[Attribute]
     """The expected attribute base type."""
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, self.attr):
             raise VerifyException(
                 f"{attr} should be of base attribute {self.attr.name}"
@@ -129,7 +172,7 @@ def attr_constr_coercion(
 class AnyAttr(AttrConstraint):
     """Constraint that is verified by all attributes."""
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         pass
 
 
@@ -145,10 +188,15 @@ class AnyOf(AttrConstraint):
     ):
         self.attr_constrs = [attr_constr_coercion(constr) for constr in attr_constrs]
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         for attr_constr in self.attr_constrs:
+            # Copy the constraint to ensure that if the constraint fails, the
+            # constraint_vars are not modified.
+            constraint_vars_copy = constraint_vars.copy()
             try:
-                attr_constr.verify(attr)
+                attr_constr.verify(attr, constraint_vars_copy)
+                # If the constraint succeeds, we update back the constraint variables
+                constraint_vars.update(constraint_vars_copy)
                 return
             except VerifyException:
                 pass
@@ -162,12 +210,12 @@ class AllOf(AttrConstraint):
     attr_constrs: list[AttrConstraint]
     """The list of constraints that are checked."""
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         exc_bucket: list[VerifyException] = []
 
         for attr_constr in self.attr_constrs:
             try:
-                attr_constr.verify(attr)
+                attr_constr.verify(attr, constraint_vars)
             except VerifyException as e:
                 exc_bucket.append(e)
 
@@ -200,7 +248,7 @@ class ParamAttrConstraint(AttrConstraint):
         self.base_attr = base_attr
         self.param_constrs = [attr_constr_coercion(constr) for constr in param_constrs]
 
-    def verify(self, attr: Attribute) -> None:
+    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, self.base_attr):
             raise VerifyException(
                 f"{attr} should be of base attribute {self.base_attr.name}"
@@ -211,7 +259,47 @@ class ParamAttrConstraint(AttrConstraint):
                 f"but got {len(attr.parameters)}"
             )
         for idx, param_constr in enumerate(self.param_constrs):
-            param_constr.verify(attr.parameters[idx])
+            param_constr.verify(attr.parameters[idx], constraint_vars)
+
+
+def _irdl_list_to_attr_constraint(
+    pyrdl_constraints: Sequence[Any],
+    *,
+    allow_type_var: bool = False,
+    type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
+) -> AttrConstraint:
+    """
+    Convert a list of PyRDL type annotations to an AttrConstraint.
+    Each list element correspond to a constraint to satisfy.
+    If there is a `ConstraintVar` annotation, we add the entire constraint to
+    the constraint variable.
+    """
+    # Check for a constraint varibale first
+    for idx, arg in enumerate(pyrdl_constraints):
+        if isinstance(arg, ConstraintVar):
+            constraint = _irdl_list_to_attr_constraint(
+                list(pyrdl_constraints[:idx]) + list(pyrdl_constraints[idx + 1 :]),
+                allow_type_var=allow_type_var,
+                type_var_mapping=type_var_mapping,
+            )
+            return VarConstraint(arg.name, constraint)
+
+    constraints: list[AttrConstraint] = []
+    for arg in pyrdl_constraints:
+        # We should not try to convert IRDL annotations, which do not
+        # correspond to constraints
+        if isinstance(arg, IRDLAnnotations):
+            continue
+        constraints.append(
+            irdl_to_attr_constraint(
+                arg,
+                allow_type_var=allow_type_var,
+                type_var_mapping=type_var_mapping,
+            )
+        )
+    if len(constraints) > 1:
+        return AllOf(constraints)
+    return constraints[0]
 
 
 def irdl_to_attr_constraint(
@@ -228,23 +316,14 @@ def irdl_to_attr_constraint(
 
     # Annotated case
     # Each argument of the Annotated type corresponds to a constraint to satisfy.
+    # If there is a `ConstraintVar` annotation, we add the entire constraint to
+    # the constraint variable.
     if get_origin(irdl) == Annotated:
-        constraints: list[AttrConstraint] = []
-        for arg in get_args(irdl):
-            # We should not try to convert IRDL annotations, which do not
-            # correspond to constraints
-            if isinstance(arg, IRDLAnnotations):
-                continue
-            constraints.append(
-                irdl_to_attr_constraint(
-                    arg,
-                    allow_type_var=allow_type_var,
-                    type_var_mapping=type_var_mapping,
-                )
-            )
-        if len(constraints) > 1:
-            return AllOf(constraints)
-        return constraints[0]
+        return _irdl_list_to_attr_constraint(
+            get_args(irdl),
+            allow_type_var=allow_type_var,
+            type_var_mapping=type_var_mapping,
+        )
 
     # Attribute class case
     # This is an `AnyAttr`, which does not constrain the attribute.
@@ -854,17 +933,20 @@ class OpDef:
     def verify(self, op: Operation):
         """Given an IRDL definition, verify that an operation satisfies its invariants."""
 
+        # Mapping from type variables to their concrete types.
+        constraint_vars: dict[str, Attribute] = {}
+
         # Verify operands.
-        irdl_op_verify_arg_list(op, self, VarIRConstruct.OPERAND)
+        irdl_op_verify_arg_list(op, self, VarIRConstruct.OPERAND, constraint_vars)
 
         # Verify results.
-        irdl_op_verify_arg_list(op, self, VarIRConstruct.RESULT)
+        irdl_op_verify_arg_list(op, self, VarIRConstruct.RESULT, constraint_vars)
 
         # Verify regions.
-        irdl_op_verify_arg_list(op, self, VarIRConstruct.REGION)
+        irdl_op_verify_arg_list(op, self, VarIRConstruct.REGION, constraint_vars)
 
         # Verify successors.
-        irdl_op_verify_arg_list(op, self, VarIRConstruct.SUCCESSOR)
+        irdl_op_verify_arg_list(op, self, VarIRConstruct.SUCCESSOR, constraint_vars)
 
         # Verify attributes.
         for attr_name, attr_def in self.attributes.items():
@@ -872,7 +954,7 @@ class OpDef:
                 if isinstance(attr_def, OptAttributeDef):
                     continue
                 raise VerifyException(f"attribute {attr_name} expected")
-            attr_def.constr.verify(op.attributes[attr_name])
+            attr_def.constr.verify(op.attributes[attr_name], constraint_vars)
 
         # Verify traits.
         for trait in self.traits:
@@ -1117,7 +1199,10 @@ def get_operand_result_or_region(
 
 
 def irdl_op_verify_arg_list(
-    op: Operation, op_def: OpDef, construct: VarIRConstruct
+    op: Operation,
+    op_def: OpDef,
+    construct: VarIRConstruct,
+    constraint_vars: dict[str, Attribute],
 ) -> None:
     """Verify the argument list of an operation."""
     arg_sizes = get_variadic_sizes(op, op_def, construct)
@@ -1132,7 +1217,7 @@ def irdl_op_verify_arg_list(
                 construct == VarIRConstruct.OPERAND
                 or construct == VarIRConstruct.RESULT
             ):
-                arg_def.constr.verify(arg.typ)
+                arg_def.constr.verify(arg.typ, constraint_vars)
             elif construct == VarIRConstruct.REGION:
                 if isinstance(arg_def, SingleBlockRegionDef) and len(arg.blocks) != 1:
                     raise VerifyException(
@@ -1679,8 +1764,9 @@ class ParamAttrDef:
                 f"{len(attr.parameters)}"
             )
 
+        constraint_vars: dict[str, Attribute] = {}
         for param, (_, param_def) in zip(attr.parameters, self.parameters):
-            param_def.verify(param)
+            param_def.verify(param, constraint_vars)
 
 
 _PAttrT = TypeVar("_PAttrT", bound=ParametrizedAttribute)

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -104,7 +104,7 @@ class VarConstraint(AttrConstraint):
             if attr != constraint_vars[self.name]:
                 raise VerifyException(
                     f"attribute {constraint_vars[self.name]} expected from variable "
-                    f"'{self.name}' but got {attr}"
+                    f"'{self.name}', but got {attr}"
                 )
         else:
             self.constraint.verify(attr, constraint_vars)
@@ -783,6 +783,9 @@ class OpDef:
             # should not be considered as part of the operation definition.
             # Also, they can provide a possiblea escape hatch.
             if field_name[:2] == "__" and field_name[-2:] == "__":
+                continue
+            # Constraint variables
+            if True:
                 continue
             # Methods, properties, and functions are allowed
             if isinstance(

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -784,14 +784,14 @@ class OpDef:
             # Also, they can provide a possiblea escape hatch.
             if field_name[:2] == "__" and field_name[-2:] == "__":
                 continue
-            # Constraint variables
-            if True:
-                continue
             # Methods, properties, and functions are allowed
             if isinstance(
                 value, (FunctionType, PropertyType, classmethod, staticmethod)
             ):
                 continue
+            if get_origin(value) is Annotated:
+                if any(isinstance(arg, ConstraintVar) for arg in get_args(value)):
+                    continue
             raise wrong_field_exception(field_name)
 
         if "name" not in clsdict:

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -72,7 +72,7 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
     if (origin is not None) and issubclass(origin, GenericData | ParametrizedAttribute):
         constraint = irdl_to_attr_constraint(hint)
         try:
-            constraint.verify(arg)
+            constraint.verify(arg, {})
             return True
         except VerifyException:
             return False


### PR DESCRIPTION
We can now specify in the PyRDL definition that some types should be equal.
BinaryOperation is now using this to specify that both operands and the result have the same type.

For instance:
```python
@irdl_op_definition
class ConstraintVarOp(IRDLOperation):
    name = "test.constraint_var_op"

    T = Annotated[IntegerType | IndexType, ConstraintVar("T")]

    operand: Annotated[Operand, T]
    result: Annotated[OpResult, T]
    attribute: OpAttr[T]
```
Both the operand, result, and attribute should have the same type (or value for the attribute).

This also magically works out of the box for generics!!!
```python
@irdl_attr_definition
class ConstraintVarAttr(ParametrizedAttribute):
    name = "test.constraint_var"

    T = Annotated[IntegerType, ConstraintVar("T")]

    param1: ParameterDef[IntegerAttr[T]]
    param2: ParameterDef[IntegerAttr[T]]
```
This means, that here, `param1` and `param2` can be different, but their "type" should be the same.
So, `#test.constraint_var<5 : i32, 7 : i32>` is valid, but `#test.constraint_var<5 : i32, 7 : i64>` is not.