### PR TITLE
core: Add methods to create blocks with the builder

### DIFF
--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -2,7 +2,7 @@ import pytest
 
 from xdsl.builder import Builder, InsertPoint
 from xdsl.dialects.arith import Constant
-from xdsl.dialects.builtin import IntAttr, i32
+from xdsl.dialects.builtin import IntAttr, i32, i64
 from xdsl.dialects.scf import If
 from xdsl.ir import Block, BlockArgument, Region
 
@@ -86,22 +86,32 @@ def test_builder_create_block():
     target = Region([block1, block2])
     builder = Builder.at_start(block1)
 
-    new_block1 = builder.create_block_at_start(target)
+    new_block1 = builder.create_block_at_start(target, (i32,))
+    assert len(new_block1.args) == 1
+    assert new_block1.args[0].type == i32
     assert len(target.blocks) == 3
     assert target.blocks[0] == new_block1
     assert builder.insertion_point == InsertPoint.at_start(new_block1)
 
-    new_block2 = builder.create_block_at_end(target)
+    new_block2 = builder.create_block_at_end(target, (i64,))
+    assert len(new_block2.args) == 1
+    assert new_block2.args[0].type == i64
     assert len(target.blocks) == 4
     assert target.blocks[3] == new_block2
     assert builder.insertion_point == InsertPoint.at_start(new_block2)
 
-    new_block3 = builder.create_block_before(block2)
+    new_block3 = builder.create_block_before(block2, (i32, i64))
+    assert len(new_block3.args) == 2
+    assert new_block3.args[0].type == i32
+    assert new_block3.args[1].type == i64
     assert len(target.blocks) == 5
     assert target.blocks[2] == new_block3
     assert builder.insertion_point == InsertPoint.at_start(new_block3)
 
-    new_block4 = builder.create_block_after(block2)
+    new_block4 = builder.create_block_after(block2, (i64, i32))
+    assert len(new_block4.args) == 2
+    assert new_block4.args[0].type == i64
+    assert new_block4.args[1].type == i32
     assert len(target.blocks) == 6
     assert target.blocks[4] == new_block4
     assert builder.insertion_point == InsertPoint.at_start(new_block4)

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -80,6 +80,33 @@ def test_builder_insertion_point():
     assert target.is_structurally_equivalent(block)
 
 
+def test_builder_create_block():
+    block1 = Block()
+    block2 = Block()
+    target = Region([block1, block2])
+    builder = Builder.at_start(block1)
+
+    new_block1 = builder.create_block_at_start(target)
+    assert len(target.blocks) == 3
+    assert target.blocks[0] == new_block1
+    assert builder.insertion_point == InsertPoint.at_start(new_block1)
+
+    new_block2 = builder.create_block_at_end(target)
+    assert len(target.blocks) == 4
+    assert target.blocks[3] == new_block2
+    assert builder.insertion_point == InsertPoint.at_start(new_block2)
+
+    new_block3 = builder.create_block_before(block2)
+    assert len(target.blocks) == 5
+    assert target.blocks[2] == new_block3
+    assert builder.insertion_point == InsertPoint.at_start(new_block3)
+
+    new_block4 = builder.create_block_after(block2)
+    assert len(target.blocks) == 6
+    assert target.blocks[4] == new_block4
+    assert builder.insertion_point == InsertPoint.at_start(new_block4)
+
+
 def test_build_region():
     one = IntAttr(1)
     two = IntAttr(2)


### PR DESCRIPTION
Add methods to create blocks with the builder.
These methods create a block, place it in the IR, and put the insertion point in it.
I'm not a fan that the insertion point is moved, but that's what MLIR does so I'd rather follow them.

The reason why these methods are in the builder is so that they can be "listened" to.