### PR TITLE
backend: (riscv) add infinite register allocation for for loops

### DIFF
--- a/docs/Toy/examples/tests/with-mlir/interpret.toy
+++ b/docs/Toy/examples/tests/with-mlir/interpret.toy
@@ -7,6 +7,7 @@
 # RUN: python -m toy %s --emit=riscv-regalloc --accelerate | filecheck %s
 # RUN: python -m toy %s --emit=riscv-asm --accelerate | filecheck %s
 
+# RUN: python -m toy %s --emit=riscv-regalloc --ir | filecheck %s --check-prefix=REGALLOC
 # RUN: python -m toy %s --emit=riscv-regalloc --ir --accelerate | filecheck %s --check-prefix=REGALLOC
 
 # User defined generic function that operates on unknown shaped arguments


### PR DESCRIPTION
Just allocates a fresh register to use as the loop variable