### PR TITLE
documentation: (toy) add lowering from `memref` to toy accelerator pass

### DIFF
--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -128,7 +128,6 @@ def main(path: Path, emit: str, ir: bool, accelerate: bool, print_generic: bool)
         # TODO: remove as we add lowerings to riscv
         interpreter.register_implementations(ScfFunctions())
         interpreter.register_implementations(ArithFunctions())
-        interpreter.register_implementations(MemrefFunctions())
         interpreter.register_implementations(PrintfFunctions())
         interpreter.register_implementations(FuncFunctions())
 

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -19,6 +19,7 @@ from .dialects import toy
 from .frontend.ir_gen import IRGen
 from .frontend.parser import Parser
 from .rewrites.inline_toy import InlineToyPass
+from .rewrites.lower_memref_riscv import LowerMemrefToRiscv
 from .rewrites.lower_to_toy_accelerator import LowerToToyAccelerator
 from .rewrites.lower_toy_accelerator_to_riscv import LowerToyAccelerator
 from .rewrites.lower_toy_affine import LowerToAffinePass
@@ -102,7 +103,7 @@ def transform(
     SetupRiscvPass().apply(ctx, module_op)
     # LowerFuncToRiscvFunc().apply(ctx, module_op)
     LowerToyAccelerator().apply(ctx, module_op)
-    # LowerMemrefToRiscv().apply(ctx, module_op)
+    LowerMemrefToRiscv().apply(ctx, module_op)
     # LowerPrintfRiscvPass().apply(ctx, module_op)
     # LowerArithRiscvPass().apply(ctx, module_op)
     DeadCodeElimination().apply(ctx, module_op)

--- a/docs/Toy/toy/rewrites/lower_memref_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_memref_riscv.py
@@ -12,7 +12,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 
-from .lower_to_toy_accelerator import cast_value_to_register
+from .helpers import cast_value_to_register
 
 
 class LowerMemrefAllocOp(RewritePattern):

--- a/docs/Toy/toy/rewrites/lower_memref_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_memref_riscv.py
@@ -45,19 +45,19 @@ def insert_shape_ops(
     """
     assert len(shape) == len(indices)
 
-    match len(shape):
-        case 1:
+    match indices:
+        case [idx1]:
             rewriter.insert_op_before_matched_op(
                 [
-                    ptr := riscv.AddOp(mem, indices[0]),
+                    ptr := riscv.AddOp(mem, idx1),
                 ]
             )
-        case 2:
+        case [idx1, idx2]:
             rewriter.insert_op_before_matched_op(
                 [
                     cols := riscv.LiOp(shape[1]),
-                    row_offset := riscv.MulOp(cols, indices[0]),
-                    offset := riscv.AddOp(row_offset, indices[1]),
+                    row_offset := riscv.MulOp(cols, idx1),
+                    offset := riscv.AddOp(row_offset, idx2),
                     offset_bytes := riscv.SlliOp(
                         offset, 2, comment="mutiply by elm size"
                     ),

--- a/docs/Toy/toy/rewrites/lower_memref_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_memref_riscv.py
@@ -1,0 +1,125 @@
+from math import prod
+from typing import Any, Sequence, cast
+
+from xdsl.dialects import memref, riscv
+from xdsl.dialects.builtin import ModuleOp, UnrealizedConversionCastOp
+from xdsl.ir.core import MLContext, SSAValue
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from .lower_to_toy_accelerator import cast_value_to_register
+
+
+class LowerMemrefAllocOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Alloc, rewriter: PatternRewriter):
+        assert isinstance(op.memref.type, memref.MemRefType)
+        memref_typ = cast(memref.MemRefType[Any], op.memref.type)
+        size = prod(op.memref.type.get_shape())
+        rewriter.replace_matched_op(
+            [
+                size_op := riscv.LiOp(size, comment="memref alloc size"),
+                alloc_op := riscv.CustomAssemblyInstructionOp(
+                    "buffer.alloc",
+                    (size_op.rd,),
+                    (riscv.IntRegisterType.unallocated(),),
+                ),
+                UnrealizedConversionCastOp.get(alloc_op.results, (memref_typ,)),
+            ]
+        )
+
+
+def insert_shape_ops(
+    mem: SSAValue,
+    indices: Sequence[SSAValue],
+    shape: Sequence[int],
+    rewriter: PatternRewriter,
+) -> SSAValue:
+    """
+    Returns ssa value representing pointer into the memref at given indices.
+    """
+    assert len(shape) == len(indices)
+
+    if len(shape) == 1:
+        rewriter.insert_op_before_matched_op(
+            [
+                ptr := riscv.AddOp(mem, indices[0]),
+            ]
+        )
+    elif len(shape) == 2:
+        rewriter.insert_op_before_matched_op(
+            [
+                cols := riscv.LiOp(shape[1]),
+                row_offset := riscv.MulOp(cols, indices[0]),
+                offset := riscv.AddOp(row_offset, indices[1]),
+                offset_bytes := riscv.SlliOp(offset, 2, comment="mutiply by elm size"),
+                ptr := riscv.AddOp(mem, offset_bytes),
+            ]
+        )
+    else:
+        raise NotImplementedError(f"Unsupported memref shape {shape}")
+    return ptr.rd
+
+
+class LowerMemrefStoreOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Store, rewriter: PatternRewriter):
+        value = cast_value_to_register(op.value, rewriter)
+        mem = cast_value_to_register(op.memref, rewriter)
+        indices = tuple(cast_value_to_register(index, rewriter) for index in op.indices)
+
+        assert isinstance(op.memref.type, memref.MemRefType)
+        memref_typ = cast(memref.MemRefType[Any], op.memref.type)
+        shape = memref_typ.get_shape()
+
+        ptr = insert_shape_ops(mem, indices, shape, rewriter)
+        rewriter.replace_matched_op(
+            [
+                riscv.SwOp(
+                    ptr, value, 0, comment=f"store value to memref of shape {shape}"
+                ),
+            ]
+        )
+
+
+class LowerMemrefLoadOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Load, rewriter: PatternRewriter):
+        mem = cast_value_to_register(op.memref, rewriter)
+        indices = tuple(cast_value_to_register(index, rewriter) for index in op.indices)
+
+        assert isinstance(op.memref.type, memref.MemRefType)
+        memref_typ = cast(memref.MemRefType[Any], op.memref.type)
+        shape = memref_typ.get_shape()
+        ptr = insert_shape_ops(mem, indices, shape, rewriter)
+        rewriter.replace_matched_op(
+            [
+                lw := riscv.LwOp(
+                    ptr, 0, comment=f"load value from memref of shape {shape}"
+                ),
+                UnrealizedConversionCastOp.get(
+                    lw.results, (riscv.IntRegisterType.unallocated(),)
+                ),
+            ],
+        )
+
+
+class LowerMemrefDeallocOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Dealloc, rewriter: PatternRewriter):
+        rewriter.erase_matched_op()
+
+
+class LowerMemrefToRiscv(ModulePass):
+    name = "lower-memref-to-riscv"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        PatternRewriteWalker(LowerMemrefAllocOp()).rewrite_module(op)
+        PatternRewriteWalker(LowerMemrefStoreOp()).rewrite_module(op)
+        PatternRewriteWalker(LowerMemrefLoadOp()).rewrite_module(op)
+        PatternRewriteWalker(LowerMemrefDeallocOp()).rewrite_module(op)

--- a/docs/Toy/toy/rewrites/lower_memref_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_memref_riscv.py
@@ -45,24 +45,27 @@ def insert_shape_ops(
     """
     assert len(shape) == len(indices)
 
-    if len(shape) == 1:
-        rewriter.insert_op_before_matched_op(
-            [
-                ptr := riscv.AddOp(mem, indices[0]),
-            ]
-        )
-    elif len(shape) == 2:
-        rewriter.insert_op_before_matched_op(
-            [
-                cols := riscv.LiOp(shape[1]),
-                row_offset := riscv.MulOp(cols, indices[0]),
-                offset := riscv.AddOp(row_offset, indices[1]),
-                offset_bytes := riscv.SlliOp(offset, 2, comment="mutiply by elm size"),
-                ptr := riscv.AddOp(mem, offset_bytes),
-            ]
-        )
-    else:
-        raise NotImplementedError(f"Unsupported memref shape {shape}")
+    match len(shape):
+        case 1:
+            rewriter.insert_op_before_matched_op(
+                [
+                    ptr := riscv.AddOp(mem, indices[0]),
+                ]
+            )
+        case 2:
+            rewriter.insert_op_before_matched_op(
+                [
+                    cols := riscv.LiOp(shape[1]),
+                    row_offset := riscv.MulOp(cols, indices[0]),
+                    offset := riscv.AddOp(row_offset, indices[1]),
+                    offset_bytes := riscv.SlliOp(
+                        offset, 2, comment="mutiply by elm size"
+                    ),
+                    ptr := riscv.AddOp(mem, offset_bytes),
+                ]
+            )
+        case _:
+            raise NotImplementedError(f"Unsupported memref shape {shape}")
     return ptr.rd
 
 

--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -1,0 +1,190 @@
+import pytest
+
+from xdsl.builder import Builder, ImplicitBuilder
+from xdsl.dialects import arith, func, memref, riscv
+from xdsl.dialects.builtin import IndexType, ModuleOp, UnrealizedConversionCastOp, f64
+from xdsl.ir import MLContext
+from xdsl.pattern_rewriter import PatternRewriter
+from xdsl.utils.test_value import TestSSAValue
+
+from ..rewrites.lower_memref_riscv import LowerMemrefToRiscv, insert_shape_ops
+
+memref_type_2xf64 = memref.MemRefType.from_element_type_and_shape(f64, ([2]))
+memref_type_2x2xf64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2]))
+memref_type_2x2x2xf64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2, 2]))
+
+register_type = riscv.IntRegisterType.unallocated()
+
+
+def test_lower_memref_alloc():
+    @ModuleOp
+    @Builder.implicit_region
+    def simple_alloc():
+        m1 = memref.Alloc.get(f64, shape=[2]).memref
+        riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (m1,), ())
+
+    @ModuleOp
+    @Builder.implicit_region
+    def expected():
+        size = riscv.LiOp(2, comment="memref alloc size")
+        alloc = riscv.CustomAssemblyInstructionOp(
+            "buffer.alloc", (size.results[0],), (register_type,)
+        )
+        cast = UnrealizedConversionCastOp.get((alloc.results[0],), (memref_type_2xf64,))
+        riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (cast.results[0],), ())
+
+    LowerMemrefToRiscv().apply(MLContext(), simple_alloc)
+    assert f"{expected}" == f"{simple_alloc}"
+
+
+def test_lower_memref_dealloc():
+    @ModuleOp
+    @Builder.implicit_region
+    def simple_dealloc():
+        with ImplicitBuilder(func.FuncOp("impl", ((memref_type_2xf64,), ())).body) as (
+            b,
+        ):
+            memref.Dealloc.get(b)
+
+    @ModuleOp
+    @Builder.implicit_region
+    def expected():
+        with ImplicitBuilder(func.FuncOp("impl", ((memref_type_2xf64,), ())).body) as (
+            b,
+        ):
+            pass
+
+    LowerMemrefToRiscv().apply(MLContext(), simple_dealloc)
+    assert f"{expected}" == f"{simple_dealloc}"
+
+
+def test_insert_shape_ops_1d():
+    mem = TestSSAValue(memref_type_2xf64)
+    indices = [TestSSAValue(register_type)]
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_1d():
+        with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
+            riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
+
+    @ModuleOp
+    @Builder.implicit_region
+    def expected_1d():
+        with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
+            _ = riscv.AddOp(mem, indices[0])
+            riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
+
+    shape = [2]
+    dummy_op = list(input_1d.walk())[-1]
+    rewriter = PatternRewriter(dummy_op)
+    _ = insert_shape_ops(mem, indices, shape, rewriter)
+
+    assert f"{expected_1d}" == f"{input_1d}"
+
+
+def test_insert_shape_ops_2d():
+    mem = TestSSAValue(memref_type_2x2xf64)
+    indices = [TestSSAValue(register_type), TestSSAValue(register_type)]
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_2d():
+        with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
+            riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
+
+    @ModuleOp
+    @Builder.implicit_region
+    def expected_2d():
+        with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
+            v1 = riscv.LiOp(2)
+            v2 = riscv.MulOp(v1, indices[0])
+            v3 = riscv.AddOp(v2, indices[1])
+            v4 = riscv.SlliOp(v3, 2, comment="mutiply by elm size")
+            _ = riscv.AddOp(mem, v4)
+            riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
+
+    shape = [2, 2]
+    dummy_op = list(input_2d.walk())[-1]
+    rewriter = PatternRewriter(dummy_op)
+    _ = insert_shape_ops(mem, indices, shape, rewriter)
+
+    assert f"{input_2d}" == f"{expected_2d}"
+
+
+def test_insert_shape_ops_invalid_dim():
+    mem = TestSSAValue(memref_type_2x2x2xf64)
+    indices = [
+        TestSSAValue(register_type),
+        TestSSAValue(register_type),
+        TestSSAValue(register_type),
+    ]
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_2d():
+        with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
+            riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
+
+    shape = [2, 2, 2]
+    dummy_op = list(input_2d.walk())[-1]
+    rewriter = PatternRewriter(dummy_op)
+
+    with pytest.raises(NotImplementedError):
+        _ = insert_shape_ops(mem, indices, shape, rewriter)
+
+
+# insert_shape_ops has already been tested in the above tests
+# so we can reduce the code here a bit to only test a single dimension
+
+
+def test_memref_load():
+    @ModuleOp
+    @Builder.implicit_region
+    def simple_load():
+        with ImplicitBuilder(
+            func.FuncOp("impl", ((memref_type_2xf64, (IndexType())), ())).body
+        ) as (v, i):
+            memref.Load.get(v, [i])
+
+    @ModuleOp
+    @Builder.implicit_region
+    def expected():
+        with ImplicitBuilder(
+            func.FuncOp("impl", ((memref_type_2xf64, IndexType()), ())).body
+        ) as (v, i):
+            v1 = UnrealizedConversionCastOp.get([v], (register_type,))
+            v2 = UnrealizedConversionCastOp.get([i], (register_type,))
+            v4 = riscv.AddOp(v1.results[0], v2.results[0])
+            v5 = riscv.LwOp(v4, 0, comment="load value from memref of shape (2,)")
+            _ = UnrealizedConversionCastOp.get([v5], (register_type,))
+
+    LowerMemrefToRiscv().apply(MLContext(), simple_load)
+    assert f"{expected}" == f"{simple_load}"
+
+
+def test_memref_store():
+    @ModuleOp
+    @Builder.implicit_region
+    def simple_store():
+        with ImplicitBuilder(
+            func.FuncOp("impl", ((f64, memref_type_2xf64, IndexType()), ())).body
+        ) as (v, m, i):
+            memref.Store.get(v, m, [i])
+
+    @ModuleOp
+    @Builder.implicit_region
+    def expected():
+        with ImplicitBuilder(
+            func.FuncOp("impl", ((f64, memref_type_2xf64, IndexType()), ())).body
+        ) as (v, m, i):
+            v1 = UnrealizedConversionCastOp.get([v], (register_type,))
+            v2 = UnrealizedConversionCastOp.get([m], (register_type,))
+            v3 = UnrealizedConversionCastOp.get([i], (register_type,))
+            v4 = riscv.AddOp(v2.results[0], v3.results[0])
+            riscv.SwOp(
+                v4, v1.results[0], 0, comment="store value to memref of shape (2,)"
+            )
+
+    LowerMemrefToRiscv().apply(MLContext(), simple_store)
+    assert f"{expected}" == f"{simple_store}"

