### PR TITLE
dialects: (riscv_snitch) add get_stream, read, write ops

### DIFF
--- a/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
@@ -1,0 +1,21 @@
+// RUN: xdsl-opt -t riscv-asm %s | filecheck %s
+
+
+riscv_func.func @main() {
+  %0 = riscv.get_register : () -> !riscv.reg<a0>
+  %1 = riscv.get_register : () -> !riscv.reg<a1>
+
+  %readable = riscv_snitch.get_stream : !stream.readable<!riscv.freg<ft0>>
+  %writable = riscv_snitch.get_stream : !stream.writable<!riscv.freg<ft1>>
+  riscv_snitch.frep_outer %0 {
+    %val0 = riscv_snitch.read from %readable : !riscv.freg<ft0>
+    %val1 = riscv.fmv.d %val0 : (!riscv.freg<ft0>) -> !riscv.freg<ft1>
+    riscv_snitch.write %val1 to %writable : !riscv.freg<ft1>
+  }
+  riscv_func.return
+}
+
+// CHECK:        main:
+// CHECK-NEXT:       frep.o a0, 1, 0, 0
+// CHECK-NEXT:       fmv.d ft1, ft0
+// CHECK-NEXT:       ret

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -25,6 +25,21 @@ riscv_func.func @main() {
   // CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
   // CHECK-NEXT:  }
 
+  %readable = riscv_snitch.get_stream : !stream.readable<!riscv.freg<ft0>>
+  %writable = riscv_snitch.get_stream : !stream.writable<!riscv.freg<ft1>>
+  riscv_snitch.frep_outer %0 {
+    %val0 = riscv_snitch.read from %readable : !riscv.freg<ft0>
+    %val1 = riscv.fmv.d %val0 : (!riscv.freg<ft0>) -> !riscv.freg<ft1>
+    riscv_snitch.write %val1 to %writable : !riscv.freg<ft1>
+  }
+  // CHECK-NEXT:  %readable = riscv_snitch.get_stream : !stream.readable<!riscv.freg<ft0>>
+  // CHECK-NEXT:  %writable = riscv_snitch.get_stream : !stream.writable<!riscv.freg<ft1>>
+  // CHECK-NEXT:  riscv_snitch.frep_outer %0 {
+  // CHECK-NEXT:    %val0 = riscv_snitch.read from %readable : !riscv.freg<ft0>
+  // CHECK-NEXT:    %val1 = riscv.fmv.d %val0 : (!riscv.freg<ft0>) -> !riscv.freg<ft1>
+  // CHECK-NEXT:    riscv_snitch.write %val1 to %writable : !riscv.freg<ft1>
+  // CHECK-NEXT:  }
+
   // Terminate block
   riscv_func.return
 }
