### PR TITLE
Implement is_optional_symbol for MLIR compliance.

### DIFF
--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -316,11 +316,11 @@ def test_optional_symbol_op_interface():
     assert interface is not None
     assert interface.is_optional_symbol(no_symbol)
     no_symbol.verify()
-    assert SymbolOpInterface.get_sym_attr_name(no_symbol) is None
+    assert interface.get_sym_attr_name(no_symbol) is None
 
     symbol = OptionalSymNameOp(attributes={"sym_name": StringAttr("main")})
     interface = symbol.get_trait(SymbolOpInterface)
     assert interface is not None
     assert interface.is_optional_symbol(symbol)
     symbol.verify()
-    assert SymbolOpInterface.get_sym_attr_name(symbol) == StringAttr("main")
+    assert interface.get_sym_attr_name(symbol) == StringAttr("main")

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -311,7 +311,7 @@ def test_optional_symbol_op_interface():
 
         traits = frozenset((OptionalSymbolOpInterface(),))
 
-    non_symbol = OptionalSymNameOp()
+    no_symbol = OptionalSymNameOp()
     interface = non_symbol.get_trait(SymbolOpInterface)
     assert interface is not None
     assert interface.is_optional_symbol(non_symbol)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -312,11 +312,11 @@ def test_optional_symbol_op_interface():
         traits = frozenset((OptionalSymbolOpInterface(),))
 
     no_symbol = OptionalSymNameOp()
-    interface = non_symbol.get_trait(SymbolOpInterface)
+    interface = no_symbol.get_trait(SymbolOpInterface)
     assert interface is not None
-    assert interface.is_optional_symbol(non_symbol)
-    non_symbol.verify()
-    assert SymbolOpInterface.get_sym_attr_name(non_symbol) is None
+    assert interface.is_optional_symbol(no_symbol)
+    no_symbol.verify()
+    assert SymbolOpInterface.get_sym_attr_name(no_symbol) is None
 
     symbol = OptionalSymNameOp(attributes={"sym_name": StringAttr("main")})
     interface = symbol.get_trait(SymbolOpInterface)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -25,9 +25,10 @@ from xdsl.irdl import (
     attr_def,
     irdl_op_definition,
     operand_def,
+    opt_attr_def,
     result_def,
 )
-from xdsl.traits import SymbolOpInterface
+from xdsl.traits import OptionalSymbolOpInterface, SymbolOpInterface
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
@@ -295,3 +296,31 @@ def test_symbol_op_interface():
 
     op2 = SymNameOp(attributes={"sym_name": StringAttr("symbol_name")})
     op2.verify()
+
+
+def test_optional_symbol_op_interface():
+    """
+    Test that operations that conform to OptionalSymbolOpInterface have necessary attributes.
+    """
+
+    @irdl_op_definition
+    class OptionalSymNameOp(IRDLOperation):
+        name = "no_sym_name"
+
+        sym_name = opt_attr_def(StringAttr)
+
+        traits = frozenset((OptionalSymbolOpInterface(),))
+
+    non_symbol = OptionalSymNameOp()
+    interface = non_symbol.get_trait(SymbolOpInterface)
+    assert interface is not None
+    assert interface.is_optional_symbol(non_symbol)
+    non_symbol.verify()
+    assert SymbolOpInterface.get_sym_attr_name(non_symbol) is None
+
+    symbol = OptionalSymNameOp(attributes={"sym_name": StringAttr("main")})
+    interface = symbol.get_trait(SymbolOpInterface)
+    assert interface is not None
+    assert interface.is_optional_symbol(symbol)
+    symbol.verify()
+    assert SymbolOpInterface.get_sym_attr_name(symbol) == StringAttr("main")

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -300,7 +300,7 @@ def test_symbol_op_interface():
 
 def test_optional_symbol_op_interface():
     """
-    Test that operations that conform to OptionalSymbolOpInterface have necessary attributes.
+    Test that operations that conform to OptionalSymbolOpInterface have the necessary attributes.
     """
 
     @irdl_op_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -53,7 +53,7 @@ from xdsl.irdl import (
     var_region_def,
     var_result_def,
 )
-from xdsl.traits import IsolatedFromAbove, NoTerminator
+from xdsl.traits import IsolatedFromAbove, NoTerminator, OptionalSymbolOpInterface
 from xdsl.utils.exceptions import VerifyException
 
 if TYPE_CHECKING:
@@ -1217,7 +1217,9 @@ class ModuleOp(IRDLOperation):
 
     body: Region = region_def("single_block")
 
