### PR TITLE
core: make IRNode.parent an abstract property parent_node

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1159,7 +1159,7 @@ class Block(IRNode):
     _first_op: Operation | None = field(repr=False)
     _last_op: Operation | None = field(repr=False)
 
-    parent: Region | None
+    parent: Region | None = field(default=None, repr=False)
     """Parent region containing the block."""
 
     def __init__(


### PR DESCRIPTION
Pyright complains that it's technically mutable with different types, so someone could set `parent` to any `IRNode`.