### PR TITLE
API: implement Printer.print_attribute_dictionary

### DIFF
--- a/tests/filecheck/dialects/builtin/module.mlir
+++ b/tests/filecheck/dialects/builtin/module.mlir
@@ -5,8 +5,8 @@ builtin.module {
     builtin.module {}
     // CHECK: builtin.module {
     // CHECK-NEXT: }
-    builtin.module attributes {a = "foo", b = "bar"} {}
-    // CHECK-NEXT: builtin.module attributes {a="foo", b="bar"} {
+    builtin.module attributes {a = "foo", b = "bar", unit} {}
+    // CHECK-NEXT: builtin.module attributes {a="foo", b="bar", unit} {
     // CHECK-NEXT: }
 }
 // CHECK: }

--- a/tests/filecheck/dialects/print/print_basics.mlir
+++ b/tests/filecheck/dialects/print/print_basics.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 builtin.module {
     print.println "Hello world!"
@@ -9,6 +9,7 @@ builtin.module {
     print.println "Uses vals twice {} {} {} {}", %12 : i32, %144 : i32, %12 : i32, %144 : i32
 
     print.println "{}", %144 : i32
+    print.println "{}", %144 : i32 {unit}
 }
 
 // CHECK:       print.println "Hello world!"
@@ -16,3 +17,4 @@ builtin.module {
 // CHECK-NEXT:  %1 = "test.op"() : () -> i32
 // CHECK-NEXT:  print.println "Uses vals twice {} {} {} {}", %1 : i32, %0 : i32, %1 : i32, %0 : i32
 // CHECK-NEXT:  print.println "{}", %0 : i32
+// CHECK-NEXT:  print.println "{}", %0 : i32 {unit}

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1304,7 +1304,9 @@ class ModuleOp(IRDLOperation):
     def print(self, printer: Printer) -> None:
         if len(self.attributes) != 0:
             printer.print(" attributes {")
-            printer.print_dictionary(self.attributes, printer.print, printer.print)
+            printer.print_attribute_dictionary(
+                self.attributes, printer.print, printer.print
+            )
             printer.print("}")
 
         if not self.body.block.ops:

--- a/xdsl/dialects/print.py
+++ b/xdsl/dialects/print.py
@@ -59,7 +59,7 @@ class PrintLnOp(IRDLOperation):
             attrs = self.attributes.copy()
             attrs.pop("format_str")
             printer.print_string(" {")
-            printer.print_dictionary(
+            printer.print_attribute_dictionary(
                 attrs, printer.print_string, printer.print_attribute
             )
             printer.print_string("}")

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -184,6 +184,21 @@ class Printer:
             self.print("=")
             print_value(value)
 
+    def print_attribute_dictionary(
+        self,
+        elems: dict[K, V],
+        print_key: Callable[[K], None],
+        print_value: Callable[[V], None],
+        delimiter: str = ", ",
+    ) -> None:
+        for i, (key, value) in enumerate(elems.items()):
+            if i:
+                self.print(delimiter)
+            print_key(key)
+            if not isinstance(value, UnitAttr):
+                self.print("=")
+                print_value(value)
+
     def _print_new_line(
         self, indent: int | None = None, print_message: bool = True
     ) -> None:


### PR DESCRIPTION
The codebase currently uses print_dictionary to print custom attribute dictionaries, which does not handle UnitAttr and print `"unitattr" = [nothing]`, which doesn't roundtrip.

The first commit is MFE for the two usages, the next commit fixes them.
