### PR TITLE
core: Cleanup Operation and IRNode definition

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1197,11 +1197,11 @@ class UnregisteredOp(IRDLOperation, ABC):
             @classmethod
             def create(
                 cls,
-                operands: Sequence[SSAValue] | None = None,
-                result_types: Sequence[Attribute] | None = None,
-                attributes: dict[str, Attribute] | None = None,
-                successors: Sequence[Block] | None = None,
-                regions: Sequence[Region] | None = None,
+                operands: Sequence[SSAValue] = (),
+                result_types: Sequence[Attribute] = (),
+                attributes: Mapping[str, Attribute] = {},
+                successors: Sequence[Block] = (),
+                regions: Sequence[Region] = (),
             ):
                 op = super().create(
                     operands, result_types, attributes, successors, regions

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -263,7 +263,7 @@ class ReduceOp(IRDLOperation):
         argument: SSAValue | Operation,
         block: Block,
     ) -> ReduceOp:
-        return ReduceOp.build(operands=[argument], regions=[Region(block, parent=None)])
+        return ReduceOp.build(operands=[argument], regions=[Region(block)])
 
     def verify_(self) -> None:
         if len(self.body.block.args) != 2:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -664,7 +664,7 @@ class Operation(IRNode):
         cls: type[OpT],
         operands: Sequence[SSAValue] = (),
         result_types: Sequence[Attribute] = (),
-        attributes: dict[str, Attribute] = {},
+        attributes: Mapping[str, Attribute] = {},
         successors: Sequence[Block] = (),
         regions: Sequence[Region] = (),
     ) -> OpT:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     Generic,
     Iterable,
+    Mapping,
     NoReturn,
     Protocol,
     Sequence,
@@ -621,9 +622,8 @@ class Operation(IRNode):
         return self._operands
 
     @operands.setter
-    def operands(self, new: list[SSAValue] | tuple[SSAValue, ...]):
-        if isinstance(new, list):
-            new = tuple(new)
+    def operands(self, new: Sequence[SSAValue]):
+        new = tuple(new)
         for idx, operand in enumerate(self._operands):
             operand.remove_use(Use(self, idx))
         for idx, operand in enumerate(new):
@@ -636,23 +636,13 @@ class Operation(IRNode):
 
     def __init__(
         self,
-        operands: Sequence[SSAValue] | None = None,
-        result_types: Sequence[Attribute] | None = None,
-        attributes: dict[str, Attribute] | None = None,
-        successors: Sequence[Block] | None = None,
-        regions: Sequence[Region] | None = None,
+        operands: Sequence[SSAValue] = (),
+        result_types: Sequence[Attribute] = (),
+        attributes: Mapping[str, Attribute] = {},
+        successors: Sequence[Block] = (),
+        regions: Sequence[Region] = (),
     ) -> None:
         super().__init__()
-        if operands is None:
-            operands = []
-        if result_types is None:
-            result_types = []
-        if attributes is None:
-            attributes = {}
-        if successors is None:
-            successors = []
-        if regions is None:
-            regions = []
 
         # This is assumed to exist by Operation.operand setter.
         self._operands = tuple()
@@ -661,7 +651,7 @@ class Operation(IRNode):
         self.results = [
             OpResult(typ, self, idx) for (idx, typ) in enumerate(result_types)
         ]
-        self.attributes = attributes
+        self.attributes = dict(attributes)
         self.successors = list(successors)
         self.regions = []
         for region in regions:
@@ -672,11 +662,11 @@ class Operation(IRNode):
     @classmethod
     def create(
         cls: type[OpT],
-        operands: Sequence[SSAValue] | None = None,
-        result_types: Sequence[Attribute] | None = None,
-        attributes: dict[str, Attribute] | None = None,
-        successors: Sequence[Block] | None = None,
-        regions: Sequence[Region] | None = None,
+        operands: Sequence[SSAValue] = (),
+        result_types: Sequence[Attribute] = (),
+        attributes: dict[str, Attribute] = {},
+        successors: Sequence[Block] = (),
+        regions: Sequence[Region] = (),
     ) -> OpT:
         op = cls.__new__(cls)
         Operation.__init__(op, operands, result_types, attributes, successors, regions)

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -1761,6 +1761,8 @@ class Parser(BaseParser):
 
         # Parse successors
         successors = self.parse_optional_successors()
+        if successors is None:
+            successors = []
 
         # Parse regions
         regions = []


### PR DESCRIPTION
This PR cleans up a bit the Operation and IRNode definition.

In particular:
* Creating an IRNode always create it with `parent=None`.
* Fields that appear in `Operation.__init__` do not need a default value.
* `Operation` constructors now have `()` defaults instead of `None`.