### PR TITLE
misc (makefile): Mark venv target as phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TESTS_COVERAGE_FILE = ${COVERAGE_FILE}.tests
 .ONESHELL:
 
 # these targets don't produce files:
-.PHONY: clean filecheck pytest pytest-nb tests-toy tests rerun-notebooks precommit-install precommit black pyright
+.PHONY: venv clean filecheck pytest pytest-nb tests-toy tests rerun-notebooks precommit-install precommit black pyright
 .PHONY: coverage coverage-tests coverage-filecheck-tests coverage-report-html coverage-report-md
 
 # set up the venv with all dependencies for development


### PR DESCRIPTION
This PR marks the `venv` Make target as phony as it should not depend on whether the directory exists or not.

If the `venv` directory is created and any of the subsequent commands of the target fail, the target is not rerun (i.e., always up to date) unless the directory is removed.
Moreover, this behaviour differs when a different venv dir is selected when `VENV_DIR` is set.
