### PR TITLE
dialects: (scf) Enhance and fix scf.for verification

### DIFF
--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -1,5 +1,9 @@
-import pytest
+"""
+Test the usage of scf dialect.
+"""
+
 from typing import cast
+import pytest
 from xdsl.builder import Builder
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import Region, IndexType, ModuleOp, i32, i64
@@ -9,26 +13,65 @@ from xdsl.dialects.test import TestTermOp
 from xdsl.utils.exceptions import VerifyException, DiagnosticException
 
 
-def test_for():
-    lb = Constant.from_int_and_width(0, IndexType())
-    ub = Constant.from_int_and_width(42, IndexType())
+def test_for_with_loop_carried_verify():
+    """Test for with loop-carried variables"""
+
+    lower = Constant.from_int_and_width(0, IndexType())
+    upper = Constant.from_int_and_width(42, IndexType())
     step = Constant.from_int_and_width(3, IndexType())
     carried = Constant.from_int_and_width(1, IndexType())
-    bodyblock = Block(arg_types=[IndexType()])
+    bodyblock = Block(arg_types=[IndexType(), IndexType()])
+    bodyblock.add_op(Yield.get(carried))
     body = Region(bodyblock)
-    f = For.get(lb, ub, step, [carried], body)
+    for_op = For.get(lower, upper, step, [carried], body)
 
-    assert f.lb is lb.result
-    assert f.ub is ub.result
-    assert f.step is step.result
-    assert f.iter_args == tuple([carried.result])
-    assert f.body is body
+    assert for_op.lb is lower.result
+    assert for_op.ub is upper.result
+    assert for_op.step is step.result
+    assert for_op.iter_args == tuple([carried.result])
+    assert for_op.body is body
 
