### PR TITLE
[WIP] dialects: Add print_int, print_char ops.

### DIFF
--- a/tests/filecheck/dialects/print/print_basics.mlir
+++ b/tests/filecheck/dialects/print/print_basics.mlir
@@ -11,6 +11,7 @@ builtin.module {
     printf.print_format "{}", %144 : i32
     printf.print_format "{}", %144 : i32 {unit}
     "printf.print_char"(%12) : (i32) -> ()
+    "printf.print_int"(%12) : (i32) -> ()
 }
 
 // CHECK:       printf.print_format "Hello world!"
@@ -20,3 +21,4 @@ builtin.module {
 // CHECK-NEXT:  printf.print_format "{}", %0 : i32
 // CHECK-NEXT:  printf.print_format "{}", %0 : i32 {"unit"}
 // CHECK-NEXT:  "printf.print_char"(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT:  "printf.print_int"(%{{.*}}) : (i32) -> ()

--- a/tests/filecheck/dialects/print/print_basics.mlir
+++ b/tests/filecheck/dialects/print/print_basics.mlir
@@ -10,6 +10,7 @@ builtin.module {
 
     printf.print_format "{}", %144 : i32
     printf.print_format "{}", %144 : i32 {unit}
+    "printf.print_char"(%12) : (i32) -> ()
 }
 
 // CHECK:       printf.print_format "Hello world!"
@@ -18,3 +19,4 @@ builtin.module {
 // CHECK-NEXT:  printf.print_format "Uses vals twice {} {} {} {}", %1 : i32, %0 : i32, %1 : i32, %0 : i32
 // CHECK-NEXT:  printf.print_format "{}", %0 : i32
 // CHECK-NEXT:  printf.print_format "{}", %0 : i32 {"unit"}
+// CHECK-NEXT:  "printf.print_char"(%{{.*}}) : (i32) -> ()

--- a/tests/filecheck/dialects/print/printchar_to_putchar.mlir
+++ b/tests/filecheck/dialects/print/printchar_to_putchar.mlir
@@ -1,0 +1,14 @@
+// RUN: xdsl-opt -p lower-printchar-to-putchar %s | xdsl-opt | filecheck %s
+
+builtin.module {
+    // 4 in ascii
+    "func.func"() ({
+        %4 = arith.constant 52 : i32
+        "printf.print_char"(%4) : (i32) -> ()
+	"func.return"() : () -> ()
+    }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
+}
+
+// CHECK: %{{.*}} = arith.constant 52 : i32
+// CHECK-NEXT: %{{.*}} = "func.call"(%{{.*}}) {"callee" = @putchar} : (i32) -> i32
+// CHECK: func.func private @putchar(i32) -> i32

--- a/tests/filecheck/dialects/print/printchar_to_putchar.mlir
+++ b/tests/filecheck/dialects/print/printchar_to_putchar.mlir
@@ -5,6 +5,7 @@ builtin.module {
     "func.func"() ({
         %4 = arith.constant 52 : i32
         "printf.print_char"(%4) : (i32) -> ()
+        "printf.print_int"(%4) : (i32) -> ()
 	"func.return"() : () -> ()
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()
 }

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -99,7 +99,17 @@ class PrintCharOp(IRDLOperation):
     char: Operand = operand_def()
 
 
+@irdl_op_definition
+class PrintIntOp(IRDLOperation):
+    """
+    Print a single Integer
+    """
+
+    name = "printf.print_int"
+    int: Operand = operand_def(builtin.IntegerType)
+
+
 Printf = Dialect(
-    [PrintFormatOp, PrintCharOp],
+    [PrintFormatOp, PrintCharOp, PrintIntOp],
     [],
 )

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -4,9 +4,11 @@ from xdsl.dialects import builtin
 from xdsl.ir import Dialect, Operation, SSAValue, VerifyException
 from xdsl.irdl import (
     IRDLOperation,
+    Operand,
     VarOperand,
     attr_def,
     irdl_op_definition,
+    operand_def,
     var_operand_def,
 )
 from xdsl.parser import Parser
@@ -85,9 +87,19 @@ class PrintFormatOp(IRDLOperation):
         return op
 
 
+@irdl_op_definition
+class PrintCharOp(IRDLOperation):
+    """
+    Print a single character
+
+    Equivalent to putchar in C.
+    """
+
+    name = "printf.print_char"
+    char: Operand = operand_def()
+
+
 Printf = Dialect(
-    [
-        PrintFormatOp,
-    ],
+    [PrintFormatOp, PrintCharOp],
     [],
 )

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -42,6 +42,7 @@ from xdsl.transforms import (
     lower_snitch_runtime,
     mlir_opt,
     printf_to_llvm,
+    printf_to_putchar,
     reconcile_unrealized_casts,
     riscv_register_allocation,
 )
@@ -100,6 +101,7 @@ def get_all_passes() -> list[type[ModulePass]]:
         lower_snitch_runtime.LowerSnitchRuntimePass,
         mlir_opt.MLIROptPass,
         printf_to_llvm.PrintfToLLVM,
+        printf_to_putchar.LowerPrintCharToPutcharPass,
         riscv_register_allocation.RISCVRegisterAllocation,
         RISCVLowerArith,
         stencil_shape_inference.StencilShapeInferencePass,

--- a/xdsl/transforms/printf_to_putchar.py
+++ b/xdsl/transforms/printf_to_putchar.py
@@ -1,0 +1,40 @@
+from xdsl.dialects import func
+from xdsl.dialects.builtin import ModuleOp, i32
+from xdsl.dialects.printf import PrintCharOp
+from xdsl.ir.core import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class LowerPrintCharToPutchar(RewritePattern):
+    """
+    Rewrite Pattern that rewrites printf.print_char to an
+    external function call
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: PrintCharOp, rewriter: PatternRewriter, /):
+        func_call = func.Call.get("putchar", [op.char], [i32])
+        # Add empty new_results, since a result is necessary for linking
+        # putchar, but the result does not exist anywhere.
+        rewriter.replace_matched_op(func_call, new_results=[])
+
+
+class LowerPrintCharToPutcharPass(ModulePass):
+    name = "lower-printchar-to-putchar"
+
+    # lower to func.call
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        walker = PatternRewriteWalker(
+            GreedyRewritePatternApplier([LowerPrintCharToPutchar()]),
+            apply_recursively=True,
+        )
+        walker.rewrite_module(op)
+        # Add external putchar reference
+        op.body.block.add_ops([func.FuncOp.external("putchar", [i32], [i32])])

--- a/xdsl/transforms/printf_to_putchar.py
+++ b/xdsl/transforms/printf_to_putchar.py
@@ -1,7 +1,8 @@
-from xdsl.dialects import func
-from xdsl.dialects.builtin import ModuleOp, i32
-from xdsl.dialects.printf import PrintCharOp
-from xdsl.ir.core import MLContext
+from xdsl.builder import ImplicitBuilder
+from xdsl.dialects import arith, func, scf
+from xdsl.dialects.builtin import IndexType, ModuleOp, f32, i32
+from xdsl.dialects.printf import PrintCharOp, PrintIntOp
+from xdsl.ir.core import Block, MLContext
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -10,6 +11,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.printer import Printer
 
 
 class LowerPrintCharToPutchar(RewritePattern):
@@ -26,15 +28,125 @@ class LowerPrintCharToPutchar(RewritePattern):
         rewriter.replace_matched_op(func_call, new_results=[])
 
 
+class ConvertPrintIntToItoa(RewritePattern):
+    """
+    Rewrite Pattern that rewrites printf.print_int to an
+    inline_itoa function
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: PrintIntOp, rewriter: PatternRewriter, /):
+        func_call = func.Call.get("inline_itoa", [op.int], [])
+        rewriter.replace_matched_op(func_call)
+
+
+def get_inline_itoa():
+    inline_itoa_func = func.FuncOp("inline_itoa", ((i32,), ()))
+    with ImplicitBuilder(inline_itoa_func.body) as (integer,):
+        zero = arith.Constant.from_int_and_width(0, i32)
+        is_negative = arith.Cmpi.get(integer, zero, "slt")
+        # If the value is zero, just print one zero
+        is_zero = arith.Cmpi.get(integer, zero, "eq")
+        is_zero_block = Block()
+        # If is_zero is true:
+        with ImplicitBuilder(is_zero_block):
+            ascii_zero = arith.Constant.from_int_and_width(48, i32)
+            # The ascii value for zero is 48 in decimal
+            PrintCharOp((ascii_zero,))
+            scf.Yield.get()
+        # If is_zero is false:
+        is_not_zero_block = Block()
+        with ImplicitBuilder(is_not_zero_block):
+            # If the value is negative, print the minus sign, return abs value
+            is_negative_block = Block()
+            with ImplicitBuilder(is_negative_block):
+                ascii_minus = arith.Constant.from_int_and_width(52, i32)
+                PrintCharOp((ascii_minus,))
+                negative_input = arith.Subi(zero, integer)
+                scf.Yield.get(negative_input)
+            # If the value is positive, just continue
+            is_positive_block = Block()
+            with ImplicitBuilder(is_positive_block):
+                scf.Yield.get(integer)
+            absolute_value = scf.If.get(
+                is_negative, [i32], [is_negative_block], [is_positive_block]
+            )
+            one = arith.Constant.from_int_and_width(1, i32)
+            plus_one = arith.Addi(absolute_value, one)
+            # FIXME has to be unsigned
+            plus_one_fp = arith.SIToFPOp((plus_one,), (f32,))
+            # FIXME this has to be replaced with a log10 op!
+            # %size = math.log10 %plus_one_fp : f32
+            # %size_ceiled = math.ceil %size : f32
+            # FIXME has to be signed
+            size_int = arith.FPToSIOp((plus_one_fp,), (i32,))
+
+            # Using indexes here, since ints are not supported
+            # by scf.for (for now?)
+            zero_index = arith.Constant.from_int_and_width(0, IndexType())
+            one_index = arith.Constant.from_int_and_width(1, IndexType())
+            size_int_index = arith.IndexCastOp((size_int,), (IndexType(),))
+
+            loop_body = Block(arg_types=(IndexType(),))
+            with ImplicitBuilder(loop_body) as (index_var,):
+                size_minus_one = arith.Subi(size_int, one)
+                index_var_int = arith.IndexCastOp((index_var,), (i32,))
+                position = arith.Subi(size_minus_one, index_var_int)
+                # digit = (num // (10**pos)) % 10
+                ten = arith.Constant.from_int_and_width(10, i32)
+                # FIXME, line below actually has to be:
+                # %i_0 = "math.ipowi"(%ten, %position): (i32, i32)-> i32
+                i_0 = arith.Addi(ten, position)
+                i_1 = arith.DivUI(absolute_value, i_0)
+                digit = arith.RemUI(i_1, ten)
+                # ascii value for zero is 48 in decimal
+                ascii_offset = arith.Constant.from_int_and_width(48, i32)
+                char = arith.Addi(digit, ascii_offset)
+                PrintCharOp((char,))
+                scf.Yield.get()
+            scf.For.get(zero_index, size_int_index, one_index, (), loop_body)
+
+            scf.Yield.get()
+        scf.If.get(
+            is_zero,
+            [],
+            [is_zero_block],
+            [is_not_zero_block],
+        )
+        func.Return()
+
+    return inline_itoa_func
+
+
+if __name__ == "__main__":
+    printer = Printer()
+    printer.print(get_inline_itoa())
+
+
 class LowerPrintCharToPutcharPass(ModulePass):
     name = "lower-printchar-to-putchar"
 
     # lower to func.call
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
-        walker = PatternRewriteWalker(
+        print_int_walker = PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    ConvertPrintIntToItoa(),
+                ]
+            ),
+            apply_recursively=True,
+        )
+        print_int_walker.rewrite_module(op)
+        # This has to happen first, since inline itoa
+        # contains some references to printf.print_char
+        op.body.block.add_ops([get_inline_itoa()])
+        # Add function implementation for inline_itoa
+        # TODO Don't insert this if the operation is not there!
+        print_char_walker = PatternRewriteWalker(
             GreedyRewritePatternApplier([LowerPrintCharToPutchar()]),
             apply_recursively=True,
         )
-        walker.rewrite_module(op)
+        print_char_walker.rewrite_module(op)
         # Add external putchar reference
+        # TODO Don't insert this if the operation is not there!
         op.body.block.add_ops([func.FuncOp.external("putchar", [i32], [i32])])


### PR DESCRIPTION
Hi, this is an initial PR for adding more self-contained printing capabilities to the `printf` dialect.
I'm still unsure about a lot of stuff, and it is not finished yet, some initial help is appreciated!

## This PR adds:
Two new ops:
* A "printf.print_char" op. An operation that prints a single character, that is taken in as a 32-bit integer.
* A "printf.print_int" op. An operation that prints a 32 bit integer.
One pass `lower-printchar-to-putchar` (naming suggestions welcome!) that implements:
* A rewrite from `print_int` to a `func.func  inline_itoa` calls. The implementation of `inline_itoa` is inserted in the pass. `Inline_itoa` was written in MLIR assembly directly.
* A rewrite that lowers `print_char`s to C style `put_chars`. 

## Rationale
Some platforms don't ship with printf implementations or are very bad at printing. This implementation allows for printing integers:
* without relying much on external libraries (besides `put_char`)
* at (maybe?) increased performance, since now MLIR-passes can actually perform constant folding and the likes.
I think we can (if necessary) even write a pass that composes the current `printf.format()` into `print_char`s and `print_int`s if necessary.

Why a `print_char` op?
* Because I felt like using putchar directly was a bit ugly (it returns what it puts, which you typically don't really need, I believe, and because some other platforms might implement these calls in a different way than the standard C approach.

Why a `print_int` op?
* Some platforms implement this directly. It is for example available as a RISC-V syscall.

## Still missing/Questions/Concerns
* It feels like I'm not implementing signless semantics properly (should I make a signed print and unsigned print instead?). The implementation currently tests if the value is negative, and then prints a minus sign if necessary.
* I feel like the added itoa routine is not very easy to read and/or review. Any ideas on making this easier?
* Should I keep this limited to 32-bit integers?
* Some ops in the conversion seem to be still missing in xdsl (math.log10?), I'll work on these next.