### PR TITLE
core: Allow multiple inheritance when one parent is generic

### DIFF
--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -573,3 +573,41 @@ def test_generic_op():
     )
     with pytest.raises(DiagnosticException):
         op_result_fail.verify()
+
+
+class OtherParentOp(IRDLOperation):
+    other_attr = attr_def(Attribute)
+
+
+@irdl_op_definition
+class OtherStringFooOp(GenericOp[StringAttr, FooType, FooType], OtherParentOp):
+    name = "test.string_specialized"
+
+
+def test_multiple_inheritance_op():
+    """Test generic operation."""
+    FooOperand = TestSSAValue(TestType("foo"))
+    FooResultType = TestType("foo")
+
+    op = OtherStringFooOp(
+        attributes={"attr": StringAttr("test"), "other_attr": StringAttr("test")},
+        operands=[FooOperand],
+        result_types=[FooResultType],
+    )
+    op.verify()
+
+    op_attr_fail = OtherStringFooOp(
+        attributes={"attr": IntAttr(1), "other_attr": StringAttr("test")},
+        operands=[FooOperand],
+        result_types=[FooResultType],
+    )
+    with pytest.raises(DiagnosticException):
+        op_attr_fail.verify()
+
+    op = OtherStringFooOp(
+        attributes={"attr": StringAttr("test")},
+        operands=[FooOperand],
+        result_types=[FooResultType],
+    )
+    with pytest.raises(DiagnosticException):
+        op_attr_fail.verify()

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -141,7 +141,9 @@ def get_type_var_mapping(
     # Get the generic parent
     orig_bases: Iterable[Any] = getattr(cls, "__orig_bases__")
     orig_bases = [
-        orig_base for orig_base in orig_bases if get_origin(orig_base) is not Generic
+        orig_base
+        for orig_base in orig_bases
+        if (origin := get_origin(orig_base)) is not Generic and origin is not None
     ]
     # Do not handle more than one generic parent in the mro.
     # It is possible to handle more than one generic parent, but


### PR DESCRIPTION
This allows Operation classes to inherit from multiple classes, when one of the classes is a generic.
Before that, this was not allowed.