### PR TITLE
transformations (riscv_scf): Change forwarded block args of `riscv_cf.blt` to use `riscv_scf.yield` operands when lowering from `riscv_scf` to `riscv_cf`

### DIFF
--- a/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
+++ b/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
@@ -66,7 +66,7 @@ builtin.module {
 // CHECK-NEXT:      riscv.label "scf_body_0_for"
 // CHECK-NEXT:      %7 = riscv.add %5, %6 : (!riscv.reg<a4>, !riscv.reg<a3>) -> !riscv.reg<a3>
 // CHECK-NEXT:      %8 = riscv.add %5, %2 : (!riscv.reg<a4>, !riscv.reg<a2>) -> !riscv.reg<a4>
-// CHECK-NEXT:      riscv_cf.blt %8 : !riscv.reg<a4>, %1 : !riscv.reg<a1>, ^1(%8 : !riscv.reg<a4>, %3 : !riscv.reg<a3>), ^0(%8 : !riscv.reg<a4>, %3 : !riscv.reg<a3>)
+// CHECK-NEXT:      riscv_cf.blt %8 : !riscv.reg<a4>, %1 : !riscv.reg<a1>, ^1(%8 : !riscv.reg<a4>, %7 : !riscv.reg<a3>), ^0(%8 : !riscv.reg<a4>, %7 : !riscv.reg<a3>)
 // CHECK-NEXT:    ^0(%9 : !riscv.reg<a4>, %10 : !riscv.reg<a3>):
 // CHECK-NEXT:      riscv.label "scf_body_end_0_for"
 // CHECK-NEXT:      %11 = riscv.mv %10 : (!riscv.reg<a3>) -> !riscv.reg<a0>
@@ -113,11 +113,11 @@ builtin.module {
 // CHECK-NEXT:      %7 = riscv.add %arg1, %arg3 : (!riscv.reg<a2>, !riscv.reg<a4>) -> !riscv.reg<a0>
 // CHECK-NEXT:      %8 = riscv.add %arg4, %7 : (!riscv.reg<a1>, !riscv.reg<a0>) -> !riscv.reg<a1>
 // CHECK-NEXT:      %9 = riscv.add %arg3, %5 : (!riscv.reg<a4>, !riscv.reg<a5>) -> !riscv.reg<a4>
-// CHECK-NEXT:      riscv_cf.blt %9 : !riscv.reg<a4>, %arg0 : !riscv.reg<a0>, ^3(%9 : !riscv.reg<a4>, %arg2 : !riscv.reg<a1>), ^2(%9 : !riscv.reg<a4>, %arg2 : !riscv.reg<a1>)
+// CHECK-NEXT:      riscv_cf.blt %9 : !riscv.reg<a4>, %arg0 : !riscv.reg<a0>, ^3(%9 : !riscv.reg<a4>, %8 : !riscv.reg<a1>), ^2(%9 : !riscv.reg<a4>, %8 : !riscv.reg<a1>)
 // CHECK-NEXT:    ^2(%10 : !riscv.reg<a4>, %11 : !riscv.reg<a1>):
 // CHECK-NEXT:      riscv.label "scf_body_end_0_for"
 // CHECK-NEXT:      %12 = riscv.add %arg1, %2 : (!riscv.reg<a2>, !riscv.reg<a3>) -> !riscv.reg<a2>
-// CHECK-NEXT:      riscv_cf.blt %12 : !riscv.reg<a2>, %arg0 : !riscv.reg<a0>, ^1(%12 : !riscv.reg<a2>, %0 : !riscv.reg<a1>), ^0(%12 : !riscv.reg<a2>, %0 : !riscv.reg<a1>)
+// CHECK-NEXT:      riscv_cf.blt %12 : !riscv.reg<a2>, %arg0 : !riscv.reg<a0>, ^1(%12 : !riscv.reg<a2>, %11 : !riscv.reg<a1>), ^0(%12 : !riscv.reg<a2>, %11 : !riscv.reg<a1>)
 // CHECK-NEXT:    ^0(%13 : !riscv.reg<a2>, %14 : !riscv.reg<a1>):
 // CHECK-NEXT:      riscv.label "scf_body_end_1_for"
 // CHECK-NEXT:      riscv_func.return %14 : !riscv.reg<a1>

--- a/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf_with_regalloc.mlir
+++ b/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf_with_regalloc.mlir
@@ -1,0 +1,33 @@
+// RUN: xdsl-opt -p riscv-allocate-registers,convert-riscv-scf-to-riscv-cf %s | filecheck %s
+
+builtin.module {
+    riscv_func.func @sum_range(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>) {
+        %2 = riscv.li 1 : () -> !riscv.reg<>
+        %3 = riscv.li 0 : () -> !riscv.reg<>
+        %4 = riscv_scf.for %5 : !riscv.reg<> = %0 to %1 step %2 iter_args(%6 = %3) -> (!riscv.reg<>) {
+            %7 = riscv.add %5, %6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+            riscv_scf.yield %7 : !riscv.reg<>
+        }
+        %8 = riscv.mv %4 : (!riscv.reg<>) -> !riscv.reg<>
+        riscv_func.return %8 : !riscv.reg<>
+    }
+}
+
+// CHECK:        builtin.module {
+// CHECK-NEXT:    riscv_func.func @sum_range(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>) {
+// CHECK-NEXT:      %2 = riscv.li 1 : () -> !riscv.reg<t2>
+// CHECK-NEXT:      %3 = riscv.li 0 : () -> !riscv.reg<t0>
+// CHECK-NEXT:      %4 = riscv.mv %0 : (!riscv.reg<a0>) -> !riscv.reg<t1>
+// CHECK-NEXT:      riscv_cf.bge %4 : !riscv.reg<t1>, %1 : !riscv.reg<a1>, ^0(%4 : !riscv.reg<t1>, %3 : !riscv.reg<t0>), ^1(%4 : !riscv.reg<t1>, %3 : !riscv.reg<t0>)
+// CHECK-NEXT:    ^1(%5 : !riscv.reg<t1>, %6 : !riscv.reg<t0>):
+// CHECK-NEXT:      riscv.label "scf_body_0_for"
+// CHECK-NEXT:      %7 = riscv.add %5, %6 : (!riscv.reg<t1>, !riscv.reg<t0>) -> !riscv.reg<t0>
+// CHECK-NEXT:      %8 = riscv.add %5, %2 : (!riscv.reg<t1>, !riscv.reg<t2>) -> !riscv.reg<t1>
+// CHECK-NEXT:      riscv_cf.blt %8 : !riscv.reg<t1>, %1 : !riscv.reg<a1>, ^1(%8 : !riscv.reg<t1>, %7 : !riscv.reg<t0>), ^0(%8 : !riscv.reg<t1>, %7 : !riscv.reg<t0>)
+// CHECK-NEXT:    ^0(%9 : !riscv.reg<t1>, %10 : !riscv.reg<t0>):
+// CHECK-NEXT:      riscv.label "scf_body_end_0_for"
+// CHECK-NEXT:      %11 = riscv.mv %10 : (!riscv.reg<t0>) -> !riscv.reg<t0>
+// CHECK-NEXT:      riscv_func.return %11 : !riscv.reg<t0>
+// CHECK-NEXT:    }
+// CHECK-NEXT:   }
+

--- a/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
@@ -112,8 +112,8 @@ class LowerRiscvScfForPattern(RewritePattern):
                 riscv_cf.BltOp(
                     add_op.rd,
                     op.ub,
-                    (add_op.rd, *op.iter_args),
-                    (add_op.rd, *op.iter_args),
+                    (add_op.rd, *yield_op.operands),
+                    (add_op.rd, *yield_op.operands),
                     first_body_block,
                     end_block,
                 ),


### PR DESCRIPTION
Lowering from `riscv_scf.for` to `riscv_cf.blt` seems to use the `iter_args` operands instead of the yielded values.
This seems to render the result from the `for` not used and DCE eliminates the main calculation result of the loop.

This can be reproduced with:

```mlir
builtin.module {
    riscv_func.func @sum_range(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>) {
        %2 = riscv.li 1 : () -> !riscv.reg<>
        %3 = riscv.li 0 : () -> !riscv.reg<>
        %4 = riscv_scf.for %5 : !riscv.reg<> = %0 to %1 step %2 iter_args(%6 = %3) -> (!riscv.reg<>) {
            %7 = riscv.add %5, %6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
            riscv_scf.yield %7 : !riscv.reg<>
        }
        %8 = riscv.mv %4 : (!riscv.reg<>) -> !riscv.reg<>
        riscv_func.return %8 : !riscv.reg<>
    }
}
```

lowered with `xdsl-opt -p riscv-allocate-registers,convert-riscv-scf-to-riscv-cf,canonicalize`.

I think the issue was not triggered because the filechecks for this lowering were manually regalloc'd (but not 100% sure).
I've tested this on the riscv experiments repo and seems to work.