### PR TITLE
interactive: adding function that takes a pipelinepasspsec and returns its strings+ tests 

### DIFF
--- a/tests/test_parse_spec_format.py
+++ b/tests/test_parse_spec_format.py
@@ -1,0 +1,64 @@
+import pytest
+
+from xdsl.utils.parse_pipeline import (
+    PipelinePassSpec,
+    parse_pipeline,
+)
+
+
+def test_pass_parser():
+    passes = list(
+        parse_pipeline(
+            'pass-1,pass-2{arg1=1 arg2=test,test2,3 arg3="test-str,2,3" '
+            "arg-4=-34.4e-12 no-val-arg},pass-3{thing=2d-grid}"
+        )
+    )
+
+    assert passes == [
+        PipelinePassSpec("pass-1", {}),
+        PipelinePassSpec(
+            "pass-2",
+            {
+                "arg1": [1],
+                "arg2": ["test", "test2", 3],
+                "arg3": ["test-str,2,3"],
+                "arg-4": [-3.44e-11],
+                "no-val-arg": [],
+            },
+        ),
+        PipelinePassSpec(
+            "pass-3",
+            {
+                "thing": ["2d-grid"],
+            },
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        PipelinePassSpec("empty", {}),
+        PipelinePassSpec(
+            "pass-2",
+            {
+                "arg1": [1],
+                "arg2": ["test", "test2", 3],
+                "arg3": ["test-str,2,3"],
+                "arg-4": [-3.44e-11],
+                "no-val-arg": [],
+            },
+        ),
+        PipelinePassSpec(
+            "pass-3",
+            {
+                "thing": ["2d-grid"],
+            },
+        ),
+    ],
+)
+def test_spec_printer(spec: PipelinePassSpec):
+    text = str(spec)
+    passes = list(parse_pipeline(text))
+    assert len(passes) == 1
+    assert passes[0] == spec

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -3,7 +3,6 @@ import pytest
 from xdsl.utils.exceptions import PassPipelineParseError
 from xdsl.utils.parse_pipeline import (
     PipelineLexer,
-    PipelinePassSpec,
     Token,
     parse_pipeline,
 )
@@ -47,35 +46,6 @@ def test_pass_lex_errors():
 
     with pytest.raises(PassPipelineParseError, match="Unknown token"):
         list(generator("pass-1{thing$=1}"))
