### PR TITLE
dialects: (scf) add custom syntax to scf for and yield

### DIFF
--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -244,7 +244,7 @@
       "  %4 = arith.constant 5 : i32\n",
       "  %5 = arith.addi %3, %4 : i32\n",
       "  %6 = \"arith.cmpi\"(%2, %5) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
-      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "  scf.yield %6 : i1\n",
       "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
     }
@@ -317,7 +317,7 @@
       "  %4 = arith.constant 5 : i32\n",
       "  %5 = arith.addi %3, %4 : i32\n",
       "  %6 = \"arith.cmpi\"(%2, %5) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
-      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "  scf.yield %6 : i1\n",
       "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
     }
@@ -383,7 +383,7 @@
       "  %4 = arith.constant 5 : i32\n",
       "  %5 = arith.addi %3, %4 : i32\n",
       "  %6 = \"arith.cmpi\"(%2, %5) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
-      "  \"scf.yield\"(%6) : (i1) -> ()\n",
+      "  scf.yield %6 : i1\n",
       "}) : (#sql.bag<i32>) -> #sql.bag<i32>"
      ]
     }
@@ -441,7 +441,7 @@
       "    %4 = arith.constant 5 : i32\n",
       "    %5 = arith.addi %3, %4 : i32\n",
       "    %6 = \"arith.cmpi\"(%2, %5) {\"predicate\" = 4 : i64} : (i32, i32) -> i1\n",
-      "    \"scf.yield\"(%6) : (i1) -> ()\n",
+      "    scf.yield %6 : i1\n",
       "  }) : (#sql.bag<i32>) -> #sql.bag<i32>\n",
       "  \"sql.sink\"(%1) : (#sql.bag<i32>) -> ()\n",
       "}\n"
@@ -471,8 +471,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -471,16 +471,8 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/tests/filecheck/dialects/scf/reduce.mlir
+++ b/tests/filecheck/dialects/scf/reduce.mlir
@@ -30,6 +30,6 @@ builtin.module {
 // CHECK-NEXT:       %9 = arith.addf %7, %8 : f32
 // CHECK-NEXT:       "scf.reduce.return"(%9) : (f32) -> ()
 // CHECK-NEXT:     }) : (f32) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 1>} : (index, index, index, f32) -> f32
-// CHECK-NEXT: 
+// CHECK-NEXT:

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -7,19 +7,19 @@ builtin.module {
   %0 = "test.op"() : () -> i1
   "scf.if"(%0) ({
     %1 = "test.op"() : () -> i32
-    "scf.yield"() : () -> ()
+    scf.yield
   }, {
     %2 = "test.op"() : () -> i32
-    "scf.yield"() : () -> ()
+    scf.yield
   }) : (i1) -> ()
 
   // CHECK:      %{{.*}} = "test.op"() : () -> i1
   // CHECK-NEXT: "scf.if"(%{{.*}}) ({
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"() : () -> ()
+  // CHECK-NEXT:   scf.yield
   // CHECK-NEXT: }, {
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"() : () -> ()
+  // CHECK-NEXT:   scf.yield
   // CHECK-NEXT: }) : (i1) -> ()
 
 
@@ -34,10 +34,10 @@ builtin.module {
 
   // CHECK:      %{{.*}} = "scf.if"(%{{.*}}) ({
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"(%{{.*}}) : (i32) -> ()
+  // CHECK-NEXT:   scf.yield %{{.*}} : i32
   // CHECK-NEXT: }, {
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   "scf.yield"(%{{.*}}) : (i32) -> ()
+  // CHECK-NEXT:   scf.yield %{{.*}} : i32
   // CHECK-NEXT: }) : (i1) -> i32
 
   func.func @while() {
@@ -63,7 +63,7 @@ builtin.module {
   // CHECK-NEXT:     "scf.condition"(%{{.*}}, %{{.*}}) : (i1, i32) -> ()
   // CHECK-NEXT:   }, {
   // CHECK-NEXT:   ^{{.*}}(%{{.*}} : i32):
-  // CHECK-NEXT:     "scf.yield"(%{{.*}}) : (i32) -> ()
+  // CHECK-NEXT:     scf.yield %{{.*}} : i32
   // CHECK-NEXT:   }) : (i32) -> i32
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
@@ -98,7 +98,7 @@ builtin.module {
   // CHECK-NEXT:    ^3(%{{.*}} : i32, %{{.*}} : f32):
   // CHECK-NEXT:      %{{.*}} = arith.constant 1.000000e+00 : f32
   // CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f32
-  // CHECK-NEXT:      "scf.yield"(%{{.*}}, %{{.*}}) : (i32, f32) -> ()
+  // CHECK-NEXT:      scf.yield %{{.*}}, %{{.*}} : i32, f32
   // CHECK-NEXT:    }) : (i32, f32) -> (i32, f32)
   // CHECK-NEXT:    func.return
   // CHECK-NEXT:  }
@@ -121,11 +121,10 @@ builtin.module {
   // CHECK-NEXT:   %{{.*}} = arith.constant 42 : index
   // CHECK-NEXT:   %{{.*}} = arith.constant 3 : index
   // CHECK-NEXT:   %{{.*}} = arith.constant 1 : index
-  // CHECK-NEXT:   %{{.*}} = "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) ({
-  // CHECK-NEXT:   ^{{.*}}(%{{.*}} : index, %{{.*}} : index):
+  // CHECK-NEXT:   %{{.*}} = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (index) {
   // CHECK-NEXT:     %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
-  // CHECK-NEXT:     "scf.yield"(%{{.*}}) : (index) -> ()
-  // CHECK-NEXT:   }) : (index, index, index, index) -> index
+  // CHECK-NEXT:     scf.yield %{{.*}} : index
+  // CHECK-NEXT:   }
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 

--- a/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
+++ b/tests/filecheck/dialects/stencil/hdiff_gpu.mlir
@@ -66,7 +66,7 @@
 // CHECK-NEXT:       %35 = arith.mulf %31, %cst : f64
 // CHECK-NEXT:       %36 = arith.addf %35, %34 : f64
 // CHECK-NEXT:       "memref.store"(%36, %6, %18, %17, %16) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 3, 3, 3, 0>} : (index, index, index, index, index, index, index, index, index) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -63,17 +63,16 @@ builtin.module {
 // CHECK-NEXT:     %time_m = arith.constant 0 : index
 // CHECK-NEXT:     %time_M = arith.constant 1000 : index
 // CHECK-NEXT:     %step = arith.constant 1 : index
-// CHECK-NEXT:     %fnp1, %fn = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
-// CHECK-NEXT:     ^0(%time : index, %fi : !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, %fip1 : !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>):
+// CHECK-NEXT:     %fnp1, %fn = scf.for %time = %time_m to %time_M step %step iter_args(%fi = %f0, %fip1 = %f1) -> (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) {
 // CHECK-NEXT:       %ti = "stencil.load"(%fi) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> !stencil.temp<?x?x?xf32>
 // CHECK-NEXT:       %tip1 = "stencil.apply"(%ti) ({
-// CHECK-NEXT:       ^1(%ti_ : !stencil.temp<?x?x?xf32>):
+// CHECK-NEXT:       ^0(%ti_ : !stencil.temp<?x?x?xf32>):
 // CHECK-NEXT:         %v = "stencil.access"(%ti_) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf32>) -> f32
 // CHECK-NEXT:         "stencil.return"(%v) : (f32) -> ()
 // CHECK-NEXT:       }) : (!stencil.temp<?x?x?xf32>) -> !stencil.temp<?x?x?xf32>
 // CHECK-NEXT:       "stencil.store"(%tip1, %fip1) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<50, 80, 40>} : (!stencil.temp<?x?x?xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
-// CHECK-NEXT:       "scf.yield"(%fip1, %fi) : (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> ()
-// CHECK-NEXT:     }) : (index, index, index, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>) -> (!stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>)
+// CHECK-NEXT:       scf.yield %fip1, %fi : !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:     }
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -11,10 +11,9 @@ with CodeContext(p):
     # CHECK:        %{{.*}} = arith.constant 0 : index
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @end} : () -> index
     # CHECK-NEXT:   %{{.*}} = arith.constant 1 : index
-    # CHECK-NEXT:   "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}) ({
-    # CHECK-NEXT:   ^0(%{{.*}} : index):
-    # CHECK-NEXT:     "scf.yield"() : () -> ()
-    # CHECK-NEXT:   }) : (index, index, index) -> ()
+    # CHECK-NEXT:   scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+    # CHECK-NEXT:     scf.yield
+    # CHECK-NEXT:   }
     # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
 
@@ -29,10 +28,9 @@ with CodeContext(p):
     # CHECK:        %{{.*}} = "symref.fetch"() {"symbol" = @start} : () -> index
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @end} : () -> index
     # CHECK-NEXT:   %{{.*}} = arith.constant 1 : index
-    # CHECK-NEXT:   "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}) ({
-    # CHECK-NEXT:   ^1(%{{.*}} : index):
-    # CHECK-NEXT:     "scf.yield"() : () -> ()
-    # CHECK-NEXT:   }) : (index, index, index) -> ()
+    # CHECK-NEXT:   scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+    # CHECK-NEXT:     scf.yield
+    # CHECK-NEXT:   }
     # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_for_II(start: index, end: index):
@@ -47,10 +45,9 @@ with CodeContext(p):
     # CHECK:        %{{.*}} = "symref.fetch"() {"symbol" = @start} : () -> index
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @end} : () -> index
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @step} : () -> index
-    # CHECK-NEXT:   "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}) ({
-    # CHECK-NEXT:   ^2(%{{.*}} : index):
-    # CHECK-NEXT:     "scf.yield"() : () -> ()
-    # CHECK-NEXT:   }) : (index, index, index) -> ()
+    # CHECK-NEXT:   scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+    # CHECK-NEXT:     scf.yield
+    # CHECK-NEXT:   }
     # CHECK-NEXT:   func.return
     # CHECK-NEXT: }
     def test_for_III(start: index, end: index, step: index):
@@ -66,24 +63,21 @@ with CodeContext(p):
     # CHECK:          %{{.*}} = arith.constant 0 : index
     # CHECK-NEXT:     %{{.*}} = "symref.fetch"() {"symbol" = @a} : () -> index
     # CHECK-NEXT:     %{{.*}} = arith.constant 1 : index
-    # CHECK-NEXT:     "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}) ({
-    # CHECK-NEXT:     ^{{.*}}(%{{.*}} : index):
+    # CHECK-NEXT:     scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
     # CHECK-NEXT:       %{{.*}} = arith.constant 0 : index
     # CHECK-NEXT:       %{{.*}} = "symref.fetch"() {"symbol" = @b} : () -> index
     # CHECK-NEXT:       %{{.*}} = arith.constant 1 : index
-    # CHECK-NEXT:       "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}) ({
-    # CHECK-NEXT:       ^{{.*}}(%{{.*}} : index):
+    # CHECK-NEXT:       scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
     # CHECK-NEXT:         %{{.*}} = arith.constant 0 : index
     # CHECK-NEXT:         %{{.*}} = "symref.fetch"() {"symbol" = @c} : () -> index
     # CHECK-NEXT:         %{{.*}} = arith.constant 1 : index
-    # CHECK-NEXT:         "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}) ({
-    # CHECK-NEXT:         ^{{.*}}(%{{.*}} : index):
-    # CHECK-NEXT:           "scf.yield"() : () -> ()
-    # CHECK-NEXT:         }) : (index, index, index) -> ()
-    # CHECK-NEXT:         "scf.yield"() : () -> ()
-    # CHECK-NEXT:       }) : (index, index, index) -> ()
-    # CHECK-NEXT:       "scf.yield"() : () -> ()
-    # CHECK-NEXT:     }) : (index, index, index) -> ()
+    # CHECK-NEXT:         scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+    # CHECK-NEXT:           scf.yield
+    # CHECK-NEXT:         }
+    # CHECK-NEXT:         scf.yield
+    # CHECK-NEXT:       }
+    # CHECK-NEXT:       scf.yield
+    # CHECK-NEXT:     }
     # CHECK-NEXT:   func.return
     # CHECK-NEXT:   }
     def test_for_IV(a: index, b: index, c: index):
@@ -147,18 +141,18 @@ p = FrontendProgram()
 with CodeContext(p):
     # CHECK:      %{{.*}} = "scf.if"(%{{.*}}) ({
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @x} : () -> i32
-    # CHECK-NEXT:   "scf.yield"(%{{.*}}) : (i32) -> ()
+    # CHECK-NEXT:   scf.yield %{{.*}} : i32
     # CHECK-NEXT: }, {
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @y} : () -> i32
-    # CHECK-NEXT:   "scf.yield"(%{{.*}}) : (i32) -> ()
+    # CHECK-NEXT:   scf.yield %{{.*}} : i32
     # CHECK-NEXT: }) : (i1) -> i32
     def test_if_expr(cond: i1, x: i32, y: i32) -> i32:
         return x if cond else y
 
     # CHECK:      "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:   "scf.yield"() : () -> ()
+    # CHECK-NEXT:   scf.yield
     # CHECK-NEXT: }, {
-    # CHECK-NEXT:   "scf.yield"() : () -> ()
+    # CHECK-NEXT:   scf.yield
     # CHECK-NEXT: }) : (i1) -> ()
     def test_if_I(cond: i1):
         if cond:
@@ -169,21 +163,21 @@ with CodeContext(p):
 
     # CHECK:      %{{.*}} = "symref.fetch"() {"symbol" = @a} : () -> i1
     # CHECK-NEXT: "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:   "scf.yield"() : () -> ()
+    # CHECK-NEXT:   scf.yield
     # CHECK-NEXT: }, {
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @b} : () -> i1
     # CHECK-NEXT:   "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:     "scf.yield"() : () -> ()
