### PR TITLE
interpreter: (riscv) Add some libc runtime things to interpreter

### DIFF
--- a/tests/interpreters/test_memref_interpreter.py
+++ b/tests/interpreters/test_memref_interpreter.py
@@ -27,7 +27,7 @@ def test_functions():
     dealloc_op = memref.Dealloc.get(alloc_op)
 
     (shaped_array,) = interpreter.run_op(alloc_op, ())
-    v = MemrefValue.Allocated
+    v = MemrefValue.Initialized
     assert shaped_array == ShapedArray([v, v, v, v, v, v], [2, 3])
     (zero,) = interpreter.run_op(zero_op, ())
     (one,) = interpreter.run_op(one_op, ())

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -45,6 +45,9 @@ class Buffer(Generic[_T]):
         Aliases the data list, so storing into the offset stores for all other references
         to the list.
         """
+        assert (
+            offset % 4 == 0
+        ), "riscv buffer currently only supports word aligned offsets"
         return Buffer(self.data, self.offset + offset // 4)
 
     def __getitem__(self, key: int) -> _T:

--- a/xdsl/interpreters/riscv_runtime.py
+++ b/xdsl/interpreters/riscv_runtime.py
@@ -1,0 +1,64 @@
+"""
+This adds support for a `libc` style runtime of functions, similar to riscemus libc
+"""
+from math import ceil
+from typing import Any
+
+from xdsl.interpreters.memref import MemrefValue
+from xdsl.interpreters.riscv import Buffer
+
+
+def _malloc(args: tuple[Any, ...], name: str) -> tuple[Any, ...]:
+    assert len(args) == 1
+    assert isinstance(args[0], int)
+    size = args[0]
+    if size % 4 != 0:
+        # malloc a bit too much if not word-aligned
+        size = ceil(size / 4) * 4
+
+    # set values to 1 to signify uninitialized memory
+    return (Buffer([MemrefValue.Initialized] * (size // 4)),)
+
+
+def _calloc(args: tuple[Any, ...], name: str) -> tuple[Any, ...]:
+    assert len(args) == 2
+    assert isinstance(args[0], int)
+    assert isinstance(args[1], int)
+    num = args[0]
+    size = args[1]
+
+    num_bytes = num * size
+
+    if num_bytes % 4 != 0:
+        # malloc a bit too much if not word-aligned
+        num_bytes = ceil(num_bytes / 4) * 4
+
+    return (Buffer([0] * (num_bytes // 4)),)
+
+
+def _free(args: tuple[Any, ...], name: str) -> tuple[Any, ...]:
+    assert len(args) == 1
+    assert isinstance(args[0], Buffer)
+    buff: Buffer = args[0]
+
+    for i in range(len(buff.data)):
+        buff.data[i] = MemrefValue.Freed
+    return tuple()
+
+
+def _putchar(args: tuple[Any, ...], name: str) -> tuple[Any, ...]:
+    assert len(args) == 1
+    char = args[0]
+    if isinstance(char, int):
+        print(bytes([char]).decode("ascii"), end="")
+    else:
+        print(char, end="")
+    return tuple()
+
+
+RUNTIME = {
+    "malloc": _malloc,
+    "calloc": _calloc,
+    "free": _free,
+    "putchar": _putchar,
+}


### PR DESCRIPTION
Adds `malloc`, `free`, `calloc` and `putchar` to the riscv runtime. Still needs to be hooked up, should probably use a decorator and fancy class to handle everything.