### PR TITLE
transforms: (dmp) Add a 3D domain decomposition (with n-d generalization)

### DIFF
--- a/tests/dialects/test_dmp.py
+++ b/tests/dialects/test_dmp.py
@@ -1,0 +1,81 @@
+from xdsl.dialects.experimental.dmp import ExchangeDeclarationAttr, ShapeAttr
+from xdsl.transforms.experimental.dmp import decompositions
+
+
+def flat_face_exchanges(
+    shape: ShapeAttr, dim: int
+) -> tuple[ExchangeDeclarationAttr, ExchangeDeclarationAttr]:
+    # we need access to the _flat_face_exchanges_for_dim method in order to test it
+    # since this is a private function, and pyright will yell whenever it's accessed,
+    # we have this wrapper function here that takes care of making the private publicly
+    # accessible in the context of this test.
+    func = (
+        decompositions._flat_face_exchanges_for_dim  # pyright: ignore[reportPrivateUsage]
+    )
+    return func(shape, dim)
+
+
+def test_decomp_flat_face_3d():
+    shape = ShapeAttr.from_index_attrs(
+        (0, 0, 0),  # buff lb
+        (4, 4, 4),  # core lb
+        (14, 14, 14),  # core ub
+        (18, 18, 18),  # buff ub
+    )
+
+    ex_pos_x, ex_neg_x = flat_face_exchanges(shape, 0)
+
+    assert ex_pos_x.offset == (14, 4, 4)
+    assert ex_pos_x.size == (4, 10, 10)
+    assert ex_pos_x.source_offset == (-4, 0, 0)
+    assert ex_pos_x.neighbor == (1, 0, 0)
+
+    assert ex_neg_x.offset == (0, 4, 4)
+    assert ex_neg_x.size == (4, 10, 10)
+    assert ex_neg_x.source_offset == (4, 0, 0)
+    assert ex_neg_x.neighbor == (-1, 0, 0)
+
+    ex_pos_y, ex_neg_y = flat_face_exchanges(shape, 1)
+
+    assert ex_pos_y.offset == (4, 14, 4)
+    assert ex_pos_y.size == (10, 4, 10)
+    assert ex_pos_y.source_offset == (0, -4, 0)
+    assert ex_pos_y.neighbor == (0, 1, 0)
+
+    assert ex_neg_y.offset == (4, 0, 4)
+    assert ex_neg_y.size == (10, 4, 10)
+    assert ex_neg_y.source_offset == (0, 4, 0)
+    assert ex_neg_y.neighbor == (0, -1, 0)
+
+    ex_pos_z, ex_neg_z = flat_face_exchanges(shape, 2)
+
+    assert ex_pos_z.offset == (4, 4, 14)
+    assert ex_pos_z.size == (10, 10, 4)
+    assert ex_pos_z.source_offset == (0, 0, -4)
+    assert ex_pos_z.neighbor == (0, 0, 1)
+
+    assert ex_neg_z.offset == (4, 4, 0)
+    assert ex_neg_z.size == (10, 10, 4)
+    assert ex_neg_z.source_offset == (0, 0, 4)
+    assert ex_neg_z.neighbor == (0, 0, -1)
+
+
+def test_decomp_flat_face_4d():
+    shape = ShapeAttr.from_index_attrs(
+        (0, 0, 0, 0),  # buff lb
+        (4, 4, 4, 4),  # core lb
+        (14, 14, 14, 14),  # core ub
+        (18, 18, 18, 18),  # buff ub
+    )
+
+    ex_pos_y, ex_neg_y = flat_face_exchanges(shape, 1)
+
+    assert ex_pos_y.offset == (4, 14, 4, 4)
+    assert ex_pos_y.size == (10, 4, 10, 10)
+    assert ex_pos_y.source_offset == (0, -4, 0, 0)
+    assert ex_pos_y.neighbor == (0, 1, 0, 0)
+
+    assert ex_neg_y.offset == (4, 0, 4, 4)
+    assert ex_neg_y.size == (10, 4, 10, 10)
+    assert ex_neg_y.source_offset == (0, 4, 0, 0)
+    assert ex_neg_y.neighbor == (0, -1, 0, 0)

