### PR TITLE
Implement and test optional operand and result variables.

### DIFF
--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -247,12 +247,12 @@ class FormatDirective(ABC):
     """A format directive for operation format."""
 
     @abstractmethod
-    def parse(self, parser: Parser, state: ParsingState) -> None:
-        ...
+    def parse(self, parser: Parser, state: ParsingState) -> None: ...
 
     @abstractmethod
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        ...
+    def print(
+        self, printer: Printer, state: PrintingState, op: IRDLOperation
+    ) -> None: ...
 
 
 class VariadicLikeFormatDirective(FormatDirective, ABC):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -247,12 +247,12 @@ class FormatDirective(ABC):
     """A format directive for operation format."""
 
     @abstractmethod
-    def parse(self, parser: Parser, state: ParsingState) -> None: ...
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        ...
 
     @abstractmethod
-    def print(
-        self, printer: Printer, state: PrintingState, op: IRDLOperation
-    ) -> None: ...
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        ...
 
 
 class VariadicLikeFormatDirective(FormatDirective, ABC):
@@ -273,13 +273,10 @@ class TypeDirective(FormatDirective, ABC):
     pass
 
 
-<<<<<<< HEAD
 class VariadicLikeVariable(VariadicLikeFormatDirective, FormatDirective, ABC):
     pass
 
 
-=======
->>>>>>> 7feedf7f (ABCs, docstrings.)
 class VariadicLikeTypeDirective(TypeDirective, VariadicLikeFormatDirective, ABC):
     pass
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -273,10 +273,13 @@ class TypeDirective(FormatDirective, ABC):
     pass
 
 
+<<<<<<< HEAD
 class VariadicLikeVariable(VariadicLikeFormatDirective, FormatDirective, ABC):
     pass
 
 
+=======
+>>>>>>> 7feedf7f (ABCs, docstrings.)
 class VariadicLikeTypeDirective(TypeDirective, VariadicLikeFormatDirective, ABC):
     pass
 


### PR DESCRIPTION
Stacked on #2106.

Add optional operands and type directives; very similar to the variadic ones. Adds the notion of "variadic-like" to relate to checks added in #2106