### PR TITLE
API: Implement and use the SymbolTable Trait

### DIFF
--- a/tests/filecheck/parser-printer/builtin_attrs.mlir
+++ b/tests/filecheck/parser-printer/builtin_attrs.mlir
@@ -4,7 +4,7 @@
   "func.func"() ({
     ^bb0(%arg0: index):
     "func.return"() : () -> ()
-  }) {function_type = (index) -> (), sym_name = "index_type"} : () -> ()
+  }) {function_type = (index) -> (), sym_name = "index_type_func"} : () -> ()
 
   // CHECK: (index)
 
@@ -67,15 +67,15 @@
 
   // CHECK: 54 : index
 
-  "func.func"() ({}) {function_type = () -> (), value = 54 : f32, sym_name = "index_attr"} : () -> ()
+  "func.func"() ({}) {function_type = () -> (), value = 54 : f32, sym_name = "f32_attr"} : () -> ()
 
   // CHECK: 5.400000e+01 : f32
 
-  "func.func"() ({}) {function_type = () -> (), value = 0x132 : i32, sym_name = "index_attr"} : () -> ()
+  "func.func"() ({}) {function_type = () -> (), value = 0x132 : i32, sym_name = "hex_int_attr"} : () -> ()
 
   // CHECK: 306 : i32
 
-  "func.func"() ({}) {function_type = () -> (), value = 0x132 : f32, sym_name = "index_attr"} : () -> ()
+  "func.func"() ({}) {function_type = () -> (), value = 0x132 : f32, sym_name = "hex_f32_attr"} : () -> ()
 
   // CHECK: 3.060000e+02 : f32
 
@@ -100,7 +100,7 @@
   "func.func"() ({
     ^bb0(%arg0: vector<[4]xf32>, %arg1: vector<[4x4]xf32>, %arg2: vector<12x[2x3]xi32>):
     "func.return"() : () -> ()
-  }) {function_type = (vector<[4]xf32>, vector<[4x4]xf32>, vector<12x[2x3]xi32>) -> (), sym_name = "vector_type"} : () -> ()
+  }) {function_type = (vector<[4]xf32>, vector<[4x4]xf32>, vector<12x[2x3]xi32>) -> (), sym_name = "nd_vector_type"} : () -> ()
 
   // CHECK: (vector<[4]xf32>, vector<[4x4]xf32>, vector<12x[2x3]xi32>)
 
