### PR TITLE
transforms: (dmp) Fix small mistake in decomp swaps generation

### DIFF
--- a/xdsl/transforms/experimental/dmp/decompositions.py
+++ b/xdsl/transforms/experimental/dmp/decompositions.py
@@ -142,7 +142,7 @@ class GridSlice2d(DomainDecompositionStrategy):
         yield dmp.HaloExchangeDecl(
             offset=(
                 dims.buffer_start(dmp.DIM_X),
-                dims.core_end(dmp.DIM_X),
+                dims.core_end(dmp.DIM_Y),
                 *residual_offsets,
             ),
             size=(


### PR DESCRIPTION
This was a tiny bug with big implications on correctness, I'm a bit sad we didn't catch it earlier...

This basically put an x-coordinate where a y-coordinate was expected. Not good.