### PR TITLE
dialects (pdl): Add better verifiers to `pdl.pattern`

### DIFF
--- a/tests/filecheck/dialects/pdl/verifiers.mlir
+++ b/tests/filecheck/dialects/pdl/verifiers.mlir
@@ -10,6 +10,7 @@ pdl.pattern @NonConstantAttrInRewrite : benefit(0) {
 }
 
 // CHECK: expected constant value when specified within a `pdl.rewrite`
+// CHECK: NonConstantAttrInRewrite
 
 // -----
 
@@ -22,6 +23,7 @@ pdl.pattern @UnnamedOpInRewrite : benefit(0) {
 }
 
 // CHECK: must have an operation name when nested within a `pdl.rewrite`
+// CHECK: UnnamedOpInRewrite
 
 // -----
 
@@ -34,6 +36,7 @@ pdl.pattern @UnusedAttribute : benefit(0) {
 }
 
 // CHECK: expected a bindable user when defined in the matcher body of a `pdl.pattern`
+// CHECK: UnusedAttribute
 
 // -----
 
@@ -46,6 +49,7 @@ pdl.pattern @UnusedType : benefit(0) {
 }
 
 // CHECK: expected a bindable user when defined in the matcher body of a `pdl.pattern`
+// CHECK: UnusedType
 
 // -----
 
@@ -58,6 +62,7 @@ pdl.pattern @UnusedTypes : benefit(0) {
 }
 
 // CHECK: expected a bindable user when defined in the matcher body of a `pdl.pattern`
+// CHECK: UnusedTypes
 
 // -----
 
@@ -71,6 +76,7 @@ pdl.pattern @UnusedOperand : benefit(0) {
 }
 
 // CHECK: expected a bindable user when defined in the matcher body of a `pdl.pattern`
+// CHECK: UnusedOperand
 
 // -----
 
@@ -84,3 +90,44 @@ pdl.pattern @UnusedOperands : benefit(0) {
 }
 
 // CHECK: expected a bindable user when defined in the matcher body of a `pdl.pattern`
+// CHECK: UnusedOperands
+
+// -----
+
+pdl.pattern @DisconnectedPattern : benefit(1) {
+  %0 = pdl.type : i32
+  %1 = pdl.operand : %0
+  %8 = pdl.operand : %0
+  %5 = pdl.operation "pdltest.matchop" (%1 : !pdl.value) -> (%0 : !pdl.type)
+  %6 = pdl.result 0 of %5
+  %10 = pdl.operation "pdltest.matchop" (%8 : !pdl.value) -> (%0 : !pdl.type)
+  %11 = pdl.result 0 of %10
+  pdl.rewrite %10 {
+    pdl.erase %5
+    pdl.erase %10
+    pdl.replace %5 with (%11 : !pdl.value)
+  }
+}
+
+// CHECK: Operations in a `pdl.pattern` must form a connected component
+// CHECK: DisconnectedPattern
+
+// -----
+
+pdl.pattern @NonRewriteTerminatedPattern : benefit(1) {
+  "test.termop"() : () -> ()
+}
+
+// CHECK: expected body to terminate with a `pdl.rewrite`
+// CHECK: NonRewriteTerminatedPattern
+
+// -----
+
+pdl.pattern @NoOperationsPattern : benefit(1) {
+  %0 = pdl.type
+  %1 = pdl.operand : %0
+  pdl.rewrite with "bloup"(%1 : !pdl.value)
+}
+
+// CHECK: the pattern must contain at least one `pdl.operation`
+// CHECK: NoOperationsPattern


### PR DESCRIPTION
Add missing patterns to `pdl.pattern`, and add tests for it.

I also realized that I merged the last PDL PR without addressing one review about the `split-input-file` tests, really sorry for that. This PR is fixing it at the same time (it's just 5-6 line changes)