### PR TITLE
dialects: (onnx) lint onnx.py

### DIFF
--- a/tests/filecheck/dialects/onnx/onnx_invalid.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_invalid.mlir
@@ -41,6 +41,16 @@ builtin.module {
 // -----
 
 builtin.module {
+  %t0 = "test.op"() : () -> (tensor<2x4xf32>)
+
+  // CHECK: operand at position 1 does not verify!
+  // CHECK: Operation does not verify: Mismatch between operand type and res type of onnx.Relu
+  %res_relu =  "onnx.Relu"(%t0) {onnx_node_name = "/Relu"} : (tensor<2x4xf32>) -> tensor<3x4xf32>
+}
+
+// -----
+
+builtin.module {
   %t0, %t1, %t2 = "test.op"() : () -> (tensor<2x4xf32>, tensor<3x2xf32>, tensor<3x2xf32>)
 
   // CHECK: Operation does not verify: operands have incompatible shapes: (2, 4) and (3, 2)

--- a/xdsl/dialects/onnx.py
+++ b/xdsl/dialects/onnx.py
@@ -5,8 +5,8 @@ from typing import Annotated, cast
 
 from xdsl.dialects.builtin import (
     AnyFloat,
+    AnyIntegerAttr,
     FloatAttr,
-    IntegerAttr,
     IntegerType,
     SSAValue,
     TensorType,
@@ -124,17 +124,15 @@ class Relu(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        if not isinstance(
-            operand_type := self.operand.type, TensorType
-        ) or not isinstance(res_type := self.res.type, TensorType):
-            assert (
-                False
-            ), "onnx elementwise operation operand and result must be of type TensorType"
-            operand_type = cast(TensorType[Attribute], operand_type)
-            res_type = cast(TensorType[Attribute], res_type)
+        assert isinstance(operand_type := self.operand.type, TensorType)
+        assert isinstance(res_type := self.res.type, TensorType)
+        operand_type = cast(TensorType[Attribute], operand_type)
+        res_type = cast(TensorType[Attribute], res_type)
 
-            if operand_type != res_type:
-                raise VerifyException("Mismatch between operand type and res type")
+        if operand_type != res_type:
+            raise VerifyException(
+                "Mismatch between operand type and res type of onnx.Relu"
+            )
 
 
 @irdl_op_definition
@@ -154,11 +152,11 @@ class Gemm(IRDLOperation):
     tensor_b = operand_def(TensorType[T])
     tensor_c = operand_def(TensorType[T])
 
-    alpha = opt_attr_def(FloatAttr)
-    beta = opt_attr_def(FloatAttr)
+    alpha = opt_attr_def(FloatAttr[AnyFloat])
+    beta = opt_attr_def(FloatAttr[AnyFloat])
 
-    trans_a = opt_attr_def(IntegerAttr, attr_name="transA")
-    trans_b = opt_attr_def(IntegerAttr, attr_name="transB")
+    trans_a = opt_attr_def(AnyIntegerAttr, attr_name="transA")
+    trans_b = opt_attr_def(AnyIntegerAttr, attr_name="transB")
 
     res_tensor = result_def(TensorType[T])
     assembly_format = (


### PR DESCRIPTION
Two small nits highligthed by VSCode that I missed in my review:

 - FloatAttr and IntegerAttr are generic, and Pylance isn't happy when the generic parameter is not specified. AnyFloatAttr and AnyIntegerAttr is probably what we want if we want to allow any bitwidth in the types. Pylance is the version of Pyright built into VSCode, not sure why it disagrees with the one we have in the CI.
 - There was dead code after the `assert False`, not sure why Pyright didn't bring this up in the CI either, but we should test for it also.