### PR TITLE
backend: (snitch) add iteration arguments to frep

### DIFF
--- a/tests/filecheck/backend/riscv/register_allocation_exclude_snitch.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_exclude_snitch.mlir
@@ -2,32 +2,29 @@
 // RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive exclude_snitch_reserved=false}" %s | filecheck %s --check-prefix=CHECK-SNITCH-UNRESERVED
 
 riscv_func.func @main() {
-  %stride_pattern, %ptr0 = "test.op"() : () -> (!snitch_stream.stride_pattern_type<2>, !riscv.reg<>)
-  %s0 = "snitch_stream.strided_read"(%ptr0, %stride_pattern) {"dm" = #builtin.int<0>, "rank" = #builtin.int<2>} : (!riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> !stream.readable<!riscv.freg<>>
+  %stream = "test.op"() : () -> (!stream.readable<!riscv.freg<ft0>>)
   %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>)
+  %read = riscv_snitch.read from %stream : !riscv.freg<ft0>
   %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-  %sum2 = riscv.fadd.s %sum1, %v2 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
   riscv_func.return
 }
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
-// CHECK-NEXT:      %stride_pattern, %ptr0 = "test.op"() : () -> (!snitch_stream.stride_pattern_type<2>, !riscv.reg<>)
-// CHECK-NEXT:      %s0 = "snitch_stream.strided_read"(%ptr0, %stride_pattern) {"dm" = #builtin.int<0>, "rank" = #builtin.int<2>} : (!riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> !stream.readable<!riscv.freg<>>
-// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft5>, !riscv.freg<ft4>)
-// CHECK-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft3>, !riscv.freg<ft5>) -> !riscv.freg<ft3>
-// CHECK-NEXT:      %sum2 = riscv.fadd.s %sum1, %v2 : (!riscv.freg<ft3>, !riscv.freg<ft4>) -> !riscv.freg<ft3>
+// CHECK-NEXT:      %stream = "test.op"() : () -> !stream.readable<!riscv.freg<ft0>>
+// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft4>, !riscv.freg<>)
+// CHECK-NEXT:      %read = riscv_snitch.read from %stream : !riscv.freg<ft0>
+// CHECK-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft3>, !riscv.freg<ft4>) -> !riscv.freg<ft3>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 // CHECK-SNITCH-UNRESERVED:       builtin.module {
 // CHECK-SNITCH-UNRESERVED-NEXT:    riscv_func.func @main() {
-// CHECK-SNITCH-UNRESERVED-NEXT:      %stride_pattern, %ptr0 = "test.op"() : () -> (!snitch_stream.stride_pattern_type<2>, !riscv.reg<>)
-// CHECK-SNITCH-UNRESERVED-NEXT:      %s0 = "snitch_stream.strided_read"(%ptr0, %stride_pattern) {"dm" = #builtin.int<0>, "rank" = #builtin.int<2>} : (!riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> !stream.readable<!riscv.freg<>>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft0>, !riscv.freg<ft2>, !riscv.freg<ft1>)
-// CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft0>, !riscv.freg<ft2>) -> !riscv.freg<ft0>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %sum2 = riscv.fadd.s %sum1, %v2 : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
+// CHECK-SNITCH-UNRESERVED-NEXT:      %stream = "test.op"() : () -> !stream.readable<!riscv.freg<ft0>>
+// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg<>)
+// CHECK-SNITCH-UNRESERVED-NEXT:      %read = riscv_snitch.read from %stream : !riscv.freg<ft0>
+// CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft1>, !riscv.freg<ft2>) -> !riscv.freg<ft1>
 // CHECK-SNITCH-UNRESERVED-NEXT:      riscv_func.return
 // CHECK-SNITCH-UNRESERVED-NEXT:    }
 // CHECK-SNITCH-UNRESERVED-NEXT:  }
