### PR TITLE
dialects: Refresh Affine, add interoperability test.

### DIFF
--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -100,7 +100,9 @@ def build_affine_for(
     region = Region(block)
 
     op = affine.For.from_region(
-        (*lb_operands, *ub_operands, *iter_args),
+        lb_operands,
+        ub_operands,
+        iter_args,
         tuple(iter_arg.type for iter_arg in iter_args),
         affine.AffineMapAttr(lb_map),
         affine.AffineMapAttr(ub_map),

--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -8,40 +8,40 @@ from xdsl.utils.exceptions import VerifyException
 
 
 def test_simple_for():
-    f = For.from_region([], [], 0, 5, Region())
+    f = For.from_region([], [], [], [], 0, 5, Region())
     assert f.lowerBoundMap.data.results == (AffineExpr.constant(0),)
     assert f.upperBoundMap.data.results == (AffineExpr.constant(5),)
 
 
 def test_for_mismatch_operands_results_counts():
     properties: dict[str, Attribute] = {
-        "lower_bound": AffineMapAttr.constant_map(0),
-        "upper_bound": AffineMapAttr.constant_map(5),
+        "lowerBoundMap": AffineMapAttr.constant_map(0),
+        "upperBoundMap": AffineMapAttr.constant_map(5),
         "step": IntegerAttr.from_index_int_value(1),
     }
-    f = For.create(
-        operands=[],
+    f = For.build(
+        operands=[[], [], []],
         regions=[Region()],
         properties=properties,
         result_types=[IndexType()],
     )
     with pytest.raises(
         VerifyException,
-        match="Expected as many operands as results, lower bound args and upper bound args.",
+        match="Expected as many init operands as results.",
     ):
         f.verify()
 
 
 def test_for_mismatch_operands_results_types():
     properties: dict[str, Attribute] = {
-        "lower_bound": AffineMapAttr.constant_map(0),
-        "upper_bound": AffineMapAttr.constant_map(5),
+        "lowerBoundMap": AffineMapAttr.constant_map(0),
+        "upperBoundMap": AffineMapAttr.constant_map(5),
         "step": IntegerAttr.from_index_int_value(1),
     }
     b = Block(arg_types=(IntegerType(32),))
     inp = b.args[0]
-    f = For.create(
-        operands=[inp],
+    f = For.build(
+        operands=[[], [], inp],
         regions=[Region()],
         properties=properties,
         result_types=[IndexType()],
@@ -55,14 +55,14 @@ def test_for_mismatch_operands_results_types():
 
 def test_for_mismatch_blockargs():
     properties: dict[str, Attribute] = {
-        "lower_bound": AffineMapAttr.constant_map(0),
-        "upper_bound": AffineMapAttr.constant_map(5),
+        "lowerBoundMap": AffineMapAttr.constant_map(0),
+        "upperBoundMap": AffineMapAttr.constant_map(5),
         "step": IntegerAttr.from_index_int_value(1),
     }
     b = Block(arg_types=(IndexType(),))
     inp = b.args[0]
-    f = For.create(
-        operands=[inp],
+    f = For.build(
+        operands=[[], [], inp],
         regions=[Region(Block([Yield.get()]))],
         properties=properties,
         result_types=[IndexType()],

--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -9,8 +9,8 @@ from xdsl.utils.exceptions import VerifyException
 
 def test_simple_for():
     f = For.from_region([], [], 0, 5, Region())
-    assert f.lower_bound.data.results == (AffineExpr.constant(0),)
-    assert f.upper_bound.data.results == (AffineExpr.constant(5),)
+    assert f.lowerBoundMap.data.results == (AffineExpr.constant(0),)
+    assert f.upperBoundMap.data.results == (AffineExpr.constant(5),)
 
 
 def test_for_mismatch_operands_results_counts():

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -78,15 +78,15 @@
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : index):
 // CHECK-NEXT:        "affine.yield"() : () -> ()
 // CHECK-NEXT:      }) : () -> ()
-// CHECK-NEXT:      "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
+// CHECK-NEXT:      "affine.if"() ({
 // CHECK-NEXT:        "affine.yield"() : () -> ()
 // CHECK-NEXT:      }, {
-// CHECK-NEXT:      }) : () -> ()
-// CHECK-NEXT:      "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
+// CHECK-NEXT:      }) {"condition" = affine_set<() : (0 == 0)>} : () -> ()
+// CHECK-NEXT:      "affine.if"() ({
 // CHECK-NEXT:        "affine.yield"() : () -> ()
 // CHECK-NEXT:      }, {
 // CHECK-NEXT:        "affine.yield"() : () -> ()
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      }) {"condition" = affine_set<() : (0 == 0)>} : () -> ()
 
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
@@ -101,11 +101,11 @@
   }
 // CHECK:    func.func @affine_if() -> f32 {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:      %{{.*}} = "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
+// CHECK-NEXT:      %{{.*}} = "affine.if"() ({
 // CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-NEXT:      }, {
 // CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
-// CHECK-NEXT:      }) : () -> f32
+// CHECK-NEXT:      }) {"condition" = affine_set<() : (0 == 0)>} : () -> f32
 // CHECK-NEXT:      func.return %{{.*}} : f32
 // CHECK-NEXT:    }
 

--- a/tests/filecheck/dialects/affine/examples.mlir
+++ b/tests/filecheck/dialects/affine/examples.mlir
@@ -7,18 +7,18 @@
   "func.func"() ({
   ^0(%ref : memref<128xi32>):
     %const0 = "arith.constant"() {"value" = 0 : i32} : () -> i32
-    %r = "affine.for"(%const0) ({
+    %r = "affine.for"(%const0) <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 1>}> ({
     ^1(%i : index, %sum : i32):
       %val = "memref.load"(%ref, %i) : (memref<128xi32>, index) -> i32
       %res = "arith.addi"(%sum, %val) : (i32, i32) -> i32
       "affine.yield"(%res) : (i32) -> ()
-    }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : (i32) -> i32
+    }) : (i32) -> i32
     func.return %r : i32
   }) {"sym_name" = "sum_vec", "function_type" = (memref<128xi32>) -> i32, "sym_visibility" = "private"} : () -> ()
 
 // CHECK:         func.func private @sum_vec(%{{.*}} : memref<128xi32>) -> i32 {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0 : i32
-// CHECK-NEXT:      %{{.*}} = "affine.for"(%{{.*}}) <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index}> ({
+// CHECK-NEXT:      %{{.*}} = "affine.for"(%const0) <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 1>}> ({
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : index, %{{.*}} : i32):
 // CHECK-NEXT:        %{{.*}} = memref.load %{{.*}}[%{{.*}}] : memref<128xi32>
 // CHECK-NEXT:        %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
@@ -32,11 +32,11 @@
 
   "func.func"() ({
   ^2(%0 : memref<256x256xf32>, %1 : memref<256x256xf32>, %2 : memref<256x256xf32>):
-    "affine.for"() ({
+    "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
     ^3(%3 : index):
-      "affine.for"() ({
+      "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
       ^4(%4 : index):
-        "affine.for"() ({
+        "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
         ^5(%5 : index):
           %6 = "memref.load"(%0, %3, %5) : (memref<256x256xf32>, index, index) -> f32
           %7 = "memref.load"(%1, %5, %4) : (memref<256x256xf32>, index, index) -> f32
@@ -45,20 +45,20 @@
           %10 = "arith.addf"(%8, %9) : (f32, f32) -> f32
           "memref.store"(%10, %2, %3, %4) : (f32, memref<256x256xf32>, index, index) -> ()
           "affine.yield"() : () -> ()
-        }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
+        })  : () -> ()
         "affine.yield"() : () -> ()
-      }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
+      }) : () -> ()
       "affine.yield"() : () -> ()
-    }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index} : () -> ()
+    }) : () -> ()
     "func.return"(%2) : (memref<256x256xf32>) -> ()
   }) {"sym_name" = "affine_mm", "function_type" = (memref<256x256xf32>, memref<256x256xf32>, memref<256x256xf32>) -> memref<256x256xf32>, "sym_visibility" = "private"} : () -> ()
 
 // CHECK:         func.func private @affine_mm(%{{.*}} : memref<256x256xf32>, %{{.*}} : memref<256x256xf32>, %{{.*}} : memref<256x256xf32>) -> memref<256x256xf32> {
