### PR TITLE
core: Add operands in declarative assembly format

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -6,7 +6,7 @@ import pytest
 
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import MLContext, Operation
-from xdsl.irdl import IRDLOperation, irdl_op_definition
+from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import PyRDLOpDefinitionError
@@ -233,3 +233,140 @@ def test_punctuations_and_keywords(format: str, program: str):
 
     check_roundtrip(program, ctx)
     check_equivalence(program, '"test.punctuation"() : () -> ()', ctx)
+
+
+################################################################################
+# Variables                                                                    #
+################################################################################
+
+
+def test_unknown_variable():
+    """Test that variables should refer to an element in the operation."""
+    with pytest.raises(
+        PyRDLOpDefinitionError,
+        match="expected variable to refer to an operand, attribute, region, result, or successor",
+    ):
+
+        @irdl_op_definition
+        class UnknownVarOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.unknown_var_op"
+
+            assembly_format = "$var attr-dict"
+
+
+################################################################################
+# Operands                                                                     #
+################################################################################
+
+
+def test_missing_operand():
+    """Test that operands should have their type parsed."""
+    with pytest.raises(PyRDLOpDefinitionError, match="operand 'operand' not found"):
+
+        @irdl_op_definition
+        class NoOperandTypeOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.no_operand_type_op"
+            operand = operand_def()
+
+            assembly_format = "attr-dict"
+
+
+def test_operands_missing_type():
+    """Test that operands should have their type parsed"""
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="type of operand 'operand' not found"
+    ):
+
+        @irdl_op_definition
+        class NoOperandTypeOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.no_operand_type_op"
+            operand = operand_def()
+
+            assembly_format = "$operand attr-dict"
+
+
+def test_operands_duplicated_type():
+    """Test that operands should not have their type parsed twice"""
+    with pytest.raises(
+        PyRDLOpDefinitionError, match="'type' of 'operand' is already bound"
+    ):
+
+        @irdl_op_definition
+        class DuplicatedOperandTypeOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+            name = "test.duplicated_operand_type_op"
+            operand = operand_def()
+
+            assembly_format = "$operand type($operand) type($operand) attr-dict"
+
+
+@pytest.mark.parametrize(
+    "format, program, generic_program",
+    [
+        (
+            "$lhs $rhs type($lhs) type($rhs) attr-dict",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
+            "test.two_operands %0 %1 i32 i64",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
+            '"test.two_operands"(%0, %1) : (i32, i64) -> ()',
+        ),
+        (
+            "$rhs $lhs type($rhs) type($lhs) attr-dict",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
+            "test.two_operands %1 %0 i64 i32",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
+            '"test.two_operands"(%0, %1) : (i32, i64) -> ()',
+        ),
+        (
+            "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) attr-dict",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
+            "test.two_operands %0, %1 : i32, i64",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
+            '"test.two_operands"(%0, %1) : (i32, i64) -> ()',
+        ),
+    ],
+)
+def test_operands(format: str, program: str, generic_program: str):
+    """Test the parsing of operands"""
+
+    @irdl_op_definition
+    class TwoOperandsOp(IRDLOperation):
+        name = "test.two_operands"
+        lhs = operand_def()
+        rhs = operand_def()
+
+        assembly_format = format
+
+    ctx = MLContext()
+    ctx.register_op(TwoOperandsOp)
+    ctx.register_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "format, program",
+    [
+        (
+            "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) attr-dict",
+            "test.two_operands %0, %1 : i32, i64\n"
+            '%0, %1 = "test.op"() : () -> (i32, i64)',
+        ),
+    ],
+)
+def test_operands_graph_region(format: str, program: str):
+    """Test the parsing of operands in a graph region"""
+
+    @irdl_op_definition
+    class TwoOperandsOp(IRDLOperation):
+        name = "test.two_operands"
+        lhs = operand_def()
+        rhs = operand_def()
+
+        assembly_format = format
+
+    ctx = MLContext()
+    ctx.register_op(TwoOperandsOp)
+    ctx.register_dialect(Test)
+
+    check_roundtrip(program, ctx)

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -5,6 +5,7 @@ from io import StringIO
 import pytest
 
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.test import Test
 from xdsl.ir import MLContext, Operation
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def
 from xdsl.parser import Parser
@@ -248,7 +249,7 @@ def test_unknown_variable():
     ):
 
         @irdl_op_definition
-        class UnknownVarOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class UnknownVarOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.unknown_var_op"
 
             assembly_format = "$var attr-dict"
@@ -264,7 +265,7 @@ def test_missing_operand():
     with pytest.raises(PyRDLOpDefinitionError, match="operand 'operand' not found"):
 
         @irdl_op_definition
-        class NoOperandTypeOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class NoOperandTypeOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_operand_type_op"
             operand = operand_def()
 
@@ -278,7 +279,7 @@ def test_operands_missing_type():
     ):
 
         @irdl_op_definition
-        class NoOperandTypeOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class NoOperandTypeOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_operand_type_op"
             operand = operand_def()
 
@@ -292,7 +293,9 @@ def test_operands_duplicated_type():
     ):
 
         @irdl_op_definition
-        class DuplicatedOperandTypeOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class DuplicatedOperandTypeOp(  # pyright: ignore[reportUnusedClass]
+            IRDLOperation
+        ):
             name = "test.duplicated_operand_type_op"
             operand = operand_def()
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from typing import Generic
 
 from xdsl.ir import Attribute
-from xdsl.irdl import IRDLOperation, IRDLOperationInvT, OpDef
-from xdsl.parser import Parser
+from xdsl.irdl import IRDLOperation, IRDLOperationInvT, OpDef, VariadicDef
+from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Token
 
 
@@ -24,20 +26,24 @@ class ParsingState:
     It contains the elements that have already been parsed.
     """
 
+    operands: list[None | UnresolvedOperand]
+    operand_types: list[None | Attribute]
     attributes: dict[str, Attribute]
 
     def __init__(self, op_def: OpDef):
-        if (
-            op_def.operands
-            or op_def.results
-            or op_def.attributes
-            or op_def.regions
-            or op_def.successors
-        ):
+        if op_def.results or op_def.attributes or op_def.regions or op_def.successors:
             raise NotImplementedError(
-                "Operation definitions with operands, results, attributes, regions, "
+                "Operation definitions with results, attributes, regions, "
                 "or successors are not yet supported"
             )
+        for _, operand in (*op_def.operands, *op_def.results):
+            if isinstance(operand, VariadicDef):
+                raise NotImplementedError(
+                    "Operation definition with variadic operand or "
+                    "result definitions are not supported."
+                )
+        self.operands = [None] * len(op_def.operands)
+        self.operand_types = [None] * len(op_def.operands)
         self.attributes = {}
 
 
@@ -93,7 +99,17 @@ class FormatProgram:
         for stmt in self.stmts:
             stmt.parse(parser, state)
 
-        return op_type.build(attributes=state.attributes)
+        # Ensure that all operands and operand types are parsed
+        unresolved_operands = state.operands
+        assert isa(unresolved_operands, list[UnresolvedOperand])
+        operand_types = state.operand_types
+        assert isa(operand_types, list[Attribute])
+
+        # Resolve all operands
+        operands = parser.resolve_operands(
+            unresolved_operands, operand_types, parser.pos
+        )
+        return op_type.build(operands=operands, attributes=state.attributes)
 
     def print(self, printer: Printer, op: IRDLOperation) -> None:
         """
@@ -150,6 +166,56 @@ class AttrDictDirective(FormatDirective):
             printer.print_op_attributes(op.attributes)
         state.last_was_punctuation = False
         state.should_emit_space = False
+
+
+@dataclass(frozen=True)
+class OperandVariable(FormatDirective):
+    """
+    An operand variable, with the following format:
+      operand-directive ::= percent-ident
+    The directive will request a space to be printed after.
+    """
+
+    name: str
+    """The operand name. This is only used for error message reporting."""
+    index: int
+    """Index of the operand definition."""
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        operand = parser.parse_unresolved_operand()
+        state.operands[self.index] = operand
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        printer.print_ssa_value(op.operands[self.index])
+        state.last_was_punctuation = False
+        state.should_emit_space = True
+
+
+@dataclass(frozen=True)
+class OperandTypeDirective(FormatDirective):
+    """
+    An operand variable type directive, with the following format:
+      operand-directive ::= type
+    The directive will request a space to be printed right after.
+    """
+
+    name: str
+    """The operand name. This is only used for error message reporting."""
+    index: int
+    """Index of the operand definition."""
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        type = parser.parse_type()
+        state.operand_types[self.index] = type
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        printer.print_attribute(op.operands[self.index].type)
+        state.last_was_punctuation = False
+        state.should_emit_space = True
 
 
 @dataclass(frozen=True)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Generic
 
 from xdsl.ir import Attribute
 from xdsl.irdl import IRDLOperation, IRDLOperationInvT, OpDef, VariadicDef
@@ -26,8 +25,8 @@ class ParsingState:
     It contains the elements that have already been parsed.
     """
 
-    operands: list[None | UnresolvedOperand]
-    operand_types: list[None | Attribute]
+    operands: list[UnresolvedOperand | None]
+    operand_types: list[Attribute | None]
     attributes: dict[str, Attribute]
 
     def __init__(self, op_def: OpDef):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -134,7 +134,8 @@ class FormatParser(BaseParser):
         """
         Parse a variable, if present, with the following format:
           variable ::= `$` bare-ident
-        The variable should refer to an operand, attribute, region, result, or succesor.
+        The variable should refer to an operand, attribute, region, result,
+        or successor.
         """
         if self._current_token.text[0] != "$":
             return None


### PR DESCRIPTION
This PR adds operands to the declarative assembly format.
An operand is parsed with the `$operand_name` syntax, and should also have its type parsed with the `type($operand_name)` syntax.
For instance, ``$lhs `,` $rhs `:` type($lhs) `,` type($rhs)`` will parse `test.op %0, %1 : i32, i64` correctly.

All operands should be parsed exactly once, and should have their type parsed exactly once as well.

Future PRs will add support for optional/variadic operands, as well as removing the need to parse their types if they have a unique type, or if their type can be deduced from the other parsed types.