### PR TITLE
testing: Expose an additional command for pure roundtripping

### DIFF
--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -1,6 +1,6 @@
-// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
+// RUN: XDSL_AUTO_ROUNDTRIP
 
-"builtin.module"() ({
+builtin.module {
 
     // For without value being passed during iterations
 
@@ -9,12 +9,6 @@
       "affine.yield"() : () -> ()
     }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
 
-    // CHECK:      "affine.for"() ({
-    // CHECK-NEXT: ^0(%{{.*}} : index):
-    // CHECK-NEXT:   "affine.yield"() : () -> ()
-    // CHECK-NEXT: }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
-
-
     // For with values being passed during iterations
 
     %init_value = "test.op"() : () -> !test.type<"int">
@@ -22,28 +16,15 @@
     ^1(%i : index, %step_value : !test.type<"int">):
       %next_value = "test.op"() : () -> !test.type<"int">
       "affine.yield"(%next_value) : (!test.type<"int">) -> ()
-    }) {"lower_bound" = affine_map<() -> (-10)>, "upper_bound" = affine_map<() -> (10)>, "step" = 1 : index} : (!test.type<"int">) -> (!test.type<"int">)
-
-    // CHECK:      %res = "affine.for"(%{{.*}}) ({
-    // CHECK-NEXT: ^1(%{{.*}} : index, %{{.*}} : !test.type<"int">):
-    // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> !test.type<"int">
-    // CHECK-NEXT:   "affine.yield"(%{{.*}}) : (!test.type<"int">) -> ()
-    // CHECK-NEXT: }) {"lower_bound" = affine_map<() -> (-10)>, "upper_bound" = affine_map<() -> (10)>, "step" = 1 : index} : (!test.type<"int">) -> !test.type<"int">
+    }) {"lower_bound" = affine_map<() -> (-10)>, "upper_bound" = affine_map<() -> (10)>, "step" = 1 : index} : (!test.type<"int">) -> !test.type<"int">
 
 
     %memref = "test.op"() : () -> memref<2x3xf64>
     %value = "test.op"() : () -> f64
     "affine.store"(%value, %memref) {"map" = affine_map<() -> (0, 0)>} : (f64, memref<2x3xf64>) -> ()
 
-    // CHECK:      %memref = "test.op"() : () -> memref<2x3xf64>
-    // CHECK-NEXT: %value = "test.op"() : () -> f64
-    // CHECK-NEXT: "affine.store"(%value, %memref) {"map" = affine_map<() -> (0, 0)>} : (f64, memref<2x3xf64>) -> ()
-
     %zero = "test.op"() : () -> index
     %same_value = "affine.load"(%memref, %zero, %zero) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (memref<2x3xf64>, index, index) -> f64
 
-    // CHECK:      %zero = "test.op"() : () -> index
-    // CHECK-NEXT: %same_value = "affine.load"(%memref, %zero, %zero) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (memref<2x3xf64>, index, index) -> f64
 
-
-}) : () -> ()
+}

--- a/tests/filecheck/dialects/affine/examples.mlir
+++ b/tests/filecheck/dialects/affine/examples.mlir
@@ -1,20 +1,19 @@
-// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
+// RUN: XDSL_AUTO_ROUNDTRIP
 
-"builtin.module"() ({
+builtin.module {
 
   // Sum elements of a vector
 
-  "func.func"() ({
-  ^0(%ref : memref<128xi32>):
-    %const0 = "arith.constant"() {"value" = 0 : i32} : () -> i32
+  func.func @sum_vec(%ref : memref<128xi32>) -> i32 {
+    %const0 = arith.constant 0 : i32
     %r = "affine.for"(%const0) ({
     ^1(%i : index, %sum : i32):
       %val = "memref.load"(%ref, %i) : (memref<128xi32>, index) -> i32
-      %res = "arith.addi"(%sum, %val) : (i32, i32) -> i32
+      %res = arith.addi %sum, %val : i32
       "affine.yield"(%res) : (i32) -> ()
     }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : (i32) -> i32
     func.return %r : i32
-  }) {"sym_name" = "sum_vec", "function_type" = (memref<128xi32>) -> i32, "sym_visibility" = "private"} : () -> ()
+  }
 
   // CHECK:      "func.func"() ({
   // CHECK-NEXT: ^{{.*}}(%{{.*}} : memref<128xi32>):
@@ -31,8 +30,7 @@
 
   // Matrix multiplication
 
-  "func.func"() ({
-  ^2(%0 : memref<256x256xf32>, %1 : memref<256x256xf32>, %2 : memref<256x256xf32>):
+  func.func @affine_mm(%0 : memref<256x256xf32>, %1 : memref<256x256xf32>, %2 : memref<256x256xf32>) -> memref<256x256xf32> {
     "affine.for"() ({
     ^3(%3 : index):
       "affine.for"() ({
@@ -42,8 +40,8 @@
           %6 = "memref.load"(%0, %3, %5) : (memref<256x256xf32>, index, index) -> f32
           %7 = "memref.load"(%1, %5, %4) : (memref<256x256xf32>, index, index) -> f32
           %8 = "memref.load"(%2, %3, %4) : (memref<256x256xf32>, index, index) -> f32
-          %9 = "arith.mulf"(%6, %7) : (f32, f32) -> f32
-          %10 = "arith.addf"(%8, %9) : (f32, f32) -> f32
+          %9 = arith.mulf %6, %7 : f32
+          %10 = arith.addf %8, %9 : f32
           "memref.store"(%10, %2, %3, %4) : (f32, memref<256x256xf32>, index, index) -> ()
           "affine.yield"() : () -> ()
         }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
@@ -51,8 +49,8 @@
       }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
       "affine.yield"() : () -> ()
     }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
-    "func.return"(%2) : (memref<256x256xf32>) -> ()
-  }) {"sym_name" = "affine_mm", "function_type" = (memref<256x256xf32>, memref<256x256xf32>, memref<256x256xf32>) -> memref<256x256xf32>, "sym_visibility" = "private"} : () -> ()
+    func.return %2 : memref<256x256xf32>
+  }
 
   //CHECK:      "func.func"() ({
   //CHECK-NEXT: ^2(%{{.*}} : memref<256x256xf32>, %{{.*}} : memref<256x256xf32>, %{{.*}} : memref<256x256xf32>):
@@ -77,4 +75,4 @@
   //CHECK-NEXT:   "func.return"(%{{.*}}) : (memref<256x256xf32>) -> ()
   //CHECK-NEXT: }) {"sym_name" = "affine_mm", "function_type" = (memref<256x256xf32>, memref<256x256xf32>, memref<256x256xf32>) -> memref<256x256xf32>, "sym_visibility" = "private"} : () -> ()
 
-}) : () -> ()
+}

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -1,6 +1,6 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
-"builtin.module"() ({
+builtin.module {
   %lhsi1, %rhsi1 = "test.op"() : () -> (i1, i1)
   %lhsi32, %rhsi32 = "test.op"() : () -> (i32, i32)
   %lhsi64, %rhsi64 = "test.op"() : () -> (i64, i64)
@@ -9,153 +9,78 @@
   %lhsf64, %rhsf64 = "test.op"() : () -> (f64, f64)
   %lhsvec, %rhsvec = "test.op"() : () -> (vector<4xf32>, vector<4xf32>)
 
-
   %divsi = arith.divsi %lhsi32, %rhsi32 : i32
   %divsi_index = arith.divsi %lhsindex, %rhsindex : index
-  // CHECK:      %divsi = arith.divsi %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %divsi_index = arith.divsi %lhsindex, %rhsindex : index
 
   %divui = arith.divui %lhsi32, %rhsi32 : i32
   %divui_index = arith.divui %lhsindex, %rhsindex : index
 
-  // CHECK-NEXT: %divui = arith.divui %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %divui_index = arith.divui %lhsindex, %rhsindex : index
-
   %ceildivsi = arith.ceildivsi %lhsi32, %rhsi32 : i32
   %ceildivsi_index = arith.ceildivsi %lhsindex, %rhsindex : index
-
-  // CHECK-NEXT: %ceildivsi = arith.ceildivsi %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %ceildivsi_index = arith.ceildivsi %lhsindex, %rhsindex : index
 
   %floordivsi = arith.floordivsi %lhsi32, %rhsi32 : i32
   %floordivsi_index = arith.floordivsi %lhsindex, %rhsindex : index
 
-  // CHECK-NEXT: %floordivsi = arith.floordivsi %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %floordivsi_index = arith.floordivsi %lhsindex, %rhsindex : index
-
   %ceildivui = arith.ceildivui %lhsi32, %rhsi32 : i32
   %ceildivui_index = arith.ceildivui %lhsindex, %rhsindex : index
 
-  // CHECK-NEXT: %ceildivui = arith.ceildivui %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %ceildivui_index = arith.ceildivui %lhsindex, %rhsindex : index
-
   %remsi = arith.remsi %lhsi32, %rhsi32 : i32
-
-  // CHECK-NEXT: %remsi = arith.remsi %lhsi32, %rhsi32 : i32
 
   %remui = arith.remui %lhsi32, %rhsi32 : i32
   %remui_index = arith.remui %lhsindex, %rhsindex : index
 
-  // CHECK-NEXT: %remui = arith.remui %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %remui_index = arith.remui %lhsindex, %rhsindex : index
-
   %maxsi = arith.maxsi %lhsi32, %rhsi32 : i32
   %maxsi_index = arith.maxsi %lhsindex, %rhsindex : index
-
-  // CHECK-NEXT: %maxsi = arith.maxsi %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %maxsi_index = arith.maxsi %lhsindex, %rhsindex : index
 
   %minsi = arith.minsi %lhsi32, %rhsi32 : i32
   %minsi_index = arith.minsi %lhsindex, %rhsindex : index
 
-  // CHECK-NEXT: %minsi = arith.minsi %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %minsi_index = arith.minsi %lhsindex, %rhsindex : index
-
   %maxui = arith.maxui %lhsi32, %rhsi32 : i32
   %maxui_index = arith.maxui %lhsindex, %rhsindex : index
-
-  // CHECK-NEXT: %maxui = arith.maxui %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %maxui_index = arith.maxui %lhsindex, %rhsindex : index
 
   %minui = arith.minui %lhsi32, %rhsi32 : i32
   %minui_index = arith.minui %lhsindex, %rhsindex : index
 
-  // CHECK-NEXT: %minui = arith.minui %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %minui_index = arith.minui %lhsindex, %rhsindex : index
-
   %shli = arith.shli %lhsi32, %rhsi32 : i32
-
-  // CHECK-NEXT: %shli = arith.shli %lhsi32, %rhsi32 : i32
 
   %shrui = arith.shrui %lhsi32, %rhsi32 : i32
   %shrui_index = arith.shrui %lhsindex, %rhsindex : index
 
-  // CHECK-NEXT: %shrui = arith.shrui %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %shrui_index = arith.shrui %lhsindex, %rhsindex : index
-
   %shrsi = arith.shrsi %lhsi32, %rhsi32 : i32
-
-  // CHECK-NEXT: %shrsi = arith.shrsi %lhsi32, %rhsi32 : i32
 
   %cmpi = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 2 : i64} : (i32, i32) -> i1
   %cmpi_index = "arith.cmpi"(%lhsindex, %rhsindex) {"predicate" = 2 : i64} : (index, index) -> i1
 
-  // CHECK-NEXT: %cmpi = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 2 : i64} : (i32, i32) -> i1
-  // CHECK-NEXT: %cmpi_index = "arith.cmpi"(%lhsindex, %rhsindex) {"predicate" = 2 : i64} : (index, index) -> i1
-
   %maxf = arith.maxf %lhsf32, %rhsf32 : f32
   %maxf_vector = arith.maxf %lhsvec, %rhsvec : vector<4xf32>
-
-  // CHECK-NEXT: %maxf = arith.maxf %lhsf32, %rhsf32 : f32
-  // CHECK-NEXT: %maxf_vector = arith.maxf %lhsvec, %rhsvec : vector<4xf32>
 
   %minf = arith.minf %lhsf32, %rhsf32 : f32
   %minf_vector = arith.minf %lhsvec, %rhsvec : vector<4xf32>
 
-  // CHECK-NEXT: %minf = arith.minf %lhsf32, %rhsf32 : f32
-  // CHECK-NEXT: %minf_vector = arith.minf %lhsvec, %rhsvec : vector<4xf32>
-
   %addf = arith.addf %lhsf32, %rhsf32 : f32
   %addf_vector = arith.addf %lhsvec, %rhsvec : vector<4xf32>
-
-  // CHECK-NEXT: %addf = arith.addf %lhsf32, %rhsf32 : f32
-  // CHECK-NEXT: %addf_vector = arith.addf %lhsvec, %rhsvec : vector<4xf32>
 
   %subf = arith.subf %lhsf32, %rhsf32 : f32
   %subf_vector = arith.subf %lhsvec, %rhsvec : vector<4xf32>
 
-  // CHECK-NEXT: %subf = arith.subf %lhsf32, %rhsf32 : f32
-  // CHECK-NEXT: %subf_vector = arith.subf %lhsvec, %rhsvec : vector<4xf32>
-
   %mulf = arith.mulf %lhsf32, %rhsf32 : f32
   %mulf_vector = arith.mulf %lhsvec, %rhsvec : vector<4xf32>
-
-  // CHECK-NEXT: %mulf = arith.mulf %lhsf32, %rhsf32 : f32
-  // CHECK-NEXT: %mulf_vector = arith.mulf %lhsvec, %rhsvec : vector<4xf32>
 
   %divf = arith.divf %lhsf32, %rhsf32 : f32
   %divf_vector = arith.divf %lhsvec, %rhsvec : vector<4xf32>
 
-  // CHECK-NEXT: %divf = arith.divf %lhsf32, %rhsf32 : f32
-  // CHECK-NEXT: %divf_vector = arith.divf %lhsvec, %rhsvec : vector<4xf32>
-
   %negf = "arith.negf"(%lhsf32) : (f32) -> f32
-
-  // CHECK-NEXT: %negf = "arith.negf"(%lhsf32) : (f32) -> f32
 
   %extf = "arith.extf"(%lhsf32) : (f32) -> f64
 
-  // CHECK-NEXT: %extf = "arith.extf"(%lhsf32) : (f32) -> f64
-
   %extui = "arith.extui"(%lhsi32) : (i32) -> i64
-
-  // CHECK-NEXT: %extui = "arith.extui"(%lhsi32) : (i32) -> i64
 
   %truncf = "arith.truncf"(%lhsf64) : (f64) -> f32
 
-  // CHECK-NEXT: %truncf = "arith.truncf"(%lhsf64) : (f64) -> f32
-
   %trunci = "arith.trunci"(%lhsi64) : (i64) -> i32
-
-  // CHECK-NEXT: %trunci = "arith.trunci"(%lhsi64) : (i64) -> i32
 
   %cmpf = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 2 : i64} : (f32, f32) -> i1
 
-  // CHECK-NEXT: %cmpf = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 2 : i64} : (f32, f32) -> i1
-
   %selecti = "arith.select"(%lhsi1, %lhsi32, %rhsi32) : (i1, i32, i32) -> i32
   %selectf = "arith.select"(%lhsi1, %lhsf32, %rhsf32) : (i1, f32, f32) -> f32
-
-  // CHECK-NEXT: %selecti = "arith.select"(%lhsi1, %lhsi32, %rhsi32) : (i1, i32, i32) -> i32
-  // CHECK-NEXT: %selectf = "arith.select"(%lhsi1, %lhsf32, %rhsf32) : (i1, f32, f32) -> f32
-}) : () -> ()
+}

