### PR TITLE
[WIP] Core: Add NoTerminator trait

### DIFF
--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -30,3 +30,14 @@ class HasParent(OpTrait):
             )
         names = ", ".join([f"'{p.name}'" for p in self.parameters])
         raise VerifyException(f"'{op.name}' expects parent op to be one of {names}")
+
+
+class NoTerminator(OpTrait):
+    """Allow the operation to have single block regions with no terminator."""
+
+    def verify(self, op: Operation) -> None:
+        for r in op.regions:
+            if len(r.blocks) > 1:
+                raise VerifyException(f"'{op.name}' expects single block region '{r}'")
+
+        return

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -33,7 +33,11 @@ class HasParent(OpTrait):
 
 
 class NoTerminator(OpTrait):
-    """Allow the operation to have single block regions with no terminator."""
+    """
+    Allow an operation to have single block regions with no terminator.
+
+    https://mlir.llvm.org/docs/Traits/#terminator
+    """
 
     def verify(self, op: Operation) -> None:
         for r in op.regions:


### PR DESCRIPTION
This PR adds the [`NoTerminator`](https://mlir.llvm.org/docs/Traits/#terminator) trait.

A current issue is that the IRDL annotations (e.g., `SingleBlockRegion`, etc) operate separately from this trait.
I'm not sure if the link between the two should be checked before an operation's `verify` method, i.e. during construction, or type-checked in this trait's `verify` method.

Any feedback on this is welcome.