### PR TITLE
core: Add segment sizes attributes to IRDL operation definition

### DIFF
--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -4,7 +4,14 @@ from typing import Annotated, Generic, TypeVar
 
 import pytest
 
-from xdsl.dialects.builtin import IndexType, IntAttr, IntegerType, StringAttr, i32
+from xdsl.dialects.builtin import (
+    DenseArrayBase,
+    IndexType,
+    IntAttr,
+    IntegerType,
+    StringAttr,
+    i32,
+)
 from xdsl.dialects.test import TestType
 from xdsl.ir import Attribute, OpResult, Region
 from xdsl.irdl import (
@@ -42,6 +49,7 @@ from xdsl.irdl import (
     var_region_def,
     var_result_def,
 )
+from xdsl.irdl.irdl import BaseAttr
 from xdsl.utils.exceptions import (
     DiagnosticException,
     PyRDLOpDefinitionError,
@@ -57,6 +65,8 @@ from xdsl.utils.test_value import TestSSAValue
 @irdl_op_definition
 class OpDefTestOp(IRDLOperation):
     name = "test.op_def_test"
+
+    irdl_options = [AttrSizedOperandSegments()]
 
     operand: Operand = operand_def()
     result: OpResult = result_def()
@@ -75,10 +85,14 @@ def test_get_definition():
         "test.op_def_test",
         operands=[("operand", OperandDef(AnyAttr()))],
         results=[("result", ResultDef(AnyAttr()))],
-        attributes={"attr": AttributeDef(AnyAttr())},
+        attributes={
+            "attr": AttributeDef(AnyAttr()),
+            "operand_segment_sizes": AttributeDef(BaseAttr(DenseArrayBase)),
+        },
         properties={"prop": PropertyDef(AnyAttr())},
         regions=[("region", RegionDef())],
         accessor_names={"attr": ("attr", "attribute"), "prop": ("prop", "property")},
+        options=[AttrSizedOperandSegments()],
     )
 
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -549,10 +549,27 @@ class IRDLOption(ABC):
 
 
 @dataclass
-class AttrSizedOperandSegments(IRDLOption):
+class AttrSizedSegments(IRDLOption):
     """
-    Expect an attribute on the op that contains
-    the sizes of the variadic operands.
+    Expect an attribute on the operation that contains the segment sizes of the
+    operand, result, region, or successor lists.
+    For instance, the list `[a, b, c, d]` with segment sizes `[1, 3]` will result
+    in the `[a], [b, c, d]` lists.
+    The attribute must be a dense array of `i32`, its lenght must be equal to the
+    number of segments (e.g. the number of operand definitions), and its sum must
+    be equal to the number of elements in the list (e.g. the number of operands).
+    """
+
+    attribute_name: ClassVar[str]
+    """Name of the attribute containing the segment sizes."""
+
+
+@dataclass
+class AttrSizedOperandSegments(AttrSizedSegments):
+    """
+    Expect an attribute on the operation that contains the sizes of the operand
+    definitions.
+    See `AttrSizedSegments` for more information.
     """
 
     attribute_name = "operand_segment_sizes"
@@ -560,10 +577,11 @@ class AttrSizedOperandSegments(IRDLOption):
 
 
 @dataclass
-class AttrSizedResultSegments(IRDLOption):
+class AttrSizedResultSegments(AttrSizedSegments):
     """
-    Expect an attribute on the operation that contains
-    the sizes of the variadic results.
+    Expect an attribute on the operation that contains the sizes of the result
+    definitions.
+    See `AttrSizedSegments` for more information.
     """
 
     attribute_name = "result_segment_sizes"
@@ -571,10 +589,11 @@ class AttrSizedResultSegments(IRDLOption):
 
 
 @dataclass
-class AttrSizedRegionSegments(IRDLOption):
+class AttrSizedRegionSegments(AttrSizedSegments):
     """
-    Expect an attribute on the op that contains
-    the sizes of the variadic regions.
+    Expect an attribute on the operation that contains the sizes of the region
+    definitions.
+    See `AttrSizedSegments` for more information.
     """
 
     attribute_name = "region_segment_sizes"
@@ -582,10 +601,11 @@ class AttrSizedRegionSegments(IRDLOption):
 
 
 @dataclass
-class AttrSizedSuccessorSegments(IRDLOption):
+class AttrSizedSuccessorSegments(AttrSizedSegments):
     """
-    Expect an attribute on the op that contains
-    the sizes of the variadic successors.
+    Expect an attribute on the operation that contains the sizes of the successor
+    definitions.
+    See `AttrSizedSegments` for more information.
     """
 
     attribute_name = "successor_segment_sizes"
@@ -1139,9 +1159,23 @@ class OpDef:
                 # in Operation, or are class functions or methods.
 
                 if field_name == "irdl_options":
-                    if not isinstance(value, list):
-                        assert False
-                    op_def.options.extend(cast(list[Any], value))
+                    value = cast(list[IRDLOption], value)
+                    op_def.options.extend(value)
+                    for option in value:
+                        if isinstance(option, AttrSizedSegments):
+                            if option.attribute_name in op_def.attributes:
+                                raise PyRDLOpDefinitionError(
+                                    f"pyrdl operation definition '{pyrdl_def.__name__}' "
+                                    f"has a '{option.attribute_name}' attribute, which "
+                                    "is incompatible with the "
+                                    f"{option.__class__.__name__} option."
+                                )
+                            from xdsl.dialects.builtin import DenseArrayBase
+
+                            attr_def = AttributeDef(
+                                attr_constr_coercion(DenseArrayBase)
+                            )
+                            op_def.attributes[option.attribute_name] = attr_def
                     continue
 
                 if field_name == "traits":


### PR DESCRIPTION
Currently, `operand_segment_sizes` is not registered as an attribute in the operation definition class (`OpDef`).
This PR adds this to the operation definition.
This is going to simplify the update to latest MLIR, as these will become properties.