### PR TITLE
core: add method for splitting block before a given operation

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -268,6 +268,159 @@ def test_empty_block_with_single_block_parent_region_requires_terminator():
         op0.verify()
 
 
+def test_split_block_first():
+    old_block = Block((test.TestOp(), test.TestOp(), test.TestOp()))
+    region = Region(old_block)
+    a, b, c = old_block.ops
+
+    # Check preconditions
+
+    assert old_block.parent is region
+    assert region.blocks == [old_block]
+
+    assert old_block.first_op is a
+    assert old_block.last_op is c
+
+    assert a.parent is old_block
+    assert b.parent is old_block
+    assert c.parent is old_block
+
+    assert a.next_op is b
+    assert b.next_op is c
+    assert c.next_op is None
+
+    assert a.prev_op is None
+    assert b.prev_op is a
+    assert c.prev_op is b
+
+    new_block = old_block.split_before(a)
+
+    # Check postconditions
+
+    assert old_block.parent is region
+    assert new_block.parent is region
+    assert region.blocks == [old_block, new_block]
+
+    assert old_block.first_op is None
+    assert old_block.last_op is None
+    assert new_block.first_op is a
+    assert new_block.last_op is c
+
+    assert a.parent is new_block
+    assert b.parent is new_block
+    assert c.parent is new_block
+
+    assert a.next_op is b
+    assert b.next_op is c
+    assert c.next_op is None
+
+    assert a.prev_op is None
+    assert b.prev_op is a
+    assert c.prev_op is b
+
+
+def test_split_block_middle():
+    old_block = Block((test.TestOp(), test.TestOp(), test.TestOp()))
+    region = Region(old_block)
+    a, b, c = old_block.ops
+
+    # Check preconditions
+
+    assert old_block.parent is region
+    assert region.blocks == [old_block]
+
+    assert old_block.first_op is a
+    assert old_block.last_op is c
+
+    assert a.parent is old_block
+    assert b.parent is old_block
+    assert c.parent is old_block
+
+    assert a.next_op is b
+    assert b.next_op is c
+    assert c.next_op is None
+
+    assert a.prev_op is None
+    assert b.prev_op is a
+    assert c.prev_op is b
+
+    new_block = old_block.split_before(b)
+
+    # Check postconditions
+
+    assert old_block.parent is region
+    assert new_block.parent is region
+    assert region.blocks == [old_block, new_block]
+
+    assert old_block.first_op is a
+    assert old_block.last_op is a
+    assert new_block.first_op is b
+    assert new_block.last_op is c
+
+    assert a.parent is old_block
+    assert b.parent is new_block
+    assert c.parent is new_block
+
+    assert a.next_op is None
+    assert b.next_op is c
+    assert c.next_op is None
+
+    assert a.prev_op is None
+    assert b.prev_op is None
+    assert c.prev_op is b
+
+
+def test_split_block_last():
+    old_block = Block((test.TestOp(), test.TestOp(), test.TestOp()))
+    region = Region(old_block)
+    a, b, c = old_block.ops
+
+    # Check preconditions
+
+    assert old_block.parent is region
+    assert region.blocks == [old_block]
+
+    assert old_block.first_op is a
+    assert old_block.last_op is c
+
+    assert a.parent is old_block
+    assert b.parent is old_block
+    assert c.parent is old_block
+
+    assert a.next_op is b
+    assert b.next_op is c
+    assert c.next_op is None
+
+    assert a.prev_op is None
+    assert b.prev_op is a
+    assert c.prev_op is b
+
+    new_block = old_block.split_before(c)
+
+    # Check postconditions
+
+    assert old_block.parent is region
+    assert new_block.parent is region
+    assert region.blocks == [old_block, new_block]
+
+    assert old_block.first_op is a
+    assert old_block.last_op is b
+    assert new_block.first_op is c
+    assert new_block.last_op is c
+
+    assert a.parent is old_block
+    assert b.parent is old_block
+    assert c.parent is new_block
+
+    assert a.next_op is b
+    assert b.next_op is None
+    assert c.next_op is None
+
+    assert a.prev_op is None
+    assert b.prev_op is a
+    assert c.prev_op is None
+
+
 def test_region_clone_into_circular_blocks():
     """
     Test that cloning a region with circular block dependency works.

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1486,7 +1486,7 @@ class Block(IRNode):
         block, and the rest of the operations in the original block are moved to the new
         block, including the old terminator.
         The original block is left without a terminator.
-        The newly formed Block is inserted into the parent region immediately after `self`
+        The newly formed block is inserted into the parent region immediately after `self`
         and returned.
         """
         # Use `a` for new contents of `self`, and `b` for new block.

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1480,11 +1480,11 @@ class Block(IRNode):
 
     def split_before(self, b_first: Operation) -> Block:
         """
-        Split the block into two blocks before the specified operation or iterator.
+        Split the block into two blocks before the specified operation.
 
-        Note that all operations before the specified iterator stay as part of the
-        original basic block, and the rest of the operations in the original block are
-        moved to the new block, including the old terminator.
+        Note that all operations before the one given stay as part of the original basic
+        block, and the rest of the operations in the original block are moved to the new
+        block, including the old terminator.
         The original block is left without a terminator.
         The newly formed Block is inserted into the parent region immediately after `self`
         and returned.


### PR DESCRIPTION
This is useful for things like scf to cf rewriting.