### PR TITLE
dialects: (riscv) remove Register class

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -15,9 +15,9 @@ def test_add_op():
 
     assert a1.type is add_op.rs1.type
     assert a2.type is add_op.rs2.type
-    assert isinstance(a0.type, riscv.RegisterType)
-    assert isinstance(a1.type, riscv.RegisterType)
-    assert isinstance(a2.type, riscv.RegisterType)
+    assert isinstance(a0.type, riscv.RegisterAttr)
+    assert isinstance(a1.type, riscv.RegisterAttr)
+    assert isinstance(a2.type, riscv.RegisterAttr)
     assert a0.type.data.name == "a0"
     assert a1.type.data.name == "a1"
     assert a2.type.data.name == "a2"
@@ -234,7 +234,7 @@ def test_immediate_shift_inst():
 
 def check_float_register():
     with pytest.raises(VerifyException):
-        riscv.RegisterType(riscv.Register("ft9"))
+        riscv.RegisterAttr(riscv.Register("ft9"))
     with pytest.raises(VerifyException):
         riscv.FloatRegisterType(riscv.Register("a0"))
 

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -15,9 +15,9 @@ def test_add_op():
 
     assert a1.type is add_op.rs1.type
     assert a2.type is add_op.rs2.type
-    assert isinstance(a0.type, riscv.RegisterAttr)
-    assert isinstance(a1.type, riscv.RegisterAttr)
-    assert isinstance(a2.type, riscv.RegisterAttr)
+    assert isinstance(a0.type, riscv.IntRegisterAttr)
+    assert isinstance(a1.type, riscv.IntRegisterAttr)
+    assert isinstance(a2.type, riscv.IntRegisterAttr)
     assert a0.type.data == "a0"
     assert a1.type.data == "a1"
     assert a2.type.data == "a2"
@@ -234,7 +234,7 @@ def test_immediate_shift_inst():
 
 def check_float_register():
     with pytest.raises(VerifyException):
-        riscv.RegisterAttr("ft9")
+        riscv.IntRegisterAttr("ft9")
     with pytest.raises(VerifyException):
         riscv.FloatRegisterAttr("a0")
 

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -15,9 +15,9 @@ def test_add_op():
 
     assert a1.type is add_op.rs1.type
     assert a2.type is add_op.rs2.type
-    assert isinstance(a0.type, riscv.IntRegisterAttr)
-    assert isinstance(a1.type, riscv.IntRegisterAttr)
-    assert isinstance(a2.type, riscv.IntRegisterAttr)
+    assert isinstance(a0.type, riscv.IntRegisterType)
+    assert isinstance(a1.type, riscv.IntRegisterType)
+    assert isinstance(a2.type, riscv.IntRegisterType)
     assert a0.type.data == "a0"
     assert a1.type.data == "a1"
     assert a2.type.data == "a2"
@@ -234,9 +234,9 @@ def test_immediate_shift_inst():
 
 def check_float_register():
     with pytest.raises(VerifyException):
-        riscv.IntRegisterAttr("ft9")
+        riscv.IntRegisterType("ft9")
     with pytest.raises(VerifyException):
-        riscv.FloatRegisterAttr("a0")
+        riscv.FloatRegisterType("a0")
 
     a1 = TestSSAValue(riscv.Registers.A1)
     a2 = TestSSAValue(riscv.Registers.A2)

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -236,7 +236,7 @@ def check_float_register():
     with pytest.raises(VerifyException):
         riscv.RegisterAttr("ft9")
     with pytest.raises(VerifyException):
-        riscv.FloatRegisterType("a0")
+        riscv.FloatRegisterAttr("a0")
 
     a1 = TestSSAValue(riscv.Registers.A1)
     a2 = TestSSAValue(riscv.Registers.A2)

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -18,9 +18,9 @@ def test_add_op():
     assert isinstance(a0.type, riscv.RegisterAttr)
     assert isinstance(a1.type, riscv.RegisterAttr)
     assert isinstance(a2.type, riscv.RegisterAttr)
-    assert a0.type.data.name == "a0"
-    assert a1.type.data.name == "a1"
-    assert a2.type.data.name == "a2"
+    assert a0.type.data == "a0"
+    assert a1.type.data == "a1"
+    assert a2.type.data == "a2"
 
 
 def test_csr_op():
@@ -234,9 +234,9 @@ def test_immediate_shift_inst():
 
 def check_float_register():
     with pytest.raises(VerifyException):
-        riscv.RegisterAttr(riscv.Register("ft9"))
+        riscv.RegisterAttr("ft9")
     with pytest.raises(VerifyException):
-        riscv.FloatRegisterType(riscv.Register("a0"))
+        riscv.FloatRegisterType("a0")
 
     a1 = TestSSAValue(riscv.Registers.A1)
     a2 = TestSSAValue(riscv.Registers.A2)

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -13,7 +13,7 @@ index = IndexType()
 @ModuleOp
 @Builder.implicit_region
 def my_module():
-    @Builder.implicit_region((riscv.RegisterType(riscv.Register()),))
+    @Builder.implicit_region((riscv.RegisterAttr(riscv.Register()),))
     def body(args: tuple[BlockArgument, ...]) -> None:
         riscv_func.ReturnOp(args)
 

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -13,7 +13,7 @@ index = IndexType()
 @ModuleOp
 @Builder.implicit_region
 def my_module():
-    @Builder.implicit_region((riscv.IntRegisterAttr.unallocated,))
+    @Builder.implicit_region((riscv.IntRegisterType.unallocated,))
     def body(args: tuple[BlockArgument, ...]) -> None:
         riscv_func.ReturnOp(args)
 

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -13,7 +13,7 @@ index = IndexType()
 @ModuleOp
 @Builder.implicit_region
 def my_module():
-    @Builder.implicit_region((riscv.IntRegisterType.unallocated,))
+    @Builder.implicit_region((riscv.IntRegisterType.unallocated(),))
     def body(args: tuple[BlockArgument, ...]) -> None:
         riscv_func.ReturnOp(args)
 

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -13,7 +13,7 @@ index = IndexType()
 @ModuleOp
 @Builder.implicit_region
 def my_module():
-    @Builder.implicit_region((riscv.RegisterAttr(""),))
+    @Builder.implicit_region((riscv.RegisterAttr.unallocated,))
     def body(args: tuple[BlockArgument, ...]) -> None:
         riscv_func.ReturnOp(args)
 

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -13,7 +13,7 @@ index = IndexType()
 @ModuleOp
 @Builder.implicit_region
 def my_module():
-    @Builder.implicit_region((riscv.RegisterAttr(riscv.Register()),))
+    @Builder.implicit_region((riscv.RegisterAttr(""),))
     def body(args: tuple[BlockArgument, ...]) -> None:
         riscv_func.ReturnOp(args)
 

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -13,7 +13,7 @@ index = IndexType()
 @ModuleOp
 @Builder.implicit_region
 def my_module():
-    @Builder.implicit_region((riscv.RegisterAttr.unallocated,))
+    @Builder.implicit_region((riscv.IntRegisterAttr.unallocated,))
     def body(args: tuple[BlockArgument, ...]) -> None:
         riscv_func.ReturnOp(args)
 

--- a/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
+++ b/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
@@ -46,7 +46,7 @@ class LowerArithConstant(RewritePattern):
             if isinstance(op.result.type, Float32Type):
                 lui = riscv.LiOp(
                     convert_float_to_int(op.value.value.data),
-                    rd=riscv.IntRegisterType.unallocated,
+                    rd=riscv.IntRegisterType.unallocated(),
                 )
                 fld = riscv.FCvtSWOp(lui.rd)
                 rewriter.replace_op(op, [lui, fld])

--- a/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
+++ b/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
@@ -46,7 +46,7 @@ class LowerArithConstant(RewritePattern):
             if isinstance(op.result.type, Float32Type):
                 lui = riscv.LiOp(
                     convert_float_to_int(op.value.value.data),
-                    rd=riscv.RegisterAttr(""),
+                    rd=riscv.RegisterAttr.unallocated,
                 )
                 fld = riscv.FCvtSWOp(lui.rd)
                 rewriter.replace_op(op, [lui, fld])

--- a/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
+++ b/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
@@ -46,7 +46,7 @@ class LowerArithConstant(RewritePattern):
             if isinstance(op.result.type, Float32Type):
                 lui = riscv.LiOp(
                     convert_float_to_int(op.value.value.data),
-                    rd=riscv.RegisterType(riscv.Register()),
+                    rd=riscv.RegisterAttr(riscv.Register()),
                 )
                 fld = riscv.FCvtSWOp(lui.rd)
                 rewriter.replace_op(op, [lui, fld])

--- a/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
+++ b/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
@@ -46,7 +46,7 @@ class LowerArithConstant(RewritePattern):
             if isinstance(op.result.type, Float32Type):
                 lui = riscv.LiOp(
                     convert_float_to_int(op.value.value.data),
-                    rd=riscv.IntRegisterAttr.unallocated,
+                    rd=riscv.IntRegisterType.unallocated,
                 )
                 fld = riscv.FCvtSWOp(lui.rd)
                 rewriter.replace_op(op, [lui, fld])

--- a/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
+++ b/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
@@ -46,7 +46,7 @@ class LowerArithConstant(RewritePattern):
             if isinstance(op.result.type, Float32Type):
                 lui = riscv.LiOp(
                     convert_float_to_int(op.value.value.data),
-                    rd=riscv.RegisterAttr.unallocated,
+                    rd=riscv.IntRegisterAttr.unallocated,
                 )
                 fld = riscv.FCvtSWOp(lui.rd)
                 rewriter.replace_op(op, [lui, fld])

--- a/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
+++ b/xdsl/backend/riscv/lowering/riscv_arith_lowering.py
@@ -46,7 +46,7 @@ class LowerArithConstant(RewritePattern):
             if isinstance(op.result.type, Float32Type):
                 lui = riscv.LiOp(
                     convert_float_to_int(op.value.value.data),
-                    rd=riscv.RegisterAttr(riscv.Register()),
+                    rd=riscv.RegisterAttr(""),
                 )
                 fld = riscv.FCvtSWOp(lui.rd)
                 rewriter.replace_op(op, [lui, fld])

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.dialects.riscv import FloatRegisterAttr, IntRegisterAttr, RISCVOp
+from xdsl.dialects.riscv import FloatRegisterType, IntRegisterType, RISCVOp
 from xdsl.ir import SSAValue
 
 
@@ -53,7 +53,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (IntRegisterAttr, FloatRegisterAttr)
+        self._register_types = (IntRegisterType, FloatRegisterType)
 
         """
         Assume that all the registers are available except the ones explicitly reserved
@@ -62,12 +62,12 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
         self.reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
 
         self.register_sets = {
-            IntRegisterAttr: [
+            IntRegisterType: [
                 reg
-                for reg in IntRegisterAttr.RV32I_INDEX_BY_NAME
+                for reg in IntRegisterType.RV32I_INDEX_BY_NAME
                 if reg not in self.reserved_registers
             ],
-            FloatRegisterAttr: list(FloatRegisterAttr.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
         }
 
         for reg_type, reg_set in self.register_sets.items():
@@ -132,7 +132,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (IntRegisterAttr, FloatRegisterAttr)
+        self._register_types = (IntRegisterType, FloatRegisterType)
         _ = limit_registers
 
         """
