### PR TITLE
backend (riscv): Factor out Snitch ISA extensions

### DIFF
--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -91,7 +91,7 @@ builtin.module {
   "test.op"(%and_bitwise_zero_r0) : (!riscv.reg<a0>) -> ()
 
   // scfgw immediates
-  %scfgw = riscv.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<zero>
+  %scfgw = riscv_snitch.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<zero>
   "test.op"(%scfgw) : (!riscv.reg<zero>) -> ()
 }
 
@@ -177,7 +177,7 @@ builtin.module {
 // CHECK-NEXT:   %and_bitwise_zero_r0 = riscv.mv %0 : (!riscv.reg<>) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%and_bitwise_zero_r0) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %scfgw = riscv.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<zero>
+// CHECK-NEXT:   %scfgw = riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<zero>
 // CHECK-NEXT:   "test.op"(%scfgw) : (!riscv.reg<zero>) -> ()
 
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/verify.mlir
+++ b/tests/filecheck/backend/riscv/verify.mlir
@@ -3,7 +3,7 @@
 %i1 = "test.op"() : () -> !riscv.reg<a1>
 %1 = riscv.li 1 : () -> !riscv.reg<>
 
-%empty_0 = riscv.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<>
+%empty_0 = riscv_snitch.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<>
 
 // CHECK: Operation does not verify: scfgw rd must be ZERO, got !riscv.reg<>
 
@@ -11,20 +11,20 @@
 
 %i1 = "test.op"() : () -> !riscv.reg<a1>
 %1 = riscv.li 1 : () -> !riscv.reg<>
-%wrong_0 = riscv.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<t0>
+%wrong_0 = riscv_snitch.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<t0>
 
 // CHECK: Operation does not verify: scfgw rd must be ZERO, got !riscv.reg<t0>
 
 // -----
 
 %i1 = "test.op"() : () -> !riscv.reg<a1>
-%empty_1 = riscv.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<>
+%empty_1 = riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<>
 
 // CHECK: Operation does not verify: scfgwi rd must be ZERO, got !riscv.reg<>
 
 // -----
 
 %i1 = "test.op"() : () -> !riscv.reg<a1>
-%wrong_1 = riscv.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<t0>
+%wrong_1 = riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<t0>
 
 // CHECK: Operation does not verify: scfgwi rd must be ZERO, got !riscv.reg<t0>

--- a/tests/filecheck/dialects/riscv/frep_verification.mlir
+++ b/tests/filecheck/dialects/riscv/frep_verification.mlir
@@ -2,7 +2,7 @@
 
 %i0 = "test.op"() : () -> !riscv.reg<a0>
 %ft0, %ft1 = "test.op"() : () -> (!riscv.freg<ft0>, !riscv.freg<ft1>)
-riscv.frep_outer %i0, 1, 0 ({
+riscv_snitch.frep_outer %i0, 1, 0 ({
 }) : (!riscv.reg<a0>) -> ()
 
 // CHECK: expected a single block, but got 0 blocks
@@ -11,7 +11,7 @@ riscv.frep_outer %i0, 1, 0 ({
 
 %i0 = "test.op"() : () -> !riscv.reg<a0>
 %ft0, %ft1 = "test.op"() : () -> (!riscv.freg<ft0>, !riscv.freg<ft1>)
-riscv.frep_outer %i0, 1, 0 ({
+riscv_snitch.frep_outer %i0, 1, 0 ({
 ^bb0:
 }) : (!riscv.reg<a0>) -> ()
 
@@ -21,7 +21,7 @@ riscv.frep_outer %i0, 1, 0 ({
 
 %i0 = "test.op"() : () -> !riscv.reg<a0>
 %ft0, %ft1 = "test.op"() : () -> (!riscv.freg<ft0>, !riscv.freg<ft1>)
-riscv.frep_outer %i0, 0, 1 ({
+riscv_snitch.frep_outer %i0, 0, 1 ({
 ^bb0:
 }) : (!riscv.reg<a0>) -> ()
 
@@ -31,7 +31,7 @@ riscv.frep_outer %i0, 0, 1 ({
 
 %i0 = "test.op"() : () -> !riscv.reg<a0>
 %ft0, %ft1 = "test.op"() : () -> (!riscv.freg<ft0>, !riscv.freg<ft1>)
-riscv.frep_outer %i0, 0, 0 ({
+riscv_snitch.frep_outer %i0, 0, 0 ({
     riscv.sw %i0, %i0, 0 : (!riscv.reg<a0>, !riscv.reg<a0>) -> ()
 }) : (!riscv.reg<a0>) -> ()
 

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -176,14 +176,14 @@
 
     // RISC-V Extensions
 
-    riscv.frep_outer %0, 0, 0 ({
+    riscv_snitch.frep_outer %0, 0, 0 ({
       %add_o = riscv.add %0, %1 : (!riscv.reg<zero>, !riscv.reg<j1>) -> !riscv.reg<j2>
     }) : (!riscv.reg<zero>) -> ()
 
     // CHECK:          frep.o zero, 1, 0, 0
     // CHECK-NEXT:     add  j2, zero, j1
 
-    riscv.frep_inner %0, 0, 0 ({
+    riscv_snitch.frep_inner %0, 0, 0 ({
       %add_i = riscv.add %0, %1 : (!riscv.reg<zero>, !riscv.reg<j1>) -> !riscv.reg<j2>
     }) : (!riscv.reg<zero>) -> ()
     // CHECK:          frep.i zero, 1, 0, 0

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -202,27 +202,6 @@
     %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
     // CHECK-NEXT:   %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
 
-
-    // RISC-V extensions
-    %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-    // CHECK-NEXT: %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-    %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
-    // CHECK-NEXT: %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
-
-    riscv_snitch.frep_outer %0, 0, 0 ({
-      %add_o = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    }) : (!riscv.reg<>) -> ()
-    // CHECK-NEXT:  riscv_snitch.frep_outer %0, 0, 0 ({
-    // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT:  }) : (!riscv.reg<>) -> ()
-
-    riscv_snitch.frep_inner %0, 0, 0 ({
-      %add_i = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    }) : (!riscv.reg<>) -> ()
-    // CHECK-NEXT:  riscv_snitch.frep_inner %0, 0, 0 ({
-    // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT:  }) : (!riscv.reg<>) -> ()
-
     // RV32F: 8 “F” Standard Extension for Single-Precision Floating-Point, Version 2.0
     %f0 = riscv.get_float_register : () -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
@@ -393,14 +372,6 @@
 // CHECK-GENERIC-NEXT:       %nested_li_1 = "riscv.li"() {"immediate" = 1 : si32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text"} : () -> ()
 // CHECK-GENERIC-NEXT:     %custom0, %custom1 = "riscv.custom_assembly_instruction"(%0, %1) {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
-// CHECK-GENERIC-NEXT:     %scfgw = "riscv_snitch.scfgw"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-// CHECK-GENERIC-NEXT:     %scfgwi_zero = "riscv_snitch.scfgwi"(%0) {"immediate" = 42 : si12} : (!riscv.reg<>) -> !riscv.reg<zero>
-// CHECK-GENERIC-NEXT:    "riscv_snitch.frep_outer"(%{{.*}}) ({
-// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #int<0>, "stagger_count" = #int<0>} : (!riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:    "riscv_snitch.frep_inner"(%{{.*}}) ({
-// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #int<0>, "stagger_count" = #int<0>} : (!riscv.reg<>) -> ()
 // CHECK-GENERIC-NEXT:     %f0 = "riscv.get_float_register"() : () -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %f1 = "riscv.get_float_register"() : () -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %f2 = "riscv.get_float_register"() : () -> !riscv.freg<>

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -204,22 +204,22 @@
 
 
     // RISC-V extensions
-    %scfgw = riscv.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-    // CHECK-NEXT: %scfgw = riscv.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-    %scfgwi_zero = riscv.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
-    // CHECK-NEXT: %scfgwi_zero = riscv.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
+    %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+    // CHECK-NEXT: %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+    %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
+    // CHECK-NEXT: %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
 
-    riscv.frep_outer %0, 0, 0 ({
+    riscv_snitch.frep_outer %0, 0, 0 ({
       %add_o = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     }) : (!riscv.reg<>) -> ()
-    // CHECK-NEXT:  riscv.frep_outer %0, 0, 0 ({
+    // CHECK-NEXT:  riscv_snitch.frep_outer %0, 0, 0 ({
     // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     // CHECK-NEXT:  }) : (!riscv.reg<>) -> ()
 
-    riscv.frep_inner %0, 0, 0 ({
+    riscv_snitch.frep_inner %0, 0, 0 ({
       %add_i = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     }) : (!riscv.reg<>) -> ()
-    // CHECK-NEXT:  riscv.frep_inner %0, 0, 0 ({
+    // CHECK-NEXT:  riscv_snitch.frep_inner %0, 0, 0 ({
     // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     // CHECK-NEXT:  }) : (!riscv.reg<>) -> ()
 
@@ -393,12 +393,12 @@
 // CHECK-GENERIC-NEXT:       %nested_li_1 = "riscv.li"() {"immediate" = 1 : si32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text"} : () -> ()
 // CHECK-GENERIC-NEXT:     %custom0, %custom1 = "riscv.custom_assembly_instruction"(%0, %1) {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
-// CHECK-GENERIC-NEXT:     %scfgw = "riscv.scfgw"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-// CHECK-GENERIC-NEXT:     %scfgwi_zero = "riscv.scfgwi"(%0) {"immediate" = 42 : si12} : (!riscv.reg<>) -> !riscv.reg<zero>
-// CHECK-GENERIC-NEXT:    "riscv.frep_outer"(%{{.*}}) ({
+// CHECK-GENERIC-NEXT:     %scfgw = "riscv_snitch.scfgw"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+// CHECK-GENERIC-NEXT:     %scfgwi_zero = "riscv_snitch.scfgwi"(%0) {"immediate" = 42 : si12} : (!riscv.reg<>) -> !riscv.reg<zero>
+// CHECK-GENERIC-NEXT:    "riscv_snitch.frep_outer"(%{{.*}}) ({
 // CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #int<0>, "stagger_count" = #int<0>} : (!riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:    "riscv.frep_inner"(%{{.*}}) ({
+// CHECK-GENERIC-NEXT:    "riscv_snitch.frep_inner"(%{{.*}}) ({
 // CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #int<0>, "stagger_count" = #int<0>} : (!riscv.reg<>) -> ()
 // CHECK-GENERIC-NEXT:     %f0 = "riscv.get_float_register"() : () -> !riscv.freg<>

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -1,0 +1,46 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+riscv_func.func @main() {
+  %0 = riscv.get_register : () -> !riscv.reg<>
+  %1 = riscv.get_register : () -> !riscv.reg<>
+
+  // RISC-V extensions
+  %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK: %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
+
+  riscv_snitch.frep_outer %0, 0, 0 ({
+    %add_o = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  }) : (!riscv.reg<>) -> ()
+  // CHECK-NEXT:  riscv_snitch.frep_outer %0, 0, 0 ({
+  // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT:  }) : (!riscv.reg<>) -> ()
+
+  riscv_snitch.frep_inner %0, 0, 0 ({
+    %add_i = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  }) : (!riscv.reg<>) -> ()
+  // CHECK-NEXT:  riscv_snitch.frep_inner %0, 0, 0 ({
+  // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT:  }) : (!riscv.reg<>) -> ()
+
+  // Terminate block
+  riscv_func.return
+}
+
+// CHECK-GENERIC: "builtin.module"() ({
+// CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
+// CHECK-GENERIC-NEXT:     %0 = "riscv.get_register"() : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %1 = "riscv.get_register"() : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %scfgw = "riscv_snitch.scfgw"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+// CHECK-GENERIC-NEXT:     %scfgwi_zero = "riscv_snitch.scfgwi"(%0) {"immediate" = 42 : si12} : (!riscv.reg<>) -> !riscv.reg<zero>
+// CHECK-GENERIC-NEXT:    "riscv_snitch.frep_outer"(%{{.*}}) ({
+// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #int<0>, "stagger_count" = #int<0>} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:    "riscv_snitch.frep_inner"(%{{.*}}) ({
+// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #int<0>, "stagger_count" = #int<0>} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
@@ -8,32 +8,32 @@ builtin.module {
   // SSR setup sequence for dimension 0
   "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 64 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 192 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} riscv.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %{{.*}} riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 768 : (!riscv.reg<>) -> !riscv.reg<>
-  // %{{.*}} = riscv.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 896 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   // SSR setup sequence for dimension 3
   "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 160 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 288 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 864 : (!riscv.reg<>) -> !riscv.reg<>
-  // riscv.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 992 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 32 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv.scfgw %rep, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %rep, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   // On/Off switching sequence
   "snitch.ssr_enable"() : () -> ()
   // CHECK: riscv.csrrsi 1984, 1

--- a/tests/filecheck/projects/riscv-backend-paper/pres.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/pres.mlir
@@ -42,12 +42,12 @@ riscv_func.func @pres_2(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.re
 riscv_func.func @pres_3(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.reg<a2>) {
     %zero = "riscv.get_register"() : () -> !riscv.reg<zero>
     %n = riscv.addi %zero 63 : (!riscv.reg<zero>) -> !riscv.reg<a3>
-    %zero_1 = riscv.scfgwi %n, 95 : (!riscv.reg<a3>) -> (!riscv.reg<zero>)
+    %zero_1 = riscv_snitch.scfgwi %n, 95 : (!riscv.reg<a3>) -> (!riscv.reg<zero>)
     %ub = riscv.addi %zero 8 : (!riscv.reg<zero>) -> !riscv.reg<a3>
-    %zero_2 = riscv.scfgwi %n, 223 : (!riscv.reg<a3>) -> !riscv.reg<zero>
-    %zero_3 = riscv.scfgwi %X, 768 : (!riscv.reg<a0>) -> !riscv.reg<zero>
-    %zero_4 = riscv.scfgwi %Y, 769 : (!riscv.reg<a1>) -> !riscv.reg<zero>
-    %zero_5 = riscv.scfgwi %Z, 898 : (!riscv.reg<a2>) -> !riscv.reg<zero>
+    %zero_2 = riscv_snitch.scfgwi %n, 223 : (!riscv.reg<a3>) -> !riscv.reg<zero>
+    %zero_3 = riscv_snitch.scfgwi %X, 768 : (!riscv.reg<a0>) -> !riscv.reg<zero>
+    %zero_4 = riscv_snitch.scfgwi %Y, 769 : (!riscv.reg<a1>) -> !riscv.reg<zero>
+    %zero_5 = riscv_snitch.scfgwi %Z, 898 : (!riscv.reg<a2>) -> !riscv.reg<zero>
     %zero_6 = riscv.csrrsi 1984, 1 : () -> !riscv.reg<zero>
     %i = riscv.addi %zero, 64 : (!riscv.reg<zero>) -> !riscv.reg<a0>
     riscv.label ".loop_body" : () -> ()
@@ -63,17 +63,17 @@ riscv_func.func @pres_3(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.re
 riscv_func.func @pres_4(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.reg<a2>) {
     %zero = "riscv.get_register"() : () -> !riscv.reg<zero>
     %n = riscv.addi %zero 63 : (!riscv.reg<zero>) -> !riscv.reg<a3>
-    %zero_1 = riscv.scfgwi %n, 95 : (!riscv.reg<a3>) -> (!riscv.reg<zero>)
+    %zero_1 = riscv_snitch.scfgwi %n, 95 : (!riscv.reg<a3>) -> (!riscv.reg<zero>)
     %ub = riscv.addi %zero 8 : (!riscv.reg<zero>) -> !riscv.reg<a3>
-    %zero_2 = riscv.scfgwi %n, 223 : (!riscv.reg<a3>) -> !riscv.reg<zero>
-    %zero_3 = riscv.scfgwi %X, 768 : (!riscv.reg<a0>) -> !riscv.reg<zero>
-    %zero_4 = riscv.scfgwi %Y, 769 : (!riscv.reg<a1>) -> !riscv.reg<zero>
-    %zero_5 = riscv.scfgwi %Z, 898 : (!riscv.reg<a2>) -> !riscv.reg<zero>
+    %zero_2 = riscv_snitch.scfgwi %n, 223 : (!riscv.reg<a3>) -> !riscv.reg<zero>
+    %zero_3 = riscv_snitch.scfgwi %X, 768 : (!riscv.reg<a0>) -> !riscv.reg<zero>
+    %zero_4 = riscv_snitch.scfgwi %Y, 769 : (!riscv.reg<a1>) -> !riscv.reg<zero>
+    %zero_5 = riscv_snitch.scfgwi %Z, 898 : (!riscv.reg<a2>) -> !riscv.reg<zero>
     %zero_6 = riscv.csrrsi 1984, 1 : () -> !riscv.reg<zero>
     %i = riscv.addi %zero, 63 : (!riscv.reg<zero>) -> !riscv.reg<a0>
     %x = riscv.get_float_register() : () -> !riscv.freg<ft0>
     %y = riscv.get_float_register() : () -> !riscv.freg<ft1>
-    riscv.frep_outer %i, 0, 0 ({
+    riscv_snitch.frep_outer %i, 0, 0 ({
         %z = riscv.vfadd.s %x, %y : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
     }) : (!riscv.reg<a0>) -> ()
     %zero_7 = riscv.csrrci 1984, 1 : () -> !riscv.reg<zero>

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
 from io import StringIO
-from typing import IO, ClassVar, Generic, TypeAlias, TypeVar, cast
+from typing import IO, ClassVar, Generic, TypeAlias, TypeVar
 
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     IndexType,
-    IntAttr,
     IntegerAttr,
     IntegerType,
     ModuleOp,
@@ -2720,228 +2719,6 @@ class GetFloatRegisterOp(GetAnyRegisterOperation[FloatRegisterType]):
 
 # endregion
 
-# region RISC-V Extensions
-
-
-class ScfgwOpHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl.transforms.canonicalization_patterns.riscv import (
-            ScfgwOpUsingImmediate,
-        )
-
-        return (ScfgwOpUsingImmediate(),)
-
-
-@irdl_op_definition
-class ScfgwOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
-    """
-    Write the value in rs1 to the Snitch stream configuration
-    location pointed by rs2 in the memory-mapped address space.
-    Register rd is always fixed to zero.
-
-    This is a RISC-V ISA extension, part of the `Xssr' extension.
-    https://pulp-platform.github.io/snitch/rm/custom_instructions/
-    """
-
-    name = "riscv.scfgw"
-
-    traits = frozenset((ScfgwOpHasCanonicalizationPatternsTrait(),))
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
-        # rd is always zero, so we omit it when printing assembly
-        return self.rs1, self.rs2
-
-    def verify_(self) -> None:
-        if cast(IntRegisterType, self.rd.type) != Registers.ZERO:
-            raise VerifyException(f"scfgw rd must be ZERO, got {self.rd.type}")
-
-
-@irdl_op_definition
-class ScfgwiOp(RdRsImmIntegerOperation):
-    """
-    Write the value in rs to the Snitch stream configuration location pointed by
-    immediate value in the memory-mapped address space.
-
-    This is a RISC-V ISA extension, part of the `Xssr' extension.
-    https://pulp-platform.github.io/snitch/rm/custom_instructions/
-    """
-
-    name = "riscv.scfgwi"
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
-        # rd is always zero, so we omit it when printing assembly
-        return self.rs1, self.immediate
-
-    def verify_(self) -> None:
-        if cast(IntRegisterType, self.rd.type) != Registers.ZERO:
-            raise VerifyException(f"scfgwi rd must be ZERO, got {self.rd.type}")
-
-
-class FRepOperation(IRDLOperation, RISCVInstruction):
-    """
-    From the Snitch paper: https://arxiv.org/abs/2002.10143
-
-    The frep instruction marks the beginning of a floating-point kernel which should be
-    repeated. It indicates how many subsequent instructions are stored in the sequence
-    buffer, how often and how (operand staggering, repetition mode) each instruction is
-    going to be repeated.
-    """
-
-    max_rep = operand_def(IntRegisterType)
-    """Number of times to repeat the instructions."""
-    body = region_def("single_block")
-    """
-    Instructions to repeat, containing maximum 15 instructions, with no side effects.
-    """
-    stagger_mask = attr_def(IntAttr)
-    """
-    4 bits for each operand (rs1 rs2 rs3 rd). If the bit is set, the corresponding operand
-    is staggered.
-    """
-    stagger_count = attr_def(IntAttr)
-    """
-    3 bits, indicating for how many iterations the stagger should increment before it
-    wraps again (up to 23 = 8).
-    """
-
-    traits = frozenset((NoTerminator(),))
-
-    def __init__(
-        self,
-        max_rep: SSAValue | Operation,
-        body: Sequence[Operation] | Sequence[Block] | Region,
-        max_inst: IntAttr,
-        stagger_mask: IntAttr,
-        stagger_count: IntAttr,
-    ):
-        super().__init__(
-            operands=(max_rep,),
-            regions=(body,),
-            attributes={
-                "max_inst": max_inst,
-                "stagger_mask": stagger_mask,
-                "stagger_count": stagger_count,
-            },
-        )
-
-    @property
-    def max_inst(self) -> int:
-        """
-        Number of instructions to be repeated.
-        """
-        return len([op for op in self.body.ops if isinstance(op, RISCVInstruction)])
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        return (
-            self.max_rep,
-            self.max_inst,
-            self.stagger_mask.data,
-            self.stagger_count.data,
-        )
-
-    def custom_print_attributes(self, printer: Printer):
-        printer.print(", ")
-        printer.print(self.stagger_mask.data)
-        printer.print_string(", ")
-        printer.print(self.stagger_count.data)
-        return {"stagger_mask", "stagger_count"}
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser):
-        attributes = dict[str, Attribute]()
-        attributes["stagger_mask"] = IntAttr(
-            parser.parse_integer(
-                allow_boolean=False, context_msg="Expected stagger mask"
-            )
-        )
-        parser.parse_punctuation(",")
-        attributes["stagger_count"] = IntAttr(
-            parser.parse_integer(
-                allow_boolean=False, context_msg="Expected stagger count"
-            )
-        )
-        return attributes
-
-    def verify_(self) -> None:
-        if self.stagger_count.data:
-            raise VerifyException("Non-zero stagger count currently unsupported")
-        if self.stagger_mask.data:
-            raise VerifyException("Non-zero stagger mask currently unsupported")
-        for instruction in self.body.ops:
-            if not instruction.has_trait(Pure):
-                raise VerifyException(
-                    "Frep operation body may not contain instructions "
-                    f"with side-effects, found {instruction.name}"
-                )
-
-
-@irdl_op_definition
-class FrepOuter(FRepOperation):
-    """
-    Repeats the instruction in the body as if the body were the body of a for loop, for
-    example:
-
-    ```
-    # Repeat 4 times, stagger 1, period 2
-    li a0, 4
-    frep.o a0, 2, 1, 0b1010
-    fadd.d fa0, ft0, ft2
-    fmul.d fa0, ft3, fa0
-    ```
-
-    is equivalent to:
-    ```
-    fadd.d fa0, ft0, ft2
-    fmul.d fa0, ft3, fa0
-    fadd.d fa1, ft0, ft3
-    fmul.d fa1, ft3, fa1
-    fadd.d fa0, ft0, ft2
-    fmul.d fa0, ft3, fa0
-    fadd.d fa1, ft0, ft3
-    fmul.d fa1, ft3, fa1
-    ```
-    """
-
-    name = "riscv.frep_outer"
-
-    def assembly_instruction_name(self) -> str:
-        return "frep.o"
-
-
-@irdl_op_definition
-class FrepInner(FRepOperation):
-    """
-    Repeats the instruction in the body, as if each were in its own body of a for loop,
-    for example:
-
-    ```
-    # Repeat three times, stagger 2, period 2
-    li a0, 3
-    frep.i a0, 2, 2, 0b0100
-    fadd.d fa0, ft0, ft2
-    fmul.d fa0, ft3, fa0
-    ```
-
-    is equivalent to:
-    ```
-    fadd.d fa0, ft0, ft2
-    fadd.d fa0, ft1, ft3
-    fadd.d fa0, ft2, ft3
-    fmul.d fa0, ft3, fa0
-    fmul.d fa0, ft4, fa0
-    fmul.d fa0, ft5, fa0
-    ```
-    """
-
-    name = "riscv.frep_inner"
-
-    def assembly_instruction_name(self) -> str:
-        return "frep.i"
-
-
-# endregion
-
 # region RV32F: 8 “F” Standard Extension for Single-Precision Floating-Point, Version 2.0
 
 
@@ -3802,10 +3579,6 @@ RISCV = Dialect(
         CommentOp,
         GetRegisterOp,
         GetFloatRegisterOp,
-        ScfgwOp,
-        ScfgwiOp,
-        FrepOuter,
-        FrepInner,
         # Floating point
         FMVOp,
         FMAddSOp,

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+from xdsl.dialects.builtin import (
+    IntAttr,
+)
+from xdsl.dialects.riscv import (
+    AssemblyInstructionArg,
+    IntRegisterType,
+    RdRsImmIntegerOperation,
+    RdRsRsOperation,
+    Registers,
+    RISCVInstruction,
+    RISCVOp,
+)
+from xdsl.ir import (
+    Attribute,
+    Block,
+    Dialect,
+    Operation,
+    Region,
+    SSAValue,
+)
+from xdsl.irdl import (
+    IRDLOperation,
+    VarOperand,
+    attr_def,
+    irdl_op_definition,
+    operand_def,
+    region_def,
+    var_operand_def,
+)
+from xdsl.parser import Parser
+from xdsl.pattern_rewriter import RewritePattern
+from xdsl.printer import Printer
+from xdsl.traits import (
+    HasCanonicalisationPatternsTrait,
+    IsTerminator,
+    NoTerminator,
+    Pure,
+)
+from xdsl.utils.exceptions import VerifyException
+
+# region Snitch Extensions
+
+
+class ScfgwOpHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.riscv import (
+            ScfgwOpUsingImmediate,
+        )
+
+        return (ScfgwOpUsingImmediate(),)
+
+
+@irdl_op_definition
+class ScfgwOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+    """
+    Write the value in rs1 to the Snitch stream configuration
+    location pointed by rs2 in the memory-mapped address space.
+    Register rd is always fixed to zero.
+
+    This is a RISC-V ISA extension, part of the `Xssr' extension.
+    https://pulp-platform.github.io/snitch/rm/custom_instructions/
+    """
+
+    name = "riscv_snitch.scfgw"
+
+    traits = frozenset((ScfgwOpHasCanonicalizationPatternsTrait(),))
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        # rd is always zero, so we omit it when printing assembly
+        return self.rs1, self.rs2
+
+    def verify_(self) -> None:
+        if cast(IntRegisterType, self.rd.type) != Registers.ZERO:
+            raise VerifyException(f"scfgw rd must be ZERO, got {self.rd.type}")
+
+
+@irdl_op_definition
+class ScfgwiOp(RdRsImmIntegerOperation):
+    """
+    Write the value in rs to the Snitch stream configuration location pointed by
+    immediate value in the memory-mapped address space.
+
+    This is a RISC-V ISA extension, part of the `Xssr' extension.
+    https://pulp-platform.github.io/snitch/rm/custom_instructions/
+    """
+
+    name = "riscv_snitch.scfgwi"
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        # rd is always zero, so we omit it when printing assembly
+        return self.rs1, self.immediate
+
+    def verify_(self) -> None:
+        if cast(IntRegisterType, self.rd.type) != Registers.ZERO:
+            raise VerifyException(f"scfgwi rd must be ZERO, got {self.rd.type}")
+
+
+class FRepOperation(IRDLOperation, RISCVInstruction):
+    """
+    From the Snitch paper: https://arxiv.org/abs/2002.10143
+
+    The frep instruction marks the beginning of a floating-point kernel which should be
+    repeated. It indicates how many subsequent instructions are stored in the sequence
+    buffer, how often and how (operand staggering, repetition mode) each instruction is
+    going to be repeated.
+    """
+
+    max_rep = operand_def(IntRegisterType)
+    """Number of times to repeat the instructions."""
+    body = region_def("single_block")
+    """
+    Instructions to repeat, containing maximum 15 instructions, with no side effects.
+    """
+    stagger_mask = attr_def(IntAttr)
+    """
+    4 bits for each operand (rs1 rs2 rs3 rd). If the bit is set, the corresponding operand
+    is staggered.
+    """
+    stagger_count = attr_def(IntAttr)
+    """
+    3 bits, indicating for how many iterations the stagger should increment before it
+    wraps again (up to 23 = 8).
+    """
+
+    traits = frozenset((NoTerminator(),))
+
+    def __init__(
+        self,
+        max_rep: SSAValue | Operation,
+        body: Sequence[Operation] | Sequence[Block] | Region,
+        stagger_mask: IntAttr,
+        stagger_count: IntAttr,
+    ):
+        super().__init__(
+            operands=(max_rep,),
+            regions=(body,),
+            attributes={
+                "stagger_mask": stagger_mask,
+                "stagger_count": stagger_count,
+            },
+        )
+
+    @property
+    def max_inst(self) -> int:
+        """
+        Number of instructions to be repeated.
+        """
+        return len([op for op in self.body.ops if isinstance(op, RISCVInstruction)])
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return (
+            self.max_rep,
+            self.max_inst,
+            self.stagger_mask.data,
+            self.stagger_count.data,
+        )
+
+    def custom_print_attributes(self, printer: Printer):
+        printer.print(", ")
+        printer.print(self.stagger_mask.data)
+        printer.print_string(", ")
+        printer.print(self.stagger_count.data)
+        return {"stagger_mask", "stagger_count"}
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser):
+        attributes = dict[str, Attribute]()
+        attributes["stagger_mask"] = IntAttr(
+            parser.parse_integer(
+                allow_boolean=False, context_msg="Expected stagger mask"
+            )
+        )
+        parser.parse_punctuation(",")
+        attributes["stagger_count"] = IntAttr(
+            parser.parse_integer(
+                allow_boolean=False, context_msg="Expected stagger count"
+            )
+        )
+        return attributes
+
+    def verify_(self) -> None:
+        if self.stagger_count.data:
+            raise VerifyException("Non-zero stagger count currently unsupported")
+        if self.stagger_mask.data:
+            raise VerifyException("Non-zero stagger mask currently unsupported")
+        for instruction in self.body.ops:
+            if not instruction.has_trait(Pure) and not isinstance(
+                instruction, FrepYieldOp
+            ):
+                raise VerifyException(
+                    "Frep operation body may not contain instructions "
+                    f"with side-effects, found {instruction.name}"
+                )
+
+
+@irdl_op_definition
+class FrepOuter(FRepOperation):
+    """
+    Repeats the instruction in the body as if the body were the body of a for loop, for
+    example:
+
+    ```
+    # Repeat 4 times, stagger 1, period 2
+    li a0, 4
+    frep.o a0, 2, 1, 0b1010
+    fadd.d fa0, ft0, ft2
+    fmul.d fa0, ft3, fa0
+    ```
+
+    is equivalent to:
+    ```
+    fadd.d fa0, ft0, ft2
+    fmul.d fa0, ft3, fa0
+    fadd.d fa1, ft0, ft3
+    fmul.d fa1, ft3, fa1
+    fadd.d fa0, ft0, ft2
+    fmul.d fa0, ft3, fa0
+    fadd.d fa1, ft0, ft3
+    fmul.d fa1, ft3, fa1
+    ```
+    """
+
+    name = "riscv_snitch.frep_outer"
+
+    def assembly_instruction_name(self) -> str:
+        return "frep.o"
+
+
+@irdl_op_definition
+class FrepInner(FRepOperation):
+    """
+    Repeats the instruction in the body, as if each were in its own body of a for loop,
+    for example:
+
+    ```
+    # Repeat three times, stagger 2, period 2
+    li a0, 3
+    frep.i a0, 2, 2, 0b0100
+    fadd.d fa0, ft0, ft2
+    fmul.d fa0, ft3, fa0
+    ```
+
+    is equivalent to:
+    ```
+    fadd.d fa0, ft0, ft2
+    fadd.d fa0, ft1, ft3
+    fadd.d fa0, ft2, ft3
+    fmul.d fa0, ft3, fa0
+    fmul.d fa0, ft4, fa0
+    fmul.d fa0, ft5, fa0
+    ```
+    """
+
+    name = "riscv_snitch.frep_inner"
+
+    def assembly_instruction_name(self) -> str:
+        return "frep.i"
+
+
+@irdl_op_definition
+class FrepYieldOp(IRDLOperation, RISCVOp):
+    name = "riscv_snitch.frep_yield"
+
+    values: VarOperand = var_operand_def()
+
+    traits = frozenset([IsTerminator()])
+
+    def __init__(self, *operands: SSAValue | Operation) -> None:
+        super().__init__(operands=[SSAValue.get(operand) for operand in operands])
+
+    def assembly_line(self) -> str | None:
+        return None
+
+
+# endregion
+
+RISCV_Snitch = Dialect(
+    [
+        ScfgwOp,
+        ScfgwiOp,
+        FrepOuter,
+        FrepInner,
+    ],
+    [],
+)

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -36,6 +36,7 @@ from xdsl.dialects.printf import Printf
 from xdsl.dialects.riscv import RISCV
 from xdsl.dialects.riscv_func import RISCV_Func
 from xdsl.dialects.riscv_scf import RISCV_Scf
+from xdsl.dialects.riscv_snitch import RISCV_Snitch
 from xdsl.dialects.scf import Scf
 from xdsl.dialects.seq import Seq
 from xdsl.dialects.snitch import Snitch
@@ -103,6 +104,7 @@ def get_all_dialects() -> list[Dialect]:
         RISCV,
         RISCV_Func,
         RISCV_Scf,
+        RISCV_Snitch,
         Scf,
         Seq,
         Snitch,

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from xdsl.dialects import riscv
+from xdsl.dialects import riscv, riscv_snitch
 from xdsl.dialects.builtin import IntegerAttr
 from xdsl.ir import OpResult
 from xdsl.pattern_rewriter import (
@@ -367,7 +367,9 @@ class BitwiseAndByZero(RewritePattern):
 
 class ScfgwOpUsingImmediate(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: riscv.ScfgwOp, rewriter: PatternRewriter) -> None:
+    def match_and_rewrite(
+        self, op: riscv_snitch.ScfgwOp, rewriter: PatternRewriter
+    ) -> None:
         if (
             isinstance(op.rs2, OpResult)
             and isinstance(op.rs2.op, riscv.LiOp)
@@ -375,7 +377,7 @@ class ScfgwOpUsingImmediate(RewritePattern):
         ):
             rd = cast(riscv.IntRegisterType, op.rd.type)
             rewriter.replace_matched_op(
-                riscv.ScfgwiOp(
+                riscv_snitch.ScfgwiOp(
                     op.rs1,
                     op.rs2.op.immediate.value.data,
                     rd=rd,

--- a/xdsl/transforms/lower_snitch.py
+++ b/xdsl/transforms/lower_snitch.py
@@ -4,7 +4,7 @@ Rewrite patterns for lowering snitch → riscv.
 
 from dataclasses import dataclass
 
-from xdsl.dialects import builtin, riscv, snitch
+from xdsl.dialects import builtin, riscv, riscv_snitch, snitch
 from xdsl.dialects.builtin import IntegerAttr, i32
 from xdsl.ir import MLContext
 from xdsl.irdl import Operand
@@ -113,7 +113,7 @@ def make_stream_set_config_ops(value: Operand, stream: Operand, baseaddr: int):
             stream,
             immediate=IntegerAttr(baseaddr << 5, i32),
         ),
-        riscv.ScfgwOp(
+        riscv_snitch.ScfgwOp(
             rs1=value,
             rs2=address,
             rd=riscv.Registers.ZERO,


### PR DESCRIPTION
This PR:

- Factors out `frep.inner`, `frep.outer`, `scfgw` and `scfgwi` from the `riscv` to the `riscv_snitch` dialect.

Nothing else changed.