### PR TITLE
core: Implement Printer property retrocompatibility.

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -742,3 +742,24 @@ def test_print_function_type():
     printer.print_function_type((i32,), (FunctionType.from_lists((i32,), (i32,)),))
 
     assert io.getvalue() == "(i32) -> ((i32) -> i32)"
+
+
+def test_print_properties_as_attributes():
+    """Test that properties can be printed as attributes."""
+
+    prog = """
+"func.func"() <{"sym_name" = "test", "function_type" = i64, "sym_visibility" = "private"}> {"extra_attr", "sym_name" = "this should be overriden by the property"} : () -> ()
+    """
+
+    retro_prog = """
+"func.func"() {"extra_attr", "sym_name" = "test", "function_type" = i64, "sym_visibility" = "private"} : () -> ()
+    """
+
+    ctx = MLContext()
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Func)
+
+    parser = Parser(ctx, prog)
+    parsed = parser.parse_op()
+
+    assert_print_op(parsed, retro_prog, None, print_properties_as_attributes=True)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -752,6 +752,12 @@ class Printer:
             self._print_op_properties(op.properties)
         self.print_regions(op.regions)
         if self.print_properties_as_attributes:
+            clashing_names = op.properties.keys() & op.attributes.keys()
+            if clashing_names:
+                raise ValueError(
+                    f"Properties {', '.join(clashing_names)} would overwrite the attributes of the same names."
+                )
+
             self.print_op_attributes(op.attributes | op.properties)
         else:
             self.print_op_attributes(op.attributes)

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -74,6 +74,7 @@ indentNumSpaces = 2
 class Printer:
     stream: Any | None = field(default=None)
     print_generic_format: bool = field(default=False)
+    print_properties_as_attributes: bool = field(default=False)
     print_debuginfo: bool = field(default=False)
     diagnostic: Diagnostic = field(default_factory=Diagnostic)
 
@@ -747,9 +748,13 @@ class Printer:
     def print_op_with_default_format(self, op: Operation) -> None:
         self.print_operands(op.operands)
         self.print_successors(op.successors)
-        self._print_op_properties(op.properties)
+        if not self.print_properties_as_attributes:
+            self._print_op_properties(op.properties)
         self.print_regions(op.regions)
-        self.print_op_attributes(op.attributes)
+        if self.print_properties_as_attributes:
+            self.print_op_attributes(op.attributes | op.properties)
+        else:
+            self.print_op_attributes(op.attributes)
         self.print(" : ")
         self.print_operation_type(op)
 

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -149,6 +149,13 @@ class xDSLOptMain(CommandLineTool):
         )
 
         arg_parser.add_argument(
+            "--print-no-properties",
+            default=False,
+            action="store_true",
+            help="Print properties as if they were attributes for retrocompatibility.",
+        )
+
+        arg_parser.add_argument(
             "--print-debuginfo",
             default=False,
             action="store_true",
@@ -187,6 +194,7 @@ class xDSLOptMain(CommandLineTool):
             printer = Printer(
                 stream=output,
                 print_generic_format=self.args.print_op_generic,
+                print_properties_as_attributes=self.args.print_no_properties,
                 print_debuginfo=self.args.print_debuginfo,
             )
             printer.print_op(prog)


### PR DESCRIPTION
I heard multiple struggles with flows working with MLIR versions predating properties.

xDSL implemented the same retro-compatibility as MLIR, that is, parsing operations with no properties and hoisting defined properties, allowing to take input predating properties.

This PR offers to add *printing* retro-compatibility: Printing all properties in the output attribute dictionary, allowing MLIR tools predating properties to parse this output.

From recent discussions, I guess @math-fehr might want to make the property/attribute name clash an error?