### PR TITLE
dialects: (riscv_scv) Add reverse order for (rof) op

### DIFF
--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -31,7 +31,7 @@ riscv_scf.rof %j : !riscv.reg<> = %ub down to %lb step %step {
 // CHECK-NEXT:     %0 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:     riscv_scf.yield
 // CHECK-NEXT:   }
-// CHECK-NEXT:   riscv_scf.rof %j : !riscv.reg<> = %ub to %lb step %step {
+// CHECK-NEXT:   riscv_scf.rof %j : !riscv.reg<> = %ub down to %lb step %step {
 // CHECK-NEXT:     %1 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:     riscv_scf.yield
 // CHECK-NEXT:   }

--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -8,7 +8,7 @@ riscv_scf.for %i : !riscv.reg<> = %lb to %ub step %step {
     "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
     "riscv_scf.yield"() : () -> ()
 }
-riscv_scf.rof %j : !riscv.reg<> = %ub to %lb step %step {
+riscv_scf.rof %j : !riscv.reg<> = %ub down to %lb step %step {
     "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
     "riscv_scf.yield"() : () -> ()
 }

--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -8,6 +8,10 @@ riscv_scf.for %i : !riscv.reg<> = %lb to %ub step %step {
     "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
     "riscv_scf.yield"() : () -> ()
 }
+riscv_scf.rof %j : !riscv.reg<> = %ub to %lb step %step {
+    "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
+    "riscv_scf.yield"() : () -> ()
+}
 %i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) {
         %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
         riscv_scf.condition(%cond : !riscv.reg<>) %i0, %ub_arg0, %step_arg0 : !riscv.reg<>, !riscv.reg<>, !riscv.reg<>
@@ -25,6 +29,10 @@ riscv_scf.for %i : !riscv.reg<> = %lb to %ub step %step {
 // CHECK-NEXT:   %acc = riscv.li 0 : () -> !riscv.reg<t0>
 // CHECK-NEXT:   riscv_scf.for %i : !riscv.reg<> = %lb to %ub step %step {
 // CHECK-NEXT:     %0 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+// CHECK-NEXT:     riscv_scf.yield
+// CHECK-NEXT:   }
+// CHECK-NEXT:   riscv_scf.rof %j : !riscv.reg<> = %ub to %lb step %step {
+// CHECK-NEXT:     %1 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:     riscv_scf.yield
 // CHECK-NEXT:   }
 // CHECK-NEXT:     %i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) {

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -226,7 +226,7 @@ class RofOp(ForRofOperation):
     In order to express loops that count down in higher-level IR, the rof op
     is needed.
 
-    Rof has the semantics of going from lb to ub, decrementing by step each time.
+    Rof has the semantics of going from ub to lb, decrementing by step each time.
     The implicit constraints are that lb < ub, and step > 0.
 
     In order to convert a for to a rof, one needs to switch lb and ub.

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -40,7 +40,9 @@ from xdsl.utils.exceptions import VerifyException
 class YieldOp(AbstractYieldOperation[RISCVRegisterType]):
     name = "riscv_scf.yield"
 
-    traits = traits_def(lambda: frozenset([IsTerminator(), HasParent(WhileOp, ForRofBaseOp)]))
+    traits = traits_def(
+        lambda: frozenset([IsTerminator(), HasParent(WhileOp, ForRofBaseOp)])
+    )
 
 
 class ForRofBaseOp(IRDLOperation):
@@ -191,6 +193,7 @@ class ForOp(ForRofBaseOp):
     """
     A for loop, counting up from lb to ub by step each iteration.
     """
+
     name = "riscv_scf.for"
 
 
@@ -209,6 +212,7 @@ class RofOp(ForRofBaseOp):
     In order to convert a for to a rof, one needs to switch lb and ub.
     (for the normalized case that (ub - lb) % step == 0)
     """
+
     name = "riscv_scf.rof"
 
 

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -221,12 +221,13 @@ class RofOp(ForRofBaseOp):
     """
     Reverse Order For loop.
 
-    MLIRs for loops have the implicit constraint that lb < ub, and step > 0.
+    MLIR's for loops have the implicit constraint that lb < ub, and step > 0.
 
     In order to express loops that count down in higher-level IR, the rof op
     is needed.
 
-    ROF has the semantics of going from lb to ub, decrementing by step each time.
+    Rof has the semantics of going from lb to ub, decrementing by step each time.
+    The implicit constraints are that lb < ub, and step > 0.
 
     In order to convert a for to a rof, one needs to switch lb and ub.
     (for the normalized case that (ub - lb) % step == 0)

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -221,9 +221,8 @@ class RofOp(ForRofOperation):
     """
     Reverse Order For loop.
 
-    MLIR's for loops have the implicit constraint that lb < ub, and step > 0.
-
-    In order to express loops that count down in higher-level IR, the rof op
+    MLIR's for loops have the constraint of always executing from lb to ub,
+    so in order to express loops that count down from ub to lb, the rof op
     is needed.
 
     Rof has the semantics of going from ub to lb, decrementing by step each time.

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -4,7 +4,7 @@ RISC-V SCF dialect
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from typing_extensions import Self
@@ -43,11 +43,11 @@ class YieldOp(AbstractYieldOperation[RISCVRegisterType]):
     name = "riscv_scf.yield"
 
     traits = traits_def(
-        lambda: frozenset([IsTerminator(), HasParent(WhileOp, ForRofBaseOp)])
+        lambda: frozenset([IsTerminator(), HasParent(WhileOp, ForRofOperation)])
     )
 
 
-class ForRofBaseOp(IRDLOperation):
+class ForRofOperation(IRDLOperation, ABC):
     lb: Operand = operand_def(IntRegisterType)
     ub: Operand = operand_def(IntRegisterType)
     step: Operand = operand_def(IntRegisterType)
@@ -196,7 +196,7 @@ class ForRofBaseOp(IRDLOperation):
 
 
 @irdl_op_definition
-class ForOp(ForRofBaseOp):
+class ForOp(ForRofOperation):
     """
     A for loop, counting up from lb to ub by step each iteration.
     """
@@ -217,7 +217,7 @@ class ForOp(ForRofBaseOp):
 
 
 @irdl_op_definition
-class RofOp(ForRofBaseOp):
+class RofOp(ForRofOperation):
     """
     Reverse Order For loop.
 


### PR DESCRIPTION
Adds the `riscv_scf.rof` (reverse order for) operation.

MLIRs for loops have the implicit constraint that `lb < ub`, and `step > 0`.

In order to express loops that count down in higher-level IR, the rof op
is needed.

ROF has the semantics of going from ub to lb, decrementing by step each time.

In order to convert a for to a rof, one needs to switch lb and ub.
(for the normalized case that `(ub - lb) % step == 0`)
