### PR TITLE
core: Add results in declarative format

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -440,8 +440,8 @@ def test_results(format: str, program: str, generic_program: str):
         assembly_format = format
 
     ctx = MLContext()
-    ctx.load_op(TwoResultOp)
-    ctx.load_dialect(Test)
+    ctx.register_op(TwoResultOp)
+    ctx.register_dialect(Test)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -751,24 +751,7 @@ class ExtFOp(IRDLOperation):
     def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
         return super().__init__(operands=[op], result_types=[target_type])
 
-    @classmethod
-    def parse(cls, parser: Parser):
-        input = parser.parse_unresolved_operand()
-        parser.parse_punctuation(":")
-        input_type = parser.parse_type()
-        parser.parse_keyword("to")
-        result_type = parser.parse_type()
-        [input] = parser.resolve_operands([input], [input_type], parser.pos)
-        result_float_type = cast(AnyFloat, result_type)
-        return cls(input, result_float_type)
-
-    def print(self, printer: Printer):
-        printer.print(" ")
-        printer.print_operand(self.input)
-        printer.print(" : ")
-        printer.print_attribute(self.input.type)
-        printer.print(" to ")
-        printer.print_attribute(self.result.type)
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
 
 
 @irdl_op_definition
@@ -781,24 +764,7 @@ class TruncFOp(IRDLOperation):
     def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
         return super().__init__(operands=[op], result_types=[target_type])
 
-    @classmethod
-    def parse(cls, parser: Parser):
-        input = parser.parse_unresolved_operand()
-        parser.parse_punctuation(":")
-        input_type = parser.parse_type()
-        parser.parse_keyword("to")
-        result_type = parser.parse_type()
-        [input] = parser.resolve_operands([input], [input_type], parser.pos)
-        result_float_type = cast(AnyFloat, result_type)
-        return cls(input, result_float_type)
-
-    def print(self, printer: Printer):
-        printer.print(" ")
-        printer.print_operand(self.input)
-        printer.print(" : ")
-        printer.print_attribute(self.input.type)
-        printer.print(" to ")
-        printer.print_attribute(self.result.type)
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
 
 
 @irdl_op_definition
@@ -819,24 +785,7 @@ class TruncIOp(IRDLOperation):
                 "Destination bit-width must be smaller than the input bit-width"
             )
 
-    @classmethod
-    def parse(cls, parser: Parser):
-        input = parser.parse_unresolved_operand()
-        parser.parse_punctuation(":")
-        input_type = parser.parse_type()
-        parser.parse_keyword("to")
-        result_type = parser.parse_type()
-        [input] = parser.resolve_operands([input], [input_type], parser.pos)
-        result_int_type = cast(IntegerType, result_type)
-        return cls(input, result_int_type)
-
-    def print(self, printer: Printer):
-        printer.print(" ")
-        printer.print_operand(self.input)
-        printer.print(" : ")
-        printer.print_attribute(self.input.type)
-        printer.print(" to ")
-        printer.print_attribute(self.result.type)
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
 
 
 @irdl_op_definition
@@ -857,24 +806,7 @@ class ExtSIOp(IRDLOperation):
                 "Destination bit-width must be larger than the input bit-width"
             )
 
-    @classmethod
-    def parse(cls, parser: Parser):
-        input = parser.parse_unresolved_operand()
-        parser.parse_punctuation(":")
-        input_type = parser.parse_type()
-        parser.parse_keyword("to")
-        result_type = parser.parse_type()
-        [input] = parser.resolve_operands([input], [input_type], parser.pos)
-        result_int_type = cast(IntegerType, result_type)
-        return cls(input, result_int_type)
-
-    def print(self, printer: Printer):
-        printer.print(" ")
-        printer.print_operand(self.input)
-        printer.print(" : ")
-        printer.print_attribute(self.input.type)
-        printer.print(" to ")
-        printer.print_attribute(self.result.type)
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
 
 
 @irdl_op_definition
@@ -895,24 +827,7 @@ class ExtUIOp(IRDLOperation):
                 "Destination bit-width must be larger than the input bit-width"
             )
 
