### PR TITLE
core: use truthiness for block ops is_empty check

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -212,7 +212,7 @@ class FuncOp(IRDLOperation):
 
         block = self.body.blocks[0]
 
-        if not block:
+        if not block.ops:
             raise VerifyException("Expected FuncOp to not be empty")
 
         last_op = block.last_op

--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -212,7 +212,7 @@ class FuncOp(IRDLOperation):
 
         block = self.body.blocks[0]
 
-        if block.is_empty:
+        if not block:
             raise VerifyException("Expected FuncOp to not be empty")
 
         last_op = block.last_op

--- a/docs/Toy/toy/frontend/ir_gen.py
+++ b/docs/Toy/toy/frontend/ir_gen.py
@@ -178,7 +178,7 @@ class IRGen:
 
         # Implicitly return void if no return statement was emitted.
         return_op = None
-        if block:
+        if block.ops:
             last_op = block.last_op
             if isinstance(last_op, ReturnOp):
                 return_op = last_op

--- a/docs/Toy/toy/frontend/ir_gen.py
+++ b/docs/Toy/toy/frontend/ir_gen.py
@@ -178,7 +178,7 @@ class IRGen:
 
         # Implicitly return void if no return statement was emitted.
         return_op = None
-        if not block.is_empty:
+        if block:
             last_op = block.last_op
             if isinstance(last_op, ReturnOp):
                 return_op = last_op

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -147,7 +147,7 @@ def test_func_get_return_op():
 def test_callable_constructor():
     f = FuncOp.from_callable("f", [], [], lambda *args: [])
     assert f.sym_name.data == "f"
-    assert f.body.block.is_empty
+    assert not f.body.block
 
 
 def test_call():

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -147,7 +147,7 @@ def test_func_get_return_op():
 def test_callable_constructor():
     f = FuncOp.from_callable("f", [], [], lambda *args: [])
     assert f.sym_name.data == "f"
-    assert not f.body.block
+    assert not f.body.block.ops
 
 
 def test_call():

--- a/tests/test_linked_list.py
+++ b/tests/test_linked_list.py
@@ -12,7 +12,7 @@ def test_block_insert():
 
     block = Block()
 
-    assert block.is_empty
+    assert not block
 
     assert block.first_op is None
     assert block.last_op is None
@@ -21,7 +21,7 @@ def test_block_insert():
 
     block.add_op(a)
 
-    assert not block.is_empty
+    assert block
 
     assert block.first_op is a
     assert block.last_op is a

--- a/tests/test_linked_list.py
+++ b/tests/test_linked_list.py
@@ -12,7 +12,7 @@ def test_block_insert():
 
     block = Block()
 
-    assert not block
+    assert not block.ops
 
     assert block.first_op is None
     assert block.last_op is None
@@ -21,7 +21,7 @@ def test_block_insert():
 
     block.add_op(a)
 
-    assert block
+    assert block.ops
 
     assert block.first_op is a
     assert block.last_op is a

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1283,7 +1283,7 @@ class ModuleOp(IRDLOperation):
             printer.print_dictionary(self.attributes, printer.print, printer.print)
             printer.print("}")
 
-        if self.body.block.is_empty:
+        if not self.body.block:
             # Do not print the entry block if the region has an empty block
             printer.print(" {\n")
             printer.print("}")

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1283,7 +1283,7 @@ class ModuleOp(IRDLOperation):
             printer.print_dictionary(self.attributes, printer.print, printer.print)
             printer.print("}")
 
-        if not self.body.block:
+        if not self.body.block.ops:
             # Do not print the entry block if the region has an empty block
             printer.print(" {\n")
             printer.print("}")

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -219,7 +219,7 @@ class AllReduceOp(IRDLOperation):
                 f"{self.operand.typ}. They must be the same type for gpu.all_reduce"
             )
 
-        non_empty_body = any(self.body.blocks)
+        non_empty_body = any(b.ops for b in self.body.blocks)
         op_attr = self.op is not None
         if non_empty_body == op_attr:
             if op_attr:
@@ -454,7 +454,7 @@ class LaunchOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        if not any(self.body.blocks):
+        if not any(b.ops for b in self.body.blocks):
             raise VerifyException("gpu.launch requires a non-empty body.")
         body_args = self.body.blocks[0].args
         args_type = [a.typ for a in body_args]

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -219,7 +219,7 @@ class AllReduceOp(IRDLOperation):
                 f"{self.operand.typ}. They must be the same type for gpu.all_reduce"
             )
 
