### PR TITLE
core: add insertion point to Builder

### DIFF
--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -27,6 +27,31 @@ def test_builder():
     assert target.is_structurally_equivalent(block)
 
 
+def test_builder_insertion_point():
+    target = Block(
+        [
+            Constant.from_int_and_width(1, 1),
+            Constant.from_int_and_width(2, 1),
+            Constant.from_int_and_width(3, 1),
+        ]
+    )
+
+    block = Block()
+    b0 = Builder(block)
+
+    x = Constant.from_int_and_width(1, 1)
+    y = Constant.from_int_and_width(2, 1)
+    z = Constant.from_int_and_width(3, 1)
+
+    b0.insert(x)
+    b0.insert(z)
+
+    b1 = Builder(block, insertion_point=z)
+    b1.insert(y)
+
+    assert target.is_structurally_equivalent(block)
+
+
 def test_build_region():
     one = IntAttr(1)
     two = IntAttr(2)

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -27,6 +27,11 @@ class Builder:
     Operations will be inserted in this block.
     """
 
+    insertion_point: Operation | None = field(default=None)
+    """
+    Operations will be inserted before this operation, or at the end of the block if None.
+    """
+
     def insert(self, op: OperationInvT) -> OperationInvT:
         """
         Inserts `op` in `self.block` at the end of the block.
@@ -39,7 +44,10 @@ class Builder:
                 "Cannot insert operation explicitly when an implicit " "builder exists."
             )
 
-        self.block.add_op(op)
+        if self.insertion_point is not None:
+            self.block.insert_op_before(op, self.insertion_point)
+        else:
+            self.block.add_op(op)
         return op
 
     @staticmethod


### PR DESCRIPTION
This is an additive change to Builder that makes it a little more powerful. Instead of only appending to the block, it can insert operations anywhere. This opens the way for implicit-builder-context-based rewrite patterns I'm playing with.