### PR TITLE
transformations: Add TypeConversionPattern

### DIFF
--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -12,7 +12,7 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.ir import Attribute, MLContext, Operation
+from xdsl.ir import MLContext, Operation
 from xdsl.parser import Parser
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1095,11 +1095,6 @@ def test_type_conversion():
 }) : () -> ()
 """
 
-    class Rewrite(TypeConversionPattern):
-        @attr_type_rewrite_pattern
-        def convert_type(self, typ: IntegerType) -> IndexType:
-            return IndexType()
-
     rewrite_and_compare(
         prog,
         expected,

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1007,7 +1007,7 @@ def test_type_conversion():
     prog = """\
 "builtin.module"() ({
   %0 = "test.op"() {"nested" = memref<*xi32>} : () -> i32
-  %1 = "test.op"() : () -> f32
+  %1 = "test.op"() {"type" = () -> memref<*xi32>} : () -> f32
   %2 = "test.op"(%0, %1) : (i32, f32) -> memref<*xi32>
   "func.return"() : () -> ()
 }) : () -> ()
@@ -1016,7 +1016,7 @@ def test_type_conversion():
     expected = """\
 "builtin.module"() ({
   %0 = "test.op"() {"nested" = memref<*xindex>} : () -> index
-  %1 = "test.op"() : () -> f32
+  %1 = "test.op"() {"type" = () -> memref<*xindex>} : () -> f32
   %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
   "func.return"() : () -> ()
 }) : () -> ()

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1038,17 +1038,19 @@ def test_type_conversion():
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        PatternRewriteWalker(Rewrite(recursive=True), apply_recursively=False),
     )
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(Rewrite(), apply_recursively=True),
+        PatternRewriteWalker(Rewrite(recursive=True), apply_recursively=True),
     )
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
+        PatternRewriteWalker(
+            Rewrite(recursive=True), apply_recursively=False, walk_reverse=True
+        ),
     )
 
     non_rec_expected = """\
