### PR TITLE
dialects: Implement stencil.BufferOp

### DIFF
--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -1,0 +1,45 @@
+// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+
+builtin.module {
+  func.func @copy_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
+    %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
+    %outt = "stencil.apply"(%int) ({
+    ^0(%intb : !stencil.temp<[-1,68]xf64>):
+      %v = "stencil.access"(%intb) {"offset" = #stencil.index<-1>} : (!stencil.temp<[-1,68]xf64>) -> f64
+      "stencil.return"(%v) : (f64) -> ()
+    }) : (!stencil.temp<[-1,68]xf64>) -> !stencil.temp<[0,68]xf64>
+    %outt_buffered = "stencil.buffer"(%outt) : (!stencil.temp<[0,68]xf64>) -> !stencil.temp<[0,68]xf64>
+    "stencil.store"(%outt, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<[0,68]xf64>, !stencil.field<[0,1024]xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK: A stencil.buffer's operand temp should only be buffered. You can use stencil.buffer's output instead!
+
+// -----
+
+builtin.module {
+  func.func @copy_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
+    %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
+    %outt = "stencil.apply"(%int) ({
+    ^0(%intb : !stencil.temp<[-1,68]xf64>):
+      %v = "stencil.access"(%intb) {"offset" = #stencil.index<-1>} : (!stencil.temp<[-1,68]xf64>) -> f64
+      "stencil.return"(%v) : (f64) -> ()
+    }) : (!stencil.temp<[-1,68]xf64>) -> !stencil.temp<[0,68]xf64>
+    %outt_buffered = "stencil.buffer"(%outt) : (!stencil.temp<[0,68]xf64>) -> !stencil.temp<?xf64>
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK: Expected operand and result type to be equal, got (!stencil.temp<[0,68]xf64>) -> !stencil.temp<?xf64>
+
+// -----
+
+builtin.module {
+  func.func @copy_1d(%temp : !stencil.temp<[0,68]xf64>) {
+    %outt_buffered = "stencil.buffer"(%temp) : (!stencil.temp<[0,68]xf64>) -> !stencil.temp<[0,68]xf64>
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK: Expected stencil.buffer to buffer a stencil.apply's output, got Block(_args=(<BlockArgument[!stencil.temp<[0,68]xf64>] index: 0, uses: 1>,), num_ops=2)

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -129,3 +129,45 @@ builtin.module {
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+// -----
+
+builtin.module {
+  func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
+    %4 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+    %5 = "stencil.apply"(%4) ({
+    ^0(%6 : !stencil.temp<?xf64>):
+      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
+      "stencil.return"(%11) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+
+    %15 = "stencil.buffer"(%5) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+
+    %12 = "stencil.apply"(%15) ({
+    ^0(%13 : !stencil.temp<?xf64>):
+      %14 = "stencil.access"(%13) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
+      "stencil.return"(%14) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+    "stencil.store"(%12, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
+// CHECK-NEXT:     %2 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     %3 = "stencil.apply"(%2) ({
+// CHECK-NEXT:     ^0(%4 : !stencil.temp<?xf64>):
+// CHECK-NEXT:       %5 = "stencil.access"(%4) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
+// CHECK-NEXT:       "stencil.return"(%5) : (f64) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     %6 = "stencil.buffer"(%3) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     %7 = "stencil.apply"(%6) ({
+// CHECK-NEXT:     ^1(%8 : !stencil.temp<?xf64>):
+// CHECK-NEXT:       %9 = "stencil.access"(%8) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
+// CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -397,5 +397,51 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
 // CHECK-NEXT:    "func.return"() : () -> ()
 // CHECK-NEXT:  }
 
+  func.func @stencil_two_stores(%59 : !stencil.field<[-4,68]xf64>, %60 : !stencil.field<[-4,68]xf64>, %61 : !stencil.field<[-4,68]xf64>) {
+    %62 = "stencil.load"(%59) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[0,64]xf64>
+    %63 = "stencil.apply"(%62) ({
+    ^10(%64 : !stencil.temp<[0,64]xf64>):
+      %65 = "stencil.access"(%64) {"offset" = #stencil.index<-1>} : (!stencil.temp<[0,64]xf64>) -> f64
+      "stencil.return"(%65) : (f64) -> ()
+    }) : (!stencil.temp<[0,64]xf64>) -> !stencil.temp<[1,65]xf64>
+    "stencil.store"(%63, %61) {"lb" = #stencil.index<1>, "ub" = #stencil.index<65>} : (!stencil.temp<[1,65]xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    %66 = "stencil.apply"(%63) ({
+    ^11(%67 : !stencil.temp<[1,65]xf64>):
+      %68 = "stencil.access"(%67) {"offset" = #stencil.index<1>} : (!stencil.temp<[1,65]xf64>) -> f64
+      "stencil.return"(%68) : (f64) -> ()
+    }) : (!stencil.temp<[1,65]xf64>) -> !stencil.temp<[0,64]xf64>
+    "stencil.store"(%66, %60) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+
+//CHECK:      func.func @stencil_two_stores(%152 : memref<72xf64>, %153 : memref<72xf64>, %154 : memref<72xf64>) {
+//CHECK-NEXT:   %155 = "memref.subview"(%153) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+//CHECK-NEXT:   %156 = "memref.subview"(%154) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+//CHECK-NEXT:   %157 = "memref.subview"(%152) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+//CHECK-NEXT:   %158 = "arith.constant"() {"value" = 1 : index} : () -> index
+//CHECK-NEXT:   %159 = "arith.constant"() {"value" = 1 : index} : () -> index
+//CHECK-NEXT:   %160 = "arith.constant"() {"value" = 65 : index} : () -> index
+//CHECK-NEXT:   "scf.parallel"(%158, %160, %159) ({
+//CHECK-NEXT:   ^18(%161 : index):
+//CHECK-NEXT:     %162 = "arith.constant"() {"value" = -1 : index} : () -> index
+//CHECK-NEXT:     %163 = arith.addi %161, %162 : index
+//CHECK-NEXT:     %164 = "memref.load"(%157, %163) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
+//CHECK-NEXT:     "memref.store"(%164, %156, %161) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
+//CHECK-NEXT:     "scf.yield"() : () -> ()
+//CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+//CHECK-NEXT:   %165 = "arith.constant"() {"value" = 0 : index} : () -> index
+//CHECK-NEXT:   %166 = "arith.constant"() {"value" = 1 : index} : () -> index
+//CHECK-NEXT:   %167 = "arith.constant"() {"value" = 64 : index} : () -> index
+//CHECK-NEXT:   "scf.parallel"(%165, %167, %166) ({
+//CHECK-NEXT:   ^19(%168 : index):
+//CHECK-NEXT:     %169 = "arith.constant"() {"value" = 1 : index} : () -> index
+//CHECK-NEXT:     %170 = arith.addi %168, %169 : index
+//CHECK-NEXT:     %171 = "memref.load"(%156, %170) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
+//CHECK-NEXT:     "memref.store"(%171, %155, %168) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
+//CHECK-NEXT:     "scf.yield"() : () -> ()
+//CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+//CHECK-NEXT:   "func.return"() : () -> ()
+//CHECK-NEXT: }
+
 }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -144,3 +144,45 @@ builtin.module {
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+// -----
+
+builtin.module {
+  func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
+    %4 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+    %5 = "stencil.apply"(%4) ({
+    ^0(%6 : !stencil.temp<?xf64>):
+      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
+      "stencil.return"(%11) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+
+    %15 = "stencil.buffer"(%5) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+
+    %12 = "stencil.apply"(%15) ({
+    ^0(%13 : !stencil.temp<?xf64>):
+      %14 = "stencil.access"(%13) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
+      "stencil.return"(%14) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+    "stencil.store"(%12, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
+// CHECK-NEXT:     %2 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[0,64]xf64>
+// CHECK-NEXT:     %3 = "stencil.apply"(%2) ({
+// CHECK-NEXT:     ^0(%4 : !stencil.temp<[0,64]xf64>):
+// CHECK-NEXT:       %5 = "stencil.access"(%4) {"offset" = #stencil.index<0>} : (!stencil.temp<[0,64]xf64>) -> f64
+// CHECK-NEXT:       "stencil.return"(%5) : (f64) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<[0,64]xf64>) -> !stencil.temp<[0,64]xf64>
+// CHECK-NEXT:     %6 = "stencil.buffer"(%3) : (!stencil.temp<[0,64]xf64>) -> !stencil.temp<[0,64]xf64>
+// CHECK-NEXT:     %7 = "stencil.apply"(%6) ({
+// CHECK-NEXT:     ^1(%8 : !stencil.temp<[0,64]xf64>):
+// CHECK-NEXT:       %9 = "stencil.access"(%8) {"offset" = #stencil.index<0>} : (!stencil.temp<[0,64]xf64>) -> f64
+// CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
+// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -495,6 +495,23 @@ class BufferOp(IRDLOperation):
     temp: Annotated[Operand, TempType]
     res: Annotated[OpResult, TempType]
 
+    def verify_(self) -> None:
+        if self.temp.typ != self.res.typ:
+            raise VerifyException(
+                f"Expected operand and result type to be equal, got ({self.temp.typ}) "
+                f"-> {self.res.typ}"
+            )
+        if not isinstance(self.temp.owner, ApplyOp):
+            raise VerifyException(
+                f"Expected stencil.buffer to buffer a stencil.apply's output, got "
+                f"{self.temp.owner}"
+            )
+        if any(not isinstance(use.operation, BufferOp) for use in self.temp.uses):
+            raise VerifyException(
+                f"A stencil.buffer's operand temp should only be buffered. You can use "
+                f"stencil.buffer's output instead!"
+            )
+
 
 @irdl_op_definition
 class StoreOp(IRDLOperation):

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -464,6 +464,7 @@ def return_target_analysis(module: builtin.ModuleOp):
                 field = None
             elif isinstance(store[0], StoreOp):
                 field = store[0].field
+            # then it's a BufferOp
             else:
                 field = store[0].temp
 

--- a/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
+++ b/xdsl/transforms/experimental/ConvertStencilToLLMLIR.py
@@ -21,6 +21,7 @@ from xdsl.dialects.stencil import CastOp
 from xdsl.dialects.stencil import (
     AccessOp,
     ApplyOp,
+    BufferOp,
     FieldType,
     LoadOp,
     ReturnOp,
@@ -88,6 +89,17 @@ def collectBlockArguments(number: int, block: Block):
         block = parent
 
     return args
+
+
+def update_return_target(
+    return_targets: dict[ReturnOp, list[SSAValue | None]],
+    old_target: SSAValue,
+    new_target: SSAValue,
+):
+    for targets in return_targets.values():
+        for i, target in enumerate(targets):
+            if target == old_target:
+                targets[i] = new_target
 
 
 @dataclass
@@ -200,7 +212,10 @@ def prepare_apply_body(op: ApplyOp, rewriter: PatternRewriter):
     return rewriter.move_region_contents_to_new_regions(op.region)
 
 
+@dataclass
 class ApplyOpToParallel(RewritePattern):
+    return_targets: dict[ReturnOp, list[SSAValue | None]]
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
         res_typ = op.res[0].typ
@@ -246,9 +261,60 @@ class ApplyOpToParallel(RewritePattern):
             body=current_region,
         )
 
+        # Handle returnd values
+        new_results: list[SSAValue] = []
+        for result in op.res:
+            assert isa(
+                result.typ, TempType[Attribute]
+            ), f"Expected return value to be a !{TempType.name}"
+            assert isinstance(
+                result.typ.bounds, StencilBoundsAttr
+            ), f"Expected output to be sized before lowering. {result.typ}"
+            shape = result.typ.get_shape()
+            element_type = result.typ.element_type
+
+            # If it is buffered, allocate the buffer
+            if any(isinstance(use.operation, BufferOp) for use in result.uses):
+                alloc = memref.Alloc.get(element_type, shape=shape)
+                alloc_type = alloc.memref.typ
+                assert isa(alloc_type, MemRefType[Attribute])
+
+                offset = list(-result.typ.bounds.lb)
+
+                view = memref.Subview.from_static_parameters(
+                    alloc,
+                    alloc_type,
+                    offset,
+                    shape,
+                    [1] * result.typ.get_num_dims(),
+                )
+                rewriter.insert_op_before_matched_op((alloc, view))
+                new_results.append(view.result)
+                update_return_target(self.return_targets, result, view.result)
+            else:
+                new_results.append(result)
+
+        deallocs: list[Operation] = []
+        # Handle input buffer deallocation
+        for input in op.args:
+            # Is this input a temp buffer?
+            if isinstance(input.typ, TempType) and isinstance(input.owner, BufferOp):
+                block = op.parent_block()
+                assert block is not None
+                self_index = block.get_operation_index(op)
+                # Is it its last use?
+                if not any(
+                    use.operation.parent_block() is block
+                    and block.get_operation_index(use.operation) > self_index
+                    for use in input.uses
+                ):
+                    # Then deallocate it
+                    deallocs.append(memref.Dealloc.get(input))
+
         # Replace with the loop and necessary constants.
         rewriter.insert_op_before_matched_op([*lowerBounds, one, *upperBounds, p])
-        rewriter.erase_matched_op()
+        rewriter.insert_op_after_matched_op([*deallocs])
+        rewriter.replace_matched_op([], new_results)
 
 
 class AccessOpToMemref(RewritePattern):
@@ -343,10 +409,13 @@ class StencilStoreToSubview(RewritePattern):
 
             rewriter.erase_op(store)
 
-            for r, c in self.return_targets.items():
-                for i in range(len(c)):
-                    if c[i] == field:
-                        self.return_targets[r][i] = subview.result
+            update_return_target(self.return_targets, field, subview.result)
+
+
+class BufferOpCleanUp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: BufferOp, rewriter: PatternRewriter):
+        rewriter.replace_matched_op([], [op.temp])
 
 
 class TrivialExternalLoadOpCleanup(RewritePattern):
@@ -381,14 +450,19 @@ def return_target_analysis(module: builtin.ModuleOp):
             store = [
                 use.operation
                 for use in list(res.uses)
-                if isinstance(use.operation, StoreOp)
+                if isinstance(use.operation, StoreOp | BufferOp)
             ]
 
             if len(store) > 1:
                 warn("Each stencil result should be stored only once.")
                 continue
 
-            field = None if len(store) == 0 else store[0].field
+            elif len(store) == 0:
+                field = None
+            elif isinstance(store[0], StoreOp):
+                field = store[0].field
+            else:
+                field = store[0].temp
 
             return_targets[op].append(field)
 
@@ -409,7 +483,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
         the_one_pass = PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
-                    ApplyOpToParallel(),
+                    ApplyOpToParallel(return_targets),
                     StencilStoreToSubview(return_targets),
                     CastOpToMemref(gpu=(self.target == "gpu")),
                     LoadOpToMemref(),
@@ -429,6 +503,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
                 [
                     UpdateLoopCarriedVarTypes(),
                     StencilTypeConversionFuncOp(),
+                    BufferOpCleanUp(),
                 ]
             )
         )

--- a/xdsl/transforms/experimental/StencilShapeInference.py
+++ b/xdsl/transforms/experimental/StencilShapeInference.py
@@ -3,6 +3,7 @@ from xdsl.dialects import builtin
 from xdsl.dialects.stencil import (
     AccessOp,
     ApplyOp,
+    BufferOp,
     FieldType,
     IndexAttr,
     LoadOp,
@@ -127,9 +128,16 @@ class ApplyOpShapeInference(RewritePattern):
             op.operands[i].typ = arg.typ
 
 
+class BufferOpShapeInference(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: BufferOp, rewriter: PatternRewriter):
+        op.temp.typ = op.res.typ
+
+
 ShapeInference = GreedyRewritePatternApplier(
     [
         ApplyOpShapeInference(),
+        BufferOpShapeInference(),
         AccessOpShapeInference(),
         LoadOpShapeInference(),
         StoreOpShapeInference(),


### PR DESCRIPTION
Implement `stencil.buffer`, and the corresponding shape inference and conversion patterns.