### PR TITLE
dialects: Updating arith to init

### DIFF
--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -471,16 +471,8 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -223,7 +223,7 @@
     "    const1 = Constant.from_int_and_width(5, 32)\n",
     "    const2 = Constant.from_int_and_width(5, 32)\n",
     "    add = Addi(const1, const2)\n",
-    "    cmp = Cmpi.get(arg, add, \"sgt\")\n",
+    "    cmp = Cmpi(arg, add, \"sgt\")\n",
     "    # sgt stands for `signed greater than`. In xDSL, this is encoded as a predicate attribute with value 4.\n",
     "    Yield.get(cmp)"
    ]
@@ -471,8 +471,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/docs/xdsl-introduction.ipynb
+++ b/docs/xdsl-introduction.ipynb
@@ -625,7 +625,7 @@
     "    const2 = arith.Constant.from_int_and_width(5, 32)\n",
     "    summed = arith.Addi(const1, const2)\n",
     "    # sgt stands for `signed greater than`. xDSL represents internally as a constant attribute \"4\"\n",
-    "    cmp_result = arith.Cmpi.get(arg0, summed, \"sgt\")\n",
+    "    cmp_result = arith.Cmpi(arg0, summed, \"sgt\")\n",
     "filter_region = Region(block)\n",
     "\n",
     "# initialises a \"Filter\" opeartion using previous selection result and defined region:\n",

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -32,6 +32,7 @@ from xdsl.dialects.arith import (
     OrI,
     RemSI,
     RemUI,
+    Select,
     ShLI,
     ShRSI,
     ShRUI,
@@ -92,14 +93,14 @@ class Test_integer_arith_construction:
         assert op.result.type == self.operand_type
 
     def test_Cmpi(self):
-        _ = Cmpi.get(self.a, self.b, 2)
+        _ = Cmpi(self.a, self.b, 2)
 
     @pytest.mark.parametrize(
         "input",
         ["eq", "ne", "slt", "sle", "ult", "ule", "ugt", "uge"],
     )
     def test_Cmpi_from_mnemonic(self, input: str):
-        _ = Cmpi.get(self.a, self.b, input)
+        _ = Cmpi(self.a, self.b, input)
 
 
 class Test_float_arith_construction:
@@ -114,6 +115,19 @@ class Test_float_arith_construction:
         op = func(self.a, self.b)
         assert op.operands[0].owner is self.a
         assert op.operands[1].owner is self.b
+
+
+def test_select_op():
+    t = Constant.from_int_and_width(1, IntegerType(1))
+    f = Constant.from_int_and_width(0, IntegerType(1))
+    select_t_op = Select(t, t, f)
+    select_f_op = Select(f, t, f)
+    select_t_op.verify_()
+    select_f_op.verify_()
+
+    # wanting to verify it actually selected the correct operand, but not sure if in correct scope
+    assert select_t_op.result.type == t.result.type
+    assert select_f_op.result.type == f.result.type
 
 
 def test_index_cast_op():
@@ -138,10 +152,10 @@ def test_cast_fp_and_si_ops():
 
 def test_negf_op():
     a = Constant.from_float_and_width(1.0, f32)
-    neg_a = Negf.get(a)
+    neg_a = Negf(a)
 
     b = Constant.from_float_and_width(1.0, f64)
-    neg_b = Negf.get(b)
+    neg_b = Negf(b)
 
     assert neg_a.result.type == f32
     assert neg_b.result.type == f64
@@ -180,7 +194,7 @@ def test_cmpf_from_mnemonic():
         "uno",
         "true",
     ]
-    cmpf_ops = [Cmpf.get(a, b, operations[i]) for i in range(len(operations))]
+    cmpf_ops = [Cmpf(a, b, operations[i]) for i in range(len(operations))]
 
     for index, op in enumerate(cmpf_ops):
         assert op.lhs.type == f64
@@ -192,7 +206,7 @@ def test_cmpf_get():
     a = Constant.from_float_and_width(1.0, f32)
     b = Constant.from_float_and_width(2.0, f32)
 
