### PR TITLE
dialects: Migrate func dialect to use init from get methods

### DIFF
--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -179,7 +179,7 @@ def test_call():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call.get(func0.sym_name.data, [a, b], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name.data, [a, b], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, b, call0])
@@ -225,7 +225,7 @@ def test_call_II():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call.get(func0.sym_name.data, [a], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name.data, [a], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, call0])

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -299,8 +299,23 @@ class Call(IRDLOperation):
 
     # Note: naming this results triggers an ArgumentError
     res: VarOpResult = var_result_def(AnyAttr())
-    # TODO how do we verify that the types are correct?
 
+    # TODO how do we verify that the types are correct?
+    def __init__(
+        self,
+        callee: str | SymbolRefAttr,
+        arguments: Sequence[SSAValue | Operation],
+        return_types: Sequence[Attribute],
+    ):
+        if isinstance(callee, str):
+            callee = SymbolRefAttr(callee)
+        super().__init__(
+            operands=[arguments],
+            result_types=[return_types],
+            attributes={"callee": callee},
+        )
+
+    @deprecated("Use func.Call(...) instead!")
     @staticmethod
     def get(
         callee: str | SymbolRefAttr,

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -328,7 +328,7 @@ class LowerMpiInit(_MPIToLLVMRewriteBase):
         """
         return [
             nullptr := llvm.NullOp.get(),
-            func.Call.get(self._mpi_name(op), [nullptr, nullptr], [i32]),
+            func.Call(self._mpi_name(op), [nullptr, nullptr], [i32]),
         ], []
 
 
@@ -342,7 +342,7 @@ class LowerMpiFinalize(_MPIToLLVMRewriteBase):
         Relatively straight forward lowering of mpi.finalize operation.
         """
         return [
-            func.Call.get(self._mpi_name(op), [], [i32]),
+            func.Call(self._mpi_name(op), [], [i32]),
         ], []
 
 
@@ -358,7 +358,7 @@ class LowerMpiWait(_MPIToLLVMRewriteBase):
         ops, new_results, res = self._emit_mpi_status_objs(len(op.results))
         return [
             *ops,
-            func.Call.get(self._mpi_name(op), [op.request, res], [i32]),
+            func.Call(self._mpi_name(op), [op.request, res], [i32]),
         ], new_results
 
 
@@ -375,7 +375,7 @@ class LowerMpiWaitall(_MPIToLLVMRewriteBase):
         ops, new_results, res = self._emit_mpi_status_objs(len(op.results))
         return [
             *ops,
-            func.Call.get(self._mpi_name(op), [op.count, op.requests, res], [i32]),
+            func.Call(self._mpi_name(op), [op.count, op.requests, res], [i32]),
         ], new_results
 
 
@@ -394,7 +394,7 @@ class LowerMpiReduce(_MPIToLLVMRewriteBase):
                 self.info.MPI_COMM_WORLD, i32
             ),
             mpi_op := self._emit_mpi_operation_load(op.operationtype),
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [
                     op.send_buffer,
@@ -440,7 +440,7 @@ class LowerMpiAllreduce(_MPIToLLVMRewriteBase):
 
         return [
             *operations,
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [
                     send_buffer_op,
@@ -469,7 +469,7 @@ class LowerMpiBcast(_MPIToLLVMRewriteBase):
             comm_global := arith.Constant.from_int_and_width(
                 self.info.MPI_COMM_WORLD, i32
             ),
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [op.buffer, op.count, op.datatype, op.root, comm_global],
                 [],
@@ -494,7 +494,7 @@ class LowerMpiIsend(_MPIToLLVMRewriteBase):
             comm_global := arith.Constant.from_int_and_width(
                 self.info.MPI_COMM_WORLD, i32
             ),
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [
                     op.buffer,
@@ -527,7 +527,7 @@ class LowerMpiIrecv(_MPIToLLVMRewriteBase):
             comm_global := arith.Constant.from_int_and_width(
                 self.info.MPI_COMM_WORLD, i32
             ),
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [
                     op.buffer,
@@ -562,7 +562,7 @@ class LowerMpiSend(_MPIToLLVMRewriteBase):
             comm_global := arith.Constant.from_int_and_width(
                 self.info.MPI_COMM_WORLD, i32
             ),
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [op.buffer, op.count, op.datatype, op.dest, op.tag, comm_global],
                 [i32],
@@ -594,7 +594,7 @@ class LowerMpiRecv(_MPIToLLVMRewriteBase):
             comm_global := arith.Constant.from_int_and_width(
                 self.info.MPI_COMM_WORLD, i32
             ),
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [
                     op.buffer,
@@ -708,7 +708,7 @@ class LowerMpiCommRank(_MPIToLLVMRewriteBase):
             ),
             lit1 := arith.Constant.from_int_and_width(1, 64),
             int_ptr := llvm.AllocaOp.get(lit1, i32),
-            func.Call.get(self._mpi_name(op), [comm_global, int_ptr], [i32]),
+            func.Call(self._mpi_name(op), [comm_global, int_ptr], [i32]),
             rank := llvm.LoadOp.get(int_ptr),
         ], [rank.dereferenced_value]
 
@@ -730,7 +730,7 @@ class LowerMpiCommSize(_MPIToLLVMRewriteBase):
             ),
             lit1 := arith.Constant.from_int_and_width(1, 64),
             int_ptr := llvm.AllocaOp.get(lit1, i32),
-            func.Call.get(self._mpi_name(op), [comm_global, int_ptr], [i32]),
+            func.Call(self._mpi_name(op), [comm_global, int_ptr], [i32]),
             rank := llvm.LoadOp.get(int_ptr),
         ], [rank.dereferenced_value]
 
@@ -810,7 +810,7 @@ class LowerMpiGatherOp(_MPIToLLVMRewriteBase):
             comm_global := arith.Constant.from_int_and_width(
                 self.info.MPI_COMM_WORLD, i32
             ),
-            func.Call.get(
+            func.Call(
                 self._mpi_name(op),
                 [
                     op.sendbuf,

--- a/xdsl/transforms/lower_snitch_runtime.py
+++ b/xdsl/transforms/lower_snitch_runtime.py
@@ -64,9 +64,7 @@ class LowerDma1DOpToFunc(RewritePattern, ABC):
         op: snitch_runtime.DmaStart1DOp | snitch_runtime.DmaStart1DWideptrOp,
         rewriter: PatternRewriter,
     ):
-        func_call = func.Call(
-            "snrt_" + op.name[5:], [op.dst, op.src, op.size], [tx_id]
-        )
+        func_call = func.Call("snrt_" + op.name[5:], [op.dst, op.src, op.size], [tx_id])
         rewriter.replace_matched_op(func_call)
 
 

--- a/xdsl/transforms/lower_snitch_runtime.py
+++ b/xdsl/transforms/lower_snitch_runtime.py
@@ -27,7 +27,7 @@ class LowerGetInfoOpToFunc(RewritePattern, ABC):
     def match_and_rewrite(
         self, op: snitch_runtime.SnitchRuntimeGetInfo, rewriter: PatternRewriter, /
     ):
-        func_call = func.Call.get("snrt_" + op.name[5:], [], [i32])
+        func_call = func.Call("snrt_" + op.name[5:], [], [i32])
         rewriter.replace_matched_op(func_call)
 
 
@@ -47,7 +47,7 @@ class LowerBarrierOpToFunc(RewritePattern, ABC):
         rewriter: PatternRewriter,
         /,
     ):
-        func_call = func.Call.get("snrt_" + op.name[5:], [], [])
+        func_call = func.Call("snrt_" + op.name[5:], [], [])
         rewriter.replace_matched_op(func_call)
 
 
@@ -64,7 +64,7 @@ class LowerDma1DOpToFunc(RewritePattern, ABC):
         op: snitch_runtime.DmaStart1DOp | snitch_runtime.DmaStart1DWideptrOp,
         rewriter: PatternRewriter,
     ):
-        func_call = func.Call.get(
+        func_call = func.Call(
             "snrt_" + op.name[5:], [op.dst, op.src, op.size], [tx_id]
         )
         rewriter.replace_matched_op(func_call)
@@ -82,7 +82,7 @@ class LowerDma2DOpToFunc(RewritePattern, ABC):
         op: snitch_runtime.DmaStart2DOp | snitch_runtime.DmaStart2DWideptrOp,
         rewriter: PatternRewriter,
     ):
-        func_call = func.Call.get(
+        func_call = func.Call(
             "snrt_" + op.name[5:],
             [op.dst, op.src, op.dst_stride, op.src_stride, op.size, op.repeat],
             [tx_id],


### PR DESCRIPTION
#1120: Migrate `func.Call` to use init from get methods