### PR TITLE
core: Rename register_* with load_*

### DIFF
--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -48,16 +48,16 @@ from .rewrites.shape_inference import ShapeInferencePass
 
 def context() -> MLContext:
     ctx = MLContext()
-    ctx.register_dialect(affine.Affine)
-    ctx.register_dialect(arith.Arith)
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(func.Func)
-    ctx.register_dialect(memref.MemRef)
-    ctx.register_dialect(printf.Printf)
-    ctx.register_dialect(riscv_func.RISCV_Func)
-    ctx.register_dialect(riscv.RISCV)
-    ctx.register_dialect(scf.Scf)
-    ctx.register_dialect(toy.Toy)
+    ctx.load_dialect(affine.Affine)
+    ctx.load_dialect(arith.Arith)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(func.Func)
+    ctx.load_dialect(memref.MemRef)
+    ctx.load_dialect(printf.Printf)
+    ctx.load_dialect(riscv_func.RISCV_Func)
+    ctx.load_dialect(riscv.RISCV)
+    ctx.load_dialect(scf.Scf)
+    ctx.load_dialect(toy.Toy)
     return ctx
 
 

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1518,14 +1518,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "name": "python",
-   "version": "3.10.12"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -39,8 +39,8 @@
     "context = MLContext()\n",
     "\n",
     "# Some useful dialects\n",
-    "context.register_dialect(Arith)\n",
-    "context.register_dialect(Builtin)\n",
+    "context.load_dialect(Arith)\n",
+    "context.load_dialect(Builtin)\n",
     "\n",
     "# Printer used to pretty-print MLIR data structures\n",
     "printer = Printer()"
