### PR TITLE
core: Move Operation create/build/init parameters to named arguments

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -350,7 +350,7 @@
     "from xdsl.dialects.arith import Constant\n",
     "\n",
     "const_op = Constant.create(\n",
-    "    [], [i64], attributes={\"value\": IntegerAttr.from_int_and_width(62, 64)}\n",
+    "    result_types=[i64], attributes={\"value\": IntegerAttr.from_int_and_width(62, 64)}\n",
     ")\n",
     "printer.print_op(const_op)"
    ]
@@ -410,7 +410,7 @@
    "source": [
     "from xdsl.dialects.arith import Addi\n",
     "\n",
-    "add_op = Addi.create([const_op.results[0], const_op.results[0]], [i64], {})\n",
+    "add_op = Addi.create(operands=[const_op.results[0], const_op.results[0]], result_types=[i64])\n",
     "printer.print_op(const_op)\n",
     "print()\n",
     "printer.print_op(add_op)"

--- a/tests/backend/riscv/test_utils.py
+++ b/tests/backend/riscv/test_utils.py
@@ -23,10 +23,12 @@ def test_op_cast_utils():
             )
         )
         def inner(args: tuple[BlockArgument, ...]):
-            v = test.TestOp.create(args, [INDEX_TYPE, INDEX_TYPE])
-            test.TestTermOp.create(v.results, [INDEX_TYPE, INDEX_TYPE])
+            v = test.TestOp.create(operands=args, result_types=[INDEX_TYPE, INDEX_TYPE])
+            test.TestTermOp.create(
+                operands=v.results, result_types=[INDEX_TYPE, INDEX_TYPE]
+            )
 
-        test.TestOp.create((), (), regions=(inner,))
+        test.TestOp.create(regions=(inner,))
 
     @builtin.ModuleOp
     @Builder.implicit_region
@@ -35,10 +37,10 @@ def test_op_cast_utils():
         def inner(args: tuple[BlockArgument, ...]):
             (first_arg, second_arg) = args
             first_arg_cast = builtin.UnrealizedConversionCastOp(
-                (first_arg,), (REGISTER_TYPE,)
+                operands=(first_arg,), result_types=(REGISTER_TYPE,)
             )
             second_arg_cast = builtin.UnrealizedConversionCastOp(
-                (second_arg,), (REGISTER_TYPE,)
+                operands=(second_arg,), result_types=(REGISTER_TYPE,)
             )
             v = riscv.CustomAssemblyInstructionOp(
                 "foo",
@@ -48,14 +50,14 @@ def test_op_cast_utils():
             v1 = builtin.UnrealizedConversionCastOp.get((v.results[0],), (INDEX_TYPE,))
             v2 = builtin.UnrealizedConversionCastOp.get((v.results[1],), (INDEX_TYPE,))
             test.TestTermOp.create(
-                (
+                operands=(
                     v1.results[0],
                     v2.results[0],
                 ),
-                [INDEX_TYPE, INDEX_TYPE],
+                result_types=[INDEX_TYPE, INDEX_TYPE],
             )
 
-        test.TestOp.create((), (), regions=(inner,))
+        test.TestOp.create(regions=(inner,))
 
     target_op = next(filter(lambda op: len(op.results) == 2, input.walk()))
     assert target_op is not None
@@ -84,10 +86,12 @@ def test_block_cast_utils():
             )
         )
         def inner(args: tuple[BlockArgument, ...]):
-            v = test.TestOp.create(args, [INDEX_TYPE, INDEX_TYPE])
-            test.TestTermOp.create(v.results, [INDEX_TYPE, INDEX_TYPE])
+            v = test.TestOp.create(operands=args, result_types=[INDEX_TYPE, INDEX_TYPE])
+            test.TestTermOp.create(
+                operands=v.results, result_types=[INDEX_TYPE, INDEX_TYPE]
+            )
 
-        test.TestOp.create((), (), regions=(inner,))
+        test.TestOp.create(regions=(inner,))
 
     @builtin.ModuleOp
     @Builder.implicit_region