-
-
-def test_pass_parser():
-    passes = list(
-        parse_pipeline(
-            'pass-1,pass-2{arg1=1 arg2=test,test2,3 arg3="test-str,2,3" '
-            "arg-4=-34.4e-12 no-val-arg},pass-3{thing=2d-grid}"
-        )
-    )
-
-    assert passes == [
-        PipelinePassSpec("pass-1", {}),
-        PipelinePassSpec(
-            "pass-2",
-            {
-                "arg1": [1],
-                "arg2": ["test", "test2", 3],
-                "arg3": ["test-str,2,3"],
-                "arg-4": [-3.44e-11],
-                "no-val-arg": [],
-            },
-        ),
-        PipelinePassSpec(
-            "pass-3",
-            {
-                "thing": ["2d-grid"],
-            },
-        ),
-    ]
 
 
 @pytest.mark.parametrize(

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -103,33 +103,6 @@ class ModulePass(ABC):
         # instantiate the dataclass using kwargs
         return cls(**arg_dict)
 
-    def get_pass_argument_names_and_types(self) -> str:
-        """
-        This method takes a ModulePassT and outputs a string containing the names of the
-        pass arguments and their types. If an argument has a default value, it is not
-        added to the string.
-        """
-        try:
-            return "\n".join(
-                [
-                    f"{field.name}={field.type}"
-                    for field in dataclasses.fields(self)
-                    if not hasattr(self, field.name)
-                ]
-            )
-        except Exception as e:
-            raise e
-
-    def from_pass_to_spec(self) -> PipelinePassSpec:
-        """
-        This function takes a ModulePassT and returns a PipelinePassSpec.
-        """
-        res = PipelinePassSpec(self.name, dict())
-        for f in dataclasses.fields(self):
-            res.args.update(getattr(self, f.name))
-
-        return res
-
 
 def _empty_callback(
     previous_pass: ModulePass, module: builtin.ModuleOp, next_pass: ModulePass

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -103,8 +103,7 @@ class ModulePass(ABC):
         # instantiate the dataclass using kwargs
         return cls(**arg_dict)
 
-    @classmethod
-    def get_pass_argument_names_and_types(cls: type[ModulePassT]) -> str:
+    def get_pass_argument_names_and_types(self) -> str:
         """
         This method takes a ModulePassT and outputs a string containing the names of the
         pass arguments and their types. If an argument has a default value, it is not
@@ -114,12 +113,22 @@ class ModulePass(ABC):
             return "\n".join(
                 [
                     f"{field.name}={field.type}"
-                    for field in dataclasses.fields(cls)
-                    if not hasattr(cls, field.name)
+                    for field in dataclasses.fields(self)
+                    if not hasattr(self, field.name)
                 ]
             )
         except Exception as e:
             raise e
+
+    def from_pass_to_spec(self) -> PipelinePassSpec:
+        """
+        This function takes a ModulePassT and returns a PipelinePassSpec.
+        """
+        res = PipelinePassSpec(self.name, dict())
+        for f in dataclasses.fields(self):
+            res.args.update(getattr(self, f.name))
+
+        return res
 
 
 def _empty_callback(

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -103,6 +103,21 @@ class ModulePass(ABC):
         # instantiate the dataclass using kwargs
         return cls(**arg_dict)
 
+    @classmethod
+    def get_pass_argument_names_and_types(cls: type[ModulePassT]) -> str:
+        """
+        This method takes a ModulePassT and outputs a string containing the names of the
+        pass arguments and their types. If an argument has a default value, it is not
+        added to the string.
+        """
+        return "\n".join(
+            [
+                f"{field.name}={field.type}"
+                for field in dataclasses.fields(cls)
+                if not hasattr(cls, field.name)
+            ]
+        )
+
 
 def _empty_callback(
     previous_pass: ModulePass, module: builtin.ModuleOp, next_pass: ModulePass

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -110,13 +110,16 @@ class ModulePass(ABC):
         pass arguments and their types. If an argument has a default value, it is not
         added to the string.
         """
-        return "\n".join(
-            [
-                f"{field.name}={field.type}"
-                for field in dataclasses.fields(cls)
-                if not hasattr(cls, field.name)
-            ]
-        )
+        try:
+            return "\n".join(
+                [
+                    f"{field.name}={field.type}"
+                    for field in dataclasses.fields(cls)
+                    if not hasattr(cls, field.name)
+                ]
+            )
+        except Exception as e:
+            raise e
 
 
 def _empty_callback(

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -129,15 +129,11 @@ class PipelinePassSpec:
         respective values for use on the commandline.
         """
         query = f"\n{self.name}"
-        arguments_pipeline = (
-            ", ".join(
-                f"{arg_name}={','.join(map(str.lower, map(str, arg_val)))}"
-                if isinstance(arg_val[0], bool)
-                else f"{arg_name}={','.join(map(str, arg_val))}"
-                for arg_name, arg_val in self.args.items()
-            )
-            if self.args
-            else ""
+        arguments_pipeline = ", ".join(
+            f"{arg_name}={','.join(map(str.lower, map(str, arg_val)))}"
+            if isinstance(arg_val[0], bool)
+            else f"{arg_name}={','.join(map(str, arg_val))}"
+            for arg_name, arg_val in self.args.items()
         )
         query += f"{{{arguments_pipeline}}}" if arguments_pipeline else ""
         query += ",\n"

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -152,7 +152,7 @@ class PipelinePassSpec:
             _pass_arg_list_type_str(arg_name, arg_val)
             for arg_name, arg_val in self.args.items()
         )
-        query += f"{{{arguments_pipeline}}}" if len(self.args) != 0 else ""
+        query += f"{{{arguments_pipeline}}}" if self.args else ""
 
         return query
 

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -106,6 +106,22 @@ PassArgElementType = str | int | bool | float
 PassArgListType = list[PassArgElementType]
 
 
+def _pass_arg_element_type_str(arg: PassArgElementType) -> str:
+    if isinstance(arg, bool):
+        if arg:
+            return str(arg).lower()
+        else:
+            return str(arg).lower()
+    elif isinstance(arg, str):
+        return f'"{arg}"'
+    else:
+        return str(arg)
+
+
+def _pass_arg_list_type_str(arg: PassArgListType) -> str:
+    return ",".join(_pass_arg_element_type_str(val) for val in arg)
+
+
 @dataclass(eq=True, frozen=True)
 class PipelinePassSpec:
     """
@@ -123,22 +139,32 @@ class PipelinePassSpec:
             del self.args[k]
             self.args[k.replace("-", "_")] = v
 
-    def spec_to_string(self) -> str:
+    def __str__(self) -> str:
         """
         This function returns a string containing the PipelineSpec name, its arguments and
         respective values for use on the commandline.
         """
-        query = f"\n{self.name}"
-        arguments_pipeline = ", ".join(
-            f"{arg_name}={','.join(map(str.lower, map(str, arg_val)))}"
-            if isinstance(arg_val[0], bool)
-            else f"{arg_name}={','.join(map(str, arg_val))}"
+        query = f"{self.name}"
+        arguments_pipeline = " ".join(
+            f"{arg_name}={_pass_arg_list_type_str(arg_val)}"
+            if len(arg_val) >= 1
+            else f"{arg_name}"
             for arg_name, arg_val in self.args.items()
         )
-        query += f"{{{arguments_pipeline}}}" if arguments_pipeline else ""
-        query += ",\n"
+        query += f"{{{arguments_pipeline}}}" if len(self.args) != 0 else ""
 
         return query
+
+        # query = f"{self.name}"
+        # arguments_pipeline = ", ".join(
+        #     f"{arg_name}={','.join(map(str.lower, map(str, arg_val)))}"
+        #     if isinstance(arg_val[0], bool)
+        #     else f"{arg_name}={','.join(map(str, arg_val))}"
+        #     for arg_name, arg_val in self.args.items()
+        # )
+        # query += f"{{{arguments_pipeline}}}" if arguments_pipeline else ""
+
+        # return query
 
 
 def parse_pipeline(

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -123,6 +123,27 @@ class PipelinePassSpec:
             del self.args[k]
             self.args[k.replace("-", "_")] = v
 
+    def spec_to_string(self) -> str:
+        """
+        This function returns a string containing the PipelineSpec name, its arguments and
+        respective values for use on the commandline.
+        """
+        query = f"\n{self.name}"
+        arguments_pipeline = (
+            ", ".join(
+                f"{arg_name}={','.join(map(str.lower, map(str, arg_val)))}"
+                if isinstance(arg_val[0], bool)
+                else f"{arg_name}={','.join(map(str, arg_val))}"
+                for arg_name, arg_val in self.args.items()
+            )
+            if self.args
+            else ""
+        )
+        query += f"{{{arguments_pipeline}}}" if arguments_pipeline else ""
+        query += ",\n"
+
+        return query
+
 
 def parse_pipeline(
     pipeline_spec: str,

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -107,19 +107,22 @@ PassArgListType = list[PassArgElementType]
 
 
 def _pass_arg_element_type_str(arg: PassArgElementType) -> str:
-    if isinstance(arg, bool):
-        if arg:
+    match arg:
+        case bool():
             return str(arg).lower()
-        else:
-            return str(arg).lower()
-    elif isinstance(arg, str):
-        return f'"{arg}"'
+        case str():
+            return f'"{arg}"'
+        case int():
+            return str(arg)
+        case float():
+            return str(arg)
+
+
+def _pass_arg_list_type_str(name: str, arg: PassArgListType) -> str:
+    if arg:
+        return f'{name}={",".join(_pass_arg_element_type_str(val) for val in arg)}'
     else:
-        return str(arg)
-
-
-def _pass_arg_list_type_str(arg: PassArgListType) -> str:
-    return ",".join(_pass_arg_element_type_str(val) for val in arg)
+        return name
 
 
 @dataclass(eq=True, frozen=True)
@@ -146,25 +149,12 @@ class PipelinePassSpec:
         """
         query = f"{self.name}"
         arguments_pipeline = " ".join(
-            f"{arg_name}={_pass_arg_list_type_str(arg_val)}"
-            if len(arg_val) >= 1
-            else f"{arg_name}"
+            _pass_arg_list_type_str(arg_name, arg_val)
             for arg_name, arg_val in self.args.items()
         )
         query += f"{{{arguments_pipeline}}}" if len(self.args) != 0 else ""
 
         return query
-
-        # query = f"{self.name}"
-        # arguments_pipeline = ", ".join(
-        #     f"{arg_name}={','.join(map(str.lower, map(str, arg_val)))}"
-        #     if isinstance(arg_val[0], bool)
-        #     else f"{arg_name}={','.join(map(str, arg_val))}"
-        #     for arg_name, arg_val in self.args.items()
-        # )
-        # query += f"{{{arguments_pipeline}}}" if arguments_pipeline else ""
-
-        # return query
 
 
 def parse_pipeline(


### PR DESCRIPTION
Added a function that takes a pipelinepasspsec and returns its string version. this helps with being able to print out directly what should be used in the terminal (after the xdsl-opt command)