### PR TITLE
misc: improve get_type_var_mapping.

### DIFF
--- a/tests/utils/test_hints.py
+++ b/tests/utils/test_hints.py
@@ -5,13 +5,14 @@ import pytest
 from xdsl.utils.hints import get_type_var_mapping
 
 T = TypeVar("T")
+R = TypeVar("R")
 
 
 class GenericBase(Generic[T]):
     pass
 
 
-class GenericSubclassOfGenericBase(GenericBase[T]):
+class GenericSubclassOfGenericBase(GenericBase[R]):
     pass
 
 
@@ -26,8 +27,9 @@ class SpecificSubclassOfGenericSubclass(GenericSubclassOfGenericBase[int]):
 @pytest.mark.parametrize(
     "specialized_type, type_var_mapping",
     [
-        (IntThing, (GenThing, {T: int})),
-        (IntThingy, (GenThingy, {T: int})),
+        (SpecificSubclassOfGenericBase, (GenericBase, {T: int})),
+        (SpecificSubclassOfGenericSubclass, (GenericSubclassOfGenericBase, {R: int})),
+        (GenericSubclassOfGenericBase[int], (GenericBase, {T: int})),
     ],  # pyright: ignore [reportUnknownArgumentType]
 )
 def test_type_var_mapping(

--- a/tests/utils/test_hints.py
+++ b/tests/utils/test_hints.py
@@ -7,19 +7,19 @@ from xdsl.utils.hints import get_type_var_mapping
 T = TypeVar("T")
 
 
-class GenThing(Generic[T]):
+class GenericBase(Generic[T]):
     pass
 
 
-class GenThingy(GenThing[T]):
+class GenericSubclassOfGenericBase(GenericBase[T]):
     pass
 
 
-class IntThing(GenThing[int]):
+class SpecificSubclassOfGenericBase(GenericBase[int]):
     pass
 
 
-class IntThingy(GenThingy[int]):
+class SpecificSubclassOfGenericSubclass(GenericSubclassOfGenericBase[int]):
     pass
 
 

--- a/tests/utils/test_hints.py
+++ b/tests/utils/test_hints.py
@@ -25,7 +25,10 @@ class IntThingy(GenThingy[int]):
 
 @pytest.mark.parametrize(
     "specialized_type, type_var_mapping",
-    [(IntThing, (GenThing, {T: int})), (IntThingy, (GenThingy, {T: int}))],
+    [
+        (IntThing, (GenThing, {T: int})),
+        (IntThingy, (GenThingy, {T: int})),
+    ],  # pyright: ignore [reportUnknownArgumentType]
 )
 def test_type_var_mapping(
     specialized_type: type, type_var_mapping: tuple[type, dict[TypeVar, type]]

--- a/tests/utils/test_hints.py
+++ b/tests/utils/test_hints.py
@@ -1,0 +1,33 @@
+from typing import Generic, TypeVar
+
+import pytest
+
+from xdsl.utils.hints import get_type_var_mapping
+
+T = TypeVar("T")
+
+
+class GenThing(Generic[T]):
+    pass
+
+
+class GenThingy(GenThing[T]):
+    pass
+
+
+class IntThing(GenThing[int]):
+    pass
+
+
+class IntThingy(GenThingy[int]):
+    pass
+
+
+@pytest.mark.parametrize(
+    "specialized_type, type_var_mapping",
+    [(IntThing, (GenThing, {T: int})), (IntThingy, (GenThingy, {T: int}))],
+)
+def test_type_var_mapping(
+    specialized_type: type, type_var_mapping: tuple[type, dict[TypeVar, type]]
+):
+    assert get_type_var_mapping(specialized_type) == type_var_mapping

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -122,7 +122,7 @@ def get_type_var_from_generic_class(cls: type[Any]) -> tuple[TypeVar, ...]:
     """Return the `TypeVar` used in the class `Generic` parent."""
     cls_orig_bases: Iterable[Any] = getattr(cls, "__orig_bases__")
     for orig_base in cls_orig_bases:
-        if get_origin(orig_base) == Generic:
+        if (o := get_origin(orig_base)) is not None and issubclass(o, Generic):
             return get_args(orig_base)
     raise ValueError(f"{cls} class does not have a `Generic` parent.")
 


### PR DESCRIPTION
Some experiments on improving generic helpers we offer. Still not crystal clear how I plan to use them, I have something in mind, will stack if it works!

For example, currently `get_type_var_from_generic_class` (used in `get_type_var_mapping`) is - to me - overprotective, and does not allow any Generic specialization not done directly at the Generic child level; i.e: (see added test)
```python
T = TypeVar("T")
R = TypeVar("R")

class GenericBase(Generic[T]):
    pass

class GenericSubclassOfGenericBase(GenericBase[R]):
    pass

class SpecificSubclassOfGenericSubclass(GenericSubclassOfGenericBase[int]):
    pass
```
```
E       ValueError: <class 'test_hints.SpecificSubclassOfGenericSubclass'> class does not have a `Generic` parent.
```
This PR adds some logic to return
```python
(SpecificSubclassOfGenericSubclass, {R: int})
```
in that case, which feels closer to the expected behavior to me?
I add support for GenericAliases too.

I'd love to get the information `T : int` out of it too.
