### PR TITLE
dialects: switch StringAttr from Data[str] to Data[bytes]

### DIFF
--- a/docs/Toy/toy/rewrites/inline_toy.py
+++ b/docs/Toy/toy/rewrites/inline_toy.py
@@ -18,7 +18,7 @@ class InlineFunctions(RewritePattern):
     def lookup_func_op(self, module: ModuleOp, name: str) -> toy.FuncOp:
         if self._func_op_by_name is None:
             self._func_op_by_name = {
-                op.sym_name.string: op
+                op.sym_name.escaped: op
                 for op in module.ops
                 if isinstance(op, toy.FuncOp)
             }

--- a/docs/Toy/toy/rewrites/inline_toy.py
+++ b/docs/Toy/toy/rewrites/inline_toy.py
@@ -18,7 +18,7 @@ class InlineFunctions(RewritePattern):
     def lookup_func_op(self, module: ModuleOp, name: str) -> toy.FuncOp:
         if self._func_op_by_name is None:
             self._func_op_by_name = {
-                op.sym_name.string_value: op
+                op.sym_name.string: op
                 for op in module.ops
                 if isinstance(op, toy.FuncOp)
             }
@@ -84,7 +84,7 @@ class RemoveUnusedPrivateFunctions(RewritePattern):
                 if isinstance(op, toy.GenericCallOp)
             }
 
-        return op.sym_name.string_value not in self._used_funcs
+        return op.sym_name.string not in self._used_funcs
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: toy.FuncOp, rewriter: PatternRewriter):

--- a/docs/Toy/toy/rewrites/inline_toy.py
+++ b/docs/Toy/toy/rewrites/inline_toy.py
@@ -18,7 +18,9 @@ class InlineFunctions(RewritePattern):
     def lookup_func_op(self, module: ModuleOp, name: str) -> toy.FuncOp:
         if self._func_op_by_name is None:
             self._func_op_by_name = {
-                op.sym_name.data: op for op in module.ops if isinstance(op, toy.FuncOp)
+                op.sym_name.string_value: op
+                for op in module.ops
+                if isinstance(op, toy.FuncOp)
             }
         return self._func_op_by_name[name]
 
@@ -82,7 +84,7 @@ class RemoveUnusedPrivateFunctions(RewritePattern):
                 if isinstance(op, toy.GenericCallOp)
             }
 
-        return op.sym_name.data not in self._used_funcs
+        return op.sym_name.string_value not in self._used_funcs
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: toy.FuncOp, rewriter: PatternRewriter):

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -390,7 +390,7 @@ class ConstantOpLowering(RewritePattern):
 class FuncOpLowering(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: toy.FuncOp, rewriter: PatternRewriter):
-        name = op.sym_name.data
+        name = op.sym_name.string_value
 
         # We only lower the main function as we expect that all other functions
         # have been inlined.

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -390,7 +390,7 @@ class ConstantOpLowering(RewritePattern):
 class FuncOpLowering(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: toy.FuncOp, rewriter: PatternRewriter):
-        name = op.sym_name.string_value
+        name = op.sym_name.string
 
         # We only lower the main function as we expect that all other functions
         # have been inlined.

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -179,7 +179,7 @@ def test_call():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call(func0.sym_name.string, [a, b], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name, [a, b], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, b, call0])
@@ -225,7 +225,7 @@ def test_call_II():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call(func0.sym_name.string, [a], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name, [a], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, call0])

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -149,7 +149,7 @@ def test_func_get_return_op():
 def test_callable_constructor():
     f = FuncOp("f", ((i32, i32, i32), ()))
 
-    assert f.sym_name.string_value == "f"
+    assert f.sym_name.string == "f"
     assert not f.body.block.ops
 
 
@@ -179,7 +179,7 @@ def test_call():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call(func0.sym_name.string_value, [a, b], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name.string, [a, b], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, b, call0])
@@ -225,7 +225,7 @@ def test_call_II():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call(func0.sym_name.string_value, [a], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name.string, [a], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, call0])
@@ -264,4 +264,4 @@ def test_external_func_def():
 
     assert len(ext.regions) == 1
     assert len(ext.regions[0].blocks) == 0
-    assert ext.sym_name.string_value == "testname"
+    assert ext.sym_name.string == "testname"

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -149,7 +149,7 @@ def test_func_get_return_op():
 def test_callable_constructor():
     f = FuncOp("f", ((i32, i32, i32), ()))
 
-    assert f.sym_name.data == "f"
+    assert f.sym_name.string_value == "f"
     assert not f.body.block.ops
 
 
@@ -179,7 +179,7 @@ def test_call():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call(func0.sym_name.data, [a, b], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name.string_value, [a, b], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, b, call0])
@@ -225,7 +225,7 @@ def test_call_II():
 
     # Create a call for this function, passing a, b as args
     # and returning the type of the return
-    call0 = Call(func0.sym_name.data, [a], [ret0.arguments[0].type])
+    call0 = Call(func0.sym_name.string_value, [a], [ret0.arguments[0].type])
 
     # Wrap all in a ModuleOp
     mod = ModuleOp([func0, a, call0])
@@ -264,4 +264,4 @@ def test_external_func_def():
 
     assert len(ext.regions) == 1
     assert len(ext.regions[0].blocks) == 0
-    assert ext.sym_name.data == "testname"
+    assert ext.sym_name.string_value == "testname"

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -175,7 +175,7 @@ def test_linkage_attr():
     linkage = llvm.LinkageAttr("internal")
 
     assert isinstance(linkage.linkage, builtin.StringAttr)
-    assert linkage.linkage.data == "internal"
+    assert linkage.linkage.string_value == "internal"
 
 
 def test_linkage_attr_unknown_str():
@@ -198,9 +198,9 @@ def test_global_op():
 
     assert global_op.global_type == builtin.i32
     assert isinstance(global_op.sym_name, builtin.StringAttr)
-    assert global_op.sym_name.data == "testsymbol"
+    assert global_op.sym_name.string_value == "testsymbol"
     assert isinstance(global_op.section, builtin.StringAttr)
-    assert global_op.section.data == "test"
+    assert global_op.section.string_value == "test"
     assert isinstance(global_op.addr_space, builtin.IntegerAttr)
     assert global_op.addr_space.value.data == 10
     assert isinstance(global_op.alignment, builtin.IntegerAttr)
@@ -217,7 +217,7 @@ def test_addressof_op():
     address_of = llvm.AddressOfOp("test", ptr_type)
 
     assert isinstance(address_of.global_name, builtin.SymbolRefAttr)
-    assert address_of.global_name.root_reference.data == "test"
+    assert address_of.global_name.root_reference.string_value == "test"
     assert address_of.result.type == ptr_type
 
 

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -175,7 +175,7 @@ def test_linkage_attr():
     linkage = llvm.LinkageAttr("internal")
 
     assert isinstance(linkage.linkage, builtin.StringAttr)
-    assert linkage.linkage.string_value == "internal"
+    assert linkage.linkage.string == "internal"
 
 
 def test_linkage_attr_unknown_str():
@@ -198,9 +198,9 @@ def test_global_op():
 
     assert global_op.global_type == builtin.i32
     assert isinstance(global_op.sym_name, builtin.StringAttr)
-    assert global_op.sym_name.string_value == "testsymbol"
+    assert global_op.sym_name.string == "testsymbol"
     assert isinstance(global_op.section, builtin.StringAttr)
-    assert global_op.section.string_value == "test"
+    assert global_op.section.string == "test"
     assert isinstance(global_op.addr_space, builtin.IntegerAttr)
     assert global_op.addr_space.value.data == 10
     assert isinstance(global_op.alignment, builtin.IntegerAttr)
@@ -217,7 +217,7 @@ def test_addressof_op():
     address_of = llvm.AddressOfOp("test", ptr_type)
 
     assert isinstance(address_of.global_name, builtin.SymbolRefAttr)
-    assert address_of.global_name.root_reference.string_value == "test"
+    assert address_of.global_name.root_reference.string == "test"
     assert address_of.result.type == ptr_type
 
 

--- a/tests/dialects/test_mpi.py
+++ b/tests/dialects/test_mpi.py
@@ -34,4 +34,4 @@ def test_mpi_baseop():
     assert recv.tag == tag.result
     assert test_res.request == recv.request
     assert source.status == wait.status
-    assert source.field.string_value == mpi.StatusTypeField.MPI_SOURCE.value
+    assert source.field.string == mpi.StatusTypeField.MPI_SOURCE.value

--- a/tests/dialects/test_mpi.py
+++ b/tests/dialects/test_mpi.py
@@ -34,4 +34,4 @@ def test_mpi_baseop():
     assert recv.tag == tag.result
     assert test_res.request == recv.request
     assert source.status == wait.status
-    assert source.field.data == mpi.StatusTypeField.MPI_SOURCE.value
+    assert source.field.string_value == mpi.StatusTypeField.MPI_SOURCE.value

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -82,7 +82,7 @@ def test_csr_op():
 def test_comment_op():
     comment_op = riscv.CommentOp("my comment")
 
-    assert comment_op.comment.data == "my comment"
+    assert comment_op.comment.string_value == "my comment"
 
     code = riscv.riscv_code(ModuleOp([comment_op]))
     assert code == "    # my comment\n"
@@ -113,7 +113,7 @@ def test_return_op():
 
     assert return_op.comment is not None
 
-    assert return_op.comment.data == "my comment"
+    assert return_op.comment.string_value == "my comment"
 
     code = riscv.riscv_code(ModuleOp([return_op]))
     assert code == "    ebreak                                       # my comment\n"

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -82,7 +82,7 @@ def test_csr_op():
 def test_comment_op():
     comment_op = riscv.CommentOp("my comment")
 
-    assert comment_op.comment.string_value == "my comment"
+    assert comment_op.comment.string == "my comment"
 
     code = riscv.riscv_code(ModuleOp([comment_op]))
     assert code == "    # my comment\n"
@@ -113,7 +113,7 @@ def test_return_op():
 
     assert return_op.comment is not None
 
-    assert return_op.comment.string_value == "my comment"
+    assert return_op.comment.string == "my comment"
 
     code = riscv.riscv_code(ModuleOp([return_op]))
     assert code == "    ebreak                                       # my comment\n"

--- a/tests/filecheck/dialects/llvm/global.mlir
+++ b/tests/filecheck/dialects/llvm/global.mlir
@@ -7,7 +7,7 @@ builtin.module {
 }
 
 // CHECK: builtin.module {
-// CHECK-NEXT:   "llvm.mlir.global"() <{"global_type" = !llvm.array<13 x i8>, "constant", "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "value" = "Hello world!\n", "addr_space" = 0 : i32, "unnamed_addr" = 0 : i64}> ({
+// CHECK-NEXT:   "llvm.mlir.global"() <{"global_type" = !llvm.array<13 x i8>, "constant", "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "value" = "Hello world!\0A", "addr_space" = 0 : i32, "unnamed_addr" = 0 : i64}> ({
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT:   %0 = "llvm.mlir.addressof"() <{"global_name" = @str0}> : () -> !llvm.ptr
 // CHECK-NEXT:   %1 = "llvm.getelementptr"(%0) <{"elem_type" = !llvm.array<13 x i8>, "rawConstantIndices" = array<i32: 0, 0>}> : (!llvm.ptr) -> !llvm.ptr

