### PR TITLE
dialects: (riscv) add custom format for lw and sw instructions

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -106,14 +106,14 @@
   %lhu = "riscv.lhu"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j2>
   // CHECK-NEXT: lhu j2, j1, 1
   %lw = "riscv.lw"(%1) {"immediate" = 1 : i32}: (!riscv.reg<j1>) -> !riscv.reg<j2>
-  // CHECK-NEXT: lw j2, j1, 1
+  // CHECK-NEXT: lw j2, 1(j1)
 
   "riscv.sb"(%2, %1) {"immediate" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
   // CHECK-NEXT: sb j2, j1, 1
   "riscv.sh"(%2, %1) {"immediate" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
   // CHECK-NEXT: sh j2, j1, 1
   "riscv.sw"(%2, %1) {"immediate" = 1 : i32}: (!riscv.reg<j2>, !riscv.reg<j1>) -> ()
-  // CHECK-NEXT: sw j2, j1, 1
+  // CHECK-NEXT: sw j1, 1(j2)
 
   // RV32I/RV64I: Control and Status Register Instructions (Section 2.8)
   %csrrw_rw = "riscv.csrrw"(%2) {"csr" = 1024 : i32}: (!riscv.reg<j2>) -> !riscv.reg<j1>

--- a/tests/filecheck/with-riscemu/riscv_emulation.mlir
+++ b/tests/filecheck/with-riscemu/riscv_emulation.mlir
@@ -49,9 +49,9 @@ builtin.module {
     "riscv.comment"() {"comment" = "decrement stack pointer by number of register values we need to store for later"} : () -> ()
     %15 = "riscv.addi"(%12) {"immediate" = -8 : si12} : (!riscv.reg<sp>) -> !riscv.reg<sp>
     "riscv.comment"() {"comment" = "save the s registers we'll use on the stack"} : () -> ()
-    "riscv.sw"(%13, %12) {"immediate" = 0 : si12} : (!riscv.reg<s0>, !riscv.reg<sp>) -> ()
+    "riscv.sw"(%12, %13) {"immediate" = 0 : si12} : (!riscv.reg<sp>, !riscv.reg<s0>) -> ()
     "riscv.comment"() {"comment" = "save the return address we'll use on the stack"} : () -> ()
-    "riscv.sw"(%14, %12) {"immediate" = 4 : si12} : (!riscv.reg<ra>, !riscv.reg<sp>) -> ()
+    "riscv.sw"(%12, %14) {"immediate" = 4 : si12} : (!riscv.reg<sp>, !riscv.reg<ra>) -> ()
     %16 = "riscv.mv"(%11) : (!riscv.reg<a2>) -> !riscv.reg<s0>
     "riscv.jal"() {"immediate" = #riscv.label<"multiply">} : () -> ()
     %17 = "riscv.mv"(%16) : (!riscv.reg<s0>) -> !riscv.reg<a1>

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -95,9 +95,9 @@ def test_multiply_add():
             )
             riscv.AddiOp(sp_muladd, -8, rd=riscv.Registers.SP)
             riscv.CommentOp("save the s registers we'll use on the stack")
-            riscv.SwOp(s0_muladd_0, sp_muladd, 0)
+            riscv.SwOp(sp_muladd, s0_muladd_0, 0)
             riscv.CommentOp("save the return address we'll use on the stack")
-            riscv.SwOp(ra_muladd, sp_muladd, 4)
+            riscv.SwOp(sp_muladd, ra_muladd, 4)
 
             # store third parameter, in a2 to the temporary register s0
             # guaranteed to be the same after call to multiply

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from io import StringIO
-from typing import IO, Iterable, Sequence, TypeAlias
+from typing import IO, Sequence, TypeAlias
 
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
@@ -324,8 +324,8 @@ class RISCVOp(Operation, ABC):
         raise NotImplementedError()
 
 
-_AssemblyInstructionArg: TypeAlias = (
-    AnyIntegerAttr | LabelAttr | SSAValue | RegisterType | str | None
+AssemblyInstructionArg: TypeAlias = (
+    AnyIntegerAttr | LabelAttr | SSAValue | RegisterType | str
 )
 
 
@@ -345,7 +345,7 @@ class RISCVInstruction(RISCVOp):
     """
 
     @abstractmethod
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         """
         The arguments to the instruction, in the order they should be printed in the
         assembly.
@@ -362,7 +362,12 @@ class RISCVInstruction(RISCVOp):
     def assembly_line(self) -> str | None:
         # default assembly code generator
         instruction_name = self.assembly_instruction_name()
-        return _assembly_line(instruction_name, self.assembly_line_args(), self.comment)
+        arg_str = ", ".join(
+            _assembly_arg_str(arg)
+            for arg in self.assembly_line_args()
+            if arg is not None
+        )
+        return _assembly_line(instruction_name, arg_str, self.comment)
 
 
 # region Assembly printing
@@ -377,46 +382,46 @@ def _append_comment(line: str, comment: StringAttr | None) -> str:
     return f"{line}{padding} # {comment.data}"
 
 
+def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
+    if isa(arg, AnyIntegerAttr):
+        return f"{arg.value.data}"
+    elif isinstance(arg, int):
+        return f"{arg}"
+    elif isinstance(arg, LabelAttr):
+        return arg.data
+    elif isinstance(arg, str):
+        return arg
+    elif isinstance(arg, RegisterType):
+        return arg.register_name
+    elif isinstance(arg, FloatRegisterType):
+        return arg.register_name
+    else:
+        if isinstance(arg.type, RegisterType):
+            reg = arg.type.register_name
+            return reg
+        elif isinstance(arg.type, FloatRegisterType):
+            reg = arg.type.register_name
+            return reg
+    assert False
+
+
 def _assembly_line(
     name: str,
-    args: Iterable[_AssemblyInstructionArg],
+    arg_str: str,
     comment: StringAttr | None = None,
     is_indented: bool = True,
 ) -> str:
-    arg_strs: list[str] = []
-
-    for arg in args:
-        if arg is None:
-            continue
-        elif isa(arg, AnyIntegerAttr):
-            arg_strs.append(f"{arg.value.data}")
-        elif isinstance(arg, LabelAttr):
-            arg_strs.append(arg.data)
-        elif isinstance(arg, str):
-            arg_strs.append(arg)
-        elif isinstance(arg, RegisterType):
-            arg_strs.append(arg.register_name)
-        elif isinstance(arg, FloatRegisterType):
-            arg_strs.append(arg.register_name)
-        else:
-            if isinstance(arg.type, RegisterType):
-                reg = arg.type.register_name
-                arg_strs.append(reg)
-            elif isinstance(arg.type, FloatRegisterType):
-                reg = arg.type.register_name
-                arg_strs.append(reg)
-
     code = "    " if is_indented else ""
     code += name
-    if arg_strs:
-        code += f" {', '.join(arg_strs)}"
+    if arg_str:
+        code += f" {arg_str}"
     code = _append_comment(code, comment)
     return code
 
 
 def print_assembly(module: ModuleOp, output: IO[str]) -> None:
     for op in module.body.walk():
-        assert isinstance(op, RISCVOp)
+        assert isinstance(op, RISCVOp), f"{op}"
         asm = op.assembly_line()
         if asm is not None:
             print(asm, file=output)
@@ -468,7 +473,7 @@ class RdRsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             result_types=[rd],
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs1, self.rs2
 
 
@@ -507,7 +512,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.immediate
 
 
@@ -549,7 +554,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
             }
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         return self.rd, self.immediate
 
 
@@ -593,7 +598,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs1, self.immediate
 
 
@@ -674,7 +679,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         return self.rd, self.rs1, self.immediate
 
 
@@ -706,7 +711,7 @@ class RdRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             attributes={"comment": comment},
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs
 
 
@@ -745,7 +750,7 @@ class RsRsOffIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rs1, self.rs2, self.offset
 
 
@@ -784,7 +789,7 @@ class RsRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rs1, self.rs2, self.immediate
 
 
@@ -802,7 +807,7 @@ class RsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             operands=[rs1, rs2],
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rs1, self.rs2
 
 
@@ -825,7 +830,7 @@ class NullaryOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return ()
 
 
@@ -881,7 +886,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
                 f"not '{self.rd.type.data.name}'"
             )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.csr, self.rs1
 
 
@@ -939,7 +944,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
                 f"not '{self.rs1.type.data.name}'"
             )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.csr, self.rs1
 
 
@@ -995,7 +1000,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
                 f"not '{self.rd.type.data.name}'"
             )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         return self.rd, self.csr, self.immediate
 
 
