### PR TITLE
[RFC] CI: Make ruff flag imports from forbidden modules.

### DIFF
--- a/docs/Toy/toy/rewrites/lower_memref_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_memref_riscv.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 from xdsl.dialects import memref, riscv
 from xdsl.dialects.builtin import ModuleOp, UnrealizedConversionCastOp
-from xdsl.ir.core import MLContext
+from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,

--- a/docs/Toy/toy/rewrites/lower_printf_riscv.py
+++ b/docs/Toy/toy/rewrites/lower_printf_riscv.py
@@ -1,6 +1,6 @@
 from xdsl.dialects import memref, printf, riscv
 from xdsl.dialects.builtin import ModuleOp, UnrealizedConversionCastOp
-from xdsl.ir.core import Attribute, MLContext
+from xdsl.ir import Attribute, MLContext
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,

--- a/docs/Toy/toy/rewrites/setup_riscv_pass.py
+++ b/docs/Toy/toy/rewrites/setup_riscv_pass.py
@@ -1,6 +1,6 @@
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir.core import Block, MLContext, Region
+from xdsl.ir import Block, MLContext, Region
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,

--- a/docs/Toy/toy/tests/test_lower_printf.py
+++ b/docs/Toy/toy/tests/test_lower_printf.py
@@ -1,7 +1,7 @@
 from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import func, memref, printf, riscv
 from xdsl.dialects.builtin import ModuleOp, UnrealizedConversionCastOp, f64
