### PR TITLE
backend: (riscv) fix riscv_scf lowering (#1457 again)

### DIFF
--- a/docs/Toy/examples/tests/with-mlir/interpret.toy
+++ b/docs/Toy/examples/tests/with-mlir/interpret.toy
@@ -1,6 +1,7 @@
 # RUN: python -m toy %s --emit=scf | filecheck %s
 # RUN: python -m toy %s --emit=riscv | filecheck %s
 # RUN: python -m toy %s --emit=riscv-regalloc | filecheck %s
+# RUN: python -m toy %s --emit=riscv-asm | filecheck %s
 
 # RUN: python -m toy %s --emit=scf --accelerate | filecheck %s
 # RUN: python -m toy %s --emit=riscv --accelerate | filecheck %s

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from xdsl.backend.riscv.lowering.lower_func_riscv_func import LowerFuncToRiscvFunc
 from xdsl.backend.riscv.lowering.riscv_arith_lowering import RISCVLowerArith
 from xdsl.backend.riscv.lowering.scf_to_riscv_scf import ScfToRiscvPass
+from xdsl.backend.riscv.riscv_scf_to_asm import (
+    LowerScfForToLabels,
+)
 from xdsl.dialects import (
     affine,
     arith,
@@ -134,6 +137,7 @@ def transform(
         return
 
     LowerRISCVFunc(insert_exit_syscall=True).apply(ctx, module_op)
+    LowerScfForToLabels().apply(ctx, module_op)
 
     if target == "riscv-lowered":
         return

--- a/tests/filecheck/backend/rvscf_lowering_labels.mlir
+++ b/tests/filecheck/backend/rvscf_lowering_labels.mlir
@@ -22,7 +22,7 @@ builtin.module {
 // CHECK-NEXT:    ^0(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>):
 // CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %3 = riscv.li 0 : () -> !riscv.reg<a3>
-// CHECK-NEXT:      %4 = riscv.get_register : () -> !riscv.reg<a4>
+// CHECK-NEXT:      %4 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<a4>
 // CHECK-NEXT:      riscv.label "scf_cond_0_for" ({
 // CHECK-NEXT:      }) : () -> ()
 // CHECK-NEXT:      riscv.bge %4, %1, "scf_body_end_0_for" : (!riscv.reg<a4>, !riscv.reg<a1>) -> ()
@@ -67,7 +67,7 @@ builtin.module {
 // CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %3 = riscv.li 0 : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %4 = riscv.fcvt.s.w %3 : (!riscv.reg<a3>) -> !riscv.freg<fa0>
-// CHECK-NEXT:      %5 = riscv.get_register : () -> !riscv.reg<a0>
+// CHECK-NEXT:      %5 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
 // CHECK-NEXT:      riscv.label "scf_cond_0_for" ({
 // CHECK-NEXT:      }) : () -> ()
 // CHECK-NEXT:      riscv.bge %5, %1, "scf_body_end_0_for" : (!riscv.reg<a0>, !riscv.reg<a1>) -> ()
@@ -117,7 +117,7 @@ builtin.module {
 // CHECK-NEXT:      %0 = riscv.li 0 : () -> !riscv.reg<a1>
 // CHECK-NEXT:      %1 = riscv.li 0 : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<a3>
-// CHECK-NEXT:      %3 = riscv.get_register : () -> !riscv.reg<a2>
+// CHECK-NEXT:      %3 = riscv.mv %1 : (!riscv.reg<a2>) -> !riscv.reg<a2>
 // CHECK-NEXT:      riscv.label "scf_cond_0_for" ({
 // CHECK-NEXT:      }) : () -> ()
 // CHECK-NEXT:      riscv.bge %3, %arg0, "scf_body_end_0_for" : (!riscv.reg<a2>, !riscv.reg<a0>) -> ()
@@ -127,7 +127,7 @@ builtin.module {
 // CHECK-NEXT:      %arg1 = riscv.get_register : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %4 = riscv.li 0 : () -> !riscv.reg<a4>
 // CHECK-NEXT:      %5 = riscv.li 1 : () -> !riscv.reg<a5>
-// CHECK-NEXT:      %6 = riscv.get_register : () -> !riscv.reg<a4>
+// CHECK-NEXT:      %6 = riscv.mv %4 : (!riscv.reg<a4>) -> !riscv.reg<a4>
 // CHECK-NEXT:      riscv.label "scf_cond_1_for" ({
 // CHECK-NEXT:      }) : () -> ()
 // CHECK-NEXT:      riscv.bge %6, %arg0, "scf_body_end_1_for" : (!riscv.reg<a4>, !riscv.reg<a0>) -> ()

--- a/xdsl/backend/riscv/riscv_scf_to_asm.py
+++ b/xdsl/backend/riscv/riscv_scf_to_asm.py
@@ -53,7 +53,7 @@ class LowerRiscvScfToLabels(RewritePattern):
         # upper bound and branching to the loop body if the condition is met.
         rewriter.insert_op_before_matched_op(
             [
-                get_loop_var := riscv.GetRegisterOp(loop_var_reg),
+                get_loop_var := riscv.MVOp(op.lb, rd=loop_var_reg),
                 riscv.LabelOp(scf_cond),
                 riscv.BgeOp(get_loop_var, op.ub, scf_body_end),
                 riscv.LabelOp(scf_body),


### PR DESCRIPTION
The changes for #1457 were reverted as part of some follow-up work stacked PR chaos. Re-merging already approved changes.