### PR TITLE
backend: (rsicv) unify RdRsRs(Integer|Float)Op

### DIFF
--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -77,9 +77,14 @@ def test_insert_shape_ops_1d():
         with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
             bytes_per_element = riscv.LiOp(4).rd
             offset_in_bytes = riscv.MulOp(
-                indices[0], bytes_per_element, comment="multiply by element size"
+                indices[0],
+                bytes_per_element,
+                rd=riscv.IntRegisterType.unallocated(),
+                comment="multiply by element size",
             ).rd
-            _ = riscv.AddOp(mem, offset_in_bytes)
+            _ = riscv.AddOp(
+                mem, offset_in_bytes, rd=riscv.IntRegisterType.unallocated()
+            )
             riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
 
     shape = [2]
@@ -106,11 +111,16 @@ def test_insert_shape_ops_2d():
     def expected_2d():
         with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
             v1 = riscv.LiOp(2)
-            v2 = riscv.MulOp(v1, indices[0])
-            v3 = riscv.AddOp(v2, indices[1])
+            v2 = riscv.MulOp(v1, indices[0], rd=riscv.IntRegisterType.unallocated())
+            v3 = riscv.AddOp(v2, indices[1], rd=riscv.IntRegisterType.unallocated())
             v4 = riscv.LiOp(4).rd
-            v5 = riscv.MulOp(v3, v4, comment="multiply by element size").rd
-            _ = riscv.AddOp(mem, v5)
+            v5 = riscv.MulOp(
+                v3,
+                v4,
+                rd=riscv.IntRegisterType.unallocated(),
+                comment="multiply by element size",
+            ).rd
+            _ = riscv.AddOp(mem, v5, rd=riscv.IntRegisterType.unallocated())
             riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
 
     shape = [2, 2]

--- a/tests/backend/riscv/test_preallocated.py
+++ b/tests/backend/riscv/test_preallocated.py
@@ -10,7 +10,7 @@ def test_gather_allocated():
         reg2 = riscv.IntRegisterType.unallocated()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(reg2).res
-        _ = riscv.AddOp(v1, v2).rd
+        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
 
     pa_regs = gather_allocated(riscv_func.FuncOp("foo", no_preallocated_body, ((), ())))
 
@@ -21,7 +21,7 @@ def test_gather_allocated():
         reg1 = riscv.IntRegisterType.unallocated()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        _ = riscv.AddOp(v1, v2).rd
+        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
 
     pa_regs = gather_allocated(
         riscv_func.FuncOp("foo", one_preallocated_body, ((), ()))
@@ -34,7 +34,7 @@ def test_gather_allocated():
         reg1 = riscv.IntRegisterType.unallocated()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        sum1 = riscv.AddOp(v1, v2).rd
+        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A7).rd
 
     pa_regs = gather_allocated(
@@ -48,7 +48,7 @@ def test_gather_allocated():
         reg1 = riscv.IntRegisterType.unallocated()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        sum1 = riscv.AddOp(v1, v2).rd
+        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A6).rd
 
     pa_regs = gather_allocated(

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -243,11 +243,11 @@ def test_float_register():
     a1 = TestSSAValue(riscv.Registers.A1)
     a2 = TestSSAValue(riscv.Registers.A2)
     with pytest.raises(VerifyException, match="Operation does not verify"):
-        riscv.FAddSOp(a1, a2).verify()
+        riscv.FAddSOp(a1, a2, rd=riscv.FloatRegisterType.unallocated()).verify()
 
     f1 = TestSSAValue(riscv.Registers.FT0)
     f2 = TestSSAValue(riscv.Registers.FT1)
-    riscv.FAddSOp(f1, f2).verify()
+    riscv.FAddSOp(f1, f2, rd=riscv.FloatRegisterType.unallocated()).verify()
 
 
 def test_riscv_parse_immediate_value():

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -25,7 +25,9 @@ def test_simple():
         def body():
             six = riscv.LiOp(6).rd
             seven = riscv.LiOp(7).rd
-            forty_two = riscv.MulOp(six, seven).rd
+            forty_two = riscv.MulOp(
+                six, seven, rd=riscv.IntRegisterType.unallocated()
+            ).rd
             riscv.CustomAssemblyInstructionOp(
                 "print", inputs=[forty_two], result_types=[]
             )

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -48,11 +48,21 @@ def test_riscv_interpreter():
     assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), -10), (5,)) == (1,)
 
     assert interpreter.run_op(
-        riscv.AddOp(TestSSAValue(register), TestSSAValue(register)), (1, 2)
+        riscv.AddOp(
+            TestSSAValue(register),
+            TestSSAValue(register),
+            rd=riscv.IntRegisterType.unallocated(),
+        ),
+        (1, 2),
     ) == (3,)
 
     assert interpreter.run_op(
-        riscv.MulOp(TestSSAValue(register), TestSSAValue(register)), (2, 3)
+        riscv.MulOp(
+            TestSSAValue(register),
+            TestSSAValue(register),
+            rd=riscv.IntRegisterType.unallocated(),
+        ),
+        (2, 3),
     ) == (6,)
 
     buffer = Buffer([0, 0, 0, 0])
