### PR TITLE
dialects: switch stencil to carry bounds in SSA values types.

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -36,6 +36,21 @@ from xdsl.utils.hints import isa
 from xdsl.utils.test_value import TestSSAValue
 
 
+def test_stencilboundsattr_verify():
+    with pytest.raises(VerifyException) as e:
+        StencilBoundsAttr.new([IndexAttr.get(1), IndexAttr.get(2, 2)])
+    assert (
+        str(e.value)
+        == "Incoherent stencil bounds: lower and upper bounds must have the same dimensionality."
+    )
+    with pytest.raises(VerifyException) as e:
+        StencilBoundsAttr.new([IndexAttr.get(2, 2), IndexAttr.get(2, 2)])
+    assert (
+        str(e.value)
+        == "Incoherent stencil bounds: upper bound must be strictly greater than lower bound."
+    )
+
+
 def test_stencil_return_single_float():
     float_val1 = TestSSAValue(FloatAttr(4.0, f32))
     return_op = ReturnOp.get([float_val1])

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -19,6 +19,7 @@ from xdsl.dialects.experimental.stencil import (
     ReturnOp,
     ResultType,
     ApplyOp,
+    StencilBoundsAttr,
     TempType,
     LoadOp,
     FieldType,
@@ -69,88 +70,42 @@ def test_stencil_return_multiple_ResultType():
 
 
 def test_stencil_cast_op_verifier():
-    field = TestSSAValue(FieldType((-1, -1, -1), f32))
+    typ = FieldType(3, f32)
+    field = TestSSAValue(typ)
 
     # check that correct op verifies correctly
-    cast = CastOp.get(
-        field,
-        IndexAttr.get(-2, -2, -2),
-        IndexAttr.get(100, 100, 100),
-        FieldType((102, 102, 102), f32),
-    )
+    cast = CastOp.get(field, StencilBoundsAttr(((-2, 100), (-2, 100), (-2, 100))))
     cast.verify()
 
-    # check that math is correct
-    with pytest.raises(VerifyException, match="math"):
-        cast = CastOp.get(
-            field,
-            IndexAttr.get(-2, -2, -2),
-            IndexAttr.get(100, 100, 100),
-            FieldType((100, 100, 100), f32),
-        )
-        cast.verify()
-
     # check that output has same dims as input and lb, ub
-    with pytest.raises(VerifyException, match="same dimensions"):
+    with pytest.raises(
+        VerifyException, match="Input and output types must have the same rank"
+    ):
         cast = CastOp.get(
             field,
-            IndexAttr.get(-2, -2, -2),
-            IndexAttr.get(100, 100, 100),
-            FieldType((102, 102), f32),
-        )
-        cast.verify()
-
-    # check that input has same shape as lb, ub, output
-    with pytest.raises(VerifyException, match="same dimensions"):
-        dyn_field_wrong_shape = TestSSAValue(FieldType((-1, -1), f32))
-        cast = CastOp.get(
-            dyn_field_wrong_shape,
-            IndexAttr.get(-2, -2, -2),
-            IndexAttr.get(100, 100, 100),
-            FieldType((102, 102, 102), f32),
+            StencilBoundsAttr(((-2, 100), (-2, 100), (-2, 100))),
+            FieldType(((-2, 102), (-2, 102)), f32),
         )
         cast.verify()
 
     # check that input and output have same element type
-    with pytest.raises(VerifyException, match="element type"):
+    with pytest.raises(
+        VerifyException,
+        match="Input and output fields must have the same element types",
+    ):
         cast = CastOp.get(
             field,
-            IndexAttr.get(-2, -2, -2),
-            IndexAttr.get(100, 100, 100),
-            FieldType((102, 102, 102), f64),
-        )
-        cast.verify()
-
-    # check that len(lb) == len(ub)
-    with pytest.raises(VerifyException, match="same dimensions"):
-        cast = CastOp.get(
-            field,
-            IndexAttr.get(
-                -2,
-                -2,
-            ),
-            IndexAttr.get(100, 100, 100),
-            FieldType((102, 102, 102), f32),
-        )
-        cast.verify()
-
-    # check that len(lb) == len(ub)
-    with pytest.raises(VerifyException, match="same dimensions"):
-        cast = CastOp.get(
-            field,
-            IndexAttr.get(-2, -2, -2),
-            IndexAttr.get(100, 100),
-            FieldType((102, 102, 102), f32),
+            StencilBoundsAttr(((-2, 100), (-2, 100), (-2, 100))),
+            FieldType(((-2, 102), (-2, 102), (-2, 102)), f64),
         )
         cast.verify()
 
     # check that non-dynamic input verifies
-    non_dyn_field = TestSSAValue(FieldType((102, 102, 102), f32))
+    non_dyn_field = TestSSAValue(FieldType(((-2, 102), (-2, 102), (-2, 102)), f32))
     cast = CastOp.get(
         non_dyn_field,
-        IndexAttr.get(-2, -2, -2),
-        IndexAttr.get(100, 100, 100),
-        FieldType((102, 102, 102), f32),
+        StencilBoundsAttr(((-2, 100), (-2, 100), (-2, 100))),
+        FieldType(((-2, 102), (-2, 102), (-2, 102)), f32),
     )
     cast.verify()
 
@@ -160,45 +115,43 @@ def test_stencil_cast_op_verifier():
     ):
         cast = CastOp.get(
             non_dyn_field,
-            IndexAttr.get(-2, -2, -2),
-            IndexAttr.get(100, 100, 101),
-            FieldType((102, 102, 103), f32),
+            StencilBoundsAttr(((-2, 100), (-2, 100), (-2, 101))),
+            FieldType(((-2, 102), (-2, 102), (-3, 103)), f32),
         )
         cast.verify()
 
 
 def test_cast_op_constructor():
-    field = TestSSAValue(FieldType((-1, -1, -1), f32))
+    field = TestSSAValue(FieldType(3, f32))
 
     cast = CastOp.get(
         field,
-        IndexAttr.get(-2, -3, -4),
-        IndexAttr.get(100, 100, 0),
+        StencilBoundsAttr(((-2, 100), (-3, 100), (-4, 0))),
     )
 
-    assert cast.result.typ == FieldType((102, 103, 4), f32)
+    assert cast.result.typ == FieldType(((-2, 100), (-3, 100), (-4, 0)), f32)
 
 
 def test_stencil_apply():
     result_type_val1 = TestSSAValue(ResultType(f32))
 
-    stencil_temptype = TempType([-1] * 2, f32)
+    stencil_temptype = TempType(2, f32)
     apply_op = ApplyOp.get([result_type_val1], Block([]), [stencil_temptype])
 
     assert len(apply_op.args) == 1
     assert len(apply_op.res) == 1
     assert isinstance(apply_op.res[0].typ, TempType)
-    assert len(apply_op.res[0].typ.shape) == 2
+    assert len(apply_op.res[0].typ.get_shape()) == 2
 
 
 def test_stencil_apply_no_args():
