### PR TITLE
testing: switch to debugpy in vscode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "xdsl-opt",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "xdsl.tools.xdsl_opt",
             "justMyCode": true,
@@ -16,7 +16,7 @@
         },
         {
             "name": "xdsl-run",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "xdsl.tools.xdsl_run",
             "justMyCode": true,
@@ -26,14 +26,14 @@
         },
         {
             "name": "interactive",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "xdsl.interactive.app",
             "justMyCode": true,
         },
         {
             "name": "toy",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "docs.Toy.toy",
             "justMyCode": true,


### PR DESCRIPTION
VSCode started telling me that "python" is deprecated, I followed it's advice to replace with "debugpy".