### PR TITLE
core: Fix terminator conditions for unregistered operations

### DIFF
--- a/tests/filecheck/parser-printer/unregistered_dialect.mlir
+++ b/tests/filecheck/parser-printer/unregistered_dialect.mlir
@@ -6,14 +6,12 @@
     %y = "op_with_res"() {otherattr = #unknown_attr<b2 ...2 [] <<>>>} : () -> (i32)
     %z = "op_with_operands"(%y, %y) : (i32, i32) -> !unknown_type<{[<()>]}>
     "op"() {ab = !unknown_singleton_type} : () -> ()
-    "test.termop"() : () -> ()
   }) {testattr = "foo"} : () -> i32
 
   // CHECK:       %{{.*}} = "region_op"() ({
   // CHECK-NEXT:   %{{.*}} = "op_with_res"() {"otherattr" = #unknown_attr<b2 ...2 [] <<>>>} : () -> i32
   // CHECK-NEXT:   %{{.*}} = "op_with_operands"(%{{.*}}, %{{.*}}) : (i32, i32) -> !unknown_type<{[<()>]}>
   // CHECK-NEXT:   "op"() {"ab" = !unknown_singleton_type} : () -> ()
-  // CHECK-NEXT:   "test.termop"() : () -> ()
   // CHECK-NEXT:  }) {"testattr" = "foo"} : () -> i32
 
 }) : () -> ()

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -907,7 +907,7 @@ class Operation(IRNode):
     ) -> bool:
         """
         Check if the operation implements a trait with the given parameters.
-        If the operation is not registered, return allow_unregistered instead.
+        If the operation is not registered, return value_if_unregisteed instead.
         """
 
         from xdsl.dialects.builtin import UnregisteredOp

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -784,9 +784,7 @@ class Operation(IRNode):
             yield from region.walk_reverse()
         yield self
 
-    def verify(
-        self, verify_nested_ops: bool = True, allow_unregistered: bool = False
-    ) -> None:
+    def verify(self, verify_nested_ops: bool = True) -> None:
         for operand in self.operands:
             if isinstance(operand, ErasedSSAValue):
                 raise Exception("Erased SSA value is used by the operation")
@@ -837,7 +835,7 @@ class Operation(IRNode):
 
         if verify_nested_ops:
             for region in self.regions:
-                region.verify(allow_unregistered=allow_unregistered)
+                region.verify()
 
         # Custom verifier
         try:
@@ -1423,13 +1421,13 @@ class Block(IRNode):
         for op in self.ops_reverse:
             yield from op.walk_reverse()
 
-    def verify(self, allow_unregistered: bool = False) -> None:
+    def verify(self) -> None:
         for operation in self.ops:
             if operation.parent != self:
                 raise Exception(
                     "Parent pointer of operation does not refer to containing region"
                 )
-            operation.verify(allow_unregistered=allow_unregistered)
+            operation.verify()
 
         if len(self.ops) == 0:
             if (region_parent := self.parent) is not None and (
@@ -1722,9 +1720,9 @@ class Region(IRNode):
         for block in reversed(self.blocks):
             yield from block.walk_reverse()
 
-    def verify(self, allow_unregistered: bool = False) -> None:
+    def verify(self) -> None:
         for block in self.blocks:
-            block.verify(allow_unregistered=allow_unregistered)
+            block.verify()
             if block.parent != self:
                 raise Exception(
                     "Parent pointer of block does not refer to containing region"

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -429,12 +429,12 @@ class xDSLOptMain:
         try:
             assert isinstance(prog, ModuleOp)
             if not self.args.disable_verify:
-                prog.verify(allow_unregistered=self.args.allow_unregistered_dialect)
+                prog.verify()
             for p in self.pipeline:
                 p.apply(self.ctx, prog)
                 assert isinstance(prog, ModuleOp)
                 if not self.args.disable_verify:
-                    prog.verify(allow_unregistered=self.args.allow_unregistered_dialect)
+                    prog.verify()
                 if self.args.print_between_passes:
                     print(f"IR after {p.name}:")
                     printer = Printer(stream=sys.stdout)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -429,12 +429,12 @@ class xDSLOptMain:
         try:
             assert isinstance(prog, ModuleOp)
             if not self.args.disable_verify:
-                prog.verify()
+                prog.verify(allow_unregistered=self.args.allow_unregistered_dialect)
             for p in self.pipeline:
                 p.apply(self.ctx, prog)
                 assert isinstance(prog, ModuleOp)
                 if not self.args.disable_verify:
-                    prog.verify()
+                    prog.verify(allow_unregistered=self.args.allow_unregistered_dialect)
                 if self.args.print_between_passes:
                     print(f"IR after {p.name}:")
                     printer = Printer(stream=sys.stdout)


### PR DESCRIPTION
This PR refines terminator conditions for unregistered operations.
Namely, if we allow unregistered operations, then their terminator conditions are implicitly fulfilled.
It also modifies `has_trait` to assume the existence of any trait for unregistered operations.

This is modelled after the [`mayBeValidWithoutTerminator`][2] and [`mightHaveTrait`][1] in MLIR.


Resolves https://github.com/xdslproject/xdsl/issues/1167

[1]: https://github.com/llvm/llvm-project/blob/268032f6f10d595bb723f6b4a21632a9f3b35be8/mlir/include/mlir/IR/OperationSupport.h#L288
[2]: https://github.com/llvm/llvm-project/blob/268032f6f10d595bb723f6b4a21632a9f3b35be8/mlir/lib/IR/Verifier.cpp#L100