### PR TITLE
dialects: Add lowering pass to convert snitch-runtime to external func.funcs

### DIFF
--- a/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
@@ -4,6 +4,11 @@
         // Runtime Info Getters
         %cluster_num = "snrt.cluster_num"() : () -> ui32
         // CHECK: %cluster_num = "func.call"() {"callee" = @snrt_cluster_num} : () -> i32
+
+        // Barriers
+        "snrt.cluster_hw_barrier"() : () -> ()
+        // CHECK: "func.call"() {"callee" = @snrt_cluster_hw_barrier} : () -> ()
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
     // CHECK: func.func private @snrt_cluster_num() -> i32
+    // CHECK: func.func private @snrt_cluster_hw_barrier() -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
@@ -1,0 +1,9 @@
+// RUN: xdsl-opt -p lower-snrt-to-func %s | filecheck %s
+"builtin.module"() ({
+    "func.func"() ({
+        // Runtime Info Getters
+        %cluster_num = "snrt.cluster_num"() : () -> ui32
+        // CHECK: %cluster_num = "func.call"() {"callee" = @snrt_cluster_num} : () -> i32
+    }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
+    // CHECK: func.func private @snrt_cluster_num() -> i32
+}) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
@@ -10,8 +10,17 @@
         // CHECK: "func.call"() {"callee" = @snrt_cluster_hw_barrier} : () -> ()
         // DMA functions
         "snrt.dma_wait_all"() : () -> ()
+
+        %dst_32 = "arith.constant"() {"value" = 100: ui32} : () -> ui32
+        %src_32 = "arith.constant"() {"value" = 0: ui32} : () -> ui32
+        %size_2 = "arith.constant"() {"value" = 100: index} : () -> index
+        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
+        // CHECK: %transfer_id_2 = "func.call"(%src_32, %dst_32, %size_2) {"callee" = @snrt_dma_start_1d} : (ui32, ui32, index) -> ui32
+
+
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
     // CHECK: func.func private @snrt_cluster_num() -> i32
     // CHECK: func.func private @snrt_cluster_hw_barrier() -> ()
     // CHECK: func.func private @snrt_dma_wait_all() -> ()
+    // CHECK "func.func private @snrt_dma_start_1d"(index, ui32, ui32) -> ui32
 }) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
@@ -15,12 +15,18 @@
         %src_32 = "arith.constant"() {"value" = 0: ui32} : () -> ui32
         %size_2 = "arith.constant"() {"value" = 100: index} : () -> index
         %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
-        // CHECK: %transfer_id_2 = "func.call"(%src_32, %dst_32, %size_2) {"callee" = @snrt_dma_start_1d} : (ui32, ui32, index) -> ui32
+        // CHECK: %transfer_id_2 = "func.call"(%dst_32, %src_32, %size_2) {"callee" = @snrt_dma_start_1d} : (ui32, ui32, index) -> ui32
+        %repeat = "arith.constant"() {"value" = 1: index} : () -> index
+        %src_stride = "arith.constant"() {"value" = 1: index} : () -> index
+        %dst_stride = "arith.constant"() {"value" = 1: index} : () -> index
+        %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
+        // CHECK: %transfer_id_4 = "func.call"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) {"callee" = @snrt_dma_start_2d} : (ui32, ui32, index, index, index, index) -> ui32
 
 
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
     // CHECK: func.func private @snrt_cluster_num() -> i32
     // CHECK: func.func private @snrt_cluster_hw_barrier() -> ()
     // CHECK: func.func private @snrt_dma_wait_all() -> ()
-    // CHECK "func.func private @snrt_dma_start_1d"(index, ui32, ui32) -> ui32
+    // CHECK: func.func private @snrt_dma_start_1d(ui32, ui32, index) -> ui32
+    // CHECK: func.func private @snrt_dma_start_2d(ui32, ui32, index, index, index, index) -> ui32
 }) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snitch_to_func.mlir
