### PR TITLE
core: Add declarative assembly format specification to IRDL

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.ir.core import MLContext, Operation
+from xdsl.irdl import IRDLOperation, irdl_op_definition
+from xdsl.parser.core import Parser
+from xdsl.printer import Printer
+from xdsl.utils.exceptions import PyRDLOpDefinitionError
+
+################################################################################
+# Utils for this test file                                                     #
+################################################################################
+
+
+def check_roundtrip(program: str, ctx: MLContext):
+    """Check that the given program roundtrips exactly (including whitespaces)."""
+    parser = Parser(ctx, program)
+    ops: list[Operation] = []
+    while op := parser.parse_optional_operation():
+        ops.append(op)
+
+    res_io = StringIO()
+    printer = Printer(stream=res_io)
+    for op in ops[:-1]:
+        printer.print_op(op)
+        printer.print("\n")
+    printer.print_op(ops[-1])
+
+    assert program == res_io.getvalue()
+
+
+def check_equivalence(program1: str, program2: str, ctx: MLContext):
+    """Check that the given programs are structurally equivalent."""
+
+    parser = Parser(ctx, program1)
+    ops1: list[Operation] = []
+    while op := parser.parse_optional_operation():
+        ops1.append(op)
+
+    parser = Parser(ctx, program2)
+    ops2: list[Operation] = []
+    while op := parser.parse_optional_operation():
+        ops2.append(op)
+
+    assert ModuleOp(ops1).is_structurally_equivalent(ModuleOp(ops2))
+
+
+################################################################################
+# Tests that we cannot have both a declarative and Python-defined format       #
+################################################################################
+
+
+def test_format_and_print_op():
+    """
+    Check that an operation with an assembly format cannot redefine the print method.
+    """
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="Cannot define both an assembly format"
+    ):
+
+        @irdl_op_definition
+        class FormatAndPrintOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.format_and_print"
+
+            assembly_format = "attr-dict"
+
+            def print(self, printer: Printer) -> None:
+                pass
+
+
+def test_format_and_parse_op():
+    """
+    Check that an operation with an assembly format cannot redefine the parse method.
+    """
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="Cannot define both an assembly format"
+    ):
+
+        @irdl_op_definition
+        class FormatAndParseOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.format_and_parse"
+
+            assembly_format = "attr-dict"
+
+            @classmethod
+            def parse(cls, parser: Parser) -> FormatAndParseOp:
+                raise NotImplementedError()
+
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="Cannot define both an assembly format"
+    ):
+
+        @irdl_op_definition
+        class FormatAndParseOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.format_and_parse"
+
+            assembly_format = "attr-dict"
+
+            @classmethod
+            def parse(cls, parser: Parser) -> FormatAndParseOp:
+                raise NotImplementedError()
+
+
+################################################################################
+# 'attr-dict' directive                                                        #
+################################################################################
+
+
+def test_expected_attr_dict():
+    """Check that an attr-dict directive is expected."""
+
+    with pytest.raises(PyRDLOpDefinitionError, match="'attr-dict' directive not found"):
+
+        @irdl_op_definition
+        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.no_attr_dict"
+
+            assembly_format = ""
+
+
+def test_two_attr_dicts():
+    """Check that we cannot have two attr-dicts."""
+
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+    ):
+
+        @irdl_op_definition
+        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.no_attr_dict"
+
+            assembly_format = "attr-dict attr-dict"
+
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+    ):
+
+        @irdl_op_definition
+        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.no_attr_dict"
+
+            assembly_format = "attr-dict attr-dict-with-keyword"
+
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+    ):
+
+        @irdl_op_definition
+        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.no_attr_dict"
+
+            assembly_format = "attr-dict-with-keyword attr-dict"
+
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+    ):
+
+        @irdl_op_definition
+        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.no_attr_dict"
+
+            assembly_format = "attr-dict-with-keyword attr-dict-with-keyword"
+
+
+@irdl_op_definition
+class AttrDictOp(IRDLOperation):
+    name = "test.attr_dict"
+
+    assembly_format = "attr-dict"
+
+
+@irdl_op_definition
+class AttrDictWithKeywordOp(IRDLOperation):
+    name = "test.attr_dict_with_keyword"
+
+    assembly_format = "attr-dict-with-keyword"
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        ("test.attr_dict", '"test.attr_dict"() : () -> ()'),
+        ("test.attr_dict_with_keyword", '"test.attr_dict_with_keyword"() : () -> ()'),
+        (
+            'test.attr_dict {"a" = 2 : i32}',
+            '"test.attr_dict"() {"a" = 2 : i32} : () -> ()',
+        ),
+        (
+            'test.attr_dict_with_keyword attributes {"a" = 2 : i32}',
+            '"test.attr_dict_with_keyword"() {"a" = 2 : i32} : () -> ()',
+        ),
+    ],
+)
+def test_attr_dict(program: str, generic_program: str):
+    """Test the 'attr-dict' and 'attr-dict-with-keyword' directives."""
+    ctx = MLContext()
+    ctx.register_op(AttrDictOp)
+    ctx.register_op(AttrDictWithKeywordOp)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -112,7 +112,7 @@ def test_two_attr_dicts():
     """Check that we cannot have two attr-dicts."""
 
     with pytest.raises(
-        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+        PyRDLOpDefinitionError, match="'attr-dict' directive can only occur once"
     ):
 
         @irdl_op_definition