-        non_empty_body = not all(b.is_empty for b in self.body.blocks)
+        non_empty_body = any(self.body.blocks)
         op_attr = self.op is not None
         if non_empty_body == op_attr:
             if op_attr:
@@ -345,9 +345,7 @@ class ModuleOp(IRDLOperation):
         return op
 
     def verify_(self):
-        if self.body.block.is_empty or not isinstance(
-            self.body.block.last_op, ModuleEndOp
-        ):
+        if not isinstance(self.body.block.last_op, ModuleEndOp):
             raise VerifyException("gpu.module must end with gpu.module_end")
 
 
@@ -456,7 +454,7 @@ class LaunchOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        if len(self.body.blocks) == 0 or all(b.is_empty for b in self.body.blocks):
+        if not any(self.body.blocks):
             raise VerifyException("gpu.launch requires a non-empty body.")
         body_args = self.body.blocks[0].args
         args_type = [a.typ for a in body_args]

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -61,7 +61,7 @@ class DialectOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if self.body.block:
+        if self.body.block.ops:
             printer.print_region(self.body)
 
 
@@ -91,7 +91,7 @@ class TypeOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if self.body.block:
+        if self.body.block.ops:
             printer.print_region(self.body)
 
 
@@ -121,7 +121,7 @@ class AttributeOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if self.body.block:
+        if self.body.block.ops:
             printer.print_region(self.body)
 
 
@@ -177,7 +177,7 @@ class OperationOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if self.body.block:
+        if self.body.block.ops:
             printer.print_region(self.body)
 
 

--- a/xdsl/dialects/irdl.py
+++ b/xdsl/dialects/irdl.py
@@ -61,7 +61,7 @@ class DialectOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if not self.body.block.is_empty:
+        if self.body.block:
             printer.print_region(self.body)
 
 
@@ -91,7 +91,7 @@ class TypeOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if not self.body.block.is_empty:
+        if self.body.block:
             printer.print_region(self.body)
 
 
@@ -121,7 +121,7 @@ class AttributeOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if not self.body.block.is_empty:
+        if self.body.block:
             printer.print_region(self.body)
 
 
@@ -177,7 +177,7 @@ class OperationOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" @", self.sym_name.data, " ")
-        if not self.body.block.is_empty:
+        if self.body.block:
             printer.print_region(self.body)
 
 

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -203,7 +203,7 @@ class PDLFunctions(InterpreterFunctions):
     ) -> tuple[Any, ...]:
         block = op.body.block
 
-        if not block:
+        if not block.ops:
             raise InterpretationError("No ops in pattern")
 
         last_op = block.last_op

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -203,7 +203,7 @@ class PDLFunctions(InterpreterFunctions):
     ) -> tuple[Any, ...]:
         block = op.body.block
 
-        if block.is_empty:
+        if not block:
             raise InterpretationError("No ops in pattern")
 
         last_op = block.last_op

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1008,8 +1008,8 @@ class BlockOps:
         return result
 
     def __bool__(self) -> bool:
-        """Returns `True` if there are no operations in this block."""
-        return self.block.first_op is not None
+        """Returns `True` if there are operations in this block."""
+        return not self.block.is_empty
 
     @property
     def first(self) -> Operation | None:
@@ -1145,6 +1145,11 @@ class Block(IRNode):
                 "Can't add an operation to a block contained in the operation."
             )
         operation.parent = self
+
+    @property
+    def is_empty(self) -> bool:
+        """Returns `True` if there are no operations in this block."""
+        return self._first_op is None
 
     @property
     def first_op(self) -> Operation | None:

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -581,7 +581,7 @@ class Operation(IRNode):
         return None
 
     def parent_region(self) -> Region | None:
-        if p := self.parent_block():
+        if (p := self.parent_block()) is not None:
             return p.parent
         return None
 
@@ -915,7 +915,11 @@ class Operation(IRNode):
             or self.attributes != other.attributes
         ):
             return False
