### PR TITLE
core: separate out decorator for anonymous rewrite pattern

### DIFF
--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -6,11 +6,9 @@ from xdsl.dialects.scf import If, Scf
 from xdsl.ir import Block, MLContext, Region, Operation
 from xdsl.pattern_rewriter import (
     PatternRewriteWalker,
-    anonymous_rewrite_pattern,
     op_type_rewrite_pattern,
     RewritePattern,
     PatternRewriter,
-    AnonymousRewritePattern,
     GreedyRewritePatternApplier,
 )
 from xdsl.parser import Parser
@@ -106,28 +104,6 @@ def test_op_type_rewrite_pattern_method_decorator():
     )
 
 
-def test_op_type_rewrite_pattern_static_decorator():
-    """Test op_type_rewrite_pattern decorator on static functions."""
-
-    prog = """"builtin.module"() ({
-  %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
-  %1 = "arith.addi"(%0, %0) : (i32, i32) -> i32
-}) : () -> ()"""
-
-    expected = """"builtin.module"() ({
-  %0 = "arith.constant"() {"value" = 43 : i32} : () -> i32
-  %1 = "arith.addi"(%0, %0) : (i32, i32) -> i32
-}) : () -> ()"""
-
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
-        rewriter.replace_matched_op(Constant.from_int_and_width(43, i32))
-
-    rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
-    )
-
-
 def test_op_type_rewrite_pattern_union_type():
     """Test op_type_rewrite_pattern decorator on static functions."""
 
@@ -143,12 +119,13 @@ def test_op_type_rewrite_pattern_union_type():
   %2 = "test"(%0, %1) : (i32, i32) -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: Constant | Addi, rewriter: PatternRewriter):
-        rewriter.replace_matched_op(Constant.from_int_and_width(42, i32))
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: Constant | Addi, rewriter: PatternRewriter):
+            rewriter.replace_matched_op(Constant.from_int_and_width(42, i32))
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -171,22 +148,25 @@ def test_recursive_rewriter():
   %8 = "arith.addi"(%6, %7) : (i32, i32) -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
-        if not isa(op.value, IntegerAttr):
-            return
-        val = op.value.value.data
-        if val == 0 or val == 1:
-            return None
-        constant_op = Constant.from_attr(
-            IntegerAttr.from_int_and_width(val - 1, 32), i32
-        )
-        constant_one = Constant.from_attr(IntegerAttr.from_int_and_width(1, 32), i32)
-        add_op = Addi(constant_op, constant_one)
-        rewriter.replace_matched_op([constant_op, constant_one, add_op])
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: Constant, rewriter: PatternRewriter):
+            if not isa(op.value, IntegerAttr):
+                return
+            val = op.value.value.data
+            if val == 0 or val == 1:
+                return None
+            constant_op = Constant.from_attr(
+                IntegerAttr.from_int_and_width(val - 1, 32), i32
+            )
+            constant_one = Constant.from_attr(
+                IntegerAttr.from_int_and_width(1, 32), i32
+            )
+            add_op = Addi(constant_op, constant_one)
+            rewriter.replace_matched_op([constant_op, constant_one, add_op])
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=True)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=True)
     )
 
 
@@ -209,26 +189,27 @@ def test_recursive_rewriter_reversed():
   %8 = "arith.addi"(%6, %7) : (i32, i32) -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
-        if not isa(op.value, IntegerAttr):
-            return
-        val = op.value.value.data
-        if val == 0 or val == 1:
-            return None
-        constant_op = Constant.from_attr(
-            IntegerAttr.from_int_and_width(val - 1, 32), i32
-        )
-        constant_one = Constant.from_attr(IntegerAttr.from_int_and_width(1, 32), i32)
-        add_op = Addi(constant_op, constant_one)
-        rewriter.replace_matched_op([constant_op, constant_one, add_op])
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: Constant, rewriter: PatternRewriter):
+            if not isa(op.value, IntegerAttr):
+                return
+            val = op.value.value.data
+            if val == 0 or val == 1:
+                return None
+            constant_op = Constant.from_attr(
+                IntegerAttr.from_int_and_width(val - 1, 32), i32
+            )
+            constant_one = Constant.from_attr(
+                IntegerAttr.from_int_and_width(1, 32), i32
+            )
+            add_op = Addi(constant_op, constant_one)
+            rewriter.replace_matched_op([constant_op, constant_one, add_op])
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(
-            match_and_rewrite, apply_recursively=True, walk_reverse=True
-        ),
+        PatternRewriteWalker(Rewrite(), apply_recursively=True, walk_reverse=True),
     )
 
 
