### PR TITLE
core: Allow graph regions in printer

### DIFF
--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -276,11 +276,11 @@
      "output_type": "stream",
      "text": [
       "%1 = \"sql.selection\"(%0) ({\n",
-      "^0(%7 : i32):\n",
+      "^0(%2 : i32):\n",
       "  %3 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
       "  %4 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
-      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
-      "  %6 = \"arith.cmpi\"(%7, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  %7 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%2, %7) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
       "  \"scf.yield\"(%6) : (i1) -> ()\n",
       "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
@@ -341,9 +341,9 @@
      "output_type": "stream",
      "text": [
       "%1 = \"sql.selection\"(%0) ({\n",
-      "^0(%9 : i32):\n",
-      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
-      "  %6 = \"arith.cmpi\"(%9, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "^0(%2 : i32):\n",
+      "  %7 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%2, %7) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
       "  \"scf.yield\"(%6) : (i1) -> ()\n",
       "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
@@ -397,9 +397,9 @@
       "builtin.module {\n",
       "  %0 = \"sql.table\"() {\"table_name\" = \"T\"} : () -> #sql.bag<i32>\n",
       "  %1 = \"sql.selection\"(%0) ({\n",
-      "  ^0(%10 : i32):\n",
-      "    %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
-      "    %6 = \"arith.cmpi\"(%10, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  ^0(%2 : i32):\n",
+      "    %7 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "    %6 = \"arith.cmpi\"(%2, %7) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
       "    \"scf.yield\"(%6) : (i1) -> ()\n",
       "  }) : (#sql.bag<i32>) -> #sql.bag<i32>\n",
       "  \"sql.sink\"(%1) : (#sql.bag<i32>) -> ()\n",

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -962,7 +962,7 @@
      "text": [
       "arith.addi32 operation does not verify\n",
       "\n",
-      "%0 = \"arith.addi32\"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i64\n",
+      "%0 = \"arith.addi32\"(%1, %1) : (i32, i32) -> i64\n",
       "\n",
       "\n"
      ]
@@ -1029,7 +1029,7 @@
      "text": [
       "binary_op operation does not verify\n",
       "\n",
-      "%0 = \"binary_op\"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i64\n",
+      "%0 = \"binary_op\"(%1, %1) : (i32, i32) -> i64\n",
       "\n",
       "\n"
      ]
@@ -1426,7 +1426,7 @@
      "text": [
       "arith.addi operation does not verify\n",
       "\n",
-      "%0 = arith.addi %<UNKNOWN>, %<UNKNOWN> : i64\n",
+      "%0 = arith.addi %1, %1 : i64\n",
       "\n",
       "\n"
      ]

--- a/docs/xdsl-introduction.ipynb
+++ b/docs/xdsl-introduction.ipynb
@@ -733,11 +733,11 @@
      "output_type": "stream",
      "text": [
       "%1 = \"sql.filter\"(%0) ({\n",
-      "^0(%7 : i32):\n",
+      "^0(%2 : i32):\n",
       "  %3 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
       "  %4 = \"arith.constant\"() {\"value\" = 5 : i32} : () -> i32\n",
-      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
-      "  %6 = \"arith.cmpi\"(%7, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "  %7 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%2, %7) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
       "  \"scf.yield\"(%6) : (i1) -> ()\n",
       "}) : (#sql.bag) -> #sql.bag"
      ]
@@ -775,9 +775,9 @@
      "output_type": "stream",
      "text": [
       "%1 = \"sql.filter\"(%0) ({\n",
-      "^0(%9 : i32):\n",
-      "  %8 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
-      "  %6 = \"arith.cmpi\"(%9, %8) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
+      "^0(%2 : i32):\n",
+      "  %7 = \"arith.constant\"() {\"value\" = 10 : i32} : () -> i32\n",
+      "  %6 = \"arith.cmpi\"(%2, %7) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
       "  \"scf.yield\"(%6) : (i1) -> ()\n",
       "}) : (#sql.bag) -> #sql.bag"
      ]

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops.mlir
@@ -26,7 +26,7 @@ builtin.module {
     "func.return"(%1) : (i32) -> ()
   }
 
-   // CHECK: func.func @arg_rec(%arg0 : i32) -> i32 {
+   // CHECK: func.func @arg_rec(%{{.*}} : i32) -> i32 {
    // CHECK-NEXT:   %{{.*}} = "func.call"(%{{.*}}) {"callee" = @arg_rec} : (i32) -> i32
    // CHECK-NEXT:   "func.return"(%{{.*}}) : (i32) -> ()
    // CHECK-NEXT: }
@@ -37,9 +37,9 @@ builtin.module {
     "func.return"(%3) : (i32) -> ()
   }
 
-  // CHECK: func.func @arg_rec_block(%1 : i32) -> i32 {
-  // CHECK-NEXT:   %2 = "func.call"(%1) {"callee" = @arg_rec_block} : (i32) -> i32
-  // CHECK-NEXT:   "func.return"(%2) : (i32) -> ()
+  // CHECK: func.func @arg_rec_block(%{{.*}} : i32) -> i32 {
+  // CHECK-NEXT:   %{{.*}} = "func.call"(%{{.*}}) {"callee" = @arg_rec_block} : (i32) -> i32
+  // CHECK-NEXT:   "func.return"(%{{.*}}) : (i32) -> ()
   // CHECK-NEXT: }
 
   func.func private @external_fn(i32) -> (i32, i32)
@@ -49,8 +49,8 @@ builtin.module {
     "func.return"(%a, %a) : (i32, i32) -> ()
   }
 
-  // CHECK: func.func @multi_return_body(%3 : i32) -> (i32, i32) {
-  // CHECK-NEXT:   "func.return"(%3, %3) : (i32, i32) -> ()
+  // CHECK: func.func @multi_return_body(%{{.*}} : i32) -> (i32, i32) {
+  // CHECK-NEXT:   "func.return"(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
   // CHECK-NEXT: }
 
 }

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -415,7 +415,7 @@ def test_op_custom_verify_is_done_last():
     assert e.value.args[0] != "Custom Verification Check"
     assert (
         e.value.args[0]
-        == 'test.custom_verify_op operation does not verify\n\n"test.custom_verify_op"(%<UNKNOWN>) : (i32) -> ()\n\n'
+        == 'test.custom_verify_op operation does not verify\n\n"test.custom_verify_op"(%0) : (i32) -> ()\n\n'
     )
 
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -413,10 +413,7 @@ def test_op_custom_verify_is_done_last():
     with pytest.raises(Exception) as e:
         b.verify()
     assert e.value.args[0] != "Custom Verification Check"
