### PR TITLE
dialects: (memref) add attributes in memref store load custom syntax

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_custom.mlir
@@ -5,7 +5,11 @@
 %i1 = "test.op"() : () -> (index)
 %m = "test.op"() : () -> (memref<2x3xi32>)
 memref.store %v0, %m[%i0, %i1] : memref<2x3xi32>
-%v1 = "memref.load"(%m, %i0, %i1) {"nontemporal" = false} : (memref<2x3xi32>, index, index) -> (i32)
+memref.store %v0, %m[%i0, %i1] {"nontemporal" = false} : memref<2x3xi32>
+memref.store %v0, %m[%i0, %i1] {"nontemporal" = true} : memref<2x3xi32>
+%v1 = memref.load %m[%i0, %i1] : memref<2x3xi32>
+%v2 = memref.load %m[%i0, %i1] {"nontemporal" = false} : memref<2x3xi32>
+%v3 = memref.load %m[%i0, %i1] {"nontemporal" = true} : memref<2x3xi32>
 
 // CHECK:      module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> i32
@@ -13,5 +17,9 @@ memref.store %v0, %m[%i0, %i1] : memref<2x3xi32>
 // CHECK-NEXT:   %2 = "test.op"() : () -> index
 // CHECK-NEXT:   %3 = "test.op"() : () -> memref<2x3xi32>
 // CHECK-NEXT:   memref.store %0, %3[%1, %2] : memref<2x3xi32>
-// CHECK-NEXT:   %4 = memref.load %3[%1, %2] : memref<2x3xi32>
+// CHECK-NEXT:   memref.store %0, %3[%1, %2] : memref<2x3xi32>
+// CHECK-NEXT:   memref.store %0, %3[%1, %2] {nontemporal = true} : memref<2x3xi32>
+// CHECK-NEXT:   %{{.*}} = memref.load %3[%1, %2] : memref<2x3xi32>
+// CHECK-NEXT:   %{{.*}} = memref.load %3[%1, %2] : memref<2x3xi32>
+// CHECK-NEXT:   %{{.*}} = memref.load %3[%1, %2] {nontemporal = true} : memref<2x3xi32>
 // CHECK-NEXT: }

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -206,20 +206,25 @@ class Load(IRDLOperation):
         unresolved_indices = parser.parse_comma_separated_list(
             parser.Delimiter.SQUARE, parser.parse_unresolved_operand
         )
+        attributes = parser.parse_optional_attr_dict()
         parser.parse_punctuation(":")
         ref_type = parser.parse_attribute()
         resolved_ref = parser.resolve_operand(unresolved_ref, ref_type)
         resolved_indices = [
             parser.resolve_operand(index, IndexType()) for index in unresolved_indices
         ]
-        return cls.get(resolved_ref, resolved_indices)
+        res = cls.get(resolved_ref, resolved_indices)
+        res.attributes.update(attributes)
+        return res
 
     def print(self, printer: Printer):
         printer.print_string(" ")
         printer.print(self.memref)
         printer.print_string("[")
         printer.print_list(self.indices, printer.print_operand)
-        printer.print_string("] : ")
+        printer.print_string("]")
+        printer.print_op_attributes(self.attributes)
+        printer.print_string(" : ")
         printer.print_attribute(self.memref.type)
 
 
@@ -258,13 +263,16 @@ class Store(IRDLOperation):
         unresolved_indices = parser.parse_comma_separated_list(
             parser.Delimiter.SQUARE, parser.parse_unresolved_operand
         )
+        attributes = parser.parse_optional_attr_dict()
         parser.parse_punctuation(":")
         ref_type = parser.parse_attribute()
         resolved_ref = parser.resolve_operand(unresolved_ref, ref_type)
         resolved_indices = [
             parser.resolve_operand(index, IndexType()) for index in unresolved_indices
         ]
-        return cls.get(value, resolved_ref, resolved_indices)
+        res = cls.get(value, resolved_ref, resolved_indices)
+        res.attributes.update(attributes)
+        return res
 
     def print(self, printer: Printer):
         printer.print_string(" ")
@@ -273,7 +281,9 @@ class Store(IRDLOperation):
         printer.print(self.memref)
         printer.print_string("[")
         printer.print_list(self.indices, printer.print_operand)
-        printer.print_string("] : ")
+        printer.print_string("]")
+        printer.print_op_attributes(self.attributes)
+        printer.print_string(" : ")
         printer.print_attribute(self.memref.type)
 
 


### PR DESCRIPTION
mlir actually drops the nontemporal = false, as that's the default. I have not reimplemented this behaviour, as it's not really critical and parses just fine.