### PR TITLE
core: test and fix IRDLOptions as properties

### DIFF
--- a/tests/test_operation_builder.py
+++ b/tests/test_operation_builder.py
@@ -262,6 +262,16 @@ class TwoVarOperandOp(IRDLOperation):
     irdl_options = [AttrSizedOperandSegments()]
 
 
+# Define a similar operation with the segment sizes as a property to test this case
+@irdl_op_definition
+class TwoVarOperandPropOp(IRDLOperation):
+    name = "test.two_var_operand_op"
+
+    res1: VarOperand = var_operand_def(StringAttr)
+    res2: VarOperand = var_operand_def(StringAttr)
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+
 def test_two_var_operand_builder():
     op1 = ResultOp.build(result_types=[StringAttr("0")])
     op2 = TwoVarOperandOp.build(operands=[[op1, op1], [op1, op1]])
@@ -278,6 +288,26 @@ def test_two_var_operand_builder2():
     op2.verify()
     assert tuple(op2.operands) == (op1.res, op1.res, op1.res, op1.res)
     assert op2.attributes[
+        AttrSizedOperandSegments.attribute_name
+    ] == DenseArrayBase.from_list(i32, [1, 3])
+
+
+def test_two_var_operand_prop_builder():
+    op1 = ResultOp.build(result_types=[StringAttr("0")])
+    op2 = TwoVarOperandPropOp.build(operands=[[op1, op1], [op1, op1]])
+    op2.verify()
+    assert tuple(op2.operands) == (op1.res, op1.res, op1.res, op1.res)
+    assert op2.properties[
+        AttrSizedOperandSegments.attribute_name
+    ] == DenseArrayBase.from_list(i32, [2, 2])
+
+
+def test_two_var_operand_prop_builder2():
+    op1 = ResultOp.build(result_types=[StringAttr("0")])
+    op2 = TwoVarOperandPropOp.build(operands=[[op1], [op1, op1, op1]])
+    op2.verify()
+    assert tuple(op2.operands) == (op1.res, op1.res, op1.res, op1.res)
+    assert op2.properties[
         AttrSizedOperandSegments.attribute_name
     ] == DenseArrayBase.from_list(i32, [1, 3])
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1498,13 +1498,14 @@ def get_variadic_sizes(
     ]
 
     # If the size is in the attributes, fetch it
-    if any(isinstance(o, attribute_option) for o in op_def.options):
+    option = next((o for o in op_def.options if isinstance(o, attribute_option)), None)
+    if option is not None:
         return get_variadic_sizes_from_attr(
             op,
             defs,
             construct,
-            attribute_option.attribute_name,
-            attribute_option.as_property,
+            option.attribute_name,
+            option.as_property,
         )
 
     # If there are no variadics arguments,


### PR DESCRIPTION
I forgot something while extracting this from #1582 in #1603; This is fixed and tested here.

Basically, by switching some helpers to use the IRDLOptions types rather than placeholder instances, I forgot to actually get the option instance when using this option in the irdl generated builder, causing this to always fall back to the attribute-based behaviour and causing errors in the property-expecting case (hence no regression appearing with no dialect ops using properties yet). Fixed :wrench: 

this is also the last core-preparing PR before #1582 :tada: Opening a Zulip thread in a moment to discuss that.