@@ -142,12 +142,12 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
         reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
 
         self.register_sets = {
-            IntRegisterAttr: [
+            IntRegisterType: [
                 reg
-                for reg in IntRegisterAttr.RV32I_INDEX_BY_NAME
+                for reg in IntRegisterType.RV32I_INDEX_BY_NAME
                 if reg not in reserved_registers
             ],
-            FloatRegisterAttr: list(FloatRegisterAttr.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
         }
 
     def allocate_registers(self, module: ModuleOp) -> None:
@@ -184,7 +184,7 @@ class RegisterAllocatorJRegs(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (IntRegisterAttr, FloatRegisterAttr)
+        self._register_types = (IntRegisterType, FloatRegisterType)
         _ = limit_registers
 
     def allocate_registers(self, module: ModuleOp) -> None:

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.dialects.riscv import FloatRegisterType, Register, RegisterType, RISCVOp
+from xdsl.dialects.riscv import FloatRegisterType, Register, RegisterAttr, RISCVOp
 from xdsl.ir import SSAValue
 
 
@@ -53,7 +53,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterType, FloatRegisterType)
+        self._register_types = (RegisterAttr, FloatRegisterType)
 
         """
         Assume that all the registers are available except the ones explicitly reserved
@@ -62,12 +62,12 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
         self.reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
 
         self.register_sets = {
-            RegisterType: [
+            RegisterAttr: [
                 reg
-                for reg in Register.RV32I_INDEX_BY_NAME
+                for reg in RegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in self.reserved_registers
             ],
-            FloatRegisterType: list(Register.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterType: list(RegisterAttr.RV32F_INDEX_BY_NAME.keys()),
         }
 
         for reg_type, reg_set in self.register_sets.items():
@@ -132,7 +132,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterType, FloatRegisterType)
+        self._register_types = (RegisterAttr, FloatRegisterType)
         _ = limit_registers
 
         """
@@ -142,12 +142,12 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
         reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
 
         self.register_sets = {
-            RegisterType: [
+            RegisterAttr: [
                 reg
-                for reg in Register.RV32I_INDEX_BY_NAME
+                for reg in RegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in reserved_registers
             ],
-            FloatRegisterType: list(Register.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterType: list(RegisterAttr.RV32F_INDEX_BY_NAME.keys()),
         }
 
     def allocate_registers(self, module: ModuleOp) -> None:
@@ -186,7 +186,7 @@ class RegisterAllocatorJRegs(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterType, FloatRegisterType)
+        self._register_types = (RegisterAttr, FloatRegisterType)
         _ = limit_registers
 
     def allocate_registers(self, module: ModuleOp) -> None:

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.dialects.riscv import FloatRegisterAttr, RegisterAttr, RISCVOp
+from xdsl.dialects.riscv import FloatRegisterAttr, IntRegisterAttr, RISCVOp
 from xdsl.ir import SSAValue
 
 
@@ -53,7 +53,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterAttr, FloatRegisterAttr)
+        self._register_types = (IntRegisterAttr, FloatRegisterAttr)
 
         """
         Assume that all the registers are available except the ones explicitly reserved
@@ -62,9 +62,9 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
         self.reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
 
         self.register_sets = {
-            RegisterAttr: [
+            IntRegisterAttr: [
                 reg
-                for reg in RegisterAttr.RV32I_INDEX_BY_NAME
+                for reg in IntRegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in self.reserved_registers
             ],
             FloatRegisterAttr: list(FloatRegisterAttr.RV32F_INDEX_BY_NAME.keys()),
@@ -132,7 +132,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterAttr, FloatRegisterAttr)
+        self._register_types = (IntRegisterAttr, FloatRegisterAttr)
         _ = limit_registers
 
         """
@@ -142,9 +142,9 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
         reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
 
         self.register_sets = {
-            RegisterAttr: [
+            IntRegisterAttr: [
                 reg
-                for reg in RegisterAttr.RV32I_INDEX_BY_NAME
+                for reg in IntRegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in reserved_registers
             ],
             FloatRegisterAttr: list(FloatRegisterAttr.RV32F_INDEX_BY_NAME.keys()),
@@ -184,7 +184,7 @@ class RegisterAllocatorJRegs(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterAttr, FloatRegisterAttr)
+        self._register_types = (IntRegisterAttr, FloatRegisterAttr)
         _ = limit_registers
 
     def allocate_registers(self, module: ModuleOp) -> None:

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.dialects.riscv import FloatRegisterType, RegisterAttr, RISCVOp
+from xdsl.dialects.riscv import FloatRegisterAttr, RegisterAttr, RISCVOp
 from xdsl.ir import SSAValue
 
 
@@ -53,7 +53,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterAttr, FloatRegisterType)
+        self._register_types = (RegisterAttr, FloatRegisterAttr)
 
         """
         Assume that all the registers are available except the ones explicitly reserved
@@ -67,7 +67,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 for reg in RegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in self.reserved_registers
             ],
-            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterAttr: list(FloatRegisterAttr.RV32F_INDEX_BY_NAME.keys()),
         }
 
         for reg_type, reg_set in self.register_sets.items():
@@ -132,7 +132,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterAttr, FloatRegisterType)
+        self._register_types = (RegisterAttr, FloatRegisterAttr)
         _ = limit_registers
 
         """
@@ -147,7 +147,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
                 for reg in RegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in reserved_registers
             ],
-            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterAttr: list(FloatRegisterAttr.RV32F_INDEX_BY_NAME.keys()),
         }
 
     def allocate_registers(self, module: ModuleOp) -> None:
@@ -184,7 +184,7 @@ class RegisterAllocatorJRegs(RegisterAllocator):
 
     def __init__(self, limit_registers: int = 0) -> None:
         self.idx = 0
-        self._register_types = (RegisterAttr, FloatRegisterType)
+        self._register_types = (RegisterAttr, FloatRegisterAttr)
         _ = limit_registers
 
     def allocate_registers(self, module: ModuleOp) -> None:

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -67,7 +67,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 for reg in RegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in self.reserved_registers
             ],
-            FloatRegisterType: list(RegisterAttr.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
         }
 
         for reg_type, reg_set in self.register_sets.items():
@@ -147,7 +147,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
                 for reg in RegisterAttr.RV32I_INDEX_BY_NAME
                 if reg not in reserved_registers
             ],
-            FloatRegisterType: list(RegisterAttr.RV32F_INDEX_BY_NAME.keys()),
+            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
         }
 
     def allocate_registers(self, module: ModuleOp) -> None:

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.dialects.riscv import FloatRegisterType, Register, RegisterAttr, RISCVOp
+from xdsl.dialects.riscv import FloatRegisterType, RegisterAttr, RISCVOp
 from xdsl.ir import SSAValue
 
 
@@ -81,10 +81,10 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
             available_regs = self.register_sets.get(reg_type, [])
 
             if not available_regs:
-                reg.type = reg_type(Register(f"j{self.idx}"))
+                reg.type = reg_type(f"j{self.idx}")
                 self.idx += 1
             else:
-                reg.type = reg_type(Register(available_regs.pop()))
+                reg.type = reg_type(available_regs.pop())
 
             return True
 
@@ -173,12 +173,10 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
 
                                 # If we run out of real registers, allocate a j register
                                 if not available_regs:
-                                    result.type = reg_type(Register(f"j{self.idx}"))
+                                    result.type = reg_type(f"j{self.idx}")
                                     self.idx += 1
                                 else:
-                                    result.type = reg_type(
-                                        Register(available_regs.pop())
-                                    )
+                                    result.type = reg_type(available_regs.pop())
 
 
 class RegisterAllocatorJRegs(RegisterAllocator):
@@ -202,5 +200,5 @@ class RegisterAllocatorJRegs(RegisterAllocator):
                 if isinstance(result.type, self._register_types):
                     if not result.type.is_allocated:
                         reg_type = type(result.type)
-                        result.type = reg_type(Register(f"j{self.idx}"))
+                        result.type = reg_type(f"j{self.idx}")
                         self.idx += 1

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -386,7 +386,7 @@ def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
         elif isinstance(arg.type, FloatRegisterAttr):
             reg = arg.type.register_name
             return reg