@@ -101,22 +105,24 @@ def test_block_cast_utils():
         def inner(args: tuple[BlockArgument, ...]):
             (first_arg, second_arg) = args
             second_arg_cast = builtin.UnrealizedConversionCastOp(
-                (second_arg,), (INDEX_TYPE,)
+                operands=(second_arg,), result_types=(INDEX_TYPE,)
             )
             first_arg_cast = builtin.UnrealizedConversionCastOp(
-                (first_arg,), (INDEX_TYPE,)
+                operands=(first_arg,), result_types=(INDEX_TYPE,)
             )
 
             v = test.TestOp.create(
-                (
+                operands=(
                     first_arg_cast.results[0],
                     second_arg_cast.results[0],
                 ),
-                [INDEX_TYPE, INDEX_TYPE],
+                result_types=[INDEX_TYPE, INDEX_TYPE],
             )
-            test.TestTermOp.create(v.results, [INDEX_TYPE, INDEX_TYPE])
+            test.TestTermOp.create(
+                operands=v.results, result_types=[INDEX_TYPE, INDEX_TYPE]
+            )
 
-        test.TestOp.create((), (), regions=(inner,))
+        test.TestOp.create(regions=(inner,))
 
     target_op = next(filter(lambda op: isinstance(op, test.TestOp), input.walk()))
     assert target_op is not None

--- a/tests/filecheck/parser-printer/operation_with_properties.mlir
+++ b/tests/filecheck/parser-printer/operation_with_properties.mlir
@@ -1,0 +1,18 @@
+// RUN: xdsl-opt %s --allow-unregistered-dialect | filecheck %s
+
+builtin.module {
+
+    // An operation with a property
+    "unregistered.op"() <{"test" = 2 : i32}> : () -> ()
+    // CHECK: "unregistered.op"() <{"test" = 2 : i32}> : () -> ()
+
+    // An operation with a property, a region, and an attribute
+    "unregistered.op"() <{"test" = 42 : i64, "test2" = 71 : i32}> ({}) {"test3" = "foo"} : () -> ()
+    // CHECK-NEXT: "unregistered.op"() <{"test" = 42 : i64, "test2" = 71 : i32}> ({
+    // CHECK-NEXT: }) {"test3" = "foo"} : () -> ()
+
+    // An operation with a property and an attribute with the same name
+    "unregistered.op"() <{"test" = 42 : i64}> {"test" = "foo"} : () -> ()
+    // CHECK-NEXT: "unregistered.op"() <{"test" = 42 : i64}> {"test" = "foo"} : () -> ()
+
+}

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -374,7 +374,9 @@ def test_symbol_table():
     ):
         op.verify()
 
-    terminator = test.TestTermOp([[]], [[]], regions=[[]], successors=[[]])
+    terminator = test.TestTermOp(
+        operands=[[]], result_types=[[]], regions=[[]], successors=[[]]
+    )
 
     # Check that symbol uniqueness is verified
     symbol = SymbolOp(attributes={"sym_name": StringAttr("name")})

--- a/xdsl/backend/riscv/lowering/utils.py
+++ b/xdsl/backend/riscv/lowering/utils.py
@@ -78,7 +78,10 @@ def cast_block_args_to_int_regs(block: Block, rewriter: PatternRewriter):
 
     for arg in block.args:
         rewriter.insert_op_at_start(
-            new_val := builtin.UnrealizedConversionCastOp([arg], [arg.type]), block
+            new_val := builtin.UnrealizedConversionCastOp(
+                operands=[arg], result_types=[arg.type]
+            ),
+            block,
         )
 
         arg.type = unallocated_reg

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1179,6 +1179,7 @@ class UnregisteredOp(IRDLOperation, ABC):
                 *,
                 operands: Sequence[SSAValue] = (),
                 result_types: Sequence[Attribute] = (),
+                properties: Mapping[str, Attribute] = {},
                 attributes: Mapping[str, Attribute] = {},
                 successors: Sequence[Block] = (),
                 regions: Sequence[Region] = (),
@@ -1186,6 +1187,7 @@ class UnregisteredOp(IRDLOperation, ABC):
                 op = super().create(
                     operands=operands,
                     result_types=result_types,
+                    properties=properties,
                     attributes=attributes,
                     successors=successors,
                     regions=regions,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1129,7 +1129,9 @@ class UnrealizedConversionCastOp(IRDLOperation):
             parser.parse_type,
         )
         attributes = parser.parse_optional_attr_dict()
