### PR TITLE
core: Fix unregistered attribute opaque syntax handling

### DIFF
--- a/tests/filecheck/parser-printer/unregistered_dialect.mlir
+++ b/tests/filecheck/parser-printer/unregistered_dialect.mlir
@@ -4,7 +4,7 @@
 "builtin.module"() ({
 
   %0 = "region_op"() ({
-    %y = "op_with_res"() {otherattr = #unknowndialect.unknown_attr<b2 ...2 [] <<>>>} : () -> (i32)
+    %x = "op_with_res"() {otherattr = #unknowndialect.unknown_attr<b2 ...2 [] <<>>>} : () -> (i32)
     %y = "op_with_res"() {otherattr = #unknowndialect<b2 ...2 [] <<>>>} : () -> (i32)
     %z = "op_with_operands"(%y, %y) : (i32, i32) -> !unknowndialect.unknown_type<{[<()>]}>
     "op"() {ab = !unknowndialect.unknown_singleton_type} : () -> ()

--- a/tests/filecheck/parser-printer/unregistered_dialect.mlir
+++ b/tests/filecheck/parser-printer/unregistered_dialect.mlir
@@ -1,4 +1,3 @@
-// XFAIL: *
 // RUN: xdsl-opt %s --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect  | filecheck %s
 
 "builtin.module"() ({

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -173,7 +173,11 @@ class AttrParser(BaseParser):
         return dict(attrs)
 
     def _parse_dialect_type_or_attribute_body(
-        self, attr_name: str, is_type: bool, is_opaque: bool
+        self,
+        attr_name: str,
+        is_type: bool,
+        is_opaque: bool,
+        starting_opaque_pos: Position | None,
     ):
         attr_def = self.ctx.get_optional_attr(
             attr_name,
@@ -182,8 +186,15 @@ class AttrParser(BaseParser):
         if attr_def is None:
             self.raise_error(f"'{attr_name}' is not registered")
         if issubclass(attr_def, UnregisteredAttr):
-            body = self._parse_unregistered_attr_body()
-            return attr_def(attr_name, is_type, is_opaque, body)
+            if not is_opaque:
+                if self.parse_optional_punctuation("<") is None:
+                    return attr_def(attr_name, is_type, is_opaque, "")
+            body = self._parse_unregistered_attr_body(starting_opaque_pos)
+            attr = attr_def(attr_name, is_type, is_opaque, body)
+            if not is_opaque:
+                self.parse_punctuation(">")
+            return attr
+
         elif issubclass(attr_def, ParametrizedAttribute):
             param_list = attr_def.parse_parameters(self)
             return attr_def.new(param_list)
@@ -207,17 +218,18 @@ class AttrParser(BaseParser):
         if the dialect attribute/type is not registered.
         """
         is_opaque = "." not in attr_or_dialect_name
+        starting_opaque_pos = None
         if is_opaque:
             self.parse_punctuation("<")
-            attr_or_dialect_name += (
-                "."
-                + self._parse_token(
-                    Token.Kind.BARE_IDENT, "Expected attribute name."
-                ).text
+            attr_name_token = self._parse_token(
+                Token.Kind.BARE_IDENT, "Expected attribute name."
             )
+            starting_opaque_pos = attr_name_token.span.end
+
+            attr_or_dialect_name += "." + attr_name_token.text
 
         attr = self._parse_dialect_type_or_attribute_body(
-            attr_or_dialect_name, is_type, is_opaque
+            attr_or_dialect_name, is_type, is_opaque, starting_opaque_pos
         )
 
         if is_opaque:
@@ -225,19 +237,18 @@ class AttrParser(BaseParser):
 
         return attr
 
-    def _parse_unregistered_attr_body(self) -> str:
+    def _parse_unregistered_attr_body(self, start_pos: Position | None) -> str:
         """
         Parse the body of an unregistered attribute, which is a balanced
         string for `<`, `(`, `[`, `{`, and may contain string literals.
+        The body ends when no parentheses are opened, and an `>` is encountered.
         """
-        start_token = self._parse_optional_token(Token.Kind.LESS)
-        if start_token is None:
-            return ""
 
-        start_pos = start_token.span.start
+        if start_pos is None:
+            start_pos = self.pos
         end_pos: Position = start_pos
 
-        symbols_stack = [Token.Kind.LESS]
+        symbols_stack = []
         parentheses = {
             Token.Kind.GREATER: Token.Kind.LESS,
             Token.Kind.R_PAREN: Token.Kind.L_PAREN,
@@ -259,17 +270,31 @@ class AttrParser(BaseParser):
                 continue
 
             # Closing a parenthesis
-            if (token := self._parse_optional_token_in(parentheses.keys())) is not None:
+            if (token := self._current_token).kind in parentheses.keys():
                 closing = parentheses[token.kind]
+
+                # If we don't have any open parenthesis, either we end the parsing if
+                # the parenthesis is a `>`, or we raise an error.
+                if len(symbols_stack) == 0:
+                    if token.kind == Token.Kind.GREATER:
+                        end_pos = self.pos
+                        break
+                    self.raise_error(
+                        "Unexpected closing parenthesis "
+                        f"{parentheses_names[token.kind]} in attribute body!",
+                        self._current_token.span,
+                    )
+
+                # If we have an open parenthesis, check that we are closing it
+                # with the right parenthesis kind.
                 if symbols_stack[-1] != closing:
                     self.raise_error(
-                        f"Mismatched {parentheses_names[token.kind]} in attribute body!",
+                        "Unexpected closing parenthesis "
+                        f"{parentheses_names[token.kind]} in attribute body! {symbols_stack}",
                         self._current_token.span,
                     )
                 symbols_stack.pop()
-                if len(symbols_stack) == 0:
-                    end_pos = token.span.end
-                    break
+                self._consume_token()
                 continue
 
             # Checking for unexpected EOF

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -248,7 +248,7 @@ class AttrParser(BaseParser):
             start_pos = self.pos
         end_pos: Position = start_pos
 
-        symbols_stack = []
+        symbols_stack: list[Token.Kind] = []
         parentheses = {
             Token.Kind.GREATER: Token.Kind.LESS,
             Token.Kind.R_PAREN: Token.Kind.L_PAREN,

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -179,6 +179,16 @@ class AttrParser(BaseParser):
         is_opaque: bool,
         starting_opaque_pos: Position | None,
     ):
+        """
+        Parse the contents of an attribute or type, with syntax:
+            dialect-attr-contents ::= `<` dialect-attr-contents+ `>`
+                                    | `(` dialect-attr-contents+ `)`
+                                    | `[` dialect-attr-contents+ `]`
+                                    | `{` dialect-attr-contents+ `}`
+                                    | [^[]<>(){}\0]+
+        In the case where the attribute or type is using the opaque syntax,
+        the attribute or type mnemonic should have already been parsed.
+        """
         attr_def = self.ctx.get_optional_attr(
             attr_name,
             create_unregistered_as_type=is_type,
@@ -209,13 +219,18 @@ class AttrParser(BaseParser):
     ) -> Attribute:
         """
         Parse the contents of a dialect type or attribute, with format:
-            dialect-attr-contents ::= `<` dialect-attribute-contents+ `>`
-                                    | `(` dialect-attribute-contents+ `)`
-                                    | `[` dialect-attribute-contents+ `]`
-                                    | `{` dialect-attribute-contents+ `}`
+            dialect-attr-contents ::= `<` dialect-attr-contents+ `>`
+                                    | `(` dialect-attr-contents+ `)`
+                                    | `[` dialect-attr-contents+ `]`
+                                    | `{` dialect-attr-contents+ `}`
                                     | [^[]<>(){}\0]+
         The contents will be parsed by a user-defined parser, or by a generic parser
         if the dialect attribute/type is not registered.
+
+        In the case that the type or attribute is using the opaque syntax (where the
+        identifier parsed is the dialect name), this function will parse the opaque
+        attribute with the following format:
+            opaque-attr-contents ::= `<` bare-ident dialect-attr-contents+ `>`
         """
         is_opaque = "." not in attr_or_dialect_name
         starting_opaque_pos = None

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -643,11 +643,14 @@ class Printer:
             self.print("!" if attribute.is_type.data else "#")
             if attribute.is_opaque.data:
                 self.print(attribute.attr_name.data.replace(".", "<", 1))
+                self.print(attribute.value.data)
+                self.print(">")
             else:
                 self.print(attribute.attr_name.data)
-            self.print(attribute.value.data)
-            if attribute.is_opaque:
-                self.print(">")
+                if attribute.value.data:
+                    self.print("<")
+                    self.print(attribute.value.data)
+                    self.print(">")
             return
 
         # Print dialect attributes


### PR DESCRIPTION
This is @math-fehr's fix on unregistered attribute for opaque syntax, sister PR to #1726.

