### PR TITLE
backend: (riscv) support any memref shape for access lowering

### DIFF
--- a/docs/Toy/toy/tests/test_lower_memref_riscv.py
+++ b/docs/Toy/toy/tests/test_lower_memref_riscv.py
@@ -1,12 +1,9 @@
-import pytest
-
 from xdsl.backend.riscv.lowering.convert_memref_to_riscv import memref_shape_ops
 from xdsl.builder import Builder, ImplicitBuilder
 from xdsl.dialects import func, memref, riscv
 from xdsl.dialects.builtin import ModuleOp, UnrealizedConversionCastOp, f32
 from xdsl.ir import MLContext
 from xdsl.pattern_rewriter import PatternRewriter
-from xdsl.utils.exceptions import DiagnosticException
 from xdsl.utils.test_value import TestSSAValue
 
 from ..rewrites.lower_memref_riscv import LowerMemrefToRiscv
@@ -132,7 +129,7 @@ def test_insert_shape_ops_2d():
     assert f"{input_2d}" == f"{expected_2d}"
 
 
-def test_insert_shape_ops_invalid_dim():
+def test_insert_shape_ops_3d():
     mem = TestSSAValue(MEMREF_TYPE_2X2X2XF32)
     indices = [
         TestSSAValue(INT_REGISTER_TYPE),
@@ -142,14 +139,35 @@ def test_insert_shape_ops_invalid_dim():
 
     @ModuleOp
     @Builder.implicit_region
-    def input_2d():
+    def input_3d():
         with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
             riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
 
+    @ModuleOp
+    @Builder.implicit_region
+    def expected_3d():
+        with ImplicitBuilder(func.FuncOp("impl", ((), ())).body):
+            v1 = riscv.LiOp(2)
+            v2 = riscv.MulOp(v1, indices[0], rd=riscv.IntRegisterType.unallocated())
+            v3 = riscv.AddOp(v2, indices[1], rd=riscv.IntRegisterType.unallocated())
+            v4 = riscv.LiOp(2)
+            v4 = riscv.MulOp(v4, v3, rd=riscv.IntRegisterType.unallocated())
+            v5 = riscv.AddOp(v4, indices[2], rd=riscv.IntRegisterType.unallocated())
+            v6 = riscv.LiOp(4).rd
+            v7 = riscv.MulOp(
+                v5,
+                v6,
+                rd=riscv.IntRegisterType.unallocated(),
+                comment="multiply by element size",
+            ).rd
+            _ = riscv.AddOp(mem, v7, rd=riscv.IntRegisterType.unallocated())
+            riscv.CustomAssemblyInstructionOp("some_memref_op", (), ())
+
     shape = [2, 2, 2]
-    dummy_op = list(input_2d.walk())[-1]
+    dummy_op = list(input_3d.walk())[-1]
     rewriter = PatternRewriter(dummy_op)
 
-    with pytest.raises(DiagnosticException):
-        ops, _ = memref_shape_ops(mem, indices, shape, MEMREF_TYPE_2XF32.element_type)
-        rewriter.insert_op_before_matched_op(ops)
+    ops, _ = memref_shape_ops(mem, indices, shape, MEMREF_TYPE_2XF32.element_type)
+    rewriter.insert_op_before_matched_op(ops)
+
+    assert f"{input_3d}" == f"{expected_3d}"

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -100,15 +100,6 @@ builtin.module {
 // -----
 
 builtin.module {
-    %v, %d0, %d1, %d2, %m = "test.op"() : () -> (f32, index, index, index, memref<3x2x1xf32>)
-    "memref.store"(%v, %m, %d0, %d1, %d2) {"nontemporal" = false} : (f32, memref<3x2x1xf32>, index, index, index) -> ()
-}
-
-// CHECK:      Unsupported memref shape (3, 2, 1), only support 1D and 2D memrefs.
-
-// -----
-
-builtin.module {
     %v, %d0, %m = "test.op"() : () -> (i8, index, memref<1xi8>)
     "memref.store"(%v, %m, %d0) {"nontemporal" = false} : (i8, memref<1xi8>, index) -> ()
 }

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -52,7 +52,8 @@ def memref_shape_ops(
     The pointer is byte-indexed, and the indices are strided by element size, so the index
     into the flat memory buffer needs to be multiplied by the size of the element.
     """
-
+    assert shape
+    assert indices
     assert len(shape) == len(indices)
 
     # Only handle a small subset of elements
@@ -76,30 +77,27 @@ def memref_shape_ops(
 
     ops: list[Operation] = []
 
-    match indices:
-        case [offset_in_elements]:
-            pass
-        case [idx1, idx2]:
-            ops = [
-                cols := riscv.LiOp(shape[1]),
-                row_offset := riscv.MulOp(
-                    cols, idx1, rd=riscv.IntRegisterType.unallocated()
+    head, *tail = indices
+
+    for factor, value in zip(shape[1:], tail):
+        ops.extend(
+            (
+                factor_op := riscv.LiOp(factor),
+                offset_op := riscv.MulOp(
+                    factor_op.rd, head, rd=riscv.IntRegisterType.unallocated()
                 ),
-                offset := riscv.AddOp(
-                    row_offset, idx2, rd=riscv.IntRegisterType.unallocated()
+                new_head_op := riscv.AddOp(
+                    offset_op, value, rd=riscv.IntRegisterType.unallocated()
                 ),
-            ]
-            offset_in_elements = offset.rd
-        case _:
-            raise DiagnosticException(
-                f"Unsupported memref shape {shape}, only support 1D and 2D memrefs."
             )
+        )
+        head = new_head_op.rd
 
     ops.extend(
         [
             bytes_per_element_op := riscv.LiOp(bytes_per_element),
             offset_bytes := riscv.MulOp(
-                offset_in_elements,
+                head,
                 bytes_per_element_op.rd,
                 rd=riscv.IntRegisterType.unallocated(),
                 comment="multiply by element size",

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -52,8 +52,6 @@ def memref_shape_ops(
     The pointer is byte-indexed, and the indices are strided by element size, so the index
     into the flat memory buffer needs to be multiplied by the size of the element.
     """
-    assert shape
-    assert indices
     assert len(shape) == len(indices)
 
     # Only handle a small subset of elements
@@ -74,6 +72,10 @@ def memref_shape_ops(
             raise DiagnosticException(
                 f"Unsupported memref element type for riscv lowering: {element_type}"
             )
+
+    if not shape:
+        # Scalar memref
+        return ([], mem)
 
     ops: list[Operation] = []
 


### PR DESCRIPTION
We only handled 1d and 2d now we handle arbitrary ranks of memrefs with known dimensions.

@xdslproject/risc-v-backend 