### PR TITLE
dialects: (print) Initial println op added

### DIFF
--- a/tests/filecheck/dialects/print/invalid.mlir
+++ b/tests/filecheck/dialects/print/invalid.mlir
@@ -1,0 +1,17 @@
+// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+
+builtin.module {
+    print.println "This will fail {}"
+}
+
+// CHECK: Operation does not verify: Number of templates in template string must match number of arguments!
+
+// -----
+// CHECK: -----
+
+builtin.module {
+    %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+    print.println "This will fail too {}", %0 : i32, %0 : i32
+}
+
+// CHECK: Operation does not verify: Number of templates in template string must match number of arguments!

--- a/tests/filecheck/dialects/print/invalid.mlir
+++ b/tests/filecheck/dialects/print/invalid.mlir
@@ -10,7 +10,7 @@ builtin.module {
 // CHECK: -----
 
 builtin.module {
-    %0 = "arith.constant"() {"value" = 42 : i32} : () -> i32
+    %0 = "test.op"() : () -> i32
     print.println "This will fail too {}", %0 : i32, %0 : i32
 }
 

--- a/tests/filecheck/dialects/print/print_basics.mlir
+++ b/tests/filecheck/dialects/print/print_basics.mlir
@@ -1,0 +1,20 @@
+// RUN: xdsl-opt %s | filecheck %s
+
+builtin.module {
+    print.println "Hello world!"
+
+    %144 = "arith.constant"() {"value" = 144 : i32} : () -> i32
+    %12 = "arith.constant"() {"value" = 12 : i32} : () -> i32
+
+    print.println "Did you know that {}^2 = {}, and fib({}) = {} too!", %12 : i32, %144 : i32, %12 : i32, %144 : i32
+
+    print.println "Furthermore, {} is the smallest number with 15 divisors", %144 : i32 {"test_thing" = 32 : i32}
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   print.println "Hello world!"
+// CHECK-NEXT:   %0 = "arith.constant"() {"value" = 144 : i32} : () -> i32
+// CHECK-NEXT:   %1 = "arith.constant"() {"value" = 12 : i32} : () -> i32
+// CHECK-NEXT:   print.println "Did you know that {}^2 = {}, and fib({}) = {} too!", %1 : i32, %0 : i32, %1 : i32, %0 : i32
+// CHECK-NEXT:   print.println "Furthermore, {} is the smallest number with 15 divisors", %0 : i32 {test_thing=32 : i32}
+// CHECK-NEXT: }

--- a/tests/filecheck/dialects/print/print_basics.mlir
+++ b/tests/filecheck/dialects/print/print_basics.mlir
@@ -3,18 +3,16 @@
 builtin.module {
     print.println "Hello world!"
 
-    %144 = "arith.constant"() {"value" = 144 : i32} : () -> i32
-    %12 = "arith.constant"() {"value" = 12 : i32} : () -> i32
+    %144 = "test.op"() : () -> i32
+    %12 = "test.op"() : () -> i32
 
-    print.println "Did you know that {}^2 = {}, and fib({}) = {} too!", %12 : i32, %144 : i32, %12 : i32, %144 : i32
+    print.println "Uses vals twice {} {} {} {}", %12 : i32, %144 : i32, %12 : i32, %144 : i32
 
-    print.println "Furthermore, {} is the smallest number with 15 divisors", %144 : i32 {"test_thing" = 32 : i32}
+    print.println "{}", %144 : i32
 }
 
-// CHECK:      builtin.module {
-// CHECK-NEXT:   print.println "Hello world!"
-// CHECK-NEXT:   %0 = "arith.constant"() {"value" = 144 : i32} : () -> i32
-// CHECK-NEXT:   %1 = "arith.constant"() {"value" = 12 : i32} : () -> i32
-// CHECK-NEXT:   print.println "Did you know that {}^2 = {}, and fib({}) = {} too!", %1 : i32, %0 : i32, %1 : i32, %0 : i32
-// CHECK-NEXT:   print.println "Furthermore, {} is the smallest number with 15 divisors", %0 : i32 {test_thing=32 : i32}
-// CHECK-NEXT: }
+// CHECK:       print.println "Hello world!"
+// CHECK-NEXT:  %0 = "test.op"() : () -> i32
+// CHECK-NEXT:  %1 = "test.op"() : () -> i32
+// CHECK-NEXT:  print.println "Uses vals twice {} {} {} {}", %1 : i32, %0 : i32, %1 : i32, %0 : i32
+// CHECK-NEXT:  print.println "{}", %0 : i32

--- a/xdsl/dialects/print.py
+++ b/xdsl/dialects/print.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.irdl import IRDLOperation, irdl_op_definition, OpAttr, VarOperand
+from xdsl.dialects import builtin
+from xdsl.ir import Dialect, SSAValue, Operation, VerifyException
+
+
+@irdl_op_definition
+class PrintLnOp(IRDLOperation):
+    """
+    A string formatting and printing utility.
+
+    Can be though of as a printf equivalent but with python style format strings.
+
+    Example uses:
+    %42 = arith.constant 42 : i32
+    print.println "The magic number is {}", %42
+    """
+
+    name = "print.println"
+    format_str: OpAttr[builtin.StringAttr]
+
+    format_vals: VarOperand
+
+    def __init__(self, format_str: str, *vals: SSAValue | Operation):
+        super().__init__(
+            operands=[vals], attributes={"format_str": builtin.StringAttr(format_str)}
+        )
+
+    def verify_(self) -> None:
+        num_of_templates = self.format_str.data.count("{}")
+        if not num_of_templates == len(self.format_vals):
+            raise VerifyException(
+                "Number of templates in template string must match number of arguments!"
+            )
+
+    def print(self, printer: Printer):
+        printer.print_string(" ")
+        printer.print_attribute(self.format_str)
+        if len(self.format_vals) > 0:
+            printer.print_string(", ")
+            printer.print_list(self.operands, printer.print_block_argument)
+
+        if len(self.attributes) > 1:
+            attrs = self.attributes.copy()
+            attrs.pop("format_str")
+            printer.print_string(" {")
+            printer.print_dictionary(
+                attrs, printer.print_string, printer.print_attribute
+            )
+            printer.print_string("}")
+
+    @classmethod
+    def parse(cls: type[PrintLnOp], parser: Parser) -> PrintLnOp:
+        format_str = parser.parse_str_literal()
+        args: list[SSAValue] = []
+        while parser.parse_optional_characters(",") is not None:
+            args.append(arg := parser.parse_operand())
+            parser.parse_characters(":", " - all arguments must have a type")
+            typ = parser.parse_type()
+            if arg.typ != typ:
+                parser.raise_error(f"Parsed ssa vlue {arg} must be of type {typ}")
+
+        attr_dict = parser.parse_optional_attr_dict()
+
+        if "format_str" in attr_dict:
+            parser.raise_error(
+                "format_str keyword is a reserved attribute for print.println!"
+            )
+
+        op = PrintLnOp(format_str, *args)
+
+        op.attributes.update(attr_dict)
+
+        return op
+
+
+Print = Dialect(
+    [
+        PrintLnOp,
+    ],
+    [],
+)

--- a/xdsl/dialects/print.py
+++ b/xdsl/dialects/print.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.irdl import IRDLOperation, irdl_op_definition, OpAttr, VarOperand
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_op_definition,
+    VarOperand,
+    attr_def,
+    var_operand_def,
+)
 from xdsl.dialects import builtin
 from xdsl.ir import Dialect, SSAValue, Operation, VerifyException
 
@@ -20,9 +26,8 @@ class PrintLnOp(IRDLOperation):
     """
 
     name = "print.println"
-    format_str: OpAttr[builtin.StringAttr]
-
-    format_vals: VarOperand
+    format_str: builtin.StringAttr = attr_def(builtin.StringAttr)
+    format_vals: VarOperand = var_operand_def()
 
     def __init__(self, format_str: str, *vals: SSAValue | Operation):
         super().__init__(

--- a/xdsl/dialects/print.py
+++ b/xdsl/dialects/print.py
@@ -39,9 +39,15 @@ class PrintLnOp(IRDLOperation):
     def print(self, printer: Printer):
         printer.print_string(" ")
         printer.print_attribute(self.format_str)
+
+        def print_val_and_type(ssa_val: SSAValue):
+            printer.print_ssa_value(ssa_val)
+            printer.print_string(" : ")
+            printer.print_attribute(ssa_val.typ)
+
         if len(self.format_vals) > 0:
             printer.print_string(", ")
-            printer.print_list(self.operands, printer.print_block_argument)
+            printer.print_list(self.operands, print_val_and_type)
 
         if len(self.attributes) > 1:
             attrs = self.attributes.copy()

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -29,6 +29,7 @@ from xdsl.dialects.irdl import IRDL
 from xdsl.dialects.riscv import RISCV, print_assembly, riscv_code
 from xdsl.dialects.snitch import Snitch
 from xdsl.dialects.snitch_runtime import SnitchRuntime
+from xdsl.dialects.print import Print
 
 from xdsl.dialects.experimental.math import Math
 from xdsl.dialects.experimental.fir import FIR
@@ -77,6 +78,7 @@ def get_all_dialects() -> list[Dialect]:
         MemRef,
         MPI,
         PDL,
+        Print,
         RISCV,
         RISCV_Func,
         Scf,


### PR DESCRIPTION
This adds the initial `print.println` operation (without lowering so far), as presented on [zulip](https://xdsl.zulipchat.com/#narrow/stream/362011-xDSL/topic/Print.20dialect/near/364592223).

@math-fehr Pyright complains because I print an SSA value with `print_block_argument`, because I want to print `%name : type`. Do you have a suggestion how to fix this? Or is printing `name: type` pairs a big no no?