### PR TITLE
dialects: (linalg) Use abstract yield operation in `linalg.yield`

### DIFF
--- a/tests/dialects/test_linalg.py
+++ b/tests/dialects/test_linalg.py
@@ -17,7 +17,7 @@ def test_linalg_on_memrefs():
 
         @Builder.implicit_region((f32, f32))
         def body(args: tuple[Any, ...]):
-            linalg.Yield(args[0])
+            linalg.YieldOp(args[0])
 
         indexing = AffineExpr.dimension(0)
         indexing_map = AffineMap(1, 0, (indexing,))
@@ -44,7 +44,7 @@ def test_loop_range_methods():
     @Builder.implicit_region((f32, f32, f32))
     def body(args: tuple[Any, ...]):
         a, b, c = args
-        linalg.Yield(arith.Addf(arith.Mulf(a, b), c))
+        linalg.YieldOp(arith.Addf(arith.Mulf(a, b), c))
 
     i = AffineExpr.dimension(0)
     j = AffineExpr.dimension(1)

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -24,7 +24,7 @@ def test_unimplemented_inputs():
         op = linalg.Generic(
             (TestSSAValue(IntegerType(1)),),
             (),
-            Region(Block([linalg.Yield()])),
+            Region(Block([linalg.YieldOp()])),
             (),
             (linalg.IteratorTypeAttr(linalg.IteratorType.REDUCTION),),
         )
@@ -38,7 +38,7 @@ def test_unimplemented_inputs():
         op = linalg.Generic(
             (),
             (),
-            Region(Block([linalg.Yield()])),
+            Region(Block([linalg.YieldOp()])),
             (),
             (),
             library_call=StringAttr("hello"),
@@ -82,7 +82,7 @@ def test_linalg_generic():
 
     with ImplicitBuilder(op.body) as (a, b):
         c = arith.Muli(a, b).result
-        linalg.Yield(c)
+        linalg.YieldOp(c)
 
     a = ShapedArray([1, 2, 3, 4, 5, 6], [2, 3])
     b = ShapedArray([1, 4, 2, 5, 3, 6], [3, 2])

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from enum import Enum
 
-from typing_extensions import Self
-
 from xdsl.dialects.builtin import (
     AffineMapAttr,
     AnyShapedType,
@@ -13,8 +11,10 @@ from xdsl.dialects.builtin import (
     ShapedType,
     StringAttr,
 )
-from xdsl.dialects.utils import parse_return_op_like, print_return_op_like
-from xdsl.ir import Attribute, Data, Dialect, Operation, Region, SSAValue
+from xdsl.dialects.utils import (
+    AbstractYieldOperation,
+)
+from xdsl.ir import Attribute, Data, Dialect, Region, SSAValue
 from xdsl.ir.affine import AffineMap
 from xdsl.irdl import (
     AttrSizedOperandSegments,
@@ -29,7 +29,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.parser import AttrParser, Parser
+from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import IsTerminator
 
@@ -192,25 +192,10 @@ class Generic(IRDLOperation):
 
 
 @irdl_op_definition
-class Yield(IRDLOperation):
+class YieldOp(AbstractYieldOperation[Attribute]):
     name = "linalg.yield"
-
-    values: VarOperand = var_operand_def()
 
     traits = frozenset([IsTerminator()])
 
-    def __init__(self, *operands: SSAValue | Operation) -> None:
-        super().__init__(operands=[operands])
 
-    def print(self, printer: Printer):
-        print_return_op_like(printer, self.attributes, self.values)
-
-    @classmethod
-    def parse(cls, parser: Parser) -> Self:
-        attrs, args = parse_return_op_like(parser)
-        op = cls(*args)
-        op.attributes.update(attrs)
-        return op
-
-
-Linalg = Dialect("linalg", [Generic, Yield], [IteratorTypeAttr])
+Linalg = Dialect("linalg", [Generic, YieldOp], [IteratorTypeAttr])

--- a/xdsl/interpreters/linalg.py
+++ b/xdsl/interpreters/linalg.py
@@ -58,8 +58,8 @@ class LinalgFunctions(InterpreterFunctions):
 
         return ()
 
-    @impl_terminator(linalg.Yield)
+    @impl_terminator(linalg.YieldOp)
     def run_yield(
-        self, interpreter: Interpreter, op: linalg.Yield, args: tuple[Any, ...]
+        self, interpreter: Interpreter, op: linalg.YieldOp, args: tuple[Any, ...]
     ):
         return ReturnedValues(args), ()


### PR DESCRIPTION
This PR:

- Uses the abstract base implementation of Yield in `linalg.yield`
- Rename class from `Yield` to `YieldOp` (white we are at it)