-    cmpf_op = Cmpf.get(a, b, 1)
+    cmpf_op = Cmpf(a, b, 1)
 
     assert cmpf_op.lhs.type == f32
     assert cmpf_op.rhs.type == f32
@@ -204,7 +218,7 @@ def test_cmpf_missmatch_type():
     b = Constant.from_float_and_width(2.0, f64)
 
     with pytest.raises(TypeError) as e:
-        _cmpf_op = Cmpf.get(a, b, 1)
+        _cmpf_op = Cmpf(a, b, 1)
     assert (
         e.value.args[0]
         == "Comparison operands must have same type, but provided f32 and f64"
@@ -216,7 +230,7 @@ def test_cmpi_mismatch_type():
     b = Constant.from_int_and_width(2, i64)
 
     with pytest.raises(TypeError) as e:
-        _cmpi_op = Cmpi.get(a, b, 1)
+        _cmpi_op = Cmpi(a, b, 1)
     assert (
         e.value.args[0]
         == "Comparison operands must have same type, but provided i32 and i64"
@@ -229,7 +243,7 @@ def test_cmpf_incorrect_comparison():
 
     with pytest.raises(VerifyException) as e:
         # 'eq' is a comparison op for cmpi but not cmpf
-        _cmpf_op = Cmpf.get(a, b, "eq")
+        _cmpf_op = Cmpf(a, b, "eq")
     assert e.value.args[0] == "Unknown comparison mnemonic: eq"
 
 
@@ -239,7 +253,7 @@ def test_cmpi_incorrect_comparison():
 
     with pytest.raises(VerifyException) as e:
         # 'oeq' is a comparison op for cmpf but not cmpi
-        _cmpi_op = Cmpi.get(a, b, "oeq")
+        _cmpi_op = Cmpi(a, b, "oeq")
     assert e.value.args[0] == "Unknown comparison mnemonic: oeq"
 
 
@@ -247,7 +261,7 @@ def test_cmpi_index_type():
     a = Constant.from_int_and_width(1, IndexType())
     b = Constant.from_int_and_width(2, IndexType())
 
-    Cmpi.get(a, b, "eq").verify()
+    Cmpi(a, b, "eq").verify()
 
 
 def test_extend_truncate_iops():

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -118,7 +118,7 @@ class Test_float_arith_construction:
 
 def test_index_cast_op():
     a = Constant.from_int_and_width(0, 32)
-    cast = IndexCastOp.get(a, IndexType())
+    cast = IndexCastOp(a, IndexType())
 
     assert cast.result.type == IndexType()
     assert cast.input.type == i32
@@ -127,8 +127,8 @@ def test_index_cast_op():
 
 def test_cast_fp_and_si_ops():
     a = Constant.from_int_and_width(0, 32)
-    fp = SIToFPOp.get(a, f32)
-    si = FPToSIOp.get(fp, i32)
+    fp = SIToFPOp(a, f32)
+    si = FPToSIOp(fp, i32)
 
     assert fp.input == a.result
     assert fp.result == si.input
@@ -150,8 +150,8 @@ def test_negf_op():
 def test_extend_truncate_fpops():
     a = Constant.from_float_and_width(1.0, f32)
     b = Constant.from_float_and_width(2.0, f64)
-    ext_op = ExtFOp.get(a, f64)
-    trunc_op = TruncFOp.get(b, f32)
+    ext_op = ExtFOp(a, f64)
+    trunc_op = TruncFOp(b, f32)
 
     assert ext_op.input == a.result
     assert ext_op.result.type == f64

--- a/tests/interpreters/test_arith_interpreter.py
+++ b/tests/interpreters/test_arith_interpreter.py
@@ -123,7 +123,7 @@ def test_cmpi(
     lhs_value: int, rhs_value: int, pred: tuple[str, Callable[[int, int], int]]
 ):
     arg, fn = pred
-    cmpi = Cmpi.get(lhs_op, rhs_op, arg)
+    cmpi = Cmpi(lhs_op, rhs_op, arg)
 
     ret = interpreter.run_op(cmpi, (lhs_value, rhs_value))
 

--- a/tests/interpreters/test_cf_interpreter.py
+++ b/tests/interpreters/test_cf_interpreter.py
@@ -35,7 +35,7 @@ def sum_to_op():
     with ImplicitBuilder(loop_iter):
         (n,) = prologue.args
         result, i = loop_iter.args
-        cond = arith.Cmpi.get(i, n, "sle")
+        cond = arith.Cmpi(i, n, "sle")
         cf.ConditionalBranch.get(cond, loop_body, (result, i), epilogue, (result,))
 
     with ImplicitBuilder(loop_body):

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -34,6 +34,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import Pure
+from xdsl.utils.deprecation import deprecated
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -405,6 +406,38 @@ class Cmpi(IRDLOperation, ComparisonOperation):
             attributes={"predicate": IntegerAttr.from_int_and_width(arg, 64)},
         )
 
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(
+        operand1: Operation | SSAValue,
+        operand2: Operation | SSAValue,
+        arg: int | str,
+    ) -> Cmpi:
+        operand1 = SSAValue.get(operand1)
+        operand2 = SSAValue.get(operand2)
+        Cmpi._validate_operand_types(operand1, operand2)
+
+        if isinstance(arg, str):
+            cmpi_comparison_operations = {
+                "eq": 0,
+                "ne": 1,
+                "slt": 2,
+                "sle": 3,
+                "sgt": 4,
+                "sge": 5,
+                "ult": 6,
+                "ule": 7,
+                "ugt": 8,
+                "uge": 9,
+            }
+            arg = Cmpi._get_comparison_predicate(arg, cmpi_comparison_operations)
+
+        return Cmpi.build(
+            operands=[operand1, operand2],
+            result_types=[IntegerType(1)],
+            attributes={"predicate": IntegerAttr.from_int_and_width(arg, 64)},
+        )
+
 
 @irdl_op_definition
 class Cmpf(IRDLOperation, ComparisonOperation):
@@ -476,6 +509,43 @@ class Cmpf(IRDLOperation, ComparisonOperation):
             attributes={"predicate": IntegerAttr.from_int_and_width(arg, 64)},
         )
 
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(
+        operand1: SSAValue | Operation, operand2: SSAValue | Operation, arg: int | str
+    ) -> Cmpf:
+        operand1 = SSAValue.get(operand1)
+        operand2 = SSAValue.get(operand2)
+
+        Cmpf._validate_operand_types(operand1, operand2)
+
+        if isinstance(arg, str):
+            cmpf_comparison_operations = {
+                "false": 0,
+                "oeq": 1,
+                "ogt": 2,
+                "oge": 3,
+                "olt": 4,
+                "ole": 5,
+                "one": 6,
+                "ord": 7,
+                "ueq": 8,
+                "ugt": 9,
+                "uge": 10,
+                "ult": 11,
+                "ule": 12,
+                "une": 13,
+                "uno": 14,
+                "true": 15,
+            }
+            arg = Cmpf._get_comparison_predicate(arg, cmpf_comparison_operations)
+
+        return Cmpf.build(
+            operands=[operand1, operand2],
+            result_types=[IntegerType(1)],
+            attributes={"predicate": IntegerAttr.from_int_and_width(arg, 64)},
+        )
+
 
 @irdl_op_definition
 class Select(IRDLOperation):
