### PR TITLE
misc: (make) make without arguments no longer deletes `venv`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ TESTS_COVERAGE_FILE = ${COVERAGE_FILE}.tests
 .PHONY: clean filecheck pytest pytest-nb tests-toy tests rerun-notebooks precommit-install precommit black pyright
 .PHONY: coverage coverage-tests coverage-filecheck-tests coverage-report-html coverage-report-md
 
+# set up the venv with all dependencies for development
+venv: requirements-optional.txt requirements.txt
+	python3 -m venv ${VENV_DIR}
+	source ${VENV_DIR}/bin/activate
+	python3 -m pip --require-virtualenv install -r requirements-optional.txt -r requirements.txt
+	python3 -m pip --require-virtualenv install -e ".[extras]"
+
 # remove all caches and the venv
 clean:
 	rm -rf ${VENV_DIR} .pytest_cache *.egg-info .coverage.*
@@ -87,10 +94,3 @@ coverage-report-html:
 # generate markdown coverage report
 coverage-report-md:
 	coverage report --format=markdown
-
-# set up the venv with all dependencies for development
-venv: requirements-optional.txt requirements.txt
-	python3 -m venv ${VENV_DIR}
-	source ${VENV_DIR}/bin/activate
-	python3 -m pip --require-virtualenv install -r requirements-optional.txt -r requirements.txt
-	python3 -m pip --require-virtualenv install -e ".[extras]"


### PR DESCRIPTION
`make` without arguments defaults to building the first entry in the makefile.

Moving `venv` to be the first target instead of `clean` solves the problem of accidentally deleting venv when running make without arguments.