### PR TITLE
dialects: (riscv_cf) add riscv_cf dialect

### DIFF
--- a/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -t riscv-asm %s | filecheck %s --match-full-lines
 
 %0 = riscv.get_register : () -> !riscv.reg<a0>
 %1 = riscv.get_register : () -> !riscv.reg<a1>
@@ -11,7 +11,7 @@ riscv_func.func @main() {
     riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else0(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else0(%e00 : !riscv.reg<a2>, %e01 : !riscv.reg<a3>):
     riscv.label "else0"
-    riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else1(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+    riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else1(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"comment" = "comment"}
   ^else1(%e10 : !riscv.reg<a2>, %e11 : !riscv.reg<a3>):
     riscv.label "else1"
     riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else2(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
@@ -26,7 +26,13 @@ riscv_func.func @main() {
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50 : !riscv.reg<a2>, %e51 : !riscv.reg<a3>):
     riscv.label "else5"
-    riscv_cf.branch ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+    riscv_cf.branch ^dummy0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^dummy0(%d00 : !riscv.reg<a2>, %d01 : !riscv.reg<a3>):
+    riscv.label "dummy0"
+    riscv_cf.branch ^dummy1(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"comment" = "comment"}
+  ^dummy1(%d10 : !riscv.reg<a2>, %d11 : !riscv.reg<a3>):
+    riscv.label "dummy1"
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"comment" = "comment"}
   ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
     riscv.label "then"
     riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
@@ -35,7 +41,7 @@ riscv_func.func @main() {
 // CHECK:       main:
 // CHECK-NEXT:      beq a0, a1, then
 // CHECK-NEXT:  else0:
-// CHECK-NEXT:      bne a0, a1, then
+// CHECK-NEXT:      bne a0, a1, then                             # comment
 // CHECK-NEXT:  else1:
 // CHECK-NEXT:      blt a0, a1, then
 // CHECK-NEXT:  else2:
@@ -45,5 +51,9 @@ riscv_func.func @main() {
 // CHECK-NEXT:  else4:
 // CHECK-NEXT:      bgeu a0, a1, then
 // CHECK-NEXT:  else5:
+// CHECK-NEXT:  dummy0:
+// CHECK-NEXT:      # comment
+// CHECK-NEXT:  dummy1:
+// CHECK-NEXT:      j then                                       # comment
 // CHECK-NEXT:  then:
 // CHECK-NEXT:      j then

--- a/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
@@ -1,0 +1,49 @@
+// RUN: xdsl-opt -t riscv-asm %s | filecheck %s
+
+%0 = riscv.get_register : () -> !riscv.reg<a0>
+%1 = riscv.get_register : () -> !riscv.reg<a1>
+%2 = riscv.get_register : () -> !riscv.reg<a2>
+%3 = riscv.get_register : () -> !riscv.reg<a3>
+%4 = riscv.get_register : () -> !riscv.reg<a2>
+%5 = riscv.get_register : () -> !riscv.reg<a3>
+
+riscv_func.func @main() {
+    riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else0(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else0(%e00 : !riscv.reg<a2>, %e01 : !riscv.reg<a3>):
+    riscv.label "else0"
+    riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else1(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else1(%e10 : !riscv.reg<a2>, %e11 : !riscv.reg<a3>):
+    riscv.label "else1"
+    riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else2(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else2(%e20 : !riscv.reg<a2>, %e21 : !riscv.reg<a3>):
+    riscv.label "else2"
+    riscv_cf.bge %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else3(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else3(%e30 : !riscv.reg<a2>, %e31 : !riscv.reg<a3>):
+    riscv.label "else3"
+    riscv_cf.bltu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else4(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else4(%e40 : !riscv.reg<a2>, %e41 : !riscv.reg<a3>):
+    riscv.label "else4"
+    riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else5(%e50 : !riscv.reg<a2>, %e51 : !riscv.reg<a3>):
+    riscv.label "else5"
+    riscv_cf.branch ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
+    riscv.label "then"
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}
+
+// CHECK:       main:
+// CHECK-NEXT:      beq a0, a1, then
+// CHECK-NEXT:  else0:
+// CHECK-NEXT:      bne a0, a1, then
+// CHECK-NEXT:  else1:
+// CHECK-NEXT:      blt a0, a1, then
+// CHECK-NEXT:  else2:
+// CHECK-NEXT:      bge a0, a1, then
+// CHECK-NEXT:  else3:
+// CHECK-NEXT:      bltu a0, a1, then
+// CHECK-NEXT:  else4:
+// CHECK-NEXT:      bgeu a0, a1, then
+// CHECK-NEXT:  else5:
+// CHECK-NEXT:  then:
+// CHECK-NEXT:      j then

--- a/tests/filecheck/dialects/riscv_cf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_cf/ops.mlir
@@ -6,10 +6,10 @@
     riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else0(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else0(%e00 : !riscv.reg<a2>, %e01 : !riscv.reg<a3>):
     riscv.label "else0"
-    riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else1(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+    riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else1(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"comment" = "comment"}
   ^else1(%e10 : !riscv.reg<a2>, %e11 : !riscv.reg<a3>):
     riscv.label "else1"
-    riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else2(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+    riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else2(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"hello" = "world"}
   ^else2(%e20 : !riscv.reg<a2>, %e21 : !riscv.reg<a3>):
     riscv.label "else2"
     riscv_cf.bge %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else3(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
@@ -21,10 +21,10 @@
     riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
   ^else5(%e50 : !riscv.reg<a2>, %e51 : !riscv.reg<a3>):
     riscv.label "else5"
-    riscv_cf.branch ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+    riscv_cf.branch ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"hello" = "world"}
   ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
     riscv.label "then"
-    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"hello" = "world"}
 }) : () -> ()
 
 // CHECK:       builtin.module {
@@ -33,10 +33,10 @@
 // CHECK-NEXT:      riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
 // CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else0"
-// CHECK-NEXT:      riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:      riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"comment" = "comment"}
 // CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else1"
-// CHECK-NEXT:      riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:      riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>) attributes {"hello" = "world"}
 // CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else2"
 // CHECK-NEXT:      riscv_cf.bge %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
@@ -48,9 +48,9 @@
 // CHECK-NEXT:      riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
 // CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "else5"
-// CHECK-NEXT:      riscv_cf.branch ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+// CHECK-NEXT:      riscv_cf.branch ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"hello" = "world"}
 // CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "then"
-// CHECK-NEXT:      riscv_cf.j ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+// CHECK-NEXT:      riscv_cf.j ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>) attributes {"hello" = "world"}
 // CHECK-NEXT:    }) : () -> ()
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/riscv_cf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_cf/ops.mlir
@@ -1,0 +1,56 @@
+// RUN: XDSL_ROUNDTRIP
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else0(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else0(%e00 : !riscv.reg<a2>, %e01 : !riscv.reg<a3>):
+    riscv.label "else0"
+    riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else1(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else1(%e10 : !riscv.reg<a2>, %e11 : !riscv.reg<a3>):
+    riscv.label "else1"
+    riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else2(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else2(%e20 : !riscv.reg<a2>, %e21 : !riscv.reg<a3>):
+    riscv.label "else2"
+    riscv_cf.bge %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else3(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else3(%e30 : !riscv.reg<a2>, %e31 : !riscv.reg<a3>):
+    riscv.label "else3"
+    riscv_cf.bltu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else4(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else4(%e40 : !riscv.reg<a2>, %e41 : !riscv.reg<a3>):
+    riscv.label "else4"
+    riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else5(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else5(%e50 : !riscv.reg<a2>, %e51 : !riscv.reg<a3>):
+    riscv.label "else5"
+    riscv_cf.branch ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
+    riscv.label "then"
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+// CHECK-NEXT:    "test.op"() ({
+// CHECK-NEXT:      riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "else0"
+// CHECK-NEXT:      riscv_cf.bne %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "else1"
+// CHECK-NEXT:      riscv_cf.blt %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "else2"
+// CHECK-NEXT:      riscv_cf.bge %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "else3"
+// CHECK-NEXT:      riscv_cf.bltu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "else4"
+// CHECK-NEXT:      riscv_cf.bgeu %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^{{.+}}(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "else5"
+// CHECK-NEXT:      riscv_cf.branch ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+// CHECK-NEXT:    ^{{.+}}(%{{.+}} : !riscv.reg<a2>, %{{.+}} : !riscv.reg<a3>):
+// CHECK-NEXT:      riscv.label "then"
+// CHECK-NEXT:      riscv_cf.j ^{{.+}}(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+// CHECK-NEXT:    }) : () -> ()
+// CHECK-NEXT:  }

--- a/tests/filecheck/dialects/riscv_cf/verification.mlir
+++ b/tests/filecheck/dialects/riscv_cf/verification.mlir
@@ -1,0 +1,109 @@
+// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else(%e0 : !riscv.reg<a2>, %e1 : !riscv.reg<a3>):
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: riscv_cf branch op then block first op must be a label
+
+// -----
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else(%4 : !riscv.reg<a2>, %4 : !riscv.reg<a2>)
+  ^else(%e0 : !riscv.reg<a2>, %e1 : !riscv.reg<a3>):
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
+    riscv.label "label"
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: Block arg types must match !riscv.reg<a2> !riscv.reg<a3>
+
+// -----
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%3 : !riscv.reg<a3>, %3 : !riscv.reg<a3>), ^else(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^else(%e0 : !riscv.reg<a2>, %e1 : !riscv.reg<a3>):
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
+    riscv.label "label"
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: Block arg types must match !riscv.reg<a3> !riscv.reg<a2>
+
+// -----
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.beq %0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>, ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>), ^else(%4 : !riscv.reg<a2>, %5 : !riscv.reg<a3>)
+  ^then(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
+    riscv.label "label"
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^else(%e0 : !riscv.reg<a2>, %e1 : !riscv.reg<a3>):
+    riscv_cf.j ^then(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: riscv_cf branch op else block must be immediately after op
+
+// -----
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.branch ^0(%0 : !riscv.reg<a0>, %0 : !riscv.reg<a0>)
+  ^0(%t0 : !riscv.reg<a2>, %t1 : !riscv.reg<a3>):
+    riscv_cf.j ^0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: Block arg types must match !riscv.reg<a0> !riscv.reg<a2>
+
+// -----
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.branch ^1(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>)
+  ^0(%t0 : !riscv.reg<a0>, %t1 : !riscv.reg<a1>):
+    riscv_cf.j ^0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+  ^1(%t2 : !riscv.reg<a0>, %t3 : !riscv.reg<a1>):
+    riscv_cf.j ^0(%2 : !riscv.reg<a2>, %3 : !riscv.reg<a3>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: Successor block must be immediately after parent block in the parent region.
+
+// -----
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.j ^0(%1 : !riscv.reg<a1>, %1 : !riscv.reg<a1>)
+  ^0(%t0 : !riscv.reg<a0>, %t1 : !riscv.reg<a1>):
+    riscv.label "label"
+    riscv_cf.j ^0(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: Block arg types must match !riscv.reg<a1> !riscv.reg<a0>
+
+// -----
+
+%0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
+
+"test.op"() ({
+    riscv_cf.branch ^0(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>)
+  ^0(%t0 : !riscv.reg<a0>, %t1 : !riscv.reg<a1>):
+    riscv_cf.j ^0(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>)
+}) : () -> ()
+
+// CHECK: Operation does not verify: riscv_cf.j operation successor must have a riscv.label operation as a first argument, found JOp(riscv_cf.j ^0(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>))

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -555,6 +555,7 @@ def test_verify_inline_region_after():
 
     with pytest.raises(ValueError, match="Cannot move region into itself."):
         Rewriter.inline_region_before(region, region.block)
+
     with pytest.raises(
         ValueError, match="Cannot inline region before a block with no parent"
     ):

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -508,3 +508,16 @@ def test_inline_region_before():
         rewriter.inline_region_before(region, module.body.blocks[1])
 
     rewrite_and_compare(prog, expected, transformation)
+
+
+def test_verify_inline_region_before():
+    block = Block()
+    region = Region(Block())
+
+    with pytest.raises(
+        ValueError, match="Cannot inline region before a block with no parent"
+    ):
+        Rewriter.inline_region_before(region, block)
+
+    with pytest.raises(ValueError, match="Cannot move region into itself."):
+        Rewriter.inline_region_before(region, region.block)

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -146,6 +146,12 @@ class ConditionalBranchOperation(IRDLOperation, RISCVInstruction, ABC):
             self.else_arguments, lambda val: _print_type_pair(printer, val)
         )
         printer.print_string(")")
+        if self.attributes:
+            printer.print_op_attributes(
+                self.attributes,
+                reserved_attr_names="operandSegmentSizes",
+                print_keyword=True,
+            )
 
     @classmethod
     def parse(cls, parser: Parser) -> Self:
@@ -162,7 +168,11 @@ class ConditionalBranchOperation(IRDLOperation, RISCVInstruction, ABC):
         else_args = parser.parse_comma_separated_list(
             parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
         )
-        return cls(rs1, rs2, then_args, else_args, then_block, else_block)
+        attrs = parser.parse_optional_attr_dict_with_keyword()
+        op = cls(rs1, rs2, then_args, else_args, then_block, else_block)
+        if attrs is not None:
+            op.attributes |= attrs.data
+        return op
 
 
 @irdl_op_definition
@@ -306,6 +316,8 @@ class BranchOp(IRDLOperation, riscv.RISCVOp):
             self.block_arguments, lambda val: _print_type_pair(printer, val)
         )
         printer.print_string(")")
+        if self.attributes:
+            printer.print_op_attributes(self.attributes, print_keyword=True)
 
     @classmethod
     def parse(cls, parser: Parser) -> Self:
@@ -313,7 +325,11 @@ class BranchOp(IRDLOperation, riscv.RISCVOp):
         block_arguments = parser.parse_comma_separated_list(
             parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
         )
-        return cls(block_arguments, successor)
+        attrs = parser.parse_optional_attr_dict_with_keyword()
+        op = cls(block_arguments, successor)
+        if attrs is not None:
+            op.attributes |= attrs.data
+        return op
 
     def assembly_line(self) -> str | None:
         return None
@@ -376,6 +392,8 @@ class JOp(IRDLOperation, RISCVInstruction):
             self.block_arguments, lambda val: _print_type_pair(printer, val)
         )
         printer.print_string(")")
+        if self.attributes:
+            printer.print_op_attributes(self.attributes, print_keyword=True)
 
     @classmethod
     def parse(cls, parser: Parser) -> Self:
@@ -383,7 +401,11 @@ class JOp(IRDLOperation, RISCVInstruction):
         block_arguments = parser.parse_comma_separated_list(
             parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
         )
-        return cls(block_arguments, successor)
+        attrs = parser.parse_optional_attr_dict_with_keyword()
+        op = cls(block_arguments, successor)
+        if attrs is not None:
+            op.attributes |= attrs.data
+        return op
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         dest_label = self.successor.first_op

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -19,6 +19,7 @@ from xdsl.irdl import (
     VarOperand,
     irdl_op_definition,
     operand_def,
+    opt_attr_def,
     successor_def,
     var_operand_def,
 )
@@ -264,6 +265,10 @@ class BranchOp(IRDLOperation, riscv.RISCVOp):
 
     block_arguments = var_operand_def(RISCVRegisterType)
     successor = successor_def()
+    comment: StringAttr | None = opt_attr_def(StringAttr)
+    """
+    An optional comment that will be printed along with the instruction.
+    """
 
     traits = frozenset([IsTerminator()])
 
@@ -332,7 +337,10 @@ class BranchOp(IRDLOperation, riscv.RISCVOp):
         return op
 
     def assembly_line(self) -> str | None:
-        return None
+        if self.comment is None:
+            return None
+
+        return f"    # {self.comment.data}"
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -1,0 +1,406 @@
+from abc import ABC
+from collections.abc import Sequence
+
+from typing_extensions import Self
+
+from xdsl.dialects import riscv
+from xdsl.dialects.builtin import StringAttr
+from xdsl.dialects.riscv import (
+    AssemblyInstructionArg,
+    IntRegisterType,
+    RISCVInstruction,
+    RISCVRegisterType,
+)
+from xdsl.ir import Dialect, Operation, SSAValue
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    Successor,
+    VarOperand,
+    irdl_op_definition,
+    operand_def,
+    successor_def,
+    var_operand_def,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.traits import IsTerminator
+from xdsl.utils.exceptions import VerifyException
+
+
+def _print_type_pair(printer: Printer, value: SSAValue) -> None:
+    printer.print_ssa_value(value)
+    printer.print_string(" : ")
+    printer.print_attribute(value.type)
+
+
+def _parse_type_pair(parser: Parser) -> SSAValue:
+    unresolved = parser.parse_unresolved_operand()
+    parser.parse_punctuation(":")
+    type = parser.parse_type()
+    return parser.resolve_operand(unresolved, type)
+
+
+class ConditionalBranchOperation(IRDLOperation, RISCVInstruction, ABC):
+    """
+    A base class for RISC-V branch operations. Lowers to RsRsOffOperation.
+    """
+
+    rs1 = operand_def(IntRegisterType)
+    rs2 = operand_def(IntRegisterType)
+
+    then_arguments = var_operand_def(IntRegisterType)
+    else_arguments = var_operand_def(IntRegisterType)
+
+    irdl_options = [AttrSizedOperandSegments()]
+
+    then_block = successor_def()
+    else_block = successor_def()
+
+    traits = frozenset([IsTerminator()])
+
+    def __init__(
+        self,
+        rs1: Operation | SSAValue,
+        rs2: Operation | SSAValue,
+        then_arguments: Sequence[SSAValue],
+        else_arguments: Sequence[SSAValue],
+        then_block: Successor,
+        else_block: Successor,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[rs1, rs2, then_arguments, else_arguments],
+            attributes={
+                "comment": comment,
+            },
+            successors=(then_block, else_block),
+        )
+
+    def verify_(self) -> None:
+        # The then block must start with a label op
+
+        then_block_first_op = self.then_block.first_op
+
+        if not isinstance(then_block_first_op, riscv.LabelOp):
+            raise VerifyException(
+                "riscv_cf branch op then block first op must be a label"
+            )
+
+        # Types of arguments must match arg types of blocks
+
+        for op_arg, block_arg in zip(self.then_arguments, self.then_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        for op_arg, block_arg in zip(self.else_arguments, self.else_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        # The else block must be the one immediately following this one
+
+        parent_block = self.parent
+        if parent_block is None:
+            return
+
+        parent_region = parent_block.parent
+        if parent_region is None:
+            return
+
+        this_index = parent_region.blocks.index(parent_block)
+        else_index = parent_region.blocks.index(self.else_block)
+
+        if this_index + 1 != else_index:
+            raise VerifyException(
+                "riscv_cf branch op else block must be immediately after op"
+            )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        then_label = self.then_block.first_op
+        assert isinstance(then_label, riscv.LabelOp)
+        return self.rs1, self.rs2, then_label.label
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        _print_type_pair(printer, self.rs1)
+        printer.print_string(", ")
+        _print_type_pair(printer, self.rs2)
+        printer.print_string(", ")
+        printer.print_block_name(self.then_block)
+        printer.print_string("(")
+        printer.print_list(
+            self.then_arguments, lambda val: _print_type_pair(printer, val)
+        )
+        printer.print_string("), ")
+        printer.print_block_name(self.else_block)
+        printer.print_string("(")
+        printer.print_list(
+            self.else_arguments, lambda val: _print_type_pair(printer, val)
+        )
+        printer.print_string(")")
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        rs1 = _parse_type_pair(parser)
+        parser.parse_punctuation(",")
+        rs2 = _parse_type_pair(parser)
+        parser.parse_punctuation(",")
+        then_block = parser.parse_successor()
+        then_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+        )
+        parser.parse_punctuation(",")
+        else_block = parser.parse_successor()
+        else_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+        )
+        return cls(rs1, rs2, then_args, else_args, then_block, else_block)
+
+
+@irdl_op_definition
+class BeqOp(ConditionalBranchOperation):
+    """
+    Take the branch if registers rs1 and rs2 are equal.
+
+    if (x[rs1] == x[rs2]) pc += sext(offset)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#beq
+    """
+
+    name = "riscv_cf.beq"
+
+
+@irdl_op_definition
+class BneOp(ConditionalBranchOperation):
+    """
+    Take the branch if registers rs1 and rs2 are not equal.
+
+    if (x[rs1] != x[rs2]) pc += sext(offset)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bne
+    """
+
+    name = "riscv_cf.bne"
+
+
+@irdl_op_definition
+class BltOp(ConditionalBranchOperation):
+    """
+    Take the branch if registers rs1 is less than rs2, using signed comparison.
+
+    if (x[rs1] <s x[rs2]) pc += sext(offset)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#blt
+    """
+
+    name = "riscv_cf.blt"
+
+
+@irdl_op_definition
+class BgeOp(ConditionalBranchOperation):
+    """
+    Take the branch if registers rs1 is greater than or equal to rs2, using signed comparison.
+
+    if (x[rs1] >=s x[rs2]) pc += sext(offset)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bge
+    """
+
+    name = "riscv_cf.bge"
+
+
+@irdl_op_definition
+class BltuOp(ConditionalBranchOperation):
+    """
+    Take the branch if registers rs1 is less than rs2, using unsigned comparison.
+
+    if (x[rs1] <u x[rs2]) pc += sext(offset)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bltu
+    """
+
+    name = "riscv_cf.bltu"
+
+
+@irdl_op_definition
+class BgeuOp(ConditionalBranchOperation):
+    """
+    Take the branch if registers rs1 is greater than or equal to rs2, using unsigned comparison.
+
+    if (x[rs1] >=u x[rs2]) pc += sext(offset)
+
+    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bgeu
+    """
+
+    name = "riscv_cf.bgeu"
+
+
+@irdl_op_definition
+class BranchOp(IRDLOperation, riscv.RISCVOp):
+    """
+    Branches to a different block, which must follow this operation's block in the parent
+    region. Is not printed in assembly.
+    """
+
+    name = "riscv_cf.branch"
+
+    block_arguments = var_operand_def(RISCVRegisterType)
+    successor = successor_def()
+
+    traits = frozenset([IsTerminator()])
+
+    def __init__(
+        self,
+        block_arguments: Sequence[SSAValue],
+        successor: Successor,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[block_arguments],
+            attributes={
+                "comment": comment,
+            },
+            successors=(successor,),
+        )
+
+    def verify_(self) -> None:
+        # Types of arguments must match arg types of blocks
+        for op_arg, block_arg in zip(self.block_arguments, self.successor.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        # The successor must immediately follow the parent block.
+        if (parent_block := self.parent) is None or (
+            parent_region := parent_block.parent
+        ) is None:
+            return
+
+        parent_index = parent_region.get_block_index(parent_block)
+        successor_index = parent_region.get_block_index(self.successor)
+
+        if parent_index + 1 != successor_index:
+            raise VerifyException(
+                "Successor block must be immediately after parent block in the parent "
+                "region."
+            )
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        printer.print_block_name(self.successor)
+        printer.print_string("(")
+        printer.print_list(
+            self.block_arguments, lambda val: _print_type_pair(printer, val)
+        )
+        printer.print_string(")")
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        successor = parser.parse_successor()
+        block_arguments = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+        )
+        return cls(block_arguments, successor)
+
+    def assembly_line(self) -> str | None:
+        return None
+
+
+@irdl_op_definition
+class JOp(IRDLOperation, RISCVInstruction):
+    """
+    A pseudo-instruction, for unconditional jumps you don't expect to return from.
+    Is equivalent to JalOp with `rd` = `x0`.
+    Used to be a part of the spec, removed in 2.0.
+    """
+
+    name = "riscv_cf.j"
+
+    block_arguments: VarOperand = var_operand_def(IntRegisterType)
+
+    successor = successor_def()
+
+    traits = frozenset([IsTerminator()])
+
+    def __init__(
+        self,
+        block_arguments: Sequence[SSAValue],
+        successor: Successor,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[block_arguments],
+            attributes={
+                "comment": comment,
+            },
+            successors=(successor,),
+        )
+
+    def verify_(self) -> None:
+        # Types of arguments must match arg types of blocks
+
+        for op_arg, block_arg in zip(self.block_arguments, self.successor.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        if not isinstance(self.successor.first_op, riscv.LabelOp):
+            raise VerifyException(
+                "riscv_cf.j operation successor must have a riscv.label operation as a "
+                f"first argument, found {self.successor.first_op}"
+            )
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        printer.print_block_name(self.successor)
+        printer.print_string("(")
+        printer.print_list(
+            self.block_arguments, lambda val: _print_type_pair(printer, val)
+        )
+        printer.print_string(")")
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        successor = parser.parse_successor()
+        block_arguments = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: _parse_type_pair(parser)
+        )
+        return cls(block_arguments, successor)
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        dest_label = self.successor.first_op
+        assert isinstance(dest_label, riscv.LabelOp)
+        return (dest_label.label,)
+
+
+RISCV_Cf = Dialect(
+    "riscv_cf",
+    [
+        JOp,
+        BranchOp,
+        BeqOp,
+        BneOp,
+        BltOp,
+        BgeOp,
+        BltuOp,
+        BgeuOp,
+    ],
+)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -471,6 +471,19 @@ class PatternRewriter(PatternRewriterListener):
             )
         return Rewriter.move_region_contents_to_new_regions(region)
 
+    def inline_region_before(self, region: Region, target: Block) -> None:
+        """Move the region blocks to an existing region."""
+        self.has_done_action = True
+        if not self._can_modify_region(region):
+            raise Exception(
+                "Cannot move regions that are not children of the matched operation"
+            )
+        if not self._can_modify_block(target):
+            raise Exception(
+                "Cannot move blocks that are not contained in the matched operation."
+            )
+        Rewriter.inline_region_before(region, target)
+
     def iter_affected_ops(self) -> Iterable[Operation]:
         """
         Iterate newly added operations, in the order that they are in the module.

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -126,6 +126,8 @@ class PatternRewriter(PatternRewriterListener):
         """Check if the region and its children can be modified by this rewriter."""
         if region.parent is None:
             return True  # Toplevel operation of current_operation is always a ModuleOp
+        if region is self.current_operation.parent_region():
+            return True
         return self._can_modify_op(region.parent)
 
     def insert_op_before_matched_op(self, op: (Operation | Sequence[Operation])):
@@ -483,6 +485,45 @@ class PatternRewriter(PatternRewriterListener):
                 "Cannot move blocks that are not contained in the matched operation."
             )
         Rewriter.inline_region_before(region, target)
+
+    def inline_region_after(self, region: Region, target: Block) -> None:
+        """Move the region blocks to an existing region."""
+        self.has_done_action = True
+        if not self._can_modify_region(region):
+            raise Exception(
+                "Cannot move regions that are not children of the matched operation"
+            )
+        if not self._can_modify_block(target):
+            raise Exception(
+                "Cannot move blocks that are not contained in the matched operation."
+            )
+        Rewriter.inline_region_after(region, target)
+
+    def inline_region_at_start(self, region: Region, target: Region) -> None:
+        """Move the region blocks to an existing region."""
+        self.has_done_action = True
+        if not self._can_modify_region(region):
+            raise Exception(
+                "Cannot move regions that are not children of the matched operation"
+            )
+        if not self._can_modify_region(target):
+            raise Exception(
+                "Cannot move blocks that are not contained in the matched operation."
+            )
+        Rewriter.inline_region_at_start(region, target)
+
+    def inline_region_at_end(self, region: Region, target: Region) -> None:
+        """Move the region blocks to an existing region."""
+        self.has_done_action = True
+        if not self._can_modify_region(region):
+            raise Exception(
+                "Cannot move regions that are not children of the matched operation"
+            )
+        if not self._can_modify_region(target):
+            raise Exception(
+                "Cannot move blocks that are not contained in the matched operation."
+            )
+        Rewriter.inline_region_at_end(region, target)
 
     def iter_affected_ops(self) -> Iterable[Operation]:
         """

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -186,3 +186,15 @@ class Rewriter:
             new_region.add_block(block)
         region.blocks = []
         return new_region
+
+    @staticmethod
+    def inline_region_before(region: Region, target: Block) -> None:
+        """Move the region blocks to an existing region."""
+        parent_region = target.parent
+        if parent_region is None:
+            raise ValueError("Cannot inline region before a block with no parent")
+        for block in region.blocks:
+            block.parent = None
+        pos = parent_region.get_block_index(target)
+        parent_region.insert_block(region.blocks, pos)
+        region.blocks = []

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -214,3 +214,13 @@ class Rewriter:
             raise ValueError("Cannot inline region before a block with no parent")
         pos = parent_region.get_block_index(target) + 1
         Rewriter._inline_region_at_pos(region, parent_region, pos)
+
+    @staticmethod
+    def inline_region_at_start(region: Region, target: Region) -> None:
+        """Move the region blocks to the start of an existing region."""
+        Rewriter._inline_region_at_pos(region, target, 0)
+
+    @staticmethod
+    def inline_region_at_end(region: Region, target: Region) -> None:
+        """Move the region blocks to the end of an existing region."""
+        Rewriter._inline_region_at_pos(region, target, len(target.blocks))

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -212,5 +212,5 @@ class Rewriter:
         parent_region = target.parent
         if parent_region is None:
             raise ValueError("Cannot inline region before a block with no parent")
-        pos = parent_region.get_block_index(target)
+        pos = parent_region.get_block_index(target) + 1
         Rewriter._inline_region_at_pos(region, parent_region, pos)

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -188,13 +188,29 @@ class Rewriter:
         return new_region
 
     @staticmethod
+    def _inline_region_at_pos(region: Region, target: Region, pos: int) -> None:
+        """Move the region blocks to an existing region, at position `pos`."""
+        if region is target:
+            raise ValueError("Cannot move region into itself.")
+        for block in region.blocks:
+            block.parent = None
+        target.insert_block(region.blocks, pos)
+        region.blocks = []
+
+    @staticmethod
     def inline_region_before(region: Region, target: Block) -> None:
-        """Move the region blocks to an existing region."""
+        """Move the region blocks to an existing region, before `target`."""
         parent_region = target.parent
         if parent_region is None:
             raise ValueError("Cannot inline region before a block with no parent")
-        for block in region.blocks:
-            block.parent = None
         pos = parent_region.get_block_index(target)
-        parent_region.insert_block(region.blocks, pos)
-        region.blocks = []
+        Rewriter._inline_region_at_pos(region, parent_region, pos)
+
+    @staticmethod
+    def inline_region_after(region: Region, target: Block) -> None:
+        """Move the region blocks to an existing region, after `target`."""
+        parent_region = target.parent
+        if parent_region is None:
+            raise ValueError("Cannot inline region before a block with no parent")
+        pos = parent_region.get_block_index(target)
+        Rewriter._inline_region_at_pos(region, parent_region, pos)

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -29,6 +29,7 @@ from xdsl.dialects.onnx import ONNX
 from xdsl.dialects.pdl import PDL
 from xdsl.dialects.printf import Printf
 from xdsl.dialects.riscv import RISCV
+from xdsl.dialects.riscv_cf import RISCV_Cf
 from xdsl.dialects.riscv_func import RISCV_Func
 from xdsl.dialects.riscv_scf import RISCV_Scf
 from xdsl.dialects.riscv_snitch import RISCV_Snitch
@@ -76,6 +77,7 @@ def get_all_dialects() -> list[Dialect]:
         PDL,
         Printf,
         RISCV,
+        RISCV_Cf,
         RISCV_Func,
         RISCV_Scf,
         RISCV_Snitch,


### PR DESCRIPTION
This adds the riscv_cf dialect, duplicating some instructions in the riscv dialect, but with dataflow semantics with successors etc. This lets us reason about dataflow using xDSL IR constructs, and is a step towards being able to interpret exactly the same IR that we use to print assembly.

I forgot to add two things, will do them tomorrow:
 - [x] attributes
 - [x] comments in assembly