### PR TITLE
core: check correctness operation signatures

### DIFF
--- a/docs/Toy/examples/tests/optimise_toy.mlir
+++ b/docs/Toy/examples/tests/optimise_toy.mlir
@@ -22,7 +22,7 @@
     %31 = "toy.reshape"(%30) : (tensor<2x3xf64>) -> tensor<6x1xf64>
     %32 = "toy.reshape"(%31) : (tensor<6x1xf64>) -> tensor<1x6xf64>
     %33 = "toy.reshape"(%32) : (tensor<1x6xf64>) -> tensor<2x3xf64>
-    "toy.return"(%33) : (tensor<*xf64>) -> ()
+    "toy.return"(%33) : (tensor<2x3xf64>) -> ()
   }) {"sym_name" = "redundant_reshape", "function_type" = () -> ()} : () -> ()
 
 // CHECK-NEXT:  "toy.func"() ({

--- a/tests/filecheck/dialects/gpu/alloc_wrong_dynamic_size.mlir
+++ b/tests/filecheck/dialects/gpu/alloc_wrong_dynamic_size.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
     %0 = "arith.constant"() {"value" = 10 : index} : () -> index
-    %gdmemref = "gpu.alloc"(%0, %0,%0) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: () -> memref<10x10x10xf64>
+    %gdmemref = "gpu.alloc"(%0, %0, %0) {"operand_segment_sizes" = array<i32: 0, 3, 0>} : (index, index, index) -> memref<10x10x10xf64>
 }) : () -> ()
 
 // CHECK-NEXT: Expected 0 dynamic sizes, got 3. All dynamic sizes need to be set in the alloc operation.

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -31,7 +31,7 @@
             %griddimz = "gpu.grid_dim"() {"dimension" = #gpu<dim z>} : () -> index
 
             %gmemref = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>}: () -> memref<10x10xi32>
-            %gdmemref = "gpu.alloc"(%griddimx, %griddimy,%griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: () -> memref<?x?x?xf64>
+            %gdmemref = "gpu.alloc"(%griddimx, %griddimy,%griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: (index, index, index) -> memref<?x?x?xf64>
 
             "gpu.memcpy"(%memref, %gmemref) {"operand_segment_sizes" = array<i32: 0, 1, 1>} : (memref<10x10xi32>, memref<10x10xi32>) -> ()
 

--- a/tests/filecheck/dialects/llvm/pointers.mlir
+++ b/tests/filecheck/dialects/llvm/pointers.mlir
@@ -6,7 +6,7 @@
   %3 = "llvm.mlir.null"() : () -> !llvm.ptr
   %4 = "llvm.alloca"(%0) {"alignment" = 32 : i64} : (i64) -> !llvm.ptr<index>
   %5 = "llvm.load"(%4) : (!llvm.ptr<index>) -> index
-  %6 = "llvm.getelementptr"(%4, %0){elem_type = i32, rawConstantIndices = array<i32:-2147483648>} : (!llvm.ptr<i32>, i32) -> !llvm.ptr<i32>
+  %6 = "llvm.getelementptr"(%4, %0){elem_type = i32, rawConstantIndices = array<i32:-2147483648>} : (!llvm.ptr<index>, i64) -> !llvm.ptr<i32>
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -5,7 +5,7 @@
   // CHECK:      li zero, 6
   %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<j1>
   // CHECK-NEXT: li j1, 5
-  %2 = "riscv.add"(%0, %1) : (!riscv.reg<j1>, !riscv.reg<zero>) -> !riscv.reg<j2>
+  %2 = "riscv.add"(%0, %1) : (!riscv.reg<zero>, !riscv.reg<j1>) -> !riscv.reg<j2>
   // CHECK-NEXT: add j2, zero, j1
   %mv = "riscv.mv"(%0) : (!riscv.reg<zero>) -> !riscv.reg<j2>
   // CHECK-NEXT: mv j2, zero

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -81,17 +81,17 @@
 
 
   // Conditional Branch Instructions
-  "riscv.beq"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.beq"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.beq"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bne"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.bne"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.bne"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.blt"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.blt"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.blt"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bge"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.bge"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.bge"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bltu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.bltu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.bltu"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bgeu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.bgeu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.bgeu"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
 
   // RV32I/RV64I: 2.6 Load and Store Instructions
@@ -106,11 +106,11 @@
   // CHECK-NEXT: %{{.*}} = "riscv.lhu"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %lw = "riscv.lw"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.lw"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  "riscv.sb"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.sb"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.sb"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.sh"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.sh"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.sh"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.sw"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
+  "riscv.sw"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: "riscv.sw"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
 
   // RV32I/RV64I: 2.8 Control and Status Register Instructions

--- a/tests/filecheck/dialects/riscv/riscv_register_allocation.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_register_allocation.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
   %0 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<>
   %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<s0>
-  %2 = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  %2 = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/filecheck/dialects/scf/for_args_number.mlir
+++ b/tests/filecheck/dialects/scf/for_args_number.mlir
@@ -7,5 +7,5 @@
   "scf.for"(%ub, %step) ({
   ^0(%iv : index):
     "scf.yield"() : () -> ()
-  }) : (index, index, index) -> ()
+  }) : (index, index) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_args_types.mlir
@@ -10,5 +10,5 @@
   "scf.for"(%lbi, %ub, %step) ({
   ^0(%iv : index):
     "scf.yield"() : () -> ()
-  }) : (index, index, index) -> ()
+  }) : (i32, index, index) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_body_args_number.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_number.mlir
@@ -8,5 +8,5 @@
 // CHECK: Wrong number of block arguments, expected 2, got 1. The body must have the induction variable and loop-carried variables as arguments.
   ^0(%iv : index):
     "scf.yield"() : () -> ()
