### PR TITLE
backend: (riscv) use register_queue for register management

### DIFF
--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -16,7 +16,7 @@ class RegisterAllocator(abc.ABC):
     Base class for register allocation strategies.
     """
 
-    def __init__(self, limit_registers: int | None = None) -> None:
+    def __init__(self) -> None:
         pass
 
     @abc.abstractmethod
@@ -54,7 +54,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
     available_registers: RegisterQueue
 
-    def __init__(self, limit_registers: int | None = None) -> None:
+    def __init__(self) -> None:
         self.available_registers = RegisterQueue(
             available_int_registers=[
                 IntRegisterType(reg)
@@ -65,9 +65,6 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 FloatRegisterType(reg) for reg in FloatRegisterType.RV32F_INDEX_BY_NAME
             ],
         )
-
-        if limit_registers is not None:
-            self.available_registers.limit_registers(limit_registers)
 
     def _allocate(self, reg: SSAValue) -> bool:
         if (
@@ -109,7 +106,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 class RegisterAllocatorBlockNaive(RegisterAllocator):
     available_registers: RegisterQueue
 
-    def __init__(self, limit_registers: int | None = None) -> None:
+    def __init__(self) -> None:
         self.available_registers = RegisterQueue(
             available_int_registers=[
                 IntRegisterType(reg)
@@ -120,9 +117,6 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
                 FloatRegisterType(reg) for reg in FloatRegisterType.RV32F_INDEX_BY_NAME
             ],
         )
-
-        if limit_registers is not None:
-            self.available_registers.limit_registers(limit_registers)
 
     def _allocate(self, reg: SSAValue) -> bool:
         if (

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -1,5 +1,6 @@
 import abc
 
+from xdsl.backend.riscv.register_queue import RegisterQueue
 from xdsl.dialects import riscv_func, riscv_scf
 from xdsl.dialects.riscv import (
     FloatRegisterType,
@@ -51,54 +52,39 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
     ```
     """
 
-    idx: int
+    available_registers: RegisterQueue
 
     def __init__(self, limit_registers: int | None = None) -> None:
-        self.idx = 0
-        self._register_types = (IntRegisterType, FloatRegisterType)
-
-        """
-        Assume that all the registers are available except the ones explicitly reserved
-        by the default RISCV ABI
-        """
-        self.reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
-
-        self.register_sets = {
-            IntRegisterType: [
-                reg
+        self.available_registers = RegisterQueue(
+            available_int_registers=[
+                IntRegisterType(reg)
                 for reg in IntRegisterType.RV32I_INDEX_BY_NAME
-                if reg not in self.reserved_registers
+                if IntRegisterType(reg) not in RegisterQueue.DEFAULT_RESERVED_REGISTERS
             ],
-            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
-        }
+            available_float_registers=[
+                FloatRegisterType(reg) for reg in FloatRegisterType.RV32F_INDEX_BY_NAME
+            ],
+        )
 
-        for reg_type, reg_set in self.register_sets.items():
-            if limit_registers is not None:
-                self.register_sets[reg_type] = reg_set[:limit_registers]
+        if limit_registers is not None:
+            self.available_registers.limit_registers(limit_registers)
 
     def _allocate(self, reg: SSAValue) -> bool:
-        if isinstance(reg.type, self._register_types) and not reg.type.is_allocated:
-            # If we run out of real registers, allocate a j register
-            reg_type = type(reg.type)
-            available_regs = self.register_sets.get(reg_type, [])
-
-            if not available_regs:
-                reg.type = reg_type(f"j{self.idx}")
-                self.idx += 1
-            else:
-                reg.type = reg_type(available_regs.pop())
-
+        if (
+            isinstance(reg.type, IntRegisterType | FloatRegisterType)
+            and not reg.type.is_allocated
+        ):
+            reg.type = self.available_registers.pop(type(reg.type))
             return True
 
         return False
 
     def _free(self, reg: SSAValue) -> None:
-        if isinstance(reg.type, self._register_types) and reg.type.is_allocated:
-            available_regs = self.register_sets.get(type(reg.type), [])
-            reg_name = reg.type.register_name
-
-            if not reg_name.startswith("j") and reg_name not in self.reserved_registers:
-                available_regs.append(reg_name)
+        if (
+            isinstance(reg.type, IntRegisterType | FloatRegisterType)
+            and reg.type.is_allocated
+        ):
+            self.available_registers.push(reg.type)
 
     def allocate_func(self, func: riscv_func.FuncOp) -> None:
         for region in func.regions:
@@ -121,43 +107,29 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
 
 class RegisterAllocatorBlockNaive(RegisterAllocator):
-    idx: int
+    available_registers: RegisterQueue
 
     def __init__(self, limit_registers: int | None = None) -> None:
-        self.idx = 0
-        self._register_types = (IntRegisterType, FloatRegisterType)
-
-        """
-        Assume that all the registers are available except the ones explicitly reserved
-        by the default RISCV ABI
-        """
-        reserved_registers = {"zero", "sp", "gp", "tp", "fp", "s0"}
-
-        self.register_sets = {
-            IntRegisterType: [
-                reg
+        self.available_registers = RegisterQueue(
+            available_int_registers=[
+                IntRegisterType(reg)
                 for reg in IntRegisterType.RV32I_INDEX_BY_NAME
-                if reg not in reserved_registers
+                if IntRegisterType(reg) not in RegisterQueue.DEFAULT_RESERVED_REGISTERS
             ],
-            FloatRegisterType: list(FloatRegisterType.RV32F_INDEX_BY_NAME.keys()),
-        }
+            available_float_registers=[
+                FloatRegisterType(reg) for reg in FloatRegisterType.RV32F_INDEX_BY_NAME
+            ],
+        )
 
-        for reg_type, reg_set in self.register_sets.items():
-            if limit_registers is not None:
-                self.register_sets[reg_type] = reg_set[:limit_registers]
+        if limit_registers is not None:
+            self.available_registers.limit_registers(limit_registers)
 
     def _allocate(self, reg: SSAValue) -> bool:
-        if isinstance(reg.type, self._register_types) and not reg.type.is_allocated:
-            # If we run out of real registers, allocate a j register
-            reg_type = type(reg.type)
-            available_regs = self.register_sets.get(reg_type, [])
-
-            if not available_regs:
-                reg.type = reg_type(f"j{self.idx}")
-                self.idx += 1
-            else:
-                reg.type = reg_type(available_regs.pop())
-
+        if (
+            isinstance(reg.type, IntRegisterType | FloatRegisterType)
+            and not reg.type.is_allocated
+        ):
+            reg.type = self.available_registers.pop(type(reg.type))
             return True
 
         return False
@@ -171,9 +143,7 @@ class RegisterAllocatorBlockNaive(RegisterAllocator):
 
         # Induction variable
         assert isinstance(block_args[0].type, IntRegisterType)
-        if not block_args[0].type.is_allocated:
-            block_args[0].type = IntRegisterType(f"j{self.idx}")
-            self.idx += 1
+        self._allocate(block_args[0])
 
         # The loop-carried variables are trickier
         # The for op operand, block arg, and yield operand must have the same type

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -16,9 +16,6 @@ class RegisterAllocator(abc.ABC):
     Base class for register allocation strategies.
     """
 
-    def __init__(self) -> None:
-        pass
-
     @abc.abstractmethod
     def allocate_func(self, func: riscv_func.FuncOp) -> None:
         raise NotImplementedError()

--- a/xdsl/backend/riscv/register_queue.py
+++ b/xdsl/backend/riscv/register_queue.py
@@ -10,18 +10,20 @@ class RegisterQueue:
     LIFO queue of registers available for allocation.
     """
 
+    DEFAULT_RESERVED_REGISTERS = {
+        Registers.ZERO,
+        Registers.SP,
+        Registers.GP,
+        Registers.TP,
+        Registers.FP,
+        Registers.S0,  # Same register as FP
+    }
+
     _idx: int = 0
     """Next `j` register index."""
 
     reserved_registers: set[IntRegisterType | FloatRegisterType] = field(
-        default_factory=lambda: {
-            Registers.ZERO,
-            Registers.SP,
-            Registers.GP,
-            Registers.TP,
-            Registers.FP,
-            Registers.S0,  # Same register as FP
-        }
+        default_factory=lambda: set(RegisterQueue.DEFAULT_RESERVED_REGISTERS)
     )
     "Registers unavailable to be used by the register allocator."
 

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -42,7 +42,7 @@ class RISCVRegisterAllocation(ModulePass):
 
         for inner_op in op.walk():
             if isinstance(inner_op, riscv_func.FuncOp):
-                allocator = allocator_strategies[self.allocation_strategy](
-                    limit_registers=self.limit_registers
-                )
+                allocator = allocator_strategies[self.allocation_strategy]()
+                if self.limit_registers is not None:
+                    allocator.available_registers.limit_registers(self.limit_registers)
                 allocator.allocate_func(inner_op)


### PR DESCRIPTION
Decouple the traversal logic from available register logic. This change just uses the helper class instead of having the logic inline, future changes will do a bit more separation.