### PR TITLE
core: add custom attr and prop name support to assembly format

### DIFF
--- a/tests/test_declarative_assembly_format.py
+++ b/tests/test_declarative_assembly_format.py
@@ -292,6 +292,31 @@ def test_attr_variable_shadowed():
         parser.parse_operation()
 
 
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        ("test.one_attr i32", '"test.one_attr"() {"irdl" = i32} : () -> ()'),
+        (
+            'test.one_attr i32 {"attr2" = i64}',
+            '"test.one_attr"() {"irdl" = i32, "attr2" = i64} : () -> ()',
+        ),
+    ],
+)
+def test_attr_name(program: str, generic_program: str):
+    @irdl_op_definition
+    class OpWithRenamedAttr(IRDLOperation):
+        name = "test.one_attr"
+
+        python = attr_def(Attribute, attr_name="irdl")
+        assembly_format = "$irdl attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(OpWithRenamedAttr)
+
+    check_equivalence(program, generic_program, ctx)
+    check_roundtrip(program, ctx)
+
+
 def test_missing_property_error():
     class OpWithMissingProp(IRDLOperation):
         name = "test.missing_prop"
@@ -327,6 +352,31 @@ def test_standard_prop_directive(program: str, generic_program: str):
 
     ctx = MLContext()
     ctx.load_op(OpWithProp)
+
+    check_equivalence(program, generic_program, ctx)
+    check_roundtrip(program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        ("test.one_prop i32", '"test.one_prop"() <{"irdl" = i32}> : () -> ()'),
+        (
+            'test.one_prop i32 {"attr2" = i64}',
+            '"test.one_prop"() <{"irdl" = i32}> {"attr2" = i64} : () -> ()',
+        ),
+    ],
+)
+def test_prop_name(program: str, generic_program: str):
+    @irdl_op_definition
+    class OpWithRenamedProp(IRDLOperation):
+        name = "test.one_prop"
+
+        python = prop_def(Attribute, prop_name="irdl")
+        assembly_format = "$irdl attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(OpWithRenamedProp)
 
     check_equivalence(program, generic_program, ctx)
     check_roundtrip(program, ctx)

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -294,9 +294,15 @@ class FormatParser(BaseParser):
             else:
                 return ResultVariable(variable_name, idx)
 
+        attr_or_prop_by_name = {
+            attr_name: attr_or_prop
+            for attr_name, attr_or_prop in self.op_def.accessor_names.values()
+        }
+
         # Check if the variable is an attribute
-        if variable_name in self.op_def.accessor_names:
-            (attr_name, attr_or_prop) = self.op_def.accessor_names[variable_name]
+        if variable_name in attr_or_prop_by_name:
+            attr_name = variable_name
+            attr_or_prop = attr_or_prop_by_name[attr_name]
             if self.context == ParsingContext.TopLevel:
                 if attr_or_prop == "property":
                     if attr_name in self.seen_properties:


### PR DESCRIPTION
We can either use the python or the irdl name in the custom assembly format, it make sense to me to stick to the IRDL name of things to be portable. Not sure if there's an aspect that I'm missing here.