### PR TITLE
core: (NFC) rewrite operation parser in lexer

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -43,7 +43,7 @@
   // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   %xor = "riscv.xor"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.xor"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-   %sll = "riscv.sll"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  %sll = "riscv.sll"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   %srl = "riscv.srl"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
@@ -81,17 +81,17 @@
 
 
   // Conditional Branch Instructions
-  "riscv.beq"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.beq"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.beq"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bne"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.bne"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.bne"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.blt"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.blt"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.blt"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bge"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.bge"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.bge"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bltu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.bltu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.bltu"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.bgeu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.bgeu"(%0, %1) {"offset" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.bgeu"(%{{.*}}, %{{.*}}) {"offset" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
 
   // RV32I/RV64I: 2.6 Load and Store Instructions
@@ -106,11 +106,11 @@
   // CHECK-NEXT: %{{.*}} = "riscv.lhu"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
   %lw = "riscv.lw"(%0) {"immediate" = 1 : i32}: (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = "riscv.lw"(%0) {"immediate" = 1 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-  "riscv.sb"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.sb"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.sb"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.sh"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.sh"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.sh"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "riscv.sw"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  "riscv.sw"(%0, %1) {"immediate" = 1 : i32}: (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK-NEXT: "riscv.sw"(%0, %1) {"immediate" = 1 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
 
   // RV32I/RV64I: 2.8 Control and Status Register Instructions

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -33,7 +33,7 @@ builtin.module {
 builtin.module {
   %0 = "test.op"() : () -> ()
 }
-// CHECK: Operation has 0 results, but were given 1 to bind.
+// CHECK: Operation has 0 results, but was given 1 to bind.
 
 // -----
 
@@ -43,7 +43,7 @@ builtin.module {
   %0 = "test.op"() : () -> (!test.type<"foo">, !test.type<"bar">)
 }
 
-// CHECK: Operation has 2 results, but were given 1 to bind.
+// CHECK: Operation has 2 results, but was given 1 to bind.
 
 // -----
 

--- a/tests/filecheck/parser-printer/value_tuple_wrong_number.mlir
+++ b/tests/filecheck/parser-printer/value_tuple_wrong_number.mlir
@@ -3,6 +3,6 @@
 "builtin.module"() ({
 
   %0:1 = "test.test"() : () -> (i32, i64, i32)
-  // CHECK: Operation has 3 results, but were given 1 to bind.
+  // CHECK: Operation has 3 results, but was given 1 to bind.
 
 }) : () -> ()

--- a/tests/test_parser_error.py
+++ b/tests/test_parser_error.py
@@ -26,21 +26,10 @@ def check_error(prog: str, line: int, column: int, message: str):
     ctx.register_op(UnkownOp)
 
     parser = Parser(ctx, prog)
-    with raises(ParseError) as e:
+    with raises(ParseError, match=message) as e:
         parser.parse_operation()
 
-    assert e.value.span
-
-    assert e.value.history is not None
-
-    for err in e.value.history.iterate():
-        if message in err.error.msg:
-            assert err.error.span.get_line_col() == (line, column)
-            break
-    else:
-        assert False, "'{}' not found in an error message {}!".format(
-            message, e.value.args
-        )
+    assert e.value.span.get_line_col() == (line, column)
 
 
 def test_parser_missing_equal():
@@ -53,7 +42,7 @@ def test_parser_missing_equal():
   %0 "unknown"() : () -> !i32
 }) : () -> ()
 """
-    check_error(prog, 3, 5, "Operation definitions expect an `=` after op-result-list!")
+    check_error(prog, 3, 5, "Expected '=' after operation result list")
 
 
 def test_parser_redefined_value():
@@ -80,4 +69,4 @@ def test_parser_missing_operation_name():
   %val =
 }) : () -> ()
 """
-    check_error(prog, 4, 0, "Expected an operation name here")
+    check_error(prog, 4, 0, "operation name expected")

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -20,9 +20,9 @@ from typing import (
     IO,
     cast,
     Literal,
-    Sequence,
     Callable,
     overload,
+    Sequence,
 )
 
 from xdsl.utils.exceptions import ParseError, MultipleSpansParseError
@@ -697,7 +697,7 @@ class Parser(ABC):
         return self._consume_token()
 
     def parse_module(self) -> ModuleOp:
-        op = self.try_parse_operation()
+        op = self.parse_optional_operation()
 
         if op is None:
             self.raise_error("Could not parse entire input!")
@@ -763,9 +763,7 @@ class Parser(ABC):
         Parse a block body, which consist of a list of operations.
         The operations are added at the end of the block.
         """
-        self._synchronize_lexer_and_tokenizer()
-        while (op := self.try_parse_operation()) is not None:
-            self._synchronize_lexer_and_tokenizer()
+        while (op := self.parse_optional_operation()) is not None:
             block.add_op(op)
 
     def _parse_block(self) -> Block:
@@ -1655,83 +1653,6 @@ class Parser(ABC):
             for val in values:
                 val.name_hint = name
 
-    def try_parse_operation(self) -> Operation | None:
-        with self.backtracking("operation"):
-            return self.parse_operation()
-
-    def parse_operation(self) -> Operation:
-        self._synchronize_lexer_and_tokenizer()
-        if self._current_token.kind == Token.Kind.PERCENT_IDENT:
-            results = self._parse_op_result_list()
-        else:
-            results = []
-        ret_types = [result[2] for result in results]
-        if len(results) > 0:
-            self.parse_characters(
-                "=", "Operation definitions expect an `=` after op-result-list!"
-            )
-
-        # Check for custom op format
-        op_name = self.try_parse_bare_id()
-        if op_name is not None:
-            op_type = self._get_op_by_name(op_name.text)
-            op = op_type.parse(self)
-        else:
-            # Check for basic op format
-            op_name = self.parse_optional_str_literal()
-            if op_name is None:
-                self.raise_error(
-                    "Expected an operation name here, either a bare-id, or a string "
-                    "literal!"
-                )
-
-            args, successors, attrs, regions, func_type = self.parse_operation_details()
-
-            if any(res_type is None for res_type in ret_types):
-                assert func_type is not None
-                ret_types = func_type.outputs.data
-            ret_types = cast(Sequence[Attribute], ret_types)
-
-            op_type = self._get_op_by_name(op_name)
-
-            op = op_type.create(
-                operands=args,
-                result_types=ret_types,
-                attributes=attrs,
-                successors=[
-                    self._get_block_from_name(block_name) for block_name in successors
-                ],
-                regions=regions,
-            )
-
-        expected_results = sum(r[1] for r in results)
-        if len(op.results) != expected_results:
-            self.raise_error(
-                f"Operation has {len(op.results)} results, "
-                f"but were given {expected_results} to bind."
-            )
-
-        # Register the result SSA value names in the parser
-        res_idx = 0
-        for res_span, res_size, _ in results:
-            ssa_val_name = res_span.text[1:]  # Removing the leading '%'
-            self._register_ssa_definition(
-                ssa_val_name, op.results[res_idx : res_idx + res_size], res_span
-            )
-            res_idx += res_size
-
-        return op
-
-    def _get_op_by_name(self, name: str) -> type[Operation]:
-        op_type = self.ctx.get_optional_op(
-            name, allow_unregistered=self.allow_unregistered_dialect
-        )
-
-        if op_type is not None:
-            return op_type
-
-        self.raise_error(f"unregistered operation {name}!")
-
     @dataclass
     class Argument:
         """
@@ -2610,69 +2531,167 @@ class Parser(ABC):
 
             name = self.tokenizer.next_token_of_pattern(ParserCommons.builtin_type)
             if name is None:
-                self.raise_error("Expected builtin name!")
+                return None
 
             return self._parse_builtin_type_with_name(name)
 
-    def _parse_op_result(self) -> tuple[Span, int, Attribute | None]:
+    def parse_optional_operation(self) -> Operation | None:
+        """
+        Parse an operation, if present, with format:
+            operation             ::= op-result-list? (generic-operation | custom-operation)
+            generic-operation     ::= string-literal `(` value-use-list? `)`  successor-list?
+                                      region-list? dictionary-attribute? `:` function-type
+            custom-operation      ::= bare-id custom-operation-format
+            op-result-list        ::= op-result (`,` op-result)* `=`
+            op-result             ::= value-id (`:` integer-literal)
+            successor-list        ::= `[` successor (`,` successor)* `]`
+            successor             ::= caret-id (`:` block-arg-list)?
+            region-list           ::= `(` region (`,` region)* `)`
+            dictionary-attribute  ::= `{` (attribute-entry (`,` attribute-entry)*)? `}`
+        """
+        if self._current_token.kind not in (
+            Token.Kind.PERCENT_IDENT,
+            Token.Kind.BARE_IDENT,
+            Token.Kind.STRING_LIT,
+        ):
+            return None
+        return self.parse_operation()
+
+    def parse_operation(self) -> Operation:
+        """
+        Parse an operation with format:
+            operation             ::= op-result-list? (generic-operation | custom-operation)
+            generic-operation     ::= string-literal `(` value-use-list? `)`  successor-list?
+                                      region-list? dictionary-attribute? `:` function-type
+            custom-operation      ::= bare-id custom-operation-format
+            op-result-list        ::= op-result (`,` op-result)* `=`
+            op-result             ::= value-id (`:` integer-literal)
+            successor-list        ::= `[` successor (`,` successor)* `]`
+            successor             ::= caret-id (`:` block-arg-list)?
+            region-list           ::= `(` region (`,` region)* `)`
+            dictionary-attribute  ::= `{` (attribute-entry (`,` attribute-entry)*)? `}`
+        """
+        self._synchronize_lexer_and_tokenizer()
+
+        # Parse the operation results
+        bound_results = self._parse_op_result_list()
+
+        if (op_name := self._parse_optional_token(Token.Kind.BARE_IDENT)) is not None:
+            # Custom operation format
+            op_type = self._get_op_by_name(op_name.text)
+            self._synchronize_lexer_and_tokenizer()
+            op = op_type.parse(self)
+            self._synchronize_lexer_and_tokenizer()
+        else:
+            # Generic operation format
+            op_name = self.expect(
+                self.parse_optional_str_literal, "operation name expected"
+            )
+            op_type = self._get_op_by_name(op_name)
+            op = self._parse_generic_operation(op_type)
+
+        self._synchronize_lexer_and_tokenizer()
+
+        n_bound_results = sum(r[1] for r in bound_results)
+        if (n_bound_results != 0) and (len(op.results) != n_bound_results):
+            self.raise_error(
+                f"Operation has {len(op.results)} results, "
+                f"but was given {n_bound_results} to bind."
+            )
+
+        # Register the result SSA value names in the parser
+        res_idx = 0
+        for res_span, res_size in bound_results:
+            ssa_val_name = res_span.text[1:]  # Removing the leading '%'
+            self._register_ssa_definition(
+                ssa_val_name, op.results[res_idx : res_idx + res_size], res_span
+            )
+            res_idx += res_size
+
+        return op
+
+    def _get_op_by_name(self, name: str) -> type[Operation]:
+        """
+        Get an operation type by its name.
+        Raises an error if the operation is not registered, and if unregistered
+        dialects are not allowed.
+        """
+        op_type = self.ctx.get_optional_op(
+            name, allow_unregistered=self.allow_unregistered_dialect
+        )
+
+        if op_type is not None:
+            return op_type
+
+        self.raise_error(f"unregistered operation {name}!")
+
+    def _parse_op_result(self) -> tuple[Span, int]:
+        """
+        Parse an operation result.
+        Returns the span of the SSA value name (including the `%`), and the size of the
+        value tuple (by default 1).
+        """
         value_token = self._parse_token(
             Token.Kind.PERCENT_IDENT, "Expected result SSA value!"
         )
         if self._parse_optional_token(Token.Kind.COLON) is None:
-            return (value_token.span, 1, None)
+            return (value_token.span, 1)
 
         size_token = self._parse_token(
             Token.Kind.INTEGER_LIT, "Expected SSA value tuple size"
         )
         size = size_token.get_int_value()
-        return (value_token.span, size, None)
+        return (value_token.span, size)
 
-    def _parse_op_result_list(self) -> list[tuple[Span, int, Attribute | None]]:
-        self._synchronize_lexer_and_tokenizer()
-        res = self.parse_comma_separated_list(
-            self.Delimiter.NONE, self._parse_op_result, " in operation result list"
-        )
-        self._synchronize_lexer_and_tokenizer()
-        return res
+    def _parse_op_result_list(self) -> list[tuple[Span, int]]:
+        """
+        Parse the list of operation results.
+        If no results are present, returns an empty list.
+        Each result is a tuple of the span of the SSA value name (including the `%`),
+        and the size of the value tuple (by default 1).
+        """
+        if self._current_token.kind == Token.Kind.PERCENT_IDENT:
+            res = self.parse_comma_separated_list(
+                self.Delimiter.NONE, self._parse_op_result, " in operation result list"
+            )
+            self.parse_punctuation("=", " after operation result list")
+            return res
+        return []
 
     def parse_optional_attr_dict(self) -> dict[str, Attribute]:
         return self.parse_optional_dictionary_attr_dict()
 
-    def parse_operation_details(
-        self,
-    ) -> tuple[
-        list[SSAValue],
-        list[Span],
-        dict[str, Attribute],
-        list[Region],
-        FunctionType | None,
-    ]:
+    def _parse_generic_operation(self, op_type: type[Operation]) -> Operation:
         """
-        Must return a tuple consisting of:
-            - a list of arguments to the operation
-            - a list of successor names
-            - the attributes attached to the OP
-            - the regions of the op
-            - An optional function type. If not supplied, `parse_op_result_list`
-              must return a second value containing the types of the returned SSAValues
-
+        Parse an operation with format:
+            generic-operation     ::= string-literal `(` value-use-list? `)`  successor-list?
+                                      region-list? dictionary-attribute? `:` function-type
+            successor-list        ::= `[` successor (`,` successor)* `]`
+            successor             ::= caret-id
+            region-list           ::= `(` region (`,` region)* `)`
+            dictionary-attribute  ::= `{` (attribute-entry (`,` attribute-entry)*)? `}`
         """
+        # Parse arguments
         args = self._parse_op_args_list()
-        succ = self._parse_optional_successor_list()
 
+        # Parse successors
+        successors = self.parse_optional_successors()
+
+        # Parse regions
         regions = []
-        if self.tokenizer.starts_with("("):
-            self.parse_characters("(", "Expected brackets enclosing regions!")
-            regions = self.parse_region_list()
-            self.parse_characters(")", "Expected brackets enclosing regions!")
+        if self._current_token.kind == Token.Kind.L_PAREN:
+            regions = self.parse_comma_separated_list(
+                self.Delimiter.PAREN, self.parse_region, " in operation region list"
+            )
 
+        # Parse attribute dictionary
         attrs = self.parse_optional_attr_dict()
 
-        self.parse_characters(
-            ":", "MLIR Operation definitions must end in a function type signature!"
-        )
+        self.parse_punctuation(":", "function type signature expected")
 
         func_type_pos = self._current_token.span.start
+
+        # Parse function type
         func_type = self.parse_function_type()
 
         if len(args) != len(func_type.inputs):
@@ -2686,40 +2705,66 @@ class Parser(ABC):
             for operand, type in zip(args, func_type.inputs)
         ]
 
-        return operands, succ, attrs, regions, func_type
-
-    def _parse_optional_successor_list(self) -> list[Span]:
-        self._synchronize_lexer_and_tokenizer()
-        if self._current_token.kind != Token.Kind.L_SQUARE:
-            return []
-        successors = self.parse_comma_separated_list(
-            self.Delimiter.SQUARE,
-            lambda: self.expect(self.try_parse_block_id, "block-id expected"),
+        return op_type.create(
+            operands=operands,
+            result_types=func_type.outputs.data,
+            attributes=attrs,
+            successors=successors,
+            regions=regions,
         )
-        return successors
+
+    def parse_optional_successor(self) -> Block | None:
+        """
+        Parse a successor with format:
+            successor      ::= caret-id
+        """
+        self._synchronize_lexer_and_tokenizer()
+        block_token = self._parse_optional_token(Token.Kind.CARET_IDENT)
+        if block_token is None:
+            return None
+        name = block_token.text[1:]
+        if name not in self.blocks:
+            self.forward_block_references[name].append(block_token.span)
+            self.blocks[name] = (Block(), None)
+        self._synchronize_lexer_and_tokenizer()
+        return self.blocks[name][0]
+
+    def parse_successor(self) -> Block:
+        """
+        Parse a successor with format:
+            successor      ::= caret-id
+        """
+        return self.expect(self.parse_optional_successor, "successor expected")
+
+    def parse_optional_successors(self) -> list[Block] | None:
+        """
+        Parse a list of successors, if present, with format
+            successor-list ::= `[` successor (`,` successor)* `]`
+            successor      ::= caret-id
+        """
+        if self._current_token.kind != Token.Kind.L_SQUARE:
+            return None
+        return self.parse_successors()
+
+    def parse_successors(self) -> list[Block]:
+        """
+        Parse a list of successors with format:
+            successor-list ::= `[` successor (`,` successor)* `]`
+            successor      ::= caret-id
+        """
+        return self.parse_comma_separated_list(
+            self.Delimiter.SQUARE,
+            lambda: self.expect(self.parse_successor, "block-id expected"),
+        )
 
     def _parse_op_args_list(self) -> list[UnresolvedOperand]:
+        """
+        Parse a list of arguments with format:
+           args-list ::= `(` value-use-list? `)`
+           value-use-list ::= `%` suffix-id (`,` `%` suffix-id)*
+        """
         return self.parse_comma_separated_list(
             self.Delimiter.PAREN,
             self.parse_unresolved_operand,
             " in operation argument list",
         )
-
-    def parse_region_list(self) -> list[Region]:
-        """
-        Parses a sequence of regions for as long as there is a `{` in the input.
-        """
-        regions: list[Region] = []
-        while not self.tokenizer.is_eof() and self.tokenizer.starts_with("{"):
-            regions.append(self.parse_region())
-            if self.tokenizer.starts_with(","):
-                self.parse_characters(
-                    ",",
-                    msg="This error should never be printed, please open "
-                    "an issue at github.com/xdslproject/xdsl",
-                )
-                if not self.tokenizer.starts_with("{"):
-                    self.raise_error(
-                        "Expected next region (because of `,` after region end)!"
-                    )
-        return regions

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -1137,9 +1137,6 @@ class Parser(ABC):
         """Parse an operand with format `%<value-id>`."""
         return self.expect(self.parse_optional_operand, msg)
 
-    def try_parse_block_id(self) -> Span | None:
-        return self.tokenizer.next_token_of_pattern(ParserCommons.block_id)
-
     def parse_type(self) -> Attribute:
         """
         Parse an xDSL type.


### PR DESCRIPTION
This removes the operation parser written with the legacy tokenizer to the lexer.
This does not change any behavior, besides a fix in the operation parser.