### PR TITLE
core: print error on operation with mismatched types, not next one

### DIFF
--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -32,7 +32,11 @@ builtin.module {
 
 builtin.module {
   %0 = "test.op"() : () -> ()
+  "test.op"() : () -> ()
 }
+
+// Checks that the diagnostic is printed about the correct operation
+// CHECK: %0 = "test.op"() : () -> ()
 // CHECK: Operation has 0 results, but was given 1 to bind.
 
 // -----

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -712,6 +712,7 @@ class Parser(AttrParser):
             dictionary-attribute  ::= `{` (attribute-entry (`,` attribute-entry)*)? `}`
         """
         # Parse the operation results
+        op_loc = self._current_token.span
         bound_results = self._parse_op_result_list()
 
         if (op_name := self._parse_optional_token(Token.Kind.BARE_IDENT)) is not None:
@@ -730,7 +731,8 @@ class Parser(AttrParser):
         if (n_bound_results != 0) and (len(op.results) != n_bound_results):
             self.raise_error(
                 f"Operation has {len(op.results)} results, "
-                f"but was given {n_bound_results} to bind."
+                f"but was given {n_bound_results} to bind.",
+                at_position=op_loc,
             )
 
         # Register the result SSA value names in the parser


### PR DESCRIPTION
After parsing the types, `current_token` points to the next operation, so the diagnostic is misleading.