@@ -245,19 +226,21 @@ def test_greedy_rewrite_pattern_applier():
   %1 = "arith.muli"(%0, %0) : (i32, i32) -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def constant_rewrite(op: Constant, rewriter: PatternRewriter):
-        rewriter.replace_matched_op([Constant.from_int_and_width(43, i32)])
+    class ConstantRewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: Constant, rewriter: PatternRewriter):
+            rewriter.replace_matched_op([Constant.from_int_and_width(43, i32)])
 
-    @anonymous_rewrite_pattern
-    def addi_rewrite(op: Addi, rewriter: PatternRewriter):
-        rewriter.replace_matched_op([Muli(op.lhs, op.rhs)])
+    class AddiRewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: Addi, rewriter: PatternRewriter):
+            rewriter.replace_matched_op([Muli(op.lhs, op.rhs)])
 
     rewrite_and_compare(
         prog,
         expected,
         PatternRewriteWalker(
-            GreedyRewritePatternApplier([constant_rewrite, addi_rewrite]),
+            GreedyRewritePatternApplier([ConstantRewrite(), AddiRewrite()]),
             apply_recursively=False,
         ),
     )
@@ -275,13 +258,15 @@ def test_insert_op_before_matched_op():
   %1 = "arith.constant"() {"value" = 5 : i32} : () -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
-        new_cst = Constant.from_int_and_width(42, i32)
-        rewriter.insert_op_before_matched_op(new_cst)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, cst: Constant, rewriter: PatternRewriter):
+            new_cst = Constant.from_int_and_width(42, i32)
+
+            rewriter.insert_op_before_matched_op(new_cst)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -297,13 +282,15 @@ def test_insert_op_at_start():
   %1 = "arith.constant"() {"value" = 5 : i32} : () -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
-        new_cst = Constant.from_int_and_width(42, i32)
-        rewriter.insert_op_at_start(new_cst, mod.regions[0].blocks[0])
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, mod: ModuleOp, rewriter: PatternRewriter):
+            new_cst = Constant.from_int_and_width(42, i32)
+
+            rewriter.insert_op_at_start(new_cst, mod.regions[0].blocks[0])
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -316,13 +303,12 @@ def test_insert_op_at_end():
 
     to_be_inserted = Constant.from_int_and_width(42, 32)
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
-        rewriter.insert_op_at_end(to_be_inserted, mod.regions[0].blocks[0])
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, mod: ModuleOp, rewriter: PatternRewriter):
+            rewriter.insert_op_at_end(to_be_inserted, mod.regions[0].blocks[0])
 
-    PatternRewriteWalker(match_and_rewrite, apply_recursively=False).rewrite_module(
-        prog
-    )
+    PatternRewriteWalker(Rewrite(), apply_recursively=False).rewrite_module(prog)
 
     assert to_be_inserted in prog.ops
     assert prog.body.block.get_operation_index(to_be_inserted) == 1
@@ -340,15 +326,17 @@ def test_insert_op_before():
   %1 = "arith.constant"() {"value" = 5 : i32} : () -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
-        new_cst = Constant.from_int_and_width(42, i32)
-        first_op = mod.ops.first
-        assert first_op is not None
-        rewriter.insert_op_before(new_cst, first_op)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, mod: ModuleOp, rewriter: PatternRewriter):
+            new_cst = Constant.from_int_and_width(42, i32)
+
+            first_op = mod.ops.first
+            assert first_op is not None
+            rewriter.insert_op_before(new_cst, first_op)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -364,15 +352,17 @@ def test_insert_op_after():
   %1 = "arith.constant"() {"value" = 42 : i32} : () -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(mod: ModuleOp, rewriter: PatternRewriter):
-        new_cst = Constant.from_int_and_width(42, i32)
-        first_op = mod.ops.first
-        assert first_op is not None
-        rewriter.insert_op_after(new_cst, first_op)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, mod: ModuleOp, rewriter: PatternRewriter):
+            new_cst = Constant.from_int_and_width(42, i32)
+
+            first_op = mod.ops.first
+            assert first_op is not None
+            rewriter.insert_op_after(new_cst, first_op)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -388,13 +378,15 @@ def test_insert_op_after_matched_op():
   %1 = "arith.constant"() {"value" = 42 : i32} : () -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
