### PR TITLE
backend: (riscv) SsrSetStreamConfigOperation has dm attr instead of stream operand

### DIFF
--- a/tests/dialects/test_snitch.py
+++ b/tests/dialects/test_snitch.py
@@ -7,30 +7,30 @@ from xdsl.utils.test_value import TestSSAValue
 
 
 def test_csr_op():
-    stream = TestSSAValue(riscv.Registers.A1)
     value = TestSSAValue(riscv.Registers.A1)
+    stream = IntAttr(0)
     valid = IntAttr(snitch.SnitchResources.dimensions - 1)
     invalid = IntAttr(snitch.SnitchResources.dimensions)
 
-    snitch.SsrSetDimensionBoundOp(stream=stream, value=value, dimension=valid).verify()
+    snitch.SsrSetDimensionBoundOp(value=value, dm=stream, dimension=valid).verify()
     with pytest.raises(VerifyException):
         snitch.SsrSetDimensionBoundOp(
-            stream=stream, value=value, dimension=invalid
+            value=value, dm=stream, dimension=invalid
         ).verify()
-    snitch.SsrSetDimensionStrideOp(stream=stream, value=value, dimension=valid).verify()
+    snitch.SsrSetDimensionStrideOp(value=value, dm=stream, dimension=valid).verify()
     with pytest.raises(VerifyException):
         snitch.SsrSetDimensionStrideOp(
-            stream=stream, value=value, dimension=invalid
+            value=value, dm=stream, dimension=invalid
         ).verify()
