### PR TITLE
misc: remove flake8 config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,16 +101,6 @@ exclude = """
 |xdsl/_version.py$
 """
 
-[tool.flake8]
-max-line-length = 90
-ignore = "F403,E226,E731,E275,W503,F405,E722,E741,W504,W605,E402"
-exclude = [".github"]
-
-[tool.flake8_nb]
-max-line-length = 90
-ignore = "F403,E226,E731,E275,W503,F405,E722,E741,W504,W605,E402"
-exclude = [".github"]
-
 [tool.pytest.ini_options]
 python_files = ["tests/*test_*.py", "docs/*test_*.py"]
 python_classes = "Test_*"


### PR DESCRIPTION
I accidentally enabled `flake8` on my computer today, to find that we're in violation of some of the rules. We don't actually specify it as a dependency, and my understanding is that ruff is now the source of truth wrt formatting, so we might as well get rid of these lines of spec.