### PR TITLE
core: Remove hardcoded angle brackets from Data printing/parsing.

### DIFF
--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -80,7 +80,8 @@ class StringData(Data[str]):
             return parser.parse_str_literal()
 
     def print_parameter(self, printer: Printer):
-        printer.print_string(self.data)
+        with printer.in_angle_brackets():
+            printer.print_string(self.data)
 
 
 def test_simple_data():

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -40,14 +40,16 @@ class BoolData(Data[bool]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> bool:
-        if parser.parse_optional_keyword("True"):
-            return True
-        if parser.parse_optional_keyword("False"):
-            return False
-        parser.raise_error("Expected True or False literal")
+        with parser.in_angle_brackets():
+            if parser.parse_optional_keyword("True"):
+                return True
+            if parser.parse_optional_keyword("False"):
+                return False
+            parser.raise_error("Expected True or False literal")
 
     def print_parameter(self, printer: Printer):
-        printer.print_string(str(self.data))
+        with printer.in_angle_brackets():
+            printer.print_string(str(self.data))
 
 
 @irdl_attr_definition
@@ -58,10 +60,12 @@ class IntData(Data[int]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> int:
-        return parser.parse_integer()
+        with parser.in_angle_brackets():
+            return parser.parse_integer()
 
     def print_parameter(self, printer: Printer):
-        printer.print_string(str(self.data))
+        with printer.in_angle_brackets():
+            printer.print_string(str(self.data))
 
 
 @irdl_attr_definition
@@ -72,7 +76,8 @@ class StringData(Data[str]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
-        return parser.parse_str_literal()
+        with parser.in_angle_brackets():
+            return parser.parse_str_literal()
 
     def print_parameter(self, printer: Printer):
         printer.print_string(self.data)
@@ -100,9 +105,10 @@ class IntListData(Data[list[int]]):
         raise NotImplementedError()
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string("[")
-        printer.print_list(self.data, lambda x: printer.print_string(str(x)))
-        printer.print_string("]")
+        with printer.in_angle_brackets():
+            printer.print_string("[")
+            printer.print_list(self.data, lambda x: printer.print_string(str(x)))
+            printer.print_string("]")
 
 
 def test_non_class_data():
@@ -457,9 +463,10 @@ class ListData(GenericData[list[A]]):
         raise NotImplementedError()
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string("[")
-        printer.print_list(self.data, printer.print_attribute)
-        printer.print_string("]")
+        with printer.in_angle_brackets():
+            printer.print_string("[")
+            printer.print_list(self.data, printer.print_attribute)
+            printer.print_string("]")
 
     @staticmethod
     def generic_constraint_coercion(args: tuple[Any]) -> AttrConstraint:

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -43,10 +43,12 @@ class IntData(Data[int]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> int:
-        return parser.parse_integer()
+        with parser.in_angle_brackets():
+            return parser.parse_integer()
 
     def print_parameter(self, printer: Printer):
-        printer.print_string(str(self.data))
+        with printer.in_angle_brackets():
+            printer.print_string(str(self.data))
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -130,12 +130,13 @@ class ArrayAttr(GenericData[tuple[AttributeCovT, ...]], Iterable[AttributeCovT])
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> tuple[AttributeCovT, ...]:
-        data = parser.parse_comma_separated_list(
-            parser.Delimiter.SQUARE, parser.parse_attribute
-        )
-        # the type system can't ensure that the elements are of type _ArrayAttrT
-        result = cast(tuple[AttributeCovT, ...], tuple(data))
-        return result
+        with parser.in_angle_brackets():
+            data = parser.parse_comma_separated_list(
+                parser.Delimiter.SQUARE, parser.parse_attribute
+            )
+            # the type system can't ensure that the elements are of type _ArrayAttrT
+            result = cast(tuple[AttributeCovT, ...], tuple(data))
+            return result
 
     def print_parameter(self, printer: Printer) -> None:
         printer.print_string("[")
@@ -177,7 +178,8 @@ class StringAttr(Data[str]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
-        return parser.parse_str_literal()
+        with parser.in_angle_brackets():
+            return parser.parse_str_literal()
 
     def print_parameter(self, printer: Printer) -> None:
         printer.print_string(f'"{self.data}"')
@@ -268,11 +270,13 @@ class IntAttr(Data[int]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> int:
-        data = parser.parse_integer()
-        return data
+        with parser.in_angle_brackets():
+            data = parser.parse_integer()
+            return data
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string(f"{self.data}")
+        with printer.in_angle_brackets():
+            printer.print_string(f"{self.data}")
 
 
 class Signedness(Enum):
@@ -291,24 +295,26 @@ class SignednessAttr(Data[Signedness]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> Signedness:
-        if parser.parse_optional_keyword("signless") is not None:
-            return Signedness.SIGNLESS
-        if parser.parse_optional_keyword("signed") is not None:
-            return Signedness.SIGNED
-        if parser.parse_optional_keyword("unsigned") is not None:
-            return Signedness.UNSIGNED
-        parser.raise_error("`signless`, `signed`, or `unsigned` expected")
+        with parser.in_angle_brackets():
+            if parser.parse_optional_keyword("signless") is not None:
+                return Signedness.SIGNLESS
+            if parser.parse_optional_keyword("signed") is not None:
+                return Signedness.SIGNED
+            if parser.parse_optional_keyword("unsigned") is not None:
+                return Signedness.UNSIGNED
+            parser.raise_error("`signless`, `signed`, or `unsigned` expected")
 
     def print_parameter(self, printer: Printer) -> None:
-        data = self.data
-        if data == Signedness.SIGNLESS:
-            printer.print_string("signless")
-        elif data == Signedness.SIGNED:
-            printer.print_string("signed")
-        elif data == Signedness.UNSIGNED:
-            printer.print_string("unsigned")
-        else:
-            raise ValueError(f"Invalid signedness {data}")
+        with printer.in_angle_brackets():
+            data = self.data
+            if data == Signedness.SIGNLESS:
+                printer.print_string("signless")
+            elif data == Signedness.SIGNED:
+                printer.print_string("signed")
+            elif data == Signedness.UNSIGNED:
+                printer.print_string("unsigned")
+            else:
+                raise ValueError(f"Invalid signedness {data}")
 
 
 @irdl_attr_definition
@@ -494,7 +500,8 @@ class FloatData(Data[float]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> float:
-        return float(parser.parse_number())
+        with parser.in_angle_brackets():
+            return float(parser.parse_number())
 
     def print_parameter(self, printer: Printer) -> None:
         printer.print_string(f"{self.data}")
@@ -1154,8 +1161,9 @@ class AffineMapAttr(Data[AffineMap]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> AffineMap:
-        data = parser.parse_affine_map()
-        return data
+        with parser.in_angle_brackets():
+            data = parser.parse_affine_map()
+            return data
 
     def print_parameter(self, printer: Printer) -> None:
         printer.print_string(f"{self.data}")

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -63,23 +63,25 @@ class IteratorTypeAttr(Data[IteratorType]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> IteratorType:
-        if parser.parse_optional_keyword("parallel") is not None:
-            return IteratorType.PARALLEL
-        if parser.parse_optional_keyword("reduction") is not None:
-            return IteratorType.REDUCTION
-        if parser.parse_optional_keyword("window") is not None:
-            return IteratorType.WINDOW
-        parser.raise_error("`parallel`, `reduction` or `window` expected")
+        with parser.in_angle_brackets():
+            if parser.parse_optional_keyword("parallel") is not None:
+                return IteratorType.PARALLEL
+            if parser.parse_optional_keyword("reduction") is not None:
+                return IteratorType.REDUCTION
+            if parser.parse_optional_keyword("window") is not None:
+                return IteratorType.WINDOW
+            parser.raise_error("`parallel`, `reduction` or `window` expected")
 
     def print_parameter(self, printer: Printer) -> None:
-        data = self.data
-        match data:
-            case IteratorType.PARALLEL:
-                printer.print_string("parallel")
-            case IteratorType.REDUCTION:
-                printer.print_string("reduction")
-            case IteratorType.WINDOW:
-                printer.print_string("window")
+        with printer.in_angle_brackets():
+            data = self.data
+            match data:
+                case IteratorType.PARALLEL:
+                    printer.print_string("parallel")
+                case IteratorType.REDUCTION:
+                    printer.print_string("reduction")
+                case IteratorType.WINDOW:
+                    printer.print_string("window")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1012,29 +1012,31 @@ class FastMathAttr(Data[tuple[FastMathFlag, ...]]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> tuple[FastMathFlag, ...]:
-        flags = FastMathFlag.try_parse(parser)
-        if flags is None:
-            return tuple()
+        with parser.in_angle_brackets():
+            flags = FastMathFlag.try_parse(parser)
+            if flags is None:
+                return tuple()
 
-        while parser.parse_optional_punctuation(",") is not None:
-            flag = parser.expect(
-                lambda: FastMathFlag.try_parse(parser), "fastmath flag expected"
-            )
-            flags.update(flag)
+            while parser.parse_optional_punctuation(",") is not None:
+                flag = parser.expect(
+                    lambda: FastMathFlag.try_parse(parser), "fastmath flag expected"
+                )
+                flags.update(flag)
 
-        return tuple(flags)
+            return tuple(flags)
 
     def print_parameter(self, printer: Printer):
-        flags = self.data
-        if len(flags) == 0:
-            printer.print("none")
-        elif len(flags) == len(FastMathFlag):
-            printer.print("fast")
-        else:
-            # make sure we emit flags in a consistent order
-            printer.print(
-                ",".join(flag.value for flag in FastMathFlag if flag in flags)
-            )
+        with printer.in_angle_brackets():
+            flags = self.data
+            if len(flags) == 0:
+                printer.print("none")
+            elif len(flags) == len(FastMathFlag):
+                printer.print("fast")
+            else:
+                # make sure we emit flags in a consistent order
+                printer.print(
+                    ",".join(flag.value for flag in FastMathFlag if flag in flags)
+                )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -84,15 +84,17 @@ class RISCVRegisterType(Data[str], TypeAttribute, ABC):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
-        name = parser.parse_optional_identifier()
-        if name is None:
-            return ""
-        if not name.startswith("j"):
-            assert name in cls.abi_index_by_name(), f"{name}"
-        return name
+        with parser.in_angle_brackets():
+            name = parser.parse_optional_identifier()
+            if name is None:
+                return ""
+            if not name.startswith("j"):
+                assert name in cls.abi_index_by_name(), f"{name}"
+            return name
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string(self.data)
+        with printer.in_angle_brackets():
+            printer.print_string(self.data)
 
     def verify(self) -> None:
         name = self.data
@@ -353,10 +355,12 @@ class LabelAttr(Data[str]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
-        return parser.parse_str_literal()
+        with parser.in_angle_brackets():
+            return parser.parse_str_literal()
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string_literal(self.data)
+        with printer.in_angle_brackets():
+            printer.print_string_literal(self.data)
 
 
 class RISCVOp(Operation, ABC):

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -122,10 +122,12 @@ class TestType(Data[str], TypeAttribute):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
-        return parser.parse_str_literal()
+        with parser.in_angle_brackets():
+            return parser.parse_str_literal()
 
     def print_parameter(self, printer: Printer) -> None:
-        printer.print_string_literal(self.data)
+        with printer.in_angle_brackets():
+            printer.print_string_literal(self.data)
 
 
 Test = Dialect("test", [TestOp, TestTermOp], [TestType])

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -199,9 +199,7 @@ class AttrParser(BaseParser):
             param_list = attr_def.parse_parameters(self)
             return attr_def.new(param_list)
         if issubclass(attr_def, Data):
-            self.parse_punctuation("<")
             param: Any = attr_def.parse_parameter(self)
-            self.parse_punctuation(">")
             return cast(Data[Any], attr_def(param))
         assert False, "Attributes are either ParametrizedAttribute or Data."
 

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -4,6 +4,7 @@ that is inherited from the different parsers used in xDSL.
 """
 
 from collections.abc import Callable, Iterable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from typing import NoReturn, TypeVar, overload
@@ -65,6 +66,14 @@ class BaseParser:
         at_position: Position | Span | None = None,
     ) -> NoReturn:
         ...
+
+    @contextmanager
+    def in_angle_brackets(self):
+        self.parse_punctuation("<")
+        try:
+            yield
+        finally:
+            self.parse_punctuation(">")
 
     def raise_error(
         self,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Iterable, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, TypeVar, cast
 
@@ -83,6 +84,14 @@ class Printer:
     _next_line_callback: list[Callable[[], None]] = field(
         default_factory=list, init=False
     )
+
+    @contextmanager
+    def in_angle_brackets(self):
+        self.print_string("<")
+        try:
+            yield
+        finally:
+            self.print_string(">")
 
     def print(self, *argv: Any) -> None:
         for arg in argv:
@@ -633,9 +642,7 @@ class Printer:
         self.print(attribute.name)
 
         if isinstance(attribute, Data):
-            self.print("<")
             attribute.print_parameter(self)
-            self.print(">")
             return
 
         assert isinstance(attribute, ParametrizedAttribute)


### PR DESCRIPTION
More MLIR compliancy! This is a step of my proper opqaue syntax implementation quest.
Basically, the angle brackets we use in Data attributes are not supposed to be part of the general syntax, but is just a convention adopted by most attributes.
This reverts this hardcoding, moving those brackets in every Data Attribute's custom parsing/printing code.
It already implements helpers for this; both for my laziness and for next users' sanity :slightly_smiling_face: 