### PR TITLE
transformations: Rename dmp-decompose-2d to dmp-decompose

### DIFF
--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -97,7 +97,7 @@ def get_all_passes() -> list[type[ModulePass]]:
         convert_stencil_to_ll_mlir.ConvertStencilToLLMLIRPass,
         dead_code_elimination.DeadCodeElimination,
         DesymrefyPass,
-        stencil_global_to_local.GlobalStencilToLocalStencil2DHorizontal,
+        stencil_global_to_local.GlobalStencilToLocalStencil,
         stencil_global_to_local.LowerHaloToMPI,
         lower_mpi.LowerMPIPass,
         lower_riscv_func.LowerRISCVFunc,

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -640,7 +640,7 @@ class DmpDecompositionPass(ModulePass, ABC):
 
 
 @dataclass
-class GlobalStencilToLocalStencil2DHorizontal(DmpDecompositionPass):
+class GlobalStencilToLocalStencil(DmpDecompositionPass):
     """
     Decompose a stencil to apply to a local domain.
 

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -648,7 +648,7 @@ class GlobalStencilToLocalStencil2DHorizontal(DmpDecompositionPass):
     pass pipeline!
     """
 
-    name = "dmp-decompose-2d"
+    name = "dmp-decompose"
 
     restrict_domain: bool = True
 


### PR DESCRIPTION
(This is targetting the devito backport branch, not main)

The actual domain (and grid) dimensionality of dmp-decompose-2d is now parameterized, making the old-name pretty confusing in user-code. Simple rename to make it clear the dimensionality is not fixed by the pass :slightly_smiling_face: 