### PR TITLE
backend: (riscv) allocate T registers then A registers then J

### DIFF
--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
@@ -43,41 +43,41 @@ builtin.module {
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:  riscv_func.func @main() {
-// CHECK-NEXT:    %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t5>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t1>
 // CHECK-NEXT:    %{{\d+}} = riscv.li 5 : () -> !riscv.reg<s0>
-// CHECK-NEXT:    %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t5>, !riscv.reg<s0>) -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 29 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 28 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 27 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 26 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 25 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 24 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 23 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 22 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 21 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 20 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 19 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 18 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 17 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 16 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 15 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 14 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 13 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 12 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 11 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 10 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 9 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 8 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 7 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 5 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 4 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 3 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 2 : () -> !riscv.reg<t5>
-// CHECK-NEXT:    %{{\d+}} = riscv.li 1 : () -> !riscv.reg<t6>
-// CHECK-NEXT:    %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t5>) -> !riscv.freg<ft11>
-// CHECK-NEXT:    %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t6>) -> !riscv.freg<ft10>
-// CHECK-NEXT:    %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft11>, !riscv.freg<ft10>) -> !riscv.freg<ft11>
+// CHECK-NEXT:    %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t1>, !riscv.reg<s0>) -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 29 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 28 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 27 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 26 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 25 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 24 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 23 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 22 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 21 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 20 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 19 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 18 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 17 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 16 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 15 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 14 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 13 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 12 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 11 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 10 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 9 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 8 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 7 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 5 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 4 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 3 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 2 : () -> !riscv.reg<t1>
+// CHECK-NEXT:    %{{\d+}} = riscv.li 1 : () -> !riscv.reg<t0>
+// CHECK-NEXT:    %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t1>) -> !riscv.freg<ft0>
+// CHECK-NEXT:    %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t0>) -> !riscv.freg<ft1>
+// CHECK-NEXT:    %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
 // CHECK-NEXT:    riscv_func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
@@ -20,21 +20,21 @@ riscv_func.func @main() {
 }
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
-// CHECK-NEXT:      %0 = riscv.li 6 : () -> !riscv.reg<ra>
+// CHECK-NEXT:      %0 = riscv.li 6 : () -> !riscv.reg<t1>
 // CHECK-NEXT:      %1 = riscv.li 5 : () -> !riscv.reg<s0>
-// CHECK-NEXT:      %2 = riscv.add %0, %1 : (!riscv.reg<ra>, !riscv.reg<s0>) -> !riscv.reg<ra>
-// CHECK-NEXT:      %3 = riscv.li 29 : () -> !riscv.reg<ra>
+// CHECK-NEXT:      %2 = riscv.add %0, %1 : (!riscv.reg<t1>, !riscv.reg<s0>) -> !riscv.reg<t1>
+// CHECK-NEXT:      %3 = riscv.li 29 : () -> !riscv.reg<t1>
 // CHECK-NEXT:      %4 = riscv.li 28 : () -> !riscv.reg<t0>
-// CHECK-NEXT:      %5 = riscv.add %3, %4 : (!riscv.reg<ra>, !riscv.reg<t0>) -> !riscv.reg<ra>
-// CHECK-NEXT:      %6 = riscv.li 26 : () -> !riscv.reg<ra>
-// CHECK-NEXT:      %7 = riscv.li 25 : () -> !riscv.reg<ra>
-// CHECK-NEXT:      %8 = riscv.li 24 : () -> !riscv.reg<ra>
-// CHECK-NEXT:      %9 = riscv.li 23 : () -> !riscv.reg<ra>
-// CHECK-NEXT:      %10 = riscv.li 2 : () -> !riscv.reg<ra>
+// CHECK-NEXT:      %5 = riscv.add %3, %4 : (!riscv.reg<t1>, !riscv.reg<t0>) -> !riscv.reg<t1>
+// CHECK-NEXT:      %6 = riscv.li 26 : () -> !riscv.reg<t1>
+// CHECK-NEXT:      %7 = riscv.li 25 : () -> !riscv.reg<t1>
+// CHECK-NEXT:      %8 = riscv.li 24 : () -> !riscv.reg<t1>
+// CHECK-NEXT:      %9 = riscv.li 23 : () -> !riscv.reg<t1>
+// CHECK-NEXT:      %10 = riscv.li 2 : () -> !riscv.reg<t1>
 // CHECK-NEXT:      %11 = riscv.li 1 : () -> !riscv.reg<t0>
-// CHECK-NEXT:      %12 = riscv.fcvt.s.w %10 : (!riscv.reg<ra>) -> !riscv.freg<ft1>
-// CHECK-NEXT:      %13 = riscv.fcvt.s.w %11 : (!riscv.reg<t0>) -> !riscv.freg<ft0>
-// CHECK-NEXT:      %14 = riscv.fadd.s %12, %13 : (!riscv.freg<ft1>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
+// CHECK-NEXT:      %12 = riscv.fcvt.s.w %10 : (!riscv.reg<t1>) -> !riscv.freg<ft0>
+// CHECK-NEXT:      %13 = riscv.fcvt.s.w %11 : (!riscv.reg<t0>) -> !riscv.freg<ft1>
+// CHECK-NEXT:      %14 = riscv.fadd.s %12, %13 : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
@@ -2,22 +2,22 @@
 
 riscv_func.func @main() {
   %0 = riscv.li 6 : () -> !riscv.reg<>
-  %1 = riscv.li 5 : () -> !riscv.reg<t6>
+  %1 = riscv.li 5 : () -> !riscv.reg<t0>
   %3 = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
-  %4 = riscv.fcvt.s.w %1 : (!riscv.reg<t6>) -> !riscv.freg<>
+  %4 = riscv.fcvt.s.w %1 : (!riscv.reg<t0>) -> !riscv.freg<>
   %5 = riscv.fadd.s %3, %4 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-  %2 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<t6>) -> !riscv.reg<>
+  %2 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<t0>) -> !riscv.reg<>
   riscv_func.return
 }
 
 // LIVE-BNAIVE:       builtin.module {
 // LIVE-BNAIVE-NEXT:    riscv_func.func @main() {