--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -9,11 +9,11 @@ from xdsl.utils.test_value import TestSSAValue
 
 from ..rewrites.lower_memref_riscv import LowerMemrefToRiscv, insert_shape_ops
 
-memref_type_2xf64 = memref.MemRefType.from_element_type_and_shape(f64, ([2]))
-memref_type_2x2xf64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2]))
-memref_type_2x2x2xf64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2, 2]))
+MEMREF_TYPE_2XF64 = memref.MemRefType.from_element_type_and_shape(f64, ([2]))
+MEMREF_TYPE_2X2XF64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2]))
+MEMREF_TYPE_2X2X2XF64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2, 2]))
 
-register_type = riscv.IntRegisterType.unallocated()
+REGISTER_TYPE = riscv.IntRegisterType.unallocated()
 
 
 def test_lower_memref_alloc():
@@ -28,9 +28,9 @@ def test_lower_memref_alloc():
     def expected():
         v1 = riscv.LiOp(2, comment="memref alloc size")
         v2 = riscv.CustomAssemblyInstructionOp(
-            "buffer.alloc", (v1.results[0],), (register_type,)
+            "buffer.alloc", (v1.results[0],), (REGISTER_TYPE,)
         )
-        v3 = UnrealizedConversionCastOp.get((v2.results[0],), (memref_type_2xf64,))
+        v3 = UnrealizedConversionCastOp.get((v2.results[0],), (MEMREF_TYPE_2XF64,))
         riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (v3.results[0],), ())
 
     LowerMemrefToRiscv().apply(MLContext(), simple_alloc)
