### PR TITLE
CI: Use PyPi token to publish package

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -18,9 +18,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload -u api -p ${{ secrets.PYPI_XDSL_TOKEN }} dist/*


### PR DESCRIPTION
Since 2FA is now activated in PyPi, we need to use an API token for publishing the package.