### PR TITLE
core: unify some attribute printing/parsing methods

### DIFF
--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -179,7 +179,9 @@ class FuncOp(IRDLOperation):
                 printer.print(" ")
         else:
             printer.print_attribute(self.function_type)
-        printer.print_op_attributes_with_keyword(self.attributes, reserved)
+        printer.print_op_attributes(
+            self.attributes, reserved_attr_names=reserved, print_keyword=True
+        )
 
         if len(self.body.blocks) > 0:
             printer.print_region(self.body, False, False)

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -2394,7 +2394,9 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
     def print(self, printer: Printer) -> None:
         printer.print_string(" ")
         printer.print_string_literal(self.directive.data)
-        printer.print_op_attributes_with_keyword(self.attributes, ("directive"))
+        printer.print_op_attributes(
+            self.attributes, reserved_attr_names=("directive",), print_keyword=True
+        )
         printer.print_string(" ")
         if self.data.block.ops:
             printer.print_region(self.data)

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -660,9 +660,23 @@ class Parser(AttrParser):
         dictionary, and usually correspond to the names of the attributes that are
         already passed through the operation custom assembly format.
         """
-        begin_pos = self.lexer.pos
         if self.parse_optional_keyword("attributes") is None:
             return None
+        return self.parse_optional_attr_dict_with_reserved_attr_names(
+            reserved_attr_names
+        )
+
+    def parse_optional_attr_dict_with_reserved_attr_names(
+        self, reserved_attr_names: Iterable[str] = ()
+    ) -> DictionaryAttr | None:
+        """
+        Parse a dictionary attribute if present.
+        This is intended to be used in operation custom assembly format.
+        `reserved_attr_names` contains names that should not be present in the attribute
+        dictionary, and usually correspond to the names of the attributes that are
+        already passed through the operation custom assembly format.
+        """
+        begin_pos = self.lexer.pos
         attr = self._parse_builtin_dict_attr()
         for reserved_name in reserved_attr_names:
             if reserved_name in attr.data:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -56,6 +56,7 @@ from xdsl.ir import (
     SSAValue,
     TypeAttribute,
 )
+from xdsl.utils.deprecation import deprecated
 from xdsl.utils.diagnostic import Diagnostic
 
 indentNumSpaces = 2
@@ -642,34 +643,45 @@ class Printer:
             self.print(f'"{attr_tuple[0]}" = ')
             self.print_attribute(attr_tuple[1])
 
-    def print_op_attributes(self, attributes: dict[str, Attribute]) -> None:
-        if len(attributes) == 0:
+    def print_op_attributes(
+        self,
+        attributes: dict[str, Attribute],
+        *,
+        reserved_attr_names: Iterable[str] = (),
+        print_keyword: bool = False,
+    ) -> None:
+        if not attributes:
             return
+
+        if reserved_attr_names:
+            attributes = {
+                name: attr
+                for name, attr in attributes.items()
+                if name not in reserved_attr_names
+            }
+
+        if not attributes:
+            return
+
+        if print_keyword:
+            self.print(" attributes")
 
         self.print(" {")
 
-        attribute_list = list(attributes.items())
-        self.print_list(attribute_list, self._print_attr_string)
+        self.print_list(attributes.items(), self._print_attr_string)
 
         self.print("}")
 
+    @deprecated(
+        "Please use print_op_attributes(attributes, reserved_attr_names=..., "
+        "print_keyword=...)"
+    )
     def print_op_attributes_with_keyword(
         self, attributes: dict[str, Attribute], reserved_attr_names: Iterable[str] = ()
     ) -> None:
-        if reserved_attr_names:
-            attribute_list = [
-                i for i in attributes.items() if i[0] not in reserved_attr_names
-            ]
-        else:
-            attribute_list = attributes.items()
-
-        if not attribute_list:
-            return
-        self.print(" attributes {")
-
-        self.print_list(attribute_list, self._print_attr_string)
-
-        self.print("}")
+        self.print_op_attributes(
+            attributes, reserved_attr_names=reserved_attr_names, print_keyword=True
+        )
 
     def print_op_with_default_format(self, op: Operation) -> None:
         self.print_operands(op.operands)


### PR DESCRIPTION
I implemented the custom parsing syntax for `func.call`, and found that I needed to make some significant changes to the helpers to make it work. The attribute dictionary is not preceded by `attributes` in `func.call`, since there's no region for it to be confused with.