### PR TITLE
dialects: Refactor and improve llvm type parsing.

### DIFF
--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -68,6 +68,27 @@ should be used for this index.
 """
 
 
+def _parse_llvm_type(parser: AttrParser):
+    if parser.parse_optional_characters("void"):
+        return LLVMVoidType()
+    if parser.parse_optional_characters("ptr"):
+        return LLVMPointerType(LLVMPointerType.parse_parameters(parser))
+    if parser.parse_optional_characters("array"):
+        return LLVMArrayType(LLVMArrayType.parse_parameters(parser))
+
+
+def parse_llvm_type(parser: AttrParser):
+    if (l := _parse_llvm_type(parser)) is not None:
+        return l
+    return parser.parse_attribute()
+
+
+def parse_optional_llvm_type(parser: AttrParser):
+    if (l := _parse_llvm_type(parser)) is not None:
+        return l
+    return parser.parse_optional_attribute()
+
+
 @irdl_attr_definition
 class LLVMStructType(ParametrizedAttribute, TypeAttribute):
     """
@@ -106,7 +127,7 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
             parser.parse_characters(",", " after type")
 
         params = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, parser.parse_type
+            parser.Delimiter.PAREN, lambda: parse_llvm_type(parser)
         )
         parser.parse_characters(">", " to close LLVM struct parameters")
         return [StringAttr(struct_name), ArrayAttr(params)]
@@ -137,7 +158,7 @@ class LLVMPointerType(
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
         if parser.parse_optional_characters("<") is None:
             return [NoneAttr(), NoneAttr()]
-        type = parser.parse_optional_type()
+        type = parse_optional_llvm_type(parser)
         if type is None:
             parser.raise_error("Expected first parameter of llvm.ptr to be a type!")
         if parser.parse_optional_characters(",") is None:
@@ -185,7 +206,7 @@ class LLVMArrayType(ParametrizedAttribute, TypeAttribute):
         if parser.parse_optional_characters(">") is not None:
             return [size, NoneAttr()]
         parser.parse_shape_delimiter()
-        type = parser.parse_optional_type()
+        type = parse_optional_llvm_type(parser)
         if type is None:
             parser.raise_error("Expected second parameter of llvm.array to be a type!")
         parser.parse_characters(">", " to end llvm.array parameters")
@@ -253,23 +274,7 @@ class LLVMFunctionType(ParametrizedAttribute, TypeAttribute):
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
         parser.parse_characters("<", " in llvm.func parameters")
-        if parser.parse_optional_characters("void"):
-            output = LLVMVoidType()
-        elif parser.parse_optional_characters("ptr"):
-            ptr_type = NoneAttr()
-            if parser.parse_optional_punctuation("<"):
-                ptr_type = parser.parse_optional_type()
-                if ptr_type is None:
-                    ptr_type = NoneAttr()
-                else:
-                    parser.parse_punctuation(",")
-                adress_space = IntAttr(parser.parse_integer())
-                parser.parse_punctuation(">")
-            else:
-                adress_space = NoneAttr()
-            output = LLVMPointerType([ptr_type, adress_space])
-        else:
-            output = parser.parse_attribute()
+        output = parse_llvm_type(parser)
 
         # save pos before args for error message printing
         pos = parser.pos
@@ -279,22 +284,9 @@ class LLVMFunctionType(ParametrizedAttribute, TypeAttribute):
             This returns either an attribute, or Ellipsis if a
             varargs specifier (`...`) was parsed.
             """
-            if parser.parse_optional_characters("ptr"):
-                ptr_type = NoneAttr()
-                if parser.parse_optional_punctuation("<"):
-                    ptr_type = parser.parse_optional_type()
-                    if ptr_type is None:
-                        ptr_type = NoneAttr()
-                    else:
-                        parser.parse_punctuation(",")
-                    adress_space = IntAttr(parser.parse_integer())
-                    parser.parse_punctuation(">")
-                else:
-                    adress_space = NoneAttr()
-                return LLVMPointerType([ptr_type, adress_space])
             if parser.parse_optional_characters("...") is not None:
                 return ...
-            return parser.parse_attribute()
+            return parse_llvm_type(parser)
 
         inputs = parser.parse_comma_separated_list(
             Parser.Delimiter.PAREN, _parse_attr_or_variadic


### PR DESCRIPTION
Before it all makes sense in MLIR someday, here's a small improvement on `llvm` types parsing from xDSL!
We had some special cases scattered over the place, I just refactored it in top-level functions.
Then, I implement the `array<>` special case too.