### PR TITLE
dialects: extend the stencil lowerings

### DIFF
--- a/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
+++ b/tests/filecheck/dialects/stencil/heat_stencil_inference_ll.mlir
@@ -188,224 +188,224 @@
 // CHECK-NEXT:       %t1_w_size = "arith.index_cast"(%t1) : (i64) -> index
 // CHECK-NEXT:       %t1_w_size_1 = "memref.load"(%data, %t1_w_size) : (memref<2xmemref<?x?x?xf32>>, index) -> memref<?x?x?xf32>
 // CHECK-NEXT:       %t1_w_size_3 = "memref.cast"(%t1_w_size_1) : (memref<?x?x?xf32>) -> memref<58x88x48xf32>
-// CHECK-NEXT:       %t1_w_size_3_1 = "memref.subview"(%t1_w_size_3) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 50, 80, 40>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<58x88x48xf32>) -> memref<50x80x40xf32, strided<[4224, 48, 1], offset: 17092>>
-// CHECK-NEXT:       %6 = "memref.subview"(%t0_w_size_3) {"static_offsets" = array<i64: 2, 2, 2>, "static_sizes" = array<i64: 54, 84, 44>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<58x88x48xf32>) -> memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>
-// CHECK-NEXT:       %7 = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:       %8 = "arith.constant"() {"value" = 1 : index} : () -> index
-// CHECK-NEXT:       %9 = "arith.constant"() {"value" = 50 : index} : () -> index
-// CHECK-NEXT:       %10 = "arith.constant"() {"value" = 80 : index} : () -> index
-// CHECK-NEXT:       %11 = "arith.constant"() {"value" = 40 : index} : () -> index
-// CHECK-NEXT:       "scf.parallel"(%7, %9, %8) ({
-// CHECK-NEXT:       ^2(%12 : index):
-// CHECK-NEXT:         "scf.for"(%7, %10, %8) ({
-// CHECK-NEXT:         ^3(%13 : index):
-// CHECK-NEXT:           "scf.for"(%7, %11, %8) ({
-// CHECK-NEXT:           ^4(%14 : index):
+// CHECK-NEXT:       %t1_w_size_3_storeview = "memref.subview"(%t1_w_size_3) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 50, 80, 40>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<58x88x48xf32>) -> memref<50x80x40xf32, strided<[4224, 48, 1], offset: 17092>>
+// CHECK-NEXT:       %t0_w_size_3_loadview = "memref.subview"(%t0_w_size_3) {"static_offsets" = array<i64: 2, 2, 2>, "static_sizes" = array<i64: 54, 84, 44>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<58x88x48xf32>) -> memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>
+// CHECK-NEXT:       %6 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:       %7 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:       %8 = "arith.constant"() {"value" = 50 : index} : () -> index
+// CHECK-NEXT:       %9 = "arith.constant"() {"value" = 80 : index} : () -> index
+// CHECK-NEXT:       %10 = "arith.constant"() {"value" = 40 : index} : () -> index
+// CHECK-NEXT:       "scf.parallel"(%6, %8, %7) ({
+// CHECK-NEXT:       ^2(%11 : index):
+// CHECK-NEXT:         "scf.for"(%6, %9, %7) ({
+// CHECK-NEXT:         ^3(%12 : index):
+// CHECK-NEXT:           "scf.for"(%6, %10, %7) ({
+// CHECK-NEXT:           ^4(%13 : index):
+// CHECK-NEXT:             %14 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %15 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %16 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %17 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %17 = "arith.addi"(%11, %14) : (index, index) -> index
 // CHECK-NEXT:             %18 = "arith.addi"(%12, %15) : (index, index) -> index
 // CHECK-NEXT:             %19 = "arith.addi"(%13, %16) : (index, index) -> index
-// CHECK-NEXT:             %20 = "arith.addi"(%14, %17) : (index, index) -> index
-// CHECK-NEXT:             %21 = "memref.load"(%6, %18, %19, %20) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %22 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:             %20 = "memref.load"(%t0_w_size_3_loadview, %17, %18, %19) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %21 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:             %22 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %23 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %24 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %24 = "arith.addi"(%11, %21) : (index, index) -> index
 // CHECK-NEXT:             %25 = "arith.addi"(%12, %22) : (index, index) -> index
 // CHECK-NEXT:             %26 = "arith.addi"(%13, %23) : (index, index) -> index
-// CHECK-NEXT:             %27 = "arith.addi"(%14, %24) : (index, index) -> index
-// CHECK-NEXT:             %28 = "memref.load"(%6, %25, %26, %27) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %29 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:             %27 = "memref.load"(%t0_w_size_3_loadview, %24, %25, %26) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %28 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:             %29 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %30 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %31 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %31 = "arith.addi"(%11, %28) : (index, index) -> index
 // CHECK-NEXT:             %32 = "arith.addi"(%12, %29) : (index, index) -> index
 // CHECK-NEXT:             %33 = "arith.addi"(%13, %30) : (index, index) -> index
