### PR TITLE
Add pass to set `fastmath` flags of FP binary operations from `arith`

### DIFF
--- a/tests/filecheck/transforms/arith-add-fastmath.mlir
+++ b/tests/filecheck/transforms/arith-add-fastmath.mlir
@@ -1,0 +1,122 @@
+// RUN: xdsl-opt -p arith-add-fastmath %s | filecheck %s
+// RUN: xdsl-opt -p "arith-add-fastmath{flags=none}" %s | filecheck %s --check-prefix=NONE
+// RUN: xdsl-opt -p "arith-add-fastmath{flags=nnan}" %s | filecheck %s --check-prefix=SINGLE
+// RUN: xdsl-opt -p "arith-add-fastmath{flags=nnan,nsz}" %s | filecheck %s --check-prefix=DOUBLE
+
+func.func public @foo1() {
+  %lhs, %rhs = "test.op"() : () -> (f64, f64)
+  %4 = arith.addf %lhs, %rhs : f64
+  %5 = arith.subf %lhs, %rhs : f64
+  %6 = arith.mulf %lhs, %rhs : f64
+  %7 = arith.divf %lhs, %rhs : f64
+  %8 = arith.minimumf %lhs, %rhs : f64
+  %9 = arith.maximumf %lhs, %rhs : f64
+  return
+}
+
+// Check the default transform
+// CHECK:       func.func public @foo1() {
+// CHECK-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// CHECK-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    func.return
+// CHECK-NEXT:  }
+
+// Check the transform with "none"
+// NONE:       func.func public @foo1() {
+// NONE-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// NONE-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    func.return
+// NONE-NEXT:  }
+
+// Check the transform with single flag
+// SINGLE:       func.func public @foo1() {
+// SINGLE-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// SINGLE-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    func.return
+// SINGLE-NEXT:  }
+
+// Check the transform with two flags
+// DOUBLE:       func.func public @foo1() {
+// DOUBLE-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// DOUBLE-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    func.return
+// DOUBLE-NEXT:  }
+
+func.func public @foo2() {
+  %lhs, %rhs = "test.op"() : () -> (f64, f64)
+  %4 = arith.addf %lhs, %rhs fastmath<fast> : f64
+  %5 = arith.subf %lhs, %rhs fastmath<fast> : f64
+  %6 = arith.mulf %lhs, %rhs fastmath<fast> : f64
+  %7 = arith.divf %lhs, %rhs fastmath<fast> : f64
+  %8 = arith.minimumf %lhs, %rhs fastmath<fast> : f64
+  %9 = arith.maximumf %lhs, %rhs fastmath<fast> : f64
+  return
+}
+
+// Check the default transform
+// CHECK:       func.func public @foo{{.*}}() {
+// CHECK-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// CHECK-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:    func.return
+// CHECK-NEXT:  }
+
+// Check the transform with "none"
+// NONE:       func.func public @foo{{.*}}() {
+// NONE-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// NONE-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} : f64
+// NONE-NEXT:    func.return
+// NONE-NEXT:  }
+
+// Check the transform with single flag
+// SINGLE:       func.func public @foo{{.*}}() {
+// SINGLE-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// SINGLE-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} fastmath<nnan> : f64
+// SINGLE-NEXT:    func.return
+// SINGLE-NEXT:  }
+
+// Check the transform with two flags
+// DOUBLE:       func.func public @foo{{.*}}() {
+// DOUBLE-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (f64, f64)
+// DOUBLE-NEXT:    %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.subf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.divf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.minimumf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    %{{.*}} = arith.maximumf %{{.*}}, %{{.*}} fastmath<nnan,nsz> : f64
+// DOUBLE-NEXT:    func.return
+// DOUBLE-NEXT:  }

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -261,6 +261,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     """Return the list of all available passes."""
 
+    def get_arith_add_fastmath():
+        from xdsl.transforms import arith_add_fastmath
+
+        return arith_add_fastmath.AddArithFastMathFlagsPass
+
     def get_canonicalize():
         from xdsl.transforms import canonicalize
 
@@ -449,6 +454,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         return stencil_unroll.StencilUnrollPass
 
     return {
+        "arith-add-fastmath": get_arith_add_fastmath,
         "canonicalize-dmp": get_canonicalize_dmp,
         "canonicalize": get_canonicalize,
         "constant-fold-interp": get_constant_fold_interp,

--- a/xdsl/transforms/arith_add_fastmath.py
+++ b/xdsl/transforms/arith_add_fastmath.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass, field
+
+from xdsl.dialects import arith, builtin, llvm
+from xdsl.ir import Operation
+from xdsl.passes import MLContext, ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+)
+
+
+def _match_string_to_enum(flag: str, enum_type: type[llvm.FastMathFlag]):
+    for member in enum_type:
+        if flag == str(member.value):
+            return member
+
+    raise ValueError(f"{flag} is not a valid fastmath flag.")
+
+
+def _get_flag_list(flags: list[str], enum_type: type[llvm.FastMathFlag]):
+    list_flags: list[enum_type] = []
+    for flag in flags:
+        list_flags.append(_match_string_to_enum(flag, llvm.FastMathFlag))
+    return list_flags
+
+
+@dataclass
+class AddArithFastMathFlags(RewritePattern):
+    arith_op_cls: type[arith.FloatingPointLikeBinaryOp]
+    fastmath_op_attr: arith.FastMathFlagsAttr
+
+    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter) -> None:
+        if not isinstance(op, self.arith_op_cls):
+            return
+
+        op.fastmath = self.fastmath_op_attr
+
+
+@dataclass
+class AddArithFastMathFlagsPass(ModulePass):
+    name = "arith-add-fastmath"
+
+    flags: list[str] = field(default_factory=lambda: ["fast"])
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        fm_flags = arith.FastMathFlagsAttr("fast")
+
+        if len(self.flags) == 1:
+            if "none" in self.flags:
+                fm_flags = arith.FastMathFlagsAttr("none")
+            elif "fast" in self.flags:
+                fm_flags = arith.FastMathFlagsAttr("fast")
+            else:
+                fm_flags = arith.FastMathFlagsAttr(
+                    _get_flag_list(self.flags, llvm.FastMathFlag)
+                )
+        else:
+            if "none" in self.flags or "fast" in self.flags:
+                raise ValueError(
+                    'f{"none" or "fast" cannot be provided along with other fastmath flags'
+                )
+
+            fm_flags = arith.FastMathFlagsAttr(
+                _get_flag_list(self.flags, llvm.FastMathFlag)
+            )
+
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    AddArithFastMathFlags(arith.Addf, fm_flags),
+                    AddArithFastMathFlags(arith.Subf, fm_flags),
+                    AddArithFastMathFlags(arith.Mulf, fm_flags),
+                    AddArithFastMathFlags(arith.Divf, fm_flags),
+                    AddArithFastMathFlags(arith.Minimumf, fm_flags),
+                    AddArithFastMathFlags(arith.Maximumf, fm_flags),
+                ]
+            ),
+            apply_recursively=False,
+        ).rewrite_module(op)

--- a/xdsl/transforms/arith_add_fastmath.py
+++ b/xdsl/transforms/arith_add_fastmath.py
@@ -1,3 +1,5 @@
+"""Passes to manipulate fastmath flags in FP arith operations."""
+
 from dataclasses import dataclass
 from typing import Literal
 


### PR DESCRIPTION
This PR:

- Adds a rewrite pass to set the `fastmath` flags of FP binary `arith` operations.
- Tests of the above.

Resolves #2017 



