### PR TITLE
dialects: (riscv-scf) Add riscv_scf.for and yield ops

### DIFF
--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -3,8 +3,10 @@
     %lb = "riscv.li"() {"immediate" = 0: i32} : () -> !riscv.reg<>
     %ub = "riscv.li"() {"immediate" = 100: i32} : () -> !riscv.reg<>
     %step = "riscv.li"() {"immediate" = 1: i32} : () -> !riscv.reg<>
+    %acc = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<t0>
     "riscv_scf.for"(%lb, %ub, %step) ({
         ^1(%i: !riscv.reg<>):
+            "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
             "riscv_scf.yield"() : () -> ()
     }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 }) : () -> ()
@@ -13,8 +15,10 @@
 // CHECK-NEXT:   %lb = riscv.li  {"immediate" = 0 : i32} : () -> !riscv.reg<>
 // CHECK-NEXT:   %ub = riscv.li  {"immediate" = 100 : i32} : () -> !riscv.reg<>
 // CHECK-NEXT:   %step = riscv.li  {"immediate" = 1 : i32} : () -> !riscv.reg<>
+// CHECK-NEXT:   %acc = riscv.li  {"immediate" = 0 : i32} : () -> !riscv.reg<t0>
 // CHECK-NEXT:   "riscv_scf.for"(%lb, %ub, %step) ({
 // CHECK-NEXT:   ^0(%i : !riscv.reg<>):