-// CHECK-NEXT:             %34 = "arith.addi"(%14, %31) : (index, index) -> index
-// CHECK-NEXT:             %35 = "memref.load"(%6, %32, %33, %34) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %36 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:             %34 = "memref.load"(%t0_w_size_3_loadview, %31, %32, %33) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %35 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:             %36 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %37 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %38 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %38 = "arith.addi"(%11, %35) : (index, index) -> index
 // CHECK-NEXT:             %39 = "arith.addi"(%12, %36) : (index, index) -> index
 // CHECK-NEXT:             %40 = "arith.addi"(%13, %37) : (index, index) -> index
-// CHECK-NEXT:             %41 = "arith.addi"(%14, %38) : (index, index) -> index
-// CHECK-NEXT:             %42 = "memref.load"(%6, %39, %40, %41) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %43 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:             %41 = "memref.load"(%t0_w_size_3_loadview, %38, %39, %40) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %42 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:             %43 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %44 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %45 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %45 = "arith.addi"(%11, %42) : (index, index) -> index
 // CHECK-NEXT:             %46 = "arith.addi"(%12, %43) : (index, index) -> index
 // CHECK-NEXT:             %47 = "arith.addi"(%13, %44) : (index, index) -> index
-// CHECK-NEXT:             %48 = "arith.addi"(%14, %45) : (index, index) -> index
-// CHECK-NEXT:             %49 = "memref.load"(%6, %46, %47, %48) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %50 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %51 = "arith.constant"() {"value" = 1 : index} : () -> index
-// CHECK-NEXT:             %52 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %48 = "memref.load"(%t0_w_size_3_loadview, %45, %46, %47) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %49 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %50 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:             %51 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %52 = "arith.addi"(%11, %49) : (index, index) -> index
 // CHECK-NEXT:             %53 = "arith.addi"(%12, %50) : (index, index) -> index
 // CHECK-NEXT:             %54 = "arith.addi"(%13, %51) : (index, index) -> index
-// CHECK-NEXT:             %55 = "arith.addi"(%14, %52) : (index, index) -> index
-// CHECK-NEXT:             %56 = "memref.load"(%6, %53, %54, %55) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %57 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %58 = "arith.constant"() {"value" = 3 : index} : () -> index
-// CHECK-NEXT:             %59 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %55 = "memref.load"(%t0_w_size_3_loadview, %52, %53, %54) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %56 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %57 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:             %58 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %59 = "arith.addi"(%11, %56) : (index, index) -> index
 // CHECK-NEXT:             %60 = "arith.addi"(%12, %57) : (index, index) -> index
 // CHECK-NEXT:             %61 = "arith.addi"(%13, %58) : (index, index) -> index
-// CHECK-NEXT:             %62 = "arith.addi"(%14, %59) : (index, index) -> index
-// CHECK-NEXT:             %63 = "memref.load"(%6, %60, %61, %62) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %64 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %65 = "arith.constant"() {"value" = 0 : index} : () -> index
-// CHECK-NEXT:             %66 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %62 = "memref.load"(%t0_w_size_3_loadview, %59, %60, %61) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %63 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %64 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:             %65 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %66 = "arith.addi"(%11, %63) : (index, index) -> index
 // CHECK-NEXT:             %67 = "arith.addi"(%12, %64) : (index, index) -> index
 // CHECK-NEXT:             %68 = "arith.addi"(%13, %65) : (index, index) -> index
-// CHECK-NEXT:             %69 = "arith.addi"(%14, %66) : (index, index) -> index
-// CHECK-NEXT:             %70 = "memref.load"(%6, %67, %68, %69) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
-// CHECK-NEXT:             %71 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %72 = "arith.constant"() {"value" = 4 : index} : () -> index
-// CHECK-NEXT:             %73 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %69 = "memref.load"(%t0_w_size_3_loadview, %66, %67, %68) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %70 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %71 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:             %72 = "arith.constant"() {"value" = 2 : index} : () -> index
+// CHECK-NEXT:             %73 = "arith.addi"(%11, %70) : (index, index) -> index
 // CHECK-NEXT:             %74 = "arith.addi"(%12, %71) : (index, index) -> index
 // CHECK-NEXT:             %75 = "arith.addi"(%13, %72) : (index, index) -> index
-// CHECK-NEXT:             %76 = "arith.addi"(%14, %73) : (index, index) -> index
-// CHECK-NEXT:             %77 = "memref.load"(%6, %74, %75, %76) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %76 = "memref.load"(%t0_w_size_3_loadview, %73, %74, %75) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %77 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %78 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %79 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %80 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:             %79 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:             %80 = "arith.addi"(%11, %77) : (index, index) -> index
 // CHECK-NEXT:             %81 = "arith.addi"(%12, %78) : (index, index) -> index
 // CHECK-NEXT:             %82 = "arith.addi"(%13, %79) : (index, index) -> index
-// CHECK-NEXT:             %83 = "arith.addi"(%14, %80) : (index, index) -> index
-// CHECK-NEXT:             %84 = "memref.load"(%6, %81, %82, %83) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %83 = "memref.load"(%t0_w_size_3_loadview, %80, %81, %82) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %84 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %85 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %86 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %87 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:             %86 = "arith.constant"() {"value" = 3 : index} : () -> index
+// CHECK-NEXT:             %87 = "arith.addi"(%11, %84) : (index, index) -> index
 // CHECK-NEXT:             %88 = "arith.addi"(%12, %85) : (index, index) -> index
 // CHECK-NEXT:             %89 = "arith.addi"(%13, %86) : (index, index) -> index
