### PR TITLE
backend: (riscv) print assembly from riscv_func, remove region from label

### DIFF
--- a/docs/Toy/toy/rewrites/setup_riscv_pass.py
+++ b/docs/Toy/toy/rewrites/setup_riscv_pass.py
@@ -26,11 +26,8 @@ class AddSections(RewritePattern):
             ),
         )
         data_section = riscv.AssemblySectionOp(".data", Region(Block()))
-        text_section = riscv.AssemblySectionOp(
-            ".text", rewriter.move_region_contents_to_new_regions(op.regions[0])
-        )
 
-        op.body.add_block(Block([heap_section, data_section, text_section]))
+        rewriter.insert_op_at_start((heap_section, data_section), op.body.block)
 
 
 class SetupRiscvPass(ModulePass):

--- a/docs/Toy/toy/tests/test_add_sections.py
+++ b/docs/Toy/toy/tests/test_add_sections.py
@@ -15,9 +15,7 @@ with ImplicitBuilder((output_module := ModuleOp([])).body):
         LabelOp("heap")
         DirectiveOp(".space", f"{1024}")
     data = AssemblySectionOp(".data", Region(Block()))
-    text = AssemblySectionOp(".text", Region(Block()))
-    with ImplicitBuilder(text.data):
-        FuncOp("main", ((), ()))
+    FuncOp("main", ((), ()))
 
 
 def test_add_sections():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,6 +1,5 @@
 import pytest
 
-from xdsl.builder import Builder
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import IntegerAttr, ModuleOp, i32
 from xdsl.ir import MLContext
@@ -107,22 +106,6 @@ def test_label_op_with_comment():
 
     code = riscv.riscv_code(ModuleOp([label_op]))
     assert code == f"{label_str}:                                         # my label\n"
-
-
-def test_label_op_with_region():
-    @Builder.implicit_region
-    def label_region():
-        a1_reg = TestSSAValue(riscv.Registers.A1)
-        a2_reg = TestSSAValue(riscv.Registers.A2)
-        riscv.AddOp(a1_reg, a2_reg, rd=riscv.Registers.A0)
-
-    label_str = "mylabel"
-    label_op = riscv.LabelOp(f"{label_str}", region=label_region)
-
-    assert label_op.label.data == label_str
-
-    code = riscv.riscv_code(ModuleOp([label_op]))
-    assert code == f"{label_str}:\n    add a0, a1, a2\n"
 
 
 def test_return_op():

--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -19,6 +19,9 @@ builtin.module {
 }
 
 // CHECK:       builtin.module {
+// CHECK-NEXT:    riscv.assembly_section ".text" {
+// CHECK-NEXT:      riscv.directive ".globl" "main" : () -> ()
+// CHECK-NEXT:      riscv.directive ".p2align" "2" : () -> ()
 // CHECK-NEXT:      riscv_func.func @main() {
 // CHECK-NEXT:          %0, %1 = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg<>
