### PR TITLE
reqs: add typing-extension dependency

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -11,7 +11,6 @@ pre-commit==3.3.3
 riscemu==2.1.0
 asv<0.6
 isort==5.12.0
-typing-extensions<4.8
 # pyright has to be the last line and fixed with `==`. The CI parses this file
 # in `.github/parse_pyright_version.py` and installs the according version for
 # typechecking.

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -11,6 +11,7 @@ pre-commit==3.3.3
 riscemu==2.1.0
 asv<0.6
 isort==5.12.0
+typing-extensions<4.8
 # pyright has to be the last line and fixed with `==`. The CI parses this file
 # in `.github/parse_pyright_version.py` and installs the according version for
 # typechecking.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pip<24.0
 immutabledict<2.2.6
-typing-extensions<4.8
+typing-extensions>=4.7,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pip<24.0
 immutabledict<2.2.6
+typing-extensions<4.8

--- a/xdsl/interpreters/shaped_array.py
+++ b/xdsl/interpreters/shaped_array.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import operator
 from itertools import accumulate, product
 from math import prod
-from typing import Generic, Iterable, Self, TypeAlias, TypeVar
+from typing import Generic, Iterable, TypeAlias, TypeVar
 
 from attr import dataclass
+from typing_extensions import Self
 
 _T = TypeVar("_T")
 

--- a/xdsl/interpreters/shaped_array.py
+++ b/xdsl/interpreters/shaped_array.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import operator
 from itertools import accumulate, product
 from math import prod
-from typing import Generic, Iterable, TypeAlias, TypeVar
+from typing import Generic, Iterable, Self, TypeAlias, TypeVar
 
 from attr import dataclass
 
@@ -64,7 +64,7 @@ class ShapedArray(Generic[_T]):
         """
         yield from product(*(range(dim) for dim in self.shape))
 
-    def transposed(self, dim0: int, dim1: int) -> ShapedArray[_T]:
+    def transposed(self, dim0: int, dim1: int) -> Self:
         """
         Returns a new ShapedArray, with the dimensions `dim0` and `dim1` transposed.
         """

--- a/xdsl/interpreters/shaped_array.py
+++ b/xdsl/interpreters/shaped_array.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import operator
+from dataclasses import dataclass
 from itertools import accumulate, product
 from math import prod
 from typing import Generic, Iterable, TypeAlias, TypeVar
 
-from attr import dataclass
 from typing_extensions import Self
 
 _T = TypeVar("_T")


### PR DESCRIPTION
Self is a very useful type to have available, introduced in 3.11. In Python 3.10 a third-party module is required for the same functionality. I reckon the extra dependency is worth it for the kind of thing we'd like to express.

It seems to me like it's necessary to make it a required dependency as core code should be able to use Self, so users of pip install should inherit it as well. It's a bit annoying to have a dependency that's only required for python 3.10 but it seems worth it to me.