### PR TITLE
transformations: Fix a crash on stencil conversion

### DIFF
--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -4,8 +4,8 @@ builtin.module {
 // CHECK: builtin.module {
 
   // The pass used to crash on external function, just regression-testing this here.
-  func.func @external() -> ()
-  // CHECK: func.func @external() -> ()
+  func.func @external(!stencil.field<?xf64>) -> ()
+  // CHECK: func.func @external(memref<?xf64>) -> ()
 
   func.func @stencil_init_float(%0 : f64, %1 : !stencil.field<?x?x?xf64>) {
     %2 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -3,6 +3,10 @@
 builtin.module {
 // CHECK: builtin.module {
 
+  // The pass used to crash on external function, just regression-testing this here.
+  func.func @external() -> ()
+  // CHECK: func.func @external() -> ()
+
   func.func @stencil_init_float(%0 : f64, %1 : !stencil.field<?x?x?xf64>) {
     %2 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
     %3 = "stencil.apply"(%0) ({

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -384,19 +384,19 @@ class AccessOpToMemref(RewritePattern):
 class StencilTypeConversionFuncOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: FuncOp, rewriter: PatternRewriter, /):
-        inputs: list[Attribute] = []
-        for arg in op.body.block.args:
-            if isa(arg.typ, FieldType[Attribute]):
-                memreftyp = StencilToMemRefType(arg.typ)
-                rewriter.modify_block_argument_type(arg, memreftyp)
-                inputs.append(memreftyp)
-            else:
-                inputs.append(arg.typ)
+        inputs: list[Attribute] = [
+            StencilToMemRefType(inp) if isa(inp, FieldType[Attribute]) else inp
+            for inp in op.function_type.inputs
+        ]
         outputs: list[Attribute] = [
             StencilToMemRefType(out) if isa(out, FieldType[Attribute]) else out
             for out in op.function_type.outputs
         ]
         op.attributes["function_type"] = FunctionType.from_lists(inputs, outputs)
+        if op.body.blocks:
+            for inp, arg in zip(inputs, op.body.blocks[0].args):
+                if inp != arg.typ:
+                    rewriter.modify_block_argument_type(arg, inp)
 
 
 class UpdateLoopCarriedVarTypes(RewritePattern):


### PR DESCRIPTION
`convert-stencil-to-ll-mlir` currently crashes on external func.func.
This fixes it, regression-tests it, and test that the type conversion happen on external funcs still.

Doesn't change the output :slightly_smiling_face: (Well, on previously working cases!)