### PR TITLE
documentation: (toy) use MLIROptPass to lower affine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,13 @@ pytest-nb:
 	pytest -W error --nbval -vv docs --ignore=docs/mlir_interoperation.ipynb --nbval-current-env
 
 # run tests for Toy tutorial
-tests-toy:
+filecheck-toy:
 	lit -v docs/Toy/examples --order=smart
+
+pytest-toy:
 	pytest docs/Toy/toy/tests
+
+tests-toy: filecheck-toy pytest-toy
 
 # run all tests
 tests: pytest tests-toy filecheck pytest-nb pyright

--- a/docs/Toy/examples/interpret.toy
+++ b/docs/Toy/examples/interpret.toy
@@ -3,6 +3,7 @@
 # RUN: python -m toy %s --emit=toy-inline | filecheck %s
 # RUN: python -m toy %s --emit=toy-infer-shapes | filecheck %s
 # RUN: python -m toy %s --emit=affine | filecheck %s
+# RUN: python -m toy %s --emit=scf | filecheck %s
 
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/tests/with-mlir/interpret.toy
+++ b/docs/Toy/examples/tests/with-mlir/interpret.toy
@@ -1,8 +1,4 @@
-# RUN: python -m toy %s --emit=toy | filecheck %s
-# RUN: python -m toy %s --emit=toy-opt | filecheck %s
-# RUN: python -m toy %s --emit=toy-inline | filecheck %s
-# RUN: python -m toy %s --emit=toy-infer-shapes | filecheck %s
-# RUN: python -m toy %s --emit=affine | filecheck %s
+# RUN: python -m toy %s --emit=scf | filecheck %s
 
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/tests/with-mlir/lit.local.cfg
+++ b/docs/Toy/examples/tests/with-mlir/lit.local.cfg
@@ -1,0 +1,4 @@
+import shutil
+
+if not shutil.which("mlir-opt"):
+    config.unsupported = True

--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -3,9 +3,11 @@ from pathlib import Path
 
 from xdsl.interpreters.affine import AffineFunctions
 from xdsl.interpreters.arith import ArithFunctions
+from xdsl.interpreters.builtin import BuiltinFunctions
 from xdsl.interpreters.func import FuncFunctions
 from xdsl.interpreters.memref import MemrefFunctions
 from xdsl.interpreters.printf import PrintfFunctions
+from xdsl.interpreters.scf import ScfFunctions
 from xdsl.parser import Parser as IRParser
 from xdsl.printer import Printer
 
@@ -26,6 +28,7 @@ parser.add_argument(
         "toy-inline",
         "toy-infer-shapes",
         "affine",
+        "scf",
     ],
     default="toy-infer-shapes",
     help="Action to perform on source file (default: toy-infer-shapes)",
@@ -69,10 +72,14 @@ def main(path: Path, emit: str, ir: bool, print_generic: bool):
         interpreter.register_implementations(ToyFunctions())
     if emit in ("affine"):
         interpreter.register_implementations(AffineFunctions())
-        interpreter.register_implementations(MemrefFunctions())
+    if emit in ("affine", "scf", "cf"):
         interpreter.register_implementations(ArithFunctions())
+        interpreter.register_implementations(MemrefFunctions())
         interpreter.register_implementations(PrintfFunctions())
         interpreter.register_implementations(FuncFunctions())
+    if emit == "scf":
+        interpreter.register_implementations(ScfFunctions())
+        interpreter.register_implementations(BuiltinFunctions())
     interpreter.call_op("main", ())
 
 


### PR DESCRIPTION
This is the first non-xdsl pass in Toy, I'm not sure whether it would be worth reimplementing `--canonicalise`, `--cse`, and `--lower-affine` in the short term.