-    stencil_temptype = TempType([-1] * 1, f32)
+    stencil_temptype = TempType(1, f32)
     apply_op = ApplyOp.get([], Block([]), [stencil_temptype, stencil_temptype])
 
     assert len(apply_op.args) == 0
     assert len(apply_op.res) == 2
     assert isinstance(apply_op.res[0].typ, TempType)
-    assert len(apply_op.res[0].typ.shape) == 1
+    assert len(apply_op.res[0].typ.get_shape()) == 1
 
 
 def test_stencil_apply_no_results():
@@ -345,10 +298,7 @@ def test_index_attr_iter(indices: tuple[int]):
     assert tuple(stencil_index_attr) == indices
 
 
-@pytest.mark.parametrize(
-    "indices",
-    (([1]), ([1, 2]), ([1, 2, 3])),
-)
+@pytest.mark.parametrize("indices", (([1]), ([1, 2]), ([1, 2, 3])))
 def test_index_attr_indices_length(indices: list[int]):
     stencil_index_attr = IndexAttr.get(*indices)
     stencil_index_attr_iter = iter(stencil_index_attr)
@@ -358,69 +308,79 @@ def test_index_attr_indices_length(indices: list[int]):
 
 
 @pytest.mark.parametrize(
-    "attr, dims",
+    "attr, bounds",
     (
-        (i32, (64, 64)),
+        (i32, ((0, 64), (0, 64))),
         (
             i64,
-            (32, 32, 32),
+            ((0, 32), (0, 32), (0, 32)),
         ),
     ),
 )
 def test_stencil_fieldtype_constructor_with_ArrayAttr(
-    attr: IntegerType, dims: tuple[int]
+    attr: IntegerType, bounds: tuple[tuple[int, int], ...]
 ):
-    stencil_fieldtype = FieldType(dims, attr)
+    stencil_fieldtype = FieldType(bounds, attr)
 
     assert stencil_fieldtype.element_type == attr
-    assert stencil_fieldtype.get_num_dims() == len(dims)
-    assert stencil_fieldtype.get_shape() == dims
+    assert stencil_fieldtype.get_num_dims() == len(bounds)
+    assert isinstance(stencil_fieldtype.bounds, StencilBoundsAttr)
+    assert (
+        tuple(zip(stencil_fieldtype.bounds.lb, stencil_fieldtype.bounds.ub)) == bounds
+    )
 
 
 @pytest.mark.parametrize(
-    "attr, dims",
+    "attr, bounds",
     (
-        (i32, (1, 2)),
-        (i32, (1, 1, 3)),
-        (i64, (1, 1, 3)),
+        (i32, ((0, 1), (0, 2))),
+        (i32, ((0, 1), (0, 1), (0, 3))),
+        (i64, ((0, 1), (0, 1), (0, 3))),
     ),
 )
-def test_stencil_fieldtype_constructor(attr: IntegerType, dims: tuple[int]):
-    stencil_fieldtype = FieldType(dims, attr)
+def test_stencil_fieldtype_constructor(
+    attr: IntegerType, bounds: tuple[tuple[int, int], ...]
+):
+    stencil_fieldtype = FieldType(bounds, attr)
 
     assert stencil_fieldtype.element_type == attr
-    assert stencil_fieldtype.get_num_dims() == len(dims)
-    assert stencil_fieldtype.get_shape() == dims
+    assert stencil_fieldtype.get_num_dims() == len(bounds)
+    assert isinstance(stencil_fieldtype.bounds, StencilBoundsAttr)
+    assert (
+        tuple(zip(stencil_fieldtype.bounds.lb, stencil_fieldtype.bounds.ub)) == bounds
+    )
 
 
 @pytest.mark.parametrize(
-    "attr, dims",
+    "attr, bounds",
     (
         (i32, []),
         (i64, []),
     ),
 )
-def test_stencil_fieldtype_constructor_empty_list(attr: IntegerType, dims: list[int]):
+def test_stencil_fieldtype_constructor_empty_list(
+    attr: IntegerType, bounds: list[tuple[int, int]]
+):
     with pytest.raises(VerifyException) as exc_info:
-        FieldType(dims, attr)
+        FieldType(bounds, attr)
     assert exc_info.value.args[0] == "Expected 1 to 3 indexes for stencil.index, got 0."
 
 
 def test_stencil_load():
-    field_type = FieldType([1, 1], f32)
+    field_type = FieldType([(0, 1), (0, 1)], f32)
     result_type_val1 = TestSSAValue(field_type)
 
     load = LoadOp.get(result_type_val1)
 
     assert isinstance(load.field.typ, FieldType)
     assert load.field.typ == field_type
-    assert len(load.field.typ.shape) == 2
+    assert len(load.field.typ.get_shape()) == 2
     assert load.lb is None
     assert load.ub is None
 
 
 def test_stencil_load_bounds():
-    field_type = FieldType([1, 1], f32)
+    field_type = FieldType([(0, 1), (0, 1)], f32)
     result_type_val1 = TestSSAValue(field_type)
 
     lb = IndexAttr.get(1, 1)
@@ -441,39 +401,43 @@ def test_stencil_load_bounds():
 @pytest.mark.parametrize(
     "attr, dims",
     (
-        (i32, (64, 64)),
+        (i32, ((0, 64), (0, 64))),
         (
             i64,
-            (32, 32, 32),
+            ((0, 32), (0, 32), (0, 32)),
         ),
     ),
 )
 def test_stencil_temptype_constructor_with_ArrayAttr(
-    attr: IntegerType, dims: tuple[int]
+    attr: IntegerType, dims: tuple[tuple[int, int], ...]
 ):
     stencil_temptype = TempType(dims, attr)
 
     assert isinstance(stencil_temptype, TempType)
     assert stencil_temptype.element_type == attr
     assert stencil_temptype.get_num_dims() == len(dims)
-    assert stencil_temptype.get_shape() == dims
+    assert isinstance(stencil_temptype.bounds, StencilBoundsAttr)
+    assert tuple(zip(stencil_temptype.bounds.lb, stencil_temptype.bounds.ub)) == dims
 
 
 @pytest.mark.parametrize(
     "attr, dims",
     (
-        (i32, (1, 2)),
-        (i32, (1, 1, 3)),
-        (i64, (1, 1, 3)),
+        (i32, ((0, 1), (0, 2))),
+        (i32, ((0, 1), (0, 1), (0, 3))),
+        (i64, ((0, 1), (0, 1), (0, 3))),
     ),
 )
-def test_stencil_temptype_constructor(attr: IntegerType, dims: tuple[int]):
+def test_stencil_temptype_constructor(
+    attr: IntegerType, dims: tuple[tuple[int, int], ...]
+):
     stencil_temptype = TempType(dims, attr)
 
     assert isinstance(stencil_temptype, TempType)
     assert stencil_temptype.element_type == attr
     assert stencil_temptype.get_num_dims() == len(dims)
