### PR TITLE
Interpreter: Use unsigned integer when calculate array index

### DIFF
--- a/tests/interpreters/test_wgsl_printer.py
+++ b/tests/interpreters/test_wgsl_printer.py
@@ -193,7 +193,7 @@ def test_2d5pt():
 builtin.module attributes {gpu.container_module} {
   "gpu.module"() ({
     "gpu.func"() ({
-    ^0(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : memref<260x260xf32>, %arg4 : index, %arg5 : f32, %arg6 : f32, %arg7 : f32, %arg8 : f32, %arg9 : f32, %arg10 : f32, %arg11 : memref<260x260xf32>):
+    ^0(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : memref<260x260xf32>, %arg4 : index, %arg5 : f32, %arg6 : f32, %arg7 : f32, %arg8 : f32, %arg9 : f32, %arg10 : f32, %arg11 : memref<260x260xf32>, %arg12: memref<260x260xindex>):
       %0 = "arith.constant"() {"value" = 2 : index} : () -> index
       %1 = "gpu.block_id"() {"dimension" = #gpu<dim x>} : () -> index
       %2 = "gpu.block_id"() {"dimension" = #gpu<dim y>} : () -> index
@@ -241,7 +241,7 @@ builtin.module attributes {gpu.container_module} {
       %44 = arith.mulf %43, %arg10 : f32
       "memref.store"(%44, %arg11, %15, %16) {"nontemporal" = false} : (f32, memref<260x260xf32>, index, index) -> ()
       "gpu.return"() : () -> ()
-    }) {"function_type" = (index, index, index, memref<260x260xf32>, index, f32, f32, f32, f32, f32, f32, memref<260x260xf32>) -> (),
+    }) {"function_type" = (index, index, index, memref<260x260xf32>, index, f32, f32, f32, f32, f32, f32, memref<260x260xf32>, memref<260x260xindex>) -> (),
         "gpu.kernel", "gpu.known_block_size" = array<i32: 128, 1, 1>, "gpu.known_grid_size" = array<i32: 2, 256, 1>,
         "sym_name" = "apply_kernel_kernel",
         "workgroup_attributions" = 0 : i64
@@ -287,6 +287,9 @@ builtin.module attributes {gpu.container_module} {
 
     @group(0) @binding(11)
     var<storage,read_write> varg11: array<f32>;
+
+    @group(0) @binding(12)
+    var<storage,read> varg12: array<u32>;
 
     @compute
     @workgroup_size(1)

--- a/tests/interpreters/test_wgsl_printer.py
+++ b/tests/interpreters/test_wgsl_printer.py
@@ -168,7 +168,7 @@ def test_memref_load():
     printer = WGSLPrinter()
     printer.print(load, file)
 
-    assert "v1 = v0[10 * v1 + 1 * v2];" in file.getvalue()
+    assert "let v1 = v0[10u * v1 + 1u * v2];" in file.getvalue()
 
 
 def test_memref_store():
@@ -185,7 +185,7 @@ def test_memref_store():
     printer = WGSLPrinter()
     printer.print(store, file)
 
-    assert "v1[10 * v1 + 1 * v2] = v0;" in file.getvalue()
+    assert "v1[10u * v1 + 1u * v2] = v0;" in file.getvalue()
 
 
 def test_2d5pt():
@@ -315,19 +315,19 @@ builtin.module attributes {gpu.container_module} {
         let v14 = v12 + v8;
         let v15 = v14 + v0;
         let v16 = v13 + v0;
-        let v17 = varg3[260 * v15 + 1 * v16];
+        let v17 = varg3[260u * v15 + 1u * v16];
         let v18 = v14 + varg4;
         let v19 = v18 + v0;
-        let v20 = varg3[260 * v19 + 1 * v16];
+        let v20 = varg3[260u * v19 + 1u * v16];
         let v21 = v14 + varg2;
         let v22 = v21 + v0;
-        let v23 = varg3[260 * v22 + 1 * v16];
+        let v23 = varg3[260u * v22 + 1u * v16];
         let v24 = v13 + varg4;
         let v25 = v24 + v0;
-        let v26 = varg3[260 * v15 + 1 * v25];
+        let v26 = varg3[260u * v15 + 1u * v25];
         let v27 = v13 + varg2;
         let v28 = v27 + v0;
-        let v29 = varg3[260 * v15 + 1 * v28];
+        let v29 = varg3[260u * v15 + 1u * v28];
         let v30 = v17 * varg5;
         let v31 = v20 * varg6;
         let v32 = v23 * varg6;
@@ -343,7 +343,7 @@ builtin.module attributes {gpu.container_module} {
         let v41 = v30 + varg9;
         let v42 = v41 + v40;
         let v43 = v42 * varg10;
-        varg11[260 * v15 + 1 * v16] = v43;
+        varg11[260u * v15 + 1u * v16] = v43;
             }
 """
     context = MLContext()

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import singledispatchmethod
-from typing import IO, cast
+from typing import IO, cast, Any
 
 from xdsl.dialects import arith, builtin, gpu, memref
 from xdsl.dialects.memref import MemRefType
@@ -128,13 +128,10 @@ class WGSLPrinter:
 
     @print.register
     def _(self, op: memref.Load, out_stream: IO[str]):
-        memref_type = cast(MemRefType[Attribute], op.memref.type)
-        memref_dimension = memref_type.get_num_dims()
-        memref_size = memref_type.get_shape()
         load_ref = self.wgsl_name(op.memref)
         name_hint = self.wgsl_name(op.res)
         indices = [self.wgsl_name(i) for i in op.indices]
-        index_value = self.calculate_index(memref_dimension, memref_size, indices)
+        index_value = self.calculate_index(op, indices)
         out_stream.write(
             f"""
         let {name_hint} = {load_ref}[{index_value}];"""
@@ -142,24 +139,28 @@ class WGSLPrinter:
 
     @print.register
     def _(self, op: memref.Store, out_stream: IO[str]):
-        memref_type = cast(MemRefType[Attribute], op.memref.type)
-        memref_dimension = memref_type.get_num_dims()
-        memref_size = memref_type.get_shape()
         value = self.wgsl_name(op.value)
         store_ref = self.wgsl_name(op.memref)
         indices = [self.wgsl_name(i) for i in op.indices]
-        index_value = self.calculate_index(memref_dimension, memref_size, indices)
+        index_value = self.calculate_index(op, indices)
         out_stream.write(
             f"""
         {store_ref}[{index_value}] = {value};"""
         )
 
     def calculate_index(
-        self, memref_dimension: int, memref_size: tuple[int], indices: list[str]
+        self, op:Any, indices: list[str]
     ):
         """
         It is used for linearizing known sizes memref accesses.
         """
+        if not op.memref:
+            raise NotImplementedError(
+                "The calculate_index only works with memref operands."
+            )
+        memref_type = cast(MemRefType[Attribute], op.memref.type)
+        memref_dimension = memref_type.get_num_dims()
+        memref_size = memref_type.get_shape()
         for size in memref_size:
             if size == -1:
                 raise NotImplementedError(
@@ -170,7 +171,7 @@ class WGSLPrinter:
             product_of_dims = 1
             for dim in memref_size[i + 1 :]:
                 product_of_dims *= dim
-            index_values.append(f"{product_of_dims} * {indices[i]}")
+            index_values.append(f"{product_of_dims}u * {indices[i]}")
         return " + ".join(index_values)
 
     @print.register

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import singledispatchmethod
-from typing import IO, cast, Any
+from typing import IO, Any, cast
 
 from xdsl.dialects import arith, builtin, gpu, memref
 from xdsl.dialects.memref import MemRefType
@@ -148,9 +148,7 @@ class WGSLPrinter:
         {store_ref}[{index_value}] = {value};"""
         )
 
-    def calculate_index(
-        self, op:Any, indices: list[str]
-    ):
+    def calculate_index(self, op: Any, indices: list[str]):
         """
         It is used for linearizing known sizes memref accesses.
         """

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import singledispatchmethod
-from typing import IO, Any, cast
+from typing import IO, cast
 
 from xdsl.dialects import arith, builtin, gpu, memref
 from xdsl.dialects.memref import MemRefType
@@ -148,14 +148,10 @@ class WGSLPrinter:
         {store_ref}[{index_value}] = {value};"""
         )
 
-    def calculate_index(self, op: Any, indices: list[str]):
+    def calculate_index(self, op: memref.Store | memref.Load, indices: list[str]):
         """
         It is used for linearizing known sizes memref accesses.
         """
-        if not op.memref:
-            raise NotImplementedError(
-                "The calculate_index only works with memref operands."
-            )
         memref_type = cast(MemRefType[Attribute], op.memref.type)
         memref_dimension = memref_type.get_num_dims()
         memref_size = memref_type.get_shape()


### PR DESCRIPTION
This pull request resolves a specific type inconsistency issue that arises when linearizing multi-dimensional arrays into a 1D array in the WebGPU Shading Language (WGSL).
