### PR TITLE
CI: Fix user name for api key

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Build and publish
       run: |
         python setup.py sdist bdist_wheel
-        twine upload -u api -p ${{ secrets.PYPI_XDSL_TOKEN }} dist/*
+        twine upload -u __token__ -p ${{ secrets.PYPI_XDSL_TOKEN }} dist/*


### PR DESCRIPTION
User should be `__token__` instead of `api` for api keys.