### PR TITLE
misc: add links to ruff documentation in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,14 @@ profile = "black"
 
 [tool.ruff]
 select = ["E", "F", "W", "I", "UP", "PT"]
-ignore = ["E741", "PT006", "PT007", "PT011", "PT012", "PT015"]
+ignore = [
+    "E741",  # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
+    "PT006", # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
+    "PT007", # https://beta.ruff.rs/docs/rules/pytest-parametrize-values-wrong-type/
+    "PT011", # https://beta.ruff.rs/docs/rules/pytest-raises-too-broad/
+    "PT012", # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
+    "PT015", # https://beta.ruff.rs/docs/rules/pytest-assert-always-false/
+]
 line-length = 300
 target-version = "py310"
 


### PR DESCRIPTION
The links have nice urls so it's easier to see what exactly we're ignoring.