@@ -115,52 +115,52 @@
   "func.func"() ({}) {function_type = () -> (),
                       value1 = dense<[[2, 3]]> : tensor<1x2xi32>,
                       value2 = dense<[0.0, 1.0]> : tensor<2xf64>,
-                      sym_name = "dense_attr"} : () -> ()
+                      sym_name = "dense_tensor_attr"} : () -> ()
 
   // CHECK: "value1" = dense<[[2, 3]]> : tensor<1x2xi32>, "value2" = dense<[0.000000e+00, 1.000000e+00]> : tensor<2xf64>
 
   "func.func"() ({}) {function_type = () -> (),
                       value1 = dense<[0]> : vector<1xi32>,
                       value2 = dense<[0.0, 1.0]> : vector<2xf64>,
-                      sym_name = "dense_attr"} : () -> ()
+                      sym_name = "dense_vector_attr"} : () -> ()
 
   // CHECK: "value1" = dense<0> : vector<1xi32>, "value2" = dense<[0.000000e+00, 1.000000e+00]> : vector<2xf64>
 
   "func.func"() ({}) {function_type = () -> (),
                       value1 = dense<> : tensor<1x23x0x4xi32>,
                       value2 = dense<[[0.0], [1.0]]> : tensor<2x1xf64>,
-                      sym_name = "dense_attr"} : () -> ()
+                      sym_name = "dense_corner_attr"} : () -> ()
 
   // CHECK: "value1" = dense<> : tensor<1x23x0x4xi32>, "value2" = dense<[[0.000000e+00], [1.000000e+00]]> : tensor<2x1xf64>
 
   "func.func"() ({}) {function_type = () -> (),
                       value1 = dense<12> : tensor<2x3xi32>,
-                      sym_name = "dense_attr"} : () -> ()
+                      sym_name = "dense_trivial_attr"} : () -> ()
 
   // CHECK: "value1" = dense<12> : tensor<2x3xi32>
 
   "func.func"() ({}) {function_type = () -> (),
                       value1 = dense<[true, false]> : tensor<2xi1>,
-                      sym_name = "dense_attr"} : () -> ()
+                      sym_name = "dense_bool_attr"} : () -> ()
 
   // CHECK: "value1" = dense<[1, 0]> : tensor<2xi1>
 
   "func.func"() ({}) {function_type = () -> (),
                       value1 = opaque<"test", "contents">,
                       value2 = opaque<"test", "contents"> : tensor<2xf64>,
-                      sym_name = "dense_attr"} : () -> ()
+                      sym_name = "opaque_attr"} : () -> ()
 
   // CHECK: "value1" = opaque<"test", "contents">, "value2" = opaque<"test", "contents"> : tensor<2xf64>
 
   "func.func"() ({}) {function_type = () -> (),
                       value = {"one"=1, "two"=2, "three"="three"},
-                      sym_name = "dense_attr"} : () -> ()
+                      sym_name = "dict_attr"} : () -> ()
 
   // CHECK: "one"=1 : i64, "two"=2 : i64, "three"="three"
 
   "func.func"() ({}) {function_type = () -> (),
                       symbol = @some_symbol,
-                      sym_name = "symbol_attr"} : () -> ()
+                      sym_name = "symbol_ref_attr"} : () -> ()
 
   // CHECK: "symbol" = @some_symbol
 
@@ -178,43 +178,43 @@
 
   "func.func"() ({}) {function_type = () -> (),
                       memref = memref<2xf32>,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "fixed_memref"} : () -> ()
 
   // CHECK: memref<2xf32>
 
   "func.func"() ({}) {function_type = () -> (),
                       memref = memref<2x?xf32>,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "semidynamic_memref"} : () -> ()
 
   // CHECK: memref<2x?xf32>
 
   "func.func"() ({}) {function_type = () -> (),
                       memref = memref<2xf32, strided<[]>>,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "strided_memref"} : () -> ()
 
   // CHECK: memref<2xf32, strided<[]>>
 
   "func.func"() ({}) {function_type = () -> (),
                       memref = memref<2xf32, strided<[]>, 2>,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "strided_memspace_memref"} : () -> ()
 
   // CHECK: memref<2xf32, strided<[]>, 2 : i64>
 
   "func.func"() ({}) {function_type = () -> (),
                       memref = memref<2xf32, 2>,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "memspace_memref"} : () -> ()
 
   // CHECK: memref<2xf32, 2 : i64>
 
   "func.func"() ({}) {function_type = () -> (),
                       memref = memref<*xf32>,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "dynamic_memref"} : () -> ()
 
   // CHECK: memref<*xf32>
 
   "func.func"() ({}) {function_type = () -> (),
                       memref = memref<*xf32, 4>,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "dynamic_memspace_memref"} : () -> ()
 
   // CHECK: memref<*xf32, 4 : i64>
 
@@ -227,13 +227,13 @@
 
   "func.func"() ({}) {function_type = () -> (),
                       type_attr = index,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "index_type"} : () -> ()
 
   // CHECK: "type_attr" = index
 
   "func.func"() ({}) {function_type = () -> (),
                       type_attr = !index,
-                      sym_name = "memref"} : () -> ()
+                      sym_name = "index_type_prefix"} : () -> ()
 
   // CHECK: "type_attr" = index
 
