### PR TITLE
bug: Fix `clone_into` with circular block regions

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -141,6 +141,27 @@ def test_op_clone_with_regions():
     assert if2.false_region.op is not if_.false_region.op
 
 
+def test_region_clone_into_circular_blocks():
+    """
+    Test that cloning a region with circular block dependency works.
+    """
+    region_str = """
+    {
+    ^0:
+        "test.op"() [^1] : () -> ()
+    ^1:
+        "test.op"() [^0] : () -> ()
+    }
+    """
+    ctx = MLContext()
+    region = Parser(ctx, region_str, allow_unregistered_dialect=True).parse_region()
+
+    region2 = Region()
+    region.clone_into(region2)
+
+    assert region.is_structurally_equivalent(region2)
+
+
 ##################### Testing is_structurally_equal #####################
 
 program_region = """

--- a/xdsl/ir.py
+++ b/xdsl/ir.py
@@ -1545,16 +1545,24 @@ class Region(IRNode):
         if block_mapper is None:
             block_mapper = {}
 
+        new_blocks: list[Block] = []
+
+        # Clone all blocks without their contents, and register the block mapping
+        # This ensures that operations can refer to blocks that are not yet cloned
         for block in self.blocks:
             new_block = Block()
+            new_blocks.append(new_block)
             block_mapper[block] = new_block
+
+        dest.insert_block(new_blocks, insert_index)
+
+        # Populate the blocks with the cloned operations
+        for block, new_block in zip(self.blocks, new_blocks):
             for idx, block_arg in enumerate(block.args):
                 new_block.insert_arg(block_arg.typ, idx)
                 value_mapper[block_arg] = new_block.args[idx]
             for op in block.ops:
                 new_block.add_op(op.clone(value_mapper, block_mapper))
-            dest.insert_block(new_block, insert_index)
-            insert_index += 1
 
     def walk(self) -> Iterator[Operation]:
         """Call a function on all operations contained in the region."""


### PR DESCRIPTION
Previously, a block referencing a future block was breaking `Region.clone_into`