### PR TITLE
dialects: (builtin) add range verifier for `IntegerAttr`

### DIFF
--- a/tests/filecheck/dialects/scf/for_body_args_number.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_number.mlir
@@ -3,7 +3,7 @@
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index
   %step = "arith.constant"() {"value" = 7 : index} : () -> index
-  %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
+  %carried = "arith.constant"() {"value" = 255 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Wrong number of block arguments, expected 2, got 1. The body must have the induction variable and loop-carried variables as arguments.
   ^0(%iv : index):

--- a/tests/filecheck/dialects/scf/for_body_args_number_much.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_number_much.mlir
@@ -3,7 +3,7 @@
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index
   %step = "arith.constant"() {"value" = 7 : index} : () -> index
-  %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
+  %carried = "arith.constant"() {"value" = 255 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step) ({
 // CHECK: Wrong number of block arguments, expected 1, got 2. The body must have the induction variable and loop-carried variables as arguments.
   ^0(%iv : index, %carried_arg : i8):

--- a/tests/filecheck/dialects/scf/for_body_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_types.mlir
@@ -3,7 +3,7 @@
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index
   %step = "arith.constant"() {"value" = 7 : index} : () -> index
-  %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
+  %carried = "arith.constant"() {"value" = 255 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Block arguments with wrong type, expected i8, got index
   ^0(%iv : index, %carried_arg : index):

--- a/tests/filecheck/dialects/scf/for_yield.mlir
+++ b/tests/filecheck/dialects/scf/for_yield.mlir
@@ -3,7 +3,7 @@
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index
   %step = "arith.constant"() {"value" = 7 : index} : () -> index
-  %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
+  %carried = "arith.constant"() {"value" = 255 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: The scf.for's body does not end with a scf.yield. A scf.for loop with loop-carried variables must yield their values at the end of its body.
   ^0(%iv : index, %carried_arg : i8):

--- a/tests/filecheck/dialects/scf/for_yield_number.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_number.mlir
@@ -3,7 +3,7 @@
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index
   %step = "arith.constant"() {"value" = 7 : index} : () -> index
-  %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
+  %carried = "arith.constant"() {"value" = 255 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Expected 1 args, got 2. The scf.for must yield its carried variables.
   ^0(%iv : index, %carried_arg : i8):

--- a/tests/filecheck/dialects/scf/for_yield_types.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_types.mlir
@@ -3,7 +3,7 @@
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index
   %step = "arith.constant"() {"value" = 7 : index} : () -> index
-  %carried = "arith.constant"() {"value" = 36000 : i8} : () -> i8
+  %carried = "arith.constant"() {"value" = 255 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
 // CHECK: Expected i8, got index. The scf.for's scf.yield must match carried variables types.
   ^0(%iv : index, %carried_arg : i8):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -406,7 +406,9 @@ class IntegerAttr(Generic[_IntegerAttrTyp], ParametrizedAttribute):
 
             if not (min_value <= self.value.data <= max_value):
                 raise VerifyException(
-                    f"Integer value {self.value.data} is out of range for type {self.typ} which supports values in the range [{min_value}, {max_value}]"
+                    f"Integer value {self.value.data} is out of range for "
+                    f"type {self.typ} which supports values in the "
+                    f"range [{min_value}, {max_value}]"
                 )
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -389,6 +389,26 @@ class IntegerAttr(Generic[_IntegerAttrTyp], ParametrizedAttribute):
     def from_index_int_value(value: int) -> IntegerAttr[IndexType]:
         return IntegerAttr(value, IndexType())
 
+    def verify(self) -> None:
+        if isinstance(self.typ, IntegerType):
+            match self.typ.signedness.data:
+                case Signedness.SIGNLESS:
+                    min_value = -(1 << self.typ.width.data)
+                    max_value = 1 << self.typ.width.data
+                case Signedness.SIGNED:
+                    min_value = -(1 << (self.typ.width.data - 1))
+                    max_value = (1 << (self.typ.width.data - 1)) - 1
+                case Signedness.UNSIGNED:
+                    min_value = 0
+                    max_value = (1 << self.typ.width.data) - 1
+                case _:
+                    assert False, "unreachable"
+
+            if not (min_value <= self.value.data <= max_value):
+                raise VerifyException(
+                    f"Integer value {self.value.data} is out of range for type {self.typ} which supports values in the range [{min_value}, {max_value}]"
+                )
+
 
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 


### PR DESCRIPTION
Follow-up PR of https://github.com/xdslproject/xdsl/pull/1027 to split the changes properly.