### PR TITLE
dialects: Add and-bitwise rewrite pattern

### DIFF
--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -160,5 +160,8 @@ builtin.module {
 // CHECK-NEXT:   %add_lhs_rhs_1 = riscv.mul %i1, %add_lhs_rhs : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_lhs_rhs_1) : (!riscv.reg<a0>) -> ()
 
+// CHECK-NEXT:   %and_bitwise_zero = riscv.and %1, 0 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%and_bitwise_zero) : (!riscv.reg<a0>) -> ()
+
 
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -82,10 +82,10 @@ builtin.module {
   %add_lhs_rhs = riscv.add %i1, %i1 : (!riscv.reg<a1>, !riscv.reg<a1>) -> !riscv.reg<a0>
   "test.op"(%add_lhs_rhs) : (!riscv.reg<a0>) -> ()
 
-  %and_bitwise_zero_l0 = riscv.and %1, 0 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
+  %and_bitwise_zero_l0 = riscv.and %1, %0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
   "test.op"(%and_bitwise_zero_l0) : (!riscv.reg<a0>) -> ()
 
-  %and_bitwise_zero_r0 = riscv.and 0, %1 : (!riscv.reg<>, !riscv.reg<a1>) -> !riscv.reg<a0>
+  %and_bitwise_zero_r0 = riscv.and %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
   "test.op"(%and_bitwise_zero_r0) : (!riscv.reg<a0>) -> ()
 }
 

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -82,8 +82,11 @@ builtin.module {
   %add_lhs_rhs = riscv.add %i1, %i1 : (!riscv.reg<a1>, !riscv.reg<a1>) -> !riscv.reg<a0>
   "test.op"(%add_lhs_rhs) : (!riscv.reg<a0>) -> ()
 
-  %and_bitwise_zero = riscv.and %1, 0 : (!riscv.reg<>) -> !riscv.reg<a0>
-  "test.op"(%and_bitwise_zero) : (!riscv.reg<a0>) -> ()
+  %and_bitwise_zero_l0 = riscv.and %1, 0 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
+  "test.op"(%and_bitwise_zero_l0) : (!riscv.reg<a0>) -> ()
+
+  %and_bitwise_zero_r0 = riscv.and 0, %1 : (!riscv.reg<>, !riscv.reg<a1>) -> !riscv.reg<a0>
+  "test.op"(%and_bitwise_zero_r0) : (!riscv.reg<a0>) -> ()
 }
 
 // CHECK: builtin.module {
@@ -160,8 +163,10 @@ builtin.module {
 // CHECK-NEXT:   %add_lhs_rhs_1 = riscv.mul %i1, %add_lhs_rhs : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_lhs_rhs_1) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %and_bitwise_zero = riscv.and %1, 0 : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:   "test.op"(%and_bitwise_zero) : (!riscv.reg<a0>) -> ()
+// CHECK-NEXT:   %and_bitwise_zero_l0 = riscv.mv %0 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%and_bitwise_zero_l0) : (!riscv.reg<a0>) -> ()
 
+// CHECK-NEXT:   %and_bitwise_zero_r0 = riscv.mv %0 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   "test.op"(%and_bitwise_zero_r0) : (!riscv.reg<a0>) -> ()
 
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -81,6 +81,9 @@ builtin.module {
 
   %add_lhs_rhs = riscv.add %i1, %i1 : (!riscv.reg<a1>, !riscv.reg<a1>) -> !riscv.reg<a0>
   "test.op"(%add_lhs_rhs) : (!riscv.reg<a0>) -> ()
+
+  %and_bitwise_zero = riscv.and %1, 0 : (!riscv.reg<>) -> !riscv.reg<a0>
+  "test.op"(%and_bitwise_zero) : (!riscv.reg<a0>) -> ()
 }
 
 // CHECK: builtin.module {

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3673,6 +3673,15 @@ def _print_immediate_value(printer: Printer, immediate: AnyIntegerAttr | LabelAt
             printer.print_string_literal(immediate.data)
 
 
+class BitwiseHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import (
+            BitwiseAndByZero
+        )
+
+        return (BitwiseAndByZero(),)
+
 RISCV = Dialect(
     [
         AddiOp,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1621,14 +1621,14 @@ class SltuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType])
 
     name = "riscv.sltu"
 
+
 class BitwiseAndHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl.transforms.canonicalization_patterns.riscv import (
-            BitwiseAndByZero
-        )
+        from xdsl.transforms.canonicalization_patterns.riscv import BitwiseAndByZero
 
         return (BitwiseAndByZero(),)
+
 
 @irdl_op_definition
 class AndOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3673,7 +3673,7 @@ def _print_immediate_value(printer: Printer, immediate: AnyIntegerAttr | LabelAt
             printer.print_string_literal(immediate.data)
 
 
-class BitwiseHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
+class BitwiseAndHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.riscv import (

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1621,6 +1621,14 @@ class SltuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType])
 
     name = "riscv.sltu"
 
+class BitwiseAndHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import (
+            BitwiseAndByZero
+        )
+
+        return (BitwiseAndByZero(),)
 
 @irdl_op_definition
 class AndOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
@@ -1633,6 +1641,8 @@ class AndOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
     """
 
     name = "riscv.and"
+
+    traits = frozenset((BitwiseAndHasCanonicalizationPatternsTrait(),))
 
 
 @irdl_op_definition
@@ -3672,15 +3682,6 @@ def _print_immediate_value(printer: Printer, immediate: AnyIntegerAttr | LabelAt
         case LabelAttr():
             printer.print_string_literal(immediate.data)
 
-
-class BitwiseAndHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl.transforms.canonicalization_patterns.riscv import (
-            BitwiseAndByZero
-        )
-
-        return (BitwiseAndByZero(),)
 
 RISCV = Dialect(
     [

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Sequence, Set
 from io import StringIO
 from typing import IO, ClassVar, Generic, TypeAlias, TypeVar
 
@@ -404,7 +404,7 @@ class RISCVOp(Operation, ABC):
         return []
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         """
         Parse attributes with custom syntax. Subclasses may override this method.
         """
@@ -625,7 +625,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(20, Signedness.UNSIGNED)
@@ -680,7 +680,7 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(20, Signedness.SIGNED)
@@ -742,7 +742,7 @@ class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.rs1, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(12, Signedness.SIGNED)
@@ -783,7 +783,7 @@ class RdRsImmShiftOperation(RdRsImmIntegerOperation):
         super().__init__(rs1, immediate, rd=rd, comment=comment)
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(5, Signedness.UNSIGNED)
@@ -844,7 +844,7 @@ class RdRsImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.rs1, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(12, Signedness.SIGNED)
@@ -929,7 +929,7 @@ class RsRsOffIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rs1, self.rs2, self.offset
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["offset"] = _parse_immediate_value(parser, IntegerType(12))
         return attributes
@@ -979,7 +979,7 @@ class RsRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rs1, self.rs2, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(12, Signedness.SIGNED)
@@ -1089,7 +1089,7 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.csr, self.rs1
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["csr"] = IntegerAttr(
             parser.parse_integer(allow_boolean=False, context_msg="Expected csr"),
@@ -1167,7 +1167,7 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.csr, self.rs1
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["csr"] = IntegerAttr(
             parser.parse_integer(allow_boolean=False, context_msg="Expected csr"),
@@ -1243,7 +1243,7 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.csr, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["csr"] = IntegerAttr(
             parser.parse_integer(allow_boolean=False, context_msg="Expected csr"),
@@ -1311,7 +1311,7 @@ class CsrBitwiseImmOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.csr, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["csr"] = IntegerAttr(
             parser.parse_integer(allow_boolean=False, context_msg="Expected csr"),
@@ -2345,7 +2345,7 @@ class LiOp(RdImmIntegerOperation):
         super().__init__(immediate, rd=rd, comment=comment)
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(32, Signedness.SIGNED)
@@ -2403,7 +2403,7 @@ class LabelOp(IRDLOperation, RISCVOp):
         return _append_comment(f"{self.label.data}:", self.comment)
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["label"] = LabelAttr(parser.parse_str_literal("Expected label"))
         return attributes
@@ -2454,7 +2454,7 @@ class DirectiveOp(IRDLOperation, RISCVOp):
         return _assembly_line(self.directive.data, arg_str, is_indented=False)
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["directive"] = StringAttr(
             parser.parse_str_literal("Expected directive")
@@ -2998,7 +2998,7 @@ class RsRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rs1, self.rs2, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(12, Signedness.SIGNED)
@@ -3054,7 +3054,7 @@ class RdRsImmFloatOperation(IRDLOperation, RISCVInstruction, ABC):
         return self.rd, self.rs1, self.immediate
 
     @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> Mapping[str, Attribute]:
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["immediate"] = _parse_immediate_value(
             parser, IntegerType(12, Signedness.SIGNED)

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -335,6 +335,7 @@ class AdditionOfSameVariablesToMultiplyByTwo(RewritePattern):
                 ]
             )
 
+
 class BitwiseAndByZero(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: riscv.AndOp, rewriter: PatternRewriter):
@@ -344,28 +345,24 @@ class BitwiseAndByZero(RewritePattern):
         """
 
         # check if the first operand is 0
-        if(
-            isinstance(op.rs1.owner, riscv.LiOp) and
-            isinstance(op.rs1.owner.immediate, IntegerAttr) and
-            op.rs1.owner.immediate.value.data == 0
+        if (
+            isinstance(op.rs1.owner, riscv.LiOp)
+            and isinstance(op.rs1.owner.immediate, IntegerAttr)
+            and op.rs1.owner.immediate.value.data == 0
         ):
-            # if first source is equal to 0, move the content of the first source (0)
-            # to the destination 
+            # if first source is equal to 0, move the content of the first source (0) to the destination
             rd = cast(riscv.IntRegisterType, op.rd.type)
             rewriter.replace_matched_op(riscv.MVOp(op.rs1, rd=rd))
-        
+
         # check if the second operand is 0
-        if(
-            isinstance(op.rs2.owner, riscv.LiOp) and
-            isinstance(op.rs2.owner.immediate, IntegerAttr) and
-            op.rs2.owner.immediate.value.data == 0
+        if (
+            isinstance(op.rs2.owner, riscv.LiOp)
+            and isinstance(op.rs2.owner.immediate, IntegerAttr)
+            and op.rs2.owner.immediate.value.data == 0
         ):
-            # if second source is equal to 0, move the content of the second source (0)
-            # to the destination
+            # if second source is equal to 0, move the content of the second source (0) to the destination
             rd = cast(riscv.IntRegisterType, op.rd.type)
             rewriter.replace_matched_op(riscv.MVOp(op.rs2, rd=rd))
-
-
 
 
 class ScfgwOpUsingImmediate(RewritePattern):

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -350,7 +350,7 @@ class BitwiseAndByZero(RewritePattern):
             and isinstance(op.rs1.owner.immediate, IntegerAttr)
             and op.rs1.owner.immediate.value.data == 0
         ):
-            # if first source is equal to 0, move the content of the first source (0) to the destination
+            # if the first operand is 0, set the destination to 0
             rd = cast(riscv.IntRegisterType, op.rd.type)
             rewriter.replace_matched_op(riscv.MVOp(op.rs1, rd=rd))
 
@@ -360,7 +360,7 @@ class BitwiseAndByZero(RewritePattern):
             and isinstance(op.rs2.owner.immediate, IntegerAttr)
             and op.rs2.owner.immediate.value.data == 0
         ):
-            # if second source is equal to 0, move the content of the second source (0) to the destination
+            # if the second operand is 0, set the destination to 0
             rd = cast(riscv.IntRegisterType, op.rd.type)
             rewriter.replace_matched_op(riscv.MVOp(op.rs2, rd=rd))
 

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -345,10 +345,9 @@ class BitwiseAndByZero(RewritePattern):
 
         # check if the first operand is 0
         if(
-            isinstance(op.rs1, OpResult) and
-            isinstance(op.rs1.op, riscv.LiOp) and
-            isinstance(op.rs1.op.immediate, IntegerAttr) and
-            op.rs1.op.immediate.value.data == 0
+            isinstance(op.rs1.owner, riscv.LiOp) and
+            isinstance(op.rs1.owner.immediate, IntegerAttr) and
+            op.rs1.owner.immediate.value.data == 0
         ):
             # if first source is equal to 0, move the content of the first source (0)
             # to the destination 
@@ -357,10 +356,9 @@ class BitwiseAndByZero(RewritePattern):
         
         # check if the second operand is 0
         if(
-            isinstance(op.rs2, OpResult) and
-            isinstance(op.rs2.op, riscv.LiOp) and
-            isinstance(op.rs2.op.immediate, IntegerAttr) and
-            op.rs2.op.immediate.value.data == 0
+            isinstance(op.rs2.owner, riscv.LiOp) and
+            isinstance(op.rs2.owner.immediate, IntegerAttr) and
+            op.rs2.owner.immediate.value.data == 0
         ):
             # if second source is equal to 0, move the content of the second source (0)
             # to the destination

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -2,7 +2,6 @@ from typing import cast
 
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import IntegerAttr
-from xdsl.ir import Operation
 from xdsl.ir.core import OpResult
 from xdsl.pattern_rewriter import (
     PatternRewriter,


### PR DESCRIPTION
**implementation of and-bitwise rewrite pattern**

This PR includes the code that implements a rewrite pattern for an and-bitwise operation. 
It was introduced:
- the class class ```BitwiseAndByZero(RewritePattern)``` in ```xdsl/transforms/canonicalization_patterns/riscv.py``` containing the rewrite pattern for the and-bitwise operation.
- the class ```BitwiseHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait)``` in ```xdsl/dialects/riscv.py``` for bitwise operations (maybe was ```AndHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait)``` better instead?). I didn't find an already existing class appropriate for and operation.
-  test for the new rewrite pattern.

@tobiasgrosser, @superlopuh, @compor, please let me know if there is anything should be done differently.
