### PR TITLE
misc: add back check for unreachable code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = ["setuptools>=42", "wheel"]
 
 [tool.pyright]
 reportImportCycles = false
-
 typeCheckingMode = "strict"
 "include" = ["docs", "xdsl", "tests", "bench"]
 "exclude" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42", "wheel"]
 
 [tool.pyright]
 reportImportCycles = false
-reportUnnecessaryIsInstance = false
+
 typeCheckingMode = "strict"
 "include" = ["docs", "xdsl", "tests", "bench"]
 "exclude" = [

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -64,7 +64,6 @@ def test_llvm_pointer_type():
 
 def test_llvm_getelementptr_op_invalid_construction():
     size = arith.Constant.from_int_and_width(1, 32)
-    ptr = llvm.AllocaOp.get(size, builtin.i32)
     opaque_ptr = llvm.AllocaOp.get(size, builtin.i32, as_untyped_ptr=True)
 
     # check that passing an opaque pointer to GEP without a pointee type fails
@@ -81,14 +80,6 @@ def test_llvm_getelementptr_op_invalid_construction():
             size,
             indices=[1],
             result_type=llvm.LLVMPointerType.opaque(),
-        )
-
-    # check that non-pointer result types fail
-    with pytest.raises(ValueError):
-        llvm.GEPOp.get(
-            ptr,
-            indices=[1],
-            result_type=builtin.i32,  # type: ignore[reportGeneralTypeIssues]
         )
 
 

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -195,7 +195,7 @@ def test_stencil_apply_no_results():
         ),
     ),
 )
-def test_create_index_attr_from_int_list(indices: list[int]):
+def test_create_index_attr_from_int_list(indices: list[int | IntAttr]):
     stencil_index_attr = IndexAttr.get(*indices)
     expected_array_attr = ArrayAttr(
         [(IntAttr(idx) if isinstance(idx, int) else idx) for idx in indices]

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -150,10 +150,14 @@ class IntListData(Data[list[int]]):
         printer.print_string("]")
 
     def verify(self) -> None:
-        if not isinstance(self.data, list):
+        if not isinstance(
+            self.data, list
+        ):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise VerifyException("int_list data should hold a list.")
         for elem in self.data:
-            if not isinstance(elem, int):
+            if not isinstance(
+                elem, int
+            ):  # pyright: ignore[reportUnnecessaryIsInstance]
                 raise VerifyException("int_list list elements should be integers.")
 
 
@@ -493,7 +497,9 @@ class ListData(GenericData[list[A]]):
         return ListData(data)
 
     def verify(self) -> None:
-        if not isinstance(self.data, list):
+        if not isinstance(
+            self.data, list
+        ):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise VerifyException(
                 f"Wrong type given to attribute {self.name}: got"
                 f" {type(self.data)}, but expected list of"
@@ -651,14 +657,11 @@ class OveriddenInitAttr(ParametrizedAttribute):
     param: ParameterDef[Attribute]
 
     def __init__(self, param: int | str):
-        if isinstance(param, int):
-            super().__init__([IntData(param)])
-        elif isinstance(param, str):
-            super().__init__([StringData(param)])
-        else:
-            raise TypeError(
-                "Expected `int` or `str` type in " "OveriddenInitAttr constructor"
-            )
+        match param:
+            case int():
+                super().__init__([IntData(param)])
+            case str():
+                super().__init__([StringData(param)])
 
 
 def test_generic_constructor():

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -139,6 +139,7 @@ class IntListData(Data[list[int]]):
 
     def verify(self) -> None:
         # We must override verify on Attribute
+        # https://github.com/xdslproject/xdsl/issues/1075
         ...
 
 

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -3,7 +3,6 @@ import pytest
 from typing import Annotated
 
 from xdsl.dialects.builtin import i32, StringAttr
-from xdsl.dialects.arith import Constant
 
 from xdsl.ir import Block, OpResult, BlockArgument, SSAValue
 from xdsl.irdl import irdl_op_definition, IRDLOperation

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -9,20 +9,6 @@ from xdsl.ir import Block, OpResult, BlockArgument, SSAValue
 from xdsl.irdl import irdl_op_definition, IRDLOperation
 
 
-def test_ssa():
-    c = Constant.from_int_and_width(1, i32)
-    with pytest.raises(TypeError):
-        # test that we raise a TypeError if we give an incorrect type
-        # hence ignore
-        _ = SSAValue.get([c])  # type: ignore
-
-    b0 = Block([c])
-    with pytest.raises(TypeError):
-        # test that we raise a TypeError if we give an incorrect type
-        # hence ignore
-        _ = SSAValue.get(b0)  # type: ignore
-
-
 @irdl_op_definition
 class TwoResultOp(IRDLOperation):
     name = "test.tworesults"

--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -99,9 +99,8 @@ def test_operation_deletion():
                 name = "remove-constant"
 
                 def apply(self, ctx: MLContext, op: builtin.ModuleOp):
-                    if isinstance(op, builtin.ModuleOp):
-                        if op.ops.first is not None:
-                            op.ops.first.detach()
+                    if op.ops.first is not None:
+                        op.ops.first.detach()
 
             self.register_pass(RemoveConstantPass)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -533,6 +533,9 @@ class DictionaryAttr(GenericData[dict[str, Attribute]]):
             to_add_data[k] = v
         return DictionaryAttr(to_add_data)
 
+    def verify(self) -> None:
+        return super().verify()
+
 
 @irdl_attr_definition
 class TupleType(ParametrizedAttribute):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -871,6 +871,11 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
         type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
         data: Sequence[int | float] | Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr],
     ) -> DenseIntOrFPElementsAttr:
+        if isinstance(type.element_type, AnyFloat):
+            new_type = cast(RankedVectorOrTensorOf[AnyFloat], type)
+            new_data = cast(Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data)
+            return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
+
         match type.element_type:
             case IntegerType():
                 new_type = cast(RankedVectorOrTensorOf[IntegerType], type)
@@ -882,12 +887,6 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
                 new_type = cast(RankedVectorOrTensorOf[IndexType], type)
                 new_data = cast(Sequence[int] | Sequence[IntegerAttr[IndexType]], data)
                 return DenseIntOrFPElementsAttr.create_dense_index(new_type, new_data)
-            case BFloat16Type() | Float16Type() | Float32Type() | Float64Type() | Float80Type() | Float128Type():
-                new_type = cast(RankedVectorOrTensorOf[AnyFloat], type)
-                new_data = cast(
-                    Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data
-                )
-                return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
 
     @staticmethod
     def vector_from_list(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -120,12 +120,6 @@ class ArrayAttr(GenericData[tuple[AttributeCovT, ...]], Iterable[AttributeCovT])
         )
 
     def verify(self) -> None:
-        if not isinstance(self.data, tuple):
-            raise VerifyException(
-                f"Wrong type given to attribute {self.name}: got"
-                f" {type(self.data)}, but expected list of"
-                " attributes"
-            )
         for idx, val in enumerate(self.data):
             if not isinstance(val, Attribute):
                 raise VerifyException(
@@ -528,25 +522,6 @@ class DictionaryAttr(GenericData[dict[str, Attribute]]):
     def generic_constraint_coercion(args: tuple[Any]) -> AttrConstraint:
         raise Exception(f"Unsupported operation on {DictionaryAttr.name}")
 
-    def verify(self) -> None:
-        if not isinstance(self.data, dict):
-            raise VerifyException(
-                f"Wrong type given to attribute {self.name}: got"
-                f" {type(self.data)}, but expected dictionary of"
-                " attributes"
-            )
-        for key, val in self.data.items():
-            if not isinstance(key, str):
-                raise VerifyException(
-                    f"{self.name} key expects str, but {key} "
-                    f"element is of type {type(key)}"
-                )
-            if not isinstance(val, Attribute):
-                raise VerifyException(
-                    f"{self.name} key expects attribute, but {val} "
-                    f"element is of type {type(val)}"
-                )
-
     @staticmethod
     @deprecated_constructor
     def from_dict(data: dict[str | StringAttr, Attribute]) -> DictionaryAttr:
@@ -555,12 +530,6 @@ class DictionaryAttr(GenericData[dict[str, Attribute]]):
             # try to coerce keys into StringAttr
             if isinstance(k, StringAttr):
                 k = k.data
-            # if coercion fails, raise KeyError!
-            if not isinstance(k, str):
-                raise TypeError(
-                    f"DictionaryAttr.from_dict expects keys to"
-                    f" be of type str or StringAttr, but {type(k)} provided"
-                )
             to_add_data[k] = v
         return DictionaryAttr(to_add_data)
 
@@ -899,20 +868,23 @@ class DenseIntOrFPElementsAttr(ParametrizedAttribute):
         type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
         data: Sequence[int | float] | Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr],
     ) -> DenseIntOrFPElementsAttr:
