### PR TITLE
transformations: Add `reconcile-unrealized-casts` pass to remove no-op casts

### DIFF
--- a/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
+++ b/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
@@ -1,0 +1,93 @@
+// RUN: xdsl-opt %s -p reconcile-unrealized-casts | filecheck %s
+
+builtin.module {
+    // CHECK:  builtin.module {
+
+    func.func @unused_cast(%arg0: i64) -> i64 {
+        %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i64) -> i16
+        "func.return"(%arg0) : (i64) -> ()
+    }
+
+    // CHECK-NEXT:  func.func @unused_cast(%arg0 : i64) -> i64 {
+    // CHECK-NEXT:    func.return %arg0 : i64
+    // CHECK-NEXT:  }
+
+    // -----
+
+    func.func @simple_cycle(%arg0: i64) -> i64 {
+        %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i64) -> i32
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> i64
+        "func.return"(%1) : (i64) -> ()
+    }
+
+    // CHECK-NEXT:  func.func @simple_cycle(%arg0_1 : i64) -> i64 {
+    // CHECK-NEXT:    func.return %arg0_1 : i64
+    // CHECK-NEXT:  }
+
+    // -----
+
+    func.func @cycle_singleblock(%arg0: i64) -> i64 {
+        %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i64) -> i16
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i16) -> i1
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i1) -> i64
+        %3 = "builtin.unrealized_conversion_cast"(%1) : (i1) -> i16
+        %4 = "builtin.unrealized_conversion_cast"(%3) : (i16) -> i64
+        %5 = "test.op"(%2, %4) : (i64, i64) -> i64
+        func.return %5 : i64
+    }
+
+    // CHECK-NEXT:    func.func @cycle_singleblock(%arg0_2 : i64) -> i64 {
+    // CHECK-NEXT:      %0 = "test.op"(%arg0_2, %arg0_2) : (i64, i64) -> i64
+    // CHECK-NEXT:      func.return %0 : i64
+    // CHECK-NEXT:    }
+
+    // -----
+
+    func.func @cycle_multiblock(%arg0: i64) -> i64 {
+        %c0 = "test.op"() : () -> i32
+        %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i64) -> i16
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i16) -> i1
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i1) -> i64
+        %3 = "builtin.unrealized_conversion_cast"(%1) : (i1) -> i16
+        "cf.br"(%c0)[^bb1] : (i32) -> ()
+        ^bb1(%33: i32):  // pred: ^bb0
+        %4 = "builtin.unrealized_conversion_cast"(%3) : (i16) -> i64
+        %5 = "test.op"(%2, %4) : (i64, i64) -> i64
+        func.return %5 : i64
+    }
+
+    // CHECK-NEXT:    func.func @cycle_multiblock(%arg0_3 : i64) -> i64 {
+    // CHECK-NEXT:      %c0 = "test.op"() : () -> i32
+    // CHECK-NEXT:      "cf.br"(%c0) [^0] : (i32) -> ()
+    // CHECK-NEXT:    ^0(%1 : i32):
+    // CHECK-NEXT:      %2 = "test.op"(%arg0_3, %arg0_3) : (i64, i64) -> i64
+    // CHECK-NEXT:      func.return %2 : i64
+    // CHECK-NEXT:    }
+
+    // -----
+
+    func.func @failure_simple_cast(%arg0: i64) -> i32 {
+        %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i64) -> i32
+        func.return %0 : i32
+    }
+
+    // CHECK-NEXT:    func.func @failure_simple_cast(%arg0_4 : i64) -> i32 {
+    // CHECK-NEXT:      %3 = "builtin.unrealized_conversion_cast"(%arg0_4) : (i64) -> i32
+    // CHECK-NEXT:      func.return %3 : i32
+    // CHECK-NEXT:    }
+
+    // -----
+
+    func.func @failure_cycle(%arg0: i64) -> i32 {
+        %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i64) -> i1
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i1) -> i32
+        func.return %1 : i32
+    }
+
+    // CHECK-NEXT:    func.func @failure_cycle(%arg0_5 : i64) -> i32 {
+    // CHECK-NEXT:      %4 = "builtin.unrealized_conversion_cast"(%arg0_5) : (i64) -> i1
+    // CHECK-NEXT:      %5 = "builtin.unrealized_conversion_cast"(%4) : (i1) -> i32
+    // CHECK-NEXT:      func.return %5 : i32
+    // CHECK-NEXT:    }
+}
+// CHECK-NEXT:  }