-    assert stencil_temptype.get_shape() == dims
+    assert isinstance(stencil_temptype.bounds, StencilBoundsAttr)
+    assert tuple(zip(stencil_temptype.bounds.lb, stencil_temptype.bounds.ub)) == dims
 
 
 @pytest.mark.parametrize(
@@ -483,7 +447,9 @@ def test_stencil_temptype_constructor(attr: IntegerType, dims: tuple[int]):
         (i64, []),
     ),
 )
-def test_stencil_temptype_constructor_empty_list(attr: IntegerType, dims: list[int]):
+def test_stencil_temptype_constructor_empty_list(
+    attr: IntegerType, dims: list[tuple[int, int]]
+):
     with pytest.raises(VerifyException) as exc_info:
         TempType(dims, attr)
     assert exc_info.value.args[0] == "Expected 1 to 3 indexes for stencil.index, got 0."

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -26,8 +26,9 @@ from xdsl.dialects.experimental.stencil import (
     IndexAttr,
 )
 from xdsl.dialects.stencil import CastOp
-from xdsl.ir import Block
+from xdsl.ir import Attribute, Block
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 from xdsl.utils.test_value import TestSSAValue
 
 
@@ -375,8 +376,10 @@ def test_stencil_load():
     assert isinstance(load.field.typ, FieldType)
     assert load.field.typ == field_type
     assert len(load.field.typ.get_shape()) == 2
-    assert load.lb is None
-    assert load.ub is None
+    assert isinstance(load.field.typ.bounds, StencilBoundsAttr)
+    assert isa(load.res.typ, TempType[Attribute])
+    assert isa(load.res.typ.bounds, IntAttr)
+    assert load.res.typ.bounds.data == 2
 
 
 def test_stencil_load_bounds():
@@ -388,14 +391,14 @@ def test_stencil_load_bounds():
 
     load = LoadOp.get(result_type_val1, lb, ub)
 
-    assert isinstance(load.lb, IndexAttr)
-    assert len(load.lb.array) == 2
-    for my_val, load_val in zip(lb.array.data, load.lb.array):
-        assert my_val.data == load_val.data
-    assert isinstance(load.ub, IndexAttr)
-    assert len(load.ub.array) == 2
-    for my_val, load_val in zip(ub.array.data, load.ub.array):
-        assert my_val.data == load_val.data
+    assert isa(load.res.typ, TempType[Attribute])
+    assert isinstance(load.res.typ.bounds, StencilBoundsAttr)
+    assert isinstance(load.res.typ.bounds.lb, IndexAttr)
+    assert isinstance(load.res.typ.bounds.ub, IndexAttr)
+    assert len(load.res.typ.bounds.lb) == 2
+    assert load.res.typ.bounds.lb == lb
+    assert len(load.res.typ.bounds.ub) == 2
+    assert load.res.typ.bounds.ub == ub
 
 
 @pytest.mark.parametrize(

--- a/tests/filecheck/dialects/stencil/copy.mlir
+++ b/tests/filecheck/dialects/stencil/copy.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %2 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
     %5 = "stencil.apply"(%4) ({
     ^1(%6 : !stencil.temp<[0,64]x[0,64]x[0,64]xf64>):
@@ -20,8 +20,8 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
 // CHECK-NEXT:     ^1(%6 : !stencil.temp<[0,64]x[0,64]x[0,64]xf64>):

--- a/tests/filecheck/dialects/stencil/copy.mlir
+++ b/tests/filecheck/dialects/stencil/copy.mlir
@@ -3,16 +3,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %4 = "stencil.load"(%2) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<64x64x64xf64>
+    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
     %5 = "stencil.apply"(%4) ({
-    ^1(%6 : !stencil.temp<64x64x64xf64>):
-      %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<64x64x64xf64>) -> f64
+    ^1(%6 : !stencil.temp<[0,64]x[0,64]x[0,64]xf64>):
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> f64
       %8 = "stencil.store_result"(%7) : (f64) -> !stencil.result<f64>
       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<64x64x64xf64>) -> !stencil.temp<64x64x64xf64>
-    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<64x64x64xf64>, !stencil.field<72x72x72xf64>) -> ()
+    }) : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
@@ -20,16 +20,16 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<64x64x64xf64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^1(%6 : !stencil.temp<64x64x64xf64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<64x64x64xf64>) -> f64
+// CHECK-NEXT:     ^1(%6 : !stencil.temp<[0,64]x[0,64]x[0,64]xf64>):
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> f64
 // CHECK-NEXT:       %8 = "stencil.store_result"(%7) : (f64) -> !stencil.result<f64>
 // CHECK-NEXT:       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<64x64x64xf64>) -> !stencil.temp<64x64x64xf64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<64x64x64xf64>, !stencil.field<72x72x72xf64>) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "stencil_copy", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -3,9 +3,9 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>, %2 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %5 = "stencil.cast"(%2) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %7, %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):

--- a/tests/filecheck/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff.mlir
@@ -3,10 +3,10 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>, %2 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %5 = "stencil.cast"(%2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %7, %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):
       %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
@@ -22,7 +22,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19, %18) : (f64, f64) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> (!stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>)
-    "stencil.store"(%7, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
+    "stencil.store"(%7, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -3,9 +3,9 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):
       %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
@@ -21,7 +21,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_inference.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_inference.mlir
@@ -33,14 +33,14 @@
 // CHECK-NEXT:   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
 // CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<-1, -1, 0>, "ub" = #stencil.index<65, 65, 64>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^1(%6 : !stencil.temp<?x?x?xf64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+// CHECK-NEXT:     ^1(%6 : !stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>):
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> f64
+// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> f64
+// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> f64
+// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> f64
+// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> f64
 // CHECK-NEXT:       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
 // CHECK-NEXT:       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
 // CHECK-NEXT:       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -48,7 +48,7 @@
 // CHECK-NEXT:       %15 = "arith.mulf"(%11, %cst) : (f64, f64) -> f64
 // CHECK-NEXT:       %16 = "arith.addf"(%15, %14) : (f64, f64) -> f64
 // CHECK-NEXT:       "stencil.return"(%16) : (f64) -> ()
-// CHECK-NEXT:     }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
+// CHECK-NEXT:     }) : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
 // CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_inference.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_inference.mlir
@@ -4,9 +4,9 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):
       %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
@@ -22,7 +22,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
@@ -31,9 +31,9 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<-1, -1, 0>, "ub" = #stencil.index<65, 65, 64>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<66x66x64xf64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<-1, -1, 0>, "ub" = #stencil.index<65, 65, 64>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
 // CHECK-NEXT:     ^1(%6 : !stencil.temp<?x?x?xf64>):
 // CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
@@ -48,8 +48,8 @@
 // CHECK-NEXT:       %15 = "arith.mulf"(%11, %cst) : (f64, f64) -> f64
 // CHECK-NEXT:       %16 = "arith.addf"(%15, %14) : (f64, f64) -> f64
 // CHECK-NEXT:       "stencil.return"(%16) : (f64) -> ()
