### PR TITLE
core: Add callbacks to the `Builder`

### DIFF
--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -130,7 +130,7 @@ def test_builder_listener_op_insert():
     def add_op_on_insert(op: Operation):
         added_ops.append(op)
 
-    b.notify_operation_inserted = add_op_on_insert
+    b.operation_insertion_handler = [add_op_on_insert]
 
     b.insert(x)
     b.insert(z)
@@ -150,7 +150,7 @@ def test_builder_listener_block_created():
     def add_block_on_create(b: Block):
         created_blocks.append(b)
 
-    b.notify_block_created = add_block_on_create
+    b.block_creation_handler = [add_block_on_create]
 
     b1 = b.create_block_at_start(region)
     b2 = b.create_block_at_end(region)

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -4,7 +4,7 @@ from xdsl.builder import Builder, InsertPoint
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import IntAttr, i32, i64
 from xdsl.dialects.scf import If
-from xdsl.ir import Block, BlockArgument, Region
+from xdsl.ir import Block, BlockArgument, Operation, Region
 
 
 def test_insertion_point_constructors():
@@ -115,6 +115,49 @@ def test_builder_create_block():
     assert len(target.blocks) == 6
     assert target.blocks[4] == new_block4
     assert builder.insertion_point == InsertPoint.at_start(new_block4)
+
+
+def test_builder_listener_op_insert():
+    block = Block()
+    b = Builder.at_end(block)
+
+    x = Constant.from_int_and_width(1, 32)
+    y = Constant.from_int_and_width(2, 32)
+    z = Constant.from_int_and_width(3, 32)
+
+    added_ops: list[Operation] = []
+
+    def add_op_on_insert(op: Operation):
+        added_ops.append(op)
+
+    b.notify_operation_inserted = add_op_on_insert
+
+    b.insert(x)
+    b.insert(z)
+    b.insertion_point = InsertPoint.before(z)
+    b.insert(y)
+
+    assert added_ops == [x, z, y]
+
+
+def test_builder_listener_block_created():
+    block = Block()
+    region = Region([block])
+    b = Builder.at_start(block)
+
+    created_blocks: list[Block] = []
+
+    def add_block_on_create(b: Block):
+        created_blocks.append(b)
+
+    b.notify_block_created = add_block_on_create
+
+    b1 = b.create_block_at_start(region)
+    b2 = b.create_block_at_end(region)
+    b3 = b.create_block_before(block)
+    b4 = b.create_block_after(block)
+
+    assert created_blocks == [b1, b2, b3, b4]
 
 
 def test_build_region():

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -76,6 +76,12 @@ class Builder:
     insertion_point: InsertPoint
     """Operations will be inserted at this location."""
 
+    notify_operation_inserted: Callable[[Operation], None] | None = field(default=None)
+    """A callback that is called when an operation is inserted by the builder."""
+
+    notify_block_created: Callable[[Block], None] | None = field(default=None)
+    """A callback that is called when a block is created by the builder."""
+
     def __init__(self, insert_point: InsertPoint) -> None:
         self.insertion_point = insert_point
 
@@ -115,6 +121,8 @@ class Builder:
             block.insert_op_before(op, insert_before)
         else:
             block.add_op(op)
+        if self.notify_operation_inserted is not None:
+            self.notify_operation_inserted(op)
 
         return op
 
@@ -128,6 +136,10 @@ class Builder:
         block = Block(arg_types=arg_types)
         Rewriter.insert_block_before(block, insert_before)
         self.insertion_point = InsertPoint.at_end(block)
+
+        if self.notify_block_created is not None:
+            self.notify_block_created(block)
+
         return block
 
     def create_block_after(
@@ -141,6 +153,10 @@ class Builder:
         block = Block(arg_types=arg_types)
         Rewriter.insert_block_after(block, insert_after)
         self.insertion_point = InsertPoint.at_end(block)
+
+        if self.notify_block_created is not None:
+            self.notify_block_created(block)
+
         return block
 
     def create_block_at_start(
@@ -153,6 +169,10 @@ class Builder:
         block = Block(arg_types=arg_types)
         region.insert_block(block, 0)
         self.insertion_point = InsertPoint.at_end(block)
+
+        if self.notify_block_created is not None:
+            self.notify_block_created(block)
+
         return block
 
     def create_block_at_end(
@@ -165,6 +185,10 @@ class Builder:
         block = Block(arg_types=arg_types)
         region.add_block(block)
         self.insertion_point = InsertPoint.at_end(block)
+
+        if self.notify_block_created is not None:
+            self.notify_block_created(block)
+
         return block
 
     @staticmethod

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -84,9 +84,6 @@ class Builder:
     block_creation_handler: list[Callable[[Block], None]] = field(default_factory=list)
     """Callback that are called when a block is created by the builder."""
 
-    def __init__(self, insert_point: InsertPoint) -> None:
-        self.insertion_point = insert_point
-
     @staticmethod
     def before(op: Operation) -> Builder:
         """Creates a builder with the insertion point before an operation."""


### PR DESCRIPTION
These callbacks are called whenever an operation or block is created and inserted.
They are used in the pattern matching engine to keep the worklist updated.