### PR TITLE
dialects: (riscv) add custom assembly format for `flw` and `fsw` instructions

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -238,9 +238,9 @@
     %fmvwx = "riscv.fmv.w.x"(%0) : (!riscv.reg<zero>) -> !riscv.freg<j8>
     // CHECK-NEXT: fmv.w.x j8, zero
     %flw = "riscv.flw"(%0) {"immediate" = 1 : i32}: (!riscv.reg<zero>) -> !riscv.freg<j8>
-    // CHECK-NEXT: flw j8, zero, 1
+    // CHECK-NEXT: flw j8, 1(zero)
     "riscv.fsw"(%0, %f0) {"immediate" = 1 : i32} : (!riscv.reg<zero>, !riscv.freg<j5>) -> ()
-    // CHECK-NEXT: fsw zero, j5, 1
+    // CHECK-NEXT: fsw j5, 1(zero)
 
     // Terminate block
     "riscv.ret"() : () -> ()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3076,6 +3076,15 @@ class FLwOp(RdRsImmFloatOperation):
 
     name = "riscv.flw"
 
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = _assembly_arg_str(self.rd)
+        imm = _assembly_arg_str(self.immediate)
+        offset = _assembly_arg_str(self.rs1)
+        return _assembly_line(
+            instruction_name, f"{value}, {imm}({offset})", self.comment
+        )
+
 
 @irdl_op_definition
 class FSwOp(RsRsImmFloatOperation):
@@ -3088,6 +3097,15 @@ class FSwOp(RsRsImmFloatOperation):
     """
 
     name = "riscv.fsw"
+
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        value = _assembly_arg_str(self.rs2)
+        imm = _assembly_arg_str(self.immediate)
+        offset = _assembly_arg_str(self.rs1)
+        return _assembly_line(
+            instruction_name, f"{value}, {imm}({offset})", self.comment
+        )
 
 
 # endregion


### PR DESCRIPTION
`flw` and `fsw` were not updated in (https://github.com/xdslproject/xdsl/pull/1256), now they are also using the same custom assembly format.