### PR TITLE
dialects: (builtin) Add bitwidth accessor to float types

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -39,12 +39,12 @@ from xdsl.utils.exceptions import VerifyException
 
 
 def test_FloatType_bitwidths():
-    assert BFloat16Type().width.data == 16
-    assert Float16Type().width.data == 16
-    assert Float32Type().width.data == 32
-    assert Float64Type().width.data == 64
-    assert Float80Type().width.data == 80
-    assert Float128Type().width.data == 128
+    assert BFloat16Type().get_bitwidth == 16
+    assert Float16Type().get_bitwidth == 16
+    assert Float32Type().get_bitwidth == 32
+    assert Float64Type().get_bitwidth == 64
+    assert Float80Type().get_bitwidth == 80
+    assert Float128Type().get_bitwidth == 128
 
 
 def test_DenseIntOrFPElementsAttr_fp_type_conversion():

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -39,12 +39,12 @@ from xdsl.utils.exceptions import VerifyException
 
 
 def test_FloatType_bitwidths():
-    assert BFloat16Type().get_bitwidth == 16
-    assert Float16Type().get_bitwidth == 16
-    assert Float32Type().get_bitwidth == 32
-    assert Float64Type().get_bitwidth == 64
-    assert Float80Type().get_bitwidth == 80
-    assert Float128Type().get_bitwidth == 128
+    assert BFloat16Type().width.data == 16
+    assert Float16Type().width.data == 16
+    assert Float32Type().width.data == 32
+    assert Float64Type().width.data == 64
+    assert Float80Type().width.data == 80
+    assert Float128Type().width.data == 128
 
 
 def test_DenseIntOrFPElementsAttr_fp_type_conversion():

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -7,10 +7,16 @@ from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import (
     AnyTensorType,
     ArrayAttr,
+    BFloat16Type,
     ComplexType,
     CustomErrorMessageAttrConstraint,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
+    Float16Type,
+    Float32Type,
+    Float64Type,
+    Float80Type,
+    Float128Type,
     FloatAttr,
     FloatData,
     IntAttr,
@@ -30,6 +36,15 @@ from xdsl.dialects.memref import MemRefType
 from xdsl.ir import Attribute
 from xdsl.irdl import AttrConstraint
 from xdsl.utils.exceptions import VerifyException
+
+
+def test_FloatType_bitwidths():
+    assert BFloat16Type().get_bitwidth == 16
+    assert Float16Type().get_bitwidth == 16
+    assert Float32Type().get_bitwidth == 32
+    assert Float64Type().get_bitwidth == 64
+    assert Float80Type().get_bitwidth == 80
+    assert Float128Type().get_bitwidth == 128
 
 
 def test_DenseIntOrFPElementsAttr_fp_type_conversion():

--- a/tests/filecheck/parser-printer/float_parsing.mlir
+++ b/tests/filecheck/parser-printer/float_parsing.mlir
@@ -11,12 +11,12 @@
   "test.op"() {"value" = 34.e0 : f32} : () -> ()
   // CHECK-NEXT: "test.op"() {"value" = 3.400000e+01 : f32} : () -> ()
 
-  "test.op"() {"value" = 34.e-23 : !f32} : () -> ()
+  "test.op"() {"value" = 34.e-23 : f32} : () -> ()
   // CHECK-NEXT: "test.op"() {"value" = 3.400000e-22 : f32} : () -> ()
 
   "test.op"() {"value" = 34.e12 : f32} : () -> ()
   // CHECK-NEXT: "test.op"() {"value" = 3.400000e+13 : f32} : () -> ()
 
-  "test.op"() {"value" = -34.e-12 : !f32} : () -> ()
+  "test.op"() {"value" = -34.e-12 : f32} : () -> ()
   // CHECK-NEXT: "test.op"() {"value" = -3.400000e-11 : f32} : () -> ()
 }) : () -> ()

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -62,7 +62,7 @@ def memref_shape_ops(
                 )
             bytes_per_element = element_type.width.data // 8
         case Float32Type():
