### PR TITLE
dialects: Replacing get with init in mpi dialect and respective places

### DIFF
--- a/tests/dialects/test_mpi.py
+++ b/tests/dialects/test_mpi.py
@@ -9,16 +9,16 @@ def test_mpi_baseop():
     """
     alloc0 = memref.Alloc.get(f64, 32, [100, 14, 14])
     dest = Constant.from_int_and_width(1, i32)
-    unwrap = mpi.UnwrapMemrefOp.get(alloc0)
-    req_vec = mpi.AllocateTypeOp.get(mpi.RequestType, dest)
-    req_obj = mpi.VectorGetOp.get(req_vec, dest)
+    unwrap = mpi.UnwrapMemrefOp(alloc0)
+    req_vec = mpi.AllocateTypeOp(mpi.RequestType, dest)
+    req_obj = mpi.VectorGetOp(req_vec, dest)
     tag = Constant.from_int_and_width(1, i32)
-    send = mpi.Isend.get(unwrap.ptr, unwrap.len, unwrap.type, dest, tag, req_obj)
-    wait = mpi.Wait.get(send.request, ignore_status=False)
-    recv = mpi.Irecv.get(unwrap.ptr, unwrap.len, unwrap.type, dest, tag, req_obj)
-    test_res = mpi.Test.get(recv.request)
+    send = mpi.Isend(unwrap.ptr, unwrap.len, unwrap.type, dest, tag, req_obj)
+    wait = mpi.Wait(send.request, ignore_status=False)
+    recv = mpi.Irecv(unwrap.ptr, unwrap.len, unwrap.type, dest, tag, req_obj)
+    test_res = mpi.Test(recv.request)
     assert wait.status is not None
-    source = mpi.GetStatusField.get(wait.status, mpi.StatusTypeField.MPI_SOURCE)
+    source = mpi.GetStatusField(wait.status, mpi.StatusTypeField.MPI_SOURCE)
 
     assert unwrap.ref == alloc0.memref
     assert send.buffer == unwrap.ptr

--- a/tests/dialects/test_mpi_lowering.py
+++ b/tests/dialects/test_mpi_lowering.py
@@ -77,7 +77,7 @@ def test_lower_mpi_finalize():
 def test_lower_mpi_wait_no_status():
     (request,) = CreateTestValsOp.get(mpi.RequestType()).results
 
-    ops, result = lower_mpi.LowerMpiWait(info).lower(mpi.Wait.get(request))
+    ops, result = lower_mpi.LowerMpiWait(info).lower(mpi.Wait(request))
 
     assert len(result) == 0
     call = extract_func_call(ops)
@@ -90,7 +90,7 @@ def test_lower_mpi_wait_with_status():
     (request,) = CreateTestValsOp.get(mpi.RequestType()).results
 
     ops, result = lower_mpi.LowerMpiWait(info).lower(
-        mpi.Wait.get(request, ignore_status=False)
+        mpi.Wait(request, ignore_status=False)
     )
 
     assert len(result) == 1
@@ -105,7 +105,7 @@ def test_lower_mpi_wait_with_status():
 
 
 def test_lower_mpi_comm_rank():
-    ops, result = lower_mpi.LowerMpiCommRank(info).lower(mpi.CommRank.get())
+    ops, result = lower_mpi.LowerMpiCommRank(info).lower(mpi.CommRank())
 
     assert len(result) == 1
     assert result[0] is not None
@@ -121,7 +121,7 @@ def test_lower_mpi_comm_rank():
 
 
 def test_lower_mpi_comm_size():
-    ops, result = lower_mpi.LowerMpiCommSize(info).lower(mpi.CommSize.get())
+    ops, result = lower_mpi.LowerMpiCommSize(info).lower(mpi.CommSize())
 
     assert len(result) == 1
     assert result[0] is not None
@@ -142,7 +142,7 @@ def test_lower_mpi_send():
     ).results
 
     ops, result = lower_mpi.LowerMpiSend(info).lower(
-        mpi.Send.get(buff, size, dtype, dest, tag)
+        mpi.Send(buff, size, dtype, dest, tag)
     )
     """
     Check for function with signature like:
