### PR TITLE
interpreter: Add support for external implementations

### DIFF
--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -345,7 +345,7 @@ class _InterpreterFunctionImpls:
         return impl(ft, input_type, output_type, value)
 
     def call_external(
-        self, sym_name: str, op: Operation, args: PythonValues
+        self, interpreter: Interpreter, sym_name: str, op: Operation, args: PythonValues
     ) -> PythonValues:
         if sym_name not in self._external_funcs_dict:
             raise InterpretationError(
@@ -354,7 +354,7 @@ class _InterpreterFunctionImpls:
 
         ft, ext_func = self._external_funcs_dict[sym_name]
 
-        return ext_func(ft, op, args)
+        return ext_func(ft, interpreter, op, args)
 
 
 @dataclass
@@ -645,7 +645,7 @@ _CastImplDict: TypeAlias = dict[
 ]
 
 ExtFuncImpl: TypeAlias = Callable[
-    [_FT, Operation, PythonValues],
+    [_FT, Interpreter, Operation, PythonValues],
     PythonValues,
 ]
 

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -509,7 +509,7 @@ class Interpreter:
 
         # TODO: make this an interface that exposes `is_external_decl` or similar
         if not body.blocks or not body.blocks[0].ops:
-            results = self._impls.call_external(name, op, inputs)
+            results = self._impls.call_external(self, name, op, inputs)
         else:
             results = self.run_ssacfg_region(body, inputs, name)
         assert results is not None

--- a/xdsl/interpreters/printf.py
+++ b/xdsl/interpreters/printf.py
@@ -1,12 +1,7 @@
 from typing import Any
 
 from xdsl.dialects.printf import PrintFormatOp
-from xdsl.interpreter import (
-    Interpreter,
-    InterpreterFunctions,
-    impl,
-    register_impls,
-)
+from xdsl.interpreter import Interpreter, InterpreterFunctions, impl, register_impls
 
 
 @register_impls

--- a/xdsl/interpreters/printf.py
+++ b/xdsl/interpreters/printf.py
@@ -1,7 +1,12 @@
 from typing import Any
 
 from xdsl.dialects.printf import PrintFormatOp
-from xdsl.interpreter import Interpreter, InterpreterFunctions, impl, register_impls
+from xdsl.interpreter import (
+    Interpreter,
+    InterpreterFunctions,
+    impl,
+    register_impls,
+)
 
 
 @register_impls


### PR DESCRIPTION
Improvement upon #1422 

Adds support for registering external functions similar to operation and cast implementations by marking them with `@impl_external(sym_name)`

