### PR TITLE
core: Make assembly format use attr-dict for properties

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -14,6 +14,7 @@ from xdsl.irdl import (
     IRDLOperation,
     irdl_op_definition,
     operand_def,
+    opt_prop_def,
     result_def,
 )
 from xdsl.parser import Parser
@@ -195,6 +196,30 @@ def test_attr_dict(program: str, generic_program: str):
     ctx = MLContext()
     ctx.load_op(AttrDictOp)
     ctx.load_op(AttrDictWithKeywordOp)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        ('test.prop {"prop" = true}', '"test.prop"() <{"prop" = true}> : () -> ()'),
+        (
+            'test.prop {"a" = 2 : i32, "prop" = true}',
+            '"test.prop"() <{"prop" = true}> {"a" = 2 : i32} : () -> ()',
+        ),
+    ],
+)
+def test_attr_dict_prop_fallack(program: str, generic_program: str):
+    @irdl_op_definition
+    class PropOp(IRDLOperation):
+        name = "test.prop"
+        prop = opt_prop_def(Attribute)
+        assembly_format = "attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(PropOp)
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -230,7 +230,6 @@ class AttrDictDirective(FormatDirective):
         state.attributes = res
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        # assert False, (op.attributes | op.properties, op)
         if not op.attributes and not op.properties:
             return
         if self.with_keyword:

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -234,6 +234,11 @@ class AttrDictDirective(FormatDirective):
             return
         if self.with_keyword:
             printer.print(" attributes")
+        if any(name in op.attributes for name in op.properties):
+            raise ValueError(
+                "Cannot print attributes and properties with the same name"
+                "in a signle dictionary"
+            )
         printer.print_op_attributes(op.attributes | op.properties)
         state.last_was_punctuation = False
         state.should_emit_space = False

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -39,9 +39,10 @@ class ParsingState:
     operand_types: list[Attribute | None]
     result_types: list[Attribute | None]
     attributes: dict[str, Attribute]
+    properties: dict[str, Attribute]
 
     def __init__(self, op_def: OpDef):
-        if op_def.attributes or op_def.regions or op_def.successors:
+        if op_def.regions or op_def.successors:
             raise NotImplementedError(
                 "Operation definitions with attributes, regions, "
                 "or successors are not yet supported"
@@ -56,6 +57,7 @@ class ParsingState:
         self.operand_types = [None] * len(op_def.operands)
         self.result_types = [None] * len(op_def.results)
         self.attributes = {}
+        self.properties = {}
 
 
 @dataclass
@@ -112,7 +114,8 @@ class FormatProgram:
         FormatProgram.
         """
         # Parse elements one by one
-        state = ParsingState(op_type.get_irdl_definition())
+        op_def = op_type.get_irdl_definition()
+        state = ParsingState(op_def)
         for stmt in self.stmts:
             stmt.parse(parser, state)
 
@@ -132,8 +135,12 @@ class FormatProgram:
         operands = parser.resolve_operands(
             unresolved_operands, operand_types, parser.pos
         )
+        properties = op_def.split_properties(state.attributes)
         return op_type.build(
-            result_types=result_types, operands=operands, attributes=state.attributes
+            result_types=result_types,
+            operands=operands,
+            attributes=state.attributes,
+            properties=properties,
         )
 
     def resolve_operand_types(self, state: ParsingState) -> None:
@@ -223,11 +230,12 @@ class AttrDictDirective(FormatDirective):
         state.attributes = res
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if not op.attributes:
+        # assert False, (op.attributes | op.properties, op)
+        if not op.attributes and not op.properties:
             return
         if self.with_keyword:
             printer.print(" attributes")
-        printer.print_op_attributes(op.attributes)
+        printer.print_op_attributes(op.attributes | op.properties)
         state.last_was_punctuation = False
         state.should_emit_space = False
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1369,7 +1369,7 @@ class OpDef:
         for trait in self.traits:
             trait.verify(op)
 
-    def split_properties(self, attr_dict: dict[str, Attribute]):
+    def split_properties(self, attr_dict: dict[str, Attribute]) -> dict[str, Attribute]:
         """
         Remove all entries of an attribute dictionary that are defined as properties
         by the operation definition, and return them in a new dictionary.

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1369,6 +1369,17 @@ class OpDef:
         for trait in self.traits:
             trait.verify(op)
 
+    def split_properties(self, attr_dict: dict[str, Attribute]):
+        """
+        Remove all entries of an attribute dictionary that are defined as properties
+        by the operation definition, and return them in a new dictionary.
+        """
+        properties: dict[str, Attribute] = {}
+        for property_name in self.properties.keys():
+            if property_name in attr_dict:
+                properties[property_name] = attr_dict.pop(property_name)
+        return properties
+
 
 class VarIRConstruct(Enum):
     """

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -885,9 +885,7 @@ class Parser(AttrParser):
         # Properties retrocompatibility : if no properties dictionary was present at all,
         # We extract them from the attribute dictionary by name.
         if issubclass(op_type, IRDLOperation) and not properties:
-            for property_name in op_type.get_irdl_definition().properties.keys():
-                if property_name in attrs:
-                    properties[property_name] = attrs.pop(property_name)
+            properties = op_type.get_irdl_definition().split_properties(attrs)
 
         return op_type.create(
             operands=operands,


### PR DESCRIPTION
This is MLIR's behaviour. Probably only when there is no specified prop-dict in the format, but on the current commit, this prop-dict is only used in their tests, so I'm not rushing implementation :)
Some secondary changes:
- Factor out the property retro-compatibility from the core Parser to OpDef
- Don't forbid Operations with defined attributes. Why was it forbidden? @math-fehr They are already usable through the attr-dict, simply not in directives, am I missing something?