-    traits = frozenset([IsolatedFromAbove(), NoTerminator()])
+    traits = frozenset(
+        [IsolatedFromAbove(), NoTerminator(), OptionalSymbolOpInterface()]
+    )
 
     def __init__(
         self,

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -370,8 +370,8 @@ class Interpreter:
             self._symbol_table = {}
 
             for op in self.module.walk():
-                if op.has_trait(SymbolOpInterface):
-                    symbol = SymbolOpInterface.get_sym_attr_name(op)
+                if (symbol_interface := op.get_trait(SymbolOpInterface)) is not None:
+                    symbol = symbol_interface.get_sym_attr_name(op)
                     if symbol:
                         self._symbol_table[symbol.data] = op
         return self._symbol_table

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -372,7 +372,8 @@ class Interpreter:
             for op in self.module.walk():
                 if op.has_trait(SymbolOpInterface):
                     symbol = SymbolOpInterface.get_sym_attr_name(op)
-                    self._symbol_table[symbol.data] = op
+                    if symbol:
+                        self._symbol_table[symbol.data] = op
         return self._symbol_table
 
     def get_values(self, values: Iterable[SSAValue]) -> tuple[Any, ...]:

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -203,7 +203,7 @@ class SymbolOpInterface(OpTrait):
     a `SymbolTable` (TODO). A Symbol operation should use the SymbolOpInterface interface to
     provide the necessary verification and accessors.
 
-    A Symbol operation may be optional or not. If - the dault - it is not optional,
+    A Symbol operation may be optional or not. If - the default - it is not optional,
     a `sym_name` attribute of type StringAttr is required. If it is optional,
     the attribute is optional too.
 

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -203,10 +203,14 @@ class SymbolOpInterface(OpTrait):
     a `SymbolTable` (TODO). A Symbol operation should use the SymbolOpInterface interface to
     provide the necessary verification and accessors.
 
-    Currently the only requirement is a "sym_name" attribute of type StringAttr.
+    A Symbol operation may be optional or not. If - the dault - it is not optional,
+    a `sym_name` attribute of type StringAttr is required. If it is optional,
+    the attribute is optional too.
 
-    Please see MLIR documentation for Symbol and SymbolTable for the requirements that are
-    upcoming in xDSL.
+    xDSL offers OptionalSymbolOpInterface as an always-optional SymbolOpInterface helper.
+
+    More requirements are defined in MLIR; Please see MLIR documentation for Symbol and
+    SymbolTable for the requirements that are upcoming in xDSL.
 
     https://mlir.llvm.org/docs/SymbolsAndSymbolTables/#symbol
     """
@@ -214,7 +218,7 @@ class SymbolOpInterface(OpTrait):
     @staticmethod
     def get_sym_attr_name(op: Operation) -> StringAttr | None:
         """
-        Returns the symbol of the operation
+        Returns the symbol of the operation, if any
         """
         # import builtin here to avoid circular import
         from xdsl.dialects.builtin import StringAttr
@@ -255,7 +259,7 @@ class SymbolOpInterface(OpTrait):
 
 class OptionalSymbolOpInterface(SymbolOpInterface):
     """
-    Helper interface specialization for an optional Symbol.
+    Helper interface specialization for an optional SymbolOpInterface.
     """
 
     @staticmethod

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -215,20 +215,27 @@ class SymbolOpInterface(OpTrait):
     https://mlir.llvm.org/docs/SymbolsAndSymbolTables/#symbol
     """
 
-    @staticmethod
-    def get_sym_attr_name(op: Operation) -> StringAttr | None:
+    def get_sym_attr_name(self, op: Operation) -> StringAttr | None:
         """
         Returns the symbol of the operation, if any
         """
         # import builtin here to avoid circular import
         from xdsl.dialects.builtin import StringAttr
 
-        concrete = op.get_trait(SymbolOpInterface)
-        assert concrete is not None
-        if concrete.is_optional_symbol(op) and "sym_name" not in op.attributes:
-            return None
+        if "sym_name" not in op.attributes:
+            if self.is_optional_symbol(op):
+                return None
+            else:
+                raise VerifyException(
+                    f'Operation {op.name} must have a "sym_name" attribute of type '
+                    f"`StringAttr` to conform to {SymbolOpInterface.__name__}"
+                )
         attr = op.attributes["sym_name"]
-        assert isinstance(attr, StringAttr)
+        if not isinstance(attr, StringAttr):
+            raise VerifyException(
+                f'Operation {op.name} must have a "sym_name" attribute of type '
+                f"`StringAttr` to conform to {SymbolOpInterface.__name__}"
+            )
         return attr
 
     def is_optional_symbol(self, op: Operation) -> bool:

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -231,8 +231,7 @@ class SymbolOpInterface(OpTrait):
         assert isinstance(attr, StringAttr)
         return attr
 
-    @staticmethod
-    def is_optional_symbol(op: Operation) -> bool:
+    def is_optional_symbol(self, op: Operation) -> bool:
         """
         Returns true if this operation optionally defines a symbol based on the
         presence of the symbol name.
@@ -244,9 +243,7 @@ class SymbolOpInterface(OpTrait):
         from xdsl.dialects.builtin import StringAttr
 
         # If this is an optional symbol, bail out early if possible.
-        concrete = op.get_trait(SymbolOpInterface)
-        assert concrete is not None
-        if concrete.is_optional_symbol(op) and "sym_name" not in op.attributes:
+        if self.is_optional_symbol(op) and "sym_name" not in op.attributes:
             return
         if "sym_name" not in op.attributes or not isinstance(
             op.attributes["sym_name"], StringAttr
@@ -262,8 +259,7 @@ class OptionalSymbolOpInterface(SymbolOpInterface):
     Helper interface specialization for an optional SymbolOpInterface.
     """
 
-    @staticmethod
-    def is_optional_symbol(op: Operation) -> bool:
+    def is_optional_symbol(self, op: Operation) -> bool:
         return True
 
 


### PR DESCRIPTION
That is, the `is_optional_symbol` method of `SymbolOpInterface`, matching MLIR's `isOptionalSymbol` on `Symbol`

Implement OptionalSymbolOpInterface for user-friendliness. Test it.

Our current implementation of SymbolOps is not compliant with MLIR's, which allows optionally symbol operations :upside_down_face: 
The most famous example being `builtin.module`, which can be anonymous as often for the top-level module, thus not containing any `sym_name` attribute.

I also take the opprtunity to make `builtin.module` an optional symbol operation. With this MLIR-compliant implementation, the only impact is to make the interpreter work with this compliance :slightly_smiling_face: 