### PR TITLE
[core] Introduce LocationAttr (unknown only)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ def assert_print_op(
     expected: str,
     diagnostic: Diagnostic | None,
     print_generic_format: bool = True,
+    print_debuginfo: bool = False,
     **printer_options: Any,
 ):
     """
@@ -55,6 +56,7 @@ def assert_print_op(
     printer = Printer(
         stream=file,
         print_generic_format=print_generic_format,
+        print_debuginfo=print_debuginfo,
         diagnostic=diagnostic,
         **printer_options,
     )

--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -31,6 +31,8 @@
     %x13 = "arith.constant"() {"value" = 0 : i64, "test" = @foo::@bar} : () -> i64
     // CHECK:  "test" = @foo::@bar::@baz
     %x14 = "arith.constant"() {"value" = 0 : i64, "test" = @foo::@bar::@baz} : () -> i64
+    // CHECK:  "test" = loc(unknown)
+    %x15 = "arith.constant"() {"value" = 0 : i64, "test" = loc(unknown)} : () -> i64
     "func.return"() : () -> ()
   }) {"function_type" = () -> (), "sym_name" = "builtin"} : () -> ()
   "test.op"() {"value"= {"one"=1 : i64, "two"=2 : i64, "three"="three"}} : () -> ()

--- a/tests/filecheck/dialects/builtin/parse_with_location.mlir
+++ b/tests/filecheck/dialects/builtin/parse_with_location.mlir
@@ -1,12 +1,10 @@
 // RUN: xdsl-opt %s --print-op-generic | filecheck %s
 // CHECK: module
 "builtin.module"() ({
-  "func.func"() ({
-    // CHECK: ^{{.*}}(%{{.*}}: i32):
-    ^bb0(%arg: i32 loc(unknown)):
-      // CHECK: "test.op"
-      %0 = "test.op"() : () -> !test.type<"int"> loc(unknown)
-      "test.op"() : () -> () loc(unknown)
-      "func.return"() : () -> () loc(unknown)
-  }) {"function_type" = (i32) -> (), "sym_name" = "builtin"} : () -> ()
+  // CHECK: ^{{.*}}(%{{.*}}: i32):
+  ^bb0(%arg: i32 loc(unknown)):
+    // CHECK: "test.op"() : () -> !test.type<"int">
+    %0 = "test.op"() : () -> !test.type<"int"> loc(unknown)
+    // CHECK: "test.op"() : () -> ()
+    "test.op"() : () -> () loc(unknown)
 }) : () -> ()

--- a/tests/filecheck/dialects/builtin/parse_with_location.mlir
+++ b/tests/filecheck/dialects/builtin/parse_with_location.mlir
@@ -1,0 +1,11 @@
+// RUN: xdsl-opt %s --print-op-generic | filecheck %s
+// CHECK: module
+"builtin.module"() ({
+  "func.func"() ({
+    // CHECK: ^{{.*}}(%{{.*}}: i32):
+    ^bb0(%arg: i32 loc(unknown)):
+      // CHECK: "arith.constant"
+      %x1 = "arith.constant"() {"value" = 0 : i64} : () -> i64 loc(unknown)
+      "func.return"() : () -> () loc(unknown)
+  }) {"function_type" = (i32) -> (), "sym_name" = "builtin"} : () -> ()
+}) : () -> ()

--- a/tests/filecheck/dialects/builtin/parse_with_location.mlir
+++ b/tests/filecheck/dialects/builtin/parse_with_location.mlir
@@ -4,8 +4,9 @@
   "func.func"() ({
     // CHECK: ^{{.*}}(%{{.*}}: i32):
     ^bb0(%arg: i32 loc(unknown)):
-      // CHECK: "arith.constant"
-      %x1 = "arith.constant"() {"value" = 0 : i64} : () -> i64 loc(unknown)
+      // CHECK: "test.op"
+      %0 = "test.op"() : () -> !test.type<"int"> loc(unknown)
+      "test.op"() : () -> () loc(unknown)
       "func.return"() : () -> () loc(unknown)
   }) {"function_type" = (i32) -> (), "sym_name" = "builtin"} : () -> ()
 }) : () -> ()

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -6,7 +6,7 @@ from io import StringIO
 from xdsl.dialects.arith import Arith, Addi, Constant
 from xdsl.dialects.builtin import Builtin, IntAttr, IntegerType, UnitAttr, i32
 from xdsl.dialects.func import Func
-from xdsl.dialects.test import TestOp
+from xdsl.dialects.test import Test, TestOp
 from xdsl.ir import (
     Attribute,
     MLContext,
@@ -56,14 +56,13 @@ def test_simple_forgotten_op():
 def test_print_op_location():
     """Test that an op can be printed with its location."""
     ctx = MLContext()
-    ctx.register_dialect(Arith)
+    ctx.register_dialect(Test)
 
-    lit = Constant.from_int_and_width(42, 32)
-    add = Addi(lit, lit)
+    add = TestOp(operands=[[]], result_types=[[i32]], regions=[[]])
 
     add.verify()
 
-    expected = """%0 = "arith.addi"(%1, %1) : (i32, i32) -> i32 loc(unknown)"""
+    expected = """%0 = "test.op"() : () -> i32 loc(unknown)"""
 
     assert_print_op(add, expected, None, print_debuginfo=True)
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -53,6 +53,21 @@ def test_simple_forgotten_op():
     assert_print_op(add, expected, None)
 
 
+def test_print_op_location():
+    """Test that an op can be printed with its location."""
+    ctx = MLContext()
+    ctx.register_dialect(Arith)
+
+    lit = Constant.from_int_and_width(42, 32)
+    add = Addi(lit, lit)
+
+    add.verify()
+
+    expected = """%0 = "arith.addi"(%1, %1) : (i32, i32) -> i32 loc(unknown)"""
+
+    assert_print_op(add, expected, None, print_debuginfo=True)
+
+
 @irdl_op_definition
 class UnitAttrOp(IRDLOperation):
     name = "unit_attr_op"
@@ -344,6 +359,18 @@ def test_print_block_argument():
     p.print(", ")
     p.print_block_argument(block.args[1], print_type=False)
     assert io.getvalue() == """%0 : i32, %1"""
+
+
+def test_print_block_argument_location():
+    """Print a block argument with location."""
+    block = Block(arg_types=[i32, i32])
+
+    io = StringIO()
+    p = Printer(stream=io, print_debuginfo=True)
+    p.print_block_argument(block.args[0])
+    p.print(", ")
+    p.print_block_argument(block.args[1])
+    assert io.getvalue() == """%0 : i32 loc(unknown), %1 : i32 loc(unknown)"""
 
 
 def test_print_block():

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1283,6 +1283,7 @@ Builtin = Dialect(
         DenseResourceAttr,
         UnitAttr,
         FloatData,
+        LocationAttr,
         NoneAttr,
         OpaqueAttr,
         # Types

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -293,6 +293,16 @@ class UnitAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
+class LocationAttr(ParametrizedAttribute):
+    """
+    An attribute representing source code location.
+    Only supports unknown locations for now.
+    """
+
+    name = "loc"
+
+
+@irdl_attr_definition
 class IndexType(ParametrizedAttribute):
     name = "index"
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -47,6 +47,7 @@ from xdsl.dialects.builtin import (
     FloatData,
     IndexType,
     IntegerType,
+    LocationAttr,
     NoneAttr,
     OpaqueAttr,
     Signedness,
@@ -73,6 +74,7 @@ indentNumSpaces = 2
 class Printer:
     stream: Optional[Any] = field(default=None)
     print_generic_format: bool = field(default=False)
+    print_debuginfo: bool = field(default=False)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
 
     _indent: int = field(default=0, init=False)
@@ -273,6 +275,8 @@ class Printer:
         self.print(arg)
         if print_type:
             self.print(" : ", arg.typ)
+            if self.print_debuginfo:
+                self.print(" loc(unknown)")
 
     def print_region(
         self,
@@ -338,6 +342,10 @@ class Printer:
 
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, UnitAttr):
+            return
+
+        if isinstance(attribute, LocationAttr):
+            self.print("loc(unknown)")
             return
 
         if isinstance(attribute, IntegerType):
@@ -682,6 +690,8 @@ class Printer:
             self.print("(")
             self.print_list(op.results, lambda result: self.print_attribute(result.typ))
             self.print(")")
+        if self.print_debuginfo:
+            self.print(" loc(unknown)")
 
     def print_op(self, op: Operation) -> None:
         begin_op_pos = self._current_column

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -329,7 +329,11 @@ class xDSLOptMain:
 
         def _output_mlir(prog: ModuleOp, output: IO[str]):
             printer = Printer(
-                stream=output, print_generic_format=self.args.print_op_generic
+                stream=output,
+                print_generic_format=self.args.print_op_generic,
+                print_debuginfo=self.args.print_debuginfo
+                if "print_debuginfo" in self.args
+                else False,
             )
             printer.print_op(prog)
             print("\n", file=output)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -283,6 +283,13 @@ class xDSLOptMain:
             help="Print operations with the generic format",
         )
 
+        arg_parser.add_argument(
+            "--print-debuginfo",
+            default=False,
+            action="store_true",
+            help="Print operations with debug info annotation, such as location.",
+        )
+
     def register_all_dialects(self):
         """
         Register all dialects that can be used.
@@ -331,9 +338,7 @@ class xDSLOptMain:
             printer = Printer(
                 stream=output,
                 print_generic_format=self.args.print_op_generic,
-                print_debuginfo=self.args.print_debuginfo
-                if "print_debuginfo" in self.args
-                else False,
+                print_debuginfo=self.args.print_debuginfo,
             )
             printer.print_op(prog)
             print("\n", file=output)


### PR DESCRIPTION
This commit introduces basic support for location attributes. This only
supports unknown locations for now.

Printers and parsers now support locations on arbitrary operations and
block arguments, along with locations as attributes.