### PR TITLE
dialects: Add memref.memory_space_cast

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -22,8 +22,8 @@ from xdsl.dialects.memref import (
     DmaWaitOp,
     ExtractAlignedPointerAsIndexOp,
     Load,
-    MemRefType,
     MemorySpaceCast,
+    MemRefType,
     Store,
     Subview,
     UnrankedMemrefType,
@@ -261,22 +261,35 @@ def test_memref_cast():
 
 
 def test_memref_memory_space_cast():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
+    i32_memref_type = MemRefType.from_element_type_and_shape(
+        i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32)
+    )
     memref_ssa_value = TestSSAValue(i32_memref_type)
 
-    res_type = MemRefType.from_element_type_and_shape(i32, [10, 2], memory_space=builtin.IntegerAttr(2, i32))
-    res_type_wrong_type = MemRefType.from_element_type_and_shape(i64, [10, 2], memory_space=builtin.IntegerAttr(2, i32))
-    res_type_wrong_shape = MemRefType.from_element_type_and_shape(i32, [10, 4], memory_space=builtin.IntegerAttr(2, i32))
+    res_type = MemRefType.from_element_type_and_shape(
+        i32, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
+    )
+    res_type_wrong_type = MemRefType.from_element_type_and_shape(
+        i64, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
+    )
+    res_type_wrong_shape = MemRefType.from_element_type_and_shape(
+        i32, [10, 4], memory_space=builtin.IntegerAttr(2, i32)
+    )
 
     memory_space_cast = MemorySpaceCast.get(memref_ssa_value, res_type)
 
     assert memory_space_cast.source is memref_ssa_value
     assert memory_space_cast.dest.type is res_type
 
-    with pytest.raises(VerifyException, match="Expected source and destination to have the same element type."):
+    with pytest.raises(
+        VerifyException,
+        match="Expected source and destination to have the same element type.",
+    ):
         MemorySpaceCast.get(memref_ssa_value, res_type_wrong_type).verify()
 
-    with pytest.raises(VerifyException, match="Expected source and destination to have the same shape."):
+    with pytest.raises(
+        VerifyException, match="Expected source and destination to have the same shape."
+    ):
         MemorySpaceCast.get(memref_ssa_value, res_type_wrong_shape).verify()
 
 

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -266,31 +266,13 @@ def test_memref_memory_space_cast():
     )
     memref_ssa_value = TestSSAValue(i32_memref_type)
 
-    res_type = MemRefType.from_element_type_and_shape(
-        i32, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
-    )
-    res_type_wrong_type = MemRefType.from_element_type_and_shape(
-        i64, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
-    )
-    res_type_wrong_shape = MemRefType.from_element_type_and_shape(
-        i32, [10, 4], memory_space=builtin.IntegerAttr(2, i32)
-    )
+    dest_space = builtin.IntegerAttr(2, i32)
 
-    memory_space_cast = MemorySpaceCast(memref_ssa_value, res_type)
+    memory_space_cast = MemorySpaceCast(memref_ssa_value, dest_space)
 
     assert memory_space_cast.source is memref_ssa_value
-    assert memory_space_cast.dest.type is res_type
-
-    with pytest.raises(
-        VerifyException,
-        match="Expected source and destination to have the same element type.",
-    ):
-        MemorySpaceCast(memref_ssa_value, res_type_wrong_type).verify()
-
-    with pytest.raises(
-        VerifyException, match="Expected source and destination to have the same shape."
-    ):
-        MemorySpaceCast(memref_ssa_value, res_type_wrong_shape).verify()
+    assert isinstance(memory_space_cast.dest.type, MemRefType)
+    assert memory_space_cast.dest.type.memory_space is dest_space
 
 
 def test_dma_start():

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -276,7 +276,7 @@ def test_memref_memory_space_cast():
         i32, [10, 4], memory_space=builtin.IntegerAttr(2, i32)
     )
 
-    memory_space_cast = MemorySpaceCast.get(memref_ssa_value, res_type)
+    memory_space_cast = MemorySpaceCast(memref_ssa_value, res_type)
 
     assert memory_space_cast.source is memref_ssa_value
     assert memory_space_cast.dest.type is res_type
@@ -285,12 +285,12 @@ def test_memref_memory_space_cast():
         VerifyException,
         match="Expected source and destination to have the same element type.",
     ):
-        MemorySpaceCast.get(memref_ssa_value, res_type_wrong_type).verify()
+        MemorySpaceCast(memref_ssa_value, res_type_wrong_type).verify()
 
     with pytest.raises(
         VerifyException, match="Expected source and destination to have the same shape."
     ):
-        MemorySpaceCast.get(memref_ssa_value, res_type_wrong_shape).verify()
+        MemorySpaceCast(memref_ssa_value, res_type_wrong_shape).verify()
 
 
 def test_dma_start():

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -266,13 +266,41 @@ def test_memref_memory_space_cast():
     )
     memref_ssa_value = TestSSAValue(i32_memref_type)
 
-    dest_space = builtin.IntegerAttr(2, i32)
+    res_type = MemRefType.from_element_type_and_shape(
+        i32, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
+    )
+    res_type_wrong_type = MemRefType.from_element_type_and_shape(
+        i64, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
+    )
+    res_type_wrong_shape = MemRefType.from_element_type_and_shape(
+        i32, [10, 4], memory_space=builtin.IntegerAttr(2, i32)
+    )
 
