### PR TITLE
core: Add successor branching verification

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -169,6 +169,11 @@ def test_op_clone_with_regions():
 
 @irdl_op_definition
 class SuccessorOp(IRDLOperation):
+    """
+    Utility operation that requires a successor and has the IsTerminator
+    trait.
+    """
+
     name = "test.successor_op"
 
     successor: Successor = successor_def()
@@ -177,6 +182,10 @@ class SuccessorOp(IRDLOperation):
 
 
 def test_block_branching_to_another_region_wrong():
+    """
+    Tests that an operation cannot have successors that branch to blocks of
+    another region.
+    """
     block1 = Block([TestOp.create(), TestOp.create()])
     region1 = Region([block1])
 
@@ -195,6 +204,10 @@ def test_block_branching_to_another_region_wrong():
 
 
 def test_block_not_branching_to_another_region():
+    """
+    Tests that an operation can have successors that branch to blocks of the
+    same region.
+    """
     block0 = Block()
 
     op0 = SuccessorOp.create(successors=[block0])

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -228,17 +228,6 @@ def test_empty_block_with_no_parent_region_requires_no_terminator():
     block0.verify()
 
 
-def test_empty_block_with_single_block_parent_region_requires_no_terminator():
-    """
-    Tests that an empty block belonging to a single-block region with no parent
-    operation requires no terminator operation.
-    """
-    block0 = Block([])
-    _ = Region([block0])
-
-    block0.verify()
-
-
 def test_empty_block_with_orphan_single_block_parent_region_requires_no_terminator():
     """
     Tests that an empty block belonging to a single-block region with no parent

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -213,9 +213,9 @@ def test_block_not_branching_to_another_region():
     op0 = SuccessorOp.create(successors=[block0])
     block1 = Block([op0])
 
-    _ = Region([block0, block1])
+    region0 = Region([block0, block1])
 
-    op0.verify()
+    region0.verify()
 
 
 def test_empty_block_with_no_parent_region_requires_no_terminator():
@@ -234,9 +234,9 @@ def test_empty_block_with_orphan_single_block_parent_region_requires_no_terminat
     operation requires no terminator operation.
     """
     block0 = Block([])
-    _ = Region([block0])
+    region0 = Region([block0])
 
-    block0.verify()
+    region0.verify()
 
 
 def test_region_clone_into_circular_blocks():
@@ -272,15 +272,16 @@ def test_op_with_successors_not_in_block():
 
 
 def test_op_with_successors_not_in_region():
-    block0 = Block()
-    op0 = TestOp.create(successors=[block0])
-    _ = Block([op0])
+    block1 = Block()
+
+    op0 = TestOp.create(successors=[block1])
+    block0 = Block([op0])
 
     with pytest.raises(
         VerifyException,
         match="Operation with block successors does not belong to a block or a region",
     ):
-        op0.verify()
+        block0.verify()
 
 
 def test_non_empty_block_with_single_block_parent_region_can_have_terminator():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -239,6 +239,23 @@ def test_empty_block_with_orphan_single_block_parent_region_requires_no_terminat
     region0.verify()
 
 
