### PR TITLE
core: Remove duplicated methods

### DIFF
--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -5,16 +5,14 @@ import re
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import cast
 
-from xdsl.dialects.builtin import DictionaryAttr, ModuleOp, UnregisteredAttr
+from xdsl.dialects.builtin import DictionaryAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
     Block,
-    Data,
     MLContext,
     Operation,
-    ParametrizedAttribute,
     Region,
     SSAValue,
 )
@@ -329,106 +327,6 @@ class Parser(AttrParser):
     def parse_operand(self, msg: str = "Expected an operand.") -> SSAValue:
         """Parse an operand with format `%<value-id>`."""
         return self.expect(self.parse_optional_operand, msg)
-
-    def parse_type(self) -> Attribute:
-        """
-        Parse an xDSL type.
-        An xDSL type is either a builtin type, which can have various format,
-        or a dialect type, with the following format:
-            dialect-type  ::= `!` type-name (`<` dialect-type-contents+ `>`)?
-            type-name     ::= bare-id
-            dialect-type-contents ::= `<` dialect-attribute-contents+ `>`
-                            | `(` dialect-attribute-contents+ `)`
-                            | `[` dialect-attribute-contents+ `]`
-                            | `{` dialect-attribute-contents+ `}`
-                            | [^[]<>(){}\0]+
-        """
-        return self.expect(self.parse_optional_type, "type expected")
-
-    def parse_optional_type(self) -> Attribute | None:
-        """
-        Parse an xDSL type, if present.
-        An xDSL type is either a builtin type, which can have various format,
-        or a dialect type, with the following format:
-            dialect-type  ::= `!` type-name (`<` dialect-type-contents+ `>`)?
-            type-name     ::= bare-id
-            dialect-type-contents ::= `<` dialect-attribute-contents+ `>`
-                            | `(` dialect-attribute-contents+ `)`
-                            | `[` dialect-attribute-contents+ `]`
-                            | `{` dialect-attribute-contents+ `}`
-                            | [^[]<>(){}\0]+
-        """
-        if (
-            token := self._parse_optional_token(Token.Kind.EXCLAMATION_IDENT)
-        ) is not None:
-            return self._parse_dialect_type_or_attribute_inner(token.text[1:], True)
-        return self._parse_optional_builtin_type()
-
-    def parse_attribute(self) -> Attribute:
-        """
-        Parse an xDSL attribute.
-        An attribute is either a builtin attribute, which can have various format,
-        or a dialect attribute, with the following format:
-            dialect-attr  ::= `!` attr-name (`<` dialect-attr-contents+ `>`)?
-            attr-name     ::= bare-id
-            dialect-attr-contents ::= `<` dialect-attribute-contents+ `>`
-                            | `(` dialect-attribute-contents+ `)`
-                            | `[` dialect-attribute-contents+ `]`
-                            | `{` dialect-attribute-contents+ `}`
-                            | [^[]<>(){}\0]+
-        """
-        return self.expect(self.parse_optional_attribute, "attribute expected")
-
-    def parse_optional_attribute(self) -> Attribute | None:
-        """
-        Parse an xDSL attribute, if present.
-        An attribute is either a builtin attribute, which can have various format,
-        or a dialect attribute, with the following format:
-            dialect-attr  ::= `!` attr-name (`<` dialect-attr-contents+ `>`)?
-            attr-name     ::= bare-id
-            dialect-attr-contents ::= `<` dialect-attribute-contents+ `>`
-                            | `(` dialect-attribute-contents+ `)`
-                            | `[` dialect-attribute-contents+ `]`
-                            | `{` dialect-attribute-contents+ `}`
-                            | [^[]<>(){}\0]+
-        """
-        if (token := self._parse_optional_token(Token.Kind.HASH_IDENT)) is not None:
-            return self._parse_dialect_type_or_attribute_inner(token.text[1:], False)
-        return self._parse_optional_builtin_attr()
-
-    def _parse_dialect_type_or_attribute_inner(
-        self, attr_name: str, is_type: bool = True
-    ) -> Attribute:
-        """
-        Parse the contents of a dialect type or attribute, with format:
-            dialect-attr-contents ::= `<` dialect-attribute-contents+ `>`
-                                    | `(` dialect-attribute-contents+ `)`
-                                    | `[` dialect-attribute-contents+ `]`
-                                    | `{` dialect-attribute-contents+ `}`
-                                    | [^[]<>(){}\0]+
-        The contents will be parsed by a user-defined parser, or by a generic parser
-        if the dialect attribute/type is not registered.
-        """
-        attr_def = self.ctx.get_optional_attr(
-            attr_name,
-            create_unregistered_as_type=is_type,
-        )
-        if attr_def is None:
-            self.raise_error(f"'{attr_name}' is not registered")
-
-        # Pass the task of parsing parameters on to the attribute/type definition
-        if issubclass(attr_def, UnregisteredAttr):
-            body = self._parse_unregistered_attr_body()
-            return attr_def(attr_name, is_type, body)
-        if issubclass(attr_def, ParametrizedAttribute):
-            param_list = attr_def.parse_parameters(self)
-            return attr_def.new(param_list)
-        if issubclass(attr_def, Data):
-            self.parse_punctuation("<")
-            param: Any = attr_def.parse_parameter(self)
-            self.parse_punctuation(">")
-            return cast(Data[Any], attr_def(param))
-        assert False, "Attributes are either ParametrizedAttribute or Data."
 
     def _register_ssa_definition(
         self, name: str, values: Sequence[SSAValue], span: Span


### PR DESCRIPTION
This removes methods in `Parser` that are already duplicated in `AttrParser`.