--- a/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
+++ b/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
@@ -8,8 +8,8 @@ builtin.module {
         "func.return"(%arg0) : (i64) -> ()
     }
 
-    // CHECK-NEXT:  func.func @unused_cast(%arg0 : i64) -> i64 {
-    // CHECK-NEXT:    func.return %arg0 : i64
+    // CHECK-NEXT:  func.func @unused_cast(%{{.*}} : i64) -> i64 {
+    // CHECK-NEXT:    func.return %{{.*}} : i64
     // CHECK-NEXT:  }
 
     // -----
@@ -20,8 +20,8 @@ builtin.module {
         "func.return"(%1) : (i64) -> ()
     }
 
-    // CHECK-NEXT:  func.func @simple_cycle(%arg0_1 : i64) -> i64 {
-    // CHECK-NEXT:    func.return %arg0_1 : i64
+    // CHECK-NEXT:  func.func @simple_cycle(%{{.*}} : i64) -> i64 {
+    // CHECK-NEXT:    func.return %{{.*}} : i64
     // CHECK-NEXT:  }
 
     // -----
@@ -36,8 +36,8 @@ builtin.module {
         func.return %5 : i64
     }
 
-    // CHECK-NEXT:    func.func @cycle_singleblock(%arg0_2 : i64) -> i64 {
-    // CHECK-NEXT:      %0 = "test.op"(%arg0_2, %arg0_2) : (i64, i64) -> i64
+    // CHECK-NEXT:    func.func @cycle_singleblock(%{{.*}} : i64) -> i64 {
+    // CHECK-NEXT:      %0 = "test.op"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
     // CHECK-NEXT:      func.return %0 : i64
     // CHECK-NEXT:    }
 
@@ -56,11 +56,11 @@ builtin.module {
         func.return %5 : i64
     }
 
-    // CHECK-NEXT:    func.func @cycle_multiblock(%arg0_3 : i64) -> i64 {
+    // CHECK-NEXT:    func.func @cycle_multiblock(%{{.*}} : i64) -> i64 {
     // CHECK-NEXT:      %c0 = "test.op"() : () -> i32
     // CHECK-NEXT:      "cf.br"(%c0) [^0] : (i32) -> ()
     // CHECK-NEXT:    ^0(%1 : i32):
-    // CHECK-NEXT:      %2 = "test.op"(%arg0_3, %arg0_3) : (i64, i64) -> i64
+    // CHECK-NEXT:      %2 = "test.op"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
     // CHECK-NEXT:      func.return %2 : i64
     // CHECK-NEXT:    }
 
@@ -71,8 +71,8 @@ builtin.module {
         func.return %0 : i32
     }
 
-    // CHECK-NEXT:    func.func @failure_simple_cast(%arg0_4 : i64) -> i32 {
-    // CHECK-NEXT:      %3 = "builtin.unrealized_conversion_cast"(%arg0_4) : (i64) -> i32
+    // CHECK-NEXT:    func.func @failure_simple_cast(%{{.*}} : i64) -> i32 {
+    // CHECK-NEXT:      %3 = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> i32
     // CHECK-NEXT:      func.return %3 : i32
     // CHECK-NEXT:    }
 
@@ -84,8 +84,8 @@ builtin.module {
         func.return %1 : i32
     }
 
