### PR TITLE
core: (parser) factor out resolve_operands

### DIFF
--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -811,11 +811,12 @@ class Parser(AttrParser):
         and checks that the type is consistent.
 
         If the length of args and input_types does not match, an error is raised at
-        the the location error_pos.
+        the location error_pos.
         """
-        if len(args) != len(input_types):
+        length = len(list(input_types))
+        if len(args) != length:
             self.raise_error(
-                f"expected {len(input_types)} operand types but had {len(args)}",
+                f"expected {length} operand types but had {len(args)}",
                 error_pos,
             )
 

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -807,17 +807,7 @@ class Parser(AttrParser):
         If the operand is not yet defined, it creates a forward reference.
         If the operand is already defined, it returns the corresponding SSA value,
         and checks that the type is consistent.
-
-        If the length of args and input_types does not match, an error is raised at
-        the current location.
         """
-        func_type_pos = self._current_token.span.start
-        if len(args) != len(input_types):
-            self.raise_error(
-                f"expected {len(input_types)} operand types but had {len(args)}",
-                func_type_pos,
-            )
-
         return [
             self.resolve_operand(operand, type)
             for operand, type in zip(args, input_types)
@@ -850,8 +840,16 @@ class Parser(AttrParser):
 
         self.parse_punctuation(":", "function type signature expected")
 
+        func_type_pos = self._current_token.span.start
+
         # Parse function type
         func_type = self.parse_function_type()
+
+        if len(args) != len(func_type.inputs):
+            self.raise_error(
+                f"expected {len(func_type.inputs)} operand types but had {len(args)}",
+                func_type_pos,
+            )
 
         self._parse_optional_location()
 

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -23,7 +23,7 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.parser.attribute_parser import AttrParser
-from xdsl.parser.base_parser import ParserState
+from xdsl.parser.base_parser import ParserState, Position
 from xdsl.utils.exceptions import MultipleSpansParseError
 from xdsl.utils.lexer import Input, Lexer, Span, Token
 
@@ -798,9 +798,11 @@ class Parser(AttrParser):
         return self.parse_optional_dictionary_attr_dict()
 
     def resolve_operands(
-        self, args: list[UnresolvedOperand], input_types: ArrayAttr[Attribute],
-        error_pos: Span
-    ) -> list[SSAValue]:
+        self,
+        args: Sequence[UnresolvedOperand],
+        input_types: Sequence[Attribute],
+        error_pos: Position,
+    ) -> Sequence[SSAValue]:
         """
         Resolve unresolved operands. For each operand in `args` and its corresponding input
         type the following happens:
@@ -815,7 +817,7 @@ class Parser(AttrParser):
         if len(args) != len(input_types):
             self.raise_error(
                 f"expected {len(input_types)} operand types but had {len(args)}",
-                error_pos.start,
+                error_pos,
             )
 
         return [
@@ -850,7 +852,7 @@ class Parser(AttrParser):
 
         self.parse_punctuation(":", "function type signature expected")
 
-        func_type_pos = self._current_token.span
+        func_type_pos = self._current_token.span.start
 
         # Parse function type
         func_type = self.parse_function_type()

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -799,7 +799,7 @@ class Parser(AttrParser):
     def resolve_operands(
         self,
         args: Sequence[UnresolvedOperand],
-        input_types: Iterable[Attribute],
+        input_types: Sequence[Attribute],
         error_pos: Position,
     ) -> Sequence[SSAValue]:
         """
@@ -859,7 +859,7 @@ class Parser(AttrParser):
 
         self._parse_optional_location()
 
-        operands = self.resolve_operands(args, func_type.inputs, func_type_pos)
+        operands = self.resolve_operands(args, func_type.inputs.data, func_type_pos)
 
         return op_type.create(
             operands=operands,

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -853,9 +853,9 @@ class Parser(AttrParser):
         # Parse function type
         func_type = self.parse_function_type()
 
-        operands = self.resolve_operands(args, func_type.inputs)
-
         self._parse_optional_location()
+
+        operands = self.resolve_operands(args, func_type.inputs)
 
         return op_type.create(
             operands=operands,

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -800,7 +800,7 @@ class Parser(AttrParser):
     def resolve_operands(
         self,
         args: Sequence[UnresolvedOperand],
-        input_types: Sequence[Attribute],
+        input_types: ArrayAttr[Attribute],
         error_pos: Position,
     ) -> Sequence[SSAValue]:
         """

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Sequence, cast
 
 from xdsl.dialects.builtin import (
-    ArrayAttr,
     DictionaryAttr,
     ModuleOp,
     UnregisteredAttr,
@@ -800,7 +799,7 @@ class Parser(AttrParser):
     def resolve_operands(
         self,
         args: Sequence[UnresolvedOperand],
-        input_types: ArrayAttr[Attribute],
+        input_types: Iterable[Attribute],
         error_pos: Position,
     ) -> Sequence[SSAValue]:
         """


### PR DESCRIPTION
Currently some hand-written parsers do not resolve operands correctly. This helper function will reduce the boilerplate needed to resolve operands.