### PR TITLE
dialects: (scf) convert constructors from get to init

### DIFF
--- a/docs/database_example.ipynb
+++ b/docs/database_example.ipynb
@@ -225,7 +225,7 @@
     "    add = Addi(const1, const2)\n",
     "    cmp = Cmpi(arg, add, \"sgt\")\n",
     "    # sgt stands for `signed greater than`. In xDSL, this is encoded as a predicate attribute with value 4.\n",
-    "    Yield.get(cmp)"
+    "    Yield(cmp)"
    ]
   },
   {

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -210,13 +210,13 @@ def test_memref_matmul_verify():
                         memref.Store.get(new_out_val, out, [i, j])
                         scf.Yield.get()
 
-                    scf.For.get(lit0, dim_a1, lit1, [], inner_loop)
+                    scf.For(lit0, dim_a1, lit1, [], inner_loop)
                     scf.Yield.get()
 
-                scf.For.get(lit0, dim_b0, lit1, [], mid_loop)
+                scf.For(lit0, dim_b0, lit1, [], mid_loop)
                 scf.Yield.get()
 
-            scf.For.get(lit0, dim_a0, lit1, [], outer_loop)
+            scf.For(lit0, dim_a0, lit1, [], outer_loop)
 
             func.Return(out)
 

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -208,13 +208,13 @@ def test_memref_matmul_verify():
                         out_i_j = memref.Load.get(out, [i, j])
                         new_out_val = arith.Addf(out_i_j, mul)
                         memref.Store.get(new_out_val, out, [i, j])
-                        scf.Yield.get()
+                        scf.Yield()
 
                     scf.For(lit0, dim_a1, lit1, [], inner_loop)
-                    scf.Yield.get()
+                    scf.Yield()
 
                 scf.For(lit0, dim_b0, lit1, [], mid_loop)
-                scf.Yield.get()
+                scf.Yield()
 
             scf.For(lit0, dim_a0, lit1, [], outer_loop)
 

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -33,9 +33,9 @@ def test_for_with_loop_carried_verify():
 
     @Builder.implicit_region((IndexType(), IndexType()))
     def body(_: tuple[BlockArgument, ...]) -> None:
-        Yield.get(carried)
+        Yield(carried)
 
-    for_op = For.get(lower, upper, step, [carried], body)
+    for_op = For(lower, upper, step, [carried], body)
 
     assert for_op.lb is lower.result
     assert for_op.ub is upper.result
@@ -66,9 +66,9 @@ def test_for_without_loop_carried_verify():
 
     @Builder.implicit_region((IndexType(),))
     def body(_: tuple[BlockArgument, ...]) -> None:
-        Yield.get()
+        Yield()
 
-    for_op = For.get(lower, upper, step, [], body)
+    for_op = For(lower, upper, step, [], body)
 
     assert for_op.lb is lower.result
     assert for_op.ub is upper.result
@@ -107,7 +107,7 @@ def test_parallel_no_init_vals():
     upperBounds = [ubi, ubj, ubk]
     steps = [si, sj, sk]
 
-    p = ParallelOp.get(lowerBounds, upperBounds, steps, body)
+    p = ParallelOp(lowerBounds, upperBounds, steps, body)
 
     assert isinstance(p, ParallelOp)
     assert p.lowerBound == tuple(l.result for l in lowerBounds)
@@ -131,7 +131,7 @@ def test_parallel_with_init_vals():
     upperBounds = [ubi]
     steps = [si]
 
-    p = ParallelOp.get(lowerBounds, upperBounds, steps, body, initVals)
+    p = ParallelOp(lowerBounds, upperBounds, steps, body, initVals)
 
     assert isinstance(p, ParallelOp)
     assert p.lowerBound == tuple(l.result for l in lowerBounds)
@@ -147,7 +147,7 @@ def test_parallel_verify_one_block():
     si = Constant.from_int_and_width(1, IndexType())
 
     body = Region()
-    p = ParallelOp.get([lbi], [ubi], [si], body)
+    p = ParallelOp([lbi], [ubi], [si], body)
     with pytest.raises(DiagnosticException):
         p.verify()
 
@@ -163,14 +163,14 @@ def test_parallel_verify_num_bounds_equal():
 
     body = Region(Block())
 
-    p = ParallelOp.get(lowerBounds, upperBounds, steps, body)
+    p = ParallelOp(lowerBounds, upperBounds, steps, body)
     with pytest.raises(VerifyException):
         p.verify()
 
     upperBounds = [ubi, ubi]
 
     body2 = Region(Block())
-    p2 = ParallelOp.get(lowerBounds, upperBounds, steps, body2)
+    p2 = ParallelOp(lowerBounds, upperBounds, steps, body2)
     with pytest.raises(VerifyException):
         p2.verify()
 
@@ -179,7 +179,7 @@ def test_parallel_verify_num_bounds_equal():
     steps = [si, si]
 
     body3 = Region(Block())
-    p3 = ParallelOp.get(lowerBounds, upperBounds, steps, body3)
+    p3 = ParallelOp(lowerBounds, upperBounds, steps, body3)
     with pytest.raises(VerifyException):
         p3.verify()
 
@@ -197,14 +197,14 @@ def test_parallel_verify_only_induction_in_block():
     b.add_op(Yield.get(init_val))
 
     body = Region(b)
-    p = ParallelOp.get([lbi], [ubi], [si], body, initVals)
+    p = ParallelOp([lbi], [ubi], [si], body, initVals)
     with pytest.raises(VerifyException):
         p.verify()
 
     b2 = Block(arg_types=[IndexType(), i32, i32])
     b2.add_op(Yield.get(init_val))
     body2 = Region(b2)
-    p2 = ParallelOp.get([lbi], [ubi], [si], body2, initVals)
+    p2 = ParallelOp([lbi], [ubi], [si], body2, initVals)
     with pytest.raises(VerifyException):
         p2.verify()
 
@@ -218,13 +218,13 @@ def test_parallel_block_arg_indextype():
     b.add_op(Yield.get())
 
     body = Region(b)
-    p = ParallelOp.get([lbi], [ubi], [si], body)
+    p = ParallelOp([lbi], [ubi], [si], body)
     p.verify()
 
     b2 = Block(arg_types=[i32])
     b2.add_op(Yield.get())
     body2 = Region(b2)
-    p2 = ParallelOp.get([lbi], [ubi], [si], body2)
+    p2 = ParallelOp([lbi], [ubi], [si], body2)
     with pytest.raises(VerifyException):
         p2.verify()
 
@@ -241,15 +241,15 @@ def test_parallel_verify_reduction_and_block_type():
     b = Block(arg_types=[IndexType()])
 
     reduce_constant = Constant.from_int_and_width(100, i32)
-    rro = ReduceReturnOp.get(reduce_constant)
+    rro = ReduceReturnOp(reduce_constant)
     reduce_block = Block(arg_types=[i32, i32])
     reduce_block.add_ops([reduce_constant, rro])
 
-    b.add_op(ReduceOp.get(init_val, reduce_block))
-    b.add_op(Yield.get())
+    b.add_op(ReduceOp(init_val, reduce_block))
+    b.add_op(Yield())
 
     body = Region(b)
-    p = ParallelOp.get([lbi], [ubi], [si], body, initVals)
+    p = ParallelOp([lbi], [ubi], [si], body, initVals)
     # This should verify
     p.verify()
 
@@ -266,15 +266,15 @@ def test_parallel_verify_reduction_and_block_type_fails():
     b = Block(arg_types=[IndexType()])
 
     reduce_constant = Constant.from_int_and_width(100, i32)
-    rro = ReduceReturnOp.get(reduce_constant)
+    rro = ReduceReturnOp(reduce_constant)
     reduce_block = Block(arg_types=[i32, i32])
     reduce_block.add_ops([reduce_constant, rro])
 
-    b.add_op(ReduceOp.get(init_val, reduce_block))
+    b.add_op(ReduceOp(init_val, reduce_block))
     b.add_op(Yield.get())
 
     body = Region(b)
-    p = ParallelOp.get([lbi], [ubi], [si], body, initVals)
+    p = ParallelOp([lbi], [ubi], [si], body, initVals)
     with pytest.raises(VerifyException):
         p.verify()
 
@@ -289,7 +289,7 @@ def test_parallel_verify_yield_zero_ops():
     b = Block(arg_types=[IndexType()])
     b.add_op(Yield.get(val))
     body = Region(b)
-    p = ParallelOp.get([lbi], [ubi], [si], body)
+    p = ParallelOp([lbi], [ubi], [si], body)
     with pytest.raises(
         VerifyException,
         match="Single-block region terminator scf.yield has 1 operands "
@@ -300,7 +300,7 @@ def test_parallel_verify_yield_zero_ops():
     b2 = Block(arg_types=[IndexType()])
     b2.add_op(Yield.get())
     body2 = Region(b2)
-    p2 = ParallelOp.get([lbi], [ubi], [si], body2)
+    p2 = ParallelOp([lbi], [ubi], [si], body2)
     # Should verify as yield is empty
     p2.verify()
 
@@ -310,9 +310,9 @@ def test_parallel_test_count_number_reduction_ops():
     def body():
         for i in range(10):
             init_val = Constant.from_int_and_width(i, i32)
-            ReduceOp.get(init_val, Block())
+            ReduceOp(init_val, Block())
 
-    p = ParallelOp.get([], [], [], body)
+    p = ParallelOp([], [], [], body)
     assert p.count_number_reduction_ops() == 10
 
 
@@ -322,9 +322,9 @@ def test_parallel_get_arg_type_of_nth_reduction_op():
         init_val1 = Constant.from_int_and_width(10, i32)
         init_val2 = Constant.from_int_and_width(10, i64)
         for i in range(10):
-            ReduceOp.get(init_val1 if i % 2 == 0 else init_val2, Block())
+            ReduceOp(init_val1 if i % 2 == 0 else init_val2, Block())
 
-    p = ParallelOp.get([], [], [], body)
+    p = ParallelOp([], [], [], body)
     assert p.count_number_reduction_ops() == 10
     for i in range(10):
         assert p.get_arg_type_of_nth_reduction_op(i) == i32 if i % 2 == 0 else i64
@@ -333,7 +333,7 @@ def test_parallel_get_arg_type_of_nth_reduction_op():
 def test_reduce_op():
     init_val = Constant.from_int_and_width(10, i32)
 
-    reduce_op = ReduceOp.get(init_val, Block(arg_types=[i32, i32]))
+    reduce_op = ReduceOp(init_val, Block(arg_types=[i32, i32]))
 
     assert reduce_op.argument is init_val.results[0]
     assert reduce_op.argument.type is i32
@@ -350,22 +350,22 @@ def test_reduce_op_num_block_args():
         VerifyException,
         match="scf.reduce block must have exactly two arguments, but ",
     ):
-        rro = ReduceReturnOp.get(reduce_constant)
-        ReduceOp.get(init_val, Block([rro], arg_types=[i32, i32, i32])).verify()
+        rro = ReduceReturnOp(reduce_constant)
+        ReduceOp(init_val, Block([rro], arg_types=[i32, i32, i32])).verify()
 
     with pytest.raises(
         VerifyException,
         match="scf.reduce block must have exactly two arguments, but ",
     ):
-        rro = ReduceReturnOp.get(reduce_constant)
-        ReduceOp.get(init_val, Block([rro], arg_types=[i32])).verify()
+        rro = ReduceReturnOp(reduce_constant)
+        ReduceOp(init_val, Block([rro], arg_types=[i32])).verify()
 
     with pytest.raises(
         VerifyException,
         match="scf.reduce block must have exactly two arguments, but ",
     ):
-        rro = ReduceReturnOp.get(reduce_constant)
-        ReduceOp.get(init_val, Block([rro], arg_types=[])).verify()
+        rro = ReduceReturnOp(reduce_constant)
+        ReduceOp(init_val, Block([rro], arg_types=[])).verify()
 
 
 def test_reduce_op_num_block_arg_types():
@@ -376,56 +376,54 @@ def test_reduce_op_num_block_arg_types():
         VerifyException,
         match="scf.reduce block argument types must be the same but have",
     ):