-    // CHECK-NEXT:    func.func @failure_chain(%arg0_5 : i64) -> i32 {
-    // CHECK-NEXT:      %4 = "builtin.unrealized_conversion_cast"(%arg0_5) : (i64) -> i1
+    // CHECK-NEXT:    func.func @failure_chain(%{{.*}} : i64) -> i32 {
+    // CHECK-NEXT:      %4 = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> i1
     // CHECK-NEXT:      %5 = "builtin.unrealized_conversion_cast"(%4) : (i1) -> i32
     // CHECK-NEXT:      func.return %5 : i32
     // CHECK-NEXT:    }

--- a/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
+++ b/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
@@ -106,6 +106,19 @@ builtin.module {
     // CHECK-NEXT:      func.return %6 : i64
     // CHECK-NEXT:    }
 
+    func.func @mismatch_size_cast_use(%arg0: i64, %arg1: i64) -> i64 {
+        %0, %1 = "builtin.unrealized_conversion_cast"(%arg0, %arg1) : (i64, i64) -> (i16, i16)
+        %3 = "builtin.unrealized_conversion_cast"(%0) : (i16) -> (i1)
+        %10 = "test.op"(%3, %3) : (i1, i1) -> i64
+        func.return %10 : i64
+    }
+
+    // CHECK-NEXT:    func.func @mismatch_size_cast_use(%{{.*}} : i64, %{{.*}} : i64) -> i64 {
+    // CHECK-NEXT:      %7, %8 = "builtin.unrealized_conversion_cast"(%{{.*}}, %{{.*}}) : (i64, i64) -> (i16, i16)
+    // CHECK-NEXT:      %9 = "builtin.unrealized_conversion_cast"(%7) : (i16) -> i1
+    // CHECK-NEXT:      %10 = "test.op"(%9, %9) : (i1, i1) -> i64
+    // CHECK-NEXT:      func.return %10 : i64
+    // CHECK-NEXT:    }
 
 }
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
+++ b/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
@@ -89,5 +89,23 @@ builtin.module {
     // CHECK-NEXT:      %5 = "builtin.unrealized_conversion_cast"(%4) : (i1) -> i32
     // CHECK-NEXT:      func.return %5 : i32
     // CHECK-NEXT:    }
+
+
+    func.func @cycle_singleblock_var_ops(%arg0: i64, %arg1: i64) -> i64 {
+        %0, %1 = "builtin.unrealized_conversion_cast"(%arg0, %arg1) : (i64, i64) -> (i16, i16)
+        %2, %3 = "builtin.unrealized_conversion_cast"(%0, %1) : (i16, i16) -> (i1, i1)
+        %4, %5 = "builtin.unrealized_conversion_cast"(%2, %3) : (i1, i1) -> (i64, i64)
+        %6, %7 = "builtin.unrealized_conversion_cast"(%2, %3) : (i1, i1) -> (i16, i16)
+        %8, %9 = "builtin.unrealized_conversion_cast"(%6, %7) : (i16, i16) -> (i64, i64)
+        %10 = "test.op"(%4, %5, %8, %9) : (i64, i64, i64, i64) -> i64
+        func.return %10 : i64
+    }
+
+    // CHECK-NEXT:    func.func @cycle_singleblock_var_ops(%{{.*}} : i64, %{{.*}} : i64) -> i64 {
+    // CHECK-NEXT:      %6 = "test.op"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (i64, i64, i64, i64) -> i64
+    // CHECK-NEXT:      func.return %6 : i64
+    // CHECK-NEXT:    }
+
+
 }
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
+++ b/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
@@ -78,13 +78,13 @@ builtin.module {
 
     // -----
 
-    func.func @failure_cycle(%arg0: i64) -> i32 {
+    func.func @failure_chain(%arg0: i64) -> i32 {
         %0 = "builtin.unrealized_conversion_cast"(%arg0) : (i64) -> i1
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i1) -> i32
         func.return %1 : i32
     }
 
-    // CHECK-NEXT:    func.func @failure_cycle(%arg0_5 : i64) -> i32 {
+    // CHECK-NEXT:    func.func @failure_chain(%arg0_5 : i64) -> i32 {
     // CHECK-NEXT:      %4 = "builtin.unrealized_conversion_cast"(%arg0_5) : (i64) -> i1
     // CHECK-NEXT:      %5 = "builtin.unrealized_conversion_cast"(%4) : (i1) -> i32
     // CHECK-NEXT:      func.return %5 : i32

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -11,10 +11,8 @@ from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import PatternRewriter
 
 
-def _try_remove_cast(op: builtin.UnrealizedConversionCastOp):
-    # We remove several casts in a single pass, which should not happen
-    # with the current implementation of the pattern rewriter.
-    # The rewriter is not notified of our deletions, so we need to
+def _try_remove_cast_chain(op: builtin.UnrealizedConversionCastOp):
+    # We remove several casts in a single pass, so we need to
     # ignore casts that have already been removed earlier in the pass
     # (i.e: no parent anymore).
 
@@ -99,7 +97,7 @@ def reconcile_unrealized_casts(module: ModuleOp):
         lambda op: isinstance(op, builtin.UnrealizedConversionCastOp), module.walk()
     ):
         assert isinstance(op, builtin.UnrealizedConversionCastOp)
