### PR TITLE
interactive: change normalize_arg_names() in parse_pipeleline.py to return a tuple instead of dict

### DIFF
--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -64,10 +64,9 @@ class ModulePass(ABC):
             )
 
         # normalize spec arg names:
-        # spec.normalize_arg_names()
-        spec_arguments_dict: dict[str, PassArgListType] = dict()
-        for k, v in list(spec.normalize_arg_names()):
-            spec_arguments_dict[k] = v
+        spec_arguments_dict: dict[
+            str, PassArgListType
+        ] = spec.normalize_arg_names().args
 
         # get all dataclass fields
         fields: tuple[Field[Any], ...] = dataclasses.fields(cls)

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -64,7 +64,10 @@ class ModulePass(ABC):
             )
 
         # normalize spec arg names:
-        spec.normalize_arg_names()
+        # spec.normalize_arg_names()
+        spec_arguments_dict: dict[str, PassArgListType] = dict()
+        for k, v in list(spec.normalize_arg_names()):
+            spec_arguments_dict[k] = v
 
         # get all dataclass fields
         fields: tuple[Field[Any], ...] = dataclasses.fields(cls)
@@ -78,7 +81,7 @@ class ModulePass(ABC):
             if op_field.name == "name" or not op_field.init:
                 continue
             # check that non-optional fields are present
-            if op_field.name not in spec.args:
+            if op_field.name not in spec_arguments_dict:
                 if _is_optional(op_field):
                     arg_dict[op_field.name] = _get_default(op_field)
                     continue
@@ -86,14 +89,14 @@ class ModulePass(ABC):
 
             # convert pass arg to the correct type:
             arg_dict[op_field.name] = _convert_pass_arg_to_type(
-                spec.args.pop(op_field.name),
+                spec_arguments_dict.pop(op_field.name),
                 op_field.type,
             )
             # we use .pop here to also remove the arg from the dict
 
         # if not all args were removed we raise an error
-        if len(spec.args) != 0:
-            arguments_str = ", ".join(f'"{arg}"' for arg in spec.args)
+        if len(spec_arguments_dict) != 0:
+            arguments_str = ", ".join(f'"{arg}"' for arg in spec_arguments_dict)
             fields_str = ", ".join(f'"{field.name}"' for field in fields)
             raise ValueError(
                 f"Provided arguments [{arguments_str}] not found in expected pass "

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -134,15 +134,14 @@ class PipelinePassSpec:
     name: str
     args: dict[str, PassArgListType]
 
-    def normalize_arg_names(self) -> tuple[tuple[str, PassArgListType], ...]:
+    def normalize_arg_names(self) -> PipelinePassSpec:
         """
         This normalized all arg names by replacing `-` with `_`
         """
-        new_args: list[tuple[str, PassArgListType]] = []
+        new_args: dict[str, PassArgListType] = dict()
         for k, v in self.args.items():
-            new_args.append(((k.replace("-", "_")), v))
-
-        return tuple(new_args)
+            new_args[k.replace("-", "_")] = v
+        return PipelinePassSpec(name=self.name, args=new_args)
 
     def __str__(self) -> str:
         """

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -134,13 +134,15 @@ class PipelinePassSpec:
     name: str
     args: dict[str, PassArgListType]
 
-    def normalize_arg_names(self):
+    def normalize_arg_names(self) -> tuple[tuple[str, PassArgListType], ...]:
         """
         This normalized all arg names by replacing `-` with `_`
         """
-        for k, v in list(self.args.items()):
-            del self.args[k]
-            self.args[k.replace("-", "_")] = v
+        new_args: list[tuple[str, PassArgListType]] = []
+        for k, v in self.args.items():
+            new_args.append(((k.replace("-", "_")), v))
+
+        return tuple(new_args)
 
     def __str__(self) -> str:
         """


### PR DESCRIPTION
The `from_pass_spec()` function in passes.py is used in my interactive app. Unfortunately, the way it is implemented is that it mutates the PassPipelineSpec and empties out its arguments dictionary. This causes some drama as I still need to reuse the spec in my app, and do not want the arguments to be altered/mutated.

After discussions with @superlopuh , we originally had the idea of altering the below code: 

```
@dataclass(eq=True, frozen=True)
class PipelinePassSpec:
    """
    A pass name and its arguments.
    """

    name: str
    args: dict[str, PassArgListType]
```

and instead replacing `args` with:


`args: tuple(tuple(str,PassArgListType))`

This will come in a future PR or issue, tbd.

And so, for now, I have changed the normalize_arg_names() to return a new `PassPipelineSpec` altogether in order to mitigate the mutation situation.