### PR TITLE
ci: (ruff) Add rule UP038

### DIFF
--- a/docs/Toy/toy/interpreter.py
+++ b/docs/Toy/toy/interpreter.py
@@ -45,7 +45,7 @@ class ToyFunctions(InterpreterFunctions):
         assert isinstance(arg, ShapedArray)
         arg = cast(ShapedArray[float], arg)
         result_type = op.results[0].type
-        assert isinstance(result_type, (VectorType, TensorType))
+        assert isinstance(result_type, VectorType | TensorType)
         new_shape = list(result_type.get_shape())
 
         return (ShapedArray(arg.data, new_shape),)

--- a/docs/Toy/toy/rewrites/lower_to_toy_accelerator.py
+++ b/docs/Toy/toy/rewrites/lower_to_toy_accelerator.py
@@ -90,7 +90,7 @@ class LowerAffineForOp(RewritePattern):
                 isinstance(lhs_load, affine.Load)
                 and isinstance(rhs_load, affine.Load)
                 and isinstance(store, affine.Store)
-                and isinstance(binop, (arith.Addf, arith.Mulf))
+                and isinstance(binop, arith.Addf | arith.Mulf)
             ):
                 return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ profile = "black"
 
 [tool.ruff]
 select = ["E", "F", "W", "I", "UP"]
-ignore = ["E741", "UP006", "UP032", "UP035", "UP038"]
+ignore = ["E741", "UP006", "UP032", "UP035"]
 line-length = 300
 target-version = "py310"
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -920,7 +920,7 @@ class AddressOfOp(IRDLOperation):
         global_name: str | StringAttr | SymbolRefAttr,
         result_type: LLVMPointerType,
     ):
-        if isinstance(global_name, (StringAttr, str)):
+        if isinstance(global_name, StringAttr | str):
             global_name = SymbolRefAttr(global_name)
 
         super().__init__(

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1111,7 +1111,7 @@ class OpDef:
 
                 # Methods, properties, and functions are allowed
                 if isinstance(
-                    value, (FunctionType, PropertyType, classmethod, staticmethod)
+                    value, FunctionType | PropertyType | classmethod | staticmethod
                 ):
                     continue
                 # Constraint variables are allowed
@@ -1943,7 +1943,7 @@ class ParamAttrDef:
             if field_name == "name":
                 continue
             if isinstance(
-                value, (FunctionType, PropertyType, classmethod, staticmethod)
+                value, FunctionType | PropertyType | classmethod | staticmethod
             ):
                 continue
             # Constraint variables are allowed

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -502,13 +502,11 @@ class MpiLoopInvariantCodeMotion:
         def match(op: Operation):
             if isinstance(
                 op,
-                (
-                    memref.Alloc,
-                    mpi.CommRank,
-                    mpi.AllocateTypeOp,
-                    mpi.UnwrapMemrefOp,
-                    mpi.Init,
-                ),
+                memref.Alloc
+                | mpi.CommRank
+                | mpi.AllocateTypeOp
+                | mpi.UnwrapMemrefOp
+                | mpi.Init,
             ):
                 worklist.append(op)
 

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -79,9 +79,7 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
 
     from xdsl.irdl import GenericData, irdl_to_attr_constraint
 
-    if (origin is not None) and issubclass(
-        origin, (GenericData, ParametrizedAttribute)
-    ):
+    if (origin is not None) and issubclass(origin, GenericData | ParametrizedAttribute):
         constraint = irdl_to_attr_constraint(hint)
         try:
             constraint.verify(arg, {})


### PR DESCRIPTION
The rule is to use `X | Y` instead of `(X, Y)` for `isinstance` and `issubclass` methods. See PEP604.