### PR TITLE
backend: (riscv) add riscv-reduce-register-pressure pass

### DIFF
--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -37,7 +37,9 @@ parser.add_argument(
         "affine",
         "scf",
         "riscv",
+        "riscv-opt",
         "riscv-regalloc",
+        "riscv-regalloc-opt",
         "riscv-lowered",
         "riscv-asm",
     ],
@@ -116,7 +118,7 @@ def main(path: Path, emit: str, ir: bool, accelerate: bool, print_generic: bool)
         interpreter.register_implementations(ScfFunctions())
         interpreter.register_implementations(BuiltinFunctions())
 
-    if emit in ("riscv", "riscv-regalloc"):
+    if emit in ("riscv", "riscv-opt", "riscv-regalloc", "riscv-regalloc-opt"):
         interpreter.register_implementations(
             ToyAcceleratorInstructionFunctions(module_op)
         )

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -124,11 +124,16 @@ def transform(
     DeadCodeElimination().apply(ctx, module_op)
     ReconcileUnrealizedCastsPass().apply(ctx, module_op)
 
-    DeadCodeElimination().apply(ctx, module_op)
-
     module_op.verify()
 
     if target == "riscv":
+        return
+
+    CanonicalizePass().apply(ctx, module_op)
+
+    module_op.verify()
+
+    if target == "riscv-opt":
         return
 
     RISCVRegisterAllocation().apply(ctx, module_op)
@@ -136,6 +141,13 @@ def transform(
     module_op.verify()
 
     if target == "riscv-regalloc":
+        return
+
+    CanonicalizePass().apply(ctx, module_op)
+
+    module_op.verify()
+
+    if target == "riscv-regalloc-opt":
         return
 
     LowerRISCVFunc(insert_exit_syscall=True).apply(ctx, module_op)

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -6,6 +6,9 @@ from xdsl.backend.riscv.lowering.convert_func_to_riscv_func import (
 )
 from xdsl.backend.riscv.lowering.convert_memref_to_riscv import ConvertMemrefToRiscvPass
 from xdsl.backend.riscv.lowering.convert_scf_to_riscv_scf import ConvertScfToRiscvPass
+from xdsl.backend.riscv.lowering.reduce_register_pressure import (
+    RiscvReduceRegisterPressurePass,
+)
 from xdsl.backend.riscv.riscv_scf_to_asm import (
     LowerScfForToLabels,
 )
@@ -130,6 +133,7 @@ def transform(
         return
 
     CanonicalizePass().apply(ctx, module_op)
+    RiscvReduceRegisterPressurePass().apply(ctx, module_op)
 
     module_op.verify()
 

--- a/tests/filecheck/backend/riscv_reduce_register_pressure.mlir
+++ b/tests/filecheck/backend/riscv_reduce_register_pressure.mlir
@@ -1,12 +1,15 @@
 // RUN: xdsl-opt -p riscv-reduce-register-pressure %s | filecheck %s
 
 builtin.module {
+  // Replace loading immediate value 0
   %0 = riscv.li 0 : () -> !riscv.reg<>
   %1 = riscv.li 0 : () -> !riscv.reg<a0>
+  %2 = riscv.li 1 : () -> !riscv.reg<>
 }
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   %0 = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %1 = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %2 = riscv.mv %1 : (!riscv.reg<zero>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %{{.*}} = riscv.get_register : () -> !riscv.reg<zero>
+// CHECK-NEXT:   %{{.*}} = riscv.get_register : () -> !riscv.reg<zero>
+// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<zero>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv_reduce_register_pressure.mlir
+++ b/tests/filecheck/backend/riscv_reduce_register_pressure.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt -p riscv-reduce-register-pressure %s | filecheck %s
+
+builtin.module {
+  %0 = riscv.li 0 : () -> !riscv.reg<>
+  %1 = riscv.li 0 : () -> !riscv.reg<a0>
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %0 = riscv.get_register : () -> !riscv.reg<zero>
+// CHECK-NEXT:   %1 = riscv.get_register : () -> !riscv.reg<zero>
+// CHECK-NEXT:   %2 = riscv.mv %1 : (!riscv.reg<zero>) -> !riscv.reg<a0>
+// CHECK-NEXT: }

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -99,7 +99,7 @@ def test_riscv_interpreter():
 
     assert (
         interpreter.run_op(
-            riscv.FSwOp(TestSSAValue(register), TestSSAValue(fregister), 2),
+            riscv.FSwOp(TestSSAValue(register), TestSSAValue(fregister), 8),
             (buffer, 3.0),
         )
         == ()
@@ -108,7 +108,7 @@ def test_riscv_interpreter():
     assert buffer == Buffer([1, 2, 3.0, 0])
 
     assert interpreter.run_op(
-        riscv.FLwOp(TestSSAValue(register), 2),
+        riscv.FLwOp(TestSSAValue(register), 8),
         (buffer,),
     ) == (3.0,)
 

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -1,3 +1,5 @@
+import pytest
+
 from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import ModuleOp
@@ -5,6 +7,7 @@ from xdsl.interpreter import Interpreter, PythonValues
 from xdsl.interpreters.riscv import Buffer, RiscvFunctions
 from xdsl.ir.core import Block, Region
 from xdsl.utils.bitwise_casts import convert_f32_to_u32
+from xdsl.utils.exceptions import InterpretationError
 from xdsl.utils.test_value import TestSSAValue
 
 
@@ -113,6 +116,15 @@ def test_riscv_interpreter():
     ) == (3.0,)
 
     assert buffer == Buffer([1, 2, 3.0, 0])
+
+    assert interpreter.run_op(riscv.GetRegisterOp(riscv.Registers.ZERO), ()) == (0,)
+
+    get_non_zero = riscv.GetRegisterOp(riscv.IntRegisterType.unallocated())
+    with pytest.raises(
+        InterpretationError,
+        match="Cannot interpret riscv.get_register op with non-ZERO type",
+    ):
+        interpreter.run_op(get_non_zero, ())
 
 
 def test_get_data():

--- a/xdsl/backend/riscv/lowering/reduce_register_pressure.py
+++ b/xdsl/backend/riscv/lowering/reduce_register_pressure.py
@@ -1,0 +1,47 @@
+from xdsl.dialects import riscv
+from xdsl.dialects.builtin import (
+    IntegerAttr,
+    ModuleOp,
+)
+from xdsl.ir.core import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class LoadZeroImmediatePattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: riscv.LiOp, rewriter: PatternRewriter) -> None:
+        if not isinstance(op.immediate, IntegerAttr) or op.immediate.value.data != 0:
+            return
+
+        assert isinstance(op.rd.type, riscv.IntRegisterType)
+
+        if op.rd.type.is_allocated:
+            rewriter.replace_matched_op(
+                (
+                    zero_op := riscv.GetRegisterOp(riscv.Registers.ZERO),
+                    riscv.MVOp(zero_op.res, rd=op.rd.type),
+                )
+            )
+        else:
+            rewriter.replace_matched_op(riscv.GetRegisterOp(riscv.Registers.ZERO))
+
+
+class RiscvReduceRegisterPressurePass(ModulePass):
+    name = "riscv-reduce-register-pressure"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    LoadZeroImmediatePattern(),
+                ]
+            ),
+            apply_recursively=False,
+        ).rewrite_module(op)

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -206,6 +206,8 @@ class RiscvFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         offset = self.get_immediate_value(op, op.immediate)
+        if isinstance(offset, int):
+            offset //= 4
         return (args[0][offset],)
 
     @impl(riscv.LabelOp)
@@ -244,7 +246,7 @@ class RiscvFunctions(InterpreterFunctions):
         op: riscv.FSwOp,
         args: tuple[Any, ...],
     ):
