### PR TITLE
dialects: (arith): use signlessIntegerLike for arith.cmpi

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -244,3 +244,10 @@ def test_cmpi_incorrect_comparison():
         # 'oeq' is a comparison op for cmpf but not cmpi
         _cmpi_op = Cmpi.get(a, b, "oeq")
     assert e.value.args[0] == "Unknown comparison mnemonic: oeq"
+
+
+def test_cmpi_index_type():
+    a = Constant.from_int_and_width(1, IndexType())
+    b = Constant.from_int_and_width(2, IndexType())
+
+    Cmpi.get(a, b, "eq").verify()

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -87,8 +87,10 @@
   // CHECK-NEXT: %shrsi = "arith.shrsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
 
   %cmpi = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 2 : i64} : (i32, i32) -> i1
+  %cmpi_index = "arith.cmpi"(%lhsindex, %rhsindex) {"predicate" = 2 : i64} : (index, index) -> i1
 
-  // CHECK: %cmpi = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 2 : i64} : (i32, i32) -> i1
+  // CHECK-NEXT: %cmpi = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 2 : i64} : (i32, i32) -> i1
+  // CHECK-NEXT: %cmpi_index = "arith.cmpi"(%lhsindex, %rhsindex) {"predicate" = 2 : i64} : (index, index) -> i1
 
   %maxf = arith.maxf %lhsf32, %rhsf32 : f32
   %maxf_vector = arith.maxf %lhsvec, %rhsvec : vector<4xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -1,17 +1,23 @@
 // RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "builtin.module"() ({
+  %0 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
   %1 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %2 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64
-  %3 = "arith.constant"() {"value" = 1 : i32} : () -> i32
-  %4 = "arith.constant"() {"value" = 2 : i32} : () -> i32
-  %5 = "arith.cmpf"(%1, %2) {"predicate" = 2 : i64} : (f64, f64) -> i1
-  %6 = "arith.select"(%5, %1, %2) : (i1, f64, f64) -> f64
-  %7 = "arith.cmpi"(%3, %4) {"predicate" = 1 : i64} : (i32, i32) -> i1
-  %8 = "arith.select"(%7, %3, %4) : (i1, i32, i32) -> i32
+  %2 = "arith.constant"() {"value" = 1 : i32} : () -> i32
+  %3 = "arith.constant"() {"value" = 2 : i32} : () -> i32
+  %4 = "arith.constant"() {"value" = 1 : index} : () -> index
+  %5 = "arith.constant"() {"value" = 2 : index} : () -> index
+  %6 = "arith.cmpf"(%0, %1) {"predicate" = 2 : i64} : (f64, f64) -> i1
+  %7 = "arith.select"(%6, %0, %1) : (i1, f64, f64) -> f64
+  %8 = "arith.cmpi"(%2, %3) {"predicate" = 1 : i64} : (i32, i32) -> i1
+  %9 = "arith.select"(%8, %2, %3) : (i1, i32, i32) -> i32
+  %10 = "arith.cmpi"(%4, %5) {"predicate" = 1 : i64} : (index, index) -> i1
+  %11 = "arith.select"(%10, %4, %5) : (i1, index, index) -> index
 }) : ()->()
 
 // CHECK:        "arith.cmpf"(%0, %1) {"predicate" = 2 : i64} : (f64, f64) -> i1
-// CHECK:        "arith.select"(%4, %0, %1) : (i1, f64, f64) -> f64
+// CHECK:        "arith.select"(%6, %0, %1) : (i1, f64, f64) -> f64
 // CHECK:        "arith.cmpi"(%2, %3) {"predicate" = 1 : i64} : (i32, i32) -> i1
-// CHECK:        "arith.select"(%6, %2, %3) : (i1, i32, i32) -> i32
+// CHECK:        "arith.select"(%8, %2, %3) : (i1, i32, i32) -> i32
+// CHECK:        "arith.cmpi"(%4, %5) {"predicate" = 1 : i64} : (index, index) -> i1
+// CHECK:        "arith.select"(%10, %4, %5) : (i1, index, index) -> index

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -334,8 +334,8 @@ class Cmpi(IRDLOperation, ComparisonOperation):
 
     name = "arith.cmpi"
     predicate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
-    lhs: Operand = operand_def(IntegerType)
-    rhs: Operand = operand_def(IntegerType)
+    lhs: Operand = operand_def(signlessIntegerLike)
+    rhs: Operand = operand_def(signlessIntegerLike)
     result: OpResult = result_def(IntegerType(1))
 
     @staticmethod


### PR DESCRIPTION
The semantic of MLIR specifies that the operands for `arith.cmpi` should use "signless-integer-like" (https://mlir.llvm.org/docs/Dialects/ArithOps/#operands-8) but currently it's using `IntegerType` in xDSL which is as far I can see incorrect.