### PR TITLE
backend: (riscv) add mechansim to reserve and unreserve registers

### DIFF
--- a/tests/backend/riscv/test_register_queue.py
+++ b/tests/backend/riscv/test_register_queue.py
@@ -38,6 +38,24 @@ def test_push_register():
     assert riscv.Registers.FA0 == register_queue.available_float_registers[-1]
 
 
+def test_reserve_register():
+    register_queue = RegisterQueue()
+
+    register_queue.reserve_register(riscv.IntRegisterType("j0"))
+    assert register_queue.reserved_registers[riscv.IntRegisterType("j0")] == 1
+
+    register_queue.reserve_register(riscv.IntRegisterType("j0"))
+    assert register_queue.reserved_registers[riscv.IntRegisterType("j0")] == 2
+
+    register_queue.unreserve_register(riscv.IntRegisterType("j0"))
+    assert register_queue.reserved_registers[riscv.IntRegisterType("j0")] == 1
+
+    register_queue.unreserve_register(riscv.IntRegisterType("j0"))
+    # assert riscv.IntRegisterType("j0") not in register_queue.reserved_registers
+
+    assert register_queue.pop(riscv.IntRegisterType).register_name == "j0"
+
+
 def test_limit():
     register_queue = RegisterQueue()
     register_queue.limit_registers(1)

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -209,7 +209,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
         for pa_reg in preallocated:
             if isinstance(pa_reg, IntRegisterType | FloatRegisterType):
-                self.available_registers.reserved_registers[pa_reg] += 1
+                self.available_registers.reserve_register(pa_reg)
 
             if pa_reg in self.available_registers.available_int_registers:
                 self.available_registers.available_int_registers.remove(pa_reg)

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -209,7 +209,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
         for pa_reg in preallocated:
             if isinstance(pa_reg, IntRegisterType | FloatRegisterType):
-                self.available_registers.reserved_registers.add(pa_reg)
+                self.available_registers.reserved_registers[pa_reg] += 1
 
             if pa_reg in self.available_registers.available_int_registers:
                 self.available_registers.available_int_registers.remove(pa_reg)

--- a/xdsl/backend/riscv/register_queue.py
+++ b/xdsl/backend/riscv/register_queue.py
@@ -79,6 +79,24 @@ class RegisterQueue:
             self._idx += 1
         return reg
 
+    def reserve_register(self, reg: IntRegisterType | FloatRegisterType) -> None:
+        """
+        Increase the reservation count for a register.
+        """
+        self.reserved_registers[reg] += 1
+
+    def unreserve_register(self, reg: IntRegisterType | FloatRegisterType) -> None:
+        """
+        Decrease the reservation count for a register. If the reservation count is 0, make
+        the register available for allocation.
+        """
+        if reg not in self.reserved_registers:
+            raise ValueError("Cannot unreserve an unreserved register")
+        self.reserved_registers[reg] -= 1
+        if not self.reserved_registers[reg]:
+            del self.reserved_registers[reg]
+            self.push(reg)
+
     def limit_registers(self, limit: int) -> None:
         """
         Limits the number of currently available registers to the provided limit.

--- a/xdsl/backend/riscv/register_queue.py
+++ b/xdsl/backend/riscv/register_queue.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import overload
 
@@ -25,8 +26,11 @@ class RegisterQueue:
     _idx: int = 0
     """Next `j` register index."""
 
-    reserved_registers: set[IntRegisterType | FloatRegisterType] = field(
-        default_factory=lambda: set(RegisterQueue.DEFAULT_RESERVED_REGISTERS)
+    reserved_registers: defaultdict[IntRegisterType | FloatRegisterType, int] = field(
+        default_factory=lambda: defaultdict[IntRegisterType | FloatRegisterType, int](
+            lambda: 0
+        )
+        | {r: 1 for r in RegisterQueue.DEFAULT_RESERVED_REGISTERS}
     )
     "Registers unavailable to be used by the register allocator."
 
@@ -44,7 +48,7 @@ class RegisterQueue:
         """
         Return a register to be made available for allocation.
         """
-        if reg in self.reserved_registers:
+        if self.reserved_registers[reg]:
             return
         if not reg.is_allocated:
             raise ValueError("Cannot push an unallocated register")


### PR DESCRIPTION
Turns out there's a bug with our handling of iteration arguments in the register allocator. This is PR 1/2 to fix this issue (I'll open the other ones in order to avoid stacking), it just abstracts reserving and unreserving registers in the register queue class.

@xdslproject/risc-v-backend 