-  }) : (index, index, index) -> ()
+  }) : (index, index, index, i8) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_body_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_types.mlir
@@ -8,5 +8,5 @@
 // CHECK: Block arguments with wrong type, expected i8, got index
   ^0(%iv : index, %carried_arg : index):
     "scf.yield"() : () -> ()
-  }) : (index, index, index) -> ()
+  }) : (index, index, index, i8) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_yield.mlir
+++ b/tests/filecheck/dialects/scf/for_yield.mlir
@@ -7,5 +7,5 @@
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: The scf.for's body does not end with a scf.yield. A scf.for loop with loop-carried variables must yield their values at the end of its body.
   ^0(%iv : index, %carried_arg : i8):
-  }) : (index, index, index) -> ()
+  }) : (index, index, index, i8) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_yield_number.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_number.mlir
@@ -7,6 +7,6 @@
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Expected 1 args, got 2. The scf.for must yield its carried variables.
   ^0(%iv : index, %carried_arg : i8):
-    "scf.yield"(%carried_arg, %step) : () -> ()
-  }) : (index, index, index) -> ()
+    "scf.yield"(%carried_arg, %step) : (i8, index) -> ()
+  }) : (index, index, index, i8) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/for_yield_types.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_types.mlir
@@ -7,6 +7,6 @@
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Expected i8, got index. The scf.for's scf.yield must match carried variables types.
   ^0(%iv : index, %carried_arg : i8):
-    "scf.yield"(%iv) : () -> ()
-  }) : (index, index, index) -> ()
+    "scf.yield"(%iv) : (index) -> ()
+  }) : (index, index, index, i8) -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/scf/parallel_bounds.mlir
+++ b/tests/filecheck/dialects/scf/parallel_bounds.mlir
@@ -9,7 +9,7 @@
   "scf.parallel"(%0, %3, %1, %4, %2) ({
   ^bb0(%i: index):
     "scf.yield"() : () -> ()
-  }) {"operand_segment_sizes" = array<i32: 2, 2, 1, 0>} : (index, index, index) -> ()
+  }) {"operand_segment_sizes" = array<i32: 2, 2, 1, 0>} : (index, index, index, index, index) -> ()
 }) : () -> ()
 
 // CHECK: Expected the same number of lower bounds, upper bounds, and steps for scf.parallel. Got 2, 2 and 1.

--- a/tests/filecheck/dialects/scf/reduce_arg_type_missmatch.mlir
+++ b/tests/filecheck/dialects/scf/reduce_arg_type_missmatch.mlir
@@ -12,7 +12,7 @@
       ^1(%9 : f64, %10 : f64):
         %11 = "arith.addf"(%9, %10) : (f64, f64) -> f64
         "scf.reduce.return"(%11) : (f64) -> ()
-      }) : (f64) -> ()
+      }) : (f32) -> ()
       "scf.yield"() : () -> ()
     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
 }) : () -> ()

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -19,7 +19,7 @@
       %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
