### PR TITLE
ci: Add ruff rule UP from pyupgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ typeCheckingMode = "strict"
 profile = "black"
 
 [tool.ruff]
-select = ["E", "F", "W", "I"]
-ignore = ["E741"]
+select = ["E", "F", "W", "I", "UP"]
+ignore = ["E741", "UP006", "UP007", "UP027", "UP032", "UP034", "UP035", "UP038"]
 line-length = 300
 target-version = "py310"
 
@@ -35,6 +35,8 @@ target-version = "py310"
 "tests/filecheck/frontend/programs/invalid.py" = ["F811", "F841"]
 "tests/filecheck/frontend/dialects/invalid.py" = ["F811"]
 "tests/test_declarative_assembly_format.py" = ["F811"]
+"versioneer.py" = ["ALL"]
+"_version.py" = ["ALL"]
 
 [tool.ruff.mccabe]
 max-complexity = 10


### PR DESCRIPTION
Add `ruff` rule [`UP`](https://beta.ruff.rs/docs/rules/#pyupgrade-up). It mainly upgrades python usages such as:
- deprecated usage, `List` to `list`, `typing.Sequence` to `collections.abc.Sequence`
- PEP604, `isinstance(x, (A, B))` to `isinstance(x, A | B)`
- prevent some weird typing hint such as `Optional[SSAValue] | None`.
- f-string usage when possible

Main file change is `pyproject.toml` and rest of files are auto-fixed by `ruff`.
```diff
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "UP"]
+"versioneer.py" = ["ALL"]
+"_version.py" = ["ALL"]
```
**Edit:**
Now some rules from UP is excepted to minimize diff.