### PR TITLE
backend: (riscv) make dimension an IntAttr in snitch ops

### DIFF
--- a/tests/dialects/test_snitch.py
+++ b/tests/dialects/test_snitch.py
@@ -1,7 +1,7 @@
 import pytest
 
 from xdsl.dialects import riscv, snitch
-from xdsl.dialects.builtin import IntegerAttr, i32
+from xdsl.dialects.builtin import IntAttr
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
@@ -9,8 +9,8 @@ from xdsl.utils.test_value import TestSSAValue
 def test_csr_op():
     stream = TestSSAValue(riscv.Registers.A1)
     value = TestSSAValue(riscv.Registers.A1)
-    valid = IntegerAttr(snitch.SnitchResources.dimensions - 1, i32)
-    invalid = IntegerAttr(snitch.SnitchResources.dimensions, i32)
+    valid = IntAttr(snitch.SnitchResources.dimensions - 1)
+    invalid = IntAttr(snitch.SnitchResources.dimensions)
 
     snitch.SsrSetDimensionBoundOp(stream=stream, value=value, dimension=valid).verify()
     with pytest.raises(VerifyException):

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -6,14 +6,14 @@
   %stride = "test.op"() : () -> !riscv.reg<>
   %rep = "test.op"() : () -> !riscv.reg<>
   // Usual SSR setup sequence:
-  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
   "snitch.ssr_enable"() : () -> ()

--- a/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
@@ -6,29 +6,29 @@ builtin.module {
   %stride = riscv.li 4 : () -> !riscv.reg<>
   %rep = riscv.li 0 : () -> !riscv.reg<>
   // SSR setup sequence for dimension 0
-  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 64 : (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 192 : (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 768 : (!riscv.reg<>) -> !riscv.reg<>
   // %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 0 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 896 : (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   // SSR setup sequence for dimension 3
-  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 160 : (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 288 : (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 864 : (!riscv.reg<>) -> !riscv.reg<>
   // riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = 3 : i32} : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
   // CHECK: %{{.*}} = riscv.addi %stream, 992 : (!riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -11,7 +11,7 @@ that aims at generating.
 from abc import ABC
 from dataclasses import dataclass
 
-from xdsl.dialects.builtin import AnyIntegerAttr
+from xdsl.dialects.builtin import IntAttr
 from xdsl.dialects.riscv import IntRegisterType
 from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, Operand, attr_def, irdl_op_definition, operand_def
@@ -36,13 +36,13 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
 
     stream: Operand = operand_def(IntRegisterType)
     value: Operand = operand_def(IntRegisterType)
-    dimension: AnyIntegerAttr = attr_def(AnyIntegerAttr)
+    dimension = attr_def(IntAttr)
 
     def __init__(
         self,
         stream: Operation | SSAValue,
         value: Operation | SSAValue,
-        dimension: AnyIntegerAttr,
+        dimension: IntAttr,
     ):
         super().__init__(
             operands=[stream, value],
@@ -52,7 +52,7 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
         )
 
     def verify_(self) -> None:
-        if self.dimension.value.data >= SnitchResources.dimensions:
+        if self.dimension.data >= SnitchResources.dimensions:
             raise VerifyException(
                 f"dimension attribute out of range [0..{SnitchResources.dimensions-1}], "
                 f"Snitch supports up to {SnitchResources.dimensions} dimensions per streamer"

--- a/xdsl/transforms/lower_snitch.py
+++ b/xdsl/transforms/lower_snitch.py
@@ -126,7 +126,7 @@ class LowerSsrSetDimensionBoundOp(RewritePattern):
     def match_and_rewrite(
         self, op: snitch.SsrSetDimensionBoundOp, rewriter: PatternRewriter, /
     ):
-        dim: int = op.dimension.value.data
+        dim: int = op.dimension.data
         ops = make_stream_set_config_ops(
             value=op.value,
             stream=op.stream,
@@ -143,7 +143,7 @@ class LowerSsrSetDimensionStrideOp(RewritePattern):
     def match_and_rewrite(
         self, op: snitch.SsrSetDimensionStrideOp, rewriter: PatternRewriter, /
     ):
-        dim: int = op.dimension.value.data
+        dim: int = op.dimension.data
         ops = make_stream_set_config_ops(
             value=op.value,
             stream=op.stream,
@@ -160,7 +160,7 @@ class LowerSsrSetDimensionSourceOp(RewritePattern):
     def match_and_rewrite(
         self, op: snitch.SsrSetDimensionSourceOp, rewriter: PatternRewriter, /
     ):
-        dim: int = op.dimension.value.data
+        dim: int = op.dimension.data
         ops = make_stream_set_config_ops(
             value=op.value,
             stream=op.stream,
@@ -177,7 +177,7 @@ class LowerSsrSetDimensionDestinationOp(RewritePattern):
     def match_and_rewrite(
         self, op: snitch.SsrSetDimensionDestinationOp, rewriter: PatternRewriter, /
     ):
-        dim: int = op.dimension.value.data
+        dim: int = op.dimension.data
         ops = make_stream_set_config_ops(
             value=op.value,
             stream=op.stream,


### PR DESCRIPTION
I'm not sure what exactly the tradeoff is between making things a plain intattr or the integer attr with signedness, but it feels like if we're operating on things that are actually 5 or 7 bits wide and keeping them in i32 for some reason then it's a bit more confusing. I'm also not sure we want to take the time now to ensure that the values fit in those widths, that'll be true for our lowerings by construction.

@xdslproject/risc-v-backend 