### PR TITLE
Core: Add IsTerminator trait

### DIFF
--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -4,21 +4,21 @@
 
 builtin.module {
     %0 = "test.op"(%1) : (i32) -> i32
-    %1 = "test.op"(%0) : (i32) -> i32
+    %1 = "test.termop"(%0) : (i32) -> i32
 }
 
 // CHECK:      %0 = "test.op"(%1) : (i32) -> i32
-// CHECK-NEXT: %1 = "test.op"(%0) : (i32) -> i32
+// CHECK-NEXT: %1 = "test.termop"(%0) : (i32) -> i32
 
 // -----
 
 // A self-cycle
 
 builtin.module {
-    %0 = "test.op"(%0) : (i32) -> i32
+    %0 = "test.termop"(%0) : (i32) -> i32
 }
 
-// CHECK:      %0 = "test.op"(%0) : (i32) -> i32
+// CHECK:      %0 = "test.termop"(%0) : (i32) -> i32
 
 // -----
 
@@ -26,17 +26,17 @@ builtin.module {
 
 builtin.module {
     "test.op"() ({
-        "test.op"(%0) : (i32) -> ()
+        "test.termop"(%0) : (i32) -> ()
         ^bb0(%0: i32):
-        "test.op"() : () -> ()
+        "test.termop"() : () -> ()
     }) : () -> ()
 }
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   "test.op"() ({
-// CHECK-NEXT:     "test.op"(%0) : (i32) -> ()
+// CHECK-NEXT:     "test.termop"(%0) : (i32) -> ()
 // CHECK-NEXT:   ^0(%0 : i32):
-// CHECK-NEXT:     "test.op"() : () -> ()
+// CHECK-NEXT:     "test.termop"() : () -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }
 
@@ -46,7 +46,7 @@ builtin.module {
 // A graph region that refers to a value that is not defined in the module.
 
 builtin.module {
-    %0 = "test.op"(%1) : (i32) -> i32
+    %0 = "test.termop"(%1) : (i32) -> i32
 }
 
 // CHECK: value %1 was used but not defined
@@ -57,7 +57,7 @@ builtin.module {
 
 builtin.module {
     "test.op"(%1#3) : (i32) -> ()
-    %1:3 = "test.op"() : () -> (i32, i32, i32)
+    %1:3 = "test.termop"() : () -> (i32, i32, i32)
 }
 
 // CHECK: SSA value %1 is referenced with an index larger than its size

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -5,10 +5,11 @@ Test the usage of builtin traits.
 import pytest
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.irdl import IRDLOperation, irdl_op_definition
-from xdsl.ir import Region
-from xdsl.traits import HasParent
+from xdsl.irdl import IRDLOperation, OptSuccessor, irdl_op_definition
+from xdsl.ir import Region, Block
+from xdsl.traits import HasParent, IsTerminator
 from xdsl.utils.exceptions import VerifyException
+from xdsl.dialects.test import TestOp
 
 
 @irdl_op_definition
@@ -100,3 +101,28 @@ def test_has_parent_verify():
 
     op = Parent2Op(regions=[[HasMultipleParentOp()]])
     op.verify()
+
+
+@irdl_op_definition
+class IsTerminatorOp(IRDLOperation):
+    """
+    An operation that provides the IsTerminator trait.
+    """
+
+    name = "test.is_terminator"
+
+    successor: OptSuccessor
+
+    traits = frozenset([IsTerminator()])
+
+
+def test_is_terminator_verify():
+    """
+    Test that an operation with an IsTerminator trait expects successor blocks.
+    """
+    block0 = Block([])
+    block1 = Block([IsTerminatorOp.create(successors=[block0])])
+    region0 = Region([block0, block1])
+    op0 = TestOp.create(regions=[region0])
+
+    op0.verify()

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -116,12 +116,25 @@ class IsTerminatorOp(IRDLOperation):
     traits = frozenset([IsTerminator()])
 
 
-def test_is_terminator_verify():
+def test_is_terminator_with_successors_verify():
     """
-    Test that an operation with an IsTerminator trait expects successor blocks.
+    Test that an operation with an IsTerminator trait may have successor blocks.
     """
     block0 = Block([])
     block1 = Block([IsTerminatorOp.create(successors=[block0])])
+    region0 = Region([block0, block1])
+    op0 = TestOp.create(regions=[region0])
+
+    op0.verify()
+
+
+def test_is_terminator_without_successors_verify():
+    """
+    Test that an operation with an IsTerminator trait may not have successor
+    blocks.
+    """
+    block0 = Block([])
+    block1 = Block([IsTerminatorOp.create()])
     region0 = Region([block0, block1])
     op0 = TestOp.create(regions=[region0])
 

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -126,3 +126,18 @@ def test_is_terminator_verify():
     op0 = TestOp.create(regions=[region0])
 
     op0.verify()
+
+
+def test_is_terminator_fails_if_not_last_operation_parent_block():
+    """
+    Test that an operation with an IsTerminator trait fails if it is not the
+    last operation in its parent block.
+    """
+    block0 = Block([IsTerminatorOp.create(), TestOp.create()])
+    region0 = Region([block0])
+    op0 = TestOp.create(regions=[region0])
+
+    with pytest.raises(
+        VerifyException, match="must be the last operation in the parent block"
+    ):
+        op0.verify()

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -197,7 +197,7 @@ def test_non_empty_block_with_parent_region_requires_terminator_without_successo
 
 def test_non_empty_block_with_parent_region_has_successors_but_not_last_block_op():
     """
-    Tests that an empty block belonging to a single-block region with parent
+    Tests that an non-empty block belonging to a multi-block region with parent
     operation requires terminator operation.
     """
     block0 = Block([])

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -13,6 +13,7 @@ from xdsl.ir import MLContext, Operation, Block, Region, ErasedSSAValue, SSAValu
 from xdsl.parser import Parser
 from xdsl.irdl import IRDLOperation, VarRegion, irdl_op_definition, Operand
 from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.exceptions import VerifyException
 
 
 def test_ops_accessor():
@@ -173,7 +174,7 @@ def test_non_empty_block_with_parent_region_requires_terminator():
     op0 = TestOp.create(regions=[region0])
 
     with pytest.raises(
-        Exception, match="Operation terminates block but is not a terminator"
+        VerifyException, match="Operation terminates block but is not a terminator"
     ):
         op0.verify()
 
@@ -189,7 +190,7 @@ def test_non_empty_block_with_parent_region_has_successors_but_not_last_block_op
     op0 = TestOp.create(regions=[region0])
 
     with pytest.raises(
-        Exception,
+        VerifyException,
         match="Operation with block successors must terminate its parent block",
     ):
         op0.verify()

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -165,7 +165,7 @@ def test_region_clone_into_circular_blocks():
 
 def test_non_empty_block_with_parent_region_requires_terminator():
     """
-    Tests that an empty block belonging to a single-block region with parent
+    Tests that an empty block belonging to a multi-block region with parent
     operation requires terminator operation.
     """
     block0 = Block([])

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -192,7 +192,11 @@ def test_non_empty_block_with_parent_region_requires_terminator_without_successo
     region0 = Region([block0, block1])
     op0 = TestOp.create(regions=[region0])
 
-    op0.verify()
+    with pytest.raises(
+        VerifyException,
+        match="Operation terminates block but is not a terminator",
+    ):
+        op0.verify()
 
 
 def test_non_empty_block_with_parent_region_has_successors_but_not_last_block_op():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -173,7 +173,7 @@ def test_non_empty_block_with_parent_region_requires_terminator():
     op0 = TestOp.create(regions=[region0])
 
     with pytest.raises(
-        Exception, match="Operation terminates block with no terminator"
+        Exception, match="Operation terminates block but is not a terminator"
     ):
         op0.verify()
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -163,10 +163,11 @@ def test_region_clone_into_circular_blocks():
     assert region.is_structurally_equivalent(region2)
 
 
-def test_non_empty_block_with_parent_region_requires_terminator():
+def test_non_empty_block_with_parent_region_requires_terminator_with_successors():
     """
-    Tests that an empty block belonging to a multi-block region with parent
+    Tests that an non-empty block belonging to a multi-block region with parent
     operation requires terminator operation.
+    The terminator operation may have successors.
     """
     block0 = Block([])
     block1 = Block([TestOp.create(successors=[block0])])

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -162,6 +162,39 @@ def test_region_clone_into_circular_blocks():
     assert region.is_structurally_equivalent(region2)
 
 
+def test_non_empty_block_with_parent_region_requires_terminator():
+    """
+    Tests that an empty block belonging to a single-block region with parent
+    operation requires terminator operation.
+    """
+    block0 = Block([])
+    block1 = Block([TestOp.create(successors=[block0])])
+    region0 = Region([block0, block1])
+    op0 = TestOp.create(regions=[region0])
+
+    with pytest.raises(
+        Exception, match="Operation terminates block with no terminator"
+    ):
+        op0.verify()
+
+
+def test_non_empty_block_with_parent_region_has_successors_but_not_last_block_op():
+    """
+    Tests that an empty block belonging to a single-block region with parent
+    operation requires terminator operation.
+    """
+    block0 = Block([])
+    block1 = Block([TestOp.create(successors=[block0]), TestOp.create()])
+    region0 = Region([block0, block1])
+    op0 = TestOp.create(regions=[region0])
+
+    with pytest.raises(
+        Exception,
+        match="Operation with block successors must terminate its parent block",
+    ):
+        op0.verify()
+
+
 ##################### Testing is_structurally_equal #####################
 
 program_region = """

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -163,6 +163,19 @@ def test_region_clone_into_circular_blocks():
     assert region.is_structurally_equivalent(region2)
 
 
+def test_non_empty_block_with_single_block_parent_region_can_have_terminator():
+    """
+    Tests that an non-empty block belonging to a single-block region with parent
+    operation can have a single terminator operation without the IsTerminator
+    trait.
+    """
+    block1 = Block([TestOp.create()])
+    region0 = Region([block1])
+    op0 = TestOp.create(regions=[region0])
+
+    op0.verify()
+
+
 def test_non_empty_block_with_parent_region_requires_terminator_with_successors():
     """
     Tests that an non-empty block belonging to a multi-block region with parent

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -163,6 +163,29 @@ def test_region_clone_into_circular_blocks():
     assert region.is_structurally_equivalent(region2)
 
 
+def test_op_with_successors_not_in_block():
+    block0 = Block()
+    op0 = TestOp.create(successors=[block0])
+
+    with pytest.raises(
+        VerifyException,
+        match="Operation with block successors does not belong to a block or a region",
+    ):
+        op0.verify()
+
+
+def test_op_with_successors_not_in_region():
+    block0 = Block()
+    op0 = TestOp.create(successors=[block0])
+    _ = Block([op0])
+
+    with pytest.raises(
+        VerifyException,
+        match="Operation with block successors does not belong to a block or a region",
+    ):
+        op0.verify()
+
+
 def test_non_empty_block_with_single_block_parent_region_can_have_terminator():
     """
     Tests that an non-empty block belonging to a single-block region with parent
@@ -182,7 +205,7 @@ def test_non_empty_block_with_parent_region_requires_terminator_with_successors(
     operation requires terminator operation.
     The terminator operation may have successors.
     """
-    block0 = Block([])
+    block0 = Block()
     block1 = Block([TestOp.create(successors=[block0])])
     region0 = Region([block0, block1])
     op0 = TestOp.create(regions=[region0])
@@ -200,7 +223,7 @@ def test_non_empty_block_with_parent_region_requires_terminator_without_successo
     operation requires terminator operation.
     The terminator operation may not have successors.
     """
-    block0 = Block([])
+    block0 = Block()
     block1 = Block([TestOp.create()])
     region0 = Region([block0, block1])
     op0 = TestOp.create(regions=[region0])
@@ -217,7 +240,7 @@ def test_non_empty_block_with_parent_region_has_successors_but_not_last_block_op
     Tests that an non-empty block belonging to a multi-block region with parent
     operation requires terminator operation.
     """
-    block0 = Block([])
+    block0 = Block()
     block1 = Block([TestOp.create(successors=[block0]), TestOp.create()])
     region0 = Region([block0, block1])
     op0 = TestOp.create(regions=[region0])

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -174,9 +174,24 @@ def test_non_empty_block_with_parent_region_requires_terminator():
     op0 = TestOp.create(regions=[region0])
 
     with pytest.raises(
-        VerifyException, match="Operation terminates block but is not a terminator"
+        VerifyException,
+        match="Operation terminates block but is not a terminator",
     ):
         op0.verify()
+
+
+def test_non_empty_block_with_parent_region_requires_terminator_without_successors():
+    """
+    Tests that an non-empty block belonging to a multi-block region with parent
+    operation requires terminator operation.
+    The terminator operation may not have successors.
+    """
+    block0 = Block([])
+    block1 = Block([TestOp.create()])
+    region0 = Region([block0, block1])
+    op0 = TestOp.create(regions=[region0])
+
+    op0.verify()
 
 
 def test_non_empty_block_with_parent_region_has_successors_but_not_last_block_op():

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -92,7 +92,10 @@ class VarResultOp(IRDLOperation):
 def test_var_result_builder():
     op = VarResultOp.build(result_types=[[StringAttr("0"), StringAttr("1")]])
     op.verify()
-    assert [res.typ for res in op.results] == [StringAttr("0"), StringAttr("1")]
+    assert [res.typ for res in op.results] == [
+        StringAttr("0"),
+        StringAttr("1"),
+    ]
 
 
 @irdl_op_definition
@@ -499,6 +502,7 @@ class SuccessorOp(IRDLOperation):
 
 
 def test_successor_op_successor():
+    """Test operation from IRDL operation definition can have successors"""
     block0 = Block()
     op = SuccessorOp.build(successors=[block0])
 
@@ -517,6 +521,10 @@ class OptSuccessorOp(IRDLOperation):
 
 
 def test_opt_successor_builder():
+    """
+    Test operation from IRDL operation definition can optionally have
+    successors
+    """
     block0 = Block()
     op1 = OptSuccessorOp.build(successors=[block0])
     op2 = OptSuccessorOp.build(successors=[None])
@@ -536,6 +544,9 @@ class VarSuccessorOp(IRDLOperation):
 
 
 def test_var_successor_builder():
+    """
+    Test operation from IRDL operation definition can have variadic successors
+    """
     block0 = Block()
     op = VarSuccessorOp.build(successors=[[block0, block0, block0]])
 
@@ -556,6 +567,10 @@ class TwoVarSuccessorOp(IRDLOperation):
 
 
 def test_two_var_successor_builder():
+    """
+    Test operation from IRDL operation definition can have variadic successors
+    along with their sizes as an attribute
+    """
     block1 = Block()
     block2 = Block()
     block3 = Block()
@@ -573,6 +588,10 @@ def test_two_var_successor_builder():
 
 
 def test_two_var_successor_builder2():
+    """
+    Test operation from IRDL operation definition can have variadic successors
+    along with their sizes as an attribute
+    """
     block1 = Block()
     block2 = Block()
     block3 = Block()

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -521,7 +521,7 @@ def test_opt_successor_builder():
     op1 = OptSuccessorOp.build(successors=[block0])
     op2 = OptSuccessorOp.build(successors=[None])
 
-    block1 = Block([op1, op2])
+    block1 = Block([op2, op1])
     _ = Region([block1])
 
     op1.verify()

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -499,8 +499,12 @@ class SuccessorOp(IRDLOperation):
 
 
 def test_successor_op_successor():
-    block = Block()
-    op = SuccessorOp.build(successors=[block])
+    block0 = Block()
+    op = SuccessorOp.build(successors=[block0])
+
+    block1 = Block([op])
+    _ = Region([block1])
+
     op.verify()
     assert len(op.successors) == 1
 
@@ -513,9 +517,13 @@ class OptSuccessorOp(IRDLOperation):
 
 
 def test_opt_successor_builder():
-    block = Block()
-    op1 = OptSuccessorOp.build(successors=[block])
+    block0 = Block()
+    op1 = OptSuccessorOp.build(successors=[block0])
     op2 = OptSuccessorOp.build(successors=[None])
+
+    block1 = Block([op1, op2])
+    _ = Region([block1])
+
     op1.verify()
     op2.verify()
 
@@ -528,8 +536,12 @@ class VarSuccessorOp(IRDLOperation):
 
 
 def test_var_successor_builder():
-    block = Block()
-    op = VarSuccessorOp.build(successors=[[block, block, block]])
+    block0 = Block()
+    op = VarSuccessorOp.build(successors=[[block0, block0, block0]])
+
+    block1 = Block([op])
+    _ = Region([block1])
+
     op.verify()
     assert len(op.successors) == 3
 
@@ -549,6 +561,10 @@ def test_two_var_successor_builder():
     block3 = Block()
     block4 = Block()
     op2 = TwoVarSuccessorOp.build(successors=[[block1, block2], [block3, block4]])
+
+    block0 = Block([op2])
+    _ = Region([block0])
+
     op2.verify()
     assert op2.successors == [block1, block2, block3, block4]
     assert op2.attributes[
@@ -562,6 +578,10 @@ def test_two_var_successor_builder2():
     block3 = Block()
     block4 = Block()
     op2 = TwoVarSuccessorOp.build(successors=[[block1], [block2, block3, block4]])
+
+    block0 = Block([op2])
+    _ = Region([block0])
+
     op2.verify()
     assert op2.successors == [block1, block2, block3, block4]
     assert op2.attributes[

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -5,6 +5,7 @@ from typing import Annotated, Union, Sequence
 
 from xdsl.dialects.builtin import IntegerType, StringAttr
 from xdsl.ir import SSAValue, Operation, Block, Dialect
+from xdsl.traits import IsTerminator
 from xdsl.irdl import (
     OpAttr,
     irdl_op_definition,
@@ -37,6 +38,8 @@ class Branch(IRDLOperation):
     arguments: Annotated[VarOperand, AnyAttr()]
     successor: Successor
 
+    traits = frozenset([IsTerminator()])
+
     @staticmethod
     def get(dest: Block, *ops: Union[Operation, SSAValue]) -> Branch:
         return Branch.build(operands=[[op for op in ops]], successors=[dest])
@@ -54,6 +57,8 @@ class ConditionalBranch(IRDLOperation):
 
     then_block: Successor
     else_block: Successor
+
+    traits = frozenset([IsTerminator()])
 
     @staticmethod
     def get(

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -26,7 +26,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.traits import HasParent
+from xdsl.traits import HasParent, IsTerminator
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -318,7 +318,7 @@ class Return(IRDLOperation):
     name = "func.return"
     arguments: Annotated[VarOperand, AnyAttr()]
 
-    traits = frozenset([HasParent(FuncOp)])
+    traits = frozenset([HasParent(FuncOp), IsTerminator()])
 
     def verify_(self) -> None:
         func_op = self.parent_op()

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -4,6 +4,7 @@ from typing import Annotated, Sequence
 
 from xdsl.dialects.builtin import IndexType, IntegerType
 from xdsl.ir import Attribute, Block, Dialect, Operation, Region, SSAValue
+from xdsl.traits import IsTerminator
 from xdsl.irdl import (
     AnyAttr,
     AttrSizedOperandSegments,
@@ -48,6 +49,8 @@ class If(IRDLOperation):
 class Yield(IRDLOperation):
     name = "scf.yield"
     arguments: Annotated[VarOperand, AnyAttr()]
+
+    traits = frozenset([IsTerminator()])
 
     @staticmethod
     def get(*operands: SSAValue | Operation) -> Yield:

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from xdsl.ir import Data, Dialect, TypeAttribute
-
+from xdsl.traits import IsTerminator
 from xdsl.irdl import (
     VarOpResult,
     VarOperand,
@@ -29,6 +29,22 @@ class TestOp(IRDLOperation):
     regs: VarRegion
 
 
+@irdl_op_definition
+class TestTermOp(TestOp):
+    """
+    This operation can produce an arbitrary number of SSAValues with arbitrary
+    types. It is used in filecheck testing to reduce to artificial dependencies
+    on other dialects (i.e. dependencies that only come from the structure of
+    the test rather than the actual dialect).
+    Its main difference from TestOp is that it satisfies the IsTerminator trait
+    and can be used as a block terminator operation.
+    """
+
+    name = "test.termop"
+
+    traits = frozenset([IsTerminator()])
+
+
 @irdl_attr_definition
 class TestType(Data[str], TypeAttribute):
     """
@@ -47,4 +63,4 @@ class TestType(Data[str], TypeAttribute):
         printer.print_string_literal(self.data)
 
 
-Test = Dialect([TestOp], [TestType])
+Test = Dialect([TestOp, TestTermOp], [TestType])

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -766,7 +766,7 @@ class Operation(IRNode):
         ) is not None:
             # TODO single-block regions dealt when the NoTerminator trait is implemented
             if len(parent_region.blocks) > 1:
-                if len(self.successors) > 0:
+                if self.successors:
                     if parent_block.last_op != self:
                         raise Exception(
                             "Operation with block successors must terminate its parent block"

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -777,6 +777,11 @@ class Operation(IRNode):
                     raise VerifyException(
                         "Operation terminates block but is not a terminator"
                     )
+        else:
+            if self.successors:
+                raise VerifyException(
+                    "Operation with block successors does not belong to a block or a region"
+                )
 
         if verify_nested_ops:
             for region in self.regions:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -773,10 +773,10 @@ class Operation(IRNode):
                             "Operation with block successors must terminate its parent block"
                         )
 
-                    if not self.has_trait(IsTerminator):
-                        raise VerifyException(
-                            "Operation terminates block but is not a terminator"
-                        )
+                if not self.has_trait(IsTerminator):
+                    raise VerifyException(
+                        "Operation terminates block but is not a terminator"
+                    )
 
         if verify_nested_ops:
             for region in self.regions:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -764,7 +764,8 @@ class Operation(IRNode):
         if (parent_block := self.parent) is not None and (
             parent_region := parent_block.parent
         ) is not None:
-            # TODO single-block regions dealt when the NoTerminator trait is implemented
+            # TODO single-block regions dealt when the NoTerminator trait is
+            # implemented (https://github.com/xdslproject/xdsl/issues/1093)
             if len(parent_region.blocks) > 1:
                 if self.successors:
                     if parent_block.last_op != self:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -761,7 +761,9 @@ class Operation(IRNode):
             if isinstance(operand, ErasedSSAValue):
                 raise Exception("Erased SSA value is used by the operation")
 
-        if (parent_block := self.parent) and (parent_region := parent_block.parent):
+        if (parent_block := self.parent) is not None and (
+            parent_region := parent_block.parent
+        ) is not None:
             # TODO single-block regions dealt when the NoTerminator trait is implemented
             if len(parent_region.blocks) > 1:
                 if len(self.successors) > 0:
@@ -771,7 +773,9 @@ class Operation(IRNode):
                         )
 
                     if not self.has_trait(IsTerminator):
-                        raise Exception("Operation terminates block with no terminator")
+                        raise Exception(
+                            "Operation terminates block but is not a terminator"
+                        )
 
         if verify_nested_ops:
             for region in self.regions:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -764,15 +764,14 @@ class Operation(IRNode):
         if (parent_block := self.parent) is not None and (
             parent_region := parent_block.parent
         ) is not None:
+            if self.successors and parent_block.last_op != self:
+                raise VerifyException(
+                    "Operation with block successors must terminate its parent block"
+                )
+
             # TODO single-block regions dealt when the NoTerminator trait is
             # implemented (https://github.com/xdslproject/xdsl/issues/1093)
             if len(parent_region.blocks) > 1:
-                if self.successors:
-                    if parent_block.last_op != self:
-                        raise VerifyException(
-                            "Operation with block successors must terminate its parent block"
-                        )
-
                 if not self.has_trait(IsTerminator):
                     raise VerifyException(
                         "Operation terminates block but is not a terminator"

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -768,12 +768,12 @@ class Operation(IRNode):
             if len(parent_region.blocks) > 1:
                 if self.successors:
                     if parent_block.last_op != self:
-                        raise Exception(
+                        raise VerifyException(
                             "Operation with block successors must terminate its parent block"
                         )
 
                     if not self.has_trait(IsTerminator):
-                        raise Exception(
+                        raise VerifyException(
                             "Operation terminates block but is not a terminator"
                         )
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -20,7 +20,7 @@ from typing import (
 )
 from xdsl.utils.deprecation import deprecated
 from xdsl.utils.exceptions import VerifyException
-from xdsl.traits import OpTrait, IsTerminator
+from xdsl.traits import OpTrait, IsTerminator, OpTraitInvT
 
 # Used for cyclic dependencies in type hints
 if TYPE_CHECKING:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -20,6 +20,7 @@ from typing import (
 )
 from xdsl.utils.deprecation import deprecated
 from xdsl.utils.exceptions import VerifyException
+from xdsl.traits import OpTrait, IsTerminator
 
 # Used for cyclic dependencies in type hints
 if TYPE_CHECKING:
@@ -515,27 +516,6 @@ class IRNode(ABC):
         ...
 
 
-@dataclass(frozen=True)
-class OpTrait:
-    """
-    A trait attached to an operation definition.
-    Traits can be used to define operation invariants, additional semantic information,
-    or to group operations that have similar properties.
-    Traits have parameters, which by default is just the `None` value. Parameters should
-    always be comparable and hashable.
-    Note that traits are the merge of traits and interfaces in MLIR.
-    """
-
-    parameters: Any = field(default=None)
-
-    def verify(self, op: Operation) -> None:
-        """Check that the operation satisfies the trait requirements."""
-        pass
-
-
-OpTraitInvT = TypeVar("OpTraitInvT", bound=OpTrait)
-
-
 @dataclass
 class Operation(IRNode):
     """A generic operation. Operation definitions inherit this class."""
@@ -780,9 +760,6 @@ class Operation(IRNode):
         for operand in self.operands:
             if isinstance(operand, ErasedSSAValue):
                 raise Exception("Erased SSA value is used by the operation")
-
-        # TODO fix circular import
-        from xdsl.traits import IsTerminator
 
         if (parent_block := self.parent) and (parent_region := parent_block.parent):
             # TODO single-block regions dealt when the NoTerminator trait is implemented

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -1,6 +1,35 @@
-from dataclasses import dataclass
-from xdsl.ir import OpTrait, Operation
+from __future__ import annotations
+from dataclasses import dataclass, field
 from xdsl.utils.exceptions import VerifyException
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from xdsl.ir import Operation
+
+
+@dataclass(frozen=True)
+class OpTrait:
+    """
+    A trait attached to an operation definition.
+    Traits can be used to define operation invariants, additional semantic information,
+    or to group operations that have similar properties.
+    Traits have parameters, which by default is just the `None` value. Parameters should
+    always be comparable and hashable.
+    Note that traits are the merge of traits and interfaces in MLIR.
+    """
+
+    parameters: Any = field(default=None)
+
+    def verify(self, op: Operation) -> None:
+        """Check that the operation satisfies the trait requirements."""
+        pass
+
+
+OpTraitInvT = TypeVar("OpTraitInvT", bound=OpTrait)
 
 
 class Pure(OpTrait):

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -68,3 +68,10 @@ class IsTerminator(OpTrait):
 
     https://mlir.llvm.org/docs/Traits/#terminator
     """
+
+    def verify(self, op: Operation) -> None:
+        """Check that the operation satisfies the IsTerminator trait requirements."""
+        if op.parent is not None and op.parent.last_op != op:
+            raise VerifyException(
+                f"'{op.name}' must be the last operation in the parent block"
+            )

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -30,3 +30,12 @@ class HasParent(OpTrait):
             )
         names = ", ".join([f"'{p.name}'" for p in self.parameters])
         raise VerifyException(f"'{op.name}' expects parent op to be one of {names}")
+
+
+class IsTerminator(OpTrait):
+    """
+    This trait provides verification and functionality for operations that are
+    known to be terminators.
+
+    https://mlir.llvm.org/docs/Traits/#terminator
+    """


### PR DESCRIPTION
This PR adds the [`IsTerminator`][3] trait.

It is a spinoff of the discussion [here][1] and specifically [this][2] recommendation regarding the initial (and pending) attempt to add the `NoTerminator` trait.

[1]: https://github.com/xdslproject/xdsl/pull/1049
[2]: https://github.com/xdslproject/xdsl/pull/1049#issuecomment-1573537005
[3]: https://mlir.llvm.org/docs/Traits/#terminator