-      "stencil.return"(%19) : (!stencil.result<f64>) -> ()
+      "stencil.return"(%19) : (f64) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
     "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -46,7 +46,7 @@ builtin.module {
       %ti = "stencil.load"(%fi) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
       %tip1 = "stencil.apply"(%ti) ({
       ^1(%ti_ : !stencil.temp<?x?x?xf32>):
-        %v = "stencil.access"(%ti) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?xf32>) -> f32
+        %v = "stencil.access"(%ti) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf32>) -> f32
         "stencil.return"(%v) : (f32) -> ()
       }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
       "stencil.store"(%tip1, %fip1) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()

--- a/tests/filecheck/dialects/vector/vector_maskedload_memref_passthrough_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedload_memref_passthrough_type_matching.mlir
@@ -4,7 +4,7 @@
 
   %0, %1, %2, %3 = "test.op"() : () -> (memref<2x2xi32>, vector<2xindex>, vector<2xi1>, index)
 
-  %4 = "vector.maskedload"(%0, %3, %3, %2, %1) : (memref<2x2xindex>, index, vector<2xi1>, vector<2xindex>) -> vector<2xi32>
+  %4 = "vector.maskedload"(%0, %3, %3, %2, %1) : (memref<2x2xi32>, index, index, vector<2xi1>, vector<2xindex>) -> vector<2xi32>
   // CHECK: MemRef element type should match the result vector and passthrough vector element type. Found different element types for memref and passthrough.
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_maskedload_memref_res_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedload_memref_res_type_matching.mlir
@@ -4,7 +4,7 @@
 
   %0, %1, %2, %3 = "test.op"() : () -> (memref<2x2xindex>, vector<2xindex>, vector<2xi1>, index)
 
-  %4 = "vector.maskedload"(%0, %3, %3, %2, %1) : (memref<2x2xindex>, index, vector<2xi1>, vector<2xindex>) -> vector<2xi32>
+  %4 = "vector.maskedload"(%0, %3, %3, %2, %1) : (memref<2x2xindex>, index, index, vector<2xi1>, vector<2xindex>) -> vector<2xi32>
   // CHECK: MemRef element type should match the result vector and passthrough vector element type. Found different element types for memref and result.
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_maskedstore_memref_storevec_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedstore_memref_storevec_type_matching.mlir
@@ -4,7 +4,7 @@
 
   %0, %1, %2, %3 = "test.op"() : () -> (memref<2x2xindex>, vector<2xi32>, vector<2xi1>, index)
 