-// LIVE-BNAIVE-NEXT:      %0 = riscv.li 6 : () -> !riscv.reg<t5>
-// LIVE-BNAIVE-NEXT:      %1 = riscv.li 5 : () -> !riscv.reg<t6>
-// LIVE-BNAIVE-NEXT:      %2 = riscv.fcvt.s.w %0 : (!riscv.reg<t5>) -> !riscv.freg<ft11>
-// LIVE-BNAIVE-NEXT:      %3 = riscv.fcvt.s.w %1 : (!riscv.reg<t6>) -> !riscv.freg<ft10>
-// LIVE-BNAIVE-NEXT:      %4 = riscv.fadd.s %2, %3 : (!riscv.freg<ft11>, !riscv.freg<ft10>) -> !riscv.freg<ft11>
-// LIVE-BNAIVE-NEXT:      %5 = riscv.add %0, %1 : (!riscv.reg<t5>, !riscv.reg<t6>) -> !riscv.reg<t5>
+// LIVE-BNAIVE-NEXT:      %0 = riscv.li 6 : () -> !riscv.reg<t1>
+// LIVE-BNAIVE-NEXT:      %1 = riscv.li 5 : () -> !riscv.reg<t0>
+// LIVE-BNAIVE-NEXT:      %2 = riscv.fcvt.s.w %0 : (!riscv.reg<t1>) -> !riscv.freg<ft0>
+// LIVE-BNAIVE-NEXT:      %3 = riscv.fcvt.s.w %1 : (!riscv.reg<t0>) -> !riscv.freg<ft1>
+// LIVE-BNAIVE-NEXT:      %4 = riscv.fadd.s %2, %3 : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
+// LIVE-BNAIVE-NEXT:      %5 = riscv.add %0, %1 : (!riscv.reg<t1>, !riscv.reg<t0>) -> !riscv.reg<t1>
 // LIVE-BNAIVE-NEXT:      riscv_func.return
 // LIVE-BNAIVE-NEXT:    }
 // LIVE-BNAIVE-NEXT:  }

--- a/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
+++ b/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
@@ -27,21 +27,21 @@ riscv_func.func @main() {
 //   CHECK-LIVENESS-BLOCK-NAIVE:       builtin.module {
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    riscv_func.func @external() -> ()
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    riscv_func.func @main() {
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t4>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t2>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.li 5 : () -> !riscv.reg<s0>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t4>) -> !riscv.freg<ft11>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<ft10>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft11>, !riscv.freg<ft10>) -> !riscv.freg<ft11>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t4>, !riscv.reg<s0>) -> !riscv.reg<t6>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t2>) -> !riscv.freg<ft0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<ft1>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t2>, !riscv.reg<s0>) -> !riscv.reg<t0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      "riscv_scf.for"(%{{\d+}}, %{{\d+}}, %{{\d+}}) ({
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      ^0(%{{\d+}} : !riscv.reg<t6>):
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      ^0(%{{\d+}} : !riscv.reg<t0>):
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        "riscv_scf.yield"() : () -> ()
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }) : (!riscv.reg<t4>, !riscv.reg<s0>, !riscv.reg<t6>) -> ()
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }) : (!riscv.reg<t2>, !riscv.reg<s0>, !riscv.reg<t0>) -> ()
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = "riscv_scf.for"(%{{\d+}}, %{{\d+}}, %{{\d+}}, %{{\d+}}) ({
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      ^1(%{{\d+}} : !riscv.reg<t5>, %{{\d+}} : !riscv.reg<t6>):
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        %{{\d+}} = riscv.mv %9 : (!riscv.reg<t6>) -> !riscv.reg<t6>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        "riscv_scf.yield"(%{{\d+}}) : (!riscv.reg<t6>) -> ()
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }) : (!riscv.reg<t4>, !riscv.reg<s0>, !riscv.reg<t6>, !riscv.reg<t6>) -> !riscv.reg<t6>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      ^1(%{{\d+}} : !riscv.reg<t1>, %{{\d+}} : !riscv.reg<t0>):
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        %{{\d+}} = riscv.mv %9 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        "riscv_scf.yield"(%{{\d+}}) : (!riscv.reg<t0>) -> ()
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }) : (!riscv.reg<t2>, !riscv.reg<s0>, !riscv.reg<t0>, !riscv.reg<t0>) -> !riscv.reg<t0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      riscv_func.return
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    }
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:  }

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -75,16 +75,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
     exclude_preallocated: bool = True
 
     def __init__(self) -> None:
-        self.available_registers = RegisterQueue(
-            available_int_registers=[
-                IntRegisterType(reg)
-                for reg in IntRegisterType.RV32I_INDEX_BY_NAME
-                if IntRegisterType(reg) not in RegisterQueue.DEFAULT_RESERVED_REGISTERS
-            ],
-            available_float_registers=[
-                FloatRegisterType(reg) for reg in FloatRegisterType.RV32F_INDEX_BY_NAME
-            ],
-        )
+        self.available_registers = RegisterQueue()
         self.live_ins_per_block = {}
 
     def allocate(self, reg: SSAValue) -> bool:


### PR DESCRIPTION
We don't handle spilling so we might as well fail early.