### PR TITLE
core: make ImplicitBuilder public

### DIFF
--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -114,6 +114,9 @@ class Builder:
         else:
             return Builder._region_args(input)
 
+    def implicit(self) -> _ImplicitBuilder:
+        return _ImplicitBuilder(self)
+
     @staticmethod
     def _implicit_region_no_args(func: Callable[[], None]) -> Region:
         """


### PR DESCRIPTION
From the discussion on #1017, I thought it might be better to make the ImplicitBuilder public in a separate PR. 