### PR TITLE
core: Add support for nested inferrence in IRDL

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -551,19 +551,19 @@ def test_eq_attr_inference():
     """Check that operands/results with a fixed type can be inferred."""
 
     @irdl_attr_definition
-    class UnitAttr(ParametrizedAttribute, TypeAttribute):
+    class UnitType(ParametrizedAttribute, TypeAttribute):
         name = "test.unit"
 
     @irdl_op_definition
     class OneOperandEqType(IRDLOperation):
         name = "test.one_operand_eq_type"
-        index = operand_def(UnitAttr())
-        res = result_def(UnitAttr())
+        index = operand_def(UnitType())
+        res = result_def(UnitType())
 
         assembly_format = "attr-dict $index"
 
     ctx = MLContext()
-    ctx.load_attr(UnitAttr)
+    ctx.load_attr(UnitType)
     ctx.load_op(OneOperandEqType)
     ctx.load_dialect(Test)
     program = textwrap.dedent(
@@ -579,18 +579,18 @@ def test_all_of_attr_inference():
     """Check that AllOf still allows for inference."""
 
     @irdl_attr_definition
-    class UnitAttr(ParametrizedAttribute, TypeAttribute):
+    class UnitType(ParametrizedAttribute, TypeAttribute):
         name = "test.unit"
 
     @irdl_op_definition
     class OneOperandEqTypeAllOfNested(IRDLOperation):
         name = "test.one_operand_eq_type_all_of_nested"
-        index = operand_def(AllOf([AnyAttr(), EqAttrConstraint(UnitAttr())]))
+        index = operand_def(AllOf([AnyAttr(), EqAttrConstraint(UnitType())]))
 
         assembly_format = "attr-dict $index"
 
     ctx = MLContext()
-    ctx.load_attr(UnitAttr)
+    ctx.load_attr(UnitType)
     ctx.load_op(OneOperandEqTypeAllOfNested)
     ctx.load_dialect(Test)
     program = textwrap.dedent(

--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -507,7 +507,7 @@ def test_results(format: str, program: str, generic_program: str):
 
 
 ################################################################################
-# Inferrence                                                                   #
+# Inference                                                                   #
 ################################################################################
 
 _T = TypeVar("_T", bound=Attribute)
@@ -522,6 +522,8 @@ _T = TypeVar("_T", bound=Attribute)
     ],
 )
 def test_basic_inference(format: str):
+    """Check that we can infer the type of an operand when ConstraintVar are used."""
+
     @irdl_op_definition
     class TwoOperandsOneResultWithVarOp(IRDLOperation):
         T = Annotated[Attribute, ConstraintVar("T")]
@@ -546,6 +548,8 @@ def test_basic_inference(format: str):
 
 
 def test_eq_attr_inference():
+    """Check that operands/results with a fixed type can be inferred."""
+
     @irdl_attr_definition
     class UnitAttr(ParametrizedAttribute, TypeAttribute):
         name = "test.unit"
@@ -554,6 +558,7 @@ def test_eq_attr_inference():
     class OneOperandEqType(IRDLOperation):
         name = "test.one_operand_eq_type"
         index = operand_def(UnitAttr())
+        res = result_def(UnitAttr())
 
         assembly_format = "attr-dict $index"
 