-// CHECK-NEXT:     }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<66x66x64xf64>) -> !stencil.temp<64x64x64xf64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<64x64x64xf64>, !stencil.field<72x72x72xf64>) -> ()
+// CHECK-NEXT:     }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_inference.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_inference.mlir
@@ -4,8 +4,8 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):
@@ -31,8 +31,8 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:     %4 = "stencil.load"(%2) {"lb" = #stencil.index<-1, -1, 0>, "ub" = #stencil.index<65, 65, 64>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
 // CHECK-NEXT:     ^1(%6 : !stencil.temp<?x?x?xf64>):

--- a/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[0,68]x[0,68]x[0,68]xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[0,68]x[0,68]x[0,68]xf64>
+    %4 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):

--- a/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_out_of_bound.mlir
@@ -3,9 +3,9 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<68x68x68xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %6 = "stencil.load"(%3) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[0,68]x[0,68]x[0,68]xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):
       %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
@@ -21,7 +21,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil.mlir
@@ -21,11 +21,11 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<?xf32>):
@@ -188,11 +188,11 @@
 // CHECK-NEXT:      %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:      %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:      %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:      %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
 // CHECK-NEXT:      %7 = "stencil.apply"(%6) ({
 // CHECK-NEXT:      ^2(%t0_buff : !stencil.temp<?xf32>):

--- a/tests/filecheck/dialects/stencil/heat_stencil.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil.mlir
@@ -21,12 +21,12 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
-      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<50x80x40xf32>) -> !stencil.temp<?x?x?xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<?xf32>):
         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
@@ -157,7 +157,7 @@
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
       }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()
@@ -188,12 +188,12 @@
 // CHECK-NEXT:      %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:      %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:      %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+// CHECK-NEXT:      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:      %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:      %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:      %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
-// CHECK-NEXT:      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<58x88x48xf32>) -> !stencil.temp<?x?x?xf32>
+// CHECK-NEXT:      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
 // CHECK-NEXT:      %7 = "stencil.apply"(%6) ({
 // CHECK-NEXT:      ^2(%t0_buff : !stencil.temp<?xf32>):
 // CHECK-NEXT:        %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
@@ -324,7 +324,7 @@
 // CHECK-NEXT:        %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
 // CHECK-NEXT:        "stencil.return"(%115) : (f32) -> ()
 // CHECK-NEXT:      }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
-// CHECK-NEXT:      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
+// CHECK-NEXT:      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
 // CHECK-NEXT:      "scf.yield"() : () -> ()
 // CHECK-NEXT:    }) : (index, index, index) -> ()
 // CHECK-NEXT:    "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
@@ -21,11 +21,11 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<?xf32>):
@@ -185,11 +185,11 @@
 // CHECK-NEXT:       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<-2, -2, -2>, "ub" = #stencil.index<52, 82, 42>} : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>
 // CHECK-NEXT:       %7 = "stencil.apply"(%6) ({
 // CHECK-NEXT:       ^2(%t0_buff : !stencil.temp<?xf32>):

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
@@ -21,12 +21,12 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
-      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<50x80x40xf32>) -> !stencil.temp<?x?x?xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<?xf32>):
         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
@@ -157,7 +157,7 @@
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
       }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()
@@ -185,12 +185,12 @@
 // CHECK-NEXT:       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
 // CHECK-NEXT:       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+// CHECK-NEXT:       %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
-// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<-2, -2, -2>, "ub" = #stencil.index<52, 82, 42>} : (!stencil.field<58x88x48xf32>) -> !stencil.temp<54x84x44xf32>
+// CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<-2, -2, -2>, "ub" = #stencil.index<52, 82, 42>} : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>
 // CHECK-NEXT:       %7 = "stencil.apply"(%6) ({
 // CHECK-NEXT:       ^2(%t0_buff : !stencil.temp<?xf32>):
 // CHECK-NEXT:         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
@@ -320,8 +320,8 @@
 // CHECK-NEXT:         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
 // CHECK-NEXT:         "stencil.return"(%115) : (f32) -> ()
-// CHECK-NEXT:       }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<54x84x44xf32>) -> !stencil.temp<50x80x40xf32>
-// CHECK-NEXT:       "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<50x80x40xf32>, !stencil.field<58x88x48xf32>) -> ()
+// CHECK-NEXT:       }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> !stencil.temp<[0,50]x[0,80]x[0,40]xf32>
+// CHECK-NEXT:       "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[0,50]x[0,80]x[0,40]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) : (index, index, index) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference.mlir
@@ -190,22 +190,22 @@
 // CHECK-NEXT:       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
 // CHECK-NEXT:       %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
-// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) {"lb" = #stencil.index<-2, -2, -2>, "ub" = #stencil.index<52, 82, 42>} : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>
+// CHECK-NEXT:       %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>
 // CHECK-NEXT:       %7 = "stencil.apply"(%6) ({
-// CHECK-NEXT:       ^2(%t0_buff : !stencil.temp<?xf32>):
-// CHECK-NEXT:         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<?xf32>) -> f32
-// CHECK-NEXT:         %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<?xf32>) -> f32
+// CHECK-NEXT:       ^2(%t0_buff : !stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>):
+// CHECK-NEXT:         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %9 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %10 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %11 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<-2, 0, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %12 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<2, 0, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %13 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %14 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %15 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, -2, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %16 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 2, 0>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %17 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -1>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %18 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 1>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %19 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, -2>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
+// CHECK-NEXT:         %20 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 2>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> f32
 // CHECK-NEXT:         %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:         %21 = "arith.constant"() {"value" = -1 : i64} : () -> i64
 // CHECK-NEXT:         %22 = "math.fpowi"(%dt, %21) : (f32, i64) -> f32
@@ -320,7 +320,7 @@
 // CHECK-NEXT:         %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
 // CHECK-NEXT:         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
 // CHECK-NEXT:         "stencil.return"(%115) : (f32) -> ()
-// CHECK-NEXT:       }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> !stencil.temp<[0,50]x[0,80]x[0,40]xf32>
+// CHECK-NEXT:       }) : (!stencil.temp<[-2,52]x[-2,82]x[-2,42]xf32>) -> !stencil.temp<[0,50]x[0,80]x[0,40]xf32>
 // CHECK-NEXT:       "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<[0,50]x[0,80]x[0,40]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) : (index, index, index) -> ()

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -21,11 +21,11 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<?xf32>):

