### PR TITLE
dialects (onnx): Initial onnx dialect support

### DIFF
--- a/tests/filecheck/dialects/onnx/onnx_invalid.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_invalid.mlir
@@ -1,0 +1,19 @@
+// RUN: xdsl-opt --verify-diagnostics --split-input-file %s | filecheck %s
+
+// Non-broadcastable operands are not allowed.
+
+builtin.module {
+  %t0, %t1 = "test.op"() : () -> (tensor<2x4xf32>, tensor<3x2xf32>)
+
+  // CHECK: Operation does not verify: operands have incompatible shapes: [2, 4] and [3, 2]
+  %res_add =  "onnx.Add"(%t0, %t1) {onnx_node_name = "/Add"} : (tensor<2x4xf32>, tensor<3x2xf32>) -> tensor<2x4xf32>
+}
+
+// -----
+
+builtin.module {
+  %t0, %t1 = "test.op"() : () -> (tensor<2x4xf32>, tensor<1x4xf32>)
+
+  // CHECK: Operation does not verify: result shape [2, 4] does not match result type tensor<1x4xf32>
+  %res_sub =  "onnx.Sub"(%t0, %t1) {onnx_node_name = "/Sub"} : (tensor<2x4xf32>, tensor<1x4xf32>) -> tensor<1x4xf32>
+}

--- a/tests/filecheck/dialects/onnx/onnx_invalid.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_invalid.mlir
@@ -5,7 +5,7 @@
 builtin.module {
   %t0, %t1 = "test.op"() : () -> (tensor<2x4xf32>, tensor<3x2xf32>)
 
-  // CHECK: Operation does not verify: operands have incompatible shapes: [2, 4] and [3, 2]
+  // CHECK: Operation does not verify: operands have incompatible shapes: (2, 4) and (3, 2)
   %res_add =  "onnx.Add"(%t0, %t1) {onnx_node_name = "/Add"} : (tensor<2x4xf32>, tensor<3x2xf32>) -> tensor<2x4xf32>
 }
 
@@ -16,4 +16,24 @@ builtin.module {
 
   // CHECK: Operation does not verify: result shape [2, 4] does not match result type tensor<1x4xf32>
   %res_sub =  "onnx.Sub"(%t0, %t1) {onnx_node_name = "/Sub"} : (tensor<2x4xf32>, tensor<1x4xf32>) -> tensor<1x4xf32>
+}
+
+// -----
+
+builtin.module {
+  %t0, %t1 = "test.op"() : () -> (f32, tensor<2x4xf32>)
+
+  // CHECK: operand at position 0 does not verify!
+  // CHECK: f32 should be of base attribute tensor
+  %res_mul =  "onnx.Mul"(%t0, %t1) {onnx_node_name = "/Mul"} : (f32, tensor<2x4xf32>) -> tensor<2x4xf32>
+}
+
+// -----
+
+builtin.module {
+  %t0, %t1 = "test.op"() : () -> (tensor<2x4xf32>, tensor<2x4xi32>)
+
+  // CHECK: operand at position 1 does not verify!
+  // CHECK: attribute f32 expected from variable 'T', but got i32
+  %res_div =  "onnx.Div"(%t0, %t1) {onnx_node_name = "/Div"} : (tensor<2x4xf32>, tensor<2x4xi32>) -> tensor<2x4xf32>
 }

--- a/tests/filecheck/dialects/onnx/onnx_ops.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_ops.mlir
@@ -1,10 +1,18 @@
 // RUN: XDSL_ROUNDTRIP
 
