### PR TITLE
Interpreter: Handling attributeOp in pdl rewrites

### DIFF
--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -302,7 +302,6 @@ def test_interpreter_attribute_rewrite():
     interpreter.register_implementations(PDLRewriteFunctions(MLContext()))
 
     input_module = constant_zero()
-    output_module = constant_zero()
     expected_module = constant_one()
     rewrite_module = change_constant_value_pdl()
     rewrite_module.verify()
@@ -321,8 +320,4 @@ def test_interpreter_attribute_rewrite():
         apply_recursively=False,
     ).rewrite_module(input_module)
 
-    assert (
-        not output_module.body.ops.first.attributes["value"]
-        == input_module.body.ops.first.attributes["value"]
-    )
     assert expected_module.is_structurally_equivalent(input_module)

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -256,6 +256,15 @@ def constant_zero():
     return ir_module
 
 
+def constant_one():
+    @ModuleOp
+    @Builder.implicit_region
+    def ir_module():
+        arith.Constant.from_int_and_width(1, 32)
+
+    return ir_module
+
+
 def change_constant_value_pdl():
     # The rewrite below changes the predicate of a cmpi operation
     @ModuleOp
@@ -294,6 +303,7 @@ def test_interpreter_attribute_rewrite():
 
     input_module = constant_zero()
     output_module = constant_zero()
+    expected_module = constant_one()
     rewrite_module = change_constant_value_pdl()
     rewrite_module.verify()
 
@@ -311,7 +321,8 @@ def test_interpreter_attribute_rewrite():
         apply_recursively=False,
     ).rewrite_module(input_module)
 
-    print(
+    assert (
         not output_module.body.ops.first.attributes["value"]
         == input_module.body.ops.first.attributes["value"]
     )
+    assert expected_module.is_structurally_equivalent(input_module)

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -274,7 +274,7 @@ def change_cmpi_predicate_pdl():
             # rHS: i32
             rhs = pdl.OperandOp().results[0]
 
-            # Constant 0: i32
+            # cmpi slt
             slt = pdl.AttributeOp(value=IntegerAttr(2, 64)).results[0]
             cmpi = pdl.OperationOp(
                 op_name=StringAttr("arith.cmpi"),
@@ -285,6 +285,7 @@ def change_cmpi_predicate_pdl():
             ).op
 
             with ImplicitBuilder(pdl.RewriteOp(cmpi).body):
+                # swapping inputs and changing to cmpi sge
                 sge = pdl.AttributeOp(value=IntegerAttr(5, 64)).results[0]
                 cmpi_new = pdl.OperationOp(
                     op_name=StringAttr("arith.cmpi"),

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -543,7 +543,7 @@ class Interpreter:
                 result = self._impls.run(self, op, inputs)
                 self.interpreter_assert(
                     len(op.results) == len(result.values),
-                    f"Incorrect number of results for op {op.name}",
+                    f"Incorrect number of results for op {op.name}, expected {len(op.results)} but got {len(result.values)}",
                 )
                 self.set_values(zip(op.results, result.values))
 

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -284,6 +284,14 @@ class PDLRewriteFunctions(InterpreterFunctions):
         assert isinstance(parent, Operation)
         return (parent.results[op.index.value.data],)
 
+    @impl(pdl.AttributeOp)
+    def run_attribute(
+        self, interpreter: Interpreter, op: pdl.AttributeOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        op.verify()
+        assert isinstance(op.value, Attribute)
+        return (op.value,)
+
     @impl(pdl.ReplaceOp)
     def run_replace(
         self, interpreter: Interpreter, op: pdl.ReplaceOp, args: tuple[Any, ...]

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -288,7 +288,6 @@ class PDLRewriteFunctions(InterpreterFunctions):
     def run_attribute(
         self, interpreter: Interpreter, op: pdl.AttributeOp, args: tuple[Any, ...]
     ) -> tuple[Any, ...]:
-        op.verify()
         assert isinstance(op.value, Attribute)
         return (op.value,)
 


### PR DESCRIPTION
added run_attribute to the pdl interpreter.  Not super happy with how the test asserts, but not sure best way to go about it. @superlopuh  @math-fehr 