@@ -507,6 +577,18 @@ class Select(IRDLOperation):
     ):
         operand2 = SSAValue.get(operand2)
         return super().__init__(
+            operands=[operand1, operand2, operand3], result_types=[operand2.type]
+        )
+
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(
+        operand1: Operation | SSAValue,
+        operand2: Operation | SSAValue,
+        operand3: Operation | SSAValue,
+    ) -> Select:
+        operand2 = SSAValue.get(operand2)
+        return Select.build(
             operands=[operand1, operand2, operand3], result_types=[operand2.type]
         )
 
@@ -548,6 +630,18 @@ class Negf(IRDLOperation):
             result_types=[operand.type],
         )
 
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(
+        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ) -> Negf:
+        operand = SSAValue.get(operand)
+        return Negf.build(
+            attributes={"fastmath": fastmath},
+            operands=[operand],
+            result_types=[operand.type],
+        )
+
 
 @irdl_op_definition
 class Maxf(FloatingPointLikeBinaryOp):
@@ -570,6 +664,11 @@ class IndexCastOp(IRDLOperation):
     def __init__(self, input_arg: SSAValue | Operation, target_type: Attribute):
         return super().__init__(operands=[input_arg], result_types=[target_type])
 
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(input_arg: SSAValue | Operation, target_type: Attribute):
+        return IndexCastOp.build(operands=[input_arg], result_types=[target_type])
+
 
 @irdl_op_definition
 class FPToSIOp(IRDLOperation):