-// CHECK-NEXT:             %90 = "arith.addi"(%14, %87) : (index, index) -> index
-// CHECK-NEXT:             %91 = "memref.load"(%6, %88, %89, %90) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %90 = "memref.load"(%t0_w_size_3_loadview, %87, %88, %89) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %91 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %92 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %93 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %94 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:             %93 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:             %94 = "arith.addi"(%11, %91) : (index, index) -> index
 // CHECK-NEXT:             %95 = "arith.addi"(%12, %92) : (index, index) -> index
 // CHECK-NEXT:             %96 = "arith.addi"(%13, %93) : (index, index) -> index
-// CHECK-NEXT:             %97 = "arith.addi"(%14, %94) : (index, index) -> index
-// CHECK-NEXT:             %98 = "memref.load"(%6, %95, %96, %97) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %97 = "memref.load"(%t0_w_size_3_loadview, %94, %95, %96) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %98 = "arith.constant"() {"value" = 2 : index} : () -> index
 // CHECK-NEXT:             %99 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %100 = "arith.constant"() {"value" = 2 : index} : () -> index
-// CHECK-NEXT:             %101 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:             %100 = "arith.constant"() {"value" = 4 : index} : () -> index
+// CHECK-NEXT:             %101 = "arith.addi"(%11, %98) : (index, index) -> index
 // CHECK-NEXT:             %102 = "arith.addi"(%12, %99) : (index, index) -> index
 // CHECK-NEXT:             %103 = "arith.addi"(%13, %100) : (index, index) -> index
-// CHECK-NEXT:             %104 = "arith.addi"(%14, %101) : (index, index) -> index
-// CHECK-NEXT:             %105 = "memref.load"(%6, %102, %103, %104) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
+// CHECK-NEXT:             %104 = "memref.load"(%t0_w_size_3_loadview, %101, %102, %103) : (memref<54x84x44xf32, strided<[4224, 48, 1], offset: 8546>>, index, index, index) -> f32
 // CHECK-NEXT:             %dt = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
-// CHECK-NEXT:             %106 = "arith.constant"() {"value" = -1 : i64} : () -> i64
-// CHECK-NEXT:             %107 = "math.fpowi"(%dt, %106) : (f32, i64) -> f32
-// CHECK-NEXT:             %108 = "arith.mulf"(%107, %21) : (f32, f32) -> f32
-// CHECK-NEXT:             %109 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:             %105 = "arith.constant"() {"value" = -1 : i64} : () -> i64
+// CHECK-NEXT:             %106 = "math.fpowi"(%dt, %105) : (f32, i64) -> f32
+// CHECK-NEXT:             %107 = "arith.mulf"(%106, %20) : (f32, f32) -> f32
+// CHECK-NEXT:             %108 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
 // CHECK-NEXT:             %h_x = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %110 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %111 = "math.fpowi"(%h_x, %110) : (f32, i64) -> f32
-// CHECK-NEXT:             %112 = "arith.mulf"(%109, %111) : (f32, f32) -> f32
-// CHECK-NEXT:             %113 = "arith.mulf"(%112, %28) : (f32, f32) -> f32
-// CHECK-NEXT:             %114 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:             %109 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %110 = "math.fpowi"(%h_x, %109) : (f32, i64) -> f32
+// CHECK-NEXT:             %111 = "arith.mulf"(%108, %110) : (f32, f32) -> f32
+// CHECK-NEXT:             %112 = "arith.mulf"(%111, %27) : (f32, f32) -> f32
+// CHECK-NEXT:             %113 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
 // CHECK-NEXT:             %h_x_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %115 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %116 = "math.fpowi"(%h_x_1, %115) : (f32, i64) -> f32
-// CHECK-NEXT:             %117 = "arith.mulf"(%114, %116) : (f32, f32) -> f32
-// CHECK-NEXT:             %118 = "arith.mulf"(%117, %35) : (f32, f32) -> f32
-// CHECK-NEXT:             %119 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
+// CHECK-NEXT:             %114 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %115 = "math.fpowi"(%h_x_1, %114) : (f32, i64) -> f32
+// CHECK-NEXT:             %116 = "arith.mulf"(%113, %115) : (f32, f32) -> f32
+// CHECK-NEXT:             %117 = "arith.mulf"(%116, %34) : (f32, f32) -> f32
+// CHECK-NEXT:             %118 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
 // CHECK-NEXT:             %h_x_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %120 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %121 = "math.fpowi"(%h_x_2, %120) : (f32, i64) -> f32
-// CHECK-NEXT:             %122 = "arith.mulf"(%119, %121) : (f32, f32) -> f32
-// CHECK-NEXT:             %123 = "arith.mulf"(%122, %21) : (f32, f32) -> f32
-// CHECK-NEXT:             %124 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:             %119 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %120 = "math.fpowi"(%h_x_2, %119) : (f32, i64) -> f32
+// CHECK-NEXT:             %121 = "arith.mulf"(%118, %120) : (f32, f32) -> f32
+// CHECK-NEXT:             %122 = "arith.mulf"(%121, %20) : (f32, f32) -> f32
+// CHECK-NEXT:             %123 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
 // CHECK-NEXT:             %h_x_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %125 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %126 = "math.fpowi"(%h_x_3, %125) : (f32, i64) -> f32