-// CHECK-NEXT:      "affine.for"() <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index}> ({
+// CHECK-NEXT:      "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : index):
-// CHECK-NEXT:        "affine.for"() <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index}> ({
+// CHECK-NEXT:        "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
 // CHECK-NEXT:        ^{{.*}}(%{{.*}} : index):
-// CHECK-NEXT:          "affine.for"() <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (256)>, "step" = 1 : index}> ({
+// CHECK-NEXT:          "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
 // CHECK-NEXT:          ^{{.*}}(%{{.*}} : index):
 // CHECK-NEXT:            %{{.*}} = memref.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<256x256xf32>
 // CHECK-NEXT:            %{{.*}} = memref.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<256x256xf32>

--- a/tests/filecheck/frontend/dialects/affine.py
+++ b/tests/filecheck/frontend/dialects/affine.py
@@ -7,7 +7,7 @@ from xdsl.frontend.program import FrontendProgram
 p = FrontendProgram()
 with CodeContext(p):
     # CHECK:      func.func @test_affine_for_I() {
-    # CHECK-NEXT:   "affine.for"() <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (100)>, "step" = 1 : index}> ({
+    # CHECK-NEXT:   "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (100)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
     # CHECK-NEXT:   ^0(%0 : index):
     # CHECK-NEXT:     "affine.yield"() : () -> ()
     # CHECK-NEXT:   }) : () -> ()
