### PR TITLE
core: Fix scalar memref printing.

### DIFF
--- a/tests/filecheck/parser-printer/builtin_attrs.mlir
+++ b/tests/filecheck/parser-printer/builtin_attrs.mlir
@@ -190,6 +190,12 @@
   // CHECK: memref<2xf32>
 
   "func.func"() ({}) {function_type = () -> (),
+                      memref = memref<f32>,
+                      sym_name = "scalar_memref"} : () -> ()
+
+  // CHEDCK: memref<f32> 
+
+  "func.func"() ({}) {function_type = () -> (),
                       memref = memref<2x?xf32>,
                       sym_name = "semidynamic_memref"} : () -> ()
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -591,14 +591,16 @@ class Printer:
         if isinstance(attribute, MemRefType):
             attribute = cast(MemRefType[Attribute], attribute)
             self.print("memref<")
-            self.print_list(
-                attribute.shape.data,
-                lambda x: self.print(x.value.data)
-                if x.value.data != -1
-                else self.print("?"),
-                "x",
-            )
-            self.print("x", attribute.element_type)
+            if len(attribute.shape.data) > 0:
+                self.print_list(
+                    attribute.shape.data,
+                    lambda x: self.print(x.value.data)
+                    if x.value.data != -1
+                    else self.print("?"),
+                    "x",
+                )
+                self.print("x")
+            self.print(attribute.element_type)
             if not isinstance(attribute.layout, NoneAttr):
                 self.print(", ", attribute.layout)
             if not isinstance(attribute.memory_space, NoneAttr):


### PR DESCRIPTION
We currently parse `memref<f64>` correctly but print it back as `memref<xf64>`.