-// CHECK-NEXT:             %127 = "arith.mulf"(%124, %126) : (f32, f32) -> f32
-// CHECK-NEXT:             %128 = "arith.mulf"(%127, %42) : (f32, f32) -> f32
-// CHECK-NEXT:             %129 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:             %124 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %125 = "math.fpowi"(%h_x_3, %124) : (f32, i64) -> f32
+// CHECK-NEXT:             %126 = "arith.mulf"(%123, %125) : (f32, f32) -> f32
+// CHECK-NEXT:             %127 = "arith.mulf"(%126, %41) : (f32, f32) -> f32
+// CHECK-NEXT:             %128 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
 // CHECK-NEXT:             %h_x_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %130 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %131 = "math.fpowi"(%h_x_4, %130) : (f32, i64) -> f32
-// CHECK-NEXT:             %132 = "arith.mulf"(%129, %131) : (f32, f32) -> f32
-// CHECK-NEXT:             %133 = "arith.mulf"(%132, %49) : (f32, f32) -> f32
-// CHECK-NEXT:             %134 = "arith.addf"(%113, %118) : (f32, f32) -> f32
-// CHECK-NEXT:             %135 = "arith.addf"(%134, %123) : (f32, f32) -> f32
-// CHECK-NEXT:             %136 = "arith.addf"(%135, %128) : (f32, f32) -> f32
-// CHECK-NEXT:             %137 = "arith.addf"(%136, %133) : (f32, f32) -> f32
-// CHECK-NEXT:             %138 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:             %129 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %130 = "math.fpowi"(%h_x_4, %129) : (f32, i64) -> f32
+// CHECK-NEXT:             %131 = "arith.mulf"(%128, %130) : (f32, f32) -> f32
+// CHECK-NEXT:             %132 = "arith.mulf"(%131, %48) : (f32, f32) -> f32
+// CHECK-NEXT:             %133 = "arith.addf"(%112, %117) : (f32, f32) -> f32
+// CHECK-NEXT:             %134 = "arith.addf"(%133, %122) : (f32, f32) -> f32
+// CHECK-NEXT:             %135 = "arith.addf"(%134, %127) : (f32, f32) -> f32
+// CHECK-NEXT:             %136 = "arith.addf"(%135, %132) : (f32, f32) -> f32
+// CHECK-NEXT:             %137 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
 // CHECK-NEXT:             %h_y = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %139 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %140 = "math.fpowi"(%h_y, %139) : (f32, i64) -> f32
-// CHECK-NEXT:             %141 = "arith.mulf"(%138, %140) : (f32, f32) -> f32
-// CHECK-NEXT:             %142 = "arith.mulf"(%141, %56) : (f32, f32) -> f32
-// CHECK-NEXT:             %143 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:             %138 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %139 = "math.fpowi"(%h_y, %138) : (f32, i64) -> f32
+// CHECK-NEXT:             %140 = "arith.mulf"(%137, %139) : (f32, f32) -> f32
+// CHECK-NEXT:             %141 = "arith.mulf"(%140, %55) : (f32, f32) -> f32
+// CHECK-NEXT:             %142 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
 // CHECK-NEXT:             %h_y_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %144 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %145 = "math.fpowi"(%h_y_1, %144) : (f32, i64) -> f32
-// CHECK-NEXT:             %146 = "arith.mulf"(%143, %145) : (f32, f32) -> f32
-// CHECK-NEXT:             %147 = "arith.mulf"(%146, %63) : (f32, f32) -> f32
-// CHECK-NEXT:             %148 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
+// CHECK-NEXT:             %143 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %144 = "math.fpowi"(%h_y_1, %143) : (f32, i64) -> f32
+// CHECK-NEXT:             %145 = "arith.mulf"(%142, %144) : (f32, f32) -> f32
+// CHECK-NEXT:             %146 = "arith.mulf"(%145, %62) : (f32, f32) -> f32
+// CHECK-NEXT:             %147 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
 // CHECK-NEXT:             %h_y_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %149 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %150 = "math.fpowi"(%h_y_2, %149) : (f32, i64) -> f32
-// CHECK-NEXT:             %151 = "arith.mulf"(%148, %150) : (f32, f32) -> f32
-// CHECK-NEXT:             %152 = "arith.mulf"(%151, %21) : (f32, f32) -> f32
-// CHECK-NEXT:             %153 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:             %148 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %149 = "math.fpowi"(%h_y_2, %148) : (f32, i64) -> f32
+// CHECK-NEXT:             %150 = "arith.mulf"(%147, %149) : (f32, f32) -> f32
+// CHECK-NEXT:             %151 = "arith.mulf"(%150, %20) : (f32, f32) -> f32
+// CHECK-NEXT:             %152 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
 // CHECK-NEXT:             %h_y_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %154 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %155 = "math.fpowi"(%h_y_3, %154) : (f32, i64) -> f32
-// CHECK-NEXT:             %156 = "arith.mulf"(%153, %155) : (f32, f32) -> f32
-// CHECK-NEXT:             %157 = "arith.mulf"(%156, %70) : (f32, f32) -> f32
-// CHECK-NEXT:             %158 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:             %153 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %154 = "math.fpowi"(%h_y_3, %153) : (f32, i64) -> f32
+// CHECK-NEXT:             %155 = "arith.mulf"(%152, %154) : (f32, f32) -> f32
+// CHECK-NEXT:             %156 = "arith.mulf"(%155, %69) : (f32, f32) -> f32
+// CHECK-NEXT:             %157 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
 // CHECK-NEXT:             %h_y_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %159 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %160 = "math.fpowi"(%h_y_4, %159) : (f32, i64) -> f32
