### PR TITLE
dialects: (memref) Make alignment for memref.alloc optional

### DIFF
--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -241,7 +241,7 @@ class Alloc(IRDLOperation):
     @staticmethod
     def get(
         return_type: Attribute,
-        alignment: int,
+        alignment: int | None = None,
         shape: Optional[Iterable[int | AnyIntegerAttr]] = None,
     ) -> Alloc:
         if shape is None:
@@ -249,7 +249,11 @@ class Alloc(IRDLOperation):
         return Alloc.build(
             operands=[[], []],
             result_types=[MemRefType.from_element_type_and_shape(return_type, shape)],
-            attributes={"alignment": IntegerAttr.from_int_and_width(alignment, 64)},
+            attributes={
+                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
+                if alignment is not None
+                else None
+            },
         )
 
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -50,6 +50,7 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     OpAttr,
     IRDLOperation,
+    OptOpAttr,
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
@@ -233,7 +234,7 @@ class Alloc(IRDLOperation):
     memref: Annotated[OpResult, MemRefType[Attribute]]
 
     # TODO how to constraint the IntegerAttr type?
-    alignment: OpAttr[AnyIntegerAttr]
+    alignment: OptOpAttr[AnyIntegerAttr]
 
     irdl_options = [AttrSizedOperandSegments()]
 


### PR DESCRIPTION
This seems to also be the case for mlir, so we don't actually need it