@@ -122,7 +122,7 @@ def test_two_attr_dicts():
             assembly_format = "attr-dict attr-dict"
 
     with pytest.raises(
-        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+        PyRDLOpDefinitionError, match="'attr-dict' directive can only occur once"
     ):
 
         @irdl_op_definition
@@ -132,7 +132,7 @@ def test_two_attr_dicts():
             assembly_format = "attr-dict attr-dict-with-keyword"
 
     with pytest.raises(
-        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+        PyRDLOpDefinitionError, match="'attr-dict' directive can only occur once"
     ):
 
         @irdl_op_definition
@@ -142,7 +142,7 @@ def test_two_attr_dicts():
             assembly_format = "attr-dict-with-keyword attr-dict"
 
     with pytest.raises(
-        PyRDLOpDefinitionError, match="'attr-dict' directive has already been seen"
+        PyRDLOpDefinitionError, match="'attr-dict' directive can only occur once"
     ):
 
         @irdl_op_definition

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -63,7 +63,7 @@ def test_format_and_print_op():
     ):
 
         @irdl_op_definition
-        class FormatAndPrintOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class FormatAndPrintOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.format_and_print"
 
             assembly_format = "attr-dict"
@@ -81,21 +81,7 @@ def test_format_and_parse_op():
     ):
 
         @irdl_op_definition
-        class FormatAndParseOp(IRDLOperation):  # type: ignore[reportUnusedImport]
-            name = "test.format_and_parse"
-
-            assembly_format = "attr-dict"
-
-            @classmethod
-            def parse(cls, parser: Parser) -> FormatAndParseOp:
-                raise NotImplementedError()
-
-    with pytest.raises(
-        PyRDLOpDefinitionError, match="Cannot define both an assembly format"
-    ):
-
-        @irdl_op_definition
-        class FormatAndParseOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class FormatAndParseOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.format_and_parse"
 
             assembly_format = "attr-dict"

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -5,9 +5,9 @@ from io import StringIO
 import pytest
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir.core import MLContext, Operation
+from xdsl.ir import MLContext, Operation
 from xdsl.irdl import IRDLOperation, irdl_op_definition
-from xdsl.parser.core import Parser
+from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import PyRDLOpDefinitionError
 
@@ -20,7 +20,7 @@ def check_roundtrip(program: str, ctx: MLContext):
     """Check that the given program roundtrips exactly (including whitespaces)."""
     parser = Parser(ctx, program)
     ops: list[Operation] = []
-    while op := parser.parse_optional_operation():
+    while (op := parser.parse_optional_operation()) is not None:
         ops.append(op)
 
     res_io = StringIO()
@@ -38,12 +38,12 @@ def check_equivalence(program1: str, program2: str, ctx: MLContext):
 
     parser = Parser(ctx, program1)
     ops1: list[Operation] = []
-    while op := parser.parse_optional_operation():
+    while (op := parser.parse_optional_operation()) is not None:
         ops1.append(op)
 
     parser = Parser(ctx, program2)
     ops2: list[Operation] = []
