### PR TITLE
core: Make SymbolOpInterface and Symboltable properties-ready.

### DIFF
--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -31,10 +31,10 @@ from xdsl.irdl import (
     operand_def,
     opt_attr_def,
     opt_region_def,
+    prop_def,
     region_def,
     result_def,
 )
-from xdsl.irdl import prop_def
 from xdsl.traits import (
     OptionalSymbolOpInterface,
     SymbolOpInterface,

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -34,7 +34,7 @@ from xdsl.irdl import (
     region_def,
     result_def,
 )
-from xdsl.irdl.irdl import prop_def
+from xdsl.irdl import prop_def
 from xdsl.traits import (
     OptionalSymbolOpInterface,
     SymbolOpInterface,

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -34,6 +34,7 @@ from xdsl.irdl import (
     region_def,
     result_def,
 )
+from xdsl.irdl.irdl import prop_def
 from xdsl.traits import (
     OptionalSymbolOpInterface,
     SymbolOpInterface,
@@ -336,7 +337,32 @@ def test_optional_symbol_op_interface():
     assert interface.get_sym_attr_name(symbol) == StringAttr("main")
 
 
-def test_symbol_table():
+@irdl_op_definition
+class SymbolOp(IRDLOperation):
+    name = "test.symbol"
+
+    sym_name = attr_def(StringAttr)
+
+    traits = frozenset([SymbolOpInterface()])
+
+    def __init__(self, name: str):
+        return super().__init__(attributes={"sym_name": StringAttr(name)})
+
+
+@irdl_op_definition
+class PropSymbolOp(IRDLOperation):
+    name = "test.symbol"
+
+    sym_name = prop_def(StringAttr)
+
+    traits = frozenset([SymbolOpInterface()])
+
+    def __init__(self, name: str):
+        return super().__init__(properties={"sym_name": StringAttr(name)})
+
+
+@pytest.mark.parametrize("SymbolOp", (SymbolOp, PropSymbolOp))
+def test_symbol_table(SymbolOp: type[PropSymbolOp | SymbolOp]):
     # Some helper classes
     @irdl_op_definition
     class SymbolTableOp(IRDLOperation):
@@ -348,14 +374,6 @@ def test_symbol_table():
         two = opt_region_def()
 
         traits = frozenset([SymbolTable(), OptionalSymbolOpInterface()])
-
-    @irdl_op_definition
-    class SymbolOp(IRDLOperation):
-        name = "test.symbol"
-
-        sym_name = attr_def(StringAttr)
-
-        traits = frozenset([SymbolOpInterface()])
 
     # Check that having a single region is verified
     op = SymbolTableOp(regions=[Region(), Region()])
@@ -377,8 +395,8 @@ def test_symbol_table():
     terminator = test.TestTermOp()
 
     # Check that symbol uniqueness is verified
-    symbol = SymbolOp(attributes={"sym_name": StringAttr("name")})
-    dup_symbol = SymbolOp(attributes={"sym_name": StringAttr("name")})
+    symbol = SymbolOp("name")
+    dup_symbol = SymbolOp("name")
     op = SymbolTableOp(
         regions=[Region(Block([symbol, dup_symbol, terminator.clone()])), []]
     )
@@ -389,7 +407,7 @@ def test_symbol_table():
         op.verify()
 
     # Check a flat happy case, with symbol lookup
-    symbol = SymbolOp(attributes={"sym_name": StringAttr("name")})
+    symbol = SymbolOp("name")
 
     op = SymbolTableOp(regions=[Region(Block([symbol, terminator.clone()])), []])
     op.verify()
@@ -398,7 +416,7 @@ def test_symbol_table():
     assert SymbolTable.lookup_symbol(op, "that_other_name") is None
 
     # Check a nested happy case, with symbol lookup
-    symbol = SymbolOp(attributes={"sym_name": StringAttr("name")})
+    symbol = SymbolOp("name")
 
     nested = SymbolTableOp(
         regions=[Region(Block([symbol, terminator.clone()])), []],

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 import wgpu  # pyright: ignore
 import wgpu.utils  # pyright: ignore
+
 from xdsl.dialects import gpu
 from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.memref import MemRefType

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 
 import wgpu  # pyright: ignore
 import wgpu.utils  # pyright: ignore
-
 from xdsl.dialects import gpu
 from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.memref import MemRefType

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -291,17 +291,15 @@ class SymbolOpInterface(OpTrait):
         # import builtin here to avoid circular import
         from xdsl.dialects.builtin import StringAttr
 
-        if "sym_name" not in op.attributes and self.is_optional_symbol(op):
+        sym_name = op.get_attr_or_prop("sym_name")
+        if sym_name is None and self.is_optional_symbol(op):
             return None
-        if "sym_name" not in op.attributes or not isinstance(
-            op.attributes["sym_name"], StringAttr
-        ):
+        if not isinstance(sym_name, StringAttr):
             raise VerifyException(
                 f'Operation {op.name} must have a "sym_name" attribute of type '
                 f"`StringAttr` to conform to {SymbolOpInterface.__name__}"
             )
-        attr = op.attributes["sym_name"]
-        return attr
+        return sym_name
 
     def is_optional_symbol(self, op: Operation) -> bool:
         """
@@ -311,19 +309,8 @@ class SymbolOpInterface(OpTrait):
         return False
 
     def verify(self, op: Operation) -> None:
-        # import builtin here to avoid circular import
-        from xdsl.dialects.builtin import StringAttr
-
         # If this is an optional symbol, bail out early if possible.
-        if self.is_optional_symbol(op) and "sym_name" not in op.attributes:
-            return
-        if "sym_name" not in op.attributes or not isinstance(
-            op.attributes["sym_name"], StringAttr
-        ):
-            raise VerifyException(
-                f'Operation {op.name} must have a "sym_name" attribute of type '
-                f"`StringAttr` to conform to {SymbolOpInterface.__name__}"
-            )
+        self.get_sym_attr_name(op)
 
 
 class OptionalSymbolOpInterface(SymbolOpInterface):

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -227,9 +227,9 @@ class SymbolTable(OpTrait):
         block = op.regions[0].blocks[0]
         met_names: set[StringAttr] = set()
         for o in block.ops:
-            if "sym_name" not in o.attributes:
+            if o.get_attr_or_prop("sym_name") is None:
                 continue
-            sym_name = o.attributes["sym_name"]
+            sym_name = o.get_attr_or_prop("sym_name")
             if not isinstance(sym_name, StringAttr):
                 continue
             if sym_name in met_names:

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -309,7 +309,9 @@ class SymbolOpInterface(OpTrait):
         return False
 
     def verify(self, op: Operation) -> None:
-        # If this is an optional symbol, bail out early if possible.
+        # This helper has the same behaviour, so we reuse it as a verifier.That is, it
+        # raises a VerifyException iff this operation is a non-optional symbol *and*
+        # there is no "sym_name" attribute or property.
         self.get_sym_attr_name(op)
 
 

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -227,9 +227,8 @@ class SymbolTable(OpTrait):
         block = op.regions[0].blocks[0]
         met_names: set[StringAttr] = set()
         for o in block.ops:
-            if o.get_attr_or_prop("sym_name") is None:
+            if (sym_name := o.get_attr_or_prop("sym_name")) is None:
                 continue
-            sym_name = o.get_attr_or_prop("sym_name")
             if not isinstance(sym_name, StringAttr):
                 continue
             if sym_name in met_names:


### PR DESCRIPTION
Extracted and polished from #1582.

This make SymbolOpInterface and SymbolTable working with the expected `sym_name` as an attribute or property transparently, as in the targetted MLIR version.