-        new_cst = Constant.from_int_and_width(42, i32)
-        rewriter.insert_op_after_matched_op(new_cst)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, cst: Constant, rewriter: PatternRewriter):
+            new_cst = Constant.from_int_and_width(42, i32)
+
+            rewriter.insert_op_after_matched_op(new_cst)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -410,17 +402,17 @@ def test_insert_op_after_matched_op_reversed():
   %1 = "arith.constant"() {"value" = 42 : i32} : () -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(cst: Constant, rewriter: PatternRewriter):
-        new_cst = Constant.from_int_and_width(42, i32)
-        rewriter.insert_op_after_matched_op(new_cst)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, cst: Constant, rewriter: PatternRewriter):
+            new_cst = Constant.from_int_and_width(42, i32)
+
+            rewriter.insert_op_after_matched_op(new_cst)
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(
-            match_and_rewrite, apply_recursively=False, walk_reverse=True
-        ),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
     )
 
 
@@ -435,11 +427,12 @@ def test_operation_deletion():
 ^0:
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
-        rewriter.erase_matched_op()
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: Constant, rewriter: PatternRewriter):
+            rewriter.erase_matched_op()
 
-    rewrite_and_compare(prog, expected, PatternRewriteWalker(match_and_rewrite))
+    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()))
 
 
 def test_operation_deletion_reversed():
