### PR TITLE
dialects: (stencil) Add access pattern analysis

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -649,7 +649,7 @@ def test_access_patterns():
         AccessOp.get(t1, (1, 1), (1, 0))
         AccessOp.get(t1, (-1, -1), (1, 0))
 
-    apply = ApplyOp.get((temp, temp), apply_op_region.detach_block(0), [temp])
+    apply = ApplyOp.get((temp, temp), apply_op_region.detach_block(0), [typ])
 
     t0_acc, t1_acc = tuple(apply.get_accesses())
 

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -1,5 +1,6 @@
 import pytest
 
+from xdsl.builder import Builder
 from xdsl.dialects.builtin import (
     AnyFloat,
     ArrayAttr,
@@ -35,7 +36,7 @@ from xdsl.dialects.stencil import (
     StoreResultOp,
     TempType,
 )
-from xdsl.ir import Attribute, Block
+from xdsl.ir import Attribute, Block, SSAValue
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.test_value import TestSSAValue
@@ -631,3 +632,31 @@ def test_buffer():
     assert isinstance(buffer, BufferOp)
     assert buffer.temp == temp
     assert buffer.res.type == res_type
+
+
+def test_access_patterns():
+    typ = TempType((5), f32)
+    temp = TestSSAValue(typ)
+
+    @Builder.implicit_region((typ, typ))
+    def apply_op_region(args: tuple[SSAValue, ...]):
+        t0, t1 = args
+        for x in (-1, 1):
+            AccessOp.get(t0, (x, 0), (1, 0))
+        for y in (-1, 1):
+            AccessOp.get(t0, (0, y), (1, 0))
+
+        AccessOp.get(t1, (1, 1), (1, 0))
+        AccessOp.get(t1, (-1, -1), (1, 0))
+
+    apply = ApplyOp.get((temp, temp), apply_op_region.detach_block(0), [temp])
+
+    t0_acc, t1_acc = tuple(apply.get_accesses())
+
+    assert t0_acc.visual_pattern() == " X \nXOX\n X "
+    assert t1_acc.visual_pattern() == "X  \n O \n  X"
+
+    assert not t0_acc.is_diagonal
+    assert t1_acc.is_diagonal
+
+    assert len(tuple(t1_acc.get_diagonals())) == 2

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -809,9 +809,9 @@ class AccessPattern:
             [" " for _ in range(y_axis_halo[1] - y_axis_halo[0] + 1)]
             for __ in range(x_axis_halo[1] - x_axis_halo[0] + 1)
         ]
-        points[-y_axis_halo[0]][-x_axis_halo[0]] = "O"
+        points[-x_axis_halo[0]][-y_axis_halo[0]] = "O"
         for access in self.accesses:
-            points[access[1] - y_axis_halo[0]][access[0] - x_axis_halo[0]] = "X"
+            points[access[0] - x_axis_halo[0]][access[1] - y_axis_halo[0]] = "X"
         return "\n".join("".join(row) for row in points)
 
 


### PR DESCRIPTION
This adds `.get_accesses()` to the stencil apply operation, which returns an `AccessPattern` for each stencil field.

Each access pattern contains a list of accesses, and offers some helpers like `is_diagonal`, `get_diagonals`, etc.