@@ -20,7 +20,7 @@ with CodeContext(p):
         return
 
     # CHECK:      func.func @test_affine_for_II() {
-    # CHECK-NEXT:   "affine.for"() <{"lower_bound" = affine_map<() -> (10)>, "upper_bound" = affine_map<() -> (30)>, "step" = 1 : index}> ({
+    # CHECK-NEXT:   "affine.for"() <{"lowerBoundMap" = affine_map<() -> (10)>, "upperBoundMap" = affine_map<() -> (30)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
     # CHECK-NEXT:   ^1(%1 : index):
     # CHECK-NEXT:     "affine.yield"() : () -> ()
     # CHECK-NEXT:   }) : () -> ()
@@ -32,7 +32,7 @@ with CodeContext(p):
         return
 
     # CHECK:      func.func @test_affine_for_III() {
-    # CHECK-NEXT:   "affine.for"() <{"lower_bound" = affine_map<() -> (1)>, "upper_bound" = affine_map<() -> (20)>, "step" = 5 : index}> ({
+    # CHECK-NEXT:   "affine.for"() <{"lowerBoundMap" = affine_map<() -> (1)>, "upperBoundMap" = affine_map<() -> (20)>, "step" = 5 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
     # CHECK-NEXT:   ^2(%2 : index):
     # CHECK-NEXT:     "affine.yield"() : () -> ()
     # CHECK-NEXT:   }) : () -> ()
@@ -44,11 +44,11 @@ with CodeContext(p):
         return
 
     # CHECK:      func.func @test_affine_for_IV() {
-    # CHECK-NEXT:   "affine.for"() <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (10)>, "step" = 1 : index}> ({
+    # CHECK-NEXT:   "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (10)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
     # CHECK-NEXT:   ^3(%3 : index):
