### PR TITLE
dialects: Use IntAttr in Vector/Tensor/MemRef types

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -409,7 +409,7 @@ class ReshapeOp(IRDLOperation):
                 " {AnyTensorTypeF64}"
             )
         element_type = arg.type.element_type
-        t = TensorTypeF64.from_type_and_list(element_type, shape)
+        t = TensorTypeF64(element_type, shape)
         return super().__init__(result_types=[t], operands=[arg])
 
     @staticmethod
@@ -443,7 +443,7 @@ class InferTransposeOpShapeTrait(ToyShapeInferenceTrait):
         if isinstance(op_res_type := op.res.type, TensorType):
             assert res_shape == op_res_type.get_shape()
         else:
-            op.res.type = TensorType.from_type_and_list(f64, res_shape)
+            op.res.type = TensorType(f64, res_shape)
 
 
 class TransposeOpHasCanonicalisationPatternsTrait(HasCanonicalisationPatternsTrait):
@@ -472,9 +472,7 @@ class TransposeOp(IRDLOperation):
         output_type: TensorTypeF64 | UnrankedTensorTypeF64
         if isa(arg.type, TensorTypeF64):
             element_type = arg.type.element_type
-            output_type = TensorType.from_type_and_list(
-                element_type, list(reversed(arg.type.get_shape()))
-            )
+            output_type = TensorType(element_type, list(reversed(arg.type.get_shape())))
         else:
             if not isa(arg.type, UnrankedTensorTypeF64):
                 raise ValueError(
@@ -500,7 +498,7 @@ class InferCastOpShapeTrait(ToyShapeInferenceTrait):
         if isinstance(op_res_type := op.res.type, TensorType):
             assert shape == op_res_type.get_shape()
         else:
-            op.res.type = TensorType.from_type_and_list(f64, shape)
+            op.res.type = TensorType(f64, shape)
 
 
 @irdl_op_definition
@@ -513,7 +511,7 @@ class CastOp(IRDLOperation):
 
     def __init__(self, arg: SSAValue, res: AnyTensorTypeF64 | None = None):
         if res is None:
-            res = UnrankedTensorType.from_type(f64)
+            res = UnrankedTensorType(f64)
 
         return super().__init__(
             operands=[arg],

--- a/docs/Toy/toy/frontend/ir_gen.py
+++ b/docs/Toy/toy/frontend/ir_gen.py
@@ -131,9 +131,9 @@ class IRGen:
         "Build a tensor type from a list of shape dimensions."
         # If the shape is empty, then this type is unranked.
         if len(shape):
-            return TensorType.from_type_and_list(f64, shape)
+            return TensorType(f64, shape)
         else:
-            return UnrankedTensorTypeF64.from_type(f64)
+            return UnrankedTensorTypeF64(f64)
 
     def ir_gen_proto(self, proto_ast: PrototypeAST) -> FuncOp:
         """
@@ -161,9 +161,7 @@ class IRGen:
 
         # Create the block for the current function
         block = Block(
-            arg_types=[
-                UnrankedTensorType.from_type(f64) for _ in range(len(proto_args))
-            ]
+            arg_types=[UnrankedTensorType(f64) for _ in range(len(proto_args))]
         )
         self.builder = Builder(block)
 
@@ -337,7 +335,7 @@ class IRGen:
         # user-defined functions are mapped to a custom call that takes the callee
         # name as an attribute.
         op = self.builder.insert(
-            GenericCallOp(callee, operands, [UnrankedTensorTypeF64.from_type(f64)])
+            GenericCallOp(callee, operands, [UnrankedTensorTypeF64(f64)])
         )
 
         return op.res[0]

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -40,7 +40,7 @@ def convert_tensor_to_memref(type: toy.TensorTypeF64) -> MemrefTypeF64:
     """
     Convert the given RankedTensorType into the corresponding MemRefType.
     """
-    return memref.MemRefType.from_element_type_and_shape(f64, type.shape)
+    return memref.MemRefType(f64, type.shape)
 
 
 def insert_alloc_and_dealloc(

--- a/docs/Toy/toy/tests/test_ir_gen.py
+++ b/docs/Toy/toy/tests/test_ir_gen.py
@@ -24,7 +24,7 @@ def test_convert_ast():
     @ModuleOp
     @Builder.implicit_region
     def module_op():
-        unrankedf64TensorType = toy.UnrankedTensorType.from_type(f64)
+        unrankedf64TensorType = toy.UnrankedTensorType(f64)
 
         multiply_transpose_type = FunctionType.from_lists(
             [unrankedf64TensorType, unrankedf64TensorType], [unrankedf64TensorType]

--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -8,9 +8,9 @@ from xdsl.utils.test_value import TestSSAValue
 
 from ..rewrites.lower_memref_riscv import LowerMemrefToRiscv
 
-MEMREF_TYPE_2XF32 = memref.MemRefType.from_element_type_and_shape(f32, ([2]))
-MEMREF_TYPE_2X2XF32 = memref.MemRefType.from_element_type_and_shape(f32, ([2, 2]))
-MEMREF_TYPE_2X2X2XF32 = memref.MemRefType.from_element_type_and_shape(f32, ([2, 2, 2]))
+MEMREF_TYPE_2XF32 = memref.MemRefType(f32, ([2]))
+MEMREF_TYPE_2X2XF32 = memref.MemRefType(f32, ([2, 2]))
+MEMREF_TYPE_2X2X2XF32 = memref.MemRefType(f32, ([2, 2, 2]))
 
 INT_REGISTER_TYPE = riscv.IntRegisterType.unallocated()
 FLOAT_REGISTER_TYPE = riscv.FloatRegisterType.unallocated()

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1205,7 +1205,7 @@
     "    operands=[[i32_ssa_var] * 2, [i32_ssa_var]],\n",
     "    result_types=[i32],\n",
     "    attributes={\n",
-    "        \"operandSegmentSizes\": VectorType.from_element_type_and_shape(i32, [2, 1])\n",
+    "        \"operandSegmentSizes\": VectorType(i32, [2, 1])\n",
     "    },\n",
     ")\n",
     "print(\"Length of add_op2.ops1:\", len(add_op2.ops1))\n",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -286,7 +286,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[IntegerType(parameters=[IntAttr(data=64), SignednessAttr(data=<Signedness.SIGNLESS: 0>)], width=IntAttr(data=64), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>))] should be of base attribute int\n"
+      "[IntegerType(parameters=[IntAttr(data=64), SignednessAttr(data=<Signedness.SIGNLESS: 0>)], width=IntAttr(data=64), signedness=SignednessAttr(data=<Signedness.SIGNLESS: 0>))] should be of base attribute builtin.int\n"
      ]
     }
    ],

--- a/tests/backend/riscv/test_utils.py
+++ b/tests/backend/riscv/test_utils.py
@@ -18,15 +18,11 @@ REGISTER_TYPE = riscv.IntRegisterType.unallocated()
 def test_register_type_for_type():
     assert register_type_for_type(builtin.i32) == riscv.IntRegisterType
     assert (
-        register_type_for_type(
-            memref.MemRefType.from_element_type_and_shape(builtin.f32, [1, 2, 3])
-        )
+        register_type_for_type(memref.MemRefType(builtin.f32, [1, 2, 3]))
         == riscv.IntRegisterType
     )
     assert (
-        register_type_for_type(
-            memref.MemRefType.from_element_type_and_shape(builtin.i32, [1, 2, 3])
-        )
+        register_type_for_type(memref.MemRefType(builtin.i32, [1, 2, 3]))
         == riscv.IntRegisterType
     )
 

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -78,7 +78,7 @@ def test_DenseIntOrFPElementsAttr_from_list():
     attr = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
 
     assert attr.data == ArrayAttr([FloatAttr(5.5, f32)])
-    assert attr.type == AnyTensorType.from_type_and_list(f32, [])
+    assert attr.type == AnyTensorType(f32, [])
 
 
 def test_DenseArrayBase_verifier_failure():
@@ -130,7 +130,7 @@ def test_array_len_and_iter_attr():
     ),
 )
 def test_vector_constructor(attr: Attribute, dims: list[int], num_scalable_dims: int):
-    vec = VectorType.from_element_type_and_shape(attr, dims, num_scalable_dims)
+    vec = VectorType(attr, dims, num_scalable_dims)
 
     assert vec.get_num_dims() == len(dims)
     assert vec.get_num_scalable_dims() == num_scalable_dims
@@ -147,21 +147,21 @@ def test_vector_constructor(attr: Attribute, dims: list[int], num_scalable_dims:
 )
 def test_vector_verifier_fail(dims: list[int], num_scalable_dims: int):
     with pytest.raises(VerifyException):
-        VectorType.from_element_type_and_shape(i32, dims, num_scalable_dims)
+        VectorType(i32, dims, num_scalable_dims)
 
     with pytest.raises(VerifyException):
-        VectorType.from_element_type_and_shape(i32, dims, -1)
+        VectorType(i32, dims, -1)
 
 
 def test_vector_rank_constraint_verify():
-    vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
+    vector_type = VectorType(i32, [1, 2])
     constraint = VectorRankConstraint(2)
 
     constraint.verify(vector_type, {})
 
 
 def test_vector_rank_constraint_rank_mismatch():
-    vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
+    vector_type = VectorType(i32, [1, 2])
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
@@ -170,7 +170,7 @@ def test_vector_rank_constraint_rank_mismatch():
 
 
 def test_vector_rank_constraint_attr_mismatch():
-    memref_type = MemRefType.from_element_type_and_shape(i32, [1, 2])
+    memref_type = MemRefType(i32, [1, 2])
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
@@ -179,14 +179,14 @@ def test_vector_rank_constraint_attr_mismatch():
 
 
 def test_vector_base_type_constraint_verify():
-    vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
+    vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeConstraint(i32)
 
     constraint.verify(vector_type, {})
 
 
 def test_vector_base_type_constraint_type_mismatch():
-    vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
+    vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeConstraint(i64)
 
     with pytest.raises(VerifyException) as e:
@@ -195,7 +195,7 @@ def test_vector_base_type_constraint_type_mismatch():
 
 
 def test_vector_base_type_constraint_attr_mismatch():
-    memref_type = MemRefType.from_element_type_and_shape(i32, [1, 2])
+    memref_type = MemRefType(i32, [1, 2])
     constraint = VectorBaseTypeConstraint(i32)
 
     with pytest.raises(VerifyException) as e:
@@ -204,14 +204,14 @@ def test_vector_base_type_constraint_attr_mismatch():
 
 
 def test_vector_base_type_and_rank_constraint_verify():
-    vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
+    vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i32, 2)
 
     constraint.verify(vector_type, {})
 
 
 def test_vector_base_type_and_rank_constraint_base_type_mismatch():
-    vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
+    vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i64, 2)
 
     with pytest.raises(VerifyException) as e:
@@ -220,7 +220,7 @@ def test_vector_base_type_and_rank_constraint_base_type_mismatch():
 
 
 def test_vector_base_type_and_rank_constraint_rank_mismatch():
-    vector_type = VectorType.from_element_type_and_shape(i32, [1, 2])
+    vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i32, 3)
 
     with pytest.raises(VerifyException) as e:
@@ -229,7 +229,7 @@ def test_vector_base_type_and_rank_constraint_rank_mismatch():
 
 
 def test_vector_base_type_and_rank_constraint_attr_mismatch():
-    memref_type = MemRefType.from_element_type_and_shape(i32, [1, 2])
+    memref_type = MemRefType(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i32, 2)
 
     error_msg = """The following constraints were not satisfied:

--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -42,9 +42,7 @@ def test_dimension():
 
 
 def test_alloc():
-    memref_type = memref.MemRefType.from_element_type_and_shape(
-        builtin.Float32Type(), [10, 10, 10]
-    )
+    memref_type = memref.MemRefType(builtin.Float32Type(), [10, 10, 10])
     alloc = AllocOp(memref_type, is_async=True)
 
     assert isinstance(alloc, AllocOp)
@@ -55,9 +53,7 @@ def test_alloc():
     assert isinstance(alloc.asyncToken.type, AsyncTokenType)
     assert alloc.hostShared is None
 
-    dyn_type = memref.MemRefType.from_element_type_and_shape(
-        builtin.Float32Type(), [-1, -1, -1]
-    )
+    dyn_type = memref.MemRefType(builtin.Float32Type(), [-1, -1, -1])
     ten = arith.Constant.from_int_and_width(10, builtin.IndexType())
     dynamic_sizes = [ten, ten, ten]
     token = alloc.asyncToken
@@ -140,9 +136,7 @@ def test_block_id():
 
 
 def test_dealloc():
-    memref_type = memref.MemRefType.from_element_type_and_shape(
-        builtin.Float32Type(), [10, 10, 10]
-    )
+    memref_type = memref.MemRefType(builtin.Float32Type(), [10, 10, 10])
     alloc = AllocOp(memref_type, is_async=True)
 
     assert alloc.asyncToken is not None  # For pyright
@@ -201,7 +195,7 @@ def test_grid_dim():
 
 
 def test_host_register():
-    memref_type = memref.MemRefType.from_element_type_and_shape(builtin.i32, [-1])
+    memref_type = memref.MemRefType(builtin.i32, [-1])
     unranked = memref.Alloca.get(memref_type, 0)
 
     register = HostRegisterOp(unranked)
@@ -211,7 +205,7 @@ def test_host_register():
 
 
 def test_host_unregister():
-    memref_type = memref.MemRefType.from_element_type_and_shape(builtin.i32, [-1])
+    memref_type = memref.MemRefType(builtin.i32, [-1])
     unranked = memref.Alloca.get(memref_type, 0)
 
     unregister = HostUnregisterOp(unranked)
@@ -338,9 +332,7 @@ def test_launchfunc():
 
 
 def test_memcpy():
-    memref_type = memref.MemRefType.from_element_type_and_shape(
-        builtin.Float32Type(), [10, 10, 10]
-    )
+    memref_type = memref.MemRefType(builtin.Float32Type(), [10, 10, 10])
     host_alloc = memref.Alloc.get(builtin.Float32Type(), 0, [10, 10, 10])
     alloc = AllocOp(memref_type, is_async=True)
 

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -35,28 +35,21 @@ from xdsl.utils.test_value import TestSSAValue
 
 
 def test_memreftype():
-    mem1 = MemRefType.from_element_type_and_shape(i32, [1])
+    mem1 = MemRefType(i32, [1])
 
     assert mem1.get_num_dims() == 1
     assert mem1.get_shape() == (1,)
     assert mem1.element_type is i32
 
-    mem2 = MemRefType.from_element_type_and_shape(i32, [3, 3, 3])
+    mem2 = MemRefType(i32, [3, 3, 3])
 
     assert mem2.get_num_dims() == 3
     assert mem2.get_shape() == (3, 3, 3)
     assert mem2.element_type is i32
 
-    my_i32 = IntegerType(32)
-    mem3 = MemRefType.from_params(my_i32)
-
-    assert mem3.get_num_dims() == 1
-    assert mem3.get_shape() == (1,)
-    assert mem3.element_type is my_i32
-
 
 def test_memref_load_i32():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
+    i32_memref_type = MemRefType(i32, [1])
     memref_ssa_value = TestSSAValue(i32_memref_type)
     load = Load.get(memref_ssa_value, [])
 
@@ -66,7 +59,7 @@ def test_memref_load_i32():
 
 
 def test_memref_load_i32_with_dimensions():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
+    i32_memref_type = MemRefType(i32, [2, 3])
     memref_ssa_value = TestSSAValue(i32_memref_type)
     index1 = TestSSAValue(IndexType())
     index2 = TestSSAValue(IndexType())
@@ -79,7 +72,7 @@ def test_memref_load_i32_with_dimensions():
 
 
 def test_memref_store_i32():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [1])
+    i32_memref_type = MemRefType(i32, [1])
     memref_ssa_value = TestSSAValue(i32_memref_type)
     i32_ssa_value = TestSSAValue(i32)
     store = Store.get(i32_ssa_value, memref_ssa_value, [])
@@ -90,7 +83,7 @@ def test_memref_store_i32():
 
 
 def test_memref_store_i32_with_dimensions():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [2, 3])
