### PR TITLE
core: Add listener in PatternRewriter

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from conftest import assert_print_op
 
 from xdsl.dialects import test
@@ -12,11 +14,12 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.ir import MLContext, Operation
+from xdsl.ir import Block, MLContext, Operation, SSAValue
 from xdsl.parser import Parser
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
     PatternRewriter,
+    PatternRewriterListener,
     PatternRewriteWalker,
     RewritePattern,
     TypeConversionPattern,
@@ -26,18 +29,68 @@ from xdsl.pattern_rewriter import (
 from xdsl.utils.hints import isa
 
 
-def rewrite_and_compare(prog: str, expected_prog: str, walker: PatternRewriteWalker):
+def rewrite_and_compare(
+    prog: str,
+    expected_prog: str,
+    walker: PatternRewriteWalker,
+    *,
+    op_inserted: int = 0,
+    op_removed: int = 0,
+    op_modified: int = 0,
+    op_replaced: int = 0,
+    block_created: int = 0,
+):
     ctx = MLContext(allow_unregistered=True)
     ctx.load_dialect(Builtin)
     ctx.load_dialect(Arith)
     ctx.load_dialect(test.Test)
 
+    num_op_inserted = 0
+    num_op_removed = 0
+    num_op_modified = 0
+    num_op_replaced = 0
+    num_block_created = 0
+
+    def op_inserted_handler(op: Operation):
+        nonlocal num_op_inserted
+        num_op_inserted += 1
+
+    def op_removed_handler(op: Operation):
+        nonlocal num_op_removed
+        num_op_removed += 1
+
+    def op_modified_handler(op: Operation):
+        nonlocal num_op_modified
+        num_op_modified += 1
+
+    def op_replaced_handler(op: Operation, values: Sequence[SSAValue | None]):
+        nonlocal num_op_replaced
+        num_op_replaced += 1
+
+    def block_created_handler(block: Block):
+        nonlocal num_block_created
+        num_block_created += 1
+
+    listener = PatternRewriterListener()
+    listener.operation_insertion_handler = [op_inserted_handler]
+    listener.operation_removal_handler = [op_removed_handler]
+    listener.operation_modification_handler = [op_modified_handler]
+    listener.operation_replacement_handler = [op_replaced_handler]
+    listener.block_creation_handler = [block_created_handler]
+
     parser = Parser(ctx, prog)
     module = parser.parse_module()
 
+    walker.listener = listener
     walker.rewrite_module(module)
 
     assert_print_op(module, expected_prog, None)
+
+    assert num_op_inserted == op_inserted
+    assert num_op_removed == op_removed
+    assert num_op_modified == op_modified
+    assert num_op_replaced == op_replaced
+    assert num_block_created == block_created
 
 
 def test_non_recursive_rewrite():
@@ -60,7 +113,13 @@ def test_non_recursive_rewrite():
                 rewriter.replace_matched_op([new_constant])
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(RewriteConst(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(RewriteConst(), apply_recursively=False),
+        op_inserted=1,
+        op_removed=1,
+        op_replaced=1,
+        op_modified=2,
     )
 
 
@@ -89,6 +148,10 @@ def test_non_recursive_rewrite_reversed():
         PatternRewriteWalker(
             RewriteConst(), apply_recursively=False, walk_reverse=True
         ),
+        op_inserted=1,
+        op_removed=1,
+        op_replaced=1,
+        op_modified=2,
     )
 
 
@@ -111,7 +174,13 @@ def test_op_type_rewrite_pattern_method_decorator():
             rewriter.replace_matched_op(Constant.from_int_and_width(43, i32))
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(RewriteConst(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(RewriteConst(), apply_recursively=False),
+        op_inserted=1,
+        op_removed=1,
+        op_replaced=1,
+        op_modified=2,
     )
 
 
@@ -136,7 +205,13 @@ def test_op_type_rewrite_pattern_union_type():
             rewriter.replace_matched_op(Constant.from_int_and_width(42, i32))
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=2,
+        op_removed=2,
+        op_replaced=2,
+        op_modified=4,
     )
 
 
@@ -173,7 +248,13 @@ def test_recursive_rewriter():
             rewriter.replace_matched_op([constant_op, constant_one, add_op])
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=True)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=True),
+        op_inserted=12,
+        op_removed=4,
+        op_replaced=4,
+        op_modified=3,
     )
 
 
