### PR TITLE
core: Add optional version of parse_comma_separated_list

### DIFF
--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -136,15 +136,10 @@ class FuncOp(IRDLOperation):
 
         # Parse return type
         if parser.parse_optional_punctuation("->"):
-            if parser.parse_optional_punctuation("(") is not None:
-                if parser.parse_optional_punctuation(")") is not None:
-                    return_types = []
-                else:
-                    return_types = parser.parse_comma_separated_list(
-                        parser.Delimiter.NONE, parser.parse_type
-                    )
-                    parser.parse_punctuation(")")
-            else:
+            return_types = parser.parse_optional_comma_separated_list(
+                parser.Delimiter.PAREN, parser.parse_type
+            )
+            if return_types is None:
                 return_types = [parser.parse_type()]
         else:
             return_types = []

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -379,18 +379,17 @@ class OperationOp(IRDLOperation):
             operands = parse_operands_with_types(parser)
             parser.parse_punctuation(")")
 
-        def parse_pattribute_entry() -> tuple[str, SSAValue]:
+        def parse_attribute_entry() -> tuple[str, SSAValue]:
             name = parser.parse_str_literal()
             parser.parse_punctuation("=")
             type = parser.parse_operand()
             return (name, type)
 
-        attributes = []
-        if parser.parse_optional_punctuation("{"):
-            attributes = parser.parse_comma_separated_list(
-                Parser.Delimiter.NONE, parse_pattribute_entry
-            )
-            parser.parse_punctuation("}")
+        attributes = parser.parse_optional_comma_separated_list(
+            Parser.Delimiter.BRACES, parse_attribute_entry
+        )
+        if attributes is None:
+            attributes = []
         attribute_names = [StringAttr(attr[0]) for attr in attributes]
         attribute_values = [attr[1] for attr in attributes]
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -162,11 +162,11 @@ class AttrParser(BaseParser):
         return name, self.parse_attribute()
 
     def parse_optional_dictionary_attr_dict(self) -> dict[str, Attribute]:
-        if self._current_token.kind != Token.Kind.L_BRACE:
-            return dict()
-        attrs = self.parse_comma_separated_list(
+        attrs = self.parse_optional_comma_separated_list(
             self.Delimiter.BRACES, self._parse_attribute_entry
         )
+        if attrs is None:
+            return dict()
         return dict(attrs)
 
     def _parse_dialect_type_or_attribute_inner(
@@ -840,10 +840,10 @@ class AttrParser(BaseParser):
         For instance, [[0, 1, 2], [3, 4, 5]] will return [0, 1, 2, 3, 4, 5] for
         the data, and [2, 3] for the shape.
         """
-        if self._current_token.kind == Token.Kind.L_SQUARE:
-            res = self.parse_comma_separated_list(
-                self.Delimiter.SQUARE, self._parse_tensor_literal
-            )
+        res = self.parse_optional_comma_separated_list(
+            self.Delimiter.SQUARE, self._parse_tensor_literal
+        )
+        if res is not None:
             if len(res) == 0:
                 return [], [0]
             sub_literal_shape = res[0][1]
@@ -977,11 +977,11 @@ class AttrParser(BaseParser):
         Parse an array attribute, if present, with format:
             array-attr ::= `[` (attribute (`,` attribute)*)? `]`
         """
-        if self._current_token.kind != Token.Kind.L_SQUARE:
-            return None
-        attrs = self.parse_comma_separated_list(
+        attrs = self.parse_optional_comma_separated_list(
             self.Delimiter.SQUARE, self.parse_attribute
         )
+        if attrs is None:
+            return None
         return ArrayAttr(attrs)
 
     def _parse_function_type(self) -> FunctionType:
@@ -1010,22 +1010,21 @@ class AttrParser(BaseParser):
         self.parse_punctuation("->")
 
         # Parse the returns
-        if self._current_token.kind == Token.Kind.L_PAREN:
-            returns = self.parse_comma_separated_list(
-                self.Delimiter.PAREN, self.parse_type
-            )
-        else:
+        returns = self.parse_optional_comma_separated_list(
+            self.Delimiter.PAREN, self.parse_type
+        )
+        if returns is None:
             returns = [self.parse_type()]
         return FunctionType.from_lists(args, returns)
 
     def parse_paramattr_parameters(
         self, skip_white_space: bool = True
     ) -> list[Attribute]:
-        if self._current_token.kind != Token.Kind.LESS:
-            return []
-        res = self.parse_comma_separated_list(
+        res = self.parse_optional_comma_separated_list(
             self.Delimiter.ANGLE, self.parse_attribute
         )
+        if res is None:
+            return []
         return res
 
     def _parse_optional_builtin_dict_attr(self) -> DictionaryAttr | None:


### PR DESCRIPTION
This adds two optional versions of `parse_comma_separated_list`:
* `parse_optional_comma_separated_list`, which takes a delimiter, and returns `None` if the delimiter wasn't found
* `parse_optional_unbounded_comma_separated_list`, which takes a `parse_optional` function as well, and will parse the first element with it (no delimiters).

This PR also updates also replace some uses of `parse_comma_separated_list` with the new methods.