### PR TITLE
documentation: (toy) add toy accelerator dialect

### DIFF
--- a/docs/Toy/examples/interpret.toy
+++ b/docs/Toy/examples/interpret.toy
@@ -4,6 +4,8 @@
 # RUN: python -m toy %s --emit=toy-infer-shapes | filecheck %s
 # RUN: python -m toy %s --emit=affine | filecheck %s
 
+# RUN: python -m toy %s --emit=affine --accelerate | filecheck %s
+
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {
   return transpose(a) * transpose(b);

--- a/docs/Toy/examples/tests/accelerate_toy.mlir
+++ b/docs/Toy/examples/tests/accelerate_toy.mlir
@@ -1,0 +1,106 @@
+// RUN: python -m toy %s --emit=affine --accelerate --ir | filecheck %s
+
+builtin.module {
+  func.func @main() {
+    %0 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<3x2xf64>
+    %1 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<3x2xf64>
+    %2 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<3x2xf64>
+    %3 = arith.constant 1.000000e+00 : f64
+    %4 = arith.constant 2.000000e+00 : f64
+    %5 = arith.constant 3.000000e+00 : f64
+    %6 = arith.constant 4.000000e+00 : f64
+    %7 = arith.constant 5.000000e+00 : f64
+    %8 = arith.constant 6.000000e+00 : f64
+    %9 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<2x3xf64>
+    %10 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<2x3xf64>
+    "affine.store"(%3, %10) {"map" = affine_map<() -> (0, 0)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%4, %10) {"map" = affine_map<() -> (0, 1)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%5, %10) {"map" = affine_map<() -> (0, 2)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%6, %10) {"map" = affine_map<() -> (1, 0)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%7, %10) {"map" = affine_map<() -> (1, 1)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%8, %10) {"map" = affine_map<() -> (1, 2)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%3, %9) {"map" = affine_map<() -> (0, 0)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%4, %9) {"map" = affine_map<() -> (0, 1)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%5, %9) {"map" = affine_map<() -> (0, 2)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%6, %9) {"map" = affine_map<() -> (1, 0)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%7, %9) {"map" = affine_map<() -> (1, 1)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.store"(%8, %9) {"map" = affine_map<() -> (1, 2)>} : (f64, memref<2x3xf64>) -> ()
+    "affine.for"() ({
+    ^0(%arg0 : index):
+      "affine.for"() ({
+      ^1(%arg1 : index):
+        %11 = "affine.load"(%9, %arg1, %arg0) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (memref<2x3xf64>, index, index) -> f64
+        "affine.store"(%11, %2, %arg0, %arg1) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (f64, memref<3x2xf64>, index, index) -> ()
+        "affine.yield"() : () -> ()
+      }) {"lower_bound" = affine_map<() -> (0)>, "step" = 1 : index, "upper_bound" = affine_map<() -> (2)>} : () -> ()
+      "affine.yield"() : () -> ()
+    }) {"lower_bound" = affine_map<() -> (0)>, "step" = 1 : index, "upper_bound" = affine_map<() -> (3)>} : () -> ()
+    "affine.for"() ({
+    ^2(%arg0_1 : index):
+      "affine.for"() ({
+      ^3(%arg1_1 : index):
+        %12 = "affine.load"(%10, %arg1_1, %arg0_1) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (memref<2x3xf64>, index, index) -> f64
+        "affine.store"(%12, %1, %arg0_1, %arg1_1) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (f64, memref<3x2xf64>, index, index) -> ()
+        "affine.yield"() : () -> ()
+      }) {"lower_bound" = affine_map<() -> (0)>, "step" = 1 : index, "upper_bound" = affine_map<() -> (2)>} : () -> ()
+      "affine.yield"() : () -> ()
+    }) {"lower_bound" = affine_map<() -> (0)>, "step" = 1 : index, "upper_bound" = affine_map<() -> (3)>} : () -> ()
+    "affine.for"() ({
+    ^4(%arg0_2 : index):
+      "affine.for"() ({
+      ^5(%arg1_2 : index):
+        %13 = "affine.load"(%2, %arg0_2, %arg1_2) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (memref<3x2xf64>, index, index) -> f64
+        %14 = "affine.load"(%1, %arg0_2, %arg1_2) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (memref<3x2xf64>, index, index) -> f64
+        %15 = arith.mulf %13, %14 : f64
+        "affine.store"(%15, %0, %arg0_2, %arg1_2) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (f64, memref<3x2xf64>, index, index) -> ()
+        "affine.yield"() : () -> ()
+      }) {"lower_bound" = affine_map<() -> (0)>, "step" = 1 : index, "upper_bound" = affine_map<() -> (2)>} : () -> ()
+      "affine.yield"() : () -> ()
+    }) {"lower_bound" = affine_map<() -> (0)>, "step" = 1 : index, "upper_bound" = affine_map<() -> (3)>} : () -> ()
+    printf.print_format "{}", %0 : memref<3x2xf64>
+    "memref.dealloc"(%10) : (memref<2x3xf64>) -> ()
+    "memref.dealloc"(%9) : (memref<2x3xf64>) -> ()
+    "memref.dealloc"(%2) : (memref<3x2xf64>) -> ()
+    "memref.dealloc"(%1) : (memref<3x2xf64>) -> ()
+    "memref.dealloc"(%0) : (memref<3x2xf64>) -> ()
+    func.return
+  }
+}
+
+// CHECK:         builtin.module {
+// CHECK-NEXT:      func.func @main() {
+// CHECK-NEXT:        %0 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<3x2xf64>
+// CHECK-NEXT:        %1 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<3x2xf64>
+// CHECK-NEXT:        %2 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<3x2xf64>
+// CHECK-NEXT:        %3 = arith.constant 1.000000e+00 : f64
+// CHECK-NEXT:        %4 = arith.constant 2.000000e+00 : f64
+// CHECK-NEXT:        %5 = arith.constant 3.000000e+00 : f64
+// CHECK-NEXT:        %6 = arith.constant 4.000000e+00 : f64
+// CHECK-NEXT:        %7 = arith.constant 5.000000e+00 : f64
+// CHECK-NEXT:        %8 = arith.constant 6.000000e+00 : f64
+// CHECK-NEXT:        %9 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<2x3xf64>
+// CHECK-NEXT:        %10 = "memref.alloc"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<2x3xf64>
+// CHECK-NEXT:        "affine.store"(%3, %10) {"map" = affine_map<() -> (0, 0)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%4, %10) {"map" = affine_map<() -> (0, 1)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%5, %10) {"map" = affine_map<() -> (0, 2)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%6, %10) {"map" = affine_map<() -> (1, 0)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%7, %10) {"map" = affine_map<() -> (1, 1)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%8, %10) {"map" = affine_map<() -> (1, 2)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%3, %9) {"map" = affine_map<() -> (0, 0)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%4, %9) {"map" = affine_map<() -> (0, 1)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%5, %9) {"map" = affine_map<() -> (0, 2)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%6, %9) {"map" = affine_map<() -> (1, 0)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%7, %9) {"map" = affine_map<() -> (1, 1)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "affine.store"(%8, %9) {"map" = affine_map<() -> (1, 2)>} : (f64, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "toy_accelerator.transpose"(%2, %9) {"source_rows" = 2 : index, "source_cols" = 3 : index} : (memref<3x2xf64>, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "toy_accelerator.transpose"(%1, %10) {"source_rows" = 2 : index, "source_cols" = 3 : index} : (memref<3x2xf64>, memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "toy_accelerator.mul"(%0, %2, %1) : (memref<3x2xf64>, memref<3x2xf64>, memref<3x2xf64>) -> ()
+// CHECK-NEXT:        printf.print_format "{}", %0 : memref<3x2xf64>
+// CHECK-NEXT:        "memref.dealloc"(%10) : (memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "memref.dealloc"(%9) : (memref<2x3xf64>) -> ()
+// CHECK-NEXT:        "memref.dealloc"(%2) : (memref<3x2xf64>) -> ()
+// CHECK-NEXT:        "memref.dealloc"(%1) : (memref<3x2xf64>) -> ()
+// CHECK-NEXT:        "memref.dealloc"(%0) : (memref<3x2xf64>) -> ()
+// CHECK-NEXT:        func.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }

--- a/docs/Toy/examples/tests/with-mlir/interpret.toy
+++ b/docs/Toy/examples/tests/with-mlir/interpret.toy
@@ -1,5 +1,7 @@
 # RUN: python -m toy %s --emit=scf | filecheck %s
 
+# RUN: python -m toy %s --emit=scf --accelerate | filecheck %s
+
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {
   return transpose(a) * transpose(b);

--- a/docs/Toy/toy/dialects/toy_accelerator.py
+++ b/docs/Toy/toy/dialects/toy_accelerator.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import abc
+from typing import Annotated
+
+from xdsl.dialects.builtin import AnyIntegerAttr, ArrayAttr
+from xdsl.dialects.memref import MemRefType
+from xdsl.ir import Attribute, Dialect, Operation, SSAValue
+from xdsl.irdl import (
+    ConstraintVar,
+    IRDLOperation,
+    attr_def,
+    irdl_op_definition,
+    operand_def,
+)
+from xdsl.utils.exceptions import VerifyException
+
+
+@irdl_op_definition
+class Transpose(IRDLOperation):
+    name = "toy_accelerator.transpose"
+
+    destination = operand_def(MemRefType)
+    source = operand_def(MemRefType)
+
+    source_rows = attr_def(AnyIntegerAttr)
+    source_cols = attr_def(AnyIntegerAttr)
+
+    def __init__(
+        self,
+        destination: SSAValue | Operation,
+        input: SSAValue | Operation,
+        source_rows: AnyIntegerAttr,
+        source_cols: AnyIntegerAttr,
+    ):
+        super().__init__(
+            operands=(destination, input),
+            attributes={
+                "source_rows": source_rows,
+                "source_cols": source_cols,
+            },
+        )
+
+    def verify_(self) -> None:
+        if not isinstance(self.source.type, MemRefType):
+            raise VerifyException(
+                f"Invalid transpose source type {self.source.type}, expected MemRefType"
+            )
+        if not isinstance(self.destination.type, MemRefType):
+            raise VerifyException(
+                f"Invalid transpose destination type {self.destination.type}, expected MemRefType"
+            )
+
+        expected_source_shape = ArrayAttr((self.source_rows, self.source_cols))
+        source_shape = self.source.type.shape
+
+        if source_shape != expected_source_shape:
+            raise VerifyException(f"Transpose source shape mismatch")
+
+        expected_destination_shape = ArrayAttr((self.source_cols, self.source_rows))
+        destination_shape = self.destination.type.shape
+
+        if destination_shape != expected_destination_shape:
+            raise VerifyException(f"Transpose source shape mismatch")
+
+
+class BinOp(IRDLOperation, abc.ABC):
+    """
+    An in-place mutating binary operation.
+    """
+
+    T = Annotated[MemRefType[Attribute], ConstraintVar("T")]
+
+    dest = operand_def(T)
+    lhs = operand_def(T)
+    rhs = operand_def(T)
+
+    def __init__(
+        self,
+        dest: SSAValue | Operation,
+        lhs: SSAValue | Operation,
+        rhs: SSAValue | Operation,
+    ):
+        super().__init__(operands=(dest, lhs, rhs))
+
+
+@irdl_op_definition
+class Add(BinOp):
+    name = "toy_accelerator.add"
+
+
+@irdl_op_definition
+class Mul(BinOp):
+    name = "toy_accelerator.mul"
+
+
+ToyAccelerator = Dialect(
+    [
+        Transpose,
+        Add,
+        Mul,
+    ],
+    [],
+)

--- a/docs/Toy/toy/emulator/toy_accelerator_functions.py
+++ b/docs/Toy/toy/emulator/toy_accelerator_functions.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any
+
+from xdsl.interpreter import Interpreter, InterpreterFunctions, impl, register_impls
+
+from ..dialects import toy_accelerator
+
+
+@register_impls
+class ToyAcceleratorFunctions(InterpreterFunctions):
+    @impl(toy_accelerator.Transpose)
+    def run_transpose(
+        self,
+        interpreter: Interpreter,
+        op: toy_accelerator.Transpose,
+        args: tuple[Any, ...],
+    ) -> tuple[Any, ...]:
+        dest, source = args
+
+        source_rows = op.source_rows.value.data
+        source_cols = op.source_cols.value.data
+
+        for row in range(source_rows):
+            for col in range(source_cols):
+                value = source.load((row, col))
+                dest.store((col, row), value)
+
+        return ()
+
+    @impl(toy_accelerator.Add)
+    def run_add(
+        self, interpreter: Interpreter, op: toy_accelerator.Add, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        dest, lhs, rhs = args
+
+        for i, (l, r) in enumerate(zip(lhs.data, rhs.data)):
+            dest.data[i] = l + r
+
+        return ()
+
+    @impl(toy_accelerator.Mul)
+    def run_mul(
+        self, interpreter: Interpreter, op: toy_accelerator.Mul, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        dest, lhs, rhs = args
+
+        for i, (l, r) in enumerate(zip(lhs.data, rhs.data)):
+            dest.data[i] = l * r
+
+        return ()

--- a/docs/Toy/toy/rewrites/lower_to_toy_accelerator.py
+++ b/docs/Toy/toy/rewrites/lower_to_toy_accelerator.py
@@ -1,0 +1,189 @@
+from xdsl.dialects import affine, arith, memref, riscv
+from xdsl.dialects.builtin import ModuleOp, UnrealizedConversionCastOp
+from xdsl.ir import MLContext, SSAValue
+from xdsl.ir.core import OpResult
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from ..dialects import toy_accelerator
+
+
+def cast_value_to_register(operand: SSAValue, rewriter: PatternRewriter) -> OpResult:
+    types = (riscv.IntRegisterType.unallocated(),)
+    cast = UnrealizedConversionCastOp.get((operand,), types)
+    rewriter.insert_op_before_matched_op(cast)
+    return cast.results[0]
+
+
+class LowerAffineForOp(RewritePattern):
+    """
+    Matches on nested loops that implement elementwise addition or transpose, and rewrites
+    them as custom toy accelerator instructions.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: affine.For, rewriter: PatternRewriter):
+        # Check this is a doubly nested affine for loop, where both loops don't yield
+        # values.
+        if (
+            len(op.body.blocks) != 1
+            or len((outer_block := op.body.blocks[0]).ops) != 2
+            or not isinstance(inner_for := outer_block.first_op, affine.For)
+            or not isinstance(outer_block.last_op, affine.Yield)
+            or outer_block.last_op.operands
+            or len(inner_for.body.blocks) != 1
+            or not (inner_block := inner_for.body.blocks[0])
+            or not isinstance(inner_block.last_op, affine.Yield)
+            or inner_block.last_op.operands
+        ):
+            return
+
+        # Check that the indices step from 0 to upper bound by 1
+
+        all_bounds = (
+            op.lower_bound.data,
+            op.upper_bound.data,
+            inner_for.lower_bound.data,
+            inner_for.upper_bound.data,
+        )
+        if any(bound.num_dims or bound.num_symbols for bound in all_bounds):
+            # Loop is not made of constant values
+            return
+
+        ostep = op.step.value.data
+        istep = inner_for.step.value.data
+
+        if ostep != 1 or istep != 1:
+            # Loop does not step by 1
+            return
+
+        olb, oub, ilb, iub = tuple(bound.eval([], [])[0] for bound in all_bounds)
+
+        if olb != 0 or ilb != 0:
+            # Loop doesn't start from 0
+            return
+
+        # We now need to check whether it's a transpose or an elementwise
+        # operation.
+
+        if len(inner_block.ops) == 3:
+            (load, store, _) = inner_block.ops
+            if not (isinstance(load, affine.Load) and isinstance(store, affine.Store)):
+                return
+
+            if load.indices != store.indices[::-1]:
+                return
+
+            # This is a transpose op
+
+            memref_typ = load.memref.type
+            assert isinstance(memref_typ, memref.MemRefType)
+            rows, cols = memref_typ.shape
+
+            if rows.value.data != iub or cols.value.data != oub:
+                # The indices aren't fully enumerated
+                return
+
+            rewriter.replace_matched_op(
+                toy_accelerator.Transpose(store.memref, load.memref, rows, cols)
+            )
+        elif len(inner_block.ops) == 5:
+            lhs_load, rhs_load, binop, store, _ = inner_block.ops
+            if not (
+                isinstance(lhs_load, affine.Load)
+                and isinstance(rhs_load, affine.Load)
+                and isinstance(store, affine.Store)
+                and isinstance(binop, (arith.Addf, arith.Mulf))
+            ):
+                return
+
+            # size = oub * iub
+
+            instr_cls = (
+                toy_accelerator.Add
+                if isinstance(binop, arith.Addf)
+                else toy_accelerator.Mul
+            )
+
+            rewriter.replace_matched_op(
+                [instr_cls(store.memref, lhs_load.memref, rhs_load.memref)]
+            )
+
+
+class LowerToToyAccelerator(ModulePass):
+    name = "lower-to-toy-accelerator"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        ctx.register_dialect(toy_accelerator.ToyAccelerator)
+        PatternRewriteWalker(LowerAffineForOp()).rewrite_module(op)
+
+
+class LowerTransposeOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: toy_accelerator.Transpose, rewriter: PatternRewriter
+    ):
+        destination = cast_value_to_register(op.destination, rewriter)
+        source = cast_value_to_register(op.source, rewriter)
+
+        rewriter.replace_matched_op(
+            [
+                rows_op := riscv.LiOp(op.source_rows.value.data, comment="source rows"),
+                cols_op := riscv.LiOp(op.source_cols.value.data, comment="source cols"),
+                riscv.CustomAssemblyInstructionOp(
+                    "tensor.transpose2d",
+                    (destination, source, rows_op.rd, cols_op.rd),
+                    (),
+                ),
+            ]
+        )
+
+
+class LowerBinOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: toy_accelerator.BinOp, rewriter: PatternRewriter):
+        typ = op.dest.type
+        assert isinstance(typ, memref.MemRefType)
+        size = typ.element_count()
+
+        instruction_name = (
+            "buffer.add" if isinstance(op, toy_accelerator.Add) else "buffer.mul"
+        )
+        dest = cast_value_to_register(op.dest, rewriter)
+        lhs = cast_value_to_register(op.lhs, rewriter)
+        rhs = cast_value_to_register(op.rhs, rewriter)
+        rewriter.replace_matched_op(
+            [
+                size_op := riscv.LiOp(size, comment="size"),
+                riscv.CustomAssemblyInstructionOp(
+                    "buffer.add",
+                    (size_op.rd, dest, lhs),
+                    (),
+                ),
+                riscv.CustomAssemblyInstructionOp(
+                    instruction_name,
+                    (size_op.rd, dest, rhs),
+                    (),
+                ),
+            ]
+        )
+
+
+class LowerToyAccelerator(ModulePass):
+    name = "lower-toy-accelerator"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    LowerTransposeOp(),
+                    LowerBinOp(),
+                ]
+            )
+        ).rewrite_module(op)

--- a/docs/Toy/toy/rewrites/lower_to_toy_accelerator.py
+++ b/docs/Toy/toy/rewrites/lower_to_toy_accelerator.py
@@ -14,6 +14,10 @@ from ..dialects import toy_accelerator
 
 
 def cast_value_to_register(operand: SSAValue, rewriter: PatternRewriter) -> OpResult:
+    """
+    Inserts a cast from any SSA value to an unallocated RISC-V register before the matched
+    op.
+    """
     types = (riscv.IntRegisterType.unallocated(),)
     cast = UnrealizedConversionCastOp.get((operand,), types)
     rewriter.insert_op_before_matched_op(cast)

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -441,17 +441,6 @@ class LowerToAffinePass(ModulePass):
     name = "toy-to-builtin"
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
-        # We define the specific operations, or dialects, that are legal targets for this
-        # lowering. In our case, we are lowering to a combination of the `Affine`,
-        # `Arith`, `Func`, and `MemRef` dialects.
-        ctx.register_dialect(affine.Affine)
-        ctx.register_dialect(arith.Arith)
-        ctx.register_dialect(func.Func)
-        ctx.register_dialect(memref.MemRef)
-
-        # Now that the conversion target has been defined, we just need to provide the set
-        # of patterns that will lower the Toy operations.
-
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [


### PR DESCRIPTION
The main idea is to show how to divert the compilation flow to a toy accelerator. This is much simpler than the plan with snitch etc, but still shows the vague idea of matching on affine loops and raising them to a different builtin operation.

As part of the Toy compilation, we know that the accelerator matches all the possible affine loops that we create, meaning that we can compile it end-to-end in python without relying on MLIR.