@@ -166,7 +166,7 @@ def test_lower_mpi_isend():
     ).results
 
     ops, result = lower_mpi.LowerMpiIsend(info).lower(
-        mpi.Isend.get(ptr, count, dtype, dest, tag, req)
+        mpi.Isend(ptr, count, dtype, dest, tag, req)
     )
     """
     Check for function with signature like:
@@ -202,7 +202,7 @@ def test_lower_mpi_recv_no_status():
     """
 
     ops, result = lower_mpi.LowerMpiRecv(info).lower(
-        mpi.Recv.get(buff, count, dtype, source, tag, ignore_status=True)
+        mpi.Recv(buff, count, dtype, source, tag, ignore_status=True)
     )
 
     assert len(result) == 0
@@ -232,7 +232,7 @@ def test_lower_mpi_recv_with_status():
     """
 
     ops, result = lower_mpi.LowerMpiRecv(info).lower(
-        mpi.Recv.get(buff, count, dtype, source, tag, ignore_status=False)
+        mpi.Recv(buff, count, dtype, source, tag, ignore_status=False)
     )
 
     assert len(result) == 1
@@ -262,7 +262,7 @@ def test_lower_mpi_irecv():
     """
 
     ops, result = lower_mpi.LowerMpiIrecv(info).lower(
-        mpi.Irecv.get(ptr, count, dtype, source, tag, req)
+        mpi.Irecv(ptr, count, dtype, source, tag, req)
     )
 
     # recv has no results
@@ -293,7 +293,7 @@ def test_lower_mpi_reduce():
     """
 
     ops, result = lower_mpi.LowerMpiReduce(info).lower(
-        mpi.Reduce.get(ptr, ptr, count, dtype, mpi.MpiOp.MPI_SUM, root)
+        mpi.Reduce(ptr, ptr, count, dtype, mpi.MpiOp.MPI_SUM, root)
     )
 
     # reduce has no results
@@ -324,7 +324,7 @@ def test_lower_mpi_all_reduce_no_send_buffer():
     """
 
     ops, result = lower_mpi.LowerMpiAllreduce(info).lower(
-        mpi.Allreduce.get(None, ptr, count, dtype, mpi.MpiOp.MPI_SUM)
+        mpi.Allreduce(None, ptr, count, dtype, mpi.MpiOp.MPI_SUM)
     )
 
     # allreduce has no results
@@ -350,9 +350,9 @@ def test_mpi_waitall():
     ).results
 
     dummy = arith.Constant.from_int_and_width(4, 32)
-    alloc_request_op = mpi.AllocateTypeOp.get(mpi.RequestType, dummy)
+    alloc_request_op = mpi.AllocateTypeOp(mpi.RequestType, dummy)
     req_op: Operand = alloc_request_op.results[0]
-    waitall = mpi.Waitall.get(req_op, count)
+    waitall = mpi.Waitall(req_op, count)
 
     assert waitall.operands[0] == req_op
     assert waitall.operands[1] == count
