### PR TITLE
backend: (riscv) free result registers before allocating

### DIFF
--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
@@ -45,7 +45,7 @@ builtin.module {
 // CHECK-NEXT:  riscv_func.func @main() {
 // CHECK-NEXT:    %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t5>
 // CHECK-NEXT:    %{{\d+}} = riscv.li 5 : () -> !riscv.reg<s0>
-// CHECK-NEXT:    %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t5>, !riscv.reg<s0>) -> !riscv.reg<t6>
+// CHECK-NEXT:    %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t5>, !riscv.reg<s0>) -> !riscv.reg<t5>
 // CHECK-NEXT:    %{{\d+}} = riscv.li 29 : () -> !riscv.reg<t5>
 // CHECK-NEXT:    %{{\d+}} = riscv.li 28 : () -> !riscv.reg<t5>
 // CHECK-NEXT:    %{{\d+}} = riscv.li 27 : () -> !riscv.reg<t5>
@@ -77,7 +77,7 @@ builtin.module {
 // CHECK-NEXT:    %{{\d+}} = riscv.li 1 : () -> !riscv.reg<t6>
 // CHECK-NEXT:    %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t5>) -> !riscv.freg<ft11>
 // CHECK-NEXT:    %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t6>) -> !riscv.freg<ft10>
-// CHECK-NEXT:    %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft11>, !riscv.freg<ft10>) -> !riscv.freg<ft9>
+// CHECK-NEXT:    %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft11>, !riscv.freg<ft10>) -> !riscv.freg<ft11>
 // CHECK-NEXT:    riscv_func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
@@ -22,10 +22,10 @@ riscv_func.func @main() {
 // CHECK-NEXT:    riscv_func.func @main() {
 // CHECK-NEXT:      %0 = riscv.li 6 : () -> !riscv.reg<ra>
 // CHECK-NEXT:      %1 = riscv.li 5 : () -> !riscv.reg<s0>
-// CHECK-NEXT:      %2 = riscv.add %0, %1 : (!riscv.reg<ra>, !riscv.reg<s0>) -> !riscv.reg<t0>
+// CHECK-NEXT:      %2 = riscv.add %0, %1 : (!riscv.reg<ra>, !riscv.reg<s0>) -> !riscv.reg<ra>
 // CHECK-NEXT:      %3 = riscv.li 29 : () -> !riscv.reg<ra>
 // CHECK-NEXT:      %4 = riscv.li 28 : () -> !riscv.reg<t0>
-// CHECK-NEXT:      %5 = riscv.add %3, %4 : (!riscv.reg<ra>, !riscv.reg<t0>) -> !riscv.reg<j1>
+// CHECK-NEXT:      %5 = riscv.add %3, %4 : (!riscv.reg<ra>, !riscv.reg<t0>) -> !riscv.reg<ra>
 // CHECK-NEXT:      %6 = riscv.li 26 : () -> !riscv.reg<ra>
 // CHECK-NEXT:      %7 = riscv.li 25 : () -> !riscv.reg<ra>
 // CHECK-NEXT:      %8 = riscv.li 24 : () -> !riscv.reg<ra>
@@ -34,7 +34,7 @@ riscv_func.func @main() {
 // CHECK-NEXT:      %11 = riscv.li 1 : () -> !riscv.reg<t0>
 // CHECK-NEXT:      %12 = riscv.fcvt.s.w %10 : (!riscv.reg<ra>) -> !riscv.freg<ft1>
 // CHECK-NEXT:      %13 = riscv.fcvt.s.w %11 : (!riscv.reg<t0>) -> !riscv.freg<ft0>
-// CHECK-NEXT:      %14 = riscv.fadd.s %12, %13 : (!riscv.freg<ft1>, !riscv.freg<ft0>) -> !riscv.freg<j0>
+// CHECK-NEXT:      %14 = riscv.fadd.s %12, %13 : (!riscv.freg<ft1>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }


### PR DESCRIPTION
I'm not sure exactly what the purpose of `to_free` was. @compor @adutilleul am I missing something here? It feels like it just prevents us from reusing the result register for operand register, which seems like generally a good idea.