-    assert len(f.results) == 1
-    assert f.results[0].typ == carried.result.typ
-    assert tuple(f.operands) == (lb.result, ub.result, step.result, carried.result)
-    assert f.regions == [body]
-    assert f.attributes == {}
+    assert len(for_op.results) == 1
+    assert for_op.results[0].typ == carried.result.typ
+    assert tuple(for_op.operands) == (
+        lower.result,
+        upper.result,
+        step.result,
+        carried.result,
+    )
+    assert for_op.regions == [body]
+    assert for_op.attributes == {}
+
+    for_op.verify()
+
+
+def test_for_without_loop_carried_verify():
+    """Test for without loop-carried variables"""
+
+    lower = Constant.from_int_and_width(0, IndexType())
+    upper = Constant.from_int_and_width(42, IndexType())
+    step = Constant.from_int_and_width(3, IndexType())
+    bodyblock = Block(arg_types=[IndexType()])
+    bodyblock.add_op(Yield.get())
+    body = Region(bodyblock)
+    for_op = For.get(lower, upper, step, [], body)
+
+    assert for_op.lb is lower.result
+    assert for_op.ub is upper.result
+    assert for_op.step is step.result
+    assert for_op.iter_args == tuple()
+    assert for_op.body is body
+
+    assert len(for_op.results) == 0
+    assert tuple(for_op.operands) == (
+        lower.result,
+        upper.result,
+        step.result,
+    )
+    assert for_op.regions == [body]
+    assert for_op.attributes == {}
+
+    for_op.verify()
 
 
 def test_parallel_no_init_vals():

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -2,8 +2,8 @@
 Test the usage of scf dialect.
 """
 
-from typing import cast
 import pytest
+from typing import cast
 from xdsl.ir.core import BlockArgument
 from xdsl.builder import Builder
 from xdsl.dialects.arith import Constant

--- a/tests/filecheck/dialects/scf/for_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_args_types.mlir
@@ -26,4 +26,4 @@
   }) : (index, index, index) -> ()
 }) : () -> ()
 
-// CHECK: Type f64 of body first argument is not an index
+// CHECK: The first block argument of the body is of type f64 instead of index

--- a/tests/filecheck/dialects/scf/for_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_args_types.mlir
@@ -1,29 +1,26 @@
 // RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
 
 "builtin.module"() ({
-  %lb = "arith.constant"() {"value" = 0 : i32} : () -> index
-  %ub = "arith.constant"() {"value" = 42 : index} : () -> index
-  %step = "arith.constant"() {"value" = 7 : index} : () -> index
-  %lbi = "arith.constant"() {"value" = 0 : i32} : () -> i32
-  %ubi = "arith.constant"() {"value" = 42 : index} : () -> i32
-  %stepi = "arith.constant"() {"value" = 7 : index} : () -> i32
-// CHECK: i32 should be of base attribute index
+  %lbi = "test.op"() {"value" = 0 : index} : () -> !test.type<"int">
+  %ub = "test.op"() {"value" = 42 : index} : () -> index
+  %step = "test.op"() {"value" = 7 : index} : () -> index
+// CHECK: !test.type<"int"> should be of base attribute index
   "scf.for"(%lbi, %ub, %step) ({
   ^0(%iv : index):
     "scf.yield"() : () -> ()
-  }) : (i32, index, index) -> ()
+  }) : (!test.type<"int">, index, index) -> ()
 }) : () -> ()
 
 // -----
 
 "builtin.module"() ({
-  %lb = "arith.constant"() {"value" = 0 : index} : () -> index
-  %ub = "arith.constant"() {"value" = 42 : index} : () -> index
-  %step = "arith.constant"() {"value" = 7 : index} : () -> index
+  %lb = "test.op"() {"value" = 0 : index} : () -> index
+  %ub = "test.op"() {"value" = 42 : index} : () -> index
+  %step = "test.op"() {"value" = 7 : index} : () -> index
   "scf.for"(%lb, %ub, %step) ({
-  ^0(%iv : f64):
+  ^0(%iv : !test.type<"int">):
     "scf.yield"() : () -> ()
   }) : (index, index, index) -> ()
 }) : () -> ()
 
-// CHECK: The first block argument of the body is of type f64 instead of index
+// CHECK: The first block argument of the body is of type !test.type<"int"> instead of index

--- a/tests/filecheck/dialects/scf/for_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_args_types.mlir
@@ -1,4 +1,5 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
+
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : i32} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index
@@ -12,3 +13,17 @@
     "scf.yield"() : () -> ()
   }) : (i32, index, index) -> ()
 }) : () -> ()
+
+// -----
+
+"builtin.module"() ({
+  %lb = "arith.constant"() {"value" = 0 : index} : () -> index
+  %ub = "arith.constant"() {"value" = 42 : index} : () -> index
+  %step = "arith.constant"() {"value" = 7 : index} : () -> index
+  "scf.for"(%lb, %ub, %step) ({
+  ^0(%iv : f64):
+    "scf.yield"() : () -> ()
+  }) : (index, index, index) -> ()
+}) : () -> ()
+
+// CHECK: Type f64 of body first argument is not an index

--- a/tests/filecheck/dialects/scf/for_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_args_types.mlir
@@ -1,11 +1,10 @@
 // RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
 
 "builtin.module"() ({
-  %lbi = "test.op"() {"value" = 0 : index} : () -> !test.type<"int">
-  %ub = "test.op"() {"value" = 42 : index} : () -> index
-  %step = "test.op"() {"value" = 7 : index} : () -> index
+  %lbi = "test.op"() : () -> !test.type<"int">
+  %x:2 = "test.op"() : () -> (index, index) // ub, step
 // CHECK: !test.type<"int"> should be of base attribute index
-  "scf.for"(%lbi, %ub, %step) ({
+  "scf.for"(%lbi, %x#0, %x#1) ({
   ^0(%iv : index):
     "scf.yield"() : () -> ()
   }) : (!test.type<"int">, index, index) -> ()
@@ -14,10 +13,8 @@
 // -----
 
 "builtin.module"() ({
-  %lb = "test.op"() {"value" = 0 : index} : () -> index
-  %ub = "test.op"() {"value" = 42 : index} : () -> index
-  %step = "test.op"() {"value" = 7 : index} : () -> index
-  "scf.for"(%lb, %ub, %step) ({
+  %x:3 = "test.op"() : () -> (index, index, index) // lb, ub, step
+  "scf.for"(%x#0, %x#1, %x#2) ({
   ^0(%iv : !test.type<"int">):
     "scf.yield"() : () -> ()
   }) : (index, index, index) -> ()

--- a/tests/filecheck/dialects/scf/for_yield.mlir
+++ b/tests/filecheck/dialects/scf/for_yield.mlir
@@ -5,7 +5,7 @@
   %step = "arith.constant"() {"value" = 7 : index} : () -> index
   %carried = "arith.constant"() {"value" = 255 : i8} : () -> i8
   "scf.for"(%lb, %ub, %step, %carried) ({
-// CHECK: The scf.for's body does not end with a scf.yield. A scf.for loop with loop-carried variables must yield their values at the end of its body.
+// CHECK: The scf.for's body does not end with an scf.yield. A scf.for loop with loop-carried variables must yield their values at the end of its body.
   ^0(%iv : index, %carried_arg : i8):
     "test.termop"() : () -> ()
   }) : (index, index, index, i8) -> ()

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -69,6 +69,11 @@ class For(IRDLOperation):
                 f"{len(self.body.block.args)}. The body must have the induction "
                 f"variable and loop-carried variables as arguments."
             )
+        if self.body.block.args and (iter_var := self.body.block.args[0]):
+            if not isinstance(iter_var.typ, IndexType):
+                raise VerifyException(
+                    f"Type {iter_var.typ} of body first argument is not an index for the induction variable"
+                )
         for idx, arg in enumerate(self.iter_args):
             if self.body.block.args[idx + 1].typ != arg.typ:
                 raise VerifyException(
@@ -81,7 +86,7 @@ class For(IRDLOperation):
                 self.body.block.last_op, Yield
             ):
                 raise VerifyException(
-                    "The scf.for's body does not end with a scf.yield. A scf.for loop "
+                    "The scf.for's body does not end with an scf.yield. A scf.for loop "
                     "with loop-carried variables must yield their values at the end of "
                     "its body."
                 )

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -72,7 +72,8 @@ class For(IRDLOperation):
         if self.body.block.args and (iter_var := self.body.block.args[0]):
             if not isinstance(iter_var.typ, IndexType):
                 raise VerifyException(
-                    f"Type {iter_var.typ} of body first argument is not an index for the induction variable"
+                    f"The first block argument of the body is of type {iter_var.typ}"
+                    " instead of index"
                 )
         for idx, arg in enumerate(self.iter_args):
             if self.body.block.args[idx + 1].typ != arg.typ:


### PR DESCRIPTION
This PR adds a custom verification condition to `scf.for` and fixes/adds pytests for a canonical for (with and without loop-carried vars).
This was picked up while adding the `SingleBlockImplicitTerminator` trait to this dialect.

In more detail:

- Adds check to make sure the iterator is of index type
- Adds filecheck test for the above
- Fixes a unit test that did not verify and actually calls `.verify()`
- Adds the equivalent test as above for the case when there are no loop-carried variables