-            bytes_per_element = 4
+            bytes_per_element = element_type.get_bitwidth // 8
         case _:
             raise DiagnosticException(
                 f"Unsupported memref element type for riscv lowering: {element_type}"

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -66,7 +66,7 @@ def memref_shape_ops(
         case Float32Type():
             bytes_per_element = element_type.get_bitwidth // 8
         case Float64Type():
-            bytes_per_element = 8
+            bytes_per_element = element_type.get_bitwidth // 8
         case _:
             raise DiagnosticException(
                 f"Unsupported memref element type for riscv lowering: {element_type}"

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -64,9 +64,9 @@ def memref_shape_ops(
                 )
             bytes_per_element = element_type.width.data // 8
         case Float32Type():
-            bytes_per_element = element_type.get_bitwidth // 8
+            bytes_per_element = element_type.width.data // 8
         case Float64Type():
-            bytes_per_element = element_type.get_bitwidth // 8
+            bytes_per_element = element_type.width.data // 8
         case _:
             raise DiagnosticException(
                 f"Unsupported memref element type for riscv lowering: {element_type}"

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -64,9 +64,9 @@ def memref_shape_ops(
                 )
             bytes_per_element = element_type.width.data // 8
         case Float32Type():
-            bytes_per_element = element_type.width.data // 8
+            bytes_per_element = element_type.get_bitwidth // 8
         case Float64Type():
-            bytes_per_element = element_type.width.data // 8
+            bytes_per_element = element_type.get_bitwidth // 8
         case _:
             raise DiagnosticException(
                 f"Unsupported memref element type for riscv lowering: {element_type}"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -423,34 +423,73 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
 
+class FloatType(ParametrizedAttribute, TypeAttribute, ABC):
+    width: ParameterDef[IntAttr]
+
+    def __init__(self, width: int | IntAttr) -> None:
+        if isinstance(width, int):
+            width = IntAttr(width)
+        super().__init__([width])
+
+    @property
+    def get_bitwidth(self) -> int:
+        return self.width.data
+
+    # @classmethod
+    # def parse_parameter(cls, parser: AttrParser) -> int:
+    # data = parser.parse_integer()
+    # return data
+
+    # def print_parameter(self, printer: Printer) -> None:
+    # printer.print_string(f"{self.data}")
+
+
 @irdl_attr_definition
-class BFloat16Type(ParametrizedAttribute, TypeAttribute):
+class BFloat16Type(FloatType):
     name = "bf16"
 
+    def __init__(self) -> None:
+        super().__init__(16)
+
 
 @irdl_attr_definition
-class Float16Type(ParametrizedAttribute, TypeAttribute):
+class Float16Type(FloatType):
     name = "f16"
 
+    def __init__(self) -> None:
+        super().__init__(16)
+
 
 @irdl_attr_definition
-class Float32Type(ParametrizedAttribute, TypeAttribute):
+class Float32Type(FloatType):
     name = "f32"
 
+    def __init__(self) -> None:
+        super().__init__(32)
+
 
 @irdl_attr_definition
-class Float64Type(ParametrizedAttribute, TypeAttribute):
+class Float64Type(FloatType):
     name = "f64"
 
+    def __init__(self) -> None:
+        super().__init__(64)
+
 
 @irdl_attr_definition
-class Float80Type(ParametrizedAttribute, TypeAttribute):
+class Float80Type(FloatType):
     name = "f80"
 
+    def __init__(self) -> None:
+        super().__init__(80)
+
 
 @irdl_attr_definition
-class Float128Type(ParametrizedAttribute, TypeAttribute):
+class Float128Type(FloatType):
     name = "f128"
+
+    def __init__(self) -> None:
+        super().__init__(128)
 
 
 AnyFloat: TypeAlias = (

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -423,9 +423,7 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
 
-@irdl_attr_definition
 class _FloatType(ParametrizedAttribute, TypeAttribute, ABC):
-    name = "float_type"
     width: ParameterDef[IntAttr]
 
     def __init__(self, width: int | IntAttr) -> None:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -423,7 +423,8 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
 
-class FloatType(ParametrizedAttribute, TypeAttribute):
+@irdl_attr_definition
+class _FloatType(ParametrizedAttribute, TypeAttribute, ABC):
     name = "float_type"
     width: ParameterDef[IntAttr]
 
@@ -449,7 +450,7 @@ class FloatType(ParametrizedAttribute, TypeAttribute):
 
 
 @irdl_attr_definition
-class BFloat16Type(FloatType):
+class BFloat16Type(_FloatType):
     name = "bf16"
 
     def __init__(self) -> None:
@@ -457,7 +458,7 @@ class BFloat16Type(FloatType):
 
 
 @irdl_attr_definition
-class Float16Type(FloatType):
+class Float16Type(_FloatType):
     name = "f16"
 
     def __init__(self) -> None:
@@ -465,7 +466,7 @@ class Float16Type(FloatType):
 
 
 @irdl_attr_definition
-class Float32Type(FloatType):
+class Float32Type(_FloatType):
     name = "f32"
 
     def __init__(self) -> None:
@@ -473,7 +474,7 @@ class Float32Type(FloatType):
 
 
 @irdl_attr_definition
-class Float64Type(FloatType):
+class Float64Type(_FloatType):
     name = "f64"
 
     def __init__(self) -> None:
@@ -481,7 +482,7 @@ class Float64Type(FloatType):
 
 
 @irdl_attr_definition
-class Float80Type(FloatType):
+class Float80Type(_FloatType):
     name = "f80"
 
     def __init__(self) -> None:
@@ -489,7 +490,7 @@ class Float80Type(FloatType):
 
 
 @irdl_attr_definition
-class Float128Type(FloatType):
+class Float128Type(_FloatType):
     name = "f128"
 
     def __init__(self) -> None:
@@ -497,13 +498,7 @@ class Float128Type(FloatType):
 
 
 AnyFloat: TypeAlias = (
-    FloatType
-    | BFloat16Type
-    | Float16Type
-    | Float32Type
-    | Float64Type
-    | Float80Type
-    | Float128Type
+    BFloat16Type | Float16Type | Float32Type | Float64Type | Float80Type | Float128Type
 )
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -424,6 +424,7 @@ AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
 
 class FloatType(ParametrizedAttribute, TypeAttribute):
+    name = "float_type"
     width: ParameterDef[IntAttr]
 
     def __init__(self, width: int | IntAttr) -> None:
@@ -436,12 +437,15 @@ class FloatType(ParametrizedAttribute, TypeAttribute):
         return self.width.data
 
     # @classmethod
-    # def parse_parameter(cls, parser: AttrParser) -> int:
-    # data = parser.parse_integer()
-    # return data
+    # def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+    # parser.parse_characters(
+    # "<",
+    # ": gpu attributes currently have the #gpu<name value> syntax.",
+    # )
 
-    # def print_parameter(self, printer: Printer) -> None:
-    # printer.print_string(f"{self.data}")
+    # def print_parameters(self, printer: Printer) -> None:
+    # printer.print(f"bits: {self.width}")
+    # printer.print("")
 
 
 @irdl_attr_definition
@@ -493,7 +497,13 @@ class Float128Type(FloatType):
 
 
 AnyFloat: TypeAlias = (
-    BFloat16Type | Float16Type | Float32Type | Float64Type | Float80Type | Float128Type
+    FloatType
+    | BFloat16Type
+    | Float16Type
+    | Float32Type
+    | Float64Type
+    | Float80Type
+    | Float128Type
 )
 
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -431,10 +431,6 @@ class _FloatType(ParametrizedAttribute, TypeAttribute, ABC):
             width = IntAttr(width)
         super().__init__([width])
 
-    @property
-    def get_bitwidth(self) -> int:
-        return self.width.data
-
 
 @irdl_attr_definition
 class BFloat16Type(_FloatType):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -423,7 +423,7 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
 
-class FloatType(ParametrizedAttribute, TypeAttribute, ABC):
+class FloatType(ParametrizedAttribute, TypeAttribute):
     width: ParameterDef[IntAttr]
 
     def __init__(self, width: int | IntAttr) -> None:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -422,8 +422,6 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
 
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
-# class _FloatType(ParametrizedAttribute, TypeAttribute, ABC):
-
 
 class _FloatType(ABC):
     @property

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -422,62 +422,68 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
 
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
 
+# class _FloatType(ParametrizedAttribute, TypeAttribute, ABC):
 
-class _FloatType(ParametrizedAttribute, TypeAttribute, ABC):
-    width: ParameterDef[IntAttr]
 
-    def __init__(self, width: int | IntAttr) -> None:
-        if isinstance(width, int):
-            width = IntAttr(width)
-        super().__init__([width])
+class _FloatType(ABC):
+    @property
+    @abstractmethod
+    def get_bitwidth(self) -> int:
+        raise NotImplementedError()
 
 
 @irdl_attr_definition
-class BFloat16Type(_FloatType):
+class BFloat16Type(ParametrizedAttribute, TypeAttribute, _FloatType):
     name = "bf16"
 
-    def __init__(self) -> None:
-        super().__init__(16)
+    @property
+    def get_bitwidth(self) -> int:
+        return 16
 
 
 @irdl_attr_definition
-class Float16Type(_FloatType):
+class Float16Type(ParametrizedAttribute, TypeAttribute, _FloatType):
     name = "f16"
 
-    def __init__(self) -> None:
-        super().__init__(16)
+    @property
+    def get_bitwidth(self) -> int:
+        return 16
 
 
 @irdl_attr_definition
-class Float32Type(_FloatType):
+class Float32Type(ParametrizedAttribute, TypeAttribute, _FloatType):
     name = "f32"
 
-    def __init__(self) -> None:
-        super().__init__(32)
+    @property
+    def get_bitwidth(self) -> int:
+        return 32
 
 
 @irdl_attr_definition
-class Float64Type(_FloatType):
+class Float64Type(ParametrizedAttribute, TypeAttribute, _FloatType):
     name = "f64"
 
-    def __init__(self) -> None:
-        super().__init__(64)
+    @property
+    def get_bitwidth(self) -> int:
+        return 64
 
 
 @irdl_attr_definition
-class Float80Type(_FloatType):
+class Float80Type(ParametrizedAttribute, TypeAttribute, _FloatType):
     name = "f80"
 
-    def __init__(self) -> None:
-        super().__init__(80)
+    @property
+    def get_bitwidth(self) -> int:
+        return 80
 
 
 @irdl_attr_definition
-class Float128Type(_FloatType):
+class Float128Type(ParametrizedAttribute, TypeAttribute, _FloatType):
     name = "f128"
 
-    def __init__(self) -> None:
-        super().__init__(128)
+    @property
+    def get_bitwidth(self) -> int:
+        return 128
 
 
 AnyFloat: TypeAlias = (

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -437,17 +437,6 @@ class _FloatType(ParametrizedAttribute, TypeAttribute, ABC):
     def get_bitwidth(self) -> int:
         return self.width.data
 
-    # @classmethod
-    # def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
-    # parser.parse_characters(
-    # "<",
-    # ": gpu attributes currently have the #gpu<name value> syntax.",
-    # )
-
-    # def print_parameters(self, printer: Printer) -> None:
-    # printer.print(f"bits: {self.width}")
-    # printer.print("")
-
 
 @irdl_attr_definition
 class BFloat16Type(_FloatType):


### PR DESCRIPTION
This PR:

- Adds a `get_bitwdith` read-only API method on `FloatType`s similar to MLIR [here](https://github.com/llvm/llvm-project/blob/39d55321bd0b8ce436d6fcd8e5ba51b8bf535559/mlir/lib/IR/BuiltinTypes.cpp#L89)
- Tests of the above
- One use case of this API method
