### PR TITLE
core: Move `allow_unregistered` to `MLContext`

### DIFF
--- a/bench/parser/bench_parser.py
+++ b/bench/parser/bench_parser.py
@@ -23,7 +23,7 @@ def parse_file(file: str, ctx: MLContext):
     """
     Parse the given file.
     """
-    parser = Parser(ctx, file, allow_unregistered_dialect=True)
+    parser = Parser(ctx, file)
     parser.parse_op()
 
 
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     file_names = list(glob.iglob(args.root_directory + "/**/*.mlir", recursive=True))
     print("Found " + str(len(file_names)) + " files to parse.")
 
-    ctx = MLContext()
+    ctx = MLContext(allow_unregistered=True)
 
     if args.profile:
         cProfile.run("run_on_files(file_names, args.mlir_path, ctx)")

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -265,8 +265,8 @@ def test_region_clone_into_circular_blocks():
         "test.op"() [^0] : () -> ()
     }
     """
-    ctx = MLContext()
-    region = Parser(ctx, region_str, allow_unregistered_dialect=True).parse_region()
+    ctx = MLContext(allow_unregistered=True)
+    region = Parser(ctx, region_str).parse_region()
 
     region2 = Region()
     region.clone_into(region2)

--- a/tests/test_mlctx.py
+++ b/tests/test_mlctx.py
@@ -41,16 +41,16 @@ def test_get_op_unregistered():
     Test `get_op` and `get_optional_op`
     methods with the `allow_unregistered` flag.
     """
-    ctx = MLContext()
+    ctx = MLContext(allow_unregistered=True)
     ctx.register_op(DummyOp)
 
-    assert ctx.get_optional_op("dummy", allow_unregistered=True) == DummyOp
-    op = ctx.get_optional_op("dummy2", allow_unregistered=True)
+    assert ctx.get_optional_op("dummy") == DummyOp
+    op = ctx.get_optional_op("dummy2")
     assert op is not None
     assert issubclass(op, UnregisteredOp)
 
-    assert ctx.get_op("dummy", allow_unregistered=True) == DummyOp
-    assert issubclass(ctx.get_op("dummy2", allow_unregistered=True), UnregisteredOp)
+    assert ctx.get_op("dummy") == DummyOp
+    assert issubclass(ctx.get_op("dummy2"), UnregisteredOp)
 
 
 def test_get_attr():
@@ -72,31 +72,22 @@ def test_get_attr_unregistered(is_type: bool):
     Test `get_attr` and `get_optional_attr`
     methods with the `allow_unregistered` flag.
     """
-    ctx = MLContext()
+    ctx = MLContext(allow_unregistered=True)
     ctx.register_attr(DummyAttr)
 
     assert (
-        ctx.get_optional_attr(
-            "dummy_attr", allow_unregistered=True, create_unregistered_as_type=is_type
-        )
+        ctx.get_optional_attr("dummy_attr", create_unregistered_as_type=is_type)
         == DummyAttr
     )
-    attr = ctx.get_optional_attr("dummy_attr2", allow_unregistered=True)
+    attr = ctx.get_optional_attr("dummy_attr2")
     assert attr is not None
     assert issubclass(attr, UnregisteredAttr)
     if is_type:
         assert issubclass(attr, TypeAttribute)
 
-    assert (
-        ctx.get_attr(
-            "dummy_attr", allow_unregistered=True, create_unregistered_as_type=is_type
-        )
-        == DummyAttr
-    )
+    assert ctx.get_attr("dummy_attr", create_unregistered_as_type=is_type) == DummyAttr
     assert issubclass(
-        ctx.get_attr(
-            "dummy_attr2", allow_unregistered=True, create_unregistered_as_type=is_type
-        ),
+        ctx.get_attr("dummy_attr2", create_unregistered_as_type=is_type),
         UnregisteredAttr,
     )
     if is_type:

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -16,12 +16,12 @@ from xdsl.utils.hints import isa
 
 
 def rewrite_and_compare(prog: str, expected_prog: str, walker: PatternRewriteWalker):
-    ctx = MLContext()
+    ctx = MLContext(allow_unregistered=True)
     ctx.register_dialect(Builtin)
     ctx.register_dialect(Arith)
     ctx.register_dialect(Scf)
 
-    parser = Parser(ctx, prog, allow_unregistered_dialect=True)
+    parser = Parser(ctx, prog)
     module = parser.parse_module()
 
     walker.rewrite_module(module)

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -150,14 +150,11 @@ class Parser(BaseParser):
     This field map a name and a tuple index to the forward declared SSA value.
     """
 
-    allow_unregistered_dialect: bool
-
     def __init__(
         self,
         ctx: MLContext,
         input: str,
         name: str = "<unknown>",
-        allow_unregistered_dialect: bool = False,
     ) -> None:
         super().__init__(ParserState(Lexer(Input(input, name))))
         self.ctx = ctx
@@ -165,7 +162,6 @@ class Parser(BaseParser):
         self.blocks = dict()
         self.forward_block_references = dict()
         self.forward_ssa_references = dict()
-        self.allow_unregistered_dialect = allow_unregistered_dialect
 
     def parse_module(self) -> ModuleOp:
         op = self.parse_optional_operation()
@@ -474,7 +470,6 @@ class Parser(BaseParser):
         """
         attr_def = self.ctx.get_optional_attr(
             attr_name,
-            self.allow_unregistered_dialect,
             create_unregistered_as_type=is_type,
         )
         if attr_def is None:
@@ -1211,7 +1206,6 @@ class Parser(BaseParser):
         # attribute definition.
         attr_def = self.ctx.get_optional_attr(
             name.text,
-            allow_unregistered=self.allow_unregistered_dialect,
             create_unregistered_as_type=False,
         )
         if attr_def is None:
@@ -1701,10 +1695,7 @@ class Parser(BaseParser):
         Raises an error if the operation is not registered, and if unregistered
         dialects are not allowed.
         """
-        op_type = self.ctx.get_optional_op(
-            name, allow_unregistered=self.allow_unregistered_dialect
-        )
-
+        op_type = self.ctx.get_optional_op(name)
         if op_type is not None:
             return op_type
 

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -165,6 +165,8 @@ class xDSLOptMain:
         self.register_all_arguments(arg_parser)
         self.args = arg_parser.parse_args(args=args)
 
+        self.ctx.allow_unregistered = self.args.allow_unregistered_dialect
+
         self.setup_pipeline()
 
     def run(self):
@@ -302,7 +304,6 @@ class xDSLOptMain:
                 self.ctx,
                 io.read(),
                 self.get_input_name(),
-                self.args.allow_unregistered_dialect,
             ).parse_module()
 
         self.available_frontends["mlir"] = parse_mlir


### PR DESCRIPTION
This makes so `allow_unregistered` is an argument of `MLContext`, instead of the Parser.
This is how it is done in MLIR, and this cleans up some area.