@@ -244,47 +244,47 @@
 
   "func.func"() ({}) {function_type = () -> (),
                       strided = strided<[], offset: ?>,
-                      sym_name = "strided"} : () -> ()
+                      sym_name = "what_strided"} : () -> ()
   // CHECK: "strided" = strided<[], offset: ?>
 
   "func.func"() ({}) {function_type = () -> (),
                       strided = strided<[], offset: 0>,
-                      sym_name = "strided"} : () -> ()
+                      sym_name = "trivial_strided"} : () -> ()
   // CHECK: "strided" = strided<[]>
 
   "func.func"() ({}) {function_type = () -> (),
                       strided = strided<[]>,
-                      sym_name = "strided"} : () -> ()
+                      sym_name = "empty_strided"} : () -> ()
   // CHECK: "strided" = strided<[]>
 
   "func.func"() ({}) {function_type = () -> (),
                       complex = complex<i32>,
-                      sym_name = "complex"} : () -> ()
+                      sym_name = "complex_i32"} : () -> ()
   // CHECK: "complex" = complex<i32>
 
   "func.func"() ({}) {function_type = () -> (),
                       complex = complex<f32>,
-                      sym_name = "complex"} : () -> ()
+                      sym_name = "complex_f32"} : () -> ()
   // CHECK: "complex" = complex<f32>
 
   "func.func"() ({}) {function_type = () -> (),
                       function = () -> i32,
-                      sym_name = "complex"} : () -> ()
+                      sym_name = "one_to_one_func"} : () -> ()
   // CHECK: "function" = () -> i32
 
   "func.func"() ({}) {function_type = () -> (),
                       function = (i1) -> (i32),
-                      sym_name = "complex"} : () -> ()
+                      sym_name = "one_to_one_func_paren"} : () -> ()
   // CHECK: "function" = (i1) -> i32
 
   "func.func"() ({}) {function_type = () -> (),
                       function = (i1, i2) -> (i32, i64),
-                      sym_name = "complex"} : () -> ()
+                      sym_name = "two_to_two_func"} : () -> ()
   // CHECK: "function" = (i1, i2) -> (i32, i64)
 
   "func.func"() ({}) {function_type = () -> (),
                       function = () -> (() -> i32),
-                      sym_name = "complex"} : () -> ()
+                      sym_name = "higher_order_func"} : () -> ()
   // CHECK: "function" = () -> (() -> i32)
 
 }) : () -> ()

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -20,15 +20,25 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import Operation, OpResult, OpTrait
 from xdsl.irdl import (
+    Block,
     IRDLOperation,
     Operand,
+    Region,
     attr_def,
     irdl_op_definition,
     operand_def,
+<<<<<<< HEAD
     opt_attr_def,
     result_def,
 )
 from xdsl.traits import OptionalSymbolOpInterface, SymbolOpInterface
+=======
+    opt_region_def,
+    region_def,
+    result_def,
+)
+from xdsl.traits import SymbolOpInterface, SymbolTable
+>>>>>>> 3779d90d (SymboleTable)
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
@@ -324,3 +334,30 @@ def test_optional_symbol_op_interface():
     assert interface.is_optional_symbol(symbol)
     symbol.verify()
     assert interface.get_sym_attr_name(symbol) == StringAttr("main")