-func.func @add(%arg0: tensor<1x2x6xf32>, %arg1: tensor<1x2x6xf32>) ->  tensor<1x2x6xf32> {
-  %0 = "onnx.Add"(%arg0, %arg1) {onnx_node_name = "/model.1/Add"} : (tensor<1x2x6xf32>, tensor<1x2x6xf32>) -> tensor<1x2x6xf32>
-  return %0 : tensor<1x2x6xf32>
-}
+%t0, %t1 = "test.op"(): () -> (tensor<1x2x6xf32>, tensor<1x2x6xf32>)
+%t2, %t3 = "test.op"(): () -> (tensor<3x2xf32>, tensor<1x2xf32>)
+%t4, %t5 = "test.op"(): () -> (tensor<3x1x2xf32>, tensor<3x4x1xf32>)
+%t6, %t7 = "test.op"(): () -> (tensor<1x5x1x3xf32>, tensor<2x1x6x3xf32>)
 
-// CHECK-LABEL: func.func @add
-// CHECK-SAME:      (%arg0 : tensor<1x2x6xf32>, %arg1 : tensor<1x2x6xf32>) -> tensor<1x2x6xf32>       
-// CHECK:   %0 = onnx.Add(%arg0, %arg1) {"onnx_node_name" = "/model.1/Add"} : (tensor<1x2x6xf32>, tensor<1x2x6xf32>) -> tensor<1x2x6xf32>
+%res_add = "onnx.Add"(%t0, %t1) {onnx_node_name = "/Add"} : (tensor<1x2x6xf32>, tensor<1x2x6xf32>) -> tensor<1x2x6xf32>
+// CHECK: %res_add = onnx.Add(%t0, %t1) {"onnx_node_name" = "/Add"}: (tensor<1x2x6xf32>, tensor<1x2x6xf32>) -> tensor<1x2x6xf32>
+
+%res_sub = "onnx.Sub"(%t2, %t3) {onnx_node_name = "/Sub"}: (tensor<3x2xf32>, tensor<1x2xf32>) -> tensor<3x2xf32>
+// CHECK: %res_sub = onnx.Sub(%t2, %t3) {"onnx_node_name" = "/Sub"}: (tensor<3x2xf32>, tensor<1x2xf32>) -> tensor<3x2xf32>
+
+%res_mul = "onnx.Mul"(%t4, %t5) {onnx_node_name = "/Mul"}: (tensor<3x1x2xf32>, tensor<3x4x1xf32>) -> tensor<3x4x2xf32>
+// CHECK: %res_mul = onnx.Mul(%t4, %t5) {"onnx_node_name" = "/Mul"}: (tensor<3x1x2xf32>, tensor<3x4x1xf32>) -> tensor<3x4x2xf32>
+
+%res_div = "onnx.Div"(%t6, %t7) {onnx_node_name = "/Div"}: (tensor<1x5x1x3xf32>, tensor<2x1x6x3xf32>) -> tensor<2x5x6x3xf32>
+// CHECK: %res_div = onnx.Div(%t6, %t7) {"onnx_node_name" = "/Div"}: (tensor<1x5x1x3xf32>, tensor<2x1x6x3xf32>) -> tensor<2x5x6x3xf32>

--- a/tests/filecheck/dialects/onnx/onnx_ops.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_ops.mlir
@@ -1,0 +1,10 @@
+// RUN: XDSL_ROUNDTRIP
+
+func.func @add(%arg0: tensor<1x2x6xf32>, %arg1: tensor<1x2x6xf32>) ->  tensor<1x2x6xf32> {
+  %0 = "onnx.Add"(%arg0, %arg1) {onnx_node_name = "/model.1/Add"} : (tensor<1x2x6xf32>, tensor<1x2x6xf32>) -> tensor<1x2x6xf32>
+  return %0 : tensor<1x2x6xf32>
+}
+
+// CHECK-LABEL: func.func @add
+// CHECK-SAME:      (%arg0 : tensor<1x2x6xf32>, %arg1 : tensor<1x2x6xf32>) -> tensor<1x2x6xf32>       
+// CHECK:   %0 = onnx.Add(%arg0, %arg1) {"onnx_node_name" = "/model.1/Add"} : (tensor<1x2x6xf32>, tensor<1x2x6xf32>) -> tensor<1x2x6xf32>

