### PR TITLE
backend: (riscv) exclude preallocated registers by default

### DIFF
--- a/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive exclude_preallocated=true}" %s | filecheck %s --check-prefix=LIVE-BNAIVE
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s --check-prefix=LIVE-BNAIVE
 
 riscv_func.func @main() {
   %0 = riscv.li 6 : () -> !riscv.reg<>

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -72,7 +72,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
     available_registers: RegisterQueue
     live_ins_per_block: dict[Block, OrderedSet[SSAValue]]
 
-    exclude_preallocated: bool = False
+    exclude_preallocated: bool = True
 
     def __init__(self) -> None:
         self.available_registers = RegisterQueue(

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -19,7 +19,7 @@ class RISCVRegisterAllocation(ModulePass):
 
     limit_registers: int | None = None
 
-    exclude_preallocated: bool = False
+    exclude_preallocated: bool = True
     """
     Enables tracking of already allocated registers and excludes them from the
     available set.


### PR DESCRIPTION
Without this our code is somewhat broken, especially in the presence of function calls or function arguments.