@@ -213,6 +294,10 @@ def test_recursive_rewriter_reversed():
         prog,
         expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=True, walk_reverse=True),
+        op_inserted=12,
+        op_removed=4,
+        op_replaced=4,
+        op_modified=3,
     )
 
 
@@ -246,6 +331,10 @@ def test_greedy_rewrite_pattern_applier():
             GreedyRewritePatternApplier([ConstantRewrite(), AddiRewrite()]),
             apply_recursively=False,
         ),
+        op_inserted=2,
+        op_removed=2,
+        op_replaced=2,
+        op_modified=2,
     )
 
 
@@ -269,7 +358,10 @@ def test_insert_op_before_matched_op():
             rewriter.insert_op_before_matched_op(new_cst)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=1,
     )
 
 
@@ -293,28 +385,11 @@ def test_insert_op_at_start():
             rewriter.insert_op_at_start(new_cst, mod.regions[0].blocks[0])
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=1,
     )
-
-
-def test_insert_op_at_end():
-    """
-    Test rewrites where operations are inserted with a negative position.
-    """
-
-    prog = ModuleOp([Constant.from_int_and_width(5, 32)])
-
-    to_be_inserted = Constant.from_int_and_width(42, 32)
-
-    class Rewrite(RewritePattern):
-        @op_type_rewrite_pattern
-        def match_and_rewrite(self, mod: ModuleOp, rewriter: PatternRewriter):
-            rewriter.insert_op_at_end(to_be_inserted, mod.regions[0].blocks[0])
-
-    PatternRewriteWalker(Rewrite(), apply_recursively=False).rewrite_module(prog)
-
-    assert to_be_inserted in prog.ops
-    assert prog.body.block.get_operation_index(to_be_inserted) == 1
 
 
 def test_insert_op_before():
@@ -339,7 +414,10 @@ def test_insert_op_before():
             rewriter.insert_op_before(new_cst, first_op)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=1,
     )
 
 
@@ -365,7 +443,10 @@ def test_insert_op_after():
             rewriter.insert_op_after(new_cst, first_op)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=1,
     )
 
 
@@ -389,7 +470,10 @@ def test_insert_op_after_matched_op():
             rewriter.insert_op_after_matched_op(new_cst)
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=1,
     )
 
 
@@ -416,6 +500,7 @@ def test_insert_op_after_matched_op_reversed():
         prog,
         expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
+        op_inserted=1,
     )
 
 
@@ -435,7 +520,7 @@ def test_operation_deletion():
         def match_and_rewrite(self, __op__: Constant, rewriter: PatternRewriter):
             rewriter.erase_matched_op()
 
-    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()))
+    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()), op_removed=1)
 
 
 def test_operation_deletion_reversed():
@@ -462,6 +547,7 @@ def test_operation_deletion_reversed():
         prog,
         expected,
         PatternRewriteWalker(EraseAll(), walk_reverse=True),
+        op_removed=2,
     )
 
 
@@ -513,7 +599,7 @@ def test_delete_inner_op():
             assert first_op is not None
             rewriter.erase_op(first_op)
 
-    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()))
+    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()), op_removed=1)
 
 
 def test_replace_inner_op():
@@ -535,7 +621,14 @@ def test_replace_inner_op():
             assert first_op is not None
             rewriter.replace_op(first_op, [Constant.from_int_and_width(42, i32)])
 
-    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()))
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite()),
+        op_inserted=1,
+        op_removed=1,
+        op_replaced=1,
+    )
 
 
 def test_block_argument_type_change():
@@ -568,7 +661,9 @@ def test_block_argument_type_change():
                 )
 
     rewrite_and_compare(
-        prog, expected, PatternRewriteWalker(Rewrite(), apply_recursively=False)
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
     )
 
 
@@ -922,6 +1017,7 @@ def test_move_region_contents_to_new_regions():
         prog,
         expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=1,
     )
 
 
@@ -991,6 +1087,9 @@ def test_insert_same_block():
         prog,
         expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=3,
+        op_removed=1,
+        op_replaced=1,
     )
 
 