+def test_empty_block_with_single_block_parent_region_requires_terminator():
+    """
+    Tests that an empty block belonging to a single-block region in a parent
+    operation requires terminator operation.
+
+    This test should fail once the NoTerminator functionality is implemented.
+    See https://github.com/xdslproject/xdsl/issues/1093
+    """
+    block0 = Block([])
+    region0 = Region([block0])
+    op0 = TestOp.create(regions=[region0])
+
+    # TODO single-block regions dealt when the NoTerminator trait is
+    # implemented (https://github.com/xdslproject/xdsl/issues/1093)
+    op0.verify()
+
+
 def test_region_clone_into_circular_blocks():
     """
     Test that cloning a region with circular block dependency works.

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -3,13 +3,29 @@ import pytest
 from typing import cast
 
 from xdsl.dialects.arith import Arith, Addi, Subi, Constant
-from xdsl.dialects.builtin import Builtin, IntegerType, i32, i64, IntegerAttr, ModuleOp
+from xdsl.dialects.builtin import (
+    Builtin,
+    IntegerType,
+    i32,
+    i64,
+    IntegerAttr,
+    ModuleOp,
+)
 from xdsl.dialects.func import Func
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.scf import If
 from xdsl.dialects.test import TestOp
 
 from xdsl.ir import MLContext, Operation, Block, Region, ErasedSSAValue, SSAValue
+from xdsl.ir import (
+    MLContext,
+    Operation,
+    Block,
+    Region,
+    ErasedSSAValue,
+    SSAValue,
+)
+from xdsl.traits import IsTerminator
 from xdsl.parser import Parser
 from xdsl.irdl import (
     IRDLOperation,
@@ -18,6 +34,8 @@ from xdsl.irdl import (
     Operand,
     operand_def,
     var_region_def,
+    Successor,
+    successor_def,
 )
 from xdsl.utils.test_value import TestSSAValue
 from xdsl.utils.exceptions import VerifyException
@@ -147,6 +165,76 @@ def test_op_clone_with_regions():
     assert len(if2.false_region.ops) == 1
     assert if2.true_region.op is not if_.true_region.op
     assert if2.false_region.op is not if_.false_region.op
+
+
+@irdl_op_definition
+class SuccessorOp(IRDLOperation):
+    name = "test.successor_op"
+
+    successor: Successor = successor_def()
+
+    traits = frozenset([IsTerminator()])
+
+
+def test_block_branching_to_another_region_wrong():
+    block1 = Block([TestOp.create(), TestOp.create()])
+    region1 = Region([block1])
+
+    op0 = TestOp.create(successors=[block1])
+    block0 = Block([op0])
+    region0 = Region([block0])
+    region0 = TestOp.create(regions=[region0, region1])
+
+    outer_block = Block([region0])
+
+    with pytest.raises(
+        VerifyException,
+        match="Branching to a block of a different region",
+    ):
+        outer_block.verify()
+
+
+def test_block_not_branching_to_another_region():
+    block0 = Block()
+
+    op0 = SuccessorOp.create(successors=[block0])
+    block1 = Block([op0])
+
+    _ = Region([block0, block1])
+
+    op0.verify()
+
+
+def test_empty_block_with_no_parent_region_requires_no_terminator():
+    """
+    Tests that an empty block belonging no parent region requires no terminator
+    operation.
+    """
+    block0 = Block([])
+
+    block0.verify()
+
+
+def test_empty_block_with_single_block_parent_region_requires_no_terminator():
+    """
+    Tests that an empty block belonging to a single-block region with no parent
+    operation requires no terminator operation.
+    """
+    block0 = Block([])
+    _ = Region([block0])
+
+    block0.verify()
+
+
+def test_empty_block_with_orphan_single_block_parent_region_requires_no_terminator():
+    """
+    Tests that an empty block belonging to a single-block region with no parent
+    operation requires no terminator operation.
+    """
+    block0 = Block([])
+    _ = Region([block0])
+
+    block0.verify()
 
 
 def test_region_clone_into_circular_blocks():

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -6,6 +6,7 @@ from xdsl.dialects.builtin import DenseArrayBase, StringAttr, i32
 from xdsl.dialects.arith import Constant
 
 from xdsl.ir import Block, OpResult, Region
+from xdsl.traits import IsTerminator
 from xdsl.irdl import (
     AttrSizedRegionSegments,
     AttrSizedSuccessorSegments,
@@ -507,14 +508,17 @@ class SuccessorOp(IRDLOperation):
 
     successor: Successor = successor_def()
 
+    traits = frozenset([IsTerminator()])
+
 
 def test_successor_op_successor():
     """Test operation from IRDL operation definition can have successors"""
     block0 = Block()
-    op = SuccessorOp.build(successors=[block0])
 
+    op = SuccessorOp.build(successors=[block0])
     block1 = Block([op])
-    _ = Region([block1])
+
+    _ = Region([block0, block1])
 
     op.verify()
     assert len(op.successors) == 1
@@ -526,6 +530,8 @@ class OptSuccessorOp(IRDLOperation):
 
     successor: OptSuccessor = opt_successor_def()
 
+    traits = frozenset([IsTerminator()])
+
 
 def test_opt_successor_builder():
     """