@@ -41,7 +41,7 @@ def test_lower_memref_dealloc():
     @ModuleOp
     @Builder.implicit_region
     def simple_dealloc():
-        with ImplicitBuilder(func.FuncOp("impl", ((memref_type_2xf64,), ())).body) as (
+        with ImplicitBuilder(func.FuncOp("impl", ((MEMREF_TYPE_2XF64,), ())).body) as (
             b,
         ):
             memref.Dealloc.get(b)
@@ -49,7 +49,7 @@ def test_lower_memref_dealloc():
     @ModuleOp
     @Builder.implicit_region
     def expected():
-        with ImplicitBuilder(func.FuncOp("impl", ((memref_type_2xf64,), ())).body) as (
+        with ImplicitBuilder(func.FuncOp("impl", ((MEMREF_TYPE_2XF64,), ())).body) as (
             _,
         ):
             pass
@@ -59,8 +59,8 @@ def test_lower_memref_dealloc():
 
 
 def test_insert_shape_ops_1d():
-    mem = TestSSAValue(memref_type_2xf64)
-    indices = [TestSSAValue(register_type)]
+    mem = TestSSAValue(MEMREF_TYPE_2XF64)
+    indices = [TestSSAValue(REGISTER_TYPE)]
 
     @ModuleOp
     @Builder.implicit_region
@@ -84,8 +84,8 @@ def test_insert_shape_ops_1d():
 
 
 def test_insert_shape_ops_2d():
-    mem = TestSSAValue(memref_type_2x2xf64)
-    indices = [TestSSAValue(register_type), TestSSAValue(register_type)]
+    mem = TestSSAValue(MEMREF_TYPE_2X2XF64)
+    indices = [TestSSAValue(REGISTER_TYPE), TestSSAValue(REGISTER_TYPE)]
 
     @ModuleOp
     @Builder.implicit_region
@@ -113,11 +113,11 @@ def test_insert_shape_ops_2d():
 
 
 def test_insert_shape_ops_invalid_dim():
-    mem = TestSSAValue(memref_type_2x2x2xf64)
+    mem = TestSSAValue(MEMREF_TYPE_2X2X2XF64)
     indices = [
-        TestSSAValue(register_type),
-        TestSSAValue(register_type),
-        TestSSAValue(register_type),
+        TestSSAValue(REGISTER_TYPE),
+        TestSSAValue(REGISTER_TYPE),
+        TestSSAValue(REGISTER_TYPE),
     ]
 
     @ModuleOp
@@ -143,7 +143,7 @@ def test_memref_load():
     @Builder.implicit_region
     def simple_load():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((memref_type_2xf64, (IndexType())), ())).body
+            func.FuncOp("impl", ((MEMREF_TYPE_2XF64, (IndexType())), ())).body
         ) as (v, i):
             memref.Load.get(v, [i])
 
