### PR TITLE
testing: add kernels from our paper with verified assembly

### DIFF
--- a/tests/filecheck/projects/riscv-backend-paper/conv_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/conv_target.mlir
@@ -1,0 +1,107 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "conv_2d_nchw_fchw_d1_s1_3x3"
+  riscv.directive ".p2align" "2"
+// x[ M x K ]
+// y[ K x N ]
+// g[ M x N ]
+riscv_func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
+    %X: !riscv.reg<a0>,
+    %Y: !riscv.reg<a1>,
+    %Z: !riscv.reg<a2>
+) -> () {
+    %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
+    %Z_moved = riscv.mv %Z : (!riscv.reg<a2>) -> !riscv.reg<>
+
+    %c0 = riscv.get_register : () -> !riscv.reg<zero>
+    %c1 = riscv.li 1 : () -> !riscv.reg<>
+    %c8 = riscv.li 8 : () -> !riscv.reg<>
+
+    %zero_float = riscv.fcvt.d.w %c0 : (!riscv.reg<zero>) -> !riscv.freg<>
+
+    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<6>, #builtin.int<6>], "strides" = [#builtin.int<8>, #builtin.int<64>, #builtin.int<8>, #builtin.int<64>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<4>
+    %stride_pattern_1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<6>, #builtin.int<6>], "strides" = [#builtin.int<8>, #builtin.int<24>, #builtin.int<0>, #builtin.int<0>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<4>
+
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern_0, %stride_pattern_1) <{"operandSegmentSizes" = array<i32: 2, 0, 2>}> ({
+    ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
+      %c288 = riscv.li 288 : () -> !riscv.reg<>
+      riscv_scf.for %z_i : !riscv.reg<> = %c0 to %c288 step %c8 {
+        %Z_dest = riscv.add %Z_moved, %z_i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+        %c = riscv.fld %Z_dest, 0 : (!riscv.reg<>) -> !riscv.freg<>
+
+        %z = riscv_snitch.frep_outer %c8 iter_args(%acc = %c) -> (!riscv.freg<>) {
+          %x = riscv_snitch.read from %X_stream : !riscv.freg<ft0>
+          %y = riscv_snitch.read from %Y_stream : !riscv.freg<ft1>
+          %res = riscv.fmadd.d %x, %y, %acc : (!riscv.freg<ft0>, !riscv.freg<ft1>, !riscv.freg<>) -> !riscv.freg<>
+          riscv_snitch.frep_yield %res : !riscv.freg<>
+        }
+
+        riscv.fsd %Z_dest, %z, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
+
+        riscv_scf.yield
+      }
+    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<4>, !snitch_stream.stride_pattern_type<4>) -> ()
+
+    riscv_func.return
+  }
+}
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  conv_2d_nchw_fchw_d1_s1_3x3:
+// CHECK-NEXT:      mv t4, a0
+// CHECK-NEXT:      mv t3, a1
+// CHECK-NEXT:      mv t1, a2
+// CHECK-NEXT:      li t0, 8
+// CHECK-NEXT:      li t5, 8
+// CHECK-NEXT:      li t6, 2
+// CHECK-NEXT:      li a3, 2
+// CHECK-NEXT:      li a4, 5
+// CHECK-NEXT:      li a5, 5
+// CHECK-NEXT:      scfgwi t6, 64
+// CHECK-NEXT:      scfgwi a3, 96
+// CHECK-NEXT:      scfgwi a4, 128
+// CHECK-NEXT:      scfgwi a5, 160
+// CHECK-NEXT:      scfgwi t5, 192
+// CHECK-NEXT:      li t5, 48
+// CHECK-NEXT:      scfgwi t5, 224
+// CHECK-NEXT:      li t5, -136
+// CHECK-NEXT:      scfgwi t5, 256
+// CHECK-NEXT:      li t5, -120
+// CHECK-NEXT:      scfgwi t5, 288
+// CHECK-NEXT:      li t5, 8
+// CHECK-NEXT:      li a5, 2
+// CHECK-NEXT:      li a4, 2
+// CHECK-NEXT:      li a3, 5
+// CHECK-NEXT:      li t6, 5
+// CHECK-NEXT:      scfgwi a5, 65
+// CHECK-NEXT:      scfgwi a4, 97
+// CHECK-NEXT:      scfgwi a3, 129
+// CHECK-NEXT:      scfgwi t6, 161
+// CHECK-NEXT:      scfgwi t5, 193
+// CHECK-NEXT:      li t5, 8
+// CHECK-NEXT:      scfgwi t5, 225
+// CHECK-NEXT:      li t5, -64
+// CHECK-NEXT:      scfgwi t5, 257
+// CHECK-NEXT:      li t5, -64
+// CHECK-NEXT:      scfgwi t5, 289
+// CHECK-NEXT:      scfgwi t4, 864
+// CHECK-NEXT:      scfgwi t3, 865
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      li t3, 288
+// CHECK-NEXT:      mv t2, zero
+// CHECK-NEXT:      bge t2, t3, scf_body_end_0_for
+// CHECK-NEXT:  scf_body_0_for:
+// CHECK-NEXT:      add t4, t1, t2
+// CHECK-NEXT:      fld ft3, 0(t4)
+// CHECK-NEXT:      frep.o t0, 1, 0, 0
+// CHECK-NEXT:      fmadd.d ft3, ft0, ft1, ft3
+// CHECK-NEXT:      fsd ft3, 0(t4)
+// CHECK-NEXT:      addi t2, t2, 8
+// CHECK-NEXT:      blt t2, t3, scf_body_0_for
+// CHECK-NEXT:  scf_body_end_0_for:
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret

