### PR TITLE
dialects: (riscv) add fmvop

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -258,11 +258,3 @@ def test_riscv_parse_immediate_value():
     parser = Parser(ctx, prog)
     with pytest.raises(ParseError, match="Expected immediate"):
         parser.parse_operation()
-
-
-def test_cannot_print_fmv_op():
-    fmv = riscv.FMVOp(TestSSAValue(riscv.Registers.FA0), rd=riscv.Registers.FA0)
-    with pytest.raises(
-        NotImplementedError, match="Cannot print assembly line for fmv instruction"
-    ):
-        fmv.assembly_line()

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -258,3 +258,11 @@ def test_riscv_parse_immediate_value():
     parser = Parser(ctx, prog)
     with pytest.raises(ParseError, match="Expected immediate"):
         parser.parse_operation()
+
+
+def test_cannot_print_fmv_op():
+    fmv = riscv.FMVOp(TestSSAValue(riscv.Registers.FA0), rd=riscv.Registers.FA0)
+    with pytest.raises(
+        NotImplementedError, match="Cannot print assembly line for fmv instruction"
+    ):
+        fmv.assembly_line()

--- a/tests/filecheck/backend/riscv/optimisation_riscv.mlir
+++ b/tests/filecheck/backend/riscv/optimisation_riscv.mlir
@@ -7,9 +7,9 @@ builtin.module {
   %o2 = riscv.mv %i2 : (!riscv.reg<>) -> !riscv.reg<>
 
   %f0, %f1, %f2 = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg<>)
-  %fo0 = riscv.fmv %f0 : (!riscv.freg<fa0>) -> !riscv.freg<fa0>
-  %fo1 = riscv.fmv %f1 : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
-  %fo2 = riscv.fmv %f2 : (!riscv.freg<>) -> !riscv.freg<>
+  %fo0 = riscv.fmv.s %f0 : (!riscv.freg<fa0>) -> !riscv.freg<fa0>
+  %fo1 = riscv.fmv.s %f1 : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
+  %fo2 = riscv.fmv.s %f2 : (!riscv.freg<>) -> !riscv.freg<>
 }
 
 // CHECK: builtin.module {
@@ -17,6 +17,6 @@ builtin.module {
 // CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a1>) -> !riscv.reg<a2>
 // CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg<>)
-// CHECK-NEXT:   %{{.*}} = riscv.fmv %{{.*}} : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
-// CHECK-NEXT:   %{{.*}} = riscv.fmv %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/optimisation_riscv.mlir
+++ b/tests/filecheck/backend/riscv/optimisation_riscv.mlir
@@ -5,10 +5,18 @@ builtin.module {
   %o0 = riscv.mv %i0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
   %o1 = riscv.mv %i1 : (!riscv.reg<a1>) -> !riscv.reg<a2>
   %o2 = riscv.mv %i2 : (!riscv.reg<>) -> !riscv.reg<>
+
+  %f0, %f1, %f2 = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg<>)
+  %fo0 = riscv.fmv %f0 : (!riscv.freg<fa0>) -> !riscv.freg<fa0>
+  %fo1 = riscv.fmv %f1 : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
+  %fo2 = riscv.fmv %f2 : (!riscv.freg<>) -> !riscv.freg<>
 }
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<>)
 // CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a1>) -> !riscv.reg<a2>
 // CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg<>)
+// CHECK-NEXT:   %{{.*}} = riscv.fmv %{{.*}} : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
+// CHECK-NEXT:   %{{.*}} = riscv.fmv %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -215,6 +215,9 @@
     %f2 = riscv.get_float_register : () -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
 
+    %fmv = riscv.fmv.s %f0 : (!riscv.freg<>) -> !riscv.freg<>
+    // CHECK: %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+
     %fmadd_s = riscv.fmadd.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fmsub_s = riscv.fmsub.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
@@ -367,6 +370,7 @@
 // CHECK-GENERIC-NEXT:     %f0 = "riscv.get_float_register"() : () -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %f1 = "riscv.get_float_register"() : () -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %f2 = "riscv.get_float_register"() : () -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fmv = "riscv.fmv.s"(%f0) : (!riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmadd_s = "riscv.fmadd.s"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmsub_s = "riscv.fmsub.s"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fnmsub_s = "riscv.fnmsub.s"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -190,7 +190,7 @@
     // CHECK-NEXT:  riscv.assembly_section ".text" attributes {"foo" = i32} {
     // CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
     // CHECK-NEXT:  }
-    
+
     riscv.assembly_section ".text" {
       %nested_li = riscv.li 1 : () -> !riscv.reg<>
     }
@@ -216,7 +216,7 @@
     // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
 
     %fmv = riscv.fmv.s %f0 : (!riscv.freg<>) -> !riscv.freg<>
-    // CHECK: %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
 
     %fmadd_s = riscv.fmadd.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>

--- a/xdsl/backend/riscv/lowering/optimise_riscv.py
+++ b/xdsl/backend/riscv/lowering/optimise_riscv.py
@@ -15,3 +15,14 @@ class RemoveRedundantMv(RewritePattern):
             and op.rd.type.is_allocated
         ):
             rewriter.replace_matched_op([], [op.rs])
+
+
+class RemoveRedundantFMv(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.FMVOp, rewriter: PatternRewriter) -> None:
+        if (
+            op.rd.type == op.rs.type
+            and isinstance(op.rd.type, riscv.RISCVRegisterType)
+            and op.rd.type.is_allocated
+        ):
+            rewriter.replace_matched_op([], [op.rs])

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1531,7 +1531,11 @@ class FMVOp(RdRsOperation[FloatRegisterType, FloatRegisterType]):
     """
     A pseudo instruction to copy contents of one float register to another.
 
-    Equivalent to `fsw rs, 0(sp); flw rd, 0(sp)` or `fsgnj.s rd, rs, rs`
+    Equivalent to `fsgnj.s rd, rs, rs`.
+
+    Both clang and gcc emit `fsw rs, 0(x); flw rd, 0(x)` to copy floats, possibly because
+    storing and loading bits from memory is a lower overhead in practice than reasoning
+    about floating-point values.
     """
 
     name = "riscv.fmv.s"

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1531,22 +1531,12 @@ class FMVOp(RdRsOperation[FloatRegisterType, FloatRegisterType]):
     """
     A pseudo instruction to copy contents of one float register to another.
 
-    Equivalent to `fsw rs, 0(sp); flw rd, 0(sp)`.
-
-    This is a much more expensive operation than mv, and does not correspond to an
-    instruction in the RISC-V F extension. Possibly due to this, there is no common
-    assembly pseudo-op for it, so it must be rewritten before assembly printing.
+    Equivalent to `fsw rs, 0(sp); flw rd, 0(sp)` or `fsgnj.s rd, rs, rs`
     """
 
-    name = "riscv.fmv"
+    name = "riscv.fmv.s"
 
     traits = frozenset((FMVHasCanonicalizationPatternsTrait(),))
-
-    def assembly_line(self) -> str | None:
-        """
-        fmv is not a supported assembly instruction.
-        """
-        raise NotImplementedError("Cannot print assembly line for fmv instruction.")
 
 
 ## Integer Register-Register Operations


### PR DESCRIPTION
This doesn't really use it anywhere yet, just provides the ability to express copying a value from one register to another. Hopefully we'll actually manage to optimise out this operation for all the cases we care about, but it's possible that we won't so we'll need to implement a lowering to the rountrip through memory before printing.