### PR TITLE
core: (trait) Implement LazyTrait to workaround circular dependency

### DIFF
--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -272,10 +272,9 @@ class IsSingleBlockImplicitTerminatorOp(IRDLOperation):
 
     name = "test.is_single_block_implicit_terminator"
 
-    # TODO fix circular reference
-    # traits = frozenset([HasParent(HasSingleBlockImplicitTerminatorOp), IsTerminator()])
-    # this is tracked by gh issue: https://github.com/xdslproject/xdsl/issues/1218
-    traits = frozenset([IsTerminator()])
+    traits = frozenset(
+        [HasParent(lambda: HasSingleBlockImplicitTerminatorOp), IsTerminator()]
+    )
 
 
 @irdl_op_definition

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -22,6 +22,7 @@ from xdsl.traits import (
     HasParent,
     IsolatedFromAbove,
     IsTerminator,
+    LazyTrait,
     NoTerminator,
     SingleBlockImplicitTerminator,
     ensure_terminator,
@@ -66,7 +67,7 @@ class HasMultipleParentOp(IRDLOperation):
 
     name = "test.has_multiple_parent"
 
-    traits = frozenset([HasParent((ParentOp, Parent2Op))])
+    traits = frozenset([HasParent(ParentOp, Parent2Op)])
 
 
 def test_has_parent_no_parent():
@@ -273,7 +274,10 @@ class IsSingleBlockImplicitTerminatorOp(IRDLOperation):
     name = "test.is_single_block_implicit_terminator"
 
     traits = frozenset(
-        [HasParent(lambda: HasSingleBlockImplicitTerminatorOp), IsTerminator()]
+        [
+            LazyTrait(lambda: HasParent(HasSingleBlockImplicitTerminatorOp)),
+            IsTerminator(),
+        ]
     )
 
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -50,6 +50,7 @@ from xdsl.traits import (
     HasParent,
     IsolatedFromAbove,
     IsTerminator,
+    LazyTrait,
     SingleBlockImplicitTerminator,
     SymbolOpInterface,
     SymbolTable,
@@ -353,7 +354,7 @@ class MemcpyOp(IRDLOperation):
 class ModuleEndOp(IRDLOperation):
     name = "gpu.module_end"
 
-    traits = frozenset([HasParent(lambda: ModuleOp), IsTerminator()])
+    traits = frozenset([LazyTrait(lambda: HasParent(ModuleOp)), IsTerminator()])
 
     def __init__(self):
         return super().__init__()

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -353,10 +353,7 @@ class MemcpyOp(IRDLOperation):
 class ModuleEndOp(IRDLOperation):
     name = "gpu.module_end"
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent(ModuleOp), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = frozenset([HasParent(lambda: ModuleOp), IsTerminator()])
 
     def __init__(self):
         return super().__init__()

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -30,7 +30,6 @@ from xdsl.printer import Printer
 from xdsl.traits import (
     HasParent,
     IsTerminator,
-    LazyTrait,
     NoTerminator,
     SymbolOpInterface,
     SymbolTable,

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -30,6 +30,7 @@ from xdsl.printer import Printer
 from xdsl.traits import (
     HasParent,
     IsTerminator,
+    LazyTrait,
     NoTerminator,
     SymbolOpInterface,
     SymbolTable,
@@ -145,7 +146,7 @@ class ParametersOp(IRDLOperation):
 
     args: VarOperand = var_operand_def(AttributeType)
 
-    traits = frozenset([HasParent((TypeOp, AttributeOp))])
+    traits = frozenset([HasParent(TypeOp, AttributeOp)])
 
     def __init__(self, args: Sequence[SSAValue]):
         super().__init__(operands=[args])

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -78,10 +78,12 @@ class Yield(IRDLOperation):
     name = "scf.yield"
     arguments: VarOperand = var_operand_def(AnyAttr())
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent((For, If, ParallelOp, While)), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = frozenset(
+        [
+            HasParent((lambda: For, lambda: If, lambda: ParallelOp, lambda: While)),
+            IsTerminator(),
+        ]
+    )
 
     @staticmethod
     def get(*operands: SSAValue | Operation) -> Yield:

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -17,7 +17,12 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.traits import HasParent, IsTerminator, SingleBlockImplicitTerminator
+from xdsl.traits import (
+    HasParent,
+    IsTerminator,
+    LazyTrait,
+    SingleBlockImplicitTerminator,
+)
 from xdsl.utils.deprecation import deprecated
 from xdsl.utils.exceptions import VerifyException
 
@@ -80,7 +85,7 @@ class Yield(IRDLOperation):
 
     traits = frozenset(
         [
-            HasParent((lambda: For, lambda: If, lambda: ParallelOp, lambda: While)),
+            LazyTrait(lambda: HasParent(For, If, ParallelOp, While)),
             IsTerminator(),
         ]
     )

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -34,6 +34,8 @@ OpTraitInvT = TypeVar("OpTraitInvT", bound=OpTrait)
 
 
 class LazyTrait(OpTrait):
+    """A trait that postpone evaluation of other traits. Can be used to workaround circular dependency."""
+
     parameters: tuple[Callable[[], OpTrait | tuple[OpTrait, ...]], ...]
 
     def __init__(self, *parameters: Callable[[], OpTrait | tuple[OpTrait, ...]]):

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from inspect import isclass
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from xdsl.utils.exceptions import VerifyException
@@ -34,6 +33,21 @@ class OpTrait:
 OpTraitInvT = TypeVar("OpTraitInvT", bound=OpTrait)
 
 
+class LazyTrait(OpTrait):
+    parameters: tuple[Callable[[], OpTrait | tuple[OpTrait, ...]], ...]
+
+    def __init__(self, *parameters: Callable[[], OpTrait | tuple[OpTrait, ...]]):
+        super().__init__(parameters)
+
+    def verify(self, op: Operation) -> None:
+        for func in self.parameters:
+            traits = func()
+            if not isinstance(traits, tuple):
+                traits = (traits,)
+            for trait in traits:
+                trait.verify(op)
+
+
 class Pure(OpTrait):
     """A trait that signals that an operation has no side effects."""
 
@@ -43,39 +57,21 @@ class HasParent(OpTrait):
     """Constraint the operation to have a specific parent operation."""
 
     parameters: tuple[type[Operation], ...]
-    _unresolved: bool = field(default=True)
 
-    def __init__(
-        self,
-        parameters: type[Operation]
-        | Callable[[], type[Operation]]
-        | tuple[type[Operation] | Callable[[], type[Operation]], ...],
-    ):
-        if not isinstance(parameters, tuple):
-            parameters = (parameters,)
+    def __init__(self, *parameters: type[Operation]):
         if len(parameters) == 0:
             raise ValueError("parameters must not be empty")
         super().__init__(parameters)
 
     def verify(self, op: Operation) -> None:
-        if self._unresolved:
-            object.__setattr__(
-                self,
-                "parameters",
-                tuple(
-                    parameter if isclass(parameter) else parameter()
-                    for parameter in self.parameters
-                ),
-            )
-            object.__setattr__(self, "_unresolved", True)
         parent = op.parent_op()
-        if isinstance(parent, tuple(self.parameters)):
+        if isinstance(parent, self.parameters):
             return
         if len(self.parameters) == 1:
             raise VerifyException(
                 f"'{op.name}' expects parent op '{self.parameters[0].name}'"
             )
-        names = ", ".join([f"'{p.name}'" for p in self.parameters])
+        names = ", ".join(f"'{p.name}'" for p in self.parameters)
         raise VerifyException(f"'{op.name}' expects parent op to be one of {names}")
 
 


### PR DESCRIPTION
Address #1218 

`LazyTrait` is implemented to postpone evaluation of provided traits.