--- a/tests/filecheck/projects/riscv-backend-paper/ddot_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/ddot_target.mlir
@@ -1,0 +1,58 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "ddot"
+  riscv.directive ".p2align" "2"
+
+  riscv_func.func @ddot(
+    %X : !riscv.reg<a0>,
+    %Y : !riscv.reg<a1>,
+    %G : !riscv.reg<a2>
+  ) {
+    %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
+    %G_moved = riscv.mv %G : (!riscv.reg<a2>) -> !riscv.reg<>
+
+    %stride_pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<128>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<1>
+
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern) <{"operandSegmentSizes" = array<i32: 2, 0, 1>}> ({
+    ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
+        %init = riscv.fld %G_moved, 0 : (!riscv.reg<>) -> !riscv.freg<>
+
+        %c127 = riscv.li 127: () -> !riscv.reg<>
+        %g = riscv_snitch.frep_outer %c127 iter_args(%acc = %init) -> (!riscv.freg<>) {
+          %x = riscv_snitch.read from %X_stream : !riscv.freg<ft0>
+          %y = riscv_snitch.read from %Y_stream : !riscv.freg<ft1>
+          %res = riscv.fmadd.d %x, %y, %acc : (!riscv.freg<ft0>, !riscv.freg<ft1>, !riscv.freg<>) -> !riscv.freg<>
+          riscv_snitch.frep_yield %res : !riscv.freg<>
+        }
+
+        riscv.fsd %G_moved, %g, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
+    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<1>) -> ()
+
+    riscv_func.return
+  }
+}
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl ddot
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  ddot:
+// CHECK-NEXT:      mv t2, a0
+// CHECK-NEXT:      mv t1, a1
+// CHECK-NEXT:      mv t0, a2
+// CHECK-NEXT:      li t3, 8
+// CHECK-NEXT:      li t4, 127
+// CHECK-NEXT:      scfgwi t4, 95
+// CHECK-NEXT:      scfgwi t3, 223
+// CHECK-NEXT:      scfgwi t2, 768
+// CHECK-NEXT:      scfgwi t1, 769
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      fld ft3, 0(t0)
+// CHECK-NEXT:      li t1, 127
+// CHECK-NEXT:      frep.o t1, 1, 0, 0
+// CHECK-NEXT:      fmadd.d ft3, ft0, ft1, ft3
+// CHECK-NEXT:      fsd ft3, 0(t0)
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret
+

