### PR TITLE
[WIP] dialects: (hw) Implement HW inner symbols

### DIFF
--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -1,0 +1,149 @@
+"""
+This is a stub of CIRCT’s hw dialect.
+It currently implements minimal types and operations used by other dialects.
+
+[1] https://circt.llvm.org/docs/Dialects/HW/
+"""
+
+from xdsl.dialects.builtin import (
+    FlatSymbolRefAttr,
+    ParameterDef,
+    StringAttr,
+)
+from xdsl.ir import (
+    Dialect,
+    Operation,
+    ParametrizedAttribute,
+)
+from xdsl.irdl import (
+    irdl_attr_definition,
+)
+
+
+class FieldIDTypeInterface:
+    """Common methods for types which can be indexed by a field_id.
+
+    field_id is a depth-first numbering of the elements of a type. For example:
+    ```
+    struct a  /* 0 */ {
+      int b; /* 1 */
+      struct c /* 2 */ {
+        int d; /* 3 */
+      }
+    }
+
+    int e; /* 0 */
+    ```
+    """
+
+    def get_max_field_id(self) -> int:
+        """Get the maximum field ID for this type"""
+        return 0
+
+    def get_sub_type_by_field_id(self, field_id: int) -> tuple[type, int]:
+        """Get the sub-type of a type for a field ID, and the subfield's ID. Strip
+        off a single layer of this type and return the sub-type and a field ID
+        targeting the same field, but rebased on the sub-type.
+
+        The resultant type *may* not be a FieldIDTypeInterface if the resulting
+        field_id is zero. This means that leaf types may be ground without
+        implementing an interface. An empty aggregate will also appear as a zero."""
+        if field_id == 0:
+            return (type(self), 0)
+        raise NotImplementedError()
+
+    def project_to_child_field_id(self, field_id: int, index: int) -> tuple[int, bool]:
+        """Returns the effective field id when treating the index field as the
+        root of the type. Essentially maps a field_id to a field_id after a
+        subfield op. Returns the new id and whether the id is in the given
+        child."""
+        ...
+
+    def get_index_for_field_id(self, field_id: int) -> int:
+        """Returns the index (e.g. struct or vector element) for a given
+        field_id. This returns the containing index in the case that the
+        field_id points to a child field of a field."""
+        ...
+
+    def get_field_id(self, index: int) -> int:
+        """Return the field_id of a given index (e.g. struct or vector element).
+        field ids start at 1, and are assigned to each field in a recursive
+        depth-first walk of all elements. A field ID of 0 is used to reference
+        the type itself."""
+        ...
+
+    def get_index_and_subfield_id(self, field_id: int) -> tuple[int, int]:
+        """Find the index of the element that contains the given field_id. As well, rebase the field_id to the element."""
+        ...
+
+
+class InnerSymTarget:
+    """The target of an inner symbol, the entity the symbol is a handle for."""
+
+    def __init__(
+        self,
+        op: Operation | None = None,
+        field_id: int = 0,
+        port_idx: int | None = None,
+    ) -> None:
+        self.op = op
+        self.field_id = field_id
+        self.port_idx = port_idx
+
+    def __bool__(self):
+        # None-valued op defines an invalid target
+        return self.op is not None
+
+    def is_port(self) -> bool:
+        return self.port_idx is not None
+
+    def is_field(self) -> bool:
+        return self.field_id != 0
+
+    def is_op_only(self) -> bool:
+        return not self.is_field() and not self.is_port()
+
+    @classmethod
+    def get_target_for_subfield(
+        cls, base: "InnerSymTarget", field_id: int
+    ) -> "InnerSymTarget":
+        return cls(base.op, base.field_id + field_id, base.port_idx)
+
+
+@irdl_attr_definition
+class InnerRefAttr(ParametrizedAttribute):
+    """This works like a symbol reference, but to a name inside a module.
+
+    NB: the parse and print for AsmPrinter are not copied from CIRCT."""
+
+    name = "hw.inner_name_ref"
+    module_ref: ParameterDef[FlatSymbolRefAttr]
+    # NB. upstream defines as “name” which clashes with Attribute.name
+    sym_name: ParameterDef[StringAttr]
+
+    def __init__(self, module: str | StringAttr, name: str | StringAttr) -> None:
+        if isinstance(module, str):
+            module = StringAttr(module)
+        if isinstance(name, str):
+            name = StringAttr(name)
+        super().__init__([FlatSymbolRefAttr(module), name])
+
+    @classmethod
+    def get_from_operation(
+        cls, op: Operation, sym_name: StringAttr, module_name: StringAttr
+    ) -> "InnerRefAttr":
+        """Get the InnerRefAttr for an operation and add the sym on it."""
+        # NB: declared upstream, but no implementation to be found
+        raise NotImplementedError
+
+    def get_module(self) -> StringAttr:
+        """Return the name of the referenced module."""
+        return self.module_ref.root_reference
+
+
+HW = Dialect(
+    [],
+    [
+        InnerRefAttr,
+    ],
+)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -947,6 +947,17 @@ class Operation(IRNode):
         """
         return [t for t in cls.traits if isinstance(t, trait_type)]
 
+    def get_parent_with_trait(
+        self, trait: type[OpTraitInvT], parameters: Any = None
+    ) -> Operation | None:
+        """
+        Returns the closest surrounding parent operation with given trait.
+        """
+        op: Operation | None = self
+        while op is not None and not op.has_trait(trait, parameters):
+            op = op.parent_op()
+        return op
+
     def erase(self, safe_erase: bool = True, drop_references: bool = True) -> None:
         """
         Erase the operation, and remove all its references to other operations.

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -246,9 +246,7 @@ class SymbolTable(OpTrait):
         # import builtin here to avoid circular import
         from xdsl.dialects.builtin import StringAttr, SymbolRefAttr
 
-        anchor: Operation | None = op
-        while anchor is not None and not anchor.has_trait(SymbolTable):
-            anchor = anchor.parent_op()
+        anchor: Operation | None = op.get_parent_with_trait(SymbolTable)
         if anchor is None:
             raise ValueError(f"Operation {op} has no SymbolTable ancestor")
         if isinstance(name, str | StringAttr):


### PR DESCRIPTION
This seems to be the minimal subset of the `HW` dialect to implement inner symbols, which are required by the `seq` dialect. Essentially it is a symbol lookup system parallel to `mlir.SymbolTable` (here `hw.InnerSymbolTable`) to be able to lookup symbols not in the direct parent but beyond that, specifying the symbol location (generally a module) by name.

I’ve gathered what I could from upstream and pythonized/xdsl’d it as much as possible, but I’m now left with a lot of interfaces/traits and a few attributes (the inner refs themselves) -- so mostly abstract things, and I’m not entirely sure how to proceed to writing tests.

I would like to avoid implementing all the operations/types etc. inheriting the traits/interfaces, to be able to split the contribution into smaller, more manageable bits for review. Keeping the commit split with 1-4 classes and ≤150 lines each would be nice (even though the first commit lacks some coherence without context ; hopefully this PR gives that context).

Any pointers on the best strategy for this are welcome, it’s kind of hard to grep for in the codebase. There aren’t any tests in CIRCT that don’t rely on concrete operations either. For example, how do you test the parsing/printing of attributes that are not used by any operations (yet)?