### PR TITLE
tests: (riscv, memref) use f32 in memref to riscv lowering test

### DIFF
--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -2,16 +2,16 @@ import pytest
 
 from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import func, memref, riscv
-from xdsl.dialects.builtin import IndexType, ModuleOp, UnrealizedConversionCastOp, f64
+from xdsl.dialects.builtin import IndexType, ModuleOp, UnrealizedConversionCastOp, f32
 from xdsl.ir import MLContext
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.utils.test_value import TestSSAValue
 
 from ..rewrites.lower_memref_riscv import LowerMemrefToRiscv, insert_shape_ops
 
-MEMREF_TYPE_2XF64 = memref.MemRefType.from_element_type_and_shape(f64, ([2]))
-MEMREF_TYPE_2X2XF64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2]))
-MEMREF_TYPE_2X2X2XF64 = memref.MemRefType.from_element_type_and_shape(f64, ([2, 2, 2]))
+MEMREF_TYPE_2XF32 = memref.MemRefType.from_element_type_and_shape(f32, ([2]))
+MEMREF_TYPE_2X2XF32 = memref.MemRefType.from_element_type_and_shape(f32, ([2, 2]))
+MEMREF_TYPE_2X2X2XF32 = memref.MemRefType.from_element_type_and_shape(f32, ([2, 2, 2]))
 
 REGISTER_TYPE = riscv.IntRegisterType.unallocated()
 
@@ -20,7 +20,7 @@ def test_lower_memref_alloc():
     @ModuleOp
     @Builder.implicit_region
     def simple_alloc():
-        v1 = memref.Alloc.get(f64, shape=[2]).memref
+        v1 = memref.Alloc.get(f32, shape=[2]).memref
         riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (v1,), ())
 
     @ModuleOp
@@ -30,7 +30,7 @@ def test_lower_memref_alloc():
         v2 = riscv.CustomAssemblyInstructionOp(
             "buffer.alloc", (v1.results[0],), (REGISTER_TYPE,)
         )
-        v3 = UnrealizedConversionCastOp.get((v2.results[0],), (MEMREF_TYPE_2XF64,))
+        v3 = UnrealizedConversionCastOp.get((v2.results[0],), (MEMREF_TYPE_2XF32,))
         riscv.CustomAssemblyInstructionOp("do_stuff_with_alloc", (v3.results[0],), ())
 
     LowerMemrefToRiscv().apply(MLContext(), simple_alloc)
@@ -41,7 +41,7 @@ def test_lower_memref_dealloc():
     @ModuleOp
     @Builder.implicit_region
     def simple_dealloc():
-        with ImplicitBuilder(func.FuncOp("impl", ((MEMREF_TYPE_2XF64,), ())).body) as (
+        with ImplicitBuilder(func.FuncOp("impl", ((MEMREF_TYPE_2XF32,), ())).body) as (
             b,
         ):
             memref.Dealloc.get(b)
@@ -49,7 +49,7 @@ def test_lower_memref_dealloc():
     @ModuleOp
     @Builder.implicit_region
     def expected():
-        with ImplicitBuilder(func.FuncOp("impl", ((MEMREF_TYPE_2XF64,), ())).body) as (
+        with ImplicitBuilder(func.FuncOp("impl", ((MEMREF_TYPE_2XF32,), ())).body) as (
             _,
         ):
             pass
@@ -59,7 +59,7 @@ def test_lower_memref_dealloc():
 
 
 def test_insert_shape_ops_1d():
-    mem = TestSSAValue(MEMREF_TYPE_2XF64)
+    mem = TestSSAValue(MEMREF_TYPE_2XF32)
     indices = [TestSSAValue(REGISTER_TYPE)]
 
     @ModuleOp
@@ -84,7 +84,7 @@ def test_insert_shape_ops_1d():
 
 
 def test_insert_shape_ops_2d():
-    mem = TestSSAValue(MEMREF_TYPE_2X2XF64)
+    mem = TestSSAValue(MEMREF_TYPE_2X2XF32)
     indices = [TestSSAValue(REGISTER_TYPE), TestSSAValue(REGISTER_TYPE)]
 
     @ModuleOp
@@ -113,7 +113,7 @@ def test_insert_shape_ops_2d():
 
 
 def test_insert_shape_ops_invalid_dim():
-    mem = TestSSAValue(MEMREF_TYPE_2X2X2XF64)
+    mem = TestSSAValue(MEMREF_TYPE_2X2X2XF32)
     indices = [
         TestSSAValue(REGISTER_TYPE),
         TestSSAValue(REGISTER_TYPE),
@@ -143,7 +143,7 @@ def test_memref_load():
     @Builder.implicit_region
     def simple_load():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((MEMREF_TYPE_2XF64, (IndexType())), ())).body
+            func.FuncOp("impl", ((MEMREF_TYPE_2XF32, (IndexType())), ())).body
         ) as (v, i):
             memref.Load.get(v, [i])
 
@@ -151,13 +151,13 @@ def test_memref_load():
     @Builder.implicit_region
     def expected():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((MEMREF_TYPE_2XF64, IndexType()), ())).body
+            func.FuncOp("impl", ((MEMREF_TYPE_2XF32, IndexType()), ())).body
         ) as (v, i):
             v1 = UnrealizedConversionCastOp.get([v], (REGISTER_TYPE,))
             v2 = UnrealizedConversionCastOp.get([i], (REGISTER_TYPE,))
             v4 = riscv.AddOp(v1.results[0], v2.results[0])
             v5 = riscv.LwOp(v4, 0, comment="load value from memref of shape (2,)")
-            _ = UnrealizedConversionCastOp.get([v5], (f64,))
+            _ = UnrealizedConversionCastOp.get([v5], (f32,))
 
     LowerMemrefToRiscv().apply(MLContext(), simple_load)
     assert f"{expected}" == f"{simple_load}"
@@ -168,7 +168,7 @@ def test_memref_store():
     @Builder.implicit_region
     def simple_store():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((f64, MEMREF_TYPE_2XF64, IndexType()), ())).body
+            func.FuncOp("impl", ((f32, MEMREF_TYPE_2XF32, IndexType()), ())).body
         ) as (v, m, i):
             memref.Store.get(v, m, [i])
 
@@ -176,7 +176,7 @@ def test_memref_store():
     @Builder.implicit_region
     def expected():
         with ImplicitBuilder(
-            func.FuncOp("impl", ((f64, MEMREF_TYPE_2XF64, IndexType()), ())).body
+            func.FuncOp("impl", ((f32, MEMREF_TYPE_2XF32, IndexType()), ())).body
         ) as (v, m, i):
             v1 = UnrealizedConversionCastOp.get([v], (REGISTER_TYPE,))
             v2 = UnrealizedConversionCastOp.get([m], (REGISTER_TYPE,))


### PR DESCRIPTION
We've decided not to support f64 officially for the time being, so I thought I'd convert the test as part of the float support changes.