### PR TITLE
transformations: Use TypeConversionPattern to simplify and improve the stencil lowering.

### DIFF
--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -411,5 +411,67 @@ builtin.module {
   //CHECK-NEXT:   func.return
   //CHECK-NEXT: }
 
+  func.func @apply_kernel(%69 : !stencil.field<[-2,13]x[-2,13]xf32>, %70 : !stencil.field<[-2,13]x[-2,13]xf32>, %timers : !llvm.ptr<f64>)  attributes {"param_names" = ["u_vec_0", "u_vec_1", "timers"]}{
+    %71 = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<15x15xf32>
+    %u_vec_1 = "builtin.unrealized_conversion_cast"(%71) : (memref<15x15xf32>) -> !stencil.field<[-2,13]x[-2,13]xf32>
+    %72 = "builtin.unrealized_conversion_cast"(%70) : (!stencil.field<[-2,13]x[-2,13]xf32>) -> memref<15x15xf32>
+    "gpu.memcpy"(%71, %72) {"operand_segment_sizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
+    %73 = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<15x15xf32>
+    %u_vec_0 = "builtin.unrealized_conversion_cast"(%73) : (memref<15x15xf32>) -> !stencil.field<[-2,13]x[-2,13]xf32>
+    %74 = "builtin.unrealized_conversion_cast"(%69) : (!stencil.field<[-2,13]x[-2,13]xf32>) -> memref<15x15xf32>
+    "gpu.memcpy"(%73, %74) {"operand_segment_sizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
+    %time_m_1 = arith.constant 0 : index
+    %time_M_1 = arith.constant 10 : index
+    %step_1 = arith.constant 1 : index
+    %75, %76 = "scf.for"(%time_m_1, %time_M_1, %step_1, %u_vec_0, %u_vec_1) ({
+    ^12(%time_1 : index, %t0 : !stencil.field<[-2,13]x[-2,13]xf32>, %t1 : !stencil.field<[-2,13]x[-2,13]xf32>):
+      %t0_temp = "stencil.load"(%t0) : (!stencil.field<[-2,13]x[-2,13]xf32>) -> !stencil.temp<[0,11]x[0,11]xf32>
+      %t1_result = "stencil.apply"(%t0_temp) ({
+      ^13(%t0_buff : !stencil.temp<[0,11]x[0,11]xf32>):
+        %77 = "stencil.access"(%t0_buff) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[0,11]x[0,11]xf32>) -> f32
+        "stencil.return"(%77) : (f32) -> ()
+      }) : (!stencil.temp<[0,11]x[0,11]xf32>) -> !stencil.temp<[0,11]x[0,11]xf32>
+      "stencil.store"(%t1_result, %t1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<11, 11>} : (!stencil.temp<[0,11]x[0,11]xf32>, !stencil.field<[-2,13]x[-2,13]xf32>) -> ()
+      "scf.yield"(%t1, %t0) : (!stencil.field<[-2,13]x[-2,13]xf32>, !stencil.field<[-2,13]x[-2,13]xf32>) -> ()
+    }) : (index, index, index, !stencil.field<[-2,13]x[-2,13]xf32>, !stencil.field<[-2,13]x[-2,13]xf32>) -> (!stencil.field<[-2,13]x[-2,13]xf32>, !stencil.field<[-2,13]x[-2,13]xf32>)
+    func.return
+  }
+
+// CHECK-NEXT: func.func @apply_kernel(%146 : memref<15x15xf32>, %147 : memref<15x15xf32>, %timers : !llvm.ptr<f64>)  attributes {"param_names" = ["u_vec_0", "u_vec_1", "timers"]}{
+// CHECK-NEXT:   %148 = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<15x15xf32>
+// CHECK-NEXT:   %u_vec_1 = "builtin.unrealized_conversion_cast"(%148) : (memref<15x15xf32>) -> memref<15x15xf32>
+// CHECK-NEXT:   %149 = "builtin.unrealized_conversion_cast"(%147) : (memref<15x15xf32>) -> memref<15x15xf32>
+// CHECK-NEXT:   "gpu.memcpy"(%148, %149) {"operand_segment_sizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
+// CHECK-NEXT:   %150 = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<15x15xf32>
+// CHECK-NEXT:   %u_vec_0 = "builtin.unrealized_conversion_cast"(%150) : (memref<15x15xf32>) -> memref<15x15xf32>
+// CHECK-NEXT:   %151 = "builtin.unrealized_conversion_cast"(%146) : (memref<15x15xf32>) -> memref<15x15xf32>
+// CHECK-NEXT:   "gpu.memcpy"(%150, %151) {"operand_segment_sizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
+// CHECK-NEXT:   %time_m_1 = arith.constant 0 : index
+// CHECK-NEXT:   %time_M_1 = arith.constant 10 : index
+// CHECK-NEXT:   %step_1 = arith.constant 1 : index
+// CHECK-NEXT:   %152, %153 = "scf.for"(%time_m_1, %time_M_1, %step_1, %u_vec_0, %u_vec_1) ({
+// CHECK-NEXT:   ^20(%time_1 : index, %t0 : memref<15x15xf32>, %t1 : memref<15x15xf32>):
+// CHECK-NEXT:     %t1_storeview = "memref.subview"(%t1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
+// CHECK-NEXT:     %t0_loadview = "memref.subview"(%t0) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
+// CHECK-NEXT:     %154 = arith.constant 0 : index
+// CHECK-NEXT:     %155 = arith.constant 0 : index
+// CHECK-NEXT:     %156 = arith.constant 1 : index
+// CHECK-NEXT:     %157 = arith.constant 11 : index
+// CHECK-NEXT:     %158 = arith.constant 11 : index
+// CHECK-NEXT:     "scf.parallel"(%154, %157, %156) ({
+// CHECK-NEXT:     ^21(%159 : index):
+// CHECK-NEXT:       "scf.for"(%155, %158, %156) ({
+// CHECK-NEXT:       ^22(%160 : index):
+// CHECK-NEXT:         %161 = "memref.load"(%t0_loadview, %159, %160) : (memref<11x11xf32, strided<[15, 1], offset: 32>>, index, index) -> f32
+// CHECK-NEXT:         "memref.store"(%161, %t1_storeview, %159, %160) : (f32, memref<11x11xf32, strided<[15, 1], offset: 32>>, index, index) -> ()
+// CHECK-NEXT:         "scf.yield"() : () -> ()
+// CHECK-NEXT:       }) : (index, index, index) -> ()
+// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
+// CHECK-NEXT:     "scf.yield"(%t1, %t0) : (memref<15x15xf32>, memref<15x15xf32>) -> ()
+// CHECK-NEXT:   }) : (index, index, index, memref<15x15xf32>, memref<15x15xf32>) -> (memref<15x15xf32>, memref<15x15xf32>)
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
 }
 // CHECK-NEXT: }

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -555,6 +555,8 @@ class TypeConversionPattern(RewritePattern):
                 regions=regions,
             )
             rewriter.replace_matched_op(new_op)
