### PR TITLE
dialects: (hw) Add InnerSymbolTable and InnerRefNamespace to HW dialect

### DIFF
--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -2,11 +2,36 @@
 Test HW traits and interfaces.
 """
 
+from unittest.mock import ANY, patch
 
+import pytest
+
+from xdsl.dialects.builtin import StringAttr
 from xdsl.dialects.hw import (
+    InnerRefAttr,
+    InnerRefNamespaceTrait,
+    InnerRefUserOpInterfaceTrait,
+    InnerSymbolTableCollection,
+    InnerSymbolTableTrait,
     InnerSymTarget,
 )
 from xdsl.dialects.test import TestOp
+from xdsl.irdl import (
+    IRDLOperation,
+    Region,
+    attr_def,
+    irdl_op_definition,
+    opt_region_def,
+    region_def,
+)
+from xdsl.traits import (
+    IsTerminator,
+    SingleBlockImplicitTerminator,
+    SymbolOpInterface,
+    SymbolTable,
+    ensure_terminator,
+)
+from xdsl.utils.exceptions import VerifyException
 
 
 def test_inner_sym_target():
@@ -25,3 +50,221 @@ def test_inner_sym_target():
     assert sub_target
     assert not sub_target.is_op_only()
     assert sub_target.is_field()
+
+
+# Module / Circuit / Wire / Output naming taken from FIRRTL classes using these interfaces.
+@irdl_op_definition
+class ModuleOp(IRDLOperation):
+    name = "module"
+    region = region_def()
+    sym_name = attr_def(StringAttr)
+    traits = frozenset({InnerSymbolTableTrait(), SymbolOpInterface()})
+
+
+@irdl_op_definition
+class OutputOp(IRDLOperation):
+    name = "output"
+    traits = frozenset({IsTerminator()})
+
+
+@irdl_op_definition
+class CircuitOp(IRDLOperation):
+    name = "circuit"
+    region: Region | None = opt_region_def()
+    sym_name = attr_def(StringAttr)
+    traits = frozenset(
+        {
+            InnerRefNamespaceTrait(),
+            SymbolTable(),
+            SingleBlockImplicitTerminator(OutputOp),
+        }
+    )
+
+    def __post_init__(self):
+        for trait in self.get_traits_of_type(SingleBlockImplicitTerminator):
+            ensure_terminator(self, trait)
+
+
+@irdl_op_definition
+class WireOp(IRDLOperation):
+    name = "wire"
+    sym_name = attr_def(StringAttr)
+    traits = frozenset({InnerRefUserOpInterfaceTrait()})
+
+
+def test_inner_symbol_table_interface():
+    """
+    Test operations that conform to InnerSymbolTableTrait
+    """
+    mod = ModuleOp(
+        attributes={"sym_name": StringAttr("symbol_name")}, regions=[[OutputOp()]]
+    )
+
+    circ = CircuitOp(attributes={"sym_name": StringAttr("other_name")}, regions=[[mod]])
+    circ.verify()
+
+    mod_no_parent = ModuleOp(
+        attributes={"sym_name": StringAttr("symbol_name")}, regions=[[OutputOp()]]
+    )
+    with pytest.raises(
+        VerifyException,
+        match="Operation module with trait InnerSymbolTableTrait must have a parent with trait SymbolOpInterface",
+    ):
+        mod_no_parent.verify()
+
+    mod_no_trait_circ = ModuleOp(
+        attributes={"sym_name": StringAttr("symbol_name")}, regions=[[OutputOp()]]
+    )
+    no_trait_circ = TestOp(regions=[[mod_no_trait_circ, OutputOp()]])
+    with pytest.raises(
+        VerifyException,
+        match="Operation module with trait InnerSymbolTableTrait must have a parent with trait InnerRefNamespaceTrait",
+    ):
+        mod_no_trait_circ.verify()
+    with pytest.raises(
+        VerifyException,
+        match="Operation module with trait InnerSymbolTableTrait must have a parent with trait InnerRefNamespaceTrait",
+    ):
+        no_trait_circ.verify()
+
+    @irdl_op_definition
+    class MissingTraitModuleOp(IRDLOperation):
+        name = "module"
+        region = region_def()
+        sym_name = attr_def(StringAttr)
+        traits = frozenset({InnerSymbolTableTrait()})
+
+    mod_missing_trait = MissingTraitModuleOp(
+        attributes={"sym_name": StringAttr("symbol_name")}, regions=[[OutputOp()]]
+    )
+    circ_mod_missing_trait = CircuitOp(regions=[[mod_missing_trait, OutputOp()]])
+    with pytest.raises(
+        VerifyException, match="Operation module must have trait SymbolOpInterface"
+    ):
+        mod_missing_trait.verify()
+    with pytest.raises(
+        VerifyException, match="Operation module must have trait SymbolOpInterface"
+    ):
+        circ_mod_missing_trait.verify()
+
+    @irdl_op_definition
+    class MissingAttrModuleOp(IRDLOperation):
+        name = "module"
+        region = region_def()
+        traits = frozenset({InnerSymbolTableTrait(), SymbolOpInterface()})
+
+    mod_missing_trait_parent = ModuleOp(regions=[[OutputOp()]])
+    MissingAttrModuleOp(regions=[[mod_missing_trait_parent, OutputOp()]])
+    with pytest.raises(
+        VerifyException,
+        match="attribute sym_name expected",
+    ):
+        mod_missing_trait_parent.verify()
+
+
+def test_inner_ref_namespace_interface():
+    """
+    Test operations that conform to InnerRefNamespaceTrait
+    """
+
+    @irdl_op_definition
+    class MissingTraitCircuitOp(IRDLOperation):
+        name = "circuit"
+        region: Region | None = opt_region_def()
+        sym_name = attr_def(StringAttr)
+        traits = frozenset(
+            {InnerRefNamespaceTrait(), SingleBlockImplicitTerminator(OutputOp)}
+        )
+
+    wire0 = WireOp(attributes={"sym_name": StringAttr("wire0")})
+    mod0 = MissingTraitCircuitOp(
+        attributes={"sym_name": StringAttr("mod0")}, regions=[[wire0, OutputOp()]]
+    )
+    circuit_no_symboltable = CircuitOp(
+        attributes={"sym_name": StringAttr("circuit")}, regions=[[mod0]]
+    )
+
+    with pytest.raises(
+        VerifyException, match="Operation circuit must have trait SymbolTable"
+    ):
+        circuit_no_symboltable.verify()
+
+    wire1 = WireOp(attributes={"sym_name": StringAttr("wire1")})
+    wire2 = WireOp(attributes={"sym_name": StringAttr("wire2")})
+    mod1 = ModuleOp(
+        attributes={"sym_name": StringAttr("mod1")}, regions=[[wire1, OutputOp()]]
+    )
+    mod2 = ModuleOp(
+        attributes={"sym_name": StringAttr("mod2")}, regions=[[wire2, OutputOp()]]
+    )
+    circuit = CircuitOp(
+        attributes={"sym_name": StringAttr("circuit")}, regions=[[mod1, mod2]]
+    )
+
+    # InnerRefUserOpInterfaceTrait.verify_inner_refs() does not do anything, so just mock
+    # to check it is called
+    with patch.object(
+        InnerRefUserOpInterfaceTrait, "verify_inner_refs"
+    ) as inner_ref_verif:
+        circuit.verify()
+
+    inner_ref_verif.assert_any_call(wire1, ANY)
+    inner_ref_verif.assert_any_call(wire2, ANY)
+    assert inner_ref_verif.call_count == 2
+
+
+def test_inner_symbol_table_collection():
+    """
+    Test operations that pertain to InnerSymbolTableCollection
+    """
+    wire1 = WireOp(attributes={"sym_name": StringAttr("wire1")})
+    wire2 = WireOp(attributes={"sym_name": StringAttr("wire2")})
+    mod1 = ModuleOp(
+        attributes={"sym_name": StringAttr("mod1")}, regions=[[wire1, OutputOp()]]
+    )
+    mod2 = ModuleOp(
+        attributes={"sym_name": StringAttr("mod2")}, regions=[[wire2, OutputOp()]]
+    )
+    circuit = CircuitOp(
+        attributes={"sym_name": StringAttr("circuit")}, regions=[[mod1, mod2]]
+    )
+
+    inner_sym_tables = InnerSymbolTableCollection(op=circuit)
+
+    with pytest.raises(
+        VerifyException, match="Operation wire should have InnerSymbolTableTrait trait"
+    ):
+        inner_sym_tables.get_inner_symbol_table(wire1)
+
+    sym_table1 = inner_sym_tables.get_inner_symbol_table(mod1)
+    sym_table2 = inner_sym_tables.get_inner_symbol_table(mod2)
+    assert (
+        sym_table1 is not sym_table2
+    ), "Different InnerSymbolTableTrait objects must return different instances of inner symbol tables"
+
+    unpopulated_inner_sym_tables = InnerSymbolTableCollection()
+    sym_table3 = unpopulated_inner_sym_tables.get_inner_symbol_table(mod1)
+    sym_table4 = unpopulated_inner_sym_tables.get_inner_symbol_table(mod2)
+    assert (
+        sym_table3 is not sym_table4
+    ), "InnerSymbolTableTrait still behave as expected when created on the fly"
+
+
+def test_inner_ref_attr():
+    """
+    Test inner reference attributes
+    """
+    wire1 = WireOp(attributes={"sym_name": StringAttr("wire1")})
+    wire2 = WireOp(attributes={"sym_name": StringAttr("wire2")})
+    mod1 = ModuleOp(
+        attributes={"sym_name": StringAttr("mod1")}, regions=[[wire1, OutputOp()]]
+    )
+    mod2 = ModuleOp(
+        attributes={"sym_name": StringAttr("mod2")}, regions=[[wire2, OutputOp()]]
+    )
+    CircuitOp(attributes={"sym_name": StringAttr("circuit")}, regions=[[mod1, mod2]])
+
+    ref = InnerRefAttr("mod2", "wire2")
+    assert (
+        ref.get_module().data == "mod2"
+    ), "Name of the referenced module should be returned correctly"

--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -229,7 +229,17 @@ def test_inner_symbol_table_collection():
         attributes={"sym_name": StringAttr("circuit")}, regions=[[mod1, mod2]]
     )
 
-    inner_sym_tables = InnerSymbolTableCollection(op=circuit)
+    with pytest.raises(
+        VerifyException, match="Operation wire should have InnerRefNamespaceTrait trait"
+    ):
+        inner_sym_tables = InnerSymbolTableCollection(wire1)
+
+    inner_sym_tables = InnerSymbolTableCollection(circuit)
+
+    with pytest.raises(
+        VerifyException, match=r"Trying to insert the same op twice in symbol tables:"
+    ):
+        inner_sym_tables.populate_and_verify_tables(circuit)
 
     with pytest.raises(
         VerifyException, match="Operation wire should have InnerSymbolTableTrait trait"

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -194,7 +194,7 @@ class InnerSymbolTableCollection:
         for op in inner_sym_table_ops:
             if op in self.symbol_tables:
                 raise VerifyException(
-                    f"Trying to insert the same op {op} twice in symbol tables"
+                    f"Trying to insert the same op twice in symbol tables: {op}"
                 )
             self.symbol_tables[op] = InnerSymbolTable(op)
 
@@ -220,11 +220,8 @@ class InnerRefNamespaceTrait(OpTrait):
                 f"Operation {op.name} must have trait {trait.__name__}"
             )
 
-        # These 2 checks are in fact redundant, as already checked as a SymbolTable
-        if len(op.regions) != 1:
-            raise VerifyException(f"Operation {op.name} must have a single region")
-        if len(op.regions[0].blocks) != 1:
-            raise VerifyException(f"Operation {op.name} must have a single block")
+        # Upstreams verifies that len(op.regions) == 1 and len(op.regions[0].blocks) == 1
+        # however this is already checked as part of SymbolTable, so would be redundant to re-check here
 
         namespace = InnerRefNamespace(op)
 

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -1,11 +1,12 @@
 """
 This is a stub of CIRCT’s hw dialect.