@@ -87,7 +97,12 @@ def test_riscv_interpreter():
     assert interpreter.run_op(custom_instruction_op, (1, 2)) == (1, 2)
 
     assert interpreter.run_op(
-        riscv.FMulSOp(TestSSAValue(fregister), TestSSAValue(fregister)), (3.0, 4.0)
+        riscv.FMulSOp(
+            TestSSAValue(fregister),
+            TestSSAValue(fregister),
+            rd=riscv.FloatRegisterType.unallocated(),
+        ),
+        (3.0, 4.0),
     ) == (12.0,)
 
     # same behaviour as riscemu currently, but incorrect

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -36,7 +36,7 @@ def sum_to_for_op():
         @Builder.implicit_region((register, register))
         def for_loop_region(args: tuple[BlockArgument, ...]):
             (i, acc) = args
-            res = riscv.AddOp(i, acc)
+            res = riscv.AddOp(i, acc, rd=riscv.IntRegisterType.unallocated())
             riscv_scf.YieldOp(res)
 
         result = riscv_scf.ForOp(lb, ub, step, (initial,), for_loop_region)

--- a/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
@@ -1,4 +1,4 @@
-from typing import overload
+from dataclasses import dataclass
 
 from xdsl.backend.riscv.lowering.utils import (
     cast_matched_op_results,
@@ -93,74 +93,54 @@ class LowerArithIndexCast(RewritePattern):
         )
 
 
-class LowerBinaryOp(RewritePattern):
-    arith_op_cls: type[arith.SignlessIntegerBinaryOp] | type[
-        arith.FloatingPointLikeBinaryOp
-    ]
-    riscv_op_cls: type[riscv.RdRsRsIntegerOperation] | type[riscv.RdRsRsFloatOperation]
-    register_type: riscv.IntRegisterType | riscv.FloatRegisterType
+RdRsRsIntegerOperation = riscv.RdRsRsOperation[
+    riscv.IntRegisterType, riscv.IntRegisterType, riscv.IntRegisterType
+]
 
-    @overload
-    def __init__(
-        self,
-        arith_op_cls: type[arith.SignlessIntegerBinaryOp],
-        riscv_op_cls: type[riscv.RdRsRsIntegerOperation],
-        register_type: riscv.IntRegisterType,
-    ) -> None:
-        ...
+RdRsRsFloatOperation = riscv.RdRsRsOperation[
+    riscv.FloatRegisterType, riscv.FloatRegisterType, riscv.FloatRegisterType
+]
 
-    @overload
-    def __init__(
-        self,
-        arith_op_cls: type[arith.FloatingPointLikeBinaryOp],
-        riscv_op_cls: type[riscv.RdRsRsFloatOperation],
-        register_type: riscv.FloatRegisterType,
-    ) -> None:
-        ...
 
-    def __init__(
-        self,
-        arith_op_cls: type[arith.SignlessIntegerBinaryOp]
-        | type[arith.FloatingPointLikeBinaryOp],
-        riscv_op_cls: type[riscv.RdRsRsIntegerOperation]
-        | type[riscv.RdRsRsFloatOperation],
-        register_type: riscv.IntRegisterType | riscv.FloatRegisterType,
-    ) -> None:
-        self.arith_op_cls = arith_op_cls
-        self.riscv_op_cls = riscv_op_cls
-        self.register_type = register_type
+@dataclass
+class LowerBinaryIntegerOp(RewritePattern):
+    arith_op_cls: type[arith.SignlessIntegerBinaryOp]
+    riscv_op_cls: type[RdRsRsIntegerOperation]
 
     def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter) -> None:
         if not isinstance(op, self.arith_op_cls):
             return
 
