### PR TITLE
dialects: (pdl) simplify rewrite pattern and implementations

### DIFF
--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -10,9 +10,8 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
     PatternRewriteWalker,
 )
-from xdsl.interpreter import Interpreter
 
-from xdsl.interpreters.experimental.pdl import PDLFunctions
+from xdsl.interpreters.experimental.pdl import PDLRewritePattern
 
 
 class SwapInputs(RewritePattern):
@@ -42,15 +41,19 @@ def test_rewrite_swap_inputs_pdl():
     output_module = swap_arguments_output()
     rewrite_module = swap_arguments_pdl()
 
+    pdl_rewrite_op = next(
+        op for op in rewrite_module.walk() if isinstance(op, pdl.RewriteOp)
+    )
+
     stream = StringIO()
-    interpreter = Interpreter(rewrite_module, file=stream)
+
     ctx = MLContext()
     ctx.register_dialect(arith.Arith)
 
-    pdl_ft = PDLFunctions(ctx, input_module)
-    interpreter.register_implementations(pdl_ft)
-
-    interpreter.run(rewrite_module)
+    PatternRewriteWalker(
+        PDLRewritePattern(pdl_rewrite_op, ctx, file=stream),
+        apply_recursively=False,
+    ).rewrite_module(input_module)
 
     assert input_module.is_structurally_equivalent(output_module)
 
@@ -150,15 +153,19 @@ def test_rewrite_add_zero_pdl():
     # output_module.verify()
     rewrite_module.verify()
 
+    pdl_rewrite_op = next(
+        op for op in rewrite_module.walk() if isinstance(op, pdl.RewriteOp)
+    )
+
     stream = StringIO()
-    interpreter = Interpreter(rewrite_module, file=stream)
+
     ctx = MLContext()
     ctx.register_dialect(arith.Arith)
 
-    pdl_ft = PDLFunctions(ctx, input_module)
-    interpreter.register_implementations(pdl_ft)
-
-    interpreter.run(interpreter.module)
+    PatternRewriteWalker(
+        PDLRewritePattern(pdl_rewrite_op, ctx, file=stream),
+        apply_recursively=False,
+    ).rewrite_module(input_module)
 
     assert input_module.is_structurally_equivalent(output_module)
 

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -221,7 +221,10 @@ class PDLRewritePattern(RewritePattern):
 @dataclass
 class PDLRewriteFunctions(InterpreterFunctions):
     """
-    The implementations in this class are for the RHS of the rewrite.
+    The implementations in this class are for the RHS of the rewrite. The SSA values
+    referenced within the rewrite block are guaranteed to have been matched with the
+    corresponding IR elements. The interpreter context stores the IR elements by SSA
+    values.
     """
 
     ctx: MLContext

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -177,7 +177,7 @@ class PDLMatcher:
 
 @dataclass
 class PDLRewritePattern(RewritePattern):
-    functions: PDLFunctions
+    functions: PDLRewriteFunctions
     pdl_rewrite_op: pdl.RewriteOp
     interpreter: Interpreter
 
@@ -188,7 +188,7 @@ class PDLRewritePattern(RewritePattern):
         assert isinstance(pdl_pattern, pdl.PatternOp)
         pdl_module = pdl_pattern.parent_op()
         assert isinstance(pdl_module, ModuleOp)
-        self.functions = PDLFunctions(ctx)
+        self.functions = PDLRewriteFunctions(ctx)
         self.interpreter = Interpreter(pdl_module, file=file)
         self.interpreter.register_implementations(self.functions)
         self.pdl_rewrite_op = pdl_rewrite_op
@@ -219,7 +219,7 @@ class PDLRewritePattern(RewritePattern):
 
 @register_impls
 @dataclass
-class PDLFunctions(InterpreterFunctions):
+class PDLRewriteFunctions(InterpreterFunctions):
     """
     The implementations in this class are for the RHS of the rewrite.
     """

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -188,7 +188,7 @@ class PDLRewritePattern(RewritePattern):
         assert isinstance(pdl_pattern, pdl.PatternOp)
         pdl_module = pdl_pattern.parent_op()
         assert isinstance(pdl_module, ModuleOp)
-        self.functions = PDLFunctions(ctx, pdl_module)
+        self.functions = PDLFunctions(ctx)
         self.interpreter = Interpreter(pdl_module, file=file)
         self.interpreter.register_implementations(self.functions)
         self.pdl_rewrite_op = pdl_rewrite_op
@@ -225,7 +225,6 @@ class PDLFunctions(InterpreterFunctions):
     """
 
     ctx: MLContext
-    module: ModuleOp
     _rewriter: PatternRewriter | None = field(default=None)
 
     @property


### PR DESCRIPTION
This PR aims to make the interpretation of the rewrite a bit less convoluted. Instead of interpreting the whole module, the rewrite pattern now interprets just the RewriteOp.