### PR TITLE
core: Add accessor to basic block

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -432,6 +432,42 @@ def test_split_block_args():
     assert arg_types == [i32, i64]
 
 
+def test_block_get_op_by_index():
+    # test block with ops
+    bb0 = Block((op0 := test.TestOp(), op1 := test.TestOp(), op2 := test.TestOp()))
+
+    assert bb0.get_operation_by_index(0) is op0
+    assert bb0.get_operation_by_index(1) is op1
+    assert bb0.get_operation_by_index(2) is op2
+
+    with pytest.raises(
+        Exception,
+        match="Cannot get operation by out-of-bounds index -1 in its parent block.",
+    ):
+        bb0.get_operation_by_index(-1)
+
+    with pytest.raises(
+        Exception,
+        match=f"Cannot get operation by out-of-bounds index {len(bb0.ops)} in its parent block.",
+    ):
+        bb0.get_operation_by_index(len(bb0.ops))
+
+    # test empty block
+    bb1 = Block()
+
+    with pytest.raises(
+        Exception,
+        match="Cannot get operation by out-of-bounds index -1 in its parent block.",
+    ):
+        bb1.get_operation_by_index(-1)
+
+    with pytest.raises(
+        Exception,
+        match=f"Cannot get operation by out-of-bounds index {len(bb0.ops)} in its parent block.",
+    ):
+        bb1.get_operation_by_index(len(bb0.ops))
+
+
 def test_region_clone_into_circular_blocks():
     """
     Test that cloning a region with circular block dependency works.

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1615,10 +1615,21 @@ class Block(IRNode):
     def get_operation_index(self, op: Operation) -> int:
         """Get the operation position in a block."""
         if op.parent is not self:
-            raise Exception("Operation is not a children of the block.")
+            raise Exception("Operation is not a child of the block.")
         for idx, block_op in enumerate(self.ops):
             if block_op is op:
                 return idx
+        assert False, "Unexpected xdsl error"
+
+    def get_operation_by_index(self, idx: int) -> Operation:
+        """Get the operation by its position in its parent block."""
+        if idx not in range(0, len(self.ops)):
+            raise Exception(
+                f"Cannot get operation by out-of-bounds index {idx} in its parent block."
+            )
+        for _idx, block_op in enumerate(self.ops):
+            if idx == _idx:
+                return block_op
         assert False, "Unexpected xdsl error"
 
     def detach_op(self, op: Operation) -> Operation:


### PR DESCRIPTION
This PR:

- Adds a block accessor to retrieve operations from within a block using their position index (`get_operation_by_index`)
- Tests of the above

I recently needed to patch cloned IR instructions between the source and the cloned block and couldn't find a better way to do that. `value_mapper` didn't make much sense since I knew exactly which operations I needed to work on from prior analyses.