-        lhs = UnrealizedConversionCastOp.get((op.lhs,), (self.register_type,))
-        rhs = UnrealizedConversionCastOp.get((op.rhs,), (self.register_type,))
-        add = self.riscv_op_cls(lhs, rhs)
+        lhs = UnrealizedConversionCastOp.get((op.lhs,), (_INT_REGISTER_TYPE,))
+        rhs = UnrealizedConversionCastOp.get((op.rhs,), (_INT_REGISTER_TYPE,))
+        add = self.riscv_op_cls(lhs, rhs, rd=_INT_REGISTER_TYPE)
         cast = UnrealizedConversionCastOp.get((add.rd,), (op.result.type,))
 
         rewriter.replace_matched_op((lhs, rhs, add, cast))
 
 
-def lower_signless_integer_binary_op(
-    arith_op_cls: type[arith.SignlessIntegerBinaryOp],
-    riscv_op_cls: type[riscv.RdRsRsIntegerOperation],
-) -> LowerBinaryOp:
-    return LowerBinaryOp(arith_op_cls, riscv_op_cls, _INT_REGISTER_TYPE)
+@dataclass
+class LowerBinaryFloatOp(RewritePattern):
+    arith_op_cls: type[arith.FloatingPointLikeBinaryOp]
+    riscv_op_cls: type[RdRsRsFloatOperation]
+
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter) -> None:
+        if not isinstance(op, self.arith_op_cls):
+            return
+
+        lhs = UnrealizedConversionCastOp.get((op.lhs,), (_FLOAT_REGISTER_TYPE,))
+        rhs = UnrealizedConversionCastOp.get((op.rhs,), (_FLOAT_REGISTER_TYPE,))
+        add = self.riscv_op_cls(lhs, rhs, rd=_FLOAT_REGISTER_TYPE)
+        cast = UnrealizedConversionCastOp.get((add.rd,), (op.result.type,))
+
+        rewriter.replace_matched_op((lhs, rhs, add, cast))
 
 
-def lower_float_binary_op(
-    arith_op_cls: type[arith.FloatingPointLikeBinaryOp],
-    riscv_op_cls: type[riscv.RdRsRsFloatOperation],
-) -> LowerBinaryOp:
-    return LowerBinaryOp(arith_op_cls, riscv_op_cls, _FLOAT_REGISTER_TYPE)
-
-
-lower_arith_addi = lower_signless_integer_binary_op(arith.Addi, riscv.AddOp)
-lower_arith_subi = lower_signless_integer_binary_op(arith.Subi, riscv.SubOp)
-lower_arith_muli = lower_signless_integer_binary_op(arith.Muli, riscv.MulOp)
-lower_arith_divui = lower_signless_integer_binary_op(arith.DivUI, riscv.DivuOp)
-lower_arith_divsi = lower_signless_integer_binary_op(arith.DivSI, riscv.DivOp)
+lower_arith_addi = LowerBinaryIntegerOp(arith.Addi, riscv.AddOp)
+lower_arith_subi = LowerBinaryIntegerOp(arith.Subi, riscv.SubOp)
+lower_arith_muli = LowerBinaryIntegerOp(arith.Muli, riscv.MulOp)
+lower_arith_divui = LowerBinaryIntegerOp(arith.DivUI, riscv.DivuOp)
+lower_arith_divsi = LowerBinaryIntegerOp(arith.DivSI, riscv.DivOp)
 
 
 class LowerArithFloorDivSI(RewritePattern):
@@ -183,8 +163,8 @@ class LowerArithCeilDivUI(RewritePattern):
         raise NotImplementedError("CeilDivUI is not supported")
 
 
-lower_arith_remui = lower_signless_integer_binary_op(arith.RemUI, riscv.RemuOp)
-lower_arith_remsi = lower_signless_integer_binary_op(arith.RemSI, riscv.RemOp)
+lower_arith_remui = LowerBinaryIntegerOp(arith.RemUI, riscv.RemuOp)
+lower_arith_remsi = LowerBinaryIntegerOp(arith.RemSI, riscv.RemOp)
 
 
 class LowerArithMinSI(RewritePattern):