-        _try_remove_cast(op)
+        _try_remove_cast_chain(op)
 
 
 class ReconcileUnrealizedCastsPass(ModulePass):

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -8,113 +8,98 @@ from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import MLContext
 from xdsl.ir.core import Use
 from xdsl.passes import ModulePass
-from xdsl.pattern_rewriter import (
-    PatternRewriter,
-    PatternRewriteWalker,
-    RewritePattern,
-    op_type_rewrite_pattern,
-)
+from xdsl.pattern_rewriter import PatternRewriter
 
 
-class ReconcileUnrealizedCasts(RewritePattern):
-    """
-    An `unrealized_conversion_cast` operation represents an unrealized conversion
-    from one set of types to another, that is used to enable the inter-mixing
-    of different type systems.
+def _try_remove_cast(op: builtin.UnrealizedConversionCastOp):
+    # We remove several casts in a single pass, which should not happen
+    # with the current implementation of the pattern rewriter.
+    # The rewriter is not notified of our deletions, so we need to
+    # ignore casts that have already been removed earlier in the pass
+    # (i.e: no parent anymore).
 
-    This pattern rewriter removes `unrealized_conversion_cast` operations
-    that are not needed.
-    """
+    if op.parent is not None:
+        # casts that either have no uses or have at least
+        # one user that isn't an unrealized cast.
+        finalized_casts = list[builtin.UnrealizedConversionCastOp]()
 
-    @op_type_rewrite_pattern
-    def match_and_rewrite(
-        self, op: builtin.UnrealizedConversionCastOp, rewriter: PatternRewriter
-    ) -> None:
-        # We remove several casts in a single pass, which should not happen
-        # with the current implementation of the pattern rewriter.
-        # The rewriter is not notified of our deletions, so we need to
-        # ignore casts that have already been removed earlier in the pass
-        # (i.e: no parent anymore).
+        # casts with only other unrealized casts as users.
+        pending_casts = deque[builtin.UnrealizedConversionCastOp]()
 
-        if op.parent is not None:
-            # casts that either have no uses or have at least
-            # one user that isn't an unrealized cast.
-            finalized_casts = list[builtin.UnrealizedConversionCastOp]()
+        # casts that neeed to be visited in the DFS traversal of the use-def chain.
+        casts_to_visit = [op]
 
-            # casts with only other unrealized casts as users.
-            pending_casts = deque[builtin.UnrealizedConversionCastOp]()
+        def gen_all_uses_cast(
+            node: builtin.UnrealizedConversionCastOp,
+        ) -> Iterable[Use]:
+            for result in node.results:
+                yield from result.uses
 
