### PR TITLE
documentation: (toy) convert f64 to f32 when lowering to affine

### DIFF
--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -10,7 +10,14 @@ from typing import TypeAlias, TypeVar, cast
 
 from xdsl.builder import Builder
 from xdsl.dialects import affine, arith, func, memref
-from xdsl.dialects.builtin import Float64Type, IndexType, IntegerAttr, ModuleOp, f64
+from xdsl.dialects.builtin import (
+    Float32Type,
+    FloatAttr,
+    IndexType,
+    IntegerAttr,
+    ModuleOp,
+    f32,
+)
 from xdsl.dialects.printf import PrintFormatOp
 from xdsl.ir import Block, MLContext, Operation, Region, SSAValue
 from xdsl.passes import ModulePass
@@ -26,18 +33,18 @@ from ..dialects import toy
 
 # region Helpers
 
-MemrefTypeF64: TypeAlias = memref.MemRefType[Float64Type]
+MemrefTypeF32: TypeAlias = memref.MemRefType[Float32Type]
 
 
-def convert_tensor_to_memref(type: toy.TensorTypeF64) -> MemrefTypeF64:
+def convert_tensor_to_memref(type: toy.TensorTypeF64) -> MemrefTypeF32:
     """
     Convert the given RankedTensorType into the corresponding MemRefType.
     """
-    return memref.MemRefType.from_element_type_and_shape(f64, type.shape)
+    return memref.MemRefType.from_element_type_and_shape(f32, type.shape)
 
 
 def insert_alloc_and_dealloc(
-    type: MemrefTypeF64, op: Operation, rewriter: PatternRewriter
+    type: MemrefTypeF32, op: Operation, rewriter: PatternRewriter
 ) -> memref.Alloc:
     """
     Insert an allocation and deallocation for the given MemRefType.
@@ -354,7 +361,7 @@ class ConstantOpLowering(RewritePattern):
 
         # Scalar constant values for elements of the tensor
         constants: list[arith.Constant] = [
-            arith.Constant(i) for i in constant_value.data
+            arith.Constant(FloatAttr(i.value.data, f32)) for i in constant_value.data
         ]
 
         # n-d indices of elements


### PR DESCRIPTION
This is a little hack as a step towards f32 support testing in RISC-V. There is already a hack to convert f64 to f32, so when we merge this PR it'll be a double hack... The idea is to keep the Toy dialect interoperable with MLIR's, so keep f64 at the high level, and test our f32 support at the lower level. The f32 to i32 hack will be removed in an upcoming PR.