-        return UnrealizedConversionCastOp([inputs], [output_types], attributes)
+        return UnrealizedConversionCastOp(
+            operands=[inputs], result_types=[output_types], attributes=attributes
+        )
 
     def print(self, printer: Printer):
         def print_fn(operand: SSAValue) -> None:
@@ -1174,6 +1176,7 @@ class UnregisteredOp(IRDLOperation, ABC):
             @classmethod
             def create(
                 cls,
+                *,
                 operands: Sequence[SSAValue] = (),
                 result_types: Sequence[Attribute] = (),
                 attributes: Mapping[str, Attribute] = {},
@@ -1181,7 +1184,11 @@ class UnregisteredOp(IRDLOperation, ABC):
                 regions: Sequence[Region] = (),
             ):
                 op = super().create(
-                    operands, result_types, attributes, successors, regions
+                    operands=operands,
+                    result_types=result_types,
+                    attributes=attributes,
+                    successors=successors,
+                    regions=regions,
                 )
                 op.attributes["op_name__"] = StringAttr(name)
                 return op

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -664,7 +664,7 @@ class ReturnOp(IRDLOperation):
     traits = frozenset([IsTerminator(), HasParent(FuncOp)])
 
     def __init__(self, operands: Sequence[SSAValue | Operation]):
-        return super().__init__([operands])
+        return super().__init__(operands=[operands])
 
 
 @irdl_op_definition
@@ -722,7 +722,7 @@ class YieldOp(IRDLOperation):
     values: VarOperand = var_operand_def(Attribute)
 
     def __init__(self, operands: Sequence[SSAValue | Operation]):
-        return super().__init__([operands])
+        return super().__init__(operands=[operands])
 
     traits = frozenset([IsTerminator()])
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -607,7 +607,7 @@ class CopyOp(IRDLOperation):
     destination: Operand = operand_def(MemRefType)
 
     def __init__(self, source: SSAValue | Operation, destination: SSAValue | Operation):