-from xdsl.ir.core import MLContext
+from xdsl.ir import MLContext
 
 from ..rewrites.lower_printf_riscv import LowerPrintfRiscvPass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ typeCheckingMode = "strict"
 profile = "black"
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "UP", "PT"]
+select = ["E", "F", "W", "I", "UP", "PT", "TID251"]
 ignore = [
     "E741",  # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
     "PT006", # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
@@ -36,6 +36,14 @@ ignore = [
 ]
 line-length = 300
 target-version = "py310"
+
+[tool.ruff.flake8-tidy-imports.banned-api]
+"xdsl.parser.core".msg = "Use xdsl.parser instead."
+"xdsl.parser.attribute_parser".msg = "Use xdsl.parser instead."
+"xdsl.parser.affine_parser".msg = "Use xdsl.parser instead."
+"xdsl.ir.core".msg = "Use xdsl.ir instead."
+"xdsl.irdl.irdl".msg = "Use xdsl.irdl instead"
+
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F403"]

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -27,8 +27,7 @@ from xdsl.dialects.memref import (
     Subview,
     UnrankedMemrefType,
 )
-from xdsl.ir import Attribute, OpResult
-from xdsl.ir.core import BlockArgument
+from xdsl.ir import Attribute, BlockArgument, OpResult
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.test_value import TestSSAValue

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -19,7 +19,7 @@ from xdsl.dialects.scf import (
     Yield,
 )
 from xdsl.dialects.test import TestTermOp
-from xdsl.ir.core import Block, BlockArgument, Region
+from xdsl.ir import Block, BlockArgument, Region
 from xdsl.utils.exceptions import DiagnosticException, VerifyException
 
 

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -21,8 +21,7 @@ from xdsl.dialects.vector import (
     Print,
     Store,
 )
-from xdsl.ir import OpResult
-from xdsl.ir.core import Attribute
+from xdsl.ir import Attribute, OpResult
 from xdsl.utils.test_value import TestSSAValue
 
 

--- a/tests/interpreters/test_cf_interpreter.py
+++ b/tests/interpreters/test_cf_interpreter.py
@@ -7,7 +7,7 @@ from xdsl.interpreter import Interpreter
 from xdsl.interpreters.arith import ArithFunctions
 from xdsl.interpreters.cf import CfFunctions
 from xdsl.interpreters.func import FuncFunctions
-from xdsl.ir.core import Block, Region
+from xdsl.ir import Block, Region
 
 
 def sum_to_fn(n: int) -> int:

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -5,8 +5,7 @@ import pytest
 from xdsl.builder import Builder
 from xdsl.dialects import riscv, riscv_func
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import MLContext
-from xdsl.ir.core import BlockArgument
+from xdsl.ir import BlockArgument, MLContext
 from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
 
 pytest.importorskip("riscemu", reason="riscemu is an optional dependency")

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -5,7 +5,7 @@ from xdsl.dialects import riscv, riscv_func
 from xdsl.dialects.builtin import IndexType, ModuleOp
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters.riscv_func import RiscvFuncFunctions
-from xdsl.ir.core import BlockArgument
+from xdsl.ir import BlockArgument
 
 index = IndexType()
 

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -7,7 +7,7 @@ from xdsl.dialects import riscv
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.interpreter import Interpreter, PythonValues
 from xdsl.interpreters.riscv import RawPtr, RiscvFunctions
-from xdsl.ir.core import Block, Region
+from xdsl.ir import Block, Region
 from xdsl.utils.bitwise_casts import convert_f32_to_u32
 from xdsl.utils.exceptions import InterpretationError
 from xdsl.utils.test_value import TestSSAValue

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -7,7 +7,7 @@ from xdsl.interpreter import Interpreter
 from xdsl.interpreters.func import FuncFunctions
 from xdsl.interpreters.riscv import RiscvFunctions
 from xdsl.interpreters.riscv_scf import RiscvScfFunctions
-from xdsl.ir.core import BlockArgument
+from xdsl.ir import BlockArgument
 
 index = IndexType()
 register = riscv.IntRegisterType.unallocated()

--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -7,7 +7,7 @@ from xdsl.interpreter import Interpreter
 from xdsl.interpreters.arith import ArithFunctions
 from xdsl.interpreters.func import FuncFunctions
 from xdsl.interpreters.scf import ScfFunctions
-from xdsl.ir.core import BlockArgument
+from xdsl.ir import BlockArgument
 
 index = IndexType()
 

--- a/tests/interpreters/test_wgsl_printer.py
+++ b/tests/interpreters/test_wgsl_printer.py
@@ -3,8 +3,8 @@ from io import StringIO
 from xdsl.dialects import arith, builtin, gpu, memref, test
 from xdsl.dialects.builtin import IndexType, IntegerAttr, IntegerType, i32
 from xdsl.interpreters.experimental.wgsl_printer import WGSLPrinter
-from xdsl.ir.core import MLContext
-from xdsl.parser.core import Parser
+from xdsl.ir import MLContext
+from xdsl.parser import Parser
 from xdsl.utils.test_value import TestSSAValue
 
 lhs_op = test.TestOp(result_types=[IndexType()])

--- a/tests/transforms/test_lower_affine.py
+++ b/tests/transforms/test_lower_affine.py
@@ -2,9 +2,9 @@ import pytest
 
 from xdsl.dialects import arith
 from xdsl.dialects.builtin import IndexType, IntegerAttr
+from xdsl.ir import Operation, SSAValue
 from xdsl.ir.affine import AffineExpr
 from xdsl.ir.affine.affine_expr import AffineBinaryOpExpr, AffineBinaryOpKind
-from xdsl.ir.core import Operation, SSAValue
 from xdsl.transforms.lower_affine import affine_expr_ops
 from xdsl.utils.test_value import TestSSAValue
 

--- a/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
@@ -15,7 +15,7 @@ from xdsl.dialects.builtin import (
     ModuleOp,
     UnrealizedConversionCastOp,
 )
-from xdsl.ir.core import MLContext, Operation
+from xdsl.ir import MLContext, Operation
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
+++ b/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
@@ -7,8 +7,7 @@ from xdsl.backend.riscv.lowering.utils import (
 )
 from xdsl.dialects import func, riscv, riscv_func
 from xdsl.dialects.builtin import ModuleOp, UnrealizedConversionCastOp
-from xdsl.ir import MLContext
-from xdsl.ir.core import Block, Operation, Region
+from xdsl.ir import Block, MLContext, Operation, Region
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -14,8 +14,7 @@ from xdsl.dialects.builtin import (
     ModuleOp,
     UnrealizedConversionCastOp,
 )
-from xdsl.ir import MLContext, Operation, SSAValue
-from xdsl.ir.core import Attribute
+from xdsl.ir import Attribute, MLContext, Operation, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/xdsl/backend/riscv/lowering/reduce_register_pressure.py
+++ b/xdsl/backend/riscv/lowering/reduce_register_pressure.py
@@ -3,7 +3,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     ModuleOp,
 )
