### PR TITLE
core: Add options to `walk` to control traversal order

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -702,7 +702,7 @@ def test_block_walk():
     block = Block(ops)
 
     assert list(block.walk()) == [a, b, c]
-    assert list(block.walk_reverse()) == [c, b, a]
+    assert list(block.walk(reverse=True)) == [c, b, a]
 
 
 def test_region_walk():
@@ -715,7 +715,7 @@ def test_region_walk():
     region = Region([block_a, block_b])
 
     assert list(region.walk()) == [a, b]
-    assert list(region.walk_reverse()) == [b, a]
+    assert list(region.walk(reverse=True)) == [b, a]
 
 
 def test_op_walk():
@@ -731,7 +731,13 @@ def test_op_walk():
     op_multi_region = test.TestOp.create(regions=[region_a, region_b])
 
     assert list(op_multi_region.walk()) == [op_multi_region, a, b]
-    assert list(op_multi_region.walk_reverse()) == [b, a, op_multi_region]
+    assert list(op_multi_region.walk(reverse=True)) == [op_multi_region, b, a]
+    assert list(op_multi_region.walk(region_first=True)) == [a, b, op_multi_region]
+    assert list(op_multi_region.walk(region_first=True, reverse=True)) == [
+        b,
+        a,
+        op_multi_region,
+    ]
 
 
 def test_region_clone():

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -893,7 +893,10 @@ class Operation(IRNode):
         self, *, reverse: bool = False, region_first: bool = False
     ) -> Iterator[Operation]:
         """
-        Iterate all operations contained in the operation (including this one)
+        Iterate all operations contained in the operation (including this one).
+        If region_first is set, then the operation regions are iterated before the
+        operation. If reverse is set, then the region, block, and operation lists are
+        iterated in reverse order.
         """
         if not region_first:
             yield self
@@ -1529,7 +1532,12 @@ class Block(IRNode):
     def walk(
         self, *, reverse: bool = False, region_first: bool = False
     ) -> Iterable[Operation]:
-        """Call a function on all operations contained in the block."""
+        """
+        Call a function on all operations contained in the block.
+        If region_first is set, then the operation regions are iterated before the
+        operation. If reverse is set, then the region, block, and operation lists are
+        iterated in reverse order.
+        """
         for op in self.ops_reverse if reverse else self.ops:
             yield from op.walk(reverse=reverse, region_first=region_first)
 
@@ -1816,7 +1824,12 @@ class Region(IRNode):
     def walk(
         self, *, reverse: bool = False, region_first: bool = False
     ) -> Iterator[Operation]:
-        """Call a function on all operations contained in the region."""
+        """
+        Call a function on all operations contained in the region.
+        If region_first is set, then the operation regions are iterated before the
+        operation. If reverse is set, then the region, block, and operation lists are
+        iterated in reverse order.
+        """
         for block in self.blocks[::-1] if reverse else self.blocks:
             yield from block.walk(reverse=reverse, region_first=region_first)
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -900,7 +900,7 @@ class Operation(IRNode):
         """
         if not region_first:
             yield self
-        for region in self.regions[::-1] if reverse else self.regions:
+        for region in reversed(self.regions) if reverse else self.regions:
             yield from region.walk(reverse=reverse, region_first=region_first)
         if region_first:
             yield self
@@ -1830,7 +1830,7 @@ class Region(IRNode):
         operation. If reverse is set, then the region, block, and operation lists are
         iterated in reverse order.
         """
-        for block in self.blocks[::-1] if reverse else self.blocks:
+        for block in reversed(self.blocks) if reverse else self.blocks:
             yield from block.walk(reverse=reverse, region_first=region_first)
 
     @deprecated("Use walk(reverse=True) instead")


### PR DESCRIPTION
This PR allows to change the traversal order of `walk` through the `region_first` option and `reverse` option.

* `reverse` will reverse the order of traversal of blocks, regions, and operation lists.
* `region_first` will make the traversal first traverse the regions, then the current operation. 

This also deprecates `walk_reverse`, which should be replaced by `walk(region_first=True, reverse=True)`.

This is stack on top of an unrelated PR because GitHub doesn't allow me to stack a PR on top of two unrelated PRs (which I'll do on the next PR).