### PR TITLE
ci: run Toy with-mlir tests on CI

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -102,6 +102,7 @@ jobs:
         # Add mlir-opt to the path
         export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
         lit -v tests/filecheck/ -DCOVERAGE
+        lit -v docs/Toy/examples/ -DCOVERAGE
 
     - name: Test MLIR dependent examples/tutorials
       run: |

--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any
 
 from xdsl.dialects import memref, riscv
-from xdsl.dialects.builtin import Float64Type
+from xdsl.dialects.builtin import Float64Type, IndexType
 from xdsl.interpreter import InterpreterFunctions, impl_cast, register_impls
 from xdsl.interpreters.affine import AffineFunctions
 from xdsl.interpreters.arith import ArithFunctions
@@ -70,6 +70,35 @@ class BufferMemrefConversion(InterpreterFunctions):
         value: Any,
     ) -> Any:
         return Buffer(value.data)
+
+    @impl_cast(IndexType, riscv.IntRegisterType)
+    def cast_index_to_int_reg(
+        self,
+        input_type: IndexType,
+        output_type: riscv.IntRegisterType,
+        value: Any,
+    ) -> Any:
+        return value
+
+    # Hack for partial lowering and lack of support for float registers
+    @impl_cast(Float64Type, riscv.IntRegisterType)
+    def cast_float_to_int_reg(
+        self,
+        input_type: Float64Type,
+        output_type: riscv.IntRegisterType,
+        value: Any,
+    ) -> Any:
+        return value
+
+    # Hack for partial lowering and lack of support for float registers
+    @impl_cast(riscv.IntRegisterType, Float64Type)
+    def cast_int_reg_to_float(
+        self,
+        input_type: riscv.IntRegisterType,
+        output_type: Float64Type,
+        value: Any,
+    ) -> Any:
+        return float(value)
 
 
 def main(path: Path, emit: str, ir: bool, accelerate: bool, print_generic: bool):

--- a/docs/Toy/toy/rewrites/lower_memref_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_memref_riscv.py
@@ -105,9 +105,7 @@ class LowerMemrefLoadOp(RewritePattern):
                 lw := riscv.LwOp(
                     ptr, 0, comment=f"load value from memref of shape {shape}"
                 ),
-                UnrealizedConversionCastOp.get(
-                    lw.results, (riscv.IntRegisterType.unallocated(),)
-                ),
+                UnrealizedConversionCastOp.get(lw.results, (op.res.type,)),
             ],
         )
 

--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -157,7 +157,7 @@ def test_memref_load():
             v2 = UnrealizedConversionCastOp.get([i], (REGISTER_TYPE,))
             v4 = riscv.AddOp(v1.results[0], v2.results[0])
             v5 = riscv.LwOp(v4, 0, comment="load value from memref of shape (2,)")
-            _ = UnrealizedConversionCastOp.get([v5], (REGISTER_TYPE,))
+            _ = UnrealizedConversionCastOp.get([v5], (f64,))
 
     LowerMemrefToRiscv().apply(MLContext(), simple_load)
     assert f"{expected}" == f"{simple_load}"

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -163,6 +163,17 @@ class RiscvFunctions(InterpreterFunctions):
     ):
         return (args[0] + args[1],)
 
+    @impl(riscv.SlliOp)
+    def run_shift_left(
+        self,
+        interpreter: Interpreter,
+        op: riscv.SlliOp,
+        args: tuple[Any, ...],
+    ):
+        imm = self.get_immediate_value(op, op.immediate)
+        assert isinstance(imm, int)
+        return (args[0] << imm,)
+
     @impl(riscv.MulOp)
     def run_mul(
         self,


### PR DESCRIPTION
Turns out the mlir-based workflow was accidentally never enabled. We are using it to prototype parts of the RISC-V backend, so would be nice to keep it tested continuously.