+// CHECK-NEXT:     %0 = riscv.addi %acc {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:     "riscv_scf.yield"() : () -> ()
 // CHECK-NEXT:   }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -1,0 +1,20 @@
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | xdsl-opt | filecheck %s
+"builtin.module"() ({
+    %lb = "riscv.li"() {"immediate" = 0: i32} : () -> !riscv.reg<>
+    %ub = "riscv.li"() {"immediate" = 100: i32} : () -> !riscv.reg<>
+    %step = "riscv.li"() {"immediate" = 1: i32} : () -> !riscv.reg<>
+    "riscv_scf.for"(%lb, %ub, %step) ({
+        ^1(%i: !riscv.reg<>):
+            "riscv_scf.yield"() : () -> ()
+    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+}) : () -> ()
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %lb = riscv.li  {"immediate" = 0 : i32} : () -> !riscv.reg<>
+// CHECK-NEXT:   %ub = riscv.li  {"immediate" = 100 : i32} : () -> !riscv.reg<>
+// CHECK-NEXT:   %step = riscv.li  {"immediate" = 1 : i32} : () -> !riscv.reg<>
+// CHECK-NEXT:   "riscv_scf.for"(%lb, %ub, %step) ({
+// CHECK-NEXT:   ^0(%i : !riscv.reg<>):
+// CHECK-NEXT:     "riscv_scf.yield"() : () -> ()
+// CHECK-NEXT:   }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT: }

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -73,7 +73,7 @@ class ForOp(IRDLOperation):
         )
 
 
-RVSCF = Dialect(
+RISCV_Scf = Dialect(
     [
         YieldOp,
         ForOp,

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -4,24 +4,11 @@ RISC-V SCF dialect
 from __future__ import annotations
 
 from typing import Sequence
-from xdsl.irdl import (
-    IRDLOperation,
-    irdl_op_definition,
-    Operand,
-    operand_def,
-    var_operand_def,
-    VarOperand,
-    SSAValue,
-    Operation,
-    VarOpResult,
-    var_result_def,
-    Region,
-    region_def,
-    Block,
-)
-from xdsl.traits import SingleBlockImplicitTerminator, IsTerminator
+
+from xdsl.dialects.riscv import IntRegisterType, RISCVRegisterType
 from xdsl.ir import Dialect
-from xdsl.dialects.riscv import RISCVRegisterType, IntRegisterType
+from xdsl.irdl import Block, IRDLOperation, Operand, Operation, Region, SSAValue, VarOperand, VarOpResult, irdl_op_definition, operand_def, region_def, var_operand_def, var_result_def
+from xdsl.traits import IsTerminator, SingleBlockImplicitTerminator
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -7,7 +7,21 @@ from typing import Sequence
 
 from xdsl.dialects.riscv import IntRegisterType, RISCVRegisterType
 from xdsl.ir import Dialect
-from xdsl.irdl import Block, IRDLOperation, Operand, Operation, Region, SSAValue, VarOperand, VarOpResult, irdl_op_definition, operand_def, region_def, var_operand_def, var_result_def
+from xdsl.irdl import (
+    Block,
+    IRDLOperation,
+    Operand,
+    Operation,
+    Region,
+    SSAValue,
+    VarOperand,
+    VarOpResult,
+    irdl_op_definition,
+    operand_def,
+    region_def,
+    var_operand_def,
+    var_result_def,
+)
 from xdsl.traits import IsTerminator, SingleBlockImplicitTerminator
 
 

--- a/xdsl/dialects/rvscf.py
+++ b/xdsl/dialects/rvscf.py
@@ -10,7 +10,6 @@ from xdsl.irdl import (
     Operand,
     operand_def,
     var_operand_def,
-    AnyAttr,
     VarOperand,
     SSAValue,
     Operation,
@@ -22,14 +21,18 @@ from xdsl.irdl import (
 )
 from xdsl.traits import SingleBlockImplicitTerminator, IsTerminator
 from xdsl.ir import Dialect
-from xdsl.dialects.riscv import RISCVRegisterType
+from xdsl.dialects.riscv import RISCVRegisterType, IntRegisterType
 
 
 @irdl_op_definition
 class YieldOp(IRDLOperation):
-    name = "rvscf.yield"
+    name = "riscv_scf.yield"
 
     arguments: VarOperand = var_operand_def(RISCVRegisterType)
+
+    # TODO circular dependency disallows this set of traits
+    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
+    # traits = frozenset([HasParent((For, If, ParallelOp, While)), IsTerminator()])
     traits = frozenset([IsTerminator()])
 
     def __init__(self, *operands: SSAValue | Operation):
@@ -38,11 +41,11 @@ class YieldOp(IRDLOperation):
 
 @irdl_op_definition
 class ForOp(IRDLOperation):
-    name = "rvscf.for"
+    name = "riscv_scf.for"
 
-    lb: Operand = operand_def(RISCVRegisterType)
-    ub: Operand = operand_def(RISCVRegisterType)
-    step: Operand = operand_def(RISCVRegisterType)
+    lb: Operand = operand_def(IntRegisterType)
+    ub: Operand = operand_def(IntRegisterType)
+    step: Operand = operand_def(IntRegisterType)
 
     iter_args: VarOperand = var_operand_def(RISCVRegisterType)
 

--- a/xdsl/dialects/rvscf.py
+++ b/xdsl/dialects/rvscf.py
@@ -29,7 +29,7 @@ from xdsl.dialects.riscv import RISCVRegisterType
 class YieldOp(IRDLOperation):
     name = "rvscf.yield"
 
-    arguments: VarOperand = var_operand_def(AnyAttr())
+    arguments: VarOperand = var_operand_def(RISCVRegisterType)
     traits = frozenset([IsTerminator()])
 
     def __init__(self, *operands: SSAValue | Operation):
@@ -44,9 +44,9 @@ class ForOp(IRDLOperation):
     ub: Operand = operand_def(RISCVRegisterType)
     step: Operand = operand_def(RISCVRegisterType)
 
-    iter_args: VarOperand = var_operand_def(AnyAttr())
+    iter_args: VarOperand = var_operand_def(RISCVRegisterType)
 
-    res: VarOpResult = var_result_def(AnyAttr())
+    res: VarOpResult = var_result_def(RISCVRegisterType)
 
     body: Region = region_def("single_block")
 

--- a/xdsl/dialects/rvscf.py
+++ b/xdsl/dialects/rvscf.py
@@ -1,0 +1,79 @@
+"""
+RISC-V SCF dialect
+"""
+from __future__ import annotations
+
+from typing import Sequence
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_op_definition,
+    Operand,
+    operand_def,
+    var_operand_def,
+    AnyAttr,
+    VarOperand,
+    SSAValue,
+    Operation,
+    VarOpResult,
+    var_result_def,
+    Region,
+    region_def,
+    Block,
+)
+from xdsl.traits import SingleBlockImplicitTerminator, IsTerminator
+from xdsl.ir import Dialect
+from xdsl.dialects.riscv import RISCVRegisterType
+
+
+@irdl_op_definition
+class YieldOp(IRDLOperation):
+    name = "rvscf.yield"
+
+    arguments: VarOperand = var_operand_def(AnyAttr())
+    traits = frozenset([IsTerminator()])
+
+    def __init__(self, *operands: SSAValue | Operation):
+        super().__init__(operands=[SSAValue.get(operand) for operand in operands])
+
+
+@irdl_op_definition
+class ForOp(IRDLOperation):
+    name = "rvscf.for"
+
+    lb: Operand = operand_def(RISCVRegisterType)
+    ub: Operand = operand_def(RISCVRegisterType)
+    step: Operand = operand_def(RISCVRegisterType)
+
+    iter_args: VarOperand = var_operand_def(AnyAttr())
+
+    res: VarOpResult = var_result_def(AnyAttr())
+
+    body: Region = region_def("single_block")
+
+    traits = frozenset([SingleBlockImplicitTerminator(YieldOp)])
+
+    def __init__(
+        self,
+        lb: SSAValue | Operation,
+        ub: SSAValue | Operation,
+        step: SSAValue | Operation,
+        iter_args: Sequence[SSAValue | Operation],
+        body: Region | Sequence[Operation] | Sequence[Block] | Block,
+    ):
+        if isinstance(body, Block):
+            body = [body]
+
+        super().__init__(
+            operands=[lb, ub, step, iter_args],
+            result_types=[[SSAValue.get(a).type for a in iter_args]],
+            regions=[body],
+        )
+
+
+RVSCF = Dialect(
+    [
+        YieldOp,
+        ForOp,
+    ],
+    [],
+)

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -23,6 +23,7 @@ from xdsl.dialects.pdl import PDL
 from xdsl.dialects.printf import Printf
 from xdsl.dialects.riscv import RISCV
 from xdsl.dialects.riscv_func import RISCV_Func
+from xdsl.dialects.riscv_scf import RISCV_Scf
 from xdsl.dialects.scf import Scf
 from xdsl.dialects.snitch import Snitch
 from xdsl.dialects.snitch_runtime import SnitchRuntime
@@ -31,26 +32,11 @@ from xdsl.dialects.test import Test
 from xdsl.dialects.vector import Vector
 from xdsl.frontend.passes.desymref import DesymrefyPass
 from xdsl.frontend.symref import Symref
-from xdsl.dialects.riscv_scf import RISCV_Scf
 from xdsl.ir import Dialect, MLContext
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass
-from xdsl.transforms import (
-    dead_code_elimination,
-    lower_mpi,
-    lower_riscv_func,
-    lower_snitch,
-    lower_snitch_runtime,
-    mlir_opt,
-    printf_to_llvm,
-    reconcile_unrealized_casts,
-    riscv_register_allocation,
-)
-from xdsl.transforms.experimental import (
-    convert_stencil_to_ll_mlir,
-    stencil_shape_inference,
-    stencil_storage_materialization,
-)
+from xdsl.transforms import dead_code_elimination, lower_mpi, lower_riscv_func, lower_snitch, lower_snitch_runtime, mlir_opt, printf_to_llvm, reconcile_unrealized_casts, riscv_register_allocation
+from xdsl.transforms.experimental import convert_stencil_to_ll_mlir, stencil_shape_inference, stencil_storage_materialization
 from xdsl.transforms.experimental.dmp import stencil_global_to_local
 from xdsl.utils.exceptions import ParseError
 

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -31,6 +31,7 @@ from xdsl.dialects.test import Test
 from xdsl.dialects.vector import Vector
 from xdsl.frontend.passes.desymref import DesymrefyPass
 from xdsl.frontend.symref import Symref
+from xdsl.dialects.riscv_scf import RISCV_Scf
 from xdsl.ir import Dialect, MLContext
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass
@@ -76,6 +77,7 @@ def get_all_dialects() -> list[Dialect]:
         Printf,
         RISCV,
         RISCV_Func,
+        RISCV_Scf,
         Scf,
         Snitch,
         SnitchRuntime,

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -35,8 +35,22 @@ from xdsl.frontend.symref import Symref
 from xdsl.ir import Dialect, MLContext
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass
-from xdsl.transforms import dead_code_elimination, lower_mpi, lower_riscv_func, lower_snitch, lower_snitch_runtime, mlir_opt, printf_to_llvm, reconcile_unrealized_casts, riscv_register_allocation
-from xdsl.transforms.experimental import convert_stencil_to_ll_mlir, stencil_shape_inference, stencil_storage_materialization
+from xdsl.transforms import (
+    dead_code_elimination,
+    lower_mpi,
+    lower_riscv_func,
+    lower_snitch,
+    lower_snitch_runtime,
+    mlir_opt,
+    printf_to_llvm,
+    reconcile_unrealized_casts,
+    riscv_register_allocation,
+)
+from xdsl.transforms.experimental import (
+    convert_stencil_to_ll_mlir,
+    stencil_shape_inference,
+    stencil_storage_materialization,
+)
 from xdsl.transforms.experimental.dmp import stencil_global_to_local
 from xdsl.utils.exceptions import ParseError
 


### PR DESCRIPTION
This adds the `rvscf.for` and `rvscf.yield` ops to the new `rvscf` dialect, which we want to use to do register allocation at higher levels