-            # casts that neeed to be visited in the DFS traversal of the use-def chain.
-            casts_to_visit = [op]
+        # DFS traversal of the use-def chain.
+        while casts_to_visit:
+            cast = casts_to_visit.pop()
 
-            def gen_all_uses_cast(
-                node: builtin.UnrealizedConversionCastOp,
-            ) -> Iterable[Use]:
-                for result in node.results:
-                    yield from result.uses
+            is_live = False
+            has_any_uses = False
 
-            # DFS traversal of the use-def chain.
-            while casts_to_visit:
-                cast = casts_to_visit.pop()
-
-                is_live = False
-                has_any_uses = False
-
-                for use in gen_all_uses_cast(cast):
-                    if isinstance(use.operation, builtin.UnrealizedConversionCastOp):
-                        # early check, it's definitely not an unifiable cast
-                        if any(
-                            r != i
-                            for r, i in itertools.zip_longest(
-                                use.operation.inputs, cast.results
-                            )
-                        ):
-                            warn(
-                                f"Unable to remove cast {cast} because "
-                                "it is not unifiable with its uses"
-                            )
-                            return
-                        casts_to_visit.append(use.operation)
-                    else:
-                        is_live = True
-                    has_any_uses = True
-
-                # check that either there is a trivial cycle we can remove
-                # because types are homogeneous (e.g. {A -> B, B -> A})
-                # otherwise it means the cast is not unifiable with its uses
-                assert len(cast.results) == len(op.inputs)
-                has_trivial_cycle = all(
-                    r.type == i.type for r, i in zip(cast.results, op.inputs)
-                )
-                if is_live and not has_trivial_cycle:
-                    warn(
-                        "Unable to remove cast "
-                        f"{cast} because it is not unifiable "
-                        "with its uses"
-                    )
-                    return
-
-                if not has_any_uses or is_live:
-                    finalized_casts.append(cast)
+            for use in gen_all_uses_cast(cast):
+                if isinstance(use.operation, builtin.UnrealizedConversionCastOp):
+                    # early check, it's definitely not an unifiable cast
+                    if any(
+                        r != i
+                        for r, i in itertools.zip_longest(
+                            use.operation.inputs, cast.results
+                        )
+                    ):
+                        warn(
+                            f"Unable to remove cast {cast} because "
+                            "it is not unifiable with its uses"
+                        )
+                        return
+                    casts_to_visit.append(use.operation)
                 else:
-                    pending_casts.appendleft(cast)
+                    is_live = True
+                has_any_uses = True
 
-            for cast in filter(lambda c: c.parent is not None, finalized_casts):
-                # replace the uses of this cast by the inputs of the root cast
-                PatternRewriter(cast).replace_matched_op([], op.inputs)
+            # check that either there is a trivial cycle we can remove
+            # because types are homogeneous (e.g. {A -> B, B -> A})
+            # otherwise it means the cast is not unifiable with its uses
+            assert len(cast.results) == len(op.inputs)
+            has_trivial_cycle = all(
+                r.type == i.type for r, i in zip(cast.results, op.inputs)
+            )
+            if is_live and not has_trivial_cycle:
+                warn(
+                    "Unable to remove cast "
+                    f"{cast} because it is not unifiable "
+                    "with its uses"
+                )
+                return
 
-            for cast in filter(lambda c: c.parent is not None, pending_casts):
-                # remove other casts in the chain in the right order
-                PatternRewriter(cast).erase_matched_op()
+            if not has_any_uses or is_live:
+                finalized_casts.append(cast)
+            else:
+                pending_casts.appendleft(cast)
+
+        for cast in filter(lambda c: c.parent is not None, finalized_casts):
+            # replace the uses of this cast by the inputs of the root cast
+            PatternRewriter(cast).replace_matched_op([], op.inputs)
+
+        for cast in filter(lambda c: c.parent is not None, pending_casts):
+            # remove other casts in the chain in the right order
+            PatternRewriter(cast).erase_matched_op()
 
 
-def reconcile_unrealized_casts(op: ModuleOp):
+def reconcile_unrealized_casts(module: ModuleOp):
     """
     Removes all `builtin.unrealized_conversion_cast` operations
     that are not needed anymore in a module.
     """