-    # CHECK-NEXT:     "affine.for"() <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (20)>, "step" = 1 : index}> ({
+    # CHECK-NEXT:     "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (20)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
     # CHECK-NEXT:     ^4(%4 : index):
-    # CHECK-NEXT:       "affine.for"() <{"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (30)>, "step" = 1 : index}> ({
+    # CHECK-NEXT:       "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (30)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
     # CHECK-NEXT:       ^5(%5 : index):
     # CHECK-NEXT:         "affine.yield"() : () -> ()
     # CHECK-NEXT:       }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: XDSL_ROUNDTRIP
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 
@@ -17,25 +17,25 @@
 
     // For with values being passed during iterations
 
-    %init_value = "test.op"() : () -> !test.type<"int">
+    %init_value = "test.op"() : () -> i32
     %res = "affine.for"(%init_value) <{"lowerBoundMap" = affine_map<() -> (-10)>, "upperBoundMap" = affine_map<() -> (10)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 1>}> ({
-    ^1(%i : index, %step_value : !test.type<"int">):
-      %next_value = "test.op"() : () -> !test.type<"int">
-      "affine.yield"(%next_value) : (!test.type<"int">) -> ()
-    }) : (!test.type<"int">) -> (!test.type<"int">)
+    ^1(%i : index, %step_value : i32):
+      %next_value = "test.op"() : () -> i32
+      "affine.yield"(%next_value) : (i32) -> ()
+    }) : (i32) -> (i32)
     %00 = "test.op"() : () -> index
     %N = "test.op"() : () -> index
     %res2 = "affine.for"(%00, %N, %init_value) <{"lowerBoundMap" = affine_map<(d0) -> (d0)>, "upperBoundMap" = affine_map<()[s0] -> (s0)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 1, 1, 1>}> ({
-    ^1(%i : index, %step_value : !test.type<"int">):
-      %next_value = "test.op"() : () -> !test.type<"int">
-      "affine.yield"(%next_value) : (!test.type<"int">) -> ()
-    }) : (index, index, !test.type<"int">) -> (!test.type<"int">)
+    ^1(%i : index, %step_value : i32):
+      %next_value = "test.op"() : () -> i32
+      "affine.yield"(%next_value) : (i32) -> ()
+    }) : (index, index, i32) -> (i32)
 
     // CHECK:      %res = "affine.for"(%{{.*}}) <{"lowerBoundMap" = affine_map<() -> (-10)>, "upperBoundMap" = affine_map<() -> (10)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 1>}> ({
-    // CHECK-NEXT: ^1(%{{.*}} : index, %{{.*}} : !test.type<"int">):
-    // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> !test.type<"int">
-    // CHECK-NEXT:   "affine.yield"(%{{.*}}) : (!test.type<"int">) -> ()
-    // CHECK-NEXT: }) : (!test.type<"int">) -> !test.type<"int">
+    // CHECK-NEXT: ^1(%{{.*}} : index, %{{.*}} : i32):
+    // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
+    // CHECK-NEXT:   "affine.yield"(%{{.*}}) : (i32) -> ()
+    // CHECK-NEXT: }) : (i32) -> i32
 
 
     %memref = "test.op"() : () -> memref<2x3xf64>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | xdsl-opt | filecheck %s
 
 "builtin.module"() ({
 
@@ -9,7 +9,7 @@
       "affine.yield"() : () -> ()
     }) : () -> ()
 
-    // CHECK:      "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (256)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
+    // CHECK:      "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "operandSegmentSizes" = array<i32: 0, 0, 0>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (256)>}> ({
     // CHECK-NEXT: ^0(%{{.*}} : index):
     // CHECK-NEXT:   "affine.yield"() : () -> ()
     // CHECK-NEXT: }) : () -> ()
@@ -31,7 +31,7 @@
       "affine.yield"(%next_value) : (i32) -> ()
     }) : (index, index, i32) -> (i32)
 
