### PR TITLE
interpreter: (riscv) use bytearray for riscv malloc

### DIFF
--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -4,7 +4,7 @@ from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.interpreter import Interpreter, PythonValues
-from xdsl.interpreters.riscv import Buffer, RiscvFunctions
+from xdsl.interpreters.riscv import RawPtr, RiscvFunctions
 from xdsl.ir.core import Block, Region
 from xdsl.utils.bitwise_casts import convert_f32_to_u32
 from xdsl.utils.exceptions import InterpretationError
@@ -31,9 +31,7 @@ def test_riscv_interpreter():
     interpreter = Interpreter(module_op)
     interpreter.register_implementations(riscv_functions)
 
-    assert interpreter.run_op(riscv.LiOp("label0"), ()) == (
-        Buffer(data=[42], offset=0),
-    )
+    assert interpreter.run_op(riscv.LiOp("label0"), ()) == (RawPtr.new_int32(42),)
     assert interpreter.run_op(
         riscv.MVOp(TestSSAValue(register), rd=riscv.IntRegisterType.unallocated()),
         (42,),
@@ -65,7 +63,10 @@ def test_riscv_interpreter():
         (2, 3),
     ) == (6,)
 
-    buffer = Buffer([0, 0, 0, 0])
+    # Buffer to be modified by the interpreter
+    buffer = RawPtr.zeros(16)
+    # Buffer to be modified by the test
+    test_buffer = RawPtr.zeros(16)
 
     assert (
         interpreter.run_op(
@@ -74,16 +75,18 @@ def test_riscv_interpreter():
         == ()
     )
 
-    assert buffer == Buffer([1, 0, 0, 0])
+    test_buffer.int32[0] = 1
+    assert buffer == test_buffer
 
     assert (
         interpreter.run_op(
-            riscv.SwOp(TestSSAValue(register), TestSSAValue(register), 1), (buffer, 2)
+            riscv.SwOp(TestSSAValue(register), TestSSAValue(register), 4), (buffer, 2)
         )
         == ()
     )
 
-    assert buffer == Buffer([1, 2, 0, 0])
+    test_buffer.int32[1] = 2
+    assert buffer == test_buffer
 
     assert interpreter.run_op(riscv.LwOp(TestSSAValue(register), 0), (buffer,)) == (1,)
     assert interpreter.run_op(riscv.LabelOp("label"), ()) == ()
@@ -123,14 +126,15 @@ def test_riscv_interpreter():
         == ()
     )
 
-    assert buffer == Buffer([1, 2, 3.0, 0])
+    test_buffer.float32[2] = 3.0
+    assert buffer == test_buffer
 
     assert interpreter.run_op(
         riscv.FLwOp(TestSSAValue(register), 8),
         (buffer,),
     ) == (3.0,)
 
-    assert buffer == Buffer([1, 2, 3.0, 0])
+    assert buffer == test_buffer
 
     assert interpreter.run_op(riscv.GetRegisterOp(riscv.Registers.ZERO), ()) == (0,)
 


### PR DESCRIPTION
This is a change in the infrastructure required for interpreting the vector arithmetic ops in riscv.

In order to interpret storing/loading 64 bit values that are actually two 32 bit floats we're going to have to start dealing with the bytes directly.