### PR TITLE
dialects: Import MemRefType from builtin.

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -20,6 +20,7 @@ from xdsl.dialects.builtin import (
     FloatAttr,
     FloatData,
     IntAttr,
+    MemRefType,
     NoneAttr,
     StridedLayoutAttr,
     SymbolRefAttr,
@@ -32,7 +33,6 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.dialects.memref import MemRefType
 from xdsl.ir import Attribute
 from xdsl.irdl import AttrConstraint
 from xdsl.utils.exceptions import VerifyException

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -8,7 +8,9 @@ from xdsl.dialects.builtin import (
     IndexType,
     IntAttr,
     IntegerType,
+    MemRefType,
     StridedLayoutAttr,
+    UnrankedMemrefType,
     i32,
     i64,
 )
@@ -23,10 +25,8 @@ from xdsl.dialects.memref import (
     ExtractAlignedPointerAsIndexOp,
     Load,
     MemorySpaceCast,
-    MemRefType,
     Store,
     Subview,
-    UnrankedMemrefType,
 )
 from xdsl.ir import Attribute, BlockArgument, OpResult
 from xdsl.utils.exceptions import VerifyException

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     IndexType,
     IntAttr,
     IntegerType,
+    MemRefType,
     ModuleOp,
     bf16,
     f16,
@@ -25,7 +26,6 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.func import (
     FuncOp,
 )
-from xdsl.dialects.memref import MemRefType
 from xdsl.dialects.stencil import (
     AccessOp,
     ApplyOp,

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -3,12 +3,12 @@ import pytest
 from xdsl.dialects.builtin import (
     IndexType,
     IntAttr,
+    MemRefType,
     VectorType,
     i1,
     i32,
     i64,
 )
-from xdsl.dialects.memref import MemRefType
 from xdsl.dialects.vector import (
     FMA,
     Broadcast,

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -2,8 +2,14 @@ import pytest
 
 from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import arith, linalg
-from xdsl.dialects.builtin import AffineMapAttr, IntegerType, ModuleOp, StringAttr, i32
-from xdsl.dialects.memref import MemRefType
+from xdsl.dialects.builtin import (
+    AffineMapAttr,
+    IntegerType,
+    MemRefType,
+    ModuleOp,
+    StringAttr,
+    i32,
+)
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters.arith import ArithFunctions
 from xdsl.interpreters.linalg import LinalgFunctions

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -6,8 +6,14 @@ from enum import Enum
 from typing import Generic, TypeVar
 
 from xdsl.dialects import llvm
-from xdsl.dialects.builtin import AnyFloat, IntegerType, Signedness, StringAttr, i32
-from xdsl.dialects.memref import MemRefType
+from xdsl.dialects.builtin import (
+    AnyFloat,
+    IntegerType,
+    MemRefType,
+    Signedness,
+    StringAttr,
+    i32,
+)
 from xdsl.ir import (
     Attribute,
     Dialect,

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -4,13 +4,13 @@ from collections.abc import Sequence
 
 from xdsl.dialects.builtin import (
     IndexType,
+    MemRefType,
     VectorBaseTypeAndRankConstraint,
     VectorBaseTypeConstraint,
     VectorRankConstraint,
     VectorType,
     i1,
 )
-from xdsl.dialects.memref import MemRefType
 from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
 from xdsl.irdl import (
     AnyAttr,

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -4,7 +4,7 @@ from functools import singledispatchmethod
 from typing import IO, cast
 
 from xdsl.dialects import arith, builtin, gpu, memref
-from xdsl.dialects.memref import MemRefType
+from xdsl.dialects.builtin import MemRefType
 from xdsl.ir import Attribute, Operation, SSAValue
 from xdsl.utils.hints import isa
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -37,6 +37,7 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     LocationAttr,
+    MemRefType,
     NoneAttr,
     OpaqueAttr,
     RankedVectorOrTensorOf,
@@ -46,12 +47,12 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     TensorType,
     UnitAttr,
+    UnrankedMemrefType,
     UnrankedTensorType,
     UnregisteredAttr,
     VectorType,
     i64,
 )
-from xdsl.dialects.memref import MemRefType, UnrankedMemrefType
 from xdsl.ir import Attribute, Data, MLContext, ParametrizedAttribute
 from xdsl.ir.affine import AffineMap, AffineSet
 from xdsl.parser.base_parser import BaseParser

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -5,8 +5,8 @@ from typing import Literal, TypeVar, cast
 from warnings import warn
 
 from xdsl.dialects import arith, builtin, gpu, memref, scf
+from xdsl.dialects.builtin import MemRefType
 from xdsl.dialects.func import FuncOp
-from xdsl.dialects.memref import MemRefType
 from xdsl.dialects.stencil import (
     AccessOp,
     ApplyOp,

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -8,6 +8,7 @@ from xdsl.dialects.builtin import (
     DenseArrayBase,
     IndexType,
     IntAttr,
+    MemRefType,
     f64,
     i32,
     i64,
@@ -32,7 +33,6 @@ from xdsl.dialects.llvm import (
     LoadOp,
     UndefOp,
 )
-from xdsl.dialects.memref import MemRefType
 from xdsl.dialects.stencil import (
     AccessOp,
     ApplyOp,

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -4,8 +4,14 @@ from math import prod
 from typing import TypeVar, cast
 
 from xdsl.dialects import arith, builtin, func, llvm, memref, mpi
-from xdsl.dialects.builtin import IndexType, IntegerType, Signedness, i32, i64
-from xdsl.dialects.memref import MemRefType
+from xdsl.dialects.builtin import (
+    IndexType,
+    IntegerType,
+    MemRefType,
+    Signedness,
+    i32,
+    i64,
+)
 from xdsl.ir import Attribute, MLContext, Operation, OpResult, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (


### PR DESCRIPTION
Following up on #1997, I forgot to switch all imports!