--- a/tests/filecheck/dialects/builtin/module.mlir
+++ b/tests/filecheck/dialects/builtin/module.mlir
@@ -1,12 +1,8 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
-  // CHECK: builtin.module {
-    builtin.module {}
-    // CHECK: builtin.module {
-    // CHECK-NEXT: }
-    builtin.module attributes {a = "foo", b = "bar", unit} {}
-    // CHECK-NEXT: builtin.module attributes {"a" = "foo", "b" = "bar", "unit"} {
-    // CHECK-NEXT: }
+    builtin.module {
+    }
+    builtin.module attributes {"a" = "foo", "b" = "bar", "unit"} {
+    }
 }
-// CHECK: }

--- a/tests/filecheck/dialects/builtin/unrealized_conv_cast.mlir
+++ b/tests/filecheck/dialects/builtin/unrealized_conv_cast.mlir
@@ -1,22 +1,14 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
-// CHECK: module
-"builtin.module"() ({
-  "func.func"() ({
-    // CHECK: %0 = arith.constant 0 : i64
-    %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64
-    // CHECK: %1 = builtin.unrealized_conversion_cast %0 : i64 to f32
-    %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> f32
-    // CHECK: %2 = builtin.unrealized_conversion_cast %0 : i64 to i32
-    %2 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i32
-    // CHECK: %3 = builtin.unrealized_conversion_cast %0 : i64 to i64
-    %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i64
-    // CHECK: %4 = builtin.unrealized_conversion_cast to i64  {"comment" = "test"}
-    %4 = "builtin.unrealized_conversion_cast"() {"comment" = "test"} : () -> i64
-    // CHECK: %5 = builtin.unrealized_conversion_cast %0, %0 : i64, i64 to f32
-    %5 = "builtin.unrealized_conversion_cast"(%0, %0) : (i64, i64) -> f32
-    // CHECK: %6, %7 = builtin.unrealized_conversion_cast %5 : f32 to i64, i64
-    %6, %7 = "builtin.unrealized_conversion_cast"(%5) : (f32) -> (i64, i64)
-    "func.return"() : () -> ()
-  }) {"function_type" = () -> (), "sym_name" = "builtin"} : () -> ()
-}) : () -> ()
+builtin.module {
+  func.func @builtin() {
+    %0 = arith.constant 0 : i64
+    %1 = builtin.unrealized_conversion_cast %0 : i64 to f32
+    %2 = builtin.unrealized_conversion_cast %0 : i64 to i32
+    %3 = builtin.unrealized_conversion_cast %0 : i64 to i64
+    %4 = builtin.unrealized_conversion_cast to i64 {"comment" = "test"}
+    %5 = builtin.unrealized_conversion_cast %0, %0 : i64, i64 to f32
+    %6, %7 = builtin.unrealized_conversion_cast %5 : f32 to i64, i64
+    func.return
+  }
+}

