### PR TITLE
documentation: (toy) add end-to-end demo notebook

### DIFF
--- a/docs/Toy/Toy_Ch0.ipynb
+++ b/docs/Toy/Toy_Ch0.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "56341c66",
+   "metadata": {},
+   "source": [
+    "# Chapter 0: Compiling and Running Toy\n",
+    "\n",
+    "Here is a simple program in the Toy programming language running in a RISC-V emulator, \n",
+    "compiled using xDSL.\n",
+    "Try changing the program and observing the output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e07ae44f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m\u001b[1mUnknown assembler directive: PSE(.p2align) ('2',) in ParseContext(\n",
+      "\tsetion=CurrentSection(name=.text,data=[],type=Instructions),\n",
+      "\tprogram=Program(name=example.asm,sections={'main'},base=['.bss', '.data', '.text'])\n",
+      ")\u001b[0m\n",
+      "[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]\n",
+      "[[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.utils.exceptions import VerifyException\n",
+    "\n",
+    "from toy.compiler import compile, emulate_riscv\n",
+    "\n",
+    "program = \"\"\"\n",
+    "def main() {\n",
+    "  # Define a variable `a` with shape <2, 3>, initialized with the literal value.\n",
+    "  # The shape is inferred from the supplied literal.\n",
+    "  var a = [[1, 2, 3], [4, 5, 6]];\n",
+    "\n",
+    "  # b is identical to a, the literal tensor is implicitly reshaped: defining new\n",
+    "  # variables is the way to reshape tensors (element count must match).\n",
+    "  var b<3, 2> = [1, 2, 3, 4, 5, 6];\n",
+    "\n",
+    "  # There is a built-in print instruction to display the contents of the tensor\n",
+    "  print(b);\n",
+    "\n",
+    "  # Reshapes are implicit on assignment\n",
+    "  var c<2, 3> = b;\n",
+    "\n",
+    "  # There are + and * operators for pointwise addition and multiplication\n",
+    "  var d = a + c;\n",
+    "\n",
+    "  print(d);\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "try:\n",
+    "  code = compile(program)\n",
+    "  emulate_riscv(code)\n",
+    "except VerifyException as e:\n",
+    "  print(e)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from pathlib import Path
 
 from xdsl.backend.riscv.lowering.convert_arith_to_riscv import ConvertArithToRiscvPass
@@ -149,6 +150,18 @@ def transform(
         return
 
     raise ValueError(f"Unknown target option {target}")
+
+
+def compile(program: str) -> str:
+    ctx = context()
+
+    op = parse_toy(program)
+    transform(ctx, op, target="riscv-lowered")
+
+    io = StringIO()
+    riscv.print_assembly(op, io)
+
+    return io.getvalue()
 
 
 def emulate_riscv(program: str):


### PR DESCRIPTION
Now that we've removed the dependency on mlir-opt we can run our end-to-end riscv compiler + emulator in the browser.