### PR TITLE
misc: disable type ignore

### DIFF
--- a/.github/workflows/update_xdsl_pyodide_build.py
+++ b/.github/workflows/update_xdsl_pyodide_build.py
@@ -7,7 +7,7 @@ import hashlib
 import os
 import sys
 
-import yaml  # type: ignore
+import yaml
 
 meta_yaml_path = sys.argv[1]
 xdsl_directory = sys.argv[2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=42", "wheel"]
 
 [tool.pyright]
 reportImportCycles = false
+enableTypeIgnoreComments = false
 typeCheckingMode = "strict"
 "include" = ["docs", "xdsl", "tests", "bench"]
 "exclude" = [
@@ -14,7 +15,10 @@ typeCheckingMode = "strict"
 "ignore" = [
     "tests/filecheck/frontend/dialects/builtin.py",
     "tests/filecheck/frontend/dialects/invalid.py",
+    "tests/filecheck/frontend/dialects/arith.py",
+    "tests/filecheck/frontend/dialects/scf.py",
     "tests/filecheck/frontend/programs/invalid.py",
+    "xdsl/_version.py",
 ]
 
 [tool.isort]

--- a/tests/dialects/test_mpi_lowering.py
+++ b/tests/dialects/test_mpi_lowering.py
@@ -489,4 +489,7 @@ def test_mpi_type_conversion():
 
     for type, target in checks:
         # we test a private member function here, so we ignore pyright
-        assert lowering._translate_to_mpi_type(type) == target  # type: ignore
+        translate_to_mpi_type = (
+            lowering._translate_to_mpi_type  # pyright: ignore[reportPrivateUsage]
+        )
+        assert translate_to_mpi_type(type) == target

--- a/tests/filecheck/frontend/dialects/affine.py
+++ b/tests/filecheck/frontend/dialects/affine.py
@@ -74,7 +74,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected integer constant for loop end, got 'float'.
         def test_not_supported_affine_loop_I():
-            for _ in range(12.0):  # type: ignore
+            for _ in range(12.0):  # pyright: ignore[reportGeneralTypeIssues]
                 pass
             return
 
@@ -87,7 +87,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected integer constant for loop start, got 'str'.
         def test_not_supported_affine_loop_II():
-            for _ in range("boom", 100):  # type: ignore
+            for _ in range("boom", 100):  # pyright: ignore[reportGeneralTypeIssues]
                 pass
             return
 
@@ -100,7 +100,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected integer constant for loop step, got 'float'.
         def test_not_supported_affine_loop_III():
-            for _ in range(0, 100, 1.0):  # type: ignore
+            for _ in range(0, 100, 1.0):  # pyright: ignore[reportGeneralTypeIssues]
                 pass
             return
 

--- a/tests/filecheck/frontend/dialects/arith.py
+++ b/tests/filecheck/frontend/dialects/arith.py
@@ -100,7 +100,7 @@ try:
         # CHECK: Binary operation 'FloorDiv' is not supported by type '_Float64' which does not overload '__floordiv__'.
         def test_missing_floordiv_overload_f64(a: f64, b: f64) -> f64:
             # We expect the type error here, since the function doesn't exist on f64
-            return a // b  # type: ignore
+            return a // b
 
     p.compile(desymref=False)
     print(p.textual_format())
@@ -112,7 +112,7 @@ try:
         # CHECK: Comparison operation 'In' is not supported by type '_Float64' which does not overload '__contains__'.
         def test_missing_contains_overload_f64(a: f64, b: f64) -> f64:
             # We expect the type error here, since the function doesn't exist on f64
-            return a in b  # type: ignore
+            return a in b
 
     p.compile(desymref=False)
     print(p.textual_format())

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -108,7 +108,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected 'index' type for loop end, got 'i32'.
         def test_not_supported_loop_I(end: i32):
-            for _ in range(end):  # type: ignore
+            for _ in range(end):
                 pass
             return
 
@@ -121,7 +121,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected 'index' type for loop start, got 'f32'.
         def test_not_supported_loop_II(start: f32, end: index):
-            for _ in range(start, end):  # type: ignore
+            for _ in range(start, end):
                 pass
             return
 
@@ -214,7 +214,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected the same types for if expression, but got i32 and f32.
         def test_type_mismatch_in_if_expr(cond: i1, x: i32, y: f32) -> i32:
-            return x if cond else y  # type: ignore
+            return x if cond else y
 
     p.compile(desymref=False)
     print(p.textual_format())

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -19,7 +19,9 @@ with CodeContext(p):
     # CHECK-NEXT: }
 
     def test_for_I(end: index):
-        for _ in range(end):  # type: ignore
+        for _ in range(
+            end  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+        ):
             pass
         return
 
@@ -34,7 +36,10 @@ with CodeContext(p):
     # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_for_II(start: index, end: index):
-        for _ in range(start, end):  # type: ignore
+        for _ in range(
+            start,  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+            end,  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+        ):
             pass
         return
 
@@ -49,7 +54,11 @@ with CodeContext(p):
     # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_for_III(start: index, end: index, step: index):
-        for _ in range(start, end, step):  # type: ignore
+        for _ in range(
+            start,  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+            end,  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+            step,  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+        ):
             pass
         return
 
@@ -78,9 +87,15 @@ with CodeContext(p):
     # CHECK-NEXT:   func.return
     # CHECK-NEXT:   }
     def test_for_IV(a: index, b: index, c: index):
-        for _ in range(a):  # type: ignore
-            for _ in range(b):  # type: ignore
-                for _ in range(c):  # type: ignore
+        for _ in range(
+            a  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+        ):
+            for _ in range(
+                b  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+            ):
+                for _ in range(
+                    c  # pyright: ignore[reportUnknownVariableType, reportGeneralTypeIssues]
+                ):
                     pass
         return
 
@@ -119,7 +134,7 @@ try:
     with CodeContext(p):
         # CHECK: Expected 'index' type for loop step, got 'f32'.
         def test_not_supported_loop_III(start: index, end: index, step: f32):
-            for _ in range(start, end, step):  # type: ignore
+            for _ in range(start, end, step):
                 pass
             return
 

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -102,7 +102,7 @@ def test_expected_attr_dict():
     with pytest.raises(PyRDLOpDefinitionError, match="'attr-dict' directive not found"):
 
         @irdl_op_definition
-        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class NoAttrDictOp0(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_attr_dict"
 
             assembly_format = ""
@@ -116,7 +116,7 @@ def test_two_attr_dicts():
     ):
 
         @irdl_op_definition
-        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class NoAttrDictOp1(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_attr_dict"
 
             assembly_format = "attr-dict attr-dict"
@@ -126,7 +126,7 @@ def test_two_attr_dicts():
     ):
 
         @irdl_op_definition
-        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class NoAttrDictOp2(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_attr_dict"
 
             assembly_format = "attr-dict attr-dict-with-keyword"
@@ -136,7 +136,7 @@ def test_two_attr_dicts():
     ):
 
         @irdl_op_definition
-        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class NoAttrDictOp3(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_attr_dict"
 
             assembly_format = "attr-dict-with-keyword attr-dict"
@@ -146,7 +146,7 @@ def test_two_attr_dicts():
     ):
 
         @irdl_op_definition
-        class NoAttrDictOp(IRDLOperation):  # type: ignore[reportUnusedImport]
+        class NoAttrDictOp4(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.no_attr_dict"
 
             assembly_format = "attr-dict-with-keyword attr-dict-with-keyword"

--- a/tests/test_frontend_type_conversion.py
+++ b/tests/test_frontend_type_conversion.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import ast
-from sys import _getframe  # type: ignore
+from sys import _getframe  # pyright: ignore[reportPrivateUsage]
 from typing import Any, Callable, Generic, Literal, Tuple, TypeAlias, TypeVar
 
 import pytest
 
-from xdsl.frontend.dialects.builtin import _FrontendType  # type: ignore
+from xdsl.frontend.dialects.builtin import (
+    _FrontendType,  # pyright: ignore[reportPrivateUsage]
+)
 from xdsl.frontend.exception import CodeGenerationException
 from xdsl.frontend.type_conversion import TypeConverter
 from xdsl.ir import ParametrizedAttribute
@@ -51,7 +53,7 @@ b: TypeAlias = _B
 c2: TypeAlias = _C[Literal[2]]
 d12: TypeAlias = _D[Tuple[Literal[1], Literal[2]]]
 
-globals = _getframe(0).f_globals
+globals: dict[str, Any] = _getframe(0).f_globals
 
 
 def test_raises_exception_on_unknown_type():

--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -437,8 +437,8 @@ class VarRegionOp(IRDLOperation):
 def test_var_region_builder():
     op = VarRegionOp.build(regions=[[Region(), [Block(), Block()]]])
     op.verify()
-    assert len(op.regs[0].blocks) == 0  # type: ignore
-    assert len(op.regs[1].blocks) == 2  # type: ignore
+    assert len(op.regs[0].blocks) == 0
+    assert len(op.regs[1].blocks) == 2
 
 
 @irdl_op_definition
@@ -453,10 +453,10 @@ def test_var_sbregion_one_block():
     op2 = VarSBRegionOp.build(regions=[[Region(), [Block(), Block()]]])
     op1.verify()
     op2.verify()
-    assert len(op1.regs) == 1  # type: ignore
-    assert len(op2.regs) == 2  # type: ignore
-    assert len(op2.regs[0].blocks) == 0  # type: ignore
-    assert len(op2.regs[1].blocks) == 2  # type: ignore
+    assert len(op1.regs) == 1
+    assert len(op2.regs) == 2
+    assert len(op2.regs[0].blocks) == 0
+    assert len(op2.regs[1].blocks) == 2
 
 
 @irdl_op_definition

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -245,10 +245,10 @@ class OperandOp(IRDLOperation):
 
 def test_operand_accessors():
     """Test accessors for operands."""
-    operand1 = OpResult(i32, None, None)  # type: ignore
-    operand2 = OpResult(i32, None, None)  # type: ignore
-    operand3 = OpResult(i32, None, None)  # type: ignore
-    operand4 = OpResult(i32, None, None)  # type: ignore
+    operand1 = TestSSAValue(i32)
+    operand2 = TestSSAValue(i32)
+    operand3 = TestSSAValue(i32)
+    operand4 = TestSSAValue(i32)
 
     op = OperandOp.build(operands=[operand1, [operand2], [operand3, operand4]])
     assert op.operand is op.operands[0]

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -10,10 +10,12 @@ from xdsl.utils.parse_pipeline import (
 
 Kind = Token.Kind
 
+generator = PipelineLexer._generator  # pyright: ignore[reportPrivateUsage]
+
 
 def test_pass_lexer():
     tokens = list(
-        PipelineLexer._generator(  # type: ignore[reportPrivateUsage]
+        generator(
             'pass-1,pass-2{arg1=1 arg2=test arg3="test-str" arg-4=-34.4e-12 no-val-arg},pass-3'
         )
     )
@@ -36,17 +38,15 @@ def test_pass_lexer():
     assert tokens[3].span.text == "{"
     assert tokens[18].span.text == "-34.4e-12"
 
-    assert (
-        len(list(PipelineLexer._generator(""))) == 1  # type: ignore[reportPrivateUsage]
-    )
+    assert len(list(generator(""))) == 1
 
 
 def test_pass_lex_errors():
     with pytest.raises(PassPipelineParseError, match="Unknown token"):
-        list(PipelineLexer._generator("pass-1["))  # type: ignore[reportPrivateUsage]
+        list(generator("pass-1["))
 
     with pytest.raises(PassPipelineParseError, match="Unknown token"):
-        list(PipelineLexer._generator("pass-1{thing$=1}"))  # type: ignore[reportPrivateUsage]
+        list(generator("pass-1{thing$=1}"))
 
 
 def test_pass_parser():

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -197,7 +197,7 @@ def test_traits_undefined():
 class WrongTraitsType(IRDLOperation):
     name = "test.no_traits"
 
-    traits = 1  # type: ignore
+    traits = 1  # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_traits_wrong_type():

--- a/xdsl/_version.py
+++ b/xdsl/_version.py
@@ -1,5 +1,3 @@
-# type: ignore
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -679,7 +679,8 @@ class ContainerOf(AttrConstraint):
 
     def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if isinstance(attr, VectorType) or isinstance(attr, TensorType):
-            self.elem_constr.verify(attr.element_type, constraint_vars)  # type: ignore
+            attr = cast(VectorType[Attribute] | TensorType[Attribute], attr)
+            self.elem_constr.verify(attr.element_type, constraint_vars)
         else:
             self.elem_constr.verify(attr, constraint_vars)
 
@@ -725,6 +726,7 @@ class VectorBaseTypeConstraint(AttrConstraint):
     def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if not isinstance(attr, VectorType):
             raise VerifyException(f"{attr} should be of type VectorType.")
+        attr = cast(VectorType[Attribute], attr)
         if attr.element_type != self.expected_type:  # type: ignore
             raise VerifyException(
                 f"Expected vector type to be {self.expected_type}, got {attr.element_type}."  # type: ignore

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -727,9 +727,9 @@ class VectorBaseTypeConstraint(AttrConstraint):
         if not isinstance(attr, VectorType):
             raise VerifyException(f"{attr} should be of type VectorType.")
         attr = cast(VectorType[Attribute], attr)
-        if attr.element_type != self.expected_type:  # type: ignore
+        if attr.element_type != self.expected_type:
             raise VerifyException(
-                f"Expected vector type to be {self.expected_type}, got {attr.element_type}."  # type: ignore
+                f"Expected vector type to be {self.expected_type}, got {attr.element_type}."
             )
 
 

--- a/xdsl/frontend/context.py
+++ b/xdsl/frontend/context.py
@@ -2,7 +2,7 @@ import ast
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from inspect import getsource
-from sys import _getframe  # type: ignore
+from sys import _getframe  # pyright: ignore[reportPrivateUsage]
 from typing import Any
 
 from xdsl.frontend.program import FrontendProgram

--- a/xdsl/frontend/dialects/builtin.py
+++ b/xdsl/frontend/dialects/builtin.py
@@ -37,72 +37,94 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
     ) -> _Integer[_Width, _Signedness]:
         from xdsl.frontend.dialects.arith import addi
 
-        return addi(self, other)  # type: ignore
+        return addi(
+            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+        )
 
     def __and__(
         self, other: _Integer[_Width, _Signedness]
     ) -> _Integer[_Width, _Signedness]:
         from xdsl.frontend.dialects.arith import andi
 
-        return andi(self, other)  # type: ignore
+        return andi(
+            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+        )
 
     def __lshift__(
         self, other: _Integer[_Width, _Signedness]
     ) -> _Integer[_Width, _Signedness]:
         from xdsl.frontend.dialects.arith import shli
 
-        return shli(self, other)  # type: ignore
+        return shli(
+            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+        )
 
     def __mul__(
         self, other: _Integer[_Width, _Signedness]
     ) -> _Integer[_Width, _Signedness]:
         from xdsl.frontend.dialects.arith import muli
 
-        return muli(self, other)  # type: ignore
+        return muli(
+            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+        )
 
     def __rshift__(
         self, other: _Integer[_Width, _Signedness]
     ) -> _Integer[_Width, _Signedness]:
         from xdsl.frontend.dialects.arith import shrsi
 
-        return shrsi(self, other)  # type: ignore
+        return shrsi(
+            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+        )
 
     def __sub__(
         self, other: _Integer[_Width, _Signedness]
     ) -> _Integer[_Width, _Signedness]:
         from xdsl.frontend.dialects.arith import subi
 
-        return subi(self, other)  # type: ignore
+        return subi(
+            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType]
+        )
 
-    def __eq__(self, other: _Integer[_Width, _Signedness]) -> i1:  # type: ignore
+    def __eq__(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self, other: _Integer[_Width, _Signedness]
+    ) -> i1:
         from xdsl.frontend.dialects.arith import cmpi
 
-        return cmpi(self, other, "eq")  # type: ignore
+        return cmpi(self, other, "eq")  # pyright: ignore[reportGeneralTypeIssues]
 
     def __ge__(self, other: _Integer[_Width, _Signedness]) -> i1:
         from xdsl.frontend.dialects.arith import cmpi
 
-        return cmpi(self, other, "sge")  # type: ignore
+        return cmpi(self, other, "sge")  # pyright: ignore[reportGeneralTypeIssues]
 
     def __gt__(self, other: _Integer[_Width, _Signedness]) -> i1:
         from xdsl.frontend.dialects.arith import cmpi
 
-        return cmpi(self, other, "sgt")  # type: ignore
+        return cmpi(self, other, "sgt")  # pyright: ignore[reportGeneralTypeIssues]
 
     def __le__(self, other: _Integer[_Width, _Signedness]) -> i1:
         from xdsl.frontend.dialects.arith import cmpi
 
-        return cmpi(self, other, "sle")  # type: ignore
+        return cmpi(self, other, "sle")  # pyright: ignore[reportGeneralTypeIssues]
 
     def __lt__(self, other: _Integer[_Width, _Signedness]) -> i1:
         from xdsl.frontend.dialects.arith import cmpi
 
-        return cmpi(self, other, "slt")  # type: ignore
+        return cmpi(self, other, "slt")  # pyright: ignore[reportGeneralTypeIssues]
 
-    def __ne__(self, other: _Integer[_Width, _Signedness]) -> i1:  # type: ignore
+    def __ne__(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self, other: _Integer[_Width, _Signedness]
+    ) -> i1:
         from xdsl.frontend.dialects.arith import cmpi
 
-        return cmpi(self, other, "ne")  # type: ignore
+        return cmpi(self, other, "ne")  # pyright: ignore[reportGeneralTypeIssues]
 
 
 # Type aliases for signless integers.

--- a/xdsl/frontend/op_resolver.py
+++ b/xdsl/frontend/op_resolver.py
@@ -4,7 +4,9 @@ import inspect
 from dataclasses import dataclass
 from typing import Callable, Type
 
-from xdsl.frontend.dialects.builtin import _FrontendType  # type: ignore
+from xdsl.frontend.dialects.builtin import (
+    _FrontendType,  # pyright: ignore[reportPrivateUsage]
+)
 from xdsl.frontend.exception import FrontendProgramException
 from xdsl.ir import Operation
 

--- a/xdsl/frontend/type_conversion.py
+++ b/xdsl/frontend/type_conversion.py
@@ -1,10 +1,18 @@
 import ast
 from dataclasses import dataclass, field
-from typing import Any, Dict, Type, TypeAlias, _GenericAlias  # type: ignore
+from typing import (
+    Any,
+    Dict,
+    Type,
+    TypeAlias,
+    _GenericAlias,  # pyright: ignore[reportPrivateUsage, reportGeneralTypeIssues, reportUnknownVariableType]
+)
 
 import xdsl.dialects.builtin as xdsl_builtin
 import xdsl.frontend.dialects.builtin as frontend_builtin
-from xdsl.frontend.dialects.builtin import _FrontendType  # type: ignore
+from xdsl.frontend.dialects.builtin import (
+    _FrontendType,  # pyright: ignore[reportPrivateUsage]
+)
 from xdsl.frontend.exception import CodeGenerationException
 from xdsl.ir import Attribute
 
@@ -43,7 +51,7 @@ class TypeConverter:
     def __post_init__(self) -> None:
         # Cache index type because it is always used implicitly in loops and
         # many other IR constructs.
-        index = frontend_builtin._Index  # type: ignore
+        index = frontend_builtin._Index  # pyright: ignore[reportPrivateUsage]
         self._cache_type(index, xdsl_builtin.IndexType(), "index")
 
     def _cache_type(

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -289,8 +289,7 @@ class OpResult(SSAValue):
     def __eq__(self, other: object) -> bool:
         return self is other
 
-    # This might be problematic, as the superclass is not hashable ...
-    def __hash__(self) -> int:  # type: ignore
+    def __hash__(self) -> int:
         return id(self)
 
 
@@ -319,7 +318,7 @@ class BlockArgument(SSAValue):
     def __eq__(self, other: object) -> bool:
         return self is other
 
-    def __hash__(self) -> int:  # type: ignore
+    def __hash__(self) -> int:
         return id(self)
 
 
@@ -336,7 +335,7 @@ class ErasedSSAValue(SSAValue):
     def owner(self) -> Operation | Block:
         return self.old_value.owner
 
-    def __hash__(self) -> int:  # type: ignore
+    def __hash__(self) -> int:
         return hash(id(self))
 
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1847,7 +1847,9 @@ def irdl_op_definition(cls: TypeIRDLOperationInvT) -> TypeIRDLOperationInvT:
         new_attrs["parse"] = parse_with_format
         new_attrs["print"] = print_with_format
 
-    return type(cls.__name__, cls.__mro__, {**cls.__dict__, **new_attrs})  # type: ignore
+    return type.__new__(
+        type(cls), cls.__name__, cls.__mro__, {**cls.__dict__, **new_attrs}
+    )
 
 
 #  ____        _
@@ -2014,8 +2016,8 @@ def irdl_param_attr_definition(cls: type[_PAttrT]) -> type[_PAttrT]:
     new_fields["irdl_definition"] = irdl_definition
 
     return dataclass(frozen=True, init=False)(
-        type(cls.__name__, (cls,), {**cls.__dict__, **new_fields})
-    )  # type: ignore
+        type.__new__(type(cls), cls.__name__, (cls,), {**cls.__dict__, **new_fields})
+    )
 
 
 TypeAttributeInvT = TypeVar("TypeAttributeInvT", bound=type[Attribute])

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1747,7 +1747,7 @@ def irdl_op_arg_definition(
     # attribute that holds the variadic sizes.
     arg_size_option = get_attr_size_option(construct)
     if previous_variadics > 1 and (arg_size_option not in op_def.options):
-        arg_size_option_name = type(arg_size_option).__name__  # type: ignore
+        arg_size_option_name = type(arg_size_option).__name__
         raise Exception(
             f"Operation {op_def.name} defines more than two variadic "
             f"{get_construct_name(construct)}s, but do not define the "

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -37,7 +37,7 @@ class ForwardDeclaredValue(SSAValue):
     def __eq__(self, other: object) -> bool:
         return self is other
 
-    def __hash__(self) -> int:  # type: ignore
+    def __hash__(self) -> int:
         return id(self)
 
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -405,8 +405,9 @@ class Printer:
             return
 
         if isinstance(attribute, ArrayAttr):
+            attribute = cast(ArrayAttr[Attribute], attribute)
             self.print_string("[")
-            self.print_list(attribute.data, self.print_attribute)  # type: ignore
+            self.print_list(attribute.data, self.print_attribute)
             self.print_string("]")
             return
 

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import dataclass
-from typing import Any, Sequence, TypeGuard
+from typing import Any, Sequence, TypeGuard, cast
 
 from immutabledict import immutabledict
 
@@ -30,7 +30,7 @@ class ISSAValue(ABC):
     users: IList[IOperation]
 
     def _add_user(self, op: IOperation):
-        self.users._unfreeze()  # type: ignore
+        self.users._unfreeze()  # pyright: ignore[reportPrivateUsage]
         self.users.append(op)
         self.users.freeze()
 
@@ -40,7 +40,7 @@ class ISSAValue(ABC):
                 f"Trying to remove a user ({op.name}) that is not an actual user of this value!"
             )
 
-        self.users._unfreeze()  # type: ignore
+        self.users._unfreeze()  # pyright: ignore[reportPrivateUsage]
         self.users.remove(op)
         self.users.freeze()
 
@@ -282,7 +282,10 @@ class IBlock:
             # The IBlock that will house this IBlockArg is not constructed yet.
             # After construction the block field will be set by the IBlock.
             immutable_arg = IBlockArg(
-                arg.type, IList([]), None, arg.index  # type: ignore
+                arg.type,
+                IList(),
+                cast(IBlock, None),
+                arg.index,
             )
             args.append(immutable_arg)
             value_map[arg] = immutable_arg
@@ -361,7 +364,7 @@ class IOperation:
         object.__setattr__(self, "attributes", attributes)
         object.__setattr__(self, "operands", IList(operands))
         for operand in operands:
-            operand._add_user(self)  # type: ignore
+            operand._add_user(self)  # pyright: ignore[reportPrivateUsage]
         object.__setattr__(
             self,
             "results",
@@ -454,7 +457,9 @@ class IOperation:
                 print(f"ERROR: op {self.name} uses SSAValue before definition")
                 # Continuing to enable printing the IR including missing
                 # operands for investigation
-                mutable_operands.append(OpResult(operand.type, None, 0))  # type: ignore
+                mutable_operands.append(
+                    OpResult(operand.type, cast(Operation, None), 0)
+                )
 
         mutable_successors: list[Block] = []
         for successor in self.successors:

--- a/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
+++ b/xdsl/rewriting/composable_rewriting/immutable_ir/immutable_ir.py
@@ -75,7 +75,7 @@ class IBlockArg(ISSAValue):
         return self is __o
 
     def __repr__(self) -> str:
-        return "BlockArg(type:" + self.type.name + ("attached") + ")"  # type: ignore
+        return "BlockArg(type:" + self.type.name + ("attached") + ")"
 
 
 @dataclass(frozen=True)

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -226,7 +226,7 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
         required by the underlying MPI library
         """
         if hasattr(self.info, op_attr.op_str.data):
-            return getattr(self.info, op_attr.op_str.data)  # type: ignore
+            return getattr(self.info, op_attr.op_str.data)
         else:
             raise RuntimeError("Unknown MPI operation type")
 

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -6,7 +6,6 @@ from typing import (
     Generic,
     Iterable,
     Literal,
-    Sequence,
     TypeGuard,
     TypeVar,
     Union,
@@ -123,7 +122,7 @@ PropertyType = type(_Class.property)
 
 def get_type_var_from_generic_class(cls: type[Any]) -> tuple[TypeVar, ...]:
     """Return the `TypeVar` used in the class `Generic` parent."""
-    cls_orig_bases = cast(Iterable[Any], cls.__orig_bases__)  # type: ignore
+    cls_orig_bases: Iterable[Any] = getattr(cls, "__orig_bases__")
     for orig_base in cls_orig_bases:
         if get_origin(orig_base) == Generic:
             return get_args(orig_base)
@@ -142,8 +141,7 @@ def get_type_var_mapping(
         raise ValueError(f"{cls} does not specialize a generic class.")
 
     # Get the generic parent
-    orig_bases = cls.__orig_bases__  # type: ignore
-    orig_bases = cast(Sequence[Any], orig_bases)
+    orig_bases: Iterable[Any] = getattr(cls, "__orig_bases__")
     orig_bases = [
         orig_base for orig_base in orig_bases if get_origin(orig_base) is not Generic
     ]

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -9,6 +9,5 @@ class TestSSAValue(SSAValue):
     def __eq__(self, other: object) -> bool:
         return self is other
 
-    # This might be problematic, as the superclass is not hashable ...
-    def __hash__(self) -> int:  # type: ignore
+    def __hash__(self) -> int:
         return id(self)


### PR DESCRIPTION
Type ignore sometimes hides the wrong issue. We sometimes want to just get pyright to stop complaining about a private funciton call and then, when the function interface changes or is deleted, we miss the type error. When ignoring pyright, it's best to always write `pyright: ignore[specific, issues]` as opposed to a blanket `type: ignore`. I also found some `type: ignore[specificIssue]` but that's not actually a syntax that `type: ignore` supports, it just ignores the whole line.