@@ -1033,11 +1132,19 @@ def test_type_conversion():
         prog,
         expected,
         PatternRewriteWalker(Rewrite(recursive=True), apply_recursively=False),
+        op_inserted=5,
+        op_removed=5,
+        op_replaced=5,
+        op_modified=4,
     )
     rewrite_and_compare(
         prog,
         expected,
         PatternRewriteWalker(Rewrite(recursive=True), apply_recursively=True),
+        op_inserted=5,
+        op_removed=5,
+        op_replaced=5,
+        op_modified=4,
     )
     rewrite_and_compare(
         prog,
@@ -1045,6 +1152,10 @@ def test_type_conversion():
         PatternRewriteWalker(
             Rewrite(recursive=True), apply_recursively=False, walk_reverse=True
         ),
+        op_inserted=5,
+        op_removed=5,
+        op_replaced=5,
+        op_modified=4,
     )
 
     non_rec_expected = """\
@@ -1065,16 +1176,28 @@ def test_type_conversion():
         prog,
         non_rec_expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_inserted=2,
+        op_removed=2,
+        op_replaced=2,
+        op_modified=3,
     )
     rewrite_and_compare(
         prog,
         non_rec_expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=True),
+        op_inserted=2,
+        op_removed=2,
+        op_replaced=2,
+        op_modified=3,
     )
     rewrite_and_compare(
         prog,
         non_rec_expected,
         PatternRewriteWalker(Rewrite(), apply_recursively=False, walk_reverse=True),
+        op_inserted=2,
+        op_removed=2,
+        op_replaced=2,
+        op_modified=3,
     )
 
     expected = """\
@@ -1097,6 +1220,10 @@ def test_type_conversion():
         PatternRewriteWalker(
             Rewrite(ops=(test.TestOp,), recursive=True), apply_recursively=False
         ),
+        op_inserted=4,
+        op_removed=4,
+        op_replaced=4,
+        op_modified=4,
     )
     rewrite_and_compare(
         prog,
@@ -1104,6 +1231,10 @@ def test_type_conversion():
         PatternRewriteWalker(
             Rewrite(ops=(test.TestOp,), recursive=True), apply_recursively=True
         ),
+        op_inserted=4,
+        op_removed=4,
+        op_replaced=4,
+        op_modified=4,
     )
     rewrite_and_compare(
         prog,
@@ -1113,4 +1244,8 @@ def test_type_conversion():
             apply_recursively=False,
             walk_reverse=True,
         ),
+        op_inserted=4,
+        op_removed=4,
+        op_replaced=4,
+        op_modified=4,
     )

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -39,6 +39,29 @@ class PatternRewriter:
     current_operation: Operation
     """The matched operation."""
 
+    operation_insertion_handler: list[Callable[[Operation], None]] = field(
+        default_factory=list
+    )
+    """Callbacks that are called when an operation is inserted."""
+
+    operation_removal_handler: list[Callable[[Operation], None]] = field(
+        default_factory=list
+    )
+    """Callbacks that are called when an operation is removed."""
+
+    operation_modification_handler: list[Callable[[Operation], None]] = field(
+        default_factory=list
+    )
+    """Callbacks that are called when an operation is modified."""
+
+    operation_replacement_handler: list[
+        Callable[[Operation, Sequence[SSAValue | None]], None]
+    ] = field(default_factory=list)
+    """Callbacks that are called when an operation is replaced."""
+
+    block_creation_handler: list[Callable[[Block], None]] = field(default_factory=list)
+    """Callback that are called when a block is created."""
+
     has_erased_matched_operation: bool = field(default=False, init=False)
     """Was the matched operation erased."""
 
@@ -50,6 +73,33 @@ class PatternRewriter:
 
     has_done_action: bool = field(default=False, init=False)
     """Has the rewriter done any action during the current match."""
