### PR TITLE
ci: Add mlir-cpu-runner to mlir-build step

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -89,7 +89,7 @@ jobs:
       if: steps.cache-binary.outputs.cache-hit != 'true'
       run: |
         cd llvm-project/build
-        cmake --build . --target mlir-opt
+        cmake --build . --target mlir-opt mlir-cpu-runner
 
     - name: Test with pytest and generate code coverage
       run: |


### PR DESCRIPTION
This PR adds `mlir-cpu-runner` to the CI, the MLIR CPU execution driver.
Basically it allows you to run a program written in MLIR, by (JIT-)compiling LLVM MLIR-dialect to an actual binary (and immediately running it.) This can be useful for end-to-end tests, where you actually want to see what comes out of running the program.
 
It is provided in the same way that mlir-opt is provided, this means that:
* It is mainly intended to be run with tests in `tests/filecheck/mlir-conversion` ([example is waiting here](https://github.com/xdslproject/xdsl/blob/a1dd52d6d80da6704d755fb0b5ec0797b0de2d7a/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printchar_to_putchar.mlir#L1))
* It is cached, just like `mlir-opt`

Note that this addition does not seem to add any extra time to the build of the uncached mlir binary: Adding this extra target to the cmake command makes the total mlir-cpu-runner build time about `1h44m` (python 3.10) and `1h29m` (python 3.11) in total without caching, which is comparable to [the last time the mlir hash was changed, to build just mlir-opt](https://github.com/xdslproject/xdsl/actions/runs/4881350421) `1h48m` ( python 3.10) and `1h12m` (python 3.11)