@@ -43,6 +58,14 @@ riscv_func.func @main() {
 // CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"() : () -> ()
 // CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:        %readable = "riscv_snitch.get_stream"() : () -> !stream.readable<!riscv.freg<ft0>>
+// CHECK-GENERIC-NEXT:        %writable = "riscv_snitch.get_stream"() : () -> !stream.writable<!riscv.freg<ft1>>
+// CHECK-GENERIC-NEXT:        "riscv_snitch.frep_outer"(%0) ({
+// CHECK-GENERIC-NEXT:          %val0 = "riscv_snitch.read"(%readable) : (!stream.readable<!riscv.freg<ft0>>) -> !riscv.freg<ft0>
+// CHECK-GENERIC-NEXT:          %val1 = "riscv.fmv.d"(%val0) : (!riscv.freg<ft0>) -> !riscv.freg<ft1>
+// CHECK-GENERIC-NEXT:          "riscv_snitch.write"(%val1, %writable) : (!riscv.freg<ft1>, !stream.writable<!riscv.freg<ft1>>) -> ()
+// CHECK-GENERIC-NEXT:          "riscv_snitch.frep_yield"() : () -> ()
+// CHECK-GENERIC-NEXT:        }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import cast
+from typing import Annotated, cast
 
 from typing_extensions import Self
 
+from xdsl.dialects import riscv, stream
 from xdsl.dialects.builtin import (
     IntAttr,
 )
@@ -27,11 +28,13 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.irdl import (
+    ConstraintVar,
     IRDLOperation,
     attr_def,
     irdl_op_definition,
     operand_def,
     region_def,
+    result_def,
     traits_def,
 )
 from xdsl.parser import Parser
@@ -219,7 +222,7 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
             raise VerifyException("Non-zero stagger mask currently unsupported")
         for instruction in self.body.ops:
             if not instruction.has_trait(Pure) and not isinstance(
-                instruction, FrepYieldOp
+                instruction, FrepYieldOp | ReadOp | WriteOp
             ):
                 raise VerifyException(
                     "Frep operation body may not contain instructions "
@@ -303,6 +306,103 @@ class FrepYieldOp(AbstractYieldOperation[Attribute], RISCVOp):
         return None
 
 
+@irdl_op_definition
+class ReadOp(IRDLOperation, RISCVOp):
+    name = "riscv_snitch.read"
+
+    T = Annotated[riscv.FloatRegisterType, ConstraintVar("T")]
+
+    stream = operand_def(stream.ReadableStreamType[T])
+    res = result_def(T)
+
+    def __init__(self, stream_val: SSAValue, result_type: Attribute | None = None):
+        if result_type is None:
+            assert isinstance(stream_type := stream_val.type, stream.ReadableStreamType)
+            stream_type = cast(stream.ReadableStreamType[Attribute], stream_type)
+            result_type = stream_type.element_type
+        super().__init__(operands=[stream_val], result_types=[result_type])
+
+    @classmethod
+    def parse(cls, parser: Parser) -> ReadOp:
+        parser.parse_characters("from")
+        unresolved = parser.parse_unresolved_operand()
+        parser.parse_punctuation(":")
+        result_type = parser.parse_attribute()
+        resolved = parser.resolve_operand(
+            unresolved, stream.ReadableStreamType(result_type)
+        )
+        return ReadOp(resolved, result_type)
+
+    def print(self, printer: Printer):
+        printer.print_string(" from ")
+        printer.print(self.stream)
+        printer.print_string(" : ")
+        printer.print_attribute(self.res.type)
+
+    def assembly_line(self) -> str | None:
+        return None
+
+
+@irdl_op_definition
+class WriteOp(IRDLOperation, RISCVOp):
+    name = "riscv_snitch.write"
+
+    T = Annotated[riscv.FloatRegisterType, ConstraintVar("T")]
+
+    value = operand_def(T)
+    stream = operand_def(stream.WritableStreamType[T])
+
+    def __init__(self, value: SSAValue, stream: SSAValue):
+        super().__init__(operands=[value, stream])
+
+    @classmethod
+    def parse(cls, parser: Parser) -> WriteOp:
+        unresolved_value = parser.parse_unresolved_operand()
+        parser.parse_characters("to")
+        unresolved_stream = parser.parse_unresolved_operand()
+        parser.parse_punctuation(":")
+        result_type = parser.parse_attribute()
+        resolved_value = parser.resolve_operand(unresolved_value, result_type)
+        resolved_stream = parser.resolve_operand(
+            unresolved_stream, stream.WritableStreamType(result_type)
+        )
+        return WriteOp(resolved_value, resolved_stream)
+
+    def print(self, printer: Printer):
+        printer.print_string(" ")
+        printer.print_ssa_value(self.value)
+        printer.print_string(" to ")
+        printer.print_ssa_value(self.stream)
+        printer.print_string(" : ")
+        printer.print_attribute(self.value.type)
+
+    def assembly_line(self) -> str | None:
+        return None
+
+
+@irdl_op_definition
+class GetStreamOp(IRDLOperation, RISCVOp):
+    name = "riscv_snitch.get_stream"
+
+    stream = result_def(stream.StreamType[riscv.FloatRegisterType])
+
+    def __init__(self, result_type: Attribute):
+        super().__init__(result_types=[result_type])
+
+    @classmethod
+    def parse(cls, parser: Parser) -> GetStreamOp:
+        parser.parse_punctuation(":")
+        result_type = parser.parse_attribute()
+        return GetStreamOp(result_type)
+
+    def print(self, printer: Printer):
+        printer.print_string(" : ")
+        printer.print_attribute(self.stream.type)
+
+    def assembly_line(self) -> str | None:
+        return None
+
+
 # endregion
 
 RISCV_Snitch = Dialect(
@@ -313,6 +413,9 @@ RISCV_Snitch = Dialect(
         FrepOuter,
         FrepInner,
         FrepYieldOp,
+        ReadOp,
+        WriteOp,
+        GetStreamOp,
     ],
     [],
 )


### PR DESCRIPTION
These ops are useful for the lowest level representation of the compiled operations, they are not printed in the assembly, but help us with leverage SSA dataflow.