### PR TITLE
CI: Add a retry on codecov upload.

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -113,10 +113,14 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.10'
-      uses: codecov/codecov-action@v3
+      uses: Wandalen/wretry.action@v1
       with:
-        fail_ci_if_error: true
-        verbose: true
-        directory: ${GITHUB_WORKSPACE}/../
-        files: coverage.xml
-        token: ${{ secrets.CODECOV_TOKEN }}
+        action: codecov/codecov-action@v3
+        attempt_delay: 10000
+        attempt_limit: 10
+        with: |
+          fail_ci_if_error: true
+          verbose: true
+          directory: ${GITHUB_WORKSPACE}/../
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Had an issue again with codecov, figured we might want to try something like this.
Just an auto-retry, 10 times spaced by 10 seconds here.