+
+    def handle_operation_insertion(self, op: Operation) -> None:
+        """Pass the operation that was just inserted to the registered callbacks."""
+        for handler in self.operation_insertion_handler:
+            handler(op)
+
+    def handle_operation_removal(self, op: Operation) -> None:
+        """Pass the operation that will be removed to the registered callbacks."""
+        for handler in self.operation_removal_handler:
+            handler(op)
+
+    def handle_operation_modification(self, op: Operation) -> None:
+        """Pass the operation that was just modified to the registered callbacks."""
+        for handler in self.operation_modification_handler:
+            handler(op)
+
+    def handle_operation_replacement(
+        self, op: Operation, new_results: Sequence[SSAValue | None]
+    ) -> None:
+        """Pass the operation that will be replaced to the registered callbacks."""
+        for handler in self.operation_replacement_handler:
+            handler(op, new_results)
+
+    def handle_block_creation(self, block: Block) -> None:
+        """Pass the block that was just created to the registered callbacks."""
+        for handler in self.block_creation_handler:
+            handler(block)
 
     def _can_modify_op(self, op: Operation) -> bool:
         """Check if the operation and its children can be modified by this rewriter."""
@@ -88,6 +138,8 @@ class PatternRewriter:
             return
         block.insert_ops_before(op, self.current_operation)
         self.added_operations_before.extend(op)
+        for op_ in op:
+            self.handle_operation_insertion(op_)
 
     def insert_op_after_matched_op(self, op: (Operation | Sequence[Operation])):
         """Insert operations after the matched operation."""
@@ -100,6 +152,8 @@ class PatternRewriter:
             return
         block.insert_ops_after(op, self.current_operation)
         self.added_operations_after.extend(op)
+        for op_ in op:
+            self.handle_operation_insertion(op_)
 
     def insert_op_at_end(self, op: Operation | Sequence[Operation], block: Block):
         """Insert operations in a block contained in the matched operation."""
@@ -110,6 +164,8 @@ class PatternRewriter:
         if len(op) == 0:
             return
         block.add_ops(op)
+        for op_ in op:
+            self.handle_operation_insertion(op_)
 
     def insert_op_at_start(self, op: Operation | Sequence[Operation], block: Block):
         """Insert operations in a block contained in the matched operation."""
@@ -135,6 +191,10 @@ class PatternRewriter:
         if len(op) == 0:
             return
         target_block.insert_ops_before(op, target_op)
+        for op_ in op:
+            self.handle_operation_insertion(op_)
+        if target_op is self.current_operation:
+            self.added_operations_before.extend(op)
 
     def insert_op_after(
         self, op: Operation | Sequence[Operation], target_op: Operation
@@ -150,6 +210,10 @@ class PatternRewriter:
         if len(ops) == 0:
             return
         target_block.insert_ops_after(ops, target_op)
+        for op_ in ops:
+            self.handle_operation_insertion(op_)
+        if target_op is self.current_operation:
+            self.added_operations_after.extend(ops)
 
     def erase_matched_op(self, safe_erase: bool = True):
         """
@@ -159,6 +223,7 @@ class PatternRewriter:
         """
         self.has_done_action = True
         self.has_erased_matched_operation = True
+        self.handle_operation_removal(self.current_operation)
         Rewriter.erase_op(self.current_operation, safe_erase=safe_erase)
 
     def erase_op(self, op: Operation, safe_erase: bool = True):
@@ -175,7 +240,19 @@ class PatternRewriter:
                 "PatternRewriter can only erase operations that are the matched operation"
                 ", or that are contained in the matched operation."
             )
+        self.handle_operation_removal(op)
         Rewriter.erase_op(op, safe_erase=safe_erase)
