### PR TITLE
interpreter: pdl native constraints constant

### DIFF
--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -438,7 +438,7 @@ def test_native_constraint():
     @ModuleOp
     @Builder.implicit_region
     def input_module_false():
-        test.TestOp.create(properties={"attr": StringAttr("fooo")})
+        test.TestOp.create(properties={"attr": StringAttr("baar")})
 
     @ModuleOp
     @Builder.implicit_region
@@ -489,7 +489,7 @@ def test_native_constraint_constant_parameter():
     @ModuleOp
     @Builder.implicit_region
     def input_module_false():
-        test.TestOp.create(properties={"attr": StringAttr("fooo")})
+        test.TestOp.create(properties={"attr": StringAttr("baar")})
 
     @ModuleOp
     @Builder.implicit_region

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -473,3 +473,57 @@ def test_native_constraint():
 
     assert new_input_module_false.is_structurally_equivalent(ModuleOp([]))
     assert new_input_module_true.is_structurally_equivalent(input_module_true)
+
+
+def test_native_constraint_constant_parameter():
+    """
+    Check that `pdl.apply_native_constraint` can take constant attribute parameters
+    that are not otherwise matched.
+    """
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_module_true():
+        test.TestOp.create(properties={"attr": StringAttr("foo")})
+
+    @ModuleOp
+    @Builder.implicit_region
+    def input_module_false():
+        test.TestOp.create(properties={"attr": StringAttr("fooo")})
+
+    @ModuleOp
+    @Builder.implicit_region
+    def pdl_module():
+        with ImplicitBuilder(pdl.PatternOp(42, None).body):
+            attr = pdl.AttributeOp().output
+            four = pdl.AttributeOp(IntegerAttr(4, i32)).output
+            pdl.ApplyNativeConstraintOp("length_string", [attr, four])
+            op = pdl.OperationOp(
+                op_name=None,
+                attribute_value_names=ArrayAttr([StringAttr("attr")]),
+                attribute_values=[attr],
+            ).op
+            with ImplicitBuilder(pdl.RewriteOp(op).body):
+                pdl.EraseOp(op)
+
+    pdl_rewrite_op = next(
+        op for op in pdl_module.walk() if isinstance(op, pdl.RewriteOp)
+    )
+
+    ctx = MLContext()
+    PDLMatcher.native_constraints["length_string"] = (
+        lambda attr, size: isinstance(attr, StringAttr)
+        and isinstance(size, IntegerAttr)
+        and len(attr.data) == size.value.data
+    )
+
+    pattern_walker = PatternRewriteWalker(PDLRewritePattern(pdl_rewrite_op, ctx))
+
+    new_input_module_true = input_module_true.clone()
+    pattern_walker.rewrite_module(new_input_module_true)
+
+    new_input_module_false = input_module_false.clone()
+    pattern_walker.rewrite_module(new_input_module_false)
+
+    assert new_input_module_false.is_structurally_equivalent(ModuleOp([]))
+    assert new_input_module_true.is_structurally_equivalent(input_module_true)


### PR DESCRIPTION
Add support for constants in `pdl.apply_native_constraint`.

Something like
```python
    %attr = attribute = 10
    pdl.apply_native_constraint "constraint"(%attr: !pdl.attribute)
```
where `%attr` is not bound