### PR TITLE
docs: (toy) add lowering to Affine

### DIFF
--- a/docs/Toy/examples/interpret.toy
+++ b/docs/Toy/examples/interpret.toy
@@ -2,6 +2,7 @@
 # RUN: python -m toy %s --emit=toy-opt | filecheck %s
 # RUN: python -m toy %s --emit=toy-inline | filecheck %s
 # RUN: python -m toy %s --emit=toy-infer-shapes | filecheck %s
+# RUN: python -m toy %s --emit=affine | filecheck %s
 
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {

--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -1,6 +1,11 @@
 import argparse
 from pathlib import Path
 
+from xdsl.interpreters.affine import AffineFunctions
+from xdsl.interpreters.arith import ArithFunctions
+from xdsl.interpreters.func import FuncFunctions
+from xdsl.interpreters.memref import MemrefFunctions
+from xdsl.interpreters.printf import PrintfFunctions
 from xdsl.parser import Parser as IRParser
 from xdsl.printer import Printer
 
@@ -20,6 +25,7 @@ parser.add_argument(
         "toy-opt",
         "toy-inline",
         "toy-infer-shapes",
+        "affine",
     ],
     default="toy-infer-shapes",
     help="Action to perform on source file (default: toy-infer-shapes)",
@@ -59,10 +65,15 @@ def main(path: Path, emit: str, ir: bool, print_generic: bool):
         return
 
     interpreter = Interpreter(module_op)
-    interpreter.register_implementations(ToyFunctions())
+    if emit in ("toy", "toy-opt", "toy-inline", "toy-infer-shapes"):
+        interpreter.register_implementations(ToyFunctions())
+    if emit in ("affine"):
+        interpreter.register_implementations(AffineFunctions())
+        interpreter.register_implementations(MemrefFunctions())
+        interpreter.register_implementations(ArithFunctions())
+        interpreter.register_implementations(PrintfFunctions())
+        interpreter.register_implementations(FuncFunctions())
     interpreter.call_op("main", ())
-
-    print(f"Unknown option {emit}")
 
 
 if __name__ == "__main__":

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -7,6 +7,7 @@ from .dialects import toy
 from .frontend.ir_gen import IRGen
 from .frontend.parser import Parser
 from .rewrites.inline_toy import InlineToyPass
+from .rewrites.lower_toy_affine import LowerToAffinePass
 from .rewrites.optimise_toy import OptimiseToy
 from .rewrites.shape_inference import ShapeInferencePass
 
@@ -42,6 +43,12 @@ def transform(ctx: MLContext, module_op: ModuleOp, *, target: str = "toy-infer-s
     ShapeInferencePass().apply(ctx, module_op)
 
     if target == "toy-infer-shapes":
+        return
+
+    LowerToAffinePass().apply(ctx, module_op)
+    module_op.verify()
+
+    if target == "affine":
         return
 
     raise ValueError(f"Unknown target option {target}")

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -1,0 +1,467 @@
+"""
+This file implements a partial lowering of Toy operations to a combination of
+affine loops, memref operations and standard operations. This lowering
+expects that all calls have been inlined, and all shapes have been resolved.
+"""
+
+from itertools import product
+from typing import Callable, Sequence, TypeAlias, TypeVar, cast
+
+from xdsl.builder import Builder
+from xdsl.dialects import affine, arith, func, memref
+from xdsl.dialects.builtin import Float64Type, IndexType, IntegerAttr, ModuleOp, f64
+from xdsl.dialects.printf import PrintFormatOp
+from xdsl.ir.core import Block, MLContext, Operation, Region, SSAValue
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from ..dialects import toy
+
+# region Helpers
+
+MemrefTypeF64: TypeAlias = memref.MemRefType[Float64Type]
+
+
+def convert_tensor_to_memref(type: toy.TensorTypeF64) -> MemrefTypeF64:
+    """
+    Convert the given RankedTensorType into the corresponding MemRefType.
+    """
+    return memref.MemRefType.from_element_type_and_shape(f64, type.shape)
+
+
+def insert_alloc_and_dealloc(
+    type: MemrefTypeF64, op: Operation, rewriter: PatternRewriter
+) -> memref.Alloc:
+    """
+    Insert an allocation and deallocation for the given MemRefType.
+    """
+    block = op.parent
+
+    assert block is not None, "Operation to be allocated must be in a block"
+    assert block.last_op is not None
+
+    # Make sure to allocate at the beginning of the block.
+    alloc = memref.Alloc.get(type.element_type, None, type.shape)
+    rewriter.insert_op_at_start(alloc, block)
+
+    # Make sure to deallocate this alloc at the end of the block. This is fine as toy
+    # functions have no control flow.
+    dealloc = memref.Dealloc.get(alloc)
+    rewriter.insert_op_before(dealloc, block.last_op)
+
+    return alloc
+
+
+_ValueRange = Sequence[SSAValue]
+_AffineForOpBodyBuilderFn: TypeAlias = Callable[[Builder, SSAValue, _ValueRange], None]
+
+
+def build_affine_for(
+    builder: Builder,
+    lb_operands: _ValueRange,
+    lb_map: affine.AffineMap,
+    ub_operands: _ValueRange,
+    ub_map: affine.AffineMap,
+    step: int,
+    iter_args: _ValueRange,
+    body_builder_fn: _AffineForOpBodyBuilderFn,
+) -> affine.For:
+    """
+    'bodyBuilder' is used to build the body of affine.for.
+    """
+
+    assert (
+        len(lb_operands) == lb_map.num_dims
+    ), "lower bound operand count does not match the affine map"
+    assert (
+        len(ub_operands) == ub_map.num_dims
+    ), "upper bound operand count does not match the affine map"
+    assert step > 0, "step has to be a positive integer constant"
+
+    # Create a region and a block for the body.
+    # The argument of the region is the loop induction variable.
+    block_arg_types = (IndexType(), *(arg.type for arg in iter_args))
+    block = Block(arg_types=block_arg_types)
+    induction_var, *rest = block.args
+    region = Region(block)
+
+    op = affine.For.from_region(
+        (*lb_operands, *ub_operands, *iter_args),
+        tuple(iter_arg.type for iter_arg in iter_args),
+        affine.AffineMapAttr(lb_map),
+        affine.AffineMapAttr(ub_map),
+        region,
+        step,
+    )
+    builder.insert(op)
+    body_builder_fn(Builder(block), induction_var, rest)
+    return op
+
+
+def build_affine_for_const(
+    builder: Builder,
+    lb: int,
+    ub: int,
+    step: int,
+    iter_args: _ValueRange,
+    body_builder_fn: _AffineForOpBodyBuilderFn,
+) -> affine.For:
+    return build_affine_for(
+        builder,
+        (),
+        affine.AffineMap.constant_map(lb),
+        (),
+        affine.AffineMap.constant_map(ub),
+        step,
+        iter_args,
+        body_builder_fn,
+    )
+
+
+_Bounds: TypeAlias = tuple[int, ...]
+
+LoopIterationFn: TypeAlias = Callable[[Builder, _ValueRange, _ValueRange], SSAValue]
+"""
+This defines the function type used to process an iteration of a lowered loop. It takes as
+input an OpBuilder, an range of memRefOperands corresponding to the operands of the input
+operation, and the range of loop induction variables for the iteration. It returns a value
+to store at the current index of the iteration.
+"""
+
+_BoundT = TypeVar("_BoundT")
+
+_BodyBuilderFn: TypeAlias = Callable[[Builder, _ValueRange], None]
+_LoopCreatorFn: TypeAlias = Callable[
+    [Builder, _BoundT, _BoundT, int, _AffineForOpBodyBuilderFn],
+    affine.For,
+]
+
+
+def build_affine_loop_nest_impl(
+    builder: Builder,
+    lbs: Sequence[_BoundT],
+    ubs: Sequence[_BoundT],
+    steps: Sequence[int],
+    body_builder_fn: _BodyBuilderFn,
+    loop_creator_fn: _LoopCreatorFn[_BoundT],
+) -> None:
+    """
+    Corresponds to affine::buildAffineLoopNestImpl in MLIR
+    """
+
+    assert len(lbs) == len(ubs), "Mismatch in number of arguments"
+    assert len(lbs) == len(steps), "Mismatch in number of arguments"
+
+    # if there are no loops to be constructed, construct the body anyway
+    if not lbs:
+        body_builder_fn(builder, ())
+        return
+
+    # Create the loops iteratively and store the induction variables.
+
+    ivs: list[SSAValue] = []
+
+    e = len(lbs)
+    for i in range(e):
+        # Callback for creating the loop body, always creates the terminator.
+        def body(nested_builder: Builder, iv: SSAValue, iter_args: _ValueRange):
+            nonlocal ivs
+
+            ivs.append(iv)
+
+            # In the innermost loop, call the body builder
+            if i == e - 1:
+                body_builder_fn(nested_builder, ivs)
+
+            nested_builder.insert(affine.Yield.get())
+
+        # Delegate actual loop creation to the callback in order to dispatch
+        # between constant- and variable-bound loops.
+
+        loop = loop_creator_fn(builder, lbs[i], ubs[i], steps[i], body)
+        builder = Builder(loop.body.block, loop.body.block.first_op)
+
+
+def build_affine_loop_from_constants(
+    builder: Builder,
+    lb: int,
+    ub: int,
+    step: int,
+    body_builder_fn: _AffineForOpBodyBuilderFn,
+) -> affine.For:
+    """
+    Creates an affine loop from the bounds known to be constants.
+    """
+    return build_affine_for_const(builder, lb, ub, step, (), body_builder_fn)
+
+
+def build_affine_loop_from_values(
+    builder: Builder,
+    lb: SSAValue,
+    ub: SSAValue,
+    step: int,
+    body_builder_fn: _AffineForOpBodyBuilderFn,
+) -> affine.For:
+    """
+    Creates an affine loop from the bounds that may or may not be constants.
+    """
+    lb_const = lb.owner
+    ub_const = ub.owner
+
+    if (
+        isinstance(lb_const, arith.Constant)
+        and isinstance(lb_const.value, IntegerAttr)
+        and isinstance(ub_const, arith.Constant)
+        and isinstance(ub_const.value, IntegerAttr)
+    ):
+        lb_val = lb_const.value.value.data
+        ub_val = ub_const.value.value.data
+        return build_affine_loop_from_constants(
+            builder, lb_val, ub_val, step, body_builder_fn
+        )
+    return build_affine_for(
+        builder,
+        (lb,),
+        affine.AffineMap(1, 0, [affine.AffineExpr.dimension(0)]),
+        (ub,),
+        affine.AffineMap(1, 0, [affine.AffineExpr.dimension(0)]),
+        step,
+        (),
+        body_builder_fn,
+    )
+
+
+def build_affine_loop_nest_const(
+    builder: Builder,
+    lbs: Sequence[int],
+    ubs: Sequence[int],
+    steps: Sequence[int],
+    body_builder_fn: _BodyBuilderFn,
+) -> None:
+    build_affine_loop_nest_impl(
+        builder, lbs, ubs, steps, body_builder_fn, build_affine_loop_from_constants
+    )
+
+
+def build_affine_loop_nest(
+    builder: Builder,
+    lbs: Sequence[SSAValue],
+    ubs: Sequence[SSAValue],
+    steps: Sequence[int],
+    body_builder_fn: _BodyBuilderFn,
+) -> None:
+    build_affine_loop_nest_impl(
+        builder, lbs, ubs, steps, body_builder_fn, build_affine_loop_from_values
+    )
+
+
+def lower_op_to_loops(
+    op: toy.AddOp | toy.MulOp | toy.TransposeOp,
+    operands: _ValueRange,
+    rewriter: PatternRewriter,
+    process_iteration: LoopIterationFn,
+):
+    tensor_type = cast(toy.TensorTypeF64, op.res.type)
+
+    # insert an allocation and deallocation for the result of this operation.
+    memref_type = convert_tensor_to_memref(tensor_type)
+    alloc = insert_alloc_and_dealloc(memref_type, op, rewriter)
+
+    # Create a nest of affine loops, with one loop per dimension of the shape.
+    # The buildAffineLoopNest function takes a callback that is used to construct the body
+    # of the innermost loop given a builder, a location and a range of loop induction
+    # variables.
+
+    rank = tensor_type.get_num_dims()
+    lower_bounds = tuple(0 for _ in range(rank))
+    steps = tuple(1 for _ in range(rank))
+
+    def impl_loop(nested_builder: Builder, ivs: _ValueRange):
+        # Call the processing function with the rewriter, the memref operands, and the
+        # loop induction variables. This function will return the value to store at the
+        # current index.
+        value_to_store = process_iteration(nested_builder, operands, ivs)
+        store_op = affine.Store(value_to_store, alloc.memref, ivs)
+        nested_builder.insert(store_op)
+
+    parent_block = op.parent
+    assert parent_block is not None
+    builder = Builder(parent_block, op)
+    build_affine_loop_nest_const(
+        builder, lower_bounds, tensor_type.get_shape(), steps, impl_loop
+    )
+    # Replace this operation with the generated alloc.
+
+    op.res.replace_by(alloc.memref)
+    rewriter.erase_matched_op()
+
+
+# endregion Helpers
+
+# region RewritePatterns
+
+
+class AddOpLowering(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy.AddOp, rewriter: PatternRewriter):
+        def body(
+            builder: Builder, memref_operands: _ValueRange, loop_ivs: _ValueRange
+        ) -> SSAValue:
+            # Generate loads for the element of 'lhs' and 'rhs' at the inner loop.
+            loaded_lhs = builder.insert(affine.Load(op.lhs, loop_ivs))
+            loaded_rhs = builder.insert(affine.Load(op.rhs, loop_ivs))
+            new_binop = builder.insert(arith.Addf(loaded_lhs, loaded_rhs))
+            return new_binop.result
+
+        lower_op_to_loops(op, op.operands, rewriter, body)
+
+
+class MulOpLowering(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy.MulOp, rewriter: PatternRewriter):
+        def body(
+            builder: Builder, memref_operands: _ValueRange, loop_ivs: _ValueRange
+        ) -> SSAValue:
+            # Generate loads for the element of 'lhs' and 'rhs' at the inner loop.
+            loaded_lhs = builder.insert(affine.Load(op.lhs, loop_ivs))
+            loaded_rhs = builder.insert(affine.Load(op.rhs, loop_ivs))
+            new_binop = builder.insert(arith.Mulf(loaded_lhs, loaded_rhs))
+            return new_binop.result
+
+        lower_op_to_loops(op, op.operands, rewriter, body)
+
+
+class ConstantOpLowering(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy.ConstantOp, rewriter: PatternRewriter):
+        constant_value = op.value
+
+        # When lowering the constant operation, we allocate and assign the constant
+        # values to a corresponding memref allocation.
+
+        tensor_type = cast(toy.TensorTypeF64, op.res.type)
+        memref_type = convert_tensor_to_memref(tensor_type)
+        alloc = insert_alloc_and_dealloc(memref_type, op, rewriter)
+
+        value_shape = memref_type.get_shape()
+
+        # Scalar constant values for elements of the tensor
+        constants: list[arith.Constant] = [
+            arith.Constant(i) for i in constant_value.data
+        ]
+
+        # n-d indices of elements
+        _indices = product(*(range(d) for d in value_shape))
+
+        # For each n-d index into the tensor, store the corresponding scalar
+        stores = [
+            affine.Store(
+                constants[offset].result,
+                alloc.memref,
+                (),
+                map=affine.AffineMapAttr(affine.AffineMap.point_map(*index)),
+            )
+            for offset, index in enumerate(_indices)
+        ]
+
+        # Insert constants used before the alloc, not before matched operation
+        rewriter.insert_op_before(constants, alloc)
+
+        # Replace the constant by the stores, and its result by the allocated value
+        rewriter.replace_matched_op(stores, (alloc.memref,))
+
+
+class FuncOpLowering(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy.FuncOp, rewriter: PatternRewriter):
+        name = op.sym_name.data
+
+        # We only lower the main function as we expect that all other functions
+        # have been inlined.
+        assert name == "main", "Only support lowering main function for now"
+
+        # Verify that the given main has no inputs and results.
+        if op.function_type.inputs or op.function_type.outputs:
+            raise ValueError("expected 'main' to have 0 inputs and 0 results")
+
+        # Create a new non-toy function, with the same region.
+        region = op.regions[0]
+
+        new_op = func.FuncOp(
+            name, op.function_type, rewriter.move_region_contents_to_new_regions(region)
+        )
+
+        rewriter.replace_matched_op(new_op)
+
+
+class PrintOpLowering(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy.PrintOp, rewriter: PatternRewriter):
+        rewriter.replace_matched_op(PrintFormatOp("{}", op.input))
+
+
+class ReturnOpLowering(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy.ReturnOp, rewriter: PatternRewriter):
+        assert (
+            op.input is None
+        ), "During this lowering, we expect that all function calls have been inlined."
+
+        rewriter.replace_matched_op(func.Return())
+
+
+class TransposeOpLowering(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy.TransposeOp, rewriter: PatternRewriter):
+        def body(
+            builder: Builder, mem_ref_operands: _ValueRange, loop_ivs: _ValueRange
+        ) -> SSAValue:
+            # Transpose the elements by generating a load from the reverse indices.
+            load_op = affine.Load(op.arg, tuple(reversed(loop_ivs)))
+            builder.insert(load_op)
+            return load_op.result
+
+        lower_op_to_loops(op, op.operands, rewriter, body)
+
+
+# endregion RewritePatterns
+
+
+class LowerToAffinePass(ModulePass):
+    """
+    A pass for lowering operations in the Toy dialect to Builtin.
+    """
+
+    name = "toy-to-builtin"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        # We define the specific operations, or dialects, that are legal targets for this
+        # lowering. In our case, we are lowering to a combination of the `Affine`,
+        # `Arith`, `Func`, and `MemRef` dialects.
+        ctx.register_dialect(affine.Affine)
+        ctx.register_dialect(arith.Arith)
+        ctx.register_dialect(func.Func)
+        ctx.register_dialect(memref.MemRef)
+
+        # Now that the conversion target has been defined, we just need to provide the set
+        # of patterns that will lower the Toy operations.
+
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    AddOpLowering(),
+                    ConstantOpLowering(),
+                    FuncOpLowering(),
+                    MulOpLowering(),
+                    PrintOpLowering(),
+                    ReturnOpLowering(),
+                    TransposeOpLowering(),
+                ]
+            )
+        ).rewrite_module(op)


### PR DESCRIPTION
The long-awaited Toy to builtin lowering. I added some code that in MLIR is in the affine dialect itself only to Toy for the time being. I think it's better to have this code in and functional enough for Toy for now, and move it to the main framework later.