+            for new, old in zip(new_op.results, op.results):
+                new.name_hint = old.name_hint
 
 
 _TypeConversionPatternT = TypeVar(

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -234,7 +234,7 @@ class ApplyOpToParallel(RewritePattern):
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
         res_type = op.res[0].type
         assert isa(res_type, TempType[Attribute])
-        assert isinstance(res_type.bounds, StencilBoundsAttr), res_type.bounds
+        assert isinstance(res_type.bounds, StencilBoundsAttr)
 
         # Get this apply's ReturnOp
         body_block = op.region.blocks[0]

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -507,11 +507,6 @@ def return_target_analysis(module: builtin.ModuleOp):
 
 
 class StencilTypeConversion(TypeConversionPattern):
-    def __init__(
-        self, recursive: bool = True, ops: tuple[type[Operation], ...] | None = None
-    ):
-        return super().__init__(recursive, ops)
-
     @attr_type_rewrite_pattern
     def convert_type(self, typ: StencilType[Attribute]) -> MemRefType[Attribute]:
         return StencilToMemRefType(typ)
@@ -549,7 +544,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
         type_pass = PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
-                    StencilTypeConversion(),
+                    StencilTypeConversion(recursive=True),
                     BufferOpCleanUp(),
                 ]
             )

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -540,6 +540,11 @@ def return_target_analysis(module: builtin.ModuleOp):
 
 
 class StencilTypeConversion(TypeConversionPattern):
+    def __init__(
+        self, recursive: bool = True, ops: tuple[type[Operation], ...] | None = None
+    ):
+        return super().__init__(recursive, ops)
+
     @attr_type_rewrite_pattern
     def convert_type(self, typ: StencilType[Attribute]) -> MemRefType[Attribute]:
         return StencilToMemRefType(typ)

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -234,7 +234,7 @@ class ApplyOpToParallel(RewritePattern):
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
         res_type = op.res[0].type
         assert isa(res_type, TempType[Attribute])
-        assert isinstance(res_type.bounds, StencilBoundsAttr)
+        assert isinstance(res_type.bounds, StencilBoundsAttr), res_type.bounds
 
         # Get this apply's ReturnOp
         body_block = op.region.blocks[0]

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -38,6 +38,8 @@ from xdsl.pattern_rewriter import (
     PatternRewriter,
     PatternRewriteWalker,
     RewritePattern,
+    TypeConversionPattern,
+    attr_type_rewrite_pattern,
     op_type_rewrite_pattern,
 )
 from xdsl.utils.exceptions import VerifyException
@@ -537,6 +539,12 @@ def return_target_analysis(module: builtin.ModuleOp):
     return return_targets
 
 
+class StencilTypeConversion(TypeConversionPattern):
+    @attr_type_rewrite_pattern
+    def convert_type(self, typ: StencilType[Attribute]) -> MemRefType[Attribute]:
+        return StencilToMemRefType(typ)
+
+
 @dataclass
 class ConvertStencilToLLMLIRPass(ModulePass):
     name = "convert-stencil-to-ll-mlir"
@@ -569,8 +577,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
         type_pass = PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
-                    UpdateLoopCarriedVarTypes(),
-                    StencilTypeConversionFuncOp(),
+                    StencilTypeConversion(),
                     BufferOpCleanUp(),
                 ]
             )


### PR DESCRIPTION
Using #1366, this trims a lot of undesired code from this lowering, while making it way more robust!
Adding a MFE for a case that would have required more random code in this lowering instead of having a more generic solution.