### PR TITLE
dialects: (seq) Add ClockType and ClockDivider

### DIFF
--- a/tests/dialects/test_seq.py
+++ b/tests/dialects/test_seq.py
@@ -1,0 +1,24 @@
+import pytest
+
+from xdsl.dialects.builtin import (
+    IntegerAttr,
+    i32,
+)
+from xdsl.dialects.seq import (
+    ClockDivider,
+    clock,
+)
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.test_value import TestSSAValue
+
+
+def test_clockdivider_verify():
+    clock_div = ClockDivider(
+        TestSSAValue(clock),
+        IntegerAttr(512, i32),
+    )
+    with pytest.raises(
+        VerifyException,
+        match="Operation does not verify: pow2 has to be an 8-bit signless integer",
+    ):
+        clock_div.verify()

--- a/tests/filecheck/dialects/seq/seq_invalid.mlir
+++ b/tests/filecheck/dialects/seq/seq_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt --verify-diagnostics --split-input-file %s | filecheck %s
+
+builtin.module {
+  %clk = "test.op"() : () -> (!seq.clock)
+
+  // CHECK: {{Operation does not verify: divider value 5 is not a power of 2}}
+  %div_clk = seq.clock_div %clk by 5
+}

--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -1,6 +1,5 @@
 // RUN: XDSL_ROUNDTRIP
 
-
 builtin.module {
   %clk = "test.op"() : () -> (!seq.clock)
   %div_clk = seq.clock_div %clk by 4

--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -1,0 +1,8 @@
+// RUN: XDSL_ROUNDTRIP
+
+
+builtin.module {
+  %clk = "test.op"() : () -> (!seq.clock)
+  %div_clk = seq.clock_div %clk by 4
+  // CHECK:      %div_clk = seq.clock_div %clk by 4
+}

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -1,0 +1,87 @@
+"""
+CIRCT’s seq dialect
+
+[1] https://circt.llvm.org/docs/Dialects/Seq/
+"""
+
+from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
+    IntegerAttr,
+    IntegerType,
+    TypeAttribute,
+)
+from xdsl.ir import Dialect, Operation, OpResult, SSAValue
+from xdsl.irdl import (
+    IRDLOperation,
+    Operand,
+    ParametrizedAttribute,
+    attr_def,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    result_def,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.utils.exceptions import VerifyException
+
+
+@irdl_attr_definition
+class ClockType(ParametrizedAttribute, TypeAttribute):
+    """
+    A type for clock-carrying wires. Signals which can be used to drive the clock input of sequential operations.
+    """
+
+    name = "seq.clock"
+
+
+clock = ClockType()
+
+
+@irdl_op_definition
+class ClockDivider(IRDLOperation):
+    """Produces a clock divided by a power of two"""
+
+    name = "seq.clock_div"
+
+    pow2 = attr_def(AnyIntegerAttr)
+    clockIn: Operand = operand_def(ClockType)
+    clockOut: OpResult = result_def(ClockType)
+
+    def __init__(self, clockIn: SSAValue | Operation, pow2: int | AnyIntegerAttr):
+        if isinstance(pow2, int):
+            pow2 = IntegerAttr(pow2, IntegerType(8))
+        super().__init__(
+            operands=[clockIn], attributes={"pow2": pow2}, result_types=[clock]
+        )
+
+    def verify_(self) -> None:
+        if self.pow2.type != IntegerType(8):
+            raise VerifyException("pow2 has to be an 8-bit signless integer")
+        if self.pow2.value.data.bit_count() != 1:
+            raise VerifyException(
+                f"divider value {self.pow2.value.data} is not a power of 2"
+            )
+
+    @classmethod
+    def parse(cls, parser: Parser):
+        input_ = parser.parse_operand()
+        parser.parse_keyword("by")
+        divider = parser.parse_integer()
+        return cls(input_, divider)
+
+    def print(self, printer: Printer):
+        printer.print(" ")
+        printer.print_operand(self.clockIn)
+        printer.print(" by ")
+        printer.print(self.pow2.value.data)
+
+
+Seq = Dialect(
+    [
+        ClockDivider,
+    ],
+    [
+        ClockType,
+    ],
+)

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -36,6 +36,7 @@ from xdsl.dialects.riscv import RISCV
 from xdsl.dialects.riscv_func import RISCV_Func
 from xdsl.dialects.riscv_scf import RISCV_Scf
 from xdsl.dialects.scf import Scf
+from xdsl.dialects.seq import Seq
 from xdsl.dialects.snitch import Snitch
 from xdsl.dialects.snitch_runtime import SnitchRuntime
 from xdsl.dialects.stencil import Stencil
@@ -100,6 +101,7 @@ def get_all_dialects() -> list[Dialect]:
         RISCV_Func,
         RISCV_Scf,
         Scf,
+        Seq,
         Snitch,
         SnitchRuntime,
         Stencil,


### PR DESCRIPTION
`seq` dialect first part, as discussed on zulip.

Opened as WIP but looking for feedback. Pinging @superlopuh @tobiasgrosser @compor and @JosseVanDelm as having participated in the discussion on zulip. Not sure who’s signing off on changes down the line.  
There seems to be quite a lot to discuss just on this first type/operation
- One thing nagging me in particular is that printing the `ClockDivider`’s power of 2 attribute with `print_attribute` means we get `seq.clock_div %clk by #int<4>` instead of the input syntax `seq.clock_div %clk by 4` -- should I print the naked `int` value to get the right syntax instead?  It seems to be parsed back fine.
- I haven’t managed to coerce this `pow2` attribute to be signless 8-bit, no matter how much I’ve been messing around with `IntAttr`, `IntegerType`, and other similarly named things. It always seems to be read by `parse_attribute()` as a 32 or 64 bit int -- suggestions welcome here.

Some questions that will need answering before any of this can go forward:

1. What’s the source of truth for a this dialect: CIRCT docs or code? They disagree in major ways, most notably docs define [`ClockType`](https://circt.llvm.org/docs/Dialects/Seq/#type-definition) with syntax `!seq.clock`, and use it throughout operations. This does not exist in the CIRCT codebase and clocks are implemented with `i1`.
2. A number of things in `seq` seem to depend on the `hw` dialect which is not in xdsl at this time. Most CIRCT tests of `seq` things use a `hw.module({})` region, and `hw.constant` values etc. More concretely, the attribute `::circt::hw::InnerSymAttr` is used in a number of  `seq` operations. There are a number of ways forward:
   a. Define a temporary `InnerSymAttr` in `seq` to be replaced by the proper import if/when `hw` is implemented,
   b. Implement operations using an `InnerSymAttr` without that attribute,
   c. Skip all operations using an `InnerSymAttr`,
   d. Create an empty `hw` dialect with just the needed attribute,
   e. Implement `hw` dialect,
   f. Something I didn’t think of?