-    // CHECK:      %res = "affine.for"(%{{.*}}) <{"lowerBoundMap" = affine_map<() -> (-10)>, "upperBoundMap" = affine_map<() -> (10)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 1>}> ({
+    // CHECK:      %{{.*}} = "affine.for"(%{{.*}}) <{"lowerBoundMap" = affine_map<() -> (-10)>, "operandSegmentSizes" = array<i32: 0, 0, 1>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (10)>}> ({
     // CHECK-NEXT: ^1(%{{.*}} : index, %{{.*}} : i32):
     // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
     // CHECK-NEXT:   "affine.yield"(%{{.*}}) : (i32) -> ()
@@ -42,19 +42,19 @@
     %value = "test.op"() : () -> f64
     "affine.store"(%value, %memref) <{"map" = affine_map<() -> (0, 0)>}> : (f64, memref<2x3xf64>) -> ()
 
-    // CHECK:      %memref = "test.op"() : () -> memref<2x3xf64>
-    // CHECK-NEXT: %value = "test.op"() : () -> f64
-    // CHECK-NEXT: "affine.store"(%value, %memref) <{"map" = affine_map<() -> (0, 0)>}> : (f64, memref<2x3xf64>) -> ()
+    // CHECK:      %{{.*}} = "test.op"() : () -> memref<2x3xf64>
+    // CHECK-NEXT: %{{.*}} = "test.op"() : () -> f64
+    // CHECK-NEXT: "affine.store"(%{{.*}}, %{{.*}}) <{"map" = affine_map<() -> (0, 0)>}> : (f64, memref<2x3xf64>) -> ()
 
     %zero = "test.op"() : () -> index
     %2 = "affine.apply"(%zero, %zero) <{"map" = affine_map<(d0)[s0] -> (((d0 + (s0 * 42)) + -1))>}> : (index, index) -> index
     %min = "affine.min"(%zero) <{"map" = affine_map<(d0) -> ((d0 + 41), d0)>}> : (index) -> index
     %same_value = "affine.load"(%memref, %zero, %zero) <{"map" = affine_map<(d0, d1) -> (d0, d1)>}> : (memref<2x3xf64>, index, index) -> f64
 
-    // CHECK:      %zero = "test.op"() : () -> index
+    // CHECK:      %{{.*}} = "test.op"() : () -> index
     // CHECK-NEXT: %{{.*}} = "affine.apply"(%{{.*}}, %{{.*}}) <{"map" = affine_map<(d0)[s0] -> (((d0 + (s0 * 42)) + -1))>}> : (index, index) -> index
     // CHECK-NEXT: %{{.*}} = "affine.min"(%{{.*}}) <{"map" = affine_map<(d0) -> ((d0 + 41), d0)>}> : (index) -> index
-    // CHECK-NEXT: %same_value = "affine.load"(%memref, %zero, %zero) <{"map" = affine_map<(d0, d1) -> (d0, d1)>}> : (memref<2x3xf64>, index, index) -> f64
+    // CHECK-NEXT: %{{.*}} = "affine.load"(%{{.*}}, %{{.*}}, %{{.*}}) <{"map" = affine_map<(d0, d1) -> (d0, d1)>}> : (memref<2x3xf64>, index, index) -> f64
 
     func.func @empty() {
     "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (10)>, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
@@ -74,19 +74,19 @@
     func.return
   }
 // CHECK:    func.func @empty() {
-// CHECK-NEXT:      "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (10)>, "operandSegmentSizes" = array<i32: 0, 0, 0>}> ({
+// CHECK-NEXT:      "affine.for"() <{"lowerBoundMap" = affine_map<() -> (0)>, "operandSegmentSizes" = array<i32: 0, 0, 0>, "step" = 1 : index, "upperBoundMap" = affine_map<() -> (10)>}> ({
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : index):
 // CHECK-NEXT:        "affine.yield"() : () -> ()
 // CHECK-NEXT:      }) : () -> ()
