### PR TITLE
core: Allow ClassVar on IRDL operations

### DIFF
--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -1656,7 +1656,7 @@ class ParamAttrDef:
             if type_hints is None:
                 type_hints = get_type_hints(pyrdl_def)
             # allow class vars
-            if get_origin(type_hints[field_name]) is ClassVar:
+            if get_origin(type_hints.get(field_name, None)) is ClassVar:
                 continue
 
             raise PyRDLAttrDefinitionError(

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -19,7 +19,8 @@ from typing import (
     get_args,
     get_origin,
     get_type_hints,
-    overload, ClassVar,
+    overload,
+    ClassVar,
 )
 from types import UnionType, GenericAlias, FunctionType
 


### PR DESCRIPTION
This makes it so you can have a `ClassVar` on PyRDL classes.

I stumbled upon this a couple of times now, where I couldn't have class variables that were non-irdl managed.