+    # CHECK-NEXT:     scf.yield
     # CHECK-NEXT:   }, {
     # CHECK-NEXT:     %{{.*}} = "symref.fetch"() {"symbol" = @c} : () -> i1
     # CHECK-NEXT:     "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:       "scf.yield"() : () -> ()
+    # CHECK-NEXT:       scf.yield
     # CHECK-NEXT:     }, {
-    # CHECK-NEXT:       "scf.yield"() : () -> ()
+    # CHECK-NEXT:       scf.yield
     # CHECK-NEXT:     }) : (i1) -> ()
-    # CHECK-NEXT:     "scf.yield"() : () -> ()
+    # CHECK-NEXT:     scf.yield
     # CHECK-NEXT:   }) : (i1) -> ()
-    # CHECK-NEXT:   "scf.yield"() : () -> ()
+    # CHECK-NEXT:   scf.yield
     # CHECK-NEXT: }) : (i1) -> ()
     def test_if_II(a: i1, b: i1, c: i1):
         if a:
@@ -196,9 +190,9 @@ with CodeContext(p):
 
     # CHECK:      %{{.*}} = "symref.fetch"() {"symbol" = @cond} : () -> i1
     # CHECK-NEXT: "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:   "scf.yield"() : () -> ()
+    # CHECK-NEXT:   scf.yield
     # CHECK-NEXT: }, {
-    # CHECK-NEXT:   "scf.yield"() : () -> ()
+    # CHECK-NEXT:   scf.yield
     # CHECK-NEXT: }) : (i1) -> ()
     def test_if_III(cond: i1):
         if cond:

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_custom.mlir
@@ -1,0 +1,26 @@
+// RUN: xdsl-opt %s | xdsl-opt | mlir-opt | filecheck %s
+
+%lb = arith.constant 0 : index
+%ub = arith.constant 42 : index
+%step = arith.constant 7 : index
+%sum_init = arith.constant 36 : index
+%sum = scf.for %iv = %lb to %ub step %step iter_args(%sum_iter = %sum_init) -> (index) {
+  %sum_new = arith.addi %sum_iter, %iv : index
+  scf.yield %sum_new : index
+}
+
+scf.for %iv = %lb to %ub step %step {
+}
+
+// CHECK:      module {
+// CHECK-NEXT:   %{{.*}} = arith.constant 0 : index
+// CHECK-NEXT:   %{{.*}} = arith.constant 42 : index
+// CHECK-NEXT:   %{{.*}} = arith.constant 7 : index
+// CHECK-NEXT:   %{{.*}} = arith.constant 36 : index
+// CHECK-NEXT:   %{{.*}} = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (index) {
+// CHECK-NEXT:     %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
+// CHECK-NEXT:     scf.yield %{{.*}} : index
+// CHECK-NEXT:   }
+// CHECK-NEXT:   scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_generic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_generic.mlir
@@ -10,6 +10,10 @@
     %sum_new = "arith.addi"(%sum_iter, %iv) : (index, index) -> index
     "scf.yield"(%sum_new) : (index) -> ()
   }) : (index, index, index, index) -> index
+  "scf.for"(%lb, %ub, %step) ({
+  ^bb0(%iv: index):
+    "scf.yield"() : () -> ()
+  }) : (index, index, index) -> ()
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
@@ -22,4 +26,8 @@
 // CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (index, index) -> index
 // CHECK-NEXT:     "scf.yield"(%{{.*}}) : (index) -> ()
 // CHECK-NEXT:   }) : (index, index, index, index) -> index