-    snitch.SsrSetDimensionSourceOp(stream=stream, value=value, dimension=valid).verify()
+    snitch.SsrSetDimensionSourceOp(value=value, dm=stream, dimension=valid).verify()
     with pytest.raises(VerifyException):
         snitch.SsrSetDimensionSourceOp(
-            stream=stream, value=value, dimension=invalid
+            value=value, dm=stream, dimension=invalid
         ).verify()
     snitch.SsrSetDimensionDestinationOp(
-        stream=stream, value=value, dimension=valid
+        value=value, dm=stream, dimension=valid
     ).verify()
     with pytest.raises(VerifyException):
         snitch.SsrSetDimensionDestinationOp(
-            stream=stream, value=value, dimension=invalid
+            value=value, dm=stream, dimension=invalid
         ).verify()

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,21 +1,20 @@
 // RUN: XDSL_ROUNDTRIP
 "builtin.module"() ({
   %addr = "test.op"() : () -> !riscv.reg<>
-  %stream = "test.op"() : () -> !riscv.reg<>
   %bound = "test.op"() : () -> !riscv.reg<>
   %stride = "test.op"() : () -> !riscv.reg<>
   %rep = "test.op"() : () -> !riscv.reg<>
   // Usual SSR setup sequence:
-  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_source"(%addr) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #int<0>} : (!riscv.reg<>) -> ()
   "snitch.ssr_enable"() : () -> ()
   // CHECK-NEXT: "snitch.ssr_enable"() : () -> ()
   "snitch.ssr_disable"() : () -> ()

--- a/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
@@ -1,38 +1,37 @@
 // RUN: xdsl-opt -p lower-snitch %s | filecheck %s
 builtin.module {
   %addr = "test.op"() : () -> !riscv.reg<>
-  %stream = riscv.li 0 : () -> !riscv.reg<>
   %bound = riscv.li 9 : () -> !riscv.reg<>
   %stride = riscv.li 4 : () -> !riscv.reg<>
   %rep = riscv.li 0 : () -> !riscv.reg<>
   // SSR setup sequence for dimension 0
-  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 64 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 64 : () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 192 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 192 : () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 768 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 768 : () -> !riscv.reg<>
   // %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<0>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 896 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #int<0>, "dimension" = #int<0>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 896 : () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   // SSR setup sequence for dimension 3
-  "snitch.ssr_set_dimension_bound"(%stream, %bound) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 160 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #int<0>, "dimension" = #int<3>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 160 : () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_stride"(%stream, %stride) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 288 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #int<0>, "dimension" = #int<3>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 288 : () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_source"(%stream, %addr) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 864 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #int<0>, "dimension" = #int<3>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 864 : () -> !riscv.reg<>
   // riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_destination"(%stream, %addr) {"dimension" = #int<3>} : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 992 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #int<0>, "dimension" = #int<3>} : (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 992 : () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_stream_repetition"(%stream, %rep) : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.addi %stream, 32 : (!riscv.reg<>) -> !riscv.reg<>
+  "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #int<0>}: (!riscv.reg<>) -> ()
+  // CHECK: %{{.*}} = riscv.li 32 : () -> !riscv.reg<>
   // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %rep, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
   // On/Off switching sequence
   "snitch.ssr_enable"() : () -> ()

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -34,19 +34,20 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
     configuration value for a specific dimension handled by a streamer.
     """
 
-    stream: Operand = operand_def(IntRegisterType)
     value: Operand = operand_def(IntRegisterType)
+    dm = attr_def(IntAttr)
     dimension = attr_def(IntAttr)
 
     def __init__(
         self,
-        stream: Operation | SSAValue,
         value: Operation | SSAValue,
+        dm: IntAttr,
         dimension: IntAttr,
     ):
         super().__init__(
-            operands=[stream, value],
+            operands=[value],
             attributes={
+                "dm": dm,
                 "dimension": dimension,
             },
         )
@@ -65,11 +66,16 @@ class SsrSetStreamConfigOperation(IRDLOperation, ABC):
     configuration value for a streamer.
     """
 
-    stream: Operand = operand_def(IntRegisterType)
     value: Operand = operand_def(IntRegisterType)
+    dm = attr_def(IntAttr)
 
-    def __init__(self, stream: Operation | SSAValue, value: Operation | SSAValue):
-        super().__init__(operands=[stream, value])
+    def __init__(self, value: Operation | SSAValue, dm: IntAttr):
+        super().__init__(
+            operands=[value],
+            attributes={
+                "dm": dm,
+            },
+        )
 
 
 @irdl_op_definition

--- a/xdsl/transforms/lower_snitch.py
+++ b/xdsl/transforms/lower_snitch.py
@@ -2,11 +2,12 @@
 Rewrite patterns for lowering snitch → riscv.
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from xdsl.dialects import builtin, riscv, riscv_snitch, snitch
 from xdsl.dialects.builtin import IntegerAttr, i32
-from xdsl.ir import MLContext
+from xdsl.ir import MLContext, Operation
 from xdsl.irdl import Operand
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -95,23 +96,30 @@ class SnitchStreamerMemoryMap:
     )
 
 
-def make_stream_set_config_ops(value: Operand, stream: Operand, baseaddr: int):
+def write_ssr_config_ops(reg: int, dm: int, value: Operand) -> Iterable[Operation]:
     """
     Return the list of riscv operations needed to set a specific SSR configuration
-    parameter located at 'baseaddr' to a specific 'value' for a specific data mover
-    identified by 'stream'.
+    parameter located at 'reg' to a specific 'value' for a specific data mover
+    identified by 'dm'.
 
     To compute the actual address of the memory-mapped configuration parameter,
     we have to compute:
 
-    address = stream + baseaddr << 5
+    address = dm + reg << 5
 
     This value is then passed to riscv.scfgw to perform the actual setting.
+
+    Reference implementation in the snitch runtime library:
+    ``` c
+    inline void write_ssr_cfg(uint32_t reg, uint32_t dm, uint32_t value) {
+        asm volatile("scfgwi %[value], %[dm] | %[reg]<<5\n" ::[value] "r"(value),
+                    [ dm ] "i"(dm), [ reg ] "i"(reg));
+    }
+    ```
     """
     return [
-        address := riscv.AddiOp(
-            stream,
-            immediate=IntegerAttr(baseaddr << 5, i32),
+        address := riscv.LiOp(
+            immediate=IntegerAttr(dm | reg << 5, i32),
         ),
         riscv_snitch.ScfgwOp(
             rs1=value,
@@ -127,10 +135,10 @@ class LowerSsrSetDimensionBoundOp(RewritePattern):
         self, op: snitch.SsrSetDimensionBoundOp, rewriter: PatternRewriter, /
     ):
         dim: int = op.dimension.data
-        ops = make_stream_set_config_ops(
+        ops = write_ssr_config_ops(
+            dm=op.dm.data,
+            reg=SnitchStreamerMemoryMap.dimension[dim].bound,
             value=op.value,
-            stream=op.stream,
-            baseaddr=SnitchStreamerMemoryMap.dimension[dim].bound,
         )
         rewriter.replace_matched_op(
             [*ops],
@@ -144,10 +152,10 @@ class LowerSsrSetDimensionStrideOp(RewritePattern):
         self, op: snitch.SsrSetDimensionStrideOp, rewriter: PatternRewriter, /
     ):
         dim: int = op.dimension.data
-        ops = make_stream_set_config_ops(
+        ops = write_ssr_config_ops(
+            dm=op.dm.data,
+            reg=SnitchStreamerMemoryMap.dimension[dim].stride,
             value=op.value,
-            stream=op.stream,
-            baseaddr=SnitchStreamerMemoryMap.dimension[dim].stride,
         )
         rewriter.replace_matched_op(
             [*ops],
@@ -161,10 +169,10 @@ class LowerSsrSetDimensionSourceOp(RewritePattern):
         self, op: snitch.SsrSetDimensionSourceOp, rewriter: PatternRewriter, /
     ):
         dim: int = op.dimension.data
-        ops = make_stream_set_config_ops(
+        ops = write_ssr_config_ops(
+            dm=op.dm.data,
+            reg=SnitchStreamerMemoryMap.dimension[dim].source,
             value=op.value,
-            stream=op.stream,
-            baseaddr=SnitchStreamerMemoryMap.dimension[dim].source,
         )
         rewriter.replace_matched_op(
             [*ops],
@@ -178,10 +186,10 @@ class LowerSsrSetDimensionDestinationOp(RewritePattern):
         self, op: snitch.SsrSetDimensionDestinationOp, rewriter: PatternRewriter, /
     ):
         dim: int = op.dimension.data
-        ops = make_stream_set_config_ops(
+        ops = write_ssr_config_ops(
+            dm=op.dm.data,
+            reg=SnitchStreamerMemoryMap.dimension[dim].destination,
             value=op.value,
-            stream=op.stream,
-            baseaddr=SnitchStreamerMemoryMap.dimension[dim].destination,
         )
         rewriter.replace_matched_op(
             [*ops],
@@ -194,10 +202,10 @@ class LowerSsrSetStreamRepetitionOp(RewritePattern):
     def match_and_rewrite(
         self, op: snitch.SsrSetStreamRepetitionOp, rewriter: PatternRewriter, /
     ):
-        ops = make_stream_set_config_ops(
+        ops = write_ssr_config_ops(
+            dm=op.dm.data,
+            reg=SnitchStreamerMemoryMap.repeat,
             value=op.value,
-            stream=op.stream,
-            baseaddr=SnitchStreamerMemoryMap.repeat,
         )
         rewriter.replace_matched_op(
             [*ops],


### PR DESCRIPTION
Two main changes:
 `stream` -> `dm` in snitch, since those ops correspond more to the assembly level than the stream level, and having naming consistent with the docs and snitch runtime library seems advantageous.
  operand -> attribute, we always have that data at compile-time, so we might as well avoid the dance of `li` + `addi` canonicalisation, and just create the `li` at the end.

@xdslproject/risc-v-backend 