### PR TITLE
dialects (riscv): Fix missing attribute name from custom format

### DIFF
--- a/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
@@ -108,17 +108,17 @@ builtin.module {
 
     // tests with fastmath flags when set to "fast"
     %addf32_fm = "arith.addf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_1, %rhsf32_1 <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %subf32_fm = "arith.subf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_1, %rhsf32_1 <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %mulf32_fm = "arith.mulf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_1, %rhsf32_1 <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %divf32_fm = "arith.divf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_1, %rhsf32_1 <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %minf32_fm = "arith.minimumf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %lhsf32_1, %rhsf32_1 <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %maxf32_fm = "arith.maximumf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %lhsf32_1, %rhsf32_1 <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %addf64 = "arith.addf"(%lhsf64, %rhsf64) : (f64, f64) -> f64
     // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
@@ -135,31 +135,31 @@ builtin.module {
 
     // tests with fastmath flags when set to "fast"
     %addf64_fm = "arith.addf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %subf64_fm = "arith.subf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %mulf64_fm = "arith.mulf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %divf64_fm = "arith.divf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %minf64_fm = "arith.minimumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %maxf64_fm = "arith.maximumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg <fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     // tests with fastmath flags when set to "contract"
     %addf64_fm_contract = "arith.addf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg <contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %subf64_fm_contract = "arith.subf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg <contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %mulf64_fm_contract = "arith.mulf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg <contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %divf64_fm_contract = "arith.divf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg <contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %minf64_fm_contract = "arith.minimumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg <contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %maxf64_fm_contract = "arith.maximumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg <contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %sitofp = "arith.sitofp"(%lhsi32) : (i32) -> f32
     // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %lhsi32 : (!riscv.reg<>) -> !riscv.freg<>

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -230,6 +230,16 @@
     // CHECK-NEXT: %{{.*}} = riscv.fmul.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fdiv_s = riscv.fdiv.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+
+    %fadd_s_fm = riscv.fadd.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fsub_s_fm = riscv.fsub.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmul_s_fm = riscv.fmul.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fdiv_s_fm = riscv.fdiv.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+
     %fsqrt_s = riscv.fsqrt.s %f0 : (!riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fsqrt.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
 
@@ -244,6 +254,11 @@
     // CHECK-NEXT: %{{.*}} = riscv.fmin.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fmax_s = riscv.fmax.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fmax.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+
+    %fmin_s_fm = riscv.fmin.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmax_s_fm = riscv.fmax.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %fcvt_w_s = riscv.fcvt.w.s %f0 : (!riscv.freg<>) -> !riscv.reg<>
     // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
@@ -297,6 +312,15 @@
     %fdiv_d = riscv.fdiv.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
+    %fadd_d_fm = riscv.fadd.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fsub_d_fm = riscv.fsub.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmul_d_fm = riscv.fmul.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fdiv_d_fm = riscv.fdiv.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+
     %fmadd_d = riscv.fmadd.d %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fmsub_d = riscv.fmsub.d %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
@@ -306,6 +330,11 @@
     // CHECK-NEXT: %{{.*}} = riscv.fmin.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     %fmax_d = riscv.fmax.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fmax.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+
+    %fmin_d_fm = riscv.fmin.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmax_d_fm = riscv.fmax.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 
     %fcvt_d_w = riscv.fcvt.d.w %0 : (!riscv.reg<>) -> !riscv.freg<>
     // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.w %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
@@ -413,12 +442,18 @@
 // CHECK-GENERIC-NEXT:     %fsub_s = "riscv.fsub.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmul_s = "riscv.fmul.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fdiv_s = "riscv.fdiv.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fadd_s_fm = "riscv.fadd.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fsub_s_fm = "riscv.fsub.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fmul_s_fm = "riscv.fmul.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fdiv_s_fm = "riscv.fdiv.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fsqrt_s = "riscv.fsqrt.s"(%f0) : (!riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fsgnj_s = "riscv.fsgnj.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fsgnjn_s = "riscv.fsgnjn.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fsgnjx_s = "riscv.fsgnjx.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmin_s = "riscv.fmin.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmax_s = "riscv.fmax.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fmin_s_fm = "riscv.fmin.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fmax_s_fm = "riscv.fmax.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fcvt_w_s = "riscv.fcvt.w.s"(%f0) : (!riscv.freg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %fcvt_wu_s = "riscv.fcvt.wu.s"(%f0) : (!riscv.freg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %fmv_x_w = "riscv.fmv.x.w"(%f0) : (!riscv.freg<>) -> !riscv.reg<>
@@ -440,10 +475,16 @@
 // CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fsub.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fmul.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fdiv.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fadd.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fsub.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fmul.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fdiv.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmadd_d = "riscv.fmadd.d"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmsub_d = "riscv.fmsub.d"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmin_d = "riscv.fmin.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     %fmax_d = "riscv.fmax.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fmin_d_fm = "riscv.fmin.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %fmax_d_fm = "riscv.fmax.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT: %{{.*}} = "riscv.fcvt.d.w"(%{{.*}}) : (!riscv.reg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT: %{{.*}} = "riscv.fcvt.d.wu"(%{{.*}}) : (!riscv.reg<>) -> !riscv.freg<>
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -636,7 +636,7 @@ class RdRsRsFloatOperationWithFastMath(IRDLOperation, RISCVInstruction, ABC):
 
     def custom_print_attributes(self, printer: Printer) -> Set[str]:
         if self.fastmath is not None and self.fastmath != FastMathFlagsAttr("none"):
-            printer.print(" ")
+            printer.print(" fastmath")
             self.fastmath.print_parameter(printer)
         return {"fastmath"}
 


### PR DESCRIPTION
This PR:

- Fixes missed bug on the custom print/parse of the earlier introduced `fastmath` flags (#2058)
- Adds test for the custom format when flags are *not* `none` (i.e., when they are `none`, they do not get printed in the custom format)