@@ -8,7 +8,10 @@
         // Barriers
         "snrt.cluster_hw_barrier"() : () -> ()
         // CHECK: "func.call"() {"callee" = @snrt_cluster_hw_barrier} : () -> ()
+        // DMA functions
+        "snrt.dma_wait_all"() : () -> ()
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
     // CHECK: func.func private @snrt_cluster_num() -> i32
     // CHECK: func.func private @snrt_cluster_hw_barrier() -> ()
+    // CHECK: func.func private @snrt_dma_wait_all() -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/lower_snrt_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snrt_to_func.mlir
@@ -10,6 +10,7 @@
         // CHECK: "func.call"() {"callee" = @snrt_cluster_hw_barrier} : () -> ()
         // DMA functions
         "snrt.dma_wait_all"() : () -> ()
+        // CHECK: "func.call"() {"callee" = @snrt_dma_wait_all} : () -> ()
 
         %dst_64 = "arith.constant"() {"value" = 100 : ui64} : () -> ui64
         %src_64 = "arith.constant"() {"value" = 0 : ui64} : () -> ui64

--- a/tests/filecheck/dialects/snitch_runtime/lower_snrt_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snrt_to_func.mlir
@@ -11,6 +11,12 @@
         // DMA functions
         "snrt.dma_wait_all"() : () -> ()
 
+        %dst_64 = "arith.constant"() {"value" = 100 : ui64} : () -> ui64
+        %src_64 = "arith.constant"() {"value" = 0 : ui64} : () -> ui64
+        %size = "arith.constant"() {"value" = 100 : index} : () -> index
+        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
+        // CHECK: %transfer_id = "func.call"(%dst_64, %src_64, %size) {"callee" = @snrt_dma_start_1d_wideptr} : (ui64, ui64, index) -> ui32
+
         %dst_32 = "arith.constant"() {"value" = 100: ui32} : () -> ui32
         %src_32 = "arith.constant"() {"value" = 0: ui32} : () -> ui32
         %size_2 = "arith.constant"() {"value" = 100: index} : () -> index
@@ -19,6 +25,8 @@
         %repeat = "arith.constant"() {"value" = 1: index} : () -> index
         %src_stride = "arith.constant"() {"value" = 1: index} : () -> index
         %dst_stride = "arith.constant"() {"value" = 1: index} : () -> index
+        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
+        // CHECK: %transfer_id_3 = "func.call"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) {"callee" = @snrt_dma_start_2d_wideptr} : (ui64, ui64, index, index, index, index) -> ui32
         %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
         // CHECK: %transfer_id_4 = "func.call"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) {"callee" = @snrt_dma_start_2d} : (ui32, ui32, index, index, index, index) -> ui32
 
@@ -27,6 +35,8 @@
     // CHECK: func.func private @snrt_cluster_num() -> i32
     // CHECK: func.func private @snrt_cluster_hw_barrier() -> ()
     // CHECK: func.func private @snrt_dma_wait_all() -> ()
+    // CHECK: func.func private @snrt_dma_start_1d_wideptr(ui64, ui64, index) -> ui32
     // CHECK: func.func private @snrt_dma_start_1d(ui32, ui32, index) -> ui32
+    // CHECK: func.func private @snrt_dma_start_2d_wideptr(ui64, ui64, index, index, index, index) -> ui32
     // CHECK: func.func private @snrt_dma_start_2d(ui32, ui32, index, index, index, index) -> ui32
 }) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/lower_snrt_to_func.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/lower_snrt_to_func.mlir
