### PR TITLE
dialects (arith): Add arith.addui_extended operation

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -5,6 +5,7 @@ import pytest
 from xdsl.dialects.arith import (
     Addf,
     Addi,
+    AddUIExtended,
     AndI,
     BinaryOperation,
     CeilDivSI,
@@ -45,9 +46,24 @@ from xdsl.dialects.arith import (
     TruncIOp,
     XOrI,
 )
-from xdsl.dialects.builtin import FloatAttr, IndexType, IntegerType, f32, f64, i32, i64
+from xdsl.dialects.builtin import (
+    AnyTensorType,
+    AnyVectorType,
+    FloatAttr,
+    IndexType,
+    IntegerType,
+    TensorType,
+    VectorType,
+    f32,
+    f64,
+    i1,
+    i32,
+    i64,
+)
 from xdsl.ir import Attribute
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
+from xdsl.utils.test_value import TestSSAValue
 
 _BinOpArgT = TypeVar("_BinOpArgT", bound=Attribute)
 
@@ -103,6 +119,57 @@ class Test_integer_arith_construction:
     )
     def test_Cmpi_from_mnemonic(self, input: str):
         _ = Cmpi(self.a, self.b, input)
+
+
+@pytest.mark.parametrize(
+    "lhs_type, rhs_type, sum_type, is_correct",
+    [
+        (i32, i32, None, True),
+        (i32, i32, i32, True),
+        (i32, i32, i64, False),
+        (i32, i64, None, False),
+        (VectorType(i32, [4]), VectorType(i32, [4]), None, True),
+        (VectorType(i32, [4]), VectorType(i32, [5]), None, False),
+        (VectorType(i32, [4]), VectorType(i64, [5]), None, False),
+        (VectorType(i32, [4]), VectorType(i32, [4]), VectorType(i32, [4]), True),
+        (VectorType(i32, [4]), VectorType(i32, [4]), VectorType(i64, [4]), False),
+        (TensorType(i32, [4]), TensorType(i32, [4]), None, True),
+        (TensorType(i32, [4]), TensorType(i32, [5]), None, False),
+        (TensorType(i32, [4]), TensorType(i64, [5]), None, False),
+        (TensorType(i32, [4]), TensorType(i32, [4]), TensorType(i32, [4]), True),
+        (TensorType(i32, [4]), TensorType(i32, [4]), TensorType(i1, [4]), False),
+        (VectorType(i32, [4]), TensorType(i32, [4]), None, False),
+        (VectorType(i32, [4]), TensorType(i32, [4]), TensorType(i32, [4]), False),
+    ],
+)
+def test_addui_extend(
+    lhs_type: Attribute,
+    rhs_type: Attribute,
+    sum_type: Attribute | None,
+    is_correct: bool,
+):
+    lhs = TestSSAValue(lhs_type)
+    rhs = TestSSAValue(rhs_type)
+
+    attributes = {"foo": i32}
+
+    if is_correct:
+        op = AddUIExtended(lhs, rhs, attributes, sum_type)
+        op.verify()
+        assert op.lhs == lhs
+        assert op.rhs == rhs
+        assert op.attributes == attributes
+        if sum_type:
+            assert op.sum.type == sum_type
+        assert op.overflow.type == AddUIExtended.infer_overflow_type(lhs_type)
+        if isa(container_type := op.overflow.type, AnyVectorType | AnyTensorType):
+            assert container_type.element_type == i1
+        else:
+            assert op.overflow.type == i1
+    else:
+        with pytest.raises((VerifyException, ValueError)):
+            op = AddUIExtended(lhs, rhs, attributes, sum_type)
+            op.verify()
 
 
 class Test_float_arith_construction:

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -172,4 +172,10 @@
 
   // CHECK-NEXT: %selecti = arith.select %lhsi1, %lhsi32, %rhsi32 : i32
   // CHECK-NEXT: %selectf = arith.select %lhsi1, %lhsf32, %rhsf32 : f32
+
+  %sum, %carry = arith.addui_extended %lhsi32, %rhsi32 : i32, i1
+  %sum_index, %carry_index = arith.addui_extended %lhsi64, %rhsi64 : i64, i1
+
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i32, i1
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i64, i1
 }) : () -> ()

--- a/tests/filecheck/dialects/arith/arith_ops_custom.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops_custom.mlir
@@ -166,4 +166,10 @@
 
   // CHECK-NEXT: %selecti = arith.select %lhsi1, %lhsi32, %rhsi32 : i32
   // CHECK-NEXT: %selectf = arith.select %lhsi1, %lhsf32, %rhsf32 : f32
+
+  %sum, %carry = arith.addui_extended %lhsi32, %rhsi32 : i32, i1
+  %sum_index, %carry_index = arith.addui_extended %lhsi64, %rhsi64 : i64, i1
+
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i32, i1
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i64, i1
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_ops_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_ops_custom.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
   %lhsi1 = "test.op"() : () -> (i1)
   %lhsi32, %rhsi32 = "test.op"() : () -> (i32, i32)
-  %lhsi64 = "test.op"() : () -> (i64)
+  %lhsi64, %rhsi64 = "test.op"() : () -> (i64, i64)
   %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
   %lhsf64 = "test.op"() : () -> (f64)
   %lhsvec, %rhsvec = "test.op"() : () -> (vector<4xf32>, vector<4xf32>)