-        super().__init__([source, destination])
+        super().__init__(operands=[source, destination])
 
     def verify_(self) -> None:
         source = cast(MemRefType[Attribute], self.source.type)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -659,6 +659,7 @@ class Operation(IRNode):
 
     def __init__(
         self,
+        *,
         operands: Sequence[SSAValue] = (),
         result_types: Sequence[Attribute] = (),
         attributes: Mapping[str, Attribute] = {},
@@ -685,6 +686,7 @@ class Operation(IRNode):
     @classmethod
     def create(
         cls: type[Self],
+        *,
         operands: Sequence[SSAValue] = (),
         result_types: Sequence[Attribute] = (),
         attributes: Mapping[str, Attribute] = {},
@@ -692,7 +694,14 @@ class Operation(IRNode):
         regions: Sequence[Region] = (),
     ) -> Self:
         op = cls.__new__(cls)
-        Operation.__init__(op, operands, result_types, attributes, successors, regions)
+        Operation.__init__(
+            op,
+            operands=operands,
+            result_types=result_types,
+            attributes=attributes,
+            successors=successors,
+            regions=regions,
+        )
         return op
 
     @deprecated("Use op.operands.__setindex__ instead")

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -559,6 +559,13 @@ class Operation(IRNode):
     This list should be empty for non-terminator operations.
     """
 
+    properties: dict[str, Attribute] = field(default_factory=dict)
+    """
+    The properties attached to the operation.
+    Properties are inherent to the definition of an operation's semantics, and
+    thus cannot be discarded by transformations.
+    """
+
     attributes: dict[str, Attribute] = field(default_factory=dict)
     """The attributes attached to the operation."""
 
@@ -662,6 +669,7 @@ class Operation(IRNode):
         *,
         operands: Sequence[SSAValue] = (),
         result_types: Sequence[Attribute] = (),
+        properties: Mapping[str, Attribute] = {},
         attributes: Mapping[str, Attribute] = {},
         successors: Sequence[Block] = (),
         regions: Sequence[Region] = (),
@@ -675,6 +683,7 @@ class Operation(IRNode):
             OpResult(result_type, self, idx)
             for (idx, result_type) in enumerate(result_types)
         ]
+        self.properties = dict(properties)
         self.attributes = dict(attributes)
         self.successors = list(successors)
         self.regions = []
@@ -689,6 +698,7 @@ class Operation(IRNode):
         *,
         operands: Sequence[SSAValue] = (),
         result_types: Sequence[Attribute] = (),
+        properties: Mapping[str, Attribute] = {},
         attributes: Mapping[str, Attribute] = {},
         successors: Sequence[Block] = (),
         regions: Sequence[Region] = (),
@@ -698,6 +708,7 @@ class Operation(IRNode):
             op,
             operands=operands,
             result_types=result_types,
+            properties=properties,
             attributes=attributes,
             successors=successors,
             regions=regions,

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -455,6 +455,7 @@ class IRDLOperation(Operation):
 
     def __init__(
         self: IRDLOperation,
+        *,
         operands: Sequence[SSAValue | Operation | Sequence[SSAValue | Operation] | None]
         | None = None,
         result_types: Sequence[Attribute | Sequence[Attribute] | None] | None = None,
@@ -482,16 +483,17 @@ class IRDLOperation(Operation):
         irdl_op_init(
             self,
             self.irdl_definition,
-            operands,
-            result_types,
-            attributes,
-            successors,
-            regions,
+            operands=operands,
+            result_types=result_types,
+            attributes=attributes,
+            successors=successors,
+            regions=regions,
         )
 
     @classmethod
     def build(
         cls: type[IRDLOperationInvT],
+        *,
         operands: Sequence[SSAValue | Operation | Sequence[SSAValue | Operation] | None]
         | None = None,
         result_types: Sequence[Attribute | Sequence[Attribute] | None] | None = None,
@@ -1644,8 +1646,9 @@ def irdl_build_regions_arg(
 def irdl_op_init(
     self: IRDLOperation,
     op_def: OpDef,
+    *,
     operands: Sequence[SSAValue | Operation | Sequence[SSAValue | Operation] | None],
-    res_types: Sequence[Attribute | Sequence[Attribute] | None],
+    result_types: Sequence[Attribute | Sequence[Attribute] | None],
     attributes: Mapping[str, Attribute | None],
     successors: Sequence[Successor | Sequence[Successor] | None],
     regions: Sequence[
@@ -1676,7 +1679,7 @@ def irdl_op_init(
 
     # Build the results
     built_res_types, result_sizes = irdl_build_arg_list(
-        VarIRConstruct.RESULT, res_types, op_def.results, error_prefix
+        VarIRConstruct.RESULT, result_types, op_def.results, error_prefix
     )
 
     # Build the regions

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -643,6 +643,14 @@ class Printer:
             self.print(f'"{attr_tuple[0]}" = ')
             self.print_attribute(attr_tuple[1])
 
+    def _print_op_properties(self, properties: dict[str, Attribute]) -> None:
+        if not properties:
+            return
+
+        self.print(" <{")
+        self.print_list(properties.items(), self._print_attr_string)
+        self.print("}>")
+
     def print_op_attributes(
         self,
         attributes: dict[str, Attribute],
@@ -686,7 +694,7 @@ class Printer:
     def print_op_with_default_format(self, op: Operation) -> None:
         self.print_operands(op.operands)
         self.print_successors(op.successors)
-
+        self._print_op_properties(op.properties)
         self.print_regions(op.regions)
         self.print_op_attributes(op.attributes)
         self.print(" : ")

--- a/xdsl/transforms/printf_to_putchar.py
+++ b/xdsl/transforms/printf_to_putchar.py
@@ -155,7 +155,7 @@ def get_mlir_itoa():
             position = arith.Subi(size_minus_one, index_var_int)
             # digit = (num // (10**pos)) % 10
             ten = arith.Constant.from_int_and_width(10, i32)
-            i_0 = math.IPowIOp((ten, position), (i32,))
+            i_0 = math.IPowIOp(operands=(ten, position), result_types=(i32,))
             i_1 = arith.DivUI(absolute_value, i_0)
             digit = arith.RemUI(i_1, ten)
             ascii_offset = arith.Constant.from_int_and_width(ord("0"), i32)


### PR DESCRIPTION
This PR moves the arguments from `__init__`, `create`, and `build` to named arguments only.
This means that `MyOperation.create([arg1, arg2])` is not allowed for instance, and should be changed to `MyOperation.create(operands=[arg1, arg2])`.

This both makes it clearer, and avoid easy mistakes.
Note that this doesn't affect custom `__init__` created by users, so things like `Addi(arg1, arg2)` will stay the same for instance.