@@ -1067,19 +1069,17 @@ def test_type_conversion():
     rewrite_and_compare(
         prog,
         non_rec_expected,
-        PatternRewriteWalker(Rewrite(recursive=False), apply_recursively=False),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
     rewrite_and_compare(
         prog,
         non_rec_expected,
-        PatternRewriteWalker(Rewrite(recursive=False), apply_recursively=True),
+        PatternRewriteWalker(Rewrite(), apply_recursively=True),
     )
     rewrite_and_compare(
         prog,
         non_rec_expected,
-        PatternRewriteWalker(
-            Rewrite(recursive=False), apply_recursively=False, walk_reverse=True
-        ),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
     )
 
     expected = """\
@@ -1098,17 +1098,23 @@ def test_type_conversion():
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(Rewrite(ops=(test.TestOp,)), apply_recursively=False),
-    )
-    rewrite_and_compare(
-        prog,
-        expected,
-        PatternRewriteWalker(Rewrite(ops=(test.TestOp,)), apply_recursively=True),
+        PatternRewriteWalker(
+            Rewrite(ops=(test.TestOp,), recursive=True), apply_recursively=False
+        ),
     )
     rewrite_and_compare(
         prog,
         expected,
         PatternRewriteWalker(
-            Rewrite(ops=(test.TestOp,)), apply_recursively=False, walk_reverse=True
+            Rewrite(ops=(test.TestOp,), recursive=True), apply_recursively=True
+        ),
+    )
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(
+            Rewrite(ops=(test.TestOp,), recursive=True),
+            apply_recursively=False,
+            walk_reverse=True,
         ),
     )

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1032,3 +1032,13 @@ def test_type_conversion():
         expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=True),
+    )
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
+    )

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1006,6 +1006,9 @@ def test_type_conversion():
     """Test rewriter on ops without results"""
     prog = """\
 "builtin.module"() ({
+  "func.func"() ({
+  ^0(%arg : i32):
+  }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xi32>} : () -> i32
   %1 = "test.op"() {"type" = () -> memref<*xi32>} : () -> f32
   %2 = "test.op"(%0, %1) : (i32, f32) -> memref<*xi32>
@@ -1016,6 +1019,9 @@ def test_type_conversion():
 
     expected = """\
 "builtin.module"() ({
+  "func.func"() ({
+  ^0(%arg : index):
+  }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xindex>} : () -> index
   %1 = "test.op"() {"type" = () -> memref<*xindex>} : () -> f32
   %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
@@ -1047,6 +1053,9 @@ def test_type_conversion():
 
     non_rec_expected = """\
 "builtin.module"() ({
+  "func.func"() ({
+  ^0(%arg : index):
+  }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xi32>} : () -> index
   %1 = "test.op"() {"type" = () -> memref<*xi32>} : () -> f32
   %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xi32>
@@ -1075,6 +1084,9 @@ def test_type_conversion():
 
     expected = """\
 "builtin.module"() ({
+  "func.func"() ({
+  ^0(%arg : i32):
+  }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xindex>} : () -> index
   %1 = "test.op"() {"type" = () -> memref<*xindex>} : () -> f32
   %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1042,3 +1042,30 @@ def test_type_conversion():
         expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
     )
+
+    non_rec_expected = """\
+"builtin.module"() ({
+  %0 = "test.op"() {"nested" = memref<*xi32>} : () -> index
+  %1 = "test.op"() {"type" = () -> memref<*xi32>} : () -> f32
+  %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xi32>
+  "func.return"() : () -> ()
+}) : () -> ()
+"""
+
+    rewrite_and_compare(
+        prog,
+        non_rec_expected,
+        PatternRewriteWalker(Rewrite(recursive=False), apply_recursively=False),
+    )
+    rewrite_and_compare(
+        prog,
+        non_rec_expected,
+        PatternRewriteWalker(Rewrite(recursive=False), apply_recursively=True),
+    )
+    rewrite_and_compare(
+        prog,
+        non_rec_expected,
+        PatternRewriteWalker(
+            Rewrite(recursive=False), apply_recursively=False, walk_reverse=True
+        ),
+    )

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -124,7 +124,7 @@ class ArrayOfConstraint(AttrConstraint):
 
 
 @irdl_attr_definition
-class ArrayAttr(GenericData[tuple[AttributeCovT, ...]]):
+class ArrayAttr(GenericData[tuple[AttributeCovT, ...]], Iterable[AttributeCovT]):
     name = "array"
 
     def __init__(self, param: Iterable[AttributeCovT]) -> None:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -124,7 +124,7 @@ class ArrayOfConstraint(AttrConstraint):
 
 
 @irdl_attr_definition
-class ArrayAttr(GenericData[tuple[AttributeCovT, ...]], Iterable[AttributeCovT]):
+class ArrayAttr(GenericData[tuple[AttributeCovT, ...]]):
     name = "array"
 
     def __init__(self, param: Iterable[AttributeCovT]) -> None:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -420,7 +420,7 @@ class Data(Generic[DataElement], Attribute, ABC):
         attr = cls.__new__(cls, params)
 
         # Call the __init__ of Data, which will set the parameters field.
-        cls.__init__(attr, params)
+        Data.__init__(attr, params)
         return attr
 
     @classmethod

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -420,7 +420,7 @@ class Data(Generic[DataElement], Attribute, ABC):
         attr = cls.__new__(cls, params)
 
         # Call the __init__ of Data, which will set the parameters field.
-        Data[Any].__init__(attr, params)
+        cls.__init__(attr, params)
         return attr
 
     @classmethod

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -417,10 +417,10 @@ class Data(Generic[DataElement], Attribute, ABC):
         """
         # Create the new attribute object, without calling its __init__.
         # We do this to allow users to redefine their own __init__.
-        attr = cls.__new__(cls, params)
+        attr = cls.__new__(cls)
 
         # Call the __init__ of Data, which will set the parameters field.
-        Data.__init__(attr, params)
+        Data.__init__(attr, params)  # type: ignore
         return attr
 
     @classmethod

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -420,7 +420,7 @@ class Data(Generic[DataElement], Attribute, ABC):
         attr = cls.__new__(cls)
 
         # Call the __init__ of Data, which will set the parameters field.
-        Data.__init__(attr, params)  # type: ignore
+        Data.__init__(attr, params)  # pyright: ignore[reportUnknownMemberType]
         return attr
 
     @classmethod

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -470,17 +470,16 @@ class TypeConversionPattern(RewritePattern):
 
     This base pattern defines two flags:
 
-    - `recursive` (defaulting to True): recurse over structured attributes to convert
+    - `recursive` (defaulting to False): recurse over structured attributes to convert
       parameters.
       e.g. a recusrive `i32` to `index` conversion will convert `vector<i32>` to
       `vector<index>`.
-
     - `ops` (defaulting to any Operation) is a tuple of Operation types on which to apply
       the defined attribute conversion.
     """
 
-    recursive: bool = True
-    ops: tuple[type[Operation]] | None = None
+    recursive: bool = False
+    ops: tuple[type[Operation], ...] | None = None
 
     @abstractmethod
     def convert_type(self, typ: Attribute, /) -> Attribute | None:

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -530,18 +530,18 @@ class TypeConversionPattern(RewritePattern):
         for result in op.results:
             converted = self._convert_type_rec(result.type)
             new_result_types.append(converted or result.type)
-            if converted and converted != result.type:
+            if converted is not None and converted != result.type:
                 changed = True
         for name, attribute in op.attributes.items():
             converted = self._convert_type_rec(attribute)
             new_attributes[name] = converted or attribute
-            if converted and converted != attribute:
+            if converted is not None and converted != attribute:
                 changed = True
         for region in op.regions:
             for block in region.blocks:
                 for arg in block.args:
                     converted = self.convert_type(arg.type)
-                    if converted and converted != arg.type:
+                    if converted is not None and converted != arg.type:
                         rewriter.modify_block_argument_type(arg, converted)
         if changed:
             regions = [op.detach_region(r) for r in op.regions]

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -15,11 +15,17 @@ from typing import (
     get_origin,
 )
 
-from xdsl.dialects.builtin import ArrayAttr, ModuleOp
-from xdsl.ir import Attribute, Block, BlockArgument, Operation, Region, SSAValue
-from xdsl.ir.core import ParametrizedAttribute
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.ir import (
+    Attribute,
+    Block,
+    BlockArgument,
+    Operation,
+    ParametrizedAttribute,
+    Region,
+    SSAValue,
+)
 from xdsl.rewriter import Rewriter
-from xdsl.utils.hints import isa
 
 
 @dataclass(eq=False)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -483,7 +483,6 @@ class TypeConversionPattern(RewritePattern):
             if converted and converted != result.type:
                 changed = True
         for name, attribute in op.attributes.items():
-            # TODO: rewriter
             converted = self.convert_type_rec(attribute)
             new_attributes[name] = converted or attribute
             if converted and converted != attribute:

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -516,7 +516,8 @@ class TypeConversionPattern(RewritePattern):
             if isa(typ, ArrayAttr[Attribute]):
                 parameters = tuple(self._convert_type_rec(p) or p for p in typ)
                 inp = type(typ).new(parameters)
-        return self.convert_type(inp) or inp
+        converted = self.convert_type(inp)
+        return converted if converted is not None else inp
 
     @final
     def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -499,7 +499,7 @@ class TypeConversionPattern(RewritePattern):
         It allows returning None, meaning "this attribute should not
         be converted".
         """
-        ...
+        raise NotImplementedError()
 
     @final
     def _convert_type_rec(self, typ: Attribute) -> Attribute | None:

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -15,7 +15,7 @@ from typing import (
     get_origin,
 )
 
-from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.builtin import ArrayAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
     Block,
@@ -26,6 +26,7 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.rewriter import Rewriter
+from xdsl.utils.hints import isa
 
 
 @dataclass(eq=False)
@@ -465,6 +466,9 @@ class TypeConversionPattern(RewritePattern):
         inp = typ
         if isinstance(typ, ParametrizedAttribute):
             parameters = tuple(self.convert_type_rec(p) or p for p in typ.parameters)
+            inp = type(typ).new(parameters)
+        if isa(typ, ArrayAttr[Attribute]):
+            parameters = tuple(self.convert_type_rec(p) for p in typ)
             inp = type(typ).new(parameters)
         return self.convert_type(inp) or inp
 

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from functools import wraps
 from types import UnionType
 from typing import (
     Callable,
@@ -590,6 +591,7 @@ def attr_type_rewrite_pattern(
             "subclasses."
         )
 
+    @wraps(func)
     def impl(self: _TypeConversionPatternT, typ: Attribute) -> Attribute | None:
         if isinstance(typ, expected_type):
             return func(self, typ)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -15,7 +15,7 @@ from typing import (
     get_origin,
 )
 
-from xdsl.dialects.builtin import ArrayAttr, ModuleOp
+from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
     Block,
@@ -468,7 +468,7 @@ class TypeConversionPattern(RewritePattern):
             parameters = tuple(self.convert_type_rec(p) or p for p in typ.parameters)
             inp = type(typ).new(parameters)
         if isa(typ, ArrayAttr[Attribute]):
-            parameters = tuple(self.convert_type_rec(p) for p in typ)
+            parameters = tuple(self.convert_type_rec(p) or p for p in typ)
             inp = type(typ).new(parameters)
         return self.convert_type(inp) or inp
 

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -479,7 +479,15 @@ class TypeConversionPattern(RewritePattern):
     """
 
     recursive: bool = False
+    """
+    recurse over structured attributes to convert parameters.
+    Defaults to False.
+    """
     ops: tuple[type[Operation], ...] | None = None
+    """
+    A tuple of Operation types on which to apply the defined attribute conversion.
+    Defaults to any operation type.
+    """
 
     @abstractmethod
     def convert_type(self, typ: Attribute, /) -> Attribute | None:

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -465,11 +465,11 @@ class TypeConversionPattern(RewritePattern):
     def convert_type_rec(self, typ: Attribute) -> Attribute | None:
         inp = typ
         if isinstance(typ, ParametrizedAttribute):
-            parameters = tuple(self.convert_type_rec(p) or p for p in typ.parameters)
-            inp = type(typ).new(parameters)
+            parameters = list(self.convert_type_rec(p) or p for p in typ.parameters)
+            inp = ParametrizedAttribute.new(parameters)
         if isa(typ, ArrayAttr[Attribute]):
             parameters = tuple(self.convert_type_rec(p) or p for p in typ)
-            inp = type(typ).new(parameters)
+            inp = ArrayAttr.new(parameters)
         return self.convert_type(inp) or inp
 
     @final
@@ -485,6 +485,7 @@ class TypeConversionPattern(RewritePattern):
             if converted:
                 operand.type = converted
         for name, attribute in op.attributes.items():
+            # TODO: rewriter
             converted = self.convert_type_rec(attribute)
             if converted:
                 op.attributes[name] = converted

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -15,7 +15,7 @@ from typing import (
     get_origin,
 )
 
-from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, ModuleOp
+from xdsl.dialects.builtin import ArrayAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
     Block,

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -581,20 +581,9 @@ def attr_type_rewrite_pattern(
         )
     expected_type: type[_AttributeT] = params[-1].annotation
 
-    expected_types = (expected_type,)
-    if get_origin(expected_type) in [Union, UnionType]:
-        expected_types = get_args(expected_type)
-
-    if not all(issubclass(t, Attribute) for t in expected_types):
-        raise Exception(
-            "attr_type_rewrite_pattern expects the non-self argument "
-            "type hint to be an `Attribute` subclass or a union of `Attribute` "
-            "subclasses."
-        )
-
     @wraps(func)
     def impl(self: _TypeConversionPatternT, typ: Attribute) -> Attribute | None:
-        if isinstance(typ, expected_type):
+        if isa(typ, expected_type):
             return func(self, typ)
         return None
 

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -460,6 +460,7 @@ def op_type_rewrite_pattern(
 @dataclass
 class TypeConversionPattern(RewritePattern):
     recursive: bool = True
+    ops: tuple[type[Operation]] | None = None
 
     @abstractmethod
     def convert_type(self, typ: Attribute, /) -> Attribute | None:
@@ -478,6 +479,8 @@ class TypeConversionPattern(RewritePattern):
 
     @final
     def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
+        if self.ops and not isinstance(op, self.ops):
+            return
         new_result_types: list[Attribute] = []
         new_attributes: dict[str, Attribute] = {}
         changed: bool = False

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -568,17 +568,11 @@ def attr_type_rewrite_pattern(
     func: Callable[[_TypeConversionPatternT, _AttributeT], _ConvertedT]
 ) -> Callable[[_TypeConversionPatternT, Attribute], Attribute | None]:
     """
-    This function is intended to be used as a decorator on a RewritePatter
-    method. It uses type hints to match on a specific operation type before
+    This function is intended to be used as a decorator on a TypeConversionPattern
+    method. It uses type hints to match on a specific attribute type before
     calling the decorated function.
     """
-    # Get the operation argument and check that it is a subclass of Operation
-    params = [param for param in inspect.signature(func).parameters.values()]
-    if len(params) != 2:
-        raise Exception(
-            "op_type_rewrite_pattern expects the decorated function to "
-            "have one non-self argument."
-        )
+    params = list(inspect.signature(func).parameters.values())
     expected_type: type[_AttributeT] = params[-1].annotation
 
     @wraps(func)


### PR DESCRIPTION
So, I want to have something that looks like type conversion infrastructure in xDSL.

MLIR offers this as TypeConverters, with many nuances, because they have well-defined infrastructure for dialect conversion passes, including partial conversions. Their type conversion smartly builds on top. We don;t have any of this, and I don't have the bandwidth right now to start implementing it all.

So I'm offering something else, still helpful and nice to use but more brutal; a PatternRewrite subclass, on which we can override
```python
def convert_type(self, typ: Attribute, /) -> Attribute | None:
        ...
```
Rather than
```python
def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
    ...
```
 Right now, it has two knobs:
 
 - recursive : Set the conversion to be recursive or not (e.g. convert `memref<A>` to `memref<B>` when translating `A` to `B`)
 - ops: A whitelist of operation types to convert, defaulting to all operation types.
 
I might want to start generating `unrealized_cast`s in cases where a whitelist is used? Not sure, as this is not part of my own usecase. Happy to discuss how that should behave if somebody is interested in this feature!