@@ -221,37 +201,45 @@ class LowerArithCmpi(RewritePattern):
         match op.predicate.value.data:
             # eq
             case 0:
-                xor_op = riscv.XorOp(lhs, rhs)
+                xor_op = riscv.XorOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
                 seqz_op = riscv.SltiuOp(xor_op, 1)
                 rewriter.replace_matched_op([xor_op, seqz_op])
             # ne
             case 1:
                 zero = riscv.GetRegisterOp(riscv.Registers.ZERO)
-                xor_op = riscv.XorOp(lhs, rhs)
-                snez_op = riscv.SltuOp(zero, xor_op)
+                xor_op = riscv.XorOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
+                snez_op = riscv.SltuOp(
+                    zero, xor_op, rd=riscv.IntRegisterType.unallocated()
+                )
                 rewriter.replace_matched_op([zero, xor_op, snez_op])
             # slt
             case 2:
-                rewriter.replace_matched_op([riscv.SltOp(lhs, rhs)])
+                rewriter.replace_matched_op(
+                    [riscv.SltOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())]
+                )
             # sle
             case 3:
-                slt = riscv.SltOp(lhs, rhs)
+                slt = riscv.SltOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
                 xori = riscv.XoriOp(slt, 1)
                 rewriter.replace_matched_op([slt, xori])
             # ult
             case 4:
-                rewriter.replace_matched_op([riscv.SltuOp(lhs, rhs)])
+                rewriter.replace_matched_op(
+                    [riscv.SltuOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())]
+                )
             # ule
             case 5:
-                sltu = riscv.SltuOp(lhs, rhs)
+                sltu = riscv.SltuOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
                 xori = riscv.XoriOp(sltu, 1)
                 rewriter.replace_matched_op([sltu, xori])
             # ugt
             case 6:
-                rewriter.replace_matched_op([riscv.SltuOp(rhs, lhs)])
+                rewriter.replace_matched_op(
+                    [riscv.SltuOp(rhs, lhs, rd=riscv.IntRegisterType.unallocated())]
+                )
             # uge
             case 7:
-                sltu = riscv.SltuOp(rhs, lhs)
+                sltu = riscv.SltuOp(rhs, lhs, rd=riscv.IntRegisterType.unallocated())
                 xori = riscv.XoriOp(sltu, 1)
                 rewriter.replace_matched_op([sltu, xori])
             case _:
@@ -264,18 +252,18 @@ class LowerArithSelect(RewritePattern):
         raise NotImplementedError("Select is not supported")
 
 
-lower_arith_andi = lower_signless_integer_binary_op(arith.AndI, riscv.AndOp)
-lower_arith_ori = lower_signless_integer_binary_op(arith.OrI, riscv.OrOp)
-lower_arith_xori = lower_signless_integer_binary_op(arith.XOrI, riscv.XorOp)
-lower_arith_shli = lower_signless_integer_binary_op(arith.ShLI, riscv.SllOp)
-lower_arith_shrui = lower_signless_integer_binary_op(arith.ShRUI, riscv.SrlOp)
-lower_arith_shrsi = lower_signless_integer_binary_op(arith.ShRSI, riscv.SraOp)
+lower_arith_andi = LowerBinaryIntegerOp(arith.AndI, riscv.AndOp)
+lower_arith_ori = LowerBinaryIntegerOp(arith.OrI, riscv.OrOp)
+lower_arith_xori = LowerBinaryIntegerOp(arith.XOrI, riscv.XorOp)
+lower_arith_shli = LowerBinaryIntegerOp(arith.ShLI, riscv.SllOp)
+lower_arith_shrui = LowerBinaryIntegerOp(arith.ShRUI, riscv.SrlOp)
+lower_arith_shrsi = LowerBinaryIntegerOp(arith.ShRSI, riscv.SraOp)
 
 
-lower_arith_addf = lower_float_binary_op(arith.Addf, riscv.FAddSOp)
-lower_arith_subf = lower_float_binary_op(arith.Subf, riscv.FSubSOp)
-lower_arith_mulf = lower_float_binary_op(arith.Mulf, riscv.FMulSOp)
-lower_arith_divf = lower_float_binary_op(arith.Divf, riscv.FDivSOp)
+lower_arith_addf = LowerBinaryFloatOp(arith.Addf, riscv.FAddSOp)
+lower_arith_subf = LowerBinaryFloatOp(arith.Subf, riscv.FSubSOp)
+lower_arith_mulf = LowerBinaryFloatOp(arith.Mulf, riscv.FMulSOp)
+lower_arith_divf = LowerBinaryFloatOp(arith.Divf, riscv.FDivSOp)
 
 
 class LowerArithNegf(RewritePattern):
