### PR TITLE
bug: fix AffineMap.inverse_permutation

### DIFF
--- a/tests/dialects/test_linalg.py
+++ b/tests/dialects/test_linalg.py
@@ -66,4 +66,4 @@ def test_loop_range_methods():
     )
 
     loops = op.get_static_loop_ranges()
-    assert loops == [100, 50, 50]
+    assert loops == (100, 100, 50)

--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -12,21 +12,21 @@ def test_simple_map():
 
     # map1: (x, y) -> (x + y, y)
     map1 = AffineMap(2, 0, (x + y, y))
-    assert map1.eval([1, 2], []) == [3, 2]
-    assert map1.eval([3, 4], []) == [7, 4]
-    assert map1.eval([5, 6], []) == [11, 6]
+    assert map1.eval([1, 2], []) == (3, 2)
+    assert map1.eval([3, 4], []) == (7, 4)
+    assert map1.eval([5, 6], []) == (11, 6)
 
     # map2: (x, y) -> (2x + 3y)
     map2 = AffineMap(2, 0, (2 * x + 3 * y,))
-    assert map2.eval([1, 2], []) == [8]
-    assert map2.eval([3, 4], []) == [18]
-    assert map2.eval([5, 6], []) == [28]
+    assert map2.eval([1, 2], []) == (8,)
+    assert map2.eval([3, 4], []) == (18,)
+    assert map2.eval([5, 6], []) == (28,)
 
     # map3: (x, y) -> (x + y, 2x + 3y)
     map3 = AffineMap(2, 0, (x + y, 2 * x + 3 * y))
-    assert map3.eval([1, 2], []) == [3, 8]
-    assert map3.eval([3, 4], []) == [7, 18]
-    assert map3.eval([5, 6], []) == [11, 28]
+    assert map3.eval([1, 2], []) == (3, 8)
+    assert map3.eval([3, 4], []) == (7, 18)
+    assert map3.eval([5, 6], []) == (11, 28)
 
 
 def test_quasiaffine_map():
@@ -37,30 +37,30 @@ def test_quasiaffine_map():
 
     # map1: (x)[N] -> (x floordiv 2)
     map1 = AffineMap(1, 1, (x.floor_div(2),))
-    assert map1.eval([1], [10]) == [0]
-    assert map1.eval([2], [10]) == [1]
-    assert map1.eval([3], [10]) == [1]
-    assert map1.eval([4], [13]) == [2]
-    assert map1.eval([5], [10]) == [2]
-    assert map1.eval([6], [11]) == [3]
+    assert map1.eval([1], [10]) == (0,)
+    assert map1.eval([2], [10]) == (1,)
+    assert map1.eval([3], [10]) == (1,)
+    assert map1.eval([4], [13]) == (2,)
+    assert map1.eval([5], [10]) == (2,)
+    assert map1.eval([6], [11]) == (3,)
 
     # map2: (x)[N] -> (-(x ceildiv 2) + N)
     map2 = AffineMap(1, 1, (-(x.ceil_div(2)) + N,))
-    assert map2.eval([1], [10]) == [9]
-    assert map2.eval([2], [10]) == [9]
-    assert map2.eval([3], [10]) == [8]
-    assert map2.eval([4], [13]) == [11]
-    assert map2.eval([5], [10]) == [7]
-    assert map2.eval([6], [11]) == [8]
+    assert map2.eval([1], [10]) == (9,)
+    assert map2.eval([2], [10]) == (9,)
+    assert map2.eval([3], [10]) == (8,)
+    assert map2.eval([4], [13]) == (11,)
+    assert map2.eval([5], [10]) == (7,)
+    assert map2.eval([6], [11]) == (8,)
 
     # map3: (x)[N] -> (x mod 2 - N)
     map3 = AffineMap(1, 1, ((x % 2) - N,))
