### PR TITLE
dialects: (affine) freeze AffineMap

### DIFF
--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -8,8 +8,8 @@ from xdsl.ir.affine.affine_expr import AffineExpr
 
 def test_simple_for():
     f = For.from_region([], [], 0, 5, Region())
-    assert f.lower_bound.data.results == [AffineExpr.constant(0)]
-    assert f.upper_bound.data.results == [AffineExpr.constant(5)]
+    assert f.lower_bound.data.results == (AffineExpr.constant(0),)
+    assert f.upper_bound.data.results == (AffineExpr.constant(5),)
 
 
 def test_for_mismatch_operands_results_counts():

--- a/tests/dialects/test_linalg.py
+++ b/tests/dialects/test_linalg.py
@@ -20,10 +20,10 @@ def test_linalg_on_memrefs():
             linalg.Yield(args[0])
 
         indexing = AffineExpr.dimension(0)
-        indexing_map = AffineMap(1, 0, [indexing])
+        indexing_map = AffineMap(1, 0, (indexing,))
 
         indexing_maps = [
-            AffineMapAttr(AffineMap(1, 0, [])),
+            AffineMapAttr(AffineMap(1, 0, ())),
             AffineMapAttr(indexing_map),
         ]
 

--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -7,19 +7,19 @@ def test_simple_map():
     y = AffineExpr.dimension(1)
 
     # map1: (x, y) -> (x + y, y)
-    map1 = AffineMap(2, 0, [x + y, y])
+    map1 = AffineMap(2, 0, (x + y, y))
     assert map1.eval([1, 2], []) == [3, 2]
     assert map1.eval([3, 4], []) == [7, 4]
     assert map1.eval([5, 6], []) == [11, 6]
 
     # map2: (x, y) -> (2x + 3y)
-    map2 = AffineMap(2, 0, [2 * x + 3 * y])
+    map2 = AffineMap(2, 0, (2 * x + 3 * y,))
     assert map2.eval([1, 2], []) == [8]
     assert map2.eval([3, 4], []) == [18]
     assert map2.eval([5, 6], []) == [28]
 
     # map3: (x, y) -> (x + y, 2x + 3y)
-    map3 = AffineMap(2, 0, [x + y, 2 * x + 3 * y])
+    map3 = AffineMap(2, 0, (x + y, 2 * x + 3 * y))
     assert map3.eval([1, 2], []) == [3, 8]
     assert map3.eval([3, 4], []) == [7, 18]
     assert map3.eval([5, 6], []) == [11, 28]
@@ -32,7 +32,7 @@ def test_quasiaffine_map():
     N = AffineExpr.symbol(0)
 
     # map1: (x)[N] -> (x floordiv 2)
-    map1 = AffineMap(1, 1, [x.floor_div(2)])
+    map1 = AffineMap(1, 1, (x.floor_div(2),))
     assert map1.eval([1], [10]) == [0]
     assert map1.eval([2], [10]) == [1]
     assert map1.eval([3], [10]) == [1]
@@ -41,7 +41,7 @@ def test_quasiaffine_map():
     assert map1.eval([6], [11]) == [3]
 
     # map2: (x)[N] -> (-(x ceildiv 2) + N)
-    map2 = AffineMap(1, 1, [-(x.ceil_div(2)) + N])
+    map2 = AffineMap(1, 1, (-(x.ceil_div(2)) + N,))
     assert map2.eval([1], [10]) == [9]
     assert map2.eval([2], [10]) == [9]
     assert map2.eval([3], [10]) == [8]
@@ -50,7 +50,7 @@ def test_quasiaffine_map():
     assert map2.eval([6], [11]) == [8]
 
     # map3: (x)[N] -> (x mod 2 - N)
-    map3 = AffineMap(1, 1, [(x % 2) - N])
+    map3 = AffineMap(1, 1, ((x % 2) - N,))
     assert map3.eval([1], [10]) == [-9]
     assert map3.eval([2], [10]) == [-10]
     assert map3.eval([3], [10]) == [-9]