--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -21,12 +21,12 @@
       %t0_w_size = "arith.index_cast"(%t0) : (i64) -> index
       %t0_w_size_1 = "memref.load"(%data, %t0_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t0_w_size_2 = "stencil.external_load"(%t0_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
+      %t0_w_size_3 = "stencil.cast"(%t0_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
       %t1_w_size_2 = "stencil.external_load"(%t1_w_size_1) : (memref<?x?x?xf32>) -> !stencil.field<?x?x?xf32>
-      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<58x88x48xf32>
-      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<50x80x40xf32>) -> !stencil.temp<?x?x?xf32>
+      %t1_w_size_3 = "stencil.cast"(%t1_w_size_2) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<54, 84, 44>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      %6 = "stencil.load"(%t0_w_size_3) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
       %7 = "stencil.apply"(%6) ({
       ^2(%t0_buff : !stencil.temp<?xf32>):
         %8 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
@@ -157,7 +157,7 @@
         %115 = "arith.mulf"(%114, %dt_1) : (f32, f32) -> f32
         "stencil.return"(%115) : (f32) -> ()
       }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
-      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<58x88x48xf32>) -> ()
+      "stencil.store"(%7, %t1_w_size_3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
       "scf.yield"() : () -> ()
     }) : (index, index, index) -> ()
     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/laplace.mlir
+++ b/tests/filecheck/dialects/stencil/laplace.mlir
@@ -3,16 +3,16 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
-    %4 = "stencil.load"(%2) : (!stencil.field<72x72xf64>) -> !stencil.temp<66x66xf64>
+    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+    %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
     %5 = "stencil.apply"(%4) ({
-    ^1(%6 : !stencil.temp<66x66xf64>):
-      %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<66x66xf64>) -> f64
-      %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<66x66xf64>) -> f64
-      %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<66x66xf64>) -> f64
-      %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<66x66xf64>) -> f64
-      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<66x66xf64>) -> f64
+    ^1(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+      %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+      %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+      %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -20,8 +20,8 @@
       %16 = "arith.mulf"(%11, %15) : (f64, f64) -> f64
       %17 = "arith.mulf"(%16, %13) : (f64, f64) -> f64
       "stencil.return"(%17) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<66x66xf64>) -> !stencil.temp<64x64xf64>
-    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<64x64xf64>, !stencil.field<72x72xf64>) -> ()
+    }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<?x?xf64>, !stencil.field<?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
@@ -29,16 +29,16 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<72x72xf64>) -> !stencil.temp<66x66xf64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^1(%6 : !stencil.temp<66x66xf64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<66x66xf64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<66x66xf64>) -> f64
-// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<66x66xf64>) -> f64
-// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<66x66xf64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<66x66xf64>) -> f64
+// CHECK-NEXT:     ^1(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
 // CHECK-NEXT:       %12 = "arith.addf"(%7, %8) : (f64, f64) -> f64
 // CHECK-NEXT:       %13 = "arith.addf"(%9, %10) : (f64, f64) -> f64
 // CHECK-NEXT:       %14 = "arith.addf"(%12, %13) : (f64, f64) -> f64
@@ -46,8 +46,8 @@
 // CHECK-NEXT:       %16 = "arith.mulf"(%11, %15) : (f64, f64) -> f64
 // CHECK-NEXT:       %17 = "arith.mulf"(%16, %13) : (f64, f64) -> f64
 // CHECK-NEXT:       "stencil.return"(%17) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<66x66xf64>) -> !stencil.temp<64x64xf64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<64x64xf64>, !stencil.field<72x72xf64>) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "stencil_laplace", "function_type" = (!stencil.field<?x?xf64>, !stencil.field<?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/stencil/laplace.mlir
+++ b/tests/filecheck/dialects/stencil/laplace.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>):
-    %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
-    %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+    %2 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%1) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
     %5 = "stencil.apply"(%4) ({
     ^1(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):
@@ -29,8 +29,8 @@
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   "func.func"() ({
 // CHECK-NEXT:   ^0(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>):
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
 // CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
 // CHECK-NEXT:     ^1(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):

--- a/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : f64, %1 : !stencil.field<?x?x?xf64>):
-    %2 = "stencil.cast"(%1) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
+    %2 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
     %3 = "stencil.apply"(%0) ({
     ^1(%4 : f64):
       %5 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
@@ -16,7 +16,7 @@
 
   "func.func"() ({
   ^2(%7 : f32, %8 : !stencil.field<?x?x?xf32>):
-    %9 = "stencil.cast"(%8) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf32>
+    %9 = "stencil.cast"(%8) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf32>
     %10 = "stencil.apply"(%7) ({
     ^3(%11 : f32):
       %12 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32

--- a/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_apply_float_arg.mlir
@@ -3,27 +3,27 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : f64, %1 : !stencil.field<?x?x?xf64>):
-    %2 = "stencil.cast"(%1) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<70x70x70xf64>
+    %2 = "stencil.cast"(%1) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
     %3 = "stencil.apply"(%0) ({
     ^1(%4 : f64):
       %5 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
       %6 = "arith.addf"(%4, %5) : (f64, f64) -> f64
       "stencil.return"(%6) : (!stencil.result<f64>) -> ()
     }) : (f64) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<?x?x?xf64>, !stencil.field<64x64x60xf64>) -> ()
+    "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[1,65]x[2,66]x[3,63]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (f64, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_float64_arg"} : () -> ()
 
   "func.func"() ({
   ^2(%7 : f32, %8 : !stencil.field<?x?x?xf32>):
-    %9 = "stencil.cast"(%8) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<70x70x70xf32>
+    %9 = "stencil.cast"(%8) {"lb" = #stencil.index<-3, -3, -3>, "ub" = #stencil.index<67, 67, 67>} : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf32>
     %10 = "stencil.apply"(%7) ({
     ^3(%11 : f32):
       %12 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32
       %13 = "arith.addf"(%11, %12) : (f32, f32) -> f32
       "stencil.return"(%13) : (f32) -> ()
     }) : (f32) -> !stencil.temp<?x?x?xf32>
-    "stencil.store"(%10, %9) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<?x?x?xf32>, !stencil.field<70x70x70xf32>) -> ()
+    "stencil.store"(%10, %9) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-3,67]x[-3,67]x[-3,67]xf32>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (f32, !stencil.field<?x?x?xf32>) -> (), "sym_name" = "stencil_float32_arg"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
@@ -3,12 +3,12 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<72xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.temp<72xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.temp<[-4,68]xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<72xf64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72xf64>) -> f64
-        }) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<72xf64>) -> ()
+        ^b0(%3: !stencil.temp<[-4,68]xf64>):
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]xf64>) -> f64
+        }) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<[-4,68]xf64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
@@ -4,11 +4,12 @@
     "func.func"() ({
     ^0(%0 : !stencil.field<?xf64>):
         %1 = "stencil.cast"(%0) : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.temp<[-4,68]xf64>
-        "stencil.apply"(%2) ({
+        %2 = "stencil.load"(%1) : (!stencil.field<?xf64>) -> !stencil.temp<[-4,68]xf64>
+        %5 = "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[-4,68]xf64>):
             %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]xf64>) -> f64
-        }) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<[-4,68]xf64>) -> ()
+            "stencil.return"(%4) : (f64) -> ()
+        }) : (!stencil.temp<[-4,68]xf64>) -> (!stencil.temp<[0,68]xf64>)
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_1d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
         %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.temp<[-4,68]xf64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[-4,68]xf64>):

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -4,11 +4,12 @@
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?xf64>):
         %1 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]xf64>
