### PR TITLE
misc: Add a version flag to xdsl

### DIFF
--- a/tests/filecheck/version.mlir
+++ b/tests/filecheck/version.mlir
@@ -1,0 +1,3 @@
+// RUN: xdsl-opt --version | filecheck %s
+
+//CHECK: xdsl-opt built from xdsl version {{.*}}

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from collections.abc import Callable, Sequence
+from importlib.metadata import version
 from io import StringIO
 from typing import IO
 
@@ -151,6 +152,13 @@ class xDSLOptMain(CommandLineTool):
             default=False,
             action="store_true",
             help="Print operations with debug info annotation, such as location.",
+        )
+
+        arg_parser.add_argument(
+            "-v",
+            "--version",
+            action="version",
+            version=f"xdsl-opt built from xdsl version {version('xdsl')}\n",
         )
 
     def register_pass(self, opPass: type[ModulePass]):


### PR DESCRIPTION
Adds a `--version` flag to xdsl-opt displaying the package version. Helpful for debugging which xdsl-opt is used in any given environment.