### PR TITLE
documentation: (toy) use RawPtr to read buffer of values

### DIFF
--- a/docs/Toy/toy/emulator/toy_accelerator_instructions.py
+++ b/docs/Toy/toy/emulator/toy_accelerator_instructions.py
@@ -11,8 +11,8 @@ from riscemu.instructions.instruction_set import InstructionSet
 from riscemu.types.instruction import Instruction
 from riscemu.types.int32 import Int32
 
+from xdsl.interpreters.riscv import RawPtr
 from xdsl.interpreters.shaped_array import ShapedArray
-from xdsl.utils.bitwise_casts import convert_u32_to_f32
 
 
 # Define a RISC-V ISA extension by subclassing InstructionSet
@@ -37,12 +37,8 @@ class ToyAccelerator(InstructionSet):
         byte_array = bytearray(value.to_bytes(4, byteorder="little"))
         self.mmu.write(ptr + offset * 4, 4, byte_array)
 
-    def buffer_read(self, ptr: int, len: int, /, offset: int = 0) -> list[int]:
-        return [self.ptr_read(ptr, offset) for offset in range(offset, offset + len)]
-
-    def buffer_write(self, ptr: int, /, data: list[int], offset: int = 0):
-        for i, value in enumerate(data):
-            self.ptr_write(ptr, value=value, offset=offset + i)
+    def buffer_read(self, ptr: int, len: int, /, offset: int = 0) -> RawPtr:
+        return RawPtr(self.mmu.read(ptr + offset, len))
 
     def buffer_copy(self, /, source: int, destination: int, count: int):
         self.mmu.write(destination, count * 4, self.mmu.read(source, count * 4))
@@ -59,9 +55,7 @@ class ToyAccelerator(InstructionSet):
 
         data = self.buffer_read(b_ptr, b_els)
 
-        shaped_array = ShapedArray(
-            [convert_u32_to_f32(value) for value in data], [b_els]
-        )
+        shaped_array = ShapedArray(data.float32.get_list(b_els), [b_els])
 
         print(f"{shaped_array}", file=type(self).stream)
 
@@ -73,12 +67,10 @@ class ToyAccelerator(InstructionSet):
 
         b_ptr, b_rows, b_cols = (self.get_reg(ins.get_reg(i)) for i in range(3))
 
-        size = b_rows * b_cols
-
-        data = self.buffer_read(b_ptr, size)
+        data = self.buffer_read(b_ptr, b_rows * b_cols * 4)
 
         shaped_array = ShapedArray(
-            [convert_u32_to_f32(value) for value in data], [b_rows, b_cols]
+            data.float32.get_list(b_rows * b_cols), [b_rows, b_cols]
         )
 
         print(f"{shaped_array}", file=type(self).stream)

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -145,14 +145,14 @@ def test_riscv_interpreter():
     assert interpreter.run_op(
         riscv.FLdOp(TestSSAValue(register), 8),
         (buffer,),
-    ) == (struct.unpack(">d", struct.pack(">ff", 3.0, 4.0))[0],)
+    ) == (struct.unpack("<d", struct.pack("<ff", 3.0, 4.0))[0],)
 
     assert buffer == test_buffer
 
     assert (
         interpreter.run_op(
             riscv.FSdOp(TestSSAValue(register), TestSSAValue(fregister), 8),
-            (buffer, struct.unpack(">d", struct.pack(">ff", 5.0, 6.0))[0]),
+            (buffer, struct.unpack("<d", struct.pack("<ff", 5.0, 6.0))[0]),
         )
         == ()
     )

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -97,27 +97,27 @@ class RawPtr:
 
     @property
     def int32(self) -> TypedPtr[int]:
-        return TypedPtr(self, ">i")
+        return TypedPtr(self, "<i")
 
     @staticmethod
     def new_int32(els: Sequence[int]) -> RawPtr:
-        return RawPtr.new(">i", [(el,) for el in els])
+        return RawPtr.new("<i", [(el,) for el in els])
 
     @property
     def float32(self) -> TypedPtr[float]:
-        return TypedPtr(self, ">f")
+        return TypedPtr(self, "<f")
 
     @staticmethod
     def new_float32(els: Sequence[float]) -> RawPtr:
-        return RawPtr.new(">f", [(el,) for el in els])
+        return RawPtr.new("<f", [(el,) for el in els])
 
     @property
     def float64(self) -> TypedPtr[float]:
-        return TypedPtr(self, ">d")
+        return TypedPtr(self, "<d")
 
     @staticmethod
     def new_float64(els: Sequence[float]) -> RawPtr:
-        return RawPtr.new(">d", [(el,) for el in els])
+        return RawPtr.new("<d", [(el,) for el in els])
 
 
 @dataclass


### PR DESCRIPTION
A first step towards handling 64-bit values in riscv, removes a bit of custom logic fromt the custom riscemu instructions in Toy. Also aligns our riscv interpreter to riscemu in using little-endian ordering.