### PR TITLE
core: AnyIntegerAttr = IntegerAttr[IntegerType] | IntegerAttr[IndexType]

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -385,7 +385,7 @@ class IntegerAttr(Generic[_IntegerAttrTyp], ParametrizedAttribute):
                 )
 
 
-AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
+AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType] | IntegerAttr[IndexType]
 
 
 @irdl_attr_definition

--- a/xdsl/parser.py
+++ b/xdsl/parser.py
@@ -2259,13 +2259,18 @@ class Parser(ABC):
         if isinstance(type, IntegerType | IndexType):
             if isinstance(value, float):
                 self.raise_error("Floating point value is not valid for integer type.")
-            return IntegerAttr(value, type)
+            # Pyright workaround, IntegerAttr[IntegerType | IndexType] is not a subtype of
+            # IntegerAttr[IntegerType] | IntegerAttr[IndexType]
+            if isinstance(type, IntegerType):
+                return IntegerAttr(value, type)
+            else:
+                return IntegerAttr(value, type)
 
         self.raise_error("Invalid type given for integer or float attribute.")
 
     def try_parse_builtin_boolean_attr(
         self,
-    ) -> IntegerAttr[IntegerType | IndexType] | None:
+    ) -> IntegerAttr[IntegerType] | None:
         self._synchronize_lexer_and_tokenizer()
         if (value := self.parse_optional_boolean()) is not None:
             self._synchronize_lexer_and_tokenizer()


### PR DESCRIPTION
We occasionally get issues with variance with the current AnyIntegerAttr definition. The new definition is a bit more restrictive, but should be good for pretty much all our use cases. It makes it easier for Pyright to infer types, and generally be a bit less annoying.