-        if isinstance(type.element_type, IntegerType):
-            new_type = cast(RankedVectorOrTensorOf[IntegerType], type)
-            new_data = cast(Sequence[int] | Sequence[IntegerAttr[IntegerType]], data)
-            return DenseIntOrFPElementsAttr.create_dense_int(new_type, new_data)
-        elif isinstance(type.element_type, IndexType):
-            new_type = cast(RankedVectorOrTensorOf[IndexType], type)
-            new_data = cast(Sequence[int] | Sequence[IntegerAttr[IndexType]], data)
-            return DenseIntOrFPElementsAttr.create_dense_index(new_type, new_data)
-        elif isinstance(type.element_type, AnyFloat):
-            new_type = cast(RankedVectorOrTensorOf[AnyFloat], type)
-            new_data = cast(Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data)
-            return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
-        else:
-            raise TypeError(f"Unsupported element type {type.element_type}")
+        match type.element_type:
+            case IntegerType():
+                new_type = cast(RankedVectorOrTensorOf[IntegerType], type)
+                new_data = cast(
+                    Sequence[int] | Sequence[IntegerAttr[IntegerType]], data
+                )
+                return DenseIntOrFPElementsAttr.create_dense_int(new_type, new_data)
+            case IndexType():
+                new_type = cast(RankedVectorOrTensorOf[IndexType], type)
+                new_data = cast(Sequence[int] | Sequence[IntegerAttr[IndexType]], data)
+                return DenseIntOrFPElementsAttr.create_dense_index(new_type, new_data)
+            case BFloat16Type() | Float16Type() | Float32Type() | Float64Type() | Float80Type() | Float128Type():
+                new_type = cast(RankedVectorOrTensorOf[AnyFloat], type)
+                new_data = cast(
+                    Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data
+                )
+                return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
 
     @staticmethod
     def vector_from_list(

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -437,9 +437,6 @@ class GEPOp(IRDLOperation):
         ptr_val = SSAValue.get(ptr)
         ptr_type = ptr_val.typ
 
-        if not isinstance(result_type, LLVMPointerType):
-            raise ValueError("Result type must be a pointer.")
-
         if not isinstance(ptr_type, LLVMPointerType):
             raise ValueError("Input must be a pointer")
 

--- a/xdsl/frontend/op_resolver.py
+++ b/xdsl/frontend/op_resolver.py
@@ -45,14 +45,8 @@ class OpResolver:
         #   from M import F
         #   return F(...)
         python_ast = ast.parse(inspect.getsource(overload).strip())
-        if not isinstance(python_ast, ast.Module) or not isinstance(
-            python_ast.body[0], ast.FunctionDef
-        ):
-            raise FrontendProgramException(
-                f"Internal failure while resolving '{python_op}'. Function AST"
-                " for resolution not found."
-            )
         func_ast = python_ast.body[0]
+        assert isinstance(func_ast, ast.FunctionDef)
 
         if (
             len(func_ast.body) != 2

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -147,12 +147,15 @@ class PDLMatcher:
         for pdl_operand, xdsl_operand in zip(pdl_operands, xdsl_operands):
             assert isinstance(pdl_operand, OpResult)
             assert isinstance(pdl_operand.op, pdl.OperandOp | pdl.ResultOp)
-            if isinstance(pdl_operand.op, pdl.OperandOp):
-                if not self.match_operand(pdl_operand, pdl_operand.op, xdsl_operand):
-                    return False
-            elif isinstance(pdl_operand.op, pdl.ResultOp):
-                if not self.match_result(pdl_operand, pdl_operand.op, xdsl_operand):
-                    return False
+            match pdl_operand.op:
+                case pdl.OperandOp():
+                    if not self.match_operand(
+                        pdl_operand, pdl_operand.op, xdsl_operand
+                    ):
+                        return False
+                case pdl.ResultOp():
+                    if not self.match_result(pdl_operand, pdl_operand.op, xdsl_operand):
+                        return False
 
         pdl_results = pdl_op.type_values
         xdsl_results = xdsl_op.results

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -215,15 +215,15 @@ class SSAValue(ABC):
     @staticmethod
     def get(arg: SSAValue | Operation) -> SSAValue:
         "Get a new SSAValue from either a SSAValue, or an operation with a single result."
-        if isinstance(arg, SSAValue):
-            return arg
-        if isinstance(arg, Operation):
-            if len(arg.results) == 1:
-                return arg.results[0]
-            raise ValueError("SSAValue.build: expected operation with a single result.")
-        raise TypeError(
-            f"Expected SSAValue or Operation for SSAValue.get, but got {arg}"
-        )
+        match arg:
+            case SSAValue():
+                return arg
+            case Operation():
+                if len(arg.results) == 1:
+                    return arg.results[0]
+                raise ValueError(
+                    "SSAValue.build: expected operation with a single result."
+                )
 
     def add_use(self, use: Use):
         """Add a new use of the value."""
@@ -1407,13 +1407,16 @@ class Region(IRNode):
     def get(arg: Region | Sequence[Block] | Sequence[Operation]) -> Region:
         if isinstance(arg, Region):
             return arg
-        if isinstance(arg, list):
-            if len(arg) == 0:
-                return Region([Block()])
-            if isinstance(arg[0], Block):
+
+        if len(arg) == 0:
+            return Region([Block()])
+
+        match arg[0]:
+            case Block():
                 return Region(cast(list[Block], arg))
-            if isinstance(arg[0], Operation):
+            case Operation():
                 return Region([Block(cast(list[Operation], arg))])
+
         raise TypeError(f"Can't build a region with argument {arg}")
 
     @property

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -39,7 +39,6 @@ from xdsl.utils.exceptions import (
     PyRDLAttrDefinitionError,
     PyRDLOpDefinitionError,
     VerifyException,
-    assert_never,
 )
 from xdsl.utils.hints import (
     PropertyType,

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -39,6 +39,7 @@ from xdsl.utils.exceptions import (
     PyRDLAttrDefinitionError,
     PyRDLOpDefinitionError,
     VerifyException,
+    assert_never,
 )
 from xdsl.utils.hints import (
     PropertyType,
@@ -971,15 +972,15 @@ class VarIRConstruct(Enum):
 
 def get_construct_name(construct: VarIRConstruct) -> str:
     """Get the type name, this is used mostly for error messages."""
-    if construct == VarIRConstruct.OPERAND:
-        return "operand"
-    if construct == VarIRConstruct.RESULT:
-        return "result"
-    if construct == VarIRConstruct.REGION:
-        return "region"
-    if construct == VarIRConstruct.SUCCESSOR:
-        return "successor"
-    assert False, "Unknown VarIRConstruct value"
+    match construct:
+        case VarIRConstruct.OPERAND:
+            return "operand"
+        case VarIRConstruct.RESULT:
+            return "result"
+        case VarIRConstruct.REGION:
+            return "region"
+        case VarIRConstruct.SUCCESSOR:
+            return "successor"
 
 
 def get_construct_defs(

--- a/xdsl/irdl.py
+++ b/xdsl/irdl.py
@@ -1436,11 +1436,6 @@ def irdl_op_init(
     for attr_name, attr in attributes.items():
         if attr is None:
             continue
-        if not isinstance(attr, Attribute):
-            raise ValueError(
-                error_prefix + f"{attr_name} is expected to be an "
-                f"attribute, but got {type(attr)}."
-            )
         built_attributes[attr_name] = attr
 
     # Take care of variadic operand and result segment sizes.

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2138,9 +2138,10 @@ class Parser(ABC):
             return float(self.value)
 
         def to_type(self, parser: Parser, type: AnyFloat | IntegerType | IndexType):
+            if isinstance(type, AnyFloat):
+                return self.to_float(parser)
+
             match type:
-                case BFloat16Type() | Float16Type() | Float32Type() | Float64Type() | Float80Type() | Float128Type():
-                    return self.to_float(parser)
                 case IntegerType():
                     return self.to_int(
                         parser,

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2140,18 +2140,19 @@ class Parser(ABC):
             return float(self.value)
 
         def to_type(self, parser: Parser, type: AnyFloat | IntegerType | IndexType):
-            if isinstance(type, AnyFloat):
-                return self.to_float(parser)
-            elif isinstance(type, IntegerType):
-                return self.to_int(
-                    parser,
-                    type.signedness.data != Signedness.UNSIGNED,
-                    type.width.data == 1,
-                )
-            elif isinstance(type, IndexType):
-                return self.to_int(parser, allow_negative=True, allow_booleans=False)
-            else:
-                assert False, "fatal error in parser"
+            match type:
+                case BFloat16Type() | Float16Type() | Float32Type() | Float64Type() | Float80Type() | Float128Type():
+                    return self.to_float(parser)
+                case IntegerType():
+                    return self.to_int(
+                        parser,
+                        type.signedness.data != Signedness.UNSIGNED,
+                        type.width.data == 1,
+                    )
+                case IndexType():
+                    return self.to_int(
+                        parser, allow_negative=True, allow_booleans=False
+                    )
 
     def _parse_tensor_literal_element(self) -> _TensorLiteralElement:
         """

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2133,8 +2133,6 @@ class Parser(ABC):
             Convert the element to a float value. Raises an error if the type
             is compatible.
             """
-            if not isinstance(self.value, int | float):
-                parser.raise_error("Expected float value", at_position=self.span)
             if self.is_negative:
                 return -float(self.value)
             return float(self.value)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -248,8 +248,6 @@ class Printer:
         Print a block with syntax `(<caret-ident>`(` <block-args> `)`)? ops* )`
         * If `print_block_args` is False, the label and arguments are not printed.
         """
-        if not isinstance(block, Block):
-            raise TypeError("Expected a Block; got %s" % type(block).__name__)
 
         if print_block_args:
             self._print_new_line()
@@ -287,8 +285,6 @@ class Printer:
           are not printed.
         * If `print_empty_block` is False, empty entry blocks are not printed.
         """
-        if not isinstance(region, Region):
-            raise TypeError("Expected a Region; got %s" % type(region).__name__)
 
         # Empty region
         self.print("{")
@@ -679,8 +675,6 @@ class Printer:
             self.print(")")
 
     def print_op(self, op: Operation) -> None:
-        if not isinstance(op, Operation):
-            raise TypeError("Expected an Operation; got %s" % type(op).__name__)
         begin_op_pos = self._current_column
         self._print_results(op)
         use_custom_format = False

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -52,7 +52,7 @@ class IOpResult(ISSAValue):
     def __hash__(self) -> int:
         return hash(id(self.op)) + hash(self.index)
 
-    def __eq__(self, __o: IOpResult) -> bool:
+    def __eq__(self, __o: object) -> bool:
         if isinstance(__o, IOpResult):
             return self.op == __o.op and self.index == __o.index
         return False

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -145,18 +145,13 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
         """
         This function retrieves the data size of a provided MPI type object
         """
-        if isinstance(mpi_dialect_dtype, mpi.RequestType):
-            return self.info.MPI_Request_size
-        elif isinstance(mpi_dialect_dtype, mpi.StatusType):
-            return self.info.MPI_Status_size
-        elif isinstance(mpi_dialect_dtype, mpi.DataType):
-            return self.info.MPI_Datatype_size
-        else:
-            raise ValueError(
-                "MPI internal type size lookup: Unsupported type: {}".format(
-                    mpi_dialect_dtype
-                )
-            )
+        match mpi_dialect_dtype:
+            case mpi.RequestType():
+                return self.info.MPI_Request_size
+            case mpi.StatusType():
+                return self.info.MPI_Status_size
+            case mpi.DataType():
+                return self.info.MPI_Datatype_size
 
     def _emit_mpi_status_objs(
         self, number_to_output: int

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -8,12 +8,16 @@ import sys
 import typing
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any, IO
+from typing import Any, IO, Never
 
 if typing.TYPE_CHECKING:
     from xdsl.parser import Span, BacktrackingHistory
     from xdsl.ir import Attribute
     from xdsl.utils.parse_pipeline import Token
+
+
+def assert_never(_: Never) -> Never:
+    raise AssertionError("Expected code to be unreachable")
 
 
 class DiagnosticException(Exception):

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -8,16 +8,12 @@ import sys
 import typing
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any, IO, Never
+from typing import Any, IO
 
 if typing.TYPE_CHECKING:
     from xdsl.parser import Span, BacktrackingHistory
     from xdsl.ir import Attribute
     from xdsl.utils.parse_pipeline import Token
-
-
-def assert_never(_: Never) -> Never:
-    raise AssertionError("Expected code to be unreachable")
 
 
 class DiagnosticException(Exception):


### PR DESCRIPTION
I feel like we can trust our types at this point, or at least trust them by default. There are some dodgy things in the Attributes that are created dynamically, but otherwise if a type says A | B we don't need to check for other things.