### PR TITLE
[WIP] dialects/riscv: add linear scan register allocation strategy over basic block

### DIFF
--- a/docs/Toy/toy/tests/test_regalloc.py
+++ b/docs/Toy/toy/tests/test_regalloc.py
@@ -2,23 +2,28 @@ from io import StringIO
 from xdsl.builder import Builder
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.interpreters.riscv_emulator import RV_Debug, run_riscv
 from xdsl.ir import MLContext
 
 from xdsl.transforms.riscv_register_allocation import (
     RISCVRegisterAllocation,
+    RegisterLiveInterval,
+    RegisterSet,
 )
 
+import pytest
+from xdsl.utils.test_value import TestSSAValue
 
-def context() -> MLContext:
-    ctx = MLContext()
-    return ctx
+pytest.importorskip("riscemu", reason="riscemu is an optional dependency")
 
-
-def riscv_code(module: ModuleOp) -> str:
-    stream = StringIO()
-    riscv.print_assembly(module, stream)
-    return stream.getvalue()
-
+RESERVERD_REGISTERS = set(["zero", "sp", "gp", "tp", "fp", "s0"])
+AVAILABLE_REGISTERS = RegisterSet(
+    [
+        reg
+        for reg in list(riscv.Register.ABI_INDEX_BY_NAME.keys())
+        if reg not in RESERVERD_REGISTERS
+    ]
+)
 
 # Handwritten riscv dialect code to test register allocation
 
@@ -67,6 +72,7 @@ def simple_linear_riscv():
             v16 = riscv.AddOp(v14, v15).rd
 
             riscv.MVOp(v16, rd=riscv.Registers.A0)
+            riscv.CustomAssemblyInstructionOp("print", [v16], [])
             riscv.AddiOp(zero, 93, rd=riscv.Registers.A7).rd
             riscv.EcallOp()
 
@@ -106,6 +112,7 @@ def simple_linear_riscv_allocated():
             v16 = riscv.AddOp(v14, v15, rd=riscv.Registers.A6).rd
 
             riscv.MVOp(v16, rd=riscv.Registers.A0)
+            riscv.CustomAssemblyInstructionOp("print", [v16], [])
             riscv.AddiOp(zero, 93, rd=riscv.Registers.A7).rd
             riscv.EcallOp()
 
@@ -114,7 +121,99 @@ def simple_linear_riscv_allocated():
     riscv.DirectiveOp(".text", None, text_region)
 
 
-def test_allocate_simple_linear():
-    RISCVRegisterAllocation("BlockNaive").apply(context(), simple_linear_riscv)
+def test_block_simple_linear():
+    linear = simple_linear_riscv.clone()
+    RISCVRegisterAllocation("BlockNaive").apply(MLContext(), linear)
+    code = riscv.riscv_code(linear)
 