@@ -2,7 +2,7 @@
 "builtin.module"() ({
     "func.func"() ({
         // Runtime Info Getters
-        %cluster_num = "snrt.cluster_num"() : () -> ui32
+        %cluster_num = "snrt.cluster_num"() : () -> i32
         // CHECK: %cluster_num = "func.call"() {"callee" = @snrt_cluster_num} : () -> i32
 
         // Barriers
@@ -12,32 +12,31 @@
         "snrt.dma_wait_all"() : () -> ()
         // CHECK: "func.call"() {"callee" = @snrt_dma_wait_all} : () -> ()
 
-        %dst_64 = "arith.constant"() {"value" = 100 : ui64} : () -> ui64
-        %src_64 = "arith.constant"() {"value" = 0 : ui64} : () -> ui64
+        %dst_64 = "arith.constant"() {"value" = 100 : i64} : () -> i64
+        %src_64 = "arith.constant"() {"value" = 0 : i64} : () -> i64
         %size = "arith.constant"() {"value" = 100 : index} : () -> index
-        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
-        // CHECK: %transfer_id = "func.call"(%dst_64, %src_64, %size) {"callee" = @snrt_dma_start_1d_wideptr} : (ui64, ui64, index) -> ui32
+        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, index) -> i32
+        // CHECK: %transfer_id = "func.call"(%dst_64, %src_64, %size) {"callee" = @snrt_dma_start_1d_wideptr} : (i64, i64, index) -> i32
 
-        %dst_32 = "arith.constant"() {"value" = 100: ui32} : () -> ui32
-        %src_32 = "arith.constant"() {"value" = 0: ui32} : () -> ui32
+        %dst_32 = "arith.constant"() {"value" = 100: i32} : () -> i32
+        %src_32 = "arith.constant"() {"value" = 0: i32} : () -> i32
         %size_2 = "arith.constant"() {"value" = 100: index} : () -> index
-        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
-        // CHECK: %transfer_id_2 = "func.call"(%dst_32, %src_32, %size_2) {"callee" = @snrt_dma_start_1d} : (ui32, ui32, index) -> ui32
+        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (i32, i32, index) -> i32
+        // CHECK: %transfer_id_2 = "func.call"(%dst_32, %src_32, %size_2) {"callee" = @snrt_dma_start_1d} : (i32, i32, index) -> i32
         %repeat = "arith.constant"() {"value" = 1: index} : () -> index
         %src_stride = "arith.constant"() {"value" = 1: index} : () -> index
         %dst_stride = "arith.constant"() {"value" = 1: index} : () -> index
-        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
-        // CHECK: %transfer_id_3 = "func.call"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) {"callee" = @snrt_dma_start_2d_wideptr} : (ui64, ui64, index, index, index, index) -> ui32
-        %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
-        // CHECK: %transfer_id_4 = "func.call"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) {"callee" = @snrt_dma_start_2d} : (ui32, ui32, index, index, index, index) -> ui32
-
-
+        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) : (i64, i64, index, index, index, index) -> i32
+        // CHECK: %transfer_id_3 = "func.call"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) {"callee" = @snrt_dma_start_2d_wideptr} : (i64, i64, index, index, index, index) -> i32
+        %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, index, index, index, index) -> i32
+        // CHECK: %transfer_id_4 = "func.call"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) {"callee" = @snrt_dma_start_2d} : (i32, i32, index, index, index, index) -> i32
+        "func.return"() : () -> ()
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
     // CHECK: func.func private @snrt_cluster_num() -> i32
     // CHECK: func.func private @snrt_cluster_hw_barrier() -> ()
     // CHECK: func.func private @snrt_dma_wait_all() -> ()
-    // CHECK: func.func private @snrt_dma_start_1d_wideptr(ui64, ui64, index) -> ui32
-    // CHECK: func.func private @snrt_dma_start_1d(ui32, ui32, index) -> ui32
-    // CHECK: func.func private @snrt_dma_start_2d_wideptr(ui64, ui64, index, index, index, index) -> ui32
-    // CHECK: func.func private @snrt_dma_start_2d(ui32, ui32, index, index, index, index) -> ui32
+    // CHECK: func.func private @snrt_dma_start_1d_wideptr(i64, i64, index) -> i32
+    // CHECK: func.func private @snrt_dma_start_1d(i32, i32, index) -> i32
+    // CHECK: func.func private @snrt_dma_start_2d_wideptr(i64, i64, index, index, index, index) -> i32
+    // CHECK: func.func private @snrt_dma_start_2d(i32, i32, index, index, index, index) -> i32
 }) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -1,34 +1,35 @@
 // RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
 "builtin.module"() ({
-    // Barriers
-    "snrt.cluster_hw_barrier"() : () -> ()
-    // CHECK: "snrt.cluster_hw_barrier"() : () -> ()
+    "func.func"() ({
+        // Barriers
+        "snrt.cluster_hw_barrier"() : () -> ()
+        // CHECK: "snrt.cluster_hw_barrier"() : () -> ()
 
-    // Runtime Info Getters
-    %cluster_num = "snrt.cluster_num"() : () -> ui32
-    // CHECK: %{{.*}} = "snrt.cluster_num"() : () -> ui32
+        // Runtime Info Getters
+        %cluster_num = "snrt.cluster_num"() : () -> ui32
+        // CHECK: %{{.*}} = "snrt.cluster_num"() : () -> ui32
 
-    // DMA Operations
-    %dst_64 = "arith.constant"() {"value" = 100 : ui64} : () -> ui64
-    %src_64 = "arith.constant"() {"value" = 0 : ui64} : () -> ui64
-    %size = "arith.constant"() {"value" = 100 : index} : () -> index
-    %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
-    // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
-    %dst_32 = "arith.constant"() {"value" = 100: ui32} : () -> ui32
-    %src_32 = "arith.constant"() {"value" = 0: ui32} : () -> ui32
-    %size_2 = "arith.constant"() {"value" = 100: index} : () -> index
-    %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
-    // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
-    "snrt.dma_wait"(%transfer_id) : (ui32) -> ()
-    // CHECK: "snrt.dma_wait"(%transfer_id) : (ui32) -> ()
-    %repeat = "arith.constant"() {"value" = 1: index} : () -> index
-    %src_stride = "arith.constant"() {"value" = 1: index} : () -> index
-    %dst_stride = "arith.constant"() {"value" = 1: index} : () -> index
-    %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
-    // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
-    %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
-    // CHECK: transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
-    "snrt.dma_wait_all"() : () -> ()
-    // CHECK: "snrt.dma_wait_all"() : () -> ()
-
+        // DMA Operations
+        %dst_64 = "arith.constant"() {"value" = 100 : ui64} : () -> ui64
+        %src_64 = "arith.constant"() {"value" = 0 : ui64} : () -> ui64
+        %size = "arith.constant"() {"value" = 100 : index} : () -> index
+        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
+        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
+        %dst_32 = "arith.constant"() {"value" = 100: ui32} : () -> ui32
+        %src_32 = "arith.constant"() {"value" = 0: ui32} : () -> ui32
+        %size_2 = "arith.constant"() {"value" = 100: index} : () -> index
+        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
+        // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
+        "snrt.dma_wait"(%transfer_id) : (ui32) -> ()
+        // CHECK: "snrt.dma_wait"(%transfer_id) : (ui32) -> ()
+        %repeat = "arith.constant"() {"value" = 1: index} : () -> index
+        %src_stride = "arith.constant"() {"value" = 1: index} : () -> index
+        %dst_stride = "arith.constant"() {"value" = 1: index} : () -> index
+        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
+        // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
+        %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
+        // CHECK: transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
+        "snrt.dma_wait_all"() : () -> ()
+        // CHECK: "snrt.dma_wait_all"() : () -> ()
+    }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -6,30 +6,31 @@
         // CHECK: "snrt.cluster_hw_barrier"() : () -> ()
 
         // Runtime Info Getters
-        %cluster_num = "snrt.cluster_num"() : () -> ui32
-        // CHECK: %{{.*}} = "snrt.cluster_num"() : () -> ui32
+        %cluster_num = "snrt.cluster_num"() : () -> i32
+        // CHECK: %{{.*}} = "snrt.cluster_num"() : () -> i32
 
         // DMA Operations
-        %dst_64 = "arith.constant"() {"value" = 100 : ui64} : () -> ui64
-        %src_64 = "arith.constant"() {"value" = 0 : ui64} : () -> ui64
+        %dst_64 = "arith.constant"() {"value" = 100 : i64} : () -> i64
+        %src_64 = "arith.constant"() {"value" = 0 : i64} : () -> i64
         %size = "arith.constant"() {"value" = 100 : index} : () -> index
-        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
-        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (ui64, ui64, index) -> ui32
-        %dst_32 = "arith.constant"() {"value" = 100: ui32} : () -> ui32
-        %src_32 = "arith.constant"() {"value" = 0: ui32} : () -> ui32
+        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, index) -> i32
+        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, index) -> i32
+        %dst_32 = "arith.constant"() {"value" = 100: i32} : () -> i32
+        %src_32 = "arith.constant"() {"value" = 0: i32} : () -> i32
         %size_2 = "arith.constant"() {"value" = 100: index} : () -> index
-        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
-        // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (ui32, ui32, index) -> ui32
-        "snrt.dma_wait"(%transfer_id) : (ui32) -> ()
-        // CHECK: "snrt.dma_wait"(%transfer_id) : (ui32) -> ()
+        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (i32, i32, index) -> i32
+        // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (i32, i32, index) -> i32
+        "snrt.dma_wait"(%transfer_id) : (i32) -> ()
+        // CHECK: "snrt.dma_wait"(%transfer_id) : (i32) -> ()
         %repeat = "arith.constant"() {"value" = 1: index} : () -> index
         %src_stride = "arith.constant"() {"value" = 1: index} : () -> index
         %dst_stride = "arith.constant"() {"value" = 1: index} : () -> index
-        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
-        // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (ui64, ui64, index, index, index, index) -> ui32
-        %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
-        // CHECK: transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (ui32, ui32, index, index, index, index) -> ui32
+        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (i64, i64, index, index, index, index) -> i32
+        // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (i64, i64, index, index, index, index) -> i32
+        %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, index, index, index, index) -> i32
+        // CHECK: transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, index, index, index, index) -> i32
         "snrt.dma_wait_all"() : () -> ()
         // CHECK: "snrt.dma_wait_all"() : () -> ()