--- a/xdsl/transforms/experimental/dmp/decompositions.py
+++ b/xdsl/transforms/experimental/dmp/decompositions.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Literal
 
 from xdsl.dialects.experimental import dmp
 
@@ -51,91 +52,98 @@ class GridSlice2d(DomainDecompositionStrategy):
         )
 
     def halo_exchange_defs(
-        self, dims: dmp.ShapeAttr
+        self, shape: dmp.ShapeAttr
     ) -> Iterable[dmp.ExchangeDeclarationAttr]:
-        # calculate values for the dimensions that were not decomposed
-        residual_offsets = [0 for _ in range(2, dims.dims)]
-        residual_sizes = [dims.buff_size(n) for n in range(2, dims.dims)]
-        residual_source_offsets = [0 for _ in range(2, dims.dims)]
+        yield from _flat_face_exchanges_for_dim(shape, 0)
 
-        # exchange to node "above" us on X axis direction
-        yield dmp.ExchangeDeclarationAttr(
-            offset=(
-                dims.buffer_start(dmp.DIM_X),
-                dims.buffer_start(dmp.DIM_Y),
-                *residual_offsets,
-            ),
-            size=(
-                dims.buff_size(dmp.DIM_X),
-                dims.halo_size(dmp.DIM_Y),
-                *residual_sizes,
-            ),
-            source_offset=(
-                0,
-                dims.halo_size(dmp.DIM_Y),
-                *residual_source_offsets,
-            ),
-            neighbor=(-1, 0),
-        )
-        # exchange to node "below" us on X axis direction
-        yield dmp.ExchangeDeclarationAttr(
-            offset=(
-                dims.buffer_start(dmp.DIM_X),
-                dims.core_end(dmp.DIM_Y),
-                *residual_offsets,
-            ),
-            size=(
-                dims.buff_size(dmp.DIM_X),
-                dims.halo_size(dmp.DIM_Y, at_end=True),
-                *residual_sizes,
-            ),
-            source_offset=(
-                0,
-                -dims.halo_size(dmp.DIM_Y, at_end=True),
-                *residual_source_offsets,
-            ),
-            neighbor=(1, 0),
-        )
-        # exchange to node "left" of us on Y axis
-        yield dmp.ExchangeDeclarationAttr(
-            offset=(
-                dims.buffer_start(dmp.DIM_X),
-                dims.buffer_start(dmp.DIM_Y),
-                *residual_offsets,
-            ),
-            size=(
-                dims.halo_size(dmp.DIM_X),
-                dims.buff_size(dmp.DIM_Y),
-                *residual_sizes,
-            ),
-            source_offset=(
-                dims.halo_size(dmp.DIM_X),
-                0,
-                *residual_source_offsets,
-            ),
-            neighbor=(0, -1),
-        )
-        # exchange to node "right" of us on Y axis
-        yield dmp.ExchangeDeclarationAttr(
-            offset=(
-                dims.core_end(dmp.DIM_X),
-                dims.buffer_start(dmp.DIM_Y),
-                *residual_offsets,
-            ),
-            size=(
-                dims.halo_size(dmp.DIM_X, at_end=True),
-                dims.buff_size(dmp.DIM_Y),
-                *residual_sizes,
-            ),
-            source_offset=(
-                -dims.halo_size(dmp.DIM_X),
-                0,
-                *residual_source_offsets,
-            ),
-            neighbor=(0, 1),
-        )
+        yield from _flat_face_exchanges_for_dim(shape, 1)
+
         # TOOD: add diagonals
         assert not self.diagonals
 
     def comm_layout(self) -> dmp.RankTopoAttr:
         return dmp.RankTopoAttr(self.topology)
