### PR TITLE
dialect: Dropping `scf.While.get`

### DIFF
--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -9,7 +9,15 @@ import pytest
 from xdsl.builder import Builder
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import IndexType, ModuleOp, i32, i64
-from xdsl.dialects.scf import For, If, ParallelOp, ReduceOp, ReduceReturnOp, Yield, While
+from xdsl.dialects.scf import (
+    For,
+    If,
+    ParallelOp,
+    ReduceOp,
+    ReduceReturnOp,
+    While,
+    Yield,
+)
 from xdsl.dialects.test import TestTermOp
 from xdsl.ir.core import Block, BlockArgument, Region
 from xdsl.utils.exceptions import DiagnosticException, VerifyException
@@ -455,16 +463,17 @@ def test_empty_else():
 
     assert len(cast(If, list(m.ops)[1]).false_region.blocks) == 0
 
+
 def test_while():
     before_block = Block(arg_types=(i32, i32))
     after_block = Block(arg_types=(i32, i32))
     a = Constant.from_int_and_width(0, i32)
     b = Constant.from_int_and_width(0, i32)
     while_loop = While(
-        operands = [a, b],
-        result_types = [i32, i32],
+        operands=[a, b],
+        result_types=[i32, i32],
         before=[before_block],
-        after=[after_block]
+        after=[after_block],
     )
     assert (len(while_loop.results)) == 2
     assert (len(while_loop.operands)) == 2

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -472,8 +472,8 @@ def test_while():
     while_loop = While(
         operands=[a, b],
         result_types=[i32, i32],
-        before=[before_block],
-        after=[after_block],
+        before_region=[before_block],
+        after_region=[after_block],
     )
     assert (len(while_loop.results)) == 2
     assert (len(while_loop.operands)) == 2

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -470,7 +470,7 @@ def test_while():
     a = Constant.from_int_and_width(0, i32)
     b = Constant.from_int_and_width(0, i32)
     while_loop = While(
-        operands=[a, b],
+        arguments=[a, b],
         result_types=[i32, i32],
         before_region=[before_block],
         after_region=[after_block],

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -9,7 +9,7 @@ import pytest
 from xdsl.builder import Builder
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import IndexType, ModuleOp, i32, i64
-from xdsl.dialects.scf import For, If, ParallelOp, ReduceOp, ReduceReturnOp, Yield
+from xdsl.dialects.scf import For, If, ParallelOp, ReduceOp, ReduceReturnOp, Yield, While
 from xdsl.dialects.test import TestTermOp
 from xdsl.ir.core import Block, BlockArgument, Region
 from xdsl.utils.exceptions import DiagnosticException, VerifyException
@@ -454,3 +454,17 @@ def test_empty_else():
     )
 
     assert len(cast(If, list(m.ops)[1]).false_region.blocks) == 0
