### PR TITLE
dialects: Fix printer function of pdl.replace

### DIFF
--- a/tests/filecheck/dialects/pdl/mlir-tests.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests.mlir
@@ -128,7 +128,7 @@ builtin.module {
 // CHECK-NEXT:   pdl.rewrite %root {
 // CHECK-NEXT:     %type3 = pdl.type
 // CHECK-NEXT:     %newOp = pdl.operation "foo.op" -> (%type1, %type3 : !pdl.type, !pdl.type)
-// CHECK-NEXT:     "pdl.replace"(%root, %newOp) {"operand_segment_sizes" = array<i32: 1, 1, 0>} : (!pdl.operation, !pdl.operation) -> ()
+// CHECK-NEXT:     pdl.replace %root with %newOp
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -609,8 +609,8 @@ class ReplaceOp(IRDLOperation):
         parser.parse_punctuation(")")
         return ReplaceOp(root, repl_values=repl_values)
 
-    def printer(self, printer: Printer) -> None:
-        printer.print(self.op_value, " with ")
+    def print(self, printer: Printer) -> None:
+        printer.print(" ", self.op_value, " with ")
         if self.repl_operation is not None:
             printer.print(self.repl_operation)
             return


### PR DESCRIPTION
`pdl.replace` had a `printer` function instead of a `print` one, so it was calling the generic print instead.