### PR TITLE
dialects: (printf) print -> printf

### DIFF
--- a/tests/dialects/test_printf.py
+++ b/tests/dialects/test_printf.py
@@ -1,5 +1,5 @@
-from xdsl.dialects import print as print_dialect, test, builtin
-from xdsl.transforms import print_to_println
+from xdsl.dialects import printf as print_dialect, test, builtin
+from xdsl.transforms import printf_to_llvm
 import pytest
 
 
@@ -14,14 +14,14 @@ import pytest
     ),
 )
 def test_symbol_sanitizer(given: str, expected: str):
-    assert print_to_println.legalize_str_for_symbol_name(given) == expected
+    assert printf_to_llvm.legalize_str_for_symbol_name(given) == expected
 
 
 def test_format_str_from_op():
     a1, a2 = test.TestOp.create(result_types=[builtin.i32, builtin.f32]).results
-    op = print_dialect.PrintLnOp("test {} value {}", a1, a2)
+    op = print_dialect.PrintFormatOp("test {} value {}", a1, a2)
 
-    parts = print_to_println._format_string_spec_from_print_op(  # pyright: ignore[reportPrivateUsage]
+    parts = printf_to_llvm._format_string_spec_from_print_op(  # pyright: ignore[reportPrivateUsage]
         op
     )
 
@@ -32,9 +32,9 @@ def test_format_str_from_op():
         a2,
     ]
 
-    op2 = print_dialect.PrintLnOp("{}", a1)
+    op2 = print_dialect.PrintFormatOp("{}", a1)
 
