### PR TITLE
dialects: Add more stencil rank verification

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -166,7 +166,7 @@ def test_stencil_apply():
     assert len(apply_op.args) == 1
     assert len(apply_op.res) == 1
     assert isinstance(apply_op.res[0].typ, TempType)
-    assert len(apply_op.res[0].typ.get_shape()) == 2
+    assert apply_op.get_rank() == 2
 
 
 def test_stencil_apply_no_args():
@@ -176,7 +176,7 @@ def test_stencil_apply_no_args():
     assert len(apply_op.args) == 0
     assert len(apply_op.res) == 2
     assert isinstance(apply_op.res[0].typ, TempType)
-    assert len(apply_op.res[0].typ.get_shape()) == 1
+    assert apply_op.get_rank() == 1
 
 
 def test_stencil_apply_no_results():

--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
 
 builtin.module {
-  func.func @copy_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
+  func.func @buffered_and_stored(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
     %outt = "stencil.apply"(%int) ({
     ^0(%intb : !stencil.temp<[-1,68]xf64>):
@@ -19,7 +19,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @copy_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
+  func.func @buffer_types_mismatch(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
     %outt = "stencil.apply"(%int) ({
     ^0(%intb : !stencil.temp<[-1,68]xf64>):
@@ -36,10 +36,72 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @copy_1d(%temp : !stencil.temp<[0,68]xf64>) {
+  func.func @buffer_operand_source(%temp : !stencil.temp<[0,68]xf64>) {
     %outt_buffered = "stencil.buffer"(%temp) : (!stencil.temp<[0,68]xf64>) -> !stencil.temp<[0,68]xf64>
     "func.return"() : () -> ()
   }
 }
 
 // CHECK: Expected stencil.buffer to buffer a stencil.apply's output, got Block(_args=(<BlockArgument[!stencil.temp<[0,68]xf64>] index: 0, uses: 1>,), num_ops=2)
+
+// -----
+
+builtin.module {
+  func.func @apply_no_return(%in : !stencil.field<[-4,68]xf64>) {
+    %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+    "stencil.apply"(%int) ({
+    ^0(%intb : !stencil.temp<?xf64>):
+      %v = "stencil.access"(%intb) {"offset" = #stencil.index<-1>} : (!stencil.temp<?xf64>) -> f64
+    }) : (!stencil.temp<?xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK: Expected stencil.apply to have at least 1 result, got 0
+
+// -----
+
+builtin.module {
+  func.func @access_bad_temp(%in : !stencil.field<[-4,68]xf64>, %bigin : !stencil.field<[-4,68]x[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
+    %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+    %bigint = "stencil.load"(%bigin) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?xf64>
+    %outt = "stencil.apply"(%int, %bigint) ({
+    ^0(%intb : !stencil.temp<?xf64>, %bigintb : !stencil.temp<?x?xf64>):
+      %v = "stencil.access"(%bigintb) {"offset" = #stencil.index<-1>} : (!stencil.temp<?x?xf64>) -> f64
+      "stencil.return"(%v) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>, !stencil.temp<?x?xf64>) -> (!stencil.temp<?xf64>)
+    "stencil.store"(%outt, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK: Operation does not verify: Expected stencil.access operand to be of rank 1 to match its parent apply, got 2
+
+// -----
+
+builtin.module {
+  func.func @access_bad_offset(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
+    %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+    %outt = "stencil.apply"(%int) ({
+    ^0(%intb : !stencil.temp<?xf64>):
+      %v = "stencil.access"(%intb) {"offset" = #stencil.index<-1, 1>} : (!stencil.temp<?xf64>) -> f64
+      "stencil.return"(%v) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>) -> (!stencil.temp<?xf64>)
+    "stencil.store"(%outt, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    "func.return"() : () -> ()
+  }
+}
+
+// CHECK: Expected offset's rank to be 1 to match the operand's rank, got 2
+
+// -----
+
+builtin.module {
+  func.func @access_out_of_apply(%in : !stencil.field<[-4,68]xf64>) {
+    %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+    %v = "stencil.access"(%int) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
+    "func.return"() : () -> ()
+  }
+}
+
+ // CHECK: 'stencil.access' expects parent op 'stencil.apply'

--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
 
 builtin.module {
-  func.func @buffered_and_stored(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
+  func.func @buffered_and_stored_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
     %outt = "stencil.apply"(%int) ({
     ^0(%intb : !stencil.temp<[-1,68]xf64>):
@@ -19,7 +19,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @buffer_types_mismatch(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
+  func.func @buffer_types_mismatch_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
     %outt = "stencil.apply"(%int) ({
     ^0(%intb : !stencil.temp<[-1,68]xf64>):
@@ -36,7 +36,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @buffer_operand_source(%temp : !stencil.temp<[0,68]xf64>) {
+  func.func @buffer_operand_source_1d(%temp : !stencil.temp<[0,68]xf64>) {
     %outt_buffered = "stencil.buffer"(%temp) : (!stencil.temp<[0,68]xf64>) -> !stencil.temp<[0,68]xf64>
     "func.return"() : () -> ()
   }
@@ -47,7 +47,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @apply_no_return(%in : !stencil.field<[-4,68]xf64>) {
+  func.func @apply_no_return_1d(%in : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
     "stencil.apply"(%int) ({
     ^0(%intb : !stencil.temp<?xf64>):
@@ -62,7 +62,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @access_bad_temp(%in : !stencil.field<[-4,68]xf64>, %bigin : !stencil.field<[-4,68]x[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
+  func.func @access_bad_temp_1d(%in : !stencil.field<[-4,68]xf64>, %bigin : !stencil.field<[-4,68]x[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
     %bigint = "stencil.load"(%bigin) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?xf64>
     %outt = "stencil.apply"(%int, %bigint) ({
@@ -80,7 +80,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @access_bad_offset(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
+  func.func @access_bad_offset_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
     %outt = "stencil.apply"(%int) ({
     ^0(%intb : !stencil.temp<?xf64>):
@@ -97,7 +97,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func @access_out_of_apply(%in : !stencil.field<[-4,68]xf64>) {
+  func.func @access_out_of_apply_1d(%in : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
     %v = "stencil.access"(%int) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
     "func.return"() : () -> ()

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -163,7 +163,7 @@ builtin.module {
       %14 = "stencil.access"(%13) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%14) : (f64) -> ()
     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-    "stencil.store"(%12, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    "stencil.store"(%12, %1) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
     "func.return"() : () -> ()
   }
 }
@@ -181,8 +181,8 @@ builtin.module {
 // CHECK-NEXT:     ^1(%8 : !stencil.temp<[0,64]xf64>):
 // CHECK-NEXT:       %9 = "stencil.access"(%8) {"offset" = #stencil.index<0>} : (!stencil.temp<[0,64]xf64>) -> f64
 // CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
-// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<[0,64]xf64>) -> !stencil.temp<[0,64]xf64>
+// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -312,6 +312,8 @@ class ApplyOp(IRDLOperation):
     region: Region = region_def()
     res: VarOpResult = var_result_def(TempType)
 
+    traits = frozenset([IsolatedFromAbove()])
+
     @staticmethod
     def get(
         args: Sequence[SSAValue] | Sequence[Operation],

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -494,6 +494,7 @@ class AccessOp(IRDLOperation):
 
         # TODO This should be handled by infra, having a way to verify things on ApplyOp
         # **before** its children.
+        # cf https://github.com/xdslproject/xdsl/issues/1112
         apply.verify_()
 
         temp_typ = self.temp.typ

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -35,11 +35,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-<<<<<<< HEAD
-from xdsl.traits import IsolatedFromAbove
-=======
-from xdsl.traits import HasParent
->>>>>>> 0a4a50b6 (Add some verifiers and checks.)
+from xdsl.traits import HasParent, IsolatedFromAbove
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.parser import Parser

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -321,20 +321,11 @@ class ApplyOp(IRDLOperation):
         args: Sequence[SSAValue] | Sequence[Operation],
         body: Block,
         result_types: Sequence[TempType[Attribute]],
-        lb: IndexAttr | None = None,
-        ub: IndexAttr | None = None,
     ):
         assert len(result_types) > 0
 
-        attributes = {}
-        if lb is not None:
-            attributes["lb"] = lb
-        if ub is not None:
-            attributes["ub"] = ub
-
         return ApplyOp.build(
             operands=[list(args)],
-            attributes=attributes,
             regions=[Region(body)],
             result_types=[result_types],
         )

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -489,12 +489,12 @@ class AccessOp(IRDLOperation):
 
     def verify_(self) -> None:
         apply = self.parent_op()
-        if apply is None:
-            raise VerifyException(f"stencil.access expects to have a parent operation.")
+        # As promised by HasParent(ApplyOp)
+        assert isinstance(apply, ApplyOp)
+
         # TODO This should be handled by infra, having a way to verify things on ApplyOp
         # **before** its children.
         apply.verify_()
-        assert isinstance(apply, ApplyOp)
 
         temp_typ = self.temp.typ
         assert isa(temp_typ, TempType[Attribute])

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -35,7 +35,11 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
+<<<<<<< HEAD
 from xdsl.traits import IsolatedFromAbove
+=======
+from xdsl.traits import HasParent
+>>>>>>> 0a4a50b6 (Add some verifiers and checks.)
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.parser import Parser
@@ -295,6 +299,59 @@ class ResultType(ParametrizedAttribute, TypeAttribute):
 
 
 @irdl_op_definition
+class ApplyOp(IRDLOperation):
+    """
+    This operation takes a stencil function plus parameters and applies
+    the stencil function to the output temp.
+
+    Example:
+
+      %0 = stencil.apply (%arg0=%0 : !stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64> {
+        ...
+      }
+    """
+
+    name = "stencil.apply"
+    args: VarOperand = var_operand_def(Attribute)
+    region: Region = region_def()
+    res: VarOpResult = var_result_def(TempType)
+
+    @staticmethod
+    def get(
+        args: Sequence[SSAValue] | Sequence[Operation],
+        body: Block,
+        result_types: Sequence[TempType[Attribute]],
+        lb: IndexAttr | None = None,
+        ub: IndexAttr | None = None,
+    ):
+        assert len(result_types) > 0
+
+        attributes = {}
+        if lb is not None:
+            attributes["lb"] = lb
+        if ub is not None:
+            attributes["ub"] = ub
+
+        return ApplyOp.build(
+            operands=[list(args)],
+            attributes=attributes,
+            regions=[Region(body)],
+            result_types=[result_types],
+        )
+
+    def verify_(self) -> None:
+        if len(self.res) < 1:
+            raise VerifyException(
+                f"Expected stencil.apply to have at least 1 result, got {len(self.res)}"
+            )
+
+    def get_rank(self) -> int:
+        res_typ = self.res[0].typ
+        assert isa(res_typ, TempType[Attribute])
+        return res_typ.get_num_dims()
+
+
+@irdl_op_definition
 class CastOp(IRDLOperation):
     """
     This operation casts dynamically shaped input fields to statically shaped fields.
@@ -419,6 +476,8 @@ class AccessOp(IRDLOperation):
     offset: IndexAttr = attr_def(IndexAttr)
     res: OpResult = result_def(Attribute)
 
+    traits = frozenset([HasParent(ApplyOp)])
+
     @staticmethod
     def get(temp: SSAValue | Operation, offset: Sequence[int]):
         temp_type = SSAValue.get(temp).typ
@@ -436,6 +495,29 @@ class AccessOp(IRDLOperation):
             },
             result_types=[temp_type.element_type],
         )
+
+    def verify_(self) -> None:
+        apply = self.parent_op()
+        if apply is None:
+            raise VerifyException(f"stencil.access expects to have a parent operation.")
+        # TODO This should be handled by infra, having a way to verify things on ApplyOp
+        # **before** its children.
+        apply.verify_()
+        assert isinstance(apply, ApplyOp)
+
+        temp_typ = self.temp.typ
+        assert isa(temp_typ, TempType[Attribute])
+        if temp_typ.get_num_dims() != apply.get_rank():
+            raise VerifyException(
+                f"Expected stencil.access operand to be of rank {apply.get_rank()} to "
+                f"match its parent apply, got {temp_typ.get_num_dims()}"
+            )
+
+        if len(self.offset) != temp_typ.get_num_dims():
+            raise VerifyException(
+                f"Expected offset's rank to be {temp_typ.get_num_dims()} to match the "
+                f"operand's rank, got {len(self.offset)}"
+            )
 
 
 @irdl_op_definition
@@ -548,50 +630,6 @@ class StoreOp(IRDLOperation):
                 raise VerifyException("Cannot Load and Store the same field!")
             if isa(use.operation, LoadOp) and use.operation is not self:
                 raise VerifyException("Can only store once to a field!")
-
-
-@irdl_op_definition
-class ApplyOp(IRDLOperation):
-    """
-    This operation takes a stencil function plus parameters and applies
-    the stencil function to the output temp.
-
-    Example:
-
-      %0 = stencil.apply (%arg0=%0 : !stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64> {
-        ...
-      }
-    """
-
-    name = "stencil.apply"
-    args: VarOperand = var_operand_def(Attribute)
-    region: Region = region_def()
-    res: VarOpResult = var_result_def(TempType)
-
-    traits = frozenset([IsolatedFromAbove()])
-
-    @staticmethod
-    def get(
-        args: Sequence[SSAValue] | Sequence[Operation],
-        body: Block,
-        result_types: Sequence[TempType[Attribute]],
-        lb: IndexAttr | None = None,
-        ub: IndexAttr | None = None,
-    ):
-        assert len(result_types) > 0
-
-        attributes = {}
-        if lb is not None:
-            attributes["lb"] = lb
-        if ub is not None:
-            attributes["ub"] = ub
-
-        return ApplyOp.build(
-            operands=[list(args)],
-            attributes=attributes,
-            regions=[Region(body)],
-            result_types=[result_types],
-        )
 
 
 @irdl_op_definition


### PR DESCRIPTION
And just move ApplyOp's definition up the file a bit, pylance was grunting otherwise with the trait definition.
I added get_rank on ApplyOp as it will probably be used all over the verifiers. Should probably be an interface method at some point :slightly_smiling_face: 