+        "func.return"() : () -> ()
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -75,7 +75,7 @@ class ClusterHwBarrierOp(SnitchRuntimeBarrier):
 _T = TypeVar("_T", bound=Attribute)
 
 
-class DmaStart1DBaseOp(SnitchRuntimeBaseOp, Generic[_T]):
+class DmaStart1DBaseOp(SnitchRuntimeBaseOp, Generic[_T], ABC):
     """
     Initiate an asynchronous 1D DMA transfer
     """
@@ -95,7 +95,7 @@ class DmaStart1DBaseOp(SnitchRuntimeBaseOp, Generic[_T]):
         super().__init__(operands=[dst, src, size], result_types=[tx_id])
 
 
-class DmaStart2DBaseOp(SnitchRuntimeBaseOp, Generic[_T]):
+class DmaStart2DBaseOp(SnitchRuntimeBaseOp, Generic[_T], ABC):
     """
     Generic base class for starting asynchronous 2D DMA transfers
     """
@@ -124,14 +124,8 @@ class DmaStart2DBaseOp(SnitchRuntimeBaseOp, Generic[_T]):
         )
 
 
-Dma1DWideptrOp = DmaStart1DBaseOp[Annotated[Attribute, u64]]
-Dma1DOp = DmaStart1DBaseOp[Annotated[Attribute, u32]]
-Dma2DWideptrOp = DmaStart2DBaseOp[Annotated[Attribute, u64]]
-Dma2DOp = DmaStart2DBaseOp[Annotated[Attribute, u32]]
-
-
 @irdl_op_definition
