### PR TITLE
dialects: (hw) Add InnerSymTarget class to HW dialect

### DIFF
--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -1,0 +1,27 @@
+"""
+Test HW traits and interfaces.
+"""
+
+
+from xdsl.dialects.hw import (
+    InnerSymTarget,
+)
+from xdsl.dialects.test import TestOp
+
+
+def test_inner_sym_target():
+    invalid_target = InnerSymTarget()
+    assert not invalid_target
+
+    operand1 = TestOp()
+
+    target = InnerSymTarget(operand1)
+    assert target
+    assert target.is_op_only()
+    assert not target.is_field()
+
+    sub_target = InnerSymTarget.get_target_for_subfield(target, 1)
+    assert isinstance(sub_target, InnerSymTarget)
+    assert sub_target
+    assert not sub_target.is_op_only()
+    assert sub_target.is_field()

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -5,6 +5,8 @@ It currently implements minimal types and operations used by other dialects.
 [1] https://circt.llvm.org/docs/Dialects/HW/
 """
 
+from dataclasses import dataclass
+
 from xdsl.dialects.builtin import (
     FlatSymbolRefAttr,
     ParameterDef,
@@ -22,6 +24,34 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
+
+
+@dataclass
+class InnerSymTarget:
+    """The target of an inner symbol, the entity the symbol is a handle for."""
+
+    op: Operation | None = None
+    field_id: int = 0
+    port_idx: int | None = None
+
+    def __bool__(self):
+        # None-valued op defines an invalid target
+        return self.op is not None
+
+    def is_port(self) -> bool:
+        return self.port_idx is not None
+
+    def is_field(self) -> bool:
+        return self.field_id != 0
+
+    def is_op_only(self) -> bool:
+        return not self.is_field() and not self.is_port()
+
+    @classmethod
+    def get_target_for_subfield(
+        cls, base: "InnerSymTarget", field_id: int
+    ) -> "InnerSymTarget":
+        return cls(base.op, base.field_id + field_id, base.port_idx)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -28,14 +28,17 @@ from xdsl.printer import Printer
 
 @dataclass
 class InnerSymTarget:
-    """The target of an inner symbol, the entity the symbol is a handle for."""
+    """The target of an inner symbol, the entity the symbol is a handle for.
+
+    A None operation defines an invalid target, which is returned from InnerSymbolTable.lookup()
+    when no matching operation is found. An invalid target is falsey when constrained to bool.
+    """
 
     op: Operation | None = None
     field_id: int = 0
     port_idx: int | None = None
 
     def __bool__(self):
-        # None-valued op defines an invalid target
         return self.op is not None
 
     def is_port(self) -> bool:
@@ -51,6 +54,10 @@ class InnerSymTarget:
     def get_target_for_subfield(
         cls, base: "InnerSymTarget", field_id: int
     ) -> "InnerSymTarget":
+        """
+        Return a target to the specified field within the given base.
+        `field_id` is relative to the specified base target.
+        """
         return cls(base.op, base.field_id + field_id, base.port_idx)
 
 


### PR DESCRIPTION
InnerSymTarget is a utility class that is used to store the targets of inner symbols. It is not usable as part of the dialect, but will be used by classes in `HW`. I’m not sure if there’s much more to test about it -- it’s really just there to keep a reference to an operation with some additional metadata.

Standalone PR in an effort to keep them small and reviewable -- see #1704 for context.