### PR TITLE
dialects: (func) Add custom syntax for func.return

### DIFF
--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -111,7 +111,7 @@ def test_func_rewriting_helpers():
     """
     func = FuncOp("test", ((i32, i32, i32), ()))
     with ImplicitBuilder(func.body):
-        Return.get()
+        Return()
 
     func.replace_argument_type(2, i64)
     assert func.function_type.inputs.data[2] is i64
@@ -143,7 +143,7 @@ def test_func_rewriting_helpers():
 def test_func_get_return_op():
     func_w_ret = FuncOp("test", ((i32, i32, i32), ()))
     with ImplicitBuilder(func_w_ret.body) as (a, _, _):
-        Return.get(a)
+        Return(a)
 
     func = FuncOp("test", ((i32, i32, i32), ()))
 
@@ -171,7 +171,7 @@ def test_call():
     # Create a Addi operation to use the args of the block
     c = Addi(block0.args[0], block0.args[1])
     # Create a return operation and add it in the block
-    ret0 = Return.get(c)
+    ret0 = Return(c)
     block0.add_ops([c, ret0])
     # Create a region with the block
     region = Region(block0)
@@ -219,7 +219,7 @@ def test_call_II():
     # Create a Addi operation to use the args of the block
     c = Addi(block0.args[0], block0.args[0])
     # Create a return operation and add it in the block
-    ret0 = Return.get(c)
+    ret0 = Return(c)
     block0.add_ops([c, ret0])
     # Create a region with the block
     region = Region(block0)
@@ -259,7 +259,7 @@ def test_return():
     c = Constant.from_int_and_width(3, i32)
 
     # Use these operations to create a Return operation
-    ret0 = Return.get(a, b, c)
+    ret0 = Return(a, b, c)
     assert len(ret0.operands) == 3
 
 

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -6,7 +6,6 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.ir import Attribute, OpResult
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import (
-    NoneAttr,
     StridedLayoutAttr,
     i32,
     i64,
@@ -221,7 +220,7 @@ def test_memref_matmul_verify():
 
             scf.For.get(lit0, dim_a0, lit1, [], outer_loop)
 
-            func.Return.get(out)
+            func.Return(out)
 
         func.FuncOp(
             "matmul",

--- a/tests/filecheck/dialects/affine/examples.mlir
+++ b/tests/filecheck/dialects/affine/examples.mlir
@@ -13,7 +13,7 @@
       %res = "arith.addi"(%sum, %val) : (i32, i32) -> i32
       "affine.yield"(%res) : (i32) -> ()
     }) {"lower_bound" = 0 : index, "upper_bound" = 256 : index, "step" = 1 : index} : (i32) -> i32
-    "func.return"(%r) : (i32) -> ()
+    func.return %r : i32
   }) {"sym_name" = "sum_vec", "function_type" = (memref<128xi32>) -> i32, "sym_visibility" = "private"} : () -> ()
 
   // CHECK:      "func.func"() ({

--- a/tests/filecheck/dialects/cf/cf_ops.mlir
+++ b/tests/filecheck/dialects/cf/cf_ops.mlir
@@ -4,12 +4,12 @@
   "func.func"() ({
     %cond = "arith.constant"() {"value" = true} : () -> i1
     "cf.assert"(%cond) {"msg" = "some message"} : (i1) -> ()
-    "func.return"() : () -> ()
+    func.return
   }) {"sym_name" = "assert", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
   // CHECK: "func.func"() ({
   // CHECK-NEXT:    %{{.*}} = "arith.constant"() {"value" = true} : () -> i1
   // CHECK-NEXT:    "cf.assert"(%cond) {"msg" = "some message"} : (i1) -> ()
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }) {"sym_name" = "assert", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
 
   "func.func"() ({

--- a/tests/filecheck/dialects/cmath/cmath_ops.mlir
+++ b/tests/filecheck/dialects/cmath/cmath_ops.mlir
@@ -6,25 +6,25 @@ builtin.module {
     %norm_p = "cmath.norm"(%p) : (!cmath.complex<f32>) -> f32
     %norm_q = "cmath.norm"(%q) : (!cmath.complex<f32>) -> f32
     %pq = "arith.mulf"(%norm_p, %norm_q) : (f32, f32) -> f32
-    "func.return"(%pq) : (f32) -> ()
+    func.return %pq : f32
   }
 
    // CHECK: func.func @conorm(%p : !cmath.complex<f32>, %q : !cmath.complex<f32>) -> f32 {
    // CHECK-NEXT:   %norm_p = "cmath.norm"(%p) : (!cmath.complex<f32>) -> f32
    // CHECK-NEXT:   %norm_q = "cmath.norm"(%q) : (!cmath.complex<f32>) -> f32
    // CHECK-NEXT:   %pq = arith.mulf %norm_p, %norm_q : f32
-   // CHECK-NEXT:   "func.return"(%pq) : (f32) -> ()
+   // CHECK-NEXT:   func.return %pq : f32
    // CHECK-NEXT: }
 
   func.func @conorm2(%a : !cmath.complex<f32>, %b : !cmath.complex<f32>) -> f32 {
     %ab = "cmath.mul"(%a, %b) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
     %conorm = "cmath.norm"(%ab) : (!cmath.complex<f32>) -> f32
-    "func.return"(%conorm) : (f32) -> ()
+    func.return %conorm : f32
   }
 
    // CHECK: func.func @conorm2(%a : !cmath.complex<f32>, %b : !cmath.complex<f32>) -> f32 {
    // CHECK-NEXT:   %ab = "cmath.mul"(%a, %b) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
    // CHECK-NEXT:   %conorm = "cmath.norm"(%ab) : (!cmath.complex<f32>) -> f32
-   // CHECK-NEXT:   "func.return"(%conorm) : (f32) -> ()
+   // CHECK-NEXT:   func.return %conorm : f32
    // CHECK-NEXT: }
 }

--- a/tests/filecheck/dialects/func/func_ops.mlir
+++ b/tests/filecheck/dialects/func/func_ops.mlir
@@ -3,53 +3,53 @@
 builtin.module {
 
   func.func @noarg_void() {
-    "func.return"() : () -> ()
+    func.return
   }
 
    // CHECK:      func.func @noarg_void() {
-   // CHECK-NEXT:   "func.return"() : () -> ()
+   // CHECK-NEXT:   func.return
    // CHECK-NEXT: }
 
   func.func @call_void() {
     "func.call"() {"callee" = @call_void} : () -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
    // CHECK: func.func @call_void() {
    // CHECK-NEXT:   "func.call"() {"callee" = @call_void} : () -> ()
-   // CHECK-NEXT:   "func.return"() : () -> ()
+   // CHECK-NEXT:   func.return
    // CHECK-NEXT: }
 
   func.func @arg_rec(%0 : !test.type<"int">) -> !test.type<"int"> {
     %1 = "func.call"(%0) {"callee" = @arg_rec} : (!test.type<"int">) -> !test.type<"int">
-    "func.return"(%1) : (!test.type<"int">) -> ()
+    func.return %1 : !test.type<"int">
   }
 
    // CHECK: func.func @arg_rec(%0 : !test.type<"int">) -> !test.type<"int"> {
    // CHECK-NEXT:   %{{.*}} = "func.call"(%{{.*}}) {"callee" = @arg_rec} : (!test.type<"int">) -> !test.type<"int">
-   // CHECK-NEXT:   "func.return"(%{{.*}}) : (!test.type<"int">) -> ()
+   // CHECK-NEXT:   func.return %{{.*}} : !test.type<"int">
    // CHECK-NEXT: }
 
   func.func @arg_rec_block(!test.type<"int">) -> !test.type<"int"> {
   ^0(%2 : !test.type<"int">):
     %3 = "func.call"(%2) {"callee" = @arg_rec_block} : (!test.type<"int">) -> !test.type<"int">
-    "func.return"(%3) : (!test.type<"int">) -> ()
+    func.return %3 : !test.type<"int">
   }
 
   // CHECK: func.func @arg_rec_block(%2 : !test.type<"int">) -> !test.type<"int"> {
   // CHECK-NEXT:   %3 = "func.call"(%2) {"callee" = @arg_rec_block} : (!test.type<"int">) -> !test.type<"int">
-  // CHECK-NEXT:   "func.return"(%3) : (!test.type<"int">) -> ()
+  // CHECK-NEXT:   func.return %3 : !test.type<"int">
   // CHECK-NEXT: }
 
   func.func private @external_fn(i32) -> (i32, i32)
   // CHECK: func.func private @external_fn(i32) -> (i32, i32)
 
   func.func @multi_return_body(%a : i32) -> (i32, i32) {
-    "func.return"(%a, %a) : (i32, i32) -> ()
+    func.return %a, %a : i32, i32
   }
 
   // CHECK: func.func @multi_return_body(%a : i32) -> (i32, i32) {
-  // CHECK-NEXT:   "func.return"(%a, %a) : (i32, i32) -> ()
+  // CHECK-NEXT:   func.return %a, %a : i32, i32
   // CHECK-NEXT: }
 
 }

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -51,7 +51,7 @@ builtin.module {
     ^1(%arg2 : i32):
       "scf.yield"(%arg2) : (i32) -> ()
     }) : (i32) -> i32
-    "func.return"() : () -> ()
+    func.return
   }
 
   // CHECK:      func.func @while() {
@@ -65,7 +65,7 @@ builtin.module {
   // CHECK-NEXT:   ^{{.*}}(%{{.*}} : i32):
   // CHECK-NEXT:     "scf.yield"(%{{.*}}) : (i32) -> ()
   // CHECK-NEXT:   }) : (i32) -> i32
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
   func.func @for() {
@@ -78,7 +78,7 @@ builtin.module {
       %prod_new = arith.muli %prod_iter, %iv : index
       "scf.yield"(%prod_new) : (index) -> ()
     }) : (index, index, index, index) -> index
-    "func.return"() : () -> ()
+    func.return
   }
 
   // CHECK-NEXT: func.func @for() {
@@ -91,7 +91,7 @@ builtin.module {
   // CHECK-NEXT:     %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
   // CHECK-NEXT:     "scf.yield"(%{{.*}}) : (index) -> ()
   // CHECK-NEXT:   }) : (index, index, index, index) -> index
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
 

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -22,7 +22,7 @@
       "stencil.return"(%19) : (f64) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
     "stencil.store"(%8, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }) {"function_type" = (!stencil.field<?x?x?xf64>, !stencil.field<?x?x?xf64>) -> (), "sym_name" = "stencil_hdiff"} : () -> ()
 }) : () -> ()
 
@@ -90,6 +90,6 @@
 // CHECK-NEXT:       "memref.store"(%58, %6, %18, %17, %16) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -12,7 +12,7 @@ builtin.module {
       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
     }) : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -28,7 +28,7 @@ builtin.module {
 // CHECK-NEXT:       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
 // CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -52,7 +52,7 @@ builtin.module {
       "stencil.store"(%tip1, %fip1) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
       "scf.yield"(%fip1, %fi) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
     }) : (index, index, index, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>)
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -74,7 +74,7 @@ builtin.module {
 // CHECK-NEXT:       "stencil.store"(%tip1, %fip1) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
 // CHECK-NEXT:       "scf.yield"(%fip1, %fi) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
 // CHECK-NEXT:     }) : (index, index, index, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>)
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -101,7 +101,7 @@ builtin.module {
       "stencil.return"(%17) : (f64) -> ()
     }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -126,7 +126,7 @@ builtin.module {
 // CHECK-NEXT:       "stencil.return"(%17) : (f64) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
 // CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -149,7 +149,7 @@ builtin.module {
       "stencil.return"(%14) : (f64) -> ()
     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
     "stencil.store"(%12, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -168,6 +168,6 @@ builtin.module {
 // CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
 // CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/frontend/dialects/affine.py
+++ b/tests/filecheck/frontend/dialects/affine.py
@@ -12,7 +12,7 @@ with CodeContext(p):
     # CHECK-NEXT:   ^0(%0 : index):
     # CHECK-NEXT:     "affine.yield"() : () -> ()
     # CHECK-NEXT:   }) {"lower_bound" = 0 : index, "upper_bound" = 100 : index, "step" = 1 : index} : () -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
 
     def test_affine_for_I():
@@ -25,7 +25,7 @@ with CodeContext(p):
     # CHECK-NEXT:   ^1(%1 : index):
     # CHECK-NEXT:     "affine.yield"() : () -> ()
     # CHECK-NEXT:   }) {"lower_bound" = 10 : index, "upper_bound" = 30 : index, "step" = 1 : index} : () -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_affine_for_II():
         for _ in range(10, 30):
@@ -37,7 +37,7 @@ with CodeContext(p):
     # CHECK-NEXT:   ^2(%2 : index):
     # CHECK-NEXT:     "affine.yield"() : () -> ()
     # CHECK-NEXT:   }) {"lower_bound" = 1 : index, "upper_bound" = 20 : index, "step" = 5 : index} : () -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_affine_for_III():
         for _ in range(1, 20, 5):
@@ -57,7 +57,7 @@ with CodeContext(p):
     # CHECK-NEXT:     }) {"lower_bound" = 0 : index, "upper_bound" = 20 : index, "step" = 1 : index} : () -> ()
     # CHECK-NEXT:     "affine.yield"() : () -> ()
     # CHECK-NEXT:   }) {"lower_bound" = 0 : index, "upper_bound" = 10 : index, "step" = 1 : index} : () -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_affine_for_IV():
         for _ in range(10):

--- a/tests/filecheck/frontend/dialects/func.py
+++ b/tests/filecheck/frontend/dialects/func.py
@@ -9,13 +9,13 @@ with CodeContext(p):
     # CHECK:      func.func @f1(%{{.*}} : i32) {
     # CHECK-NEXT:   "symref.declare"() {"sym_name" = "x"} : () -> ()
     # CHECK-NEXT:   "symref.update"(%{{.*}}) {"symbol" = @x} : (i32) -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def f1(x: i32):
         return
 
     # CHECK:      func.func @f2() {
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def f2():
         return
@@ -24,7 +24,7 @@ with CodeContext(p):
     # CHECK-NEXT:   "symref.declare"() {"sym_name" = "x"} : () -> ()
     # CHECK-NEXT:   "symref.update"(%{{.*}}) {"symbol" = @x} : (i32) -> ()
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @x} : () -> i32
-    # CHECK-NEXT:   "func.return"(%{{.*}}) : (i32) -> ()
+    # CHECK-NEXT:   func.return %{{.*}} : i32
     # CHECK-NEXT: }
     def f3(x: i32) -> i32:
         return x

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -16,7 +16,7 @@ with CodeContext(p):
     # CHECK-NEXT:   ^0(%{{.*}} : index):
     # CHECK-NEXT:     "scf.yield"() : () -> ()
     # CHECK-NEXT:   }) : (index, index, index) -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
 
     def test_for_I(end: index):
@@ -32,7 +32,7 @@ with CodeContext(p):
     # CHECK-NEXT:   ^1(%{{.*}} : index):
     # CHECK-NEXT:     "scf.yield"() : () -> ()
     # CHECK-NEXT:   }) : (index, index, index) -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_for_II(start: index, end: index):
         for _ in range(start, end):  # type: ignore
@@ -47,7 +47,7 @@ with CodeContext(p):
     # CHECK-NEXT:   ^2(%{{.*}} : index):
     # CHECK-NEXT:     "scf.yield"() : () -> ()
     # CHECK-NEXT:   }) : (index, index, index) -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_for_III(start: index, end: index, step: index):
         for _ in range(start, end, step):  # type: ignore
@@ -76,7 +76,7 @@ with CodeContext(p):
     # CHECK-NEXT:       }) : (index, index, index) -> ()
     # CHECK-NEXT:       "scf.yield"() : () -> ()
     # CHECK-NEXT:     }) : (index, index, index) -> ()
-    # CHECK-NEXT:   "func.return"() : () -> ()
+    # CHECK-NEXT:   func.return
     # CHECK-NEXT:   }
     def test_for_IV(a: index, b: index, c: index):
         for _ in range(a):  # type: ignore

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops.mlir
@@ -4,53 +4,53 @@
 builtin.module {
 
   func.func @noarg_void() {
-    "func.return"() : () -> ()
+    func.return
   }
 
    // CHECK:      func.func @noarg_void() {
-   // CHECK-NEXT:   "func.return"() : () -> ()
+   // CHECK-NEXT:   func.return
    // CHECK-NEXT: }
 
   func.func @call_void() {
     "func.call"() {"callee" = @call_void} : () -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
    // CHECK: func.func @call_void() {
    // CHECK-NEXT:   "func.call"() {"callee" = @call_void} : () -> ()
-   // CHECK-NEXT:   "func.return"() : () -> ()
+   // CHECK-NEXT:   func.return
    // CHECK-NEXT: }
 
   func.func @arg_rec(%arg0 : i32) -> i32 {
     %1 = "func.call"(%arg0) {"callee" = @arg_rec} : (i32) -> i32
-    "func.return"(%1) : (i32) -> ()
+    func.return %1 : i32
   }
 
    // CHECK: func.func @arg_rec(%{{.*}} : i32) -> i32 {
    // CHECK-NEXT:   %{{.*}} = "func.call"(%{{.*}}) {"callee" = @arg_rec} : (i32) -> i32
-   // CHECK-NEXT:   "func.return"(%{{.*}}) : (i32) -> ()
+   // CHECK-NEXT:   func.return %{{.*}} : i32
    // CHECK-NEXT: }
 
   func.func @arg_rec_block(i32) -> i32 {
   ^0(%2 : i32):
     %3 = "func.call"(%2) {"callee" = @arg_rec_block} : (i32) -> i32
-    "func.return"(%3) : (i32) -> ()
+    func.return %3 : i32
   }
 
   // CHECK: func.func @arg_rec_block(%{{.*}} : i32) -> i32 {
   // CHECK-NEXT:   %{{.*}} = "func.call"(%{{.*}}) {"callee" = @arg_rec_block} : (i32) -> i32
-  // CHECK-NEXT:   "func.return"(%{{.*}}) : (i32) -> ()
+  // CHECK-NEXT:   func.return %{{.*}} : i32
   // CHECK-NEXT: }
 
   func.func private @external_fn(i32) -> (i32, i32)
   // CHECK: func.func private @external_fn(i32) -> (i32, i32)
 
   func.func @multi_return_body(%a : i32) -> (i32, i32) {
-    "func.return"(%a, %a) : (i32, i32) -> ()
+    func.return %a, %a : i32, i32
   }
 
   // CHECK: func.func @multi_return_body(%{{.*}} : i32) -> (i32, i32) {
-  // CHECK-NEXT:   "func.return"(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
+  // CHECK-NEXT:   func.return %{{.*}}, %{{.*}} : i32, i32
   // CHECK-NEXT: }
 
 }

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -12,7 +12,7 @@ builtin.module {
       "stencil.return"(%6) : (f64) -> ()
     }) : (f64) -> !stencil.temp<[1,65]x[2,66]x[3,63]xf64>
     "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[1,65]x[2,66]x[3,63]xf64>, !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
   // CHECK:      func.func @stencil_init_float(%0 : f64, %1 : memref<?x?x?xf64>) {
@@ -40,7 +40,7 @@ builtin.module {
   // CHECK-NEXT:     }) : (index, index, index) -> ()
   // CHECK-NEXT:     "scf.yield"() : () -> ()
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
   func.func @bufferswapping(%f0 : !stencil.field<[-2,2002]x[-2,2002]xf32>, %f1 : !stencil.field<[-2,2002]x[-2,2002]xf32>) -> !stencil.field<[-2,2002]x[-2,2002]xf32> {
@@ -58,7 +58,7 @@ builtin.module {
       "stencil.store"(%ti, %fi) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<2000, 2000>} : (!stencil.temp<[0,2000]x[0,2000]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>) -> ()
       "scf.yield"(%fi, %fim1) : (!stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>) -> ()
     }) : (index, index, index, !stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>) -> (!stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>)
-    "func.return"(%t1_out) : (!stencil.field<[-2,2002]x[-2,2002]xf32>) -> ()
+    func.return %t1_out : !stencil.field<[-2,2002]x[-2,2002]xf32>
   }
 // CHECK:      func.func @bufferswapping(%f0 : memref<2004x2004xf32>, %f1 : memref<2004x2004xf32>) -> memref<2004x2004xf32> {
 // CHECK-NEXT:   %time_m = "arith.constant"() {"value" = 0 : index} : () -> index
@@ -89,7 +89,7 @@ builtin.module {
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:     "scf.yield"(%fi, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
 // CHECK-NEXT:   }) : (index, index, index, memref<2004x2004xf32>, memref<2004x2004xf32>) -> (memref<2004x2004xf32>, memref<2004x2004xf32>)
-// CHECK-NEXT:   "func.return"(%t1_out) : (memref<2004x2004xf32>) -> ()
+// CHECK-NEXT:   func.return %t1_out : memref<2004x2004xf32>
 // CHECK-NEXT: }
 
   func.func @copy_1d(%0 : !stencil.field<?xf64>, %out : !stencil.field<?xf64>) {
@@ -102,7 +102,7 @@ builtin.module {
       "stencil.return"(%5) : (f64) -> ()
     }) : (!stencil.temp<[-1,68]xf64>) -> !stencil.temp<[0,68]xf64>
     "stencil.store"(%3, %outc) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<[0,68]xf64>, !stencil.field<[0,1024]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
   // CHECK:      func.func @copy_1d(%23 : memref<?xf64>, %out : memref<?xf64>) {
@@ -121,7 +121,7 @@ builtin.module {
   // CHECK-NEXT:     "memref.store"(%32, %outc_storeview, %29) : (f64, memref<68xf64, strided<[1]>>, index) -> ()
   // CHECK-NEXT:     "scf.yield"() : () -> ()
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
   func.func @copy_2d(%0 : !stencil.field<?x?xf64>) {
@@ -132,7 +132,7 @@ builtin.module {
       %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[-1,64]x[0,68]xf64>) -> f64
       "stencil.return"(%5) : (f64) -> ()
     }) : (!stencil.temp<[-1,64]x[0,68]xf64>) -> !stencil.temp<[0,64]x[0,68]xf64>
-    "func.return"() : () -> ()
+    func.return
   }
   // CHECK:      func.func @copy_2d(%33 : memref<?x?xf64>) {
   // CHECK-NEXT:   %34 = "memref.cast"(%33) : (memref<?x?xf64>) -> memref<72x72xf64>
@@ -155,7 +155,7 @@ builtin.module {
   // CHECK-NEXT:     }) : (index, index, index) -> ()
   // CHECK-NEXT:     "scf.yield"() : () -> ()
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
   func.func @copy_3d(%0 : !stencil.field<?x?x?xf64>) {
@@ -166,7 +166,7 @@ builtin.module {
       %5 = "stencil.access"(%4) {"offset" = #stencil.index<-1, 0, 1>} : (!stencil.temp<[-1,64]x[0,64]x[0,69]xf64>) -> f64
       "stencil.return"(%5) : (f64) -> ()
     }) : (!stencil.temp<[-1,64]x[0,64]x[0,69]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,68]xf64>
-    "func.return"() : () -> ()
+    func.return
   }
 // CHECK:       func.func @copy_3d(%48 : memref<?x?x?xf64>) {
 // CHECK-NEXT:    %49 = "memref.cast"(%48) : (memref<?x?x?xf64>) -> memref<72x74x76xf64>
@@ -197,21 +197,21 @@ builtin.module {
 // CHECK-NEXT:      }) : (index, index, index) -> ()
 // CHECK-NEXT:      "scf.yield"() : () -> ()
 // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:    "func.return"() : () -> ()
+// CHECK-NEXT:    func.return
 // CHECK-NEXT:  }
 
   func.func @test_funcop_lowering(%0 : !stencil.field<?x?x?xf64>) {
-    "func.return"() : () -> ()
+    func.return
   }
   // CHECK:      func.func @test_funcop_lowering(%68 : memref<?x?x?xf64>) {
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
   func.func @test_funcop_lowering_dyn(%1 : !stencil.field<[-1,7]x[-1,7]xf64>) {
-    "func.return"() : () -> ()
+    func.return
   }
   // CHECK-NEXT: func.func @test_funcop_lowering_dyn(%69 : memref<8x8xf64>) {
-  // CHECK-NEXT:   "func.return"() : () -> ()
+  // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
   func.func @offsets(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>, %2 : !stencil.field<?x?x?xf64>) {
@@ -235,7 +235,7 @@ builtin.module {
       "stencil.return"(%19, %18) : (f64, f64) -> ()
     }) : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.temp<[0,64]x[0,64]x[0,64]xf64>)
     "stencil.store"(%7, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
 // CHECK:      func.func @offsets(%70 : memref<?x?x?xf64>, %71 : memref<?x?x?xf64>, %72 : memref<?x?x?xf64>) {
@@ -305,7 +305,7 @@ builtin.module {
 // CHECK-NEXT:     }) : (index, index, index) -> ()
 // CHECK-NEXT:     "scf.yield"() : () -> ()
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:   "func.return"() : () -> ()
+// CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 
 func.func @trivial_externals(%dyn_mem : memref<?x?x?xf64>, %sta_mem : memref<64x64x64xf64>, %dyn_field : !stencil.field<?x?x?xf64>, %sta_field : !stencil.field<[-2,62]x[0,64]x[2,66]xf64>) {
@@ -315,11 +315,11 @@ func.func @trivial_externals(%dyn_mem : memref<?x?x?xf64>, %sta_mem : memref<64x
     %1 = "stencil.external_load"(%sta_mem) : (memref<64x64x64xf64>) -> !stencil.field<[-2,62]x[0,64]x[2,66]xf64>
 
     %casted = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-2,62]x[0,64]x[2,66]xf64>
-    "func.return"() : () -> ()
+    func.return
 }
 // CHECK:       func.func @trivial_externals(%dyn_mem : memref<?x?x?xf64>, %sta_mem : memref<64x64x64xf64>, %dyn_field : memref<?x?x?xf64>, %sta_field : memref<64x64x64xf64>) {
 // CHECK-NEXT:    %casted = "memref.cast"(%dyn_mem) : (memref<?x?x?xf64>) -> memref<64x64x64xf64>
-// CHECK-NEXT:    "func.return"() : () -> ()
+// CHECK-NEXT:    func.return
 // CHECK-NEXT: }
 
 func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<[-32,32]xf64>) {
@@ -330,7 +330,7 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
     "stencil.return"(%val) : (f64) -> ()
   }) : (!stencil.temp<[-16,16]xf64>) -> !stencil.temp<[-16,16]xf64>
   "stencil.store"(%outt, %out) {"lb" = #stencil.index<-16>, "ub" = #stencil.index<16>} : (!stencil.temp<[-16,16]xf64>, !stencil.field<[-32,32]xf64>) -> ()
-  "func.return"() : () -> ()
+  func.return
 }
 // CHECK:      func.func @neg_bounds(%in : memref<64xf64>, %out_1 : memref<64xf64>) {
 // CHECK-NEXT:   %out_storeview = "memref.subview"(%out_1) {"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
@@ -346,7 +346,7 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
 // CHECK-NEXT:     "memref.store"(%val_2, %out_storeview, %131) : (f64, memref<32xf64, strided<[1], offset: 32>>, index) -> ()
 // CHECK-NEXT:     "scf.yield"() : () -> ()
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:   "func.return"() : () -> ()
+// CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 
   func.func @stencil_buffer(%49 : !stencil.field<[-4,68]xf64>, %50 : !stencil.field<[-4,68]xf64>) {
@@ -363,7 +363,7 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
       "stencil.return"(%58) : (f64) -> ()
     }) : (!stencil.temp<[1,65]xf64>) -> !stencil.temp<[0,64]xf64>
     "stencil.store"(%56, %50) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
 // CHECK:       func.func @stencil_buffer(%132 : memref<72xf64>, %133 : memref<72xf64>) {
@@ -394,7 +394,7 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
 // CHECK-NEXT:      "scf.yield"() : () -> ()
 // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:    "memref.dealloc"(%137) : (memref<64xf64, strided<[1], offset: -1>>) -> ()
-// CHECK-NEXT:    "func.return"() : () -> ()
+// CHECK-NEXT:    func.return
 // CHECK-NEXT:  }
 
   func.func @stencil_two_stores(%59 : !stencil.field<[-4,68]xf64>, %60 : !stencil.field<[-4,68]xf64>, %61 : !stencil.field<[-4,68]xf64>) {
@@ -411,7 +411,7 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
       "stencil.return"(%68) : (f64) -> ()
     }) : (!stencil.temp<[1,65]xf64>) -> !stencil.temp<[0,64]xf64>
     "stencil.store"(%66, %60) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
 //CHECK:      func.func @stencil_two_stores(%152 : memref<72xf64>, %153 : memref<72xf64>, %154 : memref<72xf64>) {
@@ -440,7 +440,7 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
 //CHECK-NEXT:     "memref.store"(%171, %155, %168) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
 //CHECK-NEXT:     "scf.yield"() : () -> ()
 //CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-//CHECK-NEXT:   "func.return"() : () -> ()
+//CHECK-NEXT:   func.return
 //CHECK-NEXT: }
 
 }

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -12,7 +12,7 @@ builtin.module {
       "stencil.return"(%o) : (f64) -> ()
     }) : (!stencil.temp<?xf64>, !stencil.temp<?xf64>) -> !stencil.temp<?xf64>
     "stencil.store"(%tout, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -28,7 +28,7 @@ builtin.module {
 // CHECK-NEXT:       "stencil.return"(%o) : (f64) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<[-1,63]xf64>, !stencil.temp<[1,65]xf64>) -> !stencil.temp<[0,64]xf64>
 // CHECK-NEXT:     "stencil.store"(%tout, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -55,7 +55,7 @@ builtin.module {
       "stencil.return"(%16) : (f64) -> ()
     }) : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -81,7 +81,7 @@ builtin.module {
 // CHECK-NEXT:       "stencil.return"(%16) : (f64) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<[-1,65]x[-1,65]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
 // CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -108,7 +108,7 @@ builtin.module {
       "stencil.return"(%16) : (f64) -> ()
     }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -127,7 +127,7 @@ builtin.module {
       "stencil.return"(%6) : (f64) -> ()
     }) : (f64) -> !stencil.temp<[1,65]x[2,66]x[3,63]xf64>
     "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[1,65]x[2,66]x[3,63]xf64>, !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -141,7 +141,7 @@ builtin.module {
 // CHECK-NEXT:       "stencil.return"(%6) : (f64) -> ()
 // CHECK-NEXT:     }) : (f64) -> !stencil.temp<[1,65]x[2,66]x[3,63]xf64>
 // CHECK-NEXT:     "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[1,65]x[2,66]x[3,63]xf64>, !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -164,7 +164,7 @@ builtin.module {
       "stencil.return"(%14) : (f64) -> ()
     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
     "stencil.store"(%12, %1) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 }
 
@@ -183,6 +183,6 @@ builtin.module {
 // CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<[0,64]xf64>) -> !stencil.temp<[0,64]xf64>
 // CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
-// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/stencil-storage-materialization.mlir
+++ b/tests/filecheck/transforms/stencil-storage-materialization.mlir
@@ -11,7 +11,7 @@ builtin.module{
       "stencil.return"(%v) : (f64) -> ()
     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
     "stencil.store"(%outt, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
 // CHECK:      func.func @copy(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
@@ -22,7 +22,7 @@ builtin.module{
 // CHECK-NEXT:     "stencil.return"(%v) : (f64) -> ()
 // CHECK-NEXT:   }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
 // CHECK-NEXT:   "stencil.store"(%outt, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-// CHECK-NEXT:   "func.return"() : () -> ()
+// CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 
  // Here we want to see a buffer added after the first apply.
@@ -40,7 +40,7 @@ builtin.module{
       "stencil.return"(%v) : (f64) -> ()
     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
     "stencil.store"(%outt, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
   //CHECK:      func.func @buffer_copy(%in_1 : !stencil.field<[-4,68]xf64>, %out_1 : !stencil.field<[-4,68]xf64>) {
@@ -57,7 +57,7 @@ builtin.module{
   //CHECK-NEXT:     "stencil.return"(%v_1) : (f64) -> ()
   //CHECK-NEXT:   }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
   //CHECK-NEXT:   "stencil.store"(%outt_1, %out_1) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-  //CHECK-NEXT:   "func.return"() : () -> ()
+  //CHECK-NEXT:   func.return
   //CHECK-NEXT: }
 
   // Here we don't want to see a buffer added after the apply, because the result is stored.
@@ -76,7 +76,7 @@ builtin.module{
       "stencil.return"(%v) : (f64) -> ()
     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
     "stencil.store"(%outt, %out) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-    "func.return"() : () -> ()
+    func.return
   }
 
 // CHECK:      func.func @stored_copy(%in_2 : !stencil.field<[-4,68]xf64>, %midout : !stencil.field<[-4,68]xf64>, %out_2 : !stencil.field<[-4,68]xf64>) {
@@ -93,7 +93,7 @@ builtin.module{
 // CHECK-NEXT:     "stencil.return"(%v_3) : (f64) -> ()
 // CHECK-NEXT:   }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
 // CHECK-NEXT:   "stencil.store"(%outt_2, %out_2) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-// CHECK-NEXT:   "func.return"() : () -> ()
+// CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 }
 

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -68,7 +68,7 @@ def swap_arguments_input():
             z = arith.Constant.from_int_and_width(1, 32).result
             x_y = arith.Addi(x, y).result
             x_y_z = arith.Addi(x_y, z).result
-            func.Return.get(x_y_z)
+            func.Return(x_y_z)
 
     return ir_module
 
@@ -83,7 +83,7 @@ def swap_arguments_output():
             z = arith.Constant.from_int_and_width(1, 32).result
             x_y = arith.Addi(x, y).result
             z_x_y = arith.Addi(z, x_y).result
-            func.Return.get(z_x_y)
+            func.Return(z_x_y)
 
     return ir_module
 
@@ -178,7 +178,7 @@ def add_zero_input():
             x = arith.Constant.from_int_and_width(4, 32)
             y = arith.Constant.from_int_and_width(0, 32)
             z = arith.Addi(x, y)
-            func.Return.get(z)
+            func.Return(z)
 
     return ir_module
 
@@ -190,7 +190,7 @@ def add_zero_output():
         with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
             x = arith.Constant.from_int_and_width(4, 32)
             _y = arith.Constant.from_int_and_width(0, 32)
-            func.Return.get(x)
+            func.Return(x)
 
     return ir_module
 

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -589,7 +589,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                     node.col_offset,
                     f"Expected '{function_name}' to return a type.",
                 )
-            self.inserter.insert_op(func.Return.get())
+            self.inserter.insert_op(func.Return())
 
     def visit_Return(self, node: ast.Return) -> None:
         # First of all, we should only be able to return if the statement is directly
@@ -625,7 +625,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                     f"Expected non-zero number of return types in function "
                     f"'{func_name}', but got 0.",
                 )
-            self.inserter.insert_op(func.Return.get())
+            self.inserter.insert_op(func.Return())
         else:
             # Return some type, check function signature matches as well.
             # TODO: Support multiple return values if we allow multiple assignemnts.
@@ -651,4 +651,4 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                         f" got {operands[i].typ}.",
                     )
 
-            self.inserter.insert_op(func.Return.get(*operands))
+            self.inserter.insert_op(func.Return(*operands))


### PR DESCRIPTION
This PR:

 - adds an `__init__` constructor for `func.Return`, deprecating the old one.
 - Adds custom print and parse as per MLIR docs