### PR TITLE
dialects: (llvm) Make llvm.alloca's alignment property optional

### DIFF
--- a/tests/filecheck/dialects/llvm/pointers.mlir
+++ b/tests/filecheck/dialects/llvm/pointers.mlir
@@ -7,6 +7,7 @@ builtin.module {
   %4 = "llvm.alloca"(%0) {"alignment" = 32 : i64} : (i64) -> !llvm.ptr
   %5 = "llvm.load"(%4) : (!llvm.ptr) -> index
   %6 = "llvm.getelementptr"(%4, %0){elem_type = i32, rawConstantIndices = array<i32:-2147483648>} : (!llvm.ptr, i64) -> !llvm.ptr
+  %7 = "llvm.alloca"(%0) : (i64) -> !llvm.ptr
 }
 
 // CHECK: builtin.module {
@@ -17,4 +18,5 @@ builtin.module {
 // CHECK-NEXT:   %4 = "llvm.alloca"(%0) <{"alignment" = 32 : i64}> : (i64) -> !llvm.ptr
 // CHECK-NEXT:   %5 = "llvm.load"(%4) : (!llvm.ptr) -> index
 // CHECK-NEXT:   %6 = "llvm.getelementptr"(%4, %0) <{"elem_type" = i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:   %7 = "llvm.alloca"(%0) : (i64) -> !llvm.ptr
 // CHECK-NEXT: }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -671,7 +671,7 @@ class AllocaOp(IRDLOperation):
 
     size: Operand = operand_def(IntegerType)
 
-    alignment: AnyIntegerAttr = prop_def(AnyIntegerAttr)
+    alignment = opt_prop_def(AnyIntegerAttr)
     elem_type = opt_prop_def(Attribute)
 
     res: OpResult = result_def()


### PR DESCRIPTION
Another small and retro-compatible update to parse some MLIR output.