@@ -286,7 +274,9 @@ class LowerArithNegf(RewritePattern):
                 operand := UnrealizedConversionCastOp.get(
                     (op.operand,), (_FLOAT_REGISTER_TYPE,)
                 ),
-                negf := riscv.FSgnJNSOp(operand, operand),
+                negf := riscv.FSgnJNSOp(
+                    operand, operand, rd=riscv.FloatRegisterType.unallocated()
+                ),
                 UnrealizedConversionCastOp.get((negf.rd,), (op.result.type,)),
             )
         )
@@ -334,17 +324,29 @@ class LowerArithCmpf(RewritePattern):
             case 6:
                 flt1 = riscv.FltSOP(lhs, rhs)
                 flt2 = riscv.FltSOP(rhs, lhs)
-                rewriter.replace_matched_op([flt1, flt2, riscv.OrOp(flt2, flt1)])
+                rewriter.replace_matched_op(
+                    [
+                        flt1,
+                        flt2,
+                        riscv.OrOp(flt2, flt1, rd=riscv.IntRegisterType.unallocated()),
+                    ]
+                )
             # ord
             case 7:
                 feq1 = riscv.FeqSOP(lhs, lhs)
                 feq2 = riscv.FeqSOP(rhs, rhs)
-                rewriter.replace_matched_op([feq1, feq2, riscv.AndOp(feq2, feq1)])
+                rewriter.replace_matched_op(
+                    [
+                        feq1,
+                        feq2,
+                        riscv.AndOp(feq2, feq1, rd=riscv.IntRegisterType.unallocated()),
+                    ]
+                )
             # ueq
             case 8:
                 flt1 = riscv.FltSOP(lhs, rhs)
                 flt2 = riscv.FltSOP(rhs, lhs)
-                or_ = riscv.OrOp(flt2, flt1)
+                or_ = riscv.OrOp(flt2, flt1, rd=riscv.IntRegisterType.unallocated())
                 rewriter.replace_matched_op([flt1, flt2, or_, riscv.XoriOp(or_, 1)])
             # ugt
             case 9:
@@ -370,7 +372,7 @@ class LowerArithCmpf(RewritePattern):
             case 14:
                 feq1 = riscv.FeqSOP(lhs, lhs)
                 feq2 = riscv.FeqSOP(rhs, rhs)
-                and_ = riscv.AndOp(feq2, feq1)
+                and_ = riscv.AndOp(feq2, feq1, rd=riscv.IntRegisterType.unallocated())
                 rewriter.replace_matched_op([feq1, feq2, and_, riscv.XoriOp(and_, 1)])
             # true
             case 15:

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -76,8 +76,12 @@ def memref_shape_ops(
         case [idx1, idx2]:
             ops = [
                 cols := riscv.LiOp(shape[1]),
-                row_offset := riscv.MulOp(cols, idx1),
-                offset := riscv.AddOp(row_offset, idx2),
+                row_offset := riscv.MulOp(
+                    cols, idx1, rd=riscv.IntRegisterType.unallocated()
+                ),
+                offset := riscv.AddOp(
+                    row_offset, idx2, rd=riscv.IntRegisterType.unallocated()
+                ),
             ]
             offset_in_elements = offset.rd
         case _:
@@ -91,9 +95,12 @@ def memref_shape_ops(
             offset_bytes := riscv.MulOp(
                 offset_in_elements,
                 bytes_per_element_op.rd,
+                rd=riscv.IntRegisterType.unallocated(),
                 comment="multiply by element size",
             ),
-            ptr := riscv.AddOp(mem, offset_bytes),
+            ptr := riscv.AddOp(
+                mem, offset_bytes, rd=riscv.IntRegisterType.unallocated()
+            ),
         ]
     )
 


### PR DESCRIPTION
Similarly to an earlier PR, unifying two abstract operations, in preparation for the addition of some vector ops required for Snitch.