### PR TITLE
interpreter: Use `sym_name` when translating a `gpu.func` to WGSL.

### DIFF
--- a/tests/interpreters/test_wgsl_printer.py
+++ b/tests/interpreters/test_wgsl_printer.py
@@ -293,7 +293,7 @@ builtin.module attributes {gpu.container_module} {
 
     @compute
     @workgroup_size(128,1,1)
-    fn main(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+    fn apply_kernel_kernel(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
     @builtin(workgroup_id) workgroup_id : vec3<u32>,
     @builtin(local_invocation_id) local_invocation_id : vec3<u32>,
     @builtin(num_workgroups) num_workgroups : vec3<u32>) {

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -66,7 +66,7 @@ class WGSLPrinter:
             f"""
     @compute
     @workgroup_size({",".join(str(i) for i in workgroup_size)})
-    fn main(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+    fn {op.sym_name.data}(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
     @builtin(workgroup_id) workgroup_id : vec3<u32>,
     @builtin(local_invocation_id) local_invocation_id : vec3<u32>,
     @builtin(num_workgroups) num_workgroups : vec3<u32>) {{


### PR DESCRIPTION
Just using the actual function name when translating it to WGSL. Will be useful for the upcoming WGPU interpreter!