### PR TITLE
core: add AbstractYieldOperation and use in riscv-scf

### DIFF
--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -9,10 +9,9 @@ from typing_extensions import Self
 
 from xdsl.dialects.riscv import IntRegisterType, RISCVRegisterType
 from xdsl.dialects.utils import (
+    AbstractYieldOperation,
     parse_assignment,
-    parse_return_op_like,
     print_assignment,
-    print_return_op_like,
 )
 from xdsl.ir import Attribute, Dialect
 from xdsl.irdl import (
@@ -38,25 +37,10 @@ from xdsl.utils.exceptions import VerifyException
 
 
 @irdl_op_definition
-class YieldOp(IRDLOperation):
+class YieldOp(AbstractYieldOperation[RISCVRegisterType]):
     name = "riscv_scf.yield"
 
-    arguments: VarOperand = var_operand_def(RISCVRegisterType)
-
     traits = traits_def(lambda: frozenset([IsTerminator(), HasParent(ForOp, WhileOp)]))
-
-    def __init__(self, *operands: SSAValue | Operation):
-        super().__init__(operands=[[SSAValue.get(operand) for operand in operands]])
-
-    def print(self, printer: Printer):
-        print_return_op_like(printer, self.attributes, self.arguments)
-
-    @classmethod
-    def parse(cls, parser: Parser) -> Self:
-        attrs, args = parse_return_op_like(parser)
-        op = cls(*args)
-        op.attributes.update(attrs)
-        return op
 
 
 @irdl_op_definition

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -97,6 +97,11 @@ def parse_return_op_like(
 
 
 class AbstractYieldOperation(Generic[AttributeInvT], IRDLOperation):
+    """
+    A base class for yielding operations to inherit, provides the standard custom syntax
+    and a definition of the `arguments` variadic operand.
+    """
+
     arguments = var_operand_def(AttributeInvT)
 
     def __init__(self, *operands: SSAValue | Operation):

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
-from typing import cast
+from typing import Generic, cast
+
+from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     DictionaryAttr,
@@ -7,7 +9,8 @@ from xdsl.dialects.builtin import (
     StringAttr,
     SymbolRefAttr,
 )
-from xdsl.ir import Attribute, BlockArgument, Operation, Region, SSAValue
+from xdsl.ir import Attribute, AttributeInvT, BlockArgument, Operation, Region, SSAValue
+from xdsl.irdl import IRDLOperation, var_operand_def
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.utils.hints import isa
@@ -91,6 +94,23 @@ def parse_return_op_like(
         args = ()
 
     return attrs, args
+
+
+class AbstractYieldOperation(Generic[AttributeInvT], IRDLOperation):
+    arguments = var_operand_def(AttributeInvT)
+
+    def __init__(self, *operands: SSAValue | Operation):
+        super().__init__(operands=[operands])
+
+    def print(self, printer: Printer):
+        print_return_op_like(printer, self.attributes, self.arguments)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        attrs, args = parse_return_op_like(parser)
+        op = cls(*args)
+        op.attributes.update(attrs)
+        return op
 
 
 def print_func_op_like(


### PR DESCRIPTION
Just a little helper that should remove some boilerplate code as we add new dialects with a yield-like operation. I only used it in riscv-scf for now but am happy to migrate the rest of them in this PR.