-        if self.parent and other.parent and context.get(self.parent) != other.parent:
+        if (
+            self.parent is not None
+            and other.parent is not None
+            and context.get(self.parent) != other.parent
+        ):
             return False
         if not all(
             context.get(operand, operand) == other_operand
@@ -1004,7 +1008,8 @@ class BlockOps:
         return result
 
     def __bool__(self) -> bool:
-        return bool(self.block)
+        """Returns `True` if there are no operations in this block."""
+        return self.block.first_op is not None
 
     @property
     def first(self) -> Operation | None:
@@ -1140,10 +1145,6 @@ class Block(IRNode):
                 "Can't add an operation to a block contained in the operation."
             )
         operation.parent = self
-
-    def __bool__(self) -> bool:
-        """Returns `True` if there are no operations in this block."""
-        return self._first_op is not None
 
     @property
     def first_op(self) -> Operation | None:
@@ -1377,7 +1378,11 @@ class Region(IRNode):
         return self.parent
 
     def parent_region(self) -> Region | None:
-        return self.parent.parent.parent if self.parent and self.parent.parent else None
+        return (
+            self.parent.parent.parent
+            if self.parent is not None and self.parent.parent is not None
+            else None
+        )
 
     def __repr__(self) -> str:
         return f"Region(num_blocks={len(self.blocks)})"

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1003,6 +1003,9 @@ class BlockOps:
             result += 1
         return result
 
+    def __bool__(self) -> bool:
+        return bool(self.block)
+
     @property
     def first(self) -> Operation | None:
         """
@@ -1016,13 +1019,6 @@ class BlockOps:
         Last operation in the block, None if block is empty.
         """
         return self.block.last_op
-
-    @property
-    def is_empty(self) -> bool:
-        """
-        True if block is empty.
-        """
-        return self.block.is_empty
 
 
 @dataclass(init=False)
@@ -1145,10 +1141,9 @@ class Block(IRNode):
             )
         operation.parent = self
 
-    @property
-    def is_empty(self) -> bool:
+    def __bool__(self) -> bool:
         """Returns `True` if there are no operations in this block."""
-        return self._first_op is None
+        return self._first_op is not None
 
     @property
     def first_op(self) -> Operation | None:

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -336,7 +336,7 @@ class PatternRewriter:
         if op is self.current_operation:
             return self.inline_block_after_matched_op(block)
         if not self._can_modify_block(block) or (
-            op.parent and not self._can_modify_block(op.parent)
+            op.parent is not None and not self._can_modify_block(op.parent)
         ):
             raise Exception(
                 "Cannot move blocks that are not contained in the matched operation."

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -326,7 +326,7 @@ class Printer:
         entry_block = region.blocks[0]
         print_entry_block_args = (
             bool(entry_block.args) and print_entry_block_args
-        ) or (not entry_block and print_empty_block)
+        ) or (not entry_block.ops and print_empty_block)
         self.print_block(entry_block, print_block_args=print_entry_block_args)
         for block in region.blocks[1:]:
             self.print_block(block)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -325,8 +325,8 @@ class Printer:
 
         entry_block = region.blocks[0]
         print_entry_block_args = (
-            len(entry_block.args) != 0 and print_entry_block_args
-        ) or (entry_block.is_empty and print_empty_block)
+            bool(entry_block.args) and print_entry_block_args
+        ) or (not entry_block and print_empty_block)
         self.print_block(entry_block, print_block_args=print_entry_block_args)
         for block in region.blocks[1:]:
             self.print_block(block)

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -13,7 +13,7 @@ class Rewriter:
         If safe_erase is True, check that the operation has no uses.
         Otherwise, replace its uses with ErasedSSAValue.
         """
-        assert op.parent, "Cannot erase an operation that has no parents"
+        assert op.parent is not None, "Cannot erase an operation that has no parents"
 
         block = op.parent
         block.erase_op(op, safe_erase=safe_erase)


### PR DESCRIPTION
I recently discovered that PEP8 recommends using truthiness for collection is empty check. This makes sense to me, as a lot of collections have O(n) length calculations, including strings and our recently introduced Block linked list. Here's the relevant bit:

```
For sequences, (strings, lists, tuples), use the fact that empty sequences are false:

Yes:

if not seq:
if seq:

No:

if len(seq):
if not len(seq):
```

https://pep8.org/#programming-recommendations
