### PR TITLE
dialects: offset mapping on stencil apply

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -184,7 +184,6 @@ def test_stencil_apply_no_results():
     with pytest.raises(AssertionError):
         ApplyOp.get([], Block([]), [])
 
-
 @pytest.mark.parametrize(
     "indices",
     (
@@ -565,6 +564,25 @@ def test_stencil_access():
     assert isinstance(access, AccessOp)
     assert access.offset == offset_index_attr
     assert access.temp.typ == temp_type
+
+
+def test_stencil_access_offset_mapping():
+    temp_type = TempType([(0, 5), (0, 5)], f32)
+    temp_type_ssa_val = TestSSAValue(temp_type)
+
+    offset = [1, 1]
+    offset_index_attr = IndexAttr.get(*offset)
+
+    offset_mapping = [1, 0]
+    offset_mapping_attr = ArrayAttr(IntAttr(value) for value in offset_mapping)
+
+    access = AccessOp.get(temp_type_ssa_val, offset, offset_mapping)
+
+    assert isinstance(access, AccessOp)
+    assert access.offset == offset_index_attr
+    assert access.temp.typ == temp_type
+    assert access.offset_mapping is not None
+    assert access.offset_mapping == offset_mapping_attr
 
 
 def test_store_result():

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -184,6 +184,7 @@ def test_stencil_apply_no_results():
     with pytest.raises(AssertionError):
         ApplyOp.get([], Block([]), [])
 
+
 @pytest.mark.parametrize(
     "indices",
     (

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -47,47 +47,25 @@
 // CHECK-NEXT:     "scf.parallel"(%11, %10, %8, %15, %14, %13, %12, %12, %12) ({
 // CHECK-NEXT:     ^0(%16 : index, %17 : index, %18 : index):
 // CHECK-NEXT:       %19 = arith.constant -1 : index
-// CHECK-NEXT:       %20 = arith.constant 0 : index
-// CHECK-NEXT:       %21 = arith.constant 0 : index
-// CHECK-NEXT:       %22 = arith.addi %18, %19 : index
-// CHECK-NEXT:       %23 = arith.addi %17, %20 : index
-// CHECK-NEXT:       %24 = arith.addi %16, %21 : index
-// CHECK-NEXT:       %25 = "memref.load"(%7, %22, %23, %24) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:       %26 = arith.constant 1 : index
-// CHECK-NEXT:       %27 = arith.constant 0 : index
-// CHECK-NEXT:       %28 = arith.constant 0 : index
-// CHECK-NEXT:       %29 = arith.addi %18, %26 : index
-// CHECK-NEXT:       %30 = arith.addi %17, %27 : index
-// CHECK-NEXT:       %31 = arith.addi %16, %28 : index
-// CHECK-NEXT:       %32 = "memref.load"(%7, %29, %30, %31) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:       %33 = arith.constant 0 : index
-// CHECK-NEXT:       %34 = arith.constant 1 : index
-// CHECK-NEXT:       %35 = arith.constant 0 : index
-// CHECK-NEXT:       %36 = arith.addi %18, %33 : index
-// CHECK-NEXT:       %37 = arith.addi %17, %34 : index
-// CHECK-NEXT:       %38 = arith.addi %16, %35 : index
-// CHECK-NEXT:       %39 = "memref.load"(%7, %36, %37, %38) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:       %40 = arith.constant 0 : index
-// CHECK-NEXT:       %41 = arith.constant -1 : index
-// CHECK-NEXT:       %42 = arith.constant 0 : index
-// CHECK-NEXT:       %43 = arith.addi %18, %40 : index
-// CHECK-NEXT:       %44 = arith.addi %17, %41 : index
-// CHECK-NEXT:       %45 = arith.addi %16, %42 : index
-// CHECK-NEXT:       %46 = "memref.load"(%7, %43, %44, %45) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:       %47 = arith.constant 0 : index
-// CHECK-NEXT:       %48 = arith.constant 0 : index
-// CHECK-NEXT:       %49 = arith.constant 0 : index
-// CHECK-NEXT:       %50 = arith.addi %18, %47 : index
-// CHECK-NEXT:       %51 = arith.addi %17, %48 : index
-// CHECK-NEXT:       %52 = arith.addi %16, %49 : index
-// CHECK-NEXT:       %53 = "memref.load"(%7, %50, %51, %52) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:       %54 = arith.addf %25, %32 : f64
-// CHECK-NEXT:       %55 = arith.addf %39, %46 : f64
-// CHECK-NEXT:       %56 = arith.addf %54, %55 : f64
+// CHECK-NEXT:       %20 = arith.addi %18, %19 : index
+// CHECK-NEXT:       %21 = "memref.load"(%7, %20, %17, %16) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+// CHECK-NEXT:       %22 = arith.constant 1 : index
+// CHECK-NEXT:       %23 = arith.addi %18, %22 : index
+// CHECK-NEXT:       %24 = "memref.load"(%7, %23, %17, %16) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+// CHECK-NEXT:       %25 = arith.constant 1 : index
+// CHECK-NEXT:       %26 = arith.addi %17, %25 : index
+// CHECK-NEXT:       %27 = "memref.load"(%7, %18, %26, %16) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+// CHECK-NEXT:       %28 = arith.constant -1 : index
+// CHECK-NEXT:       %29 = arith.addi %17, %28 : index
+// CHECK-NEXT:       %30 = "memref.load"(%7, %18, %29, %16) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+// CHECK-NEXT:       %31 = "memref.load"(%7, %18, %17, %16) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+// CHECK-NEXT:       %32 = arith.addf %21, %24 : f64
+// CHECK-NEXT:       %33 = arith.addf %27, %30 : f64
+// CHECK-NEXT:       %34 = arith.addf %32, %33 : f64
 // CHECK-NEXT:       %cst = arith.constant -4.0 : f64
-// CHECK-NEXT:       %57 = arith.mulf %53, %cst : f64
-// CHECK-NEXT:       %58 = arith.addf %57, %56 : f64
-// CHECK-NEXT:       "memref.store"(%58, %6, %18, %17, %16) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
+// CHECK-NEXT:       %35 = arith.mulf %31, %cst : f64
+// CHECK-NEXT:       %36 = arith.addf %35, %34 : f64
+// CHECK-NEXT:       "memref.store"(%36, %6, %18, %17, %16) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
 // CHECK-NEXT:       "scf.yield"() : () -> ()
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:     func.return

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -171,3 +171,43 @@ builtin.module {
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+builtin.module {
+  func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
+    %4 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+    %5 = "stencil.apply"(%4) ({
+    ^0(%6 : !stencil.temp<?xf64>):
+      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
+      "stencil.return"(%11) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+
+    %15 = "stencil.buffer"(%5) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+
+    %12 = "stencil.apply"(%15) ({
+    ^0(%13 : !stencil.temp<?xf64>):
+      %14 = "stencil.access"(%13) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
+      "stencil.return"(%14) : (f64) -> ()
+    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+    "stencil.store"(%12, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    func.return
+  }
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
+// CHECK-NEXT:     %2 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     %3 = "stencil.apply"(%2) ({
+// CHECK-NEXT:     ^0(%4 : !stencil.temp<?xf64>):
+// CHECK-NEXT:       %5 = "stencil.access"(%4) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
+// CHECK-NEXT:       "stencil.return"(%5) : (f64) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     %6 = "stencil.buffer"(%3) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     %7 = "stencil.apply"(%6) ({
+// CHECK-NEXT:     ^1(%8 : !stencil.temp<?xf64>):
+// CHECK-NEXT:       %9 = "stencil.access"(%8) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
+// CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -172,42 +172,34 @@ builtin.module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
+// -----
+
 builtin.module {
-  func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
-    %4 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
+  func.func private @stencil_offset_mapping(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>) {
+    %2 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+    %3 = "stencil.cast"(%1) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+    %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
     %5 = "stencil.apply"(%4) ({
-    ^0(%6 : !stencil.temp<?xf64>):
-      %11 = "stencil.access"(%6) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
-      "stencil.return"(%11) : (f64) -> ()
-    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-
-    %15 = "stencil.buffer"(%5) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-
-    %12 = "stencil.apply"(%15) ({
-    ^0(%13 : !stencil.temp<?xf64>):
-      %14 = "stencil.access"(%13) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
-      "stencil.return"(%14) : (f64) -> ()
-    }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-    "stencil.store"(%12, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    ^0(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):
+      %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>, "offset_mapping" = [#int<1>, #int<0>]} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+      "stencil.return"(%7) : (f64) -> ()
+    }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
+    "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
     func.return
   }
 }
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
-// CHECK-NEXT:     %2 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     %3 = "stencil.apply"(%2) ({
-// CHECK-NEXT:     ^0(%4 : !stencil.temp<?xf64>):
-// CHECK-NEXT:       %5 = "stencil.access"(%4) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
-// CHECK-NEXT:       "stencil.return"(%5) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     %6 = "stencil.buffer"(%3) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     %7 = "stencil.apply"(%6) ({
-// CHECK-NEXT:     ^1(%8 : !stencil.temp<?xf64>):
-// CHECK-NEXT:       %9 = "stencil.access"(%8) {"offset" = #stencil.index<0>, "offset_mapping" = [#int<0>]} : (!stencil.temp<?xf64>) -> f64
-// CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+// CHECK-NEXT:   func.func private @stencil_offset_mapping(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>) {
+// CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
+// CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
+// CHECK-NEXT:     ^0(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):
+// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>, "offset_mapping" = [#int<1>, #int<0>]} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
+// CHECK-NEXT:       "stencil.return"(%7) : (f64) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
+// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -43,47 +43,25 @@
 // CHECK-NEXT:       scf.for %arg3 = %c0_2 to %c64_4 step %c1 {
 // CHECK-NEXT:         scf.for %arg4 = %c0_3 to %c64_5 step %c1 {
 // CHECK-NEXT:           %c-1 = arith.constant -1 : index
-// CHECK-NEXT:           %c0_6 = arith.constant 0 : index
-// CHECK-NEXT:           %c0_7 = arith.constant 0 : index
 // CHECK-NEXT:           %0 = arith.addi %arg2, %c-1 : index
-// CHECK-NEXT:           %1 = arith.addi %arg3, %c0_6 : index
-// CHECK-NEXT:           %2 = arith.addi %arg4, %c0_7 : index
-// CHECK-NEXT:           %3 = memref.load %subview_1[%0, %1, %2] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:           %c1_8 = arith.constant 1 : index
-// CHECK-NEXT:           %c0_9 = arith.constant 0 : index
-// CHECK-NEXT:           %c0_10 = arith.constant 0 : index
-// CHECK-NEXT:           %4 = arith.addi %arg2, %c1_8 : index
-// CHECK-NEXT:           %5 = arith.addi %arg3, %c0_9 : index
-// CHECK-NEXT:           %6 = arith.addi %arg4, %c0_10 : index
-// CHECK-NEXT:           %7 = memref.load %subview_1[%4, %5, %6] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:           %c0_11 = arith.constant 0 : index
-// CHECK-NEXT:           %c1_12 = arith.constant 1 : index
-// CHECK-NEXT:           %c0_13 = arith.constant 0 : index
-// CHECK-NEXT:           %8 = arith.addi %arg2, %c0_11 : index
-// CHECK-NEXT:           %9 = arith.addi %arg3, %c1_12 : index
-// CHECK-NEXT:           %10 = arith.addi %arg4, %c0_13 : index
-// CHECK-NEXT:           %11 = memref.load %subview_1[%8, %9, %10] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:           %c0_14 = arith.constant 0 : index
-// CHECK-NEXT:           %c-1_15 = arith.constant -1 : index
-// CHECK-NEXT:           %c0_16 = arith.constant 0 : index
-// CHECK-NEXT:           %12 = arith.addi %arg2, %c0_14 : index
-// CHECK-NEXT:           %13 = arith.addi %arg3, %c-1_15 : index
-// CHECK-NEXT:           %14 = arith.addi %arg4, %c0_16 : index
-// CHECK-NEXT:           %15 = memref.load %subview_1[%12, %13, %14] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:           %c0_17 = arith.constant 0 : index
-// CHECK-NEXT:           %c0_18 = arith.constant 0 : index
-// CHECK-NEXT:           %c0_19 = arith.constant 0 : index
-// CHECK-NEXT:           %16 = arith.addi %arg2, %c0_17 : index
-// CHECK-NEXT:           %17 = arith.addi %arg3, %c0_18 : index
-// CHECK-NEXT:           %18 = arith.addi %arg4, %c0_19 : index
-// CHECK-NEXT:           %19 = memref.load %subview_1[%16, %17, %18] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:           %20 = arith.addf %3, %7 : f64
-// CHECK-NEXT:           %21 = arith.addf %11, %15 : f64
-// CHECK-NEXT:           %22 = arith.addf %20, %21 : f64
+// CHECK-NEXT:           %1 = memref.load %subview_1[%0, %arg3, %arg4] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
+// CHECK-NEXT:           %c1_6 = arith.constant 1 : index
+// CHECK-NEXT:           %2 = arith.addi %arg2, %c1_6 : index
+// CHECK-NEXT:           %3 = memref.load %subview_1[%2, %arg3, %arg4] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
+// CHECK-NEXT:           %c1_7 = arith.constant 1 : index
+// CHECK-NEXT:           %4 = arith.addi %arg3, %c1_7 : index
+// CHECK-NEXT:           %5 = memref.load %subview_1[%arg2, %4, %arg4] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
+// CHECK-NEXT:           %c-1_8 = arith.constant -1 : index
+// CHECK-NEXT:           %6 = arith.addi %arg3, %c-1_8 : index
+// CHECK-NEXT:           %7 = memref.load %subview_1[%arg2, %6, %arg4] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
+// CHECK-NEXT:           %8 = memref.load %subview_1[%arg2, %arg3, %arg4] : memref<72x72x72xf64, strided<[5184, 72, 1], offset: 21028>>
+// CHECK-NEXT:           %9 = arith.addf %1, %3 : f64
+// CHECK-NEXT:           %10 = arith.addf %5, %7 : f64
+// CHECK-NEXT:           %11 = arith.addf %9, %10 : f64
 // CHECK-NEXT:           %cst = arith.constant -4.000000e+00 : f64
-// CHECK-NEXT:           %23 = arith.mulf %19, %cst : f64
-// CHECK-NEXT:           %24 = arith.addf %23, %22 : f64
-// CHECK-NEXT:           memref.store %24, %subview[%arg2, %arg3, %arg4] : memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// CHECK-NEXT:           %12 = arith.mulf %8, %cst : f64
+// CHECK-NEXT:           %13 = arith.addf %12, %11 : f64
+// CHECK-NEXT:           memref.store %13, %subview[%arg2, %arg3, %arg4] : memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:       scf.yield

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -14,7 +14,6 @@ builtin.module {
     "stencil.store"(%3, %2) {"lb" = #stencil.index<1, 2, 3>, "ub" = #stencil.index<65, 66, 63>} : (!stencil.temp<[1,65]x[2,66]x[3,63]xf64>, !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>) -> ()
     func.return
   }
-
   // CHECK:      func.func @stencil_init_float(%0 : f64, %1 : memref<?x?x?xf64>) {
   // CHECK-NEXT:   %2 = "memref.cast"(%1) : (memref<?x?x?xf64>) -> memref<70x70x70xf64>
   // CHECK-NEXT:   %3 = "memref.subview"(%2) {"static_offsets" = array<i64: 3, 3, 3>, "static_sizes" = array<i64: 64, 64, 60>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<70x70x70xf64>) -> memref<64x64x60xf64, strided<[4900, 70, 1], offset: 14913>>
@@ -60,37 +59,33 @@ builtin.module {
     }) : (index, index, index, !stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>) -> (!stencil.field<[-2,2002]x[-2,2002]xf32>, !stencil.field<[-2,2002]x[-2,2002]xf32>)
     func.return %t1_out : !stencil.field<[-2,2002]x[-2,2002]xf32>
   }
-// CHECK:      func.func @bufferswapping(%f0 : memref<2004x2004xf32>, %f1 : memref<2004x2004xf32>) -> memref<2004x2004xf32> {
-// CHECK-NEXT:   %time_m = arith.constant 0 : index
-// CHECK-NEXT:   %time_M = arith.constant 1001 : index
-// CHECK-NEXT:   %step = arith.constant 1 : index
-// CHECK-NEXT:   %t1_out, %t0_out = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
-// CHECK-NEXT:   ^3(%time : index, %fim1 : memref<2004x2004xf32>, %fi : memref<2004x2004xf32>):
-// CHECK-NEXT:     %fi_storeview = "memref.subview"(%fi) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
-// CHECK-NEXT:     %fim1_loadview = "memref.subview"(%fim1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
-// CHECK-NEXT:     %16 = arith.constant 0 : index
-// CHECK-NEXT:     %17 = arith.constant 0 : index
-// CHECK-NEXT:     %18 = arith.constant 1 : index
-// CHECK-NEXT:     %19 = arith.constant 2000 : index
-// CHECK-NEXT:     %20 = arith.constant 2000 : index
-// CHECK-NEXT:     "scf.parallel"(%16, %19, %18) ({
-// CHECK-NEXT:     ^4(%21 : index):
-// CHECK-NEXT:       "scf.for"(%17, %20, %18) ({
-// CHECK-NEXT:       ^5(%22 : index):
-// CHECK-NEXT:         %i = arith.constant 0 : index
-// CHECK-NEXT:         %i_1 = arith.constant 0 : index
-// CHECK-NEXT:         %i_2 = arith.addi %21, %i : index
-// CHECK-NEXT:         %i_3 = arith.addi %22, %i_1 : index
-// CHECK-NEXT:         %i_4 = "memref.load"(%fim1_loadview, %i_2, %i_3) : (memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> f32
-// CHECK-NEXT:         "memref.store"(%i_4, %fi_storeview, %21, %22) : (f32, memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"(%fi, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
-// CHECK-NEXT:   }) : (index, index, index, memref<2004x2004xf32>, memref<2004x2004xf32>) -> (memref<2004x2004xf32>, memref<2004x2004xf32>)
-// CHECK-NEXT:   func.return %t1_out : memref<2004x2004xf32>
-// CHECK-NEXT: }
+  // CHECK:      func.func @bufferswapping(%f0 : memref<2004x2004xf32>, %f1 : memref<2004x2004xf32>) -> memref<2004x2004xf32> {
+  // CHECK-NEXT:   %time_m = arith.constant 0 : index
+  // CHECK-NEXT:   %time_M = arith.constant 1001 : index
+  // CHECK-NEXT:   %step = arith.constant 1 : index
+  // CHECK-NEXT:   %t1_out, %t0_out = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
+  // CHECK-NEXT:   ^3(%time : index, %fim1 : memref<2004x2004xf32>, %fi : memref<2004x2004xf32>):
+  // CHECK-NEXT:     %fi_storeview = "memref.subview"(%fi) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
+  // CHECK-NEXT:     %fim1_loadview = "memref.subview"(%fim1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
+  // CHECK-NEXT:     %16 = arith.constant 0 : index
+  // CHECK-NEXT:     %17 = arith.constant 0 : index
+  // CHECK-NEXT:     %18 = arith.constant 1 : index
+  // CHECK-NEXT:     %19 = arith.constant 2000 : index
+  // CHECK-NEXT:     %20 = arith.constant 2000 : index
+  // CHECK-NEXT:     "scf.parallel"(%16, %19, %18) ({
+  // CHECK-NEXT:     ^4(%21 : index):
+  // CHECK-NEXT:       "scf.for"(%17, %20, %18) ({
+  // CHECK-NEXT:       ^5(%22 : index):
+  // CHECK-NEXT:         %i = "memref.load"(%fim1_loadview, %21, %22) : (memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> f32
+  // CHECK-NEXT:         "memref.store"(%i, %fi_storeview, %21, %22) : (f32, memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> ()
+  // CHECK-NEXT:         "scf.yield"() : () -> ()
+  // CHECK-NEXT:       }) : (index, index, index) -> ()
+  // CHECK-NEXT:       "scf.yield"() : () -> ()
+  // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  // CHECK-NEXT:     "scf.yield"(%fi, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
+  // CHECK-NEXT:   }) : (index, index, index, memref<2004x2004xf32>, memref<2004x2004xf32>) -> (memref<2004x2004xf32>, memref<2004x2004xf32>)
+  // CHECK-NEXT:   func.return %t1_out : memref<2004x2004xf32>
+  // CHECK-NEXT: }
 
   func.func @copy_1d(%0 : !stencil.field<?xf64>, %out : !stencil.field<?xf64>) {
     %1 = "stencil.cast"(%0) : (!stencil.field<?xf64>) -> !stencil.field<[-4,68]xf64>
@@ -104,7 +99,6 @@ builtin.module {
     "stencil.store"(%3, %outc) {"lb" = #stencil.index<0>, "ub" = #stencil.index<68>} : (!stencil.temp<[0,68]xf64>, !stencil.field<[0,1024]xf64>) -> ()
     func.return
   }
-
   // CHECK:      func.func @copy_1d(%23 : memref<?xf64>, %out : memref<?xf64>) {
   // CHECK-NEXT:   %24 = "memref.cast"(%23) : (memref<?xf64>) -> memref<72xf64>
   // CHECK-NEXT:   %outc = "memref.cast"(%out) : (memref<?xf64>) -> memref<1024xf64>
@@ -147,16 +141,15 @@ builtin.module {
   // CHECK-NEXT:     "scf.for"(%37, %40, %38) ({
   // CHECK-NEXT:     ^8(%42 : index):
   // CHECK-NEXT:       %43 = arith.constant -1 : index
-  // CHECK-NEXT:       %44 = arith.constant 0 : index
-  // CHECK-NEXT:       %45 = arith.addi %41, %43 : index
-  // CHECK-NEXT:       %46 = arith.addi %42, %44 : index
-  // CHECK-NEXT:       %47 = "memref.load"(%35, %45, %46) : (memref<65x68xf64, strided<[72, 1], offset: 292>>, index, index) -> f64
+  // CHECK-NEXT:       %44 = arith.addi %41, %43 : index
+  // CHECK-NEXT:       %45 = "memref.load"(%35, %44, %42) : (memref<65x68xf64, strided<[72, 1], offset: 292>>, index, index) -> f64
   // CHECK-NEXT:       "scf.yield"() : () -> ()
   // CHECK-NEXT:     }) : (index, index, index) -> ()
   // CHECK-NEXT:     "scf.yield"() : () -> ()
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
+
 
   func.func @copy_3d(%0 : !stencil.field<?x?x?xf64>) {
     %1 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,70]x[-4,72]xf64>
@@ -168,49 +161,47 @@ builtin.module {
     }) : (!stencil.temp<[-1,64]x[0,64]x[0,69]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,68]xf64>
     func.return
   }
-// CHECK:       func.func @copy_3d(%48 : memref<?x?x?xf64>) {
-// CHECK-NEXT:    %49 = "memref.cast"(%48) : (memref<?x?x?xf64>) -> memref<72x74x76xf64>
-// CHECK-NEXT:    %50 = "memref.subview"(%49) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 65, 64, 69>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x74x76xf64>) -> memref<65x64x69xf64, strided<[5624, 76, 1], offset: 22804>>
-// CHECK-NEXT:    %51 = arith.constant 0 : index
-// CHECK-NEXT:    %52 = arith.constant 0 : index
-// CHECK-NEXT:    %53 = arith.constant 0 : index
-// CHECK-NEXT:    %54 = arith.constant 1 : index
-// CHECK-NEXT:    %55 = arith.constant 64 : index
-// CHECK-NEXT:    %56 = arith.constant 64 : index
-// CHECK-NEXT:    %57 = arith.constant 68 : index
-// CHECK-NEXT:    "scf.parallel"(%51, %55, %54) ({
-// CHECK-NEXT:    ^9(%58 : index):
-// CHECK-NEXT:      "scf.for"(%52, %56, %54) ({
-// CHECK-NEXT:      ^10(%59 : index):
-// CHECK-NEXT:        "scf.for"(%53, %57, %54) ({
-// CHECK-NEXT:        ^11(%60 : index):
-// CHECK-NEXT:          %61 = arith.constant -1 : index
-// CHECK-NEXT:          %62 = arith.constant 0 : index
-// CHECK-NEXT:          %63 = arith.constant 1 : index
-// CHECK-NEXT:          %64 = arith.addi %58, %61 : index
-// CHECK-NEXT:          %65 = arith.addi %59, %62 : index
-// CHECK-NEXT:          %66 = arith.addi %60, %63 : index
-// CHECK-NEXT:          %67 = "memref.load"(%50, %64, %65, %66) : (memref<65x64x69xf64, strided<[5624, 76, 1], offset: 22804>>, index, index, index) -> f64
-// CHECK-NEXT:          "scf.yield"() : () -> ()
-// CHECK-NEXT:        }) : (index, index, index) -> ()
-// CHECK-NEXT:        "scf.yield"() : () -> ()
-// CHECK-NEXT:      }) : (index, index, index) -> ()
-// CHECK-NEXT:      "scf.yield"() : () -> ()
-// CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:    func.return
-// CHECK-NEXT:  }
+  // CHECK:       func.func @copy_3d(%46 : memref<?x?x?xf64>) {
+  // CHECK-NEXT:    %47 = "memref.cast"(%46) : (memref<?x?x?xf64>) -> memref<72x74x76xf64>
+  // CHECK-NEXT:    %48 = "memref.subview"(%47) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 65, 64, 69>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x74x76xf64>) -> memref<65x64x69xf64, strided<[5624, 76, 1], offset: 22804>>
+  // CHECK-NEXT:    %49 = arith.constant 0 : index
+  // CHECK-NEXT:    %50 = arith.constant 0 : index
+  // CHECK-NEXT:    %51 = arith.constant 0 : index
+  // CHECK-NEXT:    %52 = arith.constant 1 : index
+  // CHECK-NEXT:    %53 = arith.constant 64 : index
+  // CHECK-NEXT:    %54 = arith.constant 64 : index
+  // CHECK-NEXT:    %55 = arith.constant 68 : index
+  // CHECK-NEXT:    "scf.parallel"(%49, %53, %52) ({
+  // CHECK-NEXT:    ^9(%56 : index):
+  // CHECK-NEXT:      "scf.for"(%50, %54, %52) ({
+  // CHECK-NEXT:      ^10(%57 : index):
+  // CHECK-NEXT:        "scf.for"(%51, %55, %52) ({
+  // CHECK-NEXT:        ^11(%58 : index):
+  // CHECK-NEXT:          %59 = arith.constant -1 : index
+  // CHECK-NEXT:          %60 = arith.addi %56, %59 : index
+  // CHECK-NEXT:          %61 = arith.constant 1 : index
+  // CHECK-NEXT:          %62 = arith.addi %58, %61 : index
+  // CHECK-NEXT:          %63 = "memref.load"(%48, %60, %57, %62) : (memref<65x64x69xf64, strided<[5624, 76, 1], offset: 22804>>, index, index, index) -> f64
+  // CHECK-NEXT:          "scf.yield"() : () -> ()
+  // CHECK-NEXT:        }) : (index, index, index) -> ()
+  // CHECK-NEXT:        "scf.yield"() : () -> ()
+  // CHECK-NEXT:      }) : (index, index, index) -> ()
+  // CHECK-NEXT:      "scf.yield"() : () -> ()
+  // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  // CHECK-NEXT:    func.return
+  // CHECK-NEXT:  }
 
   func.func @test_funcop_lowering(%0 : !stencil.field<?x?x?xf64>) {
     func.return
   }
-  // CHECK:      func.func @test_funcop_lowering(%68 : memref<?x?x?xf64>) {
+  // CHECK:      func.func @test_funcop_lowering(%64 : memref<?x?x?xf64>) {
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
   func.func @test_funcop_lowering_dyn(%1 : !stencil.field<[-1,7]x[-1,7]xf64>) {
     func.return
   }
-  // CHECK-NEXT: func.func @test_funcop_lowering_dyn(%69 : memref<8x8xf64>) {
+  // CHECK-NEXT: func.func @test_funcop_lowering_dyn(%65 : memref<8x8xf64>) {
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
@@ -237,117 +228,92 @@ builtin.module {
     "stencil.store"(%7, %4) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
     func.return
   }
+  // CHECK:      func.func @offsets(%66 : memref<?x?x?xf64>, %67 : memref<?x?x?xf64>, %68 : memref<?x?x?xf64>) {
+  // CHECK-NEXT:   %69 = "memref.cast"(%66) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+  // CHECK-NEXT:   %70 = "memref.cast"(%67) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+  // CHECK-NEXT:   %71 = "memref.subview"(%70) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 64, 64>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x72x72xf64>) -> memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+  // CHECK-NEXT:   %72 = "memref.cast"(%68) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+  // CHECK-NEXT:   %73 = "memref.subview"(%69) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 66, 66, 64>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x72x72xf64>) -> memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>
+  // CHECK-NEXT:   %74 = arith.constant 0 : index
+  // CHECK-NEXT:   %75 = arith.constant 0 : index
+  // CHECK-NEXT:   %76 = arith.constant 0 : index
+  // CHECK-NEXT:   %77 = arith.constant 1 : index
+  // CHECK-NEXT:   %78 = arith.constant 64 : index
+  // CHECK-NEXT:   %79 = arith.constant 64 : index
+  // CHECK-NEXT:   %80 = arith.constant 64 : index
+  // CHECK-NEXT:   "scf.parallel"(%74, %78, %77) ({
+  // CHECK-NEXT:   ^12(%81 : index):
+  // CHECK-NEXT:     "scf.for"(%75, %79, %77) ({
+  // CHECK-NEXT:     ^13(%82 : index):
+  // CHECK-NEXT:       "scf.for"(%76, %80, %77) ({
+  // CHECK-NEXT:       ^14(%83 : index):
+  // CHECK-NEXT:         %84 = arith.constant -1 : index
+  // CHECK-NEXT:         %85 = arith.addi %81, %84 : index
+  // CHECK-NEXT:         %86 = "memref.load"(%73, %85, %82, %83) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+  // CHECK-NEXT:         %87 = arith.constant 1 : index
+  // CHECK-NEXT:         %88 = arith.addi %81, %87 : index
+  // CHECK-NEXT:         %89 = "memref.load"(%73, %88, %82, %83) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+  // CHECK-NEXT:         %90 = arith.constant 1 : index
+  // CHECK-NEXT:         %91 = arith.addi %82, %90 : index
+  // CHECK-NEXT:         %92 = "memref.load"(%73, %81, %91, %83) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+  // CHECK-NEXT:         %93 = arith.constant -1 : index
+  // CHECK-NEXT:         %94 = arith.addi %82, %93 : index
+  // CHECK-NEXT:         %95 = "memref.load"(%73, %81, %94, %83) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+  // CHECK-NEXT:         %96 = "memref.load"(%73, %81, %82, %83) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
+  // CHECK-NEXT:         %97 = arith.addf %86, %89 : f64
+  // CHECK-NEXT:         %98 = arith.addf %92, %95 : f64
+  // CHECK-NEXT:         %99 = arith.addf %97, %98 : f64
+  // CHECK-NEXT:         %cst = arith.constant -4.0 : f64
+  // CHECK-NEXT:         %100 = arith.mulf %96, %cst : f64
+  // CHECK-NEXT:         %101 = arith.addf %100, %99 : f64
+  // CHECK-NEXT:         "memref.store"(%101, %71, %81, %82, %83) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
+  // CHECK-NEXT:         "scf.yield"() : () -> ()
+  // CHECK-NEXT:       }) : (index, index, index) -> ()
+  // CHECK-NEXT:       "scf.yield"() : () -> ()
+  // CHECK-NEXT:     }) : (index, index, index) -> ()
+  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  // CHECK-NEXT:   func.return
+  // CHECK-NEXT: }
 
-// CHECK:      func.func @offsets(%70 : memref<?x?x?xf64>, %71 : memref<?x?x?xf64>, %72 : memref<?x?x?xf64>) {
-// CHECK-NEXT:   %73 = "memref.cast"(%70) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
-// CHECK-NEXT:   %74 = "memref.cast"(%71) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
-// CHECK-NEXT:   %75 = "memref.subview"(%74) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 64, 64>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x72x72xf64>) -> memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:   %76 = "memref.cast"(%72) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
-// CHECK-NEXT:   %77 = "memref.subview"(%73) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 66, 66, 64>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x72x72xf64>) -> memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>
-// CHECK-NEXT:   %78 = arith.constant 0 : index
-// CHECK-NEXT:   %79 = arith.constant 0 : index
-// CHECK-NEXT:   %80 = arith.constant 0 : index
-// CHECK-NEXT:   %81 = arith.constant 1 : index
-// CHECK-NEXT:   %82 = arith.constant 64 : index
-// CHECK-NEXT:   %83 = arith.constant 64 : index
-// CHECK-NEXT:   %84 = arith.constant 64 : index
-// CHECK-NEXT:   "scf.parallel"(%78, %82, %81) ({
-// CHECK-NEXT:   ^12(%85 : index):
-// CHECK-NEXT:     "scf.for"(%79, %83, %81) ({
-// CHECK-NEXT:     ^13(%86 : index):
-// CHECK-NEXT:       "scf.for"(%80, %84, %81) ({
-// CHECK-NEXT:       ^14(%87 : index):
-// CHECK-NEXT:         %88 = arith.constant -1 : index
-// CHECK-NEXT:         %89 = arith.constant 0 : index
-// CHECK-NEXT:         %90 = arith.constant 0 : index
-// CHECK-NEXT:         %91 = arith.addi %85, %88 : index
-// CHECK-NEXT:         %92 = arith.addi %86, %89 : index
-// CHECK-NEXT:         %93 = arith.addi %87, %90 : index
-// CHECK-NEXT:         %94 = "memref.load"(%77, %91, %92, %93) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:         %95 = arith.constant 1 : index
-// CHECK-NEXT:         %96 = arith.constant 0 : index
-// CHECK-NEXT:         %97 = arith.constant 0 : index
-// CHECK-NEXT:         %98 = arith.addi %85, %95 : index
-// CHECK-NEXT:         %99 = arith.addi %86, %96 : index
-// CHECK-NEXT:         %100 = arith.addi %87, %97 : index
-// CHECK-NEXT:         %101 = "memref.load"(%77, %98, %99, %100) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:         %102 = arith.constant 0 : index
-// CHECK-NEXT:         %103 = arith.constant 1 : index
-// CHECK-NEXT:         %104 = arith.constant 0 : index
-// CHECK-NEXT:         %105 = arith.addi %85, %102 : index
-// CHECK-NEXT:         %106 = arith.addi %86, %103 : index
-// CHECK-NEXT:         %107 = arith.addi %87, %104 : index
-// CHECK-NEXT:         %108 = "memref.load"(%77, %105, %106, %107) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:         %109 = arith.constant 0 : index
-// CHECK-NEXT:         %110 = arith.constant -1 : index
-// CHECK-NEXT:         %111 = arith.constant 0 : index
-// CHECK-NEXT:         %112 = arith.addi %85, %109 : index
-// CHECK-NEXT:         %113 = arith.addi %86, %110 : index
-// CHECK-NEXT:         %114 = arith.addi %87, %111 : index
-// CHECK-NEXT:         %115 = "memref.load"(%77, %112, %113, %114) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:         %116 = arith.constant 0 : index
-// CHECK-NEXT:         %117 = arith.constant 0 : index
-// CHECK-NEXT:         %118 = arith.constant 0 : index
-// CHECK-NEXT:         %119 = arith.addi %85, %116 : index
-// CHECK-NEXT:         %120 = arith.addi %86, %117 : index
-// CHECK-NEXT:         %121 = arith.addi %87, %118 : index
-// CHECK-NEXT:         %122 = "memref.load"(%77, %119, %120, %121) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
-// CHECK-NEXT:         %123 = arith.addf %94, %101 : f64
-// CHECK-NEXT:         %124 = arith.addf %108, %115 : f64
-// CHECK-NEXT:         %125 = arith.addf %123, %124 : f64
-// CHECK-NEXT:         %cst = arith.constant -4.0 : f64
-// CHECK-NEXT:         %126 = arith.mulf %122, %cst : f64
-// CHECK-NEXT:         %127 = arith.addf %126, %125 : f64
-// CHECK-NEXT:         "memref.store"(%127, %75, %85, %86, %87) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
-// CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:   func.return
-// CHECK-NEXT: }
+  func.func @trivial_externals(%dyn_mem : memref<?x?x?xf64>, %sta_mem : memref<64x64x64xf64>, %dyn_field : !stencil.field<?x?x?xf64>, %sta_field : !stencil.field<[-2,62]x[0,64]x[2,66]xf64>) {
+      "stencil.external_store"(%dyn_field, %dyn_mem) : (!stencil.field<?x?x?xf64>, memref<?x?x?xf64>) -> ()
+      "stencil.external_store"(%sta_field, %sta_mem) : (!stencil.field<[-2,62]x[0,64]x[2,66]xf64>, memref<64x64x64xf64>) -> ()
+      %0 = "stencil.external_load"(%dyn_mem) : (memref<?x?x?xf64>) -> !stencil.field<?x?x?xf64>
+      %1 = "stencil.external_load"(%sta_mem) : (memref<64x64x64xf64>) -> !stencil.field<[-2,62]x[0,64]x[2,66]xf64>
 
-func.func @trivial_externals(%dyn_mem : memref<?x?x?xf64>, %sta_mem : memref<64x64x64xf64>, %dyn_field : !stencil.field<?x?x?xf64>, %sta_field : !stencil.field<[-2,62]x[0,64]x[2,66]xf64>) {
-    "stencil.external_store"(%dyn_field, %dyn_mem) : (!stencil.field<?x?x?xf64>, memref<?x?x?xf64>) -> ()
-    "stencil.external_store"(%sta_field, %sta_mem) : (!stencil.field<[-2,62]x[0,64]x[2,66]xf64>, memref<64x64x64xf64>) -> ()
-    %0 = "stencil.external_load"(%dyn_mem) : (memref<?x?x?xf64>) -> !stencil.field<?x?x?xf64>
-    %1 = "stencil.external_load"(%sta_mem) : (memref<64x64x64xf64>) -> !stencil.field<[-2,62]x[0,64]x[2,66]xf64>
+      %casted = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-2,62]x[0,64]x[2,66]xf64>
+      func.return
+  }
+  // CHECK:       func.func @trivial_externals(%dyn_mem : memref<?x?x?xf64>, %sta_mem : memref<64x64x64xf64>, %dyn_field : memref<?x?x?xf64>, %sta_field : memref<64x64x64xf64>) {
+  // CHECK-NEXT:    %casted = "memref.cast"(%dyn_mem) : (memref<?x?x?xf64>) -> memref<64x64x64xf64>
+  // CHECK-NEXT:    func.return
+  // CHECK-NEXT: }
 
-    %casted = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-2,62]x[0,64]x[2,66]xf64>
+  func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<[-32,32]xf64>) {
+    %tin = "stencil.load"(%in) : (!stencil.field<[-32,32]xf64>) -> !stencil.temp<[-16,16]xf64>
+    %outt = "stencil.apply"(%tin) ({
+    ^0(%tinb : !stencil.temp<[-16,16]xf64>):
+      %val = "stencil.access"(%tinb) {"offset" = #stencil.index<0>} : (!stencil.temp<[-16,16]xf64>) -> f64
+      "stencil.return"(%val) : (f64) -> ()
+    }) : (!stencil.temp<[-16,16]xf64>) -> !stencil.temp<[-16,16]xf64>
+    "stencil.store"(%outt, %out) {"lb" = #stencil.index<-16>, "ub" = #stencil.index<16>} : (!stencil.temp<[-16,16]xf64>, !stencil.field<[-32,32]xf64>) -> ()
     func.return
-}
-// CHECK:       func.func @trivial_externals(%dyn_mem : memref<?x?x?xf64>, %sta_mem : memref<64x64x64xf64>, %dyn_field : memref<?x?x?xf64>, %sta_field : memref<64x64x64xf64>) {
-// CHECK-NEXT:    %casted = "memref.cast"(%dyn_mem) : (memref<?x?x?xf64>) -> memref<64x64x64xf64>
-// CHECK-NEXT:    func.return
-// CHECK-NEXT: }
-
-func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<[-32,32]xf64>) {
-  %tin = "stencil.load"(%in) : (!stencil.field<[-32,32]xf64>) -> !stencil.temp<[-16,16]xf64>
-  %outt = "stencil.apply"(%tin) ({
-  ^0(%tinb : !stencil.temp<[-16,16]xf64>):
-    %val = "stencil.access"(%tinb) {"offset" = #stencil.index<0>} : (!stencil.temp<[-16,16]xf64>) -> f64
-    "stencil.return"(%val) : (f64) -> ()
-  }) : (!stencil.temp<[-16,16]xf64>) -> !stencil.temp<[-16,16]xf64>
-  "stencil.store"(%outt, %out) {"lb" = #stencil.index<-16>, "ub" = #stencil.index<16>} : (!stencil.temp<[-16,16]xf64>, !stencil.field<[-32,32]xf64>) -> ()
-  func.return
-}
-// CHECK:      func.func @neg_bounds(%in : memref<64xf64>, %out_1 : memref<64xf64>) {
-// CHECK-NEXT:   %out_storeview = "memref.subview"(%out_1) {"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
-// CHECK-NEXT:   %in_loadview = "memref.subview"(%in) {"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
-// CHECK-NEXT:   %128 = arith.constant -16 : index
-// CHECK-NEXT:   %129 = arith.constant 1 : index
-// CHECK-NEXT:   %130 = arith.constant 16 : index
-// CHECK-NEXT:   "scf.parallel"(%128, %130, %129) ({
-// CHECK-NEXT:   ^15(%131 : index):
-// CHECK-NEXT:     %val = arith.constant 0 : index
-// CHECK-NEXT:     %val_1 = arith.addi %131, %val : index
-// CHECK-NEXT:     %val_2 = "memref.load"(%in_loadview, %val_1) : (memref<32xf64, strided<[1], offset: 32>>, index) -> f64
-// CHECK-NEXT:     "memref.store"(%val_2, %out_storeview, %131) : (f64, memref<32xf64, strided<[1], offset: 32>>, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
-// CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:   func.return
-// CHECK-NEXT: }
+  }
+  // CHECK:      func.func @neg_bounds(%in : memref<64xf64>, %out_1 : memref<64xf64>) {
+  // CHECK-NEXT:   %out_storeview = "memref.subview"(%out_1) {"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
+  // CHECK-NEXT:   %in_loadview = "memref.subview"(%in) {"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
+  // CHECK-NEXT:   %102 = arith.constant -16 : index
+  // CHECK-NEXT:   %103 = arith.constant 1 : index
+  // CHECK-NEXT:   %104 = arith.constant 16 : index
+  // CHECK-NEXT:   "scf.parallel"(%102, %104, %103) ({
+  // CHECK-NEXT:   ^15(%105 : index):
+  // CHECK-NEXT:     %val = "memref.load"(%in_loadview, %105) : (memref<32xf64, strided<[1], offset: 32>>, index) -> f64
+  // CHECK-NEXT:     "memref.store"(%val, %out_storeview, %105) : (f64, memref<32xf64, strided<[1], offset: 32>>, index) -> ()
+  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  // CHECK-NEXT:   func.return
+  // CHECK-NEXT: }
 
   func.func @stencil_buffer(%49 : !stencil.field<[-4,68]xf64>, %50 : !stencil.field<[-4,68]xf64>) {
     %51 = "stencil.load"(%49) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[0,64]xf64>
@@ -365,37 +331,36 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
     "stencil.store"(%56, %50) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
     func.return
   }
-
-// CHECK:       func.func @stencil_buffer(%132 : memref<72xf64>, %133 : memref<72xf64>) {
-// CHECK-NEXT:    %134 = "memref.subview"(%133) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:    %135 = "memref.subview"(%132) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:    %136 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<64xf64>
-// CHECK-NEXT:    %137 = "memref.subview"(%136) {"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<64xf64>) -> memref<64xf64, strided<[1], offset: -1>>
-// CHECK-NEXT:    %138 = arith.constant 1 : index
-// CHECK-NEXT:    %139 = arith.constant 1 : index
-// CHECK-NEXT:    %140 = arith.constant 65 : index
-// CHECK-NEXT:    "scf.parallel"(%138, %140, %139) ({
-// CHECK-NEXT:    ^16(%141 : index):
-// CHECK-NEXT:      %142 = arith.constant -1 : index
-// CHECK-NEXT:      %143 = arith.addi %141, %142 : index
-// CHECK-NEXT:      %144 = "memref.load"(%135, %143) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
-// CHECK-NEXT:      "memref.store"(%144, %137, %141) : (f64, memref<64xf64, strided<[1], offset: -1>>, index) -> ()
-// CHECK-NEXT:      "scf.yield"() : () -> ()
-// CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:    %145 = arith.constant 0 : index
-// CHECK-NEXT:    %146 = arith.constant 1 : index
-// CHECK-NEXT:    %147 = arith.constant 64 : index
-// CHECK-NEXT:    "scf.parallel"(%145, %147, %146) ({
-// CHECK-NEXT:    ^17(%148 : index):
-// CHECK-NEXT:      %149 = arith.constant 1 : index
-// CHECK-NEXT:      %150 = arith.addi %148, %149 : index
-// CHECK-NEXT:      %151 = "memref.load"(%137, %150) : (memref<64xf64, strided<[1], offset: -1>>, index) -> f64
-// CHECK-NEXT:      "memref.store"(%151, %134, %148) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-// CHECK-NEXT:      "scf.yield"() : () -> ()
-// CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:    "memref.dealloc"(%137) : (memref<64xf64, strided<[1], offset: -1>>) -> ()
-// CHECK-NEXT:    func.return
-// CHECK-NEXT:  }
+  // CHECK:       func.func @stencil_buffer(%106 : memref<72xf64>, %107 : memref<72xf64>) {
+  // CHECK-NEXT:    %108 = "memref.subview"(%107) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+  // CHECK-NEXT:    %109 = "memref.subview"(%106) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+  // CHECK-NEXT:    %110 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<64xf64>
+  // CHECK-NEXT:    %111 = "memref.subview"(%110) {"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<64xf64>) -> memref<64xf64, strided<[1], offset: -1>>
+  // CHECK-NEXT:    %112 = arith.constant 1 : index
+  // CHECK-NEXT:    %113 = arith.constant 1 : index
+  // CHECK-NEXT:    %114 = arith.constant 65 : index
+  // CHECK-NEXT:    "scf.parallel"(%112, %114, %113) ({
+  // CHECK-NEXT:    ^16(%115 : index):
+  // CHECK-NEXT:      %116 = arith.constant -1 : index
+  // CHECK-NEXT:      %117 = arith.addi %115, %116 : index
+  // CHECK-NEXT:      %118 = "memref.load"(%109, %117) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
+  // CHECK-NEXT:      "memref.store"(%118, %111, %115) : (f64, memref<64xf64, strided<[1], offset: -1>>, index) -> ()
+  // CHECK-NEXT:      "scf.yield"() : () -> ()
+  // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  // CHECK-NEXT:    %119 = arith.constant 0 : index
+  // CHECK-NEXT:    %120 = arith.constant 1 : index
+  // CHECK-NEXT:    %121 = arith.constant 64 : index
+  // CHECK-NEXT:    "scf.parallel"(%119, %121, %120) ({
+  // CHECK-NEXT:    ^17(%122 : index):
+  // CHECK-NEXT:      %123 = arith.constant 1 : index
+  // CHECK-NEXT:      %124 = arith.addi %122, %123 : index
+  // CHECK-NEXT:      %125 = "memref.load"(%111, %124) : (memref<64xf64, strided<[1], offset: -1>>, index) -> f64
+  // CHECK-NEXT:      "memref.store"(%125, %108, %122) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
+  // CHECK-NEXT:      "scf.yield"() : () -> ()
+  // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  // CHECK-NEXT:    "memref.dealloc"(%111) : (memref<64xf64, strided<[1], offset: -1>>) -> ()
+  // CHECK-NEXT:    func.return
+  // CHECK-NEXT:  }
 
   func.func @stencil_two_stores(%59 : !stencil.field<[-4,68]xf64>, %60 : !stencil.field<[-4,68]xf64>, %61 : !stencil.field<[-4,68]xf64>) {
     %62 = "stencil.load"(%59) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[0,64]xf64>
@@ -413,35 +378,34 @@ func.func @neg_bounds(%in : !stencil.field<[-32,32]xf64>, %out : !stencil.field<
     "stencil.store"(%66, %60) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
     func.return
   }
-
-//CHECK:      func.func @stencil_two_stores(%152 : memref<72xf64>, %153 : memref<72xf64>, %154 : memref<72xf64>) {
-//CHECK-NEXT:   %155 = "memref.subview"(%153) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-//CHECK-NEXT:   %156 = "memref.subview"(%154) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-//CHECK-NEXT:   %157 = "memref.subview"(%152) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-//CHECK-NEXT:   %158 = arith.constant 1 : index
-//CHECK-NEXT:   %159 = arith.constant 1 : index
-//CHECK-NEXT:   %160 = arith.constant 65 : index
-//CHECK-NEXT:   "scf.parallel"(%158, %160, %159) ({
-//CHECK-NEXT:   ^18(%161 : index):
-//CHECK-NEXT:     %162 = arith.constant -1 : index
-//CHECK-NEXT:     %163 = arith.addi %161, %162 : index
-//CHECK-NEXT:     %164 = "memref.load"(%157, %163) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
-//CHECK-NEXT:     "memref.store"(%164, %156, %161) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-//CHECK-NEXT:     "scf.yield"() : () -> ()
-//CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-//CHECK-NEXT:   %165 = arith.constant 0 : index
-//CHECK-NEXT:   %166 = arith.constant 1 : index
-//CHECK-NEXT:   %167 = arith.constant 64 : index
-//CHECK-NEXT:   "scf.parallel"(%165, %167, %166) ({
-//CHECK-NEXT:   ^19(%168 : index):
-//CHECK-NEXT:     %169 = arith.constant 1 : index
-//CHECK-NEXT:     %170 = arith.addi %168, %169 : index
-//CHECK-NEXT:     %171 = "memref.load"(%156, %170) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
-//CHECK-NEXT:     "memref.store"(%171, %155, %168) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-//CHECK-NEXT:     "scf.yield"() : () -> ()
-//CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-//CHECK-NEXT:   func.return
-//CHECK-NEXT: }
+  //CHECK:      func.func @stencil_two_stores(%126 : memref<72xf64>, %127 : memref<72xf64>, %128 : memref<72xf64>) {
+  //CHECK-NEXT:   %129 = "memref.subview"(%127) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+  //CHECK-NEXT:   %130 = "memref.subview"(%128) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+  //CHECK-NEXT:   %131 = "memref.subview"(%126) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+  //CHECK-NEXT:   %132 = arith.constant 1 : index
+  //CHECK-NEXT:   %133 = arith.constant 1 : index
+  //CHECK-NEXT:   %134 = arith.constant 65 : index
+  //CHECK-NEXT:   "scf.parallel"(%132, %134, %133) ({
+  //CHECK-NEXT:   ^18(%135 : index):
+  //CHECK-NEXT:     %136 = arith.constant -1 : index
+  //CHECK-NEXT:     %137 = arith.addi %135, %136 : index
+  //CHECK-NEXT:     %138 = "memref.load"(%131, %137) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
+  //CHECK-NEXT:     "memref.store"(%138, %130, %135) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
+  //CHECK-NEXT:     "scf.yield"() : () -> ()
+  //CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  //CHECK-NEXT:   %139 = arith.constant 0 : index
+  //CHECK-NEXT:   %140 = arith.constant 1 : index
+  //CHECK-NEXT:   %141 = arith.constant 64 : index
+  //CHECK-NEXT:   "scf.parallel"(%139, %141, %140) ({
+  //CHECK-NEXT:   ^19(%142 : index):
+  //CHECK-NEXT:     %143 = arith.constant 1 : index
+  //CHECK-NEXT:     %144 = arith.addi %142, %143 : index
+  //CHECK-NEXT:     %145 = "memref.load"(%130, %144) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
+  //CHECK-NEXT:     "memref.store"(%145, %129, %142) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
+  //CHECK-NEXT:     "scf.yield"() : () -> ()
+  //CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+  //CHECK-NEXT:   func.return
+  //CHECK-NEXT: }
 
 }
 // CHECK-NEXT: }

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -403,7 +403,6 @@ class AccessOpToMemref(RewritePattern):
             if x != 0:
                 constant_op = arith.Constant.from_int_and_width(x, builtin.IndexType())
                 add_op = arith.Addi(block_arg, constant_op)
-                print(type(add_op.results[0]))
                 memref_load_args.append(add_op.results[0])
                 off_const_ops += [constant_op, add_op]
             else:

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -10,7 +10,15 @@ from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
     op_type_rewrite_pattern,
 )
-from xdsl.ir import Block, MLContext, Region, Operation, SSAValue
+from xdsl.ir import (
+    Block,
+    MLContext,
+    Region,
+    Operation,
+    SSAValue,
+    OpResult,
+    BlockArgument,
+)
 from xdsl.irdl import Attribute
 from xdsl.dialects.builtin import FunctionType
 from xdsl.dialects.func import FuncOp
@@ -365,11 +373,6 @@ class AccessOpToMemref(RewritePattern):
         assert (block := op.parent_block()) is not None
 
         memref_offset = op.offset
-        off_const_ops = [
-            arith.Constant.from_int_and_width(x, builtin.IndexType())
-            for x in memref_offset
-        ]
-
         if op.offset_mapping is not None:
             max_idx = 0
             for i in op.offset_mapping:
@@ -386,17 +389,29 @@ class AccessOpToMemref(RewritePattern):
         if self.target == "gpu":
             args.reverse()
 
-        if op.offset_mapping is not None:
-            off_sum_ops = [
-                arith.Addi(args[i.data], x)
-                for i, x in zip(op.offset_mapping, off_const_ops)
-            ]
-        else:
-            off_sum_ops = [arith.Addi(i, x) for i, x in zip(args, off_const_ops)]
+        off_const_ops: list[Operation] = []
+        memref_load_args: list[BlockArgument | OpResult] = []
 
-        load = memref.Load.get(op.temp, off_sum_ops)
+        # This will apply an offset to the index if one is required
+        # (e.g the offset is not zero), otherwise will use the index value directly
+        for i, x in enumerate(memref_offset):
+            block_arg = (
+                args[list(op.offset_mapping)[i].data]
+                if op.offset_mapping is not None
+                else args[i]
+            )
+            if x != 0:
+                constant_op = arith.Constant.from_int_and_width(x, builtin.IndexType())
+                add_op = arith.Addi(block_arg, constant_op)
+                print(type(add_op.results[0]))
+                memref_load_args.append(add_op.results[0])
+                off_const_ops += [constant_op, add_op]
+            else:
+                memref_load_args.append(block_arg)
 
-        rewriter.replace_matched_op([*off_const_ops, *off_sum_ops, load], [load.res])
+        load = memref.Load.get(op.temp, memref_load_args)
+
+        rewriter.replace_matched_op([*off_const_ops, load], [load.res])
 
 
 class StencilTypeConversionFuncOp(RewritePattern):


### PR DESCRIPTION
Optional offset mapping on stencil apply operation which will enable mapping of reduced number of enclosing loop dimensions. Also removed unnecessary zero addition on the stencil access index (the offset addition was put in regardless even if zero) - this would likely be optimised out by later stages of the pipeline so probably won't improve performance but it makes the generated SSA cleaner.