### PR TITLE
backend: (riscv) Clean up abi and arch specifications

### DIFF
--- a/tests/riscv/test_abi_spec.py
+++ b/tests/riscv/test_abi_spec.py
@@ -17,3 +17,40 @@ def test_march_expansion(simple: str, expanded: str):
     Test that march extensions are expanded correctly
     """
     assert targets.MachineArchSpec(simple).spec_string == expanded
+
+
+def test_abi_compatibility():
+    rv32g = targets.MachineArchSpec("RV32G")
+    rv64gq = targets.MachineArchSpec("RV64GQ")
+    rv64g = targets.MachineArchSpec("RV64G")
+    rv32i = targets.MachineArchSpec("RV32I")
+    mabis = targets.MAbi
+
+    # RV32G supports 32bit ABIs with 64bit floats
+    assert rv32g.supports_mabi(mabis.ILP32D.value)
+    assert rv32g.supports_mabi(mabis.ILP32F.value)
+    assert rv32g.supports_mabi(mabis.ILP32.value)
+
+    # RV32G supports no 64 bit ABI
+    assert not rv32g.supports_mabi(mabis.LP64D.value)
+    assert not rv32g.supports_mabi(mabis.LP64F.value)
+    assert not rv32g.supports_mabi(mabis.LP64.value)
+
+    # RV64* should not supprto LP32*
+    assert not rv64g.supports_mabi(mabis.ILP32D.value)
+    assert not rv64g.supports_mabi(mabis.ILP32.value)
+
+    # RV64G should support 64bit ABIs with up to 64 bit FLEN
+    assert rv64g.supports_mabi(mabis.LP64.value)
+    assert rv64g.supports_mabi(mabis.LP64F.value)
+    assert rv64g.supports_mabi(mabis.LP64D.value)
+    # RV64G is missing the Q extension and can therefore not support LP64Q
+    assert not rv64g.supports_mabi(mabis.LP64Q.value)
+    # RV64GQ has the Q extension and therefore supports it
+    assert rv64gq.supports_mabi(mabis.LP64Q.value)
+
+    # RV32I should only support ILP32 and no other ABI
+    assert rv32i.supports_mabi(mabis.ILP32.value)
+    assert not rv32i.supports_mabi(mabis.LP64.value)
+    assert not rv32i.supports_mabi(mabis.ILP32F.value)
+    assert not rv32i.supports_mabi(mabis.LP64F.value)

--- a/xdsl/backend/riscv/targets.py
+++ b/xdsl/backend/riscv/targets.py
@@ -1,10 +1,20 @@
 """
 This file provides tools to describe toolchain targets.
 
-Based on https://github.com/riscv-non-isa/riscv-elf-psabi-doc
+Based on:
 
