### PR TITLE
core: add PassPipelinePass with optional callback in between passes

### DIFF
--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -146,9 +146,7 @@ def test_print_between_passes():
         opt.run()
 
     output = f.getvalue()
-    assert (
-        len([l for l in output.split("\n") if "builtin.module" in l]) == len(passes) + 1
-    )
+    assert len([l for l in output.split("\n") if "builtin.module" in l]) == len(passes)
 
 
 def test_diagnostic_exception():

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -111,7 +111,7 @@ def _empty_callback(
 
 
 @dataclass
-class PassPipelinePass(ModulePass):
+class PipelinePass(ModulePass):
     passes: list[ModulePass]
     callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None] = field(
         default=_empty_callback

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -1,6 +1,7 @@
 import dataclasses
 from abc import ABC, abstractmethod
-from dataclasses import Field, dataclass
+from collections.abc import Callable
+from dataclasses import Field, dataclass, field
 from types import NoneType, UnionType
 from typing import Any, ClassVar, TypeVar, Union, get_args, get_origin
 
@@ -72,21 +73,21 @@ class ModulePass(ABC):
         arg_dict = dict[str, PassArgListType | PassArgElementType | None]()
 
         # iterate over all fields of the dataclass
-        for field in fields:
+        for op_field in fields:
             # ignore the name field and everything that's not used by __init__
-            if field.name == "name" or not field.init:
+            if op_field.name == "name" or not op_field.init:
                 continue
             # check that non-optional fields are present
-            if field.name not in spec.args:
-                if _is_optional(field):
-                    arg_dict[field.name] = _get_default(field)
+            if op_field.name not in spec.args:
+                if _is_optional(op_field):
+                    arg_dict[op_field.name] = _get_default(op_field)
                     continue
-                raise ValueError(f'Pass {cls.name} requires argument "{field.name}"')
+                raise ValueError(f'Pass {cls.name} requires argument "{op_field.name}"')
 
             # convert pass arg to the correct type:
-            arg_dict[field.name] = _convert_pass_arg_to_type(
-                spec.args.pop(field.name),
-                field.type,
+            arg_dict[op_field.name] = _convert_pass_arg_to_type(
+                spec.args.pop(op_field.name),
+                op_field.type,
             )
             # we use .pop here to also remove the arg from the dict
 
@@ -101,6 +102,35 @@ class ModulePass(ABC):
 
         # instantiate the dataclass using kwargs
         return cls(**arg_dict)
+
+
+def _empty_callback(
+    previous_pass: ModulePass, module: builtin.ModuleOp, next_pass: ModulePass
+) -> None:
+    return
+
+
+@dataclass
+class PassPipelinePass(ModulePass):
+    passes: list[ModulePass]
+    callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None] = field(
+        default=_empty_callback
+    )
+    """
+    Function called in between every pass, taking the pass that just ran, the module, and
+    the next pass.
+    """
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        if not self.passes:
+            # Early exit to avoid fetching a non-existing last pass.
+            return
+
+        for prev, next in zip(self.passes[:-1], self.passes[1:]):
+            prev.apply(ctx, op)
+            self.callback(prev, op, next)
+
+        self.passes[-1].apply(ctx, op)
 
 
 def _convert_pass_arg_to_type(

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -7,7 +7,7 @@ from typing import IO
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.riscv import print_assembly, riscv_code
 from xdsl.ir import MLContext
-from xdsl.passes import ModulePass, PassPipelinePass
+from xdsl.passes import ModulePass, PipelinePass
 from xdsl.printer import Printer
 from xdsl.tools.command_line_tool import CommandLineTool, get_all_passes
 from xdsl.utils.exceptions import DiagnosticException
@@ -26,7 +26,7 @@ class xDSLOptMain(CommandLineTool):
     stream.
     """
 
-    pipeline: PassPipelinePass
+    pipeline: PipelinePass
     """ The pass-pipeline to be applied. """
 
     def __init__(
@@ -223,7 +223,7 @@ class xDSLOptMain(CommandLineTool):
                 printer.print_op(module)
                 print("\n\n\n")
 
-        self.pipeline = PassPipelinePass(
+        self.pipeline = PipelinePass(
             [self.available_passes[p.name].from_pass_spec(p) for p in pipeline],
             callback,
         )

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -266,6 +266,8 @@ class xDSLOptMain(CommandLineTool):
             if not self.args.disable_verify:
                 prog.verify()
             self.pipeline.apply(self.ctx, prog)
+            if not self.args.disable_verify:
+                prog.verify()
         except DiagnosticException as e:
             if self.args.verify_diagnostics:
                 print(e)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -7,7 +7,7 @@ from typing import IO
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.riscv import print_assembly, riscv_code
 from xdsl.ir import MLContext
-from xdsl.passes import ModulePass
+from xdsl.passes import ModulePass, PassPipelinePass
 from xdsl.printer import Printer
 from xdsl.tools.command_line_tool import CommandLineTool, get_all_passes
 from xdsl.utils.exceptions import DiagnosticException
@@ -26,7 +26,7 @@ class xDSLOptMain(CommandLineTool):
     stream.
     """
 
-    pipeline: list[ModulePass]
+    pipeline: PassPipelinePass
     """ The pass-pipeline to be applied. """
 
     def __init__(
@@ -212,9 +212,21 @@ class xDSLOptMain(CommandLineTool):
             if p.name not in self.available_passes:
                 raise Exception(f"Unrecognized pass: {p.name}")
 
-        self.pipeline = [
-            self.available_passes[p.name].from_pass_spec(p) for p in pipeline
-        ]
+        def callback(
+            previous_pass: ModulePass, module: ModuleOp, next_pass: ModulePass
+        ) -> None:
+            if not self.args.disable_verify:
+                module.verify()
+            if self.args.print_between_passes:
+                print(f"IR after {previous_pass.name}:")
+                printer = Printer(stream=sys.stdout)
+                printer.print_op(module)
+                print("\n\n\n")
+
+        self.pipeline = PassPipelinePass(
+            [self.available_passes[p.name].from_pass_spec(p) for p in pipeline],
+            callback,
+        )
 
     def prepare_input(self) -> tuple[list[IO[str]], str]:
         """
@@ -253,16 +265,7 @@ class xDSLOptMain(CommandLineTool):
             assert isinstance(prog, ModuleOp)
             if not self.args.disable_verify:
                 prog.verify()
-            for p in self.pipeline:
-                p.apply(self.ctx, prog)
-                assert isinstance(prog, ModuleOp)
-                if not self.args.disable_verify:
-                    prog.verify()
-                if self.args.print_between_passes:
-                    print(f"IR after {p.name}:")
-                    printer = Printer(stream=sys.stdout)
-                    printer.print_op(prog)
-                    print("\n\n\n")
+            self.pipeline.apply(self.ctx, prog)
         except DiagnosticException as e:
             if self.args.verify_diagnostics:
                 print(e)


### PR DESCRIPTION
Also makes the behaviour of `print-between-passes` actually correspond to the behaviour of only printing between passes, not after every pass.