### PR TITLE
misc: (Makefile) Use a better message for `tests` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tests-toy: filecheck-toy pytest-toy
 
 # run all tests
 tests: pytest tests-toy filecheck pytest-nb pyright
-	@echo test
+	@echo All tests done.
 
 # re-generate the output from all jupyter notebooks in the docs directory
 rerun-notebooks:


### PR DESCRIPTION
This PR:

- Uses a better message in the `make` target for all tests when they succeed.


Super minor but it started becoming irksome (to me).