### PR TITLE
core: Fix cornercase fail in `isa`

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -566,7 +566,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "expected data ArrayData but got i32\n"
+      "expected attribute ArrayData but got i32\n"
      ]
     }
    ],

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -339,6 +339,11 @@ def test_generic_data():
     assert not isa(intattr, ArrayAttr[Attribute])
     assert not isa(intattr, DictionaryAttr)
 
+    integerattr = IntegerAttr.from_index_int_value(42)
+
+    assert not isa(integerattr, ArrayAttr[Attribute])
+    assert not isa(integerattr, DictionaryAttr)
+
 
 def test_nested_generic_data():
     attr = ArrayAttr([IntegerAttr.from_index_int_value(0)])

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -333,6 +333,10 @@ def test_generic_data():
     assert isa(attr2, ArrayAttr[IntAttr | FloatData])
     assert not isa(attr2, ArrayAttr[FloatData])
 
+    intattr = IntAttr(42)
+
+    assert not isa(intattr, ArrayAttr[Attribute])
+
 
 def test_nested_generic_data():
     attr = ArrayAttr([IntegerAttr.from_index_int_value(0)])

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -2,6 +2,7 @@ from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
+    DictionaryAttr,
     FloatData,
     IndexType,
     IntAttr,
@@ -336,6 +337,7 @@ def test_generic_data():
     intattr = IntAttr(42)
 
     assert not isa(intattr, ArrayAttr[Attribute])
+    assert not isa(intattr, DictionaryAttr)
 
 
 def test_nested_generic_data():

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -119,7 +119,7 @@ class ArrayOfConstraint(AttrConstraint):
 
     def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, Data):
-            raise Exception(f"expected data ArrayData but got {attr}")
+            raise VerifyException(f"expected data ArrayData but got {attr}")
         if not isinstance(cast(Data[Any], attr).data, Iterable):
             raise VerifyException(
                 f"Expected iterable data but got {cast(Data[Any], attr).data}."

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -61,7 +61,6 @@ from xdsl.traits import (
     SymbolTable,
 )
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.hints import isa
 
 if TYPE_CHECKING:
     from xdsl.parser import AttrParser, Parser

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -119,6 +119,8 @@ class ArrayOfConstraint(AttrConstraint):
     def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, Data):
             raise Exception(f"expected data ArrayData but got {attr}")
+        if not isinstance(attr.data, Iterable):
+            raise VerifyException(f"Expected iterable data but got {attr.data}.")
         for e in cast(ArrayAttr[Attribute], attr).data:
             self.elem_constr.verify(e, constraint_vars)
 
@@ -151,7 +153,7 @@ class ArrayAttr(GenericData[tuple[AttributeCovT, ...]], Iterable[AttributeCovT])
         if len(args) == 0:
             return ArrayOfConstraint(AnyAttr())
         raise TypeError(
-            f"Attribute ArrayAttr expects at most type"
+            f"Attribute ArrayAttr expects at most 1 type"
             f" parameter, but {len(args)} were given"
         )
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -61,6 +61,7 @@ from xdsl.traits import (
     SymbolTable,
 )
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 
 if TYPE_CHECKING:
     from xdsl.parser import AttrParser, Parser
@@ -119,8 +120,10 @@ class ArrayOfConstraint(AttrConstraint):
     def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, Data):
             raise Exception(f"expected data ArrayData but got {attr}")
-        if not isinstance(attr.data, Iterable):
-            raise VerifyException(f"Expected iterable data but got {attr.data}.")
+        if not isinstance(cast(Data[Any], attr).data, Iterable):
+            raise VerifyException(
+                f"Expected iterable data but got {cast(Data[Any], attr).data}."
+            )
         for e in cast(ArrayAttr[Attribute], attr).data:
             self.elem_constr.verify(e, constraint_vars)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -117,12 +117,8 @@ class ArrayOfConstraint(AttrConstraint):
         self.elem_constr = attr_constr_coercion(constr)
 
     def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
-        if not isinstance(attr, Data):
-            raise VerifyException(f"expected data ArrayData but got {attr}")
-        if not isinstance(cast(Data[Any], attr).data, Iterable):
-            raise VerifyException(
-                f"Expected iterable data but got {cast(Data[Any], attr).data}."
-            )
+        if not isinstance(attr, ArrayAttr):
+            raise VerifyException(f"expected ArrayData attribute, but got {attr}")
         for e in cast(ArrayAttr[Attribute], attr).data:
             self.elem_constr.verify(e, constraint_vars)
 


### PR DESCRIPTION
So I added a test, that fails because `isa` is failing  unexpectedly on that case, and I think it was because of the verifier of `ArrayAttr`. I solve it, then add a regression test for the related `DictionaryAttr`.