### PR TITLE
misc: (toy) Rename cast_value_to_register to cast_value_to_int_register

### DIFF
--- a/docs/Toy/toy/rewrites/helpers.py
+++ b/docs/Toy/toy/rewrites/helpers.py
@@ -5,7 +5,9 @@ from xdsl.ir.core import OpResult, SSAValue
 from xdsl.pattern_rewriter import PatternRewriter
 
 
-def cast_value_to_register(operand: SSAValue, rewriter: PatternRewriter) -> OpResult:
+def cast_value_to_int_register(
+    operand: SSAValue, rewriter: PatternRewriter
+) -> OpResult:
     types = (riscv.IntRegisterType.unallocated(),)
     cast = builtin.UnrealizedConversionCastOp.get((operand,), types)
     rewriter.insert_op_before_matched_op(cast)

--- a/docs/Toy/toy/rewrites/lower_memref_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_memref_riscv.py
@@ -12,7 +12,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 
-from .helpers import cast_value_to_register
+from .helpers import cast_value_to_int_register
 
 
 class LowerMemrefAllocOp(RewritePattern):
@@ -72,9 +72,11 @@ def insert_shape_ops(
 class LowerMemrefStoreOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.Store, rewriter: PatternRewriter):
-        value = cast_value_to_register(op.value, rewriter)
-        mem = cast_value_to_register(op.memref, rewriter)
-        indices = tuple(cast_value_to_register(index, rewriter) for index in op.indices)
+        value = cast_value_to_int_register(op.value, rewriter)
+        mem = cast_value_to_int_register(op.memref, rewriter)
+        indices = tuple(
+            cast_value_to_int_register(index, rewriter) for index in op.indices
+        )
 
         assert isinstance(op.memref.type, memref.MemRefType)
         memref_typ = cast(memref.MemRefType[Any], op.memref.type)
@@ -93,8 +95,10 @@ class LowerMemrefStoreOp(RewritePattern):
 class LowerMemrefLoadOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.Load, rewriter: PatternRewriter):
-        mem = cast_value_to_register(op.memref, rewriter)
-        indices = tuple(cast_value_to_register(index, rewriter) for index in op.indices)
+        mem = cast_value_to_int_register(op.memref, rewriter)
+        indices = tuple(
+            cast_value_to_int_register(index, rewriter) for index in op.indices
+        )
 
         assert isinstance(op.memref.type, memref.MemRefType)
         memref_typ = cast(memref.MemRefType[Any], op.memref.type)

--- a/docs/Toy/toy/rewrites/lower_toy_accelerator_to_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_toy_accelerator_to_riscv.py
@@ -11,7 +11,7 @@ from xdsl.pattern_rewriter import (
 )
 
 from ..dialects import toy_accelerator
-from .helpers import cast_value_to_register
+from .helpers import cast_value_to_int_register
 
 
 class LowerTransposeOp(RewritePattern):
@@ -19,8 +19,8 @@ class LowerTransposeOp(RewritePattern):
     def match_and_rewrite(
         self, op: toy_accelerator.Transpose, rewriter: PatternRewriter
     ):
-        destination = cast_value_to_register(op.destination, rewriter)
-        source = cast_value_to_register(op.source, rewriter)
+        destination = cast_value_to_int_register(op.destination, rewriter)
+        source = cast_value_to_int_register(op.source, rewriter)
 
         rewriter.replace_matched_op(
             [
@@ -45,9 +45,9 @@ class LowerBinOp(RewritePattern):
         instruction_name = (
             "buffer.add" if isinstance(op, toy_accelerator.Add) else "buffer.mul"
         )
-        dest = cast_value_to_register(op.dest, rewriter)
-        lhs = cast_value_to_register(op.lhs, rewriter)
-        rhs = cast_value_to_register(op.rhs, rewriter)
+        dest = cast_value_to_int_register(op.dest, rewriter)
+        lhs = cast_value_to_int_register(op.lhs, rewriter)
+        rhs = cast_value_to_int_register(op.rhs, rewriter)
         rewriter.replace_matched_op(
             [
                 size_op := riscv.LiOp(size, comment="size"),


### PR DESCRIPTION
Rename `cast_value_to_register` to `cast_value_to_int_register` in order to distinguish `cast_value_to_int_register` and `cast_value_to_float_register`.
Preparing for #1403.

