### PR TITLE
dialects: (memref) add alloc(a) dynamic dimension support

### DIFF
--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -23,6 +23,11 @@ builtin.module {
     %9 = "memref.memory_space_cast"(%5) : (memref<10x2xindex>) -> memref<10x2xindex, 1: i32>
     %10 = "memref.alloc"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
     %11 = "memref.alloca"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
+    %12, %13, %14 = "test.op"() : () -> (index, index, index)
+    %15 = "memref.alloc"(%12) {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 1, 0>} : (index) -> memref<?xindex>
+    %16 = "memref.alloc"(%12, %13, %14) {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 3, 0>} : (index, index, index) -> memref<?x?x?xindex>
+    %17 = "memref.alloca"(%12) {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 1, 0>} : (index) -> memref<?xindex>
+    %18 = "memref.alloca"(%12, %13, %14) {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 3, 0>} : (index, index, index) -> memref<?x?x?xindex>
     "memref.dealloc"(%2) : (memref<1xindex>) -> ()
     "memref.dealloc"(%5) : (memref<10x2xindex>) -> ()
     "memref.dealloc"(%8) : (memref<1xindex>) -> ()
@@ -56,6 +61,11 @@ builtin.module {
 // CHECK-NEXT:     %{{.*}} = "memref.memory_space_cast"(%{{.*}}) : (memref<10x2xindex>) -> memref<10x2xindex, 1 : i32>
 // CHECK-NEXT:     %{{.*}} = "memref.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
 // CHECK-NEXT:     %{{.*}} = "memref.alloca"() <{"operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
+// CHECK-NEXT:     %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (index, index, index)
+// CHECK-NEXT:     %{{.*}} = "memref.alloc"(%{{.*}}) <{"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xindex>
+// CHECK-NEXT:     %{{.*}} = "memref.alloc"(%{{.*}}, %{{.*}}, %{{.*}}) <{"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 3, 0>}> : (index, index, index) -> memref<?x?x?xindex>
+// CHECK-NEXT:     %{{.*}} = "memref.alloca"(%{{.*}}) <{"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 1, 0>}> : (index) -> memref<?xindex>
+// CHECK-NEXT:     %{{.*}} = "memref.alloca"(%{{.*}}, %{{.*}}, %{{.*}}) <{"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 3, 0>}> : (index, index, index) -> memref<?x?x?xindex>
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<10x2xindex>) -> ()
 // CHECK-NEXT:     "memref.dealloc"(%{{.*}}) : (memref<1xindex>) -> ()

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -342,10 +342,12 @@ class Alloc(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        if not isinstance(self.results[0].type, MemRefType):
+        memref_type = self.memref.type
+        if not isinstance(memref_type, MemRefType):
             raise VerifyException("expected result to be a memref")
+        memref_type = cast(MemRefType[Attribute], memref_type)
 
-        dyn_dims = [x for x in self.results[0].type.shape.data if x.value.data == -1]
+        dyn_dims = [x for x in memref_type.shape.data if x.value.data == -1]
         if len(dyn_dims) != len(self.dynamic_sizes):
             raise VerifyException(
                 "op dimension operand count does not equal memref dynamic dimension count."
@@ -422,10 +424,12 @@ class Alloca(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        if not isinstance(self.results[0].type, MemRefType):
+        memref_type = self.memref.type
+        if not isinstance(memref_type, MemRefType):
             raise VerifyException("expected result to be a memref")
+        memref_type = cast(MemRefType[Attribute], memref_type)
 
-        dyn_dims = [x for x in self.results[0].type.shape.data if x.value.data == -1]
+        dyn_dims = [x for x in memref_type.shape.data if x.value.data == -1]
         if len(dyn_dims) != len(self.dynamic_sizes):
             raise VerifyException(
                 "op dimension operand count does not equal memref dynamic dimension count."

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -314,26 +314,42 @@ class Alloc(IRDLOperation):
     @staticmethod
     def get(
         return_type: Attribute,
-        alignment: int | None = None,
+        alignment: int | AnyIntegerAttr | None = None,
         shape: Iterable[int | AnyIntegerAttr] | None = None,
+        dynamic_sizes: Sequence[SSAValue | Operation] | None = None,
         layout: Attribute = NoneAttr(),
         memory_space: Attribute = NoneAttr(),
     ) -> Alloc:
         if shape is None:
             shape = [1]
+
+        if dynamic_sizes is None:
+            dynamic_sizes = []
+
+        if isinstance(alignment, int):
+            alignment = IntegerAttr.from_int_and_width(alignment, 64)
+
         return Alloc.build(
-            operands=[[], []],
+            operands=[dynamic_sizes, []],
             result_types=[
                 MemRefType.from_element_type_and_shape(
                     return_type, shape, layout, memory_space
                 )
             ],
-            attributes={
-                "alignment": IntegerAttr.from_int_and_width(alignment, 64)
-                if alignment is not None
-                else None
+            properties={
+                "alignment": alignment,
             },
         )
+
+    def verify_(self) -> None:
+        if not isinstance(self.results[0].type, MemRefType):
+            raise VerifyException("expected result to be a memref")
+
+        dyn_dims = [x for x in self.results[0].type.shape.data if x.value.data == -1]
+        if len(dyn_dims) != len(self.dynamic_sizes):
+            raise VerifyException(
+                "op dimension operand count does not equal memref dynamic dimension count."
+            )
 
 
 @irdl_op_definition
@@ -404,6 +420,16 @@ class Alloca(IRDLOperation):
                 "alignment": alignment,
             },
         )
+
+    def verify_(self) -> None:
+        if not isinstance(self.results[0].type, MemRefType):
+            raise VerifyException("expected result to be a memref")
+
+        dyn_dims = [x for x in self.results[0].type.shape.data if x.value.data == -1]
+        if len(dyn_dims) != len(self.dynamic_sizes):
+            raise VerifyException(
+                "op dimension operand count does not equal memref dynamic dimension count."
+            )
 
 
 @irdl_op_definition


### PR DESCRIPTION
This PR adds support for dynamic dimensions to the `memref.alloc` and `memref.alloca` operations.

The operands of the `alloc` operation (`%d` of type `index`) indicate the size of the dynamic dimension in the result:
```mlir
%0 = memref.alloc(%d) : memref<8x?xf32, 1>
```

There is also a verify method to check if the amount of operands is equal to the amount of dynamic dimensions in the memref.

Additionally, I also aligned the implementation of `alloc` and `alloca` to be identical.

@JosseVanDelm 
