### PR TITLE
core: Implement AttrSizedSegments option to implement as a property.

### DIFF
--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -95,6 +95,7 @@ def test_get_definition():
         options=[AttrSizedOperandSegments()],
     )
 
+
 @irdl_op_definition
 class PropOptionOp(IRDLOperation):
     name = "test.prop_option_test"

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -95,6 +95,21 @@ def test_get_definition():
         options=[AttrSizedOperandSegments()],
     )
 
+@irdl_op_definition
+class PropOptionOp(IRDLOperation):
+    name = "test.prop_option_test"
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+
+def test_property_option():
+    """Test retrieval of an IRDL definition from an operation"""
+    assert PropOptionOp.irdl_definition == OpDef(
+        "test.prop_option_test",
+        properties={"operand_segment_sizes": PropertyDef(BaseAttr(DenseArrayBase))},
+        options=[AttrSizedOperandSegments(as_property=True)],
+    )
+
 
 ################################################################################
 #                            Invalid definitions                               #

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -548,7 +548,7 @@ class IRDLOption(ABC):
 
 
 @dataclass
-class AttrSizedSegments(IRDLOption):
+class AttrSizedSegments(IRDLOption, ABC):
     """
     Expect an attribute on the operation that contains the segment sizes of the
     operand, result, region, or successor lists.
@@ -560,6 +560,7 @@ class AttrSizedSegments(IRDLOption):
     """
 
     attribute_name: ClassVar[str]
+    as_property: bool = False
     """Name of the attribute containing the segment sizes."""
 
 
@@ -1162,19 +1163,26 @@ class OpDef:
                     op_def.options.extend(value)
                     for option in value:
                         if isinstance(option, AttrSizedSegments):
-                            if option.attribute_name in op_def.attributes:
+                            defs = op_def.properties if option.as_property else op_def.attributes
+                            def_name = 'property' if option.as_property else 'attribute'
+                            if option.attribute_name in defs:
                                 raise PyRDLOpDefinitionError(
                                     f"pyrdl operation definition '{pyrdl_def.__name__}' "
-                                    f"has a '{option.attribute_name}' attribute, which "
+                                    f"has a '{option.attribute_name}' {def_name}, which "
                                     "is incompatible with the "
-                                    f"{option.__class__.__name__} option."
+                                    f"{option} option."
                                 )
                             from xdsl.dialects.builtin import DenseArrayBase
-
-                            attr_def = AttributeDef(
-                                attr_constr_coercion(DenseArrayBase)
-                            )
-                            op_def.attributes[option.attribute_name] = attr_def
+                            if option.as_property:
+                                prop_def = PropertyDef(
+                                    attr_constr_coercion(DenseArrayBase)
+                                )
+                                op_def.properties[option.attribute_name] = prop_def
+                            else:
+                                attr_def = AttributeDef(
+                                    attr_constr_coercion(DenseArrayBase)
+                                )
+                                op_def.attributes[option.attribute_name] = attr_def
                     continue
 
                 if field_name == "traits":