+
+def test_while():
+    before_block = Block(arg_types=(i32, i32))
+    after_block = Block(arg_types=(i32, i32))
+    a = Constant.from_int_and_width(0, i32)
+    b = Constant.from_int_and_width(0, i32)
+    while_loop = While(
+        operands = [a, b],
+        result_types = [i32, i32],
+        before=[before_block],
+        after=[after_block]
+    )
+    assert (len(while_loop.results)) == 2
+    assert (len(while_loop.operands)) == 2

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -68,6 +68,41 @@ builtin.module {
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
+
+  func.func @while2() {
+    %a = "arith.constant"() {value = 1.000000e+00 : f32} : () -> f32
+    %b = "arith.constant"() {value = 32 : i32} : () -> i32
+    %2:2 = "scf.while"(%b, %a) ({
+    ^bb0(%arg0: i32, %arg1: f32):
+      %c = "arith.constant"() {value = 0 : i32} : () -> i32
+      %d = "arith.cmpi"(%arg0, %c) {predicate = 0 : i64} : (i32, i32) -> i1
+      "scf.condition"(%d, %arg0, %arg1) : (i1, i32, f32) -> ()
+    }, {
+    ^bb0(%arg0: i32, %arg1: f32):
+      %c = "arith.constant"() {value = 1.000000e+00 : f32} : () -> f32
+      %d = "arith.addf"(%c, %arg1) {fastmath = #arith.fastmath<none>} : (f32, f32) -> f32
+      "scf.yield"(%arg0, %d) : (i32, f32) -> ()
+    }) : (i32, f32) -> (i32, f32)
+    func.return
+  }
+
+  // CHECK-NEXT:  func.func @while2() {
+  // CHECK-NEXT:    %{{.*}} = arith.constant 1.000000e+00 : f32
+  // CHECK-NEXT:    %{{.*}} = arith.constant 32 : i32
+  // CHECK-NEXT:    %6, %7 = "scf.while"(%{{.*}}, %{{.*}}) ({
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}} : i32, %{{.*}} : f32):
+  // CHECK-NEXT:      %{{.*}} = arith.constant 0 : i32
+  // CHECK-NEXT:      %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) {"predicate" = 0 : i64} : (i32, i32) -> i1
+  // CHECK-NEXT:      "scf.condition"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, f32) -> ()
+  // CHECK-NEXT:    }, {
+  // CHECK-NEXT:    ^3(%{{.*}} : i32, %{{.*}} : f32):
+  // CHECK-NEXT:      %{{.*}} = arith.constant 1.000000e+00 : f32
+  // CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
+  // CHECK-NEXT:      "scf.yield"(%{{.*}}, %{{.*}}) : (i32, f32) -> ()
+  // CHECK-NEXT:    }) : (i32, f32) -> (i32, f32)
+  // CHECK-NEXT:    func.return
+  // CHECK-NEXT:  }
+
   func.func @for() {
     %lb = arith.constant 0 : index
     %ub = arith.constant 42 : index

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -20,6 +20,8 @@ from xdsl.irdl import (
 from xdsl.traits import HasParent, IsTerminator, SingleBlockImplicitTerminator
 from xdsl.utils.exceptions import VerifyException
 
+from xdsl.utils.deprecation import deprecated
+
 
 @irdl_op_definition
 class While(IRDLOperation):
@@ -29,6 +31,17 @@ class While(IRDLOperation):
     res: VarOpResult = var_result_def(AnyAttr())
     before_region: Region = region_def()
     after_region: Region = region_def()
+
+    def __init__(
+        self,
+        operands: Sequence[SSAValue | Operation],
+        result_types: Sequence[Attribute],
+        before: Region | Sequence[Operation] | Sequence[Block],
+        after: Region | Sequence[Operation] | Sequence[Block],
+    ):
+        super().__init__(
+            operands=[operands], result_types=[result_types], regions=[before, after]
+        )
 
     # TODO verify dependencies between scf.condition, scf.yield and the regions
     def verify_(self):
@@ -46,6 +59,7 @@ class While(IRDLOperation):
                     f"got {self.after_region.block.args[idx].type}"
                 )
 
+    @deprecated("Use While() instead!!")
     @staticmethod
     def get(
         operands: Sequence[SSAValue | Operation],
@@ -54,7 +68,7 @@ class While(IRDLOperation):
         after: Region | Sequence[Operation] | Sequence[Block],
     ) -> While:
         return While.build(
-            operands=operands, result_types=result_types, regions=[before, after]
+            operands=[operands], result_types=[result_types], regions=[before, after]
         )
 
 

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -18,9 +18,8 @@ from xdsl.irdl import (
     var_result_def,
 )
 from xdsl.traits import HasParent, IsTerminator, SingleBlockImplicitTerminator
-from xdsl.utils.exceptions import VerifyException
-
 from xdsl.utils.deprecation import deprecated
+from xdsl.utils.exceptions import VerifyException
 
 
 @irdl_op_definition

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -35,11 +35,11 @@ class While(IRDLOperation):
         self,
         operands: Sequence[SSAValue | Operation],
         result_types: Sequence[Attribute],
-        before: Region | Sequence[Operation] | Sequence[Block],
-        after: Region | Sequence[Operation] | Sequence[Block],
+        before_region: Region | Sequence[Operation] | Sequence[Block],
+        after_region: Region | Sequence[Operation] | Sequence[Block],
     ):
         super().__init__(
-            operands=[operands], result_types=[result_types], regions=[before, after]
+            operands=[operands], result_types=[result_types], regions=[before_region, after_region]
         )
 
     # TODO verify dependencies between scf.condition, scf.yield and the regions
@@ -58,7 +58,7 @@ class While(IRDLOperation):
                     f"got {self.after_region.block.args[idx].type}"
                 )
 
-    @deprecated("Use While() instead!!")
+    @deprecated("Use While() instead")
     @staticmethod
     def get(
         operands: Sequence[SSAValue | Operation],

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -33,13 +33,13 @@ class While(IRDLOperation):
 
     def __init__(
         self,
-        operands: Sequence[SSAValue | Operation],
+        arguments: Sequence[SSAValue | Operation],
         result_types: Sequence[Attribute],
         before_region: Region | Sequence[Operation] | Sequence[Block],
         after_region: Region | Sequence[Operation] | Sequence[Block],
     ):
         super().__init__(
-            operands=[operands],
+            operands=[arguments],
             result_types=[result_types],
             regions=[before_region, after_region],
         )

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -39,7 +39,9 @@ class While(IRDLOperation):
         after_region: Region | Sequence[Operation] | Sequence[Block],
     ):
         super().__init__(
-            operands=[operands], result_types=[result_types], regions=[before_region, after_region]
+            operands=[operands],
+            result_types=[result_types],
+            regions=[before_region, after_region],
         )
 
     # TODO verify dependencies between scf.condition, scf.yield and the regions


### PR DESCRIPTION
- Fixing a bug where in `scf.While.get` we used
```Python
return While.build(
            operands=operands, result_types=result_types, regions=[before, after])
```
instead of 
```Python
return While.build(
            operands=[operands], result_types=[result_types], regions=[before, after])
```
- Marking `scf.While.get` as deprecated
- Adding respective tests for the bug and `scf.While.__init__()`

