### PR TITLE
core: add helper for function type printing

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -7,7 +7,14 @@ from conftest import assert_print_op
 
 from xdsl.dialects import test
 from xdsl.dialects.arith import Addi, Arith, Constant
-from xdsl.dialects.builtin import Builtin, IntAttr, IntegerType, UnitAttr, i32
+from xdsl.dialects.builtin import (
+    Builtin,
+    FunctionType,
+    IntAttr,
+    IntegerType,
+    UnitAttr,
+    i32,
+)
 from xdsl.dialects.func import Func
 from xdsl.ir import (
     Attribute,
@@ -703,3 +710,35 @@ def test_dictionary_attr():
     parsed = parser.parse_op()
 
     assert_print_op(parsed, prog, None)
+
+
+def test_print_function_type():
+    io = StringIO()
+    printer = Printer(stream=io)
+    printer.print_function_type((), ())
+
+    assert io.getvalue() == "() -> ()"
+
+    io = StringIO()
+    printer.stream = io
+    printer.print_function_type((i32,), ())
+
+    assert io.getvalue() == "(i32) -> ()"
+
+    io = StringIO()
+    printer.stream = io
+    printer.print_function_type((i32,), (i32,))
+
+    assert io.getvalue() == "(i32) -> i32"
+
+    io = StringIO()
+    printer.stream = io
+    printer.print_function_type((i32,), (i32, i32))
+
+    assert io.getvalue() == "(i32) -> (i32, i32)"
+
+    io = StringIO()
+    printer.stream = io
+    printer.print_function_type((i32,), (FunctionType.from_lists((i32,), (i32,)),))
+
+    assert io.getvalue() == "(i32) -> ((i32) -> i32)"


### PR DESCRIPTION
Seems like it pops up a few times for custom syntax, I'd like to use this helper for the `scf` and `riscv_scf` `while` custom syntaxes.