### PR TITLE
dialects: (riscv) make LabelOp region multi-block

### DIFF
--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -2000,14 +2000,14 @@ class LabelOp(IRDLOperation, RISCVOp):
     name = "riscv.label"
     label: LabelAttr = attr_def(LabelAttr)
     comment: StringAttr | None = opt_attr_def(StringAttr)
-    data: OptRegion = opt_region_def("single_block")
+    data: OptRegion = opt_region_def()
 
     traits = frozenset([NoTerminator()])
 
     def __init__(
         self,
         label: str | LabelAttr,
-        region: OptSingleBlockRegion = None,
+        region: OptRegion = None,
         *,
         comment: str | StringAttr | None = None,
     ):


### PR DESCRIPTION
This PR adds the ability to have multiple blocks in a LabelOp, and amends the lowering from riscv_func.func to allow for multiple blocks. If we lower from func and cf, then we have no choice but to support multi-block.