### PR TITLE
fix attribute docstring

### DIFF
--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -115,7 +115,7 @@ class AttrParser(BaseParser):
         Parse an xDSL attribute, if present.
         An attribute is either a builtin attribute, which can have various format,
         or a dialect attribute, with the following format:
-            dialect-attr  ::= `!` attr-name (`<` dialect-attr-contents+ `>`)?
+            dialect-attr  ::= `#` attr-name (`<` dialect-attr-contents+ `>`)?
             attr-name     ::= bare-id
             dialect-attr-contents ::= `<` dialect-attribute-contents+ `>`
                             | `(` dialect-attribute-contents+ `)`

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -132,7 +132,7 @@ class AttrParser(BaseParser):
         Parse an xDSL attribute.
         An attribute is either a builtin attribute, which can have various format,
         or a dialect attribute, with the following format:
-            dialect-attr  ::= `!` attr-name (`<` dialect-attr-contents+ `>`)?
+            dialect-attr  ::= `#` attr-name (`<` dialect-attr-contents+ `>`)?
             attr-name     ::= bare-id
             dialect-attr-contents ::= `<` dialect-attribute-contents+ `>`
                             | `(` dialect-attribute-contents+ `)`


### PR DESCRIPTION
This PR fixes a very small mistake in the docstring of the attribute parser.
The code parses a `#` symbol (which is correct), while the docstring mentions `!`
