### PR TITLE
dialects: Implement memref.alloca_scope and memref.alloca_scope.return.

### DIFF
--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -1,6 +1,12 @@
 // RUN: XDSL_ROUNDTRIP
 
 builtin.module {
+  func.func @memref_alloca_scope() {
+    "memref.alloca_scope"() ({
+      "memref.alloca_scope.return"() : () -> ()
+    }) : () -> ()
+    func.return
+  }
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
   func.func private @memref_test() {
     %0 = "memref.get_global"() {"name" = @g} : () -> memref<1xindex>
@@ -22,6 +28,12 @@ builtin.module {
 }
 
 // CHECK-NEXT: builtin.module {
+// CHECK-NEXT:    func.func @memref_alloca_scope() {
+// CHECK-NEXT:      "memref.alloca_scope"() ({
+// CHECK-NEXT:        "memref.alloca_scope.return"() : () -> ()
+// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
 // CHECK-NEXT:   "memref.global"() <{"sym_name" = "g", "sym_visibility" = "public", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ()
 // CHECK-NEXT:   func.func private @memref_test() {
 // CHECK-NEXT:     %{{.*}} = "memref.get_global"() <{"name" = @g}> : () -> memref<1xindex>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_custom.mlir
@@ -1,5 +1,11 @@
 // RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
 
+func.func @memref_alloca_scope() {
+"memref.alloca_scope"() ({
+    "memref.alloca_scope.return"() : () -> ()
+}) : () -> ()
+func.return
+}
 %v0 = "test.op"() : () -> (i32)
 %i0 = "test.op"() : () -> (index)
 %i1 = "test.op"() : () -> (index)
@@ -11,7 +17,12 @@ memref.store %v0, %m[%i0, %i1] {"nontemporal" = true} : memref<2x3xi32>
 %v2 = memref.load %m[%i0, %i1] {"nontemporal" = false} : memref<2x3xi32>
 %v3 = memref.load %m[%i0, %i1] {"nontemporal" = true} : memref<2x3xi32>
 
-// CHECK:      module {
+// CHECK:       module {
+// CHECK-NEXT:    func.func @memref_alloca_scope() {
+// CHECK-NEXT:      memref.alloca_scope  {
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
 // CHECK-NEXT:   %0 = "test.op"() : () -> i32
 // CHECK-NEXT:   %1 = "test.op"() : () -> index
 // CHECK-NEXT:   %2 = "test.op"() : () -> index


### PR DESCRIPTION
Mirror `memref.alloca_scope` and `memref.alloca_scope.return` from MLIR.