-        rro = ReduceReturnOp.get(reduce_constant)
-        ReduceOp.get(init_val, Block([rro], arg_types=[i32, i64])).verify()
+        rro = ReduceReturnOp(reduce_constant)
+        ReduceOp(init_val, Block([rro], arg_types=[i32, i64])).verify()
 
     with pytest.raises(
         VerifyException,
         match="scf.reduce block argument types must be the same but have",
     ):
-        rro = ReduceReturnOp.get(reduce_constant)
-        ReduceOp.get(init_val, Block([rro], arg_types=[i64, i32])).verify()
+        rro = ReduceReturnOp(reduce_constant)
+        ReduceOp(init_val, Block([rro], arg_types=[i64, i32])).verify()
 
 
 def test_reduce_op_num_block_arg_types_match_operand_type():
     init_val = Constant.from_int_and_width(10, i32)
 
     with pytest.raises(VerifyException):
-        ReduceOp.get(init_val, Block(arg_types=[i64, i64])).verify()
+        ReduceOp(init_val, Block(arg_types=[i64, i64])).verify()
 
 
 def test_reduce_return_op_at_end():
     reduce_constant = Constant.from_int_and_width(100, i32)
-    rro = ReduceReturnOp.get(reduce_constant)
+    rro = ReduceReturnOp(reduce_constant)
     reduce_block = Block(arg_types=[i32, i32])
     reduce_block.add_ops([reduce_constant, rro])
 
     init_val = Constant.from_int_and_width(10, i32)
