### PR TITLE
transformations: Add a lowering test for counterintuitive stencil offsets.

### DIFF
--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -401,7 +401,6 @@ class ConvertStencilToLLMLIRPass(ModulePass):
             GreedyRewritePatternApplier(
                 [
                     ApplyOpToParallel(),
-                    StencilTypeConversionFuncOp(),
                     StencilStoreToSubview(return_targets),
                     CastOpToMemref(gpu=(self.target == "gpu")),
                     LoadOpToMemref(),
@@ -417,6 +416,8 @@ class ConvertStencilToLLMLIRPass(ModulePass):
         )
         the_one_pass.rewrite_module(op)
         type_pass = PatternRewriteWalker(
-            GreedyRewritePatternApplier([UpdateLoopCarriedVarTypes()])
+            GreedyRewritePatternApplier(
+                [UpdateLoopCarriedVarTypes(), StencilTypeConversionFuncOp()]
+            )
         )
         type_pass.rewrite_module(op)

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -417,7 +417,10 @@ class ConvertStencilToLLMLIRPass(ModulePass):
         the_one_pass.rewrite_module(op)
         type_pass = PatternRewriteWalker(
             GreedyRewritePatternApplier(
-                [UpdateLoopCarriedVarTypes(), StencilTypeConversionFuncOp()]
+                [
+                    UpdateLoopCarriedVarTypes(),
+                    StencilTypeConversionFuncOp(),
+                ]
             )
         )
         type_pass.rewrite_module(op)


### PR DESCRIPTION
The StencilTypeConversionFuncOp pattern didn't play nice with this example unless moved to the second pass.
Moving it there for now, as we first need those examples to work. Let's think of a way to interleave them at some point, but use what works first!