+    i32_memref_type = MemRefType(i32, [2, 3])
     memref_ssa_value = TestSSAValue(i32_memref_type)
     i32_ssa_value = TestSSAValue(i32)
     index1 = TestSSAValue(IndexType())
@@ -225,9 +218,7 @@ def test_memref_ExtractAlignedPointerAsIndexOp():
 
 
 def test_memref_matmul_verify():
-    memref_f64_rank2 = memref.MemRefType.from_element_type_and_shape(
-        builtin.f64, [-1, -1]
-    )
+    memref_f64_rank2 = memref.MemRefType(builtin.f64, [-1, -1])
 
     @builtin.ModuleOp
     @Builder.implicit_region
@@ -309,7 +300,7 @@ def test_memref_subview_constant_parameters():
 
 
 def test_memref_cast():
-    i32_memref_type = MemRefType.from_element_type_and_shape(i32, [10, 2])
+    i32_memref_type = MemRefType(i32, [10, 2])
     memref_ssa_value = TestSSAValue(i32_memref_type)
 
     res_type = UnrankedMemrefType.from_type(i32)
@@ -321,18 +312,14 @@ def test_memref_cast():
 
 
 def test_memref_memory_space_cast():
-    i32_memref_type = MemRefType.from_element_type_and_shape(
-        i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32)
-    )
+    i32_memref_type = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
     memref_ssa_value = TestSSAValue(i32_memref_type)
 
