### PR TITLE
transforms: (dmp) Add canonicalization for dmp

### DIFF
--- a/tests/filecheck/dialects/dmp/canonicalize.mlir
+++ b/tests/filecheck/dialects/dmp/canonicalize.mlir
@@ -1,0 +1,28 @@
+// RUN: xdsl-opt -p canonicalize-dmp %s | filecheck %s
+
+builtin.module {
+    %ref = "test.op"() : () -> (memref<1024x1024xf32>)
+
+    "dmp.swap"(%ref) {
+        grid = #dmp.grid<2x2>,
+        swaps = [
+            #dmp.exchange_decl<at [4, 0] size [100, 4] source offset [0, 4] to [-1, 0]>,
+            #dmp.exchange_decl<at [4, 104] size [100, 0] source offset [0, -4] to [1, 0]>
+        ]
+    } : (memref<1024x1024xf32>) -> ()
+
+    // CHECK: "dmp.swap"(%ref) {"grid" = #dmp.grid<2x2>, "swaps" = [#dmp.exchange_decl<at [4, 0] size [100, 4] source offset [0, 4] to [-1, 0]>]} : (memref<1024x1024xf32>) -> ()
+
+    "dmp.swap"(%ref) {
+        grid = #dmp.grid<2x2>,
+        swaps = [
+            #dmp.exchange_decl<at [4, 0] size [100, 0] source offset [0, 4] to [-1, 0]>,
+            #dmp.exchange_decl<at [4, 104] size [100, 0] source offset [0, -4] to [1, 0]>
+        ]
+    } : (memref<1024x1024xf32>) -> ()
+
+    "test.op"() : () -> ()
+
+    // this op should be completely removed since both exchanges are empty, so we expect the next op to be a test.op
+    // CHECK-NEXT: "test.op"() : () -> ()
+}

--- a/tests/filecheck/dialects/dmp/ops.mlir
+++ b/tests/filecheck/dialects/dmp/ops.mlir
@@ -1,0 +1,15 @@
+// RUN: xdsl-opt --print-op-generic %s | xdsl-opt | filecheck %s
+
+builtin.module {
+    %ref = "test.op"() : () -> (memref<1024x1024xf32>)
+
+    "dmp.swap"(%ref) {
+        grid = #dmp.grid<2x2>,
+        swaps = [
+            #dmp.exchange_decl<at [4, 0] size [100, 4] source offset [0, 4] to [-1, 0]>,
+            #dmp.exchange_decl<at [4, 104] size [100, 4] source offset [0, -4] to [1, 0]>
+        ]
+    } : (memref<1024x1024xf32>) -> ()
+
+    // CHECK: "dmp.swap"(%ref) {"grid" = #dmp.grid<2x2>, "swaps" = [#dmp.exchange_decl<at [4, 0] size [100, 4] source offset [0, 4] to [-1, 0]>, #dmp.exchange_decl<at [4, 104] size [100, 4] source offset [0, -4] to [1, 0]>]} : (memref<1024x1024xf32>) -> ()
+}

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -156,7 +156,32 @@ class HaloExchangeDecl(ParametrizedAttribute):
         printer.print_list(self.source_offset, lambda x: printer.print_string(str(x)))
         printer.print_string(f"] to {list(self.neighbor)}>")
 
-    # TODO: def parse_parameters()
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        parser.parse_characters("<")
+        parser.parse_characters("at")
+        offset = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE, parser.parse_integer
+        )
+        parser.parse_characters("size")
+        size = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE, parser.parse_integer
+        )
+        parser.parse_characters("source")
+        parser.parse_characters("offset")
+        source_offset = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE, parser.parse_integer
+        )
+        parser.parse_characters("to")
+        to = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE, parser.parse_integer
+        )
+        parser.parse_characters(">")
+
+        return [
+            builtin.DenseArrayBase.from_list(builtin.i64, x)
+            for x in (offset, size, source_offset, to)
+        ]
 
 
 @irdl_attr_definition
@@ -362,13 +387,15 @@ class NodeGrid(ParametrizedAttribute):
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
         parser.parse_characters("<")
+        shape: list[int] = [
+            parser.parse_integer(allow_negative=False, allow_boolean=False)
+        ]
 
-        shape: list[int] = [parser.parse_integer(allow_negative=False)]
-
-        while parser.parse_optional_characters("x") is not None:
-            shape.append(parser.parse_integer(allow_negative=False))
-
-        parser.parse_characters(">")
+        while parser.parse_optional_punctuation(">") is None:
+            parser.parse_shape_delimiter()
+            shape.append(
+                parser.parse_integer(allow_negative=False, allow_boolean=False)
+            )
 
         return [builtin.DenseArrayBase.from_list(builtin.i64, shape)]
 

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -36,6 +36,7 @@ from xdsl.ir import Dialect, MLContext
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass
 from xdsl.transforms import (
+    canonicalize_dmp,
     dead_code_elimination,
     lower_mpi,
     lower_riscv_func,
@@ -91,6 +92,7 @@ def get_all_dialects() -> list[Dialect]:
 def get_all_passes() -> list[type[ModulePass]]:
     """Return the list of all available passes."""
     return [
+        canonicalize_dmp.CanonicalizeDmpPass,
         convert_stencil_to_ll_mlir.ConvertStencilToLLMLIRPass,
         dead_code_elimination.DeadCodeElimination,
         DesymrefyPass,

--- a/xdsl/transforms/canonicalize_dmp.py
+++ b/xdsl/transforms/canonicalize_dmp.py
@@ -1,0 +1,31 @@
+from xdsl.dialects import builtin
+from xdsl.dialects.experimental import dmp
+from xdsl.passes import MLContext, ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class CanonicalizeDmpSwap(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: dmp.HaloSwapOp, rewriter: PatternRewriter, /):
+        keeps: list[dmp.HaloExchangeDecl] = []
+        if op.swaps is None:
+            return
+        for swap in op.swaps:
+            if swap.elem_count > 0:
+                keeps.append(swap)
+        if len(keeps) == 0:
+            rewriter.erase_matched_op()
+        else:
+            op.swaps = builtin.ArrayAttr(keeps)
+
+
+class CanonicalizeDmpPass(ModulePass):
+    name = "canonicalize-dmp"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(CanonicalizeDmpSwap()).rewrite_module(op)


### PR DESCRIPTION
This adds the `dmp-canonicalize` pass that removes empty exchange declarations and swap ops.