### PR TITLE
dialects: (builtin) fix ranges for integers

### DIFF
--- a/tests/test_attribute_definition.py
+++ b/tests/test_attribute_definition.py
@@ -226,13 +226,13 @@ def test_unsigned_integer_attr():
 def test_signless_integer_attr():
     """Test the verification of a signless integer attribute."""
     with pytest.raises(VerifyException):
-        IntegerAttr((1 << 32) + 1, IntegerType(32, Signedness.SIGNLESS))
+        IntegerAttr((1 << 32), IntegerType(32, Signedness.SIGNLESS))
 
     with pytest.raises(VerifyException):
         IntegerAttr(-(1 << 32) - 1, IntegerType(32, Signedness.SIGNLESS))
 
-    IntegerAttr(1 << 32, IntegerType(32, Signedness.SIGNLESS))
-    IntegerAttr(-(1 << 32), IntegerType(32, Signedness.SIGNLESS))
+    IntegerAttr(1 << 32 - 1, IntegerType(32, Signedness.SIGNLESS))
+    IntegerAttr(-(1 << 31), IntegerType(32, Signedness.SIGNLESS))
 
 
 ################################################################################

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -10,8 +10,8 @@ from xdsl.ir import Block, BlockArgument, Operation, Region
 def test_insertion_point_constructors():
     target = Block(
         [
-            (op1 := Constant.from_int_and_width(1, 1)),
-            (op2 := Constant.from_int_and_width(2, 1)),
+            (op1 := Constant.from_int_and_width(0, 1)),
+            (op2 := Constant.from_int_and_width(1, 1)),
         ]
     )
 
@@ -37,16 +37,16 @@ def test_insertion_point_constructors():
 def test_builder():
     target = Block(
         [
+            Constant.from_int_and_width(0, 1),
             Constant.from_int_and_width(1, 1),
-            Constant.from_int_and_width(2, 1),
         ]
     )
 
     block = Block()
     b = Builder.at_end(block)
 
-    x = Constant.from_int_and_width(1, 1)
-    y = Constant.from_int_and_width(2, 1)
+    x = Constant.from_int_and_width(0, 1)
+    y = Constant.from_int_and_width(1, 1)
 
     b.insert(x)
     b.insert(y)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -16,7 +16,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Self, assert_never
