### PR TITLE
dialects: (riscv_snitch) add FrepYieldOp to dialect definition

### DIFF
--- a/tests/filecheck/dialects/riscv/frep_verification.mlir
+++ b/tests/filecheck/dialects/riscv/frep_verification.mlir
@@ -36,3 +36,13 @@ riscv_snitch.frep_outer %i0 {
 }
 
 // CHECK: Operation does not verify: Frep operation body may not contain instructions with side-effects, found riscv.sw
+
+// -----
+
+%0 = "test.op"(): () -> !riscv.reg<>
+
+"riscv_snitch.frep_outer"(%0) ({
+^bb0:
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+
+// CHECK: Operation riscv_snitch.frep_outer contains empty block in single-block region that expects at least a terminator

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -15,14 +15,14 @@ riscv_func.func @main() {
     %add_o = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   }
   // CHECK-NEXT:  riscv_snitch.frep_outer %0 {
-  // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT:  }
 
   riscv_snitch.frep_inner %0 {
     %add_i = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   }
   // CHECK-NEXT:  riscv_snitch.frep_inner %0 {
-  // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT:  }
 
   // Terminate block
@@ -37,9 +37,11 @@ riscv_func.func @main() {
 // CHECK-GENERIC-NEXT:     %scfgwi_zero = "riscv_snitch.scfgwi"(%0) {"immediate" = 42 : si12} : (!riscv.reg<>) -> !riscv.reg<zero>
 // CHECK-GENERIC-NEXT:    "riscv_snitch.frep_outer"(%{{.*}}) ({
 // CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"() : () -> ()
 // CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
 // CHECK-GENERIC-NEXT:    "riscv_snitch.frep_inner"(%{{.*}}) ({
 // CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"() : () -> ()
 // CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()

--- a/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
+++ b/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
@@ -87,7 +87,7 @@ snitch_stream.yield %sum : !riscv.freg<ft2>
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  riscv_snitch.frep_outer %{{.*}} {
 // CHECK-NEXT:    %sum = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
-// CHECK-NEXT:    riscv_snitch.frep_yield %sum : (!riscv.freg<ft2>) -> ()
+// CHECK-NEXT:    riscv_snitch.frep_yield %sum : !riscv.freg<ft2>
 // CHECK-NEXT:  }
 // CHECK-NEXT:  "snitch.ssr_disable"() : () -> ()
 

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -141,7 +141,9 @@ def get_type_var_mapping(
     # Get the generic parent
     orig_bases: Iterable[Any] = getattr(cls, "__orig_bases__")
     orig_bases = [
-        orig_base for orig_base in orig_bases if get_origin(orig_base) is not Generic
+        orig_base
+        for orig_base in orig_bases
+        if (o := get_origin(orig_base)) is not Generic and o is not None
     ]
     # Do not handle more than one generic parent in the mro.
     # It is possible to handle more than one generic parent, but


### PR DESCRIPTION
A few things going on here:
1. turns out FrepYieldOp was never added to the dialect definition, oops
2. I made it an AbstractYieldOp but that broke irdl_op_def for some reason, @math-fehr will need your ok for my fix
3. Feels like it should be implicit, frep almost never yields things, so might as well leave it out by default