### PR TITLE
core: make ConstraintVar frozen

### DIFF
--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -118,7 +118,7 @@ class VarConstraint(AttrConstraint):
             constraint_vars[self.name] = attr
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConstraintVar:
     """
     Annotation used in PyRDL to define a constraint variable.


### PR DESCRIPTION
This makes it hashable, so able to be inserted into a set or used as a key in a dictionary. The class is already designed to be immutable, and we need this change for the frep lowering.