--- a/tests/filecheck/projects/riscv-backend-paper/dense_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/dense_target.mlir
@@ -1,0 +1,124 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "dense"
+  riscv.directive ".p2align" "2"
+
+  // * Inputs:  x[ M x K ]
+  // * Weights: w[ K x N ]
+  // * Biases:  b[ M x N ]
+  // * Outputs: y[ M x N ]
+  riscv_func.func @dense(
+    %X : !riscv.reg<a0>,
+    %W : !riscv.reg<a1>,
+    %B : !riscv.reg<a2>,
+    %Y : !riscv.reg<a3>
+  ) {
+    %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
+    %W_moved = riscv.mv %W : (!riscv.reg<a1>) -> !riscv.reg<>
+    %B_moved = riscv.mv %B : (!riscv.reg<a2>) -> !riscv.reg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a3>) -> !riscv.reg<>
+
+    %c0 = riscv.get_register : () -> !riscv.reg<zero>
+    %c1 = riscv.li 1 : () -> !riscv.reg<>
+    %c8 = riscv.li 8 : () -> !riscv.reg<>
+    %c512 = riscv.li 512 : () -> !riscv.reg<>
+
+    %zero_float = riscv.fcvt.d.w %c0 : (!riscv.reg<zero>) -> !riscv.freg<>
+
+    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<8>, #builtin.int<0>, #builtin.int<64>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<3>
+
+    %stride_pattern_1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<64>, #builtin.int<8>, #builtin.int<0>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<3>
+
+    %stride_pattern_2 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<8>, #builtin.int<64>], "dm" = #builtin.int<2>} : () -> !snitch_stream.stride_pattern_type<2>
+
+    "snitch_stream.streaming_region"(%X_moved, %W_moved, %B_moved, %stride_pattern_0, %stride_pattern_1, %stride_pattern_2) <{"operandSegmentSizes" = array<i32: 3, 0, 3>}> ({
+    ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %W_stream : !stream.readable<!riscv.freg<ft1>>, %B_stream : !stream.readable<!riscv.freg<ft2>>):
+      riscv_scf.for %y_i : !riscv.reg<> = %c0 to %c512 step %c8 {
+        %Y_dest = riscv.add %Y_moved, %y_i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+        %c = riscv.fld %Y_dest, 0 : (!riscv.reg<>) -> !riscv.freg<>
+
+        %c7 = riscv.li 7 : () -> !riscv.reg<>
+        %dot = riscv_snitch.frep_outer %c7 iter_args(%acc = %c) -> (!riscv.freg<>) {
+          %x = riscv_snitch.read from %X_stream : !riscv.freg<ft0>
+          %w = riscv_snitch.read from %W_stream : !riscv.freg<ft1>
+          %res = riscv.fmadd.d %x, %w, %acc : (!riscv.freg<ft0>, !riscv.freg<ft1>, !riscv.freg<>) -> !riscv.freg<>
+          riscv_snitch.frep_yield %res : !riscv.freg<>
+        }
+
+        %b = riscv.get_float_register : () -> !riscv.freg<ft2>
+        %y_0 = riscv.fadd.d %b, %dot : (!riscv.freg<ft2>, !riscv.freg<>) -> !riscv.freg<>
+        %y_1 = riscv.fmax.d %y_0, %zero_float : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+
+        riscv.fsd %Y_dest, %y_1, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
+
+        riscv_scf.yield
+      }
+    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<3>, !snitch_stream.stride_pattern_type<3>, !snitch_stream.stride_pattern_type<2>) -> ()
+
+    riscv_func.return
+  }
+}
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl dense
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  dense:
+// CHECK-NEXT:      mv t6, a0
+// CHECK-NEXT:      mv t5, a1
+// CHECK-NEXT:      mv t4, a2
+// CHECK-NEXT:      mv t0, a3
+// CHECK-NEXT:      li t2, 512
+// CHECK-NEXT:      fcvt.d.w ft3, zero
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      li a6, 7
+// CHECK-NEXT:      li a5, 7
+// CHECK-NEXT:      li a7, 7
+// CHECK-NEXT:      scfgwi a6, 64
+// CHECK-NEXT:      scfgwi a5, 96
+// CHECK-NEXT:      scfgwi a7, 128
+// CHECK-NEXT:      scfgwi a4, 192
+// CHECK-NEXT:      li a4, -56
+// CHECK-NEXT:      scfgwi a4, 224
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      scfgwi a4, 256
+// CHECK-NEXT:      li a4, 64
+// CHECK-NEXT:      li a7, 7
+// CHECK-NEXT:      li a5, 7
+// CHECK-NEXT:      li a6, 7
+// CHECK-NEXT:      scfgwi a7, 65
+// CHECK-NEXT:      scfgwi a5, 97
+// CHECK-NEXT:      scfgwi a6, 129
+// CHECK-NEXT:      scfgwi a4, 193
+// CHECK-NEXT:      li a4, -440
+// CHECK-NEXT:      scfgwi a4, 225
+// CHECK-NEXT:      li a4, -504
+// CHECK-NEXT:      scfgwi a4, 257
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      li a6, 7
+// CHECK-NEXT:      li a5, 7
+// CHECK-NEXT:      scfgwi a6, 66
+// CHECK-NEXT:      scfgwi a5, 98
+// CHECK-NEXT:      scfgwi a4, 194
+// CHECK-NEXT:      li a4, 8
+// CHECK-NEXT:      scfgwi a4, 226
+// CHECK-NEXT:      scfgwi t6, 832
+// CHECK-NEXT:      scfgwi t5, 833
+// CHECK-NEXT:      scfgwi t4, 802
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      mv t1, zero
+// CHECK-NEXT:      bge t1, t2, scf_body_end_0_for
+// CHECK-NEXT:  scf_body_0_for:
+// CHECK-NEXT:      add t4, t0, t1
+// CHECK-NEXT:      fld ft4, 0(t4)
+// CHECK-NEXT:      li t5, 7
+// CHECK-NEXT:      frep.o t5, 1, 0, 0
+// CHECK-NEXT:      fmadd.d ft4, ft0, ft1, ft4
+// CHECK-NEXT:      fadd.d ft4, ft2, ft4
+// CHECK-NEXT:      fmax.d ft4, ft4, ft3
+// CHECK-NEXT:      fsd ft4, 0(t4)
+// CHECK-NEXT:      addi t1, t1, 8
+// CHECK-NEXT:      blt t1, t2, scf_body_0_for
+// CHECK-NEXT:  scf_body_end_0_for:
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret

--- a/tests/filecheck/projects/riscv-backend-paper/dsum_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/dsum_target.mlir
@@ -1,0 +1,51 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+  riscv.assembly_section ".text" {
+    riscv.directive ".globl" "dsum"
+    riscv.directive ".p2align" "2"
+    riscv_func.func @dsum(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.reg<a1>, %arg2 : !riscv.reg<a2>) -> !riscv.reg<a0> {
+      %0 = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
+      %1 = riscv.mv %arg1 : (!riscv.reg<a1>) -> !riscv.reg<>
+      %2 = riscv.mv %arg2 : (!riscv.reg<a2>) -> !riscv.reg<>
+      %3 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
+      %4 = riscv.li 128 : () -> !riscv.reg<>
+      "snitch_stream.streaming_region"(%0, %1, %2, %3) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+      ^0(%5 : !stream.readable<!riscv.freg<ft0>>, %6 : !stream.readable<!riscv.freg<ft1>>, %7 : !stream.writable<!riscv.freg<ft2>>):
+        %8 = riscv.addi %4, -1 : (!riscv.reg<>) -> !riscv.reg<>
+        riscv_snitch.frep_outer %8 {
+          %9 = riscv_snitch.read from %5 : !riscv.freg<ft0>
+          %10 = riscv_snitch.read from %6 : !riscv.freg<ft1>
+          %11 = riscv.fadd.d %9, %10 : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
+          riscv_snitch.write %11 to %7 : !riscv.freg<ft2>
+        }
+      }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+      %12 = riscv.mv %2 : (!riscv.reg<>) -> !riscv.reg<a0>
+      riscv_func.return %12 : !riscv.reg<a0>
+    }
+  }
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl dsum
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  dsum:
+// CHECK-NEXT:      mv t2, a0
+// CHECK-NEXT:      mv t1, a1
+// CHECK-NEXT:      mv t0, a2
+// CHECK-NEXT:      li t3, 128
+// CHECK-NEXT:      li t5, 7
+// CHECK-NEXT:      li t4, 15
+// CHECK-NEXT:      scfgwi t5, 95
+// CHECK-NEXT:      scfgwi t4, 127
+// CHECK-NEXT:      scfgwi t3, 223
+// CHECK-NEXT:      li t3, -888
+// CHECK-NEXT:      scfgwi t3, 255
+// CHECK-NEXT:      scfgwi t2, 800
+// CHECK-NEXT:      scfgwi t1, 801
+// CHECK-NEXT:      scfgwi t0, 930
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      li t1, 127
+// CHECK-NEXT:      frep.o t1, 1, 0, 0
+// CHECK-NEXT:      fadd.d ft2, ft0, ft1
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      mv a0, t0
+// CHECK-NEXT:      ret

--- a/tests/filecheck/projects/riscv-backend-paper/fill_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/fill_target.mlir
@@ -1,0 +1,48 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "fill"
+  riscv.directive ".p2align" "2"
+
+  // y[ 16 x 16 ]
+  riscv_func.func @fill(
+    %X : !riscv.freg<fa0>,
+    %Y : !riscv.reg<a0>
+  ) {
+    %X_moved = riscv.fmv.d %X : (!riscv.freg<fa0>) -> !riscv.freg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a0>) -> !riscv.reg<>
+
+    %x = riscv.fmv.d %X_moved : (!riscv.freg<>) -> !riscv.freg<>
+
+    %stride_pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<256>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<1>
+
+    "snitch_stream.streaming_region"(%Y_moved, %stride_pattern) <{"operandSegmentSizes" = array<i32: 0, 1, 1>}> ({
+    ^bb0(%Y_stream : !stream.writable<!riscv.freg<ft0>>):
+      %c255 = riscv.li 255 : () -> !riscv.reg<>
+      riscv_snitch.frep_outer %c255 {
+        %y = riscv.fmv.d %x : (!riscv.freg<>) -> !riscv.freg<ft0>
+        riscv_snitch.write %y to %Y_stream : !riscv.freg<ft0>
+      }
+    }) : (!riscv.reg<>, !snitch_stream.stride_pattern_type<1>) -> ()
+
+    riscv_func.return
+  }
+}
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl fill
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  fill:
+// CHECK-NEXT:      fmv.d ft3, fa0
+// CHECK-NEXT:      mv t0, a0
+// CHECK-NEXT:      li t1, 8
+// CHECK-NEXT:      li t2, 255
+// CHECK-NEXT:      scfgwi t2, 64
+// CHECK-NEXT:      scfgwi t1, 192
+// CHECK-NEXT:      scfgwi t0, 896
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      li t0, 255
+// CHECK-NEXT:      frep.o t0, 1, 0, 0
+// CHECK-NEXT:      fmv.d ft0, ft3
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret

--- a/tests/filecheck/projects/riscv-backend-paper/matmul_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/matmul_target.mlir
@@ -1,0 +1,101 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "matmul"
+  riscv.directive ".p2align" "2"
+
+// x[ M x K ]
+// y[ K x N ]
+// g[ M x N ]
+  riscv_func.func @matmul(
+    %X : !riscv.reg<a0>,
+    %Y : !riscv.reg<a1>,
+    %G : !riscv.reg<a2>
+  ) {
+    %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
+    %G_moved = riscv.mv %G : (!riscv.reg<a2>) -> !riscv.reg<>
+
+    %c0 = riscv.get_register : () -> !riscv.reg<zero>
+    %c1 = riscv.li 1 : () -> !riscv.reg<>
+    %c8 = riscv.li 8 : () -> !riscv.reg<>
+    %c512 = riscv.li 512 : () -> !riscv.reg<>
+
+    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<8>, #builtin.int<0>, #builtin.int<64>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<3>
+
+    %stride_pattern_1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<64>, #builtin.int<8>, #builtin.int<0>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<3>
+
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern_0, %stride_pattern_1) <{"operandSegmentSizes" = array<i32: 2, 0, 2>}> ({
+    ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
+      %c7 = riscv.li 7 : () -> !riscv.reg<>
+      riscv_scf.for %g_i : !riscv.reg<> = %c0 to %c512 step %c8 {
+        %G_dest = riscv.add %G_moved, %g_i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+        %init = riscv.fld %G_dest, 0 : (!riscv.reg<>) -> !riscv.freg<>
+
+        %g = riscv_snitch.frep_outer %c7 iter_args(%acc = %init) -> (!riscv.freg<>) {
+          %x = riscv_snitch.read from %X_stream : !riscv.freg<ft0>
+          %y = riscv_snitch.read from %Y_stream : !riscv.freg<ft1>
+          %res = riscv.fmadd.d %x, %y, %acc : (!riscv.freg<ft0>, !riscv.freg<ft1>, !riscv.freg<>) -> !riscv.freg<>
+          riscv_snitch.frep_yield %res : !riscv.freg<>
+        }
+
+        riscv.fsd %G_dest, %g, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
+
+        riscv_scf.yield
+      }
+    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<3>, !snitch_stream.stride_pattern_type<3>) -> ()
+
+    riscv_func.return
+  }
+}
+
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl matmul
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  matmul:
+// CHECK-NEXT:      mv t5, a0
+// CHECK-NEXT:      mv t0, a1
+// CHECK-NEXT:      mv t1, a2
+// CHECK-NEXT:      li t3, 512
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      li a3, 7
+// CHECK-NEXT:      li a4, 7
+// CHECK-NEXT:      li a5, 7
+// CHECK-NEXT:      scfgwi a3, 64
+// CHECK-NEXT:      scfgwi a4, 96
+// CHECK-NEXT:      scfgwi a5, 128
+// CHECK-NEXT:      scfgwi t6, 192
+// CHECK-NEXT:      li t6, -56
+// CHECK-NEXT:      scfgwi t6, 224
+// CHECK-NEXT:      li t6, 8
+// CHECK-NEXT:      scfgwi t6, 256
+// CHECK-NEXT:      li t6, 64
+// CHECK-NEXT:      li a5, 7
+// CHECK-NEXT:      li a4, 7
+// CHECK-NEXT:      li a3, 7
+// CHECK-NEXT:      scfgwi a5, 65
+// CHECK-NEXT:      scfgwi a4, 97
+// CHECK-NEXT:      scfgwi a3, 129
+// CHECK-NEXT:      scfgwi t6, 193
+// CHECK-NEXT:      li t6, -440
+// CHECK-NEXT:      scfgwi t6, 225
+// CHECK-NEXT:      li t6, -504
+// CHECK-NEXT:      scfgwi t6, 257
+// CHECK-NEXT:      scfgwi t5, 832
+// CHECK-NEXT:      scfgwi t0, 833
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      li t0, 7
+// CHECK-NEXT:      mv t2, zero
+// CHECK-NEXT:      bge t2, t3, scf_body_end_0_for
+// CHECK-NEXT:  scf_body_0_for:
+// CHECK-NEXT:      add t5, t1, t2
+// CHECK-NEXT:      fld ft3, 0(t5)
+// CHECK-NEXT:      frep.o t0, 1, 0, 0
+// CHECK-NEXT:      fmadd.d ft3, ft0, ft1, ft3
+// CHECK-NEXT:      fsd ft3, 0(t5)
+// CHECK-NEXT:      addi t2, t2, 8
+// CHECK-NEXT:      blt t2, t3, scf_body_0_for
+// CHECK-NEXT:  scf_body_end_0_for:
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret

--- a/tests/filecheck/projects/riscv-backend-paper/max_pool_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/max_pool_target.mlir
@@ -1,0 +1,84 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "pooling_nchw_max_d1_s2_3x3"
+  riscv.directive ".p2align" "2"
+// x[ M x K ]
+// y[ K x N ]
+// g[ M x N ]
+riscv_func.func public @pooling_nchw_max_d1_s2_3x3(
+    %X: !riscv.reg<a0>,
+    %Y: !riscv.reg<a1>
+) -> () {
+    %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
+
+    %c0 = riscv.get_register : () -> !riscv.reg<zero>
+    %c1 = riscv.li 1 : () -> !riscv.reg<>
+    %c8 = riscv.li 8 : () -> !riscv.reg<>
+    %c512 = riscv.li 512 : () -> !riscv.reg<>
+
+    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<7>, #builtin.int<7>], "strides" = [#builtin.int<8>, #builtin.int<128>, #builtin.int<16>, #builtin.int<256>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<4>
+
+    "snitch_stream.streaming_region"(%X_moved, %stride_pattern_0) <{"operandSegmentSizes" = array<i32: 1, 0, 1>}> ({
+    ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
+      %c392 = riscv.li 392 : () -> !riscv.reg<>
+      riscv_scf.for %y_i : !riscv.reg<> = %c0 to %c392 step %c8 {
+        %Y_dest = riscv.add %Y_moved, %y_i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+        %init = riscv.fld %Y_dest, 0 : (!riscv.reg<>) -> !riscv.freg<>
+
+        %y = riscv_snitch.frep_outer %c8 iter_args(%acc = %init) -> (!riscv.freg<>) {
+          %x = riscv_snitch.read from %X_stream : !riscv.freg<ft0>
+          %res = riscv.fmax.d %x, %acc : (!riscv.freg<ft0>, !riscv.freg<>) -> !riscv.freg<>
+          riscv_snitch.frep_yield %res : !riscv.freg<>
+        }
+
+        riscv.fsd %Y_dest, %y, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
+
+        riscv_scf.yield
+      }
+    }) : (!riscv.reg<>, !snitch_stream.stride_pattern_type<4>) -> ()
+
+    riscv_func.return
+  }
+}
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
+// CHECK-NEXT:      mv t3, a0
+// CHECK-NEXT:      mv t1, a1
+// CHECK-NEXT:      li t0, 8
+// CHECK-NEXT:      li t4, 8
+// CHECK-NEXT:      li a3, 2
+// CHECK-NEXT:      li a2, 2
+// CHECK-NEXT:      li t6, 6
+// CHECK-NEXT:      li t5, 6
+// CHECK-NEXT:      scfgwi a3, 64
+// CHECK-NEXT:      scfgwi a2, 96
+// CHECK-NEXT:      scfgwi t6, 128
+// CHECK-NEXT:      scfgwi t5, 160
+// CHECK-NEXT:      scfgwi t4, 192
+// CHECK-NEXT:      li t4, 112
+// CHECK-NEXT:      scfgwi t4, 224
+// CHECK-NEXT:      li t4, -256
+// CHECK-NEXT:      scfgwi t4, 256
+// CHECK-NEXT:      li t4, -112
+// CHECK-NEXT:      scfgwi t4, 288
+// CHECK-NEXT:      scfgwi t3, 864
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      li t3, 392
+// CHECK-NEXT:      mv t2, zero
+// CHECK-NEXT:      bge t2, t3, scf_body_end_0_for
+// CHECK-NEXT:  scf_body_0_for:
+// CHECK-NEXT:      add t4, t1, t2
+// CHECK-NEXT:      fld ft3, 0(t4)
+// CHECK-NEXT:      frep.o t0, 1, 0, 0
+// CHECK-NEXT:      fmax.d ft3, ft0, ft3
+// CHECK-NEXT:      fsd ft3, 0(t4)
+// CHECK-NEXT:      addi t2, t2, 8
+// CHECK-NEXT:      blt t2, t3, scf_body_0_for
+// CHECK-NEXT:  scf_body_end_0_for:
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret

--- a/tests/filecheck/projects/riscv-backend-paper/relu_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/relu_target.mlir
@@ -1,0 +1,51 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "relu"
+  riscv.directive ".p2align" "2"
+  riscv_func.func @relu(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>) {
+    %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
+
+    %zero_int = riscv.get_register : () -> !riscv.reg<zero>
+    %zero_float = riscv.fcvt.d.w %zero_int : (!riscv.reg<zero>) -> !riscv.freg<>
+
+    %stride_pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<16>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
+
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern) <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> ({
+    ^0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.writable<!riscv.freg<ft1>>):
+      %c255 = riscv.li 255 : () -> !riscv.reg<>
+      riscv_snitch.frep_outer %c255 {
+        %x = riscv_snitch.read from %X_stream : !riscv.freg<ft0>
+        %y = riscv.fmax.d %x, %zero_float : (!riscv.freg<ft0>, !riscv.freg<>) -> !riscv.freg<ft1>
+        riscv_snitch.write %y to %Y_stream : !riscv.freg<ft1>
+      }
+    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+
+    riscv_func.return
+  }
+}
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl relu
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  relu:
+// CHECK-NEXT:      mv t1, a0
+// CHECK-NEXT:      mv t0, a1
+// CHECK-NEXT:      fcvt.d.w ft3, zero
+// CHECK-NEXT:      li t2, 128
+// CHECK-NEXT:      li t4, 15
+// CHECK-NEXT:      li t3, 15
+// CHECK-NEXT:      scfgwi t4, 95
+// CHECK-NEXT:      scfgwi t3, 127
+// CHECK-NEXT:      scfgwi t2, 223
+// CHECK-NEXT:      li t2, -1912
+// CHECK-NEXT:      scfgwi t2, 255
+// CHECK-NEXT:      scfgwi t1, 800
+// CHECK-NEXT:      scfgwi t0, 929
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      li t0, 255
+// CHECK-NEXT:      frep.o t0, 1, 0, 0
+// CHECK-NEXT:      fmax.d ft1, ft0, ft3
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret

--- a/tests/filecheck/projects/riscv-backend-paper/sum_pool_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/sum_pool_target.mlir
@@ -1,0 +1,85 @@
+// RUN: xdsl-opt -p test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+
+riscv.assembly_section ".text" {
+  riscv.directive ".globl" "pooling_nchw_sum_d1_s2_3x3"
+  riscv.directive ".p2align" "2"
+// x[ M x K ]
+// y[ K x N ]
+// g[ M x N ]
+riscv_func.func public @pooling_nchw_sum_d1_s2_3x3(
+    %X: !riscv.reg<a0>,
+    %Y: !riscv.reg<a1>
+) -> () {
+    %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
+    %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
+
+    %c0 = riscv.get_register : () -> !riscv.reg<zero>
+    %c1 = riscv.li 1 : () -> !riscv.reg<>
+    %c8 = riscv.li 8 : () -> !riscv.reg<>
+    %c512 = riscv.li 512 : () -> !riscv.reg<>
+
+    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<7>, #builtin.int<7>], "strides" = [#builtin.int<8>, #builtin.int<128>, #builtin.int<16>, #builtin.int<256>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<4>
+
+    "snitch_stream.streaming_region"(%X_moved, %stride_pattern_0) <{"operandSegmentSizes" = array<i32: 1, 0, 1>}> ({
+    ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
+      %c392 = riscv.li 392 : () -> !riscv.reg<>
+      riscv_scf.for %y_i : !riscv.reg<> = %c0 to %c392 step %c8 {
+        %Y_dest = riscv.add %Y_moved, %y_i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+        %init = riscv.fld %Y_dest, 0 : (!riscv.reg<>) -> !riscv.freg<>
+
+        %y = riscv_snitch.frep_outer %c8 iter_args(%acc = %init) -> (!riscv.freg<>) {
+          %x = riscv_snitch.read from %X_stream : !riscv.freg<ft0>
+          %res = riscv.fadd.d %x, %acc : (!riscv.freg<ft0>, !riscv.freg<>) -> !riscv.freg<>
+          riscv_snitch.frep_yield %res : !riscv.freg<>
+        }
+
+        riscv.fsd %Y_dest, %y, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
+
+        riscv_scf.yield
+      }
+
+    }) : (!riscv.reg<>, !snitch_stream.stride_pattern_type<4>) -> ()
+
+    riscv_func.return
+  }
+}
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  pooling_nchw_sum_d1_s2_3x3:
+// CHECK-NEXT:      mv t3, a0
+// CHECK-NEXT:      mv t1, a1
+// CHECK-NEXT:      li t0, 8
+// CHECK-NEXT:      li t4, 8
+// CHECK-NEXT:      li a3, 2
+// CHECK-NEXT:      li a2, 2
+// CHECK-NEXT:      li t6, 6
+// CHECK-NEXT:      li t5, 6
+// CHECK-NEXT:      scfgwi a3, 64
+// CHECK-NEXT:      scfgwi a2, 96
+// CHECK-NEXT:      scfgwi t6, 128
+// CHECK-NEXT:      scfgwi t5, 160
+// CHECK-NEXT:      scfgwi t4, 192
+// CHECK-NEXT:      li t4, 112
+// CHECK-NEXT:      scfgwi t4, 224
+// CHECK-NEXT:      li t4, -256
+// CHECK-NEXT:      scfgwi t4, 256
+// CHECK-NEXT:      li t4, -112
+// CHECK-NEXT:      scfgwi t4, 288
+// CHECK-NEXT:      scfgwi t3, 864
+// CHECK-NEXT:      csrrsi zero, 1984, 1
+// CHECK-NEXT:      li t3, 392
+// CHECK-NEXT:      mv t2, zero
+// CHECK-NEXT:      bge t2, t3, scf_body_end_0_for
+// CHECK-NEXT:  scf_body_0_for:
+// CHECK-NEXT:      add t4, t1, t2
+// CHECK-NEXT:      fld ft3, 0(t4)
+// CHECK-NEXT:      frep.o t0, 1, 0, 0
+// CHECK-NEXT:      fadd.d ft3, ft0, ft3
+// CHECK-NEXT:      fsd ft3, 0(t4)
+// CHECK-NEXT:      addi t2, t2, 8
+// CHECK-NEXT:      blt t2, t3, scf_body_0_for
+// CHECK-NEXT:  scf_body_end_0_for:
+// CHECK-NEXT:      csrrci zero, 1984, 1
+// CHECK-NEXT:      ret

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -458,6 +458,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return stencil_unroll.StencilUnrollPass
 