-    memory_space_cast = MemorySpaceCast(memref_ssa_value, dest_space)
+    memory_space_cast = MemorySpaceCast(memref_ssa_value, res_type)
+
+    assert memory_space_cast.source is memref_ssa_value
+    assert memory_space_cast.dest.type is res_type
+
+    with pytest.raises(
+        VerifyException,
+        match="Expected source and destination to have the same element type.",
+    ):
+        MemorySpaceCast(memref_ssa_value, res_type_wrong_type).verify()
+
+    with pytest.raises(
+        VerifyException, match="Expected source and destination to have the same shape."
+    ):
+        MemorySpaceCast(memref_ssa_value, res_type_wrong_shape).verify()
+
+    # Test helper function
+    dest_memory_space = builtin.IntegerAttr(2, i32)
+    memory_space_cast = MemorySpaceCast.from_type_and_target_space(
+        memref_ssa_value, i32_memref_type, dest_memory_space
+    )
 
     assert memory_space_cast.source is memref_ssa_value
     assert isinstance(memory_space_cast.dest.type, MemRefType)
-    assert memory_space_cast.dest.type.memory_space is dest_space
+    assert memory_space_cast.dest.type.memory_space is dest_memory_space
 
 
 def test_dma_start():

--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -20,6 +20,7 @@ builtin.module {
     %6 = "memref.subview"(%5) {"operandSegmentSizes" = array<i32: 1, 0, 0, 0>, "static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>} : (memref<10x2xindex>) -> memref<1x1xindex>
     %7 = "memref.cast"(%5) : (memref<10x2xindex>) -> memref<?x?xindex>
     %8 = "memref.alloca"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<1xindex>
+    %9 = "memref.memory_space_cast"(%5) : (memref<10x2xindex>) -> memref<10x2xindex, 1: i32>
     "memref.dealloc"(%2) : (memref<1xindex>) -> ()
     "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
     "memref.dealloc"(%8) : (memref<1xindex>) -> ()
@@ -47,6 +48,7 @@ builtin.module {
 // CHECK-NEXT:     %{{.*}} = "memref.subview"(%5) <{"static_offsets" = array<i64: 0, 0>, "static_sizes" = array<i64: 1, 1>, "static_strides" = array<i64: 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<10x2xindex>) -> memref<1x1xindex>
 // CHECK-NEXT:     %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x2xindex>) -> memref<?x?xindex>
 // CHECK-NEXT:     %{{.*}} = "memref.alloca"() <{"operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<1xindex>
+// CHECK-NEXT:     %{{.*}} = "memref.memory_space_cast"(%{{.*}}) : (memref<10x2xindex>) -> memref<10x2xindex, 1 : i32>
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<10x2xindex>) -> ()
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -600,7 +600,7 @@ class MemorySpaceCast(IRDLOperation):
         type: MemRefType[Attribute] | UnrankedMemrefType[Attribute],
     ):
         return MemorySpaceCast.build(operands=[source], result_types=[type])
-    
+
     def verify_(self) -> None:
         source = cast(MemRefType[Attribute], self.source.type)
         dest = cast(MemRefType[Attribute], self.dest.type)

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -588,6 +588,33 @@ class Cast(IRDLOperation):
 
 
 @irdl_op_definition
+class MemorySpaceCast(IRDLOperation):
+    name = "memref.memory_space_cast"
+
+    source: Operand = operand_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
+    dest: OpResult = result_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
+
+    @staticmethod
+    def get(
+        source: SSAValue | Operation,
+        type: MemRefType[Attribute] | UnrankedMemrefType[Attribute],
+    ):
+        return MemorySpaceCast.build(operands=[source], result_types=[type])
+    
+    def verify_(self) -> None:
+        source = cast(MemRefType[Attribute], self.source.type)
+        dest = cast(MemRefType[Attribute], self.dest.type)
+        if source.get_shape() != dest.get_shape():
+            raise VerifyException(
+                "Expected source and destination to have the same shape."
+            )
+        if source.get_element_type() != dest.get_element_type():
+            raise VerifyException(
+                "Expected source and destination to have the same element type."
+            )
+
+
+@irdl_op_definition
 class DmaStartOp(IRDLOperation):
     name = "memref.dma_start"
 
@@ -727,6 +754,7 @@ MemRef = Dialect(
         ExtractAlignedPointerAsIndexOp,
         Subview,
         Cast,
+        MemorySpaceCast,
         DmaStartOp,
         DmaWaitOp,
     ],

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -594,12 +594,12 @@ class MemorySpaceCast(IRDLOperation):
     source: Operand = operand_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
     dest: OpResult = result_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
 
-    @staticmethod
-    def get(
+    def __init__(
+        self,
         source: SSAValue | Operation,
-        type: MemRefType[Attribute] | UnrankedMemrefType[Attribute],
+        dest: MemRefType[Attribute] | UnrankedMemrefType[Attribute],
     ):
-        return MemorySpaceCast.build(operands=[source], result_types=[type])
+        super().__init__(operands=[source], result_types=[dest])
 
     def verify_(self) -> None:
         source = cast(MemRefType[Attribute], self.source.type)


### PR DESCRIPTION
This PR adds the `memref.memory_space_cast` op to the `memref` dialect.
We intend to use this to properly handle `memref` transfers between the different memory spaces in a snitch cluster.