-    ReduceOp.get(init_val, reduce_block).verify()
+    ReduceOp(init_val, reduce_block).verify()
 
     with pytest.raises(
         VerifyException,
         match="Block inside scf.reduce must terminate with an scf.reduce.return",
     ):
-        ReduceOp.get(
-            init_val, Block([TestTermOp.create()], arg_types=[i32, i32])
-        ).verify()
+        ReduceOp(init_val, Block([TestTermOp.create()], arg_types=[i32, i32])).verify()
 
 
 def test_reduce_return_type_is_arg_type():
     reduce_constant = Constant.from_int_and_width(100, i32)
-    rro = ReduceReturnOp.get(reduce_constant)
+    rro = ReduceReturnOp(reduce_constant)
     reduce_block = Block(arg_types=[i32, i32])
     reduce_block.add_ops([reduce_constant, rro])
 
     init_val = Constant.from_int_and_width(10, i64)
     with pytest.raises(VerifyException):
-        ReduceOp.get(init_val, reduce_block).verify()
+        ReduceOp(init_val, reduce_block).verify()
 
 
 def test_reduce_return_op():
     reduce_constant = Constant.from_int_and_width(100, i32)
-    rro = ReduceReturnOp.get(reduce_constant)
+    rro = ReduceReturnOp(reduce_constant)
 
     assert rro.result is reduce_constant.results[0]
     assert rro.result.type is i32
@@ -434,7 +432,7 @@ def test_reduce_return_op():
 def test_reduce_return_type_is_operand_type():
     reduce_constant = Constant.from_int_and_width(100, i32)
     reduce_constant_wrong_type = Constant.from_int_and_width(100, i64)
-    rro = ReduceReturnOp.get(reduce_constant_wrong_type)
+    rro = ReduceReturnOp(reduce_constant_wrong_type)
     reduce_block = Block(arg_types=[i32, i32])
     reduce_block.add_ops([reduce_constant, rro])
 
@@ -443,7 +441,7 @@ def test_reduce_return_type_is_operand_type():
         VerifyException,
         match="scf.reduce.return result type at end of scf.reduce block must",
     ):
-        ReduceOp.get(init_val, reduce_block).verify()
+        ReduceOp(init_val, reduce_block).verify()
 
 
 def test_empty_else():