--- a/tests/filecheck/dialects/cf/cf_ops.mlir
+++ b/tests/filecheck/dialects/cf/cf_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
   func.func private @assert() {
@@ -6,34 +6,18 @@ builtin.module {
     "cf.assert"(%cond) {"msg" = "some message"} : (i1) -> ()
     func.return
   }
-  // CHECK:      func.func private @assert() {
-  // CHECK-NEXT:     %{{.*}} = arith.constant true
-  // CHECK-NEXT:     "cf.assert"(%{{.*}}) {"msg" = "some message"} : (i1) -> ()
-  // CHECK-NEXT:     func.return
-  // CHECK-NEXT:   }
 
   func.func private @unconditional_br() {
     "cf.br"() [^1] : () -> ()
   ^1:
     "cf.br"() [^1] : () -> ()
   }
-  // CHECK:      func.func private @unconditional_br() {
-  // CHECK-NEXT:   "cf.br"() [^{{.*}}] : () -> ()
-  // CHECK-NEXT: ^{{.*}}:
-  // CHECK-NEXT:   "cf.br"() [^{{.*}}] : () -> ()
-  // CHECK-NEXT: }
 
   func.func private @br(%0 : i32) {
     "cf.br"(%0) [^3] : (i32) -> ()
   ^3(%1 : i32):
     "cf.br"(%1) [^3] : (i32) -> ()
   }
-  // CHECK:      func.func private @br(%{{.*}} : i32) {
-  // CHECK-NEXT:   "cf.br"(%{{.*}}) [^{{.*}}] : (i32) -> ()
-  // CHECK-NEXT: ^{{.*}}(%{{.*}} : i32):
-  // CHECK-NEXT:   "cf.br"(%{{.*}}) [^{{.*}}] : (i32) -> ()
-  // CHECK-NEXT: }
-
 
   func.func private @cond_br(%2 : i1, %3 : i32) -> i32 {
     "cf.br"(%2, %3) [^5] : (i1, i32) -> ()
@@ -42,11 +26,4 @@ builtin.module {
   ^6(%6 : i32, %7 : i32, %8 : i32):
     func.return %6 : i32
   }
-  // CHECK:      func.func private @cond_br(%2 : i1, %3 : i32) -> i32 {
-  // CHECK-NEXT:   "cf.br"(%{{.*}}, %{{.*}}) [^{{.*}}] : (i1, i32) -> ()
-  // CHECK-NEXT: ^{{.*}}(%{{.*}} : i1, %{{.*}} : i32):
-  // CHECK-NEXT:   "cf.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) [^{{.*}}, ^{{.*}}] {"operand_segment_sizes" = array<i32: 1, 2, 3>} : (i1, i1, i32, i32, i32, i32) -> ()
-  // CHECK-NEXT: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):
-  // CHECK-NEXT:   func.return %{{.*}} : i32
-  // CHECK-NEXT: }
 }

--- a/tests/filecheck/dialects/cmath/cmath_ops.mlir
+++ b/tests/filecheck/dialects/cmath/cmath_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 
 builtin.module {
@@ -9,22 +9,9 @@ builtin.module {
     func.return %pq : f32
   }
 
-   // CHECK: func.func @conorm(%p : !cmath.complex<f32>, %q : !cmath.complex<f32>) -> f32 {
-   // CHECK-NEXT:   %norm_p = "cmath.norm"(%p) : (!cmath.complex<f32>) -> f32
-   // CHECK-NEXT:   %norm_q = "cmath.norm"(%q) : (!cmath.complex<f32>) -> f32
-   // CHECK-NEXT:   %pq = arith.mulf %norm_p, %norm_q : f32
-   // CHECK-NEXT:   func.return %pq : f32
-   // CHECK-NEXT: }
-
   func.func @conorm2(%a : !cmath.complex<f32>, %b : !cmath.complex<f32>) -> f32 {
     %ab = "cmath.mul"(%a, %b) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
     %conorm = "cmath.norm"(%ab) : (!cmath.complex<f32>) -> f32
     func.return %conorm : f32
   }
-
-   // CHECK: func.func @conorm2(%a : !cmath.complex<f32>, %b : !cmath.complex<f32>) -> f32 {
-   // CHECK-NEXT:   %ab = "cmath.mul"(%a, %b) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
-   // CHECK-NEXT:   %conorm = "cmath.norm"(%ab) : (!cmath.complex<f32>) -> f32
-   // CHECK-NEXT:   func.return %conorm : f32
-   // CHECK-NEXT: }
 }

--- a/tests/filecheck/dialects/dmp/ops.mlir
+++ b/tests/filecheck/dialects/dmp/ops.mlir
@@ -1,7 +1,7 @@
 // RUN: XDSL_ROUNDTRIP
 
 builtin.module {
-    %ref = "test.op"() : () -> (memref<1024x1024xf32>)
+    %ref = "test.op"() : () -> memref<1024x1024xf32>
 
     "dmp.swap"(%ref) {
         grid = #dmp.grid<2x2>,

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module attributes {"gpu.container_module"} {
     "gpu.module"() ({
@@ -32,7 +32,7 @@ builtin.module attributes {"gpu.container_module"} {
             %griddimz = "gpu.grid_dim"() {"dimension" = #gpu<dim z>} : () -> index
 
             %gmemref = "gpu.alloc"() {"operand_segment_sizes" = array<i32: 0, 0, 0>} : () -> memref<10x10xi32>
-            %gdmemref = "gpu.alloc"(%griddimx, %griddimy,%griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>}: (index, index, index) -> memref<?x?x?xf64>
+            %gdmemref = "gpu.alloc"(%griddimx, %griddimy, %griddimz) {"operand_segment_sizes" = array<i32: 0, 3, 0>} : (index, index, index) -> memref<?x?x?xf64>
 
             "gpu.memcpy"(%memref, %gmemref) {"operand_segment_sizes" = array<i32: 0, 1, 1>} : (memref<10x10xi32>, memref<10x10xi32>) -> ()
 
@@ -57,10 +57,7 @@ builtin.module attributes {"gpu.container_module"} {
             }) : (index) -> index
 
             "gpu.launch"(%one, %one, %one, %n, %one, %one) ({
-            ^bb0(%bx : index, %by : index, %bz : index,
-                %tx : index, %ty : index, %tz : index,
-                %num_bx : index, %num_by : index, %num_bz : index,
-                %num_tx : index, %num_ty : index, %num_tz : index):
+            ^bb0(%bx : index, %by : index, %bz : index, %tx : index, %ty : index, %tz : index, %num_bx : index, %num_by : index, %num_bz : index, %num_tx : index, %num_ty : index, %num_tz : index):
                 %sum = "gpu.all_reduce"(%tx) ({
                 }) {"op" = #gpu<all_reduce_op add>} : (index) -> index
                 %final = arith.muli %sum, %one : index

--- a/tests/filecheck/dialects/irdl/cmath.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/cmath.irdl.mlir
@@ -1,15 +1,9 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
-  // CHECK: irdl.dialect @cmath {
+  
   irdl.dialect @cmath {
 
-    // CHECK: irdl.type @complex {
-    // CHECK-NEXT:   %{{.*}} = irdl.is f32
-    // CHECK-NEXT:   %{{.*}} = irdl.is f64
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
-    // CHECK-NEXT: }
     irdl.type @complex {
       %0 = irdl.is f32
       %1 = irdl.is f64
@@ -17,12 +11,6 @@ builtin.module {
       irdl.parameters(%2)
     }
 
-    // CHECK: irdl.operation @norm {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   %{{.*}} = irdl.parametric @complex<%{{.*}}>
-    // CHECK-NEXT:   irdl.operands(%{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
     irdl.operation @norm {
       %0 = irdl.any
       %1 = irdl.parametric @complex<%0>
@@ -30,14 +18,6 @@ builtin.module {
       irdl.results(%0)
     }
 
-    // CHECK: irdl.operation @mul {
-    // CHECK-NEXT:   %{{.*}} = irdl.is f32
-    // CHECK-NEXT:   %{{.*}} = irdl.is f64
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   %{{.*}} = irdl.parametric @complex<%{{.*}}>
-    // CHECK-NEXT:   irdl.operands(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
     irdl.operation @mul {
       %0 = irdl.is f32
       %1 = irdl.is f64

--- a/tests/filecheck/dialects/irdl/cyclic-types.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/cyclic-types.irdl.mlir
@@ -1,16 +1,10 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 // Types that have cyclic references.
 builtin.module {
-  // CHECK: irdl.dialect @testd {
+  
   irdl.dialect @testd {
-    // CHECK:      irdl.type @self_referencing {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   %{{.*}} = irdl.parametric @self_referencing<%{{.*}}>
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.type @self_referencing {
       %0 = irdl.any
       %1 = irdl.parametric @self_referencing<%0>
@@ -19,14 +13,6 @@ builtin.module {
       irdl.parameters(%3)
     }
 
-
-    // CHECK:      irdl.type @type1 {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   %{{.*}} = irdl.parametric @type2<%{{.*}}>
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
-    // CHECK-NEXT: }
     irdl.type @type1 {
       %0 = irdl.any
       %1 = irdl.parametric @type2<%0>
@@ -35,13 +21,6 @@ builtin.module {
       irdl.parameters(%3)
     }
 
-    // CHECK:      irdl.type @type2 {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   %{{.*}} = irdl.parametric @type1<%{{.*}}>
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
-    // CHECK-NEXT: }
     irdl.type @type2 {
         %0 = irdl.any
         %1 = irdl.parametric @type1<%0>

--- a/tests/filecheck/dialects/irdl/test-type.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/test-type.irdl.mlir
@@ -1,18 +1,11 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
-  // CHECK: irdl.dialect @testd {
+  
   irdl.dialect @testd {
-    // CHECK: irdl.type @singleton
+    
     irdl.type @singleton
-
-    // CHECK:      irdl.type @parametrized {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.is i64
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}}, %{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.type @parametrized {
       %0 = irdl.any
       %1 = irdl.is i32
@@ -20,11 +13,7 @@ builtin.module {
       %3 = irdl.any_of(%1, %2)
       irdl.parameters(%0, %3)
     }
-
-    // CHECK:      irdl.operation @any {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @any {
       %0 = irdl.any
       irdl.results(%0)

--- a/tests/filecheck/dialects/irdl/testd.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/testd.irdl.mlir
@@ -1,64 +1,35 @@
-// RUN:XDSL_ROUNDTRIP
+// RUN:XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
-  // CHECK: irdl.dialect @testd {
+
   irdl.dialect @testd {
-    // CHECK:      irdl.type @parametric {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
-    // CHECK-NEXT: }
     irdl.type @parametric {
       %0 = irdl.any
       irdl.parameters(%0)
     }
-
-    // CHECK:      irdl.attribute @parametric_attr {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.attribute @parametric_attr {
       %0 = irdl.any
       irdl.parameters(%0)
     }
-
-    // CHECK:      irdl.type @attr_in_type_out {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.type @attr_in_type_out {
       %0 = irdl.any
       irdl.parameters(%0)
     }
-
-    // CHECK:      irdl.operation @eq {
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @eq {
       %0 = irdl.is i32
       irdl.results(%0)
     }
-
-    // CHECK:      irdl.operation @anyof {
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.is i64
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @anyof {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
       irdl.results(%2)
     }
-
-    // CHECK:      irdl.operation @all_of {
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.is i64
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   %{{.*}} = irdl.all_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @all_of {
       %0 = irdl.is i32
       %1 = irdl.is i64
@@ -66,34 +37,18 @@ builtin.module {
       %3 = irdl.all_of(%2, %1)
       irdl.results(%3)
     }
-
-    // CHECK:      irdl.operation @any {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @any {
       %0 = irdl.any
       irdl.results(%0)
     }
-
-    // CHECK:      irdl.operation @dynbase {
-    // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   %{{.*}} = irdl.parametric @parametric<%{{.*}}>
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @dynbase {
       %0 = irdl.any
       %1 = irdl.parametric @parametric<%0>
       irdl.results(%1)
     }
-
-    // CHECK:      irdl.operation @dynparams {
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.is i64
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   %{{.*}} = irdl.parametric @parametric<%{{.*}}>
-    // CHECK-NEXT:   irdl.results(%{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @dynparams {
       %0 = irdl.is i32
       %1 = irdl.is i64
@@ -101,13 +56,7 @@ builtin.module {
       %3 = irdl.parametric @parametric<%2>
       irdl.results(%3)
     }
-
-    // CHECK:      irdl.operation @constraint_vars {
-    // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   %{{.*}} = irdl.is i64
-    // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}}, %{{.*}})
-    // CHECK-NEXT: }
+    
     irdl.operation @constraint_vars {
       %0 = irdl.is i32
       %1 = irdl.is i64

--- a/tests/filecheck/dialects/llvm/pointers.mlir
+++ b/tests/filecheck/dialects/llvm/pointers.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 builtin.module {
   %0 = arith.constant 0 : i64
   %1 = "llvm.inttoptr"(%0) : (i64) -> !llvm.ptr<i32>
@@ -6,15 +6,5 @@ builtin.module {
   %3 = "llvm.mlir.null"() : () -> !llvm.ptr
   %4 = "llvm.alloca"(%0) {"alignment" = 32 : i64} : (i64) -> !llvm.ptr<index>
   %5 = "llvm.load"(%4) : (!llvm.ptr<index>) -> index
-  %6 = "llvm.getelementptr"(%4, %0){elem_type = i32, rawConstantIndices = array<i32:-2147483648>} : (!llvm.ptr<index>, i64) -> !llvm.ptr<i32>
+  %6 = "llvm.getelementptr"(%4, %0) {"elem_type" = i32, "rawConstantIndices" = array<i32: -2147483648>} : (!llvm.ptr<index>, i64) -> !llvm.ptr<i32>
 }
-
-// CHECK: builtin.module {
-// CHECK-NEXT:   %0 = arith.constant 0 : i64
-// CHECK-NEXT:   %1 = "llvm.inttoptr"(%0) : (i64) -> !llvm.ptr<i32>
-// CHECK-NEXT:   %2 = "llvm.load"(%1) : (!llvm.ptr<i32>) -> i32
-// CHECK-NEXT:   %3 = "llvm.mlir.null"() : () -> !llvm.ptr
-// CHECK-NEXT:   %4 = "llvm.alloca"(%0) {"alignment" = 32 : i64} : (i64) -> !llvm.ptr<index>
-// CHECK-NEXT:   %5 = "llvm.load"(%4) : (!llvm.ptr<index>) -> index
-// CHECK-NEXT:   %6 = "llvm.getelementptr"(%4, %0) {"elem_type" = i32, "rawConstantIndices" = array<i32: -2147483648>} : (!llvm.ptr<index>, i64) -> !llvm.ptr<i32>
-// CHECK-NEXT: }

--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
@@ -20,24 +20,3 @@ builtin.module {
     func.return
   }
 }
-
-// CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
-// CHECK-NEXT:   func.func private @memref_test() {
-// CHECK-NEXT:     %{{.*}} = "memref.get_global"() {"name" = @g} : () -> memref<1xindex>
-// CHECK-NEXT:     %{{.*}} = arith.constant 0 : index
-// CHECK-NEXT:     %{{.*}} = "memref.alloca"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
-// CHECK-NEXT:     %{{.*}} = arith.constant 42 : index
-// CHECK-NEXT:     "memref.store"(%{{.*}}, %{{.*}}, %{{.*}}) : (index, memref<1xindex>, index) -> ()
-// CHECK-NEXT:     %{{.*}} = "memref.load"(%{{.*}}, %{{.*}}) : (memref<1xindex>, index) -> index
-// CHECK-NEXT:     %{{.*}} = "memref.alloc"() {"alignment" = 0 : i64, "operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<10x2xindex>
-// CHECK-NEXT:     "memref.store"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (index, memref<10x2xindex>, index, index) -> ()
-// CHECK-NEXT:     %{{.*}} = "memref.subview"(%5) {"operand_segment_sizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
-// CHECK-NEXT:     %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x2xindex>) -> memref<?x?xindex>
-// CHECK-NEXT:     %{{.*}} = "memref.alloca"() {"operand_segment_sizes" = array<i32: 0, 0>} : () -> memref<1xindex>
-// CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()
-// CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<10x2xindex>) -> ()
-// CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }

--- a/tests/filecheck/dialects/pdl/mlir-tests.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
   pdl.pattern @operations : benefit(1) {
@@ -10,7 +10,7 @@ builtin.module {
 
     // Operation with input.
     %input = pdl.operand
-    %root = pdl.operation(%op0_result, %input : !pdl.value, !pdl.value)
+    %root = pdl.operation (%op0_result, %input : !pdl.value, !pdl.value)
     pdl.rewrite %root with "rewriter"
   }
 }
@@ -31,7 +31,7 @@ builtin.module {
 builtin.module {
   pdl.pattern @rewrite_with_args : benefit(1) {
     %input = pdl.operand
-    %root = pdl.operation(%input : !pdl.value)
+    %root = pdl.operation (%input : !pdl.value)
     pdl.rewrite %root with "rewriter"(%input : !pdl.value)
   }
 }
@@ -49,12 +49,12 @@ builtin.module {
     %input1 = pdl.operand
     %input2 = pdl.operand
     %type = pdl.type
-    %op1 = pdl.operation(%input1 : !pdl.value) -> (%type : !pdl.type)
+    %op1 = pdl.operation (%input1 : !pdl.value) -> (%type : !pdl.type)
     %val1 = pdl.result 0 of %op1
-    %root1 = pdl.operation(%val1 : !pdl.value)
-    %op2 = pdl.operation(%input2 : !pdl.value) -> (%type : !pdl.type)
+    %root1 = pdl.operation (%val1 : !pdl.value)
+    %op2 = pdl.operation (%input2 : !pdl.value) -> (%type : !pdl.type)
     %val2 = pdl.result 0 of %op2
-    %root2 = pdl.operation(%val1, %val2 : !pdl.value, !pdl.value)
+    %root2 = pdl.operation (%val1, %val2 : !pdl.value, !pdl.value)
     pdl.rewrite with "rewriter"(%root1, %root2 : !pdl.operation, !pdl.operation)
   }
 }
@@ -80,12 +80,12 @@ builtin.module {
     %input1 = pdl.operand
     %input2 = pdl.operand
     %type = pdl.type
-    %op1 = pdl.operation(%input1 : !pdl.value) -> (%type : !pdl.type)
+    %op1 = pdl.operation (%input1 : !pdl.value) -> (%type : !pdl.type)
     %val1 = pdl.result 0 of %op1
-    %root1 = pdl.operation(%val1 : !pdl.value)
-    %op2 = pdl.operation(%input2 : !pdl.value) -> (%type : !pdl.type)
+    %root1 = pdl.operation (%val1 : !pdl.value)
+    %op2 = pdl.operation (%input2 : !pdl.value) -> (%type : !pdl.type)
     %val2 = pdl.result 0 of %op2
-    %root2 = pdl.operation(%val1, %val2 : !pdl.value, !pdl.value)
+    %root2 = pdl.operation (%val1, %val2 : !pdl.value, !pdl.value)
     pdl.rewrite %root1 with "rewriter"(%root2 : !pdl.operation)
   }
 }
@@ -116,7 +116,7 @@ builtin.module {
     pdl.rewrite %root {
       %type3 = pdl.type
       %newOp = pdl.operation "foo.op" -> (%type1, %type3 : !pdl.type, !pdl.type)
-      pdl.replace %root with %newOp
+      "pdl.replace"(%root, %newOp) {"operand_segment_sizes" = array<i32: 1, 1, 0>} : (!pdl.operation, !pdl.operation) -> ()
     }
   }
 }

--- a/tests/filecheck/dialects/pdl/mlir-tests.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests.mlir
@@ -15,16 +15,6 @@ builtin.module {
   }
 }
 
-// CHECK:      pdl.pattern @operations : benefit(1) {
-// CHECK-NEXT:   %attribute = pdl.attribute
-// CHECK-NEXT:   %type = pdl.type
-// CHECK-NEXT:   %op0 = pdl.operation {"attr" = %attribute} -> (%type : !pdl.type)
-// CHECK-NEXT:   %op0_result = pdl.result 0 of %op0
-// CHECK-NEXT:   %input = pdl.operand
-// CHECK-NEXT:   %root = pdl.operation (%op0_result, %input : !pdl.value, !pdl.value)
-// CHECK-NEXT:   pdl.rewrite %root with "rewriter"
-// CHECK-NEXT: }
-
 
 // -----
 
@@ -35,12 +25,6 @@ builtin.module {
     pdl.rewrite %root with "rewriter"(%input : !pdl.value)
   }
 }
-
-// CHECK:      pdl.pattern @rewrite_with_args : benefit(1) {
-// CHECK-NEXT:   %input = pdl.operand
-// CHECK-NEXT:   %root = pdl.operation (%input : !pdl.value)
-// CHECK-NEXT:   pdl.rewrite %root with "rewriter"(%input : !pdl.value)
-// CHECK-NEXT: }
 
 // -----
 
@@ -58,19 +42,6 @@ builtin.module {
     pdl.rewrite with "rewriter"(%root1, %root2 : !pdl.operation, !pdl.operation)
   }
 }
-
-// CHECK:      pdl.pattern @rewrite_multi_root_optimal : benefit(2) {
-// CHECK-NEXT:   %input1 = pdl.operand
-// CHECK-NEXT:   %input2 = pdl.operand
-// CHECK-NEXT:   %type = pdl.type
-// CHECK-NEXT:   %op1 = pdl.operation (%input1 : !pdl.value) -> (%type : !pdl.type)
-// CHECK-NEXT:   %val1 = pdl.result 0 of %op1
-// CHECK-NEXT:   %root1 = pdl.operation (%val1 : !pdl.value)
-// CHECK-NEXT:   %op2 = pdl.operation (%input2 : !pdl.value) -> (%type : !pdl.type)
-// CHECK-NEXT:   %val2 = pdl.result 0 of %op2
-// CHECK-NEXT:   %root2 = pdl.operation (%val1, %val2 : !pdl.value, !pdl.value)
-// CHECK-NEXT:   pdl.rewrite with "rewriter"(%root1, %root2 : !pdl.operation, !pdl.operation)
-// CHECK-NEXT: }
 
 
 // -----
@@ -90,19 +61,6 @@ builtin.module {
   }
 }
 
-// CHECK:      pdl.pattern @rewrite_multi_root_forced : benefit(2) {
-// CHECK-NEXT:   %input1 = pdl.operand
-// CHECK-NEXT:   %input2 = pdl.operand
-// CHECK-NEXT:   %type = pdl.type
-// CHECK-NEXT:   %op1 = pdl.operation (%input1 : !pdl.value) -> (%type : !pdl.type)
-// CHECK-NEXT:   %val1 = pdl.result 0 of %op1
-// CHECK-NEXT:   %root1 = pdl.operation (%val1 : !pdl.value)
-// CHECK-NEXT:   %op2 = pdl.operation (%input2 : !pdl.value) -> (%type : !pdl.type)
-// CHECK-NEXT:   %val2 = pdl.result 0 of %op2
-// CHECK-NEXT:   %root2 = pdl.operation (%val1, %val2 : !pdl.value, !pdl.value)
-// CHECK-NEXT:   pdl.rewrite %root1 with "rewriter"(%root2 : !pdl.operation)
-// CHECK-NEXT: }
-
 
 // -----
 
@@ -116,21 +74,10 @@ builtin.module {
     pdl.rewrite %root {
       %type3 = pdl.type
       %newOp = pdl.operation "foo.op" -> (%type1, %type3 : !pdl.type, !pdl.type)
-      "pdl.replace"(%root, %newOp) {"operand_segment_sizes" = array<i32: 1, 1, 0>} : (!pdl.operation, !pdl.operation) -> ()
+      pdl.replace %root with %newOp
     }
   }
 }
-
-// CHECK:      pdl.pattern @infer_type_from_operation_replace : benefit(1) {
-// CHECK-NEXT:   %type1 = pdl.type : i32
-// CHECK-NEXT:   %type2 = pdl.type
-// CHECK-NEXT:   %root = pdl.operation -> (%type1, %type2 : !pdl.type, !pdl.type)
-// CHECK-NEXT:   pdl.rewrite %root {
-// CHECK-NEXT:     %type3 = pdl.type
-// CHECK-NEXT:     %newOp = pdl.operation "foo.op" -> (%type1, %type3 : !pdl.type, !pdl.type)
-// CHECK-NEXT:     pdl.replace %root with %newOp
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 
 // -----
@@ -148,15 +95,6 @@ builtin.module {
   }
 }
 
-// CHECK:      pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
-// CHECK-NEXT:   %type1 = pdl.type : i32
-// CHECK-NEXT:   %type2 = pdl.type
-// CHECK-NEXT:   %root = pdl.operation -> (%type1, %type2 : !pdl.type, !pdl.type)
-// CHECK-NEXT:   pdl.rewrite %root {
-// CHECK-NEXT:     %newOp = pdl.operation "foo.op" -> (%type1, %type2 : !pdl.type, !pdl.type)
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
-
 // -----
 
 // Check that the result type of an operation within a rewrite can be inferred
@@ -171,15 +109,6 @@ builtin.module {
     }
   }
 }
-
-// CHECK:      pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
-// CHECK-NEXT:   %types = pdl.types
-// CHECK-NEXT:   %root = pdl.operation -> (%types : !pdl.range<!pdl.type>)
-// CHECK-NEXT:   pdl.rewrite %root {
-// CHECK-NEXT:     %otherTypes = pdl.types : [i32, i64]
-// CHECK-NEXT:     %newOp = pdl.operation "foo.op" -> (%types, %otherTypes : !pdl.range<!pdl.type>, !pdl.range<!pdl.type>)
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 
 // -----
@@ -199,17 +128,6 @@ builtin.module {
   }
 }
 
-// CHECK:      pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
-// CHECK-NEXT:   %type1 = pdl.type
-// CHECK-NEXT:   %type2 = pdl.type
-// CHECK-NEXT:   %operand1 = pdl.operand : %type1
-// CHECK-NEXT:   %operand2 = pdl.operand : %type2
-// CHECK-NEXT:   %root = pdl.operation (%operand1, %operand2 : !pdl.value, !pdl.value)
-// CHECK-NEXT:   pdl.rewrite %root {
-// CHECK-NEXT:     %newOp = pdl.operation "foo.op" -> (%type1, %type2 : !pdl.type, !pdl.type)
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
-
 
 // -----
 
@@ -226,15 +144,6 @@ builtin.module {
   }
 }
 
-// CHECK:       pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
-// CHECK-NEXT:    %types = pdl.types
-// CHECK-NEXT:    %operands = pdl.operands : %types
-// CHECK-NEXT:    %root = pdl.operation (%operands : !pdl.range<!pdl.value>)
-// CHECK-NEXT:    pdl.rewrite %root {
-// CHECK-NEXT:      %newOp = pdl.operation "foo.op" -> (%types : !pdl.range<!pdl.type>)
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-
 
 // -----
 
@@ -246,10 +155,3 @@ builtin.module {
     }
   }
 }
-
-// CHECK:      pdl.pattern @apply_rewrite_with_no_results : benefit(1) {
-// CHECK-NEXT:   %root = pdl.operation
-// CHECK-NEXT:   pdl.rewrite %root {
-// CHECK-NEXT:     pdl.apply_native_rewrite "NativeRewrite"(%root : !pdl.operation)
-// CHECK-NEXT:   }
-// CHECK-NEXT: }

--- a/tests/filecheck/dialects/printf/printf_basics.mlir
+++ b/tests/filecheck/dialects/printf/printf_basics.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 builtin.module {
     printf.print_format "Hello world!"
 
@@ -8,17 +8,7 @@ builtin.module {
 
     printf.print_format "Uses vals twice {} {} {} {}", %12 : i32, %144 : i32, %12 : i32, %144 : i32
     printf.print_format "{}", %144 : i32
-    printf.print_format "{}", %144 : i32 {unit}
+    printf.print_format "{}", %144 : i32 {"unit"}
     "printf.print_char"(%byte) : (i8) -> ()
     "printf.print_int"(%12) : (i32) -> ()
 }
-
-// CHECK:       printf.print_format "Hello world!"
-// CHECK-NEXT:  %0 = "test.op"() : () -> i32
-// CHECK-NEXT:  %1 = "test.op"() : () -> i32
-// CHECK-NEXT:  %byte = "test.op"() : () -> i8
-// CHECK-NEXT:  printf.print_format "Uses vals twice {} {} {} {}", %1 : i32, %0 : i32, %1 : i32, %0 : i32
-// CHECK-NEXT:  printf.print_format "{}", %0 : i32
-// CHECK-NEXT:  printf.print_format "{}", %0 : i32 {"unit"}
-// CHECK-NEXT:  "printf.print_char"(%{{.*}}) : (i8) -> ()
-// CHECK-NEXT:  "printf.print_int"(%{{.*}}) : (i32) -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -1,283 +1,177 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
-"builtin.module"() ({
+builtin.module {
   riscv.label "main" ({
     %0 = riscv.get_register : () -> !riscv.reg<>
     %1 = riscv.get_register : () -> !riscv.reg<>
     // RV32I/RV64I: 2.4 Integer Computational Instructions
 
     // Integer Register-Immediate Instructions
-    %addi = riscv.addi %0, 1: (!riscv.reg<>) -> !riscv.reg<>
+    %addi = riscv.addi %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
     // CHECK: %{{.*}} = riscv.addi %{{.*}}, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %slti = riscv.slti %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.slti %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %sltiu = riscv.sltiu %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sltiu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %andi = riscv.andi %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.andi %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %ori = riscv.ori %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.ori %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %xori = riscv.xori %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %slli = riscv.slli %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.slli %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %srli = riscv.srli %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.srli %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %srai = riscv.srai %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.srai %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %slti = riscv.slti %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %sltiu = riscv.sltiu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %andi = riscv.andi %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %ori = riscv.ori %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %xori = riscv.xori %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %slli = riscv.slli %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %srli = riscv.srli %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %srai = riscv.srai %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %lui = riscv.lui 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lui 1 : () -> !riscv.reg<>
     %auipc = riscv.auipc 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.auipc 1 : () -> !riscv.reg<>
     %mv = riscv.mv %0 : (!riscv.reg<>) -> !riscv.reg<>
     // CHECK: %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
 
     // Integer Register-Register Operations
     %add = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %slt = riscv.slt %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.slt %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %sltu = riscv.sltu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sltu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %and = riscv.and %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.and %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %or = riscv.or %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.or %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %xor = riscv.xor %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xor %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %sll = riscv.sll %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sll %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %srl = riscv.srl %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.srl %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %sub = riscv.sub %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %sra = riscv.sra %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sra %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     riscv.nop : () -> ()
-    // CHECK-NEXT: riscv.nop : () -> ()
 
     // RV32I/RV64I: 2.5 Control Transfer Instructions
 
     // Unconditional Branch Instructions
     riscv.jal 1 : () -> ()
-    // CHECK-NEXT: riscv.jal 1 : () -> ()
     riscv.jal 1, !riscv.reg<> : () -> ()
-    // CHECK-NEXT: riscv.jal 1, !riscv.reg<> : () -> ()
     riscv.jal "label" : () -> ()
-    // CHECK-NEXT: riscv.jal "label" : () -> ()
 
     riscv.j 1 : () -> ()
-    // CHECK-NEXT: riscv.j 1 : () -> ()
     riscv.j "label" : () -> ()
-    // CHECK-NEXT: riscv.j "label" : () -> ()
 
-    riscv.jalr %0, 1: (!riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.jalr %0, 1 : (!riscv.reg<>) -> ()
+    riscv.jalr %0, 1 : (!riscv.reg<>) -> ()
     riscv.jalr %0, 1, !riscv.reg<> : (!riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.jalr %0, 1, !riscv.reg<> : (!riscv.reg<>) -> ()
     riscv.jalr %0, "label" : (!riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.jalr %0, "label" : (!riscv.reg<>) -> ()
 
     riscv.ret : () -> ()
-    // CHECK-NEXT: riscv.ret : () -> ()
   ^0(%2 : !riscv.reg<>, %3 : !riscv.reg<>):
-  // CHECK-NEXT: ^0(%2 : !riscv.reg<>, %3 : !riscv.reg<>):
 
     // Conditional Branch Instructions
     riscv.beq %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.beq %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
     riscv.bne %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bne %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
     riscv.blt %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.blt %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
     riscv.bge %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bge %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
     riscv.bltu %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bltu %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
     riscv.bgeu %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bgeu %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
 
     // RV32I/RV64I: 2.6 Load and Store Instructions
 
     %lb = riscv.lb %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lb %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %lbu = riscv.lbu %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lbu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    %lbu = riscv.lbu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %lh = riscv.lh %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lh %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %lhu = riscv.lhu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lhu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %lw = riscv.lw %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lw %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    riscv.sb %0, %1, 1: (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.sb %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
+    riscv.sb %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
     riscv.sh %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.sh %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
     riscv.sw %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.sw %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
 
     // RV32I/RV64I: 2.8 Control and Status Register Instructions
 
     %csrrw_rw = riscv.csrrw %0 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrw %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
     %csrrw_w = riscv.csrrw %0 1024, "w" : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrw %0, 1024, "w" : (!riscv.reg<>) -> !riscv.reg<>
     %csrrs_rw = riscv.csrrs %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrs %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
     %csrrs_r = riscv.csrrs %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrs %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
     %csrrc_rw = riscv.csrrc %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrc %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
     %csrrc_r = riscv.csrrc %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrc %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
     %csrrsi_rw = riscv.csrrsi 1024, 8 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrsi 1024, 8 : () -> !riscv.reg<>
     %csrrsi_r = riscv.csrrsi 1024, 0 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrsi 1024, 0 : () -> !riscv.reg<>
     %csrrci_rw = riscv.csrrci 1024, 8 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrci 1024, 8 : () -> !riscv.reg<>
     %csrrci_r = riscv.csrrci 1024, 0 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrci 1024, 0 : () -> !riscv.reg<>
     %csrrwi_rw = riscv.csrrwi 1024, 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrwi 1024, 1 : () -> !riscv.reg<>
     %csrrwi_w = riscv.csrrwi 1024, 1, "w" : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrwi 1024, 1, "w" : () -> !riscv.reg<>
 
     // Machine Mode Privileged Instructions
     riscv.wfi : () -> ()
-    // CHECK-NEXT: riscv.wfi : () -> ()
 
 
     // RV32M/RV64M: 7 “M” Standard Extension for Integer Multiplication and Division
 
     // Multiplication Operations
     %mul = riscv.mul %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %mulh = riscv.mulh %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mulh %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %mulhsu = riscv.mulhsu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mulhsu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %mulhu = riscv.mulhu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mulhu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 
     // Division Operations
     %div = riscv.div %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.div %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %divu = riscv.divu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.divu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %rem = riscv.rem %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.rem %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %remu = riscv.remu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.remu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 
     // Assembler pseudo-instructions
 
     %li = riscv.li 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
     // Environment Call and Breakpoints
     riscv.ecall : () -> ()
-    // CHECK-NEXT: riscv.ecall : () -> ()
     riscv.ebreak : () -> ()
-    // CHECK-NEXT: riscv.ebreak : () -> ()
-    riscv.directive ".bss": () -> ()
-    // CHECK-NEXT: riscv.directive ".bss" : () -> ()
+    riscv.directive ".bss" : () -> ()
     riscv.directive ".align" "2" : () -> ()
-    // CHECK-NEXT: riscv.directive ".align" "2" : () -> ()
     riscv.assembly_section ".text" attributes {"foo" = i32} {
       %nested_li = riscv.li 1 : () -> !riscv.reg<>
     }
-    // CHECK-NEXT:  riscv.assembly_section ".text" attributes {"foo" = i32} {
     // CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
-    // CHECK-NEXT:  }
     
     riscv.assembly_section ".text" {
       %nested_li = riscv.li 1 : () -> !riscv.reg<>
     }
-    // CHECK-NEXT:  riscv.assembly_section ".text" {
     // CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
-    // CHECK-NEXT:  }
 
     // Custom instruction
     %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
-    // CHECK-NEXT:   %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
 
 
     // RISC-V extensions
     riscv.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> ()
 
     // RV32F: 8 “F” Standard Extension for Single-Precision Floating-Point, Version 2.0
     %f0 = riscv.get_float_register : () -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
     %f1 = riscv.get_float_register : () -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
     %f2 = riscv.get_float_register : () -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
 
     %fmadd_s = riscv.fmadd.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fmsub_s = riscv.fmsub.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmsub.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fnmsub_s = riscv.fnmsub.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fnmsub.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fnmadd_s = riscv.fnmadd.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fnmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %fadd_s = riscv.fadd.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fsub_s = riscv.fsub.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fmul_s = riscv.fmul.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fdiv_s = riscv.fdiv.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fsqrt_s = riscv.fsqrt.s %f0 : (!riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsqrt.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
 
     %fsgnj_s = riscv.fsgnj.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnj.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fsgnjn_s = riscv.fsgnjn.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnjn.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fsgnjx_s = riscv.fsgnjx.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnjx.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %fmin_s = riscv.fmin.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fmax_s = riscv.fmax.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %fcvt_w_s = riscv.fcvt.w.s %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
     %fcvt_wu_s = riscv.fcvt.wu.s %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.wu.s %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
     %fmv_x_w = riscv.fmv.x.w %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.x.w %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
 
     %feq_s = riscv.feq.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %flt_s = riscv.flt.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %fle_s = riscv.fle.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %fclass_s = riscv.fclass.s %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fclass.s %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
     %fcvt_s_w = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
     %fcvt_s_wu = riscv.fcvt.s.wu %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.wu %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
     %fmv_w_x = riscv.fmv.w.x %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.w.x %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
 
     %flw = riscv.flw %0, 1 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flw %{{.*}}, 1 : (!riscv.reg<>) -> !riscv.freg<>
     riscv.fsw %0, %f0, 1 : (!riscv.reg<>, !riscv.freg<>) -> ()
-    // CHECK-NEXT: riscv.fsw %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.freg<>) -> ()
 
     // Terminate block
     riscv.ret : () -> ()
   }) : () -> ()
-}) : () -> ()
+}
 
 // CHECK-GENERIC: "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   "riscv.label"() ({

--- a/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
+++ b/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --print-op-generic %s | xdsl-opt | filecheck %s
+// RUN: XDSL_ROUNDTRIP
 
 builtin.module {
 

--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -1,44 +1,23 @@
-// RUN: XDSL_ROUNDTRIP
-"builtin.module"() ({
-    %lb = "riscv.li"() {"immediate" = 0: i32} : () -> !riscv.reg<>
-    %ub = "riscv.li"() {"immediate" = 100: i32} : () -> !riscv.reg<>
-    %step = "riscv.li"() {"immediate" = 1: i32} : () -> !riscv.reg<>
-    %acc = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<t0>
-    "riscv_scf.for"(%lb, %ub, %step) ({
-        ^1(%i: !riscv.reg<>):
-            "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
-            "riscv_scf.yield"() : () -> ()
-    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-    %i_last, %ub_last, %step_last = "riscv_scf.while"(%lb, %ub, %step) ({
-        ^1(%i0 : !riscv.reg<>, %ub_arg0 : !riscv.reg<>, %step_arg0 : !riscv.reg<>):
-            %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-            "riscv_scf.condition"(%cond, %i0, %ub_arg0, %step_arg0) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-    }, {
-        ^2(%i1 : !riscv.reg<>, %ub_arg1 : !riscv.reg<>, %step_arg1 : !riscv.reg<>):
-            "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
-            %i_next = "riscv.add"(%i1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-            "riscv_scf.yield"(%i_next, %ub_arg1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-}) : () -> ()
+// RUN: XDSL_AUTO_ROUNDTRIP
 
-// CHECK:      builtin.module {
-// CHECK-NEXT:   %lb = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %ub = riscv.li 100 : () -> !riscv.reg<>
-// CHECK-NEXT:   %step = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:   %acc = riscv.li 0 : () -> !riscv.reg<t0>
-// CHECK-NEXT:   "riscv_scf.for"(%lb, %ub, %step) ({
-// CHECK-NEXT:   ^0(%i : !riscv.reg<>):
-// CHECK-NEXT:     %0 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
-// CHECK-NEXT:     "riscv_scf.yield"() : () -> ()
-// CHECK-NEXT:   }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:     %i_last, %ub_last, %step_last = "riscv_scf.while"(%lb, %ub, %step) ({
-// CHECK-NEXT:         ^1(%i0 : !riscv.reg<>, %ub_arg0 : !riscv.reg<>, %step_arg0 : !riscv.reg<>):
-// CHECK-NEXT:             %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:             "riscv_scf.condition"(%cond, %i0, %ub_arg0, %step_arg0) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:     }, {
-// CHECK-NEXT:         ^2(%i1 : !riscv.reg<>, %ub_arg1 : !riscv.reg<>, %step_arg1 : !riscv.reg<>):
-// CHECK-NEXT:             riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
-// CHECK-NEXT:             %i_next = riscv.add %i1, %step_arg1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:             "riscv_scf.yield"(%i_next, %ub_arg1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:     }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT: }
+builtin.module {
+  %lb = riscv.li 0 : () -> !riscv.reg<>
+  %ub = riscv.li 100 : () -> !riscv.reg<>
+  %step = riscv.li 1 : () -> !riscv.reg<>
+  %acc = riscv.li 0 : () -> !riscv.reg<t0>
+  "riscv_scf.for"(%lb, %ub, %step) ({
+  ^0(%i : !riscv.reg<>):
+    %0 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+    "riscv_scf.yield"() : () -> ()
+  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  %i_last, %ub_last, %step_last = "riscv_scf.while"(%lb, %ub, %step) ({
+  ^1(%i0 : !riscv.reg<>, %ub_arg0 : !riscv.reg<>, %step_arg0 : !riscv.reg<>):
+    %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    "riscv_scf.condition"(%cond, %i0, %ub_arg0, %step_arg0) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  }, {
+  ^2(%i1 : !riscv.reg<>, %ub_arg1 : !riscv.reg<>, %step_arg1 : !riscv.reg<>):
+    %1 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+    %i_next = riscv.add %i1, %step_arg1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    "riscv_scf.yield"(%i_next, %ub_arg1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+}

--- a/tests/filecheck/dialects/scf/reduce.mlir
+++ b/tests/filecheck/dialects/scf/reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
   %0 = arith.constant 0 : index
@@ -16,20 +16,3 @@ builtin.module {
     "scf.yield"() : () -> ()
   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
 }
-
-// CHECK:      builtin.module {
-// CHECK-NEXT:   %0 = arith.constant 0 : index
-// CHECK-NEXT:   %1 = arith.constant 1000 : index
-// CHECK-NEXT:   %2 = arith.constant 3 : index
-// CHECK-NEXT:   %3 = arith.constant 1.020000e+01 : f32
-// CHECK-NEXT:   %4 = arith.constant 1.810000e+01 : f32
-// CHECK-NEXT:   %5 = "scf.parallel"(%0, %1, %2, %3) ({
-// CHECK-NEXT:   ^0(%6 : index):
-// CHECK-NEXT:     "scf.reduce"(%4) ({
-// CHECK-NEXT:     ^1(%7 : f32, %8 : f32):
-// CHECK-NEXT:       %9 = arith.addf %7, %8 : f32
-// CHECK-NEXT:       "scf.reduce.return"(%9) : (f32) -> ()
-// CHECK-NEXT:     }) : (f32) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
-// CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
-// CHECK-NEXT: 

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -1,8 +1,7 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 
 builtin.module {
-
 
   %0 = "test.op"() : () -> i1
   "scf.if"(%0) ({
@@ -13,15 +12,6 @@ builtin.module {
     "scf.yield"() : () -> ()
   }) : (i1) -> ()
 
-  // CHECK:      %{{.*}} = "test.op"() : () -> i1
-  // CHECK-NEXT: "scf.if"(%{{.*}}) ({
-  // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"() : () -> ()
-  // CHECK-NEXT: }, {
-  // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"() : () -> ()
-  // CHECK-NEXT: }) : (i1) -> ()
-
 
   %3 = "scf.if"(%0) ({
     %4 = "test.op"() : () -> i32
@@ -30,15 +20,6 @@ builtin.module {
     %5 = "test.op"() : () -> i32
     "scf.yield"(%5) : (i32) -> ()
   }) : (i1) -> i32
-
-
-  // CHECK:      %{{.*}} = "scf.if"(%{{.*}}) ({
-  // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"(%{{.*}}) : (i32) -> ()
-  // CHECK-NEXT: }, {
-  // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"(%{{.*}}) : (i32) -> ()
-  // CHECK-NEXT: }) : (i1) -> i32
 
   func.func @while() {
     %init = arith.constant 0 : i32
@@ -54,54 +35,22 @@ builtin.module {
     func.return
   }
 
-  // CHECK:      func.func @while() {
-  // CHECK-NEXT:   %{{.*}} = arith.constant 0 : i32
-  // CHECK-NEXT:   %{{.*}} = "scf.while"(%{{.*}}) ({
-  // CHECK-NEXT:   ^{{.*}}(%{{.*}} : i32):
-  // CHECK-NEXT:     %{{.*}} = arith.constant 0 : i32
-  // CHECK-NEXT:     %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) {"predicate" = 1 : i64} : (i32, i32) -> i1
-  // CHECK-NEXT:     "scf.condition"(%{{.*}}, %{{.*}}) : (i1, i32) -> ()
-  // CHECK-NEXT:   }, {
-  // CHECK-NEXT:   ^{{.*}}(%{{.*}} : i32):
-  // CHECK-NEXT:     "scf.yield"(%{{.*}}) : (i32) -> ()
-  // CHECK-NEXT:   }) : (i32) -> i32
-  // CHECK-NEXT:   func.return
-  // CHECK-NEXT: }
-
-
   func.func @while2() {
-    %a = "arith.constant"() {value = 1.000000e+00 : f32} : () -> f32
-    %b = "arith.constant"() {value = 32 : i32} : () -> i32
-    %2:2 = "scf.while"(%b, %a) ({
-    ^bb0(%arg0: i32, %arg1: f32):
-      %c = "arith.constant"() {value = 0 : i32} : () -> i32
-      %d = "arith.cmpi"(%arg0, %c) {predicate = 0 : i64} : (i32, i32) -> i1
+    %a = arith.constant 1.000000e+00 : f32
+    %b = arith.constant 32 : i32
+    %6, %7 = "scf.while"(%b, %a) ({
+    ^2(%arg0 : i32, %arg1 : f32):
+      %c_1 = arith.constant 0 : i32
+      %d = "arith.cmpi"(%arg0, %c_1) {"predicate" = 0 : i64} : (i32, i32) -> i1
       "scf.condition"(%d, %arg0, %arg1) : (i1, i32, f32) -> ()
     }, {
-    ^bb0(%arg0: i32, %arg1: f32):
-      %c = "arith.constant"() {value = 1.000000e+00 : f32} : () -> f32
-      %d = "arith.addf"(%c, %arg1) {fastmath = #arith.fastmath<none>} : (f32, f32) -> f32
-      "scf.yield"(%arg0, %d) : (i32, f32) -> ()
+    ^3(%arg0_1 : i32, %arg1_1 : f32):
+      %c_2 = arith.constant 1.000000e+00 : f32
+      %d_1 = arith.addf %c_2, %arg1_1 : f32
+      "scf.yield"(%arg0_1, %d_1) : (i32, f32) -> ()
     }) : (i32, f32) -> (i32, f32)
     func.return
   }
-
-  // CHECK-NEXT:  func.func @while2() {
-  // CHECK-NEXT:    %{{.*}} = arith.constant 1.000000e+00 : f32
-  // CHECK-NEXT:    %{{.*}} = arith.constant 32 : i32
-  // CHECK-NEXT:    %6, %7 = "scf.while"(%{{.*}}, %{{.*}}) ({
-  // CHECK-NEXT:    ^{{.*}}(%{{.*}} : i32, %{{.*}} : f32):
-  // CHECK-NEXT:      %{{.*}} = arith.constant 0 : i32
-  // CHECK-NEXT:      %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) {"predicate" = 0 : i64} : (i32, i32) -> i1
-  // CHECK-NEXT:      "scf.condition"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, f32) -> ()
-  // CHECK-NEXT:    }, {
-  // CHECK-NEXT:    ^3(%{{.*}} : i32, %{{.*}} : f32):
-  // CHECK-NEXT:      %{{.*}} = arith.constant 1.000000e+00 : f32
-  // CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
-  // CHECK-NEXT:      "scf.yield"(%{{.*}}, %{{.*}}) : (i32, f32) -> ()
-  // CHECK-NEXT:    }) : (i32, f32) -> (i32, f32)
-  // CHECK-NEXT:    func.return
-  // CHECK-NEXT:  }
 
   func.func @for() {
     %lb = arith.constant 0 : index
@@ -109,25 +58,10 @@ builtin.module {
     %s = arith.constant 3 : index
     %prod = arith.constant 1 : index
     %res_1 = "scf.for"(%lb, %ub, %s, %prod) ({
-    ^2(%iv : index, %prod_iter : index):
+    ^4(%iv : index, %prod_iter : index):
       %prod_new = arith.muli %prod_iter, %iv : index
       "scf.yield"(%prod_new) : (index) -> ()
     }) : (index, index, index, index) -> index
     func.return
   }
-
-  // CHECK-NEXT: func.func @for() {
-  // CHECK-NEXT:   %{{.*}} = arith.constant 0 : index
-  // CHECK-NEXT:   %{{.*}} = arith.constant 42 : index
-  // CHECK-NEXT:   %{{.*}} = arith.constant 3 : index
-  // CHECK-NEXT:   %{{.*}} = arith.constant 1 : index
-  // CHECK-NEXT:   %{{.*}} = "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) ({
-  // CHECK-NEXT:   ^{{.*}}(%{{.*}} : index, %{{.*}} : index):
-  // CHECK-NEXT:     %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
-  // CHECK-NEXT:     "scf.yield"(%{{.*}}) : (index) -> ()
-  // CHECK-NEXT:   }) : (index, index, index, index) -> index
-  // CHECK-NEXT:   func.return
-  // CHECK-NEXT: }
-
-
 }

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,5 +1,5 @@
-// RUN: XDSL_ROUNDTRIP
-"builtin.module"() ({
+// RUN: XDSL_AUTO_ROUNDTRIP
+builtin.module {
   %addr = "test.op"() : () -> !riscv.reg<>
   %stream = "test.op"() : () -> !riscv.reg<>
   %bound = "test.op"() : () -> !riscv.reg<>
@@ -7,17 +7,10 @@
   %rep = "test.op"() : () -> !riscv.reg<>
   // Usual SSR setup sequence:
   "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_enable"() : () -> ()
-  // CHECK-NEXT: "snitch.ssr_enable"() : () -> ()
   "snitch.ssr_disable"() : () -> ()
-  // CHECK-NEXT: "snitch.ssr_disable"() : () -> ()
-}) : () -> ()
+}

--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -1,121 +1,80 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 builtin.module {
   func.func @main() {
         // Barriers
         "snrt.cluster_hw_barrier"() : () -> ()
-        // CHECK: "snrt.cluster_hw_barrier"() : () -> ()
         "snrt.cluster_sw_barrier"() : () -> ()
-        // CHECK: "snrt.cluster_sw_barrier"() : () -> ()
         "snrt.global_barrier"() : () -> ()
-        // CHECK: "snrt.global_barrier"() : () -> ()
 
         // Runtime Info Getters
         %global_core_base_hartid = "snrt.global_core_base_hartid"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.global_core_base_hartid"() : () -> i32
         %global_core_idx = "snrt.global_core_idx"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.global_core_idx"() : () -> i32
         %global_core_num = "snrt.global_core_num"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.global_core_num"() : () -> i32
         %global_compute_core_idx = "snrt.global_compute_core_idx"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.global_compute_core_idx"() : () -> i32
         %global_compute_core_num = "snrt.global_compute_core_num"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.global_compute_core_num"() : () -> i32
         %global_dm_core_idx = "snrt.global_dm_core_idx"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.global_dm_core_idx"() : () -> i32
         %global_dm_core_num = "snrt.global_dm_core_num"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.global_dm_core_num"() : () -> i32
         %cluster_core_base_hartid = "snrt.cluster_core_base_hartid"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_core_base_hartid"() : () -> i32
         %gcluster_core_idx = "snrt.cluster_core_idx"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_core_idx"() : () -> i32
         %cluster_core_num = "snrt.cluster_core_num"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_core_num"() : () -> i32
         %cluster_compute_core_idx = "snrt.cluster_compute_core_idx"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_compute_core_idx"() : () -> i32
         %cluster_compute_core_num = "snrt.cluster_compute_core_num"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_compute_core_num"() : () -> i32
         %cluster_dm_core_idx = "snrt.cluster_dm_core_idx"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_dm_core_idx"() : () -> i32
         %cluster_dm_core_num = "snrt.cluster_dm_core_num"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_dm_core_num"() : () -> i32
         %cluster_idx = "snrt.cluster_idx"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_idx"() : () -> i32
         %cluster_num = "snrt.cluster_num"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.cluster_num"() : () -> i32
         %is_compute_core = "snrt.is_compute_core"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.is_compute_core"() : () -> i32
         %is_dm_core = "snrt.is_dm_core"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.is_dm_core"() : () -> i32
 
         %barrier_reg_ptr = "snrt.barrier_reg_ptr"() : () -> i32
-        // CHECK: %{{.*}} = "snrt.barrier_reg_ptr"() : () -> i32
         %global_memory0, %global_memory1 = "snrt.global_memory"() : () -> (i64, i64)
-        // CHECK: %{{.*}}, %{{.*}} = "snrt.global_memory"() : () -> (i64, i64)
         %cluster_memory0, %cluster_memory1 = "snrt.cluster_memory"() : () -> (i64, i64)
-        // CHECK: %{{.*}}, %{{.*}} = "snrt.cluster_memory"() : () -> (i64, i64)
         %zero_memory0, %zero_memory1 = "snrt.zero_memory"() : () -> (i64, i64)
-        // CHECK: %{{.*}}, %{{.*}} = "snrt.zero_memory"() : () -> (i64, i64)
 
         // DMA Operations
         %dst_64 = arith.constant 100 : i64
         %src_64 = arith.constant 0 : i64
         %size = arith.constant 100 : index
         %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, index) -> i32
-        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, index) -> i32
         %dst_32 = arith.constant 100 : i32
         %src_32 = arith.constant 0 : i32
         %size_2 = arith.constant 100 : index
         %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (i32, i32, index) -> i32
-        // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (i32, i32, index) -> i32
         "snrt.dma_wait"(%transfer_id) : (i32) -> ()
-        // CHECK: "snrt.dma_wait"(%transfer_id) : (i32) -> ()
         %repeat = arith.constant 1 : index
         %src_stride = arith.constant 1 : index
         %dst_stride = arith.constant 1 : index
         %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (i64, i64, index, index, index, index) -> i32
-        // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (i64, i64, index, index, index, index) -> i32
         %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, index, index, index, index) -> i32
-        // CHECK: transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, index, index, index, index) -> i32
         "snrt.dma_wait_all"() : () -> ()
-        // CHECK: "snrt.dma_wait_all"() : () -> ()
 
         // SSR Operations
         %dm = arith.constant 0 : i32
         %b0 = arith.constant 100 : index
         %i0 = arith.constant 101 : index
         "snrt.ssr_loop_1d"(%dm, %b0, %i0) {"operand_segment_sizes" = array<i32: 1, 1, 1>} : (i32, index, index) -> ()
-        // CHECK: "snrt.ssr_loop_1d"(%dm, %b0, %i0) {"operand_segment_sizes" = array<i32: 1, 1, 1>} : (i32, index, index) -> ()
         %b1 = arith.constant 102 : index
         %i1 = arith.constant 103 : index
         "snrt.ssr_loop_2d"(%dm, %b0, %b1, %i0, %i1) {"operand_segment_sizes" = array<i32: 1, 2, 2>}  : (i32, index, index, index, index) -> ()
-        // CHECK: "snrt.ssr_loop_2d"(%dm, %b0, %b1, %i0, %i1) {"operand_segment_sizes" = array<i32: 1, 2, 2>}  : (i32, index, index, index, index) -> ()
         %b2 = arith.constant 104 : index
         %i2 = arith.constant 105 : index
         "snrt.ssr_loop_3d"(%dm, %b0, %b1, %b2, %i0, %i1, %i2) {"operand_segment_sizes" = array<i32: 1, 3, 3>} : (i32, index, index, index, index, index, index) -> ()
-        // CHECK: "snrt.ssr_loop_3d"(%dm, %b0, %b1, %b2, %i0, %i1, %i2) {"operand_segment_sizes" = array<i32: 1, 3, 3>} : (i32, index, index, index, index, index, index) -> ()
         %b3 = arith.constant 106 : index
         %i3 = arith.constant 107 : index
         "snrt.ssr_loop_4d"(%dm, %b0, %b1, %b2, %b3, %i0, %i1, %i2, %i3) {"operand_segment_sizes" = array<i32: 1, 4, 4>} : (i32, index, index, index, index, index, index, index, index) -> ()
-        //CHECK: "snrt.ssr_loop_4d"(%dm, %b0, %b1, %b2, %b3, %i0, %i1, %i2, %i3) {"operand_segment_sizes" = array<i32: 1, 4, 4>} : (i32, index, index, index, index, index, index, index, index) -> ()
         %dm2 = arith.constant 1 : i32
         %count = arith.constant 20 : index
         "snrt.ssr_repeat"(%dm2, %count) : (i32, index) -> ()
-        // CHECK: "snrt.ssr_repeat"(%dm2, %count) : (i32, index) -> ()
         "snrt.ssr_enable"() : () -> ()
-        // CHECK: "snrt.ssr_enable"() : () -> ()
         "snrt.ssr_disable"() : () -> ()
-        // CHECK: "snrt.ssr_disable"() : () -> ()
         %dm3 = arith.constant 2 : i32
         %dim = arith.constant 1 : i32
         %ptr = arith.constant 0 : i32
         "snrt.ssr_read"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
-        // CHECK: "snrt.ssr_read"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
         "snrt.ssr_write"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
-        // CHECK: "snrt.ssr_write"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
         "snrt.fpu_fence"() : () -> ()
-        // CHECK: "snrt.fpu_fence"() : () -> ()
 
 
-        "func.return"() : () -> ()
+        func.return
     }
 }

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
   func.func @stencil_copy(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>) {
@@ -15,22 +15,6 @@ builtin.module {
     func.return
   }
 }
-
-// CHECK:      builtin.module {
-// CHECK-NEXT:   func.func @stencil_copy(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>) {
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
-// CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^0(%6 : !stencil.temp<[0,64]x[0,64]x[0,64]xf64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.store_result"(%7) : (f64) -> !stencil.result<f64>
-// CHECK-NEXT:       "stencil.return"(%8) : (!stencil.result<f64>) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,64]xf64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 64>} : (!stencil.temp<[0,64]x[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> ()
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 // -----
 
@@ -56,28 +40,6 @@ builtin.module {
   }
 }
 
-// CHECK: builtin.module {
-// CHECK-NEXT:   func.func private @myfunc(%b0 : !stencil.field<?x?x?xf32>, %b1 : !stencil.field<?x?x?xf32>)  attributes {"param_names" = ["data"]}{
-// CHECK-NEXT:     %f0 = "stencil.cast"(%b0) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
-// CHECK-NEXT:     %f1 = "stencil.cast"(%b1) : (!stencil.field<?x?x?xf32>) -> !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
-// CHECK-NEXT:     %time_m = arith.constant 0 : index
-// CHECK-NEXT:     %time_M = arith.constant 1000 : index
-// CHECK-NEXT:     %step = arith.constant 1 : index
-// CHECK-NEXT:     %fnp1, %fn = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
-// CHECK-NEXT:     ^0(%time : index, %fi : !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, %fip1 : !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>):
-// CHECK-NEXT:       %ti = "stencil.load"(%fi) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
-// CHECK-NEXT:       %tip1 = "stencil.apply"(%ti) ({
-// CHECK-NEXT:       ^1(%ti_ : !stencil.temp<?x?x?xf32>):
-// CHECK-NEXT:         %v = "stencil.access"(%ti_) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf32>) -> f32
-// CHECK-NEXT:         "stencil.return"(%v) : (f32) -> ()
-// CHECK-NEXT:       }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
-// CHECK-NEXT:       "stencil.store"(%tip1, %fip1) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
-// CHECK-NEXT:       "scf.yield"(%fip1, %fi) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
-// CHECK-NEXT:     }) : (index, index, index, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>)
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
-
 // -----
 
 builtin.module {
@@ -95,7 +57,7 @@ builtin.module {
       %12 = arith.addf %7, %8 : f64
       %13 = arith.addf %9, %10 : f64
       %14 = arith.addf %12, %13 : f64
-      %15 = arith.constant -4.0 : f64
+      %15 = arith.constant -4.000000e+00 : f64
       %16 = arith.mulf %11, %15 : f64
       %17 = arith.mulf %16, %13 : f64
       "stencil.return"(%17) : (f64) -> ()
@@ -104,31 +66,6 @@ builtin.module {
     func.return
   }
 }
-
-// CHECK:      builtin.module {
-// CHECK-NEXT:   func.func private @stencil_laplace(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>) {
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
-// CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^0(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
-// CHECK-NEXT:       %8 = "stencil.access"(%6) {"offset" = #stencil.index<1, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
-// CHECK-NEXT:       %9 = "stencil.access"(%6) {"offset" = #stencil.index<0, 1>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
-// CHECK-NEXT:       %10 = "stencil.access"(%6) {"offset" = #stencil.index<0, -1>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
-// CHECK-NEXT:       %11 = "stencil.access"(%6) {"offset" = #stencil.index<0, 0>} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
-// CHECK-NEXT:       %12 = arith.addf %7, %8 : f64
-// CHECK-NEXT:       %13 = arith.addf %9, %10 : f64
-// CHECK-NEXT:       %14 = arith.addf %12, %13 : f64
-// CHECK-NEXT:       %15 = arith.constant -4.000000e+00 : f64
-// CHECK-NEXT:       %16 = arith.mulf %11, %15 : f64
-// CHECK-NEXT:       %17 = arith.mulf %16, %13 : f64
-// CHECK-NEXT:       "stencil.return"(%17) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 // -----
 
@@ -153,25 +90,6 @@ builtin.module {
   }
 }
 
-// CHECK:      builtin.module {
-// CHECK-NEXT:   func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>) {
-// CHECK-NEXT:     %2 = "stencil.load"(%0) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     %3 = "stencil.apply"(%2) ({
-// CHECK-NEXT:     ^0(%4 : !stencil.temp<?xf64>):
-// CHECK-NEXT:       %5 = "stencil.access"(%4) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
-// CHECK-NEXT:       "stencil.return"(%5) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     %6 = "stencil.buffer"(%3) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     %7 = "stencil.apply"(%6) ({
-// CHECK-NEXT:     ^1(%8 : !stencil.temp<?xf64>):
-// CHECK-NEXT:       %9 = "stencil.access"(%8) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
-// CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
-
 // -----
 
 builtin.module {
@@ -188,18 +106,3 @@ builtin.module {
     func.return
   }
 }
-
-// CHECK:      builtin.module {
-// CHECK-NEXT:   func.func private @stencil_offset_mapping(%0 : !stencil.field<?x?xf64>, %1 : !stencil.field<?x?xf64>) {
-// CHECK-NEXT:     %2 = "stencil.cast"(%0) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %3 = "stencil.cast"(%1) : (!stencil.field<?x?xf64>) -> !stencil.field<[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:     %4 = "stencil.load"(%2) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<[-1,65]x[-1,65]xf64>
-// CHECK-NEXT:     %5 = "stencil.apply"(%4) ({
-// CHECK-NEXT:     ^0(%6 : !stencil.temp<[-1,65]x[-1,65]xf64>):
-// CHECK-NEXT:       %7 = "stencil.access"(%6) {"offset" = #stencil.index<-1, 0>, "offset_mapping" = [#int<1>, #int<0>]} : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> f64
-// CHECK-NEXT:       "stencil.return"(%7) : (f64) -> ()
-// CHECK-NEXT:     }) : (!stencil.temp<[-1,65]x[-1,65]xf64>) -> !stencil.temp<[0,64]x[0,64]xf64>
-// CHECK-NEXT:     "stencil.store"(%5, %3) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<[0,64]x[0,64]xf64>, !stencil.field<[-4,68]x[-4,68]xf64>) -> ()
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }

--- a/tests/filecheck/dialects/vector/vector_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_AUTO_ROUNDTRIP
 
 builtin.module {
   func.func private @vector_test(%0 : memref<4x4xindex>, %1 : vector<1xi1>, %2 : index) {
@@ -13,18 +13,3 @@ builtin.module {
     func.return
   }
 }
-
-
-// CHECK:      builtin.module {
-// CHECK-NEXT:   func.func private @vector_test(%0 : memref<4x4xindex>, %1 : vector<1xi1>, %2 : index) {
-// CHECK-NEXT:     %3 = "vector.load"(%0, %2, %2) : (memref<4x4xindex>, index, index) -> vector<2xindex>
-// CHECK-NEXT:     "vector.store"(%3, %0, %2, %2) : (vector<2xindex>, memref<4x4xindex>, index, index) -> ()
-// CHECK-NEXT:     %4 = "vector.broadcast"(%2) : (index) -> vector<1xindex>
-// CHECK-NEXT:     %5 = "vector.fma"(%3, %3, %3) : (vector<2xindex>, vector<2xindex>, vector<2xindex>) -> vector<2xindex>
-// CHECK-NEXT:     %6 = "vector.maskedload"(%0, %2, %2, %1, %4) : (memref<4x4xindex>, index, index, vector<1xi1>, vector<1xindex>) -> vector<1xindex>
-// CHECK-NEXT:     "vector.maskedstore"(%0, %2, %2, %1, %6) : (memref<4x4xindex>, index, index, vector<1xi1>, vector<1xindex>) -> ()
-// CHECK-NEXT:     "vector.print"(%6) : (vector<1xindex>) -> ()
-// CHECK-NEXT:     %7 = "vector.create_mask"(%2) : (index) -> vector<2xi1>
-// CHECK-NEXT:     func.return
-// CHECK-NEXT:   }
-// CHECK-NEXT: }

--- a/tests/filecheck/filecheckize
+++ b/tests/filecheck/filecheckize
@@ -1,0 +1,8 @@
+# First, ignore all whitesapce-only lines
+/^\s*$/ { next }
+# Then, keep all filesplit markers (// ----) lines and also prepend a newline (To match xDSL's output)
+/^\s*\/\/ \-\-\-\-\-\s*$/ {print "\n"$0; next}
+# Then, ignore all remaining comment lines
+/^\s*\/\/.*/ { next }
+# Then, just CHECK-NEXT: everything that remains!
+{ print "//CHECK-NEXT: "$0 }

--- a/tests/filecheck/filecheckize
+++ b/tests/filecheck/filecheckize
@@ -1,19 +1,50 @@
-# First, ignore all whitesapce-only lines
-/^\s*$/ { next }
-# Then, keep all filesplit markers (// ----) lines and also prepend a newline (To match xDSL's output)
-/^\s*\/\/ \-\-\-\-\-\s*$/ {print "//CHECK-NEXT: \n//CHECK-NEXT: "$0; next}
-# Then, ignore all remaining comment lines
-/^\s*\/\/.*/ { next }
+#!/usr/bin/env python3
+import argparse
+import re
+import sys
+from io import TextIOWrapper
+from typing import cast
 
-{
-# Anonymize SSA value names, as in
-# """percent-ident  ::= `%` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)"""
-gsub(/%([[:digit:]]+|[[:alpha:]$._-][[:alnum:]$._-]*)/, "%{{.*}}");
 
-# Anonymize basic blocks names, as in
-# """caret-ident  ::= `^` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)"""
-gsub(/\^([[:digit:]]+|[[:alpha:]$._-][[:alnum:]$._-]*)/, "^{{.*}}");
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "file", type=argparse.FileType("r"), default=sys.stdin, nargs="?"
+    )
+    args = parser.parse_args(sys.argv[1:])
 
-# Then, just CHECK-NEXT: everything that remains!
-print "//CHECK-NEXT: "$0
-}
+    comment_line = re.compile(r"^\s*\/\/.*")
+    ssa_value_name = re.compile(r"%([\d]+|[\w$._-][\w\d$._-]*)")
+    basic_block_name = re.compile(r"\^([\d]+|[\w$._-][\w\d$._-]*)")
+
+    for line in cast(TextIOWrapper, args.file):
+        line = line.rstrip()
+
+        # Ignore whitespace-only lines
+        # xDSL doesn't print spacing blank lines between ops or regions
+        if not line:
+            continue
+
+        # Keep filesplit markers and prepend newlines
+        # This is the only place where xDSL prints blank lines.
+        if line == "// -----":
+            print("//CHECK-NEXT:")
+            print("//CHECK-NEXT: // -----")
+            continue
+
+        # Ignore remaining comment lines
+        if re.match(comment_line, line):
+            continue
+
+        # Anonymize SSA value names
+        line = re.sub(ssa_value_name, r"%{{.*}}", line)
+
+        # Anonymize basic blocks names
+        line = re.sub(basic_block_name, r"^{{.*}}", line)
+
+        # Print the modified line
+        print("//CHECK-NEXT:", line)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/filecheck/filecheckize
+++ b/tests/filecheck/filecheckize
@@ -1,7 +1,7 @@
 # First, ignore all whitesapce-only lines
 /^\s*$/ { next }
 # Then, keep all filesplit markers (// ----) lines and also prepend a newline (To match xDSL's output)
-/^\s*\/\/ \-\-\-\-\-\s*$/ {print "\n"$0; next}
+/^\s*\/\/ \-\-\-\-\-\s*$/ {print "//CHECK-NEXT: \n//CHECK-NEXT: "$0; next}
 # Then, ignore all remaining comment lines
 /^\s*\/\/.*/ { next }
 

--- a/tests/filecheck/filecheckize
+++ b/tests/filecheck/filecheckize
@@ -4,5 +4,16 @@
 /^\s*\/\/ \-\-\-\-\-\s*$/ {print "\n"$0; next}
 # Then, ignore all remaining comment lines
 /^\s*\/\/.*/ { next }
+
+{
+# Anonymize SSA value names, as in
+# """percent-ident  ::= `%` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)"""
+gsub(/%([[:digit:]]+|[[:alpha:]$._-][[:alnum:]$._-]*)/, "%{{.*}}");
+
+# Anonymize basic blocks names, as in
+# """caret-ident  ::= `^` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)"""
+gsub(/\^([[:digit:]]+|[[:alpha:]$._-][[:alnum:]$._-]*)/, "^{{.*}}");
+
 # Then, just CHECK-NEXT: everything that remains!
-{ print "//CHECK-NEXT: "$0 }
+print "//CHECK-NEXT: "$0
+}

--- a/tests/filecheck/filecheckize
+++ b/tests/filecheck/filecheckize
@@ -28,7 +28,7 @@ def main():
         # Keep filesplit markers and prepend newlines
         # This is the only place where xDSL prints blank lines.
         if line == "// -----":
-            print("//CHECK-NEXT:")
+            print("//CHECK-EMPTY:")
             print("//CHECK-NEXT: // -----")
             continue
 

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -13,7 +13,7 @@ xdsl_run = "xdsl/tools/xdsl_run.py"
 irdl_to_pyrdl = "xdsl/tools/irdl_to_pyrdl.py"
 
 config.substitutions.append(('XDSL_ROUNDTRIP', "xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %s"))
-config.substitutions.append(('XDSL_AUTO_ROUNDTRIP', r'awk -f tests/filecheck/filecheckize %s > %t && xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %t'))
+config.substitutions.append(('XDSL_AUTO_ROUNDTRIP', r'./tests/filecheck/filecheckize %s > %t && xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %t'))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "xdsl-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))
 if "COVERAGE" in lit_config.params:
     config.substitutions.append(('xdsl-opt', f"coverage run {xdsl_opt}"))

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -12,7 +12,8 @@ xdsl_opt = "xdsl/tools/xdsl-opt"
 xdsl_run = "xdsl/tools/xdsl_run.py"
 irdl_to_pyrdl = "xdsl/tools/irdl_to_pyrdl.py"
 
-config.substitutions.append(('XDSL_ROUNDTRIP', r'awk -f tests/filecheck/filecheckize %s > %t && xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %t'))
+config.substitutions.append(('XDSL_ROUNDTRIP', "xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %s"))
+config.substitutions.append(('XDSL_AUTO_ROUNDTRIP', r'awk -f tests/filecheck/filecheckize %s > %t && xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %t'))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "xdsl-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))
 if "COVERAGE" in lit_config.params:
     config.substitutions.append(('xdsl-opt', f"coverage run {xdsl_opt}"))

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -12,7 +12,7 @@ xdsl_opt = "xdsl/tools/xdsl-opt"
 xdsl_run = "xdsl/tools/xdsl_run.py"
 irdl_to_pyrdl = "xdsl/tools/irdl_to_pyrdl.py"
 
-config.substitutions.append(('XDSL_ROUNDTRIP', "xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %s"))
+config.substitutions.append(('XDSL_ROUNDTRIP', r'awk -f tests/filecheck/filecheckize %s > %t && xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %t'))
 config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "xdsl-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))
 if "COVERAGE" in lit_config.params:
     config.substitutions.append(('xdsl-opt', f"coverage run {xdsl_opt}"))


### PR DESCRIPTION
expose [`XDSL_AUTO_ROUNDTRIP` as a "lit command"](https://github.com/xdslproject/xdsl/pull/1497/files#diff-bbaa84334eea3850bf51e619d06018936c9edafd790020747219e8642bf560e1) and a [a Python script for automatic filecheck file generation](https://github.com/xdslproject/xdsl/pull/1497/files#diff-f1687e8b78d5088d551f59f4e7f69d39a29f2cfefd4475d974a37ab78c971a5b).

This command takes an `.mlir` file, automatically generates an exact filecheck file for it and filecheck a custom syntax roundtrip against it. What do we get from that?

- burning 800 lines of boring-to-maintain `//CHECK:` lines in our test files :blush: 
-  Way stricter checks: the input is now expected to be the exact output. This already uncovered some cornercase errors, such as  `pdl.replace` having a `printer` method instead of `print` (so effectively no custom syntax printing)

Things it does **not** cost:

- This compose well with the actual current usage of filechecks. Meaning, you can have normal `// RUN: ` commands, with normal ` // CHECK:` /  `// CUSTOMPREFIX:` *alongside* this `// RUN: XDSL_AUTO_ROUNDTRIP`. Because the filecheck generation just strip all that, those won't interfere w/ each other. (Tested, can't remember if I actually use it in the PR or not though)

More likely-controversial impacts:

- In its current state, this uses `// CHECK-NEXT:` everywhere. Meaning we can't even have something printed as a single line spread on multiple lines for a readable input. Alternatives :
    - Use `// CHECK:` instead? Might allow for extraneous output to not trigger a fail, sounds a bit risky.
- It can't be applied to situation where a custom syntax is parsable but nerver printed (e.g. `func.func` with custom syntax signature but still entry block arguments explicitely listed). Alternative for both issues:
    - Start splitting those cases and the purely roundtripping cases in two files. Use `XDSL_ROUNDTRIP` for the former. My personal opinion is that the benefits justify this, but I'm not the only one impacted :yum: 