-    walker = PatternRewriteWalker(ReconcileUnrealizedCasts())
-    walker.rewrite_module(op)
+    for op in filter(
+        lambda op: isinstance(op, builtin.UnrealizedConversionCastOp), module.walk()
+    ):
+        assert isinstance(op, builtin.UnrealizedConversionCastOp)
+        _try_remove_cast(op)
 
 
 class ReconcileUnrealizedCastsPass(ModulePass):

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -93,10 +93,9 @@ def reconcile_unrealized_casts(module: ModuleOp):
     Removes all `builtin.unrealized_conversion_cast` operations
     that are not needed anymore in a module.
     """
-    for op in filter(
-        lambda op: isinstance(op, builtin.UnrealizedConversionCastOp), module.walk()
-    ):
-        assert isinstance(op, builtin.UnrealizedConversionCastOp)
+    for op in module.walk():
+        if not isinstance(op, builtin.UnrealizedConversionCastOp):
+            continue
         _try_remove_cast_chain(op)
 
 

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -18,10 +18,12 @@ from xdsl.pattern_rewriter import (
 
 class ReconcileUnrealizedCasts(RewritePattern):
     """
-    An `unrealized_conversion_cast` operation represents an unrealized conversion from one set of types to another,
-    that is used to enable the inter-mixing of different type systems.
+    An `unrealized_conversion_cast` operation represents an unrealized conversion
+    from one set of types to another, that is used to enable the inter-mixing
+    of different type systems.
 
-    This pattern rewriter removes `unrealized_conversion_cast` operations that are not needed.
+    This pattern rewriter removes `unrealized_conversion_cast` operations
+    that are not needed.
     """
 
     @op_type_rewrite_pattern
@@ -31,7 +33,8 @@ class ReconcileUnrealizedCasts(RewritePattern):
         # We remove several casts in a single pass, which should not happen
         # with the current implementation of the pattern rewriter.
         # The rewriter is not notified of our deletions, so we need to
-        # ignore casts that have already been removed earlier in the pass (i.e: no parent anymore).
+        # ignore casts that have already been removed earlier in the pass
+        #  (i.e: no parent anymore).
 
         if op.parent is not None:
             # casts that either have no uses or have at least
@@ -67,7 +70,8 @@ class ReconcileUnrealizedCasts(RewritePattern):
                             )
                         ):
                             warn(
-                                f"Unable to remove cast {cast} because it is not unifiable with its uses"
+                                f"Unable to remove cast {cast} because "
+                                "it is not unifiable with its uses"
                             )
                             return
                         casts_to_visit.append(use.operation)
@@ -75,8 +79,8 @@ class ReconcileUnrealizedCasts(RewritePattern):
                         is_live = True
                     has_any_uses = True
 
-                # check that either there is a trivial cycle we can remove because types are homogeneous
-                # (e.g. {A -> B, B -> A})
+                # check that either there is a trivial cycle we can remove
+                # because types are homogeneous (e.g. {A -> B, B -> A})
                 # otherwise it means the cast is not unifiable with its uses
                 assert len(cast.results) == len(op.inputs)
                 has_trivial_cycle = all(
@@ -84,7 +88,9 @@ class ReconcileUnrealizedCasts(RewritePattern):
                 )
                 if is_live and not has_trivial_cycle:
                     warn(
-                        f"Unable to remove cast {cast} because it is not unifiable with its uses"
+                        "Unable to remove cast "
+                        f"{cast} because it is not unifiable "
+                        "with its uses"
                     )
                     return
 
@@ -104,7 +110,8 @@ class ReconcileUnrealizedCasts(RewritePattern):
 
 def reconcile_unrealized_casts(op: ModuleOp):
     """