+
+
+@dataclass
+class GridSlice3d(DomainDecompositionStrategy):
+    """
+    Takes a grid with two or more dimensions, slices it along the first three.
+    """
+
+    topology: tuple[int, int, int]
+
+    diagonals: bool = False
+
+    def __post_init__(self):
+        assert len(self.topology) >= 3, "GridSlice3d requires at least three dimensions"
+
+    def calc_resize(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        assert len(shape) >= 3, "GridSlice3d requires at least two dimensions"
+        for size, node_count in zip(shape, self.topology):
+            assert (
+                size % node_count == 0
+            ), "GridSlice3d requires domain be neatly divisible by shape"
+        return (
+            *(size // node_count for size, node_count in zip(shape, self.topology)),
+            *(size for size in shape[3:]),
+        )
+
+    def halo_exchange_defs(
+        self, shape: dmp.ShapeAttr
+    ) -> Iterable[dmp.ExchangeDeclarationAttr]:
+        yield from _flat_face_exchanges_for_dim(shape, 0)
+
+        yield from _flat_face_exchanges_for_dim(shape, 1)
+
+        yield from _flat_face_exchanges_for_dim(shape, 2)
+
+        # TOOD: add diagonals
+        assert not self.diagonals
+
+    def comm_layout(self) -> dmp.RankTopoAttr:
+        return dmp.RankTopoAttr(self.topology)
+
+
+def _flat_face_exchanges_for_dim(
+    shape: dmp.ShapeAttr, axis: int
+) -> tuple[dmp.ExchangeDeclarationAttr, dmp.ExchangeDeclarationAttr]:
+    """
+    Generate the two exchange delcarations to exchange the faces on the
+    axis "axis".
+    """
+    dimensions = shape.dims
+    assert axis <= dimensions
+
+    def coords(where: Literal["start", "end"]):
+        for d in range(dimensions):
+            # for the dim we want to exchange, return either start or end halo region
+            if d == axis:
+                if where == "start":
+                    # "start" halo goes from buffer start to core start
+                    yield shape.buffer_start(d), shape.core_start(d)
+                else:
+                    # "end" halo goes from core end to buffer end
+                    yield shape.core_end(d), shape.buffer_end(d)
+            else:
+                # for the sliced regions, "extrude" from core
+                # this way we don't exchange edges
+                yield shape.core_start(d), shape.core_end(d)
+
+    ex1_coords = tuple(coords("end"))
+    ex2_coords = tuple(coords("start"))
+
+    return (
+        # towards positive dim:
+        dmp.ExchangeDeclarationAttr.from_points(
+            ex1_coords,
+            axis,
+            dir_sign=1,
+        ),
+        # towards negative dim:
+        dmp.ExchangeDeclarationAttr.from_points(
+            ex2_coords,
+            axis,
+            dir_sign=-1,
+        ),
+    )

--- a/xdsl/transforms/experimental/dmp/decompositions.py
+++ b/xdsl/transforms/experimental/dmp/decompositions.py
@@ -17,7 +17,7 @@ class DomainDecompositionStrategy(ABC):
 
     @abstractmethod
     def halo_exchange_defs(
-        self, dims: dmp.ShapeAttr
+        self, shape: dmp.ShapeAttr
     ) -> Iterable[dmp.ExchangeDeclarationAttr]:
         raise NotImplementedError("SlicingStrategy must implement halo_exchange_defs!")
 


### PR DESCRIPTION
This adds a `GridSlice3d` decomposition, that used the `_flat_face_exchanges_for_dim(shape, dim)` helper.

This helper generates the exchange declarations for the two opposite flat faces in dim `dim` of any n-dimensional hypercube (n>1 I think?).

I wrote some tests for the `_flat_face_exchanges_for_dim` method, but no filechecks as of yet (they will follow). I would invite @mesham and @mcjamieson to be a second and third brain + pair of eyes, as I am not entirely sure I got everything right yet. [The test](https://github.com/xdslproject/xdsl/pull/1672/files#diff-fbe221f08ca78dc534bcc61aae61ffe1c7f1d88dec29fd56316245dae9976d66) is probably a good point to look at the result, and then you can dive into the code from there. Feel free to drop by my office too, I have some diagrams to support my code on the whiteboard.

@PapyChacal and @georgebisbas, I would love to try and run these with correctness checks, but may need your help with that too.