-// CHECK-NEXT:      "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
+// CHECK-NEXT:      "affine.if"() ({
 // CHECK-NEXT:        "affine.yield"() : () -> ()
 // CHECK-NEXT:      }, {
-// CHECK-NEXT:      }) : () -> ()
-// CHECK-NEXT:      "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
+// CHECK-NEXT:      }) {"condition" = affine_set<() : (0 == 0)>} : () -> ()
+// CHECK-NEXT:      "affine.if"() ({
 // CHECK-NEXT:        "affine.yield"() : () -> ()
 // CHECK-NEXT:      }, {
 // CHECK-NEXT:        "affine.yield"() : () -> ()
-// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT:      }) {"condition" = affine_set<() : (0 == 0)>} : () -> ()
 
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
@@ -101,11 +101,11 @@
   }
 // CHECK:    func.func @affine_if() -> f32 {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:      %{{.*}} = "affine.if"() <{"condition" = affine_set<() : (0 == 0)>}> ({
+// CHECK-NEXT:      %{{.*}} = "affine.if"() ({
 // CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-NEXT:      }, {
 // CHECK-NEXT:        "affine.yield"(%{{.*}}) : (f32) -> ()
-// CHECK-NEXT:      }) : () -> f32
+// CHECK-NEXT:      }) {"condition" = affine_set<() : (0 == 0)>} : () -> f32
 // CHECK-NEXT:      func.return %{{.*}} : f32
 // CHECK-NEXT:    }
 

--- a/tests/filecheck/transforms/lower_affine.mlir
+++ b/tests/filecheck/transforms/lower_affine.mlir
@@ -4,16 +4,16 @@
   %v0, %m = "test.op"() : () -> (f32, memref<2x3xf32>)
   "affine.store"(%v0, %m) {"map" = affine_map<() -> (1, 2)>} : (f32, memref<2x3xf32>) -> ()
   %v1 = "affine.load"(%m) {"map" = affine_map<() -> (1, 2)>} : (memref<2x3xf32>) -> f32