@@ -114,4 +114,10 @@
 
   // CHECK-NEXT: {{%.*}} = arith.select {{%.*}}, {{%.*}}#0, {{%.*}}#1 : i32
   // CHECK-NEXT: {{%.*}} = arith.select {{%.*}}, {{%.*}}#0, {{%.*}}#1 : f32
+
+  %sum, %carry = arith.addui_extended %lhsi32, %rhsi32 : i32, i1
+  %sum_index, %carry_index = arith.addui_extended %lhsi64, %rhsi64 : i64, i1
+
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i32, i1
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i64, i1
 }) : () -> ()

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Annotated, Generic, TypeVar, cast, overload
 
@@ -15,6 +16,9 @@ from xdsl.dialects.builtin import (
     IntAttr,
     IntegerAttr,
     IntegerType,
+    TensorType,
+    UnrankedTensorType,
+    VectorType,
 )
 from xdsl.dialects.llvm import FastMathAttr as LLVMFastMathAttr
 from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
@@ -36,6 +40,7 @@ from xdsl.utils.deprecation import deprecated
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
+boolLike = ContainerOf(IntegerType(1))
 signlessIntegerLike = ContainerOf(AnyOf([IntegerType, IndexType]))
 floatingPointLike = ContainerOf(AnyOf([Float16Type, Float32Type, Float64Type]))
 
@@ -261,6 +266,84 @@ class Addi(SignlessIntegerBinaryOp):
     name = "arith.addi"
 
     traits = frozenset([Pure()])
+
+
+@irdl_op_definition
+class AddUIExtended(IRDLOperation):
+    name = "arith.addui_extended"
+
+    traits = frozenset([Pure()])
+
+    T = Annotated[Attribute, signlessIntegerLike, ConstraintVar("T")]
+
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+
+    sum: OpResult = result_def(T)
+    overflow: OpResult = result_def(Annotated[Attribute, boolLike])
+
+    def __init__(
+        self,
+        operand1: Operation | SSAValue,
+        operand2: Operation | SSAValue,
+        attributes: Mapping[str, Attribute] | None = None,
+        result_type: Attribute | None = None,
+    ):
+        if result_type is None:
+            result_type = SSAValue.get(operand1).type
+        overflow_type = AddUIExtended.infer_overflow_type(result_type)
+        super().__init__(
+            operands=[operand1, operand2],
+            result_types=[result_type, overflow_type],
+            attributes=attributes,
+        )
+
+    def verify_(self):
+        expected_overflow_type = AddUIExtended.infer_overflow_type(self.lhs.type)
+        if self.overflow.type != expected_overflow_type:
+            raise VerifyException(
+                f"overflow type {self.overflow.type} does not "
+                f"match input types {self.lhs.type}. Expected {expected_overflow_type}"
+            )
+
+    def print(self, printer: Printer):
+        printer.print(" ", self.lhs, ", ", self.rhs)
+        printer.print_op_attributes(self.attributes)
+        printer.print(" : ", self.lhs.type, ", ", self.overflow.type)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> AddUIExtended:
+        lhs = parser.parse_unresolved_operand()
+        parser.parse_punctuation(",")
+        rhs = parser.parse_unresolved_operand()
+        attributes = parser.parse_optional_attr_dict()
+        parser.parse_punctuation(":")
+        sum_type = parser.parse_type()
+        parser.parse_punctuation(",")
+        overflow_type = parser.parse_type()
+        (lhs, rhs) = parser.resolve_operands([lhs, rhs], 2 * [sum_type], parser.pos)
+
+        return AddUIExtended.create(
+            operands=[lhs, rhs],
+            attributes=attributes,
+            result_types=[sum_type, overflow_type],
+        )
+
+    @staticmethod
+    def infer_overflow_type(input_type: Attribute) -> Attribute:
+        if isinstance(input_type, IntegerType):
+            return IntegerType(1)
+        if isinstance(input_type, VectorType):
+            return VectorType(
+                IntegerType(1), input_type.shape, input_type.num_scalable_dims
+            )
+        if isinstance(input_type, UnrankedTensorType):
+            return UnrankedTensorType(IntegerType(1))
+        if isinstance(input_type, TensorType):
+            return TensorType(IntegerType(1), input_type.shape, input_type.encoding)
+        raise ValueError(
+            f"Unsupported input type for {AddUIExtended.name}: {input_type}"
+        )
 
 
 @irdl_op_definition
@@ -901,6 +984,7 @@ Arith = Dialect(
         Constant,
         # Integer-like
         Addi,
+        AddUIExtended,
         Subi,
         Muli,
         DivUI,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -270,6 +270,11 @@ class Addi(SignlessIntegerBinaryOp):
 
 @irdl_op_definition
 class AddUIExtended(IRDLOperation):
+    """
+    An add operation on an unsigned representation of integers that returns a flag
+    indicating if the result overflowed.
+    """
+
     name = "arith.addui_extended"
 
     traits = frozenset([Pure()])


### PR DESCRIPTION
Add `arith.addui_extended` operation.
It works like `arith.addi`, but returns a flag that indicates if the addition overflowed.