### PR TITLE
dialects: Add PrintfOp to snrt dialect

### DIFF
--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -1,5 +1,17 @@
 // RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 "builtin.module"() ({
+    // Printf
+
+    // Pointer to format string
+    "llvm.mlir.global"() ({}) {"global_type" = !llvm.array<6 x i8>, "sym_name" = "format_str", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "%d:%d!", "unnamed_addr" = 0 : i64} : () -> ()
+    %format_str_ptr = "llvm.mlir.addressof"() {"global_name" = @format_str} : () -> !llvm.ptr<i8>
+    // Values to print
+    %element1 = "arith.constant"() {"value" = 2 : si32} : () -> si32
+    %element2 = "arith.constant"() {"value" = 0 : si32} : () -> si32
+    %count = "snrt.printf"(%format_str_ptr, %element1, %element2) : (!llvm.ptr<i8>, si32, si32) -> i32
+    // CHECK: %count = "snrt.printf"(%format_str_ptr, %element1, %element2) : (!llvm.ptr<i8>, si32, si32) -> i32
+
+
     // Barriers
     "snrt.cluster_hw_barrier"() : () -> ()
     // CHECK: "snrt.cluster_hw_barrier"() : () -> ()

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -8,7 +8,7 @@ from xdsl.irdl import (
     VarOperand,
 )
 from xdsl.ir import OpResult, Dialect
-from xdsl.dialects.builtin import IntegerType, Signedness, IndexType, i32, AnyAttr
+from xdsl.dialects.builtin import IntegerType, Signedness, IndexType, i32
 from xdsl.dialects.llvm import LLVMPointerType
 from typing import Annotated
 


### PR DESCRIPTION
This PR adds a printfop to the snrt dialect as per @nazavode 's request.
https://github.com/pulp-platform/snitch/blob/b9fe5550e26ea878fb734cfc37d161f564252305/sw/snRuntime/vendor/printf.c

Right now it is pretty low level though (reads in an 8bit/char LLVM pointer to the format string) which is a bit unfortunate:
Because right now it will be lowered to something like this:
https://github.com/xdslproject/xdsl/wiki/IO-Example-through-LLVM-stdlib

At some point (when directly lowering to RISC-V assembly, we might want to change this though, but lowering printf to RISC-V seems a bit non-trivial, and maybe not something we want to go for.
The snitch runtime basically steals this implementation of printf from somewhere else anyway.