@@ -564,12 +569,15 @@ def test_eq_attr_inference():
     program = textwrap.dedent(
         """\
     %0 = "test.op"() : () -> !test.unit
-    test.one_operand_eq_type %0"""
+    %1 = test.one_operand_eq_type %0
+    "test.op"(%1) : (!test.unit) -> ()"""
     )
     check_roundtrip(program, ctx)
 
 
 def test_all_of_attr_inference():
+    """Check that AllOf still allows for inference."""
+
     @irdl_attr_definition
     class UnitAttr(ParametrizedAttribute, TypeAttribute):
         name = "test.unit"
@@ -594,6 +602,8 @@ def test_all_of_attr_inference():
 
 
 def test_nested_inference():
+    """Check that Param<T> infers correctly T."""
+
     @irdl_attr_definition
     class ParamOne(ParametrizedAttribute, TypeAttribute, Generic[_T]):
         name = "test.param_one"

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -152,14 +152,14 @@ class FormatProgram:
         if any(type is None for type in (*state.operand_types, *state.result_types)):
             try:
                 for (_, operand_def), operand_type in zip(
-                    op_def.operands, state.operand_types
+                    op_def.operands, state.operand_types, strict=True
                 ):
                     if operand_type is not None:
                         operand_def.constr.verify(
                             operand_type, state.constraint_variables
                         )
                 for (_, result_def), result_type in zip(
-                    op_def.results, state.result_types
+                    op_def.results, state.result_types, strict=True
                 ):
                     if result_type is not None:
                         result_def.constr.verify(
@@ -176,7 +176,7 @@ class FormatProgram:
         types.
         """
         for i, (operand_type, (_, operand_def)) in enumerate(
-            zip(state.operand_types, op_def.operands)
+            zip(state.operand_types, op_def.operands, strict=True)
         ):
             if operand_type is None:
                 state.operand_types[i] = operand_def.constr.infer(
@@ -189,7 +189,7 @@ class FormatProgram:
         types.
         """
         for i, (result_type, (_, result_def)) in enumerate(
-            zip(state.result_types, op_def.results)
+            zip(state.result_types, op_def.results, strict=True)
         ):
             if result_type is None:
                 state.result_types[i] = result_def.constr.infer(

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -7,7 +7,6 @@ https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-for
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -21,6 +20,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.lexer import Token
 
@@ -40,6 +40,7 @@ class ParsingState:
     result_types: list[Attribute | None]
     attributes: dict[str, Attribute]
     properties: dict[str, Attribute]
+    constraint_variables: dict[str, Attribute]
 
     def __init__(self, op_def: OpDef):
         if op_def.regions or op_def.successors:
@@ -58,6 +59,7 @@ class ParsingState:
         self.result_types = [None] * len(op_def.results)
         self.attributes = {}
         self.properties = {}
+        self.constraint_variables = {}
 
 
 @dataclass
@@ -88,12 +90,6 @@ class FormatProgram:
     stmts: list[FormatDirective]
     """The list of statements composing the program. They are executed in order."""
 
-    type_resolutions: dict[
-        tuple[OperandOrResult, int],
-        tuple[Callable[[Attribute], Attribute], OperandOrResult, int],
-    ]
-    """A mapping describing how to resolve unparsed operand and result types."""
-
     @staticmethod
     def from_str(input: str, op_def: OpDef) -> FormatProgram:
         """
@@ -119,15 +115,37 @@ class FormatProgram:
         for stmt in self.stmts:
             stmt.parse(parser, state)
 
+        # Get constraint variables from the parsed operand and result types
+        if any(type is None for type in (*state.operand_types, *state.result_types)):
+            try:
+                for (_, operand_def), operand_type in zip(
+                    op_def.operands, state.operand_types
+                ):
+                    if operand_type is not None:
+                        operand_def.constr.verify(
+                            operand_type, state.constraint_variables
+                        )
+                for (_, result_def), result_type in zip(
+                    op_def.results, state.result_types
+                ):
+                    if result_type is not None:
+                        result_def.constr.verify(
+                            result_type, state.constraint_variables
+                        )
+            except VerifyException as e:
+                parser.raise_error(
+                    "Verification error while inferring operation type: " + str(e)
+                )
+
         # Ensure that all operands and operand types are parsed
         unresolved_operands = state.operands
         assert isa(unresolved_operands, list[UnresolvedOperand])
-        self.resolve_operand_types(state)
+        self.resolve_operand_types(state, op_def)
         operand_types = state.operand_types
         assert isa(operand_types, list[Attribute])
 
         # Ensure that all result types are parsed or resolved
-        self.resolve_result_types(state)
+        self.resolve_result_types(state, op_def)
         result_types = state.result_types
         assert isa(state.result_types, list[Attribute])
 
@@ -143,43 +161,31 @@ class FormatProgram:
             properties=properties,
         )
 
-    def resolve_operand_types(self, state: ParsingState) -> None:
+    def resolve_operand_types(self, state: ParsingState, op_def: OpDef) -> None:
         """
         Use the inferred type resolutions to fill missing operand types from other parsed
         types.
         """
-        for i, operand_type in enumerate(state.operand_types):
+        for i, (operand_type, (_, operand_def)) in enumerate(
+            zip(state.operand_types, op_def.operands)
+        ):
             if operand_type is None:
-                state.operand_types[i] = self._resolve_type(
-                    state, VarIRConstruct.OPERAND, i
+                state.operand_types[i] = operand_def.constr.infer(
+                    state.constraint_variables
                 )
 
-    def resolve_result_types(self, state: ParsingState) -> None:
+    def resolve_result_types(self, state: ParsingState, op_def: OpDef) -> None:
         """
         Use the inferred type resolutions to fill missing result types from other parsed
         types.
         """
-        for i, result_type in enumerate(state.result_types):
+        for i, (result_type, (_, result_def)) in enumerate(
+            zip(state.result_types, op_def.results)
+        ):
             if result_type is None:
-                state.result_types[i] = self._resolve_type(
-                    state, VarIRConstruct.RESULT, i
+                state.result_types[i] = result_def.constr.infer(
+                    state.constraint_variables
                 )
-
-    def _resolve_type(
-        self, state: ParsingState, construct: OperandOrResult, index: int
-    ):
-        """
-        Helper function resolving a specific operand or result type from the inferred
-        resolution map.
-        """
-        resolve, construct, idx = self.type_resolutions[construct, index]
-        match construct:
-            case VarIRConstruct.OPERAND:
-                input_type = state.operand_types[idx]
-            case VarIRConstruct.RESULT:
-                input_type = state.result_types[idx]
-        assert input_type is not None
-        return resolve(input_type)
 
     def print(self, printer: Printer, op: IRDLOperation) -> None:
         """

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -142,7 +142,12 @@ class FormatParser(BaseParser):
             seen_operand,
             seen_operand_type,
             (operand_name, operand_def),
-        ) in zip(self.seen_operands, self.seen_operand_types, self.op_def.operands):
+        ) in zip(
+            self.seen_operands,
+            self.seen_operand_types,
+            self.op_def.operands,
+            strict=True,
+        ):
             if not seen_operand:
                 self.raise_error(
                     f"operand '{operand_name}' "
@@ -162,7 +167,7 @@ class FormatParser(BaseParser):
         from another construct."""
 
         for result_type, (result_name, result_def) in zip(
-            self.seen_result_types, self.op_def.results
+            self.seen_result_types, self.op_def.results, strict=True
         ):
             if not result_type:
                 if not result_def.constr.can_infer(seen_variables):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 
 from xdsl.ir import Attribute
-from xdsl.irdl import OpDef, VarConstraint, VarIRConstruct
+from xdsl.irdl import OpDef
 from xdsl.irdl.declarative_assembly_format import (
     AttrDictDirective,
     FormatDirective,
@@ -114,95 +114,62 @@ class FormatParser(BaseParser):
         while self._current_token.kind != Token.Kind.EOF:
             elements.append(self.parse_directive())
 
-        self.resolve_types()
+        seen_variables = self.resolve_types()
         self.verify_attr_dict()
-        self.verify_operands()
-        self.verify_results()
-        return FormatProgram(elements, self.type_resolutions)
+        self.verify_operands(seen_variables)
+        self.verify_results(seen_variables)
+        return FormatProgram(elements)
 
-    def resolve_types(self):
+    def resolve_types(self) -> set[str]:
         """
-        Find out which types can be resolved through ConstraintVat propagation.
+        Find out which constraint variables can be inferred from the parsed attributes.
         """
-        resolved_variables: dict[str, tuple[OperandOrResult, int]] = {}
-        # If a result or operand type is a variable, that variable can be resolved from it
+        seen_variables = set[str]()
         for i, (_, operand_def) in enumerate(self.op_def.operands):
             if self.seen_operand_types[i]:
-                if isinstance(operand_def.constr, VarConstraint):
-                    resolved_variables[operand_def.constr.name] = (
-                        VarIRConstruct.OPERAND,
-                        i,
-                    )
+                seen_variables |= operand_def.constr.get_resolved_variables()
         for i, (_, result_def) in enumerate(self.op_def.results):
             if self.seen_result_types[i]:
-                if isinstance(result_def.constr, VarConstraint):
-                    resolved_variables[result_def.constr.name] = (
-                        VarIRConstruct.RESULT,
-                        i,
-                    )
-        # For each unseed result or operand type that is a variable, check if that
-        # variable can be resolved.
-        for i, (_, operand_def) in enumerate(self.op_def.operands):
-            if not self.seen_operand_types[i]:
-                if (
-                    isinstance(operand_def.constr, VarConstraint)
-                    and operand_def.constr.name in resolved_variables.keys()
-                ):
-                    # Create the resolution method
-                    self.type_resolutions[VarIRConstruct.OPERAND, i] = (
-                        lambda x: x,
-                        *resolved_variables[operand_def.constr.name],
-                    )
-        for i, (_, result_def) in enumerate(self.op_def.results):
-            if not self.seen_result_types[i]:
-                if (
-                    isinstance(result_def.constr, VarConstraint)
-                    and result_def.constr.name in resolved_variables.keys()
-                ):
-                    self.type_resolutions[VarIRConstruct.RESULT, i] = (
-                        lambda x: x,
-                        *resolved_variables[result_def.constr.name],
-                    )
+                seen_variables |= result_def.constr.get_resolved_variables()
+        return seen_variables
 
-    def verify_operands(self):
+    def verify_operands(self, seen_variables: set[str]):
         """
         Check that all operands and operand types are refered at least once, or inferred
         from another construct.
         """
-        for i, (operand, operand_type, (operand_name, _)) in enumerate(
-            zip(self.seen_operands, self.seen_operand_types, self.op_def.operands)
-        ):
-            if not operand:
+        for (
+            seen_operand,
+            seen_operand_type,
+            (operand_name, operand_def),
+        ) in zip(self.seen_operands, self.seen_operand_types, self.op_def.operands):
+            if not seen_operand:
                 self.raise_error(
                     f"operand '{operand_name}' "
                     f"not found, consider adding a '${operand_name}' "
                     "directive to the custom assembly format"
                 )
-            if not operand_type:
-                if (VarIRConstruct.OPERAND, i) in self.type_resolutions.keys():
-                    pass
-                else:
+            if not seen_operand_type:
+                if not operand_def.constr.can_infer(seen_variables):
                     self.raise_error(
-                        f"type of operand '{operand_name}' not found, consider "
-                        f"adding a 'type(${operand_name})' directive to the custom "
-                        "assembly format"
+                        f"type of operand '{operand_name}' cannot be inferred, "
+                        f"consider adding a 'type(${operand_name})' directive to the "
+                        "custom assembly format"
                     )
 
-    def verify_results(self):
+    def verify_results(self, seen_variables: set[str]):
         """Check that all result types are refered at least once, or inferred
         from another construct."""
 
-        for i, (result_type, (result_name, _)) in enumerate(
-            zip(self.seen_result_types, self.op_def.results)
+        for result_type, (result_name, result_def) in zip(
+            self.seen_result_types, self.op_def.results
         ):
             if not result_type:
-                if (VarIRConstruct.RESULT, i) in self.type_resolutions.keys():
-                    pass
-                else:
+                if not result_def.constr.can_infer(seen_variables):
                     self.raise_error(
-                        f"type of result '{result_name}' not found, consider "
-                        f"adding a 'type(${result_name})' directive to the custom "
-                        "assembly format"
+                        f"type of result '{result_name}' cannot be inferred, "
+                        f"consider adding a 'type(${result_name})' directive to the "
+                        "custom assembly format"
                     )
 
     def verify_attr_dict(self):

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -255,7 +255,7 @@ class AnyOf(AttrConstraint):
         if len(self.attr_constrs) == 0:
             return set()
         return set[str].intersection(
-            *[constr.get_resolved_variables() for constr in self.attr_constrs]
+            *(constr.get_resolved_variables() for constr in self.attr_constrs)
         )
 
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -336,9 +336,11 @@ class ParamAttrConstraint(AttrConstraint):
     def get_resolved_variables(self) -> set[str]:
         if not self.param_constrs:
             return set()
-        return set[str].union(
-            *[constr.get_resolved_variables() for constr in self.param_constrs]
-        )
+        return {
+            var
+            for constr in self.param_constrs
+            for var in constr.get_resolved_variables()
+        }
 
 
 def _irdl_list_to_attr_constraint(

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -334,7 +334,7 @@ class ParamAttrConstraint(AttrConstraint):
             param_constr.verify(attr.parameters[idx], constraint_vars)
 
     def get_resolved_variables(self) -> set[str]:
-        if len(self.param_constrs) == 0:
+        if not self.param_constrs:
             return set()
         return set[str].union(
             *[constr.get_resolved_variables() for constr in self.param_constrs]

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -90,6 +90,31 @@ class AttrConstraint(ABC):
         """
         ...
 
+    def get_resolved_variables(self) -> set[str]:
+        """
+        Get the set of type variables that are always resolved when verifying
+        the constraint.
+        """
+        return set()
+
+    def can_infer(self, constraint_names: set[str]) -> bool:
+        """
+        Check if there is enough information to infer the attribute given the
+        constraint variables that are already set.
+        """
+        # By default, we cannot infer anything.
+        return False
+
+    def infer(self, constraint_vars: dict[str, Attribute]) -> Attribute:
+        """
+        Infer the attribute given the constraint variables that are already set.
+
+        Raises an exception if the attribute cannot be inferred. If `can_infer`
+        returns `True` with the given constraint variables, this method should
+        not raise an exception.
+        """
+        raise ValueError("Cannot infer attribute from constraint")
+
 
 @dataclass
 class VarConstraint(AttrConstraint):
@@ -117,6 +142,17 @@ class VarConstraint(AttrConstraint):
             self.constraint.verify(attr, constraint_vars)
             constraint_vars[self.name] = attr
 
+    def get_resolved_variables(self) -> set[str]:
+        return {self.name, *self.constraint.get_resolved_variables()}
+
+    def can_infer(self, constraint_names: set[str]) -> bool:
+        return self.name in constraint_names
+
+    def infer(self, constraint_vars: dict[str, Attribute]) -> Attribute:
+        if self.name not in constraint_vars:
+            raise ValueError(f"Cannot infer attribute from constraint {self}")
+        return constraint_vars[self.name]
+
 
 @dataclass(frozen=True)
 class ConstraintVar:
@@ -143,6 +179,12 @@ class EqAttrConstraint(AttrConstraint):
     def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
         if attr != self.attr:
             raise VerifyException(f"Expected attribute {self.attr} but got {attr}")
+
+    def can_infer(self, constraint_names: set[str]) -> bool:
+        return True
+
+    def infer(self, constraint_vars: dict[str, Attribute]) -> Attribute:
+        return self.attr
 
 
 @dataclass
@@ -209,6 +251,13 @@ class AnyOf(AttrConstraint):
                 pass
         raise VerifyException(f"Unexpected attribute {attr}")
 
+    def get_resolved_variables(self) -> set[str]:
+        if len(self.attr_constrs) == 0:
+            return set()
+        return set[str].intersection(
+            *[constr.get_resolved_variables() for constr in self.attr_constrs]
+        )
+
 
 @dataclass()
 class AllOf(AttrConstraint):
@@ -232,6 +281,22 @@ class AllOf(AttrConstraint):
             exc_msg = "The following constraints were not satisfied:\n"
             exc_msg += "\n".join([str(e) for e in exc_bucket])
             raise VerifyException(exc_msg)
+
+    def get_resolved_variables(self) -> set[str]:
+        if len(self.attr_constrs) == 0:
+            return set()
+        return set[str].union(
+            *[constr.get_resolved_variables() for constr in self.attr_constrs]
+        )
+
+    def can_infer(self, constraint_names: set[str]) -> bool:
+        return any(constr.can_infer(constraint_names) for constr in self.attr_constrs)
+
+    def infer(self, constraint_vars: dict[str, Attribute]) -> Attribute:
+        for constr in self.attr_constrs:
+            if constr.can_infer(set(constraint_vars.keys())):
+                return constr.infer(constraint_vars)
+        raise ValueError("Cannot infer attribute from constraint")
 
 
 @dataclass(init=False)
@@ -267,6 +332,13 @@ class ParamAttrConstraint(AttrConstraint):
             )
         for idx, param_constr in enumerate(self.param_constrs):
             param_constr.verify(attr.parameters[idx], constraint_vars)
+
+    def get_resolved_variables(self) -> set[str]:
+        if len(self.param_constrs) == 0:
+            return set()
+        return set[str].union(
+            *[constr.get_resolved_variables() for constr in self.param_constrs]
+        )
 
 
 def _irdl_list_to_attr_constraint(


### PR DESCRIPTION
This PR allows us to infer the types of some operands and results from the types of other operands and results.

It does so by adding three functions in `AttrConstraint`:
* `get_resolved_variables`: This function returns the set of `ConstraintVar` that will be set during verification.
* `can_infer`: Returns `True` if we can infer a unique attribute represented by the `AttrConstraint` from the assignment of `ConstraintVar`.
* `infer`: Returns the only attribute that satisfy this constraint, given the constraint variables.

We use these methods to get all `ConstraintVar`  from the parsed operand/result types present in the syntax, then infer the constraints on the types that are not in the syntax.