### PR TITLE
interpreter: add mechanism to store runtime data in the interpreter

### DIFF
--- a/docs/Toy/toy/__main__.py
+++ b/docs/Toy/toy/__main__.py
@@ -115,9 +115,7 @@ def main(path: Path, emit: str, ir: bool, print_generic: bool):
         interpreter.register_implementations(BuiltinFunctions())
 
     if emit in ("riscv", "riscv-opt", "riscv-regalloc", "riscv-regalloc-opt"):
-        interpreter.register_implementations(
-            ToyAcceleratorInstructionFunctions(module_op)
-        )
+        interpreter.register_implementations(ToyAcceleratorInstructionFunctions())
         interpreter.register_implementations(RiscvFuncFunctions())
         interpreter.register_implementations(RiscvScfFunctions())
 

--- a/docs/Toy/toy/emulator/toy_accelerator_instruction_functions.py
+++ b/docs/Toy/toy/emulator/toy_accelerator_instruction_functions.py
@@ -1,14 +1,12 @@
 from xdsl.dialects import riscv
-from xdsl.dialects.builtin import ModuleOp
 from xdsl.interpreter import Interpreter, PythonValues
 from xdsl.interpreters.riscv import RawPtr, RiscvFunctions
 from xdsl.interpreters.shaped_array import ShapedArray
 
 
 class ToyAcceleratorInstructionFunctions(RiscvFunctions):
-    def __init__(self, module_op: ModuleOp):
+    def __init__(self):
         super().__init__(
-            module_op,
             custom_instructions={
                 "tensor.print1d": accelerator_tensor_print1d,
                 "tensor.print2d": accelerator_tensor_print2d,

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -21,13 +21,20 @@ def test_riscv_interpreter():
     ) -> PythonValues:
         return args
 
-    module_op = ModuleOp([])
+    module_op = ModuleOp(
+        [
+            riscv.AssemblySectionOp(
+                ".data",
+                Region(
+                    Block([riscv.LabelOp("label0"), riscv.DirectiveOp(".word", "2A")])
+                ),
+            )
+        ]
+    )
     register = riscv.IntRegisterType.unallocated()
     fregister = riscv.FloatRegisterType.unallocated()
 
     riscv_functions = RiscvFunctions(
-        module_op,
-        data={"label0": RawPtr.new_int32([42])},
         custom_instructions={"my_custom_instruction": my_custom_instruction},
     )
     interpreter = Interpreter(module_op)

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -47,7 +47,7 @@ def interp(module_op: ModuleOp, func_name: str, n: int) -> int:
     module_op.verify()
     interpreter = Interpreter(module_op)
     interpreter.register_implementations(RiscvScfFunctions())
-    interpreter.register_implementations(RiscvFunctions(module_op))
+    interpreter.register_implementations(RiscvFunctions())
     interpreter.register_implementations(FuncFunctions())
     (result,) = interpreter.call_op(func_name, (n,))
     return result

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -112,3 +112,24 @@ def test_external_func():
     i.call_op("testfunc", (100,))
 
     assert funcs.a == 100
+
+
+def test_interpreter_data():
+    class Funcs0(InterpreterFunctions):
+        ...
+
+    class Funcs1(InterpreterFunctions):
+        ...
+
+    interpreter = Interpreter(ModuleOp([]))
+
+    obj1 = interpreter.get_data(Funcs0, "a", lambda: {"b": 2})
+    assert obj1 == {"b": 2}
+
+    obj1["c"] = 3
+
+    assert interpreter.get_data(Funcs0, "a", lambda: {"b": 2}) == {"b": 2, "c": 3}
+
+    assert interpreter.get_data(Funcs0, "d", lambda: {"b": 2}) == {"b": 2}
+
+    assert interpreter.get_data(Funcs1, "a", lambda: {"b": 2}) == {"b": 2}

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -421,6 +421,12 @@ class Interpreter:
     )
     file: IO[str] | None = field(default=None)
     _symbol_table: dict[str, Operation] | None = None
+    _impl_data: dict[type[InterpreterFunctions], dict[str, Any]] = field(
+        default_factory=dict
+    )
+    """
+    Runtime data associated with an interpreter function implementation.
+    """
 
     @property
     def symbol_table(self) -> dict[str, Operation]:
@@ -581,6 +587,26 @@ class Interpreter:
             return self.symbol_table[symbol]
         else:
             raise InterpretationError(f'Could not find symbol "{symbol}"')
+
+    def get_data(
+        self,
+        functions: type[InterpreterFunctions],
+        key: str,
+        factory: Callable[[], Any],
+    ) -> Any:
+        if functions not in self._impl_data:
+            functions_data = {}
+            self._impl_data = functions_data
+        else:
+            functions_data = self._impl_data[functions]
+
+        if key not in functions_data:
+            data = factory()
+            functions_data[key] = data
+        else:
+            data = functions_data[key]
+
+        return data
 
     def print(self, *args: Any, **kwargs: Any):
         """Print to current file."""

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -601,7 +601,7 @@ class Interpreter:
         """
         if functions not in self._impl_data:
             functions_data = {}
-            self._impl_data = functions_data
+            self._impl_data[functions] = functions_data
         else:
             functions_data = self._impl_data[functions]
 

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -425,7 +425,7 @@ class Interpreter:
         default_factory=dict
     )
     """
-    Runtime data associated with an interpreter function implementation.
+    Runtime data associated with an interpreter functions implementation.
     """
 
     @property
@@ -594,6 +594,11 @@ class Interpreter:
         key: str,
         factory: Callable[[], Any],
     ) -> Any:
+        """
+        Get data associated with a specific interpreter functions class, with a given key.
+        If the data is missing, the `factory` argument will be executed and stored on the
+        interpreter.
+        """
         if functions not in self._impl_data:
             functions_data = {}
             self._impl_data = functions_data

--- a/xdsl/tools/xdsl_run.py
+++ b/xdsl/tools/xdsl_run.py
@@ -4,7 +4,6 @@ import argparse
 import sys
 from collections.abc import Sequence
 
-from xdsl.dialects.builtin import ModuleOp
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters import (
     affine,
@@ -53,10 +52,10 @@ class xDSLRunMain(CommandLineTool):
         )
         return super().register_all_arguments(arg_parser)
 
-    def register_implementations(self, interpreter: Interpreter, module: ModuleOp):
+    def register_implementations(self, interpreter: Interpreter):
         interpreter.register_implementations(func.FuncFunctions())
         interpreter.register_implementations(cf.CfFunctions())
-        interpreter.register_implementations(riscv.RiscvFunctions(module))
+        interpreter.register_implementations(riscv.RiscvFunctions())
         interpreter.register_implementations(riscv_func.RiscvFuncFunctions())
         interpreter.register_implementations(riscv_libc.RiscvLibcFunctions())
         interpreter.register_implementations(pdl.PDLRewriteFunctions(self.ctx))
@@ -78,7 +77,7 @@ class xDSLRunMain(CommandLineTool):
             if module is not None:
                 module.verify()
                 interpreter = Interpreter(module)
-                self.register_implementations(interpreter, module)
+                self.register_implementations(interpreter)
                 result = interpreter.call_op("main", ())
                 print(f"result: {result}")
         finally:


### PR DESCRIPTION
This is necessary for some further interpreter changes. The interpreter function implementations are suposed to be stateless, and the riscv interpreter functions currently violate that, by caching the data on the functions object itself. This PR fixes that by introducing a new cache on the interpreter object, which is stateful already.