@@ -580,6 +679,11 @@ class FPToSIOp(IRDLOperation):
 
     def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
         return super().__init__(operands=[op], result_types=[target_type])
+
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(op: SSAValue | Operation, target_type: IntegerType):
+        return FPToSIOp.build(operands=[op], result_types=[target_type])
 
 
 @irdl_op_definition
@@ -592,6 +696,11 @@ class SIToFPOp(IRDLOperation):
     def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
         return super().__init__(operands=[op], result_types=[target_type])
 
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(op: SSAValue | Operation, target_type: AnyFloat):
+        return SIToFPOp.build(operands=[op], result_types=[target_type])
+
 
 @irdl_op_definition
 class ExtFOp(IRDLOperation):
@@ -603,6 +712,11 @@ class ExtFOp(IRDLOperation):
     def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
         return super().__init__(operands=[op], result_types=[target_type])
 
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(op: SSAValue | Operation, target_type: AnyFloat):
+        return ExtFOp.build(operands=[op], result_types=[target_type])
+
 
 @irdl_op_definition
 class TruncFOp(IRDLOperation):
@@ -613,6 +727,11 @@ class TruncFOp(IRDLOperation):
 
     def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
         return super().__init__(operands=[op], result_types=[target_type])
+
+    @staticmethod
+    @deprecated("please use init instead of .get")
+    def get(op: SSAValue | Operation, target_type: AnyFloat):
+        return TruncFOp.build(operands=[op], result_types=[target_type])
 
 
 @irdl_op_definition

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -566,9 +566,8 @@ class IndexCastOp(IRDLOperation):
 
     result: OpResult = result_def()
 
-    @staticmethod
-    def get(input_arg: SSAValue | Operation, target_type: Attribute):
-        return IndexCastOp.build(operands=[input_arg], result_types=[target_type])
+    def __init__(self, input_arg: SSAValue | Operation, target_type: Attribute):
+        return super().__init__(operands=[input_arg], result_types=[target_type])
 
 
 @irdl_op_definition
@@ -578,9 +577,8 @@ class FPToSIOp(IRDLOperation):
     input: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(IntegerType)
 
-    @staticmethod
-    def get(op: SSAValue | Operation, target_type: IntegerType):
-        return FPToSIOp.build(operands=[op], result_types=[target_type])
+    def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
+        return super().__init__(operands=[op], result_types=[target_type])
 
 
 @irdl_op_definition
@@ -590,9 +588,8 @@ class SIToFPOp(IRDLOperation):
     input: Operand = operand_def(IntegerType)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(op: SSAValue | Operation, target_type: AnyFloat):
-        return SIToFPOp.build(operands=[op], result_types=[target_type])
+    def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
+        return super().__init__(operands=[op], result_types=[target_type])
 
 
 @irdl_op_definition
@@ -602,9 +599,8 @@ class ExtFOp(IRDLOperation):
     input: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(op: SSAValue | Operation, target_type: AnyFloat):
-        return ExtFOp.build(operands=[op], result_types=[target_type])
+    def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
+        return super().__init__(operands=[op], result_types=[target_type])
 
 
 @irdl_op_definition
@@ -614,9 +610,8 @@ class TruncFOp(IRDLOperation):
     input: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(op: SSAValue | Operation, target_type: AnyFloat):
-        return TruncFOp.build(operands=[op], result_types=[target_type])
+    def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
+        return super().__init__(operands=[op], result_types=[target_type])
 
 
 @irdl_op_definition

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -374,12 +374,12 @@ class Cmpi(IRDLOperation, ComparisonOperation):
     rhs: Operand = operand_def(signlessIntegerLike)
     result: OpResult = result_def(IntegerType(1))
 
