### PR TITLE
dialects: (maths) Using `__init__()` instead of `get()`

### DIFF
--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -31,12 +31,11 @@ class AbsFOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> AbsFOp:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         operand = SSAValue.get(operand)
-        return AbsFOp.build(
+        return super().__init__(
             attributes={"fastmath": fastmath},
             operands=[operand],
             result_types=[operand.type],
@@ -60,10 +59,9 @@ class AbsIOp(IRDLOperation):
     operand: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
-    @staticmethod
-    def get(operand: Operation | SSAValue) -> AbsIOp:
+    def __init__(self, operand: Operation | SSAValue):
         operand = SSAValue.get(operand)
-        return AbsIOp.build(operands=[operand], result_types=[operand.type])
+        return super().__init__(operands=[operand], result_types=[operand.type])
 
 
 @irdl_op_definition
@@ -94,6 +92,20 @@ class Atan2Op(IRDLOperation):
     lhs: Operand = operand_def(AnyFloat)
     rhs: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
+
+    # TODO: use __init__
+    def __init__(
+        self,
+        lhs: Operation | SSAValue,
+        rhs: Operation | SSAValue,
+        fastmath: FastMathFlagsAttr | None = None,
+    ):
+        lhs = SSAValue.get(lhs)
+        rhs = SSAValue.get(rhs)
+        attributes = {"fastmath": fastmath}
+        return super().__init__(
+            attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
+        )
 
     @staticmethod
     def get(
@@ -131,6 +143,8 @@ class AtanOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
+    # TODO: use __init__
+    #
     @staticmethod
     def get(
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
@@ -163,6 +177,7 @@ class CbrtOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
+    # TODO: use __init__
     @staticmethod
     def get(
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
@@ -196,6 +211,7 @@ class CeilOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
+    # TODO: use __init__
     @staticmethod
     def get(
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
@@ -231,6 +247,7 @@ class CopySignOp(IRDLOperation):
     rhs: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
+    # TODO: use __init__
     @staticmethod
     def get(
         lhs: Operation | SSAValue,
@@ -267,6 +284,7 @@ class CosOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
+    # TODO: use __init__
     @staticmethod
     def get(
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
@@ -295,6 +313,7 @@ class CountLeadingZerosOp(IRDLOperation):
     operand: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
+    # TODO: use __init__
     @staticmethod
     def get(operand: Operation | SSAValue) -> CountLeadingZerosOp:
         operand = SSAValue.get(operand)
@@ -319,6 +338,7 @@ class CountTrailingZerosOp(IRDLOperation):
     operand: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
+    # TODO: use __init__
     @staticmethod
     def get(operand: Operation | SSAValue) -> CountTrailingZerosOp:
         operand = SSAValue.get(operand)
@@ -343,6 +363,7 @@ class CtPopOp(IRDLOperation):
     operand: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
+    # TODO: use __init__
     @staticmethod
     def get(operand: Operation | SSAValue) -> CtPopOp:
         operand = SSAValue.get(operand)
@@ -370,14 +391,13 @@ class ErfOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> ErfOp:
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return ErfOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -403,14 +423,13 @@ class Exp2Op(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> Exp2Op:
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return Exp2Op.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -471,14 +490,13 @@ class ExpOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> ExpOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return ExpOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -513,17 +531,16 @@ class FPowIOp(IRDLOperation):
     rhs: Operand = operand_def(IntegerType)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         lhs: Operation | SSAValue,
         rhs: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
-    ) -> FPowIOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         lhs = SSAValue.get(lhs)
         rhs = SSAValue.get(rhs)
-        return FPowIOp.build(
+        return super().__init__(
             attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
         )
 
@@ -549,14 +566,13 @@ class FloorOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> FloorOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return FloorOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -589,19 +605,18 @@ class FmaOp(IRDLOperation):
     c: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         a: Operation | SSAValue,
         b: Operation | SSAValue,
         c: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
-    ) -> FmaOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         a = SSAValue.get(a)
         b = SSAValue.get(b)
         c = SSAValue.get(c)
-        return FmaOp.build(
+        return super().__init__(
             attributes=attributes, operands=[a, b, c], result_types=[a.type]
         )
 
@@ -626,11 +641,10 @@ class IPowIOp(IRDLOperation):
     rhs: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
-    @staticmethod
-    def get(lhs: Operation | SSAValue, rhs: Operation | SSAValue) -> IPowIOp:
+    def __init__(self,lhs: Operation | SSAValue, rhs: Operation | SSAValue):
         lhs = SSAValue.get(lhs)
         rhs = SSAValue.get(rhs)
-        return IPowIOp.build(operands=[lhs, rhs], result_types=[lhs.type])
+        return super().__init__(operands=[lhs, rhs], result_types=[lhs.type])
 
 
 @irdl_op_definition
@@ -651,14 +665,13 @@ class Log10Op(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> Log10Op:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return Log10Op.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -683,14 +696,13 @@ class Log1pOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> Log1pOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return Log1pOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -713,14 +725,13 @@ class Log2Op(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> Log2Op:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return Log2Op.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -743,14 +754,13 @@ class LogOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> LogOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return LogOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -777,17 +787,16 @@ class PowFOp(IRDLOperation):
     rhs: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         lhs: Operation | SSAValue,
         rhs: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
-    ) -> PowFOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         lhs = SSAValue.get(lhs)
         rhs = SSAValue.get(rhs)
-        return PowFOp.build(
+        return super().__init__(
             attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
         )
 
@@ -816,14 +825,13 @@ class RoundEvenOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> RoundEvenOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return RoundEvenOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -881,14 +889,13 @@ class RsqrtOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> RsqrtOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return RsqrtOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -914,14 +921,13 @@ class SinOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> SinOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return SinOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -943,14 +949,13 @@ class SqrtOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> SqrtOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return SqrtOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -973,14 +978,13 @@ class TanOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> TanOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return TanOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -1003,14 +1007,13 @@ class TanhOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> TanhOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return TanhOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -1038,14 +1041,13 @@ class TruncOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
+    def __init__(self,
         operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> TruncOp:
+        ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return TruncOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 

--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -424,7 +424,7 @@ class Exp2Op(IRDLOperation):
     result: OpResult = result_def(AnyFloat)
 
     def __init__(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
     ):
         attributes = {"fastmath": fastmath}
 

--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -93,32 +93,17 @@ class Atan2Op(IRDLOperation):
     rhs: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    # TODO: use __init__
     def __init__(
         self,
         lhs: Operation | SSAValue,
         rhs: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
     ):
-        lhs = SSAValue.get(lhs)
-        rhs = SSAValue.get(rhs)
         attributes = {"fastmath": fastmath}
         return super().__init__(
-            attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
-        )
-
-    @staticmethod
-    def get(
-        lhs: Operation | SSAValue,
-        rhs: Operation | SSAValue,
-        fastmath: FastMathFlagsAttr | None = None,
-    ) -> Atan2Op:
-        attributes = {"fastmath": fastmath}
-
-        lhs = SSAValue.get(lhs)
-        rhs = SSAValue.get(rhs)
-        return Atan2Op.build(
-            attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
+            attributes=attributes,
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
         )
 
 
@@ -143,14 +128,11 @@ class AtanOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    # TODO: use __init__
-    #
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> AtanOp:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         operand = SSAValue.get(operand)
-        return AtanOp.build(
+        return super().__init__(
             attributes={"fastmath": fastmath},
             operands=[operand],
             result_types=[operand.type],
@@ -177,11 +159,9 @@ class CbrtOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    # TODO: use __init__
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> CbrtOp:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -211,13 +191,11 @@ class CeilOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    # TODO: use __init__
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> CeilOp:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         operand = SSAValue.get(operand)
-        return CeilOp.build(
+        return super().__init__(
             attributes={"fastmath": fastmath},
             operands=[operand],
             result_types=[operand.type],
@@ -247,19 +225,18 @@ class CopySignOp(IRDLOperation):
     rhs: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    # TODO: use __init__
-    @staticmethod
-    def get(
+    def __init__(
+        self,
         lhs: Operation | SSAValue,
         rhs: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
-    ) -> CopySignOp:
+    ):
         attributes = {"fastmath": fastmath}
 
-        lhs = SSAValue.get(lhs)
-        rhs = SSAValue.get(rhs)
-        return CopySignOp.build(
-            attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
+        return super().__init__(
+            attributes=attributes,
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
         )
 
 
@@ -284,15 +261,13 @@ class CosOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    # TODO: use __init__
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> CosOp:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return CosOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -313,13 +288,9 @@ class CountLeadingZerosOp(IRDLOperation):
     operand: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
-    # TODO: use __init__
-    @staticmethod
-    def get(operand: Operation | SSAValue) -> CountLeadingZerosOp:
+    def __init__(self, operand: Operation | SSAValue):
         operand = SSAValue.get(operand)
-        return CountLeadingZerosOp.build(
-            operands=[operand], result_types=[operand.type]
-        )
+        return super().__init__(operands=[operand], result_types=[operand.type])
 
 
 @irdl_op_definition
@@ -338,13 +309,9 @@ class CountTrailingZerosOp(IRDLOperation):
     operand: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
-    # TODO: use __init__
-    @staticmethod
-    def get(operand: Operation | SSAValue) -> CountTrailingZerosOp:
+    def __init__(self, operand: Operation | SSAValue):
         operand = SSAValue.get(operand)
-        return CountTrailingZerosOp.build(
-            operands=[operand], result_types=[operand.type]
-        )
+        return super().__init__(operands=[operand], result_types=[operand.type])
 
 
 @irdl_op_definition
@@ -363,11 +330,9 @@ class CtPopOp(IRDLOperation):
     operand: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
-    # TODO: use __init__
-    @staticmethod
-    def get(operand: Operation | SSAValue) -> CtPopOp:
+    def __init__(self, operand: Operation | SSAValue):
         operand = SSAValue.get(operand)
-        return CtPopOp.build(operands=[operand], result_types=[operand.type])
+        return super().__init__(operands=[operand], result_types=[operand.type])
 
 
 @irdl_op_definition
@@ -457,14 +422,13 @@ class ExpM1Op(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> ExpM1Op:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return ExpM1Op.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 
@@ -539,10 +503,10 @@ class FPowIOp(IRDLOperation):
     ):
         attributes = {"fastmath": fastmath}
 
-        lhs = SSAValue.get(lhs)
-        rhs = SSAValue.get(rhs)
         return super().__init__(
-            attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
+            attributes=attributes,
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
         )
 
 
@@ -797,10 +761,10 @@ class PowFOp(IRDLOperation):
     ):
         attributes = {"fastmath": fastmath}
 
-        lhs = SSAValue.get(lhs)
-        rhs = SSAValue.get(rhs)
         return super().__init__(
-            attributes=attributes, operands=[lhs, rhs], result_types=[lhs.type]
+            attributes=attributes,
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
         )
 
 
@@ -863,14 +827,13 @@ class RoundOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    @staticmethod
-    def get(
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-    ) -> RoundOp:
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
-        return RoundOp.build(
+        return super().__init__(
             attributes=attributes, operands=[operand], result_types=[operand.type]
         )
 

--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -579,11 +579,8 @@ class FmaOp(IRDLOperation):
     ):
         attributes = {"fastmath": fastmath}
 
-        a = SSAValue.get(a)
-        b = SSAValue.get(b)
-        c = SSAValue.get(c)
         return super().__init__(
-            attributes=attributes, operands=[a, b, c], result_types=[a.type]
+            attributes=attributes, operands=[a, b, c], result_types=[SSAValue.get(a).type]
         )
 
 

--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -580,7 +580,9 @@ class FmaOp(IRDLOperation):
         attributes = {"fastmath": fastmath}
 
         return super().__init__(
-            attributes=attributes, operands=[a, b, c], result_types=[SSAValue.get(a).type]
+            attributes=attributes,
+            operands=[a, b, c],
+            result_types=[SSAValue.get(a).type],
         )
 
 

--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -391,8 +391,8 @@ class ErfOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
     ):
         attributes = {"fastmath": fastmath}
 
@@ -490,9 +490,9 @@ class ExpOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -531,11 +531,12 @@ class FPowIOp(IRDLOperation):
     rhs: Operand = operand_def(IntegerType)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
+    def __init__(
+        self,
         lhs: Operation | SSAValue,
         rhs: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
-        ):
+    ):
         attributes = {"fastmath": fastmath}
 
         lhs = SSAValue.get(lhs)
@@ -566,9 +567,9 @@ class FloorOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -605,12 +606,13 @@ class FmaOp(IRDLOperation):
     c: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
+    def __init__(
+        self,
         a: Operation | SSAValue,
         b: Operation | SSAValue,
         c: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
-        ):
+    ):
         attributes = {"fastmath": fastmath}
 
         a = SSAValue.get(a)
@@ -641,7 +643,7 @@ class IPowIOp(IRDLOperation):
     rhs: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType)
 
-    def __init__(self,lhs: Operation | SSAValue, rhs: Operation | SSAValue):
+    def __init__(self, lhs: Operation | SSAValue, rhs: Operation | SSAValue):
         lhs = SSAValue.get(lhs)
         rhs = SSAValue.get(rhs)
         return super().__init__(operands=[lhs, rhs], result_types=[lhs.type])
@@ -665,9 +667,9 @@ class Log10Op(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -696,9 +698,9 @@ class Log1pOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -725,9 +727,9 @@ class Log2Op(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -754,9 +756,9 @@ class LogOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -787,11 +789,12 @@ class PowFOp(IRDLOperation):
     rhs: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
+    def __init__(
+        self,
         lhs: Operation | SSAValue,
         rhs: Operation | SSAValue,
         fastmath: FastMathFlagsAttr | None = None,
-        ):
+    ):
         attributes = {"fastmath": fastmath}
 
         lhs = SSAValue.get(lhs)
@@ -825,9 +828,9 @@ class RoundEvenOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -889,9 +892,9 @@ class RsqrtOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -921,9 +924,9 @@ class SinOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -949,9 +952,9 @@ class SqrtOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -978,9 +981,9 @@ class TanOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -1007,9 +1010,9 @@ class TanhOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)
@@ -1041,9 +1044,9 @@ class TruncOp(IRDLOperation):
     operand: Operand = operand_def(AnyFloat)
     result: OpResult = result_def(AnyFloat)
 
-    def __init__(self,
-        operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
-        ):
+    def __init__(
+        self, operand: Operation | SSAValue, fastmath: FastMathFlagsAttr | None = None
+    ):
         attributes = {"fastmath": fastmath}
 
         operand = SSAValue.get(operand)

--- a/xdsl/transforms/printf_to_putchar.py
+++ b/xdsl/transforms/printf_to_putchar.py
@@ -155,7 +155,7 @@ def get_mlir_itoa():
             position = arith.Subi(size_minus_one, index_var_int)
             # digit = (num // (10**pos)) % 10
             ten = arith.Constant.from_int_and_width(10, i32)
-            i_0 = math.IPowIOp(operands=(ten, position), result_types=(i32,))
+            i_0 = math.IPowIOp(ten, position)
             i_1 = arith.DivUI(absolute_value, i_0)
             digit = arith.RemUI(i_1, ten)
             ascii_offset = arith.Constant.from_int_and_width(ord("0"), i32)


### PR DESCRIPTION
Using `__init__()` instead of `get()` for experimental dialect `maths`. This follows the previous changes on dialect. It will also make the tests for the dialect easier to write.