### PR TITLE
CI: Remove conditions on JupyterLite deploy.

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -78,7 +78,6 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
Good news: the new daily JupyterLite nighlty workflow seems to work (I was just mistaken and set it to run at 5AM not 5PM. If anybody cares, this PR is a nice time to argue about the exact time!)

I just forgot to remove a now obsolete condition on the deploy job, so it was not triggered. (It only built the page without deploying it) This PR solves this.

First scheduled run: https://github.com/xdslproject/xdsl/actions/runs/6092690186