-    @classmethod
-    def parse(cls, parser: Parser):
-        input = parser.parse_unresolved_operand()
-        parser.parse_punctuation(":")
-        input_type = parser.parse_type()
-        parser.parse_keyword("to")
-        result_type = parser.parse_type()
-        [input] = parser.resolve_operands([input], [input_type], parser.pos)
-        result_int_type = cast(IntegerType, result_type)
-        return cls(input, result_int_type)
-
-    def print(self, printer: Printer):
-        printer.print(" ")
-        printer.print_operand(self.input)
-        printer.print(" : ")
-        printer.print_attribute(self.input.type)
-        printer.print(" to ")
-        printer.print_attribute(self.result.type)
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
 
 
 Arith = Dialect(

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -167,10 +167,11 @@ class AttrDictDirective(FormatDirective):
         state.attributes = res
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if op.attributes:
-            if self.with_keyword:
-                printer.print(" attributes")
-            printer.print_op_attributes(op.attributes)
+        if not op.attributes:
+            return
+        if self.with_keyword:
+            printer.print(" attributes")
+        printer.print_op_attributes(op.attributes)
         state.last_was_punctuation = False
         state.should_emit_space = False
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -27,12 +27,13 @@ class ParsingState:
 
     operands: list[UnresolvedOperand | None]
     operand_types: list[Attribute | None]
+    result_types: list[Attribute | None]
     attributes: dict[str, Attribute]
 
     def __init__(self, op_def: OpDef):
-        if op_def.results or op_def.attributes or op_def.regions or op_def.successors:
+        if op_def.attributes or op_def.regions or op_def.successors:
             raise NotImplementedError(
-                "Operation definitions with results, attributes, regions, "
+                "Operation definitions with attributes, regions, "
                 "or successors are not yet supported"
             )
         for _, operand in (*op_def.operands, *op_def.results):
@@ -43,6 +44,7 @@ class ParsingState:
                 )
         self.operands = [None] * len(op_def.operands)
         self.operand_types = [None] * len(op_def.operands)
+        self.result_types = [None] * len(op_def.results)
         self.attributes = {}
 
 
@@ -104,11 +106,17 @@ class FormatProgram:
         operand_types = state.operand_types
         assert isa(operand_types, list[Attribute])
 
+        # Ensure that all result types are parsed
+        result_types = state.result_types
+        assert isa(state.result_types, list[Attribute])
+
         # Resolve all operands
         operands = parser.resolve_operands(
             unresolved_operands, operand_types, parser.pos
         )
-        return op_type.build(operands=operands, attributes=state.attributes)
+        return op_type.build(
+            result_types=result_types, operands=operands, attributes=state.attributes
+        )
 
     def print(self, printer: Printer, op: IRDLOperation) -> None:
         """
@@ -196,7 +204,7 @@ class OperandVariable(FormatDirective):
 class OperandTypeDirective(FormatDirective):
     """
     An operand variable type directive, with the following format:
-      operand-directive ::= type
+      operand-type-directive ::= type(percent-ident)
     The directive will request a space to be printed right after.
     """
 
@@ -213,6 +221,58 @@ class OperandTypeDirective(FormatDirective):
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
         printer.print_attribute(op.operands[self.index].type)
+        state.last_was_punctuation = False
+        state.should_emit_space = True
+
+
+@dataclass(frozen=True)
+class ResultVariable(FormatDirective):
+    """
+    An result variable, with the following format:
+      result-directive ::= percent-ident
+    This directive can not be used for parsing and printing directly, as result
+    parsing is not handled by the custom operation parser.
+    """
+
+    name: str
+    """The result name. This is only used for error message reporting."""
+    index: int
+    """Index of the result definition."""
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        assert (
+            "Result variables cannot be used directly to parse/print in "
+            "declarative formats."
+        )
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        assert (
+            "Result variables cannot be used directly to parse/print in "
+            "declarative formats."
+        )
+
+
+@dataclass(frozen=True)
+class ResultTypeDirective(FormatDirective):
+    """
+    A result variable type directive, with the following format:
+      result-type-directive ::= type(percent-ident)
+    The directive will request a space to be printed right after.
+    """
+
+    name: str
+    """The result name. This is only used for error message reporting."""
+    index: int
+    """Index of the result definition."""
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        type = parser.parse_type()
+        state.result_types[self.index] = type
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        printer.print_attribute(op.results[self.index].type)
         state.last_was_punctuation = False
         state.should_emit_space = True
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -18,6 +18,8 @@ from xdsl.irdl.declarative_assembly_format import (
     OperandTypeDirective,
     OperandVariable,
     PunctuationDirective,
+    ResultTypeDirective,
+    ResultVariable,
 )
 from xdsl.parser import BaseParser, ParserState
 from xdsl.utils.lexer import Input, Lexer, Token
@@ -77,6 +79,8 @@ class FormatParser(BaseParser):
     """The operand variables that are already parsed."""
     seen_operand_types: list[bool]
     """The operand types that are already parsed."""
+    seen_result_types: list[bool]
+    """The result types that are already parsed."""
     has_attr_dict: bool = field(default=False)
     """True if the attribute dictionary has already been parsed."""
     context: ParsingContext = field(default=ParsingContext.TopLevel)
@@ -87,6 +91,7 @@ class FormatParser(BaseParser):
         self.op_def = op_def
         self.seen_operands = [False] * len(op_def.operands)
         self.seen_operand_types = [False] * len(op_def.operands)
+        self.seen_result_types = [False] * len(op_def.results)
 
     def parse_format(self) -> FormatProgram:
         """