-    @staticmethod
-    def get(
+    def __init__(
+        self,
         operand1: Operation | SSAValue,
         operand2: Operation | SSAValue,
         arg: int | str,
-    ) -> Cmpi:
+    ):
         operand1 = SSAValue.get(operand1)
         operand2 = SSAValue.get(operand2)
         Cmpi._validate_operand_types(operand1, operand2)
@@ -399,7 +399,7 @@ class Cmpi(IRDLOperation, ComparisonOperation):
             }
             arg = Cmpi._get_comparison_predicate(arg, cmpi_comparison_operations)
 
-        return Cmpi.build(
+        return super().__init__(
             operands=[operand1, operand2],
             result_types=[IntegerType(1)],
             attributes={"predicate": IntegerAttr.from_int_and_width(arg, 64)},
@@ -438,10 +438,12 @@ class Cmpf(IRDLOperation, ComparisonOperation):
     rhs: Operand = operand_def(floatingPointLike)
     result: OpResult = result_def(IntegerType(1))
 
-    @staticmethod
-    def get(
-        operand1: SSAValue | Operation, operand2: SSAValue | Operation, arg: int | str
-    ) -> Cmpf:
+    def __init__(
+        self,
+        operand1: SSAValue | Operation,
+        operand2: SSAValue | Operation,
+        arg: int | str,
+    ):
         operand1 = SSAValue.get(operand1)
         operand2 = SSAValue.get(operand2)
 
@@ -468,7 +470,7 @@ class Cmpf(IRDLOperation, ComparisonOperation):
             }
             arg = Cmpf._get_comparison_predicate(arg, cmpf_comparison_operations)
 
-        return Cmpf.build(
+        return super().__init__(
             operands=[operand1, operand2],
             result_types=[IntegerType(1)],
             attributes={"predicate": IntegerAttr.from_int_and_width(arg, 64)},
@@ -497,14 +499,14 @@ class Select(IRDLOperation):
         if self.lhs.type != self.rhs.type or self.rhs.type != self.result.type:
             raise VerifyException("expect all input and output types to be equal")
 
-    @staticmethod
-    def get(
+    def __init__(
+        self,
         operand1: Operation | SSAValue,
         operand2: Operation | SSAValue,
         operand3: Operation | SSAValue,
-    ) -> Select:
+    ):
         operand2 = SSAValue.get(operand2)
-        return Select.build(
+        return super().__init__(
             operands=[operand1, operand2, operand3], result_types=[operand2.type]
         )
 
@@ -536,12 +538,11 @@ class Negf(IRDLOperation):
     operand: Operand = operand_def(floatingPointLike)
     result: OpResult = result_def(floatingPointLike)
 
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> Negf:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         operand = SSAValue.get(operand)
-        return Negf.build(
+        return super().__init__(
             attributes={"fastmath": fastmath},
             operands=[operand],
             result_types=[operand.type],

--- a/xdsl/frontend/dialects/arith.py
+++ b/xdsl/frontend/dialects/arith.py
@@ -28,7 +28,7 @@ def cmpi(lhs: _Int, rhs: _Int, mnemonic: str) -> i1:
 
 
 def resolve_cmpi() -> Callable[..., Operation]:
-    return arith.Cmpi.get
+    return arith.Cmpi
 
 
 def muli(lhs: _Int, rhs: _Int) -> _Int:

--- a/xdsl/transforms/experimental/Apply1DMPIToStencil.py
+++ b/xdsl/transforms/experimental/Apply1DMPIToStencil.py
@@ -50,11 +50,11 @@ class ApplyMPIToExternalLoad(RewritePattern):
         )
         dim_zero_const = arith.Constant.from_attr(int_attr, builtin.IndexType())
         dim_zero_size_op = memref.Dim.from_source_and_index(op.field, dim_zero_const)
-        dim_zero_i32_op = arith.IndexCastOp.get(dim_zero_size_op, builtin.i32)
-        dim_zero_i64_op = arith.IndexCastOp.get(dim_zero_size_op, builtin.i64)
+        dim_zero_i32_op = arith.IndexCastOp(dim_zero_size_op, builtin.i32)
+        dim_zero_i64_op = arith.IndexCastOp(dim_zero_size_op, builtin.i64)
 
         index_memref = memref.ExtractAlignedPointerAsIndexOp.get(op.field)
-        index_memref_i64 = arith.IndexCastOp.get(index_memref, builtin.i64)
+        index_memref_i64 = arith.IndexCastOp(index_memref, builtin.i64)
 
         mpi_operations += [
             datatype_op,
@@ -71,9 +71,9 @@ class ApplyMPIToExternalLoad(RewritePattern):
         mpi_operations += [alloc_request_op]
 
         # Comparison for top and bottom ranks
-        compare_top_op = arith.Cmpi.get(comm_rank_op, zero, "sgt")
+        compare_top_op = arith.Cmpi(comm_rank_op, zero, "sgt")
         size_minus_one = arith.Subi(comm_size_op, one)
-        compare_bottom_op = arith.Cmpi.get(comm_rank_op, size_minus_one, "slt")
+        compare_bottom_op = arith.Cmpi(comm_rank_op, size_minus_one, "slt")
         mpi_operations += [compare_top_op, size_minus_one, compare_bottom_op]
 
         # MPI Request look ups (we need these regardless)

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -132,7 +132,7 @@ def _generate_single_axis_calc_and_check(
                 0 if is_decrement else axis_size, _rank_dtype
             ),
             # comparison == true <=> we have a valid dest positon
-            cond_val := arith.Cmpi.get(dest, bound, comparison),
+            cond_val := arith.Cmpi(dest, bound, comparison),
         ],
         dest.result,
         cond_val.result,

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -312,7 +312,7 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
         """
         return [
             index := memref.ExtractAlignedPointerAsIndexOp.get(ref),
-            i64 := arith.IndexCastOp.get(index, builtin.i64),
+            i64 := arith.IndexCastOp(index, builtin.i64),
             ptr := llvm.IntToPtrOp(i64),
         ], ptr
 

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -681,8 +681,8 @@ class LowerMpiVectorGet(_MPIToLLVMRewriteBase):
         return [
             ptr_int := llvm.PtrToIntOp(op.vect, i64),
             lit1 := arith.Constant.from_int_and_width(datatype_size, 64),
-            idx_cast1 := arith.IndexCastOp.get(op.element, IndexType()),
-            idx_cast2 := arith.IndexCastOp.get(idx_cast1, i64),
+            idx_cast1 := arith.IndexCastOp(op.element, IndexType()),
+            idx_cast2 := arith.IndexCastOp(idx_cast1, i64),
             mul := arith.Muli(lit1, idx_cast2),
             add := arith.Addi(mul, ptr_int),
             out_ptr := llvm.IntToPtrOp(add, op.vect.type.type),

--- a/xdsl/transforms/printf_to_llvm.py
+++ b/xdsl/transforms/printf_to_llvm.py
@@ -117,12 +117,12 @@ class PrintlnOpToPrintfCall(RewritePattern):
                 format_str += part
             elif isinstance(part.type, builtin.IndexType):
                 # index must be cast to fixed bitwidth before printing
-                casts.append(new_val := arith.IndexCastOp.get(part, builtin.i64))
+                casts.append(new_val := arith.IndexCastOp(part, builtin.i64))
                 args.append(new_val.result)
                 format_str += "%li"
             elif part.type == builtin.f32:
                 # f32 must be promoted to f64 before printing
-                casts.append(new_val := arith.ExtFOp.get(part, builtin.f64))
+                casts.append(new_val := arith.ExtFOp(part, builtin.f64))
                 args.append(new_val.result)
                 format_str += "%f"
             else:


### PR DESCRIPTION
swapping over arith dialect to using __init__ as opposed to static get methods. Update usages of arith in xdsl tests and experimental interpreters.  added a test for arith select op but unsure if it is actually helping
@superlopuh @math-fehr 