-        "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<[-4,68]x[-4,68]xf64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]x[-4,68]xf64>) -> f64
-        }) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 68>} : (!stencil.temp<[-4,68]x[-4,68]xf64>) -> ()
+        %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]xf64>
+        %5 = "stencil.apply"(%2) ({
+        ^b0(%3: !stencil.temp<[-1,64]x[0,68]xf64>):
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[-1,64]x[0,68]xf64>) -> f64
+            "stencil.return"(%4) : (f64) -> ()
+        }) : (!stencil.temp<[0,64]x[0,68]xf64>) -> (!stencil.temp<[0,64]x[0,68]xf64>)
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -3,12 +3,12 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<72x72xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<72x72xf64>) -> !stencil.temp<72x72xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<72x72xf64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72x72xf64>) -> f64
-        }) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 68>} : (!stencil.temp<72x72xf64>) -> ()
+        ^b0(%3: !stencil.temp<[-4,68]x[-4,68]xf64>):
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]x[-4,68]xf64>) -> f64
+        }) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 68>} : (!stencil.temp<[-4,68]x[-4,68]xf64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_2d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
         %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4>, "ub" = #stencil.index<68, 68>} : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]xf64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[-4,68]x[-4,68]xf64>):

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -3,12 +3,12 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x74x76xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<72x74x76xf64>) -> !stencil.temp<72x74x76xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>) -> !stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<72x74x76xf64>):
-            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72x74x76xf64>) -> f64
-        }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 68>} : (!stencil.temp<72x74x76xf64>) -> ()
+        ^b0(%3: !stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>):
+            %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>) -> f64
+        }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 68>} : (!stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -4,11 +4,12 @@
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
         %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>) -> !stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>
-        "stencil.apply"(%2) ({
+        %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>) -> !stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>
+        %5 = "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>):
             %4 = "stencil.access"(%3) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>) -> f64
-        }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 68>} : (!stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>) -> ()
+            "stencil.return"(%4) : (f64) -> ()
+        }) : (!stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>) -> (!stencil.temp<[0,64]x[0,64]x[0,68]xf64>)
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_access_lowering_3d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>
         %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 70, 72>} : (!stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>) -> !stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[-4,68]x[-4,70]x[-4,72]xf64>):

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -4,10 +4,12 @@
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
         %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
-        "stencil.apply"(%2) ({
+        %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
+        %5 = "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>):
-        }) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
+            %zero = "arith.constant"() {value = 0.0 : f64} : () -> f64
+            "stencil.return"(%zero) : (f64) -> ()
+        }) : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>)
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
@@ -28,6 +30,7 @@
 // CHECK-NEXT:       ^2(%9 : index):
 // CHECK-NEXT:         "scf.for"(%3, %7, %4) ({
 // CHECK-NEXT:         ^3(%10 : index):
+// CHECK-NEXT:             %zero = "arith.constant"() {"value" = 0.0 : f64} : () -> f64
 // CHECK-NEXT:           "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) : (index, index, index) -> ()
 // CHECK-NEXT:         "scf.yield"() : () -> ()

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -3,11 +3,11 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<72x72x72xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
         "stencil.apply"(%2) ({
-        ^b0(%3: !stencil.temp<72x72x72xf64>):
-        }) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.temp<72x72x72xf64>) -> ()
+        ^b0(%3: !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>):
+        }) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_apply_lowering.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
         %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
         "stencil.apply"(%2) ({
         ^b0(%3: !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>):

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_1d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<72xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4>, "ub" = #stencil.index<68>} : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
+++ b/tests/filecheck/dialects/stencil/test_castop_lowering_3d.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
         %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<72x72x72xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_loadop_lowering.mlir
@@ -4,7 +4,7 @@
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>):
         %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-        %2 = "stencil.load"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
+        %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -5,13 +5,13 @@
     ^0(%0 : !stencil.field<?x?x?xf64>, %6 : !stencil.field<?x?x?xf64>):
         %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
         %7 = "stencil.cast"(%6) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-        %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
+        %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
         %8 = "stencil.apply"(%2) ({
-        ^b0(%4: !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>):
-            %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> f64
+        ^b0(%4: !stencil.temp<?x?x?xf64>):
+            %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<?x?x?xf64>) -> f64
             "stencil.return"(%5) : (f64) -> ()
-        }) : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>)
-        "stencil.store"(%8, %7) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
+        }) : (!stencil.temp<?x?x?xf64>) -> (!stencil.temp<?x?x?xf64>)
+        "stencil.store"(%8, %7) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
@@ -22,7 +22,7 @@
 // CHECK-NEXT:     %2 = "memref.cast"(%0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
 // CHECK-NEXT:     %3 = "memref.cast"(%1) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
 // CHECK-NEXT:     %4 = "memref.subview"(%3) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 64, 64>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x72x72xf64>) -> memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:     %5 = "memref.subview"(%2) {"static_offsets" = array<i64: 3, 4, 5>, "static_sizes" = array<i64: 64, 64, 64>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x72x72xf64>) -> memref<64x64x64xf64, strided<[5184, 72, 1], offset: 15845>>
+// CHECK-NEXT:     %5 = "memref.subview"(%2) {"static_offsets" = array<i64: 3, 4, 4>, "static_sizes" = array<i64: 65, 64, 65>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x72x72xf64>) -> memref<65x64x65xf64, strided<[5184, 72, 1], offset: 15844>>
 // CHECK-NEXT:     %6 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:     %7 = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:     %8 = "arith.constant"() {"value" = 64 : index} : () -> index
@@ -36,11 +36,11 @@
 // CHECK-NEXT:         ^3(%13 : index):
 // CHECK-NEXT:           %14 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:           %15 = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:           %16 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:           %16 = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:           %17 = "arith.addi"(%11, %14) : (index, index) -> index
 // CHECK-NEXT:           %18 = "arith.addi"(%12, %15) : (index, index) -> index
 // CHECK-NEXT:           %19 = "arith.addi"(%13, %16) : (index, index) -> index
