### PR TITLE
ci: (ruff) Add rule PT for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ typeCheckingMode = "strict"
 profile = "black"
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "UP"]
-ignore = ["E741"]
+select = ["E", "F", "W", "I", "UP", "PT"]
+ignore = ["E741", "PT006", "PT007", "PT011", "PT012", "PT015", "PT017", "PT018"]
 line-length = 300
 target-version = "py310"
 

--- a/tests/test_parser_error.py
+++ b/tests/test_parser_error.py
@@ -1,4 +1,4 @@
-from pytest import raises
+import pytest
 
 from xdsl.ir import MLContext
 from xdsl.irdl import (
@@ -26,7 +26,7 @@ def check_error(prog: str, line: int, column: int, message: str):
     ctx.register_op(UnkownOp)
 
     parser = Parser(ctx, prog)
-    with raises(ParseError, match=message) as e:
+    with pytest.raises(ParseError, match=message) as e:
         parser.parse_operation()
 
     assert e.value.span.get_line_col() == (line, column)


### PR DESCRIPTION
Since we are using `pytest`, it would be better if our tests are written in a consistent and concise way. Ruff's [PT](https://beta.ruff.rs/docs/rules/#flake8-pytest-style-pt) is based on flake8's pytest style.

Some rules are ignored in this PR to minimize the diff.
```diff
-select = ["E", "F", "W", "I", "UP"]
-ignore = ["E741"]
+select = ["E", "F", "W", "I", "UP", "PT"]
+ignore = ["E741", "PT006", "PT007", "PT011", "PT012", "PT015", "PT017", "PT018"]
```

This series of PR should not cause any API changes in the core xDSL code base but only for the tests.