@@ -151,13 +151,13 @@ def test_memref_load():
     @Builder.implicit_region
     def expected():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((memref_type_2xf64, IndexType()), ())).body
+            func.FuncOp("impl", ((MEMREF_TYPE_2XF64, IndexType()), ())).body
         ) as (v, i):
-            v1 = UnrealizedConversionCastOp.get([v], (register_type,))
-            v2 = UnrealizedConversionCastOp.get([i], (register_type,))
+            v1 = UnrealizedConversionCastOp.get([v], (REGISTER_TYPE,))
+            v2 = UnrealizedConversionCastOp.get([i], (REGISTER_TYPE,))
             v4 = riscv.AddOp(v1.results[0], v2.results[0])
             v5 = riscv.LwOp(v4, 0, comment="load value from memref of shape (2,)")
-            _ = UnrealizedConversionCastOp.get([v5], (register_type,))
+            _ = UnrealizedConversionCastOp.get([v5], (REGISTER_TYPE,))
 
     LowerMemrefToRiscv().apply(MLContext(), simple_load)
     assert f"{expected}" == f"{simple_load}"
@@ -168,7 +168,7 @@ def test_memref_store():
     @Builder.implicit_region
     def simple_store():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((f64, memref_type_2xf64, IndexType()), ())).body