-    Removes all `builtin.unrealized_conversion_cast` operations that are not needed in a module.
+    Removes all `builtin.unrealized_conversion_cast` operations
+    that are not needed anymore in a module.
     """
     walker = PatternRewriteWalker(ReconcileUnrealizedCasts())
     walker.rewrite_module(op)

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -1,0 +1,117 @@
+import itertools
+from collections import deque
+from typing import Iterable
+from warnings import warn
+
+from xdsl.dialects import builtin
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.ir import MLContext
+from xdsl.ir.core import Use
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class RemoveUselessConversionCast(RewritePattern):
+    """
+    An `unrealized_conversion_cast` operation represents an unrealized conversion from one set of types to another,
+    that is used to enable the inter-mixing of different type systems.
+
+    This pattern rewriter removes `unrealized_conversion_cast` operations that are not needed.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: builtin.UnrealizedConversionCastOp, rewriter: PatternRewriter
+    ) -> None:
+        # We remove severals cast in a single pass, which should not happen
+        # with the current implementation of the pattern rewriter.
+        # The rewriter is not notified of our deletions, so we need to
+        # ignore casts that have already been removed earlier in the pass (i.e: no parent anymore).
+
+        if op.parent is not None:
+            # casts that either have no uses or have at least
+            # one user that isn't an unrealized cast.
+            finalized_casts = list[builtin.UnrealizedConversionCastOp]()
+
+            # casts with only other unrealized casts as users.
+            pending_casts = deque[builtin.UnrealizedConversionCastOp]()
+
+            # casts that neeed to be visited in the DFS traversal of the use-def chain.
+            casts_to_visit = [op]
+
+            def gen_all_uses_cast(
+                node: builtin.UnrealizedConversionCastOp,
+            ) -> Iterable[Use]:
+                for result in node.results:
+                    yield from result.uses
+
+            # DFS traversal of the use-def chain.
+            while casts_to_visit:
+                cast = casts_to_visit.pop()
+
+                is_live = False
+                has_any_uses = False
+
+                for use in gen_all_uses_cast(cast):
+                    if isinstance(use.operation, builtin.UnrealizedConversionCastOp):
+                        # early check, for sure we are not able to remove such a cast
+                        if any(
+                            r != i
+                            for r, i in itertools.zip_longest(
+                                use.operation.inputs, cast.results
+                            )
+                        ):
+                            warn(
+                                f"Unable to remove cast {cast} because it is not unifiable with its uses"
+                            )
+                            return
+                        casts_to_visit.append(use.operation)
+                    else:
+                        is_live = True
+                    has_any_uses = True
+
+                # check that either there is a trivial cycle we can remove because types are homogeneous
+                # (e.g. {A -> B, B -> A})
+                # otherwise it means the cast is not unifiable with its uses
+                assert len(cast.results) == len(op.inputs)
+                has_trivial_cycle = all(
+                    r.type == i.type for r, i in zip(cast.results, op.inputs)
+                )
+                if is_live and not has_trivial_cycle:
+                    warn(
+                        f"Unable to remove cast {cast} because it is not unifiable with its uses"
+                    )
+                    return
+
+                if not has_any_uses or is_live:
+                    finalized_casts.append(cast)
+                else:
+                    pending_casts.appendleft(cast)
+
+            for cast in finalized_casts:
+                # replace the uses of this cast by the inputs of the root cast
+                PatternRewriter(cast).replace_matched_op([], op.inputs)
+
+            for cast in pending_casts:
+                # remove other casts in the chain in the right order
+                PatternRewriter(cast).erase_matched_op()
+
+
+def reconcile_unrealized_casts(op: ModuleOp):
+    """
+    Removes all `builtin.unrealized_conversion_cast` operations that are not needed in a module.
+    """
+    walker = PatternRewriteWalker(RemoveUselessConversionCast())
+    walker.rewrite_module(op)
+
+
+class ReconcileUnrealizedCasts(ModulePass):
+    name = "reconcile-unrealized-casts"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        reconcile_unrealized_casts(op)

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -93,11 +93,11 @@ class RemoveUselessConversionCast(RewritePattern):
                 else:
                     pending_casts.appendleft(cast)
 
