### PR TITLE
core: Add constructors to `Builder` and `InsertPoint`

### DIFF
--- a/docs/Toy/toy/frontend/ir_gen.py
+++ b/docs/Toy/toy/frontend/ir_gen.py
@@ -90,7 +90,7 @@ class IRGen:
         # We create an empty MLIR module and codegen functions one at a time and
         # add them to the module.
         self.module = ModuleOp([])
-        self.builder = Builder(self.module.body.blocks[0])
+        self.builder = Builder.at_end(self.module.body.blocks[0])
 
     def ir_gen_module(self, module_ast: ModuleAST) -> ModuleOp:
         """
@@ -163,7 +163,7 @@ class IRGen:
         block = Block(
             arg_types=[UnrankedTensorType(f64) for _ in range(len(proto_args))]
         )
-        self.builder = Builder(block)
+        self.builder = Builder.at_end(block)
 
         # Declare all the function arguments in the symbol table.
         for name, value in zip(proto_args, block.args):

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -108,7 +108,7 @@ def build_affine_for(
         step,
     )
     builder.insert(op)
-    body_builder_fn(Builder(block), induction_var, rest)
+    body_builder_fn(Builder.at_end(block), induction_var, rest)
     return op
 
 
@@ -298,7 +298,7 @@ def lower_op_to_loops(
         store_op = affine.Store(value_to_store, alloc.memref, ivs)
         nested_builder.insert(store_op)
 
-    builder = Builder(op)
+    builder = Builder.before(op)
     build_affine_loop_nest_const(
         builder, lower_bounds, tensor_type.get_shape(), steps, impl_loop
     )

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -7,6 +7,33 @@ from xdsl.dialects.scf import If
 from xdsl.ir import Block, BlockArgument, Region
 
 
+def test_insertion_point_constructors():
+    target = Block(
+        [
+            (op1 := Constant.from_int_and_width(1, 1)),
+            (op2 := Constant.from_int_and_width(2, 1)),
+        ]
+    )
+
+    assert InsertPoint.at_start(target) == InsertPoint(target, op1)
+    assert Builder.at_start(target).insertion_point == InsertPoint(target, op1)
+
+    assert InsertPoint.at_end(target) == InsertPoint(target, None)
+    assert Builder.at_end(target).insertion_point == InsertPoint(target, None)
+
+    assert InsertPoint.before(op1) == InsertPoint(target, op1)
+    assert Builder.before(op1).insertion_point == InsertPoint(target, op1)
+
+    assert InsertPoint.after(op1) == InsertPoint(target, op2)
+    assert Builder.after(op1).insertion_point == InsertPoint(target, op2)
+
+    assert InsertPoint.before(op2) == InsertPoint(target, op2)
+    assert Builder.before(op2).insertion_point == InsertPoint(target, op2)
+
+    assert InsertPoint.after(op2) == InsertPoint(target, None)
+    assert Builder.after(op2).insertion_point == InsertPoint(target, None)
+
+
 def test_builder():
     target = Block(
         [
@@ -16,7 +43,7 @@ def test_builder():
     )
 
     block = Block()
-    b = Builder(block)
+    b = Builder.at_end(block)
 
     x = Constant.from_int_and_width(1, 1)
     y = Constant.from_int_and_width(2, 1)
@@ -37,7 +64,7 @@ def test_builder_insertion_point():
     )
 
     block = Block()
-    b = Builder(block)
+    b = Builder.at_end(block)
 
     x = Constant.from_int_and_width(1, 8)
     y = Constant.from_int_and_width(2, 8)
@@ -46,7 +73,7 @@ def test_builder_insertion_point():
     b.insert(x)
     b.insert(z)
 
-    b.insertion_point = InsertPoint(z)
+    b.insertion_point = InsertPoint.before(z)
 
     b.insert(y)
 

--- a/xdsl/dialects/irdl/pyrdl_to_irdl.py
+++ b/xdsl/dialects/irdl/pyrdl_to_irdl.py
@@ -26,7 +26,7 @@ def op_def_to_irdl(op: type[IRDLOperation]) -> OperationOp:
     op_def = op.get_irdl_definition()
 
     block = Block()
-    builder = Builder(block)
+    builder = Builder.at_end(block)
 
     # Operands
     operand_values: list[SSAValue] = []
@@ -52,7 +52,7 @@ def attr_def_to_irdl(
     attr_def = attr.get_irdl_definition()
 
     block = Block()
-    builder = Builder(block)
+    builder = Builder.at_end(block)
 
     # Parameters
     param_values: list[SSAValue] = []
@@ -66,7 +66,7 @@ def attr_def_to_irdl(
 def dialect_to_irdl(dialect: Dialect, name: str) -> DialectOp:
     """Convert a dialect definition to an IRDL dialect definition."""
     block = Block()
-    builder = Builder(block)
+    builder = Builder.at_end(block)
 
     for attribute in dialect.attributes:
         if not issubclass(attribute, ParametrizedAttribute):


### PR DESCRIPTION
The constructors for `Builder` and `InsertPoint` were too ambiguous, so they are removed in favor of named constructors `at_begin`, `at_end`, `before` and `after`.
Some naming changed as well in `InsertPoint`, and documentation improved.

This should hopefully make the code more readable