### PR TITLE
core: (trait) Implement LazyOpTrait

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -8,7 +8,7 @@ nbval<0.11
 filecheck<0.0.24
 lit<17.0.0
 pre-commit==3.3.3
-ruff==0.0.285
+ruff==0.0.286
 riscemu==2.1.1
 asv<0.7
 isort==5.12.0

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -55,7 +55,7 @@ class HasParentOp(IRDLOperation):
 
     name = "test.has_parent"
 
-    traits = frozenset([HasParent(ParentOp)])
+    traits = frozenset([HasParent(lambda: (ParentOp,))])
 
 
 @irdl_op_definition
@@ -66,7 +66,7 @@ class HasMultipleParentOp(IRDLOperation):
 
     name = "test.has_multiple_parent"
 
-    traits = frozenset([HasParent(ParentOp, Parent2Op)])
+    traits = frozenset([HasParent(lambda: (ParentOp, Parent2Op))])
 
 
 def test_has_parent_no_parent():
@@ -272,10 +272,9 @@ class IsSingleBlockImplicitTerminatorOp(IRDLOperation):
 
     name = "test.is_single_block_implicit_terminator"
 
-    # TODO fix circular reference
-    # traits = frozenset([HasParent(HasSingleBlockImplicitTerminatorOp), IsTerminator()])
-    # this is tracked by gh issue: https://github.com/xdslproject/xdsl/issues/1218
-    traits = frozenset([IsTerminator()])
+    traits = frozenset(
+        [HasParent(lambda: (HasSingleBlockImplicitTerminatorOp,)), IsTerminator()]
+    )
 
 
 @irdl_op_definition

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -76,7 +76,7 @@ class BitwidthSumLessThanTrait(OpTrait):
     operands and results is less than a given value.
     """
 
-    parameters: int
+    _parameters: int
 
     @property
     def max_sum(self):

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -35,6 +35,7 @@ from xdsl.irdl import (
     result_def,
 )
 from xdsl.traits import (
+    LazyOpTrait,
     OptionalSymbolOpInterface,
     SymbolOpInterface,
     SymbolTable,
@@ -411,3 +412,23 @@ def test_symbol_table():
 
     assert SymbolTable.lookup_symbol(op, "name") is None
     assert SymbolTable.lookup_symbol(op, SymbolRefAttr("nested", ["name"])) is symbol
+
+
+def test_lazy_trait():
+    @dataclass(frozen=True)
+    class NormalTrait(OpTrait):
+        pass
+
+    @dataclass(frozen=True)
+    class LazyTrait(LazyOpTrait):
+        pass
+
+    with pytest.raises(NameError):
+        NormalTrait(SomeOp)  # pyright: ignore [reportUnboundVariable]  # noqa: F821
+
+    lazy_trait = LazyTrait(lambda: SomeOp)
+
+    class SomeOp(Operation):
+        pass
+
+    assert lazy_trait.parameters == SomeOp

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -286,7 +286,7 @@ class Return(IRDLOperation):
     name = "func.return"
     arguments: VarOperand = var_operand_def(AnyAttr())
 
-    traits = frozenset([HasParent(FuncOp), IsTerminator()])
+    traits = frozenset([HasParent(lambda: (FuncOp,)), IsTerminator()])
 
     def __init__(self, *return_vals: SSAValue | Operation):
         super().__init__(operands=[return_vals])

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -354,10 +354,7 @@ class MemcpyOp(IRDLOperation):
 class ModuleEndOp(IRDLOperation):
     name = "gpu.module_end"
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent(ModuleOp), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = frozenset([HasParent(lambda: (ModuleOp,)), IsTerminator()])
 
     def __init__(self):
         return super().__init__()
@@ -398,7 +395,9 @@ class FuncOp(IRDLOperation):
         DenseArrayBase, attr_name="gpu.known_grid_size"
     )
 
-    traits = frozenset([IsolatedFromAbove(), HasParent(ModuleOp), SymbolOpInterface()])
+    traits = frozenset(
+        [IsolatedFromAbove(), HasParent(lambda: (ModuleOp,)), SymbolOpInterface()]
+    )
 
     def __init__(
         self,
@@ -661,7 +660,7 @@ class ReturnOp(IRDLOperation):
 
     args: VarOperand = var_operand_def()
 
-    traits = frozenset([IsTerminator(), HasParent(FuncOp)])
+    traits = frozenset([IsTerminator(), HasParent(lambda: (FuncOp,))])
 
     def __init__(self, operands: Sequence[SSAValue | Operation]):
         return super().__init__(operands=[operands])
@@ -698,7 +697,7 @@ class SubgroupSizeOp(IRDLOperation):
 class TerminatorOp(IRDLOperation):
     name = "gpu.terminator"
 
-    traits = frozenset([HasParent(LaunchOp), IsTerminator()])
+    traits = frozenset([HasParent(lambda: (LaunchOp,)), IsTerminator()])
 
     def __init__(self):
         return super().__init__()

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -86,7 +86,9 @@ class TypeOp(IRDLOperation):
     sym_name: StringAttr = attr_def(StringAttr)
     body: Region = region_def("single_block")
 
-    traits = frozenset([NoTerminator(), HasParent(DialectOp), SymbolOpInterface()])
+    traits = frozenset(
+        [NoTerminator(), HasParent(lambda: (DialectOp,)), SymbolOpInterface()]
+    )
 
     def __init__(self, name: str | StringAttr, body: Region):
         if isinstance(name, str):
@@ -116,7 +118,9 @@ class AttributeOp(IRDLOperation):
     sym_name: StringAttr = attr_def(StringAttr)
     body: Region = region_def("single_block")
 
-    traits = frozenset([NoTerminator(), HasParent(DialectOp), SymbolOpInterface()])
+    traits = frozenset(
+        [NoTerminator(), HasParent(lambda: (DialectOp,)), SymbolOpInterface()]
+    )
 
     def __init__(self, name: str | StringAttr, body: Region):
         if isinstance(name, str):
@@ -145,7 +149,7 @@ class ParametersOp(IRDLOperation):
 
     args: VarOperand = var_operand_def(AttributeType)
 
-    traits = frozenset([HasParent(TypeOp, AttributeOp)])
+    traits = frozenset([HasParent(lambda: (TypeOp, AttributeOp))])
 
     def __init__(self, args: Sequence[SSAValue]):
         super().__init__(operands=[args])
@@ -172,7 +176,9 @@ class OperationOp(IRDLOperation):
     sym_name: StringAttr = attr_def(StringAttr)
     body: Region = region_def("single_block")
 
-    traits = frozenset([NoTerminator(), HasParent(DialectOp), SymbolOpInterface()])
+    traits = frozenset(
+        [NoTerminator(), HasParent(lambda: (DialectOp,)), SymbolOpInterface()]
+    )
 
     def __init__(self, name: str | StringAttr, body: Region):
         if isinstance(name, str):
@@ -201,7 +207,7 @@ class OperandsOp(IRDLOperation):
 
     args: VarOperand = var_operand_def(AttributeType)
 
-    traits = frozenset([HasParent(OperationOp)])
+    traits = frozenset([HasParent(lambda: (OperationOp,))])
 
     def __init__(self, args: Sequence[SSAValue]):
         super().__init__(operands=[args])
@@ -227,7 +233,7 @@ class ResultsOp(IRDLOperation):
 
     args: VarOperand = var_operand_def(AttributeType)
 
-    traits = frozenset([IsTerminator(), HasParent(OperationOp)])
+    traits = frozenset([IsTerminator(), HasParent(lambda: (OperationOp,))])
 
     def __init__(self, args: Sequence[SSAValue]):
         super().__init__(operands=[args])

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -711,7 +711,9 @@ class RewriteOp(IRDLOperation):
 
     irdl_options = [AttrSizedOperandSegments()]
 
-    traits = frozenset([HasParent(PatternOp), NoTerminator(), IsTerminator()])
+    traits = frozenset(
+        [HasParent(lambda: (PatternOp,)), NoTerminator(), IsTerminator()]
+    )
 
     def __init__(
         self,

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -199,7 +199,7 @@ class ReturnOp(IRDLOperation):
     values: VarOperand = var_operand_def(riscv.RISCVRegisterType)
     comment: StringAttr | None = opt_attr_def(StringAttr)
 
-    traits = frozenset([IsTerminator(), HasParent(FuncOp)])
+    traits = frozenset([IsTerminator(), HasParent(lambda: (FuncOp,))])
 
     def __init__(
         self,

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -32,10 +32,7 @@ class YieldOp(IRDLOperation):
 
     arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent((For, If, ParallelOp, While)), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = frozenset([HasParent(lambda: (ForOp, WhileOp)), IsTerminator()])
 
     def __init__(self, *operands: SSAValue | Operation):
         super().__init__(operands=[[SSAValue.get(operand) for operand in operands]])
@@ -172,7 +169,7 @@ class ConditionOp(IRDLOperation):
     cond: Operand = operand_def(IntRegisterType)
     arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
-    traits = frozenset([HasParent(WhileOp), IsTerminator()])
+    traits = frozenset([HasParent(lambda: (WhileOp,)), IsTerminator()])
 
     def __init__(self, cond: SSAValue | Operation, *output_ops: SSAValue | Operation):
         super().__init__(operands=[cond, output_ops])

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -65,10 +65,9 @@ class Yield(IRDLOperation):
     name = "scf.yield"
     arguments: VarOperand = var_operand_def(AnyAttr())
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent((For, If, ParallelOp, While)), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = frozenset(
+        [HasParent(lambda: (For, If, ParallelOp, While)), IsTerminator()]
+    )
 
     @staticmethod
     def get(*operands: SSAValue | Operation) -> Yield:
@@ -352,7 +351,7 @@ class ReduceReturnOp(IRDLOperation):
     name = "scf.reduce.return"
     result: Operand = operand_def(AnyAttr())
 
-    traits = frozenset([HasParent(ReduceOp), IsTerminator()])
+    traits = frozenset([HasParent(lambda: (ReduceOp,)), IsTerminator()])
 
     @staticmethod
     def get(
@@ -367,7 +366,7 @@ class Condition(IRDLOperation):
     cond: Operand = operand_def(IntegerType(1))
     arguments: VarOperand = var_operand_def(AnyAttr())
 
-    traits = frozenset([HasParent(While), IsTerminator()])
+    traits = frozenset([HasParent(lambda: (While,)), IsTerminator()])
 
     @staticmethod
     def get(cond: SSAValue | Operation, *output_ops: SSAValue | Operation) -> Condition:

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -509,7 +509,7 @@ class AccessOp(IRDLOperation):
     offset_mapping: ArrayAttr[IntAttr] | None = opt_attr_def(ArrayAttr[IntAttr])
     res: OpResult = result_def(Attribute)
 
-    traits = frozenset([HasParent(ApplyOp)])
+    traits = frozenset([HasParent(lambda: (ApplyOp,))])
 
     @staticmethod
     def get(
@@ -737,7 +737,7 @@ class ReturnOp(IRDLOperation):
     name = "stencil.return"
     arg: VarOperand = var_operand_def(ResultType | AnyFloat)
 
-    traits = frozenset([HasParent(ApplyOp), IsTerminator()])
+    traits = frozenset([HasParent(lambda: (ApplyOp,)), IsTerminator()])
 
     @staticmethod
     def get(res: Sequence[SSAValue | Operation]):

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -38,7 +38,8 @@ class OpTrait:
 @dataclass(frozen=True)
 class LazyOpTrait(OpTrait):
     """