-        args[0][op.immediate.value.data] = args[1]
+        args[0][op.immediate.value.data // 4] = args[1]
         return ()
 
     @impl(riscv.FLwOp)
@@ -255,6 +257,8 @@ class RiscvFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         offset = self.get_immediate_value(op, op.immediate)
+        if isinstance(offset, int):
+            offset //= 4
         return (args[0][offset],)
 
     # endregion

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -263,6 +263,17 @@ class RiscvFunctions(InterpreterFunctions):
 
     # endregion
 
+    @impl(riscv.GetRegisterOp)
+    def run_get_register(
+        self, interpreter: Interpreter, op: riscv.GetRegisterOp, args: PythonValues
+    ) -> PythonValues:
+        if not op.res.type == riscv.Registers.ZERO:
+            raise InterpretationError(
+                f"Cannot interpret riscv.get_register op with non-ZERO type {op.res.type}"
+            )
+
+        return (0,)
+
     @impl(riscv.CustomAssemblyInstructionOp)
     def run_custom_instruction(
         self,

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -10,6 +10,7 @@ from xdsl.backend.riscv.lowering import (
     convert_func_to_riscv_func,
     convert_memref_to_riscv,
     convert_scf_to_riscv_scf,
+    reduce_register_pressure,
 )
 from xdsl.dialects.affine import Affine
 from xdsl.dialects.arith import Arith
@@ -115,6 +116,7 @@ def get_all_passes() -> list[type[ModulePass]]:
         mlir_opt.MLIROptPass,
         printf_to_llvm.PrintfToLLVM,
         printf_to_putchar.PrintfToPutcharPass,
+        reduce_register_pressure.RiscvReduceRegisterPressurePass,
         riscv_register_allocation.RISCVRegisterAllocation,
         convert_arith_to_riscv.ConvertArithToRiscvPass,
         convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass,


### PR DESCRIPTION
First rewrite among many that will help reduce the number of registers live at any time. Future work will include things like moving constant definitions closer to their use etc.