### PR TITLE
dialects: Correct affine.for verifier.

### DIFF
--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -4,6 +4,7 @@ from xdsl.dialects.affine import For, Yield
 from xdsl.dialects.builtin import AffineMapAttr, IndexType, IntegerAttr, IntegerType
 from xdsl.ir import Attribute, Block, Region
 from xdsl.ir.affine import AffineExpr
+from xdsl.utils.exceptions import VerifyException
 
 
 def test_simple_for():
@@ -24,9 +25,11 @@ def test_for_mismatch_operands_results_counts():
         attributes=attributes,
         result_types=[IndexType()],
     )
-    with pytest.raises(Exception) as e:
+    with pytest.raises(
+        VerifyException,
+        match="Expected as many operands as results, lower bound args and upper bound args.",
+    ):
         f.verify()
-    assert e.value.args[0] == "Expected the same amount of operands and results"
 
 
 def test_for_mismatch_operands_results_types():
@@ -43,12 +46,11 @@ def test_for_mismatch_operands_results_types():
         attributes=attributes,
         result_types=[IndexType()],
     )
-    with pytest.raises(Exception) as e:
+    with pytest.raises(
+        VerifyException,
+        match="Expected all operands and result pairs to have matching types",
+    ):
         f.verify()
-    assert (
-        e.value.args[0]
-        == "Expected all operands and result pairs to have matching types"
-    )
 
 
 def test_for_mismatch_blockargs():
@@ -65,12 +67,11 @@ def test_for_mismatch_blockargs():
         attributes=attributes,
         result_types=[IndexType()],
     )
-    with pytest.raises(Exception) as e:
+    with pytest.raises(
+        VerifyException,
+        match="Expected BlockArguments to have the same types as the operands",
+    ):
         f.verify()
-    assert (
-        e.value.args[0]
-        == "Expected BlockArguments to have the same types as the operands"
-    )
 
 
 def test_yield():

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -23,6 +23,13 @@
       %next_value = "test.op"() : () -> !test.type<"int">
       "affine.yield"(%next_value) : (!test.type<"int">) -> ()
     }) {"lower_bound" = affine_map<() -> (-10)>, "upper_bound" = affine_map<() -> (10)>, "step" = 1 : index} : (!test.type<"int">) -> (!test.type<"int">)
+    %00 = "test.op"() : () -> index
+    %N = "test.op"() : () -> index
+    %res2 = "affine.for"(%00, %N, %init_value) ({
+    ^1(%i : index, %step_value : !test.type<"int">):
+      %next_value = "test.op"() : () -> !test.type<"int">
+      "affine.yield"(%next_value) : (!test.type<"int">) -> ()
+    }) {"lower_bound" = affine_map<(d0) -> (d0)>, "upper_bound" = affine_map<()[s0] -> (s0)>, "step" = 1 : index} : (index, index, !test.type<"int">) -> (!test.type<"int">)
 
     // CHECK:      %res = "affine.for"(%{{.*}}) ({
     // CHECK-NEXT: ^1(%{{.*}} : index, %{{.*}} : !test.type<"int">):


### PR DESCRIPTION
The verifier of affine.for was working on the assumption that no runtime dimension or symbols were used in the bounds.
NB, I don't use multiple variadic operands, because apparently MLIR doesn't use the segment sizes either for this operation :thinking: so I'm repeating a bit of IRDL work.