-class DmaStart1DOp(Dma1DOp):
+class DmaStart1DOp(DmaStart1DBaseOp[Annotated[Attribute, u32]]):
     """
     Initiate an asynchronous 1D DMA transfer with 32-bits pointers
     """
@@ -140,7 +134,7 @@ class DmaStart1DOp(Dma1DOp):
 
 
 @irdl_op_definition
-class DmaStart1DWideptrOp(Dma1DWideptrOp):
+class DmaStart1DWideptrOp(DmaStart1DBaseOp[Annotated[Attribute, u64]]):
     """
     Initiate an asynchronous 1D DMA transfer with 64-bits wide pointers
     """
@@ -149,7 +143,7 @@ class DmaStart1DWideptrOp(Dma1DWideptrOp):
 
 
 @irdl_op_definition
-class DmaStart2DOp(Dma2DOp):
+class DmaStart2DOp(DmaStart2DBaseOp[Annotated[Attribute, u32]]):
     """
     Initiate an asynchronous 2D DMA transfer with 32-bits pointers
     """
@@ -158,7 +152,7 @@ class DmaStart2DOp(Dma2DOp):
 
 
 @irdl_op_definition
-class DmaStart2DWideptrOp(Dma2DWideptrOp):
+class DmaStart2DWideptrOp(DmaStart2DBaseOp[Annotated[Attribute, u64]]):
     """
     Initiate an asynchronous 2D DMA transfer with 64-bits wide pointers
     """

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -71,8 +71,8 @@ class DmaStart1DWideptrOp(SnitchRuntimeBaseOp):
     """
 
     name = "snrt.dma_start_1d_wideptr"
-    src: Annotated[Operand, u64]
     dst: Annotated[Operand, u64]
+    src: Annotated[Operand, u64]
     size: Annotated[Operand, IndexType]
     transfer_id: Annotated[OpResult, tx_id]
 
@@ -82,7 +82,7 @@ class DmaStart1DWideptrOp(SnitchRuntimeBaseOp):
         dst: Operation | SSAValue,
         size: Operation | SSAValue,
     ):
-        super().__init__(operands=[src, dst, size], result_types=[tx_id])
+        super().__init__(operands=[dst, src, size], result_types=[tx_id])
 
 
 @irdl_op_definition

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -180,17 +180,11 @@ class DmaWaitOp(SnitchRuntimeBaseOp):
 
 
 @irdl_op_definition
-class DmaWaitAllOp(SnitchRuntimeBaseOp):
+class DmaWaitAllOp(SnitchRuntimeBarrier):
     """
     Block until all operations on the DMA cease
     """
-
     name = "snrt.dma_wait_all"
-
-    def __init__(
-        self,
-    ):
-        super().__init__(operands=[], result_types=[])
 
 
 SnitchRuntime = Dialect(

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -9,12 +9,10 @@ from xdsl.irdl import (
     Attribute,
 )
 from xdsl.ir import OpResult, Dialect
-from xdsl.dialects.builtin import IntegerType, Signedness, IndexType
+from xdsl.dialects.builtin import i32, i64, IndexType
 from typing import Annotated, Generic, TypeVar
 
-u32 = IntegerType(data=32, signedness=Signedness.UNSIGNED)
-u64 = IntegerType(data=64, signedness=Signedness.UNSIGNED)
-tx_id = u32
+tx_id = i32
 
 
 class SnitchRuntimeBaseOp(IRDLOperation, ABC):
@@ -35,12 +33,12 @@ class SnitchRuntimeGetInfo(SnitchRuntimeBaseOp, ABC):
     A base class for snitch runtime functions that get a certain value at runtime
     """
 