@@ -35,32 +32,29 @@ riscv_func.func @main() {
 // -----
 
 riscv_func.func @main() {
-  %stride_pattern, %ptr0 = "test.op"() : () -> (!snitch_stream.stride_pattern_type<2>, !riscv.reg<>)
-  %s0 = "snitch_stream.strided_write"(%ptr0, %stride_pattern) {"dm" = #builtin.int<0>, "rank" = #builtin.int<2>} : (!riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> !stream.writable<!riscv.freg<>>
+  %stream, %val = "test.op"() : () -> (!stream.writable<!riscv.freg<ft0>>, !riscv.freg<ft0>)
   %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>)
+  riscv_snitch.write %val to %stream : !riscv.freg<ft0>
   %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-  %sum2 = riscv.fadd.s %sum1, %v2 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
   riscv_func.return
 }
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
-// CHECK-NEXT:      %stride_pattern, %ptr0 = "test.op"() : () -> (!snitch_stream.stride_pattern_type<2>, !riscv.reg<>)
-// CHECK-NEXT:      %s0 = "snitch_stream.strided_write"(%ptr0, %stride_pattern) {"dm" = #builtin.int<0>, "rank" = #builtin.int<2>} : (!riscv.reg<>,  !snitch_stream.stride_pattern_type<2>) -> !stream.writable<!riscv.freg<>>
-// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft5>, !riscv.freg<ft4>)
-// CHECK-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft3>, !riscv.freg<ft5>) -> !riscv.freg<ft3>
-// CHECK-NEXT:      %sum2 = riscv.fadd.s %sum1, %v2 : (!riscv.freg<ft3>, !riscv.freg<ft4>) -> !riscv.freg<ft3>
+// CHECK-NEXT:      %stream, %val = "test.op"() : () -> (!stream.writable<!riscv.freg<ft0>>, !riscv.freg<ft0>)
+// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft4>, !riscv.freg<>)
+// CHECK-NEXT:      riscv_snitch.write %val to %stream : !riscv.freg<ft0>
+// CHECK-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft3>, !riscv.freg<ft4>) -> !riscv.freg<ft3>
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 // CHECK-SNITCH-UNRESERVED:       builtin.module {
 // CHECK-SNITCH-UNRESERVED-NEXT:    riscv_func.func @main() {
-// CHECK-SNITCH-UNRESERVED-NEXT:      %stride_pattern, %ptr0 = "test.op"() : () -> (!snitch_stream.stride_pattern_type<2>, !riscv.reg<>)
-// CHECK-SNITCH-UNRESERVED-NEXT:      %s0 = "snitch_stream.strided_write"(%ptr0, %stride_pattern) {"dm" = #builtin.int<0>, "rank" = #builtin.int<2>} : (!riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> !stream.writable<!riscv.freg<>>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft0>, !riscv.freg<ft2>, !riscv.freg<ft1>)
-// CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft0>, !riscv.freg<ft2>) -> !riscv.freg<ft0>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %sum2 = riscv.fadd.s %sum1, %v2 : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
+// CHECK-SNITCH-UNRESERVED-NEXT:      %stream, %val = "test.op"() : () -> (!stream.writable<!riscv.freg<ft0>>, !riscv.freg<ft0>)
+// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg<>)
+// CHECK-SNITCH-UNRESERVED-NEXT:      riscv_snitch.write %val to %stream : !riscv.freg<ft0>
+// CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft1>, !riscv.freg<ft2>) -> !riscv.freg<ft1>
 // CHECK-SNITCH-UNRESERVED-NEXT:      riscv_func.return
 // CHECK-SNITCH-UNRESERVED-NEXT:    }
 // CHECK-SNITCH-UNRESERVED-NEXT:  }

--- a/tests/filecheck/backend/riscv/register_allocation_frep.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_frep.mlir
@@ -1,0 +1,56 @@
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=0}" %s | filecheck %s --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE-J
+
+riscv_func.func @main() {
+  %0 = riscv.li 6 : () -> !riscv.reg<>
+  %1 = riscv.li 5 : () -> !riscv.reg<s0>
+  %2 = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
+  %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg<>
+  %4 = riscv.fadd.s %2, %3 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+  %5 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
+
+  riscv_snitch.frep_outer %0 {
+  }
+
+  %7 = riscv_snitch.frep_outer %0 iter_args(%6 = %5) -> (!riscv.reg<>) {
+    %8 = riscv.mv %6 : (!riscv.reg<>) -> !riscv.reg<>
+    riscv_snitch.frep_yield %8 : !riscv.reg<>
+  }
+  riscv_func.return
+}
+
+//   CHECK-LIVENESS-BLOCK-NAIVE:       builtin.module {
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    riscv_func.func @main() {
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.li 6 : () -> !riscv.reg<t1>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.li 5 : () -> !riscv.reg<s0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<t1>) -> !riscv.freg<ft0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<ft1>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<t1>, !riscv.reg<s0>) -> !riscv.reg<t0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      riscv_snitch.frep_outer %{{\d+}} {
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %{{\d+}} = riscv_snitch.frep_outer %{{\d+}} iter_args(%{{\d+}} = %{{\d+}}) -> (!riscv.reg<t0>) {
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        %{{\d+}} = riscv.mv %{{\d+}} : (!riscv.reg<t0>) -> !riscv.reg<t0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        riscv_snitch.frep_yield %{{\d+}} : !riscv.reg<t0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      riscv_func.return
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    }
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:  }
+
+//   CHECK-LIVENESS-BLOCK-NAIVE-J:       builtin.module {
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:    riscv_func.func @main() {
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.li 6 : () -> !riscv.reg<j1>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.li 5 : () -> !riscv.reg<s0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<j1>) -> !riscv.freg<j2>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<j3>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<j2>, !riscv.freg<j3>) -> !riscv.freg<j2>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<j1>, !riscv.reg<s0>) -> !riscv.reg<j0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      riscv_snitch.frep_outer %{{\d+}} {
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      }
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv_snitch.frep_outer %{{\d+}} iter_args(%{{\d+}} = %{{\d+}}) -> (!riscv.reg<j0>) {
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:        %{{\d+}} = riscv.mv %{{\d+}} : (!riscv.reg<j0>) -> !riscv.reg<j0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:        riscv_snitch.frep_yield %{{\d+}} : !riscv.reg<j0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      }
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      riscv_func.return
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:    }
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:  }

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -40,6 +40,18 @@ riscv_func.func @main() {
   // CHECK-NEXT:    riscv_snitch.write %val1 to %writable : !riscv.freg<ft1>
   // CHECK-NEXT:  }
 
+  %init = "test.op"() : () -> (!riscv.freg<ft3>)
+  %z = riscv_snitch.frep_outer %0 iter_args(%acc = %init) -> (!riscv.freg<ft3>) {
+    %res = riscv.fadd.d %acc, %acc : (!riscv.freg<ft3>, !riscv.freg<ft3>) -> !riscv.freg<ft3>
+    riscv_snitch.frep_yield %res : !riscv.freg<ft3>
+  }
+
+  // CHECK-NEXT:  %init = "test.op"() : () -> !riscv.freg<ft3>
+  // CHECK-NEXT:    %z = riscv_snitch.frep_outer %0 iter_args(%acc = %init) -> (!riscv.freg<ft3>) {
+  // CHECK-NEXT:      %res = riscv.fadd.d %acc, %acc : (!riscv.freg<ft3>, !riscv.freg<ft3>) -> !riscv.freg<ft3>
+  // CHECK-NEXT:      riscv_snitch.frep_yield %res : !riscv.freg<ft3>
+  // CHECK-NEXT:    }
+
   // Terminate block
   riscv_func.return
 }
@@ -66,6 +78,12 @@ riscv_func.func @main() {
 // CHECK-GENERIC-NEXT:          "riscv_snitch.write"(%val1, %writable) : (!riscv.freg<ft1>, !stream.writable<!riscv.freg<ft1>>) -> ()
 // CHECK-GENERIC-NEXT:          "riscv_snitch.frep_yield"() : () -> ()
 // CHECK-GENERIC-NEXT:        }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:    %init = "test.op"() : () -> !riscv.freg<ft3>
+// CHECK-GENERIC-NEXT:    %z = "riscv_snitch.frep_outer"(%0, %init) ({
+// CHECK-GENERIC-NEXT:    ^0(%acc : !riscv.freg<ft3>):
+// CHECK-GENERIC-NEXT:      %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<ft3>, !riscv.freg<ft3>) -> !riscv.freg<ft3>
+// CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"(%res) : (!riscv.freg<ft3>) -> ()
+// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>, !riscv.freg<ft3>) -> !riscv.freg<ft3>
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/riscv_snitch/verification.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/verification.mlir
@@ -1,0 +1,62 @@
+// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+
+
+%0, %init = "test.op"() : () -> (!riscv.reg<a0>, !riscv.freg<fa0>)
+
+%z = "riscv_snitch.frep_outer"(%0, %init) ({
+^0(%acc : !riscv.freg<fa0>):
+    riscv.sw %0, %0, 0 : (!riscv.reg<a0>, !riscv.reg<a0>) -> ()
+    %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa0>) -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+
+// CHECK: Operation does not verify: Frep operation body may not contain instructions with side-effects, found riscv.sw
+
+// -----
+
+%0, %init = "test.op"() : () -> (!riscv.reg<a0>, !riscv.freg<fa0>)
+
+%z = "riscv_snitch.frep_outer"(%0, %init) ({
+^0(%acc : !riscv.freg<fa0>, %extra : !riscv.freg<fa1>):
+    %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa0>) -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+
+// CHECK: Operation does not verify: Wrong number of block arguments, expected 1, got 2. The body must have the induction variable and loop-carried variables as arguments.
+
+// -----
+
+%0, %init = "test.op"() : () -> (!riscv.reg<a0>, !riscv.freg<fa0>)
+
+%z = "riscv_snitch.frep_outer"(%0, %init) ({
+^0(%acc : !riscv.freg<fa1>):
+    %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa1>, !riscv.freg<fa1>) -> !riscv.freg<fa0>
+    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa0>) -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+
+// CHECK: Operation does not verify: Block argument 0 has wrong type, expected !riscv.freg<fa0>, got !riscv.freg<fa1>. Arguments after the induction variable must match the carried variables.
+
+// -----
+
+%0, %init = "test.op"() : () -> (!riscv.reg<a0>, !riscv.freg<fa0>)
+
+%z = "riscv_snitch.frep_outer"(%0, %init) ({
+^0(%acc : !riscv.freg<fa0>):
+    %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+    "riscv_snitch.frep_yield"() : () -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+
+// CHECK: Operation does not verify: Expected 1 args, got 0. The riscv_scf.frep must yield its carried variables.
+
+// -----
+
+%0, %init = "test.op"() : () -> (!riscv.reg<a0>, !riscv.freg<fa0>)
+
+%z = "riscv_snitch.frep_outer"(%0, %init) ({
+^0(%acc : !riscv.freg<fa0>):
+    %res = "riscv.fadd.d"(%acc, %acc) : (!riscv.freg<fa0>, !riscv.freg<fa0>) -> !riscv.freg<fa1>
+    "riscv_snitch.frep_yield"(%res) : (!riscv.freg<fa1>) -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<a0>, !riscv.freg<fa0>) -> !riscv.freg<fa0>
+
+// CHECK: Operation does not verify: Expected !riscv.freg<fa0>, got !riscv.freg<fa1>. The riscv_snitch.frep's riscv_snitch.frep_yield must match carriedvariables types.
+

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -4,7 +4,7 @@ from itertools import chain
 from ordered_set import OrderedSet
 
 from xdsl.backend.riscv.register_queue import RegisterQueue
-from xdsl.dialects import riscv_func, riscv_scf, snitch_stream
+from xdsl.dialects import riscv_func, riscv_scf, riscv_snitch
 from xdsl.dialects.riscv import (
     FloatRegisterType,
     IntRegisterType,
@@ -36,8 +36,7 @@ def _uses_snitch_stream(func: riscv_func.FuncOp) -> bool:
     """Utility method to detect use of read/write ops of the `snitch_stream` dialect."""
 
     return any(
-        isinstance(op, snitch_stream.StridedReadOp | snitch_stream.StridedWriteOp)
-        for op in func.walk()
+        isinstance(op, riscv_snitch.ReadOp | riscv_snitch.WriteOp) for op in func.walk()
     )
 
 
@@ -116,6 +115,8 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
         match op:
             case riscv_scf.ForOp():
                 self.allocate_for_loop(op)
+            case riscv_snitch.FRepOperation():
+                self.allocate_frep_loop(op)
             case RISCVOp():
                 self.process_riscv_op(op)
             case _:
@@ -181,6 +182,64 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
         # Induction variable
         assert isinstance(block_args[0].type, IntRegisterType)
         self.allocate(block_args[0])
+
+        # Operands
+        for operand in loop.operands:
+            self.allocate(operand)
+
+        # Reserve the loop carried variables for allocation within the body
+        for iter_arg in loop.iter_args:
+            assert isinstance(iter_arg.type, IntRegisterType | FloatRegisterType)
+            self.available_registers.reserve_register(iter_arg.type)
+
+        for op in loop.body.block.ops_reverse:
+            self.process_operation(op)
+
+        # Unreserve the loop carried variables for allocation outside of the body
+        for iter_arg in loop.iter_args:
+            assert isinstance(iter_arg.type, IntRegisterType | FloatRegisterType)
+            self.available_registers.unreserve_register(iter_arg.type)
+
+    def allocate_frep_loop(self, loop: riscv_snitch.FRepOperation) -> None:
+        """
+        Allocate registers for riscv_snitch frep_outer or frep_inner loop, recursively
+        calling process_operation for operations in the loop.
+        """
+        # Allocate values used inside the body but defined outside.
+        # Their scope lasts for the whole body execution scope
+        live_ins = self.live_ins_per_block[loop.body.block]
+        for live_in in live_ins:
+            self.allocate(live_in)
+
+        yield_op = loop.body.block.last_op
+        assert yield_op is not None, (
+            "last op of riscv_snitch.frep_outer and riscv_snitch.frep_inner is guaranteed"
+            " to be riscv_scf.Yield"
+        )
+        block_args = loop.body.block.args
+
+        # The loop-carried variables are trickier
+        # The for op operand, block arg, and yield operand must have the same type
+        for block_arg, operand, yield_operand, op_result in zip(
+            block_args, loop.iter_args, yield_op.operands, loop.results
+        ):
+            # If some allocated then assign all to that type, otherwise get new reg
+            assert isinstance(block_arg.type, RISCVRegisterType)
+            assert isinstance(operand.type, RISCVRegisterType)
+            assert isinstance(yield_operand.type, RISCVRegisterType)
+            assert isinstance(op_result.type, RISCVRegisterType)
+
+            # Because we are walking backwards, the result of the operation may have been
+            # allocated already. If it isn't it's because it's not used below.
+            if not op_result.type.is_allocated:
+                # We only need to check one of the four since they're constrained to be
+                # the same
+                self.allocate(op_result)
+
+            shared_type = op_result.type
+            block_arg.type = shared_type
+            yield_operand.type = shared_type
+            operand.type = shared_type
 
         # Operands
         for operand in loop.operands:

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -6,9 +6,7 @@ from typing import Annotated, cast
 from typing_extensions import Self
 
 from xdsl.dialects import riscv, stream
-from xdsl.dialects.builtin import (
-    IntAttr,
-)
+from xdsl.dialects.builtin import IntAttr, UnrealizedConversionCastOp
 from xdsl.dialects.riscv import (
     AssemblyInstructionArg,
     IntRegisterType,
@@ -18,7 +16,11 @@ from xdsl.dialects.riscv import (
     RISCVInstruction,
     RISCVOp,
 )
-from xdsl.dialects.utils import AbstractYieldOperation
+from xdsl.dialects.utils import (
+    AbstractYieldOperation,
+    parse_assignment,
+    print_assignment,
+)
 from xdsl.ir import (
     Attribute,
     Block,
@@ -36,8 +38,10 @@ from xdsl.irdl import (
     region_def,
     result_def,
     traits_def,
+    var_operand_def,
+    var_result_def,
 )
-from xdsl.parser import Parser
+from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import (
@@ -124,6 +128,10 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
     """
     Instructions to repeat, containing maximum 15 instructions, with no side effects.
     """
+    iter_args = var_operand_def(riscv.RISCVRegisterType)
+    """
+    Loop-carried variable initial values.
+    """
     stagger_mask = attr_def(IntAttr)
     """
     4 bits for each operand (rs1 rs2 rs3 rd). If the bit is set, the corresponding operand
@@ -134,6 +142,10 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
     3 bits, indicating for how many iterations the stagger should increment before it
     wraps again (up to 23 = 8).
     """
+    res = var_result_def(riscv.RISCVRegisterType)
+    """
+    Loop-carried variable initial values.
+    """
 
     traits = traits_def(
         lambda: frozenset((SingleBlockImplicitTerminator(FrepYieldOp),))
@@ -143,6 +155,7 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
         self,
         max_rep: SSAValue | Operation,
         body: Sequence[Operation] | Sequence[Block] | Region,
+        iter_args: Sequence[SSAValue | Operation] = (),
         stagger_mask: IntAttr | None = None,
         stagger_count: IntAttr | None = None,
     ):
@@ -151,7 +164,8 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
         if stagger_count is None:
             stagger_count = IntAttr(0)
         super().__init__(
-            operands=(max_rep,),
+            operands=(max_rep, iter_args),
+            result_types=[[SSAValue.get(a).type for a in iter_args]],
             regions=(body,),
             attributes={
                 "stagger_mask": stagger_mask,
@@ -187,9 +201,40 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
 
         remaining_attributes = parser.parse_optional_attr_dict_with_keyword()
 
-        body = parser.parse_region()
+        # Parse iteration arguments
+        pos = parser.pos
+        unresolved_iter_args: list[Parser.UnresolvedArgument] = []
+        iter_arg_unresolved_operands: list[UnresolvedOperand] = []
+        iter_arg_types: list[Attribute] = []
+        if parser.parse_optional_characters("iter_args"):
+            for iter_arg, iter_arg_operand in parser.parse_comma_separated_list(
+                Parser.Delimiter.PAREN, lambda: parse_assignment(parser)
+            ):
+                unresolved_iter_args.append(iter_arg)
+                iter_arg_unresolved_operands.append(iter_arg_operand)
+            parser.parse_characters("->")
+            iter_arg_types = parser.parse_comma_separated_list(
+                Parser.Delimiter.PAREN, parser.parse_attribute
+            )
 
-        frep = cls(max_rep, body, IntAttr(stagger_mask), IntAttr(stagger_count))
+        iter_arg_operands = parser.resolve_operands(
+            iter_arg_unresolved_operands, iter_arg_types, pos
+        )
+
+        # Set block argument types
+        iter_args = [
+            u_arg.resolve(t) for u_arg, t in zip(unresolved_iter_args, iter_arg_types)
+        ]
+
+        body = parser.parse_region(iter_args)
+
+        frep = cls(
+            max_rep,
+            body,
+            iter_arg_operands,
+            IntAttr(stagger_mask),
+            IntAttr(stagger_count),
+        )
         if remaining_attributes is not None:
             frep.attributes |= remaining_attributes.data
 
@@ -212,12 +257,28 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
         )
         printer.print_string(" ")
 
-        yield_op = self.body.block.last_op
+        block = self.body.block
+
+        yield_op = block.last_op
         print_block_terminators = not isinstance(yield_op, FrepYieldOp) or bool(
             yield_op.operands
         )
 
-        printer.print_region(self.body, print_block_terminators=print_block_terminators)
+        if iter_args := block.args:
+            printer.print_string("iter_args(")
+            printer.print_list(
+                zip(iter_args, self.iter_args),
+                lambda pair: print_assignment(printer, *pair),
+            )
+            printer.print_string(") -> (")
+            printer.print_list((a.type for a in iter_args), printer.print_attribute)
+            printer.print_string(") ")
+
+        printer.print_region(
+            self.body,
+            print_entry_block_args=False,
+            print_block_terminators=print_block_terminators,
+        )
 
     def verify_(self) -> None:
         if self.stagger_count.data:
@@ -226,12 +287,42 @@ class FRepOperation(IRDLOperation, RISCVInstruction):
             raise VerifyException("Non-zero stagger mask currently unsupported")
         for instruction in self.body.ops:
             if not instruction.has_trait(Pure) and not isinstance(
-                instruction, FrepYieldOp | ReadOp | WriteOp
+                instruction, FrepYieldOp | ReadOp | WriteOp | UnrealizedConversionCastOp
             ):
                 raise VerifyException(
                     "Frep operation body may not contain instructions "
                     f"with side-effects, found {instruction.name}"
                 )
+        if len(self.iter_args) != len(self.body.block.args):
+            raise VerifyException(
+                f"Wrong number of block arguments, expected {len(self.iter_args)}, got "
+                f"{len(self.body.block.args)}. The body must have the induction "
+                f"variable and loop-carried variables as arguments."
+            )
+        for idx, (arg, block_arg) in enumerate(
+            zip(self.iter_args, self.body.block.args)
+        ):
+            if block_arg.type != arg.type:
+                raise VerifyException(
+                    f"Block argument {idx} has wrong type, expected {arg.type}, "
+                    f"got {block_arg.type}. Arguments after the "
+                    f"induction variable must match the carried variables."
+                )
+        if len(self.body.ops) > 0 and isinstance(
+            yieldop := self.body.block.last_op, FrepYieldOp
+        ):
+            if len(yieldop.arguments) != len(self.iter_args):
+                raise VerifyException(
+                    f"Expected {len(self.iter_args)} args, got {len(yieldop.arguments)}. "
+                    f"The riscv_scf.frep must yield its carried variables."
+                )
+            for iter_arg, yield_arg in zip(self.iter_args, yieldop.arguments):
+                if iter_arg.type != yield_arg.type:
+                    raise VerifyException(
+                        f"Expected {iter_arg.type}, got {yield_arg.type}. The "
+                        f"riscv_snitch.frep's riscv_snitch.frep_yield must match carried"
+                        f"variables types."
+                    )
 
 
 @irdl_op_definition


### PR DESCRIPTION
Adds iteration arguments to frep inner and outer, this lets us express things like dot products in frep. This PR also updates the reigster allocator to take these into account, and to treat them similarly to the carried variables in scf for loops.