--- a/tests/filecheck/parser-printer/escaped_characters.mlir
+++ b/tests/filecheck/parser-printer/escaped_characters.mlir
@@ -3,13 +3,13 @@
 "builtin.module"() ({
 
   "test.op"() {name = "\""} : () -> ()
-  // CHECK:      "test.op"() {"name" = "\""} : () -> ()
+  // CHECK:      "test.op"() {"name" = "\22"} : () -> ()
 
   "test.op"() {name = "\n"} : () -> ()
-  // CHECK-NEXT: "test.op"() {"name" = "\n"} : () -> ()
+  // CHECK-NEXT: "test.op"() {"name" = "\0A"} : () -> ()
 
   "test.op"() {name = "\t"} : () -> ()
-  // CHECK-NEXT: "test.op"() {"name" = "\t"} : () -> ()
+  // CHECK-NEXT: "test.op"() {"name" = "\09"} : () -> ()
 
   "test.op"() {name = "\\"} : () -> ()
   // CHECK-NEXT: "test.op"() {"name" = "\\"} : () -> ()

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -98,7 +98,7 @@ class StringData(Data[str]):
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
         with parser.in_angle_brackets():
-            return parser.parse_str_literal()
+            return parser.parse_str_literal().string
 
     def print_parameter(self, printer: Printer):
         with printer.in_angle_brackets():

--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -98,7 +98,7 @@ class StringData(Data[str]):
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
         with parser.in_angle_brackets():
-            return parser.parse_str_literal().string
+            return parser.parse_str_literal().escaped
 
     def print_parameter(self, printer: Printer):
         with printer.in_angle_brackets():

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -243,7 +243,7 @@ def test_token_get_float_value(text: str, expected: float):
         ('"\\t"', "\t"),
     ],
 )
-def test_token_get_string_literal_value(text: str, expected: float):
+def test_token_get_string_literal_value(text: str, expected: str):
     token = get_token(text)
     assert token.kind == Token.Kind.STRING_LIT
-    assert token.get_string_literal_value() == expected
+    assert token.get_string_literal_value().decode() == expected

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -365,10 +365,10 @@ def test_attribute_setters():
     op = AttributeOp.create(attributes={"attr": StringAttr("test")})
 
     op.attr = StringAttr("new_test")
-    assert op.attr.data == "new_test"
+    assert op.attr.string_value == "new_test"
 
     op.opt_attr = StringAttr("new_opt_test")
-    assert op.opt_attr.data == "new_opt_test"
+    assert op.opt_attr.string_value == "new_opt_test"
 
     op.opt_attr = None
     assert op.opt_attr is None
@@ -401,10 +401,10 @@ def test_property_setters():
     op = PropertyOp.create(properties={"attr": StringAttr("test")})
 
     op.attr = StringAttr("new_test")
-    assert op.attr.data == "new_test"
+    assert op.attr.string_value == "new_test"
 
     op.opt_attr = StringAttr("new_opt_test")
-    assert op.opt_attr.data == "new_opt_test"
+    assert op.opt_attr.string_value == "new_opt_test"
 
     op.opt_attr = None
     assert op.opt_attr is None

--- a/tests/test_operation_definition.py
+++ b/tests/test_operation_definition.py
@@ -365,10 +365,10 @@ def test_attribute_setters():
     op = AttributeOp.create(attributes={"attr": StringAttr("test")})
 
     op.attr = StringAttr("new_test")
-    assert op.attr.string_value == "new_test"
+    assert op.attr.string == "new_test"
 
     op.opt_attr = StringAttr("new_opt_test")
-    assert op.opt_attr.string_value == "new_opt_test"
+    assert op.opt_attr.string == "new_opt_test"
 
     op.opt_attr = None
     assert op.opt_attr is None
@@ -401,10 +401,10 @@ def test_property_setters():
     op = PropertyOp.create(properties={"attr": StringAttr("test")})
 
     op.attr = StringAttr("new_test")
-    assert op.attr.string_value == "new_test"
+    assert op.attr.string == "new_test"
 
     op.opt_attr = StringAttr("new_opt_test")
-    assert op.opt_attr.string_value == "new_opt_test"
+    assert op.opt_attr.string == "new_opt_test"
 
     op.opt_attr = None
     assert op.opt_attr is None

--- a/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
+++ b/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
@@ -34,7 +34,7 @@ class LowerFuncOp(RewritePattern):
         result_types = list(a_regs_for_types(op.function_type.outputs.data))
 
         new_func = riscv_func.FuncOp(
-            op.sym_name.string,
+            op.sym_name.escaped,
             rewriter.move_region_contents_to_new_regions(op.body),
             (input_types, result_types),
         )

--- a/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
+++ b/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
@@ -34,18 +34,16 @@ class LowerFuncOp(RewritePattern):
         result_types = list(a_regs_for_types(op.function_type.outputs.data))
 
         new_func = riscv_func.FuncOp(
-            op.sym_name.string_value,
+            op.sym_name.string,
             rewriter.move_region_contents_to_new_regions(op.body),
             (input_types, result_types),
         )
 
         new_ops: list[Operation] = []
 
-        if (
-            visibility := op.sym_visibility
-        ) is None or visibility.string_value == "public":
+        if (visibility := op.sym_visibility) is None or visibility.string == "public":
             # C-like: default is public