@@ -370,7 +370,7 @@ def test_lower_mpi_bcast():
     """
 
     ops, result = lower_mpi.LowerMpiBcast(info).lower(
-        mpi.Bcast.get(ptr, count, dtype, root)
+        mpi.Bcast(ptr, count, dtype, root)
     )
 
     # bcast has no results
@@ -391,7 +391,7 @@ def test_lower_mpi_bcast():
 
 def test_lower_mpi_allocate():
     (count,) = CreateTestValsOp.get(i32).results
-    op = mpi.AllocateTypeOp.get(mpi.RequestType, count)
+    op = mpi.AllocateTypeOp(mpi.RequestType, count)
 
     ops, res = lower_mpi.LowerMpiAllocateType(info).lower(op)
 
@@ -404,8 +404,8 @@ def test_lower_mpi_vec_get():
     mod = builtin.ModuleOp(
         [
             count := CreateTestValsOp.get(i32),
-            vec := mpi.AllocateTypeOp.get(mpi.RequestType, count),
-            get := mpi.VectorGetOp.get(vec, count),
+            vec := mpi.AllocateTypeOp(mpi.RequestType, count),
+            get := mpi.VectorGetOp(vec, count),
         ]
     )
     # we have to apply this rewrite to that the argument type of the `get`

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -8,6 +8,7 @@ from typing import Generic, TypeVar, cast
 from xdsl.dialects import llvm
 from xdsl.dialects.builtin import AnyFloat, IntegerType, Signedness, StringAttr, i32
 from xdsl.dialects.memref import MemRefType
+from xdsl.utils.deprecation import deprecated
 from xdsl.ir import (
     Attribute,
     Dialect,
@@ -174,6 +175,22 @@ class Reduce(MPIBaseOp):
     operationtype: OperationType = attr_def(OperationType)
     root: Operand = operand_def(i32)
 
+    def __init__(
+        self,
+        send_buffer: SSAValue | Operation,
+        recv_buffer: SSAValue | Operation,
+        count: SSAValue | Operation,
+        datatype: SSAValue | Operation,
+        operationtype: OperationType,
+        root: SSAValue | Operation,
+    ):
+        return super().__init__(
+            operands=[send_buffer, recv_buffer, count, datatype, root],
+            attributes={"operationtype": operationtype},
+            result_types=[],
+        )
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(
         send_buffer: SSAValue | Operation,
@@ -222,6 +239,30 @@ class Allreduce(MPIBaseOp):
     datatype: Operand = operand_def(DataType)
     operationtype: OperationType = attr_def(OperationType)
 
+    def __init__(
+        self,
+        send_buffer: SSAValue | Operation | None,
+        recv_buffer: SSAValue | Operation,
+        count: SSAValue | Operation,
+        datatype: SSAValue | Operation,
+        operationtype: OperationType,
+    ):
+        operands_to_add: Sequence[
+            SSAValue | Operation | Sequence[SSAValue | Operation]
+        ] = []
+
+        if send_buffer is None:
+            operands_to_add = [[], recv_buffer, count, datatype]
+        else:
+            operands_to_add = [[send_buffer], recv_buffer, count, datatype]
+
+        return super().__init__(
+            operands=operands_to_add,
+            attributes={"operationtype": operationtype},
+            result_types=[],
+        )
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(
         send_buffer: SSAValue | Operation | None,
@@ -275,6 +316,19 @@ class Bcast(MPIBaseOp):
     datatype: Operand = operand_def(DataType)
     root: Operand = operand_def(i32)
 
+    def __init__(
+        self,
+        buffer: SSAValue | Operation,
+        count: SSAValue | Operation,
+        datatype: SSAValue | Operation,
+        root: SSAValue | Operation,
+    ):
+        return super().__init__(
+            operands=[buffer, count, datatype, root],
+            result_types=[],
+        )
+
+    @deprecated("Use init instead")
     @staticmethod
     def get(
         buffer: SSAValue | Operation,
@@ -321,6 +375,21 @@ class Isend(MPIBaseOp):
     tag: Operand = operand_def(i32)
     request: Operand = operand_def(RequestType)
 
+    def __init__(
+        self,
+        buffer: SSAValue | Operation,
+        count: SSAValue | Operation,
+        datatype: SSAValue | Operation,
+        dest: SSAValue | Operation,
+        tag: SSAValue | Operation,
+        request: SSAValue | Operation,
+    ):
+        return super().__init__(
+            operands=[buffer, count, datatype, dest, tag, request],
+            result_types=[],
+        )
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(
         buffer: SSAValue | Operation,
@@ -368,6 +437,19 @@ class Send(MPIBaseOp):
     dest: Operand = operand_def(i32)
     tag: Operand = operand_def(i32)
 
+    def __init__(
+        self,
+        buffer: SSAValue | Operation,
+        count: SSAValue | Operation,
+        datatype: SSAValue | Operation,
+        dest: SSAValue | Operation,
+        tag: SSAValue | Operation,
+    ):
+        return super().__init__(
+            operands=[buffer, count, datatype, dest, tag], result_types=[]
+        )
+
+    @deprecated("Use init instead")
     @staticmethod
     def get(
         buffer: SSAValue | Operation,
@@ -415,6 +497,21 @@ class Irecv(MPIBaseOp):
     tag: Operand = operand_def(i32)
     request: Operand = operand_def(RequestType)
 
+    def __init__(
+        self,
+        buffer: SSAValue | Operation,
+        count: SSAValue | Operation,
+        datatype: SSAValue | Operation,
+        source: SSAValue | Operation,
+        tag: SSAValue | Operation,
+        request: SSAValue | Operation,
+    ):
+        return super().__init__(
+            operands=[buffer, count, datatype, source, tag, request],
+            result_types=[],
+        )
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(
         buffer: SSAValue | Operation,
@@ -465,6 +562,21 @@ class Recv(MPIBaseOp):
 
     status: OptOpResult = opt_result_def(StatusType)
 
+    def __init__(
+        self,
+        buffer: SSAValue | Operation,
+        count: SSAValue | Operation,
+        datatype: SSAValue | Operation,
+        source: SSAValue | Operation,
+        tag: SSAValue | Operation,
+        ignore_status: bool = True,
+    ):
+        return super().__init__(
+            operands=[buffer, count, datatype, source, tag],
+            result_types=[[]] if ignore_status else [[StatusType()]],
+        )
+
+    @deprecated("Use Init instead.")
     @staticmethod
     def get(
         buffer: SSAValue | Operation,
@@ -502,6 +614,10 @@ class Test(MPIBaseOp):
     flag: OpResult = result_def(t_bool)
     status: OpResult = result_def(StatusType)
 
+    def __init__(self, request: Operand):
+        return super().__init__(operands=[request], result_types=[t_bool, StatusType()])
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(request: Operand):
         return Test.build(operands=[request], result_types=[t_bool, StatusType()])
@@ -526,6 +642,14 @@ class Wait(MPIBaseOp):
     request: Operand = operand_def(RequestType)
     status: OptOpResult = opt_result_def(StatusType)
 
+    def __init__(self, request: Operand, ignore_status: bool = True):
+        result_types: list[list[Attribute]] = [[StatusType()]]
+        if ignore_status:
+            result_types = [[]]
+
+        return super().__init__(operands=[request], result_types=result_types)
+
+    @deprecated("Use init instead")
     @staticmethod
     def get(request: Operand, ignore_status: bool = True):
         result_types: list[list[Attribute]] = [[StatusType()]]
@@ -557,6 +681,14 @@ class Waitall(MPIBaseOp):
     count: Operand = operand_def(i32)
     statuses: OptOpResult = opt_result_def(VectorType[StatusType])
 
+    def __init__(self, requests: Operand, count: Operand, ignore_status: bool = True):
+        result_types: list[list[Attribute]] = [[VectorType.of(StatusType)]]
+        if ignore_status:
+            result_types = [[]]
+
+        return super().__init__(operands=[requests, count], result_types=result_types)
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(requests: Operand, count: Operand, ignore_status: bool = True):
         result_types: list[list[Attribute]] = [[VectorType.of(StatusType)]]
@@ -587,6 +719,14 @@ class GetStatusField(MPIBaseOp):
 
     result: OpResult = result_def(i32)
 
+    def __init__(self, status_obj: Operand, field: StatusTypeField):
+        return super().__init__(
+            operands=[status_obj],
+            attributes={"field": StringAttr(field.value)},
+            result_types=[i32],
+        )
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(status_obj: Operand, field: StatusTypeField):
         return GetStatusField.build(
@@ -609,6 +749,10 @@ class CommRank(MPIBaseOp):
 
     rank: OpResult = result_def(i32)
 
+    def __init__(self):
+        return super().__init__(result_types=[i32])
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get():
         return CommRank.build(result_types=[i32])
@@ -627,6 +771,10 @@ class CommSize(MPIBaseOp):
 
     size: OpResult = result_def(i32)
 
+    def __init__(self):
+        return super().__init__(result_types=[i32])
+
+    @deprecated("Use init instead")
     @staticmethod
     def get():
         return CommSize.build(result_types=[i32])
@@ -666,6 +814,17 @@ class UnwrapMemrefOp(MPIBaseOp):
     len: OpResult = result_def(i32)
     type: OpResult = result_def(DataType)
 
+    def __init__(self, ref: SSAValue | Operation):
+        ssa_val = SSAValue.get(ref)
+        assert isinstance(ssa_val.type, MemRefType)
+        elem_type = cast(MemRefType[AnyNumericType], ssa_val.type).element_type
+
+        return super().__init__(
+            operands=[ref],
+            result_types=[llvm.LLVMPointerType.typed(elem_type), i32, DataType()],
+        )
+
+    @deprecated("Use init instead")
     @staticmethod
     def get(ref: SSAValue | Operation) -> UnwrapMemrefOp:
         ssa_val = SSAValue.get(ref)
@@ -697,6 +856,10 @@ class GetDtypeOp(MPIBaseOp):
 
     result: OpResult = result_def(DataType)
 
+    def __init__(self, dtype: Attribute):
+        return super().__init__(result_types=[DataType()], attributes={"dtype": dtype})
+
+    @deprecated("Use init instead")
     @staticmethod
     def get(dtype: Attribute):
         return GetDtypeOp.build(result_types=[DataType()], attributes={"dtype": dtype})
@@ -722,6 +885,22 @@ class AllocateTypeOp(MPIBaseOp):
 
     result: OpResult = result_def(VectorType)
 
+    def __init__(
+        self,
+        dtype: type[VectorWrappable],
+        count: SSAValue | Operation,
+        bindc_name: StringAttr | None = None,
+    ):
+        return super().__init__(
+            result_types=[VectorType.of(dtype)],
+            attributes={
+                "dtype": dtype(),
+                "bindc_name": bindc_name,
+            },
+            operands=[count],
+        )
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(
         dtype: type[VectorWrappable],
@@ -752,6 +931,15 @@ class VectorGetOp(MPIBaseOp):
 
     result: OpResult = result_def(VectorWrappable)
 
+    def __init__(self, vect: SSAValue | Operation, element: SSAValue | Operation):
+        ssa_val = SSAValue.get(vect)
+        assert isa(ssa_val.type, VectorType[VectorWrappable])
+
+        return super().__init__(
+            result_types=[ssa_val.type.wrapped_type], operands=[vect, element]
+        )
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(vect: SSAValue | Operation, element: SSAValue | Operation) -> VectorGetOp:
         ssa_val = SSAValue.get(vect)
@@ -776,6 +964,10 @@ class NullRequestOp(MPIBaseOp):
 
     request: Operand = operand_def(RequestType)
 
+    def __init__(self, req: SSAValue | Operation):
+        return super().__init__(operands=[req])
+
+    @deprecated("Use init instead.")
     @staticmethod
     def get(req: SSAValue | Operation):
         return NullRequestOp.build(operands=[req])

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -8,7 +8,6 @@ from typing import Generic, TypeVar, cast
 from xdsl.dialects import llvm
 from xdsl.dialects.builtin import AnyFloat, IntegerType, Signedness, StringAttr, i32
 from xdsl.dialects.memref import MemRefType
-from xdsl.utils.deprecation import deprecated
 from xdsl.ir import (
     Attribute,
     Dialect,
@@ -33,6 +32,7 @@ from xdsl.irdl import (
     opt_result_def,
     result_def,
 )
+from xdsl.utils.deprecation import deprecated
 from xdsl.utils.hints import isa
 
 t_bool: IntegerType = IntegerType(1, Signedness.SIGNLESS)

--- a/xdsl/transforms/experimental/Apply1DMPIToStencil.py
+++ b/xdsl/transforms/experimental/Apply1DMPIToStencil.py
@@ -25,8 +25,8 @@ class ApplyMPIToExternalLoad(RewritePattern):
         mpi_operations: list[Operation] = []
 
         # Rank and size
-        comm_size_op = mpi.CommSize.get()
-        comm_rank_op = mpi.CommRank.get()
+        comm_size_op = mpi.CommSize()
+        comm_rank_op = mpi.CommRank()
         mpi_operations += [comm_size_op, comm_rank_op]
 
         # Constants we need to use
@@ -42,7 +42,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
 
         # The underlying datatype we use in communications and size in dimension zero
         element_type: TypeAttribute = memref_type.element_type
-        datatype_op = mpi.GetDtypeOp.get(element_type)
+        datatype_op = mpi.GetDtypeOp(element_type)
         int_attr: builtin.IntegerAttr[builtin.IndexType] = builtin.IntegerAttr(
             0, builtin.IndexType()
         )
@@ -65,7 +65,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
         ]
 
         # Four request handles, one for send, one for recv
-        alloc_request_op = mpi.AllocateTypeOp.get(mpi.RequestType, four)
+        alloc_request_op = mpi.AllocateTypeOp(mpi.RequestType, four)
         mpi_operations += [alloc_request_op]
 
         # Comparison for top and bottom ranks
@@ -75,10 +75,10 @@ class ApplyMPIToExternalLoad(RewritePattern):
         mpi_operations += [compare_top_op, size_minus_one, compare_bottom_op]
 
         # MPI Request look ups (we need these regardless)
-        alloc_lookup_op_zero = mpi.VectorGetOp.get(alloc_request_op, zero)
-        alloc_lookup_op_one = mpi.VectorGetOp.get(alloc_request_op, one)
-        alloc_lookup_op_two = mpi.VectorGetOp.get(alloc_request_op, two)
-        alloc_lookup_op_three = mpi.VectorGetOp.get(alloc_request_op, three)
+        alloc_lookup_op_zero = mpi.VectorGetOp(alloc_request_op, zero)
+        alloc_lookup_op_one = mpi.VectorGetOp(alloc_request_op, one)
+        alloc_lookup_op_two = mpi.VectorGetOp(alloc_request_op, two)
+        alloc_lookup_op_three = mpi.VectorGetOp(alloc_request_op, three)
         mpi_request_null = arith.Constant.from_int_and_width(0x2C000000, builtin.i32)
         mpi_operations += [
             alloc_lookup_op_zero,
@@ -95,7 +95,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
         added_ptr = arith.Addi(index_memref_i64, add_offset)
         send_ptr = llvm.IntToPtrOp(added_ptr)
 
-        mpi_send_top_op = mpi.Isend.get(
+        mpi_send_top_op = mpi.Isend(
             send_ptr,
             dim_zero_i32_op,
             datatype_op,
@@ -105,7 +105,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
         )
 
         recv_ptr = llvm.IntToPtrOp(index_memref_i64)
-        mpi_recv_top_op = mpi.Irecv.get(
+        mpi_recv_top_op = mpi.Irecv(
             recv_ptr,
             dim_zero_i32_op,
             datatype_op,
@@ -151,7 +151,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
         added_ptr_b_send = arith.Addi(index_memref_i64, add_offset_b_send)
         ptr_b_send = llvm.IntToPtrOp(added_ptr_b_send)
 
-        mpi_send_bottom_op = mpi.Isend.get(
+        mpi_send_bottom_op = mpi.Isend(
             ptr_b_send,
             dim_zero_i32_op,
             datatype_op,
@@ -168,7 +168,7 @@ class ApplyMPIToExternalLoad(RewritePattern):
         added_ptr_b_recv = arith.Addi(index_memref_i64, add_offset_b_recv)
         ptr_b_recv = llvm.IntToPtrOp(added_ptr_b_recv)
 
-        mpi_recv_bottom_op = mpi.Irecv.get(
+        mpi_recv_bottom_op = mpi.Irecv(
             ptr_b_recv,
             dim_zero_i32_op,
             datatype_op,

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -622,7 +622,7 @@ class LowerMpiUnwrapMemrefOp(_MPIToLLVMRewriteBase):
         return [
             *extract_ptr_ops,
             *count_ops,
-            dtype := mpi.GetDtypeOp.get(elem_type),
+            dtype := mpi.GetDtypeOp(elem_type),
         ], [ptr.results[0], count_ssa_val, dtype.result]
 
 


### PR DESCRIPTION
Replacing `get` method with `init` in mpi dialect and respective places, `get` methods in mpi diaclect are marked as deprecated.