### PR TITLE
misc: (makefile) Fix shell invocation in Makefile for venv creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TESTS_COVERAGE_FILE = ${COVERAGE_FILE}.tests
 # set up the venv with all dependencies for development
 venv: requirements-optional.txt requirements.txt
 	python3 -m venv ${VENV_DIR}
-	source ${VENV_DIR}/bin/activate
+	. ${VENV_DIR}/bin/activate
 	python3 -m pip --require-virtualenv install -r requirements-optional.txt -r requirements.txt
 	python3 -m pip --require-virtualenv install -e ".[extras]"
 


### PR DESCRIPTION
This PR replaces the `source` invocation from the `Makefile` when building a virtual env by using the dot operator.

This fails because `make` seems to search the `PATH` for a program called `source`.
The way to invoke a shell script and run its contents in the current shell within a `Makefile` is by using `.` operator (which is also POSIX-compliant).

I saw this fail on @dshaaban01's MacBook last week and I've been able to replicate it on my Linux box.
Not sure how it was missed.