### PR TITLE
dialects: Add result arguments to func.func

### DIFF
--- a/tests/filecheck/dialects/func/func_ops_generic.mlir
+++ b/tests/filecheck/dialects/func/func_ops_generic.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt %s --print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+
+"func.func"() <{function_type = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), res_attrs = [{llvm.noalias}, {llvm.noalias}], sym_name = "arg_attrs", sym_visibility = "public"}> ({
+^bb0(%arg0: tensor<8x8xf64>, %arg1: tensor<8x8xf64>):
+    "func.return"(%arg0, %arg1) : (tensor<8x8xf64>, tensor<8x8xf64>) -> ()
+}) : () -> ()
+
+
+// CHECK: "func.func"() <{"function_type" = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), "res_attrs" = [{"llvm.noalias"}, {"llvm.noalias"}], "sym_name" = "arg_attrs", "sym_visibility" = "public"}> ({
+// CHECK-NEXT: ^0(%arg0 : tensor<8x8xf64>, %arg1 : tensor<8x8xf64>):
+// CHECK-NEXT: "func.return"(%arg0, %arg1) : (tensor<8x8xf64>, tensor<8x8xf64>) -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op--generic | filecheck %s
+// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
 
 "func.func"() <{function_type = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), res_attrs = [{llvm.noalias}, {llvm.noalias}], sym_name = "arg_attrs", sym_visibility = "public"}> ({
 ^bb0(%arg0: tensor<8x8xf64>, %arg1: tensor<8x8xf64>):

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op--generic | filecheck %s
 
 "func.func"() <{function_type = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), res_attrs = [{llvm.noalias}, {llvm.noalias}], sym_name = "arg_attrs", sym_visibility = "public"}> ({
 ^bb0(%arg0: tensor<8x8xf64>, %arg1: tensor<8x8xf64>):

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+
+"func.func"() <{function_type = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), res_attrs = [{llvm.noalias}, {llvm.noalias}], sym_name = "arg_attrs", sym_visibility = "public"}> ({
+^bb0(%arg0: tensor<8x8xf64>, %arg1: tensor<8x8xf64>):
+    "func.return"(%arg0, %arg1) : (tensor<8x8xf64>, tensor<8x8xf64>) -> ()
+}) : () -> ()
+
+
+// CHECK: "func.func"() <{"function_type" = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), "res_attrs" = [{"llvm.noalias"}, {"llvm.noalias"}], "sym_name" = "arg_attrs", "sym_visibility" = "public"}> ({
+// CHECK-NEXT: ^0(%arg0 : tensor<8x8xf64>, %arg1 : tensor<8x8xf64>):
+// CHECK-NEXT: "func.return"(%arg0, %arg1) : (tensor<8x8xf64>, tensor<8x8xf64>) -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -67,6 +67,7 @@ class FuncOp(IRDLOperation):
     function_type: FunctionType = prop_def(FunctionType)
     sym_visibility: StringAttr | None = opt_prop_def(StringAttr)
     arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
+    res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
 
     traits = frozenset(
         [IsolatedFromAbove(), SymbolOpInterface(), FuncOpCallableInterface()]
@@ -80,6 +81,7 @@ class FuncOp(IRDLOperation):
         visibility: StringAttr | str | None = None,
         *,
         arg_attrs: ArrayAttr[DictionaryAttr] | None = None,
+        res_attrs: ArrayAttr[DictionaryAttr] | None = None,
     ):
         if isinstance(visibility, str):
             visibility = StringAttr(visibility)
@@ -93,6 +95,7 @@ class FuncOp(IRDLOperation):
             "function_type": function_type,
             "sym_visibility": visibility,
             "arg_attrs": arg_attrs,
+            "res_attrs": res_attrs,
         }
         super().__init__(properties=properties, regions=[region])
 


### PR DESCRIPTION
This is also part of my crusade to get some tflite models to be parseable by xDSL:

Adds an optional result arguments dictionary attribute to func.func.

This PR does not add parsing/printing support yet in its current form, could someone help me with that please!

Thanks!