@@ -457,16 +450,15 @@ def test_operation_deletion_reversed():
 ^0:
 }) : () -> ()"""
 
-    def match_and_rewrite(op: Operation, rewriter: PatternRewriter):
-        if not isinstance(op, ModuleOp):
-            rewriter.erase_matched_op()
+    class EraseAll(RewritePattern):
+        def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
+            if not isinstance(op, ModuleOp):
+                rewriter.erase_matched_op()
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(
-            AnonymousRewritePattern(match_and_rewrite), walk_reverse=True
-        ),
+        PatternRewriteWalker(EraseAll(), walk_reverse=True),
     )
 
 
@@ -482,13 +474,14 @@ def test_operation_deletion_failure():
   %1 = "arith.addi"(%0, %0) : (i32, i32) -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: Constant, rewriter: PatternRewriter):
-        rewriter.erase_matched_op()
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: Constant, rewriter: PatternRewriter):
+            rewriter.erase_matched_op()
 
     parser = Parser(ctx, prog)
     module = parser.parse_module()
-    walker = PatternRewriteWalker(match_and_rewrite)
+    walker = PatternRewriteWalker(Rewrite())
 
     # Check that the rewrite fails
     try:
@@ -509,13 +502,15 @@ def test_delete_inner_op():
 ^0:
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
-        first_op = op.ops.first
-        assert first_op is not None
-        rewriter.erase_op(first_op)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: ModuleOp, rewriter: PatternRewriter):
+            first_op = op.ops.first
 
-    rewrite_and_compare(prog, expected, PatternRewriteWalker(match_and_rewrite))
+            assert first_op is not None
+            rewriter.erase_op(first_op)
+
+    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()))
 
 
 def test_replace_inner_op():
@@ -529,13 +524,15 @@ def test_replace_inner_op():
   %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
-        first_op = op.ops.first
-        assert first_op is not None
-        rewriter.replace_op(first_op, [Constant.from_int_and_width(42, i32)])
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: ModuleOp, rewriter: PatternRewriter):
+            first_op = op.ops.first
 
-    rewrite_and_compare(prog, expected, PatternRewriteWalker(match_and_rewrite))
+            assert first_op is not None
+            rewriter.replace_op(first_op, [Constant.from_int_and_width(42, i32)])
+
+    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()))
 
 
 def test_block_argument_type_change():
@@ -558,12 +555,13 @@ def test_block_argument_type_change():
   }) : (i1) -> ()
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        rewriter.modify_block_argument_type(op.true_region.blocks[0].args[0], i64)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            rewriter.modify_block_argument_type(op.true_region.blocks[0].args[0], i64)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -588,12 +586,13 @@ def test_block_argument_erasure():
   }) : (i1) -> ()
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        rewriter.erase_block_argument(op.true_region.blocks[0].args[0])
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            rewriter.erase_block_argument(op.true_region.blocks[0].args[0])
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(match_and_rewrite, apply_recursively=False)
+        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
     )
 
 
@@ -618,14 +617,15 @@ def test_block_argument_insertion():
   }) : (i1) -> ()
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        rewriter.insert_block_argument(op.true_region.blocks[0], 0, i32)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            rewriter.insert_block_argument(op.true_region.blocks[0], 0, i32)
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(match_and_rewrite, apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
 
 
@@ -651,14 +651,15 @@ def test_inline_block_before_matched_op():
   }) : (i1) -> ()
 }) : () -> ()"""
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        rewriter.inline_block_before_matched_op(op.true_region.blocks[0])
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            rewriter.inline_block_before_matched_op(op.true_region.blocks[0])
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(match_and_rewrite, apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
 
 
@@ -694,17 +695,19 @@ def test_inline_block_before():
 }) : () -> ()
 """
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        first_op = op.true_region.blocks[0].first_op
-        if isinstance(first_op, If):
-            inner_if_block = first_op.true_region.blocks[0]
-            rewriter.inline_block_before(inner_if_block, first_op)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            first_op = op.true_region.blocks[0].first_op
+
+            if isinstance(first_op, If):
+                inner_if_block = first_op.true_region.blocks[0]
+                rewriter.inline_block_before(inner_if_block, first_op)
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(match_and_rewrite, apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
 
 
@@ -732,14 +735,15 @@ def test_inline_block_at_before_when_op_is_matched_op():
 }) : () -> ()
 """
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        rewriter.inline_block_before(op.true_region.blocks[0], op)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            rewriter.inline_block_before(op.true_region.blocks[0], op)
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(match_and_rewrite, apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
 
 
@@ -775,17 +779,19 @@ def test_inline_block_after():
 }) : () -> ()
 """
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        first_op = op.true_region.blocks[0].first_op
-        if first_op is not None and isinstance(first_op, If):
-            inner_if_block = first_op.true_region.blocks[0]
-            rewriter.inline_block_after(inner_if_block, first_op)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            first_op = op.true_region.blocks[0].first_op
+
+            if first_op is not None and isinstance(first_op, If):
+                inner_if_block = first_op.true_region.blocks[0]
+                rewriter.inline_block_after(inner_if_block, first_op)
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(match_and_rewrite, apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
 
 
@@ -821,17 +827,19 @@ def test_inline_block_after_matched():
 }) : () -> ()
 """
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: If, rewriter: PatternRewriter):
-        first_op = op.true_region.block.first_op
-        if first_op is not None and isinstance(first_op, If):
-            inner_if_block = first_op.true_region.block
-            rewriter.inline_block_after(inner_if_block, op)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: If, rewriter: PatternRewriter):
+            first_op = op.true_region.block.first_op
+
+            if first_op is not None and isinstance(first_op, If):
+                inner_if_block = first_op.true_region.block
+                rewriter.inline_block_after(inner_if_block, op)
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(match_and_rewrite, apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
 
 
@@ -858,18 +866,20 @@ def test_move_region_contents_to_new_regions():
 }) : () -> ()
 """
 
-    @anonymous_rewrite_pattern
-    def match_and_rewrite(op: ModuleOp, rewriter: PatternRewriter):
-        ops_iter = iter(op.ops)
-        _first_op = next(ops_iter)
-        old_if = next(ops_iter)
-        assert isinstance(old_if, If)
-        new_region = rewriter.move_region_contents_to_new_regions(old_if.regions[0])
-        new_if = If.get(old_if.cond, [], new_region, Region([Block()]))
-        rewriter.insert_op_after(new_if, old_if)
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: ModuleOp, rewriter: PatternRewriter):
+            ops_iter = iter(op.ops)
+
+            _first_op = next(ops_iter)
+            old_if = next(ops_iter)
+            assert isinstance(old_if, If)
+            new_region = rewriter.move_region_contents_to_new_regions(old_if.regions[0])
+            new_if = If.get(old_if.cond, [], new_region, Region([Block()]))
+            rewriter.insert_op_after(new_if, old_if)
 
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(match_and_rewrite, apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -7,7 +9,7 @@ from xdsl.dialects.builtin import IntegerAttr, IntegerType, ModuleOp
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     PatternRewriteWalker,
-    AnonymousRewritePattern,
+    RewritePattern,
 )
 from xdsl.interpreter import Interpreter, InterpreterFunctions, register_impls, impl
 from xdsl.utils.exceptions import InterpretationError
@@ -171,6 +173,35 @@ class PDLMatcher:
         return True
 
 
+@dataclass
+class InterpreterRewrite(RewritePattern):
+    functions: PDLFunctions
+    pdl_rewrite_op: pdl.RewriteOp
+    interpreter: Interpreter
+
+    def match_and_rewrite(self, xdsl_op: Operation, rewriter: PatternRewriter) -> None:
+        pdl_op_val = self.pdl_rewrite_op.root
+        assert pdl_op_val is not None, "TODO: handle None root op in pdl.RewriteOp"
+        assert (
+            self.pdl_rewrite_op.body is not None
+        ), "TODO: handle None body op in pdl.RewriteOp"
+
+        (pdl_op,) = self.interpreter.get_values((pdl_op_val,))
+        assert isinstance(pdl_op, pdl.OperationOp)
+        matcher = PDLMatcher()
+        if not matcher.match_operation(pdl_op_val, pdl_op, xdsl_op):
+            return
+
+        self.interpreter.push_scope("rewrite")
+        self.interpreter.set_values(matcher.matching_context.items())
+        self.functions.rewriter = rewriter
+
+        for rewrite_impl_op in self.pdl_rewrite_op.body.ops:
+            self.interpreter.run(rewrite_impl_op)
+
+        self.interpreter.pop_scope()
+
+
 @register_impls
 @dataclass
 class PDLFunctions(InterpreterFunctions):
@@ -235,33 +266,10 @@ class PDLFunctions(InterpreterFunctions):
     ) -> tuple[Any, ...]:
         input_module = self.module
 
-        def rewrite(xdsl_op: Operation, rewriter: PatternRewriter) -> None:
-            pdl_op_val = pdl_rewrite_op.root
-            assert pdl_op_val is not None, "TODO: handle None root op in pdl.RewriteOp"
-            assert (
-                pdl_rewrite_op.body is not None
-            ), "TODO: handle None body op in pdl.RewriteOp"
-
-            (pdl_op,) = interpreter.get_values((pdl_op_val,))
-            assert isinstance(pdl_op, pdl.OperationOp)
-            matcher = PDLMatcher()
-            if not matcher.match_operation(pdl_op_val, pdl_op, xdsl_op):
-                return
-
-            interpreter.push_scope("rewrite")
-            interpreter.set_values(matcher.matching_context.items())
-            self.rewriter = rewriter
-
-            for rewrite_impl_op in pdl_rewrite_op.body.ops:
-                interpreter.run(rewrite_impl_op)
-
-            interpreter.pop_scope()
-
-        rewriter = AnonymousRewritePattern(rewrite)
-
-        PatternRewriteWalker(rewriter, apply_recursively=False).rewrite_module(
-            input_module
-        )
+        PatternRewriteWalker(
+            InterpreterRewrite(self, pdl_rewrite_op, interpreter),
+            apply_recursively=False,
+        ).rewrite_module(input_module)
 
         return ()
 

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -12,7 +12,6 @@ from typing import (
     get_origin,
     Iterable,
     Sequence,
-    overload,
 )
 
 from xdsl.dialects.builtin import ModuleOp
@@ -396,62 +395,27 @@ class AnonymousRewritePattern(RewritePattern):
     A rewrite pattern encoded by an anonymous function.
     """
 