+
+    def replace_all_uses_with(
+        self, from_: SSAValue, to: SSAValue | None, safe_erase: bool = True
+    ):
+        """Replace all uses of an SSA value with another SSA value."""
+        for use in from_.uses:
+            self.handle_operation_modification(use.operation)
+        if to is None:
+            from_.erase(safe_erase=safe_erase)
+        else:
+            from_.replace_by(to)
 
     def replace_matched_op(
         self,
@@ -189,14 +266,9 @@ class PatternRewriter:
         If safe_erase is True, check that the operation has no uses.
         Otherwise, replace its uses with ErasedSSAValue.
         """
-        self.has_done_action = True
-        if isinstance(new_ops, Operation):
-            new_ops = [new_ops]
-        self.has_erased_matched_operation = True
-        Rewriter.replace_op(
+        self.replace_op(
             self.current_operation, new_ops, new_results, safe_erase=safe_erase
         )
-        self.added_operations_before.extend(new_ops)
 
     def replace_op(
         self,
@@ -213,14 +285,39 @@ class PatternRewriter:
         Otherwise, replace its uses with ErasedSSAValue.
         """
         self.has_done_action = True
-        if op == self.current_operation:
-            return self.replace_matched_op(new_ops, new_results, safe_erase)
         if not self._can_modify_op(op):
             raise Exception(
                 "PatternRewriter can only replace operations that are the matched "
                 "operation, or that are contained in the matched operation."
             )
-        Rewriter.replace_op(op, new_ops, new_results, safe_erase=safe_erase)
+        if isinstance(new_ops, Operation):
+            new_ops = [new_ops]
+
+        # First, insert the new operations before the matched operation
+        self.insert_op_before(new_ops, op)
+
+        if isinstance(new_ops, Operation):
+            new_ops = [new_ops]
+        if new_results is None:
+            new_results = [] if len(new_ops) == 0 else new_ops[-1].results
+
+        if len(op.results) != len(new_results):
+            raise ValueError(
+                f"Expected {len(op.results)} new results, but got {len(new_results)}"
+            )
+
+        # Then, replace the results with new ones
+        self.handle_operation_replacement(op, new_results)
+        for old_result, new_result in zip(op.results, new_results):
+            self.replace_all_uses_with(old_result, new_result)
+
+        if op.results:
+            for new_op in new_ops:
+                for res in new_op.results:
+                    res.name_hint = op.results[0].name_hint
+
+        # Then, erase the original operation
+        self.erase_op(op, safe_erase=safe_erase)
 
     def modify_block_argument_type(self, arg: BlockArgument, new_type: Attribute):
         """
@@ -228,11 +325,14 @@ class PatternRewriter:
         The block should be contained in the matched operation.
         """
         if not self._can_modify_block(arg.block):
-            raise Exception(
+            raise ValueError(
                 "Cannot modify blocks that are not contained in the matched operation"
             )
         self.has_done_action = True
         arg.type = new_type
+
+        for use in arg.uses:
+            self.handle_operation_modification(use.operation)
 
     def insert_block_argument(
         self, block: Block, index: int, arg_type: Attribute
@@ -260,7 +360,8 @@ class PatternRewriter:
                 "Cannot modify blocks that are not contained in the matched operation"
             )
         self.has_done_action = True
-        arg.block.erase_arg(arg, safe_erase=safe_erase)
+        self.replace_all_uses_with(arg, None, safe_erase=safe_erase)
+        arg.block.erase_arg(arg, safe_erase)
 
     def inline_block_at_end(self, block: Block, target_block: Block):
         """

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -243,7 +243,7 @@ class PatternRewriter:
         self.handle_operation_removal(op)
         Rewriter.erase_op(op, safe_erase=safe_erase)
 
-    def replace_all_uses_with(
+    def _replace_all_uses_with(
         self, from_: SSAValue, to: SSAValue | None, safe_erase: bool = True
     ):
         """Replace all uses of an SSA value with another SSA value."""
@@ -309,7 +309,7 @@ class PatternRewriter:
         # Then, replace the results with new ones
         self.handle_operation_replacement(op, new_results)
         for old_result, new_result in zip(op.results, new_results):
-            self.replace_all_uses_with(old_result, new_result)
+            self._replace_all_uses_with(old_result, new_result)
 
         if op.results:
             for new_op in new_ops:
@@ -360,7 +360,7 @@ class PatternRewriter:
                 "Cannot modify blocks that are not contained in the matched operation"
             )
         self.has_done_action = True
-        self.replace_all_uses_with(arg, None, safe_erase=safe_erase)
+        self._replace_all_uses_with(arg, None, safe_erase=safe_erase)
         arg.block.erase_arg(arg, safe_erase)
 
     def inline_block_at_end(self, block: Block, target_block: Block):

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -31,6 +31,8 @@ from xdsl.utils.hints import isa
 
 @dataclass(eq=False)
 class PatternRewriterListener(BuilderListener):
+    """A listener for pattern rewriter events."""
+
     operation_removal_handler: list[Callable[[Operation], None]] = field(
         default_factory=list, kw_only=True
     )


### PR DESCRIPTION
This PR adds the `Listener` class in `PatternRewriter`.
The plan is to use the `Listener` class to implement the walker with a worklist, where each callback will add the operations to the worklist (in the next PR).