@@ -455,7 +453,7 @@ def test_empty_else():
                 t,
                 [],
                 [
-                    Yield.get(),
+                    Yield(),
                 ],
             ),
         ]

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -194,7 +194,7 @@ def test_parallel_verify_only_induction_in_block():
     initVals = [init_val]
 
     b = Block(arg_types=[IndexType(), i32])
-    b.add_op(Yield.get(init_val))
+    b.add_op(Yield(init_val))
 
     body = Region(b)
     p = ParallelOp([lbi], [ubi], [si], body, initVals)
@@ -202,7 +202,7 @@ def test_parallel_verify_only_induction_in_block():
         p.verify()
 
     b2 = Block(arg_types=[IndexType(), i32, i32])
-    b2.add_op(Yield.get(init_val))
+    b2.add_op(Yield(init_val))
     body2 = Region(b2)
     p2 = ParallelOp([lbi], [ubi], [si], body2, initVals)
     with pytest.raises(VerifyException):
@@ -215,14 +215,14 @@ def test_parallel_block_arg_indextype():
     si = Constant.from_int_and_width(1, IndexType())
 
     b = Block(arg_types=[IndexType()])
-    b.add_op(Yield.get())
+    b.add_op(Yield())
 
     body = Region(b)
     p = ParallelOp([lbi], [ubi], [si], body)
     p.verify()
 
     b2 = Block(arg_types=[i32])
-    b2.add_op(Yield.get())
+    b2.add_op(Yield())
     body2 = Region(b2)
     p2 = ParallelOp([lbi], [ubi], [si], body2)
     with pytest.raises(VerifyException):
@@ -271,7 +271,7 @@ def test_parallel_verify_reduction_and_block_type_fails():
     reduce_block.add_ops([reduce_constant, rro])
 
     b.add_op(ReduceOp(init_val, reduce_block))
-    b.add_op(Yield.get())
+    b.add_op(Yield())
 
     body = Region(b)
     p = ParallelOp([lbi], [ubi], [si], body, initVals)
@@ -287,7 +287,7 @@ def test_parallel_verify_yield_zero_ops():
     val = Constant.from_int_and_width(10, i64)
 
     b = Block(arg_types=[IndexType()])