-    assert map3.eval([1], [10]) == [-9]
-    assert map3.eval([2], [10]) == [-10]
-    assert map3.eval([3], [10]) == [-9]
-    assert map3.eval([4], [13]) == [-13]
-    assert map3.eval([5], [10]) == [-9]
-    assert map3.eval([6], [11]) == [-11]
+    assert map3.eval([1], [10]) == (-9,)
+    assert map3.eval([2], [10]) == (-10,)
+    assert map3.eval([3], [10]) == (-9,)
+    assert map3.eval([4], [13]) == (-13,)
+    assert map3.eval([5], [10]) == (-9,)
+    assert map3.eval([6], [11]) == (-11,)
 
 
 def test_composition_simple():
@@ -76,10 +76,10 @@ def test_composition_simple():
     # map3 = (x, y) -> (y - x)
     map3 = map1.compose(map2)
 
-    assert map3.eval([1, 2], []) == [1]
-    assert map3.eval([3, 4], []) == [1]
-    assert map3.eval([5, 6], []) == [1]
-    assert map3.eval([20, 10], []) == [-10]
+    assert map3.eval([1, 2], []) == (1,)
+    assert map3.eval([3, 4], []) == (1,)
+    assert map3.eval([5, 6], []) == (1,)
+    assert map3.eval([20, 10], []) == (-10,)
 
 
 def test_composition():
@@ -98,9 +98,9 @@ def test_composition():
     # map3: (x, y) -> (-x floordiv 2, -2 * x - 3 * y)
     map3 = map1.compose(map2)
 
-    assert map3.eval([1, 2], []) == [-1, -8]
-    assert map3.eval([3, 4], []) == [-2, -18]
-    assert map3.eval([5, 6], []) == [-3, -28]
+    assert map3.eval([1, 2], []) == (-1, -8)
+    assert map3.eval([3, 4], []) == (-2, -18)
+    assert map3.eval([5, 6], []) == (-3, -28)
 
 
 def test_compose_expr():
@@ -175,3 +175,12 @@ def test_from_callable_fail():
         ),
     ):
         AffineMap.from_callable(lambda i: (i,), dim_symbol_split=(1, 1))
+
+
+def test_inverse_permutation():
+    assert AffineMap.empty().inverse_permutation() == AffineMap.empty()
+    assert AffineMap.from_callable(
+        lambda d0, d1, d2: (d1, d1, d0, d2, d1, d2, d1, d0)
+    ).inverse_permutation() == AffineMap(
+        8, 0, tuple(AffineExpr.dimension(d) for d in (2, 0, 3))
+    )

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -188,7 +188,7 @@ class Generic(IRDLOperation):
                     sizes.append(dim)
         return sizes
 
-    def get_static_loop_ranges(self) -> list[int]:
+    def get_static_loop_ranges(self) -> tuple[int, ...]:
         shapes_to_loops = self.get_shapes_to_loops_map()
         return shapes_to_loops.eval(self.get_static_shapes(), [])
 

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -190,25 +190,26 @@ class AffineMap:
         for i, expr in enumerate(self.results):
             match expr:
                 case AffineDimExpr():
-                    found_dims[expr.position] = i
+                    if found_dims[expr.position] == -1:
+                        found_dims[expr.position] = i
                 case _:
                     continue
 
         if -1 in found_dims:
             return None
 
-        results = tuple(self.results[i] for i in found_dims)
+        results = tuple(AffineExpr.dimension(i) for i in found_dims)
         return AffineMap(
             num_dims=len(self.results),
             num_symbols=0,
             results=results,
         )
 
-    def eval(self, dims: Sequence[int], symbols: Sequence[int]) -> list[int]:
+    def eval(self, dims: Sequence[int], symbols: Sequence[int]) -> tuple[int, ...]:
         """Evaluate the AffineMap given the values of dimensions and symbols."""
         assert len(dims) == self.num_dims
         assert len(symbols) == self.num_symbols
-        return [expr.eval(dims, symbols) for expr in self.results]
+        return tuple(expr.eval(dims, symbols) for expr in self.results)
 
     def __str__(self) -> str:
         # Create comma seperated list of dims.


### PR DESCRIPTION
Currently, loop bounds are not computed correctly for linalg.generic lowering