-            new_ops.append(riscv.DirectiveOp(".globl", op.sym_name.string_value))
+            new_ops.append(riscv.DirectiveOp(".globl", op.sym_name.string))
 
         new_ops.append(
             # FIXME we should ask the target for alignment, this works for rv32

--- a/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
+++ b/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
@@ -34,16 +34,18 @@ class LowerFuncOp(RewritePattern):
         result_types = list(a_regs_for_types(op.function_type.outputs.data))
 
         new_func = riscv_func.FuncOp(
-            op.sym_name.data,
+            op.sym_name.string_value,
             rewriter.move_region_contents_to_new_regions(op.body),
             (input_types, result_types),
         )
 
         new_ops: list[Operation] = []
 
-        if (visibility := op.sym_visibility) is None or visibility.data == "public":
+        if (
+            visibility := op.sym_visibility
+        ) is None or visibility.string_value == "public":
             # C-like: default is public
-            new_ops.append(riscv.DirectiveOp(".globl", op.sym_name.data))
+            new_ops.append(riscv.DirectiveOp(".globl", op.sym_name.string_value))
 
         new_ops.append(
             # FIXME we should ask the target for alignment, this works for rv32

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -243,7 +243,7 @@ class ConvertMemrefGlobalOp(RewritePattern):
 
         section = riscv.AssemblySectionOp(".data")
         with ImplicitBuilder(section.data):
-            riscv.LabelOp(op.sym_name.string)
+            riscv.LabelOp(op.sym_name.escaped)
             riscv.DirectiveOp(".word", text)
 
         rewriter.replace_matched_op(section)

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -243,7 +243,7 @@ class ConvertMemrefGlobalOp(RewritePattern):
 
         section = riscv.AssemblySectionOp(".data")
         with ImplicitBuilder(section.data):
-            riscv.LabelOp(op.sym_name.data)
+            riscv.LabelOp(op.sym_name.string_value)
             riscv.DirectiveOp(".word", text)
 
         rewriter.replace_matched_op(section)

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -243,7 +243,7 @@ class ConvertMemrefGlobalOp(RewritePattern):
 
         section = riscv.AssemblySectionOp(".data")
         with ImplicitBuilder(section.data):
-            riscv.LabelOp(op.sym_name.string_value)
+            riscv.LabelOp(op.sym_name.string)
             riscv.DirectiveOp(".word", text)
 
         rewriter.replace_matched_op(section)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -193,7 +193,7 @@ class StringAttr(Data[bytes]):
         super().__init__(data)
 
     @property
-    def string_value(self) -> str:
+    def string(self) -> str:
         return self.data.decode("utf-8")
 
 
@@ -228,9 +228,9 @@ class SymbolRefAttr(ParametrizedAttribute):
         super().__init__([root, nested])
 
     def string_value(self):
-        root = self.root_reference.string_value
+        root = self.root_reference.string
         for ref in self.nested_references.data:
-            root += "." + ref.string_value
+            root += "." + ref.string
         return root
 
 
@@ -1394,14 +1394,14 @@ class UnregisteredAttr(ParametrizedAttribute, ABC):
 
         class UnregisteredAttrWithName(UnregisteredAttr):
             def verify(self):
-                if self.attr_name.string_value != name:
+                if self.attr_name.string != name:
                     raise VerifyException("Unregistered attribute name mismatch")
                 if self.is_type.data != int(is_type):
                     raise VerifyException("Unregistered attribute is_type mismatch")
 
         class UnregisteredAttrTypeWithName(UnregisteredAttr, TypeAttribute):
             def verify(self):
-                if self.attr_name.string_value != name:
+                if self.attr_name.string != name:
                     raise VerifyException("Unregistered attribute name mismatch")
                 if self.is_type.data != int(is_type):
                     raise VerifyException("Unregistered attribute is_type mismatch")

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -195,11 +195,21 @@ class StringAttr(Data[bytes]):
         super().__init__(data)
 
     @property
-    def string(self) -> str:
-        return self.data.decode("utf-8")
+    def string(self) -> str | None:
+        """
+        Decode a string. Because we can parse arbitrary binary escape sequences, a StringAttr
+        might contain invalid Unicode. In that case, we return None.
+        """
+        try:
+            return self.data.decode("utf-8")
+        except Exception:
+            return None
 
     @property
     def escaped(self) -> str:
+        """
+        Return the content of the StringAttribute in escaped form.
+        """
         string = ""
         for byte in self.data:
             match byte:
@@ -243,9 +253,9 @@ class SymbolRefAttr(ParametrizedAttribute):
         super().__init__([root, nested])
 
     def string_value(self):
-        root = self.root_reference.string
+        root = self.root_reference.escaped
         for ref in self.nested_references.data:
-            root += "." + ref.string
+            root += "." + ref.escaped
         return root
 
 

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -148,7 +148,7 @@ class FuncOp(IRDLOperation):
 
     def print(self, printer: Printer):
         if self.sym_visibility:
-            visibility = self.sym_visibility.string_value
+            visibility = self.sym_visibility.string
             printer.print(f" {visibility}")
 
         print_func_op_like(

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -275,11 +275,11 @@ class Call(IRDLOperation):
     # TODO how do we verify that the types are correct?
     def __init__(
         self,
-        callee: str | SymbolRefAttr,
+        callee: str | StringAttr | SymbolRefAttr,
         arguments: Sequence[SSAValue | Operation],
         return_types: Sequence[Attribute],
     ):
-        if isinstance(callee, str):
+        if isinstance(callee, str | StringAttr):
             callee = SymbolRefAttr(callee)
         super().__init__(
             operands=[arguments],

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -148,7 +148,7 @@ class FuncOp(IRDLOperation):
 
     def print(self, printer: Printer):
         if self.sym_visibility:
-            visibility = self.sym_visibility.data
+            visibility = self.sym_visibility.string_value
             printer.print(f" {visibility}")
 
         print_func_op_like(

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -106,9 +106,9 @@ class InnerRefAttr(ParametrizedAttribute):
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print_string("<@")
-        printer.print_string(self.module_ref.root_reference.string_value)
+        printer.print_string(self.module_ref.root_reference.string)
         printer.print_string("::@")
-        printer.print_string(self.sym_name.string_value)
+        printer.print_string(self.sym_name.string)
         printer.print_string(">")
 
 

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -106,9 +106,9 @@ class InnerRefAttr(ParametrizedAttribute):
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print_string("<@")
-        printer.print_string(self.module_ref.root_reference.string)
+        printer.print_string(self.module_ref.root_reference.escaped)
         printer.print_string("::@")
-        printer.print_string(self.sym_name.string)
+        printer.print_string(self.sym_name.escaped)
         printer.print_string(">")
 
 

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -106,9 +106,9 @@ class InnerRefAttr(ParametrizedAttribute):
 
     def print_parameters(self, printer: Printer) -> None:
         printer.print_string("<@")
-        printer.print_string(self.module_ref.root_reference.data)
+        printer.print_string(self.module_ref.root_reference.string_value)
         printer.print_string("::@")
-        printer.print_string(self.sym_name.data)
+        printer.print_string(self.sym_name.string_value)
         printer.print_string(">")
 
 

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -72,7 +72,7 @@ class DialectOp(IRDLOperation):
         return DialectOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(" @", self.sym_name.string_value, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -102,7 +102,7 @@ class TypeOp(IRDLOperation):
         return TypeOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(" @", self.sym_name.string_value, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -132,7 +132,7 @@ class AttributeOp(IRDLOperation):
         return AttributeOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(" @", self.sym_name.string_value, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -188,7 +188,7 @@ class OperationOp(IRDLOperation):
         return OperationOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.data, " ")
+        printer.print(" @", self.sym_name.string_value, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 

--- a/xdsl/dialects/irdl/irdl.py
+++ b/xdsl/dialects/irdl/irdl.py
@@ -72,7 +72,7 @@ class DialectOp(IRDLOperation):
         return DialectOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.string_value, " ")
+        printer.print(" @", self.sym_name.string, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -102,7 +102,7 @@ class TypeOp(IRDLOperation):
         return TypeOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.string_value, " ")
+        printer.print(" @", self.sym_name.string, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -132,7 +132,7 @@ class AttributeOp(IRDLOperation):
         return AttributeOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.string_value, " ")
+        printer.print(" @", self.sym_name.string, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 
@@ -188,7 +188,7 @@ class OperationOp(IRDLOperation):
         return OperationOp(sym_name, region)
 
     def print(self, printer: Printer) -> None:
-        printer.print(" @", self.sym_name.string_value, " ")
+        printer.print(" @", self.sym_name.string, " ")
         if self.body.block.ops:
             printer.print_region(self.body)
 

--- a/xdsl/dialects/irdl/irdl_to_pyrdl.py
+++ b/xdsl/dialects/irdl/irdl_to_pyrdl.py
@@ -21,8 +21,8 @@ def convert_type_or_attr(op: TypeOp | AttributeOp, dialect_name: str) -> str:
     type_addition = ", TypeAttribute" if isinstance(op, TypeOp) else ""
     res = f"""\
 @irdl_attr_definition
-class {op.sym_name.data}(ParametrizedAttribute{type_addition}):
-    name = "{dialect_name}.{op.sym_name.data}"
+class {op.sym_name.string_value}(ParametrizedAttribute{type_addition}):
+    name = "{dialect_name}.{op.sym_name.string_value}"
 """
 
     for sub_op in op.body.ops:
@@ -37,8 +37,8 @@ def convert_op(op: OperationOp, dialect_name: str) -> str:
     """Convert an IRDL operation to Python code creating that operation in xDSL."""
     res = f"""\
 @irdl_op_definition
-class {op.sym_name.data}(IRDLOperation):
-    name = "{dialect_name}.{op.sym_name.data}"
+class {op.sym_name.string_value}(IRDLOperation):
+    name = "{dialect_name}.{op.sym_name.string_value}"
 """
 
     for sub_op in op.body.ops:
@@ -60,15 +60,15 @@ def convert_dialect(dialect: DialectOp) -> str:
     attrs: list[str] = []
     for op in dialect.body.ops:
         if isinstance(op, TypeOp) or isinstance(op, AttributeOp):
-            res += convert_type_or_attr(op, dialect.sym_name.data) + "\n\n"
-            attrs += [op.sym_name.data]
+            res += convert_type_or_attr(op, dialect.sym_name.string_value) + "\n\n"
+            attrs += [op.sym_name.string_value]
         if isinstance(op, OperationOp):
-            res += convert_op(op, dialect.sym_name.data) + "\n\n"
-            ops += [op.sym_name.data]
+            res += convert_op(op, dialect.sym_name.string_value) + "\n\n"
+            ops += [op.sym_name.string_value]
     op_list = "[" + ", ".join(ops) + "]"
     attr_list = "[" + ", ".join(attrs) + "]"
     return (
         res
-        + dialect.sym_name.data
-        + f' = Dialect("{dialect.sym_name.data}", {op_list}, {attr_list})'
+        + dialect.sym_name.string_value
+        + f' = Dialect("{dialect.sym_name.string_value}", {op_list}, {attr_list})'
     )

--- a/xdsl/dialects/irdl/irdl_to_pyrdl.py
+++ b/xdsl/dialects/irdl/irdl_to_pyrdl.py
@@ -21,8 +21,8 @@ def convert_type_or_attr(op: TypeOp | AttributeOp, dialect_name: str) -> str:
     type_addition = ", TypeAttribute" if isinstance(op, TypeOp) else ""
     res = f"""\
 @irdl_attr_definition
-class {op.sym_name.string_value}(ParametrizedAttribute{type_addition}):
-    name = "{dialect_name}.{op.sym_name.string_value}"
+class {op.sym_name.string}(ParametrizedAttribute{type_addition}):
+    name = "{dialect_name}.{op.sym_name.string}"
 """
 
     for sub_op in op.body.ops:
@@ -37,8 +37,8 @@ def convert_op(op: OperationOp, dialect_name: str) -> str:
     """Convert an IRDL operation to Python code creating that operation in xDSL."""
     res = f"""\
 @irdl_op_definition
-class {op.sym_name.string_value}(IRDLOperation):
-    name = "{dialect_name}.{op.sym_name.string_value}"
+class {op.sym_name.string}(IRDLOperation):
+    name = "{dialect_name}.{op.sym_name.string}"
 """
 
     for sub_op in op.body.ops:
@@ -60,15 +60,15 @@ def convert_dialect(dialect: DialectOp) -> str:
     attrs: list[str] = []
     for op in dialect.body.ops:
         if isinstance(op, TypeOp) or isinstance(op, AttributeOp):
-            res += convert_type_or_attr(op, dialect.sym_name.string_value) + "\n\n"
-            attrs += [op.sym_name.string_value]
+            res += convert_type_or_attr(op, dialect.sym_name.string) + "\n\n"
+            attrs += [op.sym_name.string]
         if isinstance(op, OperationOp):
-            res += convert_op(op, dialect.sym_name.string_value) + "\n\n"
-            ops += [op.sym_name.string_value]
+            res += convert_op(op, dialect.sym_name.string) + "\n\n"
+            ops += [op.sym_name.string]
     op_list = "[" + ", ".join(ops) + "]"
     attr_list = "[" + ", ".join(attrs) + "]"
     return (
         res
-        + dialect.sym_name.string_value
-        + f' = Dialect("{dialect.sym_name.string_value}", {op_list}, {attr_list})'
+        + dialect.sym_name.string
+        + f' = Dialect("{dialect.sym_name.string}", {op_list}, {attr_list})'
     )

--- a/xdsl/dialects/irdl/irdl_to_pyrdl.py
+++ b/xdsl/dialects/irdl/irdl_to_pyrdl.py
@@ -60,15 +60,15 @@ def convert_dialect(dialect: DialectOp) -> str:
     attrs: list[str] = []
     for op in dialect.body.ops:
         if isinstance(op, TypeOp) or isinstance(op, AttributeOp):
-            res += convert_type_or_attr(op, dialect.sym_name.string) + "\n\n"
-            attrs += [op.sym_name.string]
+            res += convert_type_or_attr(op, dialect.sym_name.escaped) + "\n\n"
+            attrs += [op.sym_name.escaped]
         if isinstance(op, OperationOp):
-            res += convert_op(op, dialect.sym_name.string) + "\n\n"
-            ops += [op.sym_name.string]
+            res += convert_op(op, dialect.sym_name.escaped) + "\n\n"
+            ops += [op.sym_name.escaped]
     op_list = "[" + ", ".join(ops) + "]"
     attr_list = "[" + ", ".join(attrs) + "]"
     return (
         res
-        + dialect.sym_name.string
+        + dialect.sym_name.escaped
         + f' = Dialect("{dialect.sym_name.string}", {op_list}, {attr_list})'
     )

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -268,7 +268,7 @@ class Generic(IRDLOperation):
                         iterator_types.append(iterator_type)
                     case StringAttr():
                         iterator_type = IteratorTypeAttr(
-                            IteratorType(iterator_type.data)
+                            IteratorType(iterator_type.string_value)
                         )
                         iterator_types.append(iterator_type)
                     case _:

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -198,8 +198,8 @@ class Generic(IRDLOperation):
         printer.print_string(", iterator_types = [")
         printer.print_list(
             self.iterator_types,
-            lambda iterator_type: printer.print_string_literal(
-                iterator_type.data.value
+            lambda iterator_type: printer.print_string_attribute(
+                StringAttr(iterator_type.data.value)
             ),
         )
         printer.print_string("]}")

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -268,7 +268,7 @@ class Generic(IRDLOperation):
                         iterator_types.append(iterator_type)
                     case StringAttr():
                         iterator_type = IteratorTypeAttr(
-                            IteratorType(iterator_type.string_value)
+                            IteratorType(iterator_type.string)
                         )
                         iterator_types.append(iterator_type)
                     case _:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -110,7 +110,7 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
     def print_parameters(self, printer: Printer) -> None:
         printer.print("<")
         if self.struct_name.data:
-            printer.print_string_literal(self.struct_name.string)
+            printer.print_string_attribute(self.struct_name)
             printer.print_string(", ")
         printer.print("(")
         printer.print_list(self.types.data, printer.print_attribute)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -110,7 +110,7 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
     def print_parameters(self, printer: Printer) -> None:
         printer.print("<")
         if self.struct_name.data:
-            printer.print_string_literal(self.struct_name.string_value)
+            printer.print_string_literal(self.struct_name.string)
             printer.print_string(", ")
         printer.print("(")
         printer.print_list(self.types.data, printer.print_attribute)
@@ -350,7 +350,7 @@ class LinkageAttr(ParametrizedAttribute):
             "weak_odr",
             "external",
         ]
-        if self.linkage.string_value not in allowed_linkage:
+        if self.linkage.string not in allowed_linkage:
             raise VerifyException(f"Specified linkage '{self.linkage.data}' is unknown")
 
 
@@ -1003,7 +1003,7 @@ class CallingConventionAttr(ParametrizedAttribute):
 
     @property
     def cconv_name(self) -> str:
-        return self.convention.string_value
+        return self.convention.string
 
     def __init__(self, conv: str):
         super().__init__([StringAttr(conv)])
@@ -1013,7 +1013,7 @@ class CallingConventionAttr(ParametrizedAttribute):
             raise VerifyException(f'Invalid calling convention "{self.cconv_name}"')
 
     def print_parameters(self, printer: Printer) -> None:
-        printer.print_string("<" + self.convention.string_value + ">")
+        printer.print_string("<" + self.convention.string + ">")
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -1003,7 +1003,7 @@ class CallingConventionAttr(ParametrizedAttribute):
 
     @property
     def cconv_name(self) -> str:
-        return self.convention.string
+        return self.convention.escaped
 
     def __init__(self, conv: str):
         super().__init__([StringAttr(conv)])
@@ -1013,7 +1013,7 @@ class CallingConventionAttr(ParametrizedAttribute):
             raise VerifyException(f'Invalid calling convention "{self.cconv_name}"')
 
     def print_parameters(self, printer: Printer) -> None:
-        printer.print_string("<" + self.convention.string + ">")
+        printer.print_string("<" + self.convention.escaped + ">")
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -110,7 +110,7 @@ class LLVMStructType(ParametrizedAttribute, TypeAttribute):
     def print_parameters(self, printer: Printer) -> None:
         printer.print("<")
         if self.struct_name.data:
-            printer.print_string_literal(self.struct_name.data)
+            printer.print_string_literal(self.struct_name.string_value)
             printer.print_string(", ")
         printer.print("(")
         printer.print_list(self.types.data, printer.print_attribute)
@@ -350,7 +350,7 @@ class LinkageAttr(ParametrizedAttribute):
             "weak_odr",
             "external",
         ]
-        if self.linkage.data not in allowed_linkage:
+        if self.linkage.string_value not in allowed_linkage:
             raise VerifyException(f"Specified linkage '{self.linkage.data}' is unknown")
 
 
@@ -1003,7 +1003,7 @@ class CallingConventionAttr(ParametrizedAttribute):
 
     @property
     def cconv_name(self) -> str:
-        return self.convention.data
+        return self.convention.string_value
 
     def __init__(self, conv: str):
         super().__init__([StringAttr(conv)])
@@ -1013,7 +1013,7 @@ class CallingConventionAttr(ParametrizedAttribute):
             raise VerifyException(f'Invalid calling convention "{self.cconv_name}"')
 
     def print_parameters(self, printer: Printer) -> None:
-        printer.print_string("<" + self.convention.data + ">")
+        printer.print_string("<" + self.convention.string_value + ">")
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -438,7 +438,7 @@ class OperationOp(IRDLOperation):
             name = parser.parse_str_literal()
             parser.parse_punctuation("=")
             type = parser.parse_operand()
-            return (name.string, type)
+            return (name.escaped, type)
 
         attributes = parser.parse_optional_comma_separated_list(
             Parser.Delimiter.BRACES, parse_attribute_entry

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -174,7 +174,7 @@ class ApplyNativeConstraintOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" ")
-        printer.print_string_literal(self.constraint_name.string_value)
+        printer.print_string_literal(self.constraint_name.string)
         printer.print("(")
         print_operands_with_types(printer, self.operands)
         printer.print(")")
@@ -220,7 +220,7 @@ class ApplyNativeRewriteOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" ")
-        printer.print_string_literal(self.constraint_name.string_value)
+        printer.print_string_literal(self.constraint_name.string)
         printer.print("(")
         print_operands_with_types(printer, self.operands)
         printer.print(")")
@@ -604,7 +604,7 @@ class PatternOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if self.sym_name is not None:
-            printer.print(" @", self.sym_name.string_value)
+            printer.print(" @", self.sym_name.string)
         printer.print(" : benefit(", self.benefit.value.data, ") ", self.body)
 
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -174,7 +174,7 @@ class ApplyNativeConstraintOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" ")
-        printer.print_string_literal(self.constraint_name.string)
+        printer.print_string_attribute(self.constraint_name)
         printer.print("(")
         print_operands_with_types(printer, self.operands)
         printer.print(")")
@@ -220,7 +220,7 @@ class ApplyNativeRewriteOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" ")
-        printer.print_string_literal(self.constraint_name.string)
+        printer.print_string_attribute(self.constraint_name)
         printer.print("(")
         print_operands_with_types(printer, self.operands)
         printer.print(")")
@@ -429,8 +429,6 @@ class OperationOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> OperationOp:
         name = parser.parse_optional_str_literal()
-        if name is not None:
-            name = name.decode()
         operands = []
         if parser.parse_optional_punctuation("(") is not None:
             operands = parse_operands_with_types(parser)
@@ -440,7 +438,7 @@ class OperationOp(IRDLOperation):
             name = parser.parse_str_literal()
             parser.parse_punctuation("=")
             type = parser.parse_operand()
-            return (name, type)
+            return (name.string, type)
 
         attributes = parser.parse_optional_comma_separated_list(
             Parser.Delimiter.BRACES, parse_attribute_entry

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -174,7 +174,7 @@ class ApplyNativeConstraintOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" ")
-        printer.print_string_literal(self.constraint_name.data)
+        printer.print_string_literal(self.constraint_name.string_value)
         printer.print("(")
         print_operands_with_types(printer, self.operands)
         printer.print(")")
@@ -220,7 +220,7 @@ class ApplyNativeRewriteOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print(" ")
-        printer.print_string_literal(self.constraint_name.data)
+        printer.print_string_literal(self.constraint_name.string_value)
         printer.print("(")
         print_operands_with_types(printer, self.operands)
         printer.print(")")
@@ -429,6 +429,8 @@ class OperationOp(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> OperationOp:
         name = parser.parse_optional_str_literal()
+        if name is not None:
+            name = name.decode()
         operands = []
         if parser.parse_optional_punctuation("(") is not None:
             operands = parse_operands_with_types(parser)
@@ -602,7 +604,7 @@ class PatternOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         if self.sym_name is not None:
-            printer.print(" @", self.sym_name.data)
+            printer.print(" @", self.sym_name.string_value)
         printer.print(" : benefit(", self.benefit.value.data, ") ", self.body)
 
 

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -34,7 +34,9 @@ class PrintFormatOp(IRDLOperation):
     format_str: builtin.StringAttr = attr_def(builtin.StringAttr)
     format_vals: VarOperand = var_operand_def()
 
-    def __init__(self, format_str: str, *vals: SSAValue | Operation):
+    def __init__(
+        self, format_str: str | builtin.StringAttr, *vals: SSAValue | Operation
+    ):
         super().__init__(
             operands=[vals], attributes={"format_str": builtin.StringAttr(format_str)}
         )

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -40,7 +40,7 @@ class PrintFormatOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        num_of_templates = self.format_str.data.count("{}")
+        num_of_templates = self.format_str.string_value.count("{}")
         if not num_of_templates == len(self.format_vals):
             raise VerifyException(
                 "Number of templates in template string must match number of arguments!"

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -40,7 +40,7 @@ class PrintFormatOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        num_of_templates = self.format_str.string_value.count("{}")
+        num_of_templates = self.format_str.string.count("{}")
         if not num_of_templates == len(self.format_vals):
             raise VerifyException(
                 "Number of templates in template string must match number of arguments!"

--- a/xdsl/dialects/printf.py
+++ b/xdsl/dialects/printf.py
@@ -42,7 +42,7 @@ class PrintFormatOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        num_of_templates = self.format_str.string.count("{}")
+        num_of_templates = self.format_str.escaped.count("{}")
         if not num_of_templates == len(self.format_vals):
             raise VerifyException(
                 "Number of templates in template string must match number of arguments!"

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -502,7 +502,7 @@ def _append_comment(line: str, comment: StringAttr | None) -> str:
 
     padding = " " * max(0, 48 - len(line))
 
-    return f"{line}{padding} # {comment.data}"
+    return f"{line}{padding} # {comment.string_value}"
 
 
 def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
@@ -2515,12 +2515,12 @@ class DirectiveOp(IRDLOperation, RISCVOp):
         )
 
     def assembly_line(self) -> str | None:
-        if self.value is not None and self.value.data:
-            arg_str = _assembly_arg_str(self.value.data)
+        if self.value is not None and self.value.string_value:
+            arg_str = _assembly_arg_str(self.value.string_value)
         else:
             arg_str = ""
 
-        return _assembly_line(self.directive.data, arg_str, is_indented=False)
+        return _assembly_line(self.directive.string_value, arg_str, is_indented=False)
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -2534,10 +2534,10 @@ class DirectiveOp(IRDLOperation, RISCVOp):
 
     def custom_print_attributes(self, printer: Printer) -> Set[str]:
         printer.print(" ")
-        printer.print_string_literal(self.directive.data)
+        printer.print_string_literal(self.directive.string_value)
         if self.value is not None:
             printer.print(" ")
-            printer.print_string_literal(self.value.data)
+            printer.print_string_literal(self.value.string_value)
         return {"directive", "value"}
 
     def print_op_type(self, printer: Printer) -> None:
@@ -2602,7 +2602,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
 
     def print(self, printer: Printer) -> None:
         printer.print_string(" ")
-        printer.print_string_literal(self.directive.data)
+        printer.print_string_literal(self.directive.string_value)
         printer.print_op_attributes(
             self.attributes, reserved_attr_names=("directive",), print_keyword=True
         )
@@ -2611,7 +2611,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
             printer.print_region(self.data)
 
     def assembly_line(self) -> str | None:
-        return _assembly_line(self.directive.data, "", is_indented=False)
+        return _assembly_line(self.directive.string_value, "", is_indented=False)
 
 
 @irdl_op_definition
@@ -2662,7 +2662,7 @@ class CustomAssemblyInstructionOp(IRDLOperation, RISCVInstruction):
         )
 
     def assembly_instruction_name(self) -> str:
-        return self.instruction_name.data
+        return self.instruction_name.string_value
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return *self.results, *self.operands
@@ -2684,7 +2684,7 @@ class CommentOp(IRDLOperation, RISCVOp):
         )
 
     def assembly_line(self) -> str | None:
-        return f"    # {self.comment.data}"
+        return f"    # {self.comment.string_value}"
 
 
 @irdl_op_definition
@@ -3659,7 +3659,7 @@ def _parse_optional_immediate_value(
     if (immediate := parser.parse_optional_integer()) is not None:
         return IntegerAttr(immediate, integer_type)
     if (immediate := parser.parse_optional_str_literal()) is not None:
-        return LabelAttr(immediate)
+        return LabelAttr(immediate.decode())
 
 
 def _parse_immediate_value(

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -356,7 +356,7 @@ class LabelAttr(Data[str]):
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
         with parser.in_angle_brackets():
-            return parser.parse_str_literal().string
+            return parser.parse_str_literal().escaped
 
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
@@ -2466,7 +2466,7 @@ class LabelOp(IRDLOperation, RISCVOp):
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
         attributes["label"] = LabelAttr(
-            parser.parse_str_literal("Expected label").string
+            parser.parse_str_literal("Expected label").escaped
         )
         return attributes
 
@@ -2517,12 +2517,12 @@ class DirectiveOp(IRDLOperation, RISCVOp):
         )
 
     def assembly_line(self) -> str | None:
-        if self.value is not None and self.value.string:
-            arg_str = _assembly_arg_str(self.value.string)
+        if self.value is not None and self.value.escaped:
+            arg_str = _assembly_arg_str(self.value.escaped)
         else:
             arg_str = ""
 
-        return _assembly_line(self.directive.string, arg_str, is_indented=False)
+        return _assembly_line(self.directive.escaped, arg_str, is_indented=False)
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -2613,7 +2613,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
             printer.print_region(self.data)
 
     def assembly_line(self) -> str | None:
-        return _assembly_line(self.directive.string, "", is_indented=False)
+        return _assembly_line(self.directive.escaped, "", is_indented=False)
 
 
 @irdl_op_definition
@@ -2664,7 +2664,7 @@ class CustomAssemblyInstructionOp(IRDLOperation, RISCVInstruction):
         )
 
     def assembly_instruction_name(self) -> str:
-        return self.instruction_name.string
+        return self.instruction_name.escaped
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return *self.results, *self.operands
@@ -3661,7 +3661,7 @@ def _parse_optional_immediate_value(
     if (immediate := parser.parse_optional_integer()) is not None:
         return IntegerAttr(immediate, integer_type)
     if (immediate := parser.parse_optional_str_literal()) is not None:
-        return LabelAttr(immediate.string)
+        return LabelAttr(immediate.escaped)
 
 
 def _parse_immediate_value(

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -502,7 +502,7 @@ def _append_comment(line: str, comment: StringAttr | None) -> str:
 
     padding = " " * max(0, 48 - len(line))
 
-    return f"{line}{padding} # {comment.string_value}"
+    return f"{line}{padding} # {comment.string}"
 
 
 def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
@@ -2515,12 +2515,12 @@ class DirectiveOp(IRDLOperation, RISCVOp):
         )
 
     def assembly_line(self) -> str | None:
-        if self.value is not None and self.value.string_value:
-            arg_str = _assembly_arg_str(self.value.string_value)
+        if self.value is not None and self.value.string:
+            arg_str = _assembly_arg_str(self.value.string)
         else:
             arg_str = ""
 
-        return _assembly_line(self.directive.string_value, arg_str, is_indented=False)
+        return _assembly_line(self.directive.string, arg_str, is_indented=False)
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -2534,10 +2534,10 @@ class DirectiveOp(IRDLOperation, RISCVOp):
 
     def custom_print_attributes(self, printer: Printer) -> Set[str]:
         printer.print(" ")
-        printer.print_string_literal(self.directive.string_value)
+        printer.print_string_literal(self.directive.string)
         if self.value is not None:
             printer.print(" ")
-            printer.print_string_literal(self.value.string_value)
+            printer.print_string_literal(self.value.string)
         return {"directive", "value"}
 
     def print_op_type(self, printer: Printer) -> None:
@@ -2602,7 +2602,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
 
     def print(self, printer: Printer) -> None:
         printer.print_string(" ")
-        printer.print_string_literal(self.directive.string_value)
+        printer.print_string_literal(self.directive.string)
         printer.print_op_attributes(
             self.attributes, reserved_attr_names=("directive",), print_keyword=True
         )
@@ -2611,7 +2611,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
             printer.print_region(self.data)
 
     def assembly_line(self) -> str | None:
-        return _assembly_line(self.directive.string_value, "", is_indented=False)
+        return _assembly_line(self.directive.string, "", is_indented=False)
 
 
 @irdl_op_definition
@@ -2662,7 +2662,7 @@ class CustomAssemblyInstructionOp(IRDLOperation, RISCVInstruction):
         )
 
     def assembly_instruction_name(self) -> str:
-        return self.instruction_name.string_value
+        return self.instruction_name.string
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return *self.results, *self.operands
@@ -2684,7 +2684,7 @@ class CommentOp(IRDLOperation, RISCVOp):
         )
 
     def assembly_line(self) -> str | None:
-        return f"    # {self.comment.string_value}"
+        return f"    # {self.comment.string}"
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -340,7 +340,7 @@ class BranchOp(IRDLOperation, riscv.RISCVOp):
         if self.comment is None:
             return None
 
-        return f"    # {self.comment.data}"
+        return f"    # {self.comment.string_value}"
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -340,7 +340,7 @@ class BranchOp(IRDLOperation, riscv.RISCVOp):
         if self.comment is None:
             return None
 
-        return f"    # {self.comment.string_value}"
+        return f"    # {self.comment.string}"
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_debug.py
+++ b/xdsl/dialects/riscv_debug.py
@@ -64,7 +64,7 @@ class PrintfOp(IRDLOperation, riscv.RISCVInstruction):
         return {"format_str"}
 
     def assembly_line_args(self) -> tuple[riscv.AssemblyInstructionArg, ...]:
-        return f'"{self.format_str.data}"', *self.operands
+        return f'"{self.format_str.string_value}"', *self.operands
 
 
 RISCV_Debug = Dialect(

--- a/xdsl/dialects/riscv_debug.py
+++ b/xdsl/dialects/riscv_debug.py
@@ -64,7 +64,7 @@ class PrintfOp(IRDLOperation, riscv.RISCVInstruction):
         return {"format_str"}
 
     def assembly_line_args(self) -> tuple[riscv.AssemblyInstructionArg, ...]:
-        return f'"{self.format_str.string_value}"', *self.operands
+        return f'"{self.format_str.string}"', *self.operands
 
 
 RISCV_Debug = Dialect(

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -205,7 +205,7 @@ class FuncOp(IRDLOperation, riscv.RISCVOp):
 
     def print(self, printer: Printer):
         if self.sym_visibility:
-            visibility = self.sym_visibility.data
+            visibility = self.sym_visibility.string_value
             printer.print(f" {visibility}")
 
         print_func_op_like(
@@ -218,7 +218,7 @@ class FuncOp(IRDLOperation, riscv.RISCVOp):
         )
 
     def assembly_line(self) -> str:
-        return f"{self.sym_name.data}:"
+        return f"{self.sym_name.string_value}:"
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -205,7 +205,7 @@ class FuncOp(IRDLOperation, riscv.RISCVOp):
 
     def print(self, printer: Printer):
         if self.sym_visibility:
-            visibility = self.sym_visibility.string_value
+            visibility = self.sym_visibility.string
             printer.print(f" {visibility}")
 
         print_func_op_like(
@@ -218,7 +218,7 @@ class FuncOp(IRDLOperation, riscv.RISCVOp):
         )
 
     def assembly_line(self) -> str:
-        return f"{self.sym_name.string_value}:"
+        return f"{self.sym_name.string}:"
 
 
 @irdl_op_definition

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -124,7 +124,7 @@ class TestType(Data[str], TypeAttribute):
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
         with parser.in_angle_brackets():
-            return parser.parse_str_literal().string
+            return parser.parse_str_literal().escaped
 
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():

--- a/xdsl/dialects/test.py
+++ b/xdsl/dialects/test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from xdsl.dialects.builtin import StringAttr
 from xdsl.ir import (
     Attribute,
     Block,
@@ -123,11 +124,11 @@ class TestType(Data[str], TypeAttribute):
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> str:
         with parser.in_angle_brackets():
-            return parser.parse_str_literal()
+            return parser.parse_str_literal().string
 
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
-            printer.print_string_literal(self.data)
+            printer.print_string_attribute(StringAttr(self.data))
 
 
 Test = Dialect("test", [TestOp, TestTermOp], [TestType])

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -128,7 +128,7 @@ def print_func_op_like(
     arg_attrs: ArrayAttr[DictionaryAttr] | None = None,
     reserved_attr_names: Sequence[str],
 ):
-    printer.print(f" @{sym_name.string_value}")
+    printer.print(f" @{sym_name.string}")
     if body.blocks:
         printer.print("(")
         if arg_attrs is not None:
@@ -173,7 +173,7 @@ def parse_func_op_like(
     Returns the function name, argument types, return types, body, extra args, and arg_attrs.
     """
     # Parse function name
-    name = parser.parse_symbol_name().string_value
+    name = parser.parse_symbol_name().string
 
     def parse_fun_input() -> Attribute | tuple[parser.Argument, dict[str, Attribute]]:
         arg = parser.parse_optional_argument()

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -128,7 +128,7 @@ def print_func_op_like(
     arg_attrs: ArrayAttr[DictionaryAttr] | None = None,
     reserved_attr_names: Sequence[str],
 ):
-    printer.print(f" @{sym_name.data}")
+    printer.print(f" @{sym_name.string_value}")
     if body.blocks:
         printer.print("(")
         if arg_attrs is not None:
@@ -173,7 +173,7 @@ def parse_func_op_like(
     Returns the function name, argument types, return types, body, extra args, and arg_attrs.
     """
     # Parse function name
-    name = parser.parse_symbol_name().data
+    name = parser.parse_symbol_name().string_value
 
     def parse_fun_input() -> Attribute | tuple[parser.Argument, dict[str, Attribute]]:
         arg = parser.parse_optional_argument()

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -173,7 +173,7 @@ def parse_func_op_like(
     Returns the function name, argument types, return types, body, extra args, and arg_attrs.
     """
     # Parse function name
-    name = parser.parse_symbol_name().string
+    name = parser.parse_symbol_name().escaped
 
     def parse_fun_input() -> Attribute | tuple[parser.Argument, dict[str, Attribute]]:
         arg = parser.parse_optional_argument()

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -610,7 +610,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                 "function body.",
             )
 
-        callee = parent_op.sym_name.data
+        callee = parent_op.sym_name.string_value
         func_return_types = parent_op.function_type.outputs.data
 
         if node.value is None:

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -610,7 +610,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                 "function body.",
             )
 
-        callee = parent_op.sym_name.string_value
+        callee = parent_op.sym_name.string
         func_return_types = parent_op.function_type.outputs.data
 
         if node.value is None:

--- a/xdsl/frontend/passes/desymref.py
+++ b/xdsl/frontend/passes/desymref.py
@@ -106,9 +106,9 @@ def get_symbol(op: Operation) -> str | None:
     attributes, None is returned.
     """
     if isinstance(op, symref.Declare):
-        return op.sym_name.string_value
+        return op.sym_name.string
     elif isinstance(op, symref.Fetch | symref.Update):
-        return op.symbol.root_reference.string_value
+        return op.symbol.root_reference.string
     else:
         return None
 

--- a/xdsl/frontend/passes/desymref.py
+++ b/xdsl/frontend/passes/desymref.py
@@ -106,9 +106,9 @@ def get_symbol(op: Operation) -> str | None:
     attributes, None is returned.
     """
     if isinstance(op, symref.Declare):
-        return op.sym_name.data
+        return op.sym_name.string_value
     elif isinstance(op, symref.Fetch | symref.Update):
-        return op.symbol.root_reference.data
+        return op.symbol.root_reference.string_value
     else:
         return None
 

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -436,7 +436,7 @@ class Interpreter:
                 if (symbol_interface := op.get_trait(SymbolOpInterface)) is not None:
                     symbol = symbol_interface.get_sym_attr_name(op)
                     if symbol:
-                        self._symbol_table[symbol.string] = op
+                        self._symbol_table[symbol.escaped] = op
         return self._symbol_table
 
     def get_values(self, values: Iterable[SSAValue]) -> tuple[Any, ...]:

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -436,7 +436,7 @@ class Interpreter:
                 if (symbol_interface := op.get_trait(SymbolOpInterface)) is not None:
                     symbol = symbol_interface.get_sym_attr_name(op)
                     if symbol:
-                        self._symbol_table[symbol.data] = op
+                        self._symbol_table[symbol.string_value] = op
         return self._symbol_table
 
     def get_values(self, values: Iterable[SSAValue]) -> tuple[Any, ...]:

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -436,7 +436,7 @@ class Interpreter:
                 if (symbol_interface := op.get_trait(SymbolOpInterface)) is not None:
                     symbol = symbol_interface.get_sym_attr_name(op)
                     if symbol:
-                        self._symbol_table[symbol.string_value] = op
+                        self._symbol_table[symbol.string] = op
         return self._symbol_table
 
     def get_values(self, values: Iterable[SSAValue]) -> tuple[Any, ...]:

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -150,10 +150,10 @@ class PDLMatcher:
             return self.matching_context[ssa_val] == xdsl_op
 
         if pdl_op.opName is not None:
-            if xdsl_op.name != pdl_op.opName.string:
+            if xdsl_op.name != pdl_op.opName.escaped:
                 return False
 
-        attribute_value_names = [avn.string for avn in pdl_op.attributeValueNames]
+        attribute_value_names = [avn.escaped for avn in pdl_op.attributeValueNames]
 
         for avn, av in zip(attribute_value_names, pdl_op.attribute_values):
             assert isinstance(av, OpResult)
@@ -285,7 +285,7 @@ class PDLRewriteFunctions(InterpreterFunctions):
         self, interpreter: Interpreter, op: pdl.OperationOp, args: tuple[Any, ...]
     ) -> tuple[Any, ...]:
         assert op.opName is not None
-        op_name = op.opName.string
+        op_name = op.opName.escaped
         op_type = self.ctx.get_optional_op(op_name)
 
         if op_type is None:
@@ -293,7 +293,7 @@ class PDLRewriteFunctions(InterpreterFunctions):
                 f"Could not find op type for name {op_name} in context"
             )
 
-        attribute_value_names = [avn.string for avn in op.attributeValueNames.data]
+        attribute_value_names = [avn.escaped for avn in op.attributeValueNames.data]
 
         # How to deal with operandSegmentSizes?
         # operand_values, attribute_values, type_values = args

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -150,10 +150,10 @@ class PDLMatcher:
             return self.matching_context[ssa_val] == xdsl_op
 
         if pdl_op.opName is not None:
-            if xdsl_op.name != pdl_op.opName.data:
+            if xdsl_op.name != pdl_op.opName.string_value:
                 return False
 
-        attribute_value_names = [avn.data for avn in pdl_op.attributeValueNames.data]
+        attribute_value_names = [avn.string_value for avn in pdl_op.attributeValueNames]
 
         for avn, av in zip(attribute_value_names, pdl_op.attribute_values):
             assert isinstance(av, OpResult)
@@ -203,7 +203,7 @@ class PDLMatcher:
         args = [
             self.get_constant_or_matched_value(operand) for operand in pdl_op.operands
         ]
-        name = pdl_op.constraint_name.data
+        name = pdl_op.constraint_name.string_value
         if name not in self.native_constraints:
             raise InterpretationError(f"{name} PDL native constraint is not registered")
         return self.native_constraints[name](*args)
@@ -285,7 +285,7 @@ class PDLRewriteFunctions(InterpreterFunctions):
         self, interpreter: Interpreter, op: pdl.OperationOp, args: tuple[Any, ...]
     ) -> tuple[Any, ...]:
         assert op.opName is not None
-        op_name = op.opName.data
+        op_name = op.opName.string_value
         op_type = self.ctx.get_optional_op(op_name)
 
         if op_type is None:
@@ -293,7 +293,9 @@ class PDLRewriteFunctions(InterpreterFunctions):
                 f"Could not find op type for name {op_name} in context"
             )
 
-        attribute_value_names = [avn.data for avn in op.attributeValueNames.data]
+        attribute_value_names = [
+            avn.string_value for avn in op.attributeValueNames.data
+        ]
 
         # How to deal with operandSegmentSizes?
         # operand_values, attribute_values, type_values = args

--- a/xdsl/interpreters/experimental/pdl.py
+++ b/xdsl/interpreters/experimental/pdl.py
@@ -150,10 +150,10 @@ class PDLMatcher:
             return self.matching_context[ssa_val] == xdsl_op
 
         if pdl_op.opName is not None:
-            if xdsl_op.name != pdl_op.opName.string_value:
+            if xdsl_op.name != pdl_op.opName.string:
                 return False
 
-        attribute_value_names = [avn.string_value for avn in pdl_op.attributeValueNames]
+        attribute_value_names = [avn.string for avn in pdl_op.attributeValueNames]
 
         for avn, av in zip(attribute_value_names, pdl_op.attribute_values):
             assert isinstance(av, OpResult)
@@ -203,7 +203,7 @@ class PDLMatcher:
         args = [
             self.get_constant_or_matched_value(operand) for operand in pdl_op.operands
         ]
-        name = pdl_op.constraint_name.string_value
+        name = pdl_op.constraint_name.string
         if name not in self.native_constraints:
             raise InterpretationError(f"{name} PDL native constraint is not registered")
         return self.native_constraints[name](*args)
@@ -285,7 +285,7 @@ class PDLRewriteFunctions(InterpreterFunctions):
         self, interpreter: Interpreter, op: pdl.OperationOp, args: tuple[Any, ...]
     ) -> tuple[Any, ...]:
         assert op.opName is not None
-        op_name = op.opName.string_value
+        op_name = op.opName.string
         op_type = self.ctx.get_optional_op(op_name)
 
         if op_type is None:
@@ -293,9 +293,7 @@ class PDLRewriteFunctions(InterpreterFunctions):
                 f"Could not find op type for name {op_name} in context"
             )
 
-        attribute_value_names = [
-            avn.string_value for avn in op.attributeValueNames.data
-        ]
+        attribute_value_names = [avn.string for avn in op.attributeValueNames.data]
 
         # How to deal with operandSegmentSizes?
         # operand_values, attribute_values, type_values = args

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 import wgpu  # pyright: ignore
 import wgpu.utils  # pyright: ignore
+
 from xdsl.dialects import gpu
 from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.memref import MemRefType

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -198,7 +198,7 @@ class WGPUFunctions(InterpreterFunctions):
             layout=pipeline_layout,  # pyright: ignore
             compute={
                 "module": shader_module,
-                "entry_point": func.sym_name.string_value,
+                "entry_point": func.sym_name.string,
             },
         )
 

--- a/xdsl/interpreters/experimental/wgpu.py
+++ b/xdsl/interpreters/experimental/wgpu.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 
 import wgpu  # pyright: ignore
 import wgpu.utils  # pyright: ignore
-
 from xdsl.dialects import gpu
 from xdsl.dialects.builtin import IndexType
 from xdsl.dialects.memref import MemRefType
@@ -197,7 +196,10 @@ class WGPUFunctions(InterpreterFunctions):
         # Create and run the pipeline
         compute_pipeline = device.create_compute_pipeline(  # pyright: ignore
             layout=pipeline_layout,  # pyright: ignore
-            compute={"module": shader_module, "entry_point": func.sym_name.data},
+            compute={
+                "module": shader_module,
+                "entry_point": func.sym_name.string_value,
+            },
         )
 
         command_encoder = device.create_command_encoder()  # pyright: ignore

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -65,7 +65,7 @@ class WGSLPrinter:
             f"""
     @compute
     @workgroup_size({",".join(str(i) for i in workgroup_size)})
-    fn {op.sym_name.data}(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+    fn {op.sym_name.string_value}(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
     @builtin(workgroup_id) workgroup_id : vec3<u32>,
     @builtin(local_invocation_id) local_invocation_id : vec3<u32>,
     @builtin(num_workgroups) num_workgroups : vec3<u32>) {{

--- a/xdsl/interpreters/experimental/wgsl_printer.py
+++ b/xdsl/interpreters/experimental/wgsl_printer.py
@@ -65,7 +65,7 @@ class WGSLPrinter:
             f"""
     @compute
     @workgroup_size({",".join(str(i) for i in workgroup_size)})
-    fn {op.sym_name.string_value}(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+    fn {op.sym_name.string}(@builtin(global_invocation_id) global_invocation_id : vec3<u32>,
     @builtin(workgroup_id) workgroup_id : vec3<u32>,
     @builtin(local_invocation_id) local_invocation_id : vec3<u32>,
     @builtin(num_workgroups) num_workgroups : vec3<u32>) {{

--- a/xdsl/interpreters/printf.py
+++ b/xdsl/interpreters/printf.py
@@ -10,5 +10,5 @@ class PrintfFunctions(InterpreterFunctions):
     def run_println(
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
-        print(op.format_str.string_value.format(*args), file=interpreter.file)
+        print(op.format_str.string.format(*args), file=interpreter.file)
         return ()

--- a/xdsl/interpreters/printf.py
+++ b/xdsl/interpreters/printf.py
@@ -10,5 +10,5 @@ class PrintfFunctions(InterpreterFunctions):
     def run_println(
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
-        print(op.format_str.string.format(*args), file=interpreter.file)
+        print(op.format_str.escaped.format(*args), file=interpreter.file)
         return ()

--- a/xdsl/interpreters/printf.py
+++ b/xdsl/interpreters/printf.py
@@ -10,5 +10,5 @@ class PrintfFunctions(InterpreterFunctions):
     def run_println(
         self, interpreter: Interpreter, op: PrintFormatOp, args: tuple[Any, ...]
     ):
-        print(op.format_str.data.format(*args), file=interpreter.file)
+        print(op.format_str.string_value.format(*args), file=interpreter.file)
         return ()

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -271,7 +271,7 @@ class RiscvFunctions(InterpreterFunctions):
         data: dict[str, RawPtr] = {}
         for op in module_op.ops:
             if isinstance(op, riscv.AssemblySectionOp):
-                if op.directive.string_value == ".data":
+                if op.directive.string == ".data":
                     assert op.data is not None
                     ops = list(op.data.block.ops)
                     for label, data_op in pairs(ops):
@@ -288,15 +288,15 @@ class RiscvFunctions(InterpreterFunctions):
                                 "Unexpected None value in data section directive"
                             )
 
-                        match data_op.directive.string_value:
+                        match data_op.directive.string:
                             case ".word":
-                                hexs = data_op.value.string_value.split(",")
+                                hexs = data_op.value.string.split(",")
                                 ints = [int(hex.strip(), 16) for hex in hexs]
                                 data[label.label.data] = RawPtr.new_int32(ints)
                             case _:
                                 raise InterpretationError(
                                     "Cannot interpret data directive "
-                                    f"{data_op.directive.string_value}"
+                                    f"{data_op.directive.string}"
                                 )
         return data
 
@@ -644,7 +644,7 @@ class RiscvFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         args = RiscvFunctions.get_reg_values(interpreter, op.operands, args)
-        instr = op.instruction_name.string_value
+        instr = op.instruction_name.string
         if instr not in self.custom_instructions:
             raise InterpretationError(
                 "Could not find custom riscv assembly instruction implementation for"

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -271,7 +271,7 @@ class RiscvFunctions(InterpreterFunctions):
         data: dict[str, RawPtr] = {}
         for op in module_op.ops:
             if isinstance(op, riscv.AssemblySectionOp):
-                if op.directive.data == ".data":
+                if op.directive.string_value == ".data":
                     assert op.data is not None
                     ops = list(op.data.block.ops)
                     for label, data_op in pairs(ops):
@@ -288,15 +288,15 @@ class RiscvFunctions(InterpreterFunctions):
                                 "Unexpected None value in data section directive"
                             )
 
-                        match data_op.directive.data:
+                        match data_op.directive.string_value:
                             case ".word":
-                                hexs = data_op.value.data.split(",")
+                                hexs = data_op.value.string_value.split(",")
                                 ints = [int(hex.strip(), 16) for hex in hexs]
                                 data[label.label.data] = RawPtr.new_int32(ints)
                             case _:
                                 raise InterpretationError(
                                     "Cannot interpret data directive "
-                                    f"{data_op.directive.data}"
+                                    f"{data_op.directive.string_value}"
                                 )
         return data
 
@@ -644,7 +644,7 @@ class RiscvFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         args = RiscvFunctions.get_reg_values(interpreter, op.operands, args)
-        instr = op.instruction_name.data
+        instr = op.instruction_name.string_value
         if instr not in self.custom_instructions:
             raise InterpretationError(
                 "Could not find custom riscv assembly instruction implementation for"

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -288,15 +288,15 @@ class RiscvFunctions(InterpreterFunctions):
                                 "Unexpected None value in data section directive"
                             )
 
-                        match data_op.directive.string:
+                        match data_op.directive.escaped:
                             case ".word":
-                                hexs = data_op.value.string.split(",")
+                                hexs = data_op.value.escaped.split(",")
                                 ints = [int(hex.strip(), 16) for hex in hexs]
                                 data[label.label.data] = RawPtr.new_int32(ints)
                             case _:
                                 raise InterpretationError(
                                     "Cannot interpret data directive "
-                                    f"{data_op.directive.string}"
+                                    f"{data_op.directive.escaped}"
                                 )
         return data
 

--- a/xdsl/interpreters/riscv_debug.py
+++ b/xdsl/interpreters/riscv_debug.py
@@ -22,5 +22,5 @@ class RiscvDebugFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         args = RiscvFunctions.get_reg_values(interpreter, op.operands, args)
-        print(op.format_str.data.format(*args), end="", file=interpreter.file)
+        print(op.format_str.string_value.format(*args), end="", file=interpreter.file)
         return ()

--- a/xdsl/interpreters/riscv_debug.py
+++ b/xdsl/interpreters/riscv_debug.py
@@ -22,5 +22,5 @@ class RiscvDebugFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         args = RiscvFunctions.get_reg_values(interpreter, op.operands, args)
-        print(op.format_str.string.format(*args), end="", file=interpreter.file)
+        print(op.format_str.escaped.format(*args), end="", file=interpreter.file)
         return ()

--- a/xdsl/interpreters/riscv_debug.py
+++ b/xdsl/interpreters/riscv_debug.py
@@ -22,5 +22,5 @@ class RiscvDebugFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ):
         args = RiscvFunctions.get_reg_values(interpreter, op.operands, args)
-        print(op.format_str.string_value.format(*args), end="", file=interpreter.file)
+        print(op.format_str.string.format(*args), end="", file=interpreter.file)
         return ()

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -175,6 +175,9 @@ class AttrParser(BaseParser):
                 "Expected bare-id or string-literal here as part of attribute entry!"
             )
 
+        if isinstance(name, bytes):
+            name = name.decode()
+
         if self.parse_optional_punctuation("=") is None:
             return name, UnitAttr()
 
@@ -531,7 +534,7 @@ class AttrParser(BaseParser):
         # We only accept strided layouts and affine_maps
         if isa(memory_or_layout, StridedLayoutAttr) or (
             isinstance(memory_or_layout, UnregisteredAttr)
-            and memory_or_layout.attr_name.data == "affine_map"
+            and memory_or_layout.attr_name.string_value == "affine_map"
         ):
             return MemRefType(type, shape, layout=memory_or_layout)
         self.raise_error(
@@ -783,7 +786,7 @@ class AttrParser(BaseParser):
             dense_contents = None
         else:
             if (hex_string := self.parse_optional_str_literal()) is not None:
-                dense_contents, shape = hex_string, None
+                dense_contents, shape = hex_string.decode(), None
             else:
                 # Expect a tensor literal instead
                 dense_contents = self._parse_tensor_literal()

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -534,7 +534,7 @@ class AttrParser(BaseParser):
         # We only accept strided layouts and affine_maps
         if isa(memory_or_layout, StridedLayoutAttr) or (
             isinstance(memory_or_layout, UnregisteredAttr)
-            and memory_or_layout.attr_name.string_value == "affine_map"
+            and memory_or_layout.attr_name.string == "affine_map"
         ):
             return MemRefType(type, shape, layout=memory_or_layout)
         self.raise_error(

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import NoReturn, TypeVar, overload
 
+from xdsl.dialects.builtin import StringAttr
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Lexer, Position, Span, Token
 
@@ -379,29 +380,31 @@ class BaseParser:
             "integer or float literal expected" + context_msg,
         )
 
-    def parse_optional_str_literal(self) -> bytes | None:
+    def parse_optional_str_literal(self) -> StringAttr | None:
         """
         Parse a string literal with the format `"..."`, if present.
 
         Returns the string contents without the quotes and with escape sequences
-        resolved.
+        resolved. Because the string is allowed to contain arbitrary binary
+        escape sequences, the result is returned as a `bytes` object.
         """
 
         if (token := self._parse_optional_token(Token.Kind.STRING_LIT)) is None:
             return None
-        return token.get_string_literal_value()
+        return StringAttr(token.get_string_literal_value())
 
-    def parse_str_literal(self, context_msg: str = "") -> str:
+    def parse_str_literal(self, context_msg: str = "") -> StringAttr:
         """
         Parse a string literal with the format `"..."`.
 
         Returns the string contents without the quotes and with escape sequences
-        resolved.
+        resolved. Because the string is allowed to contain arbitrary binary
+        escape sequences, the result is returned as a `bytes` object.
         """
         return self.expect(
             self.parse_optional_str_literal,
             "string literal expected" + context_msg,
-        ).decode()
+        )
 
     def parse_optional_identifier(self) -> str | None:
         """

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -379,7 +379,7 @@ class BaseParser:
             "integer or float literal expected" + context_msg,
         )
 
-    def parse_optional_str_literal(self) -> str | None:
+    def parse_optional_str_literal(self) -> bytes | None:
         """
         Parse a string literal with the format `"..."`, if present.
 
@@ -401,7 +401,7 @@ class BaseParser:
         return self.expect(
             self.parse_optional_str_literal,
             "string literal expected" + context_msg,
-        )
+        ).decode()
 
     def parse_optional_identifier(self) -> str | None:
         """

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -717,7 +717,7 @@ class Parser(AttrParser):
             # Generic operation format
             op_name = self.expect(
                 self.parse_optional_str_literal, "operation name expected"
-            ).decode()
+            ).escaped
             op_type = self._get_op_by_name(op_name)
             dialect_name = op_type.dialect_name()
             self._parser_state.dialect_stack.append(dialect_name)

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -717,7 +717,7 @@ class Parser(AttrParser):
             # Generic operation format
             op_name = self.expect(
                 self.parse_optional_str_literal, "operation name expected"
-            )
+            ).decode()
             op_type = self._get_op_by_name(op_name)
             dialect_name = op_type.dialect_name()
             self._parser_state.dialect_stack.append(dialect_name)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -391,13 +391,13 @@ class Printer:
             return
 
         if isinstance(attribute, StringAttr):
-            self.print_string_literal(attribute.string_value)
+            self.print_string_literal(attribute.string)
             return
 
         if isinstance(attribute, SymbolRefAttr):
-            self.print(f"@{attribute.root_reference.string_value}")
+            self.print(f"@{attribute.root_reference.string}")
             for ref in attribute.nested_references.data:
-                self.print(f"::@{ref.string_value}")
+                self.print(f"::@{ref.string}")
             return
 
         if isinstance(attribute, IntegerAttr):
@@ -515,7 +515,7 @@ class Printer:
             return
 
         if isinstance(attribute, DenseResourceAttr):
-            handle = attribute.resource_handle.string_value
+            handle = attribute.resource_handle.string
             self.print(f"dense_resource<{handle}> : ", attribute.type)
             return
 
@@ -639,14 +639,14 @@ class Printer:
             # Do not print `!` or `#` for unregistered builtin attributes
             self.print("!" if attribute.is_type.data else "#")
             if attribute.is_opaque.data:
-                self.print(attribute.attr_name.string_value.replace(".", "<", 1))
-                self.print(attribute.value.string_value)
+                self.print(attribute.attr_name.string.replace(".", "<", 1))
+                self.print(attribute.value.string)
                 self.print(">")
             else:
-                self.print(attribute.attr_name.string_value)
+                self.print(attribute.attr_name.string)
                 if attribute.value.data:
                     self.print("<")
-                    self.print(attribute.value.string_value)
+                    self.print(attribute.value.string)
                     self.print(">")
             return
 
@@ -791,7 +791,7 @@ class Printer:
         self._print_results(op)
         use_custom_format = False
         if isinstance(op, UnregisteredOp):
-            self.print(f'"{op.op_name.string_value}"')
+            self.print(f'"{op.op_name.string}"')
         # If we print with the generic format, or the operation does not have a custom
         # format
         elif self.print_generic_format or Operation.print is type(op).print:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -394,9 +394,9 @@ class Printer:
             return
 
         if isinstance(attribute, SymbolRefAttr):
-            self.print(f"@{attribute.root_reference.string}")
+            self.print(f"@{attribute.root_reference.escaped}")
             for ref in attribute.nested_references.data:
-                self.print(f"::@{ref.string}")
+                self.print(f"::@{ref.escaped}")
             return
 
         if isinstance(attribute, IntegerAttr):
@@ -638,7 +638,7 @@ class Printer:
             # Do not print `!` or `#` for unregistered builtin attributes
             self.print("!" if attribute.is_type.data else "#")
             if attribute.is_opaque.data:
-                self.print(attribute.attr_name.string.replace(".", "<", 1))
+                self.print(attribute.attr_name.escaped.replace(".", "<", 1))
                 self.print(attribute.value.string)
                 self.print(">")
             else:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -391,13 +391,13 @@ class Printer:
             return
 
         if isinstance(attribute, StringAttr):
-            self.print_string_literal(attribute.data)
+            self.print_string_literal(attribute.string_value)
             return
 
         if isinstance(attribute, SymbolRefAttr):
-            self.print(f"@{attribute.root_reference.data}")
+            self.print(f"@{attribute.root_reference.string_value}")
             for ref in attribute.nested_references.data:
-                self.print(f"::@{ref.data}")
+                self.print(f"::@{ref.string_value}")
             return
 
         if isinstance(attribute, IntegerAttr):
@@ -515,7 +515,7 @@ class Printer:
             return
 
         if isinstance(attribute, DenseResourceAttr):
-            handle = attribute.resource_handle.data
+            handle = attribute.resource_handle.string_value
             self.print(f"dense_resource<{handle}> : ", attribute.type)
             return
 
@@ -639,14 +639,14 @@ class Printer:
             # Do not print `!` or `#` for unregistered builtin attributes
             self.print("!" if attribute.is_type.data else "#")
             if attribute.is_opaque.data:
-                self.print(attribute.attr_name.data.replace(".", "<", 1))
-                self.print(attribute.value.data)
+                self.print(attribute.attr_name.string_value.replace(".", "<", 1))
+                self.print(attribute.value.string_value)
                 self.print(">")
             else:
-                self.print(attribute.attr_name.data)
+                self.print(attribute.attr_name.string_value)
                 if attribute.value.data:
                     self.print("<")
-                    self.print(attribute.value.data)
+                    self.print(attribute.value.string_value)
                     self.print(">")
             return
 
@@ -791,7 +791,7 @@ class Printer:
         self._print_results(op)
         use_custom_format = False
         if isinstance(op, UnregisteredOp):
-            self.print(f'"{op.op_name.data}"')
+            self.print(f'"{op.op_name.string_value}"')
         # If we print with the generic format, or the operation does not have a custom
         # format
         elif self.print_generic_format or Operation.print is type(op).print:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -350,8 +349,8 @@ class Printer:
         self.print_list(params, self.print_attribute)
         self.print(">")
 
-    def print_string_literal(self, string: str):
-        self.print(json.dumps(string))
+    def print_string_attribute(self, attribute: StringAttr) -> None:
+        self.print(f'"{attribute.escaped}"')
 
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, UnitAttr):
@@ -391,7 +390,7 @@ class Printer:
             return
 
         if isinstance(attribute, StringAttr):
-            self.print_string_literal(attribute.string)
+            self.print_string_attribute(attribute)
             return
 
         if isinstance(attribute, SymbolRefAttr):

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -232,7 +232,9 @@ class SymbolTable(OpTrait):
             if not isinstance(sym_name, StringAttr):
                 continue
             if sym_name in met_names:
-                raise VerifyException(f'Redefinition of symbol "{sym_name.data}"')
+                raise VerifyException(
+                    f'Redefinition of symbol "{sym_name.string_value}"'
+                )
             met_names.add(sym_name)
 
     @staticmethod

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -232,9 +232,7 @@ class SymbolTable(OpTrait):
             if not isinstance(sym_name, StringAttr):
                 continue
             if sym_name in met_names:
-                raise VerifyException(
-                    f'Redefinition of symbol "{sym_name.string_value}"'
-                )
+                raise VerifyException(f'Redefinition of symbol "{sym_name.string}"')
             met_names.add(sym_name)
 
     @staticmethod

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -949,14 +949,14 @@ class GroupLoadsUnderSameDataflow(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: Call, rewriter: PatternRewriter, /):
-        if op.callee.root_reference.string_value == "dummy_load_data":
+        if op.callee.root_reference.string == "dummy_load_data":
             self.n_input = get_number_input_stencils(
                 typing.cast(
                     func.FuncOp, typing.cast(PragmaDataflow, op.parent_op()).parent_op()
                 )
             )
         if (
-            op.callee.root_reference.string_value == "dummy_load_data"
+            op.callee.root_reference.string == "dummy_load_data"
             and self.n_current_load < self.n_input
         ):
             self.n_current_load += 1

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -949,14 +949,14 @@ class GroupLoadsUnderSameDataflow(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: Call, rewriter: PatternRewriter, /):
-        if op.callee.root_reference.data == "dummy_load_data":
+        if op.callee.root_reference.string_value == "dummy_load_data":
             self.n_input = get_number_input_stencils(
                 typing.cast(
                     func.FuncOp, typing.cast(PragmaDataflow, op.parent_op()).parent_op()
                 )
             )
         if (
-            op.callee.root_reference.data == "dummy_load_data"
+            op.callee.root_reference.string_value == "dummy_load_data"
             and self.n_current_load < self.n_input
         ):
             self.n_current_load += 1

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -263,7 +263,7 @@ class PragmaPipelineToFunc(RewritePattern):
         pipeline_func_name = f"_pipeline_{ii}_"
         func1 = FuncOp.external(pipeline_func_name, [], [])
 
-        call1 = Call(func1.sym_name.string_value, [], [])
+        call1 = Call(func1.sym_name.string, [], [])
 
         if pipeline_func_name not in self.declared_pipeline_names:
             self.module.body.block.add_op(func1)
@@ -288,7 +288,7 @@ class PragmaUnrollToFunc(RewritePattern):
         region1 = Region(block1)
         func1 = FuncOp.from_region(f"_unroll_{factor}_", [], [], region1)
 
-        call1 = Call(func1.sym_name.string_value, [], [])
+        call1 = Call(func1.sym_name.string, [], [])
 
         self.module.body.block.add_op(func1)
 

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -263,7 +263,7 @@ class PragmaPipelineToFunc(RewritePattern):
         pipeline_func_name = f"_pipeline_{ii}_"
         func1 = FuncOp.external(pipeline_func_name, [], [])
 
-        call1 = Call(func1.sym_name.data, [], [])
+        call1 = Call(func1.sym_name.string_value, [], [])
 
         if pipeline_func_name not in self.declared_pipeline_names:
             self.module.body.block.add_op(func1)
@@ -288,7 +288,7 @@ class PragmaUnrollToFunc(RewritePattern):
         region1 = Region(block1)
         func1 = FuncOp.from_region(f"_unroll_{factor}_", [], [], region1)
 
-        call1 = Call(func1.sym_name.data, [], [])
+        call1 = Call(func1.sym_name.string_value, [], [])
 
         self.module.body.block.add_op(func1)
 

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -263,7 +263,7 @@ class PragmaPipelineToFunc(RewritePattern):
         pipeline_func_name = f"_pipeline_{ii}_"
         func1 = FuncOp.external(pipeline_func_name, [], [])
 
-        call1 = Call(func1.sym_name.string, [], [])
+        call1 = Call(func1.sym_name, [], [])
 
         if pipeline_func_name not in self.declared_pipeline_names:
             self.module.body.block.add_op(func1)
@@ -288,7 +288,7 @@ class PragmaUnrollToFunc(RewritePattern):
         region1 = Region(block1)
         func1 = FuncOp.from_region(f"_unroll_{factor}_", [], [], region1)
 
-        call1 = Call(func1.sym_name.string, [], [])
+        call1 = Call(func1.sym_name, [], [])
 
         self.module.body.block.add_op(func1)
 

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -225,8 +225,8 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
         Translates an MPI dialect operation to the corresponding numeric value
         required by the underlying MPI library
         """
-        if hasattr(self.info, op_attr.op_str.data):
-            return getattr(self.info, op_attr.op_str.data)
+        if hasattr(self.info, op_attr.op_str.string_value):
+            return getattr(self.info, op_attr.op_str.string_value)
         else:
             raise RuntimeError("Unknown MPI operation type")
 

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -225,8 +225,8 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
         Translates an MPI dialect operation to the corresponding numeric value
         required by the underlying MPI library
         """
-        if hasattr(self.info, op_attr.op_str.string):
-            return getattr(self.info, op_attr.op_str.string)
+        if hasattr(self.info, op_attr.op_str.escaped):
+            return getattr(self.info, op_attr.op_str.escaped)
         else:
             raise RuntimeError("Unknown MPI operation type")
 

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -225,8 +225,8 @@ class _MPIToLLVMRewriteBase(RewritePattern, ABC):
         Translates an MPI dialect operation to the corresponding numeric value
         required by the underlying MPI library
         """
-        if hasattr(self.info, op_attr.op_str.string_value):
-            return getattr(self.info, op_attr.op_str.string_value)
+        if hasattr(self.info, op_attr.op_str.string):
+            return getattr(self.info, op_attr.op_str.string)
         else:
             raise RuntimeError("Unknown MPI operation type")
 

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -67,7 +67,7 @@ class InsertExitSyscallOp(RewritePattern):
         parent_op = op.parent_op()
         if (
             not isinstance(parent_op, riscv_func.FuncOp)
-            or parent_op.sym_name.string_value != "main"
+            or parent_op.sym_name.string != "main"
         ):
             return
 

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -67,7 +67,7 @@ class InsertExitSyscallOp(RewritePattern):
         parent_op = op.parent_op()
         if (
             not isinstance(parent_op, riscv_func.FuncOp)
-            or parent_op.sym_name.data != "main"
+            or parent_op.sym_name.string_value != "main"
         ):
             return
 

--- a/xdsl/transforms/printf_to_llvm.py
+++ b/xdsl/transforms/printf_to_llvm.py
@@ -59,7 +59,7 @@ def _format_string_spec_from_print_op(
 
     Empty string parts are omitted.
     """
-    format_str = op.format_str.string_value.split("{}")
+    format_str = op.format_str.string.split("{}")
     args = iter(op.format_vals)
 
     for part in format_str[:-1]:
@@ -130,7 +130,7 @@ class PrintlnOpToPrintfCall(RewritePattern):
                 format_str += _format_str_for_type(part.type)
 
         globl = self._construct_global(format_str + "\n")
-        self.collected_global_symbs[globl.sym_name.string_value] = globl
+        self.collected_global_symbs[globl.sym_name.string] = globl
 
         rewriter.replace_matched_op(
             casts

--- a/xdsl/transforms/printf_to_llvm.py
+++ b/xdsl/transforms/printf_to_llvm.py
@@ -59,7 +59,7 @@ def _format_string_spec_from_print_op(
 
     Empty string parts are omitted.
     """
-    format_str = op.format_str.string.split("{}")
+    format_str = op.format_str.escaped.split("{}")
     args = iter(op.format_vals)
 
     for part in format_str[:-1]:
@@ -130,7 +130,7 @@ class PrintlnOpToPrintfCall(RewritePattern):
                 format_str += _format_str_for_type(part.type)
 
         globl = self._construct_global(format_str + "\n")
-        self.collected_global_symbs[globl.sym_name.string] = globl
+        self.collected_global_symbs[globl.sym_name.escaped] = globl
 
         rewriter.replace_matched_op(
             casts

--- a/xdsl/transforms/printf_to_llvm.py
+++ b/xdsl/transforms/printf_to_llvm.py
@@ -59,7 +59,7 @@ def _format_string_spec_from_print_op(
 
     Empty string parts are omitted.
     """
-    format_str = op.format_str.data.split("{}")
+    format_str = op.format_str.string_value.split("{}")
     args = iter(op.format_vals)
 
     for part in format_str[:-1]:
@@ -130,7 +130,7 @@ class PrintlnOpToPrintfCall(RewritePattern):
                 format_str += _format_str_for_type(part.type)
 
         globl = self._construct_global(format_str + "\n")
-        self.collected_global_symbs[globl.sym_name.data] = globl
+        self.collected_global_symbs[globl.sym_name.string_value] = globl
 
         rewriter.replace_matched_op(
             casts


### PR DESCRIPTION
Welcome to this fun ride!
This started because I wanted to parse MLIR's output, including serialized GPU binaries.
So far, we escaped string literals, parsing "\n" as a newline for example, and stored this in StringAttr; all was well
Until we want to parse those serialized binaries: containing arbitrary escaped bytes. No big of a deal in C++, but in Python, escaping those lead to sequences of bytes that are not decodable as Unicode.. (C++ just doesn't decode in general)
This PR prepares the terrain by switching StringAttr to hold bytes rather than a decoded string, exposing a method to get the decoded string we were using so far.