-    assert riscv_code(simple_linear_riscv) == riscv_code(simple_linear_riscv_allocated)
+    # Check that the code is the same as one allocated by hand
+    assert code == riscv.riscv_code(simple_linear_riscv_allocated)
+
+    stream = StringIO()
+    RV_Debug.stream = stream
+    run_riscv(
+        code,
+        extensions=[RV_Debug],
+        unlimited_regs=False,
+        verbosity=1,
+    )
+
+    assert "12\n" == stream.getvalue()
+
+
+def test_dummy_linear_scan_allocator():
+    """
+    Check that the linear scan register allocator is able to allocate given hard-coded intervals.
+    """
+
+    def get_test_variable() -> TestSSAValue:
+        return TestSSAValue(riscv.RegisterType(riscv.Register()))
+
+    a = RegisterLiveInterval(get_test_variable(), 1, 10)
+    b = RegisterLiveInterval(get_test_variable(), 1, 4)
+    c = RegisterLiveInterval(get_test_variable(), 1, 3)
+    d = RegisterLiveInterval(get_test_variable(), 2, 8)
+    e = RegisterLiveInterval(get_test_variable(), 3, 6)
+    f = RegisterLiveInterval(get_test_variable(), 3, 10)
+    g = RegisterLiveInterval(get_test_variable(), 4, 8)
+
+    """
+        a        │     ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━●
+        b        │     ●━━━━━━━━━━━●
+        c        │     ●━━━━━━━●
+        d        │         ●━━━━━━━━━━━━━━━━━━━━━━━●
+        e        │             ●━━━━━━━━━━━●
+        f        │             ●━━━━━━━━━━━━━━━━━━━━━━━━━━━●
+        g        │                 ●━━━━━━━━━━━━━━━●
+                 ┕━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                   00  01  02  03  04  05  06  07  08  09  10  11
+    """
+
+    intervals: list[RegisterLiveInterval] = [a, b, c, d, e, f, g]
+
+    @ModuleOp
+    @Builder.implicit_region
+    def empty_module():
+        pass
+
+    # create the condition for spilling
+
+    AVAILABLE_REGISTERS.reset()
+    AVAILABLE_REGISTERS.limit_free_registers(3)
+
+    RISCVRegisterAllocation("LinearScan").apply(
+        MLContext(), empty_module, intervals, AVAILABLE_REGISTERS
+    )
+
+    assert a.get_riscv_register() == riscv.RegisterType(riscv.Register("j0"))
+    assert a.abstract_stack_location == 0
+    assert b.get_riscv_register() == riscv.RegisterType(riscv.Registers.T0)
+    assert c.get_riscv_register() == riscv.RegisterType(riscv.Registers.RA)
+    assert d.get_riscv_register() == riscv.RegisterType(riscv.Register("j1"))
+    assert d.abstract_stack_location == 1
+    assert e.get_riscv_register() == riscv.RegisterType(riscv.Registers.T1)
+    assert f.get_riscv_register() == riscv.RegisterType(riscv.Register("j2"))
+    assert f.abstract_stack_location == 2
+    assert g.get_riscv_register() == riscv.RegisterType(riscv.Registers.RA)
+
+
+def test_linear_scan_simple_linear():
+    AVAILABLE_REGISTERS.reset()
+    AVAILABLE_REGISTERS.limit_free_registers(3)
+
+    linear = simple_linear_riscv.clone()
+    RISCVRegisterAllocation("LinearScan").apply(
+        MLContext(), linear, None, AVAILABLE_REGISTERS
+    )
+
+    code = riscv.riscv_code(linear)
+    stream = StringIO()
+    RV_Debug.stream = stream
+    run_riscv(
+        code,
+        extensions=[RV_Debug],
+        unlimited_regs=True,
+        verbosity=1,
+    )
+
+    assert "12\n" == stream.getvalue()