-// CHECK-NEXT:           %20 = "memref.load"(%5, %17, %18, %19) : (memref<64x64x64xf64, strided<[5184, 72, 1], offset: 15845>>, index, index, index) -> f64
+// CHECK-NEXT:           %20 = "memref.load"(%5, %17, %18, %19) : (memref<65x64x65xf64, strided<[5184, 72, 1], offset: 15844>>, index, index, index) -> f64
 // CHECK-NEXT:           "memref.store"(%20, %4, %11, %12, %13) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
 // CHECK-NEXT:           "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) : (index, index, index) -> ()

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -3,15 +3,15 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>, %6 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-        %2 = "stencil.load"(%1) : (!stencil.field<72x72x72xf64>) -> !stencil.temp<72x72x72xf64>
+        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
         %8 = "stencil.apply"(%2) ({
-        ^b0(%4: !stencil.temp<72x72x72xf64>):
-            %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<72x72x72xf64>) -> f64
+        ^b0(%4: !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>):
+            %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> f64
             "stencil.return"(%5) : (f64) -> ()
-        }) : (!stencil.temp<72x72x72xf64>) -> (!stencil.temp<72x72x72xf64>)
-        "stencil.store"(%8, %7) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<72x72x72xf64>, !stencil.field<72x72x72xf64>) -> ()
+        }) : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>)
+        "stencil.store"(%8, %7) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
         "func.return"() : () -> ()
     }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/test_store_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_store_lowering.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
     "func.func"() ({
     ^0(%0 : !stencil.field<?x?x?xf64>, %6 : !stencil.field<?x?x?xf64>):
-        %1 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-        %7 = "stencil.cast"(%6) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+        %7 = "stencil.cast"(%6) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
         %2 = "stencil.load"(%1) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
         %8 = "stencil.apply"(%2) ({
         ^b0(%4: !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>):

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -5,14 +5,14 @@
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
     %3 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     %4 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %6 = "stencil.load"(%3) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
+    %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>
     %8 = "stencil.apply"(%6) ({
-    ^1(%9 : !stencil.temp<?x?x?xf64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+    ^1(%9 : !stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>):
+      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> f64
+      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} :  (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> f64
+      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} :  (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> f64
+      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> f64
+      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} :  (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> f64
       %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
       %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
       %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
@@ -20,8 +20,8 @@
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
-    }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
+    }) : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     %6 = "stencil.load"(%3) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -3,9 +3,9 @@
 "builtin.module"() ({
   "func.func"() ({
   ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<72x72x72xf64>
-    %6 = "stencil.load"(%3) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<72x72x72xf64>) -> !stencil.temp<?x?x?xf64>
+    %3 = "stencil.cast"(%0) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.cast"(%1) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %6 = "stencil.load"(%3) {"lb" = #stencil.index<-4, -4, -4>, "ub" = #stencil.index<68, 68, 68>} : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
     %8 = "stencil.apply"(%6) ({
     ^1(%9 : !stencil.temp<?x?x?xf64>):
       %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
@@ -21,7 +21,7 @@
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
       "stencil.return"(%19) : (!stencil.result<f64>) -> ()
     }) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<72x72x72xf64>) -> ()
+    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -115,6 +115,10 @@ class IndexAttr(ParametrizedAttribute, Iterable[int]):
 
 @irdl_attr_definition
 class StencilBoundsAttr(ParametrizedAttribute):
+    """
+    This attribute represents known bounds over a stencil type.
+    """
+
     name = "stencil.bounds"
     lb: ParameterDef[IndexAttr]
     ub: ParameterDef[IndexAttr]
@@ -147,6 +151,12 @@ class StencilType(
     Generic[_FieldTypeElement], ParametrizedAttribute, TypeAttribute, builtin.ShapeType
 ):
     bounds: ParameterDef[StencilBoundsAttr | IntAttr]
+    """
+    Represents the bounds information of a stencil.field or stencil.temp.
+
+    A StencilBoundsAttr encodes known bounds, where an IntAttr encodes the
+    rank of unknown bounds. A stencil.field or stencil.temp cannot be unranked!
+    """
     element_type: ParameterDef[_FieldTypeElement]
 
     def get_num_dims(self) -> int:
@@ -230,6 +240,13 @@ class FieldType(
     ParametrizedAttribute,
     TypeAttribute,
 ):
+    """
+    stencil.field represents memory from which stencil input values will be loaded,
+    or to which stencil output values will be stored.
+
+    stencil.temp are loaded from or stored to stencil.field
+    """
+
     name = "stencil.field"
 
 
@@ -240,6 +257,11 @@ class TempType(
     ParametrizedAttribute,
     TypeAttribute,
 ):
+    """
+    stencil.temp represents stencil values, and is the type on which stencil.apply operates.
+    It has value-semantics: it won't necesseraly be lowered to an actual buffer.
+    """
+
     name = "stencil.temp"
 
 
@@ -308,7 +330,7 @@ class IndexOp(IRDLOperation):
 @irdl_op_definition
 class AccessOp(IRDLOperation):
     """
-    This operation accesses a temporary element given a constant
+    This operation accesses a value from a stencil.temp given the specified offset.
     offset. The offset is specified relative to the current position.
 
     Example:
@@ -342,7 +364,7 @@ class AccessOp(IRDLOperation):
 @irdl_op_definition
 class LoadOp(IRDLOperation):
     """
-    This operation takes a field and returns a temporary values.
+    This operation takes a field and returns its values.
 
     Example:
       %0 = stencil.load %field : (!stencil.field<70x70x60xf64>) -> !stencil.temp<?x?x?xf64>
@@ -405,7 +427,7 @@ class BufferOp(IRDLOperation):
 @irdl_op_definition
 class StoreOp(IRDLOperation):
     """
-    This operation takes a temp and writes a field on a user defined range.
+    This operation writes values to a field on a user defined range.
 
     Example:
       stencil.store %temp to %field ([0,0,0] : [64,64,60]) : !stencil.temp<?x?x?xf64> to !stencil.field<70x70x60xf64>

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -224,6 +224,15 @@ class StencilType(
         | StencilBoundsAttr,
         typ: _FieldTypeElement,
     ) -> None:
+        """
+            A StencilBoundsAttr encodes known bounds, where an IntAttr encodes the
+        rank of unknown bounds. A stencil.field or stencil.temp cannot be unranked!
+
+        ### examples:
+
+        - `Field(3,f32)` is represented as `stencil.field<?x?x?xf32>`
+        - `Field([(-1,17),(-2,18)],f32)` is represented as `stencil.field<[-1,17]x[-2,18]xf32>`,
+        """
         if isinstance(bounds, Iterable):
             nbounds = StencilBoundsAttr(bounds)
         elif isinstance(bounds, int):

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -219,8 +219,6 @@ def prepare_apply_body(op: ApplyOp, rewriter: PatternRewriter):
 class ApplyOpToParallel(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
-        # if not op.res:
-        #     return
         res_typ = op.res[0].typ
         assert isa(res_typ, TempType[Attribute])
         assert isinstance(res_typ.bounds, StencilBoundsAttr)

--- a/xdsl/transforms/experimental/StencilShapeInference.py
+++ b/xdsl/transforms/experimental/StencilShapeInference.py
@@ -5,6 +5,7 @@ from xdsl.dialects.experimental.stencil import (
     ApplyOp,
     IndexAttr,
     LoadOp,
+    StencilBoundsAttr,
     StoreOp,
     TempType,
 )
@@ -65,7 +66,7 @@ class LoadOpShapeInference(RewritePattern):
         # TODO: We need to think about that. Do we want an API for this?
         # Do we just want to recreate the whole operation?
         op.res.typ = TempType(
-            IndexAttr.size_from_bounds(op.lb, op.ub),
+            StencilBoundsAttr(tuple(zip(op.lb, op.ub))),
             op.res.typ.element_type,
         )
 
@@ -105,7 +106,7 @@ class ApplyOpShapeInference(RewritePattern):
         for result in op.results:
             assert isa(result.typ, TempType[Attribute])
             result.typ = TempType(
-                IndexAttr.size_from_bounds(op.lb, op.ub), result.typ.element_type
+                StencilBoundsAttr(tuple(zip(op.lb, op.ub))), result.typ.element_type
             )
 
 

--- a/xdsl/transforms/experimental/StencilShapeInference.py
+++ b/xdsl/transforms/experimental/StencilShapeInference.py
@@ -1,16 +1,17 @@
-from typing import Iterable, TypeVar
+from typing import Iterable, TypeVar, cast
 from xdsl.dialects import builtin
 from xdsl.dialects.experimental.stencil import (
     AccessOp,
     ApplyOp,
+    FieldType,
     IndexAttr,
     LoadOp,
     StencilBoundsAttr,
     StoreOp,
     TempType,
 )
-from xdsl.dialects.stencil import CastOp
-from xdsl.ir import Attribute, BlockArgument, MLContext, Operation, SSAValue
+
+from xdsl.ir import Attribute, MLContext, Operation, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -19,7 +20,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.transforms.experimental.ConvertStencilToLLMLIR import verify_load_bounds
+from xdsl.transforms.experimental.ConvertStencilToLLMLIR import assert_subset
 from xdsl.utils.hints import isa
 
 _OpT = TypeVar("_OpT", bound=Operation)
@@ -44,9 +45,12 @@ def infer_core_size(op: LoadOp) -> tuple[IndexAttr, IndexAttr]:
     shape_ub: None | IndexAttr = None
 
     for apply in applies:
-        assert apply.lb is not None and apply.ub is not None
-        shape_lb = IndexAttr.min(apply.lb, shape_lb)
-        shape_ub = IndexAttr.max(apply.ub, shape_ub)
+        # assert apply.lb is not None and apply.ub is not None
+        assert apply.res
+        res_typ = cast(TempType[Attribute], apply.res[0])
+        assert isinstance(res_typ.bounds, StencilBoundsAttr)
+        shape_lb = IndexAttr.min(res_typ.bounds.lb, shape_lb)
+        shape_ub = IndexAttr.max(res_typ.bounds.ub, shape_ub)
 
     assert shape_lb is not None and shape_ub is not None
     return shape_lb, shape_ub
@@ -55,59 +59,59 @@ def infer_core_size(op: LoadOp) -> tuple[IndexAttr, IndexAttr]:
 class LoadOpShapeInference(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: LoadOp, rewriter: PatternRewriter, /):
-        cast = op.field.owner
-        assert isinstance(cast, CastOp)
+        field = op.field.typ
+        assert isa(field, FieldType[Attribute])
+        temp = op.res.typ
+        assert isa(temp, TempType[Attribute])
 
-        verify_load_bounds(cast, op)
-
-        assert op.lb and op.ub
-        assert isa(op.res.typ, TempType[Attribute])
-
-        # TODO: We need to think about that. Do we want an API for this?
-        # Do we just want to recreate the whole operation?
-        op.res.typ = TempType(
-            StencilBoundsAttr(tuple(zip(op.lb, op.ub))),
-            op.res.typ.element_type,
-        )
+        assert_subset(field, temp)
 
 
 class StoreOpShapeInference(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: StoreOp, rewriter: PatternRewriter, /):
-        owner = op.temp.owner
+        temp = op.temp.typ
 
-        assert isinstance(owner, ApplyOp | LoadOp)
+        assert isa(temp, TempType[Attribute])
+        temp_lb = None
+        temp_ub = None
+        if isinstance(temp.bounds, StencilBoundsAttr):
+            temp_lb = temp.bounds.lb
+            temp_ub = temp.bounds.ub
 
-        owner.attributes["lb"] = IndexAttr.min(op.lb, owner.lb)
-        owner.attributes["ub"] = IndexAttr.max(op.ub, owner.ub)
+        temp_lb = IndexAttr.min(op.lb, temp_lb)
+        temp_ub = IndexAttr.max(op.ub, temp_ub)
+        op.temp.typ = TempType(tuple(zip(temp_lb, temp_ub)), temp.element_type)
 
 
 class ApplyOpShapeInference(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
-        for access in op.walk():
-            assert (op.lb is not None) and (op.ub is not None)
-            if not isinstance(access, AccessOp):
+        if len(op.res) < 1:
+            return
+        res_typ = op.res[0].typ
+        assert isa(res_typ, TempType[Attribute])
+        assert isinstance(res_typ.bounds, StencilBoundsAttr)
+        ntyp = res_typ
+        assert isinstance(ntyp.bounds, StencilBoundsAttr)
+
+        accesses = [a for a in op.walk() if isinstance(a, AccessOp)]
+        if not accesses:
+            return
+        for access in accesses:
+            temp = access.temp.typ
+            assert isa(temp, TempType[Attribute])
+
+            lb = IndexAttr.min(res_typ.bounds.lb + access.offset, ntyp.bounds.lb)
+            ub = IndexAttr.max(res_typ.bounds.ub + access.offset, ntyp.bounds.ub)
+            ntyp = TempType(tuple(zip(lb, ub)), temp.element_type)
+            assert isinstance(ntyp.bounds, StencilBoundsAttr)
+
+        for i, arg in enumerate(op.args):
+            if not isa(arg.typ, TempType[Attribute]):
                 continue
-            assert isinstance(access.temp, BlockArgument)
-            temp_owner = op.args[access.temp.index].owner
-
-            assert isinstance(temp_owner, LoadOp | ApplyOp)
-
-            temp_owner.attributes["lb"] = IndexAttr.min(
-                op.lb + access.offset, temp_owner.lb
-            )
-            temp_owner.attributes["ub"] = IndexAttr.max(
-                op.ub + access.offset, temp_owner.ub
-            )
-
-        assert op.lb and op.ub
-
-        for result in op.results:
-            assert isa(result.typ, TempType[Attribute])
-            result.typ = TempType(
-                StencilBoundsAttr(tuple(zip(op.lb, op.ub))), result.typ.element_type
-            )
+            arg.typ = ntyp
+            op.region.block.args[i].typ = ntyp
 
 
 ShapeInference = GreedyRewritePatternApplier(


### PR DESCRIPTION
This enables `stencil.field` and `stencil.temp` to carry bounds information rather than absolute size only.
It switches the operations to not use attributes to encode this information anymore, but their operands/results types.
It potentially decouples analysis and lowering steps, and just feels more natural to me in the MLIR mindset.
As a comparison: layouted memrefs also carry this information in their type, note onloy in the defining operation's attributes, and those bounds are ultimately mapped to memref offsets.

The only exception here is `stencil.store`, as it is the starting point for shape inference. To allow giving the output size, this operation still works with "ub"/"lb" attributes, because typing the operand is the same thing as typing the defining operation's result, so requiring shape inference to be done already..

Starting from here, there's probably a more fitting way to express this on `stencil.store`? But it's clearly not an objective for me ATM, as it wouldn't help working with stencil IR significantly, only readability.

I would recommend going over [tests/filecheck/dialects/stencil/hdiff.mlir](https://github.com/xdslproject/xdsl/compare/main...emilien/stencil-types-bounds#diff-c1ba398d7430fa90ee60e4e973ceb1a3d0af56c20223849f3aa6d8035f5e828d) for a first skim!