### PR TITLE
dialects: (riscv) omit ": () -> ()" for riscv ops

### DIFF
--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -20,8 +20,8 @@ builtin.module {
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "main" : () -> ()
-// CHECK-NEXT:      riscv.directive ".p2align" "2" : () -> ()
+// CHECK-NEXT:      riscv.directive ".globl" "main"
+// CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @main() {
 // CHECK-NEXT:          %0, %1 = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg<>
@@ -37,8 +37,8 @@ builtin.module {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "foo" : () -> ()
-// CHECK-NEXT:      riscv.directive ".p2align" "2" : () -> ()
+// CHECK-NEXT:      riscv.directive ".globl" "foo"
+// CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.reg<a1>) -> (!riscv.reg<a0>, !riscv.reg<a1>) {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
 // CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
@@ -53,8 +53,8 @@ builtin.module {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "foo_float" : () -> ()
-// CHECK-NEXT:      riscv.directive ".p2align" "2" : () -> ()
+// CHECK-NEXT:      riscv.directive ".globl" "foo_float"
+// CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) {
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg<>
 // CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -74,7 +74,7 @@ builtin.module {
 // CHECK-NEXT:   %x_f64_1 = builtin.unrealized_conversion_cast %x_f64 : !riscv.freg<> to f64
 // CHECK-NEXT:   riscv.assembly_section ".data" {
 // CHECK-NEXT:       riscv.label "global"
-// CHECK-NEXT:       riscv.directive ".word" "0x0,0x3ff00000,0x0,0x40000000" : () -> ()
+// CHECK-NEXT:       riscv.directive ".word" "0x0,0x3ff00000,0x0,0x40000000"
 // CHECK-NEXT:   }
 // CHECK-NEXT:   %{{.*}} riscv.li "global" : () -> !riscv.reg<>
 // CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to memref<2xi32>

--- a/tests/filecheck/backend/rvscf_lowering_labels.mlir
+++ b/tests/filecheck/backend/rvscf_lowering_labels.mlir
@@ -20,15 +20,15 @@ builtin.module {
 // CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %3 = riscv.li 0 : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %4 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<a4>
-// CHECK-NEXT:      riscv.label "scf_cond_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_0_for"
 // CHECK-NEXT:      riscv.bge %4, %1, "scf_body_end_0_for" : (!riscv.reg<a4>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_0_for"
 // CHECK-NEXT:      %5 = riscv.get_register : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %6 = riscv.get_register : () -> !riscv.reg<a4>
 // CHECK-NEXT:      %7 = riscv.add %6, %5 : (!riscv.reg<a4>, !riscv.reg<a3>) -> !riscv.reg<a3>
 // CHECK-NEXT:      %8 = riscv.add %4, %2 : (!riscv.reg<a4>, !riscv.reg<a2>) -> !riscv.reg<a4>
 // CHECK-NEXT:      riscv.blt %4, %1, "scf_body_0_for" : (!riscv.reg<a4>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for"
 // CHECK-NEXT:      %9 = riscv.get_register : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %10 = riscv.mv %9 : (!riscv.reg<a3>) -> !riscv.reg<a0>
 // CHECK-NEXT:      riscv_func.return %10 : !riscv.reg<a0>
@@ -59,16 +59,16 @@ builtin.module {
 // CHECK-NEXT:      %3 = riscv.li 0 : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %4 = riscv.fcvt.s.w %3 : (!riscv.reg<a3>) -> !riscv.freg<fa0>
 // CHECK-NEXT:      %5 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
-// CHECK-NEXT:      riscv.label "scf_cond_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_0_for"
 // CHECK-NEXT:      riscv.bge %5, %1, "scf_body_end_0_for" : (!riscv.reg<a0>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_0_for"
 // CHECK-NEXT:      %6 = riscv.get_float_register : () -> !riscv.freg<fa0>
 // CHECK-NEXT:      %7 = riscv.get_register : () -> !riscv.reg<a0>
 // CHECK-NEXT:      %8 = riscv.fcvt.s.w %7 : (!riscv.reg<a0>) -> !riscv.freg<fa1>
 // CHECK-NEXT:      %9 = riscv.fadd.s %6, %8 : (!riscv.freg<fa0>, !riscv.freg<fa1>) -> !riscv.freg<fa0>
 // CHECK-NEXT:      %10 = riscv.add %5, %2 : (!riscv.reg<a0>, !riscv.reg<a2>) -> !riscv.reg<a0>
 // CHECK-NEXT:      riscv.blt %5, %1, "scf_body_0_for" : (!riscv.reg<a0>, !riscv.reg<a1>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for"
 // CHECK-NEXT:      %11 = riscv.get_float_register : () -> !riscv.freg<fa0>
 // CHECK-NEXT:      %12 = riscv.fcvt.w.s %11 : (!riscv.freg<fa0>) -> !riscv.reg<a0>
 // CHECK-NEXT:      riscv_func.return %12 : !riscv.reg<a0>
@@ -102,28 +102,28 @@ builtin.module {
 // CHECK-NEXT:      %1 = riscv.li 0 : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<a3>
 // CHECK-NEXT:      %3 = riscv.mv %1 : (!riscv.reg<a2>) -> !riscv.reg<a2>
-// CHECK-NEXT:      riscv.label "scf_cond_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_0_for"
 // CHECK-NEXT:      riscv.bge %3, %arg0, "scf_body_end_0_for" : (!riscv.reg<a2>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_0_for"
 // CHECK-NEXT:      %arg2 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      %arg1 = riscv.get_register : () -> !riscv.reg<a2>
 // CHECK-NEXT:      %4 = riscv.li 0 : () -> !riscv.reg<a4>
 // CHECK-NEXT:      %5 = riscv.li 1 : () -> !riscv.reg<a5>
 // CHECK-NEXT:      %6 = riscv.mv %4 : (!riscv.reg<a4>) -> !riscv.reg<a4>
-// CHECK-NEXT:      riscv.label "scf_cond_1_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_cond_1_for"
 // CHECK-NEXT:      riscv.bge %6, %arg0, "scf_body_end_1_for" : (!riscv.reg<a4>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_1_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_1_for"
 // CHECK-NEXT:      %arg4 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      %arg3 = riscv.get_register : () -> !riscv.reg<a4>
 // CHECK-NEXT:      %7 = riscv.add %arg1, %arg3 : (!riscv.reg<a2>, !riscv.reg<a4>) -> !riscv.reg<a0>
 // CHECK-NEXT:      %8 = riscv.add %arg4, %7 : (!riscv.reg<a1>, !riscv.reg<a0>) -> !riscv.reg<a1>
 // CHECK-NEXT:      %9 = riscv.add %6, %5 : (!riscv.reg<a4>, !riscv.reg<a5>) -> !riscv.reg<a4>
 // CHECK-NEXT:      riscv.blt %6, %arg0, "scf_body_1_for" : (!riscv.reg<a4>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_1_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_1_for"
 // CHECK-NEXT:      %10 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      %11 = riscv.add %3, %2 : (!riscv.reg<a2>, !riscv.reg<a3>) -> !riscv.reg<a2>
 // CHECK-NEXT:      riscv.blt %3, %arg0, "scf_body_0_for" : (!riscv.reg<a2>, !riscv.reg<a0>) -> ()
-// CHECK-NEXT:      riscv.label "scf_body_end_0_for" : () -> ()
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for"
 // CHECK-NEXT:      %12 = riscv.get_register : () -> !riscv.reg<a1>
 // CHECK-NEXT:      riscv_func.return %12 : !riscv.reg<a1>
 // CHECK-NEXT:    }

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -63,16 +63,16 @@
     // RV32I/RV64I: 2.5 Control Transfer Instructions
 
     // Unconditional Branch Instructions
-    riscv.jal 1 : () -> ()
+    riscv.jal 1
     // CHECK-NEXT: jal 1
-    riscv.jal 1, !riscv.reg<s0> : () -> ()
+    riscv.jal 1, !riscv.reg<s0>
     // CHECK-NEXT: jal s0, 1
-    riscv.jal "label" : () -> ()
+    riscv.jal "label"
     // CHECK-NEXT: jal label
 
-    riscv.j 1, !riscv.reg<zero> : () -> ()
+    riscv.j 1, !riscv.reg<zero>
     // CHECK-NEXT: j 1
-    riscv.j "label", !riscv.reg<zero> : () -> ()
+    riscv.j "label", !riscv.reg<zero>
     // CHECK-NEXT: j label
 
     riscv.jalr %0, 1 : (!riscv.reg<zero>) -> ()
@@ -158,14 +158,14 @@
     // CHECK-NEXT: ret
   ^1(%b10 : !riscv.reg<>, %b11 : !riscv.reg<>):
 
-    riscv.directive ".align" "2" : () -> ()
+    riscv.directive ".align" "2"
     // CHECK-NEXT: .align 2
     riscv.assembly_section ".text" {
       %nested_addi = riscv.addi %1, 1 : (!riscv.reg<j1>) -> !riscv.reg<j1>
     }
     // CHECK-NEXT:  .text
     // CHECK-NEXT:  addi j1, j1, 1
-    riscv.label "label0" : () -> ()
+    riscv.label "label0"
     // CHECK-NEXT: label0:
 
 

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -60,17 +60,17 @@
     // RV32I/RV64I: 2.5 Control Transfer Instructions
 
     // Unconditional Branch Instructions
-    riscv.jal 1 : () -> ()
-    // CHECK-NEXT: riscv.jal 1 : () -> ()
-    riscv.jal 1, !riscv.reg<> : () -> ()
-    // CHECK-NEXT: riscv.jal 1, !riscv.reg<> : () -> ()
-    riscv.jal "label" : () -> ()
-    // CHECK-NEXT: riscv.jal "label" : () -> ()
+    riscv.jal 1
+    // CHECK-NEXT: riscv.jal 1
+    riscv.jal 1, !riscv.reg<>
+    // CHECK-NEXT: riscv.jal 1, !riscv.reg<>
+    riscv.jal "label"
+    // CHECK-NEXT: riscv.jal "label"
 
-    riscv.j 1 : () -> ()
-    // CHECK-NEXT: riscv.j 1 : () -> ()
-    riscv.j "label" : () -> ()
-    // CHECK-NEXT: riscv.j "label" : () -> ()
+    riscv.j 1
+    // CHECK-NEXT: riscv.j 1
+    riscv.j "label"
+    // CHECK-NEXT: riscv.j "label"
 
     riscv.jalr %0, 1: (!riscv.reg<>) -> ()
     // CHECK-NEXT: riscv.jalr %0, 1 : (!riscv.reg<>) -> ()
@@ -180,10 +180,10 @@
     // CHECK-NEXT: riscv.ecall
     riscv.ebreak
     // CHECK-NEXT: riscv.ebreak
-    riscv.directive ".bss": () -> ()
-    // CHECK-NEXT: riscv.directive ".bss" : () -> ()
-    riscv.directive ".align" "2" : () -> ()
-    // CHECK-NEXT: riscv.directive ".align" "2" : () -> ()
+    riscv.directive ".bss"
+    // CHECK-NEXT: riscv.directive ".bss"
+    riscv.directive ".align" "2"
+    // CHECK-NEXT: riscv.directive ".align" "2"
     riscv.assembly_section ".text" attributes {"foo" = i32} {
       %nested_li = riscv.li 1 : () -> !riscv.reg<>
     }

--- a/tests/filecheck/projects/riscv-backend-paper/pres.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/pres.mlir
@@ -3,13 +3,13 @@
 // A test that verifies that we can emit the target assembly for Snitch, below are the
 // versions of ssum (C=A+B where all have fixed size 128xf32) .
 
-riscv.label ".text" : () -> ()
+riscv.label ".text"
 
 riscv_func.func @pres_1(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.reg<a2>) {
     %zero = "riscv.get_register"() : () -> !riscv.reg<zero>
     %i = riscv.mv %zero : (!riscv.reg<zero>) -> !riscv.reg<a3>
     %ub = riscv.addi %zero 512 : (!riscv.reg<zero>) -> !riscv.reg<a4>
-    riscv.label ".loop_body" : () -> ()
+    riscv.label ".loop_body"
     %x_i = riscv.add %X, %i : (!riscv.reg<a0>, !riscv.reg<a3>) -> !riscv.reg<a5>
     %x = riscv.flw %x_i, 0 : (!riscv.reg<a5>) -> !riscv.freg<ft0>
     %y_i = riscv.add %Y, %i : (!riscv.reg<a1>, !riscv.reg<a3>) -> !riscv.reg<a5>
@@ -26,7 +26,7 @@ riscv_func.func @pres_2(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.re
     %zero = "riscv.get_register"() : () -> !riscv.reg<zero>
     %i = riscv.mv %zero : (!riscv.reg<zero>) -> !riscv.reg<a3>
     %ub = riscv.addi %zero 512 : (!riscv.reg<zero>) -> !riscv.reg<a4>
-    riscv.label ".loop_body" : () -> ()
+    riscv.label ".loop_body"
     %x_i = riscv.add %X, %i : (!riscv.reg<a0>, !riscv.reg<a3>) -> !riscv.reg<a5>
     %x = riscv.fld %x_i, 0 : (!riscv.reg<a5>) -> !riscv.freg<ft0>
     %y_i = riscv.add %Y, %i : (!riscv.reg<a1>, !riscv.reg<a3>) -> !riscv.reg<a5>
@@ -50,7 +50,7 @@ riscv_func.func @pres_3(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.re
     %zero_5 = riscv_snitch.scfgwi %Z, 898 : (!riscv.reg<a2>) -> !riscv.reg<zero>
     %zero_6 = riscv.csrrsi 1984, 1 : () -> !riscv.reg<zero>
     %i = riscv.addi %zero, 64 : (!riscv.reg<zero>) -> !riscv.reg<a0>
-    riscv.label ".loop_body" : () -> ()
+    riscv.label ".loop_body"
     %x = riscv.get_float_register() : () -> !riscv.freg<ft0>
     %y = riscv.get_float_register() : () -> !riscv.freg<ft1>
     %z = riscv.vfadd.s %x, %y : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>

--- a/tests/filecheck/with-riscemu/riscv_emulation.mlir
+++ b/tests/filecheck/with-riscemu/riscv_emulation.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt --split-input-file -t riscemu %s | filecheck %s
 
 builtin.module {
-  riscv.directive ".globl" "main" : () -> ()
+  riscv.directive ".globl" "main"
   riscv_func.func @main() {
     %0 = riscv.li 6 : () -> !riscv.reg<j0>
     %1 = riscv.li 7 : () -> !riscv.reg<j1>
@@ -18,7 +18,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  riscv.directive ".globl" "main" : () -> ()
+  riscv.directive ".globl" "main"
   riscv_func.func @main() {
     %0 = riscv.li 3 : () -> !riscv.reg<a0>
     %1 = riscv.li 2 : () -> !riscv.reg<a1>

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -707,6 +707,15 @@ class RdImmJumpOperation(IRDLOperation, RISCVInstruction, ABC):
             printer.print_attribute(self.rd)
         return {"immediate", "rd"}
 
+    def print_op_type(self, printer: Printer) -> None:
+        return
+
+    @classmethod
+    def parse_op_type(
+        cls, parser: Parser
+    ) -> tuple[Sequence[Attribute], Sequence[Attribute]]:
+        return (), ()
+
 
 class RdRsImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     """
@@ -2460,6 +2469,15 @@ class LabelOp(IRDLOperation, RISCVOp):
         printer.print_string_literal(self.label.data)
         return {"label"}
 
+    def print_op_type(self, printer: Printer) -> None:
+        return
+
+    @classmethod
+    def parse_op_type(
+        cls, parser: Parser
+    ) -> tuple[Sequence[Attribute], Sequence[Attribute]]:
+        return (), ()
+
 
 @irdl_op_definition
 class DirectiveOp(IRDLOperation, RISCVOp):
@@ -2517,6 +2535,15 @@ class DirectiveOp(IRDLOperation, RISCVOp):
             printer.print(" ")
             printer.print_string_literal(self.value.data)
         return {"directive", "value"}
+
+    def print_op_type(self, printer: Printer) -> None:
+        return
+
+    @classmethod
+    def parse_op_type(
+        cls, parser: Parser
+    ) -> tuple[Sequence[Attribute], Sequence[Attribute]]:
+        return (), ()
 
 
 @irdl_op_definition


### PR DESCRIPTION
CC @xdslproject/risc-v-backend 