### PR TITLE
core: use worklist in pattern matching algorithm

### DIFF
--- a/docs/Toy/toy/rewrites/setup_riscv_pass.py
+++ b/docs/Toy/toy/rewrites/setup_riscv_pass.py
@@ -34,4 +34,4 @@ class SetupRiscvPass(ModulePass):
     name = "setup-lowering-to-riscv"
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
-        PatternRewriteWalker(AddSections()).rewrite_module(op)
+        PatternRewriteWalker(AddSections(), apply_recursively=False).rewrite_module(op)

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -599,7 +599,12 @@ def test_delete_inner_op():
             assert first_op is not None
             rewriter.erase_op(first_op)
 
-    rewrite_and_compare(prog, expected, PatternRewriteWalker(Rewrite()), op_removed=1)
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
+        op_removed=1,
+    )
 
 
 def test_replace_inner_op():
@@ -624,7 +629,7 @@ def test_replace_inner_op():
     rewrite_and_compare(
         prog,
         expected,
-        PatternRewriteWalker(Rewrite()),
+        PatternRewriteWalker(Rewrite(), apply_recursively=False),
         op_inserted=1,
         op_removed=1,
         op_replaced=1,

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -799,7 +799,7 @@ class PatternRewriteWalker:
 
     def _add_operands_to_worklist(self, operands: Iterable[SSAValue]) -> None:
         """
-        Add defining operations of SSA values to the worklist, if they have only
+        Add defining operations of SSA values to the worklist if they have only
         one use. This is a heuristic based on the fact that single-use operations
         have more canonicalization opportunities.
         """
@@ -839,23 +839,23 @@ class PatternRewriteWalker:
         listener passed as configuration to the walker.
         """
         return PatternRewriterListener(
-            operation_insertion_handler=(
-                self.listener.operation_insertion_handler
-                + [self._handle_operation_insertion]
-            ),
-            operation_removal_handler=(
-                self.listener.operation_removal_handler
-                + [self._handle_operation_removal]
-            ),
-            operation_modification_handler=(
-                self.listener.operation_modification_handler
-                + [self._handle_operation_modification]
-            ),
-            operation_replacement_handler=(
-                self.listener.operation_replacement_handler
-                + [self._handle_operation_replacement]
-            ),
-            block_creation_handler=(self.listener.block_creation_handler),
+            operation_insertion_handler=[
+                *self.listener.operation_insertion_handler,
+                self._handle_operation_insertion,
+            ],
+            operation_removal_handler=[
+                *self.listener.operation_removal_handler,
+                self._handle_operation_removal,
+            ],
+            operation_modification_handler=[
+                *self.listener.operation_modification_handler,
+                self._handle_operation_modification,
+            ],
+            operation_replacement_handler=[
+                *self.listener.operation_replacement_handler,
+                self._handle_operation_replacement,
+            ],
+            block_creation_handler=self.listener.block_creation_handler,
         )
 
     def rewrite_module(self, module: ModuleOp) -> None:


### PR DESCRIPTION
Use a worklist for pattern rewriting.

This means that every time an operation is modified, inserted, removed, the worklist gets updated, and only the operations in the worklist are rewritten.
This will allow us to remove restriction in our pattern matches, such that only operations right before, after, or nested in the matched operation can be rewritten.
These restrictions will be removed later on.