### PR TITLE
dialects: (scf) Add scf.rof (reverse order for)

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -261,13 +261,13 @@ def test_memref_matmul_verify():
                         memref.Store.get(new_out_val, out, [i, j])
                         scf.Yield()
 
-                    scf.For(lit0, dim_a1, lit1, [], inner_loop)
+                    scf.ForOp(lit0, dim_a1, lit1, [], inner_loop)
                     scf.Yield()
 
-                scf.For(lit0, dim_b0, lit1, [], mid_loop)
+                scf.ForOp(lit0, dim_b0, lit1, [], mid_loop)
                 scf.Yield()
 
-            scf.For(lit0, dim_a0, lit1, [], outer_loop)
+            scf.ForOp(lit0, dim_a0, lit1, [], outer_loop)
 
             func.Return(out)
 

--- a/tests/dialects/test_scf.py
+++ b/tests/dialects/test_scf.py
@@ -10,7 +10,7 @@ from xdsl.builder import Builder
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import IndexType, ModuleOp, i32, i64
 from xdsl.dialects.scf import (
-    For,
+    ForOp,
     If,
     ParallelOp,
     ReduceOp,
@@ -35,7 +35,7 @@ def test_for_with_loop_carried_verify():
     def body(_: tuple[BlockArgument, ...]) -> None:
         Yield(carried)
 
-    for_op = For(lower, upper, step, [carried], body)
+    for_op = ForOp(lower, upper, step, [carried], body)
 
     assert for_op.lb is lower.result
     assert for_op.ub is upper.result
@@ -68,7 +68,7 @@ def test_for_without_loop_carried_verify():
     def body(_: tuple[BlockArgument, ...]) -> None:
         Yield()
 
-    for_op = For(lower, upper, step, [], body)
+    for_op = ForOp(lower, upper, step, [], body)
 
     assert for_op.lb is lower.result
     assert for_op.ub is upper.result

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -158,4 +158,28 @@ builtin.module {
   // CHECK-NEXT: }
 
 
+  func.func @rof() {
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 42 : index
+    %s = arith.constant 3 : index
+    %prod = arith.constant 1 : index
+    %res_1 = scf.rof %iv = %ub down to %lb step %s iter_args(%prod_iter = %prod) -> (index) {
+      %prod_new = arith.muli %prod_iter, %iv : index
+      scf.yield %prod_new : index
+    }
+    func.return
+  }
+
+  // CHECK-NEXT: func.func @rof() {
+  // CHECK-NEXT:   %{{.*}} = arith.constant 0 : index
+  // CHECK-NEXT:   %{{.*}} = arith.constant 42 : index
+  // CHECK-NEXT:   %{{.*}} = arith.constant 3 : index
+  // CHECK-NEXT:   %{{.*}} = arith.constant 1 : index
+  // CHECK-NEXT:   %{{.*}} = scf.rof %{{.*}} = %{{.*}} down to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (index) {
+  // CHECK-NEXT:     %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
+  // CHECK-NEXT:     scf.yield %{{.*}} : index
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   func.return
+  // CHECK-NEXT: }
+
 }

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -163,7 +163,7 @@ builtin.module {
     %ub = arith.constant 42 : index
     %s = arith.constant 3 : index
     %prod = arith.constant 1 : index
-    %res_1 = scf.rof %iv = %ub down to %lb step %s iter_args(%prod_iter = %prod) -> (index) {
+    %res_1 = scf.xdsl.rof %iv = %ub down to %lb step %s iter_args(%prod_iter = %prod) -> (index) {
       %prod_new = arith.muli %prod_iter, %iv : index
       scf.yield %prod_new : index
     }
@@ -175,7 +175,7 @@ builtin.module {
   // CHECK-NEXT:   %{{.*}} = arith.constant 42 : index
   // CHECK-NEXT:   %{{.*}} = arith.constant 3 : index
   // CHECK-NEXT:   %{{.*}} = arith.constant 1 : index
-  // CHECK-NEXT:   %{{.*}} = scf.rof %{{.*}} = %{{.*}} down to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (index) {
+  // CHECK-NEXT:   %{{.*}} = scf.xdsl.rof %{{.*}} = %{{.*}} down to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (index) {
   // CHECK-NEXT:     %{{.*}} = arith.muli %{{.*}}, %{{.*}} : index
   // CHECK-NEXT:     scf.yield %{{.*}} : index
   // CHECK-NEXT:   }

--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -36,7 +36,7 @@ def sum_to_for_op():
             res = arith.Addi(i, acc)
             scf.Yield(res)
 
-        result = scf.For(lb, ub, step, (initial,), for_loop_region)
+        result = scf.ForOp(lb, ub, step, (initial,), for_loop_region)
         func.Return(result)
 
 

--- a/xdsl/backend/riscv/lowering/convert_scf_to_riscv_scf.py
+++ b/xdsl/backend/riscv/lowering/convert_scf_to_riscv_scf.py
@@ -18,7 +18,7 @@ from xdsl.pattern_rewriter import (
 
 class ScfForLowering(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: scf.For, rewriter: PatternRewriter) -> None:
+    def match_and_rewrite(self, op: scf.ForOp, rewriter: PatternRewriter) -> None:
         lb, ub, step, *args = cast_operands_to_regs(rewriter)
         new_region = rewriter.move_region_contents_to_new_regions(op.body)
         cast_block_args_to_regs(new_region.block, rewriter)

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -153,7 +153,7 @@ class Yield(AbstractYieldOperation[Attribute]):
     name = "scf.yield"
 
     traits = traits_def(
-        lambda: frozenset([IsTerminator(), HasParent(ForOp, If, ParallelOp, While)])
+        lambda: frozenset([IsTerminator(), HasParent(ForRofOperation, If, ParallelOp, While)])
     )
 
 
@@ -286,9 +286,7 @@ class ForRofOperation(IRDLOperation, ABC):
         printer.print_string(" ")
         printer.print_ssa_value(indvar)
         printer.print_string(" = ")
-        printer.print_ssa_value(self.lb)
-        printer.print_string(" to ")
-        printer.print_ssa_value(self.ub)
+        self._print_bounds(printer)
         printer.print_string(" step ")
         printer.print_ssa_value(self.step)
         printer.print_string(" ")
@@ -317,9 +315,7 @@ class ForRofOperation(IRDLOperation, ABC):
         # Parse bounds
         unresolved_indvar = parser.parse_argument(expect_type=False)
         parser.parse_characters("=")
-        lb = parser.parse_operand()
-        parser.parse_characters("to")
-        ub = parser.parse_operand()
+        lb, ub = cls._parse_bounds(parser)
         parser.parse_characters("step")
         step = parser.parse_operand()
 

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-
 from collections.abc import Sequence
 from typing import Annotated
 

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -405,7 +405,7 @@ class RofOp(ForRofOperation):
     (for the normalized case that (ub - lb) % step == 0)
     """
 
-    name = "scf.rof"
+    name = "scf.xdsl.rof"
 
     def _print_bounds(self, printer: Printer):
         printer.print_ssa_value(self.ub)

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -153,7 +153,9 @@ class Yield(AbstractYieldOperation[Attribute]):
     name = "scf.yield"
 
     traits = traits_def(
-        lambda: frozenset([IsTerminator(), HasParent(ForRofOperation, If, ParallelOp, While)])
+        lambda: frozenset(
+            [IsTerminator(), HasParent(ForRofOperation, If, ParallelOp, While)]
+        )
     )
 
 

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -455,7 +455,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
             assert isinstance(start, SSAValue)
             assert isinstance(end, SSAValue)
             assert isinstance(step, SSAValue)
-            op = scf.For(start, end, step, [], body)
+            op = scf.ForOp(start, end, step, [], body)
 
         self.inserter.set_insertion_point_from_block(curr_block)
         self.inserter.insert_op(op)

--- a/xdsl/interpreters/scf.py
+++ b/xdsl/interpreters/scf.py
@@ -21,9 +21,9 @@ class ScfFunctions(InterpreterFunctions):
         results = interpreter.run_ssacfg_region(region, ())
         return results
 
-    @impl(scf.For)
+    @impl(scf.ForOp)
     def run_for(
-        self, interpreter: Interpreter, op: scf.For, args: PythonValues
+        self, interpreter: Interpreter, op: scf.ForOp, args: PythonValues
     ) -> PythonValues:
         lb, ub, step, *loop_args = args
         loop_args = tuple(loop_args)

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -111,7 +111,7 @@ def gen_duplicate_loop(
     ub = n
     step = Constant.from_int_and_width(1, IndexType())
 
-    for_duplicate = scf.For(lb, ub, step, [], for_body)
+    for_duplicate = scf.ForOp(lb, ub, step, [], for_body)
 
     return [ii, lb, ub, step, for_duplicate]
 
@@ -418,7 +418,7 @@ def transform_apply_into_loop(
     # The for loop for the y index receives its trip variable from the get_chunk_size function, since the chunking
     # is happening in the y axis. TODO: this is currently intended for the 3D case. It should be extended to the
     # 1D and 2D cases as well.
-    y_for_op: scf.For
+    y_for_op: scf.ForOp
 
     # Pipeline the loop
     ii = Constant.from_int_and_width(1, i32)
@@ -426,9 +426,9 @@ def transform_apply_into_loop(
 
     # current_region = for_body
     current_region = body
-    for_op_lst: list[scf.For] = []
+    for_op_lst: list[scf.ForOp] = []
     for i in range(1, dim + 1):
-        for_op = scf.For(
+        for_op = scf.ForOp(
             lb=lowerBounds[-i],
             ub=upperBounds[-i],
             step=one,
@@ -1190,7 +1190,7 @@ class MakeLocaCopiesOfCoefficients(RewritePattern):
                 yield_op = scf.Yield()
                 builder.insert(yield_op)
 
-            for_local_copies = scf.For(lb, ub, step, [], for_body)
+            for_local_copies = scf.ForOp(lb, ub, step, [], for_body)
             rewriter.insert_op_before_matched_op([lb, ub, step, ii, for_local_copies])
 
             self.inserted_already = True

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -25,7 +25,7 @@ from xdsl.dialects.llvm import (
     LoadOp,
     StoreOp,
 )
-from xdsl.dialects.scf import For, ParallelOp, Yield
+from xdsl.dialects.scf import ForOp, ParallelOp, Yield
 from xdsl.ir import Block, MLContext, Operation, OpResult, Region, Use
 from xdsl.irdl import VarOperand, VarOpResult
 from xdsl.passes import ModulePass
@@ -350,9 +350,9 @@ class SCFParallelToHLSPipelinedFor(RewritePattern):
             for_region.block.erase_arg(for_region.block.args[i])
 
         if res != []:
-            for_op = For.get(lb[-1], ub[-1], step[-1], [res[0].op], for_region)
+            for_op = ForOp(lb[-1], ub[-1], step[-1], [res[0].op], for_region)
         else:
-            for_op = For.get(lb[-1], ub[-1], step[-1], [], for_region)
+            for_op = ForOp(lb[-1], ub[-1], step[-1], [], for_region)
 
         for i in range(len(lb) - 2, -1, -1):
             for_region = Region(Block([for_op]))
@@ -370,7 +370,7 @@ class SCFParallelToHLSPipelinedFor(RewritePattern):
             )
             yieldop = Yield()
             for_region.block.add_op(yieldop)
-            for_op = For.get(lb[i], ub[i], step[i], [], for_region)
+            for_op = ForOp(lb[i], ub[i], step[i], [], for_region)
 
         for_region.block.insert_op_before(
             hls_pipeline_op, cast(Operation, for_region.block.first_op)

--- a/xdsl/transforms/lower_affine.py
+++ b/xdsl/transforms/lower_affine.py
@@ -114,7 +114,7 @@ class LowerAffineFor(RewritePattern):
         step_op = arith.Constant(op.step)
         rewriter.insert_op_before_matched_op(step_op)
         rewriter.replace_matched_op(
-            scf.For(
+            scf.ForOp(
                 lb_val,
                 ub_val,
                 step_op.result,

--- a/xdsl/transforms/printf_to_putchar.py
+++ b/xdsl/transforms/printf_to_putchar.py
@@ -132,7 +132,7 @@ def get_mlir_itoa():
 
         return absolute_value.results[0]
 
-    def print_digits(digits: SSAValue, absolute_value: SSAValue) -> scf.For:
+    def print_digits(digits: SSAValue, absolute_value: SSAValue) -> scf.ForOp:
         """
         Return an scf.for loop that prints all digits of the given value.
         In python code:
@@ -147,7 +147,7 @@ def get_mlir_itoa():
         loop_body = Block(arg_types=(IndexType(),))
 
         # Print all from most significant to least
-        for_loop = scf.For(zero_index, digits_index, one_index, (), loop_body)
+        for_loop = scf.ForOp(zero_index, digits_index, one_index, (), loop_body)
         with ImplicitBuilder(loop_body) as (index_var,):
             one = arith.Constant.from_int_and_width(1, i32)
             size_minus_one = arith.Subi(digits, one)


### PR DESCRIPTION
Add the `scf.rof`, a reverse order for loop.

This PR also renames `For` to `ForOp` to be in line with other operation names.

This PR also deletes the deprecated `ForOp.get` constructor.