-    assert (
-        e.value.args[0]
-        == 'test.custom_verify_op operation does not verify\n\n"test.custom_verify_op"(%0) : (i32) -> ()\n\n'
-    )
+    assert "test.custom_verify_op operation does not verify" in e.value.args[0]
 
 
 def test_replace_operand():

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -6,7 +6,7 @@ from io import StringIO
 from typing import Annotated
 
 from xdsl.dialects.arith import Arith, Addi, Constant
-from xdsl.dialects.builtin import Builtin, IntAttr, IntegerType, ModuleOp, UnitAttr, i32
+from xdsl.dialects.builtin import Builtin, IntAttr, IntegerType, UnitAttr, i32
 from xdsl.dialects.func import Func
 from xdsl.dialects.test import TestOp
 from xdsl.ir import (
@@ -37,7 +37,7 @@ from xdsl.utils.exceptions import ParseError
 
 
 def test_simple_forgotten_op():
-    """Test that the parsing of an undefined operand raises an exception."""
+    """Test that the parsing of an undefined operand gives it a value."""
     ctx = MLContext()
     ctx.register_dialect(Arith)
 
@@ -46,61 +46,9 @@ def test_simple_forgotten_op():
 
     add.verify()
 
-    expected = """
-%0 = "arith.addi"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i32
-------------------^^^^^^^^^^---------------------------------------------------------------------
-| ERROR: SSAValue is not part of the IR, are you sure all operations are added before their uses?
--------------------------------------------------------------------------------------------------
-------------------------------^^^^^^^^^^---------------------------------------------------------
-| ERROR: SSAValue is not part of the IR, are you sure all operations are added before their uses?
--------------------------------------------------------------------------------------------------
-"""
+    expected = """%0 = "arith.addi"(%1, %1) : (i32, i32) -> i32"""
 
     assert_print_op(add, expected, None)
-
-
-def test_simple_forgotten_op_error_option():
-    """
-    Test that the parsing of an undefined operand does not print an error if
-    `print_unknown_value_error` is set to False.
-    """
-    ctx = MLContext()
-    ctx.register_dialect(Arith)
-
-    lit = Constant.from_int_and_width(42, 32)
-    add = Addi(lit, lit)
-
-    add.verify()
-
-    expected = """%0 = "arith.addi"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i32"""
-
-    assert_print_op(add, expected, None, print_unknown_value_error=False)
-
-
-def test_forgotten_op_non_fail():
-    """Test that the parsing of an undefined operand raises an exception."""
-    ctx = MLContext()
-    ctx.register_dialect(Arith)
-
-    lit = Constant.from_int_and_width(42, 32)
-    add = Addi(lit, lit)
-    add2 = Addi(add, add)
-    mod = ModuleOp([add, add2])
-    mod.verify()
-
-    expected = """
-"builtin.module"() ({
-  %0 = "arith.addi"(%<UNKNOWN>, %<UNKNOWN>) : (i32, i32) -> i32
-  ------------------^^^^^^^^^^---------------------------------------------------------------------
-  | ERROR: SSAValue is not part of the IR, are you sure all operations are added before their uses?
-  -------------------------------------------------------------------------------------------------
-  ------------------------------^^^^^^^^^^---------------------------------------------------------
-  | ERROR: SSAValue is not part of the IR, are you sure all operations are added before their uses?
-  -------------------------------------------------------------------------------------------------
-  %1 = "arith.addi"(%0, %0) : (i32, i32) -> i32
-}) : () -> ()"""
-
-    assert_print_op(mod, expected, None)
 
 
 @irdl_op_definition
@@ -381,7 +329,7 @@ def test_print_custom_block_arg_name():
     io = StringIO()
     p = Printer(stream=io)
     p.print_block(block)
-    assert io.getvalue() == """\n^0(%test : i32, %0 : i32):"""
+    assert io.getvalue() == """\n^0(%test : i32, %test_1 : i32):"""
 
 
 def test_print_block_argument():
@@ -392,7 +340,7 @@ def test_print_block_argument():
     p = Printer(stream=io)
     p.print_block_argument(block.args[0])
     p.print(", ")
-    p.print_block_argument(block.args[0], print_type=False)
+    p.print_block_argument(block.args[1], print_type=False)
     assert io.getvalue() == """%0 : i32, %1"""
 
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -31,14 +31,13 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.diagnostic import Diagnostic
-from xdsl.rewriter import Rewriter
 
 from conftest import assert_print_op
 from xdsl.utils.exceptions import ParseError
 
 
 def test_simple_forgotten_op():
-    """Test that the parsing of an undefined operand gives it a value."""
+    """Test that the parsing of an undefined operand gives it a name."""
     ctx = MLContext()
     ctx.register_dialect(Arith)
 
@@ -71,7 +70,7 @@ def test_unordered_ops():
     assert_print_op(ModuleOp([add, lit]), expected, None)
 
 
-def test_unordered_ops():
+def test_cyclic_ops():
     """Test that the printing of ops with cyclic dependencies works."""
 
     ctx = MLContext()

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -948,7 +948,7 @@ class Operation(IRNode):
         from xdsl.printer import Printer
 
         res = StringIO()
-        printer = Printer(stream=res, print_unknown_value_error=False)
+        printer = Printer(stream=res)
         printer.print_op(self)
         return res.getvalue()
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -209,55 +209,36 @@ class Printer:
         self._next_valid_block_id += 1
         return self._next_valid_block_id - 1
 
-    def _print_result_value(self, op: Operation, idx: int) -> None:
-        val = op.results[idx]
-        self.print("%")
-        if val in self._ssa_values:
-            name = self._ssa_values[val]
-        elif val.name_hint:
-            curr_ind = self._ssa_names.get(val.name_hint, 0)
-            suffix = f"_{curr_ind}" if curr_ind != 0 else ""
-            name = f"{val.name_hint}{suffix}"
-            self._ssa_values[val] = name
-            self._ssa_names[val.name_hint] = curr_ind + 1
-        else:
-            name = self._get_new_valid_name_id()
-            self._ssa_values[val] = name
-        self.print("%s" % name)
-
     def _print_results(self, op: Operation) -> None:
         results = op.results
         # No results
         if len(results) == 0:
             return
 
-        # One result
-        if len(results) == 1:
-            self._print_result_value(op, 0)
-            self.print(" = ")
-            return
-
         # Multiple results
-        self._print_result_value(op, 0)
-        for idx in range(1, len(results)):
-            self.print(", ")
-            self._print_result_value(op, idx)
+        self.print_list(op.results, self.print)
         self.print(" = ")
 
     def print_ssa_value(self, value: SSAValue) -> None:
-        if ssa_val := self._ssa_values.get(value):
-            self.print(f"%{ssa_val}")
+        """
+        Print an SSA value in the printer. This assigns a name to the value if the value
+        does not have one in the current printing context.
+        If the value has a name hint, it will use it as a prefix, and otherwise assign
+        a number as the name. Numbers are assigned in order.
+        """
+        if value in self._ssa_values:
+            name = self._ssa_values[value]
+        elif value.name_hint:
+            curr_ind = self._ssa_names.get(value.name_hint, 0)
+            suffix = f"_{curr_ind}" if curr_ind != 0 else ""
+            name = f"{value.name_hint}{suffix}"
+            self._ssa_values[value] = name
+            self._ssa_names[value.name_hint] = curr_ind + 1
         else:
-            begin_pos = self._current_column
-            self.print("%<UNKNOWN>")
-            end_pos = self._current_column
-            if self.print_unknown_value_error:
-                self._add_message_on_next_line(
-                    "ERROR: SSAValue is not part of the IR, are you sure all operations "
-                    "are added before their uses?",
-                    begin_pos,
-                    end_pos,
-                )
+            name = self._get_new_valid_name_id()
+            self._ssa_values[value] = name
+
+        self.print(f"%{name}")
 
     def _print_operand(self, operand: SSAValue) -> None:
         self.print_ssa_value(operand)
@@ -296,15 +277,7 @@ class Printer:
         Print a block argument with its type, e.g. `%arg : i32`
         Optionally, do not print the type.
         """
-
-        if arg.name_hint and arg.name_hint not in self._ssa_values.values():
-            name = arg.name_hint
-            self._ssa_names[arg.name_hint] = self._ssa_names.get(arg.name_hint, 0) + 1
-        else:
-            name = self._get_new_valid_name_id()
-        self._ssa_values[arg] = name
-
-        self.print(f"%{name}")
+        self.print(arg)
         if print_type:
             self.print(" : ", arg.typ)
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -74,12 +74,6 @@ class Printer:
     print_generic_format: bool = field(default=False)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
 
-    print_unknown_value_error: bool = field(default=True, kw_only=True)
-    """
-    If this option is set, printing an operand that was not already given a name will
-    not print an error message.
-    """
-
     _indent: int = field(default=0, init=False)
     _ssa_values: Dict[SSAValue, str] = field(default_factory=dict, init=False)
     """


### PR DESCRIPTION
This PR allows graph regions to be printed by the `Printer`.
Since there is no way of knowing if the user is currently printing operations in a graph region, this means that we cannot print operands with a `%<UNKNOWN>` when they haven't been printed yet.
Thus, printing an operation that has free operands will not fail anymore.

Note that this means that some dominance bugs are not catched anymore. These should be handled with a proper domination check in the verifier later on.