-    func: Callable[[RewritePattern, Operation, PatternRewriter], None]
-
-    def __init__(
-        self,
-        func: Callable[[RewritePattern, Operation, PatternRewriter], None]
-        | Callable[[Operation, PatternRewriter], None],
-    ):
-        params = [param for param in inspect.signature(func).parameters.values()]
-        if len(params) == 2:
-
-            def new_func(
-                self: RewritePattern, op: Operation, rewriter: PatternRewriter
-            ):
-                func(op, rewriter)  # type: ignore
-
-            self.func = new_func
-        else:
-            self.func = func  # type: ignore
+    func: Callable[[Operation, PatternRewriter], None]
 
     def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter) -> None:
-        self.func(self, op, rewriter)
+        self.func(op, rewriter)
 
 
 _RewritePatternT = TypeVar("_RewritePatternT", bound=RewritePattern)
 _OperationT = TypeVar("_OperationT", bound=Operation)
 
 
-@overload
 def op_type_rewrite_pattern(
     func: Callable[[_RewritePatternT, _OperationT, PatternRewriter], None]
 ) -> Callable[[_RewritePatternT, Operation, PatternRewriter], None]:
-    ...
-
-
-@overload
-def op_type_rewrite_pattern(
-    func: Callable[[_OperationT, PatternRewriter], None]
-) -> Callable[[RewritePattern, Operation, PatternRewriter], None]:
-    ...
-
-
-def op_type_rewrite_pattern(
-    func: Callable[[_RewritePatternT, _OperationT, PatternRewriter], None]
-    | Callable[[_OperationT, PatternRewriter], None]
-) -> (
-    Callable[[_RewritePatternT, Operation, PatternRewriter], None]
-    | Callable[[RewritePattern, Operation, PatternRewriter], None]
-):
     """
-    This function is intended to be used as a decorator on a RewritePatter method.
-    It uses type hints to match on a specific operation type before calling the decorated
-    function.
+    This function is intended to be used as a decorator on a RewritePatter
+    method. It uses type hints to match on a specific operation type before
+    calling the decorated function.
     """
     # Get the operation argument and check that it is a subclass of Operation
     params = [param for param in inspect.signature(func).parameters.values()]
