### PR TITLE
testing: Polish stencil shape inference filechecks

### DIFF
--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -79,3 +79,34 @@ builtin.module {
 }
 
 // CHECK: The stencil computation requires a field with lower bound at least #stencil.index<-1, -1, 0>, got #stencil.index<0, 0, 0>, min: #stencil.index<-1, -1, 0>
+
+// -----
+
+builtin.module {
+
+  func.func @stencil_init_float(%0 : f64, %1 : !stencil.field<?x?x?xf64>) {
+    %2 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
+    %3 = "stencil.apply"(%0) ({
+    ^0(%4 : f64):
+      %5 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
+      %6 = arith.addf %4, %5 : f64
+      "stencil.return"(%6) : (f64) -> ()
+    }) : (f64) -> !stencil.temp<[1,65]x[2,66]x[3,63]xf64>
+    "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[1,65]x[2,66]x[3,63]xf64>, !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func @stencil_init_float(%0 : f64, %1 : !stencil.field<?x?x?xf64>) {
+// CHECK-NEXT:     %2 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
+// CHECK-NEXT:     %3 = "stencil.apply"(%0) ({
+// CHECK-NEXT:     ^0(%4 : f64):
+// CHECK-NEXT:       %5 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
+// CHECK-NEXT:       %6 = arith.addf %4, %5 : f64
+// CHECK-NEXT:       "stencil.return"(%6) : (f64) -> ()
+// CHECK-NEXT:     }) : (f64) -> !stencil.temp<[1,65]x[2,66]x[3,63]xf64>
+// CHECK-NEXT:     "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[1,65]x[2,66]x[3,63]xf64>, !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -53,30 +53,29 @@ builtin.module {
 
 // -----
 
-"builtin.module"() ({
-  "func.func"() ({
-  ^0(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>):
-    %3 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[0,68]x[0,68]x[0,68]xf64>
-    %4 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    %6 = "stencil.load"(%3) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?x?xf64>
-    %8 = "stencil.apply"(%6) ({
-    ^1(%9 : !stencil.temp<?x?x?xf64>):
-      %10 = "stencil.access"(%9) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %11 = "stencil.access"(%9) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %12 = "stencil.access"(%9) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %13 = "stencil.access"(%9) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %14 = "stencil.access"(%9) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %15 = "arith.addf"(%10, %11) : (f64, f64) -> f64
-      %16 = "arith.addf"(%12, %13) : (f64, f64) -> f64
-      %17 = "arith.addf"(%15, %16) : (f64, f64) -> f64
+builtin.module {
+  func.func @stencil_hdiff(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>) {
+    %2 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[0,68]x[0,68]x[0,68]xf64>
+    %3 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    %4 = "stencil.load"(%2) : (!stencil.field<[0,68]x[0,68]x[0,68]xf64>) -> !stencil.temp<?x?x?xf64>
+    %5 = "stencil.apply"(%4) ({
+    ^0(%6 : !stencil.temp<?x?x?xf64>):
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+      %12 = arith.addf %7, %8 : f64
+      %13 = arith.addf %9, %10 : f64
+      %14 = arith.addf %12, %13 : f64
       %cst = "arith.constant"() {"value" = -4.0 : f64} : () -> f64
-      %18 = "arith.mulf"(%14, %cst) : (f64, f64) -> f64
-      %19 = "arith.addf"(%18, %17) : (f64, f64) -> f64
-      "stencil.return"(%19) : (!stencil.result<f64>) -> ()
+      %15 = arith.mulf %11, %cst : f64
+      %16 = arith.addf %15, %14 : f64
+      "stencil.return"(%16) : (f64) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
-  }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
-}) : () -> ()
+  }
+}
 
 // CHECK: The stencil computation requires a field with lower bound at least #stencil.index<-1, -1, 0>, got #stencil.index<0, 0, 0>, min: #stencil.index<-1, -1, 0>


### PR DESCRIPTION
Add a test-case with no stencil.access for Shape inference coverage; it is currently covered by shape inference + lowering tests, as revealed when switch to separate inference/lowering tests !