+    def get_test_lower_linalg_to_snitch():
+        from xdsl.transforms import test_lower_linalg_to_snitch
+
+        return test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass
+
     return {
         "arith-add-fastmath": get_arith_add_fastmath,
         "canonicalize-dmp": get_canonicalize_dmp,
@@ -498,6 +503,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "stencil-shape-inference": get_stencil_shape_inference,
         "stencil-storage-materialization": get_stencil_storage_materialization,
         "stencil-unroll": get_stencil_unroll,
+        "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
     }
 
 

--- a/xdsl/transforms/test_lower_linalg_to_snitch.py
+++ b/xdsl/transforms/test_lower_linalg_to_snitch.py
@@ -1,17 +1,3 @@
-# XDSLOPT_PASSES += snitch-allocate-registers
-# XDSLOPT_PASSES += convert-snitch-stream-to-snitch
-# XDSLOPT_PASSES += lower-snitch
-# XDSLOPT_PASSES += canonicalize
-# XDSLOPT_PASSES += riscv-scf-loop-range-folding
-# XDSLOPT_PASSES += canonicalize
-# XDSLOPT_PASSES += riscv-reduce-register-pressure
-# XDSLOPT_PASSES += riscv-allocate-registers
-# XDSLOPT_PASSES += canonicalize
-# XDSLOPT_PASSES += lower-riscv-func
-# XDSLOPT_PASSES += convert-riscv-scf-to-riscv-cf
-# XDSLOPT_PASSES += canonicalize
-
-
 from xdsl.backend.riscv.lowering.convert_riscv_scf_to_riscv_cf import (
     ConvertRiscvScfToRiscvCfPass,
 )
@@ -33,6 +19,11 @@ from xdsl.transforms.snitch_register_allocation import SnitchRegisterAllocation
 
 
 class TestLowerLinalgToSnitchPass(ModulePass):
+    """
+    A compiler pass used for testing of the lowering from ML kernels defined as
+    linalg.generic operations to riscv-assemby leveraging Snitch cores.
+    """
+
     name = "test-lower-linalg-to-snitch"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:

--- a/xdsl/transforms/test_lower_linalg_to_snitch.py
+++ b/xdsl/transforms/test_lower_linalg_to_snitch.py
@@ -1,0 +1,54 @@
+# XDSLOPT_PASSES += snitch-allocate-registers
+# XDSLOPT_PASSES += convert-snitch-stream-to-snitch
+# XDSLOPT_PASSES += lower-snitch
+# XDSLOPT_PASSES += canonicalize
+# XDSLOPT_PASSES += riscv-scf-loop-range-folding
+# XDSLOPT_PASSES += canonicalize
+# XDSLOPT_PASSES += riscv-reduce-register-pressure
+# XDSLOPT_PASSES += riscv-allocate-registers
+# XDSLOPT_PASSES += canonicalize
+# XDSLOPT_PASSES += lower-riscv-func
+# XDSLOPT_PASSES += convert-riscv-scf-to-riscv-cf
+# XDSLOPT_PASSES += canonicalize
+
+
+from xdsl.backend.riscv.lowering.convert_riscv_scf_to_riscv_cf import (
+    ConvertRiscvScfToRiscvCfPass,
+)
+from xdsl.backend.riscv.lowering.convert_snitch_stream_to_snitch import (
+    ConvertSnitchStreamToSnitch,
+)
+from xdsl.backend.riscv.lowering.reduce_register_pressure import (
+    RiscvReduceRegisterPressurePass,
+)
+from xdsl.dialects import builtin
+from xdsl.ir import MLContext
+from xdsl.passes import ModulePass, PipelinePass
+from xdsl.transforms.canonicalize import CanonicalizePass
+from xdsl.transforms.lower_riscv_func import LowerRISCVFunc
+from xdsl.transforms.lower_snitch import LowerSnitchPass
+from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
+from xdsl.transforms.riscv_scf_loop_range_folding import RiscvScfLoopRangeFoldingPass
+from xdsl.transforms.snitch_register_allocation import SnitchRegisterAllocation
+
+
+class TestLowerLinalgToSnitchPass(ModulePass):
+    name = "test-lower-linalg-to-snitch"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PipelinePass(
+            [
+                SnitchRegisterAllocation(),
+                ConvertSnitchStreamToSnitch(),
+                LowerSnitchPass(),
+                CanonicalizePass(),
+                RiscvScfLoopRangeFoldingPass(),
+                CanonicalizePass(),
+                RiscvReduceRegisterPressurePass(),
+                RISCVRegisterAllocation(),
+                CanonicalizePass(),
+                LowerRISCVFunc(),
+                ConvertRiscvScfToRiscvCfPass(),
+                CanonicalizePass(),
+            ]
+        ).apply(ctx, op)


### PR DESCRIPTION
The idea is to grow the compiler to snitch_stream bottom-up, meaning that the target output is fixed, and the input rises in abstraction level over time. This PR introduces both the kernels for which we know exactly what the assembly should be, and a test pass that fixes our compilation pipeline, currently copied from the Makefile.rules in the other repo