### PR TITLE
core: Add punctuation directive to the assembly format

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -189,3 +189,39 @@ def test_attr_dict(program: str, generic_program: str):
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
+
+
+################################################################################
+# Punctuations and keywords                                                    #
+################################################################################
+
+
+@pytest.mark.parametrize(
+    "format, program",
+    [
+        ("`)` attr-dict", "test.punctuation)"),
+        ("`(` attr-dict", "test.punctuation("),
+        ("`->` attr-dict", "test.punctuation ->"),
+        (
+            "`->` `->` attr-dict",
+            "test.punctuation -> ->",
+        ),
+        (
+            "`(` `)` attr-dict",
+            "test.punctuation()",
+        ),
+    ],
+)
+def test_punctuations_and_keywords(format: str, program: str):
+    """Test the punctuation and keyword directives."""
+
+    @irdl_op_definition
+    class PunctuationOp(IRDLOperation):
+        name = "test.punctuation"
+        assembly_format = format
+
+    ctx = MLContext()
+    ctx.register_op(PunctuationOp)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, '"test.punctuation"() : () -> ()', ctx)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -13,6 +13,7 @@ from xdsl.ir import Attribute
 from xdsl.irdl import IRDLOperation, IRDLOperationInvT, OpDef
 from xdsl.parser import Parser
 from xdsl.printer import Printer
+from xdsl.utils.lexer import Token
 
 
 @dataclass

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -149,3 +149,39 @@ class AttrDictDirective(FormatDirective):
             printer.print_op_attributes(op.attributes)
         state.last_was_punctuation = False
         state.should_emit_space = False
+
+
+@dataclass(frozen=True)
+class PunctuationDirective(FormatDirective):
+    """
+    A punctuation directive, with the following format:
+      punctuation-directive ::= punctuation
+    The directive will request a space to be printed right after, unless the punctuation
+    is `<`, `(`, `{`, or `[`.
+    It will also print a space before if a space is requested, and that the punctuation
+    is neither `>`, `)`, `}`, `]`, or `,` if the last element was a punctuation, and
+    additionally neither `<`, `(`, `}`, `]`, if the last element was not a punctuation.
+    """
+
+    punctuation: Token.PunctuationSpelling
+    """The punctuation that should be printed/parsed."""
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        parser.parse_punctuation(self.punctuation)
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        emit_space = False
+        if state.should_emit_space:
+            if state.last_was_punctuation:
+                if self.punctuation not in (">", ")", "}", "]", ","):
+                    emit_space = True
+            elif self.punctuation not in ("<", ">", "(", ")", "{", "}", "[", "]", ","):
+                emit_space = True
+
+            if emit_space:
+                printer.print(" ")
+
+        printer.print(self.punctuation)
+
+        state.should_emit_space = self.punctuation not in ("<", "(", "{", "[")
+        state.last_was_punctuation = True


### PR DESCRIPTION
This PR adds support for punctuation in the declarative assembly format.

For instance, "`(` `)` attr-dict" will parse correctly "test.op()".
Note that some punctuations will implicitly add spaces before/after them.