### PR TITLE
testing: make fewer tests fail if riscemu is not installed

### DIFF
--- a/docs/Toy/examples/lit.cfg
+++ b/docs/Toy/examples/lit.cfg
@@ -7,3 +7,8 @@ toy_src = os.path.dirname(config.test_source_root)
 config.name = "Toy"
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {toy_src}"])
 config.suffixes = ['.mlir', '.toy']
+
+try:
+    import riscemu
+except ImportError:
+    config.unsupported = True

--- a/docs/Toy/toy/compiler.py
+++ b/docs/Toy/toy/compiler.py
@@ -24,7 +24,6 @@ from xdsl.dialects import (
     scf,
 )
 from xdsl.dialects.builtin import Builtin, ModuleOp
-from xdsl.interpreters.riscv_emulator import run_riscv
 from xdsl.ir import MLContext
 from xdsl.transforms.canonicalize import CanonicalizePass
 from xdsl.transforms.dead_code_elimination import DeadCodeElimination
@@ -35,7 +34,6 @@ from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
 from xdsl.transforms.riscv_scf_loop_range_folding import RiscvScfLoopRangeFoldingPass
 
 from .dialects import toy
-from .emulator.toy_accelerator_instructions import ToyAccelerator
 from .frontend.ir_gen import IRGen
 from .frontend.parser import Parser
 from .rewrites.inline_toy import InlineToyPass
@@ -168,4 +166,8 @@ def compile(program: str) -> str:
 
 
 def emulate_riscv(program: str):
+    from xdsl.interpreters.riscv_emulator import run_riscv
+
+    from .emulator.toy_accelerator_instructions import ToyAccelerator
+
     run_riscv(program, extensions=[ToyAccelerator], unlimited_regs=True, verbosity=0)


### PR DESCRIPTION
The only one that still fails is Chapter 0 of the Toy tutorial because it runs riscemu in it... I'm not sure if we want to make riscemu required for it but I'd say that a single notebook failing if you don't have riscemu installed and otherwise local `make tests` still working seems like like progress.