-    b.add_op(Yield.get(val))
+    b.add_op(Yield(val))
     body = Region(b)
     p = ParallelOp([lbi], [ubi], [si], body)
     with pytest.raises(
@@ -298,7 +298,7 @@ def test_parallel_verify_yield_zero_ops():
         p.verify()
 
     b2 = Block(arg_types=[IndexType()])
-    b2.add_op(Yield.get())
+    b2.add_op(Yield())
     body2 = Region(b2)
     p2 = ParallelOp([lbi], [ubi], [si], body2)
     # Should verify as yield is empty
@@ -449,7 +449,7 @@ def test_empty_else():
     m = ModuleOp(
         [
             t := Constant.from_int_and_width(1, 1),
-            If.get(
+            If(
                 t,
                 [],
                 [

--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -34,7 +34,7 @@ def sum_to_for_op():
         def for_loop_region(args: tuple[BlockArgument, ...]):
             (i, acc) = args
             res = arith.Addi(i, acc)
-            scf.Yield.get(res)
+            scf.Yield(res)
 
         result = scf.For(lb, ub, step, (initial,), for_loop_region)
         func.Return(result)

--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -36,7 +36,7 @@ def sum_to_for_op():
             res = arith.Addi(i, acc)
             scf.Yield.get(res)
 
-        result = scf.For.get(lb, ub, step, (initial,), for_loop_region)
+        result = scf.For(lb, ub, step, (initial,), for_loop_region)
         func.Return(result)
 
 
@@ -64,14 +64,14 @@ def test_if():
             @Builder.implicit_region
             def true_region():
                 one = arith.Constant.from_int_and_width(1, 32)
-                scf.Yield.get(one)
+                scf.Yield(one)
 
             @Builder.implicit_region
             def false_region():
                 zero = arith.Constant.from_int_and_width(0, 32)
-                scf.Yield.get(zero)
+                scf.Yield(zero)
 
-            result = scf.If.get(cond, (i32,), true_region, false_region)
+            result = scf.If(cond, (i32,), true_region, false_region)
 
             func.Return(result)
 

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -164,7 +164,7 @@ def test_build_nested_implicit_region():
         Block(
             [
                 cond := Constant.from_int_and_width(1, 1),
-                If.get(
+                If(
                     cond,
                     (),
                     Region(
@@ -187,7 +187,7 @@ def test_build_nested_implicit_region():
         def then():
             _y = Constant.from_int_and_width(2, i32)
 
-        If.get(cond, (), then)
+        If(cond, (), then)
 
     assert target.is_structurally_equivalent(region)
 
@@ -212,9 +212,9 @@ def test_build_implicit_region_fail():
                 def then_1(b: Builder):
                     b.insert(Constant.from_int_and_width(three, i32))
 
-                If.get(cond, (), then_1)
+                If(cond, (), then_1)
 
-            If.get(cond, (), then_0)
+            If(cond, (), then_0)
 
         _ = region
     assert e.value.args[0] == (

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -95,7 +95,7 @@ class Yield(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> Self:
         attrs, args = parse_return_op_like(parser)
-        op = Yield.get(*args)
+        op = Yield(*args)
         op.attributes.update(attrs)
         return op
 
@@ -282,7 +282,7 @@ class For(IRDLOperation):
         body = parser.parse_region((index, *iter_args))
         if not body.block.ops:
             assert not iter_args, "Cannot create implicit yield with arguments"
-            body.block.add_op(Yield.get())
+            body.block.add_op(Yield())
 
         return For(lb, ub, step, iter_arg_operands, body)
 

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -28,6 +28,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.traits import HasParent, IsTerminator, SingleBlockImplicitTerminator
+from xdsl.utils.deprecation import deprecated
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -80,9 +81,13 @@ class Yield(IRDLOperation):
     # traits = frozenset([HasParent((For, If, ParallelOp, While)), IsTerminator()])
     traits = frozenset([IsTerminator()])
 
+    def __init__(self, *operands: SSAValue | Operation):
+        super().__init__(operands=[operands])
+
     @staticmethod
+    @deprecated("use Yield() instead!")
     def get(*operands: SSAValue | Operation) -> Yield:
-        return Yield.create(operands=[SSAValue.get(operand) for operand in operands])
+        return Yield(*operands)
 
     def print(self, printer: Printer):
         print_return_op_like(printer, self.attributes, self.arguments)
@@ -107,21 +112,31 @@ class If(IRDLOperation):
 
     traits = frozenset([SingleBlockImplicitTerminator(Yield)])
 
+    def __init__(
+        self,
+        cond: SSAValue | Operation,
+        return_types: Sequence[Attribute],
+        true_region: Region | Sequence[Block] | Sequence[Operation],
+        false_region: Region | Sequence[Block] | Sequence[Operation] | None = None,
+    ):
+        if false_region is None:
+            false_region = Region()
+
+        super().__init__(
+            operands=[cond],
+            result_types=[return_types],
+            regions=[true_region, false_region],
+        )
+
     @staticmethod
+    @deprecated("use If() instead!")
     def get(
         cond: SSAValue | Operation,
         return_types: Sequence[Attribute],
         true_region: Region | Sequence[Block] | Sequence[Operation],
         false_region: Region | Sequence[Block] | Sequence[Operation] | None = None,
     ) -> If:
-        if false_region is None:
-            false_region = Region()
-
-        return If.build(
-            operands=[cond],
-            result_types=[return_types],
-            regions=[true_region, false_region],
-        )
+        return If(cond, return_types, true_region, false_region)
 
 
 @irdl_op_definition
@@ -139,6 +154,34 @@ class For(IRDLOperation):
     body: Region = region_def("single_block")
 
     traits = frozenset([SingleBlockImplicitTerminator(Yield)])
+
+    def __init__(
+        self,
+        lb: SSAValue | Operation,
+        ub: SSAValue | Operation,
+        step: SSAValue | Operation,
+        iter_args: Sequence[SSAValue | Operation],
+        body: Region | Sequence[Operation] | Sequence[Block] | Block,
+    ):
+        if isinstance(body, Block):
+            body = [body]
+
+        super().__init__(
+            operands=[lb, ub, step, iter_args],
+            result_types=[[SSAValue.get(a).type for a in iter_args]],
+            regions=[body],
+        )
+
+    @staticmethod
+    @deprecated("Use init constructor instead")
+    def get(
+        lb: SSAValue | Operation,
+        ub: SSAValue | Operation,
+        step: SSAValue | Operation,
+        iter_args: Sequence[SSAValue | Operation],
+        body: Region | Sequence[Operation] | Sequence[Block] | Block,
+    ) -> For:
+        return For(lb, ub, step, iter_args, body)
 
     def verify_(self):
         if (len(self.iter_args) + 1) != len(self.body.block.args):
@@ -173,23 +216,6 @@ class For(IRDLOperation):
                         f"Expected {self.iter_args[idx].type}, got {arg.type}. The "
                         f"scf.for's scf.yield must match carried variables types."
                     )
-
-    @staticmethod
-    def get(
-        lb: SSAValue | Operation,
-        ub: SSAValue | Operation,
-        step: SSAValue | Operation,
-        iter_args: Sequence[SSAValue | Operation],
-        body: Region | Sequence[Operation] | Sequence[Block] | Block,
-    ) -> For:
-        if isinstance(body, Block):
-            body = [body]
-
-        return For.build(
-            operands=[lb, ub, step, iter_args],
-            result_types=[[SSAValue.get(a).type for a in iter_args]],
-            regions=[body],
-        )
 
     def print(self, printer: Printer):
         block = self.body.block
@@ -258,7 +284,7 @@ class For(IRDLOperation):
             assert not iter_args, "Cannot create implicit yield with arguments"
             body.block.add_op(Yield.get())
 
-        return For.get(lb, ub, step, iter_arg_operands, body)
+        return For(lb, ub, step, iter_arg_operands, body)
 
 
 @irdl_op_definition
@@ -276,7 +302,22 @@ class ParallelOp(IRDLOperation):
 
     traits = frozenset([SingleBlockImplicitTerminator(Yield)])
 
+    def __init__(
+        self,
+        lower_bounds: Sequence[SSAValue | Operation],
+        upper_bounds: Sequence[SSAValue | Operation],
+        steps: Sequence[SSAValue | Operation],
+        body: Region | Sequence[Block] | Sequence[Operation],
+        init_vals: Sequence[SSAValue | Operation] = (),
+    ):
+        super().__init__(
+            operands=[lower_bounds, upper_bounds, steps, init_vals],
+            regions=[body],
+            result_types=[[SSAValue.get(a).type for a in init_vals]],
+        )
+
     @staticmethod
+    @deprecated("use ParallelOp() instead!")
     def get(
         lowerBounds: Sequence[SSAValue | Operation],
         upperBounds: Sequence[SSAValue | Operation],
@@ -284,11 +325,7 @@ class ParallelOp(IRDLOperation):
         body: Region | Sequence[Block] | Sequence[Operation],
         initVals: Sequence[SSAValue | Operation] = [],
     ) -> ParallelOp:
-        return ParallelOp.build(
-            operands=[lowerBounds, upperBounds, steps, initVals],
-            regions=[body],
-            result_types=[[SSAValue.get(a).type for a in initVals]],
-        )
+        return ParallelOp(lowerBounds, upperBounds, steps, body, initVals)
 
     def verify_(self) -> None:
         # This verifies the scf.parallel operation, as can be seen it's fairly complex
@@ -395,12 +432,20 @@ class ReduceOp(IRDLOperation):
 
     body: Region = region_def("single_block")
 
+    def __init__(
+        self,
+        argument: SSAValue | Operation,
+        block: Block,
+    ):
+        super().__init__(operands=[argument], regions=[Region(block)])
+
     @staticmethod
+    @deprecated("use ReduceOp() instead!")
     def get(
         argument: SSAValue | Operation,
         block: Block,
     ) -> ReduceOp:
-        return ReduceOp.build(operands=[argument], regions=[Region(block)])
+        return ReduceOp(argument, block)
 
     def verify_(self) -> None:
         if len(self.body.block.args) != 2:
@@ -443,11 +488,15 @@ class ReduceReturnOp(IRDLOperation):
 
     traits = frozenset([HasParent(ReduceOp), IsTerminator()])
 
+    def __init__(self, result: SSAValue | Operation):
+        super().__init__(operands=[result])
+
     @staticmethod
+    @deprecated("use ReduceReturnOp() instead!")
     def get(
         result: SSAValue | Operation,
     ) -> ReduceReturnOp:
-        return ReduceReturnOp.build(operands=[result])
+        return ReduceReturnOp(result)
 
 
 @irdl_op_definition
@@ -458,9 +507,17 @@ class Condition(IRDLOperation):
 
     traits = frozenset([HasParent(While), IsTerminator()])
 
+    def __init__(
+        self,
+        cond: SSAValue | Operation,
+        *output_ops: SSAValue | Operation,
+    ):
+        super().__init__(operands=[cond, [output for output in output_ops]])
+
     @staticmethod
+    @deprecated("use __init__ constructor instead!")
     def get(cond: SSAValue | Operation, *output_ops: SSAValue | Operation) -> Condition:
-        return Condition.build(operands=[cond, [output for output in output_ops]])
+        return Condition(cond, *output_ops)
 
 
 Scf = Dialect(

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -451,11 +451,11 @@ class CodeGenerationVisitor(ast.NodeVisitor):
             assert isinstance(step, int)
             op = affine.For.from_region([], [], start, end, body, step)
         else:
-            self.inserter.insert_op(scf.Yield.get())
+            self.inserter.insert_op(scf.Yield())
             assert isinstance(start, SSAValue)
             assert isinstance(end, SSAValue)
             assert isinstance(step, SSAValue)
-            op = scf.For.get(start, end, step, [], body)
+            op = scf.For(start, end, step, [], body)
 
         self.inserter.set_insertion_point_from_block(curr_block)
         self.inserter.insert_op(op)
@@ -527,9 +527,9 @@ class CodeGenerationVisitor(ast.NodeVisitor):
         # In our case, if statement never returns a value and therefore we can
         # simply yield nothing. It is the responsibility of subsequent passes to
         # ensure SSA-form of IR and that values are yielded correctly.
-        true_region.blocks[-1].add_op(scf.Yield.get())
-        false_region.blocks[-1].add_op(scf.Yield.get())
-        op = scf.If.get(cond, [], true_region, false_region)
+        true_region.blocks[-1].add_op(scf.Yield())
+        false_region.blocks[-1].add_op(scf.Yield())
+        op = scf.If(cond, [], true_region, false_region)
 
         # Reset insertion point and insert a new operation.
         self.inserter.set_insertion_point_from_block(cond_block)
@@ -545,7 +545,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
             self.inserter.set_insertion_point_from_region(region)
             self.visit(expr)
             result = self.inserter.get_operand()
-            self.inserter.insert_op(scf.Yield.get(result))
+            self.inserter.insert_op(scf.Yield(result))
             return result.type, region
 
         # Generate code for both branches.
@@ -561,7 +561,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                 f"Expected the same types for if expression,"
                 f" but got {true_type} and {false_type}.",
             )
-        op = scf.If.get(cond, [true_type], true_region, false_region)
+        op = scf.If(cond, [true_type], true_region, false_region)
 
         # Reset insertion point to add scf.if.
         self.inserter.set_insertion_point_from_block(cond_block)

--- a/xdsl/transforms/experimental/Apply1DMPIToStencil.py
+++ b/xdsl/transforms/experimental/Apply1DMPIToStencil.py
@@ -124,7 +124,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
         )
         null_req_one = llvm.StoreOp(mpi_request_null, one_conv)
 
-        top_halo_exhange = scf.If.get(
+        top_halo_exhange = scf.If(
             compare_top_op,
             [],
             [
@@ -135,9 +135,9 @@ class ApplyMPIToExternalLoad(RewritePattern):
                 mpi_send_top_op,
                 recv_ptr,
                 mpi_recv_top_op,
-                scf.Yield.get(),
+                scf.Yield(),
             ],
-            [zero_conv, null_req_zero, one_conv, null_req_one, scf.Yield.get()],
+            [zero_conv, null_req_zero, one_conv, null_req_one, scf.Yield()],
         )
         mpi_operations += [top_halo_exhange]
 
@@ -187,7 +187,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
         )
         null_req_three = llvm.StoreOp(mpi_request_null, three_conv)
 
-        bottom_halo_exhange = scf.If.get(
+        bottom_halo_exhange = scf.If(
             compare_bottom_op,
             [],
             [
@@ -204,9 +204,9 @@ class ApplyMPIToExternalLoad(RewritePattern):
                 added_ptr_b_recv,
                 ptr_b_recv,
                 mpi_recv_bottom_op,
-                scf.Yield.get(),
+                scf.Yield(),
             ],
-            [two_conv, null_req_two, three_conv, null_req_three, scf.Yield.get()],
+            [two_conv, null_req_two, three_conv, null_req_three, scf.Yield()],
         )
 
         mpi_operations += [bottom_halo_exhange]

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -328,16 +328,16 @@ def generate_mpi_calls_for(
                 tag,
                 req_recv,
             )
-            yield scf.Yield.get()
+            yield scf.Yield()
 
         def else_() -> Iterable[Operation]:
             # set the request object to MPI_REQUEST_NULL s.t. they are ignored
             # in the waitall call
             yield mpi.NullRequestOp.get(req_send)
             yield mpi.NullRequestOp.get(req_recv)
-            yield scf.Yield.get()
+            yield scf.Yield()
 
-        yield scf.If.get(
+        yield scf.If(
             is_in_bounds,
             [],
             Region([Block(then())]),
@@ -349,7 +349,7 @@ def generate_mpi_calls_for(
 
     # start shuffling data into the main memref again
     for ex, buffer, cond_val in recv_buffers:
-        yield scf.If.get(
+        yield scf.If(
             cond_val,
             [],
             Region(
@@ -370,11 +370,11 @@ def generate_mpi_calls_for(
                             )
                         ]
                         * (1 if emit_debug else 0)
-                        + [scf.Yield.get()]
+                        + [scf.Yield()]
                     )
                 ]
             ),
-            Region([Block([scf.Yield.get()])]),
+            Region([Block([scf.Yield()])]),
         )
 
 

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -96,14 +96,14 @@ def gen_duplicate_loop(
             hls_write.attributes["duplicate"] = IntAttr(1)
             builder.insert(hls_write)
 
-        yield_op = scf.Yield.get()
+        yield_op = scf.Yield()
         builder.insert(yield_op)
 
     lb = Constant.from_int_and_width(0, IndexType())
     ub = n
     step = Constant.from_int_and_width(1, IndexType())
 
-    for_duplicate = scf.For.get(lb, ub, step, [], for_body)
+    for_duplicate = scf.For(lb, ub, step, [], for_body)
 
     return [ii, lb, ub, step, for_duplicate]
 
@@ -361,7 +361,7 @@ def transform_apply_into_loop(
 ):
     body = prepare_apply_body(op, rewriter)
 
-    body.block.add_op(scf.Yield.get())
+    body.block.add_op(scf.Yield())
     dim: int = ndim
     assert dim == 3
 
@@ -419,7 +419,7 @@ def transform_apply_into_loop(
     current_region = body
     for_op_lst: list[scf.For] = []
     for i in range(1, dim + 1):
-        for_op = scf.For.get(
+        for_op = scf.For(
             lb=lowerBounds[-i],
             ub=upperBounds[-i],
             step=one,
@@ -427,7 +427,7 @@ def transform_apply_into_loop(
             body=current_region,
         )
         for_op_lst.append(for_op)
-        block = Block(ops=[for_op, scf.Yield.get()], arg_types=[builtin.IndexType()])
+        block = Block(ops=[for_op, scf.Yield()], arg_types=[builtin.IndexType()])
         current_region = Region(block)
 
         # if i == 2:
@@ -442,9 +442,9 @@ def transform_apply_into_loop(
             )
 
     y_for_op = for_op_lst[1]
-    p = scf.ParallelOp.get(
-        lowerBounds=[lowerBounds[0]],
-        upperBounds=[upperBounds[0]],
+    p = scf.ParallelOp(
+        lower_bounds=[lowerBounds[0]],
+        upper_bounds=[upperBounds[0]],
         steps=[one],
         body=current_region,
     )
@@ -1172,10 +1172,10 @@ class MakeLocaCopiesOfCoefficients(RewritePattern):
                     builder.insert(load_op)
                     builder.insert(store_op)
 
-                yield_op = scf.Yield.get()
+                yield_op = scf.Yield()
                 builder.insert(yield_op)
 
-            for_local_copies = scf.For.get(lb, ub, step, [], for_body)
+            for_local_copies = scf.For(lb, ub, step, [], for_body)
             rewriter.insert_op_before_matched_op([lb, ub, step, ii, for_local_copies])
 
             self.inserted_already = True

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -342,7 +342,7 @@ class SCFParallelToHLSPipelinedFor(RewritePattern):
         if res != []:
             parallel_block.insert_arg(res[0].type, 1)
             cast(Operation, parallel_block.last_op).detach()
-            yieldop = Yield.get(res[0].op)
+            yieldop = Yield(res[0].op)
             parallel_block.add_op(yieldop)
 
         for_region = Region([parallel_block])
@@ -369,7 +369,7 @@ class SCFParallelToHLSPipelinedFor(RewritePattern):
             for_region.block.insert_op_after(
                 cast(OpResult, step[i + 1]).op, cast(OpResult, ub[i + 1]).op
             )
-            yieldop = Yield.get()
+            yieldop = Yield()
             for_region.block.add_op(yieldop)
             for_op = For.get(lb[i], ub[i], step[i], [], for_region)
 

--- a/xdsl/transforms/lower_affine.py
+++ b/xdsl/transforms/lower_affine.py
@@ -115,7 +115,7 @@ class LowerAffineFor(RewritePattern):
         step_op = arith.Constant(op.step)
         rewriter.insert_op_before_matched_op(step_op)
         rewriter.replace_matched_op(
-            scf.For.get(
+            scf.For(
                 lb_val,
                 ub_val,
                 step_op.result,
@@ -128,7 +128,7 @@ class LowerAffineFor(RewritePattern):
 class LowerAffineYield(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: affine.Yield, rewriter: PatternRewriter, /):
-        rewriter.replace_matched_op(scf.Yield.get(*op.arguments))
+        rewriter.replace_matched_op(scf.Yield(*op.arguments))
 
 
 class LowerAffinePass(ModulePass):

--- a/xdsl/transforms/printf_to_putchar.py
+++ b/xdsl/transforms/printf_to_putchar.py
@@ -90,12 +90,12 @@ def get_mlir_itoa():
         with ImplicitBuilder(before_block) as (running_integer, digits):
             # Stop when you reach zero
             is_zero = arith.Cmpi(running_integer, zero, "ne")
-            scf.Condition.get(is_zero, running_integer, digits)
+            scf.Condition(is_zero, running_integer, digits)
         with ImplicitBuilder(after_block) as (running_integer, previous_digits):
             ten = arith.Constant.from_int_and_width(10, 32)
             new_integer = arith.DivUI(running_integer, ten)
             digits = arith.Addi(previous_digits, one)
-            scf.Yield.get(new_integer, digits)
+            scf.Yield(new_integer, digits)
 
         return while_loop.results[1]
 
@@ -118,17 +118,17 @@ def get_mlir_itoa():
         is_negative = arith.Cmpi(integer, zero, "slt")
 
         # Either way get the absolute value of the number
-        absolute_value = scf.If.get(
+        absolute_value = scf.If(
             is_negative, [i32], [is_negative_block], [is_positive_block]
         )
         # If the value is negative, print the minus sign, return abs value
         with ImplicitBuilder(is_negative_block):
             PrintCharOp.from_constant_char("-")
             negative_input = arith.Subi(zero, integer)
-            scf.Yield.get(negative_input)
+            scf.Yield(negative_input)
         # If the value is positive, just return value itself as abs value
         with ImplicitBuilder(is_positive_block):
-            scf.Yield.get(integer)
+            scf.Yield(integer)
 
         return absolute_value.results[0]
 
@@ -147,7 +147,7 @@ def get_mlir_itoa():
         loop_body = Block(arg_types=(IndexType(),))
 
         # Print all from most significant to least
-        for_loop = scf.For.get(zero_index, digits_index, one_index, (), loop_body)
+        for_loop = scf.For(zero_index, digits_index, one_index, (), loop_body)
         with ImplicitBuilder(loop_body) as (index_var,):
             one = arith.Constant.from_int_and_width(1, i32)
             size_minus_one = arith.Subi(digits, one)
@@ -162,7 +162,7 @@ def get_mlir_itoa():
             char = arith.Addi(digit, ascii_offset)
             char_i8 = arith.TruncIOp(char, i8)
             PrintCharOp(char_i8)
-            scf.Yield.get()
+            scf.Yield()
         return for_loop
 
     # Beginning of mlir_itoa declaration
@@ -183,7 +183,7 @@ def get_mlir_itoa():
         is_zero_block = Block()
         is_not_zero_block = Block()
         is_zero = arith.Cmpi(integer, zero, "eq")
-        scf.If.get(
+        scf.If(
             is_zero,
             [],
             [is_zero_block],
@@ -192,7 +192,7 @@ def get_mlir_itoa():
         # If the value is zero, just print one zero
         with ImplicitBuilder(is_zero_block):
             PrintCharOp.from_constant_char("0")
-            scf.Yield.get()
+            scf.Yield()
         # Otherwise continue with itoa
         with ImplicitBuilder(is_not_zero_block):
             # Print minus sign if negative and return absolute value
@@ -201,7 +201,7 @@ def get_mlir_itoa():
             digits = get_number_of_digits(absolute_value)
             print_digits(digits, absolute_value)
             # Yield from is_not_zero_block
-            scf.Yield.get()
+            scf.Yield()
         # Return from itoa function
         func.Return()
 


### PR DESCRIPTION
Move the `scf` dialect from `.get()` to `__init__` to be more in line with the rest of the project.