@@ -533,11 +539,14 @@ def test_opt_successor_builder():
     successors
     """
     block0 = Block()
-    op1 = OptSuccessorOp.build(successors=[block0])
-    op2 = OptSuccessorOp.build(successors=[None])
 
-    block1 = Block([op2, op1])
-    _ = Region([block1])
+    op1 = OptSuccessorOp.build(successors=[block0])
+    block1 = Block([op1])
+
+    op2 = OptSuccessorOp.build(successors=[None])
+    block2 = Block([op2])
+
+    _ = Region([block0, block1, block2])
 
     op1.verify()
     op2.verify()
@@ -549,6 +558,8 @@ class VarSuccessorOp(IRDLOperation):
 
     successor: VarSuccessor = var_successor_def()
 
+    traits = frozenset([IsTerminator()])
+
 
 def test_var_successor_builder():
     """
@@ -558,7 +569,7 @@ def test_var_successor_builder():
     op = VarSuccessorOp.build(successors=[[block0, block0, block0]])
 
     block1 = Block([op])
-    _ = Region([block1])
+    _ = Region([block0, block1])
 
     op.verify()
     assert len(op.successors) == 3
@@ -572,6 +583,8 @@ class TwoVarSuccessorOp(IRDLOperation):
     res2: VarSuccessor = var_successor_def()
     irdl_options = [AttrSizedSuccessorSegments()]
 
+    traits = frozenset([IsTerminator()])
+
 
 def test_two_var_successor_builder():
     """
@@ -582,10 +595,11 @@ def test_two_var_successor_builder():
     block2 = Block()
     block3 = Block()
     block4 = Block()
-    op2 = TwoVarSuccessorOp.build(successors=[[block1, block2], [block3, block4]])
 
+    op2 = TwoVarSuccessorOp.build(successors=[[block1, block2], [block3, block4]])
     block0 = Block([op2])
-    _ = Region([block0])
+
+    _ = Region([block0, block1, block2, block3, block4])
 
     op2.verify()
     assert op2.successors == [block1, block2, block3, block4]
@@ -603,10 +617,11 @@ def test_two_var_successor_builder2():
     block2 = Block()
     block3 = Block()
     block4 = Block()
-    op2 = TwoVarSuccessorOp.build(successors=[[block1], [block2, block3, block4]])
 
+    op2 = TwoVarSuccessorOp.build(successors=[[block1], [block2, block3, block4]])
     block0 = Block([op2])
-    _ = Region([block0])
+
+    _ = Region([block0, block1, block2, block3, block4])
 
     op2.verify()
     assert op2.successors == [block1, block2, block3, block4]

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -777,6 +777,10 @@ class Operation(IRNode):
                     "Operation with block successors must terminate its parent block"
                 )
 
+            for succ in self.successors:
+                if succ.parent != parent_region:
+                    raise VerifyException("Branching to a block of a different region")
+
             # TODO single-block regions dealt when the NoTerminator trait is
             # implemented (https://github.com/xdslproject/xdsl/issues/1093)
             if len(parent_region.blocks) > 1:


### PR DESCRIPTION
This adds a verification check as implemented in MLIR [here][1].
Namely, this requires that successor blocks should belong to the same region as their terminator operation.

This is an intermediate step before addressing #1049 (`NoTerminator` trait) and after having merged #1080 (`IsTerminator` trait).


[1]: https://github.com/llvm/llvm-project/blob/22f5dc7501b5eb97e406fd6c5e44048bb712ecc3/mlir/lib/IR/Verifier.cpp#L150