+
+
+def test_symbol_table():
+    @irdl_op_definition
+    class SymbolTableOp(IRDLOperation):
+        name = "test.symbol_table"
+
+        one: Region = region_def()
+        two: Region | None = opt_region_def()
+
+        traits = frozenset([SymbolTable()])
+        pass
+
+    op = SymbolTableOp(regions=[Region(), Region()])
+    with pytest.raises(
+        VerifyException,
+        match="Operations with a 'SymbolTable' must have exactly one region",
+    ):
+        op.verify()
+
+    blocks = [Block(), Block()]
+    op = SymbolTableOp(regions=[Region(), []])
+    with pytest.raises(
+        VerifyException,
+        match="Operations with a 'SymbolTable' must have exactly one block",
+    ):
+        op.verify()

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -35,7 +35,6 @@ from xdsl.irdl import (
     result_def,
 )
 from xdsl.traits import (
-    IsTerminator,
     OptionalSymbolOpInterface,
     SymbolOpInterface,
     SymbolTable,

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -337,7 +337,7 @@ def test_optional_symbol_op_interface():
 
 
 def test_symbol_table():
-    # Some helpers classes
+    # Some helper classes
     @irdl_op_definition
     class SymbolTableOp(IRDLOperation):
         name = "test.symbol_table"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -53,7 +53,11 @@ from xdsl.irdl import (
     var_region_def,
     var_result_def,
 )
+<<<<<<< HEAD
 from xdsl.traits import IsolatedFromAbove, NoTerminator, OptionalSymbolOpInterface
+=======
+from xdsl.traits import IsolatedFromAbove, NoTerminator, SymbolTable
+>>>>>>> 3779d90d (SymboleTable)
 from xdsl.utils.exceptions import VerifyException
 
 if TYPE_CHECKING:
@@ -199,11 +203,11 @@ class SymbolRefAttr(ParametrizedAttribute):
     def __init__(
         self,
         root: str | StringAttr,
-        nested: list[str] | list[StringAttr] | ArrayAttr[StringAttr] = [],
+        nested: Sequence[str] | Sequence[StringAttr] | ArrayAttr[StringAttr] = [],
     ) -> None:
         if isinstance(root, str):
             root = StringAttr(root)
-        if isinstance(nested, list):
+        if isinstance(nested, Sequence):
             nested = ArrayAttr(
                 [StringAttr(x) if isinstance(x, str) else x for x in nested]
             )

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -209,7 +209,7 @@ class SymbolRefAttr(ParametrizedAttribute):
     ) -> None:
         if isinstance(root, str):
             root = StringAttr(root)
-        if isinstance(nested, Sequence):
+        if not isinstance(nested, ArrayAttr):
             nested = ArrayAttr(
                 [StringAttr(x) if isinstance(x, str) else x for x in nested]
             )

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -48,6 +48,7 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     irdl_to_attr_constraint,
+    opt_attr_def,
     region_def,
     var_operand_def,
     var_region_def,
@@ -1220,7 +1221,7 @@ class UnregisteredAttr(ParametrizedAttribute, ABC):
 class ModuleOp(IRDLOperation):
     name = "builtin.module"
 
-    sym_name = attr_def(StringAttr)
+    sym_name = opt_attr_def(StringAttr)
 
     body: Region = region_def("single_block")
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -53,11 +53,12 @@ from xdsl.irdl import (
     var_region_def,
     var_result_def,
 )
-<<<<<<< HEAD
-from xdsl.traits import IsolatedFromAbove, NoTerminator, OptionalSymbolOpInterface
-=======
-from xdsl.traits import IsolatedFromAbove, NoTerminator, SymbolTable
->>>>>>> 3779d90d (SymboleTable)
+from xdsl.traits import (
+    IsolatedFromAbove,
+    NoTerminator,
+    OptionalSymbolOpInterface,
+    SymbolTable,
+)
 from xdsl.utils.exceptions import VerifyException
 
 if TYPE_CHECKING:
@@ -1219,10 +1220,17 @@ class UnregisteredAttr(ParametrizedAttribute, ABC):
 class ModuleOp(IRDLOperation):
     name = "builtin.module"
 
