### PR TITLE
core: Add keyword to the declarative assembly format

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -210,6 +210,14 @@ def test_attr_dict(program: str, generic_program: str):
             "`(` `)` attr-dict",
             "test.punctuation()",
         ),
+        (
+            "`keyword` attr-dict",
+            "test.punctuation keyword",
+        ),
+        (
+            "`keyword` `,` `keyword` attr-dict",
+            "test.punctuation keyword, keyword",
+        ),
     ],
 )
 def test_punctuations_and_keywords(format: str, program: str):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -186,3 +186,26 @@ class PunctuationDirective(FormatDirective):
 
         state.should_emit_space = self.punctuation not in ("<", "(", "{", "[")
         state.last_was_punctuation = True
+
+
+@dataclass(frozen=True)
+class KeywordDirective(FormatDirective):
+    """
+    A keyword directive, with the following format:
+      keyword-directive ::= bare-ident
+    The directive expects a specific identifier, and will request a space to be printed
+    after.
+    """
+
+    keyword: str
+    """The identifier that should be printed."""
+
+    def parse(self, parser: Parser, state: ParsingState):
+        parser.parse_keyword(self.keyword)
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space:
+            printer.print(" ")
+        printer.print(self.keyword)
+        state.should_emit_space = True
+        state.last_was_punctuation = False

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -14,6 +14,7 @@ from xdsl.irdl.declarative_assembly_format import (
     AttrDictDirective,
     FormatDirective,
     FormatProgram,
+    KeywordDirective,
     PunctuationDirective,
 )
 from xdsl.parser import BaseParser, ParserState
@@ -141,7 +142,13 @@ class FormatParser(BaseParser):
             assert Token.Kind.is_spelling_of_punctuation(punctuation)
             return PunctuationDirective(punctuation)
 
-        self.raise_error("punctuation or identifier expected")
+        # Identifier case
+        ident = self.parse_optional_identifier()
+        if ident is None or ident == "`":
+            self.raise_error("punctuation or identifier expected")
+
+        self.parse_characters("`")
+        return KeywordDirective(ident)
 
     def parse_directive(self) -> FormatDirective:
         """


### PR DESCRIPTION
This PR adds keyword to the declarative assembly format.
For instance, "`keyword` attr-dict" will parse "test.op keyword" correctly.