### PR TITLE
core: (affine) add AffineMap.transpose_map

### DIFF
--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -99,6 +99,12 @@ def test_composition():
     assert map3.eval([5, 6], []) == [-3, -28]
 
 
+def test_transpose():
+    assert AffineMap.empty().transpose == AffineMap.empty()
+    m2 = AffineMap.identity(2).transpose
+    assert m2 == AffineMap(2, 0, (AffineExpr.dimension(1), AffineExpr.dimension(0)))
+
+
 def test_helpers():
     m0 = AffineMap.constant_map(0)
     assert m0 == AffineMap(0, 0, (AffineExpr.constant(0),))

--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -106,7 +106,7 @@ def test_helpers():
     assert m1 == AffineMap(0, 0, (AffineExpr.constant(0), AffineExpr.constant(1)))
     m2 = AffineMap.identity(2)
     assert m2 == AffineMap(2, 0, (AffineExpr.dimension(0), AffineExpr.dimension(1)))
-    m2 = AffineMap.transpose(2)
+    m2 = AffineMap.transpose_map()
     assert m2 == AffineMap(2, 0, (AffineExpr.dimension(1), AffineExpr.dimension(0)))
     m3 = AffineMap.empty()
     assert m3 == AffineMap(0, 0, ())

--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -99,12 +99,6 @@ def test_composition():
     assert map3.eval([5, 6], []) == [-3, -28]
 
 
-def test_transpose():
-    assert AffineMap.empty().transpose == AffineMap.empty()
-    m2 = AffineMap.identity(2).transpose
-    assert m2 == AffineMap(2, 0, (AffineExpr.dimension(1), AffineExpr.dimension(0)))
-
-
 def test_helpers():
     m0 = AffineMap.constant_map(0)
     assert m0 == AffineMap(0, 0, (AffineExpr.constant(0),))
@@ -112,5 +106,7 @@ def test_helpers():
     assert m1 == AffineMap(0, 0, (AffineExpr.constant(0), AffineExpr.constant(1)))
     m2 = AffineMap.identity(2)
     assert m2 == AffineMap(2, 0, (AffineExpr.dimension(0), AffineExpr.dimension(1)))
+    m2 = AffineMap.transpose(2)
+    assert m2 == AffineMap(2, 0, (AffineExpr.dimension(1), AffineExpr.dimension(0)))
     m3 = AffineMap.empty()
     assert m3 == AffineMap(0, 0, ())

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -31,6 +31,15 @@ class AffineMap:
         )
 
     @staticmethod
+    def transpose(rank: int) -> AffineMap:
+        """
+        Reverses the indices.
+        """
+        return AffineMap(
+            rank, 0, tuple(AffineExpr.dimension(dim) for dim in reversed(range(rank)))
+        )
+
+    @staticmethod
     def empty() -> AffineMap:
         return AffineMap(0, 0, ())
 
@@ -87,18 +96,6 @@ class AffineMap:
             num_symbols=0,
             results=results,
         )
-
-    @property
-    def transpose(self) -> AffineMap:
-        """
-        Returns a map with transposed codomain.
-
-        Example:
-           (d0, d1, d2) -> (d1, d1, d0, d2, d1, d2, d1, d0)
-        returns:
-           (d0, d1, d2) -> (d0, d1, d2, d1, d2, d0, d1, d1)
-        """
-        return AffineMap(self.num_dims, self.num_symbols, tuple(reversed(self.results)))
 
     def eval(self, dims: list[int], symbols: list[int]) -> list[int]:
         """Evaluate the AffineMap given the values of dimensions and symbols."""

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -88,6 +88,18 @@ class AffineMap:
             results=results,
         )
 
+    @property
+    def transpose(self) -> AffineMap:
+        """
+        Returns a map with transposed codomain.
+
+        Example:
+           (d0, d1, d2) -> (d1, d1, d0, d2, d1, d2, d1, d0)
+        returns:
+           (d0, d1, d2) -> (d0, d1, d2, d1, d2, d0, d1, d1)
+        """
+        return AffineMap(self.num_dims, self.num_symbols, tuple(reversed(self.results)))
+
     def eval(self, dims: list[int], symbols: list[int]) -> list[int]:
         """Evaluate the AffineMap given the values of dimensions and symbols."""
         assert len(dims) == self.num_dims

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -32,13 +32,11 @@ class AffineMap:
         )
 
     @staticmethod
-    def transpose(rank: int) -> AffineMap:
+    def transpose_map() -> AffineMap:
         """
-        Reverses the indices.
+        Returns the map transposing a 2D matrix: `(i, j) -> (j, i)`.
         """
-        return AffineMap(
-            rank, 0, tuple(AffineExpr.dimension(dim) for dim in reversed(range(rank)))
-        )
+        return AffineMap(2, 0, (AffineExpr.dimension(1), AffineExpr.dimension(1)))
 
     @staticmethod
     def empty() -> AffineMap:

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -36,7 +36,7 @@ class AffineMap:
         """
         Returns the map transposing a 2D matrix: `(i, j) -> (j, i)`.
         """
-        return AffineMap(2, 0, (AffineExpr.dimension(1), AffineExpr.dimension(1)))
+        return AffineMap(2, 0, (AffineExpr.dimension(1), AffineExpr.dimension(0)))
 
     @staticmethod
     def empty() -> AffineMap:


### PR DESCRIPTION
I couldn't find an equivalent helper in MLIR Affine, but seems like an appropriate place to put it. Adds a helper to create the affine map from a matrix to its transpose.