+            func.FuncOp("impl", ((f64, MEMREF_TYPE_2XF64, IndexType()), ())).body
         ) as (v, m, i):
             memref.Store.get(v, m, [i])
 
@@ -176,11 +176,11 @@ def test_memref_store():
     @Builder.implicit_region
     def expected():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((f64, memref_type_2xf64, IndexType()), ())).body
+            func.FuncOp("impl", ((f64, MEMREF_TYPE_2XF64, IndexType()), ())).body
         ) as (v, m, i):
-            v1 = UnrealizedConversionCastOp.get([v], (register_type,))
-            v2 = UnrealizedConversionCastOp.get([m], (register_type,))
-            v3 = UnrealizedConversionCastOp.get([i], (register_type,))
+            v1 = UnrealizedConversionCastOp.get([v], (REGISTER_TYPE,))
+            v2 = UnrealizedConversionCastOp.get([m], (REGISTER_TYPE,))
+            v3 = UnrealizedConversionCastOp.get([i], (REGISTER_TYPE,))
             v4 = riscv.AddOp(v2.results[0], v3.results[0])
             riscv.SwOp(
                 v4, v1.results[0], 0, comment="store value to memref of shape (2,)"

--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -1,7 +1,7 @@
 import pytest
 
 from xdsl.builder import Builder, ImplicitBuilder
-from xdsl.dialects import arith, func, memref, riscv
+from xdsl.dialects import func, memref, riscv
 from xdsl.dialects.builtin import IndexType, ModuleOp, UnrealizedConversionCastOp, f64
 from xdsl.ir import MLContext
 from xdsl.pattern_rewriter import PatternRewriter
@@ -20,18 +20,18 @@ def test_lower_memref_alloc():
     @ModuleOp
     @Builder.implicit_region
     def simple_alloc():
-        m1 = memref.Alloc.get(f64, shape=[2]).memref
-        riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (m1,), ())
+        v1 = memref.Alloc.get(f64, shape=[2]).memref
+        riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (v1,), ())
 
     @ModuleOp
     @Builder.implicit_region
     def expected():
-        size = riscv.LiOp(2, comment="memref alloc size")
-        alloc = riscv.CustomAssemblyInstructionOp(
-            "buffer.alloc", (size.results[0],), (register_type,)
+        v1 = riscv.LiOp(2, comment="memref alloc size")
+        v2 = riscv.CustomAssemblyInstructionOp(
+            "buffer.alloc", (v1.results[0],), (register_type,)
         )
-        cast = UnrealizedConversionCastOp.get((alloc.results[0],), (memref_type_2xf64,))
-        riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (cast.results[0],), ())
+        v3 = UnrealizedConversionCastOp.get((v2.results[0],), (memref_type_2xf64,))
+        riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (v3.results[0],), ())
 
     LowerMemrefToRiscv().apply(MLContext(), simple_alloc)
     assert f"{expected}" == f"{simple_alloc}"
@@ -50,7 +50,7 @@ def test_lower_memref_dealloc():
     @Builder.implicit_region
     def expected():
         with ImplicitBuilder(func.FuncOp("impl", ((memref_type_2xf64,), ())).body) as (
-            b,
+            _,
         ):
             pass
 


### PR DESCRIPTION
Memref lowering with tests as part of the toy flow upstreaming (https://github.com/xdslproject/xdsl/pull/1379).