### PR TITLE
misc: fix diagnostic region printing

### DIFF
--- a/xdsl/utils/diagnostic.py
+++ b/xdsl/utils/diagnostic.py
@@ -34,8 +34,7 @@ class Diagnostic:
         elif isinstance(toplevel, Block):
             p.print_block(toplevel)
         elif isinstance(toplevel, Region):
-            # TOFIX: Is that ever used. Revisit the whole exception
-            p._print_region(toplevel)  # TOFIX #type: ignore
+            p.print_region(toplevel)
         else:
             assert "xDSL internal error: get_toplevel_object returned unknown construct"
 


### PR DESCRIPTION
`# type: ignore` considered harmful...

I hit this while working on Toy