### PR TITLE
dialects: (mpi) Add NullRequestOp and GatherOp to dialect def

### DIFF
--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -856,6 +856,8 @@ MPI = Dialect(
         GetDtypeOp,
         AllocateTypeOp,
         VectorGetOp,
+        NullRequestOp,
+        GatherOp,
     ],
     [
         OperationType,


### PR DESCRIPTION
This was just missing from the `Dialect()` 