@@ -1518,8 +1518,14 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -1,501 +1,501 @@
 {
- "cells": [
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "478e8ef4-f3a7-4aec-b1f6-ffa60aa88697",
-   "metadata": {},
-   "source": [
-    "# xDSL tutorial"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "a3721339-9b8d-4743-b5da-e920f9afd3e9",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "# Imports and setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "e86541f5-af35-4c73-9a8c-4c43e7d365d6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from xdsl.ir import MLContext\n",
-    "from xdsl.dialects.arith import Arith\n",
-    "from xdsl.dialects.func import Func\n",
-    "from xdsl.dialects.builtin import Builtin\n",
-    "from xdsl.printer import Printer\n",
-    "\n",
-    "# MLContext, containing information about the registered dialects\n",
-    "context = MLContext()\n",
-    "\n",
-    "# Some useful dialects\n",
-    "context.register_dialect(Arith)\n",
-    "context.register_dialect(Func)\n",
-    "context.register_dialect(Builtin)\n",
-    "\n",
-    "# Printer used to pretty-print MLIR data structures\n",
-    "printer = Printer()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "f1270219-eeeb-4687-81e5-cce88afcb901",
-   "metadata": {},
-   "source": [
-    "## High-level presentation (TODO)\n",
-    "\n",
-    "Base ideas of what xDSL is. Example of a small program, and SSA."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "ce39e1f4-3a54-463d-b2eb-d4fb4f7a6133",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "# Base IR features"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "ab4f67ba-68c1-4232-9ba1-b82a5bfaaf2b",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## Dialects"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "e36e9032-ccd2-4175-98c1-cfa3d86f722c",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "Dialects are namespaces that contain a collection of attributes and operations. For instance, the Builtin dialect contains (but not exclusively) the attribute `!i32` and the operation `builtin.func`.\n",
-    "A dialect is usually a single level of abstraction in the IR, and multiple dialects can be used together in the same MLIR program.\n",
-    "\n",
-    "Dialects are currently Python classes registering operations and attributes, and providing simple accessors to their attributes and dialects.\n",
-    "This will however change in the near future to provide a better interface to dialects."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "946e362d-0948-4c9e-b6b9-307afbe978a0",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## Attributes"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "e45b3a1b-b125-4393-93ad-7bff203a85bf",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "Attributes represent compile-time information.\n",
-    "In particular, each SSA-value is associated with an attribute, representing its type.\n",
-    "Each attribute type has a name and belongs in a dialect. The textual representation of attributes is prefixed with `!`, and the dialect name.\n",
-    "For instance, the `vector` attribute has the format `!builtin.vector<T>`, where `T` is the expected parameter of the attribute.\n",
-    "\n",
-    "In Python, attributes are always expected to be immutable objects heriting from either `Data` or `ParametrizedAttribute`."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "5eaa4b21-cdf2-43b2-a998-7119ce7daf55",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Data attributes"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "2924d529-6d63-48ff-bfdc-21958d90559b",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "`Data` attributes are used to wrap python data structures. For instance, the `IntAttr` is an attribute containing an `int`, and the `StringAttr` is an attribute containing a `str`.\n",
-    "`Data` attributes are parsed and printed with the format `dialect_name.attr_name<custom_format>`, where `custom_format` is the format defined by the parser and printer of each `Data` attribute.\n",
-    "Note that some attributes, such as `StringAttr`, are shortened by the printer, and do not require the use of `dialect_name.attr_name`. For instance, `builtin.str<\"foo\">` is shortened to `\"foo\"`. \n",
-    "\n",
-    "Here is an example on how to create and print an `IntAttr` attribute:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "f3061d94-b2f1-4d85-a0b6-d4486f7a45bc",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#int<42>"
-     ]
-    }
-   ],
-   "source": [
-    "from xdsl.dialects.builtin import IntAttr\n",
-    "\n",
-    "# Attribute definitions usually define custom `__init__` to simplify their creation\n",
-    "my_int = IntAttr(42)\n",
-    "printer.print_attribute(my_int)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "e5578732-a5d0-48a2-9a2b-0010b3d13135",
-   "metadata": {},
-   "source": [
-    "Note that here, the `IntAttr` does not print a dialect prefix. This will be fixed soon-ish."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "8127a458-1d34-4dd9-aaff-468b93c9fe4b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "42\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Access the data in the IntAttr:\n",
-    "print(my_int.data)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "a4b9b668-63ad-4660-8016-65e8d1e9d617",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Parametrized attributes\n",
-    "\n",
-    "Parametrized attributes are attributes containing optionally multiple attributes as parameters.\n",
-    "For instance, the `integer` attribute from `builtin` is a parametrized attribute and expects two attributes as parameter.\n",
-    "Parametrized attributes are printed with the format `!dialect.attr_name<attr_1, ... attr_N>`, where `attr_i` are the attribute parameters.\n",
-    "\n",
-    "Here is an example on how to create and inspect an `integer_type` attribute, which represent a machine integer type. It is parametrized by a single `IntAttr` parameter, representing the bitwidth."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "b6b89a95-2b0b-4f37-9769-758cf2246eeb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "i64"
-     ]
-    }
-   ],
-   "source": [
-    "from xdsl.dialects.builtin import IntegerType\n",
-    "\n",
-    "# Get the int that will be passed as parameter to the integer_type\n",
-    "int_64 = IntAttr(64)\n",
-    "i64 = IntegerType(int_64.data)\n",
-    "printer.print_attribute(i64)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "f4dfc1ef-9070-42d9-bf82-ec30b9bb7da1",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#int<64>"
-     ]
-    }
-   ],
-   "source": [
-    "# Get back the parameters of IntegerType\n",
-    "printer.print_attribute(i64.parameters[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "c060d5e5-6ead-45e3-b7ec-4bf9250271ae",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Use the custom constructor from IntegerType to construct it\n",
-    "assert IntegerType(64) == i64"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "9bd2c802-4e09-432a-bd2c-c512b073a681",
-   "metadata": {},
-   "source": [
-    "Note that parametrized attributes may define invariants that need to be respected.\n",
-    "For instance, constructing an `integer_type` with wrong parameters will trigger an error:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "a35bc488-dd35-46e9-aa58-9734b06b555b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[IntegerType(parameters=[IntAttr(data=64), SignednessAttr(data=<Signedness.SIGNLESS: 0>)], width=IntAttr(data=64), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>))] should be of base attribute int\n"
-     ]
-    }
-   ],
-   "source": [
-    "# NBVAL_IGNORE_OUTPUT\n",
-    "# pyright: reportGeneralTypeIssues=false\n",
-    "# Try to create an IntegerType with wrong parameters\n",
-    "try:\n",
-    "    bad_attr = IntegerType([i64])\n",
-    "except Exception as err:\n",
-    "    print(err)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "8e5e4b80-9dc7-4238-8d4e-b0998b4bed2c",
-   "metadata": {},
-   "source": [
-    "## Operations"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "1a9b803e-eddf-4a7c-903d-a012ac6b61f9",
-   "metadata": {},
-   "source": [
-    "Operations represent the computation that a program can do. They span in all abstraction levels, and can be domain-specific.\n",
-    "For instance, `arith.addi` will add two integers, while `scf.if` represent an if/else structure.\n",
-    "\n",
-    "Operations are composed of:\n",
-    "* A base operation type, which represent the semantics of the operation;\n",
-    "* Operands, which are SSA-values previously defined;\n",
-    "* Results, which are new SSA-values defined by the operation;\n",
-    "* Attributes, which encode compile-time information about the operation;\n",
-    "* Regions, which contain operations, and are used to represent more complex control-flow;\n",
-    "* Successors, which are basic block names for which the operation can give control to.\n",
-    "\n",
-    "The format of an operation is: `results = dialect_name.op_name(operands) (successors) [attributes] regions`\n",
-    "\n",
-    "Here is for example how to create a constant operation, representing a constant value:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "150ea21b-979b-494d-8e10-53327c17be38",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "%0 = arith.constant 62 : i64"
-     ]
-    }
-   ],
-   "source": [
-    "from xdsl.dialects.builtin import IntegerAttr\n",
-    "from xdsl.dialects.arith import Constant\n",
-    "\n",
-    "const_op = Constant.create(\n",
-    "    result_types=[i64], properties={\"value\": IntegerAttr.from_int_and_width(62, 64)}\n",
-    ")\n",
-    "printer.print_op(const_op)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "0c32595c-644f-46e8-b9b6-2baf81679ea2",
-   "metadata": {},
-   "source": [
-    "Note that dialects usually define methods to ease the definition of such operations:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "66a37c45-7c2f-4d82-b2e3-759e75719817",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "%1 = arith.constant 62 : i64"
-     ]
-    }
-   ],
-   "source": [
-    "const_op2 = Constant(IntegerAttr.from_int_and_width(62, 64), i64)\n",
-    "printer.print_op(const_op2)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "608559d8-3b1f-4a92-99c5-a50f3ab74fd5",
-   "metadata": {},
-   "source": [
-    "We can use the results from the operation to pass them as operands for a later operation. For instance, we will add the constant to itself using the `arith.addi` operation:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "b7f1a4d8-31bb-4466-a125-5abd5c91c957",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "%0 = arith.constant 62 : i64\n",
-      "%2 = arith.addi %0, %0 : i64"
-     ]
-    }
-   ],
-   "source": [
-    "from xdsl.dialects.arith import Addi\n",
-    "\n",
-    "add_op = Addi.create(operands=[const_op.results[0], const_op.results[0]], result_types=[i64])\n",
-    "printer.print_op(const_op)\n",
-    "print()\n",
-    "printer.print_op(add_op)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "2bdc9fb2-3cfa-4a03-b0da-2d453570adc2",
-   "metadata": {},
-   "source": [
-    "We can also put the operations in regions, which can be then used by other operations (such as func)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "f80adc50-9d38-41bd-9947-319a0dcadd10",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  %0 = arith.constant 62 : i64\n",
-      "  %2 = arith.addi %0, %0 : i64\n",
-      "}"
-     ]
-    }
-   ],
-   "source": [
-    "from xdsl.ir import Region, Block\n",
-    "\n",
-    "my_region = Region([Block([const_op, add_op])])\n",
-    "printer.print_region(my_region)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "38f4deb5-5e73-48db-a86e-41c6685401df",
-   "metadata": {},
-   "source": [
-    "Functions are created using the `builtin.func` op, which contain a single region:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "52ccaee1-ce0e-434b-81ed-3c00838ab29b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "func.func @my_function() {\n",
-      "  %0 = arith.constant 62 : i64\n",
-      "  %2 = arith.addi %0, %0 : i64\n",
-      "}"
-     ]
-    }
-   ],
-   "source": [
-    "from xdsl.dialects.func import FuncOp\n",
-    "\n",
-    "my_func = FuncOp.from_region(\"my_function\", [], [], my_region)\n",
-    "printer.print_op(my_func)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ca2fe54d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "478e8ef4-f3a7-4aec-b1f6-ffa60aa88697",
+            "metadata": {},
+            "source": [
+                "# xDSL tutorial"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "a3721339-9b8d-4743-b5da-e920f9afd3e9",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "# Imports and setup"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "e86541f5-af35-4c73-9a8c-4c43e7d365d6",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from xdsl.ir import MLContext\n",
+                "from xdsl.dialects.arith import Arith\n",
+                "from xdsl.dialects.func import Func\n",
+                "from xdsl.dialects.builtin import Builtin\n",
+                "from xdsl.printer import Printer\n",
+                "\n",
+                "# MLContext, containing information about the registered dialects\n",
+                "context = MLContext()\n",
+                "\n",
+                "# Some useful dialects\n",
+                "context.load_dialect(Arith)\n",
+                "context.load_dialect(Func)\n",
+                "context.load_dialect(Builtin)\n",
+                "\n",
+                "# Printer used to pretty-print MLIR data structures\n",
+                "printer = Printer()"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "f1270219-eeeb-4687-81e5-cce88afcb901",
+            "metadata": {},
+            "source": [
+                "## High-level presentation (TODO)\n",
+                "\n",
+                "Base ideas of what xDSL is. Example of a small program, and SSA."
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "ce39e1f4-3a54-463d-b2eb-d4fb4f7a6133",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "# Base IR features"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "ab4f67ba-68c1-4232-9ba1-b82a5bfaaf2b",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "## Dialects"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "e36e9032-ccd2-4175-98c1-cfa3d86f722c",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "Dialects are namespaces that contain a collection of attributes and operations. For instance, the Builtin dialect contains (but not exclusively) the attribute `!i32` and the operation `builtin.func`.\n",
+                "A dialect is usually a single level of abstraction in the IR, and multiple dialects can be used together in the same MLIR program.\n",
+                "\n",
+                "Dialects are currently Python classes registering operations and attributes, and providing simple accessors to their attributes and dialects.\n",
+                "This will however change in the near future to provide a better interface to dialects."
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "946e362d-0948-4c9e-b6b9-307afbe978a0",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "## Attributes"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "e45b3a1b-b125-4393-93ad-7bff203a85bf",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "Attributes represent compile-time information.\n",
+                "In particular, each SSA-value is associated with an attribute, representing its type.\n",
+                "Each attribute type has a name and belongs in a dialect. The textual representation of attributes is prefixed with `!`, and the dialect name.\n",
+                "For instance, the `vector` attribute has the format `!builtin.vector<T>`, where `T` is the expected parameter of the attribute.\n",
+                "\n",
+                "In Python, attributes are always expected to be immutable objects heriting from either `Data` or `ParametrizedAttribute`."
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "5eaa4b21-cdf2-43b2-a998-7119ce7daf55",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "### Data attributes"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "2924d529-6d63-48ff-bfdc-21958d90559b",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "`Data` attributes are used to wrap python data structures. For instance, the `IntAttr` is an attribute containing an `int`, and the `StringAttr` is an attribute containing a `str`.\n",
+                "`Data` attributes are parsed and printed with the format `dialect_name.attr_name<custom_format>`, where `custom_format` is the format defined by the parser and printer of each `Data` attribute.\n",
+                "Note that some attributes, such as `StringAttr`, are shortened by the printer, and do not require the use of `dialect_name.attr_name`. For instance, `builtin.str<\"foo\">` is shortened to `\"foo\"`. \n",
+                "\n",
+                "Here is an example on how to create and print an `IntAttr` attribute:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "f3061d94-b2f1-4d85-a0b6-d4486f7a45bc",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "#int<42>"
+                    ]
+                }
+            ],
+            "source": [
+                "from xdsl.dialects.builtin import IntAttr\n",
+                "\n",
+                "# Attribute definitions usually define custom `__init__` to simplify their creation\n",
+                "my_int = IntAttr(42)\n",
+                "printer.print_attribute(my_int)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "e5578732-a5d0-48a2-9a2b-0010b3d13135",
+            "metadata": {},
+            "source": [
+                "Note that here, the `IntAttr` does not print a dialect prefix. This will be fixed soon-ish."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "8127a458-1d34-4dd9-aaff-468b93c9fe4b",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "42\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# Access the data in the IntAttr:\n",
+                "print(my_int.data)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "a4b9b668-63ad-4660-8016-65e8d1e9d617",
+            "metadata": {
+                "tags": []
+            },
+            "source": [
+                "### Parametrized attributes\n",
+                "\n",
+                "Parametrized attributes are attributes containing optionally multiple attributes as parameters.\n",
+                "For instance, the `integer` attribute from `builtin` is a parametrized attribute and expects two attributes as parameter.\n",
+                "Parametrized attributes are printed with the format `!dialect.attr_name<attr_1, ... attr_N>`, where `attr_i` are the attribute parameters.\n",
+                "\n",
+                "Here is an example on how to create and inspect an `integer_type` attribute, which represent a machine integer type. It is parametrized by a single `IntAttr` parameter, representing the bitwidth."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "b6b89a95-2b0b-4f37-9769-758cf2246eeb",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "i64"
+                    ]
+                }
+            ],
+            "source": [
+                "from xdsl.dialects.builtin import IntegerType\n",
+                "\n",
+                "# Get the int that will be passed as parameter to the integer_type\n",
+                "int_64 = IntAttr(64)\n",
+                "i64 = IntegerType(int_64.data)\n",
+                "printer.print_attribute(i64)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "f4dfc1ef-9070-42d9-bf82-ec30b9bb7da1",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "#int<64>"
+                    ]
+                }
+            ],
+            "source": [
+                "# Get back the parameters of IntegerType\n",
+                "printer.print_attribute(i64.parameters[0])"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "c060d5e5-6ead-45e3-b7ec-4bf9250271ae",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Use the custom constructor from IntegerType to construct it\n",
+                "assert IntegerType(64) == i64"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "9bd2c802-4e09-432a-bd2c-c512b073a681",
+            "metadata": {},
+            "source": [
+                "Note that parametrized attributes may define invariants that need to be respected.\n",
+                "For instance, constructing an `integer_type` with wrong parameters will trigger an error:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "id": "a35bc488-dd35-46e9-aa58-9734b06b555b",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "[IntegerType(parameters=[IntAttr(data=64), SignednessAttr(data=<Signedness.SIGNLESS: 0>)], width=IntAttr(data=64), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>))] should be of base attribute int\n"
+                    ]
+                }
+            ],
+            "source": [
+                "# NBVAL_IGNORE_OUTPUT\n",
+                "# pyright: reportGeneralTypeIssues=false\n",
+                "# Try to create an IntegerType with wrong parameters\n",
+                "try:\n",
+                "    bad_attr = IntegerType([i64])\n",
+                "except Exception as err:\n",
+                "    print(err)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "8e5e4b80-9dc7-4238-8d4e-b0998b4bed2c",
+            "metadata": {},
+            "source": [
+                "## Operations"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "1a9b803e-eddf-4a7c-903d-a012ac6b61f9",
+            "metadata": {},
+            "source": [
+                "Operations represent the computation that a program can do. They span in all abstraction levels, and can be domain-specific.\n",
+                "For instance, `arith.addi` will add two integers, while `scf.if` represent an if/else structure.\n",
+                "\n",
+                "Operations are composed of:\n",
+                "* A base operation type, which represent the semantics of the operation;\n",
+                "* Operands, which are SSA-values previously defined;\n",
+                "* Results, which are new SSA-values defined by the operation;\n",
+                "* Attributes, which encode compile-time information about the operation;\n",
+                "* Regions, which contain operations, and are used to represent more complex control-flow;\n",
+                "* Successors, which are basic block names for which the operation can give control to.\n",
+                "\n",
+                "The format of an operation is: `results = dialect_name.op_name(operands) (successors) [attributes] regions`\n",
+                "\n",
+                "Here is for example how to create a constant operation, representing a constant value:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "id": "150ea21b-979b-494d-8e10-53327c17be38",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "%0 = arith.constant 62 : i64"
+                    ]
+                }
+            ],
+            "source": [
+                "from xdsl.dialects.builtin import IntegerAttr\n",
+                "from xdsl.dialects.arith import Constant\n",
+                "\n",
+                "const_op = Constant.create(\n",
+                "    result_types=[i64], properties={\"value\": IntegerAttr.from_int_and_width(62, 64)}\n",
+                ")\n",
+                "printer.print_op(const_op)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "0c32595c-644f-46e8-b9b6-2baf81679ea2",
+            "metadata": {},
+            "source": [
+                "Note that dialects usually define methods to ease the definition of such operations:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "id": "66a37c45-7c2f-4d82-b2e3-759e75719817",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "%1 = arith.constant 62 : i64"
+                    ]
+                }
+            ],
+            "source": [
+                "const_op2 = Constant(IntegerAttr.from_int_and_width(62, 64), i64)\n",
+                "printer.print_op(const_op2)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "608559d8-3b1f-4a92-99c5-a50f3ab74fd5",
+            "metadata": {},
+            "source": [
+                "We can use the results from the operation to pass them as operands for a later operation. For instance, we will add the constant to itself using the `arith.addi` operation:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "id": "b7f1a4d8-31bb-4466-a125-5abd5c91c957",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "%0 = arith.constant 62 : i64\n",
+                        "%2 = arith.addi %0, %0 : i64"
+                    ]
+                }
+            ],
+            "source": [
+                "from xdsl.dialects.arith import Addi\n",
+                "\n",
+                "add_op = Addi.create(operands=[const_op.results[0], const_op.results[0]], result_types=[i64])\n",
+                "printer.print_op(const_op)\n",
+                "print()\n",
+                "printer.print_op(add_op)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "2bdc9fb2-3cfa-4a03-b0da-2d453570adc2",
+            "metadata": {},
+            "source": [
+                "We can also put the operations in regions, which can be then used by other operations (such as func)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 11,
+            "id": "f80adc50-9d38-41bd-9947-319a0dcadd10",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "{\n",
+                        "  %0 = arith.constant 62 : i64\n",
+                        "  %2 = arith.addi %0, %0 : i64\n",
+                        "}"
+                    ]
+                }
+            ],
+            "source": [
+                "from xdsl.ir import Region, Block\n",
+                "\n",
+                "my_region = Region([Block([const_op, add_op])])\n",
+                "printer.print_region(my_region)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "38f4deb5-5e73-48db-a86e-41c6685401df",
+            "metadata": {},
+            "source": [
+                "Functions are created using the `builtin.func` op, which contain a single region:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "id": "52ccaee1-ce0e-434b-81ed-3c00838ab29b",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "func.func @my_function() {\n",
+                        "  %0 = arith.constant 62 : i64\n",
+                        "  %2 = arith.addi %0, %0 : i64\n",
+                        "}"
+                    ]
+                }
+            ],
+            "source": [
+                "from xdsl.dialects.func import FuncOp\n",
+                "\n",
+                "my_func = FuncOp.from_region(\"my_function\", [], [], my_region)\n",
+                "printer.print_op(my_func)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "ca2fe54d",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "language_info": {
+            "name": "python"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -1,501 +1,501 @@
 {
-    "cells": [
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "478e8ef4-f3a7-4aec-b1f6-ffa60aa88697",
-            "metadata": {},
-            "source": [
-                "# xDSL tutorial"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "a3721339-9b8d-4743-b5da-e920f9afd3e9",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "# Imports and setup"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "id": "e86541f5-af35-4c73-9a8c-4c43e7d365d6",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from xdsl.ir import MLContext\n",
-                "from xdsl.dialects.arith import Arith\n",
-                "from xdsl.dialects.func import Func\n",
-                "from xdsl.dialects.builtin import Builtin\n",
-                "from xdsl.printer import Printer\n",
-                "\n",
-                "# MLContext, containing information about the registered dialects\n",
-                "context = MLContext()\n",
-                "\n",
-                "# Some useful dialects\n",
-                "context.load_dialect(Arith)\n",
-                "context.load_dialect(Func)\n",
-                "context.load_dialect(Builtin)\n",
-                "\n",
-                "# Printer used to pretty-print MLIR data structures\n",
-                "printer = Printer()"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "f1270219-eeeb-4687-81e5-cce88afcb901",
-            "metadata": {},
-            "source": [
-                "## High-level presentation (TODO)\n",
-                "\n",
-                "Base ideas of what xDSL is. Example of a small program, and SSA."
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "ce39e1f4-3a54-463d-b2eb-d4fb4f7a6133",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "# Base IR features"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "ab4f67ba-68c1-4232-9ba1-b82a5bfaaf2b",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "## Dialects"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "e36e9032-ccd2-4175-98c1-cfa3d86f722c",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "Dialects are namespaces that contain a collection of attributes and operations. For instance, the Builtin dialect contains (but not exclusively) the attribute `!i32` and the operation `builtin.func`.\n",
-                "A dialect is usually a single level of abstraction in the IR, and multiple dialects can be used together in the same MLIR program.\n",
-                "\n",
-                "Dialects are currently Python classes registering operations and attributes, and providing simple accessors to their attributes and dialects.\n",
-                "This will however change in the near future to provide a better interface to dialects."
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "946e362d-0948-4c9e-b6b9-307afbe978a0",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "## Attributes"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "e45b3a1b-b125-4393-93ad-7bff203a85bf",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "Attributes represent compile-time information.\n",
-                "In particular, each SSA-value is associated with an attribute, representing its type.\n",
-                "Each attribute type has a name and belongs in a dialect. The textual representation of attributes is prefixed with `!`, and the dialect name.\n",
-                "For instance, the `vector` attribute has the format `!builtin.vector<T>`, where `T` is the expected parameter of the attribute.\n",
-                "\n",
-                "In Python, attributes are always expected to be immutable objects heriting from either `Data` or `ParametrizedAttribute`."
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "5eaa4b21-cdf2-43b2-a998-7119ce7daf55",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "### Data attributes"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "2924d529-6d63-48ff-bfdc-21958d90559b",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "`Data` attributes are used to wrap python data structures. For instance, the `IntAttr` is an attribute containing an `int`, and the `StringAttr` is an attribute containing a `str`.\n",
-                "`Data` attributes are parsed and printed with the format `dialect_name.attr_name<custom_format>`, where `custom_format` is the format defined by the parser and printer of each `Data` attribute.\n",
-                "Note that some attributes, such as `StringAttr`, are shortened by the printer, and do not require the use of `dialect_name.attr_name`. For instance, `builtin.str<\"foo\">` is shortened to `\"foo\"`. \n",
-                "\n",
-                "Here is an example on how to create and print an `IntAttr` attribute:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "id": "f3061d94-b2f1-4d85-a0b6-d4486f7a45bc",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "#int<42>"
-                    ]
-                }
-            ],
-            "source": [
-                "from xdsl.dialects.builtin import IntAttr\n",
-                "\n",
-                "# Attribute definitions usually define custom `__init__` to simplify their creation\n",
-                "my_int = IntAttr(42)\n",
-                "printer.print_attribute(my_int)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "e5578732-a5d0-48a2-9a2b-0010b3d13135",
-            "metadata": {},
-            "source": [
-                "Note that here, the `IntAttr` does not print a dialect prefix. This will be fixed soon-ish."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "id": "8127a458-1d34-4dd9-aaff-468b93c9fe4b",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "42\n"
-                    ]
-                }
-            ],
-            "source": [
-                "# Access the data in the IntAttr:\n",
-                "print(my_int.data)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "a4b9b668-63ad-4660-8016-65e8d1e9d617",
-            "metadata": {
-                "tags": []
-            },
-            "source": [
-                "### Parametrized attributes\n",
-                "\n",
-                "Parametrized attributes are attributes containing optionally multiple attributes as parameters.\n",
-                "For instance, the `integer` attribute from `builtin` is a parametrized attribute and expects two attributes as parameter.\n",
-                "Parametrized attributes are printed with the format `!dialect.attr_name<attr_1, ... attr_N>`, where `attr_i` are the attribute parameters.\n",
-                "\n",
-                "Here is an example on how to create and inspect an `integer_type` attribute, which represent a machine integer type. It is parametrized by a single `IntAttr` parameter, representing the bitwidth."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "id": "b6b89a95-2b0b-4f37-9769-758cf2246eeb",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "i64"
-                    ]
-                }
-            ],
-            "source": [
-                "from xdsl.dialects.builtin import IntegerType\n",
-                "\n",
-                "# Get the int that will be passed as parameter to the integer_type\n",
-                "int_64 = IntAttr(64)\n",
-                "i64 = IntegerType(int_64.data)\n",
-                "printer.print_attribute(i64)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 5,
-            "id": "f4dfc1ef-9070-42d9-bf82-ec30b9bb7da1",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "#int<64>"
-                    ]
-                }
-            ],
-            "source": [
-                "# Get back the parameters of IntegerType\n",
-                "printer.print_attribute(i64.parameters[0])"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 6,
-            "id": "c060d5e5-6ead-45e3-b7ec-4bf9250271ae",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Use the custom constructor from IntegerType to construct it\n",
-                "assert IntegerType(64) == i64"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "9bd2c802-4e09-432a-bd2c-c512b073a681",
-            "metadata": {},
-            "source": [
-                "Note that parametrized attributes may define invariants that need to be respected.\n",
-                "For instance, constructing an `integer_type` with wrong parameters will trigger an error:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 7,
-            "id": "a35bc488-dd35-46e9-aa58-9734b06b555b",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "[IntegerType(parameters=[IntAttr(data=64), SignednessAttr(data=<Signedness.SIGNLESS: 0>)], width=IntAttr(data=64), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>))] should be of base attribute int\n"
-                    ]
-                }
-            ],
-            "source": [
-                "# NBVAL_IGNORE_OUTPUT\n",
-                "# pyright: reportGeneralTypeIssues=false\n",
-                "# Try to create an IntegerType with wrong parameters\n",
-                "try:\n",
-                "    bad_attr = IntegerType([i64])\n",
-                "except Exception as err:\n",
-                "    print(err)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "8e5e4b80-9dc7-4238-8d4e-b0998b4bed2c",
-            "metadata": {},
-            "source": [
-                "## Operations"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "1a9b803e-eddf-4a7c-903d-a012ac6b61f9",
-            "metadata": {},
-            "source": [
-                "Operations represent the computation that a program can do. They span in all abstraction levels, and can be domain-specific.\n",
-                "For instance, `arith.addi` will add two integers, while `scf.if` represent an if/else structure.\n",
-                "\n",
-                "Operations are composed of:\n",
-                "* A base operation type, which represent the semantics of the operation;\n",
-                "* Operands, which are SSA-values previously defined;\n",
-                "* Results, which are new SSA-values defined by the operation;\n",
-                "* Attributes, which encode compile-time information about the operation;\n",
-                "* Regions, which contain operations, and are used to represent more complex control-flow;\n",
-                "* Successors, which are basic block names for which the operation can give control to.\n",
-                "\n",
-                "The format of an operation is: `results = dialect_name.op_name(operands) (successors) [attributes] regions`\n",
-                "\n",
-                "Here is for example how to create a constant operation, representing a constant value:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 8,
-            "id": "150ea21b-979b-494d-8e10-53327c17be38",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "%0 = arith.constant 62 : i64"
-                    ]
-                }
-            ],
-            "source": [
-                "from xdsl.dialects.builtin import IntegerAttr\n",
-                "from xdsl.dialects.arith import Constant\n",
-                "\n",
-                "const_op = Constant.create(\n",
-                "    result_types=[i64], properties={\"value\": IntegerAttr.from_int_and_width(62, 64)}\n",
-                ")\n",
-                "printer.print_op(const_op)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "0c32595c-644f-46e8-b9b6-2baf81679ea2",
-            "metadata": {},
-            "source": [
-                "Note that dialects usually define methods to ease the definition of such operations:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 9,
-            "id": "66a37c45-7c2f-4d82-b2e3-759e75719817",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "%1 = arith.constant 62 : i64"
-                    ]
-                }
-            ],
-            "source": [
-                "const_op2 = Constant(IntegerAttr.from_int_and_width(62, 64), i64)\n",
-                "printer.print_op(const_op2)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "608559d8-3b1f-4a92-99c5-a50f3ab74fd5",
-            "metadata": {},
-            "source": [
-                "We can use the results from the operation to pass them as operands for a later operation. For instance, we will add the constant to itself using the `arith.addi` operation:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "id": "b7f1a4d8-31bb-4466-a125-5abd5c91c957",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "%0 = arith.constant 62 : i64\n",
-                        "%2 = arith.addi %0, %0 : i64"
-                    ]
-                }
-            ],
-            "source": [
-                "from xdsl.dialects.arith import Addi\n",
-                "\n",
-                "add_op = Addi.create(operands=[const_op.results[0], const_op.results[0]], result_types=[i64])\n",
-                "printer.print_op(const_op)\n",
-                "print()\n",
-                "printer.print_op(add_op)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "2bdc9fb2-3cfa-4a03-b0da-2d453570adc2",
-            "metadata": {},
-            "source": [
-                "We can also put the operations in regions, which can be then used by other operations (such as func)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "id": "f80adc50-9d38-41bd-9947-319a0dcadd10",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "{\n",
-                        "  %0 = arith.constant 62 : i64\n",
-                        "  %2 = arith.addi %0, %0 : i64\n",
-                        "}"
-                    ]
-                }
-            ],
-            "source": [
-                "from xdsl.ir import Region, Block\n",
-                "\n",
-                "my_region = Region([Block([const_op, add_op])])\n",
-                "printer.print_region(my_region)"
-            ]
-        },
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "id": "38f4deb5-5e73-48db-a86e-41c6685401df",
-            "metadata": {},
-            "source": [
-                "Functions are created using the `builtin.func` op, which contain a single region:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "id": "52ccaee1-ce0e-434b-81ed-3c00838ab29b",
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "func.func @my_function() {\n",
-                        "  %0 = arith.constant 62 : i64\n",
-                        "  %2 = arith.addi %0, %0 : i64\n",
-                        "}"
-                    ]
-                }
-            ],
-            "source": [
-                "from xdsl.dialects.func import FuncOp\n",
-                "\n",
-                "my_func = FuncOp.from_region(\"my_function\", [], [], my_region)\n",
-                "printer.print_op(my_func)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "ca2fe54d",
-            "metadata": {},
-            "outputs": [],
-            "source": []
-        }
-    ],
-    "metadata": {
-        "language_info": {
-            "name": "python"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "478e8ef4-f3a7-4aec-b1f6-ffa60aa88697",
+   "metadata": {},
+   "source": [
+    "# xDSL tutorial"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "a3721339-9b8d-4743-b5da-e920f9afd3e9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Imports and setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e86541f5-af35-4c73-9a8c-4c43e7d365d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xdsl.ir import MLContext\n",
+    "from xdsl.dialects.arith import Arith\n",
+    "from xdsl.dialects.func import Func\n",
+    "from xdsl.dialects.builtin import Builtin\n",
+    "from xdsl.printer import Printer\n",
+    "\n",
+    "# MLContext, containing information about the registered dialects\n",
+    "context = MLContext()\n",
+    "\n",
+    "# Some useful dialects\n",
+    "context.load_dialect(Arith)\n",
+    "context.load_dialect(Func)\n",
+    "context.load_dialect(Builtin)\n",
+    "\n",
+    "# Printer used to pretty-print MLIR data structures\n",
+    "printer = Printer()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "f1270219-eeeb-4687-81e5-cce88afcb901",
+   "metadata": {},
+   "source": [
+    "## High-level presentation (TODO)\n",
+    "\n",
+    "Base ideas of what xDSL is. Example of a small program, and SSA."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ce39e1f4-3a54-463d-b2eb-d4fb4f7a6133",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Base IR features"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ab4f67ba-68c1-4232-9ba1-b82a5bfaaf2b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Dialects"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e36e9032-ccd2-4175-98c1-cfa3d86f722c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Dialects are namespaces that contain a collection of attributes and operations. For instance, the Builtin dialect contains (but not exclusively) the attribute `!i32` and the operation `builtin.func`.\n",
+    "A dialect is usually a single level of abstraction in the IR, and multiple dialects can be used together in the same MLIR program.\n",
+    "\n",
+    "Dialects are currently Python classes registering operations and attributes, and providing simple accessors to their attributes and dialects.\n",
+    "This will however change in the near future to provide a better interface to dialects."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "946e362d-0948-4c9e-b6b9-307afbe978a0",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Attributes"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e45b3a1b-b125-4393-93ad-7bff203a85bf",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Attributes represent compile-time information.\n",
+    "In particular, each SSA-value is associated with an attribute, representing its type.\n",
+    "Each attribute type has a name and belongs in a dialect. The textual representation of attributes is prefixed with `!`, and the dialect name.\n",
+    "For instance, the `vector` attribute has the format `!builtin.vector<T>`, where `T` is the expected parameter of the attribute.\n",
+    "\n",
+    "In Python, attributes are always expected to be immutable objects heriting from either `Data` or `ParametrizedAttribute`."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "5eaa4b21-cdf2-43b2-a998-7119ce7daf55",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Data attributes"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2924d529-6d63-48ff-bfdc-21958d90559b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "`Data` attributes are used to wrap python data structures. For instance, the `IntAttr` is an attribute containing an `int`, and the `StringAttr` is an attribute containing a `str`.\n",
+    "`Data` attributes are parsed and printed with the format `dialect_name.attr_name<custom_format>`, where `custom_format` is the format defined by the parser and printer of each `Data` attribute.\n",
+    "Note that some attributes, such as `StringAttr`, are shortened by the printer, and do not require the use of `dialect_name.attr_name`. For instance, `builtin.str<\"foo\">` is shortened to `\"foo\"`. \n",
+    "\n",
+    "Here is an example on how to create and print an `IntAttr` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f3061d94-b2f1-4d85-a0b6-d4486f7a45bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#int<42>"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.dialects.builtin import IntAttr\n",
+    "\n",
+    "# Attribute definitions usually define custom `__init__` to simplify their creation\n",
+    "my_int = IntAttr(42)\n",
+    "printer.print_attribute(my_int)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e5578732-a5d0-48a2-9a2b-0010b3d13135",
+   "metadata": {},
+   "source": [
+    "Note that here, the `IntAttr` does not print a dialect prefix. This will be fixed soon-ish."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8127a458-1d34-4dd9-aaff-468b93c9fe4b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Access the data in the IntAttr:\n",
+    "print(my_int.data)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "a4b9b668-63ad-4660-8016-65e8d1e9d617",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Parametrized attributes\n",
+    "\n",
+    "Parametrized attributes are attributes containing optionally multiple attributes as parameters.\n",
+    "For instance, the `integer` attribute from `builtin` is a parametrized attribute and expects two attributes as parameter.\n",
+    "Parametrized attributes are printed with the format `!dialect.attr_name<attr_1, ... attr_N>`, where `attr_i` are the attribute parameters.\n",
+    "\n",
+    "Here is an example on how to create and inspect an `integer_type` attribute, which represent a machine integer type. It is parametrized by a single `IntAttr` parameter, representing the bitwidth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b6b89a95-2b0b-4f37-9769-758cf2246eeb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "i64"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.dialects.builtin import IntegerType\n",
+    "\n",
+    "# Get the int that will be passed as parameter to the integer_type\n",
+    "int_64 = IntAttr(64)\n",
+    "i64 = IntegerType(int_64.data)\n",
+    "printer.print_attribute(i64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f4dfc1ef-9070-42d9-bf82-ec30b9bb7da1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#int<64>"
+     ]
+    }
+   ],
+   "source": [
+    "# Get back the parameters of IntegerType\n",
+    "printer.print_attribute(i64.parameters[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c060d5e5-6ead-45e3-b7ec-4bf9250271ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the custom constructor from IntegerType to construct it\n",
+    "assert IntegerType(64) == i64"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "9bd2c802-4e09-432a-bd2c-c512b073a681",
+   "metadata": {},
+   "source": [
+    "Note that parametrized attributes may define invariants that need to be respected.\n",
+    "For instance, constructing an `integer_type` with wrong parameters will trigger an error:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a35bc488-dd35-46e9-aa58-9734b06b555b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[IntegerType(parameters=[IntAttr(data=64), SignednessAttr(data=<Signedness.SIGNLESS: 0>)], width=IntAttr(data=64), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>))] should be of base attribute int\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# pyright: reportGeneralTypeIssues=false\n",
+    "# Try to create an IntegerType with wrong parameters\n",
+    "try:\n",
+    "    bad_attr = IntegerType([i64])\n",
+    "except Exception as err:\n",
+    "    print(err)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "8e5e4b80-9dc7-4238-8d4e-b0998b4bed2c",
+   "metadata": {},
+   "source": [
+    "## Operations"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "1a9b803e-eddf-4a7c-903d-a012ac6b61f9",
+   "metadata": {},
+   "source": [
+    "Operations represent the computation that a program can do. They span in all abstraction levels, and can be domain-specific.\n",
+    "For instance, `arith.addi` will add two integers, while `scf.if` represent an if/else structure.\n",
+    "\n",
+    "Operations are composed of:\n",
+    "* A base operation type, which represent the semantics of the operation;\n",
+    "* Operands, which are SSA-values previously defined;\n",
+    "* Results, which are new SSA-values defined by the operation;\n",
+    "* Attributes, which encode compile-time information about the operation;\n",
+    "* Regions, which contain operations, and are used to represent more complex control-flow;\n",
+    "* Successors, which are basic block names for which the operation can give control to.\n",
+    "\n",
+    "The format of an operation is: `results = dialect_name.op_name(operands) (successors) [attributes] regions`\n",
+    "\n",
+    "Here is for example how to create a constant operation, representing a constant value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "150ea21b-979b-494d-8e10-53327c17be38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "%0 = arith.constant 62 : i64"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.dialects.builtin import IntegerAttr\n",
+    "from xdsl.dialects.arith import Constant\n",
+    "\n",
+    "const_op = Constant.create(\n",
+    "    result_types=[i64], properties={\"value\": IntegerAttr.from_int_and_width(62, 64)}\n",
+    ")\n",
+    "printer.print_op(const_op)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "0c32595c-644f-46e8-b9b6-2baf81679ea2",
+   "metadata": {},
+   "source": [
+    "Note that dialects usually define methods to ease the definition of such operations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "66a37c45-7c2f-4d82-b2e3-759e75719817",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "%1 = arith.constant 62 : i64"
+     ]
+    }
+   ],
+   "source": [
+    "const_op2 = Constant(IntegerAttr.from_int_and_width(62, 64), i64)\n",
+    "printer.print_op(const_op2)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "608559d8-3b1f-4a92-99c5-a50f3ab74fd5",
+   "metadata": {},
+   "source": [
+    "We can use the results from the operation to pass them as operands for a later operation. For instance, we will add the constant to itself using the `arith.addi` operation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b7f1a4d8-31bb-4466-a125-5abd5c91c957",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "%0 = arith.constant 62 : i64\n",
+      "%2 = arith.addi %0, %0 : i64"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.dialects.arith import Addi\n",
+    "\n",
+    "add_op = Addi.create(operands=[const_op.results[0], const_op.results[0]], result_types=[i64])\n",
+    "printer.print_op(const_op)\n",
+    "print()\n",
+    "printer.print_op(add_op)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2bdc9fb2-3cfa-4a03-b0da-2d453570adc2",
+   "metadata": {},
+   "source": [
+    "We can also put the operations in regions, which can be then used by other operations (such as func)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f80adc50-9d38-41bd-9947-319a0dcadd10",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  %0 = arith.constant 62 : i64\n",
+      "  %2 = arith.addi %0, %0 : i64\n",
+      "}"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.ir import Region, Block\n",
+    "\n",
+    "my_region = Region([Block([const_op, add_op])])\n",
+    "printer.print_region(my_region)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "38f4deb5-5e73-48db-a86e-41c6685401df",
+   "metadata": {},
+   "source": [
+    "Functions are created using the `builtin.func` op, which contain a single region:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "52ccaee1-ce0e-434b-81ed-3c00838ab29b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "func.func @my_function() {\n",
+      "  %0 = arith.constant 62 : i64\n",
+      "  %2 = arith.addi %0, %0 : i64\n",
+      "}"
+     ]
+    }
+   ],
+   "source": [
+    "from xdsl.dialects.func import FuncOp\n",
+    "\n",
+    "my_func = FuncOp.from_region(\"my_function\", [], [], my_region)\n",
+    "printer.print_op(my_func)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca2fe54d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -235,7 +235,7 @@ def test_float_register():
 
 def test_riscv_parse_immediate_value():
     ctx = MLContext()
-    ctx.register_dialect(riscv.RISCV)
+    ctx.load_dialect(riscv.RISCV)
 
     prog = """riscv.jalr %0, 1.1, !riscv.reg<> : (!riscv.reg<>) -> ()"""
     parser = Parser(ctx, prog)

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -62,7 +62,7 @@ def test_rewrite_swap_inputs_pdl():
     stream = StringIO()
 
     ctx = MLContext()
-    ctx.register_dialect(arith.Arith)
+    ctx.load_dialect(arith.Arith)
 
     PatternRewriteWalker(
         PDLRewritePattern(pdl_rewrite_op, ctx, file=stream),
@@ -176,7 +176,7 @@ def test_rewrite_add_zero_pdl():
     stream = StringIO()
 
     ctx = MLContext()
-    ctx.register_dialect(arith.Arith)
+    ctx.load_dialect(arith.Arith)
 
     PatternRewriteWalker(
         PDLRewritePattern(pdl_rewrite_op, ctx, file=stream),
@@ -326,7 +326,7 @@ def test_interpreter_attribute_rewrite():
     stream = StringIO()
 
     ctx = MLContext()
-    ctx.register_dialect(arith.Arith)
+    ctx.load_dialect(arith.Arith)
 
     PatternRewriteWalker(
         PDLRewritePattern(pdl_rewrite_op, ctx, file=stream),
@@ -390,8 +390,8 @@ def test_property_rewrite():
     stream = StringIO()
 
     ctx = MLContext()
-    ctx.register_dialect(arith.Arith)
-    ctx.register_op(OnePropOp)
+    ctx.load_dialect(arith.Arith)
+    ctx.load_op(OnePropOp)
 
     PatternRewriteWalker(
         PDLRewritePattern(pdl_rewrite_op, ctx, file=stream),

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -13,7 +13,7 @@ pytest.importorskip("riscemu", reason="riscemu is an optional dependency")
 from xdsl.interpreters.riscv_emulator import RV_Debug, run_riscv  # noqa: E402
 
 ctx = MLContext()
-ctx.register_dialect(riscv.RISCV)
+ctx.load_dialect(riscv.RISCV)
 
 
 def test_simple():

--- a/tests/interpreters/test_wgpu.py
+++ b/tests/interpreters/test_wgpu.py
@@ -63,12 +63,12 @@ builtin.module attributes {gpu.container_module} {
 }
 """
     context = MLContext()
-    context.register_dialect(arith.Arith)
-    context.register_dialect(memref.MemRef)
-    context.register_dialect(builtin.Builtin)
-    context.register_dialect(gpu.GPU)
-    context.register_dialect(func.Func)
-    context.register_dialect(printf.Printf)
+    context.load_dialect(arith.Arith)
+    context.load_dialect(memref.MemRef)
+    context.load_dialect(builtin.Builtin)
+    context.load_dialect(gpu.GPU)
+    context.load_dialect(func.Func)
+    context.load_dialect(printf.Printf)
     parser = Parser(context, mlir_source)
     module = parser.parse_module()
 

--- a/tests/interpreters/test_wgsl_printer.py
+++ b/tests/interpreters/test_wgsl_printer.py
@@ -347,10 +347,10 @@ builtin.module attributes {gpu.container_module} {
             }
 """
     context = MLContext()
-    context.register_dialect(arith.Arith)
-    context.register_dialect(memref.MemRef)
-    context.register_dialect(builtin.Builtin)
-    context.register_dialect(gpu.GPU)
+    context.load_dialect(arith.Arith)
+    context.load_dialect(memref.MemRef)
+    context.load_dialect(builtin.Builtin)
+    context.load_dialect(gpu.GPU)
     parser = Parser(context, mlir_source)
     module = parser.parse_module()
 

--- a/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
+++ b/tests/rewriting/composable_rewriting/immutable_ir/test_immutable_ir.py
@@ -95,11 +95,11 @@ program_attr_and_prop = """
 )
 def test_immutable_ir(program_str: str):
     ctx = MLContext()
-    ctx.register_dialect(Test)
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Func)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Cf)
+    ctx.load_dialect(Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Func)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Cf)
 
     parser = Parser(ctx, program_str)
     program: Operation = parser.parse_op()

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -185,8 +185,8 @@ class AttrDictWithKeywordOp(IRDLOperation):
 def test_attr_dict(program: str, generic_program: str):
     """Test the 'attr-dict' and 'attr-dict-with-keyword' directives."""
     ctx = MLContext()
-    ctx.load_op(AttrDictOp)
-    ctx.load_op(AttrDictWithKeywordOp)
+    ctx.register_op(AttrDictOp)
+    ctx.register_op(AttrDictWithKeywordOp)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
@@ -230,7 +230,7 @@ def test_punctuations_and_keywords(format: str, program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.load_op(PunctuationOp)
+    ctx.register_op(PunctuationOp)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, '"test.punctuation"() : () -> ()', ctx)
@@ -340,8 +340,8 @@ def test_operands(format: str, program: str, generic_program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.load_op(TwoOperandsOp)
-    ctx.load_dialect(Test)
+    ctx.register_op(TwoOperandsOp)
+    ctx.register_dialect(Test)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
@@ -369,8 +369,8 @@ def test_operands_graph_region(format: str, program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.load_op(TwoOperandsOp)
-    ctx.load_dialect(Test)
+    ctx.register_op(TwoOperandsOp)
+    ctx.register_dialect(Test)
 
     check_roundtrip(program, ctx)
 

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -185,8 +185,8 @@ class AttrDictWithKeywordOp(IRDLOperation):
 def test_attr_dict(program: str, generic_program: str):
     """Test the 'attr-dict' and 'attr-dict-with-keyword' directives."""
     ctx = MLContext()
-    ctx.register_op(AttrDictOp)
-    ctx.register_op(AttrDictWithKeywordOp)
+    ctx.load_op(AttrDictOp)
+    ctx.load_op(AttrDictWithKeywordOp)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
@@ -230,7 +230,7 @@ def test_punctuations_and_keywords(format: str, program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.register_op(PunctuationOp)
+    ctx.load_op(PunctuationOp)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, '"test.punctuation"() : () -> ()', ctx)
@@ -340,8 +340,8 @@ def test_operands(format: str, program: str, generic_program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.register_op(TwoOperandsOp)
-    ctx.register_dialect(Test)
+    ctx.load_op(TwoOperandsOp)
+    ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
@@ -369,8 +369,8 @@ def test_operands_graph_region(format: str, program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.register_op(TwoOperandsOp)
-    ctx.register_dialect(Test)
+    ctx.load_op(TwoOperandsOp)
+    ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)
 
@@ -440,8 +440,8 @@ def test_results(format: str, program: str, generic_program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.register_op(TwoResultOp)
-    ctx.register_dialect(Test)
+    ctx.load_op(TwoResultOp)
+    ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -185,8 +185,8 @@ class AttrDictWithKeywordOp(IRDLOperation):
 def test_attr_dict(program: str, generic_program: str):
     """Test the 'attr-dict' and 'attr-dict-with-keyword' directives."""
     ctx = MLContext()
-    ctx.register_op(AttrDictOp)
-    ctx.register_op(AttrDictWithKeywordOp)
+    ctx.load_op(AttrDictOp)
+    ctx.load_op(AttrDictWithKeywordOp)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
@@ -230,7 +230,7 @@ def test_punctuations_and_keywords(format: str, program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.register_op(PunctuationOp)
+    ctx.load_op(PunctuationOp)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, '"test.punctuation"() : () -> ()', ctx)
@@ -340,8 +340,8 @@ def test_operands(format: str, program: str, generic_program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.register_op(TwoOperandsOp)
-    ctx.register_dialect(Test)
+    ctx.load_op(TwoOperandsOp)
+    ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
@@ -369,7 +369,7 @@ def test_operands_graph_region(format: str, program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.register_op(TwoOperandsOp)
-    ctx.register_dialect(Test)
+    ctx.load_op(TwoOperandsOp)
+    ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -495,10 +495,10 @@ program_successors = """
 )
 def test_is_structurally_equivalent(args: list[str], expected_result: bool):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Func)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Cf)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Func)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Cf)
 
     parser = Parser(ctx, args[0])
     lhs: Operation = parser.parse_op()
@@ -547,10 +547,10 @@ def test_is_structurally_equivalent_incompatible_ir_nodes():
 }) : () -> ()
 """
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Func)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Cf)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Func)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Cf)
 
     parser = Parser(ctx, program_func)
     program = parser.parse_operation()

--- a/tests/test_mlctx.py
+++ b/tests/test_mlctx.py
@@ -26,7 +26,7 @@ class DummyAttr2(ParametrizedAttribute):
 def test_get_op():
     """Test `get_op` and `get_optional_op` methods."""
     ctx = MLContext()
-    ctx.register_op(DummyOp)
+    ctx.load_op(DummyOp)
 
     assert ctx.get_op("dummy") == DummyOp
     with pytest.raises(Exception):
@@ -42,7 +42,7 @@ def test_get_op_unregistered():
     methods with the `allow_unregistered` flag.
     """
     ctx = MLContext(allow_unregistered=True)
-    ctx.register_op(DummyOp)
+    ctx.load_op(DummyOp)
 
     assert ctx.get_optional_op("dummy") == DummyOp
     op = ctx.get_optional_op("dummy2")
@@ -56,7 +56,7 @@ def test_get_op_unregistered():
 def test_get_attr():
     """Test `get_attr` and `get_optional_attr` methods."""
     ctx = MLContext()
-    ctx.register_attr(DummyAttr)
+    ctx.load_attr(DummyAttr)
 
     assert ctx.get_attr("dummy_attr") == DummyAttr
     with pytest.raises(Exception):
@@ -73,7 +73,7 @@ def test_get_attr_unregistered(is_type: bool):
     methods with the `allow_unregistered` flag.
     """
     ctx = MLContext(allow_unregistered=True)
-    ctx.register_attr(DummyAttr)
+    ctx.load_attr(DummyAttr)
 
     assert (
         ctx.get_optional_attr("dummy_attr", create_unregistered_as_type=is_type)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -51,7 +51,7 @@ def test_dictionary_attr(data: dict[str, Attribute]):
         text = io.getvalue()
 
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     attr1 = Parser(ctx, text).parse_attribute()
     attr2 = Parser(ctx, "attributes " + text).parse_optional_attr_dict_with_keyword()
@@ -65,7 +65,7 @@ def test_dictionary_attr(data: dict[str, Attribute]):
 @pytest.mark.parametrize("text", ["{}", "{a = 1}", "attr {}"])
 def test_dictionary_attr_with_keyword_missing(text: str):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     assert Parser(ctx, text).parse_optional_attr_dict_with_keyword() is None
 
@@ -76,7 +76,7 @@ def test_dictionary_attr_with_keyword_missing(text: str):
 )
 def test_dictionary_attr_with_keyword_reserved(text: str, reserved_names: list[str]):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     with pytest.raises(ParseError):
         Parser(ctx, "attributes" + text).parse_optional_attr_dict_with_keyword(
@@ -90,7 +90,7 @@ def test_dictionary_attr_with_keyword_reserved(text: str, reserved_names: list[s
 )
 def test_dictionary_attr_with_keyword_not_reserved(text: str, expected: list[str]):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     res = Parser(ctx, "attributes" + text).parse_optional_attr_dict_with_keyword(
         expected
@@ -109,7 +109,7 @@ def test_parsing():
     parse attribute arguments without the delimiters.
     """
     ctx = MLContext()
-    ctx.register_attr(DummyAttr)
+    ctx.load_attr(DummyAttr)
 
     prog = '#dummy.attr "foo"'
     parser = Parser(ctx, prog)
@@ -134,7 +134,7 @@ def test_parsing():
 )
 def test_symbol_name(text: str, expected: StringAttr | None):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, text)
     assert parser.parse_optional_symbol_name() == expected
@@ -162,7 +162,7 @@ def test_symref(ref: str, expected: Attribute | None):
     Test that symbol references are correctly parsed.
     """
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, ref)
     parsed_ref = parser.parse_attribute()
@@ -192,7 +192,7 @@ def test_parse_argument(
     arg ::= percent-id ':' type     if expect_type is True
     """
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     # parse_optional_argument
     parser = Parser(ctx, text)
@@ -227,7 +227,7 @@ def test_parse_argument(
 )
 def test_parse_argument_fail(text: str, expect_type: bool):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Builtin)
 
     # parse_optional_argument
     parser = Parser(ctx, text)
