### PR TITLE
ci: (ruff) Add rule UP034

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ profile = "black"
 
 [tool.ruff]
 select = ["E", "F", "W", "I", "UP"]
-ignore = ["E741", "UP006", "UP007", "UP027", "UP032", "UP034", "UP035", "UP038"]
+ignore = ["E741", "UP006", "UP007", "UP027", "UP032", "UP035", "UP038"]
 line-length = 300
 target-version = "py310"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ typeCheckingMode = "strict"
 profile = "black"
 
 [tool.ruff]
-select = ["E", "F", "W", "I"]
-ignore = ["E741"]
+select = ["E", "F", "W", "I", "UP"]
+ignore = ["E741", "UP006", "UP007", "UP027", "UP032", "UP034", "UP035", "UP038"]
 line-length = 300
 target-version = "py310"
 
@@ -35,6 +35,8 @@ target-version = "py310"
 "tests/filecheck/frontend/programs/invalid.py" = ["F811", "F841"]
 "tests/filecheck/frontend/dialects/invalid.py" = ["F811"]
 "tests/test_declarative_assembly_format.py" = ["F811"]
+"versioneer.py" = ["ALL"]
+"_version.py" = ["ALL"]
 
 [tool.ruff.mccabe]
 max-complexity = 10

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -2380,7 +2380,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
     @classmethod
     def parse(cls, parser: Parser) -> AssemblySectionOp:
         directive = parser.parse_str_literal()
-        attr_dict = parser.parse_optional_attr_dict_with_keyword(("directive"))
+        attr_dict = parser.parse_optional_attr_dict_with_keyword(("directive",))
         region = parser.parse_optional_region()
 
         if region is None:


### PR DESCRIPTION
The rule is to avoid extraneous parentheses.

A bug was found when adding ruff rule UP034. The code intends to have a tuple of strings but a missing comma makes it becomes extraneous parentheses.