+    sym_name = attr_def(StringAttr)
+
     body: Region = region_def("single_block")
 
     traits = frozenset(
-        [IsolatedFromAbove(), NoTerminator(), OptionalSymbolOpInterface()]
+        [
+            IsolatedFromAbove(),
+            NoTerminator(),
+            OptionalSymbolOpInterface(),
+            SymbolTable(),
+        ]
     )
 
     def __init__(

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -51,7 +51,11 @@ from xdsl.traits import (
     IsolatedFromAbove,
     IsTerminator,
     SingleBlockImplicitTerminator,
+<<<<<<< HEAD
     SymbolOpInterface,
+=======
+    SymbolTable,
+>>>>>>> 3779d90d (SymboleTable)
 )
 from xdsl.utils.exceptions import VerifyException
 
@@ -373,6 +377,7 @@ class ModuleOp(IRDLOperation):
             IsolatedFromAbove(),
             SingleBlockImplicitTerminator(ModuleEndOp),
             SymbolOpInterface(),
+            SymbolTable(),
         ]
     )
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -51,11 +51,8 @@ from xdsl.traits import (
     IsolatedFromAbove,
     IsTerminator,
     SingleBlockImplicitTerminator,
-<<<<<<< HEAD
     SymbolOpInterface,
-=======
     SymbolTable,
->>>>>>> 3779d90d (SymboleTable)
 )
 from xdsl.utils.exceptions import VerifyException
 

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -27,7 +27,13 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.traits import HasParent, IsTerminator, NoTerminator, SymbolOpInterface
+from xdsl.traits import (
+    HasParent,
+    IsTerminator,
+    NoTerminator,
+    SymbolOpInterface,
+    SymbolTable,
+)
 
 ################################################################################
 # Dialect, Operation, and Attribute definitions                                #
@@ -50,7 +56,7 @@ class DialectOp(IRDLOperation):
     sym_name: StringAttr = attr_def(StringAttr)
     body: Region = region_def("single_block")
 
-    traits = frozenset([NoTerminator(), SymbolOpInterface()])
+    traits = frozenset([NoTerminator(), SymbolOpInterface(), SymbolTable()])
 
     def __init__(self, name: str | StringAttr, body: Region):
         if isinstance(name, str):

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -443,7 +443,7 @@ class ParametrizedAttribute(Attribute):
     parameters: list[Attribute] = field(default_factory=list)
 
     @classmethod
-    def new(cls: type[_PA], params: list[Attribute]) -> _PA:
+    def new(cls: type[_PA], params: Sequence[Attribute]) -> _PA:
         """
         Create a new `ParametrizedAttribute` given its parameters.
 
@@ -457,7 +457,7 @@ class ParametrizedAttribute(Attribute):
 
         # Call the __init__ of ParametrizedAttribute, which will set the
         # parameters field.
-        ParametrizedAttribute.__init__(attr, params)
+        ParametrizedAttribute.__init__(attr, list(params))
         return attr
 
     @classmethod

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -202,7 +202,7 @@ class SymbolTable(OpTrait):
     SymbolTable operations are containers for Symbol operations. They offer lookup
     functionality for Symbols, and enforce unique symbols amongst its children.
 
-    A SymbolTable operation is constrained to have a sing-block single region.
+    A SymbolTable operation is constrained to have a single single-block region.
     """
 
     def verify(self, op: Operation):

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from xdsl.utils.exceptions import VerifyException
 
@@ -253,12 +253,7 @@ class SymbolTable(OpTrait):
             ) is not None and sym_interface.get_sym_attr_name(o) == name.root_reference:
                 if not name.nested_references:
                     return o
-                nested_root = name.nested_references.data[0]
-                nested_references: Sequence[StringAttr] = (
-                    name.nested_references.data[1:]
-                    if len(name.nested_references) > 1
-                    else []
-                )
+                nested_root, *nested_references = name.nested_references.data
                 nested_name = SymbolRefAttr(nested_root, nested_references)
                 return SymbolTable.lookup_symbol(o, nested_name)
         return None

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -233,9 +233,8 @@ class SymbolTable(OpTrait):
             name = SymbolRefAttr(name)
         for o in op.regions[0].block.ops:
             if (
-                o.has_trait(SymbolOpInterface)
-                and SymbolOpInterface.get_sym_attr_name(o) == name.root_reference
-            ):
+                sym_interface := o.get_trait(SymbolOpInterface)
+            ) is not None and sym_interface.get_sym_attr_name(o) == name.root_reference:
                 if not name.nested_references:
                     return o
                 nested_root = name.nested_references.data[0]