-from xdsl.ir.core import MLContext
+from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -17,8 +17,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
 )
 from xdsl.dialects.llvm import FastMathAttr as LLVMFastMathAttr
-from xdsl.ir import Dialect, Operation, OpResult, SSAValue
-from xdsl.ir.core import Attribute
+from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
 from xdsl.irdl import (
     AnyOf,
     ConstraintVar,

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -11,8 +11,7 @@ from collections.abc import Sequence
 from typing import Annotated
 
 from xdsl.dialects.builtin import IntegerAttr, IntegerType, UnitAttr, i32, i64
-from xdsl.ir import Dialect, Operation, OpResult, SSAValue
-from xdsl.ir.core import Attribute
+from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
 from xdsl.irdl import (
     ConstraintVar,
     IRDLOperation,

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -11,8 +11,7 @@ from xdsl.dialects.builtin import (
     TupleType,
     UnitAttr,
 )
-from xdsl.ir import Attribute, Dialect, ParametrizedAttribute, TypeAttribute
-from xdsl.ir.core import OpResult
+from xdsl.ir import Attribute, Dialect, OpResult, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,

--- a/xdsl/dialects/experimental/hls.py
+++ b/xdsl/dialects/experimental/hls.py
@@ -7,8 +7,7 @@ from xdsl.dialects.builtin import (
     ParametrizedAttribute,
     StringAttr,
 )
-from xdsl.ir import Dialect, Operation, OpResult, SSAValue, TypeAttribute
-from xdsl.ir.core import Region
+from xdsl.ir import Dialect, Operation, OpResult, Region, SSAValue, TypeAttribute
 from xdsl.irdl import (
     AnyAttr,
     IRDLOperation,

--- a/xdsl/dialects/fsm.py
+++ b/xdsl/dialects/fsm.py
@@ -13,15 +13,18 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import (
     Attribute,
     Block,
+    Dialect,
     Operation,
+    ParametrizedAttribute,
     Region,
     SSAValue,
+    TypeAttribute,
 )
-from xdsl.ir.core import Dialect, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (
     AnyAttr,
     IRDLOperation,
     attr_def,
+    irdl_attr_definition,
     irdl_op_definition,
     operand_def,
     opt_attr_def,
@@ -31,7 +34,6 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.irdl.irdl import irdl_attr_definition
 from xdsl.traits import (
     HasParent,
     IsTerminator,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -17,6 +17,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import (
     Attribute,
+    Block,
     Dialect,
     Operation,
     OpResult,
@@ -25,7 +26,6 @@ from xdsl.ir import (
     SSAValue,
     TypeAttribute,
 )
-from xdsl.ir.core import Block
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,

--- a/xdsl/dialects/irdl/pyrdl_to_irdl.py
+++ b/xdsl/dialects/irdl/pyrdl_to_irdl.py
@@ -8,7 +8,7 @@ from xdsl.dialects.irdl.irdl import (
     ParametersOp,
     ResultsOp,
 )
-from xdsl.ir.core import Block, Dialect, ParametrizedAttribute, Region, SSAValue
+from xdsl.ir import Block, Dialect, ParametrizedAttribute, Region, SSAValue
 from xdsl.irdl import AttrConstraint, IRDLOperation
 
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -26,7 +26,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.parser.attribute_parser import AttrParser
+from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import IsTerminator
 

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -34,7 +34,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.parser.core import Parser
+from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import CallableOpInterface, HasParent, IsTerminator, SymbolOpInterface
 from xdsl.utils.exceptions import VerifyException

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -3,8 +3,7 @@ from collections.abc import Sequence
 from typing import Annotated, Generic, TypeVar
 
 from xdsl.dialects.builtin import IndexType, i32, i64
-from xdsl.ir import Attribute, Dialect, OpResult
-from xdsl.ir.core import Operation, SSAValue
+from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     ConstraintVar,

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -13,11 +13,11 @@ from xdsl.ir import (
     Dialect,
     Operation,
     OpResult,
+    ParametrizedAttribute,
     Region,
     SSAValue,
     TypeAttribute,
 )
-from xdsl.ir.core import ParametrizedAttribute
 from xdsl.irdl import (
     IRDLOperation,
     Operand,

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -12,8 +12,7 @@ from typing import (
 )
 
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import Operation, OperationInvT, SSAValue
-from xdsl.ir.core import Attribute, Block, Region
+from xdsl.ir import Attribute, Block, Operation, OperationInvT, Region, SSAValue
 from xdsl.traits import CallableOpInterface, IsTerminator, SymbolOpInterface
 from xdsl.utils.exceptions import InterpretationError
 

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 import wgpu  # pyright: ignore
 import wgpu.utils  # pyright: ignore
+
 from xdsl.dialects import gpu
 from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.memref import MemRefType

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -4,14 +4,13 @@ from typing import Any, cast
 
 import wgpu  # pyright: ignore
 import wgpu.utils  # pyright: ignore
-
 from xdsl.dialects import gpu
 from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.memref import MemRefType
 from xdsl.interpreter import Interpreter, InterpreterFunctions, impl, register_impls
 from xdsl.interpreters.experimental.wgsl_printer import WGSLPrinter
 from xdsl.interpreters.shaped_array import ShapedArray
-from xdsl.ir.core import Attribute, SSAValue
+from xdsl.ir import Attribute, SSAValue
 from xdsl.traits import SymbolTable
 from xdsl.utils.hints import isa
 

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -5,8 +5,7 @@ from typing import IO, cast
 
 from xdsl.dialects import arith, builtin, gpu, memref
 from xdsl.dialects.memref import MemRefType
-from xdsl.ir import Operation, SSAValue
-from xdsl.ir.core import Attribute
+from xdsl.ir import Attribute, Operation, SSAValue
 from xdsl.utils.hints import isa
 
 

--- a/xdsl/interpreters/memref.py
+++ b/xdsl/interpreters/memref.py
@@ -11,7 +11,7 @@ from xdsl.interpreter import (
     register_impls,
 )
 from xdsl.interpreters.shaped_array import ShapedArray
-from xdsl.ir.core import Attribute
+from xdsl.ir import Attribute
 from xdsl.traits import SymbolTable
 from xdsl.utils.exceptions import InterpretationError
 

--- a/xdsl/ir/__init__.py
+++ b/xdsl/ir/__init__.py
@@ -1,1 +1,3 @@
-from .core import *
+# TID 251 enforces to not import from core
+# We need to skip it here to allow importing from here instead.
+from .core import *  # noqa: TID251

--- a/xdsl/irdl/__init__.py
+++ b/xdsl/irdl/__init__.py
@@ -1,1 +1,3 @@
-from .irdl import *
+# TID 251 enforces to not import from nested irdl
+# We need to skip it here to allow importing from here instead.
+from .irdl import *  # noqa: TID251

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -26,6 +26,7 @@ from typing import (
 
 from xdsl.ir import (
     Attribute,
+    AttributeInvT,
     Block,
     Data,
     Operation,
@@ -35,7 +36,6 @@ from xdsl.ir import (
     Region,
     SSAValue,
 )
-from xdsl.ir.core import AttributeInvT
 from xdsl.utils.diagnostic import Diagnostic
 from xdsl.utils.exceptions import (
     ParseError,

--- a/xdsl/parser/__init__.py
+++ b/xdsl/parser/__init__.py
@@ -1,4 +1,7 @@
 # To avoid circular imports, affine_parser needs to be imported first
-from .affine_parser import *
-from .attribute_parser import *
-from .core import *
+
+# TID 251 enforces to not import from nested modules
+# We need to skip it here to allow importing from here instead.
+from .affine_parser import *  # noqa: TID251
+from .attribute_parser import *  # noqa: TID251
+from .core import *  # noqa: TID251

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal, NoReturn, cast
 
-import xdsl.parser.affine_parser as affine_parser
+import xdsl.parser as affine_parser
 from xdsl.dialects.builtin import (
     AffineMapAttr,
     AnyArrayAttr,

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -19,8 +19,7 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.irdl import IRDLOperation
-from xdsl.parser.attribute_parser import AttrParser
-from xdsl.parser.base_parser import ParserState, Position
+from xdsl.parser import AttrParser, ParserState, Position
 from xdsl.utils.exceptions import MultipleSpansParseError
 from xdsl.utils.lexer import Input, Lexer, Span, Token
 

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import IntegerAttr
-from xdsl.ir.core import OpResult
+from xdsl.ir import OpResult
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -43,8 +43,16 @@ from xdsl.dialects.stencil import (
     StencilBoundsAttr,
     TempType,
 )
-from xdsl.ir import Attribute, MLContext, Operation, OpResult, SSAValue
-from xdsl.ir.core import Block, BlockArgument, Region
+from xdsl.ir import (
+    Attribute,
+    Block,
+    BlockArgument,
+    MLContext,
+    Operation,
+    OpResult,
+    Region,
+    SSAValue,
+)
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -26,8 +26,7 @@ from xdsl.dialects.llvm import (
     StoreOp,
 )
 from xdsl.dialects.scf import For, ParallelOp, Yield
-from xdsl.ir import Block, MLContext, Operation, OpResult, Region
-from xdsl.ir.core import Use
+from xdsl.ir import Block, MLContext, Operation, OpResult, Region, Use
 from xdsl.irdl import VarOperand, VarOpResult
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (

--- a/xdsl/transforms/experimental/stencil_storage_materialization.py
+++ b/xdsl/transforms/experimental/stencil_storage_materialization.py
@@ -1,7 +1,6 @@
 from xdsl.dialects import builtin
 from xdsl.dialects.stencil import ApplyOp, BufferOp, StoreOp
-from xdsl.ir import MLContext, SSAValue
-from xdsl.ir.core import OpResult
+from xdsl.ir import MLContext, OpResult, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/xdsl/transforms/lower_affine.py
+++ b/xdsl/transforms/lower_affine.py
@@ -1,5 +1,5 @@
 from xdsl.dialects import affine, arith, builtin, memref, scf
-from xdsl.ir import MLContext, SSAValue
+from xdsl.ir import MLContext, Operation, SSAValue
 from xdsl.ir.affine import AffineConstantExpr
 from xdsl.ir.affine.affine_expr import (
     AffineBinaryOpExpr,
@@ -7,7 +7,6 @@ from xdsl.ir.affine.affine_expr import (
     AffineDimExpr,
     AffineSymExpr,
 )
-from xdsl.ir.core import Operation
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,

--- a/xdsl/transforms/mlir_opt.py
+++ b/xdsl/transforms/mlir_opt.py
@@ -5,7 +5,7 @@ from io import StringIO
 
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import MLContext
-from xdsl.parser.core import Parser
+from xdsl.parser import Parser
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.printer import Printer

--- a/xdsl/transforms/reconcile_unrealized_casts.py
+++ b/xdsl/transforms/reconcile_unrealized_casts.py
@@ -5,8 +5,7 @@ from warnings import warn
 
 from xdsl.dialects import builtin
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import MLContext
-from xdsl.ir.core import Use
+from xdsl.ir import MLContext, Use
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import PatternRewriter
 

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -1,5 +1,5 @@
 from xdsl.dialects import builtin, riscv, riscv_scf
-from xdsl.ir.core import MLContext
+from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     PatternRewriter,


### PR DESCRIPTION
RFC Because I'm not sure if we're interested in doing it this way?

We try in reviews to prevent imports from some modules (`xdsl.parser.X`, `xdsl.irdl.irdl` and `xdsl.ir.core`, to my knowledge. please tell me if I missed some.)
It feels to me like something we want a tool to check.

Ruff has a rule for it.

- CON: No auto-fix provided. it is the developer's responsibility to fix it.
- PRO: Well, it automatically finds them. Also allows for a clear to-the-point error message to not make the user scratch his/her head too much.

Also note that for those cases, it's always only about removing the last nested module from the from, it's really not cumbersome, for what it's worth. It then often leads to misformatted imports, but *those* are then auto-fixed.

WDYT?