### PR TITLE
transforms: implement gpu-map-parallel-loops

### DIFF
--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -3,7 +3,7 @@
 builtin.module attributes {"gpu.container_module"} {
     "gpu.module"() ({
         func.func @kernel() {
-            %n = arith.constant 13 : index
+            %n = arith.constant {"proc" = #gpu<processor thread_x>} 13 : index
             %one = arith.constant 1 : index
 
             %memref = "memref.alloc"() {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<10x10xi32>
@@ -81,7 +81,7 @@ builtin.module attributes {"gpu.container_module"} {
 // CHECK:      builtin.module attributes {"gpu.container_module"} {
 // CHECK-NEXT:     "gpu.module"() ({
 // CHECK-NEXT:         func.func @kernel() {
-// CHECK-NEXT:             %{{.*}} = arith.constant 13 : index
+// CHECK-NEXT:             %{{.*}} = arith.constant {"proc" = #gpu<processor thread_x>} 13 : index
 // CHECK-NEXT:             %{{.*}} = arith.constant 1 : index
 
 // CHECK-NEXT:             %{{.*}} = "memref.alloc"() <{"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<10x10xi32>

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -4,7 +4,7 @@ builtin.module attributes {"gpu.container_module"} {
     "gpu.module"() ({
         func.func @kernel() {
             %n = arith.constant {"proc" = #gpu<processor thread_x>} 13 : index
-            %one = arith.constant 1 : index
+            %one = arith.constant {"loopdim" = #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>} 1 : index
 
             %memref = "memref.alloc"() {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<10x10xi32>
             %unranked = "memref.cast"(%memref) : (memref<10x10xi32>) -> memref<*xi32>
@@ -82,7 +82,7 @@ builtin.module attributes {"gpu.container_module"} {
 // CHECK-NEXT:     "gpu.module"() ({
 // CHECK-NEXT:         func.func @kernel() {
 // CHECK-NEXT:             %{{.*}} = arith.constant {"proc" = #gpu<processor thread_x>} 13 : index
-// CHECK-NEXT:             %{{.*}} = arith.constant 1 : index
+// CHECK-NEXT:             %{{.*}} = arith.constant {"loopdim" = #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>} 1 : index
 
 // CHECK-NEXT:             %{{.*}} = "memref.alloc"() <{"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<10x10xi32>
 // CHECK-NEXT:             %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x10xi32>) -> memref<*xi32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
@@ -4,7 +4,7 @@
     "gpu.module"() ({
         "func.func"() ({
             %n = "arith.constant"() {"value" = 13 : index} : () -> index
-            %one = "arith.constant"() {"value" = 1 : index} : () -> index
+            %one = arith.constant {"loopdim" = #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>} 1 : index
 
             %memref = "memref.alloc"() {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<10x10xi32>
             %unranked = "memref.cast"(%memref) : (memref<10x10xi32>) -> memref<*xi32>
@@ -82,8 +82,7 @@
 // CHECK-NEXT:     "gpu.module"() ({
 // CHECK-NEXT:         "func.func"() <{"function_type" = () -> (), "sym_name" = "kernel"}> ({
 // CHECK-NEXT:             %{{.*}} = "arith.constant"() <{"value" = 13 : index}> : () -> index
-// CHECK-NEXT:             %{{.*}} = "arith.constant"() <{"value" = 1 : index}> : () -> index
-
+// CHECK-NEXT:             %{{.*}} = "arith.constant"() <{"value" = 1 : index}> {"loopdim" = #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>} : () -> index
 // CHECK-NEXT:             %{{.*}} = "memref.alloc"() <{"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<10x10xi32>
 // CHECK-NEXT:             %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x10xi32>) -> memref<*xi32>
 // CHECK-NEXT:             "gpu.host_register"(%{{.*}}) : (memref<*xi32>) -> ()

--- a/tests/filecheck/transforms/gpu-map-parallel-loops.mlir
+++ b/tests/filecheck/transforms/gpu-map-parallel-loops.mlir
@@ -1,0 +1,62 @@
+// RUN: xdsl-opt -p gpu-map-parallel-loops --split-input-file %s | filecheck %s
+
+func.func @parallel_loop(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : index) {
+  %0 = arith.constant 0 : index
+  %1 = arith.constant 1 : index
+  %2 = arith.constant 4 : index
+  "scf.parallel"(%arg0, %arg1, %arg2, %arg3, %2, %2) <{"operandSegmentSizes" = array<i32: 2, 2, 2, 0>}> ({
+  ^0(%arg4 : index, %arg5 : index):
+    "scf.parallel"(%0, %0, %2, %2, %1, %1) <{"operandSegmentSizes" = array<i32: 2, 2, 2, 0>}> ({
+    ^1(%arg6 : index, %arg7 : index):
+      scf.yield
+    }) : (index, index, index, index, index, index) -> ()
+    scf.yield
+  }) : (index, index, index, index, index, index) -> ()
+  func.return
+}
+
+// CHECK:         func @parallel_loop(
+// CHECK:           scf.parallel
+// CHECK:             scf.parallel
+// CHECK:      {"mapping" = [#gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+// CHECK:      {"mapping" = [#gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+
+// -----
+
+func.func @parallel_loop_4d(%arg0_1 : index, %arg1_1 : index, %arg2_1 : index, %arg3_1 : index) {
+  %3 = arith.constant 0 : index
+  %4 = arith.constant 1 : index
+  %5 = arith.constant 4 : index
+  "scf.parallel"(%3, %3, %3, %3, %arg0_1, %arg1_1, %arg2_1, %arg3_1, %5, %5, %5, %5) <{"operandSegmentSizes" = array<i32: 4, 4, 4, 0>}> ({
+  ^2(%arg4_1 : index, %arg5_1 : index, %arg6_1 : index, %arg7_1 : index):
+    "scf.parallel"(%3, %3, %3, %3, %5, %5, %5, %5, %4, %4, %4, %4) <{"operandSegmentSizes" = array<i32: 4, 4, 4, 0>}> ({
+    ^3(%arg8 : index, %arg9 : index, %arg10 : index, %arg11 : index):
+      "scf.parallel"(%3, %3, %3, %3, %5, %5, %5, %5, %4, %4, %4, %4) <{"operandSegmentSizes" = array<i32: 4, 4, 4, 0>}> ({
+      ^4(%arg12 : index, %arg13 : index, %arg14 : index, %arg15 : index):
+        scf.yield
+      }) : (index, index, index, index, index, index, index, index, index, index, index, index) -> ()
+      scf.yield
+    }) : (index, index, index, index, index, index, index, index, index, index, index, index) -> ()
+    scf.yield
+  }) : (index, index, index, index, index, index, index, index, index, index, index, index) -> ()
+  func.return
+}
+
+// CHECK:         func @parallel_loop_4d(
+// CHECK:           scf.parallel
+// CHECK:             scf.parallel
+// CHECK:               scf.parallel
+// CHECK:      {"mapping" = [#gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+// CHECK:      {"mapping" = [#gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = thread_z, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = thread_y, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = thread_x, map = (d0) -> (d0), bound = (d0) -> (d0)>]}
+// CHECK:      {"mapping" = [#gpu.loop_dim_map<processor = sequential, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = block_z, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = block_y, map = (d0) -> (d0), bound = (d0) -> (d0)>,
+// CHECK-SAME:             #gpu.loop_dim_map<processor = block_x, map = (d0) -> (d0), bound = (d0) -> (d0)>]}

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -83,12 +83,25 @@ class DimensionEnum(StrEnum):
     Z = auto()
 
 
+class ProcessorEnum(StrEnum):
+    Block_X = auto()
+    Block_Y = auto()
+    Block_Z = auto()
+    Thread_X = auto()
+    Thread_Y = auto()
+    Thread_Z = auto()
+
+
 class AllReduceOpAttr(EnumAttribute[AllReduceOpEnum], OpaqueSyntaxAttribute):
     name = "gpu.all_reduce_op"
 
 
 class DimensionAttr(EnumAttribute[DimensionEnum], OpaqueSyntaxAttribute):
     name = "gpu.dim"
+
+
+class ProcessorAttr(EnumAttribute[ProcessorEnum], OpaqueSyntaxAttribute):
+    name = "gpu.processor"
 
 
 _Element = TypeVar("_Element", bound=Attribute, covariant=True)
@@ -719,5 +732,5 @@ GPU = Dialect(
         ThreadIdOp,
         YieldOp,
     ],
-    [AllReduceOpAttr, DimensionAttr],
+    [AllReduceOpAttr, DimensionAttr, ProcessorAttr],
 )

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -570,7 +570,7 @@ class ParametrizedAttribute(Attribute):
         return attr
 
     @classmethod
-    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+    def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
         """Parse the attribute parameters."""
         return parser.parse_paramattr_parameters()
 

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -60,6 +60,7 @@ from xdsl.transforms import (
     constant_fold_interp,
     convert_scf_to_openmp,
     dead_code_elimination,
+    gpu_map_parallel_loops,
     lower_affine,
     lower_mpi,
     lower_riscv_func,
@@ -130,6 +131,7 @@ def get_all_dialects() -> list[Dialect]:
 def get_all_passes() -> list[type[ModulePass]]:
     """Return the list of all available passes."""
     return [
+        gpu_map_parallel_loops.GpuMapParallelLoopsPass,
         canonicalize.CanonicalizePass,
         canonicalize_dmp.CanonicalizeDmpPass,
         convert_scf_to_openmp.ConvertScfToOpenMPPass,

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -131,7 +131,6 @@ def get_all_dialects() -> list[Dialect]:
 def get_all_passes() -> list[type[ModulePass]]:
     """Return the list of all available passes."""
     return [
-        gpu_map_parallel_loops.GpuMapParallelLoopsPass,
         canonicalize.CanonicalizePass,
         canonicalize_dmp.CanonicalizeDmpPass,
         convert_scf_to_openmp.ConvertScfToOpenMPPass,
@@ -140,6 +139,7 @@ def get_all_passes() -> list[type[ModulePass]]:
         convert_stencil_to_ll_mlir.ConvertStencilToLLMLIRPass,
         dead_code_elimination.DeadCodeElimination,
         DesymrefyPass,
+        gpu_map_parallel_loops.GpuMapParallelLoopsPass,
         stencil_global_to_local.DistributeStencilPass,
         stencil_global_to_local.LowerHaloToMPI,
         lower_affine.LowerAffinePass,

--- a/xdsl/transforms/gpu_map_parallel_loops.py
+++ b/xdsl/transforms/gpu_map_parallel_loops.py
@@ -1,0 +1,109 @@
+from xdsl.dialects.builtin import AffineMapAttr, ArrayAttr, ModuleOp
+from xdsl.dialects.gpu import LoopDimMapAttr, ProcessorAttr, ProcessorEnum
+from xdsl.dialects.scf import ParallelOp
+from xdsl.ir import MLContext, Operation
+from xdsl.ir.affine import AffineMap
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+MappingAttrName = "mapping"
+
+MapGrid = 0
+MapBlock = 1
+Sequential = 2
+
+kNumHardwareIds = 3
+
+
+def getHardwareIdForMapping(level: int, dimension: int) -> ProcessorEnum:
+    """
+    Computed the hardware id to use for a given mapping level. Will
+    assign x,y and z hardware ids for the first 3 dimensions and use
+    sequential after.
+    """
+
+    if dimension >= kNumHardwareIds or level == Sequential:
+        return ProcessorEnum.Sequential
+    match level:
+        case 0:
+            match dimension:
+                case 0:
+                    return ProcessorEnum.Block_X
+                case 1:
+                    return ProcessorEnum.Block_Y
+                case 2:
+                    return ProcessorEnum.Block_Z
+                case _:
+                    return ProcessorEnum.Sequential
+        case 1:
+            match dimension:
+                case 0:
+                    return ProcessorEnum.Thread_X
+                case 1:
+                    return ProcessorEnum.Thread_Y
+                case 2:
+                    return ProcessorEnum.Thread_Z
+                case _:
+                    return ProcessorEnum.Sequential
+        case _:
+            return ProcessorEnum.Sequential
+
+
+def mapParallelOp(parallelOp: ParallelOp, mappingLevel: int = MapGrid):
+    """
+    Add mapping information to the given parallel loop. Do not add
+    mapping information if the loop already has it. Also, don't
+    start a mapping at a nested loop.
+    """
+    # Do not try to add a mapping to already mapped loops or nested loops.
+    anchor: Operation | None = parallelOp.parent_op()
+    while (anchor is not None) and (not isinstance(anchor, ParallelOp)):
+        anchor = anchor.parent_op()
+
+    if (MappingAttrName in parallelOp.attributes) or (
+        (mappingLevel == MapGrid) and anchor is not None
+    ):
+        return
+    attrs = [
+        getHardwareIdForMapping(mappingLevel, i)
+        for i in range(len(parallelOp.lowerBound))
+    ]
+    attrs = ArrayAttr(
+        [
+            LoopDimMapAttr(
+                [
+                    ProcessorAttr(attr),
+                    AffineMapAttr(AffineMap.identity(1)),
+                    AffineMapAttr(AffineMap.identity(1)),
+                ]
+            )
+            for attr in reversed(attrs)
+        ]
+    )
+    parallelOp.attributes[MappingAttrName] = attrs
+    mappingLevel += 1
+    for op in parallelOp.body.ops:
+        if isinstance(op, ParallelOp):
+            mapParallelOp(op, mappingLevel)
+
+
+class GpuMapParallelLoopsPattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ParallelOp, rewriter: PatternRewriter, /):
+        mapParallelOp(op)
+
+
+class GpuMapParallelLoopsPass(ModulePass):
+    name = "gpu-map-parallel-loops"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        walker = PatternRewriteWalker(
+            GreedyRewritePatternApplier([GpuMapParallelLoopsPattern()])
+        )
+        walker.rewrite_module(op)


### PR DESCRIPTION
Implement `gpu-map-parallel-loops`, and the corresponding attribute `gpu.loop_dim_map`.

Dimension wise, this is doing the reverse of MLIR's `gpu-map-parallel-loops`, as per their own [TODO](https://github.com/llvm/llvm-project/blob/9930f3e2982cd590b75f1252ea5253e53401b605/mlir/lib/Dialect/GPU/Transforms/ParallelLoopMapper.cpp#L70), which maps `scf.parallel`'s faster varying iterator to `gpu.launch` innermost dimension, to have performing codegen for both GPU and CPU cases without specializing the `scf.parallel`. 

Tests are exactly the ones from MLIR, with the said mapped dimensions swapped.