-    if len(params) < 2:
+    if len(params) != 3:
         raise Exception(
             "op_type_rewrite_pattern expects the decorated function to "
             "have two non-self arguments."
@@ -474,6 +438,7 @@ def op_type_rewrite_pattern(
     expected_types = (expected_type,)
     if get_origin(expected_type) in [Union, UnionType]:
         expected_types = get_args(expected_type)
+
     if not all(issubclass(t, Operation) for t in expected_types):
         raise Exception(
             "op_type_rewrite_pattern expects the first non-self argument "
@@ -481,25 +446,46 @@ def op_type_rewrite_pattern(
             "subclasses."
         )
 
-    if not is_method:
+    def impl(self: _RewritePatternT, op: Operation, rewriter: PatternRewriter) -> None:
+        if isinstance(op, expected_type):
+            func(self, op, rewriter)
 
-        def op_type_rewrite_pattern_static_wrapper(
-            self: RewritePattern, op: Operation, rewriter: PatternRewriter
-        ) -> None:
-            if not isinstance(op, expected_type):
-                return None
-            func(op, rewriter)  # type: ignore
+    return impl
 
-        return op_type_rewrite_pattern_static_wrapper
 
-    def op_type_rewrite_pattern_method_wrapper(
-        self: _RewritePatternT, op: Operation, rewriter: PatternRewriter
-    ) -> None:
-        if not isinstance(op, expected_type):
-            return None
-        func(self, op, rewriter)  # type: ignore
+def anonymous_rewrite_pattern(
+    func: Callable[[_OperationT, PatternRewriter], None]
+) -> AnonymousRewritePattern:
+    """
+    This function is intended to be used as a decorator on a method implementing
+    a rewrite pattern. It uses type hints to match on a specific operation type
+    before calling the decorated function.
+    """
+    # Get the operation argument and check that it is a subclass of Operation
+    params = [param for param in inspect.signature(func).parameters.values()]
+    if len(params) != 2:
+        raise Exception(
+            "op_type_rewrite_pattern expects the decorated function to "
+            "have two arguments."
+        )
 
-    return op_type_rewrite_pattern_method_wrapper
+    expected_type: type[_OperationT] = params[0].annotation
+    expected_types = (expected_type,)
+    if get_origin(expected_type) in [Union, UnionType]:
+        expected_types = get_args(expected_type)
+
+    if not all(issubclass(t, Operation) for t in expected_types):
+        raise Exception(
+            "op_type_rewrite_pattern expects the first non-self argument "
+            "type hint to be an `Operation` subclass or a union of `Operation` "
+            "subclasses."
+        )
+
+    def impl(op: Operation, rewriter: PatternRewriter) -> None:
+        if isinstance(op, expected_type):
+            func(op, rewriter)
+
+    return AnonymousRewritePattern(impl)
 
 
 @dataclass(eq=False, repr=False)


### PR DESCRIPTION
I never liked the overload based on number of parameters for the op type thing, this PR separates out the two flows. I think that this makes things a bit less confusing, there's one annotation for the method rewrite, and another annotation that builds a rewrite based on a standalone function.

I'm doing a bit of work in the rewrites, and having the two be separate also makes it easier for me to experiment, but that's not really the primary goal of the PR.