### PR TITLE
core: check for properties in clone and equivalence check

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -5,17 +5,24 @@ from xdsl.dialects.arith import Addi, Arith, Constant, Subi
 from xdsl.dialects.builtin import Builtin, IntegerAttr, ModuleOp, i32, i64
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.func import Func
-from xdsl.ir import Block, ErasedSSAValue, MLContext, Operation, Region, SSAValue
-from xdsl.ir.core import Attribute
+from xdsl.ir import (
+    Attribute,
+    Block,
+    ErasedSSAValue,
+    MLContext,
+    Operation,
+    Region,
+    SSAValue,
+)
 from xdsl.irdl import (
     IRDLOperation,
     Operand,
     VarRegion,
     irdl_op_definition,
     operand_def,
+    prop_def,
     var_region_def,
 )
-from xdsl.irdl.irdl import prop_def
 from xdsl.parser import Parser
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,13 +1,12 @@
-from typing import cast
-
 import pytest
 
 from xdsl.dialects import test
 from xdsl.dialects.arith import Addi, Arith, Constant, Subi
-from xdsl.dialects.builtin import Builtin, IntegerAttr, IntegerType, ModuleOp, i32, i64
+from xdsl.dialects.builtin import Builtin, IntegerAttr, ModuleOp, i32, i64
 from xdsl.dialects.cf import Cf
 from xdsl.dialects.func import Func
 from xdsl.ir import Block, ErasedSSAValue, MLContext, Operation, Region, SSAValue
+from xdsl.ir.core import Attribute
 from xdsl.irdl import (
     IRDLOperation,
     Operand,
@@ -16,9 +15,17 @@ from xdsl.irdl import (
     operand_def,
     var_region_def,
 )
+from xdsl.irdl.irdl import prop_def
 from xdsl.parser import Parser
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue
+
+
+@irdl_op_definition
+class TestWithPropOp(IRDLOperation):
+    name = "test.op_with_prop"
+
+    prop = prop_def(Attribute)
 
 
 def test_ops_accessor():
@@ -152,16 +159,12 @@ def test_op_operands_indexing():
 
 
 def test_op_clone():
-    a = Constant.from_int_and_width(1, 32)
+    a = TestWithPropOp.create(properties={"prop": i32}, attributes={"attr": i64})
     b = a.clone()
 
     assert a is not b
 
-    assert isinstance(b.value, IntegerAttr)
-    b_value = cast(IntegerAttr[IntegerType], b.value)
-
-    assert b_value.value.data == 1
-    assert b_value.type.width.data == 32
+    assert a.is_structurally_equivalent(b)
 
 
 def test_op_clone_with_regions():
@@ -497,6 +500,14 @@ def test_is_structurally_equivalent(args: list[str], expected_result: bool):
     rhs: Operation = parser.parse_op()
 
     assert lhs.is_structurally_equivalent(rhs) == expected_result
+
+
+def test_is_structurally_equivalent_properties():
+    op32 = TestWithPropOp.create(properties={"prop": i32})
+    op32prime = TestWithPropOp.create(properties={"prop": i32})
+    op64 = TestWithPropOp.create(properties={"prop": i64})
+    assert op32.is_structurally_equivalent(op32prime)
+    assert not op32.is_structurally_equivalent(op64)
 
 
 def test_is_structurally_equivalent_free_operands():

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -852,6 +852,7 @@ class Operation(IRNode):
         ]
         result_types = [res.type for res in self.results]
         attributes = self.attributes.copy()
+        properties = self.properties.copy()
         successors = [
             (block_mapper[successor] if successor in block_mapper else successor)
             for successor in self.successors
@@ -861,6 +862,7 @@ class Operation(IRNode):
             operands=operands,
             result_types=result_types,
             attributes=attributes,
+            properties=properties,
             successors=successors,
             regions=regions,
         )
@@ -963,6 +965,7 @@ class Operation(IRNode):
             or len(self.regions) != len(other.regions)
             or len(self.successors) != len(other.successors)
             or self.attributes != other.attributes
+            or self.properties != other.properties
         ):
             return False
         if (


### PR DESCRIPTION
`Operation.clone` and `Operation.is_structurally_equivalent` weren't checking for properties.