-            for cast in finalized_casts:
+            for cast in filter(lambda c: c.parent is not None, finalized_casts):
                 # replace the uses of this cast by the inputs of the root cast
                 PatternRewriter(cast).replace_matched_op([], op.inputs)
 
-            for cast in pending_casts:
+            for cast in filter(lambda c: c.parent is not None, pending_casts):
                 # remove other casts in the chain in the right order
                 PatternRewriter(cast).erase_matched_op()
 

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -93,10 +93,12 @@ def reconcile_unrealized_casts(module: ModuleOp):
     Removes all `builtin.unrealized_conversion_cast` operations
     that are not needed anymore in a module.
     """
-    for op in module.walk():
-        if not isinstance(op, builtin.UnrealizedConversionCastOp):
-            continue
-        _try_remove_cast_chain(op)
+    casts = [
+        op for op in module.walk() if isinstance(op, builtin.UnrealizedConversionCastOp)
+    ]
+
+    for cast in casts:
+        _try_remove_cast_chain(cast)
 
 
 class ReconcileUnrealizedCastsPass(ModulePass):

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -34,7 +34,7 @@ class ReconcileUnrealizedCasts(RewritePattern):
         # with the current implementation of the pattern rewriter.
         # The rewriter is not notified of our deletions, so we need to
         # ignore casts that have already been removed earlier in the pass
-        #  (i.e: no parent anymore).
+        # (i.e: no parent anymore).
 
         if op.parent is not None:
             # casts that either have no uses or have at least

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -58,6 +58,7 @@ from xdsl.transforms.lower_riscv_func import LowerRISCVFunc
 from xdsl.transforms.lower_snitch import LowerSnitchPass
 from xdsl.transforms.lower_snitch_runtime import LowerSnitchRuntimePass
 from xdsl.transforms.printf_to_llvm import PrintfToLLVM
+from xdsl.transforms.reconcile_unrealized_casts import ReconcileUnrealizedCasts
 from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
 from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.parse_pipeline import parse_pipeline
@@ -113,6 +114,7 @@ def get_all_passes() -> list[type[ModulePass]]:
         RISCVLowerArith,
         StencilShapeInferencePass,
         StencilStorageMaterializationPass,
+        ReconcileUnrealizedCasts,
     ]
 
 

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -58,7 +58,7 @@ from xdsl.transforms.lower_riscv_func import LowerRISCVFunc
 from xdsl.transforms.lower_snitch import LowerSnitchPass
 from xdsl.transforms.lower_snitch_runtime import LowerSnitchRuntimePass
 from xdsl.transforms.printf_to_llvm import PrintfToLLVM
-from xdsl.transforms.reconcile_unrealized_casts import ReconcileUnrealizedCasts
+from xdsl.transforms.reconcile_unrealized_casts import ReconcileUnrealizedCastsPass
 from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
 from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.parse_pipeline import parse_pipeline
@@ -114,7 +114,7 @@ def get_all_passes() -> list[type[ModulePass]]:
         RISCVLowerArith,
         StencilShapeInferencePass,
         StencilStorageMaterializationPass,
-        ReconcileUnrealizedCasts,
+        ReconcileUnrealizedCastsPass,
     ]
 
 


### PR DESCRIPTION
During multiple partial conversions when lowering to a target dialect, casts operations (`builtin.unrealized_conversion_cast`) are added to a module to ensure it is still type-checkable at any stage (by MLIR invariant).

Thus, cast operations that became no-op can be removed at the end of a given lowering.
This PR adds such a pass that might be useful in the general case and should soon be used for the `riscv` infrastructure.