### PR TITLE
backend: (riscv) limit_registers None by default

### DIFF
--- a/tests/filecheck/backend/riscv/riscv_register_allocation_jregs_no_loops.mlir
+++ b/tests/filecheck/backend/riscv/riscv_register_allocation_jregs_no_loops.mlir
@@ -1,0 +1,23 @@
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=BlockNaive limit_registers=0}" %s | filecheck %s
+
+riscv_func.func @main() {
+  %0 = riscv.li 6 : () -> !riscv.reg<>
+  %1 = riscv.li 5 : () -> !riscv.reg<s0>
+  %2 = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
+  %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg<>
+  %4 = riscv.fadd.s %2, %3 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+  %5 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
+  riscv_func.return
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    riscv_func.func @main() {
+// CHECK-NEXT:      %{{\d+}} = riscv.li 6 : () -> !riscv.reg<j0>
+// CHECK-NEXT:      %{{\d+}} = riscv.li 5 : () -> !riscv.reg<s0>
+// CHECK-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<j0>) -> !riscv.freg<j1>
+// CHECK-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<j2>
+// CHECK-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<j1>, !riscv.freg<j2>) -> !riscv.freg<j3>
+// CHECK-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<j0>, !riscv.reg<s0>) -> !riscv.reg<j4>
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -15,7 +15,7 @@ class RegisterAllocator(abc.ABC):
     Base class for register allocation strategies.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, limit_registers: int | None = None) -> None:
         pass
 
     @abc.abstractmethod
@@ -53,7 +53,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
     idx: int
 
-    def __init__(self, limit_registers: int = 0) -> None:
+    def __init__(self, limit_registers: int | None = None) -> None:
         self.idx = 0
         self._register_types = (IntRegisterType, FloatRegisterType)
 
@@ -73,7 +73,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
         }
 
         for reg_type, reg_set in self.register_sets.items():
-            if limit_registers:
+            if limit_registers is not None:
                 self.register_sets[reg_type] = reg_set[:limit_registers]
 
     def _allocate(self, reg: SSAValue) -> bool:
@@ -132,10 +132,9 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 class RegisterAllocatorBlockNaive(RegisterAllocator):
     idx: int
 
-    def __init__(self, limit_registers: int = 0) -> None:
+    def __init__(self, limit_registers: int | None = None) -> None:
         self.idx = 0
         self._register_types = (IntRegisterType, FloatRegisterType)
-        _ = limit_registers
 
         """
         Assume that all the registers are available except the ones explicitly reserved
@@ -151,6 +150,10 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
             ],
             FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
         }
+
+        for reg_type, reg_set in self.register_sets.items():
+            if limit_registers is not None:
+                self.register_sets[reg_type] = reg_set[:limit_registers]
 
     def allocate_func(self, func: riscv_func.FuncOp) -> None:
         """
@@ -184,7 +187,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
 class RegisterAllocatorJRegs(RegisterAllocator):
     idx: int
 
-    def __init__(self, limit_registers: int = 0) -> None:
+    def __init__(self, limit_registers: int | None = None) -> None:
         self.idx = 0
         self._register_types = (IntRegisterType, FloatRegisterType)
         _ = limit_registers

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,7 +1,6 @@
 import abc
 
 from xdsl.dialects import riscv_func, riscv_scf
-from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.riscv import (
     FloatRegisterType,
     IntRegisterType,
@@ -22,14 +21,6 @@ class RegisterAllocator(abc.ABC):
     @abc.abstractmethod
     def allocate_func(self, func: riscv_func.FuncOp) -> None:
         raise NotImplementedError()
-
-    def allocate_registers(self, module: ModuleOp) -> None:
-        """
-        Allocates unallocated registers in the module.
-        """
-        for op in module.walk():
-            if isinstance(op, riscv_func.FuncOp):
-                self.allocate_func(op)
 
 
 class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -5,6 +5,7 @@ from xdsl.backend.riscv.register_allocation import (
     RegisterAllocatorJRegs,
     RegisterAllocatorLivenessBlockNaive,
 )
+from xdsl.dialects import riscv_func
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
@@ -41,7 +42,9 @@ class RISCVRegisterAllocation(ModulePass):
                 "When set to 0 it signifies all available registers are used."
             )
 
-        allocator = allocator_strategies[self.allocation_strategy](
-            limit_registers=self.limit_registers
-        )
-        allocator.allocate_registers(op)
+        for inner_op in op.walk():
+            if isinstance(inner_op, riscv_func.FuncOp):
+                allocator = allocator_strategies[self.allocation_strategy](
+                    limit_registers=self.limit_registers
+                )
+                allocator.allocate_func(inner_op)

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -21,7 +21,7 @@ class RISCVRegisterAllocation(ModulePass):
 
     allocation_strategy: str = "GlobalJRegs"
 
-    limit_registers: int = 0
+    limit_registers: int | None = None
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
         allocator_strategies = {
@@ -36,7 +36,7 @@ class RISCVRegisterAllocation(ModulePass):
                 f"Available allocation types: {allocator_strategies.keys()}"
             )
 
-        if self.limit_registers < 0:
+        if self.limit_registers is not None and self.limit_registers < 0:
             raise ValueError(
                 "The limit of available registers cannot be less than 0."
                 "When set to 0 it signifies all available registers are used."


### PR DESCRIPTION
We can simulate the J reg allocator with the block naive allocators limited to 0. This PR allows passing 0 as the value, and tests that for code with no loops the result is the same as the J register allocator.