### PR TITLE
core: Add support for lazy traits in IRDL

### DIFF
--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -34,8 +34,10 @@ from xdsl.irdl import (
     prop_def,
     region_def,
     result_def,
+    traits_def,
 )
 from xdsl.traits import (
+    HasParent,
     OptionalSymbolOpInterface,
     SymbolOpInterface,
     SymbolTable,
@@ -427,3 +429,21 @@ def test_symbol_table(SymbolOp: type[PropSymbolOp | SymbolOp]):
 
     assert SymbolTable.lookup_symbol(op, "name") is None
     assert SymbolTable.lookup_symbol(op, SymbolRefAttr("nested", ["name"])) is symbol
+
+
+@irdl_op_definition
+class HasLazyParentOp(IRDLOperation):
+    """An operation with traits that are defined "lazily"."""
+
+    name = "test.has_lazy_parent"
+
+    traits = traits_def(lambda: frozenset([HasParent(TestOp)]))
+
+
+def test_lazy_parent():
+    """Test the trait infrastructure for an operation that defines a trait "lazily"."""
+    op = HasLazyParentOp.create()
+    assert len(op.get_traits_of_type(HasParent)) != 0
+    assert op.get_traits_of_type(HasParent)[0].parameters == (TestOp,)
+    assert op.has_trait(HasParent, (TestOp,))
+    assert op.traits == frozenset([HasParent(TestOp)])

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -47,6 +47,7 @@ from xdsl.irdl import (
     result_def,
     var_operand_def,
 )
+from xdsl.irdl.irdl import traits_def
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import (
@@ -356,10 +357,7 @@ class MemcpyOp(IRDLOperation):
 class ModuleEndOp(IRDLOperation):
     name = "gpu.module_end"
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent(ModuleOp), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = traits_def(lambda: frozenset([IsTerminator()]))
 
     def __init__(self):
         return super().__init__()

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -45,9 +45,9 @@ from xdsl.irdl import (
     prop_def,
     region_def,
     result_def,
+    traits_def,
     var_operand_def,
 )
-from xdsl.irdl.irdl import traits_def
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import (
@@ -357,7 +357,7 @@ class MemcpyOp(IRDLOperation):
 class ModuleEndOp(IRDLOperation):
     name = "gpu.module_end"
 
-    traits = traits_def(lambda: frozenset([IsTerminator()]))
+    traits = traits_def(lambda: frozenset([IsTerminator(), HasParent(ModuleOp)]))
 
     def __init__(self):
         return super().__init__()


### PR DESCRIPTION
This is an alternative implementation to #1505, which implements the laziness at the traits field level, instead of the trait definition level.
Note that we could force all traits definitions to use `traits_def`, while right now operations can both use `traits = frozenset(...)` and `traits = traits_def(frozenset(...))` and `traits = traits_def(lambda: frozenset(...))`.

I believe this implementation reduces the complexity of the traits definitions, as they don't need to specify if they are lazy or not. If a circular dependency arise, this only require a change in the operation definition, and not the trait definition, which I think is better.