-    result: Annotated[OpResult, u32]
+    result: Annotated[OpResult, i32]
 
     def __init__(
         self,
     ):
-        super().__init__(operands=[], result_types=[u32])
+        super().__init__(operands=[], result_types=[i32])
 
 
 class SnitchRuntimeBarrier(SnitchRuntimeBaseOp, ABC):
@@ -125,7 +123,7 @@ class DmaStart2DBaseOp(SnitchRuntimeBaseOp, Generic[_T], ABC):
 
 
 @irdl_op_definition
-class DmaStart1DOp(DmaStart1DBaseOp[Annotated[Attribute, u32]]):
+class DmaStart1DOp(DmaStart1DBaseOp[Annotated[Attribute, i32]]):
     """
     Initiate an asynchronous 1D DMA transfer with 32-bits pointers
     """
@@ -134,7 +132,7 @@ class DmaStart1DOp(DmaStart1DBaseOp[Annotated[Attribute, u32]]):
 
 
 @irdl_op_definition
-class DmaStart1DWideptrOp(DmaStart1DBaseOp[Annotated[Attribute, u64]]):
+class DmaStart1DWideptrOp(DmaStart1DBaseOp[Annotated[Attribute, i64]]):
     """
     Initiate an asynchronous 1D DMA transfer with 64-bits wide pointers
     """
