### PR TITLE
dialects: Add element_count to ShapedType and add ContainerType

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -93,7 +93,7 @@ class ConstantOp(IRDLOperation):
         return cast(TensorTypeF64, self.value.type)
 
     def get_shape(self) -> list[int]:
-        return self.get_type().get_shape()
+        return list(self.get_type().get_shape())
 
     def get_data(self) -> list[float]:
         return [float(el.value.data) for el in self.value.data.data]

--- a/docs/Toy/toy/interpreter.py
+++ b/docs/Toy/toy/interpreter.py
@@ -86,7 +86,7 @@ class ToyFunctions(InterpreterFunctions):
         assert isinstance(arg, Tensor)
         result_typ = op.results[0].typ
         assert isinstance(result_typ, VectorType | TensorType)
-        new_shape = result_typ.get_shape()
+        new_shape = list(result_typ.get_shape())
 
         return (Tensor(arg.data, new_shape),)
 

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -101,11 +101,11 @@ def test_array_len_and_iter_attr():
 @pytest.mark.parametrize(
     "attr, dims, num_scalable_dims",
     (
-        (i32, [1, 2], 0),
-        (i32, [1, 2], 1),
-        (i32, [1, 1, 3], 0),
-        (i64, [1, 1, 3], 2),
-        (i64, [], 0),
+        (i32, (1, 2), 0),
+        (i32, (1, 2), 1),
+        (i32, (1, 1, 3), 0),
+        (i64, (1, 1, 3), 2),
+        (i64, (), 0),
     ),
 )
 def test_vector_constructor(attr: Attribute, dims: list[int], num_scalable_dims: int):

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -45,7 +45,7 @@ def test_vectorType():
     vec = VectorType.from_element_type_and_shape(i32, [1])
 
     assert vec.get_num_dims() == 1
-    assert vec.get_shape() == [1]
+    assert vec.get_shape() == (1,)
     assert vec.element_type is i32
 
 
@@ -53,7 +53,7 @@ def test_vectorType_with_dimensions():
     vec = VectorType.from_element_type_and_shape(i32, [3, 3, 3])
 
     assert vec.get_num_dims() == 3
-    assert vec.get_shape() == [3, 3, 3]
+    assert vec.get_shape() == (3, 3, 3)
     assert vec.element_type is i32
 
 
@@ -62,7 +62,7 @@ def test_vectorType_from_params():
     vec = VectorType.from_params(my_i32)
 
     assert vec.get_num_dims() == 1
-    assert vec.get_shape() == [1]
+    assert vec.get_shape() == (1,)
     assert vec.element_type is my_i32
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -70,7 +70,7 @@ class ShapeType(ABC):
         ...
 
     @abstractmethod
-    def get_shape(self) -> tuple[int]:
+    def get_shape(self) -> tuple[int, ...]:
         ...
 
     def element_count(self) -> int:
@@ -651,7 +651,7 @@ class VectorType(
     def get_num_scalable_dims(self) -> int:
         return self.num_scalable_dims.data
 
-    def get_shape(self) -> tuple[int]:
+    def get_shape(self) -> tuple[int, ...]:
         return tuple(i.value.data for i in self.shape.data)
 
     def get_element_type(self) -> AttributeCovT:
@@ -724,7 +724,7 @@ class TensorType(
     def get_num_dims(self) -> int:
         return len(self.shape.data)
 
-    def get_shape(self) -> tuple[int]:
+    def get_shape(self) -> tuple[int, ...]:
         return tuple(i.value.data for i in self.shape.data)
 
     def get_element_type(self) -> AttributeCovT:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
     from xdsl.printer import Printer
 
 
-class ShapeType(ABC):
+class ShapedType(ABC):
     @abstractmethod
     def get_num_dims(self) -> int:
         ...
@@ -636,7 +636,7 @@ class VectorType(
     Generic[AttributeCovT],
     ParametrizedAttribute,
     TypeAttribute,
-    ShapeType,
+    ShapedType,
     ContainerType[AttributeCovT],
 ):
     name = "vector"
@@ -712,7 +712,7 @@ class TensorType(
     Generic[AttributeCovT],
     ParametrizedAttribute,
     TypeAttribute,
-    ShapeType,
+    ShapedType,
     ContainerType[AttributeCovT],
 ):
     name = "tensor"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from abc import ABC
+from abc import ABC, abstractmethod
 
 from dataclasses import dataclass
 from enum import Enum
@@ -16,7 +16,10 @@ from typing import (
     TypeVar,
     overload,
     Iterator,
+    Generic,
 )
+
+from math import prod
 
 from xdsl.ir import (
     Block,
@@ -1323,11 +1326,27 @@ f128 = Float64Type()
 
 
 class ShapeType(ABC):
+    @abstractmethod
     def get_num_dims(self) -> int:
         ...
 
+    @abstractmethod
     def get_shape(self) -> tuple[int]:
         ...
+
+    def element_count(self) -> int:
+        return prod(self.get_shape())
+
+
+_ContainerElementTypeT = TypeVar(
+    "_ContainerElementTypeT", bound=Attribute, covariant=True
+)
+
+
+class ContainerType(Generic[_ContainerElementTypeT], ABC):
+    @abstractmethod
+    def get_element_type(self) -> _ContainerElementTypeT:
+        pass
 
 
 Builtin = Dialect(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1339,7 +1339,7 @@ class ShapeType(ABC):
 
 
 _ContainerElementTypeT = TypeVar(
-    "_ContainerElementTypeT", bound=Attribute, covariant=True
+    "_ContainerElementTypeT", bound=Attribute | None, covariant=True
 )
 
 

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -170,7 +170,7 @@ class StencilType(
         else:
             return len(self.bounds.ub.array.data)
 
-    def get_shape(self) -> tuple[int]:
+    def get_shape(self) -> tuple[int, ...]:
         if isinstance(self.bounds, IntAttr):
             return (-1,) * self.bounds.data
         else:

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -151,7 +151,7 @@ class StencilType(
     Generic[_FieldTypeElement],
     ParametrizedAttribute,
     TypeAttribute,
-    builtin.ShapeType,
+    builtin.ShapedType,
     builtin.ContainerType[_FieldTypeElement],
 ):
     name = "stencil.type"

--- a/xdsl/dialects/experimental/stencil.py
+++ b/xdsl/dialects/experimental/stencil.py
@@ -148,7 +148,11 @@ class StencilBoundsAttr(ParametrizedAttribute):
 
 
 class StencilType(
-    Generic[_FieldTypeElement], ParametrizedAttribute, TypeAttribute, builtin.ShapeType
+    Generic[_FieldTypeElement],
+    ParametrizedAttribute,
+    TypeAttribute,
+    builtin.ShapeType,
+    builtin.ContainerType[_FieldTypeElement],
 ):
     name = "stencil.type"
     bounds: ParameterDef[StencilBoundsAttr | IntAttr]
@@ -171,6 +175,9 @@ class StencilType(
             return (-1,) * self.bounds.data
         else:
             return tuple(self.bounds.ub - self.bounds.lb)
+
+    def get_element_type(self) -> _FieldTypeElement:
+        return self.element_type
 
     @staticmethod
     def parse_parameters(parser: Parser) -> list[Attribute]:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -15,6 +15,7 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     i32,
     i64,
+    ContainerType,
 )
 from xdsl.ir import (
     Block,
@@ -99,7 +100,9 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
 
 
 @irdl_attr_definition
-class LLVMPointerType(ParametrizedAttribute, TypeAttribute):
+class LLVMPointerType(
+    ParametrizedAttribute, TypeAttribute, ContainerType[Attribute | None]
+):
     name = "llvm.ptr"
 
     type: ParameterDef[Attribute | NoneAttr]
@@ -143,6 +146,9 @@ class LLVMPointerType(ParametrizedAttribute, TypeAttribute):
 
     def is_typed(self):
         return not isinstance(self.type, NoneAttr)
+
+    def get_element_type(self) -> Attribute | None:
+        return self.type
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -11,7 +11,6 @@ from typing import (
     cast,
 )
 
-from xdsl.utils.hints import isa
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     DenseIntOrFPElementsAttr,
@@ -29,6 +28,7 @@ from xdsl.dialects.builtin import (
     UnitAttr,
     i32,
     IntegerType,
+    ContainerType,
 )
 from xdsl.ir import (
     TypeAttribute,
@@ -64,7 +64,11 @@ _MemRefTypeElement = TypeVar("_MemRefTypeElement", bound=Attribute)
 
 @irdl_attr_definition
 class MemRefType(
-    Generic[_MemRefTypeElement], ParametrizedAttribute, TypeAttribute, ShapeType
+    Generic[_MemRefTypeElement],
+    ParametrizedAttribute,
+    TypeAttribute,
+    ShapeType,
+    ContainerType[_MemRefTypeElement],
 ):
     name = "memref"
 
@@ -78,6 +82,9 @@ class MemRefType(
 
     def get_shape(self) -> tuple[int]:
         return tuple(i.value.data for i in self.shape.data)
+
+    def get_element_type(self) -> _MemRefTypeElement:
+        return self.element_type
 
     @staticmethod
     def from_element_type_and_shape(

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -18,7 +18,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     DenseArrayBase,
     IndexType,
-    ShapeType,
+    ShapedType,
     StridedLayoutAttr,
     ArrayAttr,
     NoneAttr,
@@ -67,7 +67,7 @@ class MemRefType(
     Generic[_MemRefTypeElement],
     ParametrizedAttribute,
     TypeAttribute,
-    ShapeType,
+    ShapedType,
     ContainerType[_MemRefTypeElement],
 ):
     name = "memref"

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -80,7 +80,7 @@ class MemRefType(
     def get_num_dims(self) -> int:
         return len(self.shape.data)
 
-    def get_shape(self) -> tuple[int]:
+    def get_shape(self) -> tuple[int, ...]:
         return tuple(i.value.data for i in self.shape.data)
 
     def get_element_type(self) -> _MemRefTypeElement:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -467,7 +467,7 @@ class Printer:
 
             def print_dense_list(
                 array: Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr],
-                shape: List[int],
+                shape: Sequence[int],
             ):
                 self.print("[")
                 if len(shape) > 1:
@@ -482,7 +482,9 @@ class Printer:
 
             self.print("dense<")
             data = attribute.data.data
-            shape = attribute.shape if attribute.shape_is_complete else [len(data)]
+            shape = (
+                attribute.get_shape() if attribute.shape_is_complete else (len(data),)
+            )
             assert shape is not None, "If shape is complete, then it cannot be None"
             if len(data) == 0:
                 pass
@@ -525,7 +527,7 @@ class Printer:
             # Separate the dimensions between the static and the scalable ones
             if attribute.get_num_scalable_dims() == 0:
                 static_dimensions = shape
-                scalable_dimensions = []
+                scalable_dimensions = ()
             else:
                 static_dimensions = shape[: -attribute.get_num_scalable_dims()]
                 scalable_dimensions = shape[-attribute.get_num_scalable_dims() :]

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -107,7 +107,7 @@ class ReturnOpToMemref(RewritePattern):
             if target is None:
                 break
 
-            assert isinstance(target.typ, builtin.ShapeType)
+            assert isinstance(target.typ, builtin.ShapedType)
 
             assert (block := op.parent_block()) is not None
 


### PR DESCRIPTION
This adds two things:

 - an `element_count` property to the `ShapeType`, that is automatically derived and uses the `get_shape` method internally
 - A new `ContainerType` class that allows us to have a common interface for types that encompass another type (e.g. MemRef, Vector, Tensor, Dense, llvm pointer)

In the process, I moved most of them over to this. That changed their shape return value to `tuple` (previously array for some builtins). I fixed some tests and had to touch the printer a bit sadly.

(This was done in response to me finding a bug in how memref element counts are calculated in the mpi lowering, which was pretty sad)