@@ -1039,7 +1044,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
             result_types=[rd],
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.csr, self.immediate
 
 
@@ -1406,7 +1411,7 @@ class JOp(RdImmJumpOperation):
     ):
         super().__init__(immediate, rd=Registers.ZERO, comment=comment)
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         # J op is a special case of JalOp with zero return register
         return (self.immediate,)
 
@@ -1596,6 +1601,15 @@ class LwOp(RdRsImmIntegerOperation):
 
     name = "riscv.lw"
 
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = _assembly_arg_str(self.rd)
+        imm = _assembly_arg_str(self.immediate)
+        offset = _assembly_arg_str(self.rs1)
+        return _assembly_line(
+            instruction_name, f"{value}, {imm}({offset})", self.comment
+        )
+
 
 @irdl_op_definition
 class SbOp(RsRsImmIntegerOperation):
@@ -1635,6 +1649,15 @@ class SwOp(RsRsImmIntegerOperation):
     """
 
     name = "riscv.sw"
+
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = _assembly_arg_str(self.rs2)
+        imm = _assembly_arg_str(self.immediate)
+        offset = _assembly_arg_str(self.rs1)
+        return _assembly_line(
+            instruction_name, f"{value}, {imm}({offset})", self.comment
+        )
 
 
 # endregion
@@ -2031,11 +2054,11 @@ class DirectiveOp(IRDLOperation, RISCVOp):
 
     def assembly_line(self) -> str | None:
         if self.value is not None and self.value.data:
-            value = self.value.data
+            arg_str = _assembly_arg_str(self.value.data)
         else:
-            value = None
+            arg_str = ""
 
-        return _assembly_line(self.directive.data, (value,), is_indented=False)
+        return _assembly_line(self.directive.data, arg_str, is_indented=False)
 
 
 @irdl_op_definition
@@ -2088,7 +2111,7 @@ class CustomAssemblyInstructionOp(IRDLOperation, RISCVInstruction):
     def assembly_instruction_name(self) -> str:
         return self.instruction_name.data
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return *self.results, *self.operands
 
 
@@ -2262,7 +2285,7 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             result_types=[rd],
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs1, self.rs2, self.rs3
 
 
@@ -2299,7 +2322,7 @@ class RdRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             result_types=[rd],
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs1, self.rs2
 
 
@@ -2336,7 +2359,7 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             result_types=[rd],
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs1, self.rs2
 
 
@@ -2368,7 +2391,7 @@ class RdRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             attributes={"comment": comment},
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs
 
 
@@ -2400,7 +2423,7 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             attributes={"comment": comment},
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs
 
 
@@ -2432,7 +2455,7 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             attributes={"comment": comment},
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs
 
 
@@ -2469,7 +2492,7 @@ class RsRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rs1, self.rs2, self.immediate
 
 
@@ -2512,7 +2535,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             },
         )
 
-    def assembly_line_args(self) -> tuple[_AssemblyInstructionArg, ...]:
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs1, self.immediate
 
 


### PR DESCRIPTION
riscemu currently has a bug in sw, mixing up the rs1 and rs2 operations, but only for `sw rs1 rs2 imm`, not the `sw rs2 imm(rs1)` format. This PR introduces the custom format printing for those two ops, as well as a bit of refactoring in the instruction printing code.