### PR TITLE
dialects: (riscv) fix signedness in riscv

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,14 +1,9 @@
 import pytest
 
 from xdsl.dialects import riscv
-from xdsl.dialects.builtin import IntegerAttr, ModuleOp, i32
+from xdsl.dialects.builtin import IntegerAttr, ModuleOp, Signedness, i32
 from xdsl.ir import MLContext
 from xdsl.parser import Parser
-from xdsl.utils.comparisons import (
-    signed_lower_bound,
-    signed_upper_bound,
-    unsigned_upper_bound,
-)
 from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
@@ -155,9 +150,8 @@ def test_immediate_s_inst():
 
 def test_immediate_u_j_inst():
     # U-Type and J-Type - 20-bits immediate
-    ub = signed_upper_bound(20)
-    lb = signed_lower_bound(20)
-    assert ub == 524288
+    lb, ub = Signedness.SIGNLESS.value_range(20)
+    assert ub == 1048576
     assert lb == -524288
 
     with pytest.raises(VerifyException):
@@ -184,8 +178,7 @@ def test_immediate_jalr_inst():
 
 
 def test_immediate_pseudo_inst():
-    ub = unsigned_upper_bound(32)
-    lb = signed_lower_bound(32)
+    lb, ub = Signedness.SIGNLESS.value_range(32)
     assert ub == 4294967296
     assert lb == -2147483648
 

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -359,8 +359,8 @@
 // CHECK-GENERIC-NEXT:     %slli = "riscv.slli"(%0) {"immediate" = 1 : ui5} : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %srli = "riscv.srli"(%0) {"immediate" = 1 : ui5} : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %srai = "riscv.srai"(%0) {"immediate" = 1 : ui5} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %lui = "riscv.lui"() {"immediate" = 1 : ui20} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %auipc = "riscv.auipc"() {"immediate" = 1 : ui20} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %lui = "riscv.lui"() {"immediate" = 1 : i20} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %auipc = "riscv.auipc"() {"immediate" = 1 : i20} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %mv = "riscv.mv"(%0) : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %add = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %slt = "riscv.slt"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
@@ -418,16 +418,16 @@
 // CHECK-GENERIC-NEXT:     %divu = "riscv.divu"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %rem = "riscv.rem"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     %remu = "riscv.remu"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %li = "riscv.li"() {"immediate" = 1 : si32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     "riscv.ecall"() : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.ebreak"() : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.directive"() {"directive" = ".bss"} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.directive"() {"directive" = ".align", "value" = "2"} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.assembly_section"() ({
-// CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : si32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text", "foo" = i32} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.assembly_section"() ({
-// CHECK-GENERIC-NEXT:       %nested_li_1 = "riscv.li"() {"immediate" = 1 : si32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:       %nested_li_1 = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text"} : () -> ()
 // CHECK-GENERIC-NEXT:     %custom0, %custom1 = "riscv.custom_assembly_instruction"(%0, %1) {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
 // CHECK-GENERIC-NEXT:     %f0 = "riscv.get_float_register"() : () -> !riscv.freg<>

--- a/tests/filecheck/dialects/snitch_stream/ops.mlir
+++ b/tests/filecheck/dialects/snitch_stream/ops.mlir
@@ -44,7 +44,7 @@
 // CHECK-GENERIC-NEXT:  %Z_str = "snitch_stream.strided_write"(%Z, %pattern) {"dm" = #builtin.int<2>, "rank" = #builtin.int<2>} : (!riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> !stream.writable<!riscv.freg<>>
 // CHECK-GENERIC-NEXT:    "snitch_stream.streaming_region"(%X, %Y, %Z, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
-// CHECK-GENERIC-NEXT:      %c5 = "riscv.li"() {"immediate" = 5 : si32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:      %c5 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_outer"(%c5) ({
 // CHECK-GENERIC-NEXT:        %a = "riscv_snitch.read"(%a_stream) : (!stream.readable<!riscv.freg<ft0>>) -> !riscv.freg<ft0>
 // CHECK-GENERIC-NEXT:        %b = "riscv_snitch.read"(%b_stream) : (!stream.readable<!riscv.freg<ft1>>) -> !riscv.freg<ft1>

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -648,7 +648,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     """
 
     rd: OpResult = result_def(IntRegisterType)
-    immediate: AnyIntegerAttr | LabelAttr = attr_def(AnyIntegerAttr | LabelAttr)
+    immediate: SImm20Attr | LabelAttr = attr_def(SImm20Attr | LabelAttr)
 
     def __init__(
         self,
@@ -658,7 +658,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
-            immediate = IntegerAttr(immediate, IntegerType(20, Signedness.UNSIGNED))
+            immediate = IntegerAttr(immediate, si20)
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
@@ -682,9 +682,7 @@ class RdImmIntegerOperation(IRDLOperation, RISCVInstruction, ABC):
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
         attributes = dict[str, Attribute]()
-        attributes["immediate"] = _parse_immediate_value(
-            parser, IntegerType(20, Signedness.UNSIGNED)
-        )
+        attributes["immediate"] = _parse_immediate_value(parser, si20)
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> Set[str]:

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -221,10 +221,13 @@ class SubAddi(RewritePattern):
         if (
             isinstance(op.rs1, OpResult)
             and isinstance(op.rs1.op, riscv.AddiOp)
+            and isinstance(op.rs1.op.immediate, IntegerAttr)
             and op.rs2 == op.rs1.op.rs1
         ):
             rd = cast(riscv.IntRegisterType, op.rd.type)
-            rewriter.replace_matched_op(riscv.LiOp(op.rs1.op.immediate, rd=rd))
+            rewriter.replace_matched_op(
+                riscv.LiOp(op.rs1.op.immediate.value.data, rd=rd)
+            )
 
 
 class ShiftLeftImmediate(RewritePattern):


### PR DESCRIPTION
We currently have some inconsistencies/inaccuracies in the bitwidths in the riscv dialect, this PR attempts to make things more structured. We have 5 kinds of immediate values:

1. ui5 for shifting ops, we can only shift by a positive value
2. si20 for jump ops, where we want to be explicit about jumping by a negative number of ops
3. i12, i20, and i32 when the immediate values represent bits as they will be loaded into a register

This will make reasoning about constant values much easier, and will help fix some bugs in canonicalization