### PR TITLE
core: Implement properties retrocompatibility in the parser.

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1144,7 +1144,7 @@ class UnrealizedConversionCastOp(IRDLOperation):
         printer.print_op_attributes(self.attributes)
 
 
-class UnregisteredOp(IRDLOperation, ABC):
+class UnregisteredOp(Operation, ABC):
     """
     An unregistered operation.
 

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -18,6 +18,7 @@ from xdsl.ir import (
     Region,
     SSAValue,
 )
+from xdsl.irdl.irdl import IRDLOperation
 from xdsl.parser.attribute_parser import AttrParser
 from xdsl.parser.base_parser import ParserState, Position
 from xdsl.utils.exceptions import MultipleSpansParseError
@@ -895,6 +896,13 @@ class Parser(AttrParser):
         self._parse_optional_location()
 
         operands = self.resolve_operands(args, func_type.inputs.data, func_type_pos)
+
+        # Properties retrocompatibility : if no properties dictionary was present at all,
+        # We extract them from the attribute dictionary by name.
+        if issubclass(op_type, IRDLOperation) and not properties:
+            for property_name in op_type.irdl_definition.properties.keys():
+                if property_name in attrs:
+                    properties[property_name] = attrs.pop(property_name)
 
         return op_type.create(
             operands=operands,


### PR DESCRIPTION
This implements properties retrocompatibility in the parser as MLIR does, that is, allow to parse a properties-defining operation in generic syntax when it has no property dictionary at all.
In that case, and only that case, it will extract properties from the attribute dictionnary to the properties one.

By *only* that case, I mean that the point is not to relax the cut between properties and attributes: if properties are present on the generic syntax of the operation, we won't be fetching missing ones from the attribute dictionary. This is meant only to parse operations printed before switching to properties.