-It currently implements minimal types and operations used by other dialects.
+It currently implements minimal types and operations for the symbols and inner symbols used by other dialects.
 
 [1] https://circt.llvm.org/docs/Dialects/HW/
+[2] https://circt.llvm.org/docs/RationaleSymbols/
 """
 
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass, field
 
 from xdsl.dialects.builtin import (
     FlatSymbolRefAttr,
@@ -24,6 +25,12 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
+from xdsl.traits import (
+    OpTrait,
+    SymbolOpInterface,
+    SymbolTable,
+)
+from xdsl.utils.exceptions import VerifyException
 
 
 @dataclass
@@ -110,6 +117,138 @@ class InnerRefAttr(ParametrizedAttribute):
         printer.print_string("::@")
         printer.print_string(self.sym_name.data)
         printer.print_string(">")
+
+
+@dataclass(frozen=True)
+class InnerSymbolTableTrait(OpTrait):
+    """A trait for inner symbol table functionality on an operation."""
+
+    def verify(self, op: Operation):
+        # Insist that ops with InnerSymbolTable's provide a Symbol, this is
+        # essential to how InnerRef's work.
+        if not op.has_trait(trait := SymbolOpInterface):
+            raise VerifyException(
+                f"Operation {op.name} must have trait {trait.__name__}"
+            )
+
+        # InnerSymbolTable's must be directly nested within an InnerRefNamespaceTrait,
+        # however don’t test InnerRefNamespace’s symbol lookups
+        parent = op.parent_op()
+        if (
+            parent is None
+            or len(parent.get_traits_of_type(trait := InnerRefNamespaceTrait)) != 1
+        ):
+            raise VerifyException(
+                f"Operation {op.name} with trait {type(self).__name__} must have a parent with trait {trait.__name__}"
+            )
+
+
+@dataclass
+class InnerSymbolTable:
+    """A class for lookups in inner symbol tables. Called InnerSymbolTable in upstream (name clash with trait)."""
+
+    op: InitVar[Operation | None] = None
+    symbol_table: dict[StringAttr, InnerSymTarget] = field(default_factory=dict)
+
+    def __post_init__(self, op: Operation | None = None) -> None:
+        pass
+        # Here will populate self.symbol_table
+
+
+@dataclass
+class InnerSymbolTableCollection:
+    """This class represents a collection of InnerSymbolTable."""
+
+    symbol_tables: dict[Operation, InnerSymbolTable] = field(
+        default_factory=dict, init=False
+    )
+    op: InitVar[Operation | None] = None
+
+    def __post_init__(self, op: Operation | None = None) -> None:
+        if op is None:
+            return
+        if not op.has_trait(trait := InnerRefNamespaceTrait):
+            raise VerifyException(
+                f"Operation {op.name} should have {trait.__name__} trait"
+            )
+        self.populate_and_verify_tables(op)
+
+    def get_inner_symbol_table(self, op: Operation) -> InnerSymbolTable:
+        """Returns the InnerSymolTable trait, ensuring `op` is in the collection"""
+        if not op.has_trait(trait := InnerSymbolTableTrait):
+            raise VerifyException(
+                f"Operation {op.name} should have {trait.__name__} trait"
+            )
+        if op not in self.symbol_tables:
+            self.symbol_tables[op] = InnerSymbolTable(op)
+        return self.symbol_tables[op]
+
+    def populate_and_verify_tables(self, inner_ref_ns_op: Operation):
+        """Populate tables for all InnerSymbolTable operations in the given InnerRefNamespace operation, verifying each."""
+        # Gather top-level operations that have the InnerSymbolTable trait.
+        inner_sym_table_ops = (
+            op for op in inner_ref_ns_op.walk() if op.has_trait(InnerSymbolTableTrait)
+        )
+
+        # Construct the tables
+        for op in inner_sym_table_ops:
+            if op in self.symbol_tables:
+                raise VerifyException(
+                    f"Trying to insert the same op {op} twice in symbol tables"
+                )
+            self.symbol_tables[op] = InnerSymbolTable(op)
+
+
+class InnerRefUserOpInterfaceTrait(OpTrait):
+    """This interface describes an operation that may use a `InnerRef`. This
+    interface allows for users of inner symbols to hook into verification and
+    other inner symbol related utilities that are either costly or otherwise
+    disallowed within a traditional operation."""
+
+    def verify_inner_refs(self, op: Operation, namespace: "InnerRefNamespace"):
+        """Verify the inner ref uses held by this operation."""
+        ...
+
+
+@dataclass(frozen=True)
+class InnerRefNamespaceTrait(OpTrait):
+    """Trait for operations defining a new scope for InnerRef’s. Operations with this trait must be a SymbolTable."""
+
+    def verify(self, op: Operation):
+        if not op.has_trait(trait := SymbolTable):
+            raise VerifyException(
+                f"Operation {op.name} must have trait {trait.__name__}"
+            )
+
+        # These 2 checks are in fact redundant, as already checked as a SymbolTable
+        if len(op.regions) != 1:
+            raise VerifyException(f"Operation {op.name} must have a single region")
+        if len(op.regions[0].blocks) != 1:
+            raise VerifyException(f"Operation {op.name} must have a single block")
+
+        namespace = InnerRefNamespace(op)
+
+        for inner_op in op.walk():
+            inner_ref_user_op_trait = inner_op.get_trait(InnerRefUserOpInterfaceTrait)
+            if inner_ref_user_op_trait is not None:
+                inner_ref_user_op_trait.verify_inner_refs(inner_op, namespace)
+
+
+@dataclass
+class InnerRefNamespace:
+    """Class to perform symbol lookups within a InnerRef namespace, used during verification.
+    Combines InnerSymbolTableCollection with a SymbolTable for resolution of InnerRefAttrs.
+
+    Inner symbols are more costly than normal symbols, with tricker verification. For this reason,
+    verification is driven as a trait verifier on InnerRefNamespace which constructs and verifies InnerSymbolTables in parallel.
+    See: https://circt.llvm.org/docs/RationaleSymbols/#innerrefnamespace
+    """
+
+    inner_sym_tables: InnerSymbolTableCollection = field(init=False)
+    inner_ref_ns_op: InitVar[Operation]
+
+    def __init__(self, inner_ref_ns_op: Operation):
+        self.inner_sym_tables = InnerSymbolTableCollection(inner_ref_ns_op)
 
 
 HW = Dialect(


### PR DESCRIPTION
This is another standalone part of #1704 (which you can refer to for broader context). It introduces 2 main classes, `InnerSymbolTable` and `InnerRefNamespace` (which are too interconnected to add separately), as well as 2 smaller (and similarly intricated) `InnerSymbolTableCollection` and `InnerRefUserOpInterface`.

Note that I’ve tried reducing as much as I could but this is as small as I can make this contribution (~150 loc / 4 classes + tests).

The PR introduces a verification step, called `verifyInnerRefs`:
- I think the most explicit description is from the [Symbol and Inner Symbol Rationale document](https://circt.llvm.org/docs/RationaleSymbols/#innerrefnamespace):

  > **InnerRefNamespace**
  > 
  > [As class:] Combines InnerSymbolTableCollection with a SymbolTable for resolution of InnerRefAttrs, primarily used during verification as argument to the verifyInnerRefs hook which operations may use for more efficient checking of InnerRefAttrs.
  > 
  > [As trait:] InnerRefNamespace is used by Operations to define a new scope for InnerRef’s. Operations with this trait must also be a SymbolTable. Presently the only user is CircuitOp.
  > 
  > Inner symbols are more costly than normal symbols, precisely from the relaxation of MLIR symbol constraints. Since nested regions are allowed, finding all operations defining an inner_sym requires a recursive IR scan.
  > Verification is likewise trickier, partly due the significant increase in non-local references.
  > 
  > For this reason, verification is driven as a trait verifier on InnerRefNamespace which constructs and verifies InnerSymbolTables in parallel, and uses these to conduct a per-InnerSymbolTable parallelized walk to verify references by calling the verifyInnerRefs hook on InnerRefUserOpInterface operations.

  I’ve tried to summarise this in the `InnerRefNamespace` docstring.
- I still have a couple of doubts on how/where this `verify_inner_refs()` should be called. It seems to be called primarily from `verifyRegionTrait`, though I couldn’t find what that corresponds to in xdsl terminology. Just a `verify()` or `verify_()`?  
- <details><summary><code>verify_inner_refs</code> is additionally called in a <code>VerifyInnerRefNamespacePass</code> HW transform, but I left that out for now as it seems we can do without it (at least for now).</summary> 
  
  - The doc for `VerifyInnerRefNamespacePass` says it’s used to “_to drive verification of operations that want to be InnerRefNamespace's but don't have the trait_” using `InnerRefNamespaceLike` to find applicable operations.  
  - `InnerRefNamespaceLike` interface in turn says “_Classify operations that are InnerRefNamespace-like, until structure is in place to do this via Traits. […] Prefer putting the trait on operations here or downstream._”.
  </details>

@PapyChacal since AFAIU you worked on the main symbol table, can you try and see if I tested this right, and find what more could be tested in here? Especially I think my attempts at creating synthetic ops using the interfaces in the python tests might be clunky/simplifiable.