-    res_type = MemRefType.from_element_type_and_shape(
-        i32, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
-    )
-    res_type_wrong_type = MemRefType.from_element_type_and_shape(
+    res_type = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(2, i32))
+    res_type_wrong_type = MemRefType(
         i64, [10, 2], memory_space=builtin.IntegerAttr(2, i32)
     )
-    res_type_wrong_shape = MemRefType.from_element_type_and_shape(
+    res_type_wrong_shape = MemRefType(
         i32, [10, 4], memory_space=builtin.IntegerAttr(2, i32)
     )
 
@@ -364,14 +351,10 @@ def test_memref_memory_space_cast():
 
 
 def test_dma_start():
-    src_type = MemRefType.from_element_type_and_shape(
-        i64, [4, 512], memory_space=IntAttr(1)
-    )
-    dest_type = MemRefType.from_element_type_and_shape(
-        i64, [4 * 512], memory_space=IntAttr(2)
-    )
+    src_type = MemRefType(i64, [4, 512], memory_space=IntAttr(1))
+    dest_type = MemRefType(i64, [4 * 512], memory_space=IntAttr(2))
 
-    tag_type = MemRefType.from_element_type_and_shape(i32, [4])
+    tag_type = MemRefType(i32, [4])
 
     src = TestSSAValue(src_type)
     dest = TestSSAValue(dest_type)
@@ -426,7 +409,7 @@ def test_dma_start():
 
 
 def test_memref_dma_wait():
-    tag_type = MemRefType.from_element_type_and_shape(i32, [4])
+    tag_type = MemRefType(i32, [4])
     tag = TestSSAValue(tag_type)
     index = TestSSAValue(IndexType())
     num_elements = TestSSAValue(IndexType())
@@ -443,16 +426,16 @@ def test_memref_dma_wait():
 
     # check that tag element type is verified
     with pytest.raises(VerifyException, match="Expected tag to be a memref of i32"):
-        wrong_tag_type = MemRefType.from_element_type_and_shape(i64, [4])
+        wrong_tag_type = MemRefType(i64, [4])
         wrong_tag = TestSSAValue(wrong_tag_type)
 
         DmaWaitOp.get(wrong_tag, [index], num_elements).verify()
 
 
 def test_memref_copy():
-    i32type4 = MemRefType.from_element_type_and_shape(i32, [4])
-    i32type3 = MemRefType.from_element_type_and_shape(i32, [3])
-    i64type4 = MemRefType.from_element_type_and_shape(i64, [4])
+    i32type4 = MemRefType(i32, [4])
+    i32type3 = MemRefType(i32, [3])
+    i64type4 = MemRefType(i64, [4])
     source = TestSSAValue(i32type4)
     destination = TestSSAValue(i32type4)
 

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -612,7 +612,7 @@ def test_store_result():
 
 
 def test_external_load():
-    memref = TestSSAValue(MemRefType.from_element_type_and_shape(f32, ([5])))
+    memref = TestSSAValue(MemRefType(f32, ([5])))
     field_type = FieldType((5), f32)
 
     external_load = ExternalLoadOp.get(memref, field_type)
@@ -624,7 +624,7 @@ def test_external_load():
 
 def test_external_store():
     field = TestSSAValue(FieldType((5), f32))
-    memref = TestSSAValue(MemRefType.from_element_type_and_shape(f32, ([5])))
+    memref = TestSSAValue(MemRefType(f32, ([5])))
 
     external_store = ExternalStoreOp.build(operands=[field, memref])
 

--- a/tests/interpreters/test_affine_interpreter.py
+++ b/tests/interpreters/test_affine_interpreter.py
@@ -22,8 +22,8 @@ def module_op():
             (
                 (),
                 (
-                    memref.MemRefType.from_element_type_and_shape(index, (2, 3)),
-                    memref.MemRefType.from_element_type_and_shape(index, (3, 2)),
+                    memref.MemRefType(index, (2, 3)),
+                    memref.MemRefType(index, (3, 2)),
                 ),
             ),
         ).body

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -54,10 +54,10 @@ def test_linalg_generic():
 
     op = linalg.Generic(
         (
-            TestSSAValue(MemRefType.from_element_type_and_shape(i32, [2, 3])),
-            TestSSAValue(MemRefType.from_element_type_and_shape(i32, [3, 2])),
+            TestSSAValue(MemRefType(i32, [2, 3])),
+            TestSSAValue(MemRefType(i32, [3, 2])),
         ),
-        (TestSSAValue(MemRefType.from_element_type_and_shape(i32, [1, 6])),),
+        (TestSSAValue(MemRefType(i32, [1, 6])),),
         Region(Block(arg_types=(i32, i32))),
         (
             AffineMapAttr(AffineMap.identity(2)),

--- a/tests/interpreters/test_memref_interpreter.py
+++ b/tests/interpreters/test_memref_interpreter.py
@@ -59,8 +59,8 @@ def test_functions():
 
 
 def test_memref_get_global():
-    memref_type = memref.MemRefType.from_element_type_and_shape(i32, (2, 2))
-    tensor_type = TensorType.from_type_and_list(i32, (2, 2))
+    memref_type = memref.MemRefType(i32, (2, 2))
+    tensor_type = TensorType(i32, (2, 2))
     module = ModuleOp([])
     with ImplicitBuilder(module.body):
         memref.Global.get(

--- a/tests/interpreters/test_wgsl_printer.py
+++ b/tests/interpreters/test_wgsl_printer.py
@@ -159,7 +159,7 @@ def test_arith_mulf():
 def test_memref_load():
     file = StringIO("")
 
-    memref_type = memref.MemRefType.from_element_type_and_shape(i32, [10, 10])
+    memref_type = memref.MemRefType(i32, [10, 10])
 
     memref_val = TestSSAValue(memref_type)
 
@@ -174,7 +174,7 @@ def test_memref_load():
 def test_memref_store():
     file = StringIO("")
 
-    memref_type = memref.MemRefType.from_element_type_and_shape(i32, [10, 10])
+    memref_type = memref.MemRefType(i32, [10, 10])
 
     memref_val = TestSSAValue(memref_type)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -59,7 +59,9 @@ from xdsl.traits import (
     OptionalSymbolOpInterface,
     SymbolTable,
 )
+from xdsl.utils.deprecation import deprecated_constructor
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
 
 if TYPE_CHECKING:
     from xdsl.parser import AttrParser, Parser
@@ -630,9 +632,22 @@ class VectorType(
 ):
     name = "vector"
 
-    shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]
+    shape: ParameterDef[ArrayAttr[IntAttr]]
     element_type: ParameterDef[AttributeCovT]
     num_scalable_dims: ParameterDef[IntAttr]
+
+    def __init__(
+        self: VectorType[AttributeCovT],
+        element_type: AttributeCovT,
+        shape: Iterable[int | IntAttr],
+        num_scalable_dims: int | IntAttr = 0,
+    ) -> None:
+        shape = ArrayAttr(
+            [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
+        )
+        if isinstance(num_scalable_dims, int):
+            num_scalable_dims = IntAttr(num_scalable_dims)
+        super().__init__([shape, element_type, num_scalable_dims])
 
     def get_num_dims(self) -> int:
         return len(self.shape.data)
@@ -641,7 +656,7 @@ class VectorType(
         return self.num_scalable_dims.data
 
     def get_shape(self) -> tuple[int, ...]:
-        return tuple(i.value.data for i in self.shape.data)
+        return tuple(i.data for i in self.shape)
 
     def get_element_type(self) -> AttributeCovT:
         return self.element_type
@@ -659,6 +674,7 @@ class VectorType(
                 f" {self.get_num_dims()}"
             )
 
+    @deprecated_constructor
     @staticmethod
     def from_element_type_and_shape(
         referenced_type: AttributeInvT,
@@ -667,21 +683,12 @@ class VectorType(
     ) -> VectorType[AttributeInvT]:
         if isinstance(num_scalable_dims, int):
             num_scalable_dims = IntAttr(num_scalable_dims)
-        return VectorType(
-            [
-                ArrayAttr(
-                    [
-                        IntegerAttr[IntegerType].from_index_int_value(d)
-                        if isinstance(d, int)
-                        else d
-                        for d in shape
-                    ]
-                ),
-                referenced_type,
-                num_scalable_dims,
-            ]
-        )
+        shape_int = [
+            IntAttr(dim) if isinstance(dim, int) else dim.value.data for dim in shape
+        ]
+        return VectorType(referenced_type, shape_int, num_scalable_dims)
 
+    @deprecated_constructor
     @staticmethod
     def from_params(
         referenced_type: AttributeInvT,
@@ -690,7 +697,8 @@ class VectorType(
         ),
         num_scalable_dims: IntAttr = IntAttr(0),
     ) -> VectorType[AttributeInvT]:
-        return VectorType([shape, referenced_type, num_scalable_dims])
+        shape_int = [dim.value.data for dim in shape.data]
+        return VectorType(referenced_type, shape_int, num_scalable_dims)
 
 
 AnyVectorType: TypeAlias = VectorType[Attribute]
@@ -706,19 +714,31 @@ class TensorType(
 ):
     name = "tensor"
 
-    shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]
+    shape: ParameterDef[ArrayAttr[IntAttr]]
     element_type: ParameterDef[AttributeCovT]
     encoding: ParameterDef[Attribute]
+
+    def __init__(
+        self: TensorType[AttributeCovT],
+        element_type: AttributeCovT,
+        shape: Iterable[int | IntAttr],
+        encoding: Attribute = NoneAttr(),
+    ):
+        shape = ArrayAttr(
+            [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
+        )
+        super().__init__([shape, element_type, encoding])
 
     def get_num_dims(self) -> int:
         return len(self.shape.data)
 
     def get_shape(self) -> tuple[int, ...]:
-        return tuple(i.value.data for i in self.shape.data)
+        return tuple(i.data for i in self.shape.data)
 
     def get_element_type(self) -> AttributeCovT:
         return self.element_type
 
+    @deprecated_constructor
     @staticmethod
     def from_type_and_list(
         referenced_type: AttributeInvT,
@@ -727,28 +747,22 @@ class TensorType(
     ) -> TensorType[AttributeInvT]:
         if shape is None:
             shape = [1]
-        return TensorType(
-            [
-                ArrayAttr(
-                    [
-                        IntegerAttr[IntegerType].from_index_int_value(d)
-                        if isinstance(d, int)
-                        else d
-                        for d in shape
-                    ]
-                ),
-                referenced_type,
-                encoding,
-            ]
-        )
+        shape_int = [
+            IntAttr(dim) if isinstance(dim, int) else dim.value.data for dim in shape
+        ]
+        return TensorType(referenced_type, shape_int, encoding)
 
+    @deprecated_constructor
     @staticmethod
     def from_params(
         referenced_type: AttributeInvT,
         shape: AnyArrayAttr = AnyArrayAttr([IntegerAttr.from_int_and_width(1, 64)]),
         encoding: Attribute = NoneAttr(),
     ) -> TensorType[AttributeInvT]:
-        return TensorType([shape, referenced_type, encoding])
+        if not isa(shape, ArrayAttr[AnyIntegerAttr]):
+            raise TypeError(f"Unsupported shape type {type(shape)}")
+        shape_int = [dim.value.data for dim in shape.data]
+        return TensorType(referenced_type, shape_int, encoding)
 
 
 AnyTensorType: TypeAlias = TensorType[Attribute]
@@ -760,9 +774,10 @@ class UnrankedTensorType(Generic[AttributeCovT], ParametrizedAttribute, TypeAttr
 
     element_type: ParameterDef[AttributeCovT]
 
-    @staticmethod
-    def from_type(referenced_type: AttributeInvT) -> UnrankedTensorType[AttributeInvT]:
-        return UnrankedTensorType([referenced_type])
+    def __init__(
+        self: UnrankedTensorType[AttributeCovT], element_type: AttributeCovT
+    ) -> None:
+        super().__init__([element_type])
 
 
 AnyUnrankedTensorType: TypeAlias = UnrankedTensorType[Attribute]
@@ -983,7 +998,7 @@ class DenseIntOrFPElementsAttr(
         data: Sequence[int] | Sequence[float],
         data_type: IntegerType | IndexType | AnyFloat,
     ) -> DenseIntOrFPElementsAttr:
-        t = VectorType.from_element_type_and_shape(data_type, [len(data)])
+        t = VectorType(data_type, [len(data)])
         return DenseIntOrFPElementsAttr.from_list(t, data)
 
     @staticmethod
@@ -996,7 +1011,7 @@ class DenseIntOrFPElementsAttr(
         data_type: IntegerType | IndexType | AnyFloat,
         shape: Sequence[int],
     ) -> DenseIntOrFPElementsAttr:
-        t = AnyTensorType.from_type_and_list(data_type, shape)
+        t = TensorType(data_type, shape)
         return DenseIntOrFPElementsAttr.from_list(t, data)
 
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -166,7 +166,7 @@ class AllocOp(IRDLOperation):
     def verify_(self) -> None:
         ndyn = len(self.dynamicSizes)
         assert isinstance(res_type := self.result.type, memref.MemRefType)
-        ndyn_type = len([i for i in res_type.shape.data if i.value.data == -1])
+        ndyn_type = len([i for i in res_type.get_shape() if i == -1])
         if ndyn != ndyn_type:
             raise VerifyException(
                 f"Expected {ndyn_type} dynamic sizes, got {ndyn}. All "

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -57,6 +57,7 @@ from xdsl.traits import (
     IsTerminator,
     SymbolOpInterface,
 )
+from xdsl.utils.deprecation import deprecated_constructor
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -78,20 +79,40 @@ class MemRefType(
 ):
     name = "memref"
 
-    shape: ParameterDef[ArrayAttr[AnyIntegerAttr]]
+    shape: ParameterDef[ArrayAttr[IntAttr]]
     element_type: ParameterDef[_MemRefTypeElement]
-    layout: ParameterDef[StridedLayoutAttr | NoneAttr]
+    layout: ParameterDef[Attribute]
     memory_space: ParameterDef[Attribute]
+
+    def __init__(
+        self: MemRefType[_MemRefTypeElement],
+        element_type: _MemRefTypeElement,
+        shape: Iterable[int | IntAttr],
+        layout: Attribute = NoneAttr(),
+        memory_space: Attribute = NoneAttr(),
+    ):
+        shape = ArrayAttr(
+            [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
+        )
+        super().__init__(
+            [
+                shape,
+                element_type,
+                layout,
+                memory_space,
+            ]
+        )
 
     def get_num_dims(self) -> int:
         return len(self.shape.data)
 
     def get_shape(self) -> tuple[int, ...]:
-        return tuple(i.value.data for i in self.shape.data)
+        return tuple(i.data for i in self.shape.data)
 
     def get_element_type(self) -> _MemRefTypeElement:
         return self.element_type
 
+    @deprecated_constructor
     @staticmethod
     def from_element_type_and_shape(
         referenced_type: _MemRefTypeElement,
@@ -99,22 +120,10 @@ class MemRefType(
         layout: Attribute = NoneAttr(),
         memory_space: Attribute = NoneAttr(),
     ) -> MemRefType[_MemRefTypeElement]:
-        return MemRefType(
-            [
-                ArrayAttr[AnyIntegerAttr](
-                    [
-                        d
-                        if isinstance(d, IntegerAttr)
-                        else IntegerAttr.from_index_int_value(d)
-                        for d in shape
-                    ]
-                ),
-                referenced_type,
-                layout,
-                memory_space,
-            ]
-        )
+        shape_int = [i if isinstance(i, int) else i.value.data for i in shape]
+        return MemRefType(referenced_type, shape_int, layout, memory_space)
 
+    @deprecated_constructor
     @staticmethod
     def from_params(
         referenced_type: _MemRefTypeElement,
@@ -124,7 +133,8 @@ class MemRefType(
         layout: Attribute = NoneAttr(),
         memory_space: Attribute = NoneAttr(),
     ) -> MemRefType[_MemRefTypeElement]:
-        return MemRefType([shape, referenced_type, layout, memory_space])
+        shape_int = [i.value.data for i in shape.data]
+        return MemRefType(referenced_type, shape_int, layout, memory_space)
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
@@ -314,8 +324,8 @@ class Alloc(IRDLOperation):
     @staticmethod
     def get(
         return_type: Attribute,
-        alignment: int | AnyIntegerAttr | None = None,
-        shape: Iterable[int | AnyIntegerAttr] | None = None,
+        alignment: int | None = None,
+        shape: Iterable[int | IntAttr] | None = None,
         dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
         layout: Attribute = NoneAttr(),
         memory_space: Attribute = NoneAttr(),
@@ -331,13 +341,14 @@ class Alloc(IRDLOperation):
 
         return Alloc.build(
             operands=[dynamic_sizes, []],
-            result_types=[
-                MemRefType.from_element_type_and_shape(
-                    return_type, shape, layout, memory_space
-                )
-            ],
+            result_types=[MemRefType(return_type, shape, layout, memory_space)],
             properties={
                 "alignment": alignment,
+            },
+            attributes={
+                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
+                if alignment is not None
+                else None
             },
         )
 
@@ -397,7 +408,7 @@ class Alloca(IRDLOperation):
     def get(
         return_type: Attribute,
         alignment: int | AnyIntegerAttr | None = None,
-        shape: Iterable[int | AnyIntegerAttr] | None = None,
+        shape: Iterable[int | IntAttr] | None = None,
         dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
         layout: Attribute = NoneAttr(),
         memory_space: Attribute = NoneAttr(),
@@ -413,11 +424,7 @@ class Alloca(IRDLOperation):
 
         return Alloca.build(
             operands=[dynamic_sizes, []],
-            result_types=[
-                MemRefType.from_element_type_and_shape(
-                    return_type, shape, layout, memory_space
-                )
-            ],
+            result_types=[MemRefType(return_type, shape, layout, memory_space)],
             properties={
                 "alignment": alignment,
             },
@@ -582,7 +589,7 @@ class Subview(IRDLOperation):
     ) -> Subview:
         source = SSAValue.get(source)
 
-        source_shape = [e.value.data for e in source_type.shape.data]
+        source_shape = source_type.get_shape()
         source_offset = 0
         source_strides = [1]
         for input_size in reversed(source_shape[1:]):
@@ -616,7 +623,7 @@ class Subview(IRDLOperation):
 
         layout = StridedLayoutAttr(layout_strides, layout_offset)
 
-        return_type = MemRefType.from_element_type_and_shape(
+        return_type = MemRefType(
             source_type.element_type,
             result_sizes,
             layout,
@@ -669,7 +676,7 @@ class MemorySpaceCast(IRDLOperation):
         type: MemRefType[Attribute],
         dest_memory_space: Attribute,
     ) -> MemorySpaceCast:
-        dest = MemRefType.from_element_type_and_shape(
+        dest = MemRefType(
             type.get_element_type(),
             shape=type.get_shape(),
             layout=type.layout,

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -324,7 +324,7 @@ class Alloc(IRDLOperation):
     @staticmethod
     def get(
         return_type: Attribute,
-        alignment: int | None = None,
+        alignment: int | AnyIntegerAttr | None = None,
         shape: Iterable[int | IntAttr] | None = None,
         dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
         layout: Attribute = NoneAttr(),
@@ -345,11 +345,6 @@ class Alloc(IRDLOperation):
             properties={
                 "alignment": alignment,
             },
-            attributes={
-                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
-                if alignment is not None
-                else None
-            },
         )
 
     def verify_(self) -> None:
@@ -358,7 +353,7 @@ class Alloc(IRDLOperation):
             raise VerifyException("expected result to be a memref")
         memref_type = cast(MemRefType[Attribute], memref_type)
 
-        dyn_dims = [x for x in memref_type.shape.data if x.value.data == -1]
+        dyn_dims = [x for x in memref_type.shape.data if x.data == -1]
         if len(dyn_dims) != len(self.dynamic_sizes):
             raise VerifyException(
                 "op dimension operand count does not equal memref dynamic dimension count."
@@ -436,7 +431,7 @@ class Alloca(IRDLOperation):
             raise VerifyException("expected result to be a memref")
         memref_type = cast(MemRefType[Attribute], memref_type)
 
-        dyn_dims = [x for x in memref_type.shape.data if x.value.data == -1]
+        dyn_dims = [x for x in memref_type.shape.data if x.data == -1]
         if len(dyn_dims) != len(self.dynamic_sizes):
             raise VerifyException(
                 "op dimension operand count does not equal memref dynamic dimension count."

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -52,9 +52,7 @@ class Load(IRDLOperation):
 
         return Load.build(
             operands=[ref, indices],
-            result_types=[
-                VectorType.from_element_type_and_shape(ref.type.element_type, [1])
-            ],
+            result_types=[VectorType(ref.type.element_type, [1])],
         )
 
 
@@ -104,9 +102,7 @@ class Broadcast(IRDLOperation):
     def get(source: Operation | SSAValue) -> Broadcast:
         return Broadcast.build(
             operands=[source],
-            result_types=[
-                VectorType.from_element_type_and_shape(SSAValue.get(source).type, [1])
-            ],
+            result_types=[VectorType(SSAValue.get(source).type, [1])],
         )
 
 
@@ -164,9 +160,7 @@ class FMA(IRDLOperation):
 
         return FMA.build(
             operands=[lhs, rhs, acc],
-            result_types=[
-                VectorType.from_element_type_and_shape(lhs.type.element_type, [1])
-            ],
+            result_types=[VectorType(lhs.type.element_type, [1])],
         )
 
 
@@ -218,9 +212,7 @@ class Maskedload(IRDLOperation):
 
         return Maskedload.build(
             operands=[memref, indices, mask, passthrough],
-            result_types=[
-                VectorType.from_element_type_and_shape(memref.type.element_type, [1])
-            ],
+            result_types=[VectorType(memref.type.element_type, [1])],
         )
 
 
@@ -293,7 +285,7 @@ class Createmask(IRDLOperation):
     def get(mask_operands: list[Operation | SSAValue]) -> Createmask:
         return Createmask.build(
             operands=[mask_operands],
-            result_types=[VectorType.from_element_type_and_shape(i1, [1])],
+            result_types=[VectorType(i1, [1])],
         )
 
 

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -140,7 +140,7 @@ class WGPUFunctions(InterpreterFunctions):
                 raise NotImplementedError(
                     f"copy for element type {dst_type.element_type} not yet implemented."
                 )
-        memview = memview.cast(format, [i.value.data for i in dst_type.shape])
+        memview = memview.cast(format, dst_type.get_shape())
         for index in dst.indices():
             dst.store(index, memview.__getitem__(index))  # pyright: ignore
         return ()

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -525,9 +525,7 @@ class Printer:
             self.print("tensor<")
             self.print_list(
                 attribute.shape.data,
-                lambda x: self.print(x.value.data)
-                if x.value.data != -1
-                else self.print("?"),
+                lambda x: self.print(x.data) if x.data != -1 else self.print("?"),
                 "x",
             )
             if len(attribute.shape.data) != 0:
@@ -595,9 +593,7 @@ class Printer:
             if attribute.shape.data:
                 self.print_list(
                     attribute.shape.data,
-                    lambda x: self.print(x.value.data)
-                    if x.value.data != -1
-                    else self.print("?"),
+                    lambda x: self.print(x.data) if x.data != -1 else self.print("?"),
                     "x",
                 )
                 self.print("x")

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -55,9 +55,7 @@ _TypeElement = TypeVar("_TypeElement", bound=Attribute)
 def StencilToMemRefType(
     input_type: StencilType[_TypeElement],
 ) -> MemRefType[_TypeElement]:
-    return MemRefType.from_element_type_and_shape(
-        input_type.element_type, input_type.get_shape()
-    )
+    return MemRefType(input_type.element_type, input_type.get_shape())
 
 
 @dataclass

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -776,9 +776,9 @@ class StencilExternalStoreToHLSWriteData(RewritePattern):
             op_field_type = op.field.type
             assert isinstance(op_field_type, MemRefType)
             shape = op_field_type.shape
-            shape_x = Constant.from_int_and_width(shape.data[0].value.data, i32)
-            shape_y = Constant.from_int_and_width(shape.data[1].value.data, i32)
-            shape_z = Constant.from_int_and_width(shape.data[2].value.data, i32)
+            shape_x = Constant.from_int_and_width(shape.data[0].data, i32)
+            shape_y = Constant.from_int_and_width(shape.data[1].data, i32)
+            shape_z = Constant.from_int_and_width(shape.data[2].data, i32)
 
             call_write_data = Call(
                 write_data_func_name,
@@ -1132,7 +1132,7 @@ class GetRepeatedCoefficients(RewritePattern):
         cast.clone()
 
         dim = len(cast_dest_type.shape.data)
-        cast_dest_type.shape.data[0].value.data
+        cast_dest_type.shape.data[0].data
         if dim == 1:
             uses_copy = set(op.results[0].uses)
             for use in uses_copy:
@@ -1167,7 +1167,7 @@ class MakeLocaCopiesOfCoefficients(RewritePattern):
         ):
             original_memref_lst_dest_type = self.original_memref_lst[0].dest.type
             assert isinstance(original_memref_lst_dest_type, memref.MemRefType)
-            dim = original_memref_lst_dest_type.shape.data[0].value.data
+            dim = original_memref_lst_dest_type.shape.data[0].data
 
             lb = Constant.from_int_and_width(0, IndexType())
             ub = Constant.from_int_and_width(dim, IndexType())

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -203,10 +203,10 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
 
         # Note: we only allow MemRef, not UnrankedMemref!
         # TODO: handle -1 in sizes
-        if not all(dim.value.data >= 0 for dim in ssa_val_type.shape.data):
+        if not all(dim >= 0 for dim in ssa_val_type.get_shape()):
             raise RuntimeError("MPI lowering does not support unknown-size memrefs!")
 
-        size = prod(dim.value.data for dim in ssa_val_type.shape.data)
+        size = prod(ssa_val_type.get_shape())
 
         literal = arith.Constant.from_int_and_width(size, i32)
         return [literal], literal.result

--- a/xdsl/transforms/printf_to_llvm.py
+++ b/xdsl/transforms/printf_to_llvm.py
@@ -95,7 +95,7 @@ class PrintlnOpToPrintfCall(RewritePattern):
         """
         data = val.encode() + b"\x00"
 
-        t_type = builtin.TensorType.from_type_and_list(i8, [len(data)])
+        t_type = builtin.TensorType(i8, [len(data)])
 
         return llvm.GlobalOp(
             llvm.LLVMArrayType.from_size_and_type(len(data), i8),


### PR DESCRIPTION
We currently use `IntegerAttr` for shapes in vector, tensor, and memref types.
They were also inconsistent, since some of them allowed index types, while other did not.
In MLIR, these dimensions are not typed anyway, so that makes sense.

I also removed the "get" constructors in favor of a single `__init__` one. It is not possible to deprecate
these constructors, as their type changed anyway.