### PR TITLE
misc: add a launch.json to launch xdsl-opt from vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "xdsl-opt",
+            "type": "python",
+            "request": "launch",
+            "module": "xdsl.tools.xdsl_opt",
+            "justMyCode": true,
+            "args": [
+                "${file}"
+            ]
+        },
+    ]
+}

--- a/xdsl/tools/xdsl_opt.py
+++ b/xdsl/tools/xdsl_opt.py
@@ -3,3 +3,7 @@ from xdsl.xdsl_opt_main import xDSLOptMain
 
 def main():
     xDSLOptMain().run()
+
+
+if "__main__" == __name__:
+    main()


### PR DESCRIPTION
This should only affect users of VSCode, and not really impact anyone else. By default xdsl-opt launches with the currently open file as argument, parsing and printing it. I use launch configs a lot for debugging and would love to have the file in the repo.