### PR TITLE
core: Remove print_attribute_dictionary in favour of print_op_attributes

### DIFF
--- a/tests/filecheck/dialects/builtin/module.mlir
+++ b/tests/filecheck/dialects/builtin/module.mlir
@@ -6,7 +6,7 @@ builtin.module {
     // CHECK: builtin.module {
     // CHECK-NEXT: }
     builtin.module attributes {a = "foo", b = "bar", unit} {}
-    // CHECK-NEXT: builtin.module attributes {a="foo", b="bar", unit} {
+    // CHECK-NEXT: builtin.module attributes {"a" = "foo", "b" = "bar", "unit"} {
     // CHECK-NEXT: }
 }
 // CHECK: }

--- a/tests/filecheck/dialects/print/print_basics.mlir
+++ b/tests/filecheck/dialects/print/print_basics.mlir
@@ -17,4 +17,4 @@ builtin.module {
 // CHECK-NEXT:  %1 = "test.op"() : () -> i32
 // CHECK-NEXT:  print.println "Uses vals twice {} {} {} {}", %1 : i32, %0 : i32, %1 : i32, %0 : i32
 // CHECK-NEXT:  print.println "{}", %0 : i32
-// CHECK-NEXT:  print.println "{}", %0 : i32 {unit}
+// CHECK-NEXT:  print.println "{}", %0 : i32 {"unit"}

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1303,9 +1303,8 @@ class ModuleOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if len(self.attributes) != 0:
-            printer.print(" attributes {")
-            printer.print_attribute_dictionary(self.attributes)
-            printer.print("}")
+            printer.print(" attributes ")
+            printer.print_op_attributes(self.attributes)
 
         if not self.body.block.ops:
             # Do not print the entry block if the region has an empty block

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -342,7 +342,7 @@ class Return(IRDLOperation):
     def print(self, printer: Printer):
         if self.attributes:
             printer.print(" ")
-            printer.print_attribute_dictionary(self.attributes)
+            printer.print_op_attributes(self.attributes)
 
         if self.arguments:
             printer.print(" ")

--- a/xdsl/dialects/print.py
+++ b/xdsl/dialects/print.py
@@ -58,9 +58,7 @@ class PrintLnOp(IRDLOperation):
         if len(self.attributes) > 1:
             attrs = self.attributes.copy()
             attrs.pop("format_str")
-            printer.print_string(" {")
-            printer.print_attribute_dictionary(attrs)
-            printer.print_string("}")
+            printer.print_op_attributes(attrs)
 
     @classmethod
     def parse(cls: type[PrintLnOp], parser: Parser) -> PrintLnOp:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -184,18 +184,6 @@ class Printer:
             self.print("=")
             print_value(value)
 
-    def print_attribute_dictionary(
-        self,
-        elems: dict[str, Attribute],
-    ) -> None:
-        for i, (name, attribute) in enumerate(elems.items()):
-            if i:
-                self.print(", ")
-            self.print(name)
-            if not isinstance(attribute, UnitAttr):
-                self.print("=")
-                self.print_attribute(attribute)
-
     def _print_new_line(
         self, indent: int | None = None, print_message: bool = True
     ) -> None:


### PR DESCRIPTION
Stacked on top of #1170 

This removes the `print_attribute_dictionary` method from the printer in favor of the `print_op_attribute` method already used by the default format.