-  "vector.maskedstore"(%0, %3, %3, %2, %1) : (memref<2x2xindex>, index, index, vector<2xi1>, vector<2xindex>) -> ()
+  "vector.maskedstore"(%0, %3, %3, %2, %1) : (memref<2x2xindex>, index, index, vector<2xi1>, vector<2xi32>) -> ()
   // CHECK: MemRef element type should match the stored vector type. Obtained types were index and i32.
 
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
@@ -31,7 +31,7 @@
             %griddimz = "gpu.grid_dim"() {"dimension" = #gpu<dim z>} : () -> index
 
             %gmemref = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<10x10xi32>
-            %gdmemref = "gpu.alloc"(%griddimx, %griddimy,%griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: () -> memref<?x?x?xf64>
+            %gdmemref = "gpu.alloc"(%griddimx, %griddimy,%griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: (index, index, index) -> memref<?x?x?xf64>
 
             "gpu.memcpy"(%memref, %gmemref) {"operand_segment_sizes" = array<i32: 0, 1, 1>} : (memref<10x10xi32>, memref<10x10xi32>) -> ()
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -19,7 +19,7 @@
       %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
       %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
       %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
-      "stencil.return"(%19) : (!stencil.result<f64>) -> ()
+      "stencil.return"(%19) : (f64) -> ()
     }) : (!stencil.temp<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
     "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -1,0 +1,62 @@
+// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+
+// A correct operation
+
+builtin.module {
+  %0 = "test.op"() : () -> !test.type<"foo">
+  %1 = "test.op"(%0) : (!test.type<"foo">) -> !test.type<"bar">
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %0 = "test.op"() : () -> !test.type<"foo">
+// CHECK-NEXT:   %1 = "test.op"(%0) : (!test.type<"foo">) -> !test.type<"bar">
+// CHECK-NEXT: }
+
+// -----
+
+// An operation signature with not enough results
+
+builtin.module {
+  %0 = "test.op"() : () -> ()
+}
+// CHECK: Operation has 0 results, but were given 1 to bind.
+
+// -----
+
+// An operation signature with too many results
+
+builtin.module {
+  %0 = "test.op"() : () -> (!test.type<"foo">, !test.type<"bar">)
+}
+
+// -----
+
+// An operation signature that has not enough operands
+
+builtin.module {
+  %0 = "test.op"() : () -> !test.type<"foo">
+  "test.op"(%0) : () -> ()
+}
+
+// CHECK: expected 1 operand types but had 0
+
+// -----
+
+// An operation signature that has too many operands
+
+builtin.module {
+  "test.op"() : (i32) -> ()
+}
+
+// CHECK: expected 0 operand types but had 1
+
+// -----
+
+// An operation signature that doesn't have the correct operand type
+
+builtin.module {
+  %0 = "test.op"() : () -> !test.type<"foo">
+  %1 = "test.op"(%0) : (!test.type<"bar">) -> !test.type<"bar">
+}
+
+// CHECK: mismatch between operand types and operation signature for operand #0. Expected !test.type<"bar"> but got !test.type<"foo">.

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -14,6 +14,20 @@ builtin.module {
 
 // -----
 
+// A correct operation with tuple values
+
+builtin.module {
+  %0 = "test.op"() : () -> !test.type<"foo">
+  %1:2 = "test.op"(%0) : (!test.type<"foo">) -> (!test.type<"bar">, !test.type<"foo">)
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %0 = "test.op"() : () -> !test.type<"foo">
+// CHECK-NEXT:   %1, %2 = "test.op"(%0) : (!test.type<"foo">) -> (!test.type<"bar">, !test.type<"foo">)
+// CHECK-NEXT: }
+
+// -----
+
 // An operation signature with not enough results
 
 builtin.module {
@@ -62,3 +76,14 @@ builtin.module {
 }
 
 // CHECK: mismatch between operand types and operation signature for operand #0. Expected !test.type<"bar"> but got !test.type<"foo">.
+
+// -----
+
+// An operation signature using tuples that doesn't have the correct operand type
+
+builtin.module {
+  %0:2 = "test.op"() : () -> (!test.type<"foo1">, !test.type<"foo2">)
+  %1 = "test.op"(%0#1) : (!test.type<"bar">) -> !test.type<"bar">
+}
+
+// CHECK: mismatch between operand types and operation signature for operand #0. Expected !test.type<"bar"> but got !test.type<"foo2">.

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -40,7 +40,7 @@ builtin.module {
   "test.op"(%0) : () -> ()
 }
 
-// CHECK: expected 1 operand types but had 0
+// CHECK: expected 0 operand types but had 1
 
 // -----
 
@@ -50,7 +50,7 @@ builtin.module {
   "test.op"() : (i32) -> ()
 }
 
-// CHECK: expected 0 operand types but had 1
+// CHECK: expected 1 operand types but had 0
 
 // -----
 

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -29,6 +29,8 @@ builtin.module {
   %0 = "test.op"() : () -> (!test.type<"foo">, !test.type<"bar">)
 }
 
+// CHECK: Operation has 2 results, but were given 1 to bind.
+
 // -----
 
 // An operation signature that has not enough operands

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2565,7 +2565,23 @@ class Parser(ABC):
         self.parse_characters(
             ":", "MLIR Operation definitions must end in a function type signature!"
         )
+
+        func_type_pos = self._current_token.span.start
         func_type = self.parse_function_type()
+
+        if len(args) != len(func_type.inputs):
+            self.raise_error(
+                f"expected {len(args)} operand types but had {len(func_type.inputs)}",
+                func_type_pos,
+            )
+
+        for idx, (arg, arg_type) in enumerate(zip(args, func_type.inputs)):
+            if arg_type != arg.typ:
+                self.raise_error(
+                    f"mismatch between operand types and operation signature for operand #{idx}. "
+                    f"Expected {arg_type} but got {arg.typ}.",
+                    func_type_pos,
+                )
 
         return args, succ, attrs, regions, func_type
 

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2571,7 +2571,7 @@ class Parser(ABC):
 
         if len(args) != len(func_type.inputs):
             self.raise_error(
-                f"expected {len(args)} operand types but had {len(func_type.inputs)}",
+                f"expected {len(func_type.inputs)} operand types but had {len(args)}",
                 func_type_pos,
             )
 


### PR DESCRIPTION
This checks that the operation signature is consistent with the given operands.
For instance:
```mlir
builtin.module {
  %0 = "test.op"() : () -> !test.type<"foo">
  %1 = "test.op"(%0) : (!test.type<"bar">) -> !test.type<"bar">
}
```
will raise an error at parsing time, since the operation signature has the wrong type for the operand.

Will fix #472 