@@ -61,10 +61,10 @@ def test_quasiaffine_map():
 
 def test_helpers():
     m0 = AffineMap.constant_map(0)
-    assert m0 == AffineMap(0, 0, [AffineExpr.constant(0)])
+    assert m0 == AffineMap(0, 0, (AffineExpr.constant(0),))
     m1 = AffineMap.point_map(0, 1)
-    assert m1 == AffineMap(0, 0, [AffineExpr.constant(0), AffineExpr.constant(1)])
+    assert m1 == AffineMap(0, 0, (AffineExpr.constant(0), AffineExpr.constant(1)))
     m2 = AffineMap.identity(2)
-    assert m2 == AffineMap(2, 0, [AffineExpr.dimension(0), AffineExpr.dimension(1)])
+    assert m2 == AffineMap(2, 0, (AffineExpr.dimension(0), AffineExpr.dimension(1)))
     m3 = AffineMap.empty()
-    assert m3 == AffineMap(0, 0, [])
+    assert m3 == AffineMap(0, 0, ())

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -78,11 +78,11 @@ class For(IRDLOperation):
     ) -> For:
         if isinstance(lower_bound, int):
             lower_bound = AffineMapAttr(
-                AffineMap(0, 0, [AffineExpr.constant(lower_bound)])
+                AffineMap(0, 0, (AffineExpr.constant(lower_bound),))
             )
         if isinstance(upper_bound, int):
             upper_bound = AffineMapAttr(
-                AffineMap(0, 0, [AffineExpr.constant(upper_bound)])
+                AffineMap(0, 0, (AffineExpr.constant(upper_bound),))
             )
         if isinstance(step, int):
             step = IntegerAttr.from_index_int_value(step)

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from .affine_expr import AffineExpr
 
 
-@dataclass
+@dataclass(frozen=True)
 class AffineMap:
     """
     AffineMap represents a map from a set of dimensions and symbols to a
@@ -13,23 +13,25 @@ class AffineMap:
 
     num_dims: int
     num_symbols: int
-    results: list[AffineExpr]
+    results: tuple[AffineExpr, ...]
 
     @staticmethod
     def constant_map(value: int) -> AffineMap:
-        return AffineMap(0, 0, [AffineExpr.constant(value)])
+        return AffineMap(0, 0, (AffineExpr.constant(value),))
 
     @staticmethod
     def point_map(*values: int) -> AffineMap:
-        return AffineMap(0, 0, [AffineExpr.constant(value) for value in values])
+        return AffineMap(0, 0, tuple(AffineExpr.constant(value) for value in values))
 
     @staticmethod
     def identity(rank: int) -> AffineMap:
-        return AffineMap(rank, 0, [AffineExpr.dimension(dim) for dim in range(rank)])
+        return AffineMap(
+            rank, 0, tuple(AffineExpr.dimension(dim) for dim in range(rank))
+        )
 
     @staticmethod
     def empty() -> AffineMap:
-        return AffineMap(0, 0, [])
+        return AffineMap(0, 0, ())
 
     def eval(self, dims: list[int], symbols: list[int]) -> list[int]:
         """Evaluate the AffineMap given the values of dimensions and symbols."""

--- a/xdsl/parser/affine_parser.py
+++ b/xdsl/parser/affine_parser.py
@@ -153,4 +153,4 @@ class AffineParser(BaseParser):
         # Parse list of affine expressions
         exprs = self._parse_multi_affine_expr(dims, syms)
         # Create map and return.
-        return AffineMap(len(dims), len(syms), exprs)
+        return AffineMap(len(dims), len(syms), tuple(exprs))


### PR DESCRIPTION
This is kind of an RFC. It seems that most of the time we use affine maps as an immutable data structure, thought I'd leverage some python tools to enforce it. @Groverkss WDYT?