### PR TITLE
API: Add reserved attribute names functionality to the printer.

### DIFF
--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -178,9 +178,7 @@ class FuncOp(IRDLOperation):
                 printer.print(" ")
         else:
             printer.print_attribute(self.function_type)
-        printer.print_op_attributes_with_keyword(
-            self.attributes, reserved, keyword=True
-        )
+        printer.print_op_attributes_with_keyword(self.attributes, reserved)
 
         if len(self.body.blocks) > 0:
             printer.print_region(self.body, False, False)

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -158,6 +158,7 @@ class FuncOp(IRDLOperation):
         return func
 
     def print(self, printer: Printer):
+        reserved = {"sym_name", "function_type", "sym_visibility"}
         if self.sym_visibility:
             visibility = self.sym_visibility.data
             printer.print(f" {visibility}")
@@ -177,8 +178,6 @@ class FuncOp(IRDLOperation):
                 printer.print(" ")
         else:
             printer.print_attribute(self.function_type)
-
-        reserved = ("sym_name", "function_type", "sym_visibility")
         if any(k not in reserved for k in self.attributes.keys()):
             printer.print(" attributes")
             printer.print_op_attributes(self.attributes, reserved)

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -178,9 +178,9 @@ class FuncOp(IRDLOperation):
                 printer.print(" ")
         else:
             printer.print_attribute(self.function_type)
-        if any(k not in reserved for k in self.attributes.keys()):
-            printer.print(" attributes")
-            printer.print_op_attributes(self.attributes, reserved)
+        printer.print_op_attributes_with_keyword(
+            self.attributes, reserved, keyword=True
+        )
 
         if len(self.body.blocks) > 0:
             printer.print_region(self.body, False, False)

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -177,17 +177,11 @@ class FuncOp(IRDLOperation):
                 printer.print(" ")
         else:
             printer.print_attribute(self.function_type)
-        attr_dict = {
-            k: v
-            for k, v in self.attributes.items()
-            if k not in ("sym_name", "function_type", "sym_visibility")
-        }
-        if len(attr_dict) > 0:
-            printer.print(" attributes {")
-            printer.print_list(
-                attr_dict.items(), lambda i: printer.print(f'"{i[0]}" = {i[1]}')
-            )
-            printer.print("}")
+
+        reserved = ("sym_name", "function_type", "sym_visibility")
+        if any(k not in reserved for k in self.attributes.keys()):
+            printer.print(" attributes")
+            printer.print_op_attributes(self.attributes, reserved)
 
         if len(self.body.blocks) > 0:
             printer.print_region(self.body, False, False)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -648,7 +648,7 @@ class Printer:
             i for i in attributes.items() if i[0] not in reserved_attr_names
         ]
 
-        if attribute_list:
+        if not attribute_list:
             return
         self.print(" {")
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -644,11 +644,11 @@ class Printer:
     def print_op_attributes(
         self, attributes: dict[str, Attribute], reserved_attr_names: Iterable[str] = []
     ) -> None:
-        attribute_list = list(
+        attribute_list = [
             i for i in attributes.items() if i[0] not in reserved_attr_names
-        )
+        ]
 
-        if len(attribute_list) == 0:
+        if attribute_list:
             return
         self.print(" {")
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -641,8 +641,22 @@ class Printer:
             self.print(f'"{attr_tuple[0]}" = ')
             self.print_attribute(attr_tuple[1])
 
-    def print_op_attributes(
-        self, attributes: dict[str, Attribute], reserved_attr_names: Iterable[str] = []
+    def print_op_attributes(self, attributes: dict[str, Attribute]) -> None:
+        if len(attributes) == 0:
+            return
+
+        self.print(" {")
+
+        attribute_list = list(attributes.items())
+        self.print_list(attribute_list, self._print_attr_string)
+
+        self.print("}")
+
+    def print_op_attributes_with_keyword(
+        self,
+        attributes: dict[str, Attribute],
+        reserved_attr_names: Iterable[str] = (),
+        keyword: bool = False,
     ) -> None:
         attribute_list = [
             i for i in attributes.items() if i[0] not in reserved_attr_names
@@ -650,6 +664,8 @@ class Printer:
 
         if not attribute_list:
             return
+        if keyword:
+            self.print(" attributes")
         self.print(" {")
 
         self.print_list(attribute_list, self._print_attr_string)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -641,13 +641,17 @@ class Printer:
             self.print(f'"{attr_tuple[0]}" = ')
             self.print_attribute(attr_tuple[1])
 
-    def print_op_attributes(self, attributes: dict[str, Attribute]) -> None:
-        if len(attributes) == 0:
-            return
+    def print_op_attributes(
+        self, attributes: dict[str, Attribute], reserved_attr_names: Iterable[str] = []
+    ) -> None:
+        attribute_list = list(
+            i for i in attributes.items() if i[0] not in reserved_attr_names
+        )
 
+        if len(attribute_list) == 0:
+            return
         self.print(" {")
 
-        attribute_list = list(attributes.items())
         self.print_list(attribute_list, self._print_attr_string)
 
         self.print("}")

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -653,20 +653,18 @@ class Printer:
         self.print("}")
 
     def print_op_attributes_with_keyword(
-        self,
-        attributes: dict[str, Attribute],
-        reserved_attr_names: Iterable[str] = (),
-        keyword: bool = False,
+        self, attributes: dict[str, Attribute], reserved_attr_names: Iterable[str] = ()
     ) -> None:
-        attribute_list = [
-            i for i in attributes.items() if i[0] not in reserved_attr_names
-        ]
+        if reserved_attr_names:
+            attribute_list = [
+                i for i in attributes.items() if i[0] not in reserved_attr_names
+            ]
+        else:
+            attribute_list = attributes.items()
 
         if not attribute_list:
             return
-        if keyword:
-            self.print(" attributes")
-        self.print(" {")
+        self.print(" attributes {")
 
         self.print_list(attribute_list, self._print_attr_string)
 


### PR DESCRIPTION
The parser already have an optional parameter on `parse_optional_attr_dict_with_keyword` to handle attribute names that should not be in the generic attribute dictionnary of the custom syntax.
I'd like to do the same thing on the printing side, to simplify func here.

I'm preparing to merge an implementation of the SymbolTable trait, adding a *bunch* of `sym_name` attributes all over, I feel this might help. (e.g. next user is `builtin.module`)