### PR TITLE
core: Correctly parse identifiers that start with a number [Minor]

### DIFF
--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -53,7 +53,7 @@ def test_pass_parser():
     passes = list(
         parse_pipeline(
             'pass-1,pass-2{arg1=1 arg2=test,test2,3 arg3="test-str,2,3" '
-            "arg-4=-34.4e-12 no-val-arg},pass-3"
+            "arg-4=-34.4e-12 no-val-arg},pass-3{thing=2d-grid}"
         )
     )
 
@@ -69,7 +69,12 @@ def test_pass_parser():
                 "no-val-arg": [],
             },
         ),
-        PipelinePassSpec("pass-3", {}),
+        PipelinePassSpec(
+            "pass-3",
+            {
+                "thing": ["2d-grid"],
+            },
+        ),
     ]
 
 

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -27,6 +27,8 @@ class Token:
 
 
 _lexer_rules: list[tuple[re.Pattern[str], Token.Kind]] = [
+    # first rule is special to allow 2d-slice to be recognized as an ident
+    (re.compile(r"[0-9]+[A-Za-z_-]+[A-Za-z0-9_-]*"), Token.Kind.IDENT),
     (re.compile(r"[-+]?[0-9]+(\.[0-9]*([eE][-+]?[0-9]+)?)?"), Token.Kind.NUMBER),
     (re.compile(r"[A-Za-z0-9_-]+"), Token.Kind.IDENT),
     (re.compile(r'"(\\[nfvtr"\\]|[^\n\f\v\r"\\])*"'), Token.Kind.STRING_LIT),


### PR DESCRIPTION
This change makes it so `2d-grid` is tokenized to `[IDENT(2d-grid)]` instead of `[NUMBER(2), IDENT(d-grid)]`