### PR TITLE
core: better errors printing in operation

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1285,7 +1285,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "attribute value expected\n"
+      "Operation does not verify: attribute value expected\n",
+      "\n",
+      "\"string_attr_op\"() : () -> ()\n",
+      "\n",
+      "\n"
      ]
     }
    ],
@@ -1426,7 +1430,7 @@
      "text": [
       "arith.addi operation does not verify\n",
       "\n",
-      "%0 = arith.addi %1, %1 : i64\n",
+      "%0 = \"arith.addi\"(%1, %1) : (i32, i32) -> i64\n",
       "\n",
       "\n"
      ]

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -95,9 +95,9 @@ def test_wrong_blockarg_types():
     with pytest.raises(VerifyException) as e:
         f.verify()
 
-    assert e.value.args[0] == (
+    assert (
         "Expected entry block arguments to have the same "
-        "types as the function input types"
+        "types as the function input types" in e.value.args[0]
     )
 
 

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -92,13 +92,13 @@ def test_func_II():
 def test_wrong_blockarg_types():
     r = Region(Block.from_callable([i32], lambda *x: [Addi(x[0], x[0])]))
     f = FuncOp.from_region("f", [i32, i32], [], r)
-    with pytest.raises(VerifyException) as e:
-        f.verify()
 
-    assert (
-        "Expected entry block arguments to have the same "
-        "types as the function input types" in e.value.args[0]
+    message = (
+        "Expected entry block arguments to have the "
+        "same types as the function input types"
     )
+    with pytest.raises(VerifyException, match=message):
+        f.verify()
 
 
 def test_func_rewriting_helpers():

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -526,11 +526,11 @@ def test_stencil_store_load_overlap():
 
     with pytest.raises(VerifyException) as exc_info:
         load.verify()
-    assert exc_info.value.args[0] == "Cannot Load and Store the same field!"
+    assert "Cannot Load and Store the same field!" in exc_info.value.args[0]
 
     with pytest.raises(VerifyException) as exc_info:
         store.verify()
-    assert exc_info.value.args[0] == "Cannot Load and Store the same field!"
+    assert "Cannot Load and Store the same field!" in exc_info.value.args[0]
 
 
 def test_stencil_index():

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -524,13 +524,11 @@ def test_stencil_store_load_overlap():
     load = LoadOp.get(field_type_ssa_val, lb, ub)
     store = StoreOp.get(temp_type_ssa_val, field_type_ssa_val, lb, ub)
 
-    with pytest.raises(VerifyException) as exc_info:
+    with pytest.raises(VerifyException, match="Cannot Load and Store the same field!"):
         load.verify()
-    assert "Cannot Load and Store the same field!" in exc_info.value.args[0]
 
-    with pytest.raises(VerifyException) as exc_info:
+    with pytest.raises(VerifyException, match="Cannot Load and Store the same field!"):
         store.verify()
-    assert "Cannot Load and Store the same field!" in exc_info.value.args[0]
 
 
 def test_stencil_index():

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -97,8 +97,8 @@ def test_vector_load_verify_type_matching():
     with pytest.raises(Exception) as exc_info:
         load.verify()
     assert (
-        exc_info.value.args[0]
-        == "MemRef element type should match the Vector element type."
+        "MemRef element type should match the Vector element type."
+        in exc_info.value.args[0]
     )
 
 
@@ -109,7 +109,7 @@ def test_vector_load_verify_indexing_exception():
 
     with pytest.raises(Exception) as exc_info:
         load.verify()
-    assert exc_info.value.args[0] == "Expected an index for each dimension."
+    assert "Expected an index for each dimension." in exc_info.value.args[0]
 
 
 def test_vector_store_i32():
@@ -146,8 +146,8 @@ def test_vector_store_verify_type_matching():
     with pytest.raises(Exception) as exc_info:
         store.verify()
     assert (
-        exc_info.value.args[0]
-        == "MemRef element type should match the Vector element type."
+        "MemRef element type should match the Vector element type."
+        in exc_info.value.args[0]
     )
 
 
@@ -159,7 +159,7 @@ def test_vector_store_verify_indexing_exception():
 
     with pytest.raises(Exception) as exc_info:
         store.verify()
-    assert exc_info.value.args[0] == "Expected an index for each dimension."
+    assert "Expected an index for each dimension." in exc_info.value.args[0]
 
 
 def test_vector_broadcast():
@@ -180,8 +180,8 @@ def test_vector_broadcast_verify_type_matching():
     with pytest.raises(Exception) as exc_info:
         broadcast.verify()
     assert (
-        exc_info.value.args[0]
-        == "Source operand and result vector must have the same element type."
+        "Source operand and result vector must have the same element type."
+        in exc_info.value.args[0]
     )
 
 
@@ -231,8 +231,8 @@ def test_vector_fma_verify_res_lhs_type_matching():
     with pytest.raises(Exception) as exc_info:
         fma.verify()
     assert (
-        exc_info.value.args[0]
-        == "Result vector type must match with all source vectors. Found different types for result vector and lhs vector."
+        "Result vector type must match with all source vectors. Found "
+        "different types for result vector and lhs vector." in exc_info.value.args[0]
     )
 
 
@@ -250,8 +250,9 @@ def test_vector_fma_verify_res_rhs_type_matching():
     with pytest.raises(Exception) as exc_info:
         fma.verify()
     assert (
-        exc_info.value.args[0]
-        == "Result vector type must match with all source vectors. Found different types for result vector and rhs vector."
+        "Result vector type must match with all source vectors. "
+        "Found different types for result vector and rhs vector."
+        in exc_info.value.args[0]
     )
 
 
@@ -269,8 +270,9 @@ def test_vector_fma_verify_res_acc_type_matching():
     with pytest.raises(Exception) as exc_info:
         fma.verify()
     assert (
-        exc_info.value.args[0]
-        == "Result vector type must match with all source vectors. Found different types for result vector and acc vector."
+        "Result vector type must match with all source vectors. "
+        "Found different types for result vector and acc vector."
+        in exc_info.value.args[0]
     )
 
 
@@ -288,8 +290,9 @@ def test_vector_fma_verify_res_lhs_shape_matching():
     with pytest.raises(Exception) as exc_info:
         fma.verify()
     assert (
-        exc_info.value.args[0]
-        == "Result vector shape must match with all source vector shapes. Found different shapes for result vector and lhs vector."
+        "Result vector shape must match with all source vector shapes. "
+        "Found different shapes for result vector and lhs vector."
+        in exc_info.value.args[0]
     )
 
 
@@ -307,8 +310,9 @@ def test_vector_fma_verify_res_rhs_shape_matching():
     with pytest.raises(Exception) as exc_info:
         fma.verify()
     assert (
-        exc_info.value.args[0]
-        == "Result vector shape must match with all source vector shapes. Found different shapes for result vector and rhs vector."
+        "Result vector shape must match with all source vector shapes. "
+        "Found different shapes for result vector and rhs vector."
+        in exc_info.value.args[0]
     )
 
 
@@ -326,8 +330,9 @@ def test_vector_fma_verify_res_acc_shape_matching():
     with pytest.raises(Exception) as exc_info:
         fma.verify()
     assert (
-        exc_info.value.args[0]
-        == "Result vector shape must match with all source vector shapes. Found different shapes for result vector and acc vector."
+        "Result vector shape must match with all source vector shapes. "
+        "Found different shapes for result vector and acc vector."
+        in exc_info.value.args[0]
     )
 
 
@@ -392,8 +397,9 @@ def test_vector_masked_load_verify_memref_res_type_matching():
     with pytest.raises(Exception) as exc_info:
         maskedload.verify()
     assert (
-        exc_info.value.args[0]
-        == "MemRef element type should match the result vector and passthrough vector element type. Found different element types for memref and result."
+        "MemRef element type should match the result vector and passthrough "
+        "vector element type. Found different element types for memref and result."
+        in exc_info.value.args[0]
     )
 
 
@@ -419,8 +425,9 @@ def test_vector_masked_load_verify_memref_passthrough_type_matching():
     with pytest.raises(Exception) as exc_info:
         maskedload.verify()
     assert (
-        exc_info.value.args[0]
-        == "MemRef element type should match the result vector and passthrough vector element type. Found different element types for memref and passthrough."
+        "MemRef element type should match the result vector and passthrough "
+        "vector element type. Found different element types for memref and passthrough."
+        in exc_info.value.args[0]
     )
 
 
@@ -437,7 +444,7 @@ def test_vector_masked_load_verify_indexing_exception():
 
     with pytest.raises(Exception) as exc_info:
         maskedload.verify()
-    assert exc_info.value.args[0] == "Expected an index for each memref dimension."
+    assert "Expected an index for each memref dimension." in exc_info.value.args[0]
 
 
 def test_vector_masked_store():
@@ -494,9 +501,9 @@ def test_vector_masked_store_verify_memref_value_to_store_type_matching():
 
     with pytest.raises(Exception) as exc_info:
         maskedstore.verify()
-    assert exc_info.value.args[0] == (
+    assert (
         "MemRef element type should match the stored vector type. "
-        "Obtained types were i32 and i64."
+        "Obtained types were i32 and i64." in exc_info.value.args[0]
     )
 
 
@@ -513,7 +520,7 @@ def test_vector_masked_store_verify_indexing_exception():
 
     with pytest.raises(Exception) as exc_info:
         maskedstore.verify()
-    assert exc_info.value.args[0] == "Expected an index for each memref dimension."
+    assert "Expected an index for each memref dimension." in exc_info.value.args[0]
 
 
 def test_vector_print():
@@ -552,6 +559,6 @@ def test_vector_create_mask_verify_indexing_exception():
     with pytest.raises(Exception) as exc_info:
         create_mask.verify()
     assert (
-        exc_info.value.args[0]
-        == "Expected an operand value for each dimension of resultant mask."
+        "Expected an operand value for each dimension of resultant mask."
+        in exc_info.value.args[0]
     )

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -94,12 +94,10 @@ def test_vector_load_verify_type_matching():
 
     load = Load.build(operands=[memref_ssa_value, []], result_types=[res_vector_type])
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(
+        Exception, match="MemRef element type should match the Vector element type."
+    ):
         load.verify()
-    assert (
-        "MemRef element type should match the Vector element type."
-        in exc_info.value.args[0]
-    )
 
 
 def test_vector_load_verify_indexing_exception():
@@ -107,9 +105,8 @@ def test_vector_load_verify_indexing_exception():
 
     load = Load.get(memref_ssa_value, [])
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Expected an index for each dimension."):
         load.verify()
-    assert "Expected an index for each dimension." in exc_info.value.args[0]
 
 
 def test_vector_store_i32():
@@ -143,12 +140,10 @@ def test_vector_store_verify_type_matching():
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(
+        Exception, match="MemRef element type should match the Vector element type."
+    ):
         store.verify()
-    assert (
-        "MemRef element type should match the Vector element type."
-        in exc_info.value.args[0]
-    )
 
 
 def test_vector_store_verify_indexing_exception():
@@ -157,9 +152,8 @@ def test_vector_store_verify_indexing_exception():
 
     store = Store.get(vector_ssa_value, memref_ssa_value, [])
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Expected an index for each dimension."):
         store.verify()
-    assert "Expected an index for each dimension." in exc_info.value.args[0]
 
 
 def test_vector_broadcast():
@@ -177,12 +171,11 @@ def test_vector_broadcast_verify_type_matching():
 
     broadcast = Broadcast.build(operands=[index1], result_types=[res_vector_type])
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(
+        Exception,
+        match="Source operand and result vector must have the same element type.",
+    ):
         broadcast.verify()
-    assert (
-        "Source operand and result vector must have the same element type."
-        in exc_info.value.args[0]
-    )
 
 
 def test_vector_fma():
@@ -228,12 +221,12 @@ def test_vector_fma_verify_res_lhs_type_matching():
         result_types=[i64_vector_type],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        fma.verify()
-    assert (
+    message = (
         "Result vector type must match with all source vectors. Found "
-        "different types for result vector and lhs vector." in exc_info.value.args[0]
+        "different types for result vector and lhs vector."
     )
+    with pytest.raises(Exception, match=message):
+        fma.verify()
 
 
 def test_vector_fma_verify_res_rhs_type_matching():
@@ -247,13 +240,13 @@ def test_vector_fma_verify_res_rhs_type_matching():
         result_types=[i64_vector_type],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        fma.verify()
-    assert (
+    message = (
         "Result vector type must match with all source vectors. "
         "Found different types for result vector and rhs vector."
-        in exc_info.value.args[0]
     )
+
+    with pytest.raises(Exception, match=message):
+        fma.verify()
 
 
 def test_vector_fma_verify_res_acc_type_matching():
@@ -267,13 +260,13 @@ def test_vector_fma_verify_res_acc_type_matching():
         result_types=[i64_vector_type],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        fma.verify()
-    assert (
+    message = (
         "Result vector type must match with all source vectors. "
         "Found different types for result vector and acc vector."
-        in exc_info.value.args[0]
     )
+
+    with pytest.raises(Exception, match=message):
+        fma.verify()
 
 
 def test_vector_fma_verify_res_lhs_shape_matching():
@@ -287,13 +280,12 @@ def test_vector_fma_verify_res_lhs_shape_matching():
         result_types=[i32_vector_type2],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        fma.verify()
-    assert (
+    message = (
         "Result vector shape must match with all source vector shapes. "
         "Found different shapes for result vector and lhs vector."
-        in exc_info.value.args[0]
     )
+    with pytest.raises(Exception, match=message):
+        fma.verify()
 
 
 def test_vector_fma_verify_res_rhs_shape_matching():
@@ -307,13 +299,12 @@ def test_vector_fma_verify_res_rhs_shape_matching():
         result_types=[i32_vector_type2],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        fma.verify()
-    assert (
+    message = (
         "Result vector shape must match with all source vector shapes. "
         "Found different shapes for result vector and rhs vector."
-        in exc_info.value.args[0]
     )
+    with pytest.raises(Exception, match=message):
+        fma.verify()
 
 
 def test_vector_fma_verify_res_acc_shape_matching():
@@ -327,13 +318,12 @@ def test_vector_fma_verify_res_acc_shape_matching():
         result_types=[i32_vector_type2],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        fma.verify()
-    assert (
+    message = (
         "Result vector shape must match with all source vector shapes. "
         "Found different shapes for result vector and acc vector."
-        in exc_info.value.args[0]
     )
+    with pytest.raises(Exception, match=message):
+        fma.verify()
 
 
 def test_vector_masked_load():
@@ -394,13 +384,12 @@ def test_vector_masked_load_verify_memref_res_type_matching():
         result_types=[i64_res_vector_type],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        maskedload.verify()
-    assert (
+    message = (
         "MemRef element type should match the result vector and passthrough "
         "vector element type. Found different element types for memref and result."
-        in exc_info.value.args[0]
     )
+    with pytest.raises(Exception, match=message):
+        maskedload.verify()
 
 
 def test_vector_masked_load_verify_memref_passthrough_type_matching():
@@ -422,13 +411,13 @@ def test_vector_masked_load_verify_memref_passthrough_type_matching():
         result_types=[i64_res_vector_type],
     )
 
-    with pytest.raises(Exception) as exc_info:
-        maskedload.verify()
-    assert (
+    message = (
         "MemRef element type should match the result vector and passthrough "
         "vector element type. Found different element types for memref and passthrough."
-        in exc_info.value.args[0]
     )
+
+    with pytest.raises(Exception, match=message):
+        maskedload.verify()
 
 
 def test_vector_masked_load_verify_indexing_exception():
@@ -442,9 +431,8 @@ def test_vector_masked_load_verify_indexing_exception():
         memref_ssa_value, [], mask_vector_ssa_value, passthrough_vector_ssa_value
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Expected an index for each memref dimension."):
         maskedload.verify()
-    assert "Expected an index for each memref dimension." in exc_info.value.args[0]
 
 
 def test_vector_masked_store():
@@ -499,12 +487,12 @@ def test_vector_masked_store_verify_memref_value_to_store_type_matching():
         memref_ssa_value, [], mask_vector_ssa_value, value_to_store_vector_ssa_value
     )
 
-    with pytest.raises(Exception) as exc_info:
-        maskedstore.verify()
-    assert (
+    message = (
         "MemRef element type should match the stored vector type. "
-        "Obtained types were i32 and i64." in exc_info.value.args[0]
+        "Obtained types were i32 and i64."
     )
+    with pytest.raises(Exception, match=message):
+        maskedstore.verify()
 
 
 def test_vector_masked_store_verify_indexing_exception():
@@ -518,9 +506,8 @@ def test_vector_masked_store_verify_indexing_exception():
         memref_ssa_value, [], mask_vector_ssa_value, value_to_store_vector_ssa_value
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Expected an index for each memref dimension."):
         maskedstore.verify()
-    assert "Expected an index for each memref dimension." in exc_info.value.args[0]
 
 
 def test_vector_print():
@@ -556,9 +543,8 @@ def test_vector_create_mask_verify_indexing_exception():
 
     create_mask = Createmask.build(operands=[[]], result_types=[mask_vector_type])
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(
+        Exception,
+        match="Expected an operand value for each dimension of resultant mask.",
+    ):
         create_mask.verify()
-    assert (
-        "Expected an operand value for each dimension of resultant mask."
-        in exc_info.value.args[0]
-    )

--- a/tests/filecheck/parser-printer/verifier_error.mlir
+++ b/tests/filecheck/parser-printer/verifier_error.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
 
 builtin.module {
     // Operation has an unexpected result

--- a/tests/filecheck/parser-printer/verifier_error.mlir
+++ b/tests/filecheck/parser-printer/verifier_error.mlir
@@ -1,0 +1,13 @@
+// RUN: xdsl-opt %s | filecheck %s
+
+builtin.module {
+    // Operation has an unexpected result
+    %x = "builtin.module"() : () -> (i32)
+}
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   %x = "builtin.module"() : () -> i32
+// CHECK-NEXT:   ^^^^^^^^^^^^^^^^^^^^^------------------------------------
+// CHECK-NEXT:   | Operation does not verify: Expected 0 result, but got 1
+// CHECK-NEXT:   ---------------------------------------------------------
+// CHECK-NEXT: }) : () -> ()

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -53,17 +53,18 @@ def test_has_parent_no_parent():
     fails with no parents.
     """
     has_parent_op = HasParentOp()
-    with pytest.raises(VerifyException) as exc_info:
+    with pytest.raises(
+        VerifyException, match="'test.has_parent' expects parent op 'test.parent'"
+    ):
         has_parent_op.verify()
-    assert "'test.has_parent' expects parent op 'test.parent'" in str(exc_info.value)
 
     has_multiple_parent_op = HasMultipleParentOp()
-    with pytest.raises(VerifyException) as exc_info:
-        has_multiple_parent_op.verify()
-    assert (
+    message = (
         "'test.has_multiple_parent' expects parent op to "
-        "be one of 'test.parent', 'test.parent2'" in str(exc_info.value)
+        "be one of 'test.parent', 'test.parent2'"
     )
+    with pytest.raises(VerifyException, match=message):
+        has_multiple_parent_op.verify()
 
 
 def test_has_parent_wrong_parent():
@@ -72,17 +73,18 @@ def test_has_parent_wrong_parent():
     fails with a wrong parent.
     """
     module = ModuleOp([HasParentOp()])
-    with pytest.raises(VerifyException) as exc_info:
+    with pytest.raises(
+        VerifyException, match="'test.has_parent' expects parent op 'test.parent'"
+    ):
         module.verify()
-    assert "'test.has_parent' expects parent op 'test.parent'" in str(exc_info.value)
 
     module = ModuleOp([HasMultipleParentOp()])
-    with pytest.raises(VerifyException) as exc_info:
-        module.verify()
-    assert (
+    message = (
         "'test.has_multiple_parent' expects parent op to "
-        "be one of 'test.parent', 'test.parent2'" in str(exc_info.value)
+        "be one of 'test.parent', 'test.parent2'"
     )
+    with pytest.raises(VerifyException, match=message):
+        module.verify()
 
 
 def test_has_parent_verify():

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -55,14 +55,14 @@ def test_has_parent_no_parent():
     has_parent_op = HasParentOp()
     with pytest.raises(VerifyException) as exc_info:
         has_parent_op.verify()
-    assert str(exc_info.value) == "'test.has_parent' expects parent op 'test.parent'"
+    assert "'test.has_parent' expects parent op 'test.parent'" in str(exc_info.value)
 
     has_multiple_parent_op = HasMultipleParentOp()
     with pytest.raises(VerifyException) as exc_info:
         has_multiple_parent_op.verify()
-    assert str(exc_info.value) == (
+    assert (
         "'test.has_multiple_parent' expects parent op to "
-        "be one of 'test.parent', 'test.parent2'"
+        "be one of 'test.parent', 'test.parent2'" in str(exc_info.value)
     )
 
 
@@ -74,14 +74,14 @@ def test_has_parent_wrong_parent():
     module = ModuleOp([HasParentOp()])
     with pytest.raises(VerifyException) as exc_info:
         module.verify()
-    assert str(exc_info.value) == "'test.has_parent' expects parent op 'test.parent'"
+    assert "'test.has_parent' expects parent op 'test.parent'" in str(exc_info.value)
 
     module = ModuleOp([HasMultipleParentOp()])
     with pytest.raises(VerifyException) as exc_info:
         module.verify()
-    assert str(exc_info.value) == (
+    assert (
         "'test.has_multiple_parent' expects parent op to "
-        "be one of 'test.parent', 'test.parent2'"
+        "be one of 'test.parent', 'test.parent2'" in str(exc_info.value)
     )
 
 

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -111,7 +111,7 @@ def test_attr_verify():
     op = AttrOp.create(attributes={"attr": IntAttr(1)})
     with pytest.raises(VerifyException) as e:
         op.verify()
-    assert e.value.args[0] == "#int<1> should be of base attribute string"
+    assert "#int<1> should be of base attribute string" in e.value.args[0]
 
 
 @irdl_op_definition

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -109,9 +109,10 @@ class AttrOp(IRDLOperation):
 
 def test_attr_verify():
     op = AttrOp.create(attributes={"attr": IntAttr(1)})
-    with pytest.raises(VerifyException) as e:
+    with pytest.raises(
+        VerifyException, match="#int<1> should be of base attribute string"
+    ):
         op.verify()
-    assert "#int<1> should be of base attribute string" in e.value.args[0]
 
 
 @irdl_op_definition

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -112,17 +112,18 @@ def test_verifier():
     operand32 = TestSSAValue(i32)
     operand1 = TestSSAValue(i1)
     op = TestOp.create(operands=[operand1], result_types=[i32])
-    with pytest.raises(VerifyException) as e:
-        op.verify()
-    assert (
-        "Operation has a result bitwidth greater"
-        " or equal to the operand bitwidth." in e.value.args[0]
+
+    message = (
+        "Operation has a result bitwidth greater or equal to the operand bitwidth."
     )
+    with pytest.raises(VerifyException, match=message):
+        op.verify()
 
     op = TestOp.create(operands=[operand64], result_types=[i32])
-    with pytest.raises(VerifyException) as e:
+    with pytest.raises(
+        VerifyException, match="Operation has a bitwidth sum greater or equal to 64."
+    ):
         op.verify()
-    assert "Operation has a bitwidth sum " "greater or equal to 64." in e.value.args[0]
 
     op = TestOp.create(operands=[operand32], result_types=[i1])
     op.verify()
@@ -133,9 +134,8 @@ def test_verifier_order():
     Check that trait verifiers are called after IRDL verifiers.
     """
     op = TestOp.create(operands=[], result_types=[i1])
-    with pytest.raises(VerifyException) as e:
+    with pytest.raises(VerifyException, match="Expected 1 operand, but got 0"):
         op.verify()
-    assert "Expected 1 operand, but got 0" in e.value.args[0]
 
 
 class LargerOperandOp(IRDLOperation, ABC):

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -114,16 +114,15 @@ def test_verifier():
     op = TestOp.create(operands=[operand1], result_types=[i32])
     with pytest.raises(VerifyException) as e:
         op.verify()
-    assert e.value.args[0] == (
-        "Operation has a result bitwidth greater" " or equal to the operand bitwidth."
+    assert (
+        "Operation has a result bitwidth greater"
+        " or equal to the operand bitwidth." in e.value.args[0]
     )
 
     op = TestOp.create(operands=[operand64], result_types=[i32])
     with pytest.raises(VerifyException) as e:
         op.verify()
-    assert e.value.args[0] == (
-        "Operation has a bitwidth sum " "greater or equal to 64."
-    )
+    assert "Operation has a bitwidth sum " "greater or equal to 64." in e.value.args[0]
 
     op = TestOp.create(operands=[operand32], result_types=[i1])
     op.verify()
@@ -136,7 +135,7 @@ def test_verifier_order():
     op = TestOp.create(operands=[], result_types=[i1])
     with pytest.raises(VerifyException) as e:
         op.verify()
-    assert e.value.args[0] == ("Expected 1 operand, but got 0")
+    assert "Expected 1 operand, but got 0" in e.value.args[0]
 
 
 class LargerOperandOp(IRDLOperation, ABC):

--- a/xdsl/utils/diagnostic.py
+++ b/xdsl/utils/diagnostic.py
@@ -25,7 +25,7 @@ class Diagnostic:
         from xdsl.printer import Printer
 
         f = StringIO()
-        p = Printer(stream=f, diagnostic=self)
+        p = Printer(stream=f, diagnostic=self, print_generic_format=True)
         toplevel = ir.get_toplevel_object()
         if isinstance(toplevel, Operation):
             p.print_op(toplevel)

--- a/xdsl/utils/diagnostic.py
+++ b/xdsl/utils/diagnostic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from io import StringIO
+from typing import NoReturn
 
 from xdsl.ir import IRNode, Block, Operation, Region
 from xdsl.utils.exceptions import DiagnosticException
@@ -19,7 +20,7 @@ class Diagnostic:
         message: str,
         ir: IRNode,
         exception_type: type[Exception] = DiagnosticException,
-    ) -> None:
+    ) -> NoReturn:
         """Raise an exception, that will also print all messages in the IR."""
         from xdsl.printer import Printer
 


### PR DESCRIPTION
This PR improves debugging on errors triggered in Operation.
It adds an `emit_error` method that will print back the IR, and display an error at the correct location.
Additionally, the `verify` method of `Operation` will now print back the entire IR if verification fails.