### PR TITLE
core: correct `__str__`/`__repr__` usage in ParseError

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -43,13 +43,13 @@ async def test_inputs():
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == "(Span[5:6](text=''), 'Operation builtin.unregistered does not have a custom format.')"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
         )
 
         assert isinstance(app.current_module, ParseError)
         assert (
             str(app.current_module)
-            == "(Span[5:6](text=''), 'Operation builtin.unregistered does not have a custom format.')"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
         )
 
         # Test corect input

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -68,6 +68,9 @@ class ParseError(Exception):
     span: Span
     msg: str
 
+    def __str__(self) -> str:
+        return self.__repr__()
+
     def __repr__(self) -> str:
         return self.span.print_with_context(self.msg)
 

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -69,9 +69,6 @@ class ParseError(Exception):
     msg: str
 
     def __str__(self) -> str:
-        return self.__repr__()
-
-    def __repr__(self) -> str:
         return self.span.print_with_context(self.msg)
 
     def with_context(self) -> str:


### PR DESCRIPTION
Hey, I'm trying to have fun with MLIROptPass as part of our Python DSL integration.

Sadly, when chaining a ParserError (such as when MLIROptPass fails because xDSL can't parse back MLIR's output), it looks like this:
```
>       raise ParseError(at_position, msg)
E       xdsl.utils.exceptions.ParseError: (Span[1151:1154](text='ptr'), 'type expected')
```
Which isn't very helpful.
This PR offers to force it to display nicely in this case too, yielding instead:
```
    raise ParseError(at_position, msg)
xdsl.utils.exceptions.ParseError: <unknown>:23:52
    %19 = "llvm.mlir.undef"() : () -> !llvm.struct<(ptr, ptr, i64, array<3 x i64>, array<3 x i64>)>
                                                    ^^^
                                                    type expected
```
Which is more actionnable.

I'm not sure overriding `__str__` is the only nor the best solution though. WDYT?