@@ -289,8 +289,8 @@ def test_parse_region_no_args(
     text: str, num_ops_and_args: list[tuple[int, int]] | None
 ):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
 
     parser = Parser(ctx, text)
     if num_ops_and_args is None:
@@ -322,8 +322,8 @@ def test_parse_region_no_args(
 )
 def test_parse_region_fail(text: str):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
 
     parser = Parser(ctx, text)
     with pytest.raises(ParseError):
@@ -344,8 +344,8 @@ def test_parse_region_fail(text: str):
 def test_parse_region_with_args(text: str):
     """Parse a region with args already provided."""
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
 
     parser = Parser(ctx, text)
     arg = parser.parse_argument()
@@ -370,8 +370,8 @@ def test_parse_region_with_args(text: str):
 def test_parse_region_with_args_fail(text: str):
     """Parse a region with args already provided."""
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
 
     parser = Parser(ctx, text)
     arg = parser.parse_argument()
@@ -393,7 +393,7 @@ class MultiRegionOp(IRDLOperation):
 
 def test_parse_multi_region_mlir():
     ctx = MLContext()
-    ctx.register_op(MultiRegionOp)
+    ctx.load_op(MultiRegionOp)
 
     op_str = """
     "test.multi_region" () ({
@@ -812,7 +812,7 @@ class PropertyOp(IRDLOperation):
 def test_properties_retrocompatibility():
     # Straightforward case
     ctx = MLContext()
-    ctx.register_op(PropertyOp)
+    ctx.load_op(PropertyOp)
     parser = Parser(ctx, '"test.prop_op"() <{first = "str", second = 42}> : () -> ()')
 
     op = parser.parse_op()

--- a/tests/test_parser_error.py
+++ b/tests/test_parser_error.py
@@ -23,7 +23,7 @@ class UnkownOp(IRDLOperation):
 
 def check_error(prog: str, line: int, column: int, message: str):
     ctx = MLContext()
-    ctx.register_op(UnkownOp)
+    ctx.load_op(UnkownOp)
 
     parser = Parser(ctx, prog)
     with pytest.raises(ParseError, match=message) as e:
@@ -35,7 +35,7 @@ def check_error(prog: str, line: int, column: int, message: str):
 def test_parser_missing_equal():
     """Test a missing equal sign error."""
     ctx = MLContext()
-    ctx.register_op(UnkownOp)
+    ctx.load_op(UnkownOp)
 
     prog = """
 "unknown"() ({
@@ -48,7 +48,7 @@ def test_parser_missing_equal():
 def test_parser_redefined_value():
     """Test an SSA value redefinition error."""
     ctx = MLContext()
-    ctx.register_op(UnkownOp)
+    ctx.load_op(UnkownOp)
 
     prog = """
 "unknown"() ({
@@ -62,7 +62,7 @@ def test_parser_redefined_value():
 def test_parser_missing_operation_name():
     """Test a missing operation name error."""
     ctx = MLContext()
-    ctx.register_op(UnkownOp)
+    ctx.load_op(UnkownOp)
 
     prog = """
 "unknown"() ({

--- a/tests/test_pattern_rewriter.py
+++ b/tests/test_pattern_rewriter.py
@@ -28,9 +28,9 @@ from xdsl.utils.hints import isa
 
 def rewrite_and_compare(prog: str, expected_prog: str, walker: PatternRewriteWalker):
     ctx = MLContext(allow_unregistered=True)
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(test.Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(test.Test)
 
     parser = Parser(ctx, prog)
     module = parser.parse_module()
@@ -469,8 +469,8 @@ def test_operation_deletion_failure():
     """Test rewrites where SSA values are deleted with still uses."""
 
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Arith)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Arith)
 
     prog = """"builtin.module"() ({
   %0 = "arith.constant"() <{"value" = 5 : i32}> : () -> i32

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -40,7 +40,7 @@ from xdsl.utils.exceptions import DiagnosticException, ParseError
 def test_simple_forgotten_op():
     """Test that the parsing of an undefined operand gives it a name."""
     ctx = MLContext()
-    ctx.register_dialect(Arith)
+    ctx.load_dialect(Arith)
 
     lit = Constant.from_int_and_width(42, 32)
     add = Addi(lit, lit)
@@ -55,7 +55,7 @@ def test_simple_forgotten_op():
 def test_print_op_location():
     """Test that an op can be printed with its location."""
     ctx = MLContext()
-    ctx.register_dialect(test.Test)
+    ctx.load_dialect(test.Test)
 
     add = test.TestOp(result_types=[i32])
 
@@ -127,8 +127,8 @@ def test_op_message():
 """
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, prog)
     module = parser.parse_module()
@@ -162,8 +162,8 @@ def test_two_different_op_messages():
 }) : () -> ()"""
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, prog)
     module = parser.parse_module()
@@ -197,8 +197,8 @@ def test_two_same_op_messages():
 }) : () -> ()"""
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, prog)
     module = parser.parse_module()