-    while op := parser.parse_optional_operation():
+    while (op := parser.parse_optional_operation()) is not None:
         ops2.append(op)
 
     assert ModuleOp(ops1).is_structurally_equivalent(ModuleOp(ops2))

--- a/xdsl/irdl/__init__.py
+++ b/xdsl/irdl/__init__.py
@@ -1,0 +1,1 @@
+from .irdl import *

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1,0 +1,152 @@
+"""
+This file contains the data structures necessary for the parsing and printing
+of the MLIR declarative assembly format defined at
+https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-format .
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+from xdsl.ir import Attribute
+from xdsl.irdl import IRDLOperation, IRDLOperationInvT, OpDef
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.utils.lexer import Token
+
+
+@dataclass
+class ParsingState:
+    """
+    State carried during the parsing of an operation using the declarative assembly
+    format.
+    It contains the elements that have already been parsed.
+    """
+
+    attributes: dict[str, Attribute]
+
+    def __init__(self, op_def: OpDef):
+        if (
+            op_def.operands
+            or op_def.results
+            or op_def.attributes
+            or op_def.regions
+            or op_def.successors
+        ):
+            raise NotImplementedError(
+                "Operation definitions with operands, results, attributes, regions, "
+                "or successors are not yet supported"
+            )
+        self.attributes = {}
+
+
+@dataclass
+class PrintingState:
+    """
+    State carried during the printing of an operation using the declarative assembly
+    format.
+    It contains information on the last token, to know if a space should be emitted.
+    """
+
+    last_was_punctuation: bool = field(default=False)
+    """Was the last element parsed a punctuation."""
+    should_emit_space: bool = field(default=True)
+    """
+    Should the printer emit a space before the next element.
+    Depending on the directive, the space might not be printed
+    (for instance for some punctuations).
+    """
+
+
+@dataclass(frozen=True)
+class FormatProgram:
+    """
+    The toplevel data structure of a declarative assembly format program.
+    It is used to parse and print an operation.
+    """
+
+    stmts: list[FormatDirective]
+    """The list of statements composing the program. They are executed in order."""
+
+    @staticmethod
+    def from_str(input: str, op_def: OpDef) -> FormatProgram:
+        """
+        Create the assembly format data program from its string representation.
+        This might raise a ParseError exception if the string is invalid.
+        """
+        from xdsl.irdl.declarative_assembly_format_parser import FormatParser
+
+        return FormatParser(input, op_def).parse_format()
+
+    def parse(
+        self, parser: Parser, op_type: type[IRDLOperationInvT]
+    ) -> IRDLOperationInvT:
+        """
+        Parse the operation with this format.
+        The given operation type is expected to be the operation type represented by
+        the operation definition passed to the FormatParser that created this
+        FormatProgram.
+        """
+        # Parse elements one by one
+        state = ParsingState(op_type.irdl_definition)
+        for stmt in self.stmts:
+            stmt.parse(parser, state)
+
+        return op_type.build(attributes=state.attributes)
+
+    def print(self, printer: Printer, op: IRDLOperation) -> None:
+        """
+        Print the operation with this format.
+        The given operation is expected to be defined using the operation definition
+        passed to the FormatParser that created this FormatProgram.
+        """
+        state = PrintingState()
+        for stmt in self.stmts:
+            stmt.print(printer, state, op)
+
+
+@dataclass(frozen=True)
+class FormatDirective(ABC):
+    """A format directive for operation format."""
+
+    @abstractmethod
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        ...
+
+    @abstractmethod
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class AttrDictDirective(FormatDirective):
+    """
+    An attribute dictionary directive, with the following format:
+       attr-dict-directive ::= attr-dict
+       attr-dict-with-format-directive ::= `attributes` attr-dict
+    The directive (with and without the keyword) will always print a space before, and
+    will not request a space to be printed after.
+    """
+
+    with_keyword: bool
+    """If this is set, the format starts with the `attributes` keyword."""
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        if self.with_keyword:
+            res = parser.parse_optional_attr_dict_with_keyword()
+            if res is None:
+                res = {}
+            else:
+                res = res.data
+        else:
+            res = parser.parse_optional_attr_dict()
+        state.attributes = res
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if op.attributes:
+            if self.with_keyword:
+                printer.print(" attributes")
+            printer.print_op_attributes(op.attributes)
+        state.last_was_punctuation = False
+        state.should_emit_space = False

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -13,7 +13,6 @@ from xdsl.ir import Attribute
 from xdsl.irdl import IRDLOperation, IRDLOperationInvT, OpDef
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.utils.lexer import Token
 
 
 @dataclass

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -1,0 +1,149 @@
+"""
+This file contains a lexer and a parser for the MLIR declarative assembly format:
+https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-format
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+from xdsl.irdl import OpDef
+from xdsl.irdl.declarative_assembly_format import (
+    AttrDictDirective,
+    FormatDirective,
+    FormatProgram,
+)
+from xdsl.parser import BaseParser, ParserState
+from xdsl.utils.lexer import Input, Lexer, Token
+
+
+@dataclass
+class FormatLexer(Lexer):
+    """
+    A lexer for the declarative assembly format.
+    The differences with the MLIR lexer are the following:
+    * It can parse '`' or '$' as tokens. The token will have the `BARE_IDENT` kind.
+    * Bare identifiers may also may contain `-`.
+    """
+
+    def lex(self) -> Token:
+        """Lex a token from the input, and returns it."""
+        # First, skip whitespaces
+        self._consume_whitespace()
+
+        start_pos = self.pos
+        current_char = self._peek_chars()
+
+        # Handle end of file
+        if current_char is None:
+            return self._form_token(Token.Kind.EOF, start_pos)
+
+        # We parse '`' and '$' as a BARE_IDENT.
+        # This is a hack to reuse the MLIR lexer.
+        if current_char in ("`", "$"):
+            self._consume_chars()
+            return self._form_token(Token.Kind.BARE_IDENT, start_pos)
+        return super().lex()
+
+    # Authorize `-` in bare identifier
+    _bare_identifier_suffix_regex = re.compile(r"[a-zA-Z0-9_$.\-]*")
+
+
+class ParsingContext(Enum):
+    """Indicates if the parser is nested in a particular directive."""
+
+    TopLevel = auto()
+    TypeDirective = auto()
+
+
+@dataclass(init=False)
+class FormatParser(BaseParser):
+    """
+    Parser for the declarative assembly format.
+    The parser keeps track of the operands, operand types, results, regions, and
+    attributes that are already parsed, and checks at the end that the provided format
+    is correct, i.e., that it is unambiguous and refer to all elements exactly once.
+    """
+
+    op_def: OpDef
+    """The operation definition we are parsing the format for."""
+    seen_operands: list[bool]
+    """The operand variables that are already parsed."""
+    seen_operand_types: list[bool]
+    """The operand types that are already parsed."""
+    has_attr_dict: bool = field(default=False)
+    """True if the attribute dictionary has already been parsed."""
+    context: ParsingContext = field(default=ParsingContext.TopLevel)
+    """Indicates if the parser is nested in a particular directive."""
+
+    def __init__(self, input: str, op_def: OpDef):
+        super().__init__(ParserState(FormatLexer(Input(input, "<input>"))))
+        self.op_def = op_def
+        self.seen_operands = [False] * len(op_def.operands)
+        self.seen_operand_types = [False] * len(op_def.operands)
+
+    def parse_format(self) -> FormatProgram:
+        """
+        Parse a declarative format, with the following syntax:
+          format ::= directive*
+        Once the format is parsed, check that it is correct, i.e., that it is
+        unambiguous and refer to all elements exactly once.
+        """
+        elements: list[FormatDirective] = []
+        while self._current_token.kind != Token.Kind.EOF:
+            elements.append(self.parse_directive())
+
+        self.verify_attr_dict()
+        self.verify_operands()
+        return FormatProgram(elements)
+
+    def verify_operands(self):
+        """
+        Check that all operands and operand types are refered at least once.
+        """
+        for operand, operand_type, (operand_name, _) in zip(
+            self.seen_operands, self.seen_operand_types, self.op_def.operands
+        ):
+            if not operand:
+                self.raise_error(
+                    f"operand '{operand_name}' "
+                    f"not found, consider adding a '${operand_name}' "
+                    "directive to the custom assembly format"
+                )
+            if not operand_type:
+                self.raise_error(
+                    f"type of operand '{operand_name}' not found, consider "
+                    f"adding a 'type(${operand_name})' directive to the custom "
+                    "assembly format"
+                )
+
+    def verify_attr_dict(self):
+        """
+        Check that the attribute dictionary is present.
+        """
+        if not self.has_attr_dict:
+            self.raise_error("'attr-dict' directive not found")
+
+    def parse_directive(self) -> FormatDirective:
+        """
+        Parse a format directive, with the following forrmat:
+          directive ::= `attr-dict`
+                        | `attr-dict-with-keyword`
+                        | type-directive
+                        | keyword-or-punctuation-directive
+                        | variable
+        """
+        if self.parse_optional_keyword("attr-dict"):
+            return self.create_attr_dict_directive(False)
+        if self.parse_optional_keyword("attr-dict-with-keyword"):
+            return self.create_attr_dict_directive(True)
+        self.raise_error(f"unexpected token '{self._current_token.text}'")
+
+    def create_attr_dict_directive(self, with_keyword: bool) -> AttrDictDirective:
+        """Create an attribute dictionary directive, and update the parsing state."""
+        if self.has_attr_dict:
+            self.raise_error("'attr-dict' directive has already been seen")
+        self.has_attr_dict = True
+        return AttrDictDirective(with_keyword=with_keyword)

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -144,6 +144,9 @@ class FormatParser(BaseParser):
     def create_attr_dict_directive(self, with_keyword: bool) -> AttrDictDirective:
         """Create an attribute dictionary directive, and update the parsing state."""
         if self.has_attr_dict:
-            self.raise_error("'attr-dict' directive has already been seen")
+            self.raise_error(
+                "'attr-dict' directive can only occur once "
+                "in the assembly format description"
+            )
         self.has_attr_dict = True
         return AttrDictDirective(with_keyword=with_keyword)

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -128,7 +128,7 @@ class FormatParser(BaseParser):
 
     def parse_directive(self) -> FormatDirective:
         """
-        Parse a format directive, with the following forrmat:
+        Parse a format directive, with the following format:
           directive ::= `attr-dict`
                         | `attr-dict-with-keyword`
                         | type-directive

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1830,10 +1830,12 @@ def irdl_op_definition(cls: type[IRDLOperationInvT]) -> type[IRDLOperationInvT]:
             ) from e
 
         @classmethod
-        def parse_with_format(cls: type[_OpT], parser: Parser) -> _OpT:
+        def parse_with_format(
+            cls: type[IRDLOperationInvT], parser: Parser
+        ) -> IRDLOperationInvT:
             return assembly_program.parse(parser, cls)
 
-        def print_with_format(self: _OpT, printer: Printer):
+        def print_with_format(self: IRDLOperationInvT, printer: Printer):
             return assembly_program.print(printer, self)
 
         new_attrs["parse"] = parse_with_format

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -1166,9 +1167,10 @@ class OpDef:
                 raise wrong_field_exception(field_name)
 
         op_def.assembly_format = pyrdl_def.assembly_format
+        assert inspect.ismethod(Operation.parse)
         if op_def.assembly_format is not None and (
             pyrdl_def.print != Operation.print
-            or not hasattr(pyrdl_def.parse, "__func__")
+            or not inspect.ismethod(pyrdl_def.parse)
             or pyrdl_def.parse.__func__ != Operation.parse.__func__
         ):
             raise PyRDLOpDefinitionError(


### PR DESCRIPTION
This PR adds the first version of the [declarative assembly format](https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-format).
In its current form, it only supports the `attr-dict` directive, which specifies where the attribute dictionary should be parsed.

The structure of the PR is:
* `irdl.py` was modified (and moved to `irdl/irdl.py`) to allow specifying a declarative format with the `assembly_format` field.
* `declarative_assembly_format_parser.py` will parse the format and create the corresponding data structures, as well as checking that the format is correct. The parser is written by reusing the MLIR format lexer and parser. This is slightly hacky, but makes the change much smaller.
* `declarative_assembly_format.py` contains the data structure to represent the declarative format, and to parse/print a particular format.

Following PRs will incrementally add more features. I couldn't really remove more from this PR without making it impossible to understand.