-    TODO: Add doc
+    A lazy version of OpTrait which postpone the evaluation of parameters.
+    It can used to workaround the circular dependencies in code.
     """
 
     _parameters: Callable[[], Any] | Any = field(default=None)
@@ -48,7 +49,7 @@ class LazyOpTrait(OpTrait):
     def parameters(self) -> Any:
         if self._is_unresolved:
             object.__setattr__(self, "_parameters", self._parameters())
-            object.__setattr__(self, "_unresolved", False)
+            object.__setattr__(self, "_is_unresolved", False)
         return self._parameters
 
     def verify(self, op: Operation) -> None:

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -39,7 +39,7 @@ class OpTrait:
 class LazyOpTrait(OpTrait):
     """
     A lazy version of OpTrait which postpone the evaluation of parameters.
-    It can used to workaround the circular dependencies in code.
+    It can used to work around the circular dependencies in code.
     """
 
     _parameters: Callable[[], Any] | Any = field(default=None)

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -42,11 +42,11 @@ class LazyOpTrait(OpTrait):
     """
 
     _parameters: Callable[[], Any] | Any = field(default=None)
-    _unresolved: bool = field(default=True)
+    _is_unresolved: bool = field(default=True)
 
     @property
     def parameters(self) -> Any:
-        if self._unresolved:
+        if self._is_unresolved:
             object.__setattr__(self, "_parameters", self._parameters())
             object.__setattr__(self, "_unresolved", False)
         return self._parameters


### PR DESCRIPTION
From #1359, #1375. Implemented `LazyOpTrait` which inherit rom `OpTrait` but the `parameters` are *lazy* (resolve later).

One example usage is the `HasParent` trait is now inheriting from the `LazyOpTrait`.

Main implementation reside in `xdsl/traits.py`.