@@ -230,8 +230,8 @@ def test_op_message_with_region():
 }) : () -> ()"""
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -263,8 +263,8 @@ def test_op_message_with_region_and_overflow():
 }) : () -> ()"""
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -286,8 +286,8 @@ def test_diagnostic():
 }) : () -> ()"""
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -325,8 +325,8 @@ def test_print_custom_name():
 """
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -538,9 +538,9 @@ builtin.module {
 """
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
-    ctx.register_op(PlusCustomFormatOp)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
+    ctx.load_op(PlusCustomFormatOp)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -567,9 +567,9 @@ builtin.module {
 """
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
-    ctx.register_op(PlusCustomFormatOp)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
+    ctx.load_op(PlusCustomFormatOp)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -596,9 +596,9 @@ def test_custom_format_II():
 """
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
-    ctx.register_op(PlusCustomFormatOp)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
+    ctx.load_op(PlusCustomFormatOp)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -626,9 +626,9 @@ def test_missing_custom_format():
 """
 
     ctx = MLContext()
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(Builtin)
-    ctx.register_op(PlusCustomFormatOp)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
+    ctx.load_op(PlusCustomFormatOp)
 
     parser = Parser(ctx, prog)
     with pytest.raises(ParseError):
@@ -678,9 +678,9 @@ def test_custom_format_attr():
 }) : () -> ()"""
 
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_op(AnyOp)
-    ctx.register_attr(CustomFormatAttr)
+    ctx.load_dialect(Builtin)
+    ctx.load_op(AnyOp)
+    ctx.load_attr(CustomFormatAttr)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
@@ -696,8 +696,8 @@ def test_dictionary_attr():
     """
 
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Func)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Func)
 
     parser = Parser(ctx, prog)
     parsed = parser.parse_op()

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -15,9 +15,9 @@ def rewrite_and_compare(
     prog: str, expected_prog: str, transformation: Callable[[ModuleOp, Rewriter], None]
 ):
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Arith)
-    ctx.register_dialect(test.Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(test.Test)
 
     parser = Parser(ctx, prog)
     module = parser.parse_module()

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -13,8 +13,8 @@ test_prog = """
 
 def test_main():
     ctx = MLContext()
-    ctx.register_dialect(Builtin)
-    ctx.register_dialect(Test)
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
 
     parser = Parser(ctx, test_prog)
     module = parser.parse_op()

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -216,7 +216,7 @@ class CommandLineTool:
         Add other/additional dialects by overloading this function.
         """
         for dialect in get_all_dialects():
-            self.ctx.register_dialect(dialect)
+            self.ctx.load_dialect(dialect)
 
     def register_all_frontends(self):
         """

--- a/xdsl/tools/irdl_to_pyrdl.py
+++ b/xdsl/tools/irdl_to_pyrdl.py
@@ -24,7 +24,7 @@ def main():
     ctx = MLContext()
     dialects = get_all_dialects()
     for dialect in dialects:
-        ctx.register_dialect(dialect)
+        ctx.load_dialect(dialect)
 
     # Parse the input file
     f = open(args.input_file)

--- a/xdsl/transforms/canonicalize.py
+++ b/xdsl/transforms/canonicalize.py
@@ -19,7 +19,7 @@ class CanonicalizePass(ModulePass):
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         patterns = [
             pattern
-            for ctx_op in ctx.registered_ops()
+            for ctx_op in ctx.loaded_ops
             if (trait := ctx_op.get_trait(HasCanonicalisationPatternsTrait)) is not None
             for pattern in trait.get_canonicalization_patterns()
         ]


### PR DESCRIPTION
This PR renames `register_*` with `load_*`.
`load_*` is the naming used by MLIR, so it makes sense to go there.
Also, I would like to add a `register_*` methods, as in #1116 