+from typing_extensions import Self
 
 from xdsl.ir import (
     Attribute,
@@ -304,6 +304,27 @@ class Signedness(Enum):
     SIGNED = 1
     UNSIGNED = 2
 
+    def value_range(self, bitwidth: int) -> tuple[int, int]:
+        """
+        For a given bitwidth, returns (min, max+1), where min and max are the smallest and
+        largest representable values.
+
+        Signless integers are bit patterns, so the representable range is the union of the
+        signed and unsigned representable ranges.
+        """
+        match self:
+            case Signedness.SIGNLESS:
+                min_value = -(1 << (bitwidth - 1))
+                max_value = 1 << bitwidth
+            case Signedness.SIGNED:
+                min_value = -(1 << (bitwidth - 1))
+                max_value = 1 << (bitwidth - 1)
+            case Signedness.UNSIGNED:
+                min_value = 0
+                max_value = 1 << bitwidth
+
+        return min_value, max_value
+
 
 @irdl_attr_definition
 class SignednessAttr(Data[Signedness]):
@@ -349,6 +370,9 @@ class IntegerType(ParametrizedAttribute, TypeAttribute):
         if isinstance(signedness, Signedness):
             signedness = SignednessAttr(signedness)
         super().__init__([data, signedness])
+
+    def value_range(self) -> tuple[int, int]:
+        return self.signedness.data.value_range(self.width.data)
 
 
 i64 = IntegerType(64)
@@ -432,36 +456,17 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
     def from_index_int_value(value: int) -> IntegerAttr[IndexType]:
         return IntegerAttr(value, IndexType())
 
-    @staticmethod
-    def _get_value_range(int_type: IntegerType) -> tuple[int, int]:
-        signedness = int_type.signedness.data
-        width = int_type.width.data
-
-        if signedness == Signedness.SIGNLESS:
-            min_value = -(1 << width)
-            max_value = 1 << width
-        elif signedness == Signedness.SIGNED:
-            min_value = -(1 << (width - 1))
-            max_value = (1 << (width - 1)) - 1
-        elif signedness == Signedness.UNSIGNED:
-            min_value = 0
-            max_value = (1 << width) - 1
-        else:
-            assert_never(signedness)
-
-        return min_value, max_value
-
     def verify(self) -> None:
         if isinstance(int_type := self.type, IndexType):
             return
 
-        min_value, max_value = self._get_value_range(int_type)
+        min_value, max_value = int_type.value_range()
 
-        if not (min_value <= self.value.data <= max_value):
+        if not (min_value <= self.value.data < max_value):
             raise VerifyException(
                 f"Integer value {self.value.data} is out of range for "
                 f"type {self.type} which supports values in the "
-                f"range [{min_value}, {max_value}]"
+                f"range [{min_value}, {max_value})"
             )
 
 
@@ -967,9 +972,11 @@ class DenseIntOrFPElementsAttr(
     @staticmethod
     def from_list(
         type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
-        data: Sequence[int]
-        | Sequence[IntegerAttr[IndexType]]
-        | Sequence[IntegerAttr[IntegerType]],
+        data: (
+            Sequence[int]
+            | Sequence[IntegerAttr[IndexType]]
+            | Sequence[IntegerAttr[IntegerType]]
+        ),
     ) -> DenseIntOrFPElementsAttr:
         ...
 
@@ -1013,11 +1020,13 @@ class DenseIntOrFPElementsAttr(
 
     @staticmethod
     def tensor_from_list(
-        data: Sequence[int]
-        | Sequence[float]
-        | Sequence[IntegerAttr[IndexType]]
-        | Sequence[IntegerAttr[IntegerType]]
-        | Sequence[AnyFloatAttr],
+        data: (
+            Sequence[int]
+            | Sequence[float]
+            | Sequence[IntegerAttr[IndexType]]
+            | Sequence[IntegerAttr[IntegerType]]
+            | Sequence[AnyFloatAttr]
+        ),
         data_type: IntegerType | IndexType | AnyFloat,
         shape: Sequence[int],
     ) -> DenseIntOrFPElementsAttr:
@@ -1103,10 +1112,12 @@ class DenseArrayBase(ParametrizedAttribute):
     @staticmethod
     def from_list(
         data_type: Attribute,
-        data: Sequence[int]
-        | Sequence[int | float]
-        | Sequence[IntAttr]
-        | Sequence[FloatData],
+        data: (
+            Sequence[int]
+            | Sequence[int | float]
+            | Sequence[IntAttr]
+            | Sequence[FloatData]
+        ),
     ) -> DenseArrayBase:
         if isinstance(data_type, IndexType | IntegerType):
             _data = cast(Sequence[int] | Sequence[IntAttr], data)
@@ -1180,8 +1191,9 @@ class StridedLayoutAttr(ParametrizedAttribute):
 
     def __init__(
         self,
-        strides: ArrayAttr[IntAttr | NoneAttr]
-        | Sequence[int | None | IntAttr | NoneAttr],
+        strides: (
+            ArrayAttr[IntAttr | NoneAttr] | Sequence[int | None | IntAttr | NoneAttr]
+        ),
         offset: int | None | IntAttr | NoneAttr = 0,
     ) -> None:
         if not isinstance(strides, ArrayAttr):

--- a/xdsl/utils/comparisons.py
+++ b/xdsl/utils/comparisons.py
@@ -32,26 +32,31 @@
     their bit representations are the same.
 """
 
+from xdsl.dialects.builtin import Signedness
+
 
 def unsigned_upper_bound(bitwidth: int) -> int:
     """
     The maximum representable value + 1.
     """
-    return 1 << bitwidth
+    _, ub = Signedness.UNSIGNED.value_range(bitwidth)
+    return ub
 
 
 def signed_lower_bound(bitwidth: int) -> int:
     """
     The minimum representable value.
     """
-    return -(1 << (bitwidth - 1))
+    lb, _ = Signedness.SIGNED.value_range(bitwidth)
+    return lb
 
 
 def signed_upper_bound(bitwidth: int) -> int:
     """
     The maximum representable value + 1.
     """
-    return 1 << (bitwidth - 1)
+    _, ub = Signedness.SIGNED.value_range(bitwidth)
+    return ub
 
 
 def to_unsigned(signless: int, bitwidth: int) -> int:


### PR DESCRIPTION
Also uses same calculation for the interpreter helpers and the integer attr verifier.