### PR TITLE
[WIP/RFC] core: Add OpaqueAttribute

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -520,6 +520,7 @@ class CastOp(IRDLOperation):
 
 
 Toy = Dialect(
+    "toy",
     [
         ConstantOp,
         AddOp,

--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -3,7 +3,7 @@ from xdsl.dialects import arith, builtin, memref
 from xdsl.dialects.gpu import (
     AllocOp,
     AllReduceOp,
-    AllReduceOperationAttr,
+    AllReduceOpAttr,
     AsyncTokenType,
     BarrierOp,
     BlockDimOp,
@@ -34,7 +34,7 @@ from xdsl.ir import Block, Operation, Region, SSAValue
 
 
 def test_dimension():
-    dim = DimensionAttr.from_dimension("x")
+    dim = DimensionAttr("x")
 
     assert dim.data == "x"
 
@@ -79,13 +79,13 @@ def test_alloc():
 
 
 def test_all_reduce_operation():
-    op = AllReduceOperationAttr.from_op("add")
+    op = AllReduceOpAttr("add")
 
     assert op.data == "add"
 
 
 def test_all_reduce():
-    op = AllReduceOperationAttr.from_op("add")
+    op = AllReduceOpAttr("add")
 
     init = arith.Constant.from_int_and_width(0, builtin.IndexType())
 
@@ -120,7 +120,7 @@ def test_barrier():
 
 
 def test_block_dim():
-    dim = DimensionAttr.from_dimension("x")
+    dim = DimensionAttr("x")
 
     block_dim = BlockDimOp(dim)
 
@@ -129,7 +129,7 @@ def test_block_dim():
 
 
 def test_block_id():
-    dim = DimensionAttr.from_dimension("x")
+    dim = DimensionAttr("x")
 
     block_id = BlockIdOp(dim)
 
@@ -181,7 +181,7 @@ def test_gpu_module_end():
 
 
 def test_global_id():
-    dim = DimensionAttr.from_dimension("x")
+    dim = DimensionAttr("x")
 
     global_id = GlobalIdOp(dim)
 
@@ -190,7 +190,7 @@ def test_global_id():
 
 
 def test_grid_dim():
-    dim = DimensionAttr.from_dimension("x")
+    dim = DimensionAttr("x")
 
     grid_dim = GridDimOp(dim)
 
@@ -395,7 +395,7 @@ def test_subgroup_size():
 
 
 def test_thread_id():
-    dim = DimensionAttr.from_dimension("x")
+    dim = DimensionAttr("x")
 
     thread_id = ThreadIdOp(dim)
 

--- a/tests/filecheck/dialects/gpu/invalid.mlir
+++ b/tests/filecheck/dialects/gpu/invalid.mlir
@@ -19,7 +19,14 @@
 "builtin.module"() ({
 }) {"wrong_all_reduce_operation" = #gpu<all_reduce_op magic>}: () -> ()
 
-// CHECK: Unexpected op magic. A gpu all_reduce_op can only be add, and, max, min, mul, or, or xor
+// CHECK: Expected add, and, max, min, mul, or, or xor.
+
+// -----
+
+"builtin.module"() ({
+}) {"wrong_dim" = #gpu<dim w>}: () -> ()
+
+// CHECK: Expected x, y or z.
 
 // -----
 
@@ -71,13 +78,6 @@
 }) : () -> ()
 
 // CHECK: Expected 0 dynamic sizes, got 3. All dynamic sizes need to be set in the alloc operation.
-
-// -----
-
-"builtin.module"() ({
-}) {"wrong_dim" = #gpu<dim w>}: () -> ()
-
-// CHECK: Unexpected dim w. A gpu dim can only be x, y, or z
 
 // -----
 

--- a/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
@@ -133,4 +133,4 @@ builtin.module {
   }
 }
 
-// CHECK: testd = Dialect([eq, anyof, all_of, any, dynbase, dynparams, constraint_vars], [parametric, parametric_attr, attr_in_type_out])
+// CHECK: testd = Dialect("testd", [eq, anyof, all_of, any, dynbase, dynparams, constraint_vars], [parametric, parametric_attr, attr_in_type_out])

--- a/tests/interpreters/test_wgsl_printer.py
+++ b/tests/interpreters/test_wgsl_printer.py
@@ -14,7 +14,7 @@ rhs_op = test.TestOp(result_types=[IndexType()])
 def test_gpu_global_id():
     file = StringIO("")
 
-    global_id_x = gpu.GlobalIdOp(gpu.DimensionAttr.from_dimension("x"))
+    global_id_x = gpu.GlobalIdOp(gpu.DimensionAttr("x"))
 
     printer = WGSLPrinter()
     printer.print(global_id_x, file)
@@ -25,7 +25,7 @@ def test_gpu_global_id():
 def test_gpu_thread_id():
     file = StringIO("")
 
-    thread_id_x = gpu.ThreadIdOp(gpu.DimensionAttr.from_dimension("x"))
+    thread_id_x = gpu.ThreadIdOp(gpu.DimensionAttr("x"))
 
     printer = WGSLPrinter()
     printer.print(thread_id_x, file)
@@ -36,7 +36,7 @@ def test_gpu_thread_id():
 def test_gpu_block_id():
     file = StringIO("")
 
-    block_id_x = gpu.BlockIdOp(gpu.DimensionAttr.from_dimension("x"))
+    block_id_x = gpu.BlockIdOp(gpu.DimensionAttr("x"))
 
     printer = WGSLPrinter()
     printer.print(block_id_x, file)
@@ -47,7 +47,7 @@ def test_gpu_block_id():
 def test_gpu_grid_dim():
     file = StringIO("")
 
-    num_workgroups = gpu.GridDimOp(gpu.DimensionAttr.from_dimension("x"))
+    num_workgroups = gpu.GridDimOp(gpu.DimensionAttr("x"))
 
     printer = WGSLPrinter()
     printer.print(num_workgroups, file)

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -194,6 +194,7 @@ class Yield(IRDLOperation):
 
 
 Affine = Dialect(
+    "affine",
     [
         For,
         Store,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -831,6 +831,7 @@ class ExtUIOp(IRDLOperation):
 
 
 Arith = Dialect(
+    "arith",
     [
         Constant,
         # Integer-like

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1411,6 +1411,7 @@ f128 = Float64Type()
 
 
 Builtin = Dialect(
+    "builtin",
     [
         ModuleOp,
         UnregisteredOp,

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -99,6 +99,7 @@ class ConditionalBranch(IRDLOperation):
 
 
 Cf = Dialect(
+    "cf",
     [
         Assert,
         Branch,

--- a/xdsl/dialects/cmath.py
+++ b/xdsl/dialects/cmath.py
@@ -71,4 +71,4 @@ class Mul(IRDLOperation):
         return Mul.build(operands=[operand1, operand2], result_types=[operand1.type])
 
 
-CMath = Dialect([Norm, Mul], [ComplexType])
+CMath = Dialect("cmath", [Norm, Mul], [ComplexType])

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -517,6 +517,7 @@ class MuxOp(IRDLOperation):
 
 
 Comb = Dialect(
+    "comb",
     [
         AddOp,
         MulOp,
@@ -537,5 +538,5 @@ Comb = Dialect(
         ConcatOp,
         ReplicateOp,
         MuxOp,
-    ]
+    ],
 )

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -429,6 +429,7 @@ class SwapOp(IRDLOperation):
 
 
 DMP = Dialect(
+    "dmp",
     [
         SwapOp,
     ],

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -2056,6 +2056,7 @@ class ZeroBits(IRDLOperation):
 
 
 FIR = Dialect(
+    "fir",
     [
         Absent,
         Addc,

--- a/xdsl/dialects/experimental/hls.py
+++ b/xdsl/dialects/experimental/hls.py
@@ -163,6 +163,7 @@ class HLSExtractStencilValue(IRDLOperation):
 
 
 HLS = Dialect(
+    "hls",
     [
         PragmaPipeline,
         PragmaUnroll,

--- a/xdsl/dialects/experimental/math.py
+++ b/xdsl/dialects/experimental/math.py
@@ -1018,6 +1018,7 @@ class TruncOp(IRDLOperation):
 
 
 Math = Dialect(
+    "math",
     [
         AbsFOp,
         AbsIOp,
@@ -1051,5 +1052,5 @@ Math = Dialect(
         TanOp,
         TanhOp,
         TruncOp,
-    ]
+    ],
 )

--- a/xdsl/dialects/fsm.py
+++ b/xdsl/dialects/fsm.py
@@ -535,6 +535,7 @@ class HWInstanceOp(IRDLOperation):
 
 
 FSM = Dialect(
+    "fsm",
     [
         MachineOp,
         OutputOp,

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -318,4 +318,4 @@ class Return(IRDLOperation):
         return op
 
 
-Func = Dialect([FuncOp, Call, Return], [])
+Func = Dialect("func", [FuncOp, Call, Return], [])

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -735,6 +735,7 @@ class YieldOp(IRDLOperation):
 # Hopefully MLIR will parse it in a more xDSL-friendly way soon, so all that can be factored in proper xDSL
 # atrributes.
 GPU = Dialect(
+    "gpu",
     [
         AllocOp,
         AllReduceOp,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Generic, TypeVar
+from typing import Literal, TypeVar
 
 from xdsl.dialects import memref
 from xdsl.dialects.builtin import (
@@ -19,6 +19,7 @@ from xdsl.ir import (
     Attribute,
     Block,
     Dialect,
+    OpaqueAttribute,
     Operation,
     OpResult,
     ParametrizedAttribute,
@@ -66,85 +67,41 @@ class AsyncTokenType(ParametrizedAttribute, TypeAttribute):
     name = "gpu.async.token"
 
 
-@irdl_attr_definition
-class _AllReduceOperationAttr(ParametrizedAttribute):
-    name = "all_reduce_op"
+class AllReduceOpAttr(
+    OpaqueAttribute[Literal["add", "and", "max", "min", "mul", "or", "xor"]]
+):
+    name = "gpu.all_reduce_op"
 
     param: ParameterDef[StringAttr]
 
-    def print_parameters(self, printer: Printer) -> None:
-        printer.print(f"all_reduce_op {self.param.data}")
-
-
-@irdl_attr_definition
-class _DimensionAttr(ParametrizedAttribute):
-    name = "dim"
-
-    param: ParameterDef[StringAttr]
-
-    def print_parameters(self, printer: Printer) -> None:
-        printer.print(f"dim {self.param.data}")
-
-
-T = TypeVar("T", bound=_AllReduceOperationAttr | _DimensionAttr, covariant=True)
-
-
-@irdl_attr_definition
-class _GPUAttr(ParametrizedAttribute, Generic[T]):
-    name = "gpu"
-
-    value: ParameterDef[T]
+    def print_parameter(self, printer: Printer) -> None:
+        printer.print(f"{self.data}")
 
     @classmethod
-    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
-        parser.parse_characters(
-            "<",
-            ": gpu attributes currently have the #gpu<name value> syntax.",
-        )
-        if parser.parse_optional_keyword("dim"):
-            attrtype = _DimensionAttr
-            vtok = parser.parse_optional_identifier()
-            if vtok not in ["x", "y", "z"]:
-                parser.raise_error(
-                    f"Unexpected dim {vtok}. A gpu dim can only be x, y, or z",
-                )
-
-        elif parser.parse_optional_keyword("all_reduce_op"):
-            attrtype = _AllReduceOperationAttr
-            vtok = parser.parse_optional_identifier()
-            if vtok not in ["add", "and", "max", "min", "mul", "or", "xor"]:
-                parser.raise_error(
-                    f"Unexpected op {vtok}. A gpu all_reduce_op can only be add, "
-                    "and, max, min, mul, or, or xor ",
-                )
-        else:
-            parser.raise_error("'dim' or 'all_reduce_op' expected")
-        parser.parse_characters(
-            ">",
-            ". gpu attributes currently have the #gpu<name value> syntax.",
-        )
-        return [attrtype([StringAttr(vtok)])]
-
-    @staticmethod
-    def from_op(value: str) -> AllReduceOperationAttr:
-        return AllReduceOperationAttr([_AllReduceOperationAttr([StringAttr(value)])])
-
-    @property
-    def data(self) -> str:
-        return self.value.param.data
-
-    @staticmethod
-    def from_dimension(value: str) -> DimensionAttr:
-        return DimensionAttr([_DimensionAttr([StringAttr(value)])])
-
-    def print_parameters(self, printer: Printer) -> None:
-        printer.print_string("<")
-        self.value.print_parameters(printer)
-        printer.print_string(">")
+    def parse_parameter(
+        cls, parser: AttrParser
+    ) -> Literal["add", "and", "max", "min", "mul", "or", "xor"]:
+        for kw in ("add", "and", "max", "min", "mul", "or", "xor"):
+            val = parser.parse_optional_keyword(kw)
+            if val in ("add", "and", "max", "min", "mul", "or", "xor"):
+                return val
+        parser.raise_error("Expected add, and, max, min, mul, or, or xor.")
 
 
-DimensionAttr = _GPUAttr[_DimensionAttr]
-AllReduceOperationAttr = _GPUAttr[_AllReduceOperationAttr]
+class DimensionAttr(OpaqueAttribute[Literal["x", "y", "z"]]):
+    name = "gpu.dim"
+
+    def print_parameter(self, printer: Printer) -> None:
+        printer.print(f"{self.data}")
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> Literal["x", "y", "z"]:
+        for kw in ("x", "y", "z"):
+            val = parser.parse_optional_keyword(kw)
+            if val in ("x", "y", "z"):
+                return val
+        parser.raise_error("Expected x, y or z.")
+
 
 _Element = TypeVar("_Element", bound=Attribute, covariant=True)
 
@@ -201,7 +158,7 @@ class AllocOp(IRDLOperation):
 @irdl_op_definition
 class AllReduceOp(IRDLOperation):
     name = "gpu.all_reduce"
-    op: AllReduceOperationAttr | None = opt_prop_def(AllReduceOperationAttr)
+    op: AllReduceOpAttr | None = opt_prop_def(AllReduceOpAttr)
     uniform: UnitAttr | None = opt_prop_def(UnitAttr)
     operand: Operand = operand_def(Attribute)
     result: OpResult = result_def(Attribute)
@@ -211,7 +168,7 @@ class AllReduceOp(IRDLOperation):
 
     @staticmethod
     def from_op(
-        op: AllReduceOperationAttr,
+        op: AllReduceOpAttr,
         operand: SSAValue | Operation,
         uniform: UnitAttr | None = None,
     ):
@@ -763,5 +720,5 @@ GPU = Dialect(
         ThreadIdOp,
         YieldOp,
     ],
-    [_GPUAttr],
+    [AllReduceOpAttr, DimensionAttr],
 )

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -383,6 +383,7 @@ class AllOfOp(IRDLOperation):
 
 
 IRDL = Dialect(
+    "irdl",
     [
         DialectOp,
         TypeOp,

--- a/xdsl/dialects/irdl/irdl_to_pyrdl.py
+++ b/xdsl/dialects/irdl/irdl_to_pyrdl.py
@@ -67,4 +67,8 @@ def convert_dialect(dialect: DialectOp) -> str:
             ops += [op.sym_name.data]
     op_list = "[" + ", ".join(ops) + "]"
     attr_list = "[" + ", ".join(attrs) + "]"
-    return res + dialect.sym_name.data + f" = Dialect({op_list}, {attr_list})"
+    return (
+        res
+        + dialect.sym_name.data
+        + f' = Dialect("{dialect.sym_name.data}", {op_list}, {attr_list})'
+    )

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -213,4 +213,4 @@ class Yield(IRDLOperation):
         return op
 
 
-Linalg = Dialect([Generic, Yield], [IteratorTypeAttr])
+Linalg = Dialect("linalg", [Generic, Yield], [IteratorTypeAttr])

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1095,6 +1095,7 @@ class CallOp(IRDLOperation):
 
 
 LLVM = Dialect(
+    "llvm",
     [
         ExtractValueOp,
         InsertValueOp,

--- a/xdsl/dialects/ltl.py
+++ b/xdsl/dialects/ltl.py
@@ -69,6 +69,7 @@ class AndOp(IRDLOperation):
 
 
 LTL = Dialect(
+    "ltl",
     [
         AndOp,
     ],

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -684,6 +684,7 @@ class CopyOp(IRDLOperation):
 
 
 MemRef = Dialect(
+    "memref",
     [
         Load,
         Store,

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -839,6 +839,7 @@ class GatherOp(MPIBaseOp):
 
 
 MPI = Dialect(
+    "mpi",
     [
         Isend,
         Irecv,

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -843,6 +843,7 @@ class TypesOp(IRDLOperation):
 
 
 PDL = Dialect(
+    "pdl",
     [
         ApplyNativeConstraintOp,
         ApplyNativeRewriteOp,

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -139,6 +139,7 @@ class PrintIntOp(IRDLOperation):
 
 
 Printf = Dialect(
+    "printf",
     [
         PrintFormatOp,
         PrintCharOp,

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3555,6 +3555,7 @@ def _print_immediate_value(printer: Printer, immediate: AnyIntegerAttr | LabelAt
 
 
 RISCV = Dialect(
+    "riscv",
     [
         AddiOp,
         SltiOp,

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -266,6 +266,7 @@ class ReturnOp(IRDLOperation, riscv.RISCVInstruction):
 
 
 RISCV_Func = Dialect(
+    "riscv_func",
     [
         SyscallOp,
         CallOp,

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -270,6 +270,7 @@ class ConditionOp(IRDLOperation):
 
 
 RISCV_Scf = Dialect(
+    "riscv_scf",
     [
         YieldOp,
         ForOp,

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -281,6 +281,7 @@ class FrepYieldOp(IRDLOperation, RISCVOp):
 # endregion
 
 RISCV_Snitch = Dialect(
+    "riscv_snitch",
     [
         ScfgwOp,
         ScfgwiOp,

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -521,6 +521,7 @@ class Condition(IRDLOperation):
 
 
 Scf = Dialect(
+    "scf",
     [
         If,
         For,

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -78,6 +78,7 @@ class ClockDivider(IRDLOperation):
 
 
 Seq = Dialect(
+    "seq",
     [
         ClockDivider,
     ],

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -152,6 +152,7 @@ class SsrDisable(IRDLOperation):
 
 
 Snitch = Dialect(
+    "snitch",
     [
         SsrSetDimensionBoundOp,
         SsrSetDimensionStrideOp,

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -610,6 +610,7 @@ class FpuFenceOp(NoOperandNoResultBaseOperation):
 
 
 SnitchRuntime = Dialect(
+    "snrt",
     [
         GlobalCoreBaseHartidOp,
         GlobalCoreIdxOp,

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -864,6 +864,7 @@ class AccessPattern:
 
 
 Stencil = Dialect(
+    "stencil",
     [
         CastOp,
         ExternalLoadOp,

--- a/xdsl/dialects/stream.py
+++ b/xdsl/dialects/stream.py
@@ -121,6 +121,7 @@ class WriteOp(IRDLOperation):
 
 
 Stream = Dialect(
+    "stream",
     [
         ReadOp,
         WriteOp,

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -128,4 +128,4 @@ class TestType(Data[str], TypeAttribute):
         printer.print_string_literal(self.data)
 
 
-Test = Dialect([TestOp, TestTermOp], [TestType])
+Test = Dialect("test", [TestOp, TestTermOp], [TestType])

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -298,5 +298,7 @@ class Createmask(IRDLOperation):
 
 
 Vector = Dialect(
-    [Load, Store, Broadcast, FMA, Maskedload, Maskedstore, Print, Createmask], []
+    "vector",
+    [Load, Store, Broadcast, FMA, Maskedload, Maskedstore, Print, Createmask],
+    [],
 )

--- a/xdsl/frontend/symref.py
+++ b/xdsl/frontend/symref.py
@@ -51,4 +51,4 @@ class Update(IRDLOperation):
         return Update.build(operands=[value], attributes={"symbol": symbol})
 
 
-Symref = Dialect([Declare, Fetch, Update], [])
+Symref = Dialect("symref", [Declare, Fetch, Update], [])

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -85,7 +85,7 @@ class WGSLPrinter:
 
     @print.register
     def _(self, op: gpu.BlockIdOp, out_stream: IO[str]):
-        dim = str(op.dimension.value.param).strip('"')
+        dim = str(op.dimension.data).strip('"')
         name_hint = self.wgsl_name(op.result)
         out_stream.write(
             f"""
@@ -94,7 +94,7 @@ class WGSLPrinter:
 
     @print.register
     def _(self, op: gpu.ThreadIdOp, out_stream: IO[str]):
-        dim = str(op.dimension.value.param).strip('"')
+        dim = str(op.dimension.data).strip('"')
         name_hint = self.wgsl_name(op.result)
         out_stream.write(
             f"""
@@ -103,7 +103,7 @@ class WGSLPrinter:
 
     @print.register
     def _(self, op: gpu.GridDimOp, out_stream: IO[str]):
-        dim = str(op.dimension.value.param).strip('"')
+        dim = str(op.dimension.data).strip('"')
         name_hint = self.wgsl_name(op.result)
         out_stream.write(
             f"""
@@ -112,7 +112,7 @@ class WGSLPrinter:
 
     @print.register
     def _(self, op: gpu.BlockDimOp, out_stream: IO[str]):
-        dim = str(op.dimension.value.param).strip('"')
+        dim = str(op.dimension.data).strip('"')
         name_hint = self.wgsl_name(op.result)
         out_stream.write(
             f"""
@@ -121,7 +121,7 @@ class WGSLPrinter:
 
     @print.register
     def _(self, op: gpu.GlobalIdOp, out_stream: IO[str]):
-        dim = str(op.dimension.value.param).strip('"')
+        dim = str(op.dimension.data).strip('"')
         name_hint = self.wgsl_name(op.result)
         out_stream.write(
             f"""

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -126,6 +126,12 @@ class MLContext:
             return op_type
         return None
 
+    def has_op(self, name: str) -> bool:
+        return name in self._loaded_ops
+
+    def has_attr(self, name: str) -> bool:
+        return name in self._loaded_attrs
+
     def get_op(self, name: str) -> type[Operation]:
         """
         Get an operation class from its name.
@@ -392,13 +398,6 @@ class Attribute(ABC):
         return res.getvalue()
 
 
-class TypeAttribute(Attribute):
-    """
-    This class is only used for printing attributes in the MLIR format,
-    inheriting this class prefix the attribute by `!` instead of `#`.
-    """
-
-
 DataElement = TypeVar("DataElement", covariant=True)
 
 AttributeCovT = TypeVar("AttributeCovT", bound=Attribute, covariant=True)
@@ -439,6 +438,21 @@ class Data(Generic[DataElement], Attribute, ABC):
     @abstractmethod
     def print_parameter(self, printer: Printer) -> None:
         """Print the attribute parameter."""
+
+
+class TypeAttribute(Attribute):
+    """
+    This class is only used for printing attributes in the MLIR format,
+    inheriting this class prefix the attribute by `!` instead of `#`.
+    """
+
+
+class OpaqueAttribute(Data[DataElement], ABC):
+    """
+    This class is only used for printing attributes in the MLIR opaque format,
+    inheriting this class use the `dialect<name param>` syntax rather than the
+    "pretty" `dialect.name<param>`.
+    """
 
 
 @dataclass(frozen=True)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -356,21 +356,6 @@ class ErasedSSAValue(SSAValue):
         return hash(id(self))
 
 
-@dataclass
-class TypeAttribute:
-    """
-    This class should only be inherited by classes inheriting Attribute.
-    This class is only used for printing attributes in the MLIR format,
-    inheriting this class prefix the attribute by `!` instead of `#`.
-    """
-
-    def __post_init__(self):
-        if not isinstance(self, Attribute):
-            raise TypeError(
-                "TypeAttribute should only be inherited by classes inheriting Attribute"
-            )
-
-
 A = TypeVar("A", bound="Attribute")
 
 
@@ -405,6 +390,13 @@ class Attribute(ABC):
         printer = Printer(stream=res)
         printer.print_attribute(self)
         return res.getvalue()
+
+
+class TypeAttribute(Attribute):
+    """
+    This class is only used for printing attributes in the MLIR format,
+    inheriting this class prefix the attribute by `!` instead of `#`.
+    """
 
 
 DataElement = TypeVar("DataElement", covariant=True)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -184,10 +184,16 @@ class AttrParser(BaseParser):
         The contents will be parsed by a user-defined parser, or by a generic parser
         if the dialect attribute/type is not registered.
         """
-        attr_def = self.ctx.get_optional_attr(
-            attr_name,
-            create_unregistered_as_type=is_type,
-        )
+        if not (attr_def := self.ctx.get_attr(attr_name)):
+            self.parse_punctuation("<")
+            if (token := self._parse_optional_token(Token.Kind.BARE_IDENT)) is not None:
+                opaque_attr_name = f"{attr_name}.{token.text}"
+                if not (attr_def := self.ctx.get_attr(opaque_attr_name)):
+                    attr_def = self.ctx.get_optional_attr(
+                        attr_name,
+                        create_unregistered_as_type=is_type,
+                    )
+
         if attr_def is None:
             self.raise_error(f"'{attr_name}' is not registered")
 

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -413,13 +413,13 @@ class Parser(AttrParser):
         attr_def = None
         if self.ctx.has_attr(attr_name):
             attr_def = self.ctx.get_attr(attr_name)
-        else:
+        elif (dialect := self.ctx.get_optional_dialect(attr_name)) is not None:
             if (
                 self.parse_optional_punctuation("<")
-                and (token := self._parse_optional_token(Token.Kind.BARE_IDENT))
+                and (opaque_name := self._parse_optional_token(Token.Kind.BARE_IDENT))
                 is not None
             ):
-                opaque_attr_name = f"{attr_name}.{token.text}"
+                opaque_attr_name = f"{dialect.name}.{opaque_name.text}"
                 if self.ctx.has_attr(opaque_attr_name):
                     attr_def = self.ctx.get_attr(opaque_attr_name)
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -50,6 +50,7 @@ from xdsl.ir import (
     Block,
     BlockArgument,
     Data,
+    OpaqueAttribute,
     Operation,
     ParametrizedAttribute,
     Region,
@@ -630,6 +631,14 @@ class Printer:
 
         # Print dialect attributes
         self.print("!" if isinstance(attribute, TypeAttribute) else "#")
+
+        if isinstance(attribute, OpaqueAttribute):
+            self.print(attribute.name.replace(".", "<", 1))
+            self.print(" ")
+            attribute.print_parameter(self)
+            self.print(">")
+            return
+
         self.print(attribute.name)
 
         if isinstance(attribute, Data):


### PR DESCRIPTION
This is WIP for implementing OpaqueAttribute, as defined at https://mlir.llvm.org/docs/LangRef/#dialect-attribute-values. (The term "opaque" seems overloaded)
It uses it on my early hack for the `gpu.dim` and `gpu.all_reduce_op` attributes, as an example and sanitychecker; happy to split the PR once we agree on the result!

Opening as a draft to have feedback before overengineering the wrong way!
This on implements it as a syntax tweak, similarly to `TypeAttribute`, specifically it only implements attributes having the `$dialect<$name body>` syntax, not the fully generic `$dialect<whateverbody>` one. Started with that and opening discussion because I fell I'll easily get lost otherwise:

1. I didn't encounter any opaque attribute not using that one (ruling out builtin ones, cooked in the parser logic itself either way!). But it might be dangerous to not care; WDYT?
2. Thinking about it, I think worst case we can use this one for matching attributes, and if counterexamples showup, we could factor out the more generic logic and keep this one as a common helper?