-    parts2 = print_to_println._format_string_spec_from_print_op(  # pyright: ignore[reportPrivateUsage]
+    parts2 = printf_to_llvm._format_string_spec_from_print_op(  # pyright: ignore[reportPrivateUsage]
         op2
     )
 
@@ -48,11 +48,11 @@ def test_global_symbol_name_generation():
 
     Similarly, test that the same string results in the same symbol name.
     """
-    s1 = print_to_println._key_from_str("(")  # pyright: ignore[reportPrivateUsage]
-    s2 = print_to_println._key_from_str(")")  # pyright: ignore[reportPrivateUsage]
+    s1 = printf_to_llvm._key_from_str("(")  # pyright: ignore[reportPrivateUsage]
+    s2 = printf_to_llvm._key_from_str(")")  # pyright: ignore[reportPrivateUsage]
 
     assert s1 != s2
 
-    s3 = print_to_println._key_from_str(")")  # pyright: ignore[reportPrivateUsage]
+    s3 = printf_to_llvm._key_from_str(")")  # pyright: ignore[reportPrivateUsage]
 
     assert s2 == s3

--- a/tests/filecheck/dialects/print/invalid.mlir
+++ b/tests/filecheck/dialects/print/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
 
 builtin.module {
-    print.println "This will fail {}"
+    printf.print_format "This will fail {}"
 }
 
 // CHECK: Operation does not verify: Number of templates in template string must match number of arguments!
@@ -11,7 +11,7 @@ builtin.module {
 
 builtin.module {
     %0 = "test.op"() : () -> i32
-    print.println "This will fail too {}", %0 : i32, %0 : i32
+    printf.print_format "This will fail too {}", %0 : i32, %0 : i32
 }
 
 // CHECK: Operation does not verify: Number of templates in template string must match number of arguments!

--- a/tests/filecheck/dialects/print/print_basics.mlir
+++ b/tests/filecheck/dialects/print/print_basics.mlir
@@ -1,20 +1,20 @@
 // RUN: xdsl-opt %s | xdsl-opt | filecheck %s
 
 builtin.module {
-    print.println "Hello world!"
+    printf.print_format "Hello world!"
 
     %144 = "test.op"() : () -> i32
     %12 = "test.op"() : () -> i32
 
-    print.println "Uses vals twice {} {} {} {}", %12 : i32, %144 : i32, %12 : i32, %144 : i32
+    printf.print_format "Uses vals twice {} {} {} {}", %12 : i32, %144 : i32, %12 : i32, %144 : i32
 
-    print.println "{}", %144 : i32
-    print.println "{}", %144 : i32 {unit}
+    printf.print_format "{}", %144 : i32
+    printf.print_format "{}", %144 : i32 {unit}
 }
 
-// CHECK:       print.println "Hello world!"
+// CHECK:       printf.print_format "Hello world!"
 // CHECK-NEXT:  %0 = "test.op"() : () -> i32
 // CHECK-NEXT:  %1 = "test.op"() : () -> i32
-// CHECK-NEXT:  print.println "Uses vals twice {} {} {} {}", %1 : i32, %0 : i32, %1 : i32, %0 : i32
-// CHECK-NEXT:  print.println "{}", %0 : i32
-// CHECK-NEXT:  print.println "{}", %0 : i32 {"unit"}
+// CHECK-NEXT:  printf.print_format "Uses vals twice {} {} {} {}", %1 : i32, %0 : i32, %1 : i32, %0 : i32
+// CHECK-NEXT:  printf.print_format "{}", %0 : i32
+// CHECK-NEXT:  printf.print_format "{}", %0 : i32 {"unit"}

--- a/tests/filecheck/dialects/print/printf_to_llvm.mlir
+++ b/tests/filecheck/dialects/print/printf_to_llvm.mlir
@@ -1,11 +1,11 @@
-// RUN: xdsl-opt %s -p print-to-printf | filecheck %s
+// RUN: xdsl-opt %s -p printf-to-llvm | filecheck %s
 
 builtin.module {
     "func.func"() ({
         %pi = "arith.constant"() {value = 3.14159:f32} : () -> f32
         %12 = "arith.constant"() {value = 12 : i32} : () -> i32
 
-        print.println "Hello: {} {}", %pi : f32, %12 : i32
+        printf.print_format "Hello: {} {}", %pi : f32, %12 : i32
 
         "func.return"() : () -> ()
     }) {sym_name = "main", function_type=() -> ()} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_llvm.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p print-to-printf | mlir-opt --test-lower-to-llvm  | filecheck %s
+// RUN: xdsl-opt %s -p printf-to-llvm | mlir-opt --test-lower-to-llvm  | filecheck %s
 // this tests straight to llvmir to verify intended target compatibility
 
 builtin.module {
@@ -6,7 +6,7 @@ builtin.module {
         %pi = "arith.constant"() {value = 3.14159:f32} : () -> f32
         %12 = "arith.constant"() {value = 12 : i32} : () -> i32
 
-        print.println "Hello: {} {}", %pi : f32, %12 : i32
+        printf.print_format "Hello: {} {}", %pi : f32, %12 : i32
 
         "func.return"() : () -> ()
     }) {sym_name = "main", function_type=() -> ()} : () -> ()

--- a/tests/interpreters/test_print_interpreter.py
+++ b/tests/interpreters/test_print_interpreter.py
@@ -3,16 +3,16 @@ from io import StringIO
 from xdsl.builder import Builder
 from xdsl.dialects import arith
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.dialects.print import PrintLnOp
+from xdsl.dialects.printf import PrintFormatOp
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters.arith import ArithFunctions
-from xdsl.interpreters.print import PrintFunctions
+from xdsl.interpreters.printf import PrintfFunctions
 
 
 def _print(module: ModuleOp) -> str:
     output = StringIO()
     interpreter = Interpreter(module, file=output)
-    interpreter.register_implementations(PrintFunctions())
+    interpreter.register_implementations(PrintfFunctions())
     interpreter.register_implementations(ArithFunctions())
     interpreter.run_ssacfg_region(module.body, ())
     return output.getvalue()
@@ -31,7 +31,7 @@ def test_print_constant():
     @ModuleOp
     @Builder.implicit_region
     def hello():
-        PrintLnOp("hello")
+        PrintFormatOp("hello")
 
     assert _print(hello) == "hello\n"
 
@@ -42,6 +42,6 @@ def test_print_format():
     def hello():
         one = arith.Constant.from_int_and_width(1, 32).result
         two = arith.Constant.from_int_and_width(2, 32).result
-        PrintLnOp("{} {} {}", one, one, two)
+        PrintFormatOp("{} {} {}", one, one, two)
 
     assert _print(hello) == "1 1 2\n"

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -14,7 +14,7 @@ from xdsl.ir import Dialect, SSAValue, Operation, VerifyException
 
 
 @irdl_op_definition
-class PrintLnOp(IRDLOperation):
+class PrintFormatOp(IRDLOperation):
     """
     A string formatting and printing utility.
 
@@ -22,10 +22,10 @@ class PrintLnOp(IRDLOperation):
 
     Example uses:
     %42 = arith.constant 42 : i32
-    print.println "The magic number is {}", %42
+    printf.print_format "The magic number is {}", %42
     """
 
-    name = "print.println"
+    name = "printf.print_format"
 
     format_str: builtin.StringAttr = attr_def(builtin.StringAttr)
     format_vals: VarOperand = var_operand_def()
@@ -61,7 +61,7 @@ class PrintLnOp(IRDLOperation):
             printer.print_op_attributes(attrs)
 
     @classmethod
-    def parse(cls: type[PrintLnOp], parser: Parser) -> PrintLnOp:
+    def parse(cls: type[PrintFormatOp], parser: Parser) -> PrintFormatOp:
         format_str = parser.parse_str_literal()
         args: list[SSAValue] = []
         while parser.parse_optional_characters(",") is not None:
@@ -75,19 +75,19 @@ class PrintLnOp(IRDLOperation):
 
         if "format_str" in attr_dict:
             parser.raise_error(
-                "format_str keyword is a reserved attribute for print.println!"
+                "format_str keyword is a reserved attribute for printf.print_format!"
             )
 
-        op = PrintLnOp(format_str, *args)
+        op = PrintFormatOp(format_str, *args)
 
         op.attributes.update(attr_dict)
 
         return op
 
 
-Print = Dialect(
+Printf = Dialect(
     [
-        PrintLnOp,
+        PrintFormatOp,
     ],
     [],
 )

--- a/xdsl/interpreters/printf.py
+++ b/xdsl/interpreters/printf.py
@@ -1,15 +1,15 @@
 from typing import Any
 
-from xdsl.dialects.print import PrintLnOp
+from xdsl.dialects.printf import PrintFormatOp
 
 from xdsl.interpreter import Interpreter, InterpreterFunctions, impl, register_impls
 
 
 @register_impls
-class PrintFunctions(InterpreterFunctions):
-    @impl(PrintLnOp)
+class PrintfFunctions(InterpreterFunctions):
+    @impl(PrintFormatOp)
     def run_println(
-        self, interpreter: Interpreter, op: PrintLnOp, args: tuple[Any, ...]
+        self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
         print(op.format_str.data.format(*args), file=interpreter.file)
         return ()

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -29,7 +29,7 @@ from xdsl.dialects.irdl import IRDL
 from xdsl.dialects.riscv import RISCV, print_assembly, riscv_code
 from xdsl.dialects.snitch import Snitch
 from xdsl.dialects.snitch_runtime import SnitchRuntime
-from xdsl.dialects.print import Print
+from xdsl.dialects.printf import Printf
 
 from xdsl.dialects.experimental.math import Math
 from xdsl.dialects.experimental.fir import FIR
@@ -58,7 +58,7 @@ from xdsl.transforms.experimental.dmp.stencil_global_to_local import (
 from xdsl.transforms.experimental.dmp.scatter_gather import (
     DmpScatterGatherTrivialLowering,
 )
-from xdsl.transforms.print_to_println import PrintToPrintf
+from xdsl.transforms.printf_to_llvm import PrintfToLLVM
 
 from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.parse_pipeline import parse_pipeline
@@ -84,7 +84,7 @@ def get_all_dialects() -> list[Dialect]:
         MemRef,
         MPI,
         PDL,
-        Print,
+        Printf,
         RISCV,
         RISCV_Func,
         Scf,
@@ -110,7 +110,7 @@ def get_all_passes() -> list[type[ModulePass]]:
         LowerRISCVFunc,
         LowerSnitchPass,
         LowerSnitchRuntimePass,
-        PrintToPrintf,
+        PrintfToLLVM,
         RISCVRegisterAllocation,
         StencilShapeInferencePass,
         StencilStorageMaterializationPass,


### PR DESCRIPTION
`print` is a pretty useful builtin Python function that is not available if you write `from xdsl.dialects import print`