### PR TITLE
dialects: (scf, riscv_scf) Use lazy traits support

### DIFF
--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -17,6 +17,7 @@ from xdsl.irdl import (
     opt_region_def,
     opt_successor_def,
     region_def,
+    traits_def,
 )
 from xdsl.traits import (
     HasParent,
@@ -272,10 +273,11 @@ class IsSingleBlockImplicitTerminatorOp(IRDLOperation):
 
     name = "test.is_single_block_implicit_terminator"
 
-    # TODO fix circular reference
-    # traits = frozenset([HasParent(HasSingleBlockImplicitTerminatorOp), IsTerminator()])
-    # this is tracked by gh issue: https://github.com/xdslproject/xdsl/issues/1218
-    traits = frozenset([IsTerminator()])
+    traits = traits_def(
+        lambda: frozenset(
+            [IsTerminator(), HasParent(HasSingleBlockImplicitTerminatorOp)]
+        )
+    )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -29,6 +29,7 @@ from xdsl.irdl import (
     region_def,
     var_operand_def,
     var_result_def,
+    traits_def,
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
@@ -42,10 +43,7 @@ class YieldOp(IRDLOperation):
 
     arguments: VarOperand = var_operand_def(RISCVRegisterType)
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent((For, If, ParallelOp, While)), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = traits_def(lambda: frozenset([IsTerminator(), HasParent(ForOp, WhileOp)]))
 
     def __init__(self, *operands: SSAValue | Operation):
         super().__init__(operands=[[SSAValue.get(operand) for operand in operands]])

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -27,9 +27,9 @@ from xdsl.irdl import (
     irdl_op_definition,
     operand_def,
     region_def,
+    traits_def,
     var_operand_def,
     var_result_def,
-    traits_def,
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -24,6 +24,7 @@ from xdsl.irdl import (
     region_def,
     var_operand_def,
     var_result_def,
+    traits_def,
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
@@ -76,10 +77,9 @@ class Yield(IRDLOperation):
     name = "scf.yield"
     arguments: VarOperand = var_operand_def(AnyAttr())
 
-    # TODO circular dependency disallows this set of traits
-    # tracked by gh issues https://github.com/xdslproject/xdsl/issues/1218
-    # traits = frozenset([HasParent((For, If, ParallelOp, While)), IsTerminator()])
-    traits = frozenset([IsTerminator()])
+    traits = traits_def(
+        lambda: frozenset([IsTerminator(), HasParent(For, If, ParallelOp, While)])
+    )
 
     def __init__(self, *operands: SSAValue | Operation):
         super().__init__(operands=[operands])

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -22,9 +22,9 @@ from xdsl.irdl import (
     irdl_op_definition,
     operand_def,
     region_def,
+    traits_def,
     var_operand_def,
     var_result_def,
-    traits_def,
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer


### PR DESCRIPTION
This PR resolves #1218 :

- Adds lazy traits support (introduced in #1529) to break the circular dependency between ops and traits that require them.