### PR TITLE
backend: (riscv) use canonicalization to optimize riscv

### DIFF
--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -19,7 +19,7 @@ from xdsl.dialects import (
 from xdsl.dialects.builtin import Builtin, ModuleOp
 from xdsl.interpreters.riscv_emulator import run_riscv
 from xdsl.ir import MLContext
-from xdsl.transforms.canonicalize.canonicalize_pass import CanonicalizationPass
+from xdsl.transforms.canonicalize import CanonicalizePass
 from xdsl.transforms.dead_code_elimination import DeadCodeElimination
 from xdsl.transforms.lower_riscv_func import LowerRISCVFunc
 from xdsl.transforms.mlir_opt import MLIROptPass
@@ -73,7 +73,7 @@ def transform(
     if target == "toy":
         return
 
-    CanonicalizationPass().apply(ctx, module_op)
+    CanonicalizePass().apply(ctx, module_op)
 
     if target == "toy-opt":
         return
@@ -127,6 +127,11 @@ def transform(
     module_op.verify()
 
     if target == "riscv":
+        return
+
+    CanonicalizePass().apply(ctx, module_op)
+
+    if target == "riscv-opt":
         return
 
     RISCVRegisterAllocation().apply(ctx, module_op)

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -129,11 +129,6 @@ def transform(
     if target == "riscv":
         return
 
-    CanonicalizePass().apply(ctx, module_op)
-
-    if target == "riscv-opt":
-        return
-
     RISCVRegisterAllocation().apply(ctx, module_op)
 
     module_op.verify()

--- a/tests/filecheck/backend/riscv/optimisation_riscv.mlir
+++ b/tests/filecheck/backend/riscv/optimisation_riscv.mlir
@@ -1,12 +1,14 @@
-// RUN: xdsl-opt -p optimise-riscv %s | filecheck %s
+// RUN: xdsl-opt -p canonicalize %s | filecheck %s
 
 builtin.module {
-  %0, %1 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>)
-  %2 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
-  %3 = riscv.mv %1 : (!riscv.reg<a1>) -> !riscv.reg<a2>
+  %i0, %i1, %i2 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<>)
+  %o0 = riscv.mv %i0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
+  %o1 = riscv.mv %i1 : (!riscv.reg<a1>) -> !riscv.reg<a2>
+  %o2 = riscv.mv %i2 : (!riscv.reg<>) -> !riscv.reg<>
 }
 
 // CHECK: builtin.module {
-// CHECK-NEXT:   %0, %1 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>)
-// CHECK-NEXT:   %2 = riscv.mv %1 : (!riscv.reg<a1>) -> !riscv.reg<a2>
+// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<>)
+// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a1>) -> !riscv.reg<a2>
+// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT: }

--- a/xdsl/backend/riscv/lowering/optimisation_riscv.py
+++ b/xdsl/backend/riscv/lowering/optimisation_riscv.py
@@ -1,11 +1,6 @@
 from xdsl.dialects import riscv
-from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir.core import MLContext
-from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
-    GreedyRewritePatternApplier,
     PatternRewriter,
-    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
@@ -14,20 +9,9 @@ from xdsl.pattern_rewriter import (
 class RemoveRedundantMv(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.MVOp, rewriter: PatternRewriter) -> None:
-        if op.rd.type == op.rs.type:
+        if (
+            op.rd.type == op.rs.type
+            and isinstance(op.rd.type, riscv.RISCVRegisterType)
+            and op.rd.type.is_allocated
+        ):
             rewriter.replace_matched_op([], [op.rs])
-
-
-class OptimiseRiscvPass(ModulePass):
-    name = "optimise-riscv"
-
-    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
-        walker = PatternRewriteWalker(
-            GreedyRewritePatternApplier(
-                [
-                    RemoveRedundantMv(),
-                ]
-            ),
-            apply_recursively=False,
-        )
-        walker.rewrite_module(op)

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -45,8 +45,9 @@ from xdsl.irdl import (
 )
 from xdsl.irdl.irdl import OptRegion, opt_region_def, region_def
 from xdsl.parser import AttrParser, Parser, UnresolvedOperand
+from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
-from xdsl.traits import IsTerminator, NoTerminator
+from xdsl.traits import HasCanonicalisationPatternsTrait, IsTerminator, NoTerminator
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -1464,6 +1465,14 @@ class AuipcOp(RdImmIntegerOperation):
     name = "riscv.auipc"
 
 
+class MVHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.backend.riscv.lowering.optimisation_riscv import RemoveRedundantMv
+
+        return (RemoveRedundantMv(),)
+
+
 @irdl_op_definition
 class MVOp(RdRsIntegerOperation):
     """
@@ -1473,6 +1482,8 @@ class MVOp(RdRsIntegerOperation):
     """
 
     name = "riscv.mv"
+
+    traits = frozenset((MVHasCanonicalizationPatternsTrait(),))
 
 
 ## Integer Register-Register Operations

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -7,7 +7,6 @@ from typing import IO
 from xdsl.backend.riscv import riscv_scf_to_asm
 from xdsl.backend.riscv.lowering import scf_to_riscv_scf
 from xdsl.backend.riscv.lowering.lower_func_riscv_func import LowerFuncToRiscvFunc
-from xdsl.backend.riscv.lowering.optimisation_riscv import OptimiseRiscvPass
 from xdsl.backend.riscv.lowering.riscv_arith_lowering import RISCVLowerArith
 from xdsl.dialects.affine import Affine
 from xdsl.dialects.arith import Arith
@@ -41,6 +40,7 @@ from xdsl.ir import Dialect, MLContext
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass
 from xdsl.transforms import (
+    canonicalize,
     canonicalize_dmp,
     dead_code_elimination,
     lower_mpi,
@@ -98,6 +98,7 @@ def get_all_dialects() -> list[Dialect]:
 def get_all_passes() -> list[type[ModulePass]]:
     """Return the list of all available passes."""
     return [
+        canonicalize.CanonicalizePass,
         canonicalize_dmp.CanonicalizeDmpPass,
         convert_stencil_to_ll_mlir.ConvertStencilToLLMLIRPass,
         dead_code_elimination.DeadCodeElimination,
@@ -114,7 +115,6 @@ def get_all_passes() -> list[type[ModulePass]]:
         riscv_register_allocation.RISCVRegisterAllocation,
         RISCVLowerArith,
         LowerFuncToRiscvFunc,
-        OptimiseRiscvPass,
         scf_to_riscv_scf.ScfToRiscvPass,
         riscv_scf_to_asm.LowerScfForToLabels,
         stencil_shape_inference.StencilShapeInferencePass,

--- a/xdsl/transforms/canonicalize.py
+++ b/xdsl/transforms/canonicalize.py
@@ -9,7 +9,7 @@ from xdsl.traits import HasCanonicalisationPatternsTrait
 from xdsl.transforms.dead_code_elimination import dce
 
 
-class CanonicalizationPass(ModulePass):
+class CanonicalizePass(ModulePass):
     """
     Applies all canonicalization patterns.
     """


### PR DESCRIPTION
Also fixes some other issues:

 - redundant mv elimination should only eliminate allocated registers, not unallocated
 - I forgot to register `CanonicalizePass` with xdsl-opt
 - move the file definiing the canonicalization pattern one level up in the hierarchy