### PR TITLE
misc: Remove pyright __new__ overload fix

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -344,22 +344,6 @@ class IntegerAttr(Generic[_IntegerAttrTyp], ParametrizedAttribute):
     typ: ParameterDef[_IntegerAttrTyp]
 
     @overload
-    def __new__(
-        cls,
-        value: int | IntAttr,
-        typ: _IntegerAttrTyp,
-    ) -> IntegerAttr[_IntegerAttrTyp]:
-        ...
-
-    @overload
-    def __new__(cls, value: int | IntAttr, typ: int) -> IntegerAttr[IntegerType]:
-        ...
-
-    # These overloads are required to make pyright infer the correct result type.
-    def __new__(cls, *args: Any, **kwargs: Any) -> IntegerAttr[Any]:
-        return super().__new__(cls)
-
-    @overload
     def __init__(
         self: IntegerAttr[_IntegerAttrTyp], value: int | IntAttr, typ: _IntegerAttrTyp
     ) -> None:


### PR DESCRIPTION
This was required in an earlier version of pyright, but is not needed anymore.