--- a/xdsl/dialects/onnx.py
+++ b/xdsl/dialects/onnx.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TypeAlias, TypeVar
 
 from xdsl.dialects.builtin import AnyTensorType, SSAValue
 from xdsl.ir import (
@@ -10,25 +9,21 @@ from xdsl.ir import (
     OpResult,
 )
 from xdsl.irdl import (
-    Attribute,
     IRDLOperation,
     irdl_op_definition,
     operand_def,
     result_def,
 )
-from xdsl.parser import Parser
-from xdsl.printer import Printer
-
-ArgT = TypeVar("ArgT", bound=Attribute)
-Operand: TypeAlias = SSAValue
+from xdsl.utils.exceptions import VerifyException
 
 
 class ElementwiseBinOpBase(IRDLOperation, ABC):
     """Base class for element-wise binary operations on tensors with Numpy-style broadcasting."""
 
-    lhs: Operand = operand_def()
-    rhs: Operand = operand_def()
+    lhs = operand_def()
+    rhs = operand_def()
     res: OpResult = result_def(AnyTensorType)
+    assembly_format = "`(` $lhs `,` $rhs `)` attr-dict `:` `(` type($lhs) `,` type($rhs) `)` `->` type($res)"
 
     def __init__(
         self,
@@ -42,30 +37,37 @@ class ElementwiseBinOpBase(IRDLOperation, ABC):
             result_types=[[]],
         )
 
-    @classmethod
-    def parse(cls, parser: Parser):
-        lhs = parser.parse_unresolved_operand()
-        parser.parse_characters(",")
-        rhs = parser.parse_unresolved_operand()
-        attributes = parser.parse_optional_attr_dict()
-        parser.parse_characters(":")
-        type = parser.parse_type()
-        operands = parser.resolve_operands([lhs, rhs], [type, type], parser.pos)
-        return cls(operands[0], operands[1], attributes)
-
-    def print(self, printer: Printer) -> None:
-        printer.print("(", self.lhs, ", ", self.rhs, ") ")
-        printer.print_op_attributes(self.attributes)
-        for x in [
-            " : ",
-            " (",
-            self.lhs.type,
-            ", ",
-            self.rhs.type,
-            ") -> ",
-            self.res.type,
-        ]:
-            printer.print(x)
+    def verify_(self) -> None:
+        # Check that the arguments are broadcastable (using Numpy semantics) and that the result type is correct.
+        res_shape: list[int] = []
+        # Iterate over the shapes in reverse order and compute the result shape.
+        lhs_shape: list[int] = [x.data for x in self.lhs.type.shape]
+        rhs_shape: list[int] = [x.data for x in self.rhs.type.shape]
+        i = max(len(lhs_shape), len(rhs_shape))
+        while i > 0:
+            i -= 1
+            d1 = lhs_shape[i] if i >= 0 else 1
+            d2 = rhs_shape[i] if i >= 0 else 1
+            if d1 == d2:
+                res_shape.append(d1)
+                continue
+            if d1 == 1:
+                res_shape.append(d2)
+                continue
+            if d2 == 1:
+                res_shape.append(d1)
+                continue
+            raise VerifyException(
+                f"operands have incompatible shapes: {lhs_shape} and {rhs_shape}"
+            )
+        # Reverse the result shape and check that it matches the result type.
+        res_shape.reverse()
+        if not all(
+            x == y for x, y in zip(res_shape, [v.data for v in self.res.type.shape])
+        ):
+            raise VerifyException(
+                f"result shape {res_shape} does not match result type {self.res.type}"
+            )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/onnx.py
+++ b/xdsl/dialects/onnx.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from abc import ABC
+from typing import TypeAlias, TypeVar
+
+from xdsl.dialects.builtin import AnyTensorType, SSAValue
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    OpResult,
+)
+from xdsl.irdl import (
+    Attribute,
+    IRDLOperation,
+    irdl_op_definition,
+    operand_def,
+    result_def,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+
+ArgT = TypeVar("ArgT", bound=Attribute)
+Operand: TypeAlias = SSAValue
+
+
+class ElementwiseBinOpBase(IRDLOperation, ABC):
+    """Base class for element-wise binary operations on tensors with Numpy-style broadcasting."""
+
+    lhs: Operand = operand_def()
+    rhs: Operand = operand_def()
+    res: OpResult = result_def(AnyTensorType)
+
+    def __init__(
+        self,
+        lhs: SSAValue,
+        rhs: SSAValue,
+        attributes: dict[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[lhs, rhs],
+            attributes=attributes,
+            result_types=[[]],
+        )
+
+    @classmethod
+    def parse(cls, parser: Parser):
+        lhs = parser.parse_unresolved_operand()
+        parser.parse_characters(",")
+        rhs = parser.parse_unresolved_operand()
+        attributes = parser.parse_optional_attr_dict()
+        parser.parse_characters(":")
+        type = parser.parse_type()
+        operands = parser.resolve_operands([lhs, rhs], [type, type], parser.pos)
+        return cls(operands[0], operands[1], attributes)
+
+    def print(self, printer: Printer) -> None:
+        printer.print("(", self.lhs, ", ", self.rhs, ") ")
+        printer.print_op_attributes(self.attributes)
+        for x in [
+            " : ",
+            " (",
+            self.lhs.type,
+            ", ",
+            self.rhs.type,
+            ") -> ",
+            self.res.type,
+        ]:
+            printer.print(x)
+
+
+@irdl_op_definition
+class Add(ElementwiseBinOpBase):
+    name = "onnx.Add"
+
+
+@irdl_op_definition
+class Sub(ElementwiseBinOpBase):
+    name = "onnx.Sub"
+
+
+@irdl_op_definition
+class Mul(ElementwiseBinOpBase):
+    name = "onnx.Mul"
+
+
+@irdl_op_definition
+class Div(ElementwiseBinOpBase):
+    name = "onnx.Div"
+
+
+ONNX = Dialect("onnx", [Add, Sub, Mul, Div])

--- a/xdsl/dialects/onnx.py
+++ b/xdsl/dialects/onnx.py
@@ -4,6 +4,8 @@ from abc import ABC
 from typing import Annotated
 
 from xdsl.dialects.builtin import (
+    AnyFloat,
+    IntegerType,
     SSAValue,
     TensorType,
 )
@@ -24,7 +26,7 @@ from xdsl.utils.exceptions import VerifyException
 class ElementwiseBinOpBase(IRDLOperation, ABC):
     """Base class for element-wise binary operations on tensors with Numpy-style broadcasting."""
 
-    T = Annotated[Attribute, ConstraintVar("T")]
+    T = Annotated[AnyFloat | IntegerType, ConstraintVar("T")]
     lhs = operand_def(TensorType[T])
     rhs = operand_def(TensorType[T])
     res = result_def(TensorType[T])

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -34,6 +34,7 @@ from xdsl.dialects.ltl import LTL
 from xdsl.dialects.memref import MemRef
 from xdsl.dialects.mpi import MPI
 from xdsl.dialects.omp import OMP
+from xdsl.dialects.onnx import ONNX
 from xdsl.dialects.pdl import PDL
 from xdsl.dialects.printf import Printf
 from xdsl.dialects.riscv import RISCV
@@ -111,6 +112,7 @@ def get_all_dialects() -> list[Dialect]:
         MemRef,
         MPI,
         OMP,
+        ONNX,
         PDL,
         Printf,
         RISCV,


### PR DESCRIPTION
onnx dialect initial support, as discussed on zulip. 

* Add elementwise binary operations, `onnx.Add`, `onnx.Sub`, `onnx.Mul`, `onnx.Div` (see [doc](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Add) for add semantics; the others are equivalent). 
* Add verification of broadcastable arguments
* Add lit tests

Resolves #1894 