### PR TITLE
interpreter: Support properties in PDL interpreter

### DIFF
--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -2,10 +2,19 @@ from io import StringIO
 
 from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import arith, func, pdl
-from xdsl.dialects.builtin import ArrayAttr, IntegerAttr, ModuleOp, StringAttr, i32
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    IntegerAttr,
+    IntegerType,
+    ModuleOp,
+    StringAttr,
+    i32,
+    i64,
+)
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters.experimental.pdl import PDLRewriteFunctions, PDLRewritePattern
 from xdsl.ir import MLContext, OpResult
+from xdsl.irdl.irdl import IRDLOperation, irdl_op_definition, prop_def
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     PatternRewriteWalker,
@@ -320,4 +329,69 @@ def test_interpreter_attribute_rewrite():
         apply_recursively=False,
     ).rewrite_module(input_module)
 
+    assert expected_module.is_structurally_equivalent(input_module)
+
+
+@irdl_op_definition
+class OnePropOp(IRDLOperation):
+    name = "test.one_prop"
+
+    prop = prop_def(IntegerType)
+
+
+def test_property_rewrite():
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(PDLRewriteFunctions(MLContext()))
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_i32():
+        OnePropOp.create(properties={"prop": i32})
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_i64():
+        OnePropOp.create(properties={"prop": i64})
+
+    @ModuleOp
+    @Builder.implicit_region
+    def pdl_module():
+        with ImplicitBuilder(pdl.PatternOp(42, None).body):
+            attr_i32 = pdl.AttributeOp(i32).results[0]
+            const_op = pdl.OperationOp(
+                op_name=OnePropOp.name,
+                attribute_value_names=ArrayAttr([StringAttr("prop")]),
+                attribute_values=[attr_i32],
+            ).op
+
+            with ImplicitBuilder(pdl.RewriteOp(const_op).body):
+                # changing constants value via attributes
+                attr_i64 = pdl.AttributeOp(i64).results[0]
+                const_new = pdl.OperationOp(
+                    op_name=StringAttr(OnePropOp.name),
+                    attribute_value_names=ArrayAttr([StringAttr("prop")]),
+                    attribute_values=[attr_i64],
+                ).op
+                pdl.ReplaceOp(const_op, repl_operation=const_new)
+
+    input_module = input_i32
+    expected_module = input_i64
+    rewrite_module = pdl_module
+    rewrite_module.verify()
+
+    pdl_rewrite_op = next(
+        op for op in rewrite_module.walk() if isinstance(op, pdl.RewriteOp)
+    )
+
+    stream = StringIO()
+
+    ctx = MLContext()
+    ctx.register_dialect(arith.Arith)
+    ctx.register_op(OnePropOp)
+
+    PatternRewriteWalker(
+        PDLRewritePattern(pdl_rewrite_op, ctx, file=stream),
+        apply_recursively=False,
+    ).rewrite_module(input_module)
+    assert str(expected_module) == str(input_module)
     assert expected_module.is_structurally_equivalent(input_module)

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -2,7 +2,7 @@ import pytest
 
 from xdsl.dialects import test
 from xdsl.dialects.arith import Addi, Arith, Constant, Subi
-from xdsl.dialects.builtin import Builtin, IntegerAttr, ModuleOp, i32, i64
+from xdsl.dialects.builtin import Builtin, IntegerAttr, ModuleOp, StringAttr, i32, i64
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.func import Func
 from xdsl.ir import (
@@ -740,3 +740,14 @@ def test_region_clone():
     region = Region(block_a)
     region2 = region.clone()
     assert region.is_structurally_equivalent(region2)
+
+
+def test_get_attr_or_prop():
+    a = test.TestOp.create(
+        attributes={"attr": StringAttr("attr"), "attr_and_prop": StringAttr("attr")},
+        properties={"prop": StringAttr("prop"), "attr_and_prop": StringAttr("prop")},
+    )
+    assert a.get_attr_or_prop("attr") == StringAttr("attr")
+    assert a.get_attr_or_prop("prop") == StringAttr("prop")
+    assert a.get_attr_or_prop("attr_and_prop") == StringAttr("prop")
+    assert a.get_attr_or_prop("none") is None

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -7,6 +7,7 @@ from xdsl.dialects import pdl
 from xdsl.dialects.builtin import IntegerAttr, IntegerType, ModuleOp
 from xdsl.interpreter import Interpreter, InterpreterFunctions, impl, register_impls
 from xdsl.ir import Attribute, MLContext, Operation, OpResult, SSAValue, TypeAttribute
+from xdsl.irdl.irdl import IRDLOperation
 from xdsl.pattern_rewriter import PatternRewriter, RewritePattern
 from xdsl.utils.exceptions import InterpretationError
 from xdsl.utils.hints import isa
@@ -130,10 +131,10 @@ class PDLMatcher:
         for avn, av in zip(attribute_value_names, pdl_op.attribute_values):
             assert isinstance(av, OpResult)
             assert isinstance(av.op, pdl.AttributeOp)
-            if avn not in xdsl_op.attributes:
+            if (attr := xdsl_op.get_attr_or_prop(avn)) is None:
                 return False
 
-            if not self.match_attribute(av, av.op, avn, xdsl_op.attributes[avn]):
+            if not self.match_attribute(av, av.op, avn, attr):
                 return False
 
         pdl_operands = pdl_op.operand_values
@@ -268,10 +269,30 @@ class PDLRewriteFunctions(InterpreterFunctions):
         for type_value in type_values:
             assert isinstance(type_value, TypeAttribute)
 
-        attributes = dict(zip(attribute_value_names, attribute_values))
+        attributes = dict[str, Attribute]()
+        properties = dict[str, Attribute]()
+
+        # If the op is an IRDL-defined operation, get the property names.
+        if issubclass(op_type, IRDLOperation):
+            property_names = op_type.irdl_definition.properties.keys()
+        else:
+            property_names = []
+
+        # Move the attributes to the attribute or property dictionary
+        # depending on whether they are a properties or not.
+        for attribute_name, attribute_value in zip(
+            attribute_value_names, attribute_values
+        ):
+            if attribute_name in property_names:
+                properties[attribute_name] = attribute_value
+            else:
+                attributes[attribute_name] = attribute_value
 
         result_op = op_type.create(
-            operands=operand_values, result_types=type_values, attributes=attributes
+            operands=operand_values,
+            result_types=type_values,
+            attributes=attributes,
+            properties=properties,
         )
 
         return (result_op,)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -769,6 +769,13 @@ class Operation(IRNode):
             yield from region.walk_reverse()
         yield self
 
+    def get_attr_or_prop(self, name: str) -> Attribute | None:
+        if name in self.properties:
+            return self.properties[name]
+        if name in self.attributes:
+            return self.attributes[name]
+        return None
+
     def verify(self, verify_nested_ops: bool = True) -> None:
         for operand in self.operands:
             if isinstance(operand, ErasedSSAValue):

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -770,6 +770,10 @@ class Operation(IRNode):
         yield self
 
     def get_attr_or_prop(self, name: str) -> Attribute | None:
+        """
+        Get a named attribute or property.
+        It first look into the property dictionary, then into the attribute dictionary.
+        """
         if name in self.properties:
             return self.properties[name]
         if name in self.attributes:


### PR DESCRIPTION
This PR adds support for properties in the PDL interpreter.
In particular, this means that matching an operation will match attributes both in the attribute and property dictionary.
Also, creating a new operation with the PDL attribute dictionary will split the dictionary into an attribute and property dictionary, using the IRDL operation specification.