### PR TITLE
dialects: (memref): make alignment attribute optional in memref.alloca

### DIFF
--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -13,8 +13,10 @@
     "memref.store"(%3, %5, %3, %4) : (index, memref<10x2xindex>, index, index) -> ()
     %6 = "memref.subview"(%5) {"operand_segment_sizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
     %7 = "memref.cast"(%5) : (memref<10x2xindex>) -> memref<?x?xindex>
+    %8 = "memref.alloca"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
     "memref.dealloc"(%2) : (memref<1xindex>) -> ()
     "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
+    "memref.dealloc"(%8) : (memref<1xindex>) -> ()
     "func.return"() : () -> ()
   }) {"sym_name" = "memref_test", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
 }) : () -> ()
@@ -32,8 +34,10 @@
 // CHECK-NEXT:     "memref.store"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (index, memref<10x2xindex>, index, index) -> ()
 // CHECK-NEXT:     %{{.*}} = "memref.subview"(%5) {"operand_segment_sizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
 // CHECK-NEXT:     %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x2xindex>) -> memref<?x?xindex>
+// CHECK-NEXT:     %{{.*}} = "memref.alloca"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<10x2xindex>) -> ()
+// CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()
 // CHECK-NEXT:     "func.return"() : () -> ()
 // CHECK-NEXT:   }) {"sym_name" = "memref_test", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -48,8 +48,8 @@
 // CHECK-NEXT: "memref.store"(%3, %5, %3, %4) : (index, memref<10x2xindex>, index, index) -> ()
 // CHECK-NEXT: %6 = "memref.subview"(%5) {"operand_segment_sizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
 // CHECK-NEXT: %7 = "memref.cast"(%5) : (memref<10x2xindex>) -> memref<?x?xindex>
-// CHECK-NEXT: %no_align = "memref.alloca"() {"i64", "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
-// CHECK-NEXT: "memref.dealloc"(%no_align) : (memref<1xindex>) -> ()
+// CHECK-NEXT: %8 = "memref.alloca"() {"i64", "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
+// CHECK-NEXT: "memref.dealloc"(%8) : (memref<1xindex>) -> ()
 // CHECK-NEXT: "memref.dealloc"(%2) : (memref<1xindex>) -> ()
 // CHECK-NEXT: "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -53,8 +53,8 @@
 // CHECK-NEXT: "memref.dealloc"(%2) : (memref<1xindex>) -> ()
 // CHECK-NEXT: "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
 
-// CHECK:      "memref.dma_start"(%8, %1, %9, %1, %3, %10, %1) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1, 1, 1, 1>} : (memref<100xi32, 10 : i64>, index, memref<100xi32, 9 : i64>, index, index, memref<100xi32>, index) -> ()
-// CHECK-NEXT: "memref.dma_wait"(%10, %1, %3) {"operand_segment_sizes" = array<i32: 1, 1, 1>} : (memref<100xi32>, index, index) -> ()
+// CHECK:      "memref.dma_start"(%9, %1, %10, %1, %3, %11, %1) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1, 1, 1, 1>} : (memref<100xi32, 10 : i64>, index, memref<100xi32, 9 : i64>, index, index, memref<100xi32>, index) -> ()
+// CHECK-NEXT: "memref.dma_wait"(%11, %1, %3) {"operand_segment_sizes" = array<i32: 1, 1, 1>} : (memref<100xi32>, index, index) -> ()
 // CHECK-NEXT: "func.return"() : () -> ()
 // CHECK-NEXT: }) {"function_type" = () -> (), "sym_name" = "memref_test", "sym_visibility" = "private"} : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -13,6 +13,8 @@
     "memref.store"(%3, %5, %3, %4) : (index, memref<10x2xindex>, index, index) -> ()
     %6 = "memref.subview"(%5) {"operand_segment_sizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
     %7 = "memref.cast"(%5) : (memref<10x2xindex>) -> memref<?x?xindex>
+    %no_align = "memref.alloca"() {i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
+    "memref.dealloc"(%no_align) : (memref<1xindex>) -> ()
     "memref.dealloc"(%2) : (memref<1xindex>) -> ()
     "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
     %m1 = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>}: () -> memref<100xi32, 10>
@@ -46,6 +48,8 @@
 // CHECK-NEXT: "memref.store"(%3, %5, %3, %4) : (index, memref<10x2xindex>, index, index) -> ()
 // CHECK-NEXT: %6 = "memref.subview"(%5) {"operand_segment_sizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
 // CHECK-NEXT: %7 = "memref.cast"(%5) : (memref<10x2xindex>) -> memref<?x?xindex>
+// CHECK-NEXT: %no_align = "memref.alloca"() {"i64", "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
+// CHECK-NEXT: "memref.dealloc"(%no_align) : (memref<1xindex>) -> ()
 // CHECK-NEXT: "memref.dealloc"(%2) : (memref<1xindex>) -> ()
 // CHECK-NEXT: "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -274,14 +274,14 @@ class Alloca(IRDLOperation):
     memref: OpResult = result_def(MemRefType[Attribute])
 
     # TODO how to constraint the IntegerAttr type?
-    alignment: AnyIntegerAttr = attr_def(AnyIntegerAttr)
+    alignment: AnyIntegerAttr | None = opt_attr_def(AnyIntegerAttr)
 
     irdl_options = [AttrSizedOperandSegments()]
 
     @staticmethod
     def get(
         return_type: Attribute,
-        alignment: int,
+        alignment: int | None = None,
         shape: Optional[Iterable[int | AnyIntegerAttr]] = None,
         dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
     ) -> Alloca:
@@ -294,7 +294,11 @@ class Alloca(IRDLOperation):
         return Alloca.build(
             operands=[dynamic_sizes, []],
             result_types=[MemRefType.from_element_type_and_shape(return_type, shape)],
-            attributes={"alignment": IntegerAttr.from_int_and_width(alignment, 64)},
+            attributes={
+                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
+                if alignment is not None
+                else None
+            },
         )
 
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -281,7 +281,7 @@ class Alloca(IRDLOperation):
     @staticmethod
     def get(
         return_type: Attribute,
-        alignment: Optional[int | AnyIntegerAttr] = None,
+        alignment: int | AnyIntegerAttr | None = None,
         shape: Optional[Iterable[int | AnyIntegerAttr]] = None,
         dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
     ) -> Alloca:

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -281,7 +281,7 @@ class Alloca(IRDLOperation):
     @staticmethod
     def get(
         return_type: Attribute,
-        alignment: int | None = None,
+        alignment: Optional[int | AnyIntegerAttr] = None,
         shape: Optional[Iterable[int | AnyIntegerAttr]] = None,
         dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
     ) -> Alloca:
@@ -291,13 +291,14 @@ class Alloca(IRDLOperation):
         if dynamic_sizes is None:
             dynamic_sizes = []
 
+        if isinstance(alignment, int):
+            alignment = IntegerAttr.from_int_and_width(alignment, 64)
+
         return Alloca.build(
             operands=[dynamic_sizes, []],
             result_types=[MemRefType.from_element_type_and_shape(return_type, shape)],
             attributes={
-                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
-                if alignment is not None
-                else None
+                "alignment": alignment,
             },
         )
 


### PR DESCRIPTION
The semantic of MLIR specifies that the alignment attribute should be optional for `memref.alloca` "An optional alignment attribute, if specified, guarantees alignment at least to that boundary." (https://mlir.llvm.org/docs/Dialects/MemRef/#memrefalloca-memrefallocaop).