@@ -101,6 +106,7 @@ class FormatParser(BaseParser):
 
         self.verify_attr_dict()
         self.verify_operands()
+        self.verify_results()
         return FormatProgram(elements)
 
     def verify_operands(self):
@@ -123,6 +129,19 @@ class FormatParser(BaseParser):
                     "assembly format"
                 )
 
+    def verify_results(self):
+        """Check that all result types are refered at least once."""
+
+        for result_type, (result_name, _) in zip(
+            self.seen_result_types, self.op_def.results
+        ):
+            if not result_type:
+                self.raise_error(
+                    f"type of result '{result_name}' not found, consider "
+                    f"adding a 'type(${result_name})' directive to the custom "
+                    "assembly format"
+                )
+
     def verify_attr_dict(self):
         """
         Check that the attribute dictionary is present.
@@ -130,7 +149,7 @@ class FormatParser(BaseParser):
         if not self.has_attr_dict:
             self.raise_error("'attr-dict' directive not found")
 
-    def parse_optional_variable(self) -> FormatDirective | None:
+    def parse_optional_variable(self) -> OperandVariable | ResultVariable | None:
         """
         Parse a variable, if present, with the following format:
           variable ::= `$` bare-ident
@@ -151,6 +170,18 @@ class FormatParser(BaseParser):
                     self.raise_error(f"operand '{variable_name}' is already bound")
                 self.seen_operands[idx] = True
             return OperandVariable(variable_name, idx)
+
+        # Check if the variable is a result
+        for idx, (result_name, _) in enumerate(self.op_def.results):
+            if variable_name != result_name:
+                continue
+            if self.context == ParsingContext.TopLevel:
+                self.raise_error(
+                    "result variable cannot be in a toplevel directive. "
+                    f"Consider using 'type({variable_name})' instead."
+                )
+            return ResultVariable(variable_name, idx)
+
         self.raise_error(
             "expected variable to refer to an operand, "
             "attribute, region, result, or successor"
@@ -169,15 +200,19 @@ class FormatParser(BaseParser):
         self.context = ParsingContext.TypeDirective
 
         variable = self.parse_optional_variable()
-        if variable is None:
-            self.raise_error("'type' directive expects a variable argument")
-        if isinstance(variable, OperandVariable):
-            if self.seen_operand_types[variable.index]:
-                self.raise_error(f"'type' of '{variable.name}' is already bound")
-            self.seen_operand_types[variable.index] = True
-            res = OperandTypeDirective(variable.name, variable.index)
-        else:
-            assert False, "Unknown variable in declarative assembly format"
+        match variable:
+            case None:
+                self.raise_error("'type' directive expects a variable argument")
+            case OperandVariable():
+                if self.seen_operand_types[variable.index]:
+                    self.raise_error(f"type of '{variable.name}' is already bound")
+                self.seen_operand_types[variable.index] = True
+                res = OperandTypeDirective(variable.name, variable.index)
+            case ResultVariable():
+                if self.seen_result_types[variable.index]:
+                    self.raise_error(f"type of '{variable.name}' is already bound")
+                self.seen_result_types[variable.index] = True
+                res = ResultTypeDirective(variable.name, variable.index)
 
         self.parse_punctuation(")")
         self.context = previous_context


### PR DESCRIPTION
This PR adds support for results in the declarative assembly format.
The rule is that all results should appear exactly once in the declarative format, and nested under a `type` directive.

This PR also adds this format for `arith.ext*` and `arith.trunc*` operations.