### PR TITLE
core: Add support for `isa(..., set)`

### DIFF
--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -204,6 +204,52 @@ def test_tuple_hint_nested():
 
 
 ################################################################################
+# Set
+################################################################################
+
+
+def test_set_hint_empty():
+    """Test that empty set satisfy all set hints."""
+    assert isa(set(), set[int])
+    assert isa(set(), set[bool])
+    assert isa(set(), set[Class1])
+
+
+def test_set_hint_correct():
+    """
+    Test that set hints work correcly on non-empty sets of the right type.
+    """
+    assert isa({42}, set[int])
+    assert isa({0, 3, 5}, set[int])
+    assert isa({False}, set[bool])
+    assert isa({True, False}, set[bool])
+    assert isa({True, 1, "test"}, set[bool | int | str])
+    assert isa({Class1(), SubClass1()}, set[Class1])
+
+
+def test_set_hint_not_list_failure():
+    """Test that set hints work correcly on non set."""
+    assert not isa(0, set[int])
+    assert not isa(0, set[Any])
+    assert not isa(True, set[bool])
+    assert not isa(True, set[Any])
+    assert not isa("", set[Any])
+    assert not isa("", set[str])
+    assert not isa(Class1(), set[Class1])
+    assert not isa(Class1(), set[Any])
+    assert not isa([], set[dict[Any, Any]])
+    assert not isa([], set[Any])
+
+
+def test_set_hint_failure():
+    """
+    Test that set hints work correcly on non-empty sets of the wrong type.
+    """
+    assert not isa({0}, set[bool])
+    assert not isa({0, "hello"}, set[int])
+
+
+################################################################################
 # Dictionary
 ################################################################################
 

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -43,6 +43,13 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
         (elem_hint,) = get_args(hint)
         return all(isa(elem, elem_hint) for elem in arg_list)
 
+    if origin is set:
+        if not isinstance(arg, set):
+            return False
+        arg_list: set[Any] = cast(set[Any], arg)
+        (elem_hint,) = get_args(hint)
+        return all(isa(elem, elem_hint) for elem in arg_list)
+
     if origin is tuple:
         if not isinstance(arg, tuple):
             return False

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -46,9 +46,9 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
     if origin is set:
         if not isinstance(arg, set):
             return False
-        arg_list: set[Any] = cast(set[Any], arg)
+        arg_set: set[Any] = cast(set[Any], arg)
         (elem_hint,) = get_args(hint)
-        return all(isa(elem, elem_hint) for elem in arg_list)
+        return all(isa(elem, elem_hint) for elem in arg_set)
 
     if origin is tuple:
         if not isinstance(arg, tuple):


### PR DESCRIPTION
This adds `set` to the list of supported types for `isa` checks