### PR TITLE
core: Allow parsing graph regions

### DIFF
--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -1,0 +1,42 @@
+// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+
+// A cyclic dependency
+
+builtin.module {
+    %0 = "test.op"(%1) : (i32) -> i32
+    %1 = "test.op"(%0) : (i32) -> i32
+}
+
+// CHECK:      %0 = "test.op"(%1) : (i32) -> i32
+// CHECK-NEXT: %1 = "test.op"(%0) : (i32) -> i32
+
+// -----
+
+// A self-cycle
+
+builtin.module {
+    %0 = "test.op"(%0) : (i32) -> i32
+}
+
+// CHECK:      %0 = "test.op"(%0) : (i32) -> i32
+
+// -----
+
+// A graph region that refers to a value that is not defined in the module.
+
+builtin.module {
+    %0 = "test.op"(%1) : (i32) -> i32
+}
+
+// CHECK: value %1 was used but not defined
+
+// -----
+
+// A forward value used with a wrong index
+
+builtin.module {
+    "test.op"(%1#3) : (i32) -> ()
+    %1:3 = "test.op"() : () -> (i32, i32, i32)
+}
+
+// CHECK: SSA value %1 is referenced with an index larger than its size

--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -22,6 +22,27 @@ builtin.module {
 
 // -----
 
+// A forward value defined by a block argument
+
+builtin.module {
+    "test.op"() ({
+        "test.op"(%0) : (i32) -> ()
+        ^bb0(%0: i32):
+        "test.op"() : () -> ()
+    }) : () -> ()
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   "test.op"() ({
+// CHECK-NEXT:     "test.op"(%0) : (i32) -> ()
+// CHECK-NEXT:   ^0(%0 : i32):
+// CHECK-NEXT:     "test.op"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }
+
+
+// -----
+
 // A graph region that refers to a value that is not defined in the module.
 
 builtin.module {

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -87,3 +87,15 @@ builtin.module {
 }
 
 // CHECK: mismatch between operand types and operation signature for operand #0. Expected !test.type<"bar"> but got !test.type<"foo2">.
+
+// -----
+
+// A forward declared operand that is used with an incorrect type
+
+builtin.module {
+  %1 = "test.op"(%0) : (!test.type<"bar">) -> !test.type<"bar">
+  %0 = "test.op"() : () -> !test.type<"foo">
+}
+
+// CHECK: Result %0 is defined with type !test.type<"foo">, but used with type !test.type<"bar">
+

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -75,7 +75,7 @@ builtin.module {
   %1 = "test.op"(%0) : (!test.type<"bar">) -> !test.type<"bar">
 }
 
-// CHECK: mismatch between operand types and operation signature for operand #0. Expected !test.type<"bar"> but got !test.type<"foo">.
+// CHECK: operand is used with type !test.type<"bar">, but has been previously used or defined with type !test.type<"foo">
 
 // -----
 
@@ -86,7 +86,7 @@ builtin.module {
   %1 = "test.op"(%0#1) : (!test.type<"bar">) -> !test.type<"bar">
 }
 
-// CHECK: mismatch between operand types and operation signature for operand #0. Expected !test.type<"bar"> but got !test.type<"foo2">.
+// CHECK: operand is used with type !test.type<"bar">, but has been previously used or defined with type !test.type<"foo2">
 
 // -----
 
@@ -99,3 +99,13 @@ builtin.module {
 
 // CHECK: Result %0 is defined with type !test.type<"foo">, but used with type !test.type<"bar">
 
+// -----
+
+// A forward declared operand tuple that is used with an incorrect type
+
+builtin.module {
+  %1 = "test.op"(%0#1) : (!test.type<"bar">) -> !test.type<"bar">
+  %0:2 = "test.op"() : () -> (!test.type<"foo1">, !test.type<"foo2">)
+}
+
+// CHECK: Result %0#1 is defined with type !test.type<"foo2">, but used with type !test.type<"bar">

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -6,7 +6,7 @@ from io import StringIO
 from typing import Annotated
 
 from xdsl.dialects.arith import Arith, Addi, Constant
-from xdsl.dialects.builtin import Builtin, IntAttr, IntegerType, ModuleOp, UnitAttr, i32
+from xdsl.dialects.builtin import Builtin, IntAttr, IntegerType, UnitAttr, i32
 from xdsl.dialects.func import Func
 from xdsl.dialects.test import TestOp
 from xdsl.ir import (

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -51,45 +51,6 @@ def test_simple_forgotten_op():
     assert_print_op(add, expected, None)
 
 
-def test_unordered_ops():
-    """Test that the printing of unordered ops works."""
-
-    ctx = MLContext()
-    ctx.register_dialect(Arith)
-
-    lit = Constant.from_int_and_width(42, 32)
-    add = Addi(lit, lit)
-
-    expected = """
-"builtin.module"() ({
-  %0 = "arith.addi"(%1, %1) : (i32, i32) -> i32
-  %1 = "arith.constant"() {"value" = 42 : i32} : () -> i32
-}) : () -> ()
-"""
-
-    assert_print_op(ModuleOp([add, lit]), expected, None)
-
-
-def test_cyclic_ops():
-    """Test that the printing of ops with cyclic dependencies works."""
-
-    ctx = MLContext()
-    ctx.register_dialect(Arith)
-
-    op1 = TestOp(result_types=[i32], operands=[[]], regions=[[]])
-    op2 = TestOp(result_types=[i32], operands=[op1], regions=[[]])
-    op1.operands = [op2.results[0]]
-
-    expected = """
-"builtin.module"() ({
-  %0 = "test.op"(%1) : (i32) -> i32
-  %1 = "test.op"(%0) : (i32) -> i32
-}) : () -> ()
-"""
-
-    assert_print_op(ModuleOp([op1, op2]), expected, None)
-
-
 @irdl_op_definition
 class UnitAttrOp(IRDLOperation):
     name = "unit_attr_op"

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2674,15 +2674,12 @@ class Parser(ABC):
                 func_type_pos,
             )
 
-        for idx, (arg, arg_type) in enumerate(zip(args, func_type.inputs)):
-            if arg_type != arg.typ:
-                self.raise_error(
-                    f"mismatch between operand types and operation signature for operand #{idx}. "
-                    f"Expected {arg_type} but got {arg.typ}.",
-                    func_type_pos,
-                )
+        operands = [
+            self.resolve_operand(operand, type)
+            for operand, type in zip(args, func_type.inputs)
+        ]
 
-        return args, succ, attrs, regions, func_type
+        return operands, succ, attrs, regions, func_type
 
     def _parse_optional_successor_list(self) -> list[Span]:
         self._synchronize_lexer_and_tokenizer()
@@ -2694,9 +2691,11 @@ class Parser(ABC):
         )
         return successors
 
-    def _parse_op_args_list(self) -> list[SSAValue]:
+    def _parse_op_args_list(self) -> list[UnresolvedOperand]:
         return self.parse_comma_separated_list(
-            self.Delimiter.PAREN, self.parse_operand, " in operation argument list"
+            self.Delimiter.PAREN,
+            self.parse_unresolved_operand,
+            " in operation argument list",
         )
 
     def parse_region_list(self) -> list[Region]:

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1851,14 +1851,7 @@ class Parser(ABC):
             # Set the block arguments in the context
             entry_block = Block(arg_types=arg_types)
             for block_arg, arg in zip(entry_block.args, arguments):
-                if arg.name.text[1:] in self.ssa_values:
-                    self.raise_error(
-                        f"block argument %{arg.name} is already defined", arg.name
-                    )
-                parsed_name = arg.name.text[1:]
-                self.ssa_values[parsed_name] = (block_arg,)
-                if SSAValue.is_valid_name(parsed_name):
-                    block_arg.name_hint = arg.name.text[1:]
+                self._register_ssa_definition(arg.name.text[1:], (block_arg,), arg.name)
 
             # Parse the entry block body
             self._parse_block_body(entry_block)


### PR DESCRIPTION
This PR allows the parsing of graph regions, by allowing the parsing of operations with undefined operands.

How this works:
* `parse_optional_unresolved_operand` parse an operand that may be forward declared.
* `resolve_operand` takes an unresolved operand, and either return a proper `SSAValue`, or returns a forward declared value.
* A forward declared value is represented by a type of `SSAValue`. At the end of `parse_module`, it is checked that no forward declared values are left in the parser context.
* When a result is parsed, if the value was already defined as a forward declared value, all uses of this value are replaced by the operation result.