@@ -32,6 +35,10 @@ builtin.module {
 // CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
 // CHECK-NEXT:          riscv_func.return
 // CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv.assembly_section ".text" {
+// CHECK-NEXT:      riscv.directive ".globl" "foo" : () -> ()
+// CHECK-NEXT:      riscv.directive ".p2align" "2" : () -> ()
 // CHECK-NEXT:      riscv_func.func @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.reg<a1>) -> (!riscv.reg<a0>, !riscv.reg<a1>) {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
 // CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
@@ -44,6 +51,10 @@ builtin.module {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a1>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.reg<a0>, !riscv.reg<a1>
 // CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv.assembly_section ".text" {
+// CHECK-NEXT:      riscv.directive ".globl" "foo_float" : () -> ()
+// CHECK-NEXT:      riscv.directive ".p2align" "2" : () -> ()
 // CHECK-NEXT:      riscv_func.func @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) {
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg<>
 // CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
@@ -56,4 +67,5 @@ builtin.module {
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa1>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.freg<fa1>
 // CHECK-NEXT:      }
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/backend/rvscf_lowering_labels.mlir
+++ b/tests/filecheck/backend/rvscf_lowering_labels.mlir
@@ -21,18 +21,15 @@ builtin.module {
 // CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %3 = riscv.li 0 : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %4 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<a4>
-// CHECK-NEXT:      riscv.label "scf_cond_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_0_for" : () -> ()
 // CHECK-NEXT:      riscv.bge %4, %1, "scf_body_end_0_for" : (!riscv.reg<a4>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_0_for" : () -> ()
 // CHECK-NEXT:      %5 = riscv.get_register : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %6 = riscv.get_register : () -> !riscv.reg<a4>
 // CHECK-NEXT:      %7 = riscv.add %6, %5 : (!riscv.reg<a4>, !riscv.reg<a3>) -> !riscv.reg<a3>
 // CHECK-NEXT:      %8 = riscv.add %4, %2 : (!riscv.reg<a4>, !riscv.reg<a2>) -> !riscv.reg<a4>
 // CHECK-NEXT:      riscv.blt %4, %1, "scf_body_0_for" : (!riscv.reg<a4>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for" : () -> ()
 // CHECK-NEXT:      %9 = riscv.get_register : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %10 = riscv.mv %9 : (!riscv.reg<a3>) -> !riscv.reg<a0>
 // CHECK-NEXT:      riscv_func.return %10 : !riscv.reg<a0>
@@ -64,19 +61,16 @@ builtin.module {
 // CHECK-NEXT:      %3 = riscv.li 0 : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %4 = riscv.fcvt.s.w %3 : (!riscv.reg<a3>) -> !riscv.freg<fa0>
 // CHECK-NEXT:      %5 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
-// CHECK-NEXT:      riscv.label "scf_cond_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_0_for" : () -> ()
 // CHECK-NEXT:      riscv.bge %5, %1, "scf_body_end_0_for" : (!riscv.reg<a0>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_0_for" : () -> ()
 // CHECK-NEXT:      %6 = riscv.get_float_register : () -> !riscv.freg<fa0>
 // CHECK-NEXT:      %7 = riscv.get_register : () -> !riscv.reg<a0>
 // CHECK-NEXT:      %8 = riscv.fcvt.s.w %7 : (!riscv.reg<a0>) -> !riscv.freg<fa1>
 // CHECK-NEXT:      %9 = riscv.fadd.s %6, %8 : (!riscv.freg<fa0>, !riscv.freg<fa1>) -> !riscv.freg<fa0>
 // CHECK-NEXT:      %10 = riscv.add %5, %2 : (!riscv.reg<a0>, !riscv.reg<a2>) -> !riscv.reg<a0>
 // CHECK-NEXT:      riscv.blt %5, %1, "scf_body_0_for" : (!riscv.reg<a0>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for" : () -> ()
 // CHECK-NEXT:      %11 = riscv.get_float_register : () -> !riscv.freg<fa0>
 // CHECK-NEXT:      %12 = riscv.fcvt.w.s %11 : (!riscv.freg<fa0>) -> !riscv.reg<a0>
 // CHECK-NEXT:      riscv_func.return %12 : !riscv.reg<a0>
@@ -112,34 +106,28 @@ builtin.module {
 // CHECK-NEXT:      %1 = riscv.li 0 : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %3 = riscv.mv %1 : (!riscv.reg<a2>) -> !riscv.reg<a2>
-// CHECK-NEXT:      riscv.label "scf_cond_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_0_for" : () -> ()
 // CHECK-NEXT:      riscv.bge %3, %arg0, "scf_body_end_0_for" : (!riscv.reg<a2>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_0_for" : () -> ()
 // CHECK-NEXT:      %arg2 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      %arg1 = riscv.get_register : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %4 = riscv.li 0 : () -> !riscv.reg<a4>
 // CHECK-NEXT:      %5 = riscv.li 1 : () -> !riscv.reg<a5>
 // CHECK-NEXT:      %6 = riscv.mv %4 : (!riscv.reg<a4>) -> !riscv.reg<a4>
-// CHECK-NEXT:      riscv.label "scf_cond_1_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_1_for" : () -> ()
 // CHECK-NEXT:      riscv.bge %6, %arg0, "scf_body_end_1_for" : (!riscv.reg<a4>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_1_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_1_for" : () -> ()
 // CHECK-NEXT:      %arg4 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      %arg3 = riscv.get_register : () -> !riscv.reg<a4>
 // CHECK-NEXT:      %7 = riscv.add %arg1, %arg3 : (!riscv.reg<a2>, !riscv.reg<a4>) -> !riscv.reg<a0>
 // CHECK-NEXT:      %8 = riscv.add %arg4, %7 : (!riscv.reg<a1>, !riscv.reg<a0>) -> !riscv.reg<a1>
 // CHECK-NEXT:      %9 = riscv.add %6, %5 : (!riscv.reg<a4>, !riscv.reg<a5>) -> !riscv.reg<a4>
 // CHECK-NEXT:      riscv.blt %6, %arg0, "scf_body_1_for" : (!riscv.reg<a4>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_1_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_1_for" : () -> ()
 // CHECK-NEXT:      %10 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      %11 = riscv.add %3, %2 : (!riscv.reg<a2>, !riscv.reg<a3>) -> !riscv.reg<a2>
 // CHECK-NEXT:      riscv.blt %3, %arg0, "scf_body_0_for" : (!riscv.reg<a2>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_0_for" ({
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for" : () -> ()
 // CHECK-NEXT:      %12 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      riscv_func.return %12 : !riscv.reg<a1>
 // CHECK-NEXT:    }

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt -t riscv-asm %s | filecheck %s
 
 "builtin.module"() ({
-  riscv.label "main" ({
+  riscv_func.func @main() {
     %0 = riscv.li 6 : () -> !riscv.reg<zero>
     // CHECK:      li zero, 6
     %1 = riscv.li 5 : () -> !riscv.reg<j1>
@@ -167,13 +167,6 @@
     // CHECK-NEXT:  addi j1, j1, 1
     riscv.label "label0" : () -> ()
     // CHECK-NEXT: label0:
-    riscv.label "label1" ({
-      %nested_addi = riscv.addi %1, 1 : (!riscv.reg<j1>) -> !riscv.reg<j1>
-      riscv.ret : () -> ()
-    }) : () -> ()
-    // CHECK-NEXT: label1:
-    // CHECK-NEXT: addi j1, j1, 1
-    // CHECK-NEXT: ret
 
 
     // Custom instruction
@@ -243,7 +236,7 @@
     // CHECK-NEXT: fsw j5, 1(zero)
 
     // Terminate block
-    riscv.ret : () -> ()
+    riscv_func.return
     // CHECK-NEXT: ret
-  }) : () -> ()
+  }
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -2,7 +2,7 @@
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
 "builtin.module"() ({
-  riscv.label "main" ({
+  riscv_func.func @main() {
     %0 = riscv.get_register : () -> !riscv.reg<>
     %1 = riscv.get_register : () -> !riscv.reg<>
     // RV32I/RV64I: 2.4 Integer Computational Instructions
@@ -278,12 +278,12 @@
     // CHECK-NEXT: riscv.fsw %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.freg<>) -> ()
 
     // Terminate block
-    riscv.ret : () -> ()
-  }) : () -> ()
+    riscv_func.return
+  }
 }) : () -> ()
 
 // CHECK-GENERIC: "builtin.module"() ({
-// CHECK-GENERIC-NEXT:   "riscv.label"() ({
+// CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
 // CHECK-GENERIC-NEXT:     %0 = "riscv.get_register"() : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %1 = "riscv.get_register"() : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %addi = "riscv.addi"(%0) {"immediate" = 1 : si12} : (!riscv.reg<>) -> !riscv.reg<>
@@ -397,6 +397,6 @@
 // CHECK-GENERIC-NEXT:     %fmv_w_x = "riscv.fmv.w.x"(%0) : (!riscv.reg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %flw = "riscv.flw"(%0) {"immediate" = 1 : si12} : (!riscv.reg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     "riscv.fsw"(%0, %f0) {"immediate" = 1 : si12} : (!riscv.reg<>, !riscv.freg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.ret"() : () -> ()
-// CHECK-GENERIC-NEXT:   }) {"label" = #riscv.label<"main">} : () -> ()
+// CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
+++ b/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
@@ -24,38 +24,22 @@
         riscv_func.call @my_print(%2) : (!riscv.reg<>) -> ()
         riscv_func.return
     }
-// CHECK-NEXT:   riscv.assembly_section ".text" {
-// CHECK-NEXT:     riscv.directive ".globl" "main" : () -> ()
-// CHECK-NEXT:     riscv.directive ".p2align" "2" : () -> ()
-// CHECK-NEXT:     riscv.label "main" ({
-// CHECK-NEXT:         riscv.jal "get_one" : () -> ()
-// CHECK-NEXT:         %{{.*}} = riscv.get_register : () -> !riscv.reg<a0>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:         riscv.jal "get_one" : () -> ()
-// CHECK-NEXT:         %{{.*}} = riscv.get_register : () -> !riscv.reg<a0>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a1>
-// CHECK-NEXT:         riscv.jal "add" : () -> ()
-// CHECK-NEXT:         %{{.*}} = riscv.get_register : () -> !riscv.reg<a0>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:         riscv.jal "my_print" : () -> ()
-// CHECK-NEXT:         riscv.ret : () -> ()
-// CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:   }
+
+// CHECK-NEXT:    riscv_func.func @main() {
+// CHECK-NEXT:        %{{.*}} = riscv_func.call @get_one() : () -> !riscv.reg<>
+// CHECK-NEXT:        %{{.*}} = riscv_func.call @get_one() : () -> !riscv.reg<>
+// CHECK-NEXT:        %{{.*}} = riscv_func.call @add(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:        riscv_func.call @my_print(%{{.*}}) : (!riscv.reg<>) -> ()
+// CHECK-NEXT:        riscv_func.return
+// CHECK-NEXT:    }
 
 
     riscv_func.func @my_print() {
         riscv_func.return
     }
 
-// CHECK-NEXT:   riscv.assembly_section ".text" {
-// CHECK-NEXT:     riscv.directive ".globl" "my_print" : () -> ()
-// CHECK-NEXT:     riscv.directive ".p2align" "2" : () -> ()
-// CHECK-NEXT:     riscv.label "my_print" ({
-// CHECK-NEXT:         riscv.ret : () -> ()
-// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:   riscv_func.func @my_print() {
+// CHECK-NEXT:       riscv_func.return
 // CHECK-NEXT:   }
 
     riscv_func.func @get_one() {
@@ -63,54 +47,35 @@
         riscv_func.return %0 : !riscv.reg<>
     }
 
-// CHECK-NEXT:   riscv.assembly_section ".text" {
-// CHECK-NEXT:     riscv.directive ".globl" "get_one" : () -> ()
-// CHECK-NEXT:     riscv.directive ".p2align" "2" : () -> ()
-// CHECK-NEXT:     riscv.label "get_one" ({
-// CHECK-NEXT:         %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:         riscv.ret : () -> ()
-// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:   riscv_func.func @get_one() {
+// CHECK-NEXT:       %{{\d+}} = riscv.li 1 : () -> !riscv.reg<>
+// CHECK-NEXT:       riscv_func.return %{{\d+}} : !riscv.reg<>
 // CHECK-NEXT:   }
 
-    riscv_func.func @add(%0 : !riscv.reg<>, %1 : !riscv.reg<>) {
-        %2 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        riscv_func.return %2 : !riscv.reg<>
+    riscv_func.func @add(%arg0 : !riscv.reg<>, %arg1 : !riscv.reg<>) {
+        %res = riscv.add %arg0, %arg1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+        riscv_func.return %res : !riscv.reg<>
     }
 
-// CHECK-NEXT:   riscv.assembly_section ".text" {
-// CHECK-NEXT:     riscv.directive ".globl" "add" : () -> ()
-// CHECK-NEXT:     riscv.directive ".p2align" "2" : () -> ()
-// CHECK-NEXT:     riscv.label "add" ({
-// CHECK-NEXT:         %{{.*}} = riscv.get_register : () -> !riscv.reg<a0>
-// CHECK-NEXT:         %{{.*}} = riscv.get_register : () -> !riscv.reg<a1>
-// CHECK-NEXT:         %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<>
-// CHECK-NEXT:         %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:         riscv.ret : () -> ()
-// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:   riscv_func.func @add(%arg0 : !riscv.reg<>, %arg1 : !riscv.reg<>) {
+// CHECK-NEXT:       %res = riscv.add %arg0, %arg1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:       riscv_func.return %res : !riscv.reg<>
 // CHECK-NEXT:   }
 
     riscv_func.func private @visibility_private() {
         riscv_func.return
     }
 
-// CHECK-NEXT:   riscv.assembly_section ".text" {
-// CHECK-NEXT:     riscv.directive ".p2align" "2" : () -> ()
-// CHECK-NEXT:     riscv.label "visibility_private" ({
-// CHECK-NEXT:         riscv.ret : () -> ()
-// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:   riscv_func.func private @visibility_private() {
+// CHECK-NEXT:       riscv_func.return
 // CHECK-NEXT:   }
 
     riscv_func.func public @visibility_public() {
         riscv_func.return
     }
 
-// CHECK-NEXT:   riscv.assembly_section ".text" {
-// CHECK-NEXT:     riscv.directive ".globl" "visibility_public" : () -> ()
-// CHECK-NEXT:     riscv.directive ".p2align" "2" : () -> ()
-// CHECK-NEXT:     riscv.label "visibility_public" ({
-// CHECK-NEXT:         riscv.ret : () -> ()
-// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:   riscv_func.func public @visibility_public() {
+// CHECK-NEXT:       riscv_func.return
 // CHECK-NEXT:   }
 
 }) : () -> ()

--- a/tests/filecheck/dialects/riscv_func/lower_riscv_func_main.mlir
+++ b/tests/filecheck/dialects/riscv_func/lower_riscv_func_main.mlir
@@ -4,18 +4,14 @@
 // CHECK:      builtin.module {
 
     riscv_func.func @main() {
-        "riscv_func.return"() : () -> ()
+        riscv_func.return
     }
 
-// CHECK-NEXT:   riscv.assembly_section ".text" {
-// CHECK-NEXT:     riscv.directive ".globl" "main" : () -> ()
-// CHECK-NEXT:     riscv.directive ".p2align" "2" : () -> ()
-// CHECK-NEXT:     riscv.label "main" ({
+// CHECK-NEXT:     riscv_func.func @main() {
 // CHECK-NEXT:         %{{.*}} = riscv.li 93 : () -> !riscv.reg<a7>
 // CHECK-NEXT:         riscv.ecall : () -> ()
-// CHECK-NEXT:         riscv.ret : () -> ()
-// CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:   }
+// CHECK-NEXT:         riscv_func.return
+// CHECK-NEXT:     }
 
 }) : () -> ()
 

--- a/tests/filecheck/with-riscemu/riscv_emulation.mlir
+++ b/tests/filecheck/with-riscemu/riscv_emulation.mlir
@@ -15,35 +15,29 @@ builtin.module {
 // -----
 
 builtin.module {
-  riscv.label "main" ({
+  riscv_func.func @main() {
     %0 = riscv.li 3 : () -> !riscv.reg<a0>
     %1 = riscv.li 2 : () -> !riscv.reg<a1>
     %2 = riscv.li 1 : () -> !riscv.reg<a2>
-    riscv.jal "muladd" : () -> ()
-    %3 = riscv.get_register : () -> !riscv.reg<a0>
-    riscv.custom_assembly_instruction %3 {"instruction_name" = "print"} : (!riscv.reg<a0>) -> ()
+    %xyz = riscv_func.call @muladd(%x, %y, %z) : (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>) -> !riscv.reg<a0>
+    riscv.custom_assembly_instruction %xyz {"instruction_name" = "print"} : (!riscv.reg<a0>) -> ()
     %4 = riscv.li 93 : () -> !riscv.reg<a7>
     riscv.ecall : () -> ()
-    riscv.ret : () -> ()
-  }): () -> ()
-  riscv.label "multiply" ({
+    riscv_func.return
+  }
+  riscv_func.func @multiply(%x : !riscv.reg<a0>, %y : !riscv.reg<a1>) {
     "riscv.comment"() {"comment" = "no extra registers needed, so no need to deal with stack"} : () -> ()
-    %5 = riscv.get_register : () -> !riscv.reg<a0>
-    %6 = riscv.get_register : () -> !riscv.reg<a1>
-    %7 = riscv.mul %5, %6 : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
-    riscv.ret : () -> ()
-  }): () -> ()
-  riscv.label "add" ({
+    %product = riscv.mul %x, %y : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
+    riscv_func.return %product : !riscv.reg<a0>
+  }
+  riscv_func.func @add(%x : !riscv.reg<a0>, %y : !riscv.reg<a1>) {
     "riscv.comment"() {"comment" = "no extra registers needed, so no need to deal with stack"} : () -> ()
-    %8 = riscv.get_register : () -> !riscv.reg<a0>
-    %9 = riscv.get_register : () -> !riscv.reg<a1>
-    %10 = riscv.add %8, %9 : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
-    riscv.ret : () -> ()
-  }): () -> ()
-  riscv.label "muladd" ({
+    %sum = "riscv.add"(%x, %y) : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
+    riscv_func.return %sum : !riscv.reg<a0>
+  }
+  riscv_func.func @muladd(%x : !riscv.reg<a0>, %y : !riscv.reg<a1>, %z : !riscv.reg<a2>) {
     "riscv.comment"() {"comment" = "a0 <- a0 * a1 + a2"} : () -> ()
     "riscv.comment"() {"comment" = "prologue"} : () -> ()
-    %11 = riscv.get_register : () -> !riscv.reg<a2>
     %12 = riscv.get_register : () -> !riscv.reg<sp>
     %13 = riscv.get_register : () -> !riscv.reg<s0>
     %14 = riscv.get_register : () -> !riscv.reg<ra>
@@ -53,10 +47,10 @@ builtin.module {
     riscv.sw %12, %13, 0: (!riscv.reg<sp>, !riscv.reg<s0>) -> ()
     "riscv.comment"() {"comment" = "save the return address we'll use on the stack"} : () -> ()
     riscv.sw %12, %14, 4: (!riscv.reg<sp>, !riscv.reg<ra>) -> ()
-    %16 = riscv.mv %11 : (!riscv.reg<a2>) -> !riscv.reg<s0>
-    riscv.jal "multiply" : () -> ()
+    %16 = riscv.mv %z : (!riscv.reg<a2>) -> !riscv.reg<s0>
+    %xy = riscv_func.call @multiply(%x, %y) : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
     %17 = riscv.mv %16 : (!riscv.reg<s0>) -> !riscv.reg<a1>
-    riscv.jal "add" : () -> ()
+    %xyz = riscv_func.call @add(%xy, %17) : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
     "riscv.comment"() {"comment" = "epilogue"} : () -> ()
     "riscv.comment"() {"comment" = "store the old values back into the s registers"} : () -> ()
     %18 = riscv.lw %12, 0: (!riscv.reg<sp>) -> !riscv.reg<s0>
@@ -65,8 +59,8 @@ builtin.module {
     "riscv.comment"() {"comment" = "set the sp back to what it was at the start of the function call"} : () -> ()
     %20 = riscv.addi %12, 8: (!riscv.reg<sp>) -> !riscv.reg<sp>
     "riscv.comment"() {"comment" = "jump back to caller"} : () -> ()
-    riscv.ret : () -> ()
-  }): () -> ()
+    riscv_func.return %xyz : !riscv.reg<a0>
+  }
 }
 
 // CHECK: 7

--- a/tests/filecheck/with-riscemu/rvscf_lowering_emu.mlir
+++ b/tests/filecheck/with-riscemu/rvscf_lowering_emu.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt -p lower-riscv-scf-to-labels -t riscemu %s
 
 builtin.module {
-  riscv.label "main" ({
+  riscv_func.func @main() {
     %0 = riscv.li 0 : () -> !riscv.reg<a0>
     %1 = riscv.li 10 : () -> !riscv.reg<a1>
     %2 = riscv.li 1 : () -> !riscv.reg<a2>
@@ -15,8 +15,8 @@ builtin.module {
     riscv.custom_assembly_instruction %4 {"instruction_name" = "print"} : (!riscv.reg<a3>) -> ()
     riscv.li 93 : () -> !riscv.reg<a7>
     riscv.ecall : () -> ()
-    riscv.ret : () -> ()
-  }) : () -> ()
+    riscv_func.return
+  }
 }
 
 // CHECK: 45

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -6,7 +6,7 @@ from xdsl.builder import Builder
 from xdsl.dialects import riscv, riscv_func
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import MLContext
-from xdsl.transforms.lower_riscv_func import LowerRISCVFunc
+from xdsl.ir.core import BlockArgument
 from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
 
 pytest.importorskip("riscemu", reason="riscemu is an optional dependency")
@@ -33,7 +33,6 @@ def test_simple():
         riscv_func.FuncOp("main", body, ((), ()))
 
     RISCVRegisterAllocation().apply(ctx, module)
-    LowerRISCVFunc().apply(ctx, module)
 
     code = riscv.riscv_code(module)
 
@@ -65,34 +64,42 @@ def test_multiply_add():
             riscv.LiOp(93, rd=riscv.Registers.A7)
             riscv.EcallOp()
 
-        riscv.LabelOp("main", main)
+        riscv_func.FuncOp("main", main, ((), ()))
 
-        @Builder.implicit_region
-        def multiply():
+        @Builder.implicit_region((riscv.Registers.A0, riscv.Registers.A1))
+        def multiply(args: tuple[BlockArgument, ...]):
             riscv.CommentOp("no extra registers needed, so no need to deal with stack")
-            a0_multiply = riscv.GetRegisterOp(riscv.Registers.A0)
-            a1_multiply = riscv.GetRegisterOp(riscv.Registers.A1)
-            riscv.MulOp(a0_multiply, a1_multiply, rd=riscv.Registers.A0)
-            riscv.ReturnOp()
+            rs1, rs2 = args
+            res = riscv.MulOp(rs1, rs2, rd=riscv.Registers.A0).rd
+            riscv_func.ReturnOp(res)
 
-        riscv.LabelOp("multiply", multiply)
+        riscv_func.FuncOp(
+            "multiply",
+            multiply,
+            ((riscv.Registers.A0, riscv.Registers.A1), (riscv.Registers.A0,)),
+        )
 
-        @Builder.implicit_region
-        def add():
+        @Builder.implicit_region((riscv.Registers.A0, riscv.Registers.A1))
+        def add(args: tuple[BlockArgument, ...]):
             riscv.CommentOp("no extra registers needed, so no need to deal with stack")
-            a0_add = riscv.GetRegisterOp(riscv.Registers.A0)
-            a1_add = riscv.GetRegisterOp(riscv.Registers.A1)
-            riscv.AddOp(a0_add, a1_add, rd=riscv.Registers.A0)
-            riscv.ReturnOp()
+            rs1, rs2 = args
+            res = riscv.AddOp(rs1, rs2, rd=riscv.Registers.A0).rd
+            riscv_func.ReturnOp(res)
 
-        riscv.LabelOp("add", add)
+        riscv_func.FuncOp(
+            "add",
+            add,
+            ((riscv.Registers.A0, riscv.Registers.A1), (riscv.Registers.A0,)),
+        )
 
-        @Builder.implicit_region
-        def muladd():
+        @Builder.implicit_region(
+            (riscv.Registers.A0, riscv.Registers.A1, riscv.Registers.A2)
+        )
+        def muladd(args: tuple[BlockArgument, ...]):
             riscv.CommentOp("a0 <- a0 * a1 + a2")
             riscv.CommentOp("prologue")
             # get registers with the arguments to muladd
-            a2_muladd = riscv.GetRegisterOp(riscv.Registers.A2)
+            _, _, a2_muladd = args
 
             # get registers we'll use in this section
             sp_muladd = riscv.GetRegisterOp(riscv.Registers.SP)
@@ -134,7 +141,14 @@ def test_multiply_add():
             riscv.CommentOp("jump back to caller")
             riscv.ReturnOp()
 
-        riscv.LabelOp("muladd", muladd)
+        riscv_func.FuncOp(
+            "muladd",
+            muladd,
+            (
+                (riscv.Registers.A0, riscv.Registers.A1, riscv.Registers.A2),
+                (riscv.Registers.A0,),
+            ),
+        )
 
     RISCVRegisterAllocation().apply(ctx, module)
 

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -17,7 +17,7 @@ def my_module():
 
     @Builder.implicit_region((register,))
     def body(args: tuple[BlockArgument, ...]) -> None:
-        riscv_func.ReturnOp(args)
+        riscv_func.ReturnOp(*args)
 
     riscv_func.FuncOp("id", body, ((register,), (register,)))
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -43,7 +43,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.irdl.irdl import OptRegion, opt_region_def, region_def
+from xdsl.irdl.irdl import region_def
 from xdsl.parser import AttrParser, Parser, UnresolvedOperand
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
@@ -2358,38 +2358,15 @@ class LabelOp(IRDLOperation, RISCVOp):
     as branch, unconditional jump targets and symbol offsets.
 
     https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#labels
-
-    Optionally, a label can be associated with a single-block region, since
-    that is a common target for jump instructions.
-
-    For example, to generate this assembly:
-    ```
-    label1:
-        add a0, a1, a2
-    ```
-
-    One needs to do the following:
-
-    ``` python
-    @Builder.implicit_region
-    def my_add():
-        a1_reg = TestSSAValue(riscv.Registers.A1)
-        a2_reg = TestSSAValue(riscv.Registers.A2)
-        riscv.AddOp(a1_reg, a2_reg, rd=riscv.Registers.A0)
-
-    label_op = riscv.LabelOp("label1", my_add)
-    ```
     """
 
     name = "riscv.label"
     label: LabelAttr = attr_def(LabelAttr)
     comment: StringAttr | None = opt_attr_def(StringAttr)
-    data: OptRegion = opt_region_def()
 
     def __init__(
         self,
         label: str | LabelAttr,
-        region: OptRegion = None,
         *,
         comment: str | StringAttr | None = None,
     ):
@@ -2397,15 +2374,12 @@ class LabelOp(IRDLOperation, RISCVOp):
             label = LabelAttr(label)
         if isinstance(comment, str):
             comment = StringAttr(comment)
-        if region is None:
-            region = Region()
 
         super().__init__(
             attributes={
                 "label": label,
                 "comment": comment,
             },
-            regions=[region],
         )
 
     def assembly_line(self) -> str | None:


### PR DESCRIPTION
I don't think we need the extra step of rewriting to labels, and we benefit from skipping it. For one, fewer rewrites means fewer opportunities for bugs. Also, we get fewer `GetRegisterOp`s, and having 0 of them lets us interpret the code directly. As discussed before, dropping the region from labels also makes the code a bit less weird/confusing.