-    assert False
+    assert False, f"{arg}"
 
 
 def _assembly_line(

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from io import StringIO
 from typing import IO, Sequence, TypeAlias
 
+from typing_extensions import Self
+
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     IntegerAttr,
@@ -59,6 +61,11 @@ class RISCVRegisterAttr(Data[str], TypeAttribute, ABC):
         if not self.is_allocated:
             raise ValueError("Cannot get name for unallocated register")
         return self.data
+
+    @classmethod
+    @property
+    def unallocated(cls) -> Self:
+        return cls("")
 
     @property
     def is_allocated(self) -> bool:
@@ -386,6 +393,8 @@ def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
         elif isinstance(arg.type, FloatRegisterAttr):
             reg = arg.type.register_name
             return reg
+        else:
+            assert False, f"{arg.type}"
     assert False, f"{arg}"
 
 
@@ -443,7 +452,7 @@ class RdRsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -482,7 +491,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -568,7 +577,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -684,7 +693,7 @@ class RdRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -844,7 +853,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -902,7 +911,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -958,7 +967,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -1014,7 +1023,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -2255,7 +2264,7 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr("")
+            rd = FloatRegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
@@ -2292,7 +2301,7 @@ class RdRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr("")
+            rd = FloatRegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
@@ -2329,7 +2338,7 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -2364,7 +2373,7 @@ class RdRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr("")
+            rd = FloatRegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
@@ -2396,7 +2405,7 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr("")
+            rd = RegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
@@ -2428,7 +2437,7 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr("")
+            rd = FloatRegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
@@ -2505,7 +2514,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = FloatRegisterAttr("")
+            rd = FloatRegisterAttr.unallocated
         elif isinstance(rd, str):
             rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -57,7 +57,6 @@ class RISCVRegisterType(Data[str], TypeAttribute, ABC):
     _unallocated: ClassVar[Self | None] = None
 
     @classmethod
-    @property
     def unallocated(cls) -> Self:
         if cls._unallocated is None:
             cls._unallocated = cls("")
@@ -455,7 +454,7 @@ class RdRsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -494,7 +493,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -580,7 +579,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -696,7 +695,7 @@ class RdRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -856,7 +855,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -914,7 +913,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -970,7 +969,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -1026,7 +1025,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -2267,7 +2266,7 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType.unallocated
+            rd = FloatRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
@@ -2304,7 +2303,7 @@ class RdRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType.unallocated
+            rd = FloatRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
@@ -2341,7 +2340,7 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -2376,7 +2375,7 @@ class RdRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType.unallocated
+            rd = FloatRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
@@ -2408,7 +2407,7 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated
+            rd = IntRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -2440,7 +2439,7 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType.unallocated
+            rd = FloatRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
@@ -2517,7 +2516,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = FloatRegisterType.unallocated
+            rd = FloatRegisterType.unallocated()
         elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -94,7 +94,7 @@ class RISCVRegisterType(Data[str], TypeAttribute, ABC):
     @classmethod
     @abstractmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        raise NotImplemented
+        raise NotImplementedError
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -62,6 +62,47 @@ class Register:
         """Returns true if a RISCV register is allocated, otherwise false"""
         return self.name is not None
 
+
+@irdl_attr_definition
+class RegisterAttr(Data[Register], TypeAttribute):
+    """
+    A RISC-V register type.
+    """
+
+    name = "riscv.reg"
+
+    @property
+    def register_name(self) -> str:
+        """Returns name if allocated, raises ValueError if not"""
+        if self.data.name is None:
+            raise ValueError("Cannot get name for unallocated register")
+        return self.data.name
+
+    @property
+    def is_allocated(self) -> bool:
+        """Returns true if a RISCV register is allocated, otherwise false"""
+        return self.data.is_allocated
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> Register:
+        name = parser.parse_optional_identifier()
+        if name is None:
+            return Register()
+        if not name.startswith("j"):
+            assert name in RegisterAttr.RV32I_INDEX_BY_NAME
+        return Register(name)
+
+    def print_parameter(self, printer: Printer) -> None:
+        name = self.data.name
+        if name is None:
+            return
+        printer.print_string(name)
+
+    def verify(self) -> None:
+        if self.data.name is None or self.data.name.startswith("j"):
+            return
+        assert self.data.name in RegisterAttr.RV32I_INDEX_BY_NAME
+
     RV32I_INDEX_BY_NAME = {
         "zero": 0,
         "ra": 1,
@@ -135,47 +176,6 @@ class Register:
 
 
 @irdl_attr_definition
-class RegisterType(Data[Register], TypeAttribute):
-    """
-    A RISC-V register type.
-    """
-
-    name = "riscv.reg"
-
-    @property
-    def register_name(self) -> str:
-        """Returns name if allocated, raises ValueError if not"""
-        if self.data.name is None:
-            raise ValueError("Cannot get name for unallocated register")
-        return self.data.name
-
-    @property
-    def is_allocated(self) -> bool:
-        """Returns true if a RISCV register is allocated, otherwise false"""
-        return self.data.is_allocated
-
-    @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> Register:
-        name = parser.parse_optional_identifier()
-        if name is None:
-            return Register()
-        if not name.startswith("j"):
-            assert name in Register.RV32I_INDEX_BY_NAME
-        return Register(name)
-
-    def print_parameter(self, printer: Printer) -> None:
-        name = self.data.name
-        if name is None:
-            return
-        printer.print_string(name)
-
-    def verify(self) -> None:
-        if self.data.name is None or self.data.name.startswith("j"):
-            return
-        assert self.data.name in Register.RV32I_INDEX_BY_NAME
-
-
-@irdl_attr_definition
 class FloatRegisterType(Data[Register], TypeAttribute):
     """
     A RISC-V register type.
@@ -201,7 +201,7 @@ class FloatRegisterType(Data[Register], TypeAttribute):
         if name is None:
             return Register()
         if not name.startswith("j"):
-            assert name in Register.RV32F_INDEX_BY_NAME
+            assert name in RegisterAttr.RV32F_INDEX_BY_NAME
         return Register(name)
 
     def print_parameter(self, printer: Printer) -> None:
@@ -213,45 +213,45 @@ class FloatRegisterType(Data[Register], TypeAttribute):
     def verify(self) -> None:
         if self.data.name is None or self.data.name.startswith("j"):
             return
-        assert self.data.name in Register.RV32F_INDEX_BY_NAME
+        assert self.data.name in RegisterAttr.RV32F_INDEX_BY_NAME
 
 
 class Registers(ABC):
     """Namespace for named register constants."""
 
-    ZERO = RegisterType(Register("zero"))
-    RA = RegisterType(Register("ra"))
-    SP = RegisterType(Register("sp"))
-    GP = RegisterType(Register("gp"))
-    TP = RegisterType(Register("tp"))
-    T0 = RegisterType(Register("t0"))
-    T1 = RegisterType(Register("t1"))
-    T2 = RegisterType(Register("t2"))
-    FP = RegisterType(Register("fp"))
-    S0 = RegisterType(Register("s0"))
-    S1 = RegisterType(Register("s1"))
-    A0 = RegisterType(Register("a0"))
-    A1 = RegisterType(Register("a1"))
-    A2 = RegisterType(Register("a2"))
-    A3 = RegisterType(Register("a3"))
-    A4 = RegisterType(Register("a4"))
-    A5 = RegisterType(Register("a5"))
-    A6 = RegisterType(Register("a6"))
-    A7 = RegisterType(Register("a7"))
-    S2 = RegisterType(Register("s2"))
-    S3 = RegisterType(Register("s3"))
-    S4 = RegisterType(Register("s4"))
-    S5 = RegisterType(Register("s5"))
-    S6 = RegisterType(Register("s6"))
-    S7 = RegisterType(Register("s7"))
-    S8 = RegisterType(Register("s8"))
-    S9 = RegisterType(Register("s9"))
-    S10 = RegisterType(Register("s10"))
-    S11 = RegisterType(Register("s11"))
-    T3 = RegisterType(Register("t3"))
-    T4 = RegisterType(Register("t4"))
-    T5 = RegisterType(Register("t5"))
-    T6 = RegisterType(Register("t6"))
+    ZERO = RegisterAttr(Register("zero"))
+    RA = RegisterAttr(Register("ra"))
+    SP = RegisterAttr(Register("sp"))
+    GP = RegisterAttr(Register("gp"))
+    TP = RegisterAttr(Register("tp"))
+    T0 = RegisterAttr(Register("t0"))
+    T1 = RegisterAttr(Register("t1"))
+    T2 = RegisterAttr(Register("t2"))
+    FP = RegisterAttr(Register("fp"))
+    S0 = RegisterAttr(Register("s0"))
+    S1 = RegisterAttr(Register("s1"))
+    A0 = RegisterAttr(Register("a0"))
+    A1 = RegisterAttr(Register("a1"))
+    A2 = RegisterAttr(Register("a2"))
+    A3 = RegisterAttr(Register("a3"))
+    A4 = RegisterAttr(Register("a4"))
+    A5 = RegisterAttr(Register("a5"))
+    A6 = RegisterAttr(Register("a6"))
+    A7 = RegisterAttr(Register("a7"))
+    S2 = RegisterAttr(Register("s2"))
+    S3 = RegisterAttr(Register("s3"))
+    S4 = RegisterAttr(Register("s4"))
+    S5 = RegisterAttr(Register("s5"))
+    S6 = RegisterAttr(Register("s6"))
+    S7 = RegisterAttr(Register("s7"))
+    S8 = RegisterAttr(Register("s8"))
+    S9 = RegisterAttr(Register("s9"))
+    S10 = RegisterAttr(Register("s10"))
+    S11 = RegisterAttr(Register("s11"))
+    T3 = RegisterAttr(Register("t3"))
+    T4 = RegisterAttr(Register("t4"))
+    T5 = RegisterAttr(Register("t5"))
+    T6 = RegisterAttr(Register("t6"))
 
     FT0 = FloatRegisterType(Register("ft0"))
     FT1 = FloatRegisterType(Register("ft1"))
@@ -340,7 +340,7 @@ class RISCVOp(Operation, ABC):
 
 
 AssemblyInstructionArg: TypeAlias = (
-    AnyIntegerAttr | LabelAttr | SSAValue | RegisterType | str
+    AnyIntegerAttr | LabelAttr | SSAValue | RegisterAttr | str
 )
 
 
@@ -406,12 +406,12 @@ def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
         return arg.data
     elif isinstance(arg, str):
         return arg
-    elif isinstance(arg, RegisterType):
+    elif isinstance(arg, RegisterAttr):
         return arg.register_name
     elif isinstance(arg, FloatRegisterType):
         return arg.register_name
     else:
-        if isinstance(arg.type, RegisterType):
+        if isinstance(arg.type, RegisterAttr):
             reg = arg.type.register_name
             return reg
         elif isinstance(arg.type, FloatRegisterType):
@@ -461,22 +461,22 @@ class RdRsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called R-Type in the RISC-V specification.
     """
 
-    rd: OpResult = result_def(RegisterType)
-    rs1: Operand = operand_def(RegisterType)
-    rs2: Operand = operand_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
+    rs1: Operand = operand_def(RegisterAttr)
+    rs2: Operand = operand_def(RegisterAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -498,14 +498,14 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     immediate operand (e.g. U-Type and J-Type instructions in the RISC-V spec).
     """
 
-    rd: OpResult = result_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -513,9 +513,9 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -539,7 +539,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rd: RegisterType | None = opt_attr_def(RegisterType)
+    rd: RegisterAttr | None = opt_attr_def(RegisterAttr)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
@@ -550,7 +550,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -558,7 +558,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -581,8 +581,8 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called I-Type in the RISC-V specification.
     """
 
-    rd: OpResult = result_def(RegisterType)
-    rs1: Operand = operand_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
+    rs1: Operand = operand_def(RegisterAttr)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -590,7 +590,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -599,9 +599,9 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -636,7 +636,7 @@ class RdRsImmShiftOperation(RdRsImmIntegerOperation):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -658,8 +658,8 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rs1: Operand = operand_def(RegisterType)
-    rd: RegisterType | None = opt_attr_def(RegisterType)
+    rs1: Operand = operand_def(RegisterAttr)
+    rd: RegisterAttr | None = opt_attr_def(RegisterAttr)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
@@ -671,7 +671,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -680,7 +680,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
 
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -704,20 +704,20 @@ class RdRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     source register.
     """
 
-    rd: OpResult = result_def(RegisterType)
-    rs: Operand = operand_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
+    rs: Operand = operand_def(RegisterAttr)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -738,8 +738,8 @@ class RsRsOffIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called B-Type in the RISC-V specification.
     """
 
-    rs1: Operand = operand_def(RegisterType)
-    rs2: Operand = operand_def(RegisterType)
+    rs1: Operand = operand_def(RegisterAttr)
+    rs2: Operand = operand_def(RegisterAttr)
     offset: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -777,8 +777,8 @@ class RsRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called S-Type in the RISC-V specification.
     """
 
-    rs1: Operand = operand_def(RegisterType)
-    rs2: Operand = operand_def(RegisterType)
+    rs1: Operand = operand_def(RegisterAttr)
+    rs2: Operand = operand_def(RegisterAttr)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -814,8 +814,8 @@ class RsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     registers.
     """
 
-    rs1: Operand = operand_def(RegisterType)
-    rs2: Operand = operand_def(RegisterType)
+    rs1: Operand = operand_def(RegisterAttr)
+    rs2: Operand = operand_def(RegisterAttr)
 
     def __init__(self, rs1: Operation | SSAValue, rs2: Operation | SSAValue):
         super().__init__(
@@ -860,8 +860,8 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
       returned in rd
     """
 
-    rd: OpResult = result_def(RegisterType)
-    rs1: Operand = operand_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
+    rs1: Operand = operand_def(RegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
@@ -871,13 +871,13 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -893,7 +893,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if not self.writeonly:
             return
-        if not isinstance(self.rd.type, RegisterType):
+        if not isinstance(self.rd.type, RegisterAttr):
             return
         if self.rd.type.data.name is not None and self.rd.type.data.name != "zero":
             raise VerifyException(
@@ -918,8 +918,8 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
       to writing to a CSR takes place even if the mask in rs has no actual bits set.
     """
 
-    rd: OpResult = result_def(RegisterType)
-    rs1: Operand = operand_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
+    rs1: Operand = operand_def(RegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     readonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
@@ -929,13 +929,13 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         readonly: bool = False,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -951,7 +951,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if not self.readonly:
             return
-        if not isinstance(self.rs1.type, RegisterType):
+        if not isinstance(self.rs1.type, RegisterAttr):
             return
         if self.rs1.type.data.name is not None and self.rs1.type.data.name != "zero":
             raise VerifyException(
@@ -974,7 +974,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
       returned in rd
     """
 
-    rd: OpResult = result_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
     immediate: AnyIntegerAttr | None = opt_attr_def(AnyIntegerAttr)
@@ -985,13 +985,13 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
         immediate: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1007,7 +1007,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if self.writeonly is None:
             return
-        if not isinstance(self.rd.type, RegisterType):
+        if not isinstance(self.rd.type, RegisterAttr):
             return
         if self.rd.type.data.name is not None and self.rd.type.data.name != "zero":
             raise VerifyException(
@@ -1032,7 +1032,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
       place.
     """
 
-    rd: OpResult = result_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
@@ -1041,13 +1041,13 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         immediate: AnyIntegerAttr,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1943,7 +1943,7 @@ class LiOp(RdImmIntegerOperation):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -2203,14 +2203,14 @@ class GetRegisterOp(IRDLOperation, RISCVOp):
     """
 
     name = "riscv.get_register"
-    res: OpResult = result_def(RegisterType)
+    res: OpResult = result_def(RegisterAttr)
 
     def __init__(
         self,
-        register_type: RegisterType | Register,
+        register_type: RegisterAttr | Register,
     ):
         if isinstance(register_type, Register):
-            register_type = RegisterType(register_type)
+            register_type = RegisterAttr(register_type)
         super().__init__(result_types=[register_type])
 
     def assembly_line(self) -> str | None:
@@ -2347,7 +2347,7 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     two floating-point input registers and an integer destination register.
     """
 
-    rd: OpResult = result_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
     rs1: Operand = operand_def(FloatRegisterType)
     rs2: Operand = operand_def(FloatRegisterType)
 
@@ -2356,13 +2356,13 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2416,20 +2416,20 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     input register and an integer destination register.
     """
 
-    rd: OpResult = result_def(RegisterType)
+    rd: OpResult = result_def(RegisterAttr)
     rs: Operand = operand_def(FloatRegisterType)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: RegisterType | Register | None = None,
+        rd: RegisterAttr | Register | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterType(Register())
+            rd = RegisterAttr(Register())
         elif isinstance(rd, Register):
-            rd = RegisterType(rd)
+            rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2449,7 +2449,7 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rd: OpResult = result_def(FloatRegisterType)
-    rs: Operand = operand_def(RegisterType)
+    rs: Operand = operand_def(RegisterAttr)
 
     def __init__(
         self,
@@ -2480,7 +2480,7 @@ class RsRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     (one integer and one floating-point) and an immediate.
     """
 
-    rs1: Operand = operand_def(RegisterType)
+    rs1: Operand = operand_def(RegisterAttr)
     rs2: Operand = operand_def(FloatRegisterType)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
@@ -2519,7 +2519,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rd: OpResult = result_def(FloatRegisterType)
-    rs1: Operand = operand_def(RegisterType)
+    rs1: Operand = operand_def(RegisterAttr)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -3005,7 +3005,7 @@ RISCV = Dialect(
         FSwOp,
     ],
     [
-        RegisterType,
+        RegisterAttr,
         FloatRegisterType,
         LabelAttr,
     ],

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -99,7 +99,7 @@ class RISCVRegisterAttr(Data[str], TypeAttribute, ABC):
 
 
 @irdl_attr_definition
-class RegisterAttr(RISCVRegisterAttr):
+class IntRegisterAttr(RISCVRegisterAttr):
     """
     A RISC-V register type.
     """
@@ -108,7 +108,7 @@ class RegisterAttr(RISCVRegisterAttr):
 
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        return RegisterAttr.RV32I_INDEX_BY_NAME
+        return IntRegisterAttr.RV32I_INDEX_BY_NAME
 
     RV32I_INDEX_BY_NAME = {
         "zero": 0,
@@ -198,39 +198,39 @@ class FloatRegisterAttr(RISCVRegisterAttr):
 class Registers(ABC):
     """Namespace for named register constants."""
 
-    ZERO = RegisterAttr("zero")
-    RA = RegisterAttr("ra")
-    SP = RegisterAttr("sp")
-    GP = RegisterAttr("gp")
-    TP = RegisterAttr("tp")
-    T0 = RegisterAttr("t0")
-    T1 = RegisterAttr("t1")
-    T2 = RegisterAttr("t2")
-    FP = RegisterAttr("fp")
-    S0 = RegisterAttr("s0")
-    S1 = RegisterAttr("s1")
-    A0 = RegisterAttr("a0")
-    A1 = RegisterAttr("a1")
-    A2 = RegisterAttr("a2")
-    A3 = RegisterAttr("a3")
-    A4 = RegisterAttr("a4")
-    A5 = RegisterAttr("a5")
-    A6 = RegisterAttr("a6")
-    A7 = RegisterAttr("a7")
-    S2 = RegisterAttr("s2")
-    S3 = RegisterAttr("s3")
-    S4 = RegisterAttr("s4")
-    S5 = RegisterAttr("s5")
-    S6 = RegisterAttr("s6")
-    S7 = RegisterAttr("s7")
-    S8 = RegisterAttr("s8")
-    S9 = RegisterAttr("s9")
-    S10 = RegisterAttr("s10")
-    S11 = RegisterAttr("s11")
-    T3 = RegisterAttr("t3")
-    T4 = RegisterAttr("t4")
-    T5 = RegisterAttr("t5")
-    T6 = RegisterAttr("t6")
+    ZERO = IntRegisterAttr("zero")
+    RA = IntRegisterAttr("ra")
+    SP = IntRegisterAttr("sp")
+    GP = IntRegisterAttr("gp")
+    TP = IntRegisterAttr("tp")
+    T0 = IntRegisterAttr("t0")
+    T1 = IntRegisterAttr("t1")
+    T2 = IntRegisterAttr("t2")
+    FP = IntRegisterAttr("fp")
+    S0 = IntRegisterAttr("s0")
+    S1 = IntRegisterAttr("s1")
+    A0 = IntRegisterAttr("a0")
+    A1 = IntRegisterAttr("a1")
+    A2 = IntRegisterAttr("a2")
+    A3 = IntRegisterAttr("a3")
+    A4 = IntRegisterAttr("a4")
+    A5 = IntRegisterAttr("a5")
+    A6 = IntRegisterAttr("a6")
+    A7 = IntRegisterAttr("a7")
+    S2 = IntRegisterAttr("s2")
+    S3 = IntRegisterAttr("s3")
+    S4 = IntRegisterAttr("s4")
+    S5 = IntRegisterAttr("s5")
+    S6 = IntRegisterAttr("s6")
+    S7 = IntRegisterAttr("s7")
+    S8 = IntRegisterAttr("s8")
+    S9 = IntRegisterAttr("s9")
+    S10 = IntRegisterAttr("s10")
+    S11 = IntRegisterAttr("s11")
+    T3 = IntRegisterAttr("t3")
+    T4 = IntRegisterAttr("t4")
+    T5 = IntRegisterAttr("t5")
+    T6 = IntRegisterAttr("t6")
 
     FT0 = FloatRegisterAttr("ft0")
     FT1 = FloatRegisterAttr("ft1")
@@ -319,7 +319,7 @@ class RISCVOp(Operation, ABC):
 
 
 AssemblyInstructionArg: TypeAlias = (
-    AnyIntegerAttr | LabelAttr | SSAValue | RegisterAttr | str
+    AnyIntegerAttr | LabelAttr | SSAValue | IntRegisterAttr | str
 )
 
 
@@ -385,12 +385,12 @@ def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
         return arg.data
     elif isinstance(arg, str):
         return arg
-    elif isinstance(arg, RegisterAttr):
+    elif isinstance(arg, IntRegisterAttr):
         return arg.register_name
     elif isinstance(arg, FloatRegisterAttr):
         return arg.register_name
     else:
-        if isinstance(arg.type, RegisterAttr):
+        if isinstance(arg.type, IntRegisterAttr):
             reg = arg.type.register_name
             return reg
         elif isinstance(arg.type, FloatRegisterAttr):
@@ -442,22 +442,22 @@ class RdRsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called R-Type in the RISC-V specification.
     """
 
-    rd: OpResult = result_def(RegisterAttr)
-    rs1: Operand = operand_def(RegisterAttr)
-    rs2: Operand = operand_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
+    rs2: Operand = operand_def(IntRegisterAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -479,14 +479,14 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     immediate operand (e.g. U-Type and J-Type instructions in the RISC-V spec).
     """
 
-    rd: OpResult = result_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -494,9 +494,9 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -520,7 +520,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rd: RegisterAttr | None = opt_attr_def(RegisterAttr)
+    rd: IntRegisterAttr | None = opt_attr_def(IntRegisterAttr)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
@@ -531,7 +531,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -539,7 +539,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -562,8 +562,8 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called I-Type in the RISC-V specification.
     """
 
-    rd: OpResult = result_def(RegisterAttr)
-    rs1: Operand = operand_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -571,7 +571,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -580,9 +580,9 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -617,7 +617,7 @@ class RdRsImmShiftOperation(RdRsImmIntegerOperation):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -639,8 +639,8 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rs1: Operand = operand_def(RegisterAttr)
-    rd: RegisterAttr | None = opt_attr_def(RegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
+    rd: IntRegisterAttr | None = opt_attr_def(IntRegisterAttr)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
@@ -652,7 +652,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -661,7 +661,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
 
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -685,20 +685,20 @@ class RdRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     source register.
     """
 
-    rd: OpResult = result_def(RegisterAttr)
-    rs: Operand = operand_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
+    rs: Operand = operand_def(IntRegisterAttr)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -719,8 +719,8 @@ class RsRsOffIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called B-Type in the RISC-V specification.
     """
 
-    rs1: Operand = operand_def(RegisterAttr)
-    rs2: Operand = operand_def(RegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
+    rs2: Operand = operand_def(IntRegisterAttr)
     offset: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -758,8 +758,8 @@ class RsRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called S-Type in the RISC-V specification.
     """
 
-    rs1: Operand = operand_def(RegisterAttr)
-    rs2: Operand = operand_def(RegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
+    rs2: Operand = operand_def(IntRegisterAttr)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -795,8 +795,8 @@ class RsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     registers.
     """
 
-    rs1: Operand = operand_def(RegisterAttr)
-    rs2: Operand = operand_def(RegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
+    rs2: Operand = operand_def(IntRegisterAttr)
 
     def __init__(self, rs1: Operation | SSAValue, rs2: Operation | SSAValue):
         super().__init__(
@@ -841,8 +841,8 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
       returned in rd
     """
 
-    rd: OpResult = result_def(RegisterAttr)
-    rs1: Operand = operand_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
@@ -852,13 +852,13 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -874,7 +874,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if not self.writeonly:
             return
-        if not isinstance(self.rd.type, RegisterAttr):
+        if not isinstance(self.rd.type, IntRegisterAttr):
             return
         if self.rd.type.is_allocated and self.rd.type.data != "zero":
             raise VerifyException(
@@ -899,8 +899,8 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
       to writing to a CSR takes place even if the mask in rs has no actual bits set.
     """
 
-    rd: OpResult = result_def(RegisterAttr)
-    rs1: Operand = operand_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     readonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
@@ -910,13 +910,13 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         readonly: bool = False,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -932,7 +932,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if not self.readonly:
             return
-        if not isinstance(self.rs1.type, RegisterAttr):
+        if not isinstance(self.rs1.type, IntRegisterAttr):
             return
         if self.rs1.type.is_allocated and self.rs1.type.data != "zero":
             raise VerifyException(
@@ -955,7 +955,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
       returned in rd
     """
 
-    rd: OpResult = result_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
     immediate: AnyIntegerAttr | None = opt_attr_def(AnyIntegerAttr)
@@ -966,13 +966,13 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
         immediate: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -988,7 +988,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if self.writeonly is None:
             return
-        if not isinstance(self.rd.type, RegisterAttr):
+        if not isinstance(self.rd.type, IntRegisterAttr):
             return
         if self.rd.type.is_allocated and self.rd.type.data != "zero":
             raise VerifyException(
@@ -1013,7 +1013,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
       place.
     """
 
-    rd: OpResult = result_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
@@ -1022,13 +1022,13 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         immediate: AnyIntegerAttr,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1924,7 +1924,7 @@ class LiOp(RdImmIntegerOperation):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -2184,14 +2184,14 @@ class GetRegisterOp(IRDLOperation, RISCVOp):
     """
 
     name = "riscv.get_register"
-    res: OpResult = result_def(RegisterAttr)
+    res: OpResult = result_def(IntRegisterAttr)
 
     def __init__(
         self,
-        register_type: RegisterAttr | str,
+        register_type: IntRegisterAttr | str,
     ):
         if isinstance(register_type, str):
-            register_type = RegisterAttr(register_type)
+            register_type = IntRegisterAttr(register_type)
         super().__init__(result_types=[register_type])
 
     def assembly_line(self) -> str | None:
@@ -2328,7 +2328,7 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     two floating-point input registers and an integer destination register.
     """
 
-    rd: OpResult = result_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
     rs1: Operand = operand_def(FloatRegisterAttr)
     rs2: Operand = operand_def(FloatRegisterAttr)
 
@@ -2337,13 +2337,13 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2397,20 +2397,20 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     input register and an integer destination register.
     """
 
-    rd: OpResult = result_def(RegisterAttr)
+    rd: OpResult = result_def(IntRegisterAttr)
     rs: Operand = operand_def(FloatRegisterAttr)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: RegisterAttr | str | None = None,
+        rd: IntRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr.unallocated
+            rd = IntRegisterAttr.unallocated
         elif isinstance(rd, str):
-            rd = RegisterAttr(rd)
+            rd = IntRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2430,7 +2430,7 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rd: OpResult = result_def(FloatRegisterAttr)
-    rs: Operand = operand_def(RegisterAttr)
+    rs: Operand = operand_def(IntRegisterAttr)
 
     def __init__(
         self,
@@ -2461,7 +2461,7 @@ class RsRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     (one integer and one floating-point) and an immediate.
     """
 
-    rs1: Operand = operand_def(RegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
     rs2: Operand = operand_def(FloatRegisterAttr)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
@@ -2500,7 +2500,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rd: OpResult = result_def(FloatRegisterAttr)
-    rs1: Operand = operand_def(RegisterAttr)
+    rs1: Operand = operand_def(IntRegisterAttr)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -2986,7 +2986,7 @@ RISCV = Dialect(
         FSwOp,
     ],
     [
-        RegisterAttr,
+        IntRegisterAttr,
         FloatRegisterAttr,
         LabelAttr,
     ],

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from io import StringIO
 from typing import IO, Sequence, TypeAlias
 
@@ -48,23 +47,8 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
 
-@dataclass(frozen=True)
-class Register:
-    """
-    A RISC-V register.
-    """
-
-    name: str = field(default="")
-    """The register name. Should be one of `ABI_INDEX_BY_NAME` or `None`"""
-
-    @property
-    def is_allocated(self) -> bool:
-        """Returns true if a RISCV register is allocated, otherwise false"""
-        return bool(self.name)
-
-
 @irdl_attr_definition
-class RegisterAttr(Data[Register], TypeAttribute):
+class RegisterAttr(Data[str], TypeAttribute):
     """
     A RISC-V register type.
     """
@@ -74,34 +58,31 @@ class RegisterAttr(Data[Register], TypeAttribute):
     @property
     def register_name(self) -> str:
         """Returns name if allocated, raises ValueError if not"""
-        if not self.data.is_allocated:
+        if not self.is_allocated:
             raise ValueError("Cannot get name for unallocated register")
-        return self.data.name
+        return self.data
 
     @property
     def is_allocated(self) -> bool:
         """Returns true if a RISCV register is allocated, otherwise false"""
-        return self.data.is_allocated
+        return bool(self.data)
 
     @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> Register:
+    def parse_parameter(cls, parser: AttrParser) -> str:
         name = parser.parse_optional_identifier()
         if name is None:
-            return Register()
+            return ""
         if not name.startswith("j"):
             assert name in RegisterAttr.RV32I_INDEX_BY_NAME
-        return Register(name)
+        return name
 
     def print_parameter(self, printer: Printer) -> None:
-        name = self.data.name
-        if not self.data.is_allocated:
-            return
-        printer.print_string(name)
+        printer.print_string(self.data)
 
     def verify(self) -> None:
-        if not self.data.is_allocated or self.data.name.startswith("j"):
+        if not self.is_allocated or self.data.startswith("j"):
             return
-        assert self.data.name in RegisterAttr.RV32I_INDEX_BY_NAME
+        assert self.data in RegisterAttr.RV32I_INDEX_BY_NAME
 
     RV32I_INDEX_BY_NAME = {
         "zero": 0,
@@ -176,7 +157,7 @@ class RegisterAttr(Data[Register], TypeAttribute):
 
 
 @irdl_attr_definition
-class FloatRegisterType(Data[Register], TypeAttribute):
+class FloatRegisterType(Data[str], TypeAttribute):
     """
     A RISC-V register type.
     """
@@ -186,105 +167,102 @@ class FloatRegisterType(Data[Register], TypeAttribute):
     @property
     def register_name(self) -> str:
         """Returns name if allocated, raises ValueError if not"""
-        if not self.data.is_allocated:
+        if not self.is_allocated:
             raise ValueError("Cannot get name for unallocated register")
-        return self.data.name
+        return self.data
 
     @property
     def is_allocated(self) -> bool:
         """Returns true if a RISCV register is allocated, otherwise false"""
-        return self.data.is_allocated
+        return bool(self.data)
 
     @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> Register:
+    def parse_parameter(cls, parser: AttrParser) -> str:
         name = parser.parse_optional_identifier()
         if name is None:
-            return Register()
+            return ""
         if not name.startswith("j"):
             assert name in RegisterAttr.RV32F_INDEX_BY_NAME
-        return Register(name)
+        return name
 
     def print_parameter(self, printer: Printer) -> None:
-        name = self.data.name
-        if not self.data.is_allocated:
-            return
-        printer.print_string(name)
+        printer.print_string(self.data)
 
     def verify(self) -> None:
-        if not self.data.is_allocated or self.data.name.startswith("j"):
+        if not self.is_allocated or self.data.startswith("j"):
             return
-        assert self.data.name in RegisterAttr.RV32F_INDEX_BY_NAME
+        assert self.data in RegisterAttr.RV32F_INDEX_BY_NAME
 
 
 class Registers(ABC):
     """Namespace for named register constants."""
 
-    ZERO = RegisterAttr(Register("zero"))
-    RA = RegisterAttr(Register("ra"))
-    SP = RegisterAttr(Register("sp"))
-    GP = RegisterAttr(Register("gp"))
-    TP = RegisterAttr(Register("tp"))
-    T0 = RegisterAttr(Register("t0"))
-    T1 = RegisterAttr(Register("t1"))
-    T2 = RegisterAttr(Register("t2"))
-    FP = RegisterAttr(Register("fp"))
-    S0 = RegisterAttr(Register("s0"))
-    S1 = RegisterAttr(Register("s1"))
-    A0 = RegisterAttr(Register("a0"))
-    A1 = RegisterAttr(Register("a1"))
-    A2 = RegisterAttr(Register("a2"))
-    A3 = RegisterAttr(Register("a3"))
-    A4 = RegisterAttr(Register("a4"))
-    A5 = RegisterAttr(Register("a5"))
-    A6 = RegisterAttr(Register("a6"))
-    A7 = RegisterAttr(Register("a7"))
-    S2 = RegisterAttr(Register("s2"))
-    S3 = RegisterAttr(Register("s3"))
-    S4 = RegisterAttr(Register("s4"))
-    S5 = RegisterAttr(Register("s5"))
-    S6 = RegisterAttr(Register("s6"))
-    S7 = RegisterAttr(Register("s7"))
-    S8 = RegisterAttr(Register("s8"))
-    S9 = RegisterAttr(Register("s9"))
-    S10 = RegisterAttr(Register("s10"))
-    S11 = RegisterAttr(Register("s11"))
-    T3 = RegisterAttr(Register("t3"))
-    T4 = RegisterAttr(Register("t4"))
-    T5 = RegisterAttr(Register("t5"))
-    T6 = RegisterAttr(Register("t6"))
+    ZERO = RegisterAttr("zero")
+    RA = RegisterAttr("ra")
+    SP = RegisterAttr("sp")
+    GP = RegisterAttr("gp")
+    TP = RegisterAttr("tp")
+    T0 = RegisterAttr("t0")
+    T1 = RegisterAttr("t1")
+    T2 = RegisterAttr("t2")
+    FP = RegisterAttr("fp")
+    S0 = RegisterAttr("s0")
+    S1 = RegisterAttr("s1")
+    A0 = RegisterAttr("a0")
+    A1 = RegisterAttr("a1")
+    A2 = RegisterAttr("a2")
+    A3 = RegisterAttr("a3")
+    A4 = RegisterAttr("a4")
+    A5 = RegisterAttr("a5")
+    A6 = RegisterAttr("a6")
+    A7 = RegisterAttr("a7")
+    S2 = RegisterAttr("s2")
+    S3 = RegisterAttr("s3")
+    S4 = RegisterAttr("s4")
+    S5 = RegisterAttr("s5")
+    S6 = RegisterAttr("s6")
+    S7 = RegisterAttr("s7")
+    S8 = RegisterAttr("s8")
+    S9 = RegisterAttr("s9")
+    S10 = RegisterAttr("s10")
+    S11 = RegisterAttr("s11")
+    T3 = RegisterAttr("t3")
+    T4 = RegisterAttr("t4")
+    T5 = RegisterAttr("t5")
+    T6 = RegisterAttr("t6")
 
-    FT0 = FloatRegisterType(Register("ft0"))
-    FT1 = FloatRegisterType(Register("ft1"))
-    FT2 = FloatRegisterType(Register("ft2"))
-    FT3 = FloatRegisterType(Register("ft3"))
-    FT4 = FloatRegisterType(Register("ft4"))
-    FT5 = FloatRegisterType(Register("ft5"))
-    FT6 = FloatRegisterType(Register("ft6"))
-    FT7 = FloatRegisterType(Register("ft7"))
-    FS0 = FloatRegisterType(Register("fs0"))
-    FS1 = FloatRegisterType(Register("fs1"))
-    FA0 = FloatRegisterType(Register("fa0"))
-    FA1 = FloatRegisterType(Register("fa1"))
-    FA2 = FloatRegisterType(Register("fa2"))
-    FA3 = FloatRegisterType(Register("fa3"))
-    FA4 = FloatRegisterType(Register("fa4"))
-    FA5 = FloatRegisterType(Register("fa5"))
-    FA6 = FloatRegisterType(Register("fa6"))
-    FA7 = FloatRegisterType(Register("fa7"))
-    FS2 = FloatRegisterType(Register("fs2"))
-    FS3 = FloatRegisterType(Register("fs3"))
-    FS4 = FloatRegisterType(Register("fs4"))
-    FS5 = FloatRegisterType(Register("fs5"))
-    FS6 = FloatRegisterType(Register("fs6"))
-    FS7 = FloatRegisterType(Register("fs7"))
-    FS8 = FloatRegisterType(Register("fs8"))
-    FS9 = FloatRegisterType(Register("fs9"))
-    FS10 = FloatRegisterType(Register("fs10"))
-    FS11 = FloatRegisterType(Register("fs11"))
-    FT8 = FloatRegisterType(Register("ft8"))
-    FT9 = FloatRegisterType(Register("ft9"))
-    FT10 = FloatRegisterType(Register("ft10"))
-    FT11 = FloatRegisterType(Register("ft11"))
+    FT0 = FloatRegisterType("ft0")
+    FT1 = FloatRegisterType("ft1")
+    FT2 = FloatRegisterType("ft2")
+    FT3 = FloatRegisterType("ft3")
+    FT4 = FloatRegisterType("ft4")
+    FT5 = FloatRegisterType("ft5")
+    FT6 = FloatRegisterType("ft6")
+    FT7 = FloatRegisterType("ft7")
+    FS0 = FloatRegisterType("fs0")
+    FS1 = FloatRegisterType("fs1")
+    FA0 = FloatRegisterType("fa0")
+    FA1 = FloatRegisterType("fa1")
+    FA2 = FloatRegisterType("fa2")
+    FA3 = FloatRegisterType("fa3")
+    FA4 = FloatRegisterType("fa4")
+    FA5 = FloatRegisterType("fa5")
+    FA6 = FloatRegisterType("fa6")
+    FA7 = FloatRegisterType("fa7")
+    FS2 = FloatRegisterType("fs2")
+    FS3 = FloatRegisterType("fs3")
+    FS4 = FloatRegisterType("fs4")
+    FS5 = FloatRegisterType("fs5")
+    FS6 = FloatRegisterType("fs6")
+    FS7 = FloatRegisterType("fs7")
+    FS8 = FloatRegisterType("fs8")
+    FS9 = FloatRegisterType("fs9")
+    FS10 = FloatRegisterType("fs10")
+    FS11 = FloatRegisterType("fs11")
+    FT8 = FloatRegisterType("ft8")
+    FT9 = FloatRegisterType("ft9")
+    FT10 = FloatRegisterType("ft10")
+    FT11 = FloatRegisterType("ft11")
 
 
 @irdl_attr_definition
@@ -470,12 +448,12 @@ class RdRsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -505,7 +483,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -513,8 +491,8 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -550,14 +528,14 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(immediate, IntegerType(20, Signedness.SIGNED))
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
-        if isinstance(rd, Register):
+        if isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -590,7 +568,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -599,8 +577,8 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -636,7 +614,7 @@ class RdRsImmShiftOperation(RdRsImmIntegerOperation):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -671,7 +649,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -679,7 +657,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
 
-        if isinstance(rd, Register):
+        if isinstance(rd, str):
             rd = RegisterAttr(rd)
 
         if isinstance(comment, str):
@@ -711,12 +689,12 @@ class RdRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         rs: Operation | SSAValue,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -871,12 +849,12 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -895,10 +873,10 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
             return
         if not isinstance(self.rd.type, RegisterAttr):
             return
-        if self.rd.type.is_allocated and self.rd.type.data.name != "zero":
+        if self.rd.type.is_allocated and self.rd.type.data != "zero":
             raise VerifyException(
                 "When in 'writeonly' mode, destination must be register x0 (a.k.a. 'zero'), "
-                f"not '{self.rd.type.data.name}'"
+                f"not '{self.rd.type.data}'"
             )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
@@ -929,12 +907,12 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         readonly: bool = False,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -953,10 +931,10 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
             return
         if not isinstance(self.rs1.type, RegisterAttr):
             return
-        if self.rs1.type.is_allocated and self.rs1.type.data.name != "zero":
+        if self.rs1.type.is_allocated and self.rs1.type.data != "zero":
             raise VerifyException(
                 "When in 'readonly' mode, source must be register x0 (a.k.a. 'zero'), "
-                f"not '{self.rs1.type.data.name}'"
+                f"not '{self.rs1.type.data}'"
             )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
@@ -985,12 +963,12 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
         immediate: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -1009,10 +987,10 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
             return
         if not isinstance(self.rd.type, RegisterAttr):
             return
-        if self.rd.type.is_allocated and self.rd.type.data.name != "zero":
+        if self.rd.type.is_allocated and self.rd.type.data != "zero":
             raise VerifyException(
                 "When in 'writeonly' mode, destination must be register x0 (a.k.a. 'zero'), "
-                f"not '{self.rd.type.data.name}'"
+                f"not '{self.rd.type.data}'"
             )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
@@ -1041,12 +1019,12 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         immediate: AnyIntegerAttr,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -1943,7 +1921,7 @@ class LiOp(RdImmIntegerOperation):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -2207,9 +2185,9 @@ class GetRegisterOp(IRDLOperation, RISCVOp):
 
     def __init__(
         self,
-        register_type: RegisterAttr | Register,
+        register_type: RegisterAttr | str,
     ):
-        if isinstance(register_type, Register):
+        if isinstance(register_type, str):
             register_type = RegisterAttr(register_type)
         super().__init__(result_types=[register_type])
 
@@ -2231,9 +2209,9 @@ class GetFloatRegisterOp(IRDLOperation, RISCVOp):
 
     def __init__(
         self,
-        register_type: FloatRegisterType | Register,
+        register_type: FloatRegisterType | str,
     ):
-        if isinstance(register_type, Register):
+        if isinstance(register_type, str):
             register_type = FloatRegisterType(register_type)
         super().__init__(result_types=[register_type])
 
@@ -2282,12 +2260,12 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         rs2: Operation | SSAValue,
         rs3: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | Register | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType(Register())
-        elif isinstance(rd, Register):
+            rd = FloatRegisterType("")
+        elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -2319,12 +2297,12 @@ class RdRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | Register | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType(Register())
-        elif isinstance(rd, Register):
+            rd = FloatRegisterType("")
+        elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -2356,12 +2334,12 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -2391,12 +2369,12 @@ class RdRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         rs: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | Register | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType(Register())
-        elif isinstance(rd, Register):
+            rd = FloatRegisterType("")
+        elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -2423,12 +2401,12 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         rs: Operation | SSAValue,
         *,
-        rd: RegisterAttr | Register | None = None,
+        rd: RegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = RegisterAttr(Register())
-        elif isinstance(rd, Register):
+            rd = RegisterAttr("")
+        elif isinstance(rd, str):
             rd = RegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -2455,12 +2433,12 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         rs: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | Register | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType(Register())
-        elif isinstance(rd, Register):
+            rd = FloatRegisterType("")
+        elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -2527,7 +2505,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: FloatRegisterType | Register | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -2536,8 +2514,8 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = FloatRegisterType(Register())
-        elif isinstance(rd, Register):
+            rd = FloatRegisterType("")
+        elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from io import StringIO
-from typing import IO, Sequence, TypeAlias
+from typing import IO, ClassVar, Sequence, TypeAlias
 
 from typing_extensions import Self
 
@@ -55,17 +55,21 @@ class RISCVRegisterAttr(Data[str], TypeAttribute, ABC):
     A RISC-V register type.
     """
 
+    _unallocated: ClassVar[Self | None] = None
+
+    @classmethod
+    @property
+    def unallocated(cls) -> Self:
+        if cls._unallocated is None:
+            cls._unallocated = cls("")
+        return cls._unallocated
+
     @property
     def register_name(self) -> str:
         """Returns name if allocated, raises ValueError if not"""
         if not self.is_allocated:
             raise ValueError("Cannot get name for unallocated register")
         return self.data
-
-    @classmethod
-    @property
-    def unallocated(cls) -> Self:
-        return cls("")
 
     @property
     def is_allocated(self) -> bool:

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -138,7 +138,7 @@ class RegisterAttr(RISCVRegisterAttr):
 
 
 @irdl_attr_definition
-class FloatRegisterType(RISCVRegisterAttr):
+class FloatRegisterAttr(RISCVRegisterAttr):
     """
     A RISC-V register type.
     """
@@ -147,7 +147,7 @@ class FloatRegisterType(RISCVRegisterAttr):
 
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        return FloatRegisterType.RV32F_INDEX_BY_NAME
+        return FloatRegisterAttr.RV32F_INDEX_BY_NAME
 
     RV32F_INDEX_BY_NAME = {
         "ft0": 0,
@@ -222,38 +222,38 @@ class Registers(ABC):
     T5 = RegisterAttr("t5")
     T6 = RegisterAttr("t6")
 
-    FT0 = FloatRegisterType("ft0")
-    FT1 = FloatRegisterType("ft1")
-    FT2 = FloatRegisterType("ft2")
-    FT3 = FloatRegisterType("ft3")
-    FT4 = FloatRegisterType("ft4")
-    FT5 = FloatRegisterType("ft5")
-    FT6 = FloatRegisterType("ft6")
-    FT7 = FloatRegisterType("ft7")
-    FS0 = FloatRegisterType("fs0")
-    FS1 = FloatRegisterType("fs1")
-    FA0 = FloatRegisterType("fa0")
-    FA1 = FloatRegisterType("fa1")
-    FA2 = FloatRegisterType("fa2")
-    FA3 = FloatRegisterType("fa3")
-    FA4 = FloatRegisterType("fa4")
-    FA5 = FloatRegisterType("fa5")
-    FA6 = FloatRegisterType("fa6")
-    FA7 = FloatRegisterType("fa7")
-    FS2 = FloatRegisterType("fs2")
-    FS3 = FloatRegisterType("fs3")
-    FS4 = FloatRegisterType("fs4")
-    FS5 = FloatRegisterType("fs5")
-    FS6 = FloatRegisterType("fs6")
-    FS7 = FloatRegisterType("fs7")
-    FS8 = FloatRegisterType("fs8")
-    FS9 = FloatRegisterType("fs9")
-    FS10 = FloatRegisterType("fs10")
-    FS11 = FloatRegisterType("fs11")
-    FT8 = FloatRegisterType("ft8")
-    FT9 = FloatRegisterType("ft9")
-    FT10 = FloatRegisterType("ft10")
-    FT11 = FloatRegisterType("ft11")
+    FT0 = FloatRegisterAttr("ft0")
+    FT1 = FloatRegisterAttr("ft1")
+    FT2 = FloatRegisterAttr("ft2")
+    FT3 = FloatRegisterAttr("ft3")
+    FT4 = FloatRegisterAttr("ft4")
+    FT5 = FloatRegisterAttr("ft5")
+    FT6 = FloatRegisterAttr("ft6")
+    FT7 = FloatRegisterAttr("ft7")
+    FS0 = FloatRegisterAttr("fs0")
+    FS1 = FloatRegisterAttr("fs1")
+    FA0 = FloatRegisterAttr("fa0")
+    FA1 = FloatRegisterAttr("fa1")
+    FA2 = FloatRegisterAttr("fa2")
+    FA3 = FloatRegisterAttr("fa3")
+    FA4 = FloatRegisterAttr("fa4")
+    FA5 = FloatRegisterAttr("fa5")
+    FA6 = FloatRegisterAttr("fa6")
+    FA7 = FloatRegisterAttr("fa7")
+    FS2 = FloatRegisterAttr("fs2")
+    FS3 = FloatRegisterAttr("fs3")
+    FS4 = FloatRegisterAttr("fs4")
+    FS5 = FloatRegisterAttr("fs5")
+    FS6 = FloatRegisterAttr("fs6")
+    FS7 = FloatRegisterAttr("fs7")
+    FS8 = FloatRegisterAttr("fs8")
+    FS9 = FloatRegisterAttr("fs9")
+    FS10 = FloatRegisterAttr("fs10")
+    FS11 = FloatRegisterAttr("fs11")
+    FT8 = FloatRegisterAttr("ft8")
+    FT9 = FloatRegisterAttr("ft9")
+    FT10 = FloatRegisterAttr("ft10")
+    FT11 = FloatRegisterAttr("ft11")
 
 
 @irdl_attr_definition
@@ -377,13 +377,13 @@ def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
         return arg
     elif isinstance(arg, RegisterAttr):
         return arg.register_name
-    elif isinstance(arg, FloatRegisterType):
+    elif isinstance(arg, FloatRegisterAttr):
         return arg.register_name
     else:
         if isinstance(arg.type, RegisterAttr):
             reg = arg.type.register_name
             return reg
-        elif isinstance(arg.type, FloatRegisterType):
+        elif isinstance(arg.type, FloatRegisterAttr):
             reg = arg.type.register_name
             return reg
     assert False
@@ -2196,14 +2196,14 @@ class GetFloatRegisterOp(IRDLOperation, RISCVOp):
     """
 
     name = "riscv.get_float_register"
-    res: OpResult = result_def(FloatRegisterType)
+    res: OpResult = result_def(FloatRegisterAttr)
 
     def __init__(
         self,
-        register_type: FloatRegisterType | str,
+        register_type: FloatRegisterAttr | str,
     ):
         if isinstance(register_type, str):
-            register_type = FloatRegisterType(register_type)
+            register_type = FloatRegisterAttr(register_type)
         super().__init__(result_types=[register_type])
 
     def assembly_line(self) -> str | None:
@@ -2240,10 +2240,10 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     e.g: fused-multiply-add (FMA) instructions.
     """
 
-    rd: OpResult = result_def(FloatRegisterType)
-    rs1: Operand = operand_def(FloatRegisterType)
-    rs2: Operand = operand_def(FloatRegisterType)
-    rs3: Operand = operand_def(FloatRegisterType)
+    rd: OpResult = result_def(FloatRegisterAttr)
+    rs1: Operand = operand_def(FloatRegisterAttr)
+    rs2: Operand = operand_def(FloatRegisterAttr)
+    rs3: Operand = operand_def(FloatRegisterAttr)
 
     def __init__(
         self,
@@ -2251,13 +2251,13 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         rs2: Operation | SSAValue,
         rs3: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | str | None = None,
+        rd: FloatRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType("")
+            rd = FloatRegisterAttr("")
         elif isinstance(rd, str):
-            rd = FloatRegisterType(rd)
+            rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2279,22 +2279,22 @@ class RdRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     take two floating-point input registers and a destination.
     """
 
-    rd: OpResult = result_def(FloatRegisterType)
-    rs1: Operand = operand_def(FloatRegisterType)
-    rs2: Operand = operand_def(FloatRegisterType)
+    rd: OpResult = result_def(FloatRegisterAttr)
+    rs1: Operand = operand_def(FloatRegisterAttr)
+    rs2: Operand = operand_def(FloatRegisterAttr)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | str | None = None,
+        rd: FloatRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType("")
+            rd = FloatRegisterAttr("")
         elif isinstance(rd, str):
-            rd = FloatRegisterType(rd)
+            rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2317,8 +2317,8 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rd: OpResult = result_def(RegisterAttr)
-    rs1: Operand = operand_def(FloatRegisterType)
-    rs2: Operand = operand_def(FloatRegisterType)
+    rs1: Operand = operand_def(FloatRegisterAttr)
+    rs2: Operand = operand_def(FloatRegisterAttr)
 
     def __init__(
         self,
@@ -2353,20 +2353,20 @@ class RdRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     input register and a floating destination register.
     """
 
-    rd: OpResult = result_def(FloatRegisterType)
-    rs: Operand = operand_def(FloatRegisterType)
+    rd: OpResult = result_def(FloatRegisterAttr)
+    rs: Operand = operand_def(FloatRegisterAttr)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | str | None = None,
+        rd: FloatRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType("")
+            rd = FloatRegisterAttr("")
         elif isinstance(rd, str):
-            rd = FloatRegisterType(rd)
+            rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2386,7 +2386,7 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rd: OpResult = result_def(RegisterAttr)
-    rs: Operand = operand_def(FloatRegisterType)
+    rs: Operand = operand_def(FloatRegisterAttr)
 
     def __init__(
         self,
@@ -2417,20 +2417,20 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     input register and a floating-point destination register.
     """
 
-    rd: OpResult = result_def(FloatRegisterType)
+    rd: OpResult = result_def(FloatRegisterAttr)
     rs: Operand = operand_def(RegisterAttr)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | str | None = None,
+        rd: FloatRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType("")
+            rd = FloatRegisterAttr("")
         elif isinstance(rd, str):
-            rd = FloatRegisterType(rd)
+            rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2450,7 +2450,7 @@ class RsRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rs1: Operand = operand_def(RegisterAttr)
-    rs2: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterAttr)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -2487,7 +2487,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     one immediate operand.
     """
 
-    rd: OpResult = result_def(FloatRegisterType)
+    rd: OpResult = result_def(FloatRegisterAttr)
     rs1: Operand = operand_def(RegisterAttr)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
@@ -2496,7 +2496,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: FloatRegisterType | str | None = None,
+        rd: FloatRegisterAttr | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -2505,9 +2505,9 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = FloatRegisterType("")
+            rd = FloatRegisterAttr("")
         elif isinstance(rd, str):
-            rd = FloatRegisterType(rd)
+            rd = FloatRegisterAttr(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2975,7 +2975,7 @@ RISCV = Dialect(
     ],
     [
         RegisterAttr,
-        FloatRegisterType,
+        FloatRegisterAttr,
         LabelAttr,
     ],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -49,7 +49,7 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
 
-class RISCVRegisterAttr(Data[str], TypeAttribute, ABC):
+class RISCVRegisterType(Data[str], TypeAttribute, ABC):
     """
     A RISC-V register type.
     """
@@ -99,7 +99,7 @@ class RISCVRegisterAttr(Data[str], TypeAttribute, ABC):
 
 
 @irdl_attr_definition
-class IntRegisterAttr(RISCVRegisterAttr):
+class IntRegisterType(RISCVRegisterType):
     """
     A RISC-V register type.
     """
@@ -108,7 +108,7 @@ class IntRegisterAttr(RISCVRegisterAttr):
 
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        return IntRegisterAttr.RV32I_INDEX_BY_NAME
+        return IntRegisterType.RV32I_INDEX_BY_NAME
 
     RV32I_INDEX_BY_NAME = {
         "zero": 0,
@@ -148,7 +148,7 @@ class IntRegisterAttr(RISCVRegisterAttr):
 
 
 @irdl_attr_definition
-class FloatRegisterAttr(RISCVRegisterAttr):
+class FloatRegisterType(RISCVRegisterType):
     """
     A RISC-V register type.
     """
@@ -157,7 +157,7 @@ class FloatRegisterAttr(RISCVRegisterAttr):
 
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        return FloatRegisterAttr.RV32F_INDEX_BY_NAME
+        return FloatRegisterType.RV32F_INDEX_BY_NAME
 
     RV32F_INDEX_BY_NAME = {
         "ft0": 0,
@@ -198,72 +198,72 @@ class FloatRegisterAttr(RISCVRegisterAttr):
 class Registers(ABC):
     """Namespace for named register constants."""
 
-    ZERO = IntRegisterAttr("zero")
-    RA = IntRegisterAttr("ra")
-    SP = IntRegisterAttr("sp")
-    GP = IntRegisterAttr("gp")
-    TP = IntRegisterAttr("tp")
-    T0 = IntRegisterAttr("t0")
-    T1 = IntRegisterAttr("t1")
-    T2 = IntRegisterAttr("t2")
-    FP = IntRegisterAttr("fp")
-    S0 = IntRegisterAttr("s0")
-    S1 = IntRegisterAttr("s1")
-    A0 = IntRegisterAttr("a0")
-    A1 = IntRegisterAttr("a1")
-    A2 = IntRegisterAttr("a2")
-    A3 = IntRegisterAttr("a3")
-    A4 = IntRegisterAttr("a4")
-    A5 = IntRegisterAttr("a5")
-    A6 = IntRegisterAttr("a6")
-    A7 = IntRegisterAttr("a7")
-    S2 = IntRegisterAttr("s2")
-    S3 = IntRegisterAttr("s3")
-    S4 = IntRegisterAttr("s4")
-    S5 = IntRegisterAttr("s5")
-    S6 = IntRegisterAttr("s6")
-    S7 = IntRegisterAttr("s7")
-    S8 = IntRegisterAttr("s8")
-    S9 = IntRegisterAttr("s9")
-    S10 = IntRegisterAttr("s10")
-    S11 = IntRegisterAttr("s11")
-    T3 = IntRegisterAttr("t3")
-    T4 = IntRegisterAttr("t4")
-    T5 = IntRegisterAttr("t5")
-    T6 = IntRegisterAttr("t6")
+    ZERO = IntRegisterType("zero")
+    RA = IntRegisterType("ra")
+    SP = IntRegisterType("sp")
+    GP = IntRegisterType("gp")
+    TP = IntRegisterType("tp")
+    T0 = IntRegisterType("t0")
+    T1 = IntRegisterType("t1")
+    T2 = IntRegisterType("t2")
+    FP = IntRegisterType("fp")
+    S0 = IntRegisterType("s0")
+    S1 = IntRegisterType("s1")
+    A0 = IntRegisterType("a0")
+    A1 = IntRegisterType("a1")
+    A2 = IntRegisterType("a2")
+    A3 = IntRegisterType("a3")
+    A4 = IntRegisterType("a4")
+    A5 = IntRegisterType("a5")
+    A6 = IntRegisterType("a6")
+    A7 = IntRegisterType("a7")
+    S2 = IntRegisterType("s2")
+    S3 = IntRegisterType("s3")
+    S4 = IntRegisterType("s4")
+    S5 = IntRegisterType("s5")
+    S6 = IntRegisterType("s6")
+    S7 = IntRegisterType("s7")
+    S8 = IntRegisterType("s8")
+    S9 = IntRegisterType("s9")
+    S10 = IntRegisterType("s10")
+    S11 = IntRegisterType("s11")
+    T3 = IntRegisterType("t3")
+    T4 = IntRegisterType("t4")
+    T5 = IntRegisterType("t5")
+    T6 = IntRegisterType("t6")
 
-    FT0 = FloatRegisterAttr("ft0")
-    FT1 = FloatRegisterAttr("ft1")
-    FT2 = FloatRegisterAttr("ft2")
-    FT3 = FloatRegisterAttr("ft3")
-    FT4 = FloatRegisterAttr("ft4")
-    FT5 = FloatRegisterAttr("ft5")
-    FT6 = FloatRegisterAttr("ft6")
-    FT7 = FloatRegisterAttr("ft7")
-    FS0 = FloatRegisterAttr("fs0")
-    FS1 = FloatRegisterAttr("fs1")
-    FA0 = FloatRegisterAttr("fa0")
-    FA1 = FloatRegisterAttr("fa1")
-    FA2 = FloatRegisterAttr("fa2")
-    FA3 = FloatRegisterAttr("fa3")
-    FA4 = FloatRegisterAttr("fa4")
-    FA5 = FloatRegisterAttr("fa5")
-    FA6 = FloatRegisterAttr("fa6")
-    FA7 = FloatRegisterAttr("fa7")
-    FS2 = FloatRegisterAttr("fs2")
-    FS3 = FloatRegisterAttr("fs3")
-    FS4 = FloatRegisterAttr("fs4")
-    FS5 = FloatRegisterAttr("fs5")
-    FS6 = FloatRegisterAttr("fs6")
-    FS7 = FloatRegisterAttr("fs7")
-    FS8 = FloatRegisterAttr("fs8")
-    FS9 = FloatRegisterAttr("fs9")
-    FS10 = FloatRegisterAttr("fs10")
-    FS11 = FloatRegisterAttr("fs11")
-    FT8 = FloatRegisterAttr("ft8")
-    FT9 = FloatRegisterAttr("ft9")
-    FT10 = FloatRegisterAttr("ft10")
-    FT11 = FloatRegisterAttr("ft11")
+    FT0 = FloatRegisterType("ft0")
+    FT1 = FloatRegisterType("ft1")
+    FT2 = FloatRegisterType("ft2")
+    FT3 = FloatRegisterType("ft3")
+    FT4 = FloatRegisterType("ft4")
+    FT5 = FloatRegisterType("ft5")
+    FT6 = FloatRegisterType("ft6")
+    FT7 = FloatRegisterType("ft7")
+    FS0 = FloatRegisterType("fs0")
+    FS1 = FloatRegisterType("fs1")
+    FA0 = FloatRegisterType("fa0")
+    FA1 = FloatRegisterType("fa1")
+    FA2 = FloatRegisterType("fa2")
+    FA3 = FloatRegisterType("fa3")
+    FA4 = FloatRegisterType("fa4")
+    FA5 = FloatRegisterType("fa5")
+    FA6 = FloatRegisterType("fa6")
+    FA7 = FloatRegisterType("fa7")
+    FS2 = FloatRegisterType("fs2")
+    FS3 = FloatRegisterType("fs3")
+    FS4 = FloatRegisterType("fs4")
+    FS5 = FloatRegisterType("fs5")
+    FS6 = FloatRegisterType("fs6")
+    FS7 = FloatRegisterType("fs7")
+    FS8 = FloatRegisterType("fs8")
+    FS9 = FloatRegisterType("fs9")
+    FS10 = FloatRegisterType("fs10")
+    FS11 = FloatRegisterType("fs11")
+    FT8 = FloatRegisterType("ft8")
+    FT9 = FloatRegisterType("ft9")
+    FT10 = FloatRegisterType("ft10")
+    FT11 = FloatRegisterType("ft11")
 
 
 @irdl_attr_definition
@@ -319,7 +319,7 @@ class RISCVOp(Operation, ABC):
 
 
 AssemblyInstructionArg: TypeAlias = (
-    AnyIntegerAttr | LabelAttr | SSAValue | IntRegisterAttr | str
+    AnyIntegerAttr | LabelAttr | SSAValue | IntRegisterType | str
 )
 
 
@@ -385,15 +385,15 @@ def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
         return arg.data
     elif isinstance(arg, str):
         return arg
-    elif isinstance(arg, IntRegisterAttr):
+    elif isinstance(arg, IntRegisterType):
         return arg.register_name
-    elif isinstance(arg, FloatRegisterAttr):
+    elif isinstance(arg, FloatRegisterType):
         return arg.register_name
     else:
-        if isinstance(arg.type, IntRegisterAttr):
+        if isinstance(arg.type, IntRegisterType):
             reg = arg.type.register_name
             return reg
-        elif isinstance(arg.type, FloatRegisterAttr):
+        elif isinstance(arg.type, FloatRegisterType):
             reg = arg.type.register_name
             return reg
         else:
@@ -442,22 +442,22 @@ class RdRsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called R-Type in the RISC-V specification.
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
-    rs1: Operand = operand_def(IntRegisterAttr)
-    rs2: Operand = operand_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -479,14 +479,14 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     immediate operand (e.g. U-Type and J-Type instructions in the RISC-V spec).
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -494,9 +494,9 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -520,7 +520,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rd: IntRegisterAttr | None = opt_attr_def(IntRegisterAttr)
+    rd: IntRegisterType | None = opt_attr_def(IntRegisterType)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
@@ -531,7 +531,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -539,7 +539,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -562,8 +562,8 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called I-Type in the RISC-V specification.
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
-    rs1: Operand = operand_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -571,7 +571,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -580,9 +580,9 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -617,7 +617,7 @@ class RdRsImmShiftOperation(RdRsImmIntegerOperation):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -639,8 +639,8 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
     most sense as an attribute.
     """
 
-    rs1: Operand = operand_def(IntRegisterAttr)
-    rd: IntRegisterAttr | None = opt_attr_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterType)
+    rd: IntRegisterType | None = opt_attr_def(IntRegisterType)
     """
     The rd register here is not a register storing the result, rather the register where
     the program counter is stored before jumping.
@@ -652,7 +652,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -661,7 +661,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
 
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -685,20 +685,20 @@ class RdRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     source register.
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
-    rs: Operand = operand_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
+    rs: Operand = operand_def(IntRegisterType)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -719,8 +719,8 @@ class RsRsOffIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called B-Type in the RISC-V specification.
     """
 
-    rs1: Operand = operand_def(IntRegisterAttr)
-    rs2: Operand = operand_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
     offset: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -758,8 +758,8 @@ class RsRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     This is called S-Type in the RISC-V specification.
     """
 
-    rs1: Operand = operand_def(IntRegisterAttr)
-    rs2: Operand = operand_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -795,8 +795,8 @@ class RsRsIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     registers.
     """
 
-    rs1: Operand = operand_def(IntRegisterAttr)
-    rs2: Operand = operand_def(IntRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(IntRegisterType)
 
     def __init__(self, rs1: Operation | SSAValue, rs2: Operation | SSAValue):
         super().__init__(
@@ -841,8 +841,8 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
       returned in rd
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
-    rs1: Operand = operand_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
@@ -852,13 +852,13 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -874,7 +874,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if not self.writeonly:
             return
-        if not isinstance(self.rd.type, IntRegisterAttr):
+        if not isinstance(self.rd.type, IntRegisterType):
             return
         if self.rd.type.is_allocated and self.rd.type.data != "zero":
             raise VerifyException(
@@ -899,8 +899,8 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
       to writing to a CSR takes place even if the mask in rs has no actual bits set.
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
-    rs1: Operand = operand_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     readonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
@@ -910,13 +910,13 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         *,
         readonly: bool = False,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -932,7 +932,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if not self.readonly:
             return
-        if not isinstance(self.rs1.type, IntRegisterAttr):
+        if not isinstance(self.rs1.type, IntRegisterType):
             return
         if self.rs1.type.is_allocated and self.rs1.type.data != "zero":
             raise VerifyException(
@@ -955,7 +955,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
       returned in rd
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
     immediate: AnyIntegerAttr | None = opt_attr_def(AnyIntegerAttr)
@@ -966,13 +966,13 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
         immediate: AnyIntegerAttr,
         *,
         writeonly: bool = False,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -988,7 +988,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
     def verify_(self) -> None:
         if self.writeonly is None:
             return
-        if not isinstance(self.rd.type, IntRegisterAttr):
+        if not isinstance(self.rd.type, IntRegisterType):
             return
         if self.rd.type.is_allocated and self.rd.type.data != "zero":
             raise VerifyException(
@@ -1013,7 +1013,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
       place.
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
@@ -1022,13 +1022,13 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
         csr: AnyIntegerAttr,
         immediate: AnyIntegerAttr,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1924,7 +1924,7 @@ class LiOp(RdImmIntegerOperation):
         self,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -2184,14 +2184,14 @@ class GetRegisterOp(IRDLOperation, RISCVOp):
     """
 
     name = "riscv.get_register"
-    res: OpResult = result_def(IntRegisterAttr)
+    res: OpResult = result_def(IntRegisterType)
 
     def __init__(
         self,
-        register_type: IntRegisterAttr | str,
+        register_type: IntRegisterType | str,
     ):
         if isinstance(register_type, str):
-            register_type = IntRegisterAttr(register_type)
+            register_type = IntRegisterType(register_type)
         super().__init__(result_types=[register_type])
 
     def assembly_line(self) -> str | None:
@@ -2208,14 +2208,14 @@ class GetFloatRegisterOp(IRDLOperation, RISCVOp):
     """
 
     name = "riscv.get_float_register"
-    res: OpResult = result_def(FloatRegisterAttr)
+    res: OpResult = result_def(FloatRegisterType)
 
     def __init__(
         self,
-        register_type: FloatRegisterAttr | str,
+        register_type: FloatRegisterType | str,
     ):
         if isinstance(register_type, str):
-            register_type = FloatRegisterAttr(register_type)
+            register_type = FloatRegisterType(register_type)
         super().__init__(result_types=[register_type])
 
     def assembly_line(self) -> str | None:
@@ -2252,10 +2252,10 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     e.g: fused-multiply-add (FMA) instructions.
     """
 
-    rd: OpResult = result_def(FloatRegisterAttr)
-    rs1: Operand = operand_def(FloatRegisterAttr)
-    rs2: Operand = operand_def(FloatRegisterAttr)
-    rs3: Operand = operand_def(FloatRegisterAttr)
+    rd: OpResult = result_def(FloatRegisterType)
+    rs1: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
+    rs3: Operand = operand_def(FloatRegisterType)
 
     def __init__(
         self,
@@ -2263,13 +2263,13 @@ class RdRsRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         rs2: Operation | SSAValue,
         rs3: Operation | SSAValue,
         *,
-        rd: FloatRegisterAttr | str | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr.unallocated
+            rd = FloatRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = FloatRegisterAttr(rd)
+            rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2291,22 +2291,22 @@ class RdRsRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     take two floating-point input registers and a destination.
     """
 
-    rd: OpResult = result_def(FloatRegisterAttr)
-    rs1: Operand = operand_def(FloatRegisterAttr)
-    rs2: Operand = operand_def(FloatRegisterAttr)
+    rd: OpResult = result_def(FloatRegisterType)
+    rs1: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: FloatRegisterAttr | str | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr.unallocated
+            rd = FloatRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = FloatRegisterAttr(rd)
+            rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2328,22 +2328,22 @@ class RdRsRsFloatFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     two floating-point input registers and an integer destination register.
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
-    rs1: Operand = operand_def(FloatRegisterAttr)
-    rs2: Operand = operand_def(FloatRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
+    rs1: Operand = operand_def(FloatRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
 
     def __init__(
         self,
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -2365,20 +2365,20 @@ class RdRsFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     input register and a floating destination register.
     """
 
-    rd: OpResult = result_def(FloatRegisterAttr)
-    rs: Operand = operand_def(FloatRegisterAttr)
+    rd: OpResult = result_def(FloatRegisterType)
+    rs: Operand = operand_def(FloatRegisterType)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: FloatRegisterAttr | str | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr.unallocated
+            rd = FloatRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = FloatRegisterAttr(rd)
+            rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2397,20 +2397,20 @@ class RdRsFloatIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     input register and an integer destination register.
     """
 
-    rd: OpResult = result_def(IntRegisterAttr)
-    rs: Operand = operand_def(FloatRegisterAttr)
+    rd: OpResult = result_def(IntRegisterType)
+    rs: Operand = operand_def(FloatRegisterType)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: IntRegisterAttr | str | None = None,
+        rd: IntRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterAttr.unallocated
+            rd = IntRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = IntRegisterAttr(rd)
+            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2429,20 +2429,20 @@ class RdRsIntegerFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     input register and a floating-point destination register.
     """
 
-    rd: OpResult = result_def(FloatRegisterAttr)
-    rs: Operand = operand_def(IntRegisterAttr)
+    rd: OpResult = result_def(FloatRegisterType)
+    rs: Operand = operand_def(IntRegisterType)
 
     def __init__(
         self,
         rs: Operation | SSAValue,
         *,
-        rd: FloatRegisterAttr | str | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterAttr.unallocated
+            rd = FloatRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = FloatRegisterAttr(rd)
+            rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2461,8 +2461,8 @@ class RsRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     (one integer and one floating-point) and an immediate.
     """
 
-    rs1: Operand = operand_def(IntRegisterAttr)
-    rs2: Operand = operand_def(FloatRegisterAttr)
+    rs1: Operand = operand_def(IntRegisterType)
+    rs2: Operand = operand_def(FloatRegisterType)
     immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -2499,8 +2499,8 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
     one immediate operand.
     """
 
-    rd: OpResult = result_def(FloatRegisterAttr)
-    rs1: Operand = operand_def(IntRegisterAttr)
+    rd: OpResult = result_def(FloatRegisterType)
+    rs1: Operand = operand_def(IntRegisterType)
     immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
 
     def __init__(
@@ -2508,7 +2508,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | AnyIntegerAttr | str | LabelAttr,
         *,
-        rd: FloatRegisterAttr | str | None = None,
+        rd: FloatRegisterType | str | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -2517,9 +2517,9 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = FloatRegisterAttr.unallocated
+            rd = FloatRegisterType.unallocated
         elif isinstance(rd, str):
-            rd = FloatRegisterAttr(rd)
+            rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -2986,8 +2986,8 @@ RISCV = Dialect(
         FSwOp,
     ],
     [
-        IntRegisterAttr,
-        FloatRegisterAttr,
+        IntRegisterType,
+        FloatRegisterType,
         LabelAttr,
     ],
 )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -49,7 +49,6 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
 
-@irdl_attr_definition
 class RISCVRegisterAttr(Data[str], TypeAttribute, ABC):
     """
     A RISC-V register type.

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -96,7 +96,7 @@ class RISCVRegisterType(Data[str], TypeAttribute, ABC):
     @classmethod
     @abstractmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -40,7 +40,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.RegisterAttr("") if has_result else None],
+            result_types=[riscv.RegisterAttr.unallocated if has_result else None],
         )
 
     def verify_(self):

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -25,9 +25,9 @@ from xdsl.utils.exceptions import VerifyException
 @irdl_op_definition
 class SyscallOp(IRDLOperation):
     name = "riscv_func.syscall"
-    args: VarOperand = var_operand_def(riscv.IntRegisterAttr)
+    args: VarOperand = var_operand_def(riscv.IntRegisterType)
     syscall_num: IntegerAttr[IntegerType] = attr_def(IntegerAttr[IntegerType])
-    result: OptOpResult = opt_result_def(riscv.IntRegisterAttr)
+    result: OptOpResult = opt_result_def(riscv.IntRegisterType)
 
     def __init__(
         self,
@@ -40,7 +40,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.IntRegisterAttr.unallocated if has_result else None],
+            result_types=[riscv.IntRegisterType.unallocated if has_result else None],
         )
 
     def verify_(self):
@@ -59,15 +59,15 @@ class CallOp(IRDLOperation):
     """RISC-V function call operation"""
 
     name = "riscv_func.call"
-    args: VarOperand = var_operand_def(riscv.IntRegisterAttr)
+    args: VarOperand = var_operand_def(riscv.IntRegisterType)
     callee: StringAttr = attr_def(StringAttr)
-    ress: VarOpResult = var_result_def(riscv.IntRegisterAttr)
+    ress: VarOpResult = var_result_def(riscv.IntRegisterType)
 
     def __init__(
         self,
         callee: StringAttr,
         args: Sequence[Operation | SSAValue],
-        result_types: Sequence[riscv.IntRegisterAttr],
+        result_types: Sequence[riscv.IntRegisterType],
         comment: StringAttr | None = None,
     ):
         super().__init__(
@@ -119,7 +119,7 @@ class ReturnOp(IRDLOperation):
     """RISC-V function return operation"""
 
     name = "riscv_func.return"
-    values: VarOperand = var_operand_def(riscv.IntRegisterAttr)
+    values: VarOperand = var_operand_def(riscv.IntRegisterType)
     comment: StringAttr | None = opt_attr_def(StringAttr)
 
     traits = frozenset([IsTerminator(), HasParent(FuncOp)])

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -25,9 +25,9 @@ from xdsl.utils.exceptions import VerifyException
 @irdl_op_definition
 class SyscallOp(IRDLOperation):
     name = "riscv_func.syscall"
-    args: VarOperand = var_operand_def(riscv.RegisterAttr)
+    args: VarOperand = var_operand_def(riscv.IntRegisterAttr)
     syscall_num: IntegerAttr[IntegerType] = attr_def(IntegerAttr[IntegerType])
-    result: OptOpResult = opt_result_def(riscv.RegisterAttr)
+    result: OptOpResult = opt_result_def(riscv.IntRegisterAttr)
 
     def __init__(
         self,
@@ -40,7 +40,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.RegisterAttr.unallocated if has_result else None],
+            result_types=[riscv.IntRegisterAttr.unallocated if has_result else None],
         )
 
     def verify_(self):
@@ -59,15 +59,15 @@ class CallOp(IRDLOperation):
     """RISC-V function call operation"""
 
     name = "riscv_func.call"
-    args: VarOperand = var_operand_def(riscv.RegisterAttr)
+    args: VarOperand = var_operand_def(riscv.IntRegisterAttr)
     callee: StringAttr = attr_def(StringAttr)
-    ress: VarOpResult = var_result_def(riscv.RegisterAttr)
+    ress: VarOpResult = var_result_def(riscv.IntRegisterAttr)
 
     def __init__(
         self,
         callee: StringAttr,
         args: Sequence[Operation | SSAValue],
-        result_types: Sequence[riscv.RegisterAttr],
+        result_types: Sequence[riscv.IntRegisterAttr],
         comment: StringAttr | None = None,
     ):
         super().__init__(
@@ -119,7 +119,7 @@ class ReturnOp(IRDLOperation):
     """RISC-V function return operation"""
 
     name = "riscv_func.return"
-    values: VarOperand = var_operand_def(riscv.RegisterAttr)
+    values: VarOperand = var_operand_def(riscv.IntRegisterAttr)
     comment: StringAttr | None = opt_attr_def(StringAttr)
 
     traits = frozenset([IsTerminator(), HasParent(FuncOp)])

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -40,7 +40,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.IntRegisterType.unallocated if has_result else None],
+            result_types=[riscv.IntRegisterType.unallocated() if has_result else None],
         )
 
     def verify_(self):

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -40,7 +40,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.RegisterAttr(riscv.Register()) if has_result else None],
+            result_types=[riscv.RegisterAttr("") if has_result else None],
         )
 
     def verify_(self):

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -25,9 +25,9 @@ from xdsl.utils.exceptions import VerifyException
 @irdl_op_definition
 class SyscallOp(IRDLOperation):
     name = "riscv_func.syscall"
-    args: VarOperand = var_operand_def(riscv.RegisterType)
+    args: VarOperand = var_operand_def(riscv.RegisterAttr)
     syscall_num: IntegerAttr[IntegerType] = attr_def(IntegerAttr[IntegerType])
-    result: OptOpResult = opt_result_def(riscv.RegisterType)
+    result: OptOpResult = opt_result_def(riscv.RegisterAttr)
 
     def __init__(
         self,
@@ -40,7 +40,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.RegisterType(riscv.Register()) if has_result else None],
+            result_types=[riscv.RegisterAttr(riscv.Register()) if has_result else None],
         )
 
     def verify_(self):
@@ -59,15 +59,15 @@ class CallOp(IRDLOperation):
     """RISC-V function call operation"""
 
     name = "riscv_func.call"
-    args: VarOperand = var_operand_def(riscv.RegisterType)
+    args: VarOperand = var_operand_def(riscv.RegisterAttr)
     callee: StringAttr = attr_def(StringAttr)
-    ress: VarOpResult = var_result_def(riscv.RegisterType)
+    ress: VarOpResult = var_result_def(riscv.RegisterAttr)
 
     def __init__(
         self,
         callee: StringAttr,
         args: Sequence[Operation | SSAValue],
-        result_types: Sequence[riscv.RegisterType],
+        result_types: Sequence[riscv.RegisterAttr],
         comment: StringAttr | None = None,
     ):
         super().__init__(
@@ -119,7 +119,7 @@ class ReturnOp(IRDLOperation):
     """RISC-V function return operation"""
 
     name = "riscv_func.return"
-    values: VarOperand = var_operand_def(riscv.RegisterType)
+    values: VarOperand = var_operand_def(riscv.RegisterAttr)
     comment: StringAttr | None = opt_attr_def(StringAttr)
 
     traits = frozenset([IsTerminator(), HasParent(FuncOp)])

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -12,7 +12,7 @@ from abc import ABC
 from dataclasses import dataclass
 
 from xdsl.dialects.builtin import AnyIntegerAttr
-from xdsl.dialects.riscv import IntRegisterAttr
+from xdsl.dialects.riscv import IntRegisterType
 from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, Operand, attr_def, irdl_op_definition, operand_def
 from xdsl.utils.exceptions import VerifyException
@@ -34,8 +34,8 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
     configuration value for a specific dimension handled by a streamer.
     """
 
-    stream: Operand = operand_def(IntRegisterAttr)
-    value: Operand = operand_def(IntRegisterAttr)
+    stream: Operand = operand_def(IntRegisterType)
+    value: Operand = operand_def(IntRegisterType)
     dimension: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -65,8 +65,8 @@ class SsrSetStreamConfigOperation(IRDLOperation, ABC):
     configuration value for a streamer.
     """
 
-    stream: Operand = operand_def(IntRegisterAttr)
-    value: Operand = operand_def(IntRegisterAttr)
+    stream: Operand = operand_def(IntRegisterType)
+    value: Operand = operand_def(IntRegisterType)
 
     def __init__(self, stream: Operation | SSAValue, value: Operation | SSAValue):
         super().__init__(operands=[stream, value])

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -12,7 +12,7 @@ from abc import ABC
 from dataclasses import dataclass
 
 from xdsl.dialects.builtin import AnyIntegerAttr
-from xdsl.dialects.riscv import RegisterAttr
+from xdsl.dialects.riscv import IntRegisterAttr
 from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, Operand, attr_def, irdl_op_definition, operand_def
 from xdsl.utils.exceptions import VerifyException
@@ -34,8 +34,8 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
     configuration value for a specific dimension handled by a streamer.
     """
 
-    stream: Operand = operand_def(RegisterAttr)
-    value: Operand = operand_def(RegisterAttr)
+    stream: Operand = operand_def(IntRegisterAttr)
+    value: Operand = operand_def(IntRegisterAttr)
     dimension: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -65,8 +65,8 @@ class SsrSetStreamConfigOperation(IRDLOperation, ABC):
     configuration value for a streamer.
     """
 
-    stream: Operand = operand_def(RegisterAttr)
-    value: Operand = operand_def(RegisterAttr)
+    stream: Operand = operand_def(IntRegisterAttr)
+    value: Operand = operand_def(IntRegisterAttr)
 
     def __init__(self, stream: Operation | SSAValue, value: Operation | SSAValue):
         super().__init__(operands=[stream, value])

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -12,7 +12,7 @@ from abc import ABC
 from dataclasses import dataclass
 
 from xdsl.dialects.builtin import AnyIntegerAttr
-from xdsl.dialects.riscv import RegisterType
+from xdsl.dialects.riscv import RegisterAttr
 from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, Operand, attr_def, irdl_op_definition, operand_def
 from xdsl.utils.exceptions import VerifyException
@@ -34,8 +34,8 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
     configuration value for a specific dimension handled by a streamer.
     """
 
-    stream: Operand = operand_def(RegisterType)
-    value: Operand = operand_def(RegisterType)
+    stream: Operand = operand_def(RegisterAttr)
+    value: Operand = operand_def(RegisterAttr)
     dimension: AnyIntegerAttr = attr_def(AnyIntegerAttr)
 
     def __init__(
@@ -65,8 +65,8 @@ class SsrSetStreamConfigOperation(IRDLOperation, ABC):
     configuration value for a streamer.
     """
 
-    stream: Operand = operand_def(RegisterType)
-    value: Operand = operand_def(RegisterType)
+    stream: Operand = operand_def(RegisterAttr)
+    value: Operand = operand_def(RegisterAttr)
 
     def __init__(self, stream: Operation | SSAValue, value: Operation | SSAValue):
         super().__init__(operands=[stream, value])

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -54,7 +54,7 @@ class LowerSyscallOp(RewritePattern):
             ops.append(gr)
             res = gr.res
 
-            mv = riscv.MVOp(res, rd=cast(riscv.RegisterAttr, op.result.type))
+            mv = riscv.MVOp(res, rd=cast(riscv.IntRegisterAttr, op.result.type))
             ops.append(mv)
             new_results = mv.results
 

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -54,7 +54,7 @@ class LowerSyscallOp(RewritePattern):
             ops.append(gr)
             res = gr.res
 
-            mv = riscv.MVOp(res, rd=cast(riscv.IntRegisterAttr, op.result.type))
+            mv = riscv.MVOp(res, rd=cast(riscv.IntRegisterType, op.result.type))
             ops.append(mv)
             new_results = mv.results
 

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -37,7 +37,7 @@ class LowerSyscallOp(RewritePattern):
             ops.append(
                 riscv.MVOp(
                     arg,
-                    rd=riscv.Register(f"a{i}"),
+                    rd=f"a{i}",
                 )
             )
 
@@ -72,7 +72,7 @@ class LowerRISCVFuncOp(RewritePattern):
             # replace arguments with `GetRegisterOp`s
             index = len(body.args) - 1
             last_arg = body.args[-1]
-            get_reg_op = riscv.GetRegisterOp(riscv.Register(f"a{index}"))
+            get_reg_op = riscv.GetRegisterOp(f"a{index}")
             last_arg.replace_by(get_reg_op.res)
             rewriter.insert_op_before(get_reg_op, first_op)
             first_op = get_reg_op
@@ -99,9 +99,7 @@ class LowerRISCVFuncReturnOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv_func.ReturnOp, rewriter: PatternRewriter):
         for i, value in enumerate(op.values):
-            rewriter.insert_op_before_matched_op(
-                riscv.MVOp(value, rd=riscv.Register(f"a{i}"))
-            )
+            rewriter.insert_op_before_matched_op(riscv.MVOp(value, rd=f"a{i}"))
         rewriter.replace_matched_op(riscv.ReturnOp())
 
 
@@ -110,9 +108,7 @@ class LowerRISCVCallOp(RewritePattern):
     def match_and_rewrite(self, op: riscv_func.CallOp, rewriter: PatternRewriter):
         for i, arg in enumerate(op.operands):
             # Load arguments into a0...
-            rewriter.insert_op_before_matched_op(
-                riscv.MVOp(arg, rd=riscv.Register(f"a{i}"))
-            )
+            rewriter.insert_op_before_matched_op(riscv.MVOp(arg, rd=f"a{i}"))
 
         ops: list[Operation] = [
             riscv.JalOp(op.callee.data),
@@ -120,7 +116,7 @@ class LowerRISCVCallOp(RewritePattern):
         new_results: list[OpResult] = []
 
         for i in range(len(op.results)):
-            get_reg = riscv.GetRegisterOp(riscv.Register(f"a{i}"))
+            get_reg = riscv.GetRegisterOp(f"a{i}")
             move_res = riscv.MVOp(get_reg)
             ops.extend((get_reg, move_res))
             new_results.append(move_res.rd)

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -54,7 +54,7 @@ class LowerSyscallOp(RewritePattern):
             ops.append(gr)
             res = gr.res
 
-            mv = riscv.MVOp(res, rd=cast(riscv.RegisterType, op.result.type))
+            mv = riscv.MVOp(res, rd=cast(riscv.RegisterAttr, op.result.type))
             ops.append(mv)
             new_results = mv.results
 


### PR DESCRIPTION
When I initially wrote the register types, the reasoning in my mind was that I wanted an optional register name, and `Data` cannot accept an optional generic parameter. But actually an empty string seems more appropriate than None anyway. Now that we have floats in riscv, and some duplication, it feels like a good idea to simplify. This also includes a rename of RegisterType to RegisterAttr, since we don't exclusively use them as types.

After some discussions with @kingiler  on the changes in #1269, I thought I'd play around with the code to see how to make the generics work for both Register/FloatRegister and RegisterType/FloatRegisterType. There were always some issues with it locally, and quite a lot of complexity due to the extra step of indirection. This is what led me to the changes in this PR, which I propose as an alternative to #1269. It's probably a good idea for reviewers to take a look at both to have a better view of multiple potential ways forward.