### PR TITLE
core: Name dialects and make then citizens of MLContext.

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -520,6 +520,7 @@ class CastOp(IRDLOperation):
 
 
 Toy = Dialect(
+    "toy",
     [
         ConstantOp,
         AddOp,

--- a/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
@@ -133,4 +133,4 @@ builtin.module {
   }
 }
 
-// CHECK: testd = Dialect([eq, anyof, all_of, any, dynbase, dynparams, constraint_vars], [parametric, parametric_attr, attr_in_type_out])
+// CHECK: testd = Dialect("testd", [eq, anyof, all_of, any, dynbase, dynparams, constraint_vars], [parametric, parametric_attr, attr_in_type_out])

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -194,6 +194,7 @@ class Yield(IRDLOperation):
 
 
 Affine = Dialect(
+    "affine",
     [
         For,
         Store,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -831,6 +831,7 @@ class ExtUIOp(IRDLOperation):
 
 
 Arith = Dialect(
+    "arith",
     [
         Constant,
         # Integer-like

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1411,6 +1411,7 @@ f128 = Float64Type()
 
 
 Builtin = Dialect(
+    "builtin",
     [
         ModuleOp,
         UnregisteredOp,

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -99,6 +99,7 @@ class ConditionalBranch(IRDLOperation):
 
 
 Cf = Dialect(
+    "cf",
     [
         Assert,
         Branch,

--- a/xdsl/dialects/cmath.py
+++ b/xdsl/dialects/cmath.py
@@ -71,4 +71,4 @@ class Mul(IRDLOperation):
         return Mul.build(operands=[operand1, operand2], result_types=[operand1.type])
 
 
-CMath = Dialect([Norm, Mul], [ComplexType])
+CMath = Dialect("cmath", [Norm, Mul], [ComplexType])

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -517,6 +517,7 @@ class MuxOp(IRDLOperation):
 
 
 Comb = Dialect(
+    "comb",
     [
         AddOp,
         MulOp,
@@ -537,5 +538,5 @@ Comb = Dialect(
         ConcatOp,
         ReplicateOp,
         MuxOp,
-    ]
+    ],
 )

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -429,6 +429,7 @@ class SwapOp(IRDLOperation):
 
 
 DMP = Dialect(
+    "dmp",
     [
         SwapOp,
     ],

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -2056,6 +2056,7 @@ class ZeroBits(IRDLOperation):
 
 
 FIR = Dialect(
+    "fir",
     [
         Absent,
         Addc,

--- a/xdsl/dialects/experimental/hls.py
+++ b/xdsl/dialects/experimental/hls.py
@@ -163,6 +163,7 @@ class HLSExtractStencilValue(IRDLOperation):
 
 
 HLS = Dialect(
+    "hls",
     [
         PragmaPipeline,
         PragmaUnroll,

--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -1018,6 +1018,7 @@ class TruncOp(IRDLOperation):
 
 
 Math = Dialect(
+    "math",
     [
         AbsFOp,
         AbsIOp,
@@ -1051,5 +1052,5 @@ Math = Dialect(
         TanOp,
         TanhOp,
         TruncOp,
-    ]
+    ],
 )

--- a/xdsl/dialects/fsm.py
+++ b/xdsl/dialects/fsm.py
@@ -535,6 +535,7 @@ class HWInstanceOp(IRDLOperation):
 
 
 FSM = Dialect(
+    "fsm",
     [
         MachineOp,
         OutputOp,

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -318,4 +318,4 @@ class Return(IRDLOperation):
         return op
 
 
-Func = Dialect([FuncOp, Call, Return], [])
+Func = Dialect("func", [FuncOp, Call, Return], [])

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -735,6 +735,7 @@ class YieldOp(IRDLOperation):
 # Hopefully MLIR will parse it in a more xDSL-friendly way soon, so all that can be factored in proper xDSL
 # atrributes.
 GPU = Dialect(
+    "gpu",
     [
         AllocOp,
         AllReduceOp,

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -383,6 +383,7 @@ class AllOfOp(IRDLOperation):
 
 
 IRDL = Dialect(
+    "irdl",
     [
         DialectOp,
         TypeOp,

--- a/xdsl/dialects/irdl/irdl_to_pyrdl.py
+++ b/xdsl/dialects/irdl/irdl_to_pyrdl.py
@@ -67,4 +67,8 @@ def convert_dialect(dialect: DialectOp) -> str:
             ops += [op.sym_name.data]
     op_list = "[" + ", ".join(ops) + "]"
     attr_list = "[" + ", ".join(attrs) + "]"
-    return res + dialect.sym_name.data + f" = Dialect({op_list}, {attr_list})"
+    return (
+        res
+        + dialect.sym_name.data
+        + f' = Dialect("{dialect.sym_name.data}", {op_list}, {attr_list})'
+    )

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -213,4 +213,4 @@ class Yield(IRDLOperation):
         return op
 
 
-Linalg = Dialect([Generic, Yield], [IteratorTypeAttr])
+Linalg = Dialect("linalg", [Generic, Yield], [IteratorTypeAttr])

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1095,6 +1095,7 @@ class CallOp(IRDLOperation):
 
 
 LLVM = Dialect(
+    "llvm",
     [
         ExtractValueOp,
         InsertValueOp,

--- a/xdsl/dialects/ltl.py
+++ b/xdsl/dialects/ltl.py
@@ -69,6 +69,7 @@ class AndOp(IRDLOperation):
 
 
 LTL = Dialect(
+    "ltl",
     [
         AndOp,
     ],

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -684,6 +684,7 @@ class CopyOp(IRDLOperation):
 
 
 MemRef = Dialect(
+    "memref",
     [
         Load,
         Store,

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -839,6 +839,7 @@ class GatherOp(MPIBaseOp):
 
 
 MPI = Dialect(
+    "mpi",
     [
         Isend,
         Irecv,

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -843,6 +843,7 @@ class TypesOp(IRDLOperation):
 
 
 PDL = Dialect(
+    "pdl",
     [
         ApplyNativeConstraintOp,
         ApplyNativeRewriteOp,

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -139,6 +139,7 @@ class PrintIntOp(IRDLOperation):
 
 
 Printf = Dialect(
+    "printf",
     [
         PrintFormatOp,
         PrintCharOp,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3555,6 +3555,7 @@ def _print_immediate_value(printer: Printer, immediate: AnyIntegerAttr | LabelAt
 
 
 RISCV = Dialect(
+    "riscv",
     [
         AddiOp,
         SltiOp,

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -266,6 +266,7 @@ class ReturnOp(IRDLOperation, riscv.RISCVInstruction):
 
 
 RISCV_Func = Dialect(
+    "riscv_func",
     [
         SyscallOp,
         CallOp,

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -270,6 +270,7 @@ class ConditionOp(IRDLOperation):
 
 
 RISCV_Scf = Dialect(
+    "riscv_scf",
     [
         YieldOp,
         ForOp,

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -281,6 +281,7 @@ class FrepYieldOp(IRDLOperation, RISCVOp):
 # endregion
 
 RISCV_Snitch = Dialect(
+    "riscv_snitch",
     [
         ScfgwOp,
         ScfgwiOp,

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -521,6 +521,7 @@ class Condition(IRDLOperation):
 
 
 Scf = Dialect(
+    "scf",
     [
         If,
         For,

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -78,6 +78,7 @@ class ClockDivider(IRDLOperation):
 
 
 Seq = Dialect(
+    "seq",
     [
         ClockDivider,
     ],

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -152,6 +152,7 @@ class SsrDisable(IRDLOperation):
 
 
 Snitch = Dialect(
+    "snitch",
     [
         SsrSetDimensionBoundOp,
         SsrSetDimensionStrideOp,

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -610,6 +610,7 @@ class FpuFenceOp(NoOperandNoResultBaseOperation):
 
 
 SnitchRuntime = Dialect(
+    "snrt",
     [
         GlobalCoreBaseHartidOp,
         GlobalCoreIdxOp,

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -864,6 +864,7 @@ class AccessPattern:
 
 
 Stencil = Dialect(
+    "stencil",
     [
         CastOp,
         ExternalLoadOp,

--- a/xdsl/dialects/stream.py
+++ b/xdsl/dialects/stream.py
@@ -121,6 +121,7 @@ class WriteOp(IRDLOperation):
 
 
 Stream = Dialect(
+    "stream",
     [
         ReadOp,
         WriteOp,

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -128,4 +128,4 @@ class TestType(Data[str], TypeAttribute):
         printer.print_string_literal(self.data)
 
 
-Test = Dialect([TestOp, TestTermOp], [TestType])
+Test = Dialect("test", [TestOp, TestTermOp], [TestType])

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -298,5 +298,7 @@ class Createmask(IRDLOperation):
 
 
 Vector = Dialect(
-    [Load, Store, Broadcast, FMA, Maskedload, Maskedstore, Print, Createmask], []
+    "vector",
+    [Load, Store, Broadcast, FMA, Maskedload, Maskedstore, Print, Createmask],
+    [],
 )

--- a/xdsl/frontend/symref.py
+++ b/xdsl/frontend/symref.py
@@ -51,4 +51,4 @@ class Update(IRDLOperation):
         return Update.build(operands=[value], attributes={"symbol": symbol})
 
 
-Symref = Dialect([Declare, Fetch, Update], [])
+Symref = Dialect("symref", [Declare, Fetch, Update], [])


### PR DESCRIPTION
This is to

1. Get closer to MLIR
2. Specifically, allow to handle opaque dialect attributes properly (as defined here https://mlir.llvm.org/docs/LangRef/#dialect-attribute-values; "opaque" seems overloaded on MLIR's side.). Stacked #1712 

