### PR TITLE
interpreter: Add support for pdl.apply_native_constraints

### DIFF
--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -13,6 +13,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters.experimental.pdl import (
+    PDLMatcher,
     PDLRewriteFunctions,
     PDLRewritePattern,
 )
@@ -426,3 +427,49 @@ def test_erase_op():
     pattern_walker.rewrite_module(input_module)
 
     assert input_module.is_structurally_equivalent(ModuleOp([]))
+
+
+def test_native_constraint():
+    @ModuleOp
+    @Builder.implicit_region
+    def input_module_true():
+        test.TestOp.create(properties={"attr": StringAttr("foo")})
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_module_false():
+        test.TestOp.create(properties={"attr": StringAttr("fooo")})
+
+    @ModuleOp
+    @Builder.implicit_region
+    def pdl_module():
+        with ImplicitBuilder(pdl.PatternOp(42, None).body):
+            attr = pdl.AttributeOp().output
+            pdl.ApplyNativeConstraintOp("even_length_string", [attr])
+            op = pdl.OperationOp(
+                op_name=None,
+                attribute_value_names=ArrayAttr([StringAttr("attr")]),
+                attribute_values=[attr],
+            ).op
+            with ImplicitBuilder(pdl.RewriteOp(op).body):
+                pdl.EraseOp(op)
+
+    pdl_rewrite_op = next(
+        op for op in pdl_module.walk() if isinstance(op, pdl.RewriteOp)
+    )
+
+    ctx = MLContext()
+    PDLMatcher.native_constraints["even_length_string"] = (
+        lambda attr: isinstance(attr, StringAttr) and len(attr.data) == 4
+    )
+
+    pattern_walker = PatternRewriteWalker(PDLRewritePattern(pdl_rewrite_op, ctx))
+
+    new_input_module_true = input_module_true.clone()
+    pattern_walker.rewrite_module(new_input_module_true)
+
+    new_input_module_false = input_module_false.clone()
+    pattern_walker.rewrite_module(new_input_module_false)
+
+    assert new_input_module_false.is_structurally_equivalent(ModuleOp([]))
+    assert new_input_module_true.is_structurally_equivalent(input_module_true)

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import IO, Any
+from typing import IO, Any, ClassVar
 
 from xdsl.dialects import pdl
 from xdsl.dialects.builtin import IntegerAttr, IntegerType, ModuleOp
@@ -27,6 +28,12 @@ class PDLMatcher:
     """
     For each SSAValue that is an OpResult of an operation in the PDL dialect,
     the corresponding xDSL object.
+    """
+
+    native_constraints: ClassVar[dict[str, Callable[..., bool]]] = {}
+    """
+    The functions that can be used in `pdl.apply_native_constraint`. Note that we do
+    not verify that the functions are used with the correct types.
     """
 
     def match_operand(
@@ -172,6 +179,13 @@ class PDLMatcher:
 
         return True
 
+    def check_native_constraints(self, pdl_op: pdl.ApplyNativeConstraintOp) -> bool:
+        args = [self.matching_context[operand] for operand in pdl_op.operands]
+        name = pdl_op.constraint_name.data
+        if name not in self.native_constraints:
+            raise InterpretationError(f"{name} PDL native constraint is not registered")
+        return self.native_constraints[name](*args)
+
 
 @dataclass
 class PDLRewritePattern(RewritePattern):
@@ -205,6 +219,13 @@ class PDLRewritePattern(RewritePattern):
         matcher = PDLMatcher()
         if not matcher.match_operation(pdl_op_val, pdl_op, xdsl_op):
             return
+
+        parent = self.pdl_rewrite_op.parent_op()
+        assert isinstance(parent, pdl.PatternOp)
+        for constraint_op in parent.walk():
+            if isinstance(constraint_op, pdl.ApplyNativeConstraintOp):
+                if not matcher.check_native_constraints(constraint_op):
+                    return
 
         self.interpreter.push_scope("rewrite")
         self.interpreter.set_values(matcher.matching_context.items())


### PR DESCRIPTION
Add support for `pdl.apply_native_constraints` in the PDL interpreter, and test it