### PR TITLE
dialects: Add constant unitattr to global

### DIFF
--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -8,6 +8,7 @@ builtin.module {
     func.return
   }
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
+  "memref.global"() {"sym_name" = "g_constant", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public", "constant"} : () -> ()
   "memref.global"() {"alignment" = 64 : i64, "sym_name" = "g_with_alignment", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
   func.func private @memref_test() {
     %0 = "memref.get_global"() {"name" = @g} : () -> memref<1xindex>
@@ -47,6 +48,7 @@ builtin.module {
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:   "memref.global"() <{"sym_name" = "g", "sym_visibility" = "public", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ()
+// CHECK-NEXT:   "memref.global"() <{"sym_name" = "g_constant", "sym_visibility" = "public", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "constant"}> : () -> ()
 // CHECK-NEXT:   "memref.global"() <{"sym_name" = "g_with_alignment", "sym_visibility" = "public", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "alignment" = 64 : i64}> : () -> ()
 // CHECK-NEXT:   func.func private @memref_test() {
 // CHECK-NEXT:     %{{.*}} = "memref.get_global"() <{"name" = @g}> : () -> memref<1xindex>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -41,7 +41,7 @@
 // CHECK: "builtin.module"() ({
 // CHECK-NEXT: "memref.global"() <{"alignment" = 64 : i64, "initial_value" = dense<0> : tensor<1xindex>, "sym_name" = "g_with_alignment", "sym_visibility" = "public", "type" = memref<1xindex>}> : () -> ()
 // CHECK-NEXT: "memref.global"() <{"initial_value" = dense<0> : tensor<1xindex>, "sym_name" = "g", "sym_visibility" = "public", "type" = memref<1xindex>}> : () -> ()
-// CHECK-NEXT: "memref.global"() <{constant, initial_value = dense<0> : tensor<1xindex>, sym_name = "g_constant", sym_visibility = "public", type = memref<1xindex>}> : () -> ()
+// CHECK-NEXT: "memref.global"() <{"constant", "initial_value" = dense<0> : tensor<1xindex>, "sym_name" = "g_constant", "sym_visibility" = "public", "type" = memref<1xindex>}> : () -> ()
 // CHECK-NEXT: "func.func"() <{"function_type" = () -> (), "sym_name" = "memref_test", "sym_visibility" = "private"}> ({
 // CHECK-NEXT: %0 = "memref.get_global"() <{"name" = @g}> : () -> memref<1xindex>
 // CHECK-NEXT: %1 = "arith.constant"() <{"value" = 0 : index}> : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -3,6 +3,7 @@
 "builtin.module"() ({
   "memref.global"() {"alignment" = 64 : i64, "sym_name" = "g_with_alignment", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
   "memref.global"() {"sym_name" = "g", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()
+  "memref.global"() {"sym_name" = "g_constant", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public", "constant"} : () -> ()
   "func.func"() ({
     %0 = "memref.get_global"() {"name" = @g} : () -> memref<1xindex>
     %1 = "arith.constant"() {"value" = 0 : index} : () -> index
@@ -40,6 +41,7 @@
 // CHECK: "builtin.module"() ({
 // CHECK-NEXT: "memref.global"() <{"alignment" = 64 : i64, "initial_value" = dense<0> : tensor<1xindex>, "sym_name" = "g_with_alignment", "sym_visibility" = "public", "type" = memref<1xindex>}> : () -> ()
 // CHECK-NEXT: "memref.global"() <{"initial_value" = dense<0> : tensor<1xindex>, "sym_name" = "g", "sym_visibility" = "public", "type" = memref<1xindex>}> : () -> ()
+// CHECK-NEXT: "memref.global"() <{constant, initial_value = dense<0> : tensor<1xindex>, sym_name = "g_constant", sym_visibility = "public", type = memref<1xindex>}> : () -> ()
 // CHECK-NEXT: "func.func"() <{"function_type" = () -> (), "sym_name" = "memref_test", "sym_visibility" = "private"}> ({
 // CHECK-NEXT: %0 = "memref.get_global"() <{"name" = @g}> : () -> memref<1xindex>
 // CHECK-NEXT: %1 = "arith.constant"() <{"value" = 0 : index}> : () -> index

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -516,7 +516,7 @@ class Global(IRDLOperation):
         }
         if constant is not None and constant:
             props["constant"] = UnitAttr()
-        return Global.build(*props)
+        return Global.build(properties=props)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -473,7 +473,7 @@ class Global(IRDLOperation):
     sym_visibility: StringAttr = prop_def(StringAttr)
     type: Attribute = prop_def(Attribute)
     initial_value: Attribute = prop_def(Attribute)
-    constant: Attribute | None = opt_prop_def(UnitAttr)
+    constant = opt_prop_def(UnitAttr)
     alignment = opt_prop_def(IntegerAttr[Annotated[IntegerType, IntegerType(64)]])
 
     traits = frozenset([SymbolOpInterface()])
@@ -502,21 +502,22 @@ class Global(IRDLOperation):
         sym_type: Attribute,
         initial_value: Attribute,
         sym_visibility: StringAttr = StringAttr("private"),
-        constant: bool | None = None,
+        constant: UnitAttr | None = None,
         alignment: int | IntegerAttr[IntegerType] | None = None,
     ) -> Global:
         if isinstance(alignment, int):
             alignment = IntegerAttr.from_int_and_width(alignment, 64)
-        props: dict[str, Attribute | None] = {
-            "sym_name": sym_name,
-            "type": sym_type,
-            "initial_value": initial_value,
-            "sym_visibility": sym_visibility,
-            "alignment": alignment,
-        }
-        if constant is not None and constant:
-            props["constant"] = UnitAttr()
-        return Global.build(properties=props)
+
+        return Global.build(
+            properties={
+                "sym_name": sym_name,
+                "type": sym_type,
+                "initial_value": initial_value,
+                "sym_visibility": sym_visibility,
+                "constant": constant,
+                "alignment": alignment,
+            }
+        )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -473,6 +473,7 @@ class Global(IRDLOperation):
     sym_visibility: StringAttr = prop_def(StringAttr)
     type: Attribute = prop_def(Attribute)
     initial_value: Attribute = prop_def(Attribute)
+    constant: Attribute | None = opt_prop_def(UnitAttr)
     alignment = opt_prop_def(IntegerAttr[Annotated[IntegerType, IntegerType(64)]])
 
     traits = frozenset([SymbolOpInterface()])
@@ -501,20 +502,21 @@ class Global(IRDLOperation):
         sym_type: Attribute,
         initial_value: Attribute,
         sym_visibility: StringAttr = StringAttr("private"),
+        constant: bool | None = None,
         alignment: int | IntegerAttr[IntegerType] | None = None,
     ) -> Global:
         if isinstance(alignment, int):
             alignment = IntegerAttr.from_int_and_width(alignment, 64)
-
-        return Global.build(
-            properties={
-                "sym_name": sym_name,
-                "type": sym_type,
-                "initial_value": initial_value,
-                "sym_visibility": sym_visibility,
-                "alignment": alignment,
-            }
-        )
+        props: dict[str, Attribute | None] = {
+            "sym_name": sym_name,
+            "type": sym_type,
+            "initial_value": initial_value,
+            "sym_visibility": sym_visibility,
+            "alignment": alignment,
+        }
+        if constant is not None and constant:
+            props["constant"] = UnitAttr()
+        return Global.build(*props)
 
 
 @irdl_op_definition


### PR DESCRIPTION
Adds an optional "constant" unit attribute to the memref global, which is emitted by upstream MLIR, but not yet parsed by xDSL :(