### PR TITLE
backend: (riscv) add sym_visibility attr to riscv_func.FuncOp

### DIFF
--- a/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
+++ b/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
@@ -59,4 +59,20 @@ builtin.module {
   // CHECK-NEXT:   riscv_func.return %a, %a : !riscv.reg<>, !riscv.reg<>
   // CHECK-NEXT: }
 
+  riscv_func.func private @visibility_private() {
+    riscv_func.return
+  }
+
+  // CHECK: riscv_func.func private @visibility_private() {
+  // CHECK-NEXT:   riscv_func.return
+  // CHECK-NEXT: }
+
+  riscv_func.func public @visibility_public() {
+    riscv_func.return
+  }
+
+  // CHECK: riscv_func.func public @visibility_public() {
+  // CHECK-NEXT:   riscv_func.return
+  // CHECK-NEXT: }
+
 }


### PR DESCRIPTION
This PR adds to `riscv_func.FuncOp` the same visibility attribute that `func.FuncOp` has. This is the first step towards emitting correct assembler directives for global symbols.