### PR TITLE
documentation: (Toy) add instruction on how to jit Toy using lli

### DIFF
--- a/docs/Toy/Toy_Ch0.ipynb
+++ b/docs/Toy/Toy_Ch0.ipynb
@@ -74,18 +74,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "id": "3af9c75a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[1.000000, 16.000000], [4.000000, 25.000000], [9.000000, 36.000000]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Uncomment the following line to execute\n",
     "# !python -m toy examples/interpret.toy --emit=scf --ir | xdsl-opt -p printf-to-llvm | mlir-opt --test-lower-to-llvm | mlir-translate -mlir-to-llvmir | lli"

--- a/docs/Toy/Toy_Ch0.ipynb
+++ b/docs/Toy/Toy_Ch0.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "# Uncomment the following line to execute\n",
-    "# !python -m toy examples/interpret.toy --emit=scf --ir | xdsl-opt -p printf-to-llvm | mlir-opt --test-lower-to-llvm | mlir-translate -mlir-to-llvmir | lli"
+    "# !python -m toy examples/interpret.toy --emit=scf --ir | xdsl-opt -p printf-to-llvm | mlir-opt --test-lower-to-llvm | mlir-cpu-runner --entry-point-result=void"
    ]
   }
  ],

--- a/docs/Toy/Toy_Ch0.ipynb
+++ b/docs/Toy/Toy_Ch0.ipynb
@@ -62,6 +62,34 @@
     "except VerifyException as e:\n",
     "    print(e)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39a4b4ea",
+   "metadata": {},
+   "source": [
+    "It is also possible to use MLIR + LLVM to compile and execute Toy natively on your machine.\n",
+    "For this to work, MLIR and LLVM need to be built from source with the commit specified in the README, and the binaries used below must be in the path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3af9c75a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1.000000, 16.000000], [4.000000, 25.000000], [9.000000, 36.000000]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Uncomment the following line to execute\n",
+    "# !python -m toy examples/interpret.toy --emit=scf --ir | xdsl-opt -p printf-to-llvm | mlir-opt --test-lower-to-llvm | mlir-translate -mlir-to-llvmir | lli"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Now that Toy lowers to print_format, we can compile it to LLVM, leveraging the printf flow added in #1142 .