### PR TITLE
backend: (riscv) move module walking logic to register allocation pass

### DIFF
--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,7 +1,6 @@
 import abc
 
 from xdsl.dialects import riscv_func, riscv_scf
-from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.riscv import (
     FloatRegisterType,
     IntRegisterType,
@@ -22,14 +21,6 @@ class RegisterAllocator(abc.ABC):
     @abc.abstractmethod
     def allocate_func(self, func: riscv_func.FuncOp) -> None:
         raise NotImplementedError()
-
-    def allocate_registers(self, module: ModuleOp) -> None:
-        """
-        Allocates unallocated registers in the module.
-        """
-        for op in module.walk():
-            if isinstance(op, riscv_func.FuncOp):
-                self.allocate_func(op)
 
 
 class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -5,6 +5,7 @@ from xdsl.backend.riscv.register_allocation import (
     RegisterAllocatorJRegs,
     RegisterAllocatorLivenessBlockNaive,
 )
+from xdsl.dialects import riscv_func
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
@@ -41,7 +42,9 @@ class RISCVRegisterAllocation(ModulePass):
                 "When set to 0 it signifies all available registers are used."
             )
 
-        allocator = allocator_strategies[self.allocation_strategy](
-            limit_registers=self.limit_registers
-        )
-        allocator.allocate_registers(op)
+        for inner_op in op.walk():
+            if isinstance(inner_op, riscv_func.FuncOp):
+                allocator = allocator_strategies[self.allocation_strategy](
+                    limit_registers=self.limit_registers
+                )
+                allocator.allocate_func(inner_op)


### PR DESCRIPTION
Functions are a natural boundary for register allocation scopes, this is a small refactoring change that simplifies the register allocation code a little bit.