@@ -1388,20 +1396,20 @@ def get_op_constructs(
 def get_attr_size_option(
     construct: VarIRConstruct,
 ) -> (
-    AttrSizedOperandSegments
+    type[AttrSizedOperandSegments
     | AttrSizedResultSegments
     | AttrSizedRegionSegments
-    | AttrSizedSuccessorSegments
+    | AttrSizedSuccessorSegments]
 ):
     """Get the AttrSized option for this type."""
     if construct == VarIRConstruct.OPERAND:
-        return AttrSizedOperandSegments()
+        return AttrSizedOperandSegments
     if construct == VarIRConstruct.RESULT:
-        return AttrSizedResultSegments()
+        return AttrSizedResultSegments
     if construct == VarIRConstruct.REGION:
-        return AttrSizedRegionSegments()
+        return AttrSizedRegionSegments
     if construct == VarIRConstruct.SUCCESSOR:
-        return AttrSizedSuccessorSegments()
+        return AttrSizedSuccessorSegments
     assert False, "Unknown VarIRConstruct value"
 
 
@@ -1410,6 +1418,7 @@ def get_variadic_sizes_from_attr(
     defs: Sequence[tuple[str, OperandDef | ResultDef | RegionDef | SuccessorDef]],
     construct: VarIRConstruct,
     size_attribute_name: str,
+    from_prop: bool = False,
 ) -> list[int]:
     """
     Get the sizes of the variadic definitions
@@ -1418,20 +1427,23 @@ def get_variadic_sizes_from_attr(
     # Circular import because DenseArrayBase is defined using IRDL
     from xdsl.dialects.builtin import DenseArrayBase, i32
 
+    container = op.properties if from_prop else op.attributes
+    container_name = 'property' if from_prop else 'attribute'
+
     # Check that the attribute is present
-    if size_attribute_name not in op.attributes:
+    if size_attribute_name not in container:
         raise VerifyException(
-            f"Expected {size_attribute_name} attribute in {op.name} operation."
+            f"Expected {size_attribute_name} {container_name} in {op.name} operation."
         )
-    attribute = op.attributes[size_attribute_name]
+    attribute = container[size_attribute_name]
     if not isinstance(attribute, DenseArrayBase):
         raise VerifyException(
-            f"{size_attribute_name} attribute is expected " "to be a DenseArrayBase."
+            f"{size_attribute_name} {container_name} is expected " "to be a DenseArrayBase."
         )
 
     if attribute.elt_type != i32:
         raise VerifyException(
-            f"{size_attribute_name} attribute is expected to "
+            f"{size_attribute_name} {container_name} is expected to "
             "be a DenseArrayBase of i32"
         )
     def_sizes = cast(list[int], [size_attr.data for size_attr in attribute.data.data])
@@ -1480,9 +1492,9 @@ def get_variadic_sizes(
     ]
 
     # If the size is in the attributes, fetch it
-    if attribute_option in op_def.options:
+    if any(isinstance(o, attribute_option) for o in op_def.options):
         return get_variadic_sizes_from_attr(
-            op, defs, construct, attribute_option.attribute_name
+            op, defs, construct, attribute_option.attribute_name, attribute_option.as_property
         )
 
     # If there are no variadics arguments,
@@ -1814,25 +1826,34 @@ def irdl_op_init(
         built_attributes[attr_name] = attr
 
     # Take care of variadic operand and result segment sizes.
-    if AttrSizedOperandSegments() in op_def.options:
-        built_attributes[
-            AttrSizedOperandSegments.attribute_name
-        ] = DenseArrayBase.from_list(i32, operand_sizes)
+    for option in op_def.options:
+        match option:
+            case AttrSizedSegments():
+                container = built_properties if option.as_property else built_attributes
+                match option:
+                    case AttrSizedOperandSegments():
+                        container[
+                            AttrSizedOperandSegments.attribute_name
+                        ] = DenseArrayBase.from_list(i32, operand_sizes)
 
-    if AttrSizedResultSegments() in op_def.options:
-        built_attributes[
-            AttrSizedResultSegments.attribute_name
-        ] = DenseArrayBase.from_list(i32, result_sizes)
+                    case AttrSizedResultSegments():
+                        container[
+                            AttrSizedResultSegments.attribute_name
+                        ] = DenseArrayBase.from_list(i32, result_sizes)
 
-    if AttrSizedRegionSegments() in op_def.options:
-        built_attributes[
-            AttrSizedRegionSegments.attribute_name
-        ] = DenseArrayBase.from_list(i32, region_sizes)
+                    case AttrSizedRegionSegments():
+                        container[
+                            AttrSizedRegionSegments.attribute_name
+                        ] = DenseArrayBase.from_list(i32, region_sizes)
 
-    if AttrSizedSuccessorSegments() in op_def.options:
-        built_attributes[
-            AttrSizedSuccessorSegments.attribute_name
-        ] = DenseArrayBase.from_list(i32, successor_sizes)
+                    case AttrSizedSuccessorSegments():
+                        container[
+                            AttrSizedSuccessorSegments.attribute_name
+                        ] = DenseArrayBase.from_list(i32, successor_sizes)
+                    case _:
+                        raise ValueError(f"Unexpected option {option} in operation definition {op_def}.")
+            case _:
+                raise ValueError(f"Unexpected option {option} in operation definition {op_def}.")
 
     Operation.__init__(
         self,
@@ -1864,7 +1885,7 @@ def irdl_op_arg_definition(
     # If we have multiple variadics, check that we have an
     # attribute that holds the variadic sizes.
     arg_size_option = get_attr_size_option(construct)
-    if previous_variadics > 1 and (arg_size_option not in op_def.options):
+    if previous_variadics > 1 and (not any(isinstance(o, arg_size_option) for o in op_def.options)):
         arg_size_option_name = type(arg_size_option).__name__
         raise Exception(
             f"Operation {op_def.name} defines more than two variadic "

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1163,8 +1163,12 @@ class OpDef:
                     op_def.options.extend(value)
                     for option in value:
                         if isinstance(option, AttrSizedSegments):
-                            defs = op_def.properties if option.as_property else op_def.attributes
-                            def_name = 'property' if option.as_property else 'attribute'
+                            defs = (
+                                op_def.properties
+                                if option.as_property
+                                else op_def.attributes
+                            )
+                            def_name = "property" if option.as_property else "attribute"
                             if option.attribute_name in defs:
                                 raise PyRDLOpDefinitionError(
                                     f"pyrdl operation definition '{pyrdl_def.__name__}' "
@@ -1173,6 +1177,7 @@ class OpDef:
                                     f"{option} option."
                                 )
                             from xdsl.dialects.builtin import DenseArrayBase
+
                             if option.as_property:
                                 prop_def = PropertyDef(
                                     attr_constr_coercion(DenseArrayBase)
@@ -1395,12 +1400,12 @@ def get_op_constructs(
 
 def get_attr_size_option(
     construct: VarIRConstruct,
-) -> (
-    type[AttrSizedOperandSegments
+) -> type[
+    AttrSizedOperandSegments
     | AttrSizedResultSegments
     | AttrSizedRegionSegments
-    | AttrSizedSuccessorSegments]
-):
+    | AttrSizedSuccessorSegments
+]:
     """Get the AttrSized option for this type."""
     if construct == VarIRConstruct.OPERAND:
         return AttrSizedOperandSegments
@@ -1428,7 +1433,7 @@ def get_variadic_sizes_from_attr(
     from xdsl.dialects.builtin import DenseArrayBase, i32
 
     container = op.properties if from_prop else op.attributes
-    container_name = 'property' if from_prop else 'attribute'
+    container_name = "property" if from_prop else "attribute"
 
     # Check that the attribute is present
     if size_attribute_name not in container:
@@ -1438,7 +1443,8 @@ def get_variadic_sizes_from_attr(
     attribute = container[size_attribute_name]
     if not isinstance(attribute, DenseArrayBase):
         raise VerifyException(
-            f"{size_attribute_name} {container_name} is expected " "to be a DenseArrayBase."
+            f"{size_attribute_name} {container_name} is expected "
+            "to be a DenseArrayBase."
         )
 
     if attribute.elt_type != i32:
@@ -1494,7 +1500,11 @@ def get_variadic_sizes(
     # If the size is in the attributes, fetch it
     if any(isinstance(o, attribute_option) for o in op_def.options):
         return get_variadic_sizes_from_attr(
-            op, defs, construct, attribute_option.attribute_name, attribute_option.as_property
+            op,
+            defs,
+            construct,
+            attribute_option.attribute_name,
+            attribute_option.as_property,
         )
 
     # If there are no variadics arguments,
@@ -1851,9 +1861,13 @@ def irdl_op_init(
                             AttrSizedSuccessorSegments.attribute_name
                         ] = DenseArrayBase.from_list(i32, successor_sizes)
                     case _:
-                        raise ValueError(f"Unexpected option {option} in operation definition {op_def}.")
+                        raise ValueError(
+                            f"Unexpected option {option} in operation definition {op_def}."
+                        )
             case _:
-                raise ValueError(f"Unexpected option {option} in operation definition {op_def}.")
+                raise ValueError(
+                    f"Unexpected option {option} in operation definition {op_def}."
+                )
 
     Operation.__init__(
         self,
@@ -1885,7 +1899,9 @@ def irdl_op_arg_definition(
     # If we have multiple variadics, check that we have an
     # attribute that holds the variadic sizes.
     arg_size_option = get_attr_size_option(construct)
-    if previous_variadics > 1 and (not any(isinstance(o, arg_size_option) for o in op_def.options)):
+    if previous_variadics > 1 and (
+        not any(isinstance(o, arg_size_option) for o in op_def.options)
+    ):
         arg_size_option_name = type(arg_size_option).__name__
         raise Exception(
             f"Operation {op_def.name} defines more than two variadic "


### PR DESCRIPTION
Extracted (and cleaned up) from the MLIR bump PR, this allows to make "operand_segment_sizes" and friends implemented as property on the Op rather than an attribute.