@@ -245,7 +244,7 @@ class SymbolTable(OpTrait):
                     else []
                 )
                 nested_name = SymbolRefAttr(nested_root, nested_references)
-                return SymbolTable.lookup_symbol(op, nested_name)
+                return SymbolTable.lookup_symbol(o, nested_name)
         return None
 
 

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -244,10 +244,10 @@ class SymbolTable(OpTrait):
         while anchor is not None and not anchor.has_trait(SymbolTable):
             anchor = anchor.parent_op()
         if anchor is None:
-            raise ValueError(f"Operation {op} had no parent SymbolTable")
+            raise ValueError(f"Operation {op} had no SymbolTable ancestor")
         if isinstance(name, str | StringAttr):
             name = SymbolRefAttr(name)
-        for o in op.regions[0].block.ops:
+        for o in anchor.regions[0].block.ops:
             if (
                 sym_interface := o.get_trait(SymbolOpInterface)
             ) is not None and sym_interface.get_sym_attr_name(o) == name.root_reference:

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -217,7 +217,7 @@ class SymbolTable(OpTrait):
             raise VerifyException(
                 "Operations with a 'SymbolTable' must have exactly one block"
             )
-        block = op.regions[0].block
+        block = op.regions[0].blocks[0]
         met_names: set[StringAttr] = set()
         for o in block.ops:
             if "sym_name" not in o.attributes:

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -244,7 +244,7 @@ class SymbolTable(OpTrait):
         while anchor is not None and not anchor.has_trait(SymbolTable):
             anchor = anchor.parent_op()
         if anchor is None:
-            raise ValueError(f"Operation {op} had no SymbolTable ancestor")
+            raise ValueError(f"Operation {op} has no SymbolTable ancestor")
         if isinstance(name, str | StringAttr):
             name = SymbolRefAttr(name)
         for o in anchor.regions[0].block.ops:

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -199,10 +199,10 @@ class IsolatedFromAbove(OpTrait):
 
 class SymbolTable(OpTrait):
     """
-    An operation constrained to have a sing-block single region.
+    SymbolTable operations are containers for Symbol operations. They offer lookup
+    functionality for Symbols, and enforce unique symbols amongst its children.
 
-    It offers lookup functionality for Symbols, and enforce unique symbols amongst
-    its children.
+    A SymbolTable operation is constrained to have a sing-block single region.
     """
 
     def verify(self, op: Operation):

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -220,20 +220,21 @@ class SymbolTable(OpTrait):
                 continue
             if sym_name in met_names:
                 raise VerifyException(f'Redefinition of symbol "{sym_name.data}"')
+            met_names.add(sym_name)
 
     @staticmethod
     def lookup_symbol(
         op: Operation, name: str | StringAttr | SymbolRefAttr
     ) -> Operation | None:
         # import builtin here to avoid circular import
-        from xdsl.dialects.builtin import StringAttr
+        from xdsl.dialects.builtin import StringAttr, SymbolRefAttr
 
         if isinstance(name, str | StringAttr):
             name = SymbolRefAttr(name)
         for o in op.regions[0].block.ops:
             if (
                 o.has_trait(SymbolOpInterface)
-                and SymbolOpInterface.get_sym_attr_name(op) == name.root_reference
+                and SymbolOpInterface.get_sym_attr_name(o) == name.root_reference
             ):
                 if not name.nested_references:
                     return o


### PR DESCRIPTION
The SymbolTable  trait offer Symbol lookup utilites and ensure Symbol uniqueness amongst its children Symbols.
This implements it, tests it, and use it on implemented operations, that is: `builtin.module`, `gpu.module`, and `irdl.dialect`.
For reference: https://mlir.llvm.org/docs/SymbolsAndSymbolTables/
NB: This documentation states "Described above are Symbols, which reside within a region of an operation defining a SymbolTable." but I could not find any enforcment of this anywhere in the codebase, so I didn't implement it. If anyone finds it, please tell :slightly_smiling_face: 