### PR TITLE
core: (printer) Allow optional printing of block terminator operations

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -408,7 +408,10 @@ def test_print_block_with_terminator():
     p.print_block(block, print_block_terminator=True)
     assert (
         io.getvalue()
-        == """\n^0:\n  "test.op"() : () -> ()\n  "test.termop"() : () -> ()"""
+        == """
+^0:
+  "test.op"() : () -> ()
+  "test.termop"() : () -> ()"""
     )
 
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -424,14 +424,11 @@ def test_print_block_without_terminator():
     io = StringIO()
     p = Printer(stream=io)
     p.print_block(block, print_block_terminator=False)
-    p.print("\n  ")
-    p.print_op(term_op)
     assert (
         io.getvalue()
         == """
 ^0:
-  "test.op"() : () -> ()
-  "test.termop"() : () -> ()"""
+  "test.op"() : () -> ()"""
     )
 
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -428,7 +428,10 @@ def test_print_block_without_terminator():
     p.print_op(term_op)
     assert (
         io.getvalue()
-        == """\n^0:\n  "test.op"() : () -> ()\n  "test.termop"() : () -> ()"""
+        == """
+^0:
+  "test.op"() : () -> ()
+  "test.termop"() : () -> ()"""
     )
 
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -261,11 +261,7 @@ class Printer:
 
         self._indent += 1
         for op in block.ops:
-            if not (
-                op is block.last_op
-                and op.has_trait(IsTerminator)
-                and not print_block_terminator
-            ):
+            if not (op.has_trait(IsTerminator) and not print_block_terminator):
                 self._print_new_line()
                 self.print_op(op)
         self._indent -= 1

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -261,9 +261,10 @@ class Printer:
 
         self._indent += 1
         for op in block.ops:
-            if not (op.has_trait(IsTerminator) and not print_block_terminator):
-                self._print_new_line()
-                self.print_op(op)
+            if not print_block_terminator and op.has_trait(IsTerminator):
+                continue
+            self._print_new_line()
+            self.print_op(op)
         self._indent -= 1
 
     def print_block_argument(self, arg: BlockArgument, print_type: bool = True) -> None:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -283,14 +283,14 @@ class Printer:
         region: Region,
         print_entry_block_args: bool = True,
         print_empty_block: bool = True,
-        print_block_terminator: bool = True,
+        print_block_terminators: bool = True,
     ) -> None:
         """
         Print a region with syntax `{ <block>* }`
         * If `print_entry_block_args` is False, the arguments of the entry block
           are not printed.
         * If `print_empty_block` is False, empty entry blocks are not printed.
-        * If `print_block_terminator` is False, the block terminators are not printed.
+        * If `print_block_terminators` is False, the block terminators are not printed.
         """
 
         # Empty region
@@ -307,10 +307,10 @@ class Printer:
         self.print_block(
             entry_block,
             print_block_args=print_entry_block_args,
-            print_block_terminator=print_block_terminator,
+            print_block_terminator=print_block_terminators,
         )
         for block in region.blocks[1:]:
-            self.print_block(block, print_block_terminator=print_block_terminator)
+            self.print_block(block, print_block_terminator=print_block_terminators)
         self._print_new_line()
         self.print("}")
 


### PR DESCRIPTION
This PR is part of #1607 and adds:

- Ability to optionally skip printing a terminator operation
- Tests of the above

When this is to happen is left on the specific dialect; the immediate application of this is used in custom printing/parsing in order to avoid printing implicit terminators (this is part of #1607).