--- a/tests/filecheck/dialects/riscv/riscv_register_allocation_linear_scan.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_register_allocation_linear_scan.mlir
@@ -1,0 +1,71 @@
+// RUN: xdsl-opt -p riscv-allocate-registers{allocation_strategy=LinearScan} %s --print-op-generic | filecheck %s
+
+"builtin.module"() ({
+  %0 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<>
+  %1 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<s0>
+  %2 = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
+  %3 = "riscv.li"() {"immediate" = 29 : i32} : () -> !riscv.reg<>
+  %4 = "riscv.li"() {"immediate" = 28 : i32} : () -> !riscv.reg<>
+  %5 = "riscv.li"() {"immediate" = 27 : i32} : () -> !riscv.reg<>
+  %6 = "riscv.li"() {"immediate" = 26 : i32} : () -> !riscv.reg<>
+  %7 = "riscv.li"() {"immediate" = 25 : i32} : () -> !riscv.reg<>
+  %8 = "riscv.li"() {"immediate" = 24 : i32} : () -> !riscv.reg<>
+  %9 = "riscv.li"() {"immediate" = 23 : i32} : () -> !riscv.reg<>
+  %10 = "riscv.li"() {"immediate" = 22 : i32} : () -> !riscv.reg<>
+  %11 = "riscv.li"() {"immediate" = 21 : i32} : () -> !riscv.reg<>
+  %12 = "riscv.li"() {"immediate" = 20 : i32} : () -> !riscv.reg<>
+  %13 = "riscv.li"() {"immediate" = 19 : i32} : () -> !riscv.reg<>
+  %14 = "riscv.li"() {"immediate" = 18 : i32} : () -> !riscv.reg<>
+  %15 = "riscv.li"() {"immediate" = 17 : i32} : () -> !riscv.reg<>
+  %16 = "riscv.li"() {"immediate" = 16 : i32} : () -> !riscv.reg<>
+  %17 = "riscv.li"() {"immediate" = 15 : i32} : () -> !riscv.reg<>
+  %18 = "riscv.li"() {"immediate" = 14 : i32} : () -> !riscv.reg<>
+  %19 = "riscv.li"() {"immediate" = 13 : i32} : () -> !riscv.reg<>
+  %20 = "riscv.li"() {"immediate" = 12 : i32} : () -> !riscv.reg<>
+  %21 = "riscv.li"() {"immediate" = 11 : i32} : () -> !riscv.reg<>
+  %22 = "riscv.li"() {"immediate" = 10 : i32} : () -> !riscv.reg<>
+  %23 = "riscv.li"() {"immediate" = 9 : i32} : () -> !riscv.reg<>
+  %24 = "riscv.li"() {"immediate" = 8 : i32} : () -> !riscv.reg<>
+  %25 = "riscv.li"() {"immediate" = 7 : i32} : () -> !riscv.reg<>
+  %26 = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<>
+  %27 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<>
+  %28 = "riscv.li"() {"immediate" = 4 : i32} : () -> !riscv.reg<>
+  %29 = "riscv.li"() {"immediate" = 3 : i32} : () -> !riscv.reg<>
+  %30 = "riscv.li"() {"immediate" = 2 : i32} : () -> !riscv.reg<>
+  %31 = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<t6>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<s0>
+// CHECK-NEXT:  %{{\d+}} = "riscv.add"(%{{\d+}}, %{{\d+}}) : (!riscv.reg<t6>, !riscv.reg<s0>) -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 29 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 28 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 27 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 26 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 25 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 24 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 23 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 22 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 21 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 20 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 19 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 18 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 17 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 16 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 15 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 14 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 13 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 12 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 11 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 10 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 9 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 8 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 7 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 6 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 4 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 3 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 2 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT:  %{{\d+}} = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<t5>
+// CHECK-NEXT: }) : () -> ()

--- a/tests/test_live_range.py
+++ b/tests/test_live_range.py
@@ -25,7 +25,7 @@ def test_live_range_single_use():
 
     block0 = Block([a, b, c, d])
     region0 = Region([block0])
-    op = TestOp.create(regions=[region0])
+    TestOp.create(regions=[region0])
 
     lr0 = LiveRange(SSAValue.get(c))
 

--- a/tests/test_live_range.py
+++ b/tests/test_live_range.py
@@ -1,0 +1,46 @@
+from xdsl.ir import Block, Region, SSAValue
+from xdsl.dialects.arith import Addi, Constant
+from xdsl.dialects.builtin import i32
+from xdsl.dialects.test import TestOp
+from xdsl.transforms.experimental.live_range import LiveRange
+
+
+def test_live_range_no_use():
+    a = Constant.from_int_and_width(1, i32)
+    b = Constant.from_int_and_width(2, i32)
+    c = Addi(a, b)
+
+    _ = Block([a, b, c])
+
+    lr0 = LiveRange(SSAValue.get(c))
+
+    assert lr0.start == 2 and lr0.end == 2
+
+
+def test_live_range_single_use():
+    a = Constant.from_int_and_width(1, i32)
+    b = Constant.from_int_and_width(2, i32)
+    c = Addi(a, b)
+    d = Addi(c, b)
+
+    block0 = Block([a, b, c, d])
+    region0 = Region([block0])
+    op = TestOp.create(regions=[region0])
+
+    lr0 = LiveRange(SSAValue.get(c))
+
+    assert lr0.start == 2 and lr0.end == 3
+
+
+def test_live_range_multiple_uses():
+    a = Constant.from_int_and_width(1, i32)
+    b = Constant.from_int_and_width(2, i32)
+    c = Addi(a, b)
+    d = Addi(c, b)
+    e = Addi(c, b)
+
+    _ = Block([a, b, c, d, e])
+
+    lr0 = LiveRange(SSAValue.get(c))
+
+    assert lr0.start == 2 and lr0.end == 4

--- a/xdsl/transforms/experimental/live_range.py
+++ b/xdsl/transforms/experimental/live_range.py
@@ -14,32 +14,39 @@ class LiveRange:
     start: int
     end: int
 
-    def __init__(self, value: SSAValue) -> None:
-        if not value.owner:
-            raise InvalidIRException(
-                "Cannot calculate live range for value not belonging to a block"
-            )
-        if isinstance(value.owner, Block):
-            raise NotImplementedError("Cannot support block arguments")
-
-        owner = value.owner
-
-        if isinstance(value, OpResult) and isinstance(owner.parent, Block):
+    def __init__(
+        self, value: SSAValue, start: int | None = None, end: int | None = None
+    ) -> None:
+        if start is not None and end is not None:
             object.__setattr__(self, "value", value)
-            object.__setattr__(
-                self, "start", owner.parent.get_operation_index(value.owner)
-            )
-
-            end = self.start
-            for use in value.uses:
-                if parent_block := use.operation.parent:
-                    end = max(
-                        end,
-                        parent_block.get_operation_index(use.operation),
-                    )
-                else:
-                    raise NotImplementedError(
-                        "Cannot calculate live range for value across blocks"
-                    )
-
+            object.__setattr__(self, "start", start)
             object.__setattr__(self, "end", end)
+        else:
+            if not value.owner:
+                raise InvalidIRException(
+                    "Cannot calculate live range for value not belonging to a block"
+                )
+            if isinstance(value.owner, Block):
+                raise NotImplementedError("Cannot support block arguments")
+
+            owner = value.owner
+
+            if isinstance(value, OpResult) and isinstance(owner.parent, Block):
+                object.__setattr__(self, "value", value)
+                object.__setattr__(
+                    self, "start", owner.parent.get_operation_index(value.owner)
+                )
+
+                end = self.start
+                for use in value.uses:
+                    if parent_block := use.operation.parent:
+                        end = max(
+                            end,
+                            parent_block.get_operation_index(use.operation),
+                        )
+                    else:
+                        raise NotImplementedError(
+                            "Cannot calculate live range for value across blocks"
+                        )
+
+                object.__setattr__(self, "end", end)

--- a/xdsl/transforms/experimental/live_range.py
+++ b/xdsl/transforms/experimental/live_range.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from xdsl.ir import Block, OpResult, SSAValue
+from xdsl.utils.exceptions import InvalidIRException
+
+
+@dataclass(init=False, frozen=True)
+class LiveRange:
+    """
+    Represents the live range of an SSA value as half-open interval using the
+    index of an Operation within its parent Block.
+    """
+
+    value: SSAValue
+    start: int
+    end: int
+
+    def __init__(self, value: SSAValue) -> None:
+        if not value.owner:
+            raise InvalidIRException(
+                "Cannot calculate live range for value not belonging to a block"
+            )
+        if isinstance(value.owner, Block):
+            raise NotImplementedError("Cannot support block arguments")
+
+        owner = value.owner
+
+        if isinstance(value, OpResult) and isinstance(owner.parent, Block):
+            object.__setattr__(self, "value", value)
+            object.__setattr__(
+                self, "start", owner.parent.get_operation_index(value.owner)
+            )
+
+            end = self.start
+            for use in value.uses:
+                if parent_block := use.operation.parent:
+                    end = max(
+                        end,
+                        parent_block.get_operation_index(use.operation),
+                    )
+                else:
+                    raise NotImplementedError(
+                        "Cannot calculate live range for value across blocks"
+                    )
+
+            object.__setattr__(self, "end", end)

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -1,9 +1,64 @@
 from abc import ABC
+from collections import OrderedDict
 from dataclasses import dataclass
+from typing import Any
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.riscv import Register, RegisterType, RISCVOp
-from xdsl.ir import MLContext
+from xdsl.ir import MLContext, SSAValue
 from xdsl.passes import ModulePass
+from xdsl.transforms.experimental.live_range import LiveRange
+
+
+class RegisterSet:
+    def __init__(self, registers: list[str]) -> None:
+        self.registers = registers
+        self.free: list[str] = list(registers)
+        self.occupied: set[str] = set()
+
+    def get_free(self) -> str | None:
+        if not self.free:
+            return None
+
+        reg = self.free.pop()
+        self.occupied.add(reg)
+        return reg
+
+    def set_free(self, reg: str) -> None:
+        self.occupied.remove(reg)
+        self.free.append(reg)
+
+    def set_occupied(self, reg: str) -> None:
+        assert self.is_free(reg)
+
+        self.free.remove(reg)
+        self.occupied.add(reg)
+
+    def is_free(self, reg: str) -> bool:
+        return reg in self.free
+
+    def reset(self) -> None:
+        self.free = list(self.registers)
+        self.occupied = set()
+
+    def num_free_registers(self) -> int:
+        return len(self.free)
+
+    def has_available_registers(self) -> bool:
+        return not self.free
+
+    def limit_free_registers(self, limit: int) -> None:
+        self.free = self.free[:limit]
+        self.occupied = set(self.registers) - set(self.free)
+
+
+_DEFAULT_RESERVED_REGISTERS = set(["zero", "sp", "gp", "tp", "fp", "s0"])
+_DEFAULT_REGISTER_SET = RegisterSet(
+    [
+        reg
+        for reg in list(Register.ABI_INDEX_BY_NAME.keys())
+        if reg not in _DEFAULT_RESERVED_REGISTERS
+    ]
+)
 
 
 class AbstractRegisterAllocator(ABC):
@@ -24,20 +79,11 @@ class AbstractRegisterAllocator(ABC):
 
 class RegisterAllocatorBlockNaive(AbstractRegisterAllocator):
     idx: int
+    register_set: RegisterSet
 
-    def __init__(self) -> None:
+    def __init__(self, register_set: RegisterSet = _DEFAULT_REGISTER_SET) -> None:
         self.idx = 0
-
-        """
-        Since we've got neither right now a handling of a consistent ABI nor of a calling convention,
-        let's just assume that we have all the registers available for our use except the one explicitly reserved by the default riscv ABI.
-        """
-
-        self.available_registers = list(Register.ABI_INDEX_BY_NAME.keys())
-        reserved_registers = set(["zero", "sp", "gp", "tp", "fp", "s0"])
-        self.available_registers = [
-            reg for reg in self.available_registers if reg not in reserved_registers
-        ]
+        self.register_set = register_set
 
     def allocate_registers(self, module: ModuleOp) -> None:
         """
@@ -47,8 +93,7 @@ class RegisterAllocatorBlockNaive(AbstractRegisterAllocator):
 
         for region in module.regions:
             for block in region.blocks:
-                block_registers = self.available_registers.copy()
-
+                self.register_set.reset()
                 for op in block.walk():
                     if not isinstance(op, RISCVOp):
                         # Don't perform register allocations on non-RISCV-ops
@@ -58,12 +103,12 @@ class RegisterAllocatorBlockNaive(AbstractRegisterAllocator):
                         assert isinstance(result.typ, RegisterType)
                         if result.typ.data.name is None:
                             # If we run out of real registers, allocate a j register
-                            if not block_registers:
+                            if self.register_set.has_available_registers():
                                 result.typ = RegisterType(Register(f"j{self.idx}"))
                                 self.idx += 1
                             else:
                                 result.typ = RegisterType(
-                                    Register(block_registers.pop())
+                                    Register(self.register_set.get_free())
                                 )
 
 
@@ -89,6 +134,136 @@ class RegisterAllocatorJRegs(AbstractRegisterAllocator):
                     self.idx += 1
 
 
+class RegisterLiveInterval(LiveRange):
+    abstract_stack_location: int | None
+
+    def __init__(
+        self,
+        value: SSAValue,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> None:
+        super().__init__(value, start, end)
+        self.abstract_stack_location = None
+
+    def spill(self, stack_location: int) -> None:
+        self.abstract_stack_location = stack_location
+        self.value.typ = RegisterType(Register(f"j{stack_location}"))
+
+    def set_riscv_register(self, register: Register) -> None:
+        self.abstract_stack_location = None
+        self.value.typ = RegisterType(register)
+
+    def get_riscv_register(self) -> RegisterType:
+        assert isinstance(self.value.typ, RegisterType)
+        return self.value.typ
+
+
+class RegisterAllocatorLinearScan(AbstractRegisterAllocator):
+    """
+    Linear scan register allocation strategy.
+
+    Basic form of the algorithm based on the paper "Linear Scan Register Allocation"
+    by Massimiliano Poletto and Vivek Sarkar.
+    """
+
+    idx_abstract_stack_location: int
+    intervals: list[RegisterLiveInterval]
+    active: OrderedDict[RegisterLiveInterval, None]
+    register_set: RegisterSet
+
+    def __init__(
+        self,
+        intervals: list[RegisterLiveInterval] | None = None,
+        register_set: RegisterSet = _DEFAULT_REGISTER_SET,
+    ) -> None:
+        self.active = OrderedDict()
+        self.register_set = register_set
+        self.intervals = intervals or []
+        self.idx_abstract_stack_location = 0
+
+    # TO:DO - Refactor the following methods to use a proper SortedSet (C++ fashion)
+    # This requires an extra dependency, so right now stick with this subpar implementation
+    ###
+    def insert_active_interval(self, interval: RegisterLiveInterval) -> None:
+        self.active[interval] = None
+        self.active = OrderedDict(sorted(self.active.items(), key=lambda x: x[0].end))
+
+    def remove_active_interval(self, interval: RegisterLiveInterval) -> None:
+        self.active.pop(interval)
+        self.active = OrderedDict(sorted(self.active.items(), key=lambda x: x[0].end))
+
+    ###
+
+    def fresh_stack_location(self) -> int:
+        old_stack_location = self.idx_abstract_stack_location
+        self.idx_abstract_stack_location += 1
+        return old_stack_location
+
+    def expire_old_intervals(self, i: RegisterLiveInterval) -> None:
+        for j in list(filter(lambda j: j.end < i.start, self.active.keys())):
+            register = j.get_riscv_register()
+            if register.data.name is not None:
+                self.remove_active_interval(j)
+                self.register_set.set_free(register.data.name)
+
+    def spill_at_interval(self, i: RegisterLiveInterval) -> None:
+        # Spill the interval with the furthest endpoint
+        spill = next(reversed(self.active.keys()))
+        if spill.end > i.end:
+            i.set_riscv_register(spill.get_riscv_register().data)
+            self.remove_active_interval(spill)
+            spill.spill(self.fresh_stack_location())
+            self.insert_active_interval(i)
+        else:
+            i.spill(self.fresh_stack_location())
+
+    def prepare_intervals(self, module: ModuleOp) -> None:
+        # Build all live intervals if not already provided
+        if not self.intervals:
+            for op in module.walk():
+                if isinstance(op, RISCVOp):
+                    for result in op.results:
+                        self.intervals.append(RegisterLiveInterval(result))
+
+        # Algorithm requires values intervals to be sorted by start point
+        self.intervals = sorted(self.intervals, key=lambda x: x.start)
+
+        # already registers are removed from set of the available registers
+        for interval in self.intervals:
+            register = interval.get_riscv_register()
+            if register.data.name is not None:
+                if self.register_set.is_free(register.data.name):
+                    self.register_set.set_occupied(register.data.name)
+
+    def allocate_registers(self, module: ModuleOp) -> None:
+        """
+        Allocates unallocated registers in the module.
+        """
+
+        # Prepare intervals
+        self.prepare_intervals(module)
+
+        num_registers = self.register_set.num_free_registers()
+
+        for iv in self.intervals:
+            """
+            Expire all intervals whose endpoint is smaller than the start point of the current interval being processed.
+            This means that the current interval can be mapped to a register that was previously assigned
+            to one of the expired intervals, which is no longer needed because it has expired.
+            """
+
+            self.expire_old_intervals(iv)
+
+            if len(self.active) >= num_registers:
+                self.spill_at_interval(iv)
+            else:
+                iv.set_riscv_register(Register(self.register_set.get_free()))
+                self.insert_active_interval(iv)
+
+        return
+
+
 @dataclass
 class RISCVRegisterAllocation(ModulePass):
     """
@@ -99,10 +274,11 @@ class RISCVRegisterAllocation(ModulePass):
 
     allocation_strategy: str = "GlobalJRegs"
 
-    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+    def apply(self, ctx: MLContext, op: ModuleOp, *args: Any) -> None:
         allocator_strategies = {
             "GlobalJRegs": RegisterAllocatorJRegs,
             "BlockNaive": RegisterAllocatorBlockNaive,
+            "LinearScan": RegisterAllocatorLinearScan,
         }
 
         if self.allocation_strategy not in allocator_strategies:
@@ -111,5 +287,5 @@ class RISCVRegisterAllocation(ModulePass):
                 f"Available allocation types: {allocator_strategies.keys()}"
             )
 
-        allocator = allocator_strategies[self.allocation_strategy]()
+        allocator = allocator_strategies[self.allocation_strategy](*args)
         allocator.allocate_registers(op)

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -236,10 +236,10 @@ class RegisterAllocatorLinearScan(AbstractRegisterAllocator):
                     for result in op.results:
                         self.intervals.append(RegisterLiveInterval(result))
 
-        # Algorithm requires values intervals to be sorted by start point
+        # The algorithm requires values intervals to be sorted by their start point
         self.intervals = sorted(self.intervals, key=lambda x: x.start)
 
-        # already registers are removed from set of the available registers
+        # Already allocated registers are removed from the set of free registers
         for interval in self.intervals:
             register = interval.get_riscv_register()
             if register.data.name is not None:


### PR DESCRIPTION
This PR introduces a basic version of the linear scan register allocation algorithm, which outperforms the current best register allocation strategy in the codebase.

The current approach limits live range computations to within the same basic block. However, future developments will enable cross-block computations (to handle loops and branching).

This improvement will lead to additional PRs by @compor and I, aimed at enhancing the algorithm's completeness and performance. For instance, incorporating a dependency like `sortedcontainers` could greatly benefit this algorithm and in general workset-related operations since the Python standard library lacks sorted collections.