### PR TITLE
riscv: make CSRRWI immediate mandatory

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -141,10 +141,10 @@
     // CHECK-NEXT: csrrci j0, 1024, 8
     %csrrci_r = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32}: () -> !riscv.reg<j1>
     // CHECK-NEXT: csrrci j1, 1024, 0
-    %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32}: () -> !riscv.reg<j0>
-    // CHECK-NEXT: csrrwi j0, 1024
-    %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "writeonly"}: () -> !riscv.reg<zero>
-    // CHECK-NEXT: csrrwi zero, 1024
+    %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 8}: () -> !riscv.reg<j0>
+    // CHECK-NEXT: csrrwi j0, 1024, 8
+    %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 8, "writeonly"}: () -> !riscv.reg<zero>
+    // CHECK-NEXT: csrrwi zero, 1024, 8
 
     // Assembler pseudo-instructions
     %li = "riscv.li"() {"immediate" = 1 : i32}: () -> !riscv.reg<j0>

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1122,8 +1122,8 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
 
     rd: OpResult = result_def(IntRegisterType)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
+    immediate: AnyIntegerAttr | None = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
-    immediate: AnyIntegerAttr | None = opt_attr_def(AnyIntegerAttr)
 
     def __init__(
         self,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1122,7 +1122,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
 
     rd: OpResult = result_def(IntRegisterType)
     csr: AnyIntegerAttr = attr_def(AnyIntegerAttr)
-    immediate: AnyIntegerAttr | None = attr_def(AnyIntegerAttr)
+    immediate: AnyIntegerAttr = attr_def(AnyIntegerAttr)
     writeonly: UnitAttr | None = opt_attr_def(UnitAttr)
 
     def __init__(


### PR DESCRIPTION
Immediate argument to `riscv.csrrwi` was marked as optional. Fixed by marking it as mandatory to abide by the ISA.