### PR TITLE
dialects: (riscv) assembly section op creates a valid region in init

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -241,3 +241,8 @@ def test_riscv_parse_immediate_value():
     parser = Parser(ctx, prog)
     with pytest.raises(ParseError, match="Expected immediate"):
         parser.parse_operation()
+
+
+def test_asm_section():
+    section = riscv.AssemblySectionOp("section")
+    section.verify()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -2546,7 +2546,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
         if isinstance(directive, str):
             directive = StringAttr(directive)
         if region is None:
-            region = Region()
+            region = Region(Block())
 
         super().__init__(
             regions=[region],


### PR DESCRIPTION


@xdslproject/risc-v-backend 