### PR TITLE
transforms: Add canonicalization infrastructure with example

### DIFF
--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -46,6 +46,7 @@ from xdsl.transforms import (
     reconcile_unrealized_casts,
     riscv_register_allocation,
 )
+from xdsl.transforms.canonicalize import CanonicalizationPass
 from xdsl.transforms.experimental import (
     convert_stencil_to_ll_mlir,
     stencil_shape_inference,
@@ -91,6 +92,7 @@ def get_all_dialects() -> list[Dialect]:
 def get_all_passes() -> list[type[ModulePass]]:
     """Return the list of all available passes."""
     return [
+        CanonicalizationPass,
         convert_stencil_to_ll_mlir.ConvertStencilToLLMLIRPass,
         dead_code_elimination.DeadCodeElimination,
         DesymrefyPass,

--- a/xdsl/transforms/canonicalize/__init__.py
+++ b/xdsl/transforms/canonicalize/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa
+# type: ignore[reportUnusedImport]
 # import main module first
 from xdsl.transforms.canonicalize.canonicalize_pass import (
     CanonicalizationPass,

--- a/xdsl/transforms/canonicalize/__init__.py
+++ b/xdsl/transforms/canonicalize/__init__.py
@@ -1,0 +1,6 @@
+# list all canonicalization things here so they are included:
+import xdsl.transforms.canonicalize.canonicalize_riscv
+from xdsl.transforms.canonicalize.canonicalize_pass import (
+    CanonicalizationPass,
+    is_canonicalization,
+)

--- a/xdsl/transforms/canonicalize/__init__.py
+++ b/xdsl/transforms/canonicalize/__init__.py
@@ -1,6 +1,9 @@
-# list all canonicalization things here so they are included:
-import xdsl.transforms.canonicalize.canonicalize_riscv
+# ruff: noqa
+# import main module first
 from xdsl.transforms.canonicalize.canonicalize_pass import (
     CanonicalizationPass,
     is_canonicalization,
 )
+
+# THEN import the other things so they resolve dependencies correctly:
+import xdsl.transforms.canonicalize.canonicalize_riscv

--- a/xdsl/transforms/canonicalize/canonicalize_pass.py
+++ b/xdsl/transforms/canonicalize/canonicalize_pass.py
@@ -1,0 +1,56 @@
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+from xdsl.dialects import builtin
+from xdsl.ir import MLContext, Operation
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+)
+
+_canonicalize_passes = set()
+
+_RewritePatternT = TypeVar("_RewritePatternT", bound=RewritePattern)
+
+
+def is_canonicalization(pat: type[_RewritePatternT]) -> type[_RewritePatternT]:
+    _canonicalize_passes.add(pat)
+    return pat
+
+
+@dataclass
+class CanonicalizationPattern(GreedyRewritePatternApplier):
+    """
+    A variant on the GreedyRewritePatternApplier that applies at most
+    n times per op to prevent infinite loops.
+    """
+
+    op_match_count: dict[Operation, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    repeat_apply_limit: int = field(default=5)
+
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
+        # apply at most n times per op
+        if self.op_match_count[op] > self.repeat_apply_limit:
+            return
+        self.op_match_count[op] += 1
+        # invoke the greedy rewrite pattern applier
+        super().match_and_rewrite(op, rewriter)
+
+
+class CanonicalizationPass(ModulePass):
+    """
+    Applies all canonicalization patters.
+    """
+
+    name = "canonicalize"
+
+    def apply(self, ctx: MLContext, module: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            CanonicalizationPattern([p() for p in _canonicalize_passes])
+        ).rewrite_module(module)

--- a/xdsl/transforms/canonicalize/canonicalize_riscv.py
+++ b/xdsl/transforms/canonicalize/canonicalize_riscv.py
@@ -1,0 +1,93 @@
+from math import ceil, log2
+
+from xdsl.dialects import riscv
+from xdsl.ir import SSAValue
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.transforms.canonicalize import is_canonicalization
+
+_HAS_IMMEDIATE_FORM_OP: dict[riscv.RISCVOp, riscv.RdRsImmIntegerOperation] = {
+    riscv.AddOp: riscv.AddiOp,
+    riscv.AndOp: riscv.AndiOp,
+    riscv.SltOp: riscv.SltiOp,
+    riscv.SllOp: riscv.SlliOp,
+    riscv.SrlOp: riscv.SrliOp,
+    riscv.SraOp: riscv.SraiOp,
+    riscv.OrOp: riscv.OriOp,
+    riscv.XorOp: riscv.XoriOp,
+    riscv.SltuOp: riscv.SltiuOp,
+}
+
+# TODO: make interface
+_COMMUTATIVE_OPS = (riscv.AddOp, riscv.AndOp, riscv.OrOp, riscv.XorOp)
+
+
+def twos_complement_bitwidth(num: int):
+    """
+    Quick approximation of number of bits required to represent a number in two's
+    complement.
+    """
+    is_neg = 1 if num < 0 else 0
+    num = abs(num)
+    return ceil(log2(num)) + is_neg
+
+
+def can_be_imm_arg(arg: SSAValue):
+    return (
+        isinstance(arg.owner, riscv.LiOp)
+        and twos_complement_bitwidth(arg.owner.immediate.value.data) <= 12
+    )
+
+
+@is_canonicalization
+class FoldRiscvImmediates(RewritePattern):
+    """
+    Folds a `li` followed by an op that has an immediate form into the immediate
+    form of the operation.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self,
+        op: riscv.AddOp
+        | riscv.AndOp
+        | riscv.SltOp
+        | riscv.SllOp
+        | riscv.SrlOp
+        | riscv.SraOp
+        | riscv.OrOp
+        | riscv.XorOp
+        | riscv.SltuOp,
+        rewriter: PatternRewriter,
+        /,
+    ):
+        args_to_check = op.operands
+        if not isinstance(op, _COMMUTATIVE_OPS):
+            args_to_check = [op.rs1]
+        print(f"{args_to_check=}")
+        arg_to_replace = None
+
+        for arg in args_to_check:
+            print(f"{can_be_imm_arg(arg)=}")
+            if can_be_imm_arg(arg):
+                arg_to_replace = arg
+                break
+
+        # do nothing if no suitable arg was found
+        if arg_to_replace is None:
+            return
+
+        # copy arguments to op
+        args = list(op.operands)
+        # remove the replaced operand
+        args.remove(arg_to_replace)
+        assert len(args) == 1
+        # construct new op
+        new_op = _HAS_IMMEDIATE_FORM_OP[type(op)](
+            args[0], arg_to_replace.owner.immediate.value.data, rd=op.rd.type
+        )
+        # replace old op
+        rewriter.replace_matched_op(new_op)


### PR DESCRIPTION
This adds canonicalization infrastructure.

 - A new subfolder `xdsl.transforms.canonicalization`
 - Contains the `CanonicalizationPass`
 - Contains an example riscv canonicalization pattern to fold immediates
 - Canonicalization patterns can be added using the `@is_canonicalization` decorator
 - Canonicalization patterns are only applied up to 5 times to prevent infinite loops

This PR also includes a RISC-V canonicalization pass I wrote to check out how this feels/works. Will remove once we are done with the general discussion and are ready to review PRs.
