### PR TITLE
misc: make pyright only runs on .py files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,6 @@ precommit-install:
 precommit:
 	pre-commit run --all
 
-
-
-
 # run pyright on all files in the current git commit
 pyright:
 	pyright $(shell git diff --staged --name-only  -- '*.py')

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,12 @@ precommit-install:
 precommit:
 	pre-commit run --all
 
+
+
+
 # run pyright on all files in the current git commit
 pyright:
-	pyright $(shell git diff --staged --name-only)
+	pyright $(shell git diff --staged --name-only  -- '*.py')
 
 # run black on all files currently staged
 black:


### PR DESCRIPTION
I frequently run `make tests` (thanks again) and this is minor noise when the diff contains files that aren't Python.