### PR TITLE
dialects: Add snrt memory ops and barrier

### DIFF
--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -9,6 +9,15 @@
         %cluster_num = "snrt.cluster_num"() : () -> i32
         // CHECK: %{{.*}} = "snrt.cluster_num"() : () -> i32
 
+        %barrier_reg_ptr = "snrt.barrier_reg_ptr"() : () -> i32
+        // CHECK: %{{.*}} = "snrt.barrier_reg_ptr"() : () -> i32
+        %global_memory0, %global_memory1 = "snrt.global_memory"() : () -> (i64, i64)
+        // CHECK: %{{.*}}, %{{.*}} = "snrt.global_memory"() : () -> (i64, i64)
+        %cluster_memory0, %cluster_memory1 = "snrt.cluster_memory"() : () -> (i64, i64)
+        // CHECK: %{{.*}}, %{{.*}} = "snrt.cluster_memory"() : () -> (i64, i64)
+        %zero_memory0, %zero_memory1 = "snrt.zero_memory"() : () -> (i64, i64)
+        // CHECK: %{{.*}}, %{{.*}} = "snrt.zero_memory"() : () -> (i64, i64)
+
         // DMA Operations
         %dst_64 = "arith.constant"() {"value" = 100 : i64} : () -> i64
         %src_64 = "arith.constant"() {"value" = 0 : i64} : () -> i64

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -14,6 +14,8 @@ from xdsl.dialects.builtin import i32, i64, IndexType
 from typing import Generic, TypeVar, Annotated
 
 tx_id = i32
+slice_t_begin = i64
+slice_t_end = i64
 
 
 class SnitchRuntimeBaseOp(IRDLOperation, ABC):
@@ -72,6 +74,56 @@ class ClusterHwBarrierOp(SnitchRuntimeBarrier):
 
 
 _T = TypeVar("_T", bound=Attribute)
+
+
+@irdl_op_definition
+class BarrierRegPtrOp(SnitchRuntimeGetInfo):
+    """
+    Get pointer to barrier register
+    """
+
+    name = "snrt.barrier_reg_ptr"
+
+
+class GetMemoryInfoBaseOp(SnitchRuntimeBaseOp, ABC):
+    """
+    Generic base class for operations returning memory slices
+    """
+
+    slice_begin: OpResult = result_def(slice_t_begin)
+    slice_end: OpResult = result_def(slice_t_end)
+
+    def __init__(
+        self,
+    ):
+        super().__init__(operands=[], result_types=[slice_t_begin, slice_t_end])
+
+
+@irdl_op_definition
+class GlobalMemoryOp(GetMemoryInfoBaseOp):
+    """
+    Get start address of global memory
+    """
+
+    name = "snrt.global_memory"
+
+
+@irdl_op_definition
+class ClusterMemoryOp(GetMemoryInfoBaseOp):
+    """
+    Get start address of the cluster's TCDM memory
+    """
+
+    name = "snrt.cluster_memory"
+
+
+@irdl_op_definition
+class ZeroMemoryOp(GetMemoryInfoBaseOp):
+    """
+    Get start address of the cluster's zero memory
+    """
+
+    name = "snrt.zero_memory"
 
 
 class DmaStart1DBaseOp(SnitchRuntimeBaseOp, Generic[_T], ABC):
@@ -185,6 +237,10 @@ SnitchRuntime = Dialect(
     [
         ClusterNumOp,
         ClusterHwBarrierOp,
+        BarrierRegPtrOp,
+        GlobalMemoryOp,
+        ClusterMemoryOp,
+        ZeroMemoryOp,
         DmaStart1DWideptrOp,
         DmaStart1DOp,
         DmaStart2DWideptrOp,

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -13,7 +13,9 @@ from xdsl.ir import OpResult, Dialect, Attribute
 from xdsl.dialects.builtin import i32, i64, IndexType
 from typing import Generic, TypeVar, Annotated
 
+# Transfer ID
 tx_id = i32
+# Indicates address range in memory, a "memory slice"
 slice_t_begin = i64
 slice_t_end = i64
 


### PR DESCRIPTION
This PR adds support for some operations that read memory adresses at runtime