### PR TITLE
misc: ignore wgpu interpreter file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ typeCheckingMode = "strict"
     "tests/test_frontend_op_resolver.py",
     "tests/test_frontend_python_code_check.py",
     "tests/dialects/test_memref.py",
+    "xdsl/interpreters/experimental/wgpu.py",
 ]
 "ignore" = [
     "tests/filecheck/frontend/dialects/builtin.py",


### PR DESCRIPTION
The dependency has linting issues, I don't think we care about them