@@ -143,7 +141,7 @@ class DmaStart1DWideptrOp(DmaStart1DBaseOp[Annotated[Attribute, u64]]):
 
 
 @irdl_op_definition
-class DmaStart2DOp(DmaStart2DBaseOp[Annotated[Attribute, u32]]):
+class DmaStart2DOp(DmaStart2DBaseOp[Annotated[Attribute, i32]]):
     """
     Initiate an asynchronous 2D DMA transfer with 32-bits pointers
     """
@@ -152,7 +150,7 @@ class DmaStart2DOp(DmaStart2DBaseOp[Annotated[Attribute, u32]]):
 
 
 @irdl_op_definition
-class DmaStart2DWideptrOp(DmaStart2DBaseOp[Annotated[Attribute, u64]]):
+class DmaStart2DWideptrOp(DmaStart2DBaseOp[Annotated[Attribute, i64]]):
     """
     Initiate an asynchronous 2D DMA transfer with 64-bits wide pointers
     """

--- a/xdsl/transforms/lower_snitch_runtime.py
+++ b/xdsl/transforms/lower_snitch_runtime.py
@@ -1,0 +1,63 @@
+from abc import ABC
+from xdsl.ir import Operation, SSAValue, MLContext, Attribute
+from xdsl.dialects.builtin import i32, ModuleOp
+from xdsl.dialects import snitch_runtime, func
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+    PatternRewriteWalker,
+    GreedyRewritePatternApplier,
+)
+
+
+class LowerClusterNumOp(RewritePattern, ABC):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: snitch_runtime.ClusterNumOp, rewriter: PatternRewriter, /
+    ):
+        rewriter.replace_matched_op(*self.lower(op))
+
+    def lower(
+        self, op: snitch_runtime.ClusterNumOp
+    ) -> tuple[Operation, list[SSAValue]]:
+        return func.Call.get("snrt_cluster_num", [], [i32]), [op.result]
+
+
+class AddExternalFuncs(RewritePattern, ABC):
+    """
+    Looks for snrt ops and adds an external func call to it for LLVM to link in
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, module: ModuleOp, rewriter: PatternRewriter, /):
+        funcs_to_emit: dict[str, tuple[list[Attribute], list[Attribute]]] = dict()
+        for op in module.walk():
+            if not isinstance(op, func.Call):
+                continue
+            if "snrt" not in op.callee.string_value():
+                continue
+            funcs_to_emit[op.callee.string_value()] = (
+                [arg.typ for arg in op.arguments],
+                [res.typ for res in op.results],
+            )
+
+        for name, types in funcs_to_emit.items():
+            arg, res = types
+            rewriter.insert_op_at_end(
+                func.FuncOp.external(name, arg, res), module.body.block
+            )
+
+
+class LowerSnitchRuntimePass(ModulePass):
+    name = "lower-snrt-to-func"
+
+    # lower to func.call
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        walker1 = PatternRewriteWalker(
+            GreedyRewritePatternApplier([LowerClusterNumOp()]), apply_recursively=True
+        )
+        walker2 = PatternRewriteWalker(AddExternalFuncs())
+        walker1.rewrite_module(op)
+        walker2.rewrite_module(op)

--- a/xdsl/transforms/lower_snitch_runtime.py
+++ b/xdsl/transforms/lower_snitch_runtime.py
@@ -58,17 +58,18 @@ class LowerBarrierOpToFunc(RewritePattern, ABC):
 class LowerDma1DOpToFunc(RewritePattern, ABC):
     """
     Rewrite pattern that matches on DmaStart1DOp instances and lowers to external