-  %v2 = "affine.for"(%v1) ({
+  %v2 = "affine.for"(%v1) <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (2)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 1>}> ({
   ^0(%r : index, %acc0 : f32):
-    %v3 = "affine.for"(%acc0) ({
+    %v3 = "affine.for"(%acc0) <{"lowerBoundMap" = affine_map<() -> (0)>, "upperBoundMap" = affine_map<() -> (3)>, "step" = 1 : index, "operandSegmentSizes" = array<i32: 0, 0, 1>}> ({
     ^2(%c : index, %acc1 : f32):
       %v4 = "affine.load"(%m, %r, %c) {"map" = affine_map<(d0, d1) -> (d0, d1)>} : (memref<2x3xf32>, index, index) -> f32
       %acc_new = "test.op"(%acc1, %v4) : (f32, f32) -> f32
       "affine.yield"(%acc_new) : (f32) -> ()
-    }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (3)>, "step" = 1 : index} : (f32) -> f32
+    }) : (f32) -> f32
     "affine.yield"(%v3) : (f32) -> ()
-  }) {"lower_bound" = affine_map<() -> (0)>, "upper_bound" = affine_map<() -> (2)>, "step" = 1 : index} : (f32) -> f32
+  }) : (f32) -> f32
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({

--- a/tests/interpreters/test_affine_interpreter.py
+++ b/tests/interpreters/test_affine_interpreter.py
@@ -42,11 +42,11 @@ def module_op():
                 affine.Store(sum_op.result, alloc_op_0.memref, (row, col))
                 affine.Yield.get()
 
-            affine.For.from_region((), (), 0, 3, init_cols_region)
+            affine.For.from_region((), (), (), (), 0, 3, init_cols_region)
 
             affine.Yield.get()
 
-        affine.For.from_region((), (), 0, 2, init_rows_region)
+        affine.For.from_region((), (), (), (), 0, 2, init_rows_region)
 
         @Builder.implicit_region((index,))
         def transpose_rows_region(args: tuple[Any, ...]):
@@ -59,11 +59,11 @@ def module_op():
                 affine.Store(res, alloc_op_1.memref, (col, row))
                 affine.Yield.get()
 
-            affine.For.from_region((), (), 0, 3, transpose_cols_region)
+            affine.For.from_region((), (), (), (), 0, 3, transpose_cols_region)
 
             affine.Yield.get()
 
-        affine.For.from_region((), (), 0, 2, transpose_rows_region)
+        affine.For.from_region((), (), (), (), 0, 2, transpose_rows_region)
         func.Return(alloc_op_0.memref, alloc_op_1.memref)
 
 

--- a/tests/test_frontend_op_inserter.py
+++ b/tests/test_frontend_op_inserter.py
@@ -28,7 +28,7 @@ def test_raises_exception_on_op_with_no_regions():
 
 def test_raises_exception_on_op_with_no_blocks():
     inserter = OpInserter(Block())
-    op_with_no_region = For.from_region([], [], 0, 10, Region())
+    op_with_no_region = For.from_region([], [], [], [], 0, 10, Region())
     with pytest.raises(FrontendProgramException) as err:
         inserter.set_insertion_point_from_op(op_with_no_region)
     assert err.value.msg == (

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -449,7 +449,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
             assert isinstance(start, int)
             assert isinstance(end, int)
             assert isinstance(step, int)
-            op = affine.For.from_region([], [], start, end, body, step)
+            op = affine.For.from_region([], [], [], [], start, end, body, step)
         else:
             self.inserter.insert_op(scf.Yield())
             assert isinstance(start, SSAValue)

--- a/xdsl/interpreters/affine.py
+++ b/xdsl/interpreters/affine.py
@@ -52,8 +52,8 @@ class AffineFunctions(InterpreterFunctions):
         assert not args, "Arguments not supported yet"
         assert not op.results, "Results not supported yet"
 
-        lower_bound = op.lower_bound.data.eval([], [])
-        upper_bound = op.upper_bound.data.eval([], [])
+        lower_bound = op.lowerBoundMap.data.eval([], [])
+        upper_bound = op.upperBoundMap.data.eval([], [])
         assert len(lower_bound) == 1
         assert len(upper_bound) == 1
 

--- a/xdsl/transforms/lower_affine.py
+++ b/xdsl/transforms/lower_affine.py
@@ -103,8 +103,8 @@ class LowerAffineLoad(RewritePattern):
 class LowerAffineFor(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: affine.For, rewriter: PatternRewriter):
-        lb_map = op.lower_bound.data
-        ub_map = op.upper_bound.data
+        lb_map = op.lowerBoundMap.data
+        ub_map = op.upperBoundMap.data
         assert len(lb_map.results) == 1, "Affine for lower_bound must have one result"
         assert len(ub_map.results) == 1, "Affine for upper_bound must have one result"
         lb_ops, lb_val = affine_expr_ops(lb_map.results[0], [], [])

--- a/xdsl/transforms/lower_affine.py
+++ b/xdsl/transforms/lower_affine.py
@@ -118,7 +118,7 @@ class LowerAffineFor(RewritePattern):
                 lb_val,
                 ub_val,
                 step_op.result,
-                op.arguments,
+                op.inits,
                 rewriter.move_region_contents_to_new_regions(op.body),
             )
         )


### PR DESCRIPTION
Refresh affine:
- `affine.for`:
  - Rename (lower|upper)_bound -> (lower|upper)BoundMap
  - Split variadics arguments in 3 variadic arguments :tada: 
- `affine.if`:
  For some reason `affine.if`'s condition is not a property.

Add interoperability test.