### PR TITLE
transformations: Add a flag for target selection on stencil conversion.

### DIFF
--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-gpu --print-op-generic | filecheck %s
+// RUN: xdsl-opt %s -p stencil-shape-inference,convert-stencil-to-ll-mlir{target=gpu} --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/test_pass_from_spec.py
+++ b/tests/test_pass_from_spec.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Literal
 
 import pytest
 
@@ -22,6 +23,8 @@ class CustomPass(ModulePass):
     str_thing: str
 
     nullable_str: str | None
+
+    literal: Literal["yes", "no", "maybe"] = "no"
 
     optional_bool: bool = False
 
@@ -56,6 +59,7 @@ def test_pass_instantiation():
                 "number": [2],
                 "int-list": [1, 2, 3],
                 "str-thing": ["hello world"],
+                "literal": ["maybe"]
                 # "optional" was left out here, as it is optional
             },
         )
@@ -65,6 +69,7 @@ def test_pass_instantiation():
     assert p.int_list == [1, 2, 3]
     assert p.str_thing == "hello world"
     assert p.nullable_str is None
+    assert p.literal == "maybe"
     assert p.optional_bool is False
 
     # this should just work
@@ -82,6 +87,10 @@ def test_pass_instantiation():
         ),
         (PipelinePassSpec("simple", {"a": []}), "Argument must contain a value"),
         (PipelinePassSpec("simple", {"a": ["test"]}), "Incompatible types"),
+        (
+            PipelinePassSpec("simple", {"a": ["test"], "literal": ["definitely"]}),
+            "Incompatible types",
+        ),
     ),
 )
 def test_pass_instantiation_error(spec: PipelinePassSpec, error_msg: str):

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -39,7 +39,6 @@ from xdsl.transforms.lower_riscv_func import LowerRISCVFunc
 from xdsl.transforms.lower_mpi import LowerMPIPass
 from xdsl.transforms.lower_snitch import LowerSnitchPass
 from xdsl.transforms.experimental.ConvertStencilToLLMLIR import (
-    ConvertStencilToGPUPass,
     ConvertStencilToLLMLIRPass,
 )
 from xdsl.transforms.experimental.StencilShapeInference import StencilShapeInferencePass
@@ -275,7 +274,6 @@ class xDSLOptMain:
         """
         self.register_pass(LowerMPIPass)
         self.register_pass(ConvertStencilToLLMLIRPass)
-        self.register_pass(ConvertStencilToGPUPass)
         self.register_pass(StencilShapeInferencePass)
         self.register_pass(GlobalStencilToLocalStencil2DHorizontal)
         self.register_pass(DesymrefyPass)


### PR DESCRIPTION
Get rid of `convert-stencil-to-gpu` as it can be a simple flag now.
Use a `Literal` flag type to enforce specific values only.
Add tests for that case.
Stacked on #1030