-    function calls
+    function calls.
+    Works on both DmaStart1DOp and DmaStart1DWideptrOp.
     """
 
     @op_type_rewrite_pattern
     def match_and_rewrite(
-        self, op: snitch_runtime.DmaStart1DOp, rewriter: PatternRewriter, /
+        self, op: snitch_runtime.DmaStart1DOp | snitch_runtime.DmaStart1DWideptrOp, rewriter: PatternRewriter, /
     ):
         rewriter.replace_matched_op(*self.lower(op))
 
     def lower(
-        self, op: snitch_runtime.DmaStart1DOp
+        self, op: snitch_runtime.DmaStart1DOp | snitch_runtime.DmaStart1DWideptrOp
     ) -> tuple[Operation, list[SSAValue]]:
         # Get all function inputs types
         return func.Call.get(
@@ -84,12 +85,12 @@ class LowerDma2DOpToFunc(RewritePattern, ABC):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(
-        self, op: snitch_runtime.DmaStart2DOp, rewriter: PatternRewriter, /
+        self, op: snitch_runtime.DmaStart2DOp | snitch_runtime.DmaStart2DWideptrOp, rewriter: PatternRewriter, /
     ):
         rewriter.replace_matched_op(*self.lower(op))
 
     def lower(
-        self, op: snitch_runtime.DmaStart2DOp
+        self, op: snitch_runtime.DmaStart2DOp | snitch_runtime.DmaStart2DWideptrOp
     ) -> tuple[Operation, list[SSAValue]]:
         # Get all function inputs types
         return func.Call.get(

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -40,6 +40,7 @@ from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
 from xdsl.transforms.lower_riscv_func import LowerRISCVFunc
 from xdsl.transforms.lower_mpi import LowerMPIPass
 from xdsl.transforms.lower_snitch import LowerSnitchPass
+from xdsl.transforms.lower_snitch_runtime import LowerSnitchRuntimePass
 from xdsl.transforms.experimental.ConvertStencilToLLMLIR import (
     ConvertStencilToLLMLIRPass,
 )
@@ -286,6 +287,7 @@ class xDSLOptMain:
         self.register_pass(DesymrefyPass)
         self.register_pass(DeadCodeElimination)
         self.register_pass(LowerSnitchPass)
+        self.register_pass(LowerSnitchRuntimePass)
         self.register_pass(RISCVRegisterAllocation)
         self.register_pass(LowerRISCVFunc)
         self.register_pass(LowerHaloToMPI)


### PR DESCRIPTION
This pull request does two things:
* it introduces a lowering pass that lowers all snrt runtime operations, to a currently present to func.func, with an accompanying external function call for use with mlir-opt and clang -x ir. (interop tests with mlir-opt and clang are not included).
* It slightly refactors snitch runtime with the recently introduced generics #979 to reduce code size (1D and 2D DMA operations now have their own base classes for both regular and `wideptr` variants).