+// CHECK-NEXT:   "scf.for"(%{{.*}}, %{{.*}}, %{{.*}}) ({
+// CHECK-NEXT:   ^1(%{{.*}}: index):
+// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:   }) : (index, index, index) -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir-tiled.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir-tiled.mlir
@@ -32,32 +32,28 @@ builtin.module {
 // CHECK-NEXT:   %12 = arith.constant 63 : index
 // CHECK-NEXT:   "scf.parallel"(%4, %8, %10) ({
 // CHECK-NEXT:   ^0(%13 : index):
-// CHECK-NEXT:     "scf.for"(%5, %9, %11) ({
-// CHECK-NEXT:     ^1(%14 : index):
+// CHECK-NEXT:     scf.for %14 = %5 to %9 step %11 {
 // CHECK-NEXT:       %15 = arith.addi %13, %10 : index
 // CHECK-NEXT:       %16 = "arith.cmpi"(%15, %8) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:       %17 = "arith.select"(%16, %15, %8) : (i1, index, index) -> index
-// CHECK-NEXT:       "scf.for"(%13, %17, %7) ({
-// CHECK-NEXT:       ^2(%18 : index):
+// CHECK-NEXT:       scf.for %18 = %13 to %17 step %7 {
 // CHECK-NEXT:         %19 = arith.addi %14, %11 : index
 // CHECK-NEXT:         %20 = "arith.cmpi"(%19, %9) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:         %21 = "arith.select"(%20, %19, %9) : (i1, index, index) -> index
-// CHECK-NEXT:         "scf.for"(%14, %21, %7) ({
-// CHECK-NEXT:         ^3(%22 : index):
-// CHECK-NEXT:           "scf.for"(%6, %12, %7) ({
-// CHECK-NEXT:           ^4(%23 : index):
+// CHECK-NEXT:         scf.for %22 = %14 to %21 step %7 {
+// CHECK-NEXT:           scf.for %23 = %6 to %12 step %7 {
 // CHECK-NEXT:             %24 = arith.constant 1.000000e+00 : f64
 // CHECK-NEXT:             %25 = arith.addf %0, %24 : f64
 // CHECK-NEXT:             "memref.store"(%25, %3, %18, %22, %23) : (f64, memref<64x64x60xf64, strided<[4900, 70, 1], offset: 14913>>, index, index, index) -> ()
-// CHECK-NEXT:             "scf.yield"() : () -> ()
-// CHECK-NEXT:           }) : (index, index, index) -> ()
-// CHECK-NEXT:           "scf.yield"() : () -> ()
-// CHECK-NEXT:         }) : (index, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:             scf.yield
+// CHECK-NEXT:           }
+// CHECK-NEXT:           scf.yield
+// CHECK-NEXT:         }
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
@@ -84,8 +80,7 @@ builtin.module {
 // CHECK-NEXT:   %time_m = arith.constant 0 : index
 // CHECK-NEXT:   %time_M = arith.constant 1001 : index
 // CHECK-NEXT:   %step = arith.constant 1 : index
-// CHECK-NEXT:   %t1_out, %t0_out = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
-// CHECK-NEXT:   ^5(%time : index, %fim1 : memref<2004x2004xf32>, %fi : memref<2004x2004xf32>):
+// CHECK-NEXT:   %t1_out, %t0_out = scf.for %time = %time_m to %time_M step %step iter_args(%fim1 = %f0, %fi = %f1) -> (memref<2004x2004xf32>, memref<2004x2004xf32>) {
 // CHECK-NEXT:     %fi_storeview = "memref.subview"(%fi) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
 // CHECK-NEXT:     %fim1_loadview = "memref.subview"(%fim1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
 // CHECK-NEXT:     %26 = arith.constant 0 : index
@@ -96,31 +91,28 @@ builtin.module {
 // CHECK-NEXT:     %31 = arith.constant 24 : index
 // CHECK-NEXT:     %32 = arith.constant 2000 : index
 // CHECK-NEXT:     "scf.parallel"(%26, %29, %30) ({
-// CHECK-NEXT:     ^6(%33 : index):
-// CHECK-NEXT:       "scf.for"(%27, %32, %31) ({
-// CHECK-NEXT:       ^7(%34 : index):
+// CHECK-NEXT:     ^1(%33 : index):
+// CHECK-NEXT:       scf.for %34 = %27 to %32 step %31 {
 // CHECK-NEXT:         %35 = arith.addi %33, %30 : index
 // CHECK-NEXT:         %36 = "arith.cmpi"(%35, %29) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:         %37 = "arith.select"(%36, %35, %29) : (i1, index, index) -> index
-// CHECK-NEXT:         "scf.for"(%33, %37, %28) ({
-// CHECK-NEXT:         ^8(%38 : index):
+// CHECK-NEXT:         scf.for %38 = %33 to %37 step %28 {
 // CHECK-NEXT:           %39 = arith.addi %34, %31 : index
 // CHECK-NEXT:           %40 = "arith.cmpi"(%39, %32) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:           %41 = "arith.select"(%40, %39, %32) : (i1, index, index) -> index
-// CHECK-NEXT:           "scf.for"(%34, %41, %28) ({
-// CHECK-NEXT:           ^9(%42 : index):
+// CHECK-NEXT:           scf.for %42 = %34 to %41 step %28 {
 // CHECK-NEXT:             %i = "memref.load"(%fim1_loadview, %38, %42) : (memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> f32
 // CHECK-NEXT:             "memref.store"(%i, %fi_storeview, %38, %42) : (f32, memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> ()
-// CHECK-NEXT:             "scf.yield"() : () -> ()
-// CHECK-NEXT:           }) : (index, index, index) -> ()
-// CHECK-NEXT:           "scf.yield"() : () -> ()
-// CHECK-NEXT:         }) : (index, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:             scf.yield
+// CHECK-NEXT:           }
+// CHECK-NEXT:           scf.yield
+// CHECK-NEXT:         }
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"(%fi, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
-// CHECK-NEXT:   }) : (index, index, index, memref<2004x2004xf32>, memref<2004x2004xf32>) -> (memref<2004x2004xf32>, memref<2004x2004xf32>)
+// CHECK-NEXT:     scf.yield %fi, %fim1 : memref<2004x2004xf32>, memref<2004x2004xf32>
+// CHECK-NEXT:   }
 // CHECK-NEXT:   func.return %t1_out : memref<2004x2004xf32>
 // CHECK-NEXT: }
 
@@ -147,19 +139,18 @@ builtin.module {
 // CHECK-NEXT:   %48 = arith.constant 16 : index
 // CHECK-NEXT:   %49 = arith.constant 68 : index
 // CHECK-NEXT:   "scf.parallel"(%46, %49, %48) ({
-// CHECK-NEXT:   ^10(%50 : index):
+// CHECK-NEXT:   ^2(%50 : index):
 // CHECK-NEXT:     %51 = arith.addi %50, %48 : index
 // CHECK-NEXT:     %52 = "arith.cmpi"(%51, %49) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:     %53 = "arith.select"(%52, %51, %49) : (i1, index, index) -> index
-// CHECK-NEXT:     "scf.for"(%50, %53, %47) ({
-// CHECK-NEXT:     ^11(%54 : index):
+// CHECK-NEXT:     scf.for %54 = %50 to %53 step %47 {
 // CHECK-NEXT:       %55 = arith.constant -1 : index
 // CHECK-NEXT:       %56 = arith.addi %54, %55 : index
 // CHECK-NEXT:       %57 = "memref.load"(%45, %56) : (memref<69xf64, strided<[1], offset: 4>>, index) -> f64
 // CHECK-NEXT:       "memref.store"(%57, %outc_storeview, %54) : (f64, memref<68xf64, strided<[1]>>, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
@@ -186,29 +177,26 @@ builtin.module {
   // CHECK-NEXT:   %66 = arith.constant 24 : index
   // CHECK-NEXT:   %67 = arith.constant 68 : index
   // CHECK-NEXT:   "scf.parallel"(%61, %64, %65) ({
-  // CHECK-NEXT:   ^12(%68 : index):
-  // CHECK-NEXT:     "scf.for"(%62, %67, %66) ({
-  // CHECK-NEXT:     ^13(%69 : index):
+  // CHECK-NEXT:   ^3(%68 : index):
+  // CHECK-NEXT:     scf.for %69 = %62 to %67 step %66 {
   // CHECK-NEXT:       %70 = arith.addi %68, %65 : index
   // CHECK-NEXT:       %71 = "arith.cmpi"(%70, %64) {"predicate" = 6 : i64} : (index, index) -> i1
   // CHECK-NEXT:       %72 = "arith.select"(%71, %70, %64) : (i1, index, index) -> index
-  // CHECK-NEXT:       "scf.for"(%68, %72, %63) ({
-  // CHECK-NEXT:       ^14(%73 : index):
+  // CHECK-NEXT:       scf.for %73 = %68 to %72 step %63 {
   // CHECK-NEXT:         %74 = arith.addi %69, %66 : index
   // CHECK-NEXT:         %75 = "arith.cmpi"(%74, %67) {"predicate" = 6 : i64} : (index, index) -> i1
   // CHECK-NEXT:         %76 = "arith.select"(%75, %74, %67) : (i1, index, index) -> index
-  // CHECK-NEXT:         "scf.for"(%69, %76, %63) ({
-  // CHECK-NEXT:         ^15(%77 : index):
+  // CHECK-NEXT:         scf.for %77 = %69 to %76 step %63 {
   // CHECK-NEXT:           %78 = arith.constant -1 : index
   // CHECK-NEXT:           %79 = arith.addi %73, %78 : index
   // CHECK-NEXT:           %80 = "memref.load"(%60, %79, %77) : (memref<65x68xf64, strided<[72, 1], offset: 292>>, index, index) -> f64
-  // CHECK-NEXT:           "scf.yield"() : () -> ()
-  // CHECK-NEXT:         }) : (index, index, index) -> ()
-  // CHECK-NEXT:         "scf.yield"() : () -> ()
-  // CHECK-NEXT:       }) : (index, index, index) -> ()
-  // CHECK-NEXT:       "scf.yield"() : () -> ()
-  // CHECK-NEXT:     }) : (index, index, index) -> ()
-  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:           scf.yield
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         scf.yield
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       scf.yield
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     scf.yield
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
@@ -224,7 +212,7 @@ builtin.module {
     }) : (!stencil.temp<[-1,64]x[0,64]x[0,69]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,68]xf64>
     func.return
   }
-  
+
 // CHECK-NEXT: func.func @copy_3d(%81 : memref<?x?x?xf64>) {
 // CHECK-NEXT:   %82 = "memref.cast"(%81) : (memref<?x?x?xf64>) -> memref<72x74x76xf64>
 // CHECK-NEXT:   %83 = "memref.subview"(%82) {"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 65, 64, 69>, "static_strides" = array<i64: 1, 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72x74x76xf64>) -> memref<65x64x69xf64, strided<[5624, 76, 1], offset: 22804>>
@@ -238,35 +226,31 @@ builtin.module {
 // CHECK-NEXT:   %91 = arith.constant 24 : index
 // CHECK-NEXT:   %92 = arith.constant 68 : index
 // CHECK-NEXT:   "scf.parallel"(%84, %88, %90) ({
-// CHECK-NEXT:   ^16(%93 : index):
-// CHECK-NEXT:     "scf.for"(%85, %89, %91) ({
-// CHECK-NEXT:     ^17(%94 : index):
+// CHECK-NEXT:   ^4(%93 : index):
+// CHECK-NEXT:     scf.for %94 = %85 to %89 step %91 {
 // CHECK-NEXT:       %95 = arith.addi %93, %90 : index
 // CHECK-NEXT:       %96 = "arith.cmpi"(%95, %88) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:       %97 = "arith.select"(%96, %95, %88) : (i1, index, index) -> index
-// CHECK-NEXT:       "scf.for"(%93, %97, %87) ({
-// CHECK-NEXT:       ^18(%98 : index):
+// CHECK-NEXT:       scf.for %98 = %93 to %97 step %87 {
 // CHECK-NEXT:         %99 = arith.addi %94, %91 : index
 // CHECK-NEXT:         %100 = "arith.cmpi"(%99, %89) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:         %101 = "arith.select"(%100, %99, %89) : (i1, index, index) -> index
-// CHECK-NEXT:         "scf.for"(%94, %101, %87) ({
-// CHECK-NEXT:         ^19(%102 : index):
-// CHECK-NEXT:           "scf.for"(%86, %92, %87) ({
-// CHECK-NEXT:           ^20(%103 : index):
+// CHECK-NEXT:         scf.for %102 = %94 to %101 step %87 {
+// CHECK-NEXT:           scf.for %103 = %86 to %92 step %87 {
 // CHECK-NEXT:             %104 = arith.constant -1 : index
 // CHECK-NEXT:             %105 = arith.addi %98, %104 : index
 // CHECK-NEXT:             %106 = arith.constant 1 : index
 // CHECK-NEXT:             %107 = arith.addi %103, %106 : index
 // CHECK-NEXT:             %108 = "memref.load"(%83, %105, %102, %107) : (memref<65x64x69xf64, strided<[5624, 76, 1], offset: 22804>>, index, index, index) -> f64
-// CHECK-NEXT:             "scf.yield"() : () -> ()
-// CHECK-NEXT:           }) : (index, index, index) -> ()
-// CHECK-NEXT:           "scf.yield"() : () -> ()
-// CHECK-NEXT:         }) : (index, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:             scf.yield
+// CHECK-NEXT:           }
+// CHECK-NEXT:           scf.yield
+// CHECK-NEXT:         }
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
@@ -325,21 +309,17 @@ builtin.module {
 // CHECK-NEXT:   %126 = arith.constant 24 : index
 // CHECK-NEXT:   %127 = arith.constant 64 : index
 // CHECK-NEXT:   "scf.parallel"(%119, %123, %125) ({
-// CHECK-NEXT:   ^21(%128 : index):
-// CHECK-NEXT:     "scf.for"(%120, %124, %126) ({
-// CHECK-NEXT:     ^22(%129 : index):
+// CHECK-NEXT:   ^5(%128 : index):
+// CHECK-NEXT:     scf.for %129 = %120 to %124 step %126 {
 // CHECK-NEXT:       %130 = arith.addi %128, %125 : index
 // CHECK-NEXT:       %131 = "arith.cmpi"(%130, %123) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:       %132 = "arith.select"(%131, %130, %123) : (i1, index, index) -> index
-// CHECK-NEXT:       "scf.for"(%128, %132, %122) ({
-// CHECK-NEXT:       ^23(%133 : index):
+// CHECK-NEXT:       scf.for %133 = %128 to %132 step %122 {
 // CHECK-NEXT:         %134 = arith.addi %129, %126 : index
 // CHECK-NEXT:         %135 = "arith.cmpi"(%134, %124) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:         %136 = "arith.select"(%135, %134, %124) : (i1, index, index) -> index
-// CHECK-NEXT:         "scf.for"(%129, %136, %122) ({
-// CHECK-NEXT:         ^24(%137 : index):
-// CHECK-NEXT:           "scf.for"(%121, %127, %122) ({
-// CHECK-NEXT:           ^25(%138 : index):
+// CHECK-NEXT:         scf.for %137 = %129 to %136 step %122 {
+// CHECK-NEXT:           scf.for %138 = %121 to %127 step %122 {
 // CHECK-NEXT:             %139 = arith.constant -1 : index
 // CHECK-NEXT:             %140 = arith.addi %133, %139 : index
 // CHECK-NEXT:             %141 = "memref.load"(%118, %140, %137, %138) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
@@ -360,15 +340,15 @@ builtin.module {
 // CHECK-NEXT:             %155 = arith.mulf %151, %cst : f64
 // CHECK-NEXT:             %156 = arith.addf %155, %154 : f64
 // CHECK-NEXT:             "memref.store"(%156, %116, %133, %137, %138) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
-// CHECK-NEXT:             "scf.yield"() : () -> ()
-// CHECK-NEXT:           }) : (index, index, index) -> ()
-// CHECK-NEXT:           "scf.yield"() : () -> ()
-// CHECK-NEXT:         }) : (index, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:             scf.yield
+// CHECK-NEXT:           }
+// CHECK-NEXT:           scf.yield
+// CHECK-NEXT:         }
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
@@ -406,17 +386,16 @@ builtin.module {
 // CHECK-NEXT:   %159 = arith.constant 16 : index
 // CHECK-NEXT:   %160 = arith.constant 16 : index
 // CHECK-NEXT:   "scf.parallel"(%157, %160, %159) ({
-// CHECK-NEXT:   ^26(%161 : index):
+// CHECK-NEXT:   ^6(%161 : index):
 // CHECK-NEXT:     %162 = arith.addi %161, %159 : index
 // CHECK-NEXT:     %163 = "arith.cmpi"(%162, %160) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:     %164 = "arith.select"(%163, %162, %160) : (i1, index, index) -> index
-// CHECK-NEXT:     "scf.for"(%161, %164, %158) ({
-// CHECK-NEXT:     ^27(%165 : index):
+// CHECK-NEXT:     scf.for %165 = %161 to %164 step %158 {
 // CHECK-NEXT:       %val = "memref.load"(%in_loadview, %165) : (memref<32xf64, strided<[1], offset: 32>>, index) -> f64
 // CHECK-NEXT:       "memref.store"(%val, %out_storeview, %165) : (f64, memref<32xf64, strided<[1], offset: 32>>, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
@@ -437,7 +416,7 @@ builtin.module {
     "stencil.store"(%56, %50) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<[0,64]xf64>, !stencil.field<[-4,68]xf64>) -> ()
     func.return
   }
-  
+
 // CHECK-NEXT: func.func @stencil_buffer(%166 : memref<72xf64>, %167 : memref<72xf64>) {
 // CHECK-NEXT:   %168 = "memref.subview"(%167) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:   %169 = "memref.subview"(%166) {"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
@@ -448,38 +427,36 @@ builtin.module {
 // CHECK-NEXT:   %174 = arith.constant 16 : index
 // CHECK-NEXT:   %175 = arith.constant 65 : index
 // CHECK-NEXT:   "scf.parallel"(%172, %175, %174) ({
-// CHECK-NEXT:   ^28(%176 : index):
+// CHECK-NEXT:   ^7(%176 : index):
 // CHECK-NEXT:     %177 = arith.addi %176, %174 : index
 // CHECK-NEXT:     %178 = "arith.cmpi"(%177, %175) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:     %179 = "arith.select"(%178, %177, %175) : (i1, index, index) -> index
-// CHECK-NEXT:     "scf.for"(%176, %179, %173) ({
-// CHECK-NEXT:     ^29(%180 : index):
+// CHECK-NEXT:     scf.for %180 = %176 to %179 step %173 {
 // CHECK-NEXT:       %181 = arith.constant -1 : index
 // CHECK-NEXT:       %182 = arith.addi %180, %181 : index
 // CHECK-NEXT:       %183 = "memref.load"(%169, %182) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
 // CHECK-NEXT:       "memref.store"(%183, %171, %180) : (f64, memref<64xf64, strided<[1], offset: -1>>, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   %184 = arith.constant 0 : index
 // CHECK-NEXT:   %185 = arith.constant 1 : index
 // CHECK-NEXT:   %186 = arith.constant 16 : index
 // CHECK-NEXT:   %187 = arith.constant 64 : index
 // CHECK-NEXT:   "scf.parallel"(%184, %187, %186) ({
-// CHECK-NEXT:   ^30(%188 : index):
+// CHECK-NEXT:   ^8(%188 : index):
 // CHECK-NEXT:     %189 = arith.addi %188, %186 : index
 // CHECK-NEXT:     %190 = "arith.cmpi"(%189, %187) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:     %191 = "arith.select"(%190, %189, %187) : (i1, index, index) -> index
-// CHECK-NEXT:     "scf.for"(%188, %191, %185) ({
-// CHECK-NEXT:     ^31(%192 : index):
+// CHECK-NEXT:     scf.for %192 = %188 to %191 step %185 {
 // CHECK-NEXT:       %193 = arith.constant 1 : index
 // CHECK-NEXT:       %194 = arith.addi %192, %193 : index
 // CHECK-NEXT:       %195 = "memref.load"(%171, %194) : (memref<64xf64, strided<[1], offset: -1>>, index) -> f64
 // CHECK-NEXT:       "memref.store"(%195, %168, %192) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   "memref.dealloc"(%171) : (memref<64xf64, strided<[1], offset: -1>>) -> ()
 // CHECK-NEXT:   func.return
@@ -511,38 +488,36 @@ builtin.module {
 // CHECK-NEXT:   %204 = arith.constant 16 : index
 // CHECK-NEXT:   %205 = arith.constant 65 : index
 // CHECK-NEXT:   "scf.parallel"(%202, %205, %204) ({
-// CHECK-NEXT:   ^32(%206 : index):
+// CHECK-NEXT:   ^9(%206 : index):
 // CHECK-NEXT:     %207 = arith.addi %206, %204 : index
 // CHECK-NEXT:     %208 = "arith.cmpi"(%207, %205) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:     %209 = "arith.select"(%208, %207, %205) : (i1, index, index) -> index
-// CHECK-NEXT:     "scf.for"(%206, %209, %203) ({
-// CHECK-NEXT:     ^33(%210 : index):
+// CHECK-NEXT:     scf.for %210 = %206 to %209 step %203 {
 // CHECK-NEXT:       %211 = arith.constant -1 : index
 // CHECK-NEXT:       %212 = arith.addi %210, %211 : index
 // CHECK-NEXT:       %213 = "memref.load"(%201, %212) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
 // CHECK-NEXT:       "memref.store"(%213, %200, %210) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   %214 = arith.constant 0 : index
 // CHECK-NEXT:   %215 = arith.constant 1 : index
 // CHECK-NEXT:   %216 = arith.constant 16 : index
 // CHECK-NEXT:   %217 = arith.constant 64 : index
 // CHECK-NEXT:   "scf.parallel"(%214, %217, %216) ({
-// CHECK-NEXT:   ^34(%218 : index):
+// CHECK-NEXT:   ^10(%218 : index):
 // CHECK-NEXT:     %219 = arith.addi %218, %216 : index
 // CHECK-NEXT:     %220 = "arith.cmpi"(%219, %217) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:     %221 = "arith.select"(%220, %219, %217) : (i1, index, index) -> index
-// CHECK-NEXT:     "scf.for"(%218, %221, %215) ({
-// CHECK-NEXT:     ^35(%222 : index):
+// CHECK-NEXT:     scf.for %222 = %218 to %221 step %215 {
 // CHECK-NEXT:       %223 = arith.constant 1 : index
 // CHECK-NEXT:       %224 = arith.addi %222, %223 : index
 // CHECK-NEXT:       %225 = "memref.load"(%200, %224) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
 // CHECK-NEXT:       "memref.store"(%225, %199, %222) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
-// CHECK-NEXT:     }) : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"() : () -> ()
+// CHECK-NEXT:       scf.yield
+// CHECK-NEXT:     }
+// CHECK-NEXT:     scf.yield
 // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
@@ -585,8 +560,7 @@ builtin.module {
 // CHECK-NEXT:   %time_m_1 = arith.constant 0 : index
 // CHECK-NEXT:   %time_M_1 = arith.constant 10 : index
 // CHECK-NEXT:   %step_1 = arith.constant 1 : index
-// CHECK-NEXT:   %232, %233 = "scf.for"(%time_m_1, %time_M_1, %step_1, %u_vec_0, %u_vec_1) ({
-// CHECK-NEXT:   ^36(%time_1 : index, %t0 : memref<15x15xf32>, %t1 : memref<15x15xf32>):
+// CHECK-NEXT:   %232, %233 = scf.for %time_1 = %time_m_1 to %time_M_1 step %step_1 iter_args(%t0 = %u_vec_0, %t1 = %u_vec_1) -> (memref<15x15xf32>, memref<15x15xf32>) {
 // CHECK-NEXT:     %t1_storeview = "memref.subview"(%t1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
 // CHECK-NEXT:     %t0_loadview = "memref.subview"(%t0) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
 // CHECK-NEXT:     %234 = arith.constant 0 : index
@@ -597,31 +571,28 @@ builtin.module {
 // CHECK-NEXT:     %239 = arith.constant 24 : index
 // CHECK-NEXT:     %240 = arith.constant 11 : index
 // CHECK-NEXT:     "scf.parallel"(%234, %237, %238) ({
-// CHECK-NEXT:     ^37(%241 : index):
-// CHECK-NEXT:       "scf.for"(%235, %240, %239) ({
-// CHECK-NEXT:       ^38(%242 : index):
+// CHECK-NEXT:     ^11(%241 : index):
+// CHECK-NEXT:       scf.for %242 = %235 to %240 step %239 {
 // CHECK-NEXT:         %243 = arith.addi %241, %238 : index
 // CHECK-NEXT:         %244 = "arith.cmpi"(%243, %237) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:         %245 = "arith.select"(%244, %243, %237) : (i1, index, index) -> index
-// CHECK-NEXT:         "scf.for"(%241, %245, %236) ({
-// CHECK-NEXT:         ^39(%246 : index):
+// CHECK-NEXT:         scf.for %246 = %241 to %245 step %236 {
 // CHECK-NEXT:           %247 = arith.addi %242, %239 : index
 // CHECK-NEXT:           %248 = "arith.cmpi"(%247, %240) {"predicate" = 6 : i64} : (index, index) -> i1
 // CHECK-NEXT:           %249 = "arith.select"(%248, %247, %240) : (i1, index, index) -> index
-// CHECK-NEXT:           "scf.for"(%242, %249, %236) ({
-// CHECK-NEXT:           ^40(%250 : index):
+// CHECK-NEXT:           scf.for %250 = %242 to %249 step %236 {
 // CHECK-NEXT:             %251 = "memref.load"(%t0_loadview, %246, %250) : (memref<11x11xf32, strided<[15, 1], offset: 32>>, index, index) -> f32
 // CHECK-NEXT:             "memref.store"(%251, %t1_storeview, %246, %250) : (f32, memref<11x11xf32, strided<[15, 1], offset: 32>>, index, index) -> ()
-// CHECK-NEXT:             "scf.yield"() : () -> ()
-// CHECK-NEXT:           }) : (index, index, index) -> ()
-// CHECK-NEXT:           "scf.yield"() : () -> ()
-// CHECK-NEXT:         }) : (index, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:             scf.yield
+// CHECK-NEXT:           }
+// CHECK-NEXT:           scf.yield
+// CHECK-NEXT:         }
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"(%t1, %t0) : (memref<15x15xf32>, memref<15x15xf32>) -> ()
-// CHECK-NEXT:   }) : (index, index, index, memref<15x15xf32>, memref<15x15xf32>) -> (memref<15x15xf32>, memref<15x15xf32>)
+// CHECK-NEXT:     scf.yield %t1, %t0 : memref<15x15xf32>, memref<15x15xf32>
+// CHECK-NEXT:   }
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -30,18 +30,16 @@ builtin.module {
   // CHECK-NEXT:   %10 = arith.constant 63 : index
   // CHECK-NEXT:   "scf.parallel"(%4, %8, %7) ({
   // CHECK-NEXT:   ^0(%11 : index):
-  // CHECK-NEXT:     "scf.for"(%5, %9, %7) ({
-  // CHECK-NEXT:     ^1(%12 : index):
-  // CHECK-NEXT:       "scf.for"(%6, %10, %7) ({
-  // CHECK-NEXT:       ^2(%13 : index):
+  // CHECK-NEXT:     scf.for %12 = %5 to %9 step %7 {
+  // CHECK-NEXT:       scf.for %13 = %6 to %10 step %7 {
   // CHECK-NEXT:         %14 = arith.constant 1.000000e+00 : f64
   // CHECK-NEXT:         %15 = arith.addf %0, %14 : f64
   // CHECK-NEXT:         "memref.store"(%15, %3, %11, %12, %13) : (f64, memref<64x64x60xf64, strided<[4900, 70, 1], offset: 14913>>, index, index, index) -> ()
-  // CHECK-NEXT:         "scf.yield"() : () -> ()
-  // CHECK-NEXT:       }) : (index, index, index) -> ()
-  // CHECK-NEXT:       "scf.yield"() : () -> ()
-  // CHECK-NEXT:     }) : (index, index, index) -> ()
-  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:         scf.yield
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       scf.yield
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     scf.yield
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
@@ -67,8 +65,7 @@ builtin.module {
   // CHECK-NEXT:   %time_m = arith.constant 0 : index
   // CHECK-NEXT:   %time_M = arith.constant 1001 : index
   // CHECK-NEXT:   %step = arith.constant 1 : index
-  // CHECK-NEXT:   %t1_out, %t0_out = "scf.for"(%time_m, %time_M, %step, %f0, %f1) ({
-  // CHECK-NEXT:   ^3(%time : index, %fim1 : memref<2004x2004xf32>, %fi : memref<2004x2004xf32>):
+  // CHECK-NEXT:   %t1_out, %t0_out = scf.for %time = %time_m to %time_M step %step iter_args(%fim1 = %f0, %fi = %f1) -> (memref<2004x2004xf32>, memref<2004x2004xf32>) {
   // CHECK-NEXT:     %fi_storeview = "memref.subview"(%fi) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
   // CHECK-NEXT:     %fim1_loadview = "memref.subview"(%fim1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 2000, 2000>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<2004x2004xf32>) -> memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>
   // CHECK-NEXT:     %16 = arith.constant 0 : index
@@ -77,17 +74,16 @@ builtin.module {
   // CHECK-NEXT:     %19 = arith.constant 2000 : index
   // CHECK-NEXT:     %20 = arith.constant 2000 : index
   // CHECK-NEXT:     "scf.parallel"(%16, %19, %18) ({
-  // CHECK-NEXT:     ^4(%21 : index):
-  // CHECK-NEXT:       "scf.for"(%17, %20, %18) ({
-  // CHECK-NEXT:       ^5(%22 : index):
+  // CHECK-NEXT:     ^1(%21 : index):
+  // CHECK-NEXT:       scf.for %22 = %17 to %20 step %18 {
   // CHECK-NEXT:         %i = "memref.load"(%fim1_loadview, %21, %22) : (memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> f32
   // CHECK-NEXT:         "memref.store"(%i, %fi_storeview, %21, %22) : (f32, memref<2000x2000xf32, strided<[2004, 1], offset: 4010>>, index, index) -> ()
-  // CHECK-NEXT:         "scf.yield"() : () -> ()
-  // CHECK-NEXT:       }) : (index, index, index) -> ()
-  // CHECK-NEXT:       "scf.yield"() : () -> ()
+  // CHECK-NEXT:         scf.yield
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       scf.yield
   // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-  // CHECK-NEXT:     "scf.yield"(%fi, %fim1) : (memref<2004x2004xf32>, memref<2004x2004xf32>) -> ()
-  // CHECK-NEXT:   }) : (index, index, index, memref<2004x2004xf32>, memref<2004x2004xf32>) -> (memref<2004x2004xf32>, memref<2004x2004xf32>)
+  // CHECK-NEXT:     scf.yield %fi, %fim1 : memref<2004x2004xf32>, memref<2004x2004xf32>
+  // CHECK-NEXT:   }
   // CHECK-NEXT:   func.return %t1_out : memref<2004x2004xf32>
   // CHECK-NEXT: }
 
@@ -112,12 +108,12 @@ builtin.module {
   // CHECK-NEXT:   %27 = arith.constant 1 : index
   // CHECK-NEXT:   %28 = arith.constant 68 : index
   // CHECK-NEXT:   "scf.parallel"(%26, %28, %27) ({
-  // CHECK-NEXT:   ^6(%29 : index):
+  // CHECK-NEXT:   ^2(%29 : index):
   // CHECK-NEXT:     %30 = arith.constant -1 : index
   // CHECK-NEXT:     %31 = arith.addi %29, %30 : index
   // CHECK-NEXT:     %32 = "memref.load"(%25, %31) : (memref<69xf64, strided<[1], offset: 4>>, index) -> f64
   // CHECK-NEXT:     "memref.store"(%32, %outc_storeview, %29) : (f64, memref<68xf64, strided<[1]>>, index) -> ()
-  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:     scf.yield
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
@@ -141,15 +137,14 @@ builtin.module {
   // CHECK-NEXT:   %39 = arith.constant 64 : index
   // CHECK-NEXT:   %40 = arith.constant 68 : index
   // CHECK-NEXT:   "scf.parallel"(%36, %39, %38) ({
-  // CHECK-NEXT:   ^7(%41 : index):
-  // CHECK-NEXT:     "scf.for"(%37, %40, %38) ({
-  // CHECK-NEXT:     ^8(%42 : index):
+  // CHECK-NEXT:   ^3(%41 : index):
+  // CHECK-NEXT:     scf.for %42 = %37 to %40 step %38 {
   // CHECK-NEXT:       %43 = arith.constant -1 : index
   // CHECK-NEXT:       %44 = arith.addi %41, %43 : index
   // CHECK-NEXT:       %45 = "memref.load"(%35, %44, %42) : (memref<65x68xf64, strided<[72, 1], offset: 292>>, index, index) -> f64
-  // CHECK-NEXT:       "scf.yield"() : () -> ()
-  // CHECK-NEXT:     }) : (index, index, index) -> ()
-  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:       scf.yield
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     scf.yield
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
@@ -176,21 +171,19 @@ builtin.module {
   // CHECK-NEXT:    %54 = arith.constant 64 : index
   // CHECK-NEXT:    %55 = arith.constant 68 : index
   // CHECK-NEXT:    "scf.parallel"(%49, %53, %52) ({
-  // CHECK-NEXT:    ^9(%56 : index):
-  // CHECK-NEXT:      "scf.for"(%50, %54, %52) ({
-  // CHECK-NEXT:      ^10(%57 : index):
-  // CHECK-NEXT:        "scf.for"(%51, %55, %52) ({
-  // CHECK-NEXT:        ^11(%58 : index):
+  // CHECK-NEXT:    ^4(%56 : index):
+  // CHECK-NEXT:      scf.for %57 = %50 to %54 step %52 {
+  // CHECK-NEXT:        scf.for %58 = %51 to %55 step %52 {
   // CHECK-NEXT:          %59 = arith.constant -1 : index
   // CHECK-NEXT:          %60 = arith.addi %56, %59 : index
   // CHECK-NEXT:          %61 = arith.constant 1 : index
   // CHECK-NEXT:          %62 = arith.addi %58, %61 : index
   // CHECK-NEXT:          %63 = "memref.load"(%48, %60, %57, %62) : (memref<65x64x69xf64, strided<[5624, 76, 1], offset: 22804>>, index, index, index) -> f64
-  // CHECK-NEXT:          "scf.yield"() : () -> ()
-  // CHECK-NEXT:        }) : (index, index, index) -> ()
-  // CHECK-NEXT:        "scf.yield"() : () -> ()
-  // CHECK-NEXT:      }) : (index, index, index) -> ()
-  // CHECK-NEXT:      "scf.yield"() : () -> ()
+  // CHECK-NEXT:          scf.yield
+  // CHECK-NEXT:        }
+  // CHECK-NEXT:        scf.yield
+  // CHECK-NEXT:      }
+  // CHECK-NEXT:      scf.yield
   // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:    func.return
   // CHECK-NEXT:  }
@@ -246,11 +239,9 @@ builtin.module {
   // CHECK-NEXT:   %79 = arith.constant 64 : index
   // CHECK-NEXT:   %80 = arith.constant 64 : index
   // CHECK-NEXT:   "scf.parallel"(%74, %78, %77) ({
-  // CHECK-NEXT:   ^12(%81 : index):
-  // CHECK-NEXT:     "scf.for"(%75, %79, %77) ({
-  // CHECK-NEXT:     ^13(%82 : index):
-  // CHECK-NEXT:       "scf.for"(%76, %80, %77) ({
-  // CHECK-NEXT:       ^14(%83 : index):
+  // CHECK-NEXT:   ^5(%81 : index):
+  // CHECK-NEXT:     scf.for %82 = %75 to %79 step %77 {
+  // CHECK-NEXT:       scf.for %83 = %76 to %80 step %77 {
   // CHECK-NEXT:         %84 = arith.constant -1 : index
   // CHECK-NEXT:         %85 = arith.addi %81, %84 : index
   // CHECK-NEXT:         %86 = "memref.load"(%73, %85, %82, %83) : (memref<66x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> f64
@@ -271,11 +262,11 @@ builtin.module {
   // CHECK-NEXT:         %100 = arith.mulf %96, %cst : f64
   // CHECK-NEXT:         %101 = arith.addf %100, %99 : f64
   // CHECK-NEXT:         "memref.store"(%101, %71, %81, %82, %83) : (f64, memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>, index, index, index) -> ()
-  // CHECK-NEXT:         "scf.yield"() : () -> ()
-  // CHECK-NEXT:       }) : (index, index, index) -> ()
-  // CHECK-NEXT:       "scf.yield"() : () -> ()
-  // CHECK-NEXT:     }) : (index, index, index) -> ()
-  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:         scf.yield
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       scf.yield
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     scf.yield
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
@@ -311,10 +302,10 @@ builtin.module {
   // CHECK-NEXT:   %103 = arith.constant 1 : index
   // CHECK-NEXT:   %104 = arith.constant 16 : index
   // CHECK-NEXT:   "scf.parallel"(%102, %104, %103) ({
-  // CHECK-NEXT:   ^15(%105 : index):
+  // CHECK-NEXT:   ^6(%105 : index):
   // CHECK-NEXT:     %val = "memref.load"(%in_loadview, %105) : (memref<32xf64, strided<[1], offset: 32>>, index) -> f64
   // CHECK-NEXT:     "memref.store"(%val, %out_storeview, %105) : (f64, memref<32xf64, strided<[1], offset: 32>>, index) -> ()
-  // CHECK-NEXT:     "scf.yield"() : () -> ()
+  // CHECK-NEXT:     scf.yield
   // CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
@@ -344,23 +335,23 @@ builtin.module {
   // CHECK-NEXT:    %113 = arith.constant 1 : index
   // CHECK-NEXT:    %114 = arith.constant 65 : index
   // CHECK-NEXT:    "scf.parallel"(%112, %114, %113) ({
-  // CHECK-NEXT:    ^16(%115 : index):
+  // CHECK-NEXT:    ^7(%115 : index):
   // CHECK-NEXT:      %116 = arith.constant -1 : index
   // CHECK-NEXT:      %117 = arith.addi %115, %116 : index
   // CHECK-NEXT:      %118 = "memref.load"(%109, %117) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
   // CHECK-NEXT:      "memref.store"(%118, %111, %115) : (f64, memref<64xf64, strided<[1], offset: -1>>, index) -> ()
-  // CHECK-NEXT:      "scf.yield"() : () -> ()
+  // CHECK-NEXT:      scf.yield
   // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:    %119 = arith.constant 0 : index
   // CHECK-NEXT:    %120 = arith.constant 1 : index
   // CHECK-NEXT:    %121 = arith.constant 64 : index
   // CHECK-NEXT:    "scf.parallel"(%119, %121, %120) ({
-  // CHECK-NEXT:    ^17(%122 : index):
+  // CHECK-NEXT:    ^8(%122 : index):
   // CHECK-NEXT:      %123 = arith.constant 1 : index
   // CHECK-NEXT:      %124 = arith.addi %122, %123 : index
   // CHECK-NEXT:      %125 = "memref.load"(%111, %124) : (memref<64xf64, strided<[1], offset: -1>>, index) -> f64
   // CHECK-NEXT:      "memref.store"(%125, %108, %122) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-  // CHECK-NEXT:      "scf.yield"() : () -> ()
+  // CHECK-NEXT:      scf.yield
   // CHECK-NEXT:    }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   // CHECK-NEXT:    "memref.dealloc"(%111) : (memref<64xf64, strided<[1], offset: -1>>) -> ()
   // CHECK-NEXT:    func.return
@@ -390,23 +381,23 @@ builtin.module {
   //CHECK-NEXT:   %133 = arith.constant 1 : index
   //CHECK-NEXT:   %134 = arith.constant 65 : index
   //CHECK-NEXT:   "scf.parallel"(%132, %134, %133) ({
-  //CHECK-NEXT:   ^18(%135 : index):
+  //CHECK-NEXT:   ^9(%135 : index):
   //CHECK-NEXT:     %136 = arith.constant -1 : index
   //CHECK-NEXT:     %137 = arith.addi %135, %136 : index
   //CHECK-NEXT:     %138 = "memref.load"(%131, %137) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
   //CHECK-NEXT:     "memref.store"(%138, %130, %135) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-  //CHECK-NEXT:     "scf.yield"() : () -> ()
+  //CHECK-NEXT:     scf.yield
   //CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   //CHECK-NEXT:   %139 = arith.constant 0 : index
   //CHECK-NEXT:   %140 = arith.constant 1 : index
   //CHECK-NEXT:   %141 = arith.constant 64 : index
   //CHECK-NEXT:   "scf.parallel"(%139, %141, %140) ({
-  //CHECK-NEXT:   ^19(%142 : index):
+  //CHECK-NEXT:   ^10(%142 : index):
   //CHECK-NEXT:     %143 = arith.constant 1 : index
   //CHECK-NEXT:     %144 = arith.addi %142, %143 : index
   //CHECK-NEXT:     %145 = "memref.load"(%130, %144) : (memref<64xf64, strided<[1], offset: 4>>, index) -> f64
   //CHECK-NEXT:     "memref.store"(%145, %129, %142) : (f64, memref<64xf64, strided<[1], offset: 4>>, index) -> ()
-  //CHECK-NEXT:     "scf.yield"() : () -> ()
+  //CHECK-NEXT:     scf.yield
   //CHECK-NEXT:   }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
   //CHECK-NEXT:   func.return
   //CHECK-NEXT: }
@@ -449,8 +440,7 @@ builtin.module {
 // CHECK-NEXT:   %time_m_1 = arith.constant 0 : index
 // CHECK-NEXT:   %time_M_1 = arith.constant 10 : index
 // CHECK-NEXT:   %step_1 = arith.constant 1 : index
-// CHECK-NEXT:   %152, %153 = "scf.for"(%time_m_1, %time_M_1, %step_1, %u_vec_0, %u_vec_1) ({
-// CHECK-NEXT:   ^20(%time_1 : index, %t0 : memref<15x15xf32>, %t1 : memref<15x15xf32>):
+// CHECK-NEXT:   %152, %153 = scf.for %time_1 = %time_m_1 to %time_M_1 step %step_1 iter_args(%t0 = %u_vec_0, %t1 = %u_vec_1) -> (memref<15x15xf32>, memref<15x15xf32>) {
 // CHECK-NEXT:     %t1_storeview = "memref.subview"(%t1) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
 // CHECK-NEXT:     %t0_loadview = "memref.subview"(%t0) {"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operand_segment_sizes" = array<i32: 1, 0, 0, 0>} : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
 // CHECK-NEXT:     %154 = arith.constant 0 : index
@@ -459,17 +449,16 @@ builtin.module {
 // CHECK-NEXT:     %157 = arith.constant 11 : index
 // CHECK-NEXT:     %158 = arith.constant 11 : index
 // CHECK-NEXT:     "scf.parallel"(%154, %157, %156) ({
-// CHECK-NEXT:     ^21(%159 : index):
-// CHECK-NEXT:       "scf.for"(%155, %158, %156) ({
-// CHECK-NEXT:       ^22(%160 : index):
+// CHECK-NEXT:     ^11(%159 : index):
+// CHECK-NEXT:       scf.for %160 = %155 to %158 step %156 {
 // CHECK-NEXT:         %161 = "memref.load"(%t0_loadview, %159, %160) : (memref<11x11xf32, strided<[15, 1], offset: 32>>, index, index) -> f32
 // CHECK-NEXT:         "memref.store"(%161, %t1_storeview, %159, %160) : (f32, memref<11x11xf32, strided<[15, 1], offset: 32>>, index, index) -> ()
-// CHECK-NEXT:         "scf.yield"() : () -> ()
-// CHECK-NEXT:       }) : (index, index, index) -> ()
-// CHECK-NEXT:       "scf.yield"() : () -> ()
+// CHECK-NEXT:         scf.yield
+// CHECK-NEXT:       }
+// CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }) {"operand_segment_sizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
-// CHECK-NEXT:     "scf.yield"(%t1, %t0) : (memref<15x15xf32>, memref<15x15xf32>) -> ()
-// CHECK-NEXT:   }) : (index, index, index, memref<15x15xf32>, memref<15x15xf32>) -> (memref<15x15xf32>, memref<15x15xf32>)
+// CHECK-NEXT:     scf.yield %t1, %t0 : memref<15x15xf32>, memref<15x15xf32>
+// CHECK-NEXT:   }
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -204,13 +204,13 @@ def test_parse_argument(
     # parse_argument
     parser = Parser(ctx, text)
     if expected is not None:
-        res = parser.parse_argument(expect_type)
+        res = parser.parse_argument(expect_type=expect_type)
         assert res is not None
         assert res.name.text[1:] == expected[0]
         assert res.type == expected[1]
     else:
         with pytest.raises(ParseError):
-            parser.parse_argument(expect_type)
+            parser.parse_argument(expect_type=expect_type)
 
 
 @pytest.mark.parametrize(
@@ -234,7 +234,7 @@ def test_parse_argument_fail(text: str, expect_type: bool):
     # parse_argument
     parser = Parser(ctx, text)
     with pytest.raises(ParseError):
-        parser.parse_argument(expect_type)
+        parser.parse_argument(expect_type=expect_type)
 
 
 @pytest.mark.parametrize(

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from typing_extensions import Self
+
 from xdsl.dialects.builtin import IndexType, IntegerType
+from xdsl.dialects.utils import (
+    parse_assignment,
+    parse_return_op_like,
+    print_assignment,
+    print_return_op_like,
+)
 from xdsl.ir import Attribute, Block, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     AnyAttr,
@@ -17,6 +25,8 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
+from xdsl.parser import Parser
+from xdsl.printer import Printer
 from xdsl.traits import HasParent, IsTerminator, SingleBlockImplicitTerminator
 from xdsl.utils.exceptions import VerifyException
 
@@ -73,6 +83,16 @@ class Yield(IRDLOperation):
     @staticmethod
     def get(*operands: SSAValue | Operation) -> Yield:
         return Yield.create(operands=[SSAValue.get(operand) for operand in operands])
+
+    def print(self, printer: Printer):
+        print_return_op_like(printer, self.attributes, self.arguments)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        attrs, args = parse_return_op_like(parser)
+        op = Yield.get(*args)
+        op.attributes.update(attrs)
+        return op
 
 
 @irdl_op_definition
@@ -170,6 +190,60 @@ class For(IRDLOperation):
             result_types=[[SSAValue.get(a).type for a in iter_args]],
             regions=[body],
         )
+
+    def print(self, printer: Printer):
+        block = self.body.block
+        index, *iter_args = block.args
+        printer.print_string(" ")
+        printer.print_ssa_value(index)
+        printer.print_string(" = ")
+        printer.print_ssa_value(self.lb)
+        printer.print_string(" to ")
+        printer.print_ssa_value(self.ub)
+        printer.print_string(" step ")
+        printer.print_ssa_value(self.step)
+        printer.print_string(" ")
+        if iter_args:
+            printer.print_string("iter_args(")
+            printer.print_list(
+                zip(iter_args, self.iter_args),
+                lambda pair: print_assignment(printer, *pair),
+            )
+            printer.print_string(") -> (")
+            printer.print_list((a.type for a in iter_args), printer.print_attribute)
+            printer.print_string(") ")
+        printer.print_region(
+            self.body, print_entry_block_args=False, print_empty_block=False
+        )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        index, lb = parse_assignment(parser)
+        parser.parse_characters("to")
+        ub = parser.parse_operand()
+        parser.parse_characters("step")
+        step = parser.parse_operand()
+        iter_args: list[Parser.Argument] = []
+        iter_arg_operands: list[SSAValue] = []
+        if parser.parse_optional_characters("iter_args"):
+            for iter_arg, iter_arg_operand in parser.parse_comma_separated_list(
+                Parser.Delimiter.PAREN, lambda: parse_assignment(parser)
+            ):
+                iter_args.append(iter_arg)
+                iter_arg_operands.append(iter_arg_operand)
+            parser.parse_characters("->")
+            iter_arg_types = parser.parse_comma_separated_list(
+                Parser.Delimiter.PAREN, parser.parse_attribute
+            )
+            # PR: am I doing this right? Seems like duplicated information
+            assert iter_arg_types == [arg.type for arg in iter_args]
+
+        body = parser.parse_region((index, *iter_args))
+        if not body.block.ops:
+            assert not iter_args, "Cannot create implicit yield with arguments"
+            body.block.add_op(Yield.get())
+
+        return For.get(lb, ub, step, iter_arg_operands, body)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -8,7 +8,7 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
 )
 from xdsl.ir import Attribute, BlockArgument, Operation, Region, SSAValue
-from xdsl.parser import Parser
+from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.utils.hints import isa
 
@@ -189,9 +189,8 @@ def print_assignment(printer: Printer, arg: BlockArgument, val: SSAValue):
     printer.print_ssa_value(val)
 
 
-def parse_assignment(parser: Parser) -> tuple[Parser.Argument, SSAValue]:
+def parse_assignment(parser: Parser) -> tuple[Parser.Argument, UnresolvedOperand]:
     arg = parser.parse_argument(expect_type=False)
     parser.parse_characters("=")
-    val = parser.parse_operand("expected block argument")
-    arg.type = val.type
+    val = parser.parse_unresolved_operand()
     return arg, val

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -7,8 +7,7 @@ from xdsl.dialects.builtin import (
     StringAttr,
     SymbolRefAttr,
 )
-from xdsl.ir import Attribute, Operation, SSAValue
-from xdsl.ir.core import Region
+from xdsl.ir import Attribute, BlockArgument, Operation, Region, SSAValue
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.hints import isa
@@ -182,3 +181,17 @@ def parse_func_op_like(
         region = Region()
 
     return name, input_types, return_types, region, extra_attributes
+
+
+def print_assignment(printer: Printer, arg: BlockArgument, val: SSAValue):
+    printer.print_block_argument(arg, print_type=False)
+    printer.print_string(" = ")
+    printer.print_ssa_value(val)
+
+
+def parse_assignment(parser: Parser) -> tuple[Parser.Argument, SSAValue]:
+    arg = parser.parse_argument(expect_type=False)
+    parser.parse_characters("=")
+    val = parser.parse_operand("expected block argument")
+    arg.type = val.type
+    return arg, val

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -515,7 +515,7 @@ class Parser(AttrParser):
             type = self.parse_type()
         return self.Argument(name_token.span, type)
 
-    def parse_argument(self, expect_type: bool = True) -> Argument:
+    def parse_argument(self, *, expect_type: bool = True) -> Argument:
         """
         Parse a block argument with format:
           arg ::= percent-id `:` type


### PR DESCRIPTION
Also makes a minor change to the parser API, to require the argument label for `expect_type` in parse_argument. Happy to remove it, but seems like a good thing to require the argument label for an ambiguous bool-valued argument such as this.