-// CHECK-NEXT:             %161 = "arith.mulf"(%158, %160) : (f32, f32) -> f32
-// CHECK-NEXT:             %162 = "arith.mulf"(%161, %77) : (f32, f32) -> f32
-// CHECK-NEXT:             %163 = "arith.addf"(%142, %147) : (f32, f32) -> f32
-// CHECK-NEXT:             %164 = "arith.addf"(%163, %152) : (f32, f32) -> f32
-// CHECK-NEXT:             %165 = "arith.addf"(%164, %157) : (f32, f32) -> f32
-// CHECK-NEXT:             %166 = "arith.addf"(%165, %162) : (f32, f32) -> f32
-// CHECK-NEXT:             %167 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:             %158 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %159 = "math.fpowi"(%h_y_4, %158) : (f32, i64) -> f32
+// CHECK-NEXT:             %160 = "arith.mulf"(%157, %159) : (f32, f32) -> f32
+// CHECK-NEXT:             %161 = "arith.mulf"(%160, %76) : (f32, f32) -> f32
+// CHECK-NEXT:             %162 = "arith.addf"(%141, %146) : (f32, f32) -> f32
+// CHECK-NEXT:             %163 = "arith.addf"(%162, %151) : (f32, f32) -> f32
+// CHECK-NEXT:             %164 = "arith.addf"(%163, %156) : (f32, f32) -> f32
+// CHECK-NEXT:             %165 = "arith.addf"(%164, %161) : (f32, f32) -> f32
+// CHECK-NEXT:             %166 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
 // CHECK-NEXT:             %h_z = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %168 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %169 = "math.fpowi"(%h_z, %168) : (f32, i64) -> f32
-// CHECK-NEXT:             %170 = "arith.mulf"(%167, %169) : (f32, f32) -> f32
-// CHECK-NEXT:             %171 = "arith.mulf"(%170, %84) : (f32, f32) -> f32
-// CHECK-NEXT:             %172 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
+// CHECK-NEXT:             %167 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %168 = "math.fpowi"(%h_z, %167) : (f32, i64) -> f32
+// CHECK-NEXT:             %169 = "arith.mulf"(%166, %168) : (f32, f32) -> f32
+// CHECK-NEXT:             %170 = "arith.mulf"(%169, %83) : (f32, f32) -> f32
+// CHECK-NEXT:             %171 = "arith.constant"() {"value" = 1.3333333332557231 : f32} : () -> f32
 // CHECK-NEXT:             %h_z_1 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %173 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %174 = "math.fpowi"(%h_z_1, %173) : (f32, i64) -> f32
-// CHECK-NEXT:             %175 = "arith.mulf"(%172, %174) : (f32, f32) -> f32
-// CHECK-NEXT:             %176 = "arith.mulf"(%175, %91) : (f32, f32) -> f32
-// CHECK-NEXT:             %177 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
+// CHECK-NEXT:             %172 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %173 = "math.fpowi"(%h_z_1, %172) : (f32, i64) -> f32
+// CHECK-NEXT:             %174 = "arith.mulf"(%171, %173) : (f32, f32) -> f32
+// CHECK-NEXT:             %175 = "arith.mulf"(%174, %90) : (f32, f32) -> f32
+// CHECK-NEXT:             %176 = "arith.constant"() {"value" = -2.5 : f32} : () -> f32
 // CHECK-NEXT:             %h_z_2 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %178 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %179 = "math.fpowi"(%h_z_2, %178) : (f32, i64) -> f32
-// CHECK-NEXT:             %180 = "arith.mulf"(%177, %179) : (f32, f32) -> f32
-// CHECK-NEXT:             %181 = "arith.mulf"(%180, %21) : (f32, f32) -> f32
-// CHECK-NEXT:             %182 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:             %177 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %178 = "math.fpowi"(%h_z_2, %177) : (f32, i64) -> f32
+// CHECK-NEXT:             %179 = "arith.mulf"(%176, %178) : (f32, f32) -> f32
+// CHECK-NEXT:             %180 = "arith.mulf"(%179, %20) : (f32, f32) -> f32
+// CHECK-NEXT:             %181 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
 // CHECK-NEXT:             %h_z_3 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %183 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %184 = "math.fpowi"(%h_z_3, %183) : (f32, i64) -> f32
-// CHECK-NEXT:             %185 = "arith.mulf"(%182, %184) : (f32, f32) -> f32
-// CHECK-NEXT:             %186 = "arith.mulf"(%185, %98) : (f32, f32) -> f32
-// CHECK-NEXT:             %187 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
+// CHECK-NEXT:             %182 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %183 = "math.fpowi"(%h_z_3, %182) : (f32, i64) -> f32
+// CHECK-NEXT:             %184 = "arith.mulf"(%181, %183) : (f32, f32) -> f32
+// CHECK-NEXT:             %185 = "arith.mulf"(%184, %97) : (f32, f32) -> f32
+// CHECK-NEXT:             %186 = "arith.constant"() {"value" = -0.0833333333284827 : f32} : () -> f32
 // CHECK-NEXT:             %h_z_4 = "arith.constant"() {"value" = 0.020202020183205605 : f32} : () -> f32