-And the RISC-V specification
+ [0]: https://github.com/riscv-non-isa/riscv-elf-psabi-doc
+ [1]: `RISC-V ABIs Specification, Document Version 1.0', Editors Kito Cheng and Jessica
+      Clarke, RISC-V International, November 2022.
+      https://github.com/riscv-non-isa/riscv-elf-psabi-doc/releases/tag/v1.0
+ [2]: “The RISC-V Instruction Set Manual, Volume I: User-Level ISA, Document Version
+      20191213”, Editors Andrew Waterman and Krste Asanovi´c, RISC-V Foundation,
+      December 2019.
+      https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf
+
 """
+
+from __future__ import annotations
 
 import re
 from collections.abc import Sequence
@@ -23,6 +33,8 @@ def _isa_sort_key(ext: str) -> int:
     First come the letters from _ISA_ORDER
     Then the extensions from _ISA_EXT_ORDER
     And then custom extensions, prefixed with X
+
+    Implemented according to chapter 27 in [2].
     """
     if ext in _ISA_ORDER:
         return _ISA_ORDER.index(ext)
@@ -37,8 +49,7 @@ def _expand_isa_letters(extensions_: Sequence[str]) -> tuple[str]:
     """
     Normalizes (expands) ISA extensions as per RISC-V ISA Manual version 20191213
 
-    See Section 27.11 at:
-    https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf
+    See Section 27.11 in [2] for reference.
     """
     extensions = set(extensions_)
 
@@ -62,27 +73,22 @@ class ABISpec:
     """
     This defines the ABI.
 
-    Based on
-    https://github.com/riscv-non-isa/riscv-toolchain-conventions#specifying-the-target-abi-with--mabi
-    (better source might be nice though)
+    Largely based on chapter 2 of [1]
     """
 
     # various type bitwidths:
     int_width: int
     long_width: int
-    index_width: int
+    pointer_width: int
 
-    # stack alignment:
-    stack_alignment: int
-
-    # argument passing:
-    call_with_floats: Literal[None, 32, 64]
+    #
+    abi_flen: Literal[0, 32, 64, 128]
     """
-    Are the floating point registers used to pass arguments?
+    ABI_FLEN refers to the width of a floating-point register in the ABI. The ABI_FLEN
+    must be no wider than the ISA’s FLEN. The ISA might have wider floating-point
+    registers than the ABI.
 
-    None => No
-    32   => 32-bit fp registers are used
-    64   => 64-bit fp registers are used
+    (cited from section 2.2 [1], p. 10)
     """
 
     # binary file format:
@@ -91,6 +97,17 @@ class ABISpec:
     The output file format (for example of object files).
 
     "elf" is the default for most
+    """
+
+    # stack alignment:
+    stack_alignment: int = 128
+    """
+    The stack grows downwards (towards lower addresses) and the stack pointer shall be
+    aligned to a 128-bit boundary upon procedure entry. The first argument passed on the
+    stack is located at offset zero of the stack pointer on function entry; following
+    arguments are stored at correspondingly higher addresses.
+
+    (cited from section 2.1 [1] p. 9)
     """
 
 
@@ -106,7 +123,7 @@ class MachineArchSpec:
     """
     flen: int
     """
-    Floating point register width (32/64/128)
+    Floating point register width (0/32/64/128)
     """
 
     extensions: tuple[str]
@@ -163,6 +180,24 @@ class MachineArchSpec:
             flen = 0
         object.__setattr__(self, "flen", flen)
 
+    def supports_mabi(self, abi: ABISpec) -> bool:
+        """
+        Implements checks lined out in section 2.4 of [2], p. 12
+        """
+        # check that abi flen is not larger than the march flen
+        if abi.abi_flen > self.flen:
+            return False
+        # check that ilp32* is only used on RV32*
+        # and lp64* is only used on RV64*
+        if abi.pointer_width != self.xlen:
+            return False
+        if abi.long_width != self.xlen:
+            return False
+        # check that an int always fits in a single register
+        if abi.int_width > self.xlen:
+            return False
+        return True
+
 
 @dataclass
 class TargetDefinition:
@@ -189,25 +224,30 @@ class TargetDefinition:
     address range. auipc and addi pairs are used to generate addresses.
     """
 
+    def is_valid(self) -> bool:
+        return self.march.supports_mabi(self.abi) and self.code_model in ("any", "low")
+
 
 class MAbi(Enum):
     """
-    Collection of common -mabi values
+    Collection of named ABIs as per chapter 2.4 of [1].
+
+    ILP32E is omitted as the E extension is currently not ratified.
     """
 
-    ILP32 = ABISpec(32, 32, 32, stack_alignment=32, call_with_floats=None)
-    ILP32F = ABISpec(32, 32, 32, stack_alignment=32, call_with_floats=32)
-    ILP32D = ABISpec(32, 32, 32, stack_alignment=64, call_with_floats=64)
+    ILP32 = ABISpec(32, 32, 32, abi_flen=0)
+    ILP32F = ABISpec(32, 32, 32, abi_flen=32)
+    ILP32D = ABISpec(32, 32, 32, abi_flen=64)
 
-    LP64 = ABISpec(32, 64, 64, stack_alignment=64, call_with_floats=None)
-    LP64F = ABISpec(32, 64, 64, stack_alignment=64, call_with_floats=32)
-    LP64D = ABISpec(32, 64, 64, stack_alignment=64, call_with_floats=64)
-
-    ILP64 = ABISpec(64, 64, 64, stack_alignment=64, call_with_floats=None)
-    ILP64F = ABISpec(64, 64, 64, stack_alignment=64, call_with_floats=32)
-    ILP64D = ABISpec(64, 64, 64, stack_alignment=64, call_with_floats=64)
+    LP64 = ABISpec(32, 64, 64, abi_flen=0)
+    LP64F = ABISpec(32, 64, 64, abi_flen=32)
+    LP64D = ABISpec(32, 64, 64, abi_flen=64)
+    LP64Q = ABISpec(32, 64, 64, abi_flen=128)
 
 
 class RecognizedTargets(Enum):
     riscv32_riscemu = TargetDefinition(MAbi.ILP32.value, MachineArchSpec("RV32IMA_Zto"))
-    riscv64_linux = TargetDefinition(MAbi.ILP64D.value, MachineArchSpec("RV64G"))
+    riscv64_linux = TargetDefinition(MAbi.LP64D.value, MachineArchSpec("RV64G"))
+    snitch = TargetDefinition(
+        MAbi.ILP32D.value, MachineArchSpec("RV32IMAD_Xssr_Xfrep_Xdma")
+    )

--- a/xdsl/backend/riscv/targets.py
+++ b/xdsl/backend/riscv/targets.py
@@ -81,7 +81,7 @@ class ABISpec:
     long_width: int
     pointer_width: int
 
-    #
+    # The ABIs flen is allowed to smaller than the machine flen
     abi_flen: Literal[0, 32, 64, 128]
     """
     ABI_FLEN refers to the width of a floating-point register in the ABI. The ABI_FLEN

--- a/xdsl/backend/riscv/targets.py
+++ b/xdsl/backend/riscv/targets.py
@@ -108,6 +108,25 @@ class ABISpec:
     arguments are stored at correspondingly higher addresses.
 
     (cited from section 2.1 [1] p. 9)
+
+    A supporting illustration:
+
+    +--------------------------+ <--- stack "end", higher address
+    |       In-use stack       |
+    | (from calling functions) |
+    +--------------------------+
+    |    Padding if needed     |
+    +--------------------------+
+    |     stack argument n     |
+    |     stack argument n-1   |
+    |            ...           |
+    |     stack argument 0     |
+    +--------------------------+ <--- Stack pointer, aligned to 128 bits
+    |           empty          |
+    |                          |
+    +--------------------------+ <--- stack "start", lower address
+
+    This means `0(sp)` is stack argument 0, and `4*n(sp)` is stack argument n.
     """
 
 


### PR DESCRIPTION
I managed to find a proper document specifying the ABI, and did some exploring in the compiler explorer.

My initial version of the ABI was almost correct, I had just missed a couple of smaller issues (such as stack alignment and float calling conventions).

This should now conform to the original spec.
