### PR TITLE
backend: (riscv) use stack for float constants

### DIFF
--- a/tests/filecheck/backend/riscv/riscv_arith_lowering.mlir
+++ b/tests/filecheck/backend/riscv/riscv_arith_lowering.mlir
@@ -8,12 +8,16 @@ builtin.module {
     // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
     %rhsindex = "arith.constant"() {value = 2 : index} : () -> index
     // CHECK-NEXT: %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
-    %lhsf32 = "arith.constant"() {value = 1.000000e+00 : f32} : () -> f32
+    %lhsf32_reg, %rhsf32_reg = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>)
+    %lhsf32 = builtin.unrealized_conversion_cast %lhsf32_reg : !riscv.freg<> to f32
+    %rhsf32 = builtin.unrealized_conversion_cast %rhsf32_reg : !riscv.freg<> to f32
+    // CHECK-NEXT: %lhsf32_reg, %rhsf32_reg = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>)
+
+    %f32 = "arith.constant"() {value = 1.000000e+00 : f32} : () -> f32
+    // CHECK-NEXT: %{{.*}} = riscv.get_register : () -> !riscv.reg<sp>
     // CHECK-NEXT: %{{.*}} = riscv.li 1065353216 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %lhsf32 : (!riscv.reg<>) -> !riscv.freg<>
-    %rhsf32 = "arith.constant"() {value = 2.000000e+00 : f32} : () -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.li 1073741824 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %rhsf32 : (!riscv.reg<>) -> !riscv.freg<>
+    // CHECK-NEXT: riscv.sw {{.*}}, {{.*}}, -4 : (!riscv.reg<sp>, !riscv.reg<>) -> ()
+    // CHECK-NEXT: %{{.*}} = riscv.flw {{.*}}, -4 : (!riscv.reg<sp>) -> !riscv.freg<>
 
     %addi32 = "arith.addi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
     // CHECK-NEXT: %{{.*}} = riscv.add %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
@@ -78,64 +82,64 @@ builtin.module {
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpi7, 1 : (!riscv.reg<>) -> !riscv.reg<>
 
     %addf32 = "arith.addf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %subf32 = "arith.subf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %mulf32 = "arith.mulf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %divf32 = "arith.divf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %negf32 = "arith.negf"(%rhsf32) : (f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnjn.s %rhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsgnjn.s %rhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %sitofp = "arith.sitofp"(%lhsi32) : (i32) -> f32
     // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %lhsi32 : (!riscv.reg<>) -> !riscv.freg<>
     %fptosi = "arith.fptosi"(%lhsf32) : (f32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %lhsf32_1 : (!riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %lhsf32_reg : (!riscv.freg<>) -> !riscv.reg<>
 
     %cmpf0 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 0 : i32} : (f32, f32) -> i1
     // CHECK-NEXT: %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
     %cmpf1 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 1 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %cmpf2 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 2 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %cmpf3 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 3 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %cmpf4 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 4 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %cmpf5 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 5 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     %cmpf6 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 6 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.or %cmpf6_1, %cmpf6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %cmpf7 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 7 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.and %cmpf7_1, %cmpf7 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     %cmpf8 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 8 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.or %cmpf8_1, %cmpf8 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf8_2, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %cmpf9 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 9 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf9, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %cmpf10 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 10 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf10, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %cmpf11 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 11 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf11, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %cmpf12 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 12 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf12, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %cmpf13 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 13 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf13, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %cmpf14 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 14 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_reg, %lhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_reg, %rhsf32_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.and %cmpf14_1, %cmpf14 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf14_2, 1 : (!riscv.reg<>) -> !riscv.reg<>
     %cmpf15 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 15 : i32} : (f32, f32) -> i1


### PR DESCRIPTION
The current use of fcvt relies on an incorrect implementation in riscemu. This patch changes the arith.const lowering to mirror the way llvm and gcc do things, which is to load the bits into a register, store them to memory, and then load from memory again. There's no standard instruction in RISC-V to do this from register to register. Once this PR is merged, we can update riscemu version.