### PR TITLE
dialects: implement partial gpu.FuncOp and gpu.ReturnOp

### DIFF
--- a/tests/filecheck/dialects/gpu/invalid.mlir
+++ b/tests/filecheck/dialects/gpu/invalid.mlir
@@ -155,3 +155,29 @@
 }) {} : () -> ()
 
 // CHECK: Expected ['index'], got ['f32']. The gpu.yield values types must match its enclosing operation result types.
+
+// -----
+
+"builtin.module"()({
+    "gpu.module"()({
+        "gpu.func"() ({
+        ^bb0(%arg0: index):
+            "gpu.return"() : () -> ()
+        }) {"sym_name" = "foo", "kernel", "function_type" = () -> ()} : () -> ()
+    }) {"sym_name" = "gpu"} : () -> ()
+}) : () -> ()
+
+// CHECK: Expected first entry block arguments to have the same types as the function input types
+
+// -----
+
+"builtin.module"()({
+    "gpu.module"()({
+        "gpu.func"() ({
+        ^bb0(%arg0: index):
+            "gpu.return"(%arg0) : (index) -> ()
+        }) {"sym_name" = "foo", "kernel", "function_type" = (index) -> (index)} : () -> ()
+    }) {"sym_name" = "gpu"} : () -> ()
+}) : () -> ()
+
+// CHECK: Operation does not verify: Expected void return type for kernel function

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -68,6 +68,10 @@
 
             "func.return"() : () -> ()
         }) {"function_type" = () -> (), "sym_name" = "kernel"} : () -> ()
+        "gpu.func"() ({
+        ^bb0(%arg0: index):
+            "gpu.return"() : () -> ()
+        }) {"sym_name" = "foo", "kernel", "function_type" = (index) -> ()} : () -> ()
         "gpu.module_end"() : () -> ()
     }) {"sym_name" = "gpu"} : () -> ()
 }) : () -> ()
@@ -140,6 +144,10 @@
 
 // CHECK-NEXT:             "func.return"() : () -> ()
 // CHECK-NEXT:         }) {"function_type" = () -> (), "sym_name" = "kernel"} : () -> ()
+// CHECK-NEXT:         "gpu.func"() ({
+// CHECK-NEXT:         ^{{.*}}(%{{.*}}: index):
+// CHECK-NEXT:             "gpu.return"() : () -> ()
+// CHECK-NEXT:         }) {"sym_name" = "foo", "kernel", "function_type" = (index) -> ()} : () -> ()
 // CHECK-NEXT:          "gpu.module_end"() : () -> ()
 // CHECK-NEXT:     }) {"sym_name" = "gpu"} : () -> ()
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -372,8 +372,6 @@ class FuncOp(IRDLOperation):
                 "function input types"
             )
         if (self.kernel is not None) and (len(self.function_type.outputs) != 0):
-            print(self.kernel)
-            print(self.function_type)
             raise VerifyException(f"Expected void return type for kernel function")
 
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -11,6 +11,7 @@ from xdsl.ir import (
     Region,
     SSAValue,
 )
+from xdsl.ir.core import Block
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     Operand,
@@ -30,7 +31,14 @@ from xdsl.irdl import (
     opt_result_def,
     var_operand_def,
 )
-from xdsl.dialects.builtin import IndexType, StringAttr, SymbolRefAttr, UnitAttr, i32
+from xdsl.dialects.builtin import (
+    FunctionType,
+    IndexType,
+    StringAttr,
+    SymbolRefAttr,
+    UnitAttr,
+    i32,
+)
 from xdsl.dialects import memref
 from xdsl.parser import Parser
 from xdsl.printer import Printer
@@ -344,6 +352,32 @@ class ModuleOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FuncOp(IRDLOperation):
+    name = "gpu.func"
+
+    body: Region = region_def()
+    sym_name: StringAttr = attr_def(StringAttr)
+    function_type: FunctionType = attr_def(FunctionType)
+    kernel: UnitAttr | None = opt_attr_def(UnitAttr)
+
+    traits = frozenset([IsolatedFromAbove(), HasParent(ModuleOp)])
+
+    def verify_(self):
+        entry_block: Block = self.body.blocks[0]
+        function_inputs = self.function_type.inputs.data
+        block_arg_types = tuple(a.typ for a in entry_block.args)
+        if function_inputs != block_arg_types:
+            raise VerifyException(
+                "Expected first entry block arguments to have the same types as the "
+                "function input types"
+            )
+        if (self.kernel is not None) and (len(self.function_type.outputs) != 0):
+            print(self.kernel)
+            print(self.function_type)
+            raise VerifyException(f"Expected void return type for kernel function")
+
+
+@irdl_op_definition
 class GlobalIdOp(IRDLOperation):
     name = "gpu.global_id"
     dimension: DimensionAttr = attr_def(DimensionAttr)
@@ -476,6 +510,18 @@ class NumSubgroupsOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ReturnOp(IRDLOperation):
+    name = "gpu.return"
+
+    args: VarOperand = var_operand_def()
+
+    traits = frozenset([IsTerminator(), HasParent(FuncOp)])
+
+    def __init__(self, operands: Sequence[SSAValue | Operation]):
+        return super().__init__([operands])
+
+
+@irdl_op_definition
 class SetDefaultDeviceOp(IRDLOperation):
     name = "gpu.set_default_device"
     devIndex: Operand = operand_def(i32)
@@ -558,6 +604,7 @@ GPU = Dialect(
         BlockDimOp,
         BlockIdOp,
         DeallocOp,
+        FuncOp,
         GlobalIdOp,
         GridDimOp,
         HostRegisterOp,
@@ -567,6 +614,7 @@ GPU = Dialect(
         ModuleOp,
         ModuleEndOp,
         NumSubgroupsOp,
+        ReturnOp,
         SetDefaultDeviceOp,
         SubgroupIdOp,
         SubgroupSizeOp,


### PR DESCRIPTION
And test them.

The `gpu.func` implementation is partial:
- In the same sense as the `func.func` one. All that's missing there is missing here (e.g. argument attributes)
- It is not handling any workgroup/private memory allocation.
- It is not implementing `gpu.known_block_size` nor `gpu.known_grid_size`. Those two will follow, we use them in the stencil->GPU flow. I don't have any motivating usecase yet for the others though :shrug: 

