### PR TITLE
documentation: (toy) add optimisation steps to Toy

### DIFF
--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -37,7 +37,9 @@ parser.add_argument(
         "affine",
         "scf",
         "riscv",
+        "riscv-opt",
         "riscv-regalloc",
+        "riscv-regalloc-opt",
         "riscv-lowered",
         "riscv-asm",
     ],
@@ -116,7 +118,7 @@ def main(path: Path, emit: str, ir: bool, accelerate: bool, print_generic: bool)
         interpreter.register_implementations(ScfFunctions())
         interpreter.register_implementations(BuiltinFunctions())
 
-    if emit in ("riscv", "riscv-regalloc"):
+    if emit in ("riscv", "riscv-opt", "riscv-regalloc", "riscv-regalloc-opt"):
         interpreter.register_implementations(
             ToyAcceleratorInstructionFunctions(module_op)
         )

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -129,6 +129,8 @@ def transform(
     if target == "riscv":
         return
 
+    # Perform optimizations that don't depend on register allocation
+    # e.g. constant folding
     CanonicalizePass().apply(ctx, module_op)
 
     module_op.verify()
@@ -143,6 +145,8 @@ def transform(
     if target == "riscv-regalloc":
         return
 
+    # Perform optimizations that depend on register allocation
+    # e.g. redundant moves
     CanonicalizePass().apply(ctx, module_op)
 
     module_op.verify()

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -124,11 +124,16 @@ def transform(
     DeadCodeElimination().apply(ctx, module_op)
     ReconcileUnrealizedCastsPass().apply(ctx, module_op)
 
-    DeadCodeElimination().apply(ctx, module_op)
-
     module_op.verify()
 
     if target == "riscv":
+        return
+
+    CanonicalizePass().apply(ctx, module_op)
+
+    module_op.verify()
+
+    if target == "riscv-opt":
         return
 
     RISCVRegisterAllocation().apply(ctx, module_op)
@@ -136,6 +141,13 @@ def transform(
     module_op.verify()
 
     if target == "riscv-regalloc":
+        return
+
+    CanonicalizePass().apply(ctx, module_op)
+
+    module_op.verify()
+
+    if target == "riscv-regalloc-opt":
         return
 
     LowerRISCVFunc(insert_exit_syscall=True).apply(ctx, module_op)

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -99,7 +99,7 @@ def test_riscv_interpreter():
 
     assert (
         interpreter.run_op(
-            riscv.FSwOp(TestSSAValue(register), TestSSAValue(fregister), 2),
+            riscv.FSwOp(TestSSAValue(register), TestSSAValue(fregister), 8),
             (buffer, 3.0),
         )
         == ()
@@ -108,7 +108,7 @@ def test_riscv_interpreter():
     assert buffer == Buffer([1, 2, 3.0, 0])
 
     assert interpreter.run_op(
-        riscv.FLwOp(TestSSAValue(register), 2),
+        riscv.FLwOp(TestSSAValue(register), 8),
         (buffer,),
     ) == (3.0,)
 

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -206,6 +206,8 @@ class RiscvFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         offset = self.get_immediate_value(op, op.immediate)
+        if isinstance(offset, int):
+            offset //= 4
         return (args[0][offset],)
 
     @impl(riscv.LabelOp)
@@ -244,7 +246,7 @@ class RiscvFunctions(InterpreterFunctions):
         op: riscv.FSwOp,
         args: tuple[Any, ...],
     ):
-        args[0][op.immediate.value.data] = args[1]
+        args[0][op.immediate.value.data // 4] = args[1]
         return ()
 
     @impl(riscv.FLwOp)
@@ -255,6 +257,8 @@ class RiscvFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         offset = self.get_immediate_value(op, op.immediate)
+        if isinstance(offset, int):
+            offset //= 4
         return (args[0][offset],)
 
     # endregion


### PR DESCRIPTION
This is technically in Toy but we're currently using this pipeline for the riscv paper experiments, so would benefit from this change for critical work.