### PR TITLE
dialects / bug : (linalg) linalg.generic constructor does not have a result types argument

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -38,6 +38,6 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-NEXT:    %2 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %3 = arith.addf %in, %in_0 : f32
-// CHECK-NEXT:      linalg.yield %4 : f32
+// CHECK-NEXT:      linalg.yield %3 : f32
 // CHECK-NEXT:    } -> tensor<2x3xf32>
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -33,8 +33,7 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-NEXT:    ^bb0(%in: f32, %out: f32):
 // CHECK-NEXT:      linalg.yield %in : f32
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }
-// CHECK-NEXT:    %1:2 = "test.op"() : () -> (tensor<2x3xf32>, tensor<2x3xf32>)
+/// CHECK-NEXT:   %1:2 = "test.op"() : () -> (tensor<2x3xf32>, tensor<2x3xf32>)
 // CHECK-NEXT:    %2 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %3 = arith.addf %in, %in_0 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -15,9 +15,7 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 
 %2, %3 = "test.op"() : () -> (tensor<2x3xf32>, tensor<2x3xf32>)
 
-%sum = linalg.add ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%3 : tensor<2x3xf32>) -> tensor<2x3xf32>
-
-%sum_2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) {
+%sum = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) {
 ^bb0(%in: f32, %in_0: f32, %out: f32):
     %acc = arith.addf %in, %in_0 : f32
     linalg.yield %acc : f32
@@ -37,10 +35,9 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:    %1:2 = "test.op"() : () -> (tensor<2x3xf32>, tensor<2x3xf32>)
-// CHECK-NEXT:    %2 = linalg.add ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#1 : tensor<2x3xf32>) -> tensor<2x3xf32>
-// CHECK-NEXT:    %3 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
+// CHECK-NEXT:    %2 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
-// CHECK-NEXT:      %4 = arith.addf %in, %in_0 : f32
+// CHECK-NEXT:      %3 = arith.addf %in, %in_0 : f32
 // CHECK-NEXT:      linalg.yield %4 : f32
 // CHECK-NEXT:    } -> tensor<2x3xf32>
 // CHECK-NEXT:  }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -13,6 +13,16 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
     linalg.yield %arg3 : f32
 }
 
+%2, %3 = "test.op"() : () -> (tensor<2x3xf32>, tensor<2x3xf32>)
+
+%sum = linalg.add ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%3 : tensor<2x3xf32>) -> tensor<2x3xf32>
+
+%sum_2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) {
+^bb0(%in: f32, %in_0: f32, %out: f32):
+    %acc = arith.addf %in, %in_0 : f32
+    linalg.yield %acc : f32
+} -> tensor<2x3xf32>
+
 // CHECK-NEXT:  #map = affine_map<(d0, d1) -> ()>
 // CHECK-NEXT:  #map1 = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-NEXT:  module {
@@ -25,4 +35,12 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-NEXT:    ^bb0(%in: f32, %out: f32):
 // CHECK-NEXT:      linalg.yield %in : f32
 // CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// CHECK-NEXT:    %1:2 = "test.op"() : () -> (tensor<2x3xf32>, tensor<2x3xf32>)
+// CHECK-NEXT:    %2 = linalg.add ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#1 : tensor<2x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:    %3 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
+// CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
+// CHECK-NEXT:      %4 = arith.addf %in, %in_0 : f32
+// CHECK-NEXT:      linalg.yield %4 : f32
+// CHECK-NEXT:    } -> tensor<2x3xf32>
 // CHECK-NEXT:  }

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -347,7 +347,21 @@ class Generic(IRDLOperation):
 
         body = parser.parse_region()
 
-        generic = cls(ins, outs, body, indexing_maps, iterator_types, doc, library_call)
+        if parser.parse_optional_characters(" -> "):
+            result_types = parser._parse_op_result()
+        else:
+            result_types = ()
+
+        generic = cls(
+            ins,
+            outs,
+            body,
+            indexing_maps,
+            iterator_types,
+            result_types,
+            doc,
+            library_call,
+        )
         generic.attributes |= attrs
         generic.attributes |= extra_attrs
 

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -347,10 +347,7 @@ class Generic(IRDLOperation):
 
         body = parser.parse_region()
 
-        if parser.parse_optional_characters(" -> "):
-            result_types = parser._parse_op_result()
-        else:
-            result_types = ()
+        result_types = ()
 
         generic = cls(
             ins,

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -110,12 +110,13 @@ class Generic(IRDLOperation):
         body: Region,
         indexing_maps: Sequence[AffineMapAttr] | ArrayAttr[AffineMapAttr],
         iterator_types: Sequence[Attribute] | ArrayAttr[Attribute],
+        result_types: Sequence[Attribute] = (),
         doc: StringAttr | None = None,
         library_call: StringAttr | None = None,
     ) -> None:
         super().__init__(
             operands=[inputs, outputs],
-            result_types=[[]],
+            result_types=[result_types],
             properties={
                 "indexing_maps": ArrayAttr(indexing_maps),
                 "iterator_types": ArrayAttr(iterator_types),
@@ -238,6 +239,10 @@ class Generic(IRDLOperation):
 
         printer.print_string(" ")
         printer.print_region(self.body)
+
+        if self.res:
+            printer.print_string(" -> ")
+            printer.print_list(self.res, lambda res: printer.print_attribute(res.type))
 
     @classmethod
     def parse(cls, parser: Parser) -> Self:

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -347,7 +347,12 @@ class Generic(IRDLOperation):
 
         body = parser.parse_region()
 
-        result_types = ()
+        if parser.parse_optional_punctuation("->"):
+            res_types = parser.parse_comma_separated_list(
+                parser.Delimiter.NONE, parser.parse_attribute
+            )
+        else:
+            res_types = ()
 
         generic = cls(
             ins,
@@ -355,7 +360,7 @@ class Generic(IRDLOperation):
             body,
             indexing_maps,
             iterator_types,
-            result_types,
+            res_types,
             doc,
             library_call,
         )


### PR DESCRIPTION
resolves #2115, where no argument is present for results type. 
Note: Parsing code for the result is also added in this PR 