### PR TITLE
misc: Add support for isa(arg, Literal[...])

### DIFF
--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -331,3 +331,11 @@ def test_literal():
     assert isa("string", Literal["string", "another string"])
     assert isa("another string", Literal["string", "another string"])
     assert not isa("not this string", Literal["string", "another string"])
+
+    assert isa(1, Literal[1])
+    assert isa(1, Literal[1, 2])
+    assert isa(2, Literal[1, 2])
+    assert not isa(3, Literal[1, 2])
+
+    assert not isa(1, Literal["1"])
+    assert not isa("1", Literal[1])

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, TypeAlias, TypeVar
+from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
 from xdsl.ir import Attribute, ParametrizedAttribute
 from xdsl.irdl import ParameterDef, irdl_attr_definition
@@ -319,3 +319,15 @@ def test_parametrized_attribute():
     assert isa(attr, MyParamAttr[IntAttr])
     assert isa(attr, MyParamAttr[IntAttr | FloatData])
     assert not isa(attr, MyParamAttr[FloatData])
+
+
+################################################################################
+# Literal
+################################################################################
+
+
+def test_literal():
+    assert isa("string", Literal["string"])
+    assert isa("string", Literal["string", "another string"])
+    assert isa("another string", Literal["string", "another string"])
+    assert not isa("not this string", Literal["string", "another string"])

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     Generic,
     Iterable,
+    Literal,
     Sequence,
     TypeGuard,
     TypeVar,
@@ -66,6 +67,9 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
 
     if origin in [Union, UnionType]:
         return any(isa(arg, union_arg) for union_arg in get_args(hint))
+
+    if origin is Literal:
+        return arg in get_args(hint)
 
     from xdsl.irdl import GenericData, irdl_to_attr_constraint
 


### PR DESCRIPTION
Adds support for `Literal` in isa, as in:

```python
assert isa("cpu", Literal["cpu"])
```

It looks super useless, and it is for direct use!
It gets handy when used in infra though; stacked PR ~~coming up soon!~~ opened: #1031 