### PR TITLE
interpreter: don't use wgpu interpreter functions for constant folding

### DIFF
--- a/xdsl/transforms/constant_fold_interp.py
+++ b/xdsl/transforms/constant_fold_interp.py
@@ -81,6 +81,7 @@ class ConstantFoldInterpPass(ModulePass):
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         interpreter = Interpreter(op)
-        register_implementations(interpreter, ctx)
+        # Do not call wgpu interpreter functions for this pass
+        register_implementations(interpreter, ctx, include_wgpu=False)
         pattern = ConstantFoldInterpPattern(interpreter)
         PatternRewriteWalker(pattern).rewrite_module(op)


### PR DESCRIPTION
I often uninstall wgpu to make my tests run faster, since there's a very small chance of me breaking it with my work. Turns out that if you don't have it installed then the new constant folding using the interpreter messes with some tests. This PR removes this weird behaviour.

