### PR TITLE
core: Remove the tokenizer

### DIFF
--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -39,12 +39,11 @@ class BoolData(Data[bool]):
 
     @staticmethod
     def parse_parameter(parser: Parser) -> bool:
-        val = parser.tokenizer.next_token_of_pattern("(True|False)")
-        if val is None or val.text not in ("True", "False"):
-            parser.raise_error("Expected True or False literal")
-        if val.text == "True":
+        if parser.parse_optional_keyword("True"):
             return True
-        return False
+        if parser.parse_optional_keyword("False"):
+            return False
+        parser.raise_error("Expected True or False literal")
 
     def print_parameter(self, printer: Printer):
         printer.print_string(str(self.data))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -539,10 +539,8 @@ def test_get_punctuation_kind(punctuation: Token.Kind):
 def test_parse_punctuation(punctuation: Token.PunctuationSpelling):
     parser = Parser(MLContext(), punctuation)
 
-    parser._synchronize_lexer_and_tokenizer()
     res = parser.parse_punctuation(punctuation)
     assert res == punctuation
-    parser._synchronize_lexer_and_tokenizer()
     assert parser._parse_token(Token.Kind.EOF, "").kind == Token.Kind.EOF
 
 
@@ -551,7 +549,6 @@ def test_parse_punctuation(punctuation: Token.PunctuationSpelling):
 )
 def test_parse_punctuation_fail(punctuation: Token.PunctuationSpelling):
     parser = Parser(MLContext(), "e +")
-    parser._synchronize_lexer_and_tokenizer()
     with pytest.raises(ParseError) as e:
         parser.parse_punctuation(punctuation, " in test")
     assert e.value.span.text == "e"
@@ -563,10 +560,8 @@ def test_parse_punctuation_fail(punctuation: Token.PunctuationSpelling):
 )
 def test_parse_optional_punctuation(punctuation: Token.PunctuationSpelling):
     parser = Parser(MLContext(), punctuation)
-    parser._synchronize_lexer_and_tokenizer()
     res = parser.parse_optional_punctuation(punctuation)
     assert res == punctuation
-    parser._synchronize_lexer_and_tokenizer()
     assert parser._parse_token(Token.Kind.EOF, "").kind == Token.Kind.EOF
 
 
@@ -575,7 +570,6 @@ def test_parse_optional_punctuation(punctuation: Token.PunctuationSpelling):
 )
 def test_parse_optional_punctuation_fail(punctuation: Token.PunctuationSpelling):
     parser = Parser(MLContext(), "e +")
-    parser._synchronize_lexer_and_tokenizer()
     assert parser.parse_optional_punctuation(punctuation) is None
 
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -584,10 +584,10 @@ class CustomFormatAttr(ParametrizedAttribute):
     @staticmethod
     def parse_parameters(parser: Parser) -> list[Attribute]:
         parser.parse_characters("<")
-        if parser.parse_optional_keyword("zero"):
+        if parser.parse_optional_keyword("zero") is not None:
             parser.parse_characters(">")
             return [IntAttr(0)]
-        if parser.parse_optional_keyword("one"):
+        if parser.parse_optional_keyword("one") is not None:
             parser.parse_characters(">")
             return [IntAttr(1)]
         assert False

--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -33,8 +33,7 @@ def test_empty_program():
 @pytest.mark.parametrize(
     "args, expected_error",
     [
-        (["tests/xdsl_opt/not_module.mlir"], "Expected ModuleOp at top level!"),
-        (["tests/xdsl_opt/not_module.mlir"], "Expected ModuleOp at top level!"),
+        (["tests/xdsl_opt/not_module.mlir"], "builtin.module operation expected"),
         (["tests/xdsl_opt/empty_program.wrong"], "Unrecognized file extension 'wrong'"),
     ],
 )

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -316,9 +316,7 @@ class HaloShapeInformation(ParametrizedAttribute):
             parser.parse_characters(",")
             buff_ub.append(parser.parse_integer())
             parser.parse_characters("]")
-            if parser.tokenizer.starts_with("x"):
-                parser.parse_characters("x")
-            else:
+            if parser.parse_optional_characters("x") is None:
                 break
         parser.parse_characters(">")
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -122,7 +122,6 @@ class MemRefType(
 
     @staticmethod
     def parse_parameters(parser: Parser) -> list[Attribute]:
-        parser._synchronize_lexer_and_tokenizer()  # pyright: ignore[reportPrivateUsage]
         parser.parse_punctuation("<", " in memref attribute")
         shape = parser.parse_attribute()
         parser.parse_punctuation(",", " between shape and element type parameters")
@@ -135,7 +134,6 @@ class MemRefType(
         parser.parse_punctuation(",", " between layout and memory space")
         memory_space = parser.parse_attribute()
         parser.parse_punctuation(">", " at end of memref attribute")
-        parser._synchronize_lexer_and_tokenizer()  # pyright: ignore[reportPrivateUsage]
 
         return [shape, type, layout, memory_space]
 


### PR DESCRIPTION
This removes the tokenizer, in favor of the parser.
This makes the parser twice as fast (since we don't keep the synchronization between the lexer and the tokenizer)