-// CHECK-NEXT:             %188 = "arith.constant"() {"value" = -2 : i64} : () -> i64
-// CHECK-NEXT:             %189 = "math.fpowi"(%h_z_4, %188) : (f32, i64) -> f32
-// CHECK-NEXT:             %190 = "arith.mulf"(%187, %189) : (f32, f32) -> f32
-// CHECK-NEXT:             %191 = "arith.mulf"(%190, %105) : (f32, f32) -> f32
-// CHECK-NEXT:             %192 = "arith.addf"(%171, %176) : (f32, f32) -> f32
-// CHECK-NEXT:             %193 = "arith.addf"(%192, %181) : (f32, f32) -> f32
-// CHECK-NEXT:             %194 = "arith.addf"(%193, %186) : (f32, f32) -> f32
-// CHECK-NEXT:             %195 = "arith.addf"(%194, %191) : (f32, f32) -> f32
-// CHECK-NEXT:             %196 = "arith.addf"(%137, %166) : (f32, f32) -> f32
-// CHECK-NEXT:             %197 = "arith.addf"(%196, %195) : (f32, f32) -> f32
+// CHECK-NEXT:             %187 = "arith.constant"() {"value" = -2 : i64} : () -> i64
+// CHECK-NEXT:             %188 = "math.fpowi"(%h_z_4, %187) : (f32, i64) -> f32
+// CHECK-NEXT:             %189 = "arith.mulf"(%186, %188) : (f32, f32) -> f32
+// CHECK-NEXT:             %190 = "arith.mulf"(%189, %104) : (f32, f32) -> f32
+// CHECK-NEXT:             %191 = "arith.addf"(%170, %175) : (f32, f32) -> f32
+// CHECK-NEXT:             %192 = "arith.addf"(%191, %180) : (f32, f32) -> f32
+// CHECK-NEXT:             %193 = "arith.addf"(%192, %185) : (f32, f32) -> f32
+// CHECK-NEXT:             %194 = "arith.addf"(%193, %190) : (f32, f32) -> f32
+// CHECK-NEXT:             %195 = "arith.addf"(%136, %165) : (f32, f32) -> f32
+// CHECK-NEXT:             %196 = "arith.addf"(%195, %194) : (f32, f32) -> f32
 // CHECK-NEXT:             %a = "arith.constant"() {"value" = 0.5 : f32} : () -> f32
-// CHECK-NEXT:             %198 = "arith.mulf"(%197, %a) : (f32, f32) -> f32
-// CHECK-NEXT:             %199 = "arith.addf"(%108, %198) : (f32, f32) -> f32
+// CHECK-NEXT:             %197 = "arith.mulf"(%196, %a) : (f32, f32) -> f32
+// CHECK-NEXT:             %198 = "arith.addf"(%107, %197) : (f32, f32) -> f32
 // CHECK-NEXT:             %dt_1 = "arith.constant"() {"value" = 4.122440608513459e-06 : f32} : () -> f32
-// CHECK-NEXT:             %200 = "arith.mulf"(%199, %dt_1) : (f32, f32) -> f32
-// CHECK-NEXT:             "memref.store"(%200, %t1_w_size_3_1, %12, %13, %14) : (f32, memref<50x80x40xf32, strided<[4224, 48, 1], offset: 17092>>, index, index, index) -> ()
+// CHECK-NEXT:             %199 = "arith.mulf"(%198, %dt_1) : (f32, f32) -> f32
+// CHECK-NEXT:             "memref.store"(%199, %t1_w_size_3_storeview, %11, %12, %13) : (f32, memref<50x80x40xf32, strided<[4224, 48, 1], offset: 17092>>, index, index, index) -> ()
 // CHECK-NEXT:             "scf.yield"() : () -> ()
 // CHECK-NEXT:           }) : (index, index, index) -> ()
 // CHECK-NEXT:           "scf.yield"() : () -> ()

--- a/tests/filecheck/dialects/stencil/iterate.mlir
+++ b/tests/filecheck/dialects/stencil/iterate.mlir
@@ -27,15 +27,15 @@ builtin.module {
   }
 }
 
-// CHECK-NEXT: builtin.module {
+// CHECK: builtin.module {
 // CHECK-NEXT:   func.func @bufferswapping_stencil(%f0 : memref<2004x2004xf32>, %f1 : memref<2004x2004xf32>) -> memref<2004x2004xf32> {
 // CHECK-NEXT:     %time_m = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:     %time_M = "arith.constant"() {"value" = 1001 : index} : () -> index
 // CHECK-NEXT:     %step = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:     %t1_out, %t0_out = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
 // CHECK-NEXT:     ^0(%time : index, %fim1 : memref<2004x2004xf32>, %fi : memref<2004x2004xf32>):
-// CHECK-NEXT:       %fi_1 = "memref.subview"(%fi) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2004x2004xf32>
-// CHECK-NEXT:       %tim1 = "memref.subview"(%fim1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
+// CHECK-NEXT:       %fi_storeview = "memref.subview"(%fi) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
+// CHECK-NEXT:       %fim1_loadview = "memref.subview"(%fim1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
 // CHECK-NEXT:       %0 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:       %1 = "arith.constant"() {"value" = 1 : index} : () -> index
 // CHECK-NEXT:       %2 = "arith.constant"() {"value" = 2000 : index} : () -> index
@@ -48,13 +48,13 @@ builtin.module {
 // CHECK-NEXT:           %i_1 = "arith.constant"() {"value" = 0 : index} : () -> index
 // CHECK-NEXT:           %i_2 = arith.addi %4, %i : index
 // CHECK-NEXT:           %i_3 = arith.addi %5, %i_1 : index
-// CHECK-NEXT:           %i_4 = "memref.load"(%tim1, %i_2, %i_3) : (memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> f32
-// CHECK-NEXT:           "memref.store"(%i_4, %fi_1, %4, %5) : (f32, memref<2004x2004xf32>, index, index) -> ()
+// CHECK-NEXT:           %i_4 = "memref.load"(%fim1_loadview, %i_2, %i_3) : (memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> f32
+// CHECK-NEXT:           "memref.store"(%i_4, %fi_storeview, %4, %5) : (f32, memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> ()
 // CHECK-NEXT:           "scf.yield"() : () -> ()
 // CHECK-NEXT:         }) : (index, index, index) -> ()
 // CHECK-NEXT:         "scf.yield"() : () -> ()
 // CHECK-NEXT:       }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"(%fi_1, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
+// CHECK-NEXT:       "scf.yield"(%fi, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
 // CHECK-NEXT:     }) : (index, index, index, memref<2004x2004xf32>, memref<2004x2004xf32>) -> (memref<2004x2004xf32>, memref<2004x2004xf32>)
 // CHECK-NEXT:     "func.return"(%t1_out) : (memref<2004x2004xf32>) -> ()
 // CHECK-NEXT:   }

--- a/tests/filecheck/dialects/stencil/iterate.mlir
+++ b/tests/filecheck/dialects/stencil/iterate.mlir
@@ -1,0 +1,61 @@
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s
+
+builtin.module {
+  func.func @bufferswapping_stencil(%f0 : !stencil.field<[-2,2002]x[-2,2002]xf32>, %f1 : !stencil.field<[-2,2002]x[-2,2002]xf32>) -> (!stencil.field<[-2,2002]x[-2,2002]xf32>) {
+
+    %time_m = "arith.constant"() {"value" = 0 : index} : () -> index
+    %time_M = "arith.constant"() {"value" = 1001 : index} : () -> index
+    %step = "arith.constant"() {"value" = 1 : index} : () -> index
+
+    %t1_out, %t0_out = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
+    ^1(%time : index, %fim1 : !stencil.field<[-2,2002]x[-2,2002]xf32>, %fi : !stencil.field<[-2,2002]x[-2,2002]xf32>):
+
+      %tim1 = "stencil.load"(%fim1) : (!stencil.field<[-2,2002]x[-2,2002]xf32>) -> !stencil.temp<?x?xf32>
+
+      %ti = "stencil.apply"(%tim1) ({
+      ^2(%tim1_b : !stencil.temp<?x?xf32>):
+        %i = "stencil.access"(%tim1) {"offset" = #stencil.index<0,0,0>} : (!stencil.temp<?x?xf32>) -> f32
+        "stencil.return"(%i) : (f32) -> ()
+      }) : (!stencil.temp<?x?xf32>) -> !stencil.temp<?x?xf32>
+
+      "stencil.store"(%ti, %fi) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<2000, 2000>} : (!stencil.temp<?x?xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>) -> ()
+
+      "scf.yield"(%fi, %fim1) : (!stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>) -> ()
+    }) : (index, index, index, !stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>) -> (!stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>)
+
+    "func.return"(%t1_out) : (!stencil.field<[-2,2002]x[-2,2002]xf32>) -> ()
+  }
+}
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func @bufferswapping_stencil(%f0 : memref<2004x2004xf32>, %f1 : memref<2004x2004xf32>) -> memref<2004x2004xf32> {
+// CHECK-NEXT:     %time_m = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:     %time_M = "arith.constant"() {"value" = 1001 : index} : () -> index
+// CHECK-NEXT:     %step = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:     %t1_out, %t0_out = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
+// CHECK-NEXT:     ^0(%time : index, %fim1 : memref<2004x2004xf32>, %fi : memref<2004x2004xf32>):
+// CHECK-NEXT:       %fi_1 = "memref.subview"(%fi) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2004x2004xf32>
+// CHECK-NEXT:       %tim1 = "memref.subview"(%fim1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
+// CHECK-NEXT:       %0 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:       %1 = "arith.constant"() {"value" = 1 : index} : () -> index
+// CHECK-NEXT:       %2 = "arith.constant"() {"value" = 2000 : index} : () -> index
+// CHECK-NEXT:       %3 = "arith.constant"() {"value" = 2000 : index} : () -> index
+// CHECK-NEXT:       "scf.parallel"(%0, %2, %1) ({
+// CHECK-NEXT:       ^1(%4 : index):
+// CHECK-NEXT:         "scf.for"(%0, %3, %1) ({
+// CHECK-NEXT:         ^2(%5 : index):
+// CHECK-NEXT:           %i = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:           %i_1 = "arith.constant"() {"value" = 0 : index} : () -> index
+// CHECK-NEXT:           %i_2 = arith.addi %4, %i : index
+// CHECK-NEXT:           %i_3 = arith.addi %5, %i_1 : index
+// CHECK-NEXT:           %i_4 = "memref.load"(%tim1, %i_2, %i_3) : (memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> f32
+// CHECK-NEXT:           "memref.store"(%i_4, %fi_1, %4, %5) : (f32, memref<2004x2004xf32>, index, index) -> ()
+// CHECK-NEXT:           "scf.yield"() : () -> ()
+// CHECK-NEXT:         }) : (index, index, index) -> ()
+// CHECK-NEXT:         "scf.yield"() : () -> ()
+// CHECK-NEXT:       }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+// CHECK-NEXT:       "scf.yield"(%fi_1, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
+// CHECK-NEXT:     }) : (index, index, index, memref<2004x2004xf32>, memref<2004x2004xf32>) -> (memref<2004x2004xf32>, memref<2004x2004xf32>)
+// CHECK-NEXT:     "func.return"(%t1_out) : (memref<2004x2004xf32>) -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
+++ b/tests/filecheck/dialects/stencil/test_funcop_lowering.mlir
@@ -1,15 +1,20 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir --print-op-generic | filecheck %s
+// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
 
-"builtin.module"() ({
-  "func.func"() ({
-  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
+builtin.module {
+  func.func @test_funcop_lowering(%0 : !stencil.field<?x?x?xf64>) {
     "func.return"() : () -> ()
-  }) {"sym_name" = "test_funcop_lowering", "function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
-}) : () -> ()
+  }
 
-// CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   "func.func"() ({
-// CHECK-NEXT:   ^0(%0 : memref<?x?x?xf64>, %1 : memref<?x?x?xf64>):
+  func.func @test_funcop_lowering(%1 : !stencil.field<[-1,7]x[-1,7]xf64>) {
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func @test_funcop_lowering(%0 : memref<?x?x?xf64>) {
 // CHECK-NEXT:     "func.return"() : () -> ()
-// CHECK-NEXT:   }) {"sym_name" = "test_funcop_lowering", "function_type" = (memref<?x?x?xf64>, memref<?x?x?xf64>) -> (), "sym_visibility" = "private"} : () -> ()
-// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func @test_funcop_lowering(%1 : memref<8x8xf64>) {
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -150,6 +150,7 @@ class StencilBoundsAttr(ParametrizedAttribute):
 class StencilType(
     Generic[_FieldTypeElement], ParametrizedAttribute, TypeAttribute, builtin.ShapeType
 ):
+    name = "stencil.type"
     bounds: ParameterDef[StencilBoundsAttr | IntAttr]
     """
     Represents the bounds information of a stencil.field or stencil.temp.

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -288,7 +288,7 @@ class StencilTypeConversionFuncOp(RewritePattern):
         op.attributes["function_type"] = FunctionType.from_lists(inputs, outputs)
 
 
-class TypeSpreadingForOp(RewritePattern):
+class UpdateLoopCarriedVarTypes(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: scf.For, rewriter: PatternRewriter, /):
         for i in range(len(op.iter_args)):
@@ -430,7 +430,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
             GreedyRewritePatternApplier(
                 [
                     StencilTypeConversionFuncOp(),
-                    TypeSpreadingForOp(),
+                    UpdateLoopCarriedVarTypes(),
                 ]
             )
         )

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -401,6 +401,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
             GreedyRewritePatternApplier(
                 [
                     ApplyOpToParallel(),
+                    StencilTypeConversionFuncOp(),
                     StencilStoreToSubview(return_targets),
                     CastOpToMemref(gpu=(self.target == "gpu")),
                     LoadOpToMemref(),
@@ -416,11 +417,6 @@ class ConvertStencilToLLMLIRPass(ModulePass):
         )
         the_one_pass.rewrite_module(op)
         type_pass = PatternRewriteWalker(
-            GreedyRewritePatternApplier(
-                [
-                    StencilTypeConversionFuncOp(),
-                    UpdateLoopCarriedVarTypes(),
-                ]
-            )
+            GreedyRewritePatternApplier([UpdateLoopCarriedVarTypes()])
         )
         type_pass.rewrite_module(op)

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -85,13 +85,6 @@ class CastOpToMemref(RewritePattern):
         rewriter.replace_matched_op(cast)
 
 
-class StoreOpCleanup(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: StoreOp, rewriter: PatternRewriter, /):
-        rewriter.erase_matched_op()
-        pass
-
-
 # Collect up to 'number' block arguments by walking up the region tree
 # and collecting block arguments as we reach new parent regions.
 def collectBlockArguments(number: int, block: Block):
@@ -395,7 +388,6 @@ def StencilConversion(return_targets: dict[ReturnOp, list[SSAValue | None]], gpu
             AccessOpToMemref(),
             ReturnOpToMemref(return_targets),
             IndexOpToLoopSSA(),
-            StoreOpCleanup(),
             TrivialExternalLoadOpCleanup(),
             TrivialExternalStoreOpCleanup(),
             StencilTypeConversionFuncOp(),


### PR DESCRIPTION
This adds support for returning `stencil.field` from a `func.func`, and using `stencil.field`s as `scf.for` carried variables.