### PR TITLE
dialects: Move MemRefType et al. to builtin.

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1204,9 +1204,7 @@
     "add_op2 = AddVariadicOp2.build(\n",
     "    operands=[[i32_ssa_var] * 2, [i32_ssa_var]],\n",
     "    result_types=[i32],\n",
-    "    attributes={\n",
-    "        \"operandSegmentSizes\": VectorType(i32, [2, 1])\n",
-    "    },\n",
+    "    attributes={\"operandSegmentSizes\": VectorType(i32, [2, 1])},\n",
     ")\n",
     "print(\"Length of add_op2.ops1:\", len(add_op2.ops1))\n",
     "print(\"Length of add_op2.ops2:\", len(add_op2.ops2))"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1472,6 +1472,123 @@ f80 = Float64Type()
 f128 = Float64Type()
 
 
+_MemRefTypeElement = TypeVar("_MemRefTypeElement", bound=Attribute)
+_UnrankedMemrefTypeElems = TypeVar(
+    "_UnrankedMemrefTypeElems", bound=Attribute, covariant=True
+)
+_UnrankedMemrefTypeElemsInit = TypeVar("_UnrankedMemrefTypeElemsInit", bound=Attribute)
+
+
+@irdl_attr_definition
+class MemRefType(
+    Generic[_MemRefTypeElement],
+    ParametrizedAttribute,
+    TypeAttribute,
+    ShapedType,
+    ContainerType[_MemRefTypeElement],
+):
+    name = "memref"
+
+    shape: ParameterDef[ArrayAttr[IntAttr]]
+    element_type: ParameterDef[_MemRefTypeElement]
+    layout: ParameterDef[Attribute]
+    memory_space: ParameterDef[Attribute]
+
+    def __init__(
+        self: MemRefType[_MemRefTypeElement],
+        element_type: _MemRefTypeElement,
+        shape: Iterable[int | IntAttr],
+        layout: Attribute = NoneAttr(),
+        memory_space: Attribute = NoneAttr(),
+    ):
+        shape = ArrayAttr(
+            [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
+        )
+        super().__init__(
+            [
+                shape,
+                element_type,
+                layout,
+                memory_space,
+            ]
+        )
+
+    def get_num_dims(self) -> int:
+        return len(self.shape.data)
+
+    def get_shape(self) -> tuple[int, ...]:
+        return tuple(i.data for i in self.shape.data)
+
+    def get_element_type(self) -> _MemRefTypeElement:
+        return self.element_type
+
+    @deprecated_constructor
+    @staticmethod
+    def from_element_type_and_shape(
+        referenced_type: _MemRefTypeElement,
+        shape: Iterable[int | AnyIntegerAttr],
+        layout: Attribute = NoneAttr(),
+        memory_space: Attribute = NoneAttr(),
+    ) -> MemRefType[_MemRefTypeElement]:
+        shape_int = [i if isinstance(i, int) else i.value.data for i in shape]
+        return MemRefType(referenced_type, shape_int, layout, memory_space)
+
+    @deprecated_constructor
+    @staticmethod
+    def from_params(
+        referenced_type: _MemRefTypeElement,
+        shape: ArrayAttr[AnyIntegerAttr] = ArrayAttr(
+            [IntegerAttr.from_int_and_width(1, 64)]
+        ),
+        layout: Attribute = NoneAttr(),
+        memory_space: Attribute = NoneAttr(),
+    ) -> MemRefType[_MemRefTypeElement]:
+        shape_int = [i.value.data for i in shape.data]
+        return MemRefType(referenced_type, shape_int, layout, memory_space)
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        parser.parse_punctuation("<", " in memref attribute")
+        shape = parser.parse_attribute()
+        parser.parse_punctuation(",", " between shape and element type parameters")
+        type = parser.parse_attribute()
+        # If we have a layout or a memory space, parse both of them.
+        if parser.parse_optional_punctuation(",") is None:
+            parser.parse_punctuation(">", " at end of memref attribute")
+            return [shape, type, NoneAttr(), NoneAttr()]
+        layout = parser.parse_attribute()
+        parser.parse_punctuation(",", " between layout and memory space")
+        memory_space = parser.parse_attribute()
+        parser.parse_punctuation(">", " at end of memref attribute")
+
+        return [shape, type, layout, memory_space]
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print("<", self.shape, ", ", self.element_type)
+        if self.layout != NoneAttr() or self.memory_space != NoneAttr():
+            printer.print(", ", self.layout, ", ", self.memory_space)
+        printer.print(">")
+
+
+@irdl_attr_definition
+class UnrankedMemrefType(
+    Generic[_UnrankedMemrefTypeElems], ParametrizedAttribute, TypeAttribute
+):
+    name = "unranked_memref"
+
+    element_type: ParameterDef[_UnrankedMemrefTypeElems]
+    memory_space: ParameterDef[Attribute]
+
+    @staticmethod
+    def from_type(
+        referenced_type: _UnrankedMemrefTypeElemsInit,
+        memory_space: Attribute = NoneAttr(),
+    ) -> UnrankedMemrefType[_UnrankedMemrefTypeElemsInit]:
+        return UnrankedMemrefType([referenced_type, memory_space])
+
+
+AnyUnrankedMemrefType: TypeAlias = UnrankedMemrefType[Attribute]
+
 Builtin = Dialect(
     "builtin",
     [
@@ -1515,5 +1632,7 @@ Builtin = Dialect(
         UnrankedTensorType,
         AffineMapAttr,
         AffineSetAttr,
+        MemRefType,
+        UnrankedMemrefType,
     ],
 )

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 
 import wgpu  # pyright: ignore
 import wgpu.utils  # pyright: ignore
-
 from xdsl.dialects import gpu
 from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.memref import MemRefType

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     AffineSetAttr,
     AnyFloatAttr,
     AnyIntegerAttr,
+    AnyUnrankedMemrefType,
     AnyUnrankedTensorType,
     AnyVectorType,
     ArrayAttr,
@@ -34,6 +35,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     LocationAttr,
+    MemRefType,
     NoneAttr,
     OpaqueAttr,
     Signedness,
@@ -42,12 +44,12 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     TensorType,
     UnitAttr,
+    UnrankedMemrefType,
     UnrankedTensorType,
     UnregisteredAttr,
     UnregisteredOp,
     VectorType,
 )
-from xdsl.dialects.memref import AnyUnrankedMemrefType, MemRefType, UnrankedMemrefType
 from xdsl.ir import (
     Attribute,
     Block,


### PR DESCRIPTION
(Unranked)MemRefType are builtin attributes, at least in the sense that they have special handling in the core parser/printer, and as such should live in the `builtin` dialect, to avoid spreading dependencies. (This is the MLIR case too)
I am working towards having our assembly_format system ready enough for memeref, and one of the issues is that using it triggers a circular dependency if we leave those types in `memref` rather than `builtin` :slightly_smiling_face: 