### PR TITLE
core: Add support for properties in attribute converter

### DIFF
--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -1003,8 +1003,9 @@ def test_type_conversion():
   }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xi32>} : () -> i32
   %1 = "test.op"() {"type" = () -> memref<*xi32>} : () -> f32
-  %2 = "test.op"(%0, %1) : (i32, f32) -> memref<*xi32>
-  %3 = "arith.addi"(%0, %0) : (i32, i32) -> i32
+  %2 = "test.op"() <{"prop" = memref<*xi32>}> : () -> f32
+  %3 = "test.op"(%0, %1) : (i32, f32) -> memref<*xi32>
+  %4 = "arith.addi"(%0, %0) : (i32, i32) -> i32
   "func.return"() : () -> ()
 }) : () -> ()
 """
@@ -1016,8 +1017,9 @@ def test_type_conversion():
   }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xindex>} : () -> index
   %1 = "test.op"() {"type" = () -> memref<*xindex>} : () -> f32
-  %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
-  %3 = "arith.addi"(%0, %0) : (index, index) -> index
+  %2 = "test.op"() <{"prop" = memref<*xindex>}> : () -> f32
+  %3 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
+  %4 = "arith.addi"(%0, %0) : (index, index) -> index
   "func.return"() : () -> ()
 }) : () -> ()
 """
@@ -1052,8 +1054,9 @@ def test_type_conversion():
   }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xi32>} : () -> index
   %1 = "test.op"() {"type" = () -> memref<*xi32>} : () -> f32
-  %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xi32>
-  %3 = "arith.addi"(%0, %0) : (index, index) -> index
+  %2 = "test.op"() <{"prop" = memref<*xi32>}> : () -> f32
+  %3 = "test.op"(%0, %1) : (index, f32) -> memref<*xi32>
+  %4 = "arith.addi"(%0, %0) : (index, index) -> index
   "func.return"() : () -> ()
 }) : () -> ()
 """
@@ -1081,126 +1084,9 @@ def test_type_conversion():
   }) : () -> ()
   %0 = "test.op"() {"nested" = memref<*xindex>} : () -> index
   %1 = "test.op"() {"type" = () -> memref<*xindex>} : () -> f32
-  %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
-  %3 = "arith.addi"(%0, %0) : (index, index) -> i32
-  "func.return"() : () -> ()
-}) : () -> ()
-"""
-
-    rewrite_and_compare(
-        prog,
-        expected,
-        PatternRewriteWalker(
-            Rewrite(ops=(test.TestOp,), recursive=True), apply_recursively=False
-        ),
-    )
-    rewrite_and_compare(
-        prog,
-        expected,
-        PatternRewriteWalker(
-            Rewrite(ops=(test.TestOp,), recursive=True), apply_recursively=True
-        ),
-    )
-    rewrite_and_compare(
-        prog,
-        expected,
-        PatternRewriteWalker(
-            Rewrite(ops=(test.TestOp,), recursive=True),
-            apply_recursively=False,
-            walk_reverse=True,
-        ),
-    )
-
-
-def test_type_conversion_property():
-    """Test rewriter on ops without results"""
-    prog = """\
-"builtin.module"() ({
-  "func.func"() ({
-  ^0(%arg : i32):
-  }) : () -> ()
-  %0 = "test.op"() <{"prop1" = memref<*xi32>}> : () -> i32
-  %1 = "test.op"() <{"prop1" = () -> memref<*xi32>}> : () -> f32
-  %2 = "test.op"(%0, %1) : (i32, f32) -> memref<*xi32>
-  %3 = "arith.addi"(%0, %0) : (i32, i32) -> i32
-  "func.return"() : () -> ()
-}) : () -> ()
-"""
-
-    expected = """\
-"builtin.module"() ({
-  "func.func"() ({
-  ^0(%arg : index):
-  }) : () -> ()
-  %0 = "test.op"() <{"prop1" = memref<*xindex>}> : () -> index
-  %1 = "test.op"() <{"prop1" = () -> memref<*xindex>}> : () -> f32
-  %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
-  %3 = "arith.addi"(%0, %0) : (index, index) -> index
-  "func.return"() : () -> ()
-}) : () -> ()
-"""
-
-    class Rewrite(TypeConversionPattern):
-        @attr_type_rewrite_pattern
-        def convert_type(self, typ: IntegerType) -> IndexType:
-            return IndexType()
-
-    rewrite_and_compare(
-        prog,
-        expected,
-        PatternRewriteWalker(Rewrite(recursive=True), apply_recursively=False),
-    )
-    rewrite_and_compare(
-        prog,
-        expected,
-        PatternRewriteWalker(Rewrite(recursive=True), apply_recursively=True),
-    )
-    rewrite_and_compare(
-        prog,
-        expected,
-        PatternRewriteWalker(
-            Rewrite(recursive=True), apply_recursively=False, walk_reverse=True
-        ),
-    )
-
-    non_rec_expected = """\
-"builtin.module"() ({
-  "func.func"() ({
-  ^0(%arg : index):
-  }) : () -> ()
-  %0 = "test.op"() <{"prop1" = memref<*xi32>}> : () -> index
-  %1 = "test.op"() <{"prop1" = () -> memref<*xi32>}> : () -> f32
-  %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xi32>
-  %3 = "arith.addi"(%0, %0) : (index, index) -> index
-  "func.return"() : () -> ()
-}) : () -> ()
-"""
-
-    rewrite_and_compare(
-        prog,
-        non_rec_expected,
-        PatternRewriteWalker(Rewrite(), apply_recursively=False),
-    )
-    rewrite_and_compare(
-        prog,
-        non_rec_expected,
-        PatternRewriteWalker(Rewrite(), apply_recursively=True),
-    )
-    rewrite_and_compare(
-        prog,
-        non_rec_expected,
-        PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
-    )
-
-    expected = """\
-"builtin.module"() ({
-  "func.func"() ({
-  ^0(%arg : i32):
-  }) : () -> ()
-  %0 = "test.op"() <{"prop1" = memref<*xindex>}> : () -> index
-  %1 = "test.op"() <{"prop1" = () -> memref<*xindex>}> : () -> f32
-  %2 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
-  %3 = "arith.addi"(%0, %0) : (index, index) -> i32
+  %2 = "test.op"() <{"prop" = memref<*xindex>}> : () -> f32
+  %3 = "test.op"(%0, %1) : (index, f32) -> memref<*xindex>
+  %4 = "arith.addi"(%0, %0) : (index, index) -> i32
   "func.return"() : () -> ()
 }) : () -> ()
 """

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -25,6 +25,7 @@ from xdsl.irdl import (
     var_result_def,
     var_successor_def,
 )
+from xdsl.irdl.irdl import opt_prop_def
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import IsTerminator
@@ -45,17 +46,23 @@ class TestOp(IRDLOperation):
     ops: VarOperand = var_operand_def()
     regs: VarRegion = var_region_def()
 
+    prop1 = opt_prop_def(Attribute)
+    prop2 = opt_prop_def(Attribute)
+    prop3 = opt_prop_def(Attribute)
+
     def __init__(
         self,
         operands: Sequence[SSAValue | Operation] = (),
         result_types: Sequence[Attribute] = (),
         attributes: Mapping[str, Attribute | None] | None = None,
+        properties: Mapping[str, Attribute | None] | None = None,
         regions: Sequence[Region | Sequence[Operation] | Sequence[Block]] = (),
     ):
         super().__init__(
             operands=(operands,),
             result_types=(result_types,),
             attributes=attributes,
+            properties=properties,
             regions=(regions,),
         )
 
@@ -78,6 +85,10 @@ class TestTermOp(IRDLOperation):
     regs: VarRegion = var_region_def()
     successor: VarSuccessor = var_successor_def()
 
+    prop1 = opt_prop_def(Attribute)
+    prop2 = opt_prop_def(Attribute)
+    prop3 = opt_prop_def(Attribute)
+
     traits = frozenset([IsTerminator()])
 
     def __init__(
@@ -85,6 +96,7 @@ class TestTermOp(IRDLOperation):
         operands: Sequence[SSAValue | Operation] = (),
         result_types: Sequence[Attribute] = (),
         attributes: Mapping[str, Attribute | None] | None = None,
+        properties: Mapping[str, Attribute | None] | None = None,
         successors: Sequence[Block] = (),
         regions: Sequence[Region | Sequence[Operation] | Sequence[Block]] = (),
     ):
@@ -92,6 +104,7 @@ class TestTermOp(IRDLOperation):
             operands=(operands,),
             result_types=(result_types,),
             attributes=attributes,
+            properties=properties,
             successors=(successors,),
             regions=(regions,),
         )

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -526,6 +526,7 @@ class TypeConversionPattern(RewritePattern):
             return
         new_result_types: list[Attribute] = []
         new_attributes: dict[str, Attribute] = {}
+        new_properties: dict[str, Attribute] = {}
         changed: bool = False
         for result in op.results:
             converted = self._convert_type_rec(result.type)
@@ -535,6 +536,11 @@ class TypeConversionPattern(RewritePattern):
         for name, attribute in op.attributes.items():
             converted = self._convert_type_rec(attribute)
             new_attributes[name] = converted or attribute
+            if converted is not None and converted != attribute:
+                changed = True
+        for name, attribute in op.properties.items():
+            converted = self._convert_type_rec(attribute)
+            new_properties[name] = converted or attribute
             if converted is not None and converted != attribute:
                 changed = True
         for region in op.regions:
@@ -548,6 +554,7 @@ class TypeConversionPattern(RewritePattern):
             new_op = type(op).create(
                 operands=op.operands,
                 result_types=new_result_types,
+                properties=new_properties,
                 attributes=new_attributes,
                 successors=op.successors,
                 regions=regions,


### PR DESCRIPTION
This adds support for properties in the attribute/type converter.
Note that this also adds properties to the `TestOp` classes. They are required unlike attributes because only defined propreties can be used.