### PR TITLE
frontend: (onnx) add get_shape and get_tensor_type

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -46,6 +46,8 @@ jobs:
         # Change directory so that xdsl-opt can be found during installation.
         cd xdsl
         pip install -r requirements.txt
+        # install onnx dependencies
+        pip install -e ".[onnx]"
 
     - name: Cache binaries
       id: cache-binary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,10 @@ typeCheckingMode = "strict"
 "exclude" = [
     "tests/test_frontend_op_resolver.py",
     "tests/test_frontend_python_code_check.py",
+    "tests/frontend/onnx/test_tensor_type.py",
     "tests/dialects/test_memref.py",
     "xdsl/interpreters/experimental/wgpu.py",
-    "xdsl/frontend/onnx.py",
+    "xdsl/frontend/onnx/shape_type.py",
 ]
 "ignore" = [
     "tests/filecheck/frontend/dialects/builtin.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 extras = ["riscemu==2.2.5", "wgpu==0.13.2", "textual==0.47.1", "pyclip==0.7"]
+onnx = ["onnx-weekly"]
 
 [project.urls]
 Homepage = "https://xdsl.dev/"
@@ -46,6 +47,7 @@ typeCheckingMode = "strict"
     "tests/test_frontend_python_code_check.py",
     "tests/dialects/test_memref.py",
     "xdsl/interpreters/experimental/wgpu.py",
+    "xdsl/frontend/onnx.py",
 ]
 "ignore" = [
     "tests/filecheck/frontend/dialects/builtin.py",

--- a/tests/frontend/onnx/test_tensor_type.py
+++ b/tests/frontend/onnx/test_tensor_type.py
@@ -1,0 +1,49 @@
+import pytest
+
+from xdsl.dialects.builtin import TensorType, f32, f64
+
+pytest.importorskip("onnx", reason="riscemu is an optional dependency")
+
+from onnx import TensorShapeProto, TypeProto  # noqa: E402
+
+from xdsl.frontend.onnx.shape_type import get_shape, get_tensor_type  # noqa: E402
+
+
+def test_get_shape():
+    assert get_shape(TensorShapeProto()) == ()
+    assert get_shape(
+        TensorShapeProto(dim=(TensorShapeProto.Dimension(dim_value=1),))
+    ) == (1,)
+    assert get_shape(
+        TensorShapeProto(
+            dim=(
+                TensorShapeProto.Dimension(dim_value=1),
+                TensorShapeProto.Dimension(dim_value=2),
+            )
+        )
+    ) == (1, 2)
+
+
+def test_get_tensor_type():
+    assert get_tensor_type(
+        TypeProto.Tensor(
+            elem_type=1,
+            shape=TensorShapeProto(
+                dim=(
+                    TensorShapeProto.Dimension(dim_value=2),
+                    TensorShapeProto.Dimension(dim_value=3),
+                )
+            ),
+        )
+    ) == TensorType(f32, (2, 3))
+    assert get_tensor_type(
+        TypeProto.Tensor(
+            elem_type=11,
+            shape=TensorShapeProto(
+                dim=(
+                    TensorShapeProto.Dimension(dim_value=4),
+                    TensorShapeProto.Dimension(dim_value=5),
+                )
+            ),
+        )
+    ) == TensorType(f64, (4, 5))

--- a/tests/frontend/onnx/test_tensor_type.py
+++ b/tests/frontend/onnx/test_tensor_type.py
@@ -2,11 +2,13 @@ import pytest
 
 from xdsl.dialects.builtin import TensorType, f32, f64
 
-pytest.importorskip("onnx-weekly", reason="onnx is an optional dependency")
+try:
+    from onnx import TensorShapeProto, TypeProto  # noqa: E402
 
-from onnx import TensorShapeProto, TypeProto  # noqa: E402
-
-from xdsl.frontend.onnx.shape_type import get_shape, get_tensor_type  # noqa: E402
+    from xdsl.frontend.onnx.shape_type import get_shape, get_tensor_type  # noqa: E402
+except ImportError as exc:
+    print(exc)
+    pytest.skip("onnx is an optional dependency", allow_module_level=True)
 
 
 def test_get_shape():

--- a/tests/frontend/onnx/test_tensor_type.py
+++ b/tests/frontend/onnx/test_tensor_type.py
@@ -2,7 +2,7 @@ import pytest
 
 from xdsl.dialects.builtin import TensorType, f32, f64
 
-pytest.importorskip("onnx", reason="riscemu is an optional dependency")
+pytest.importorskip("onnx-weekly", reason="onnx is an optional dependency")
 
 from onnx import TensorShapeProto, TypeProto  # noqa: E402
 

--- a/xdsl/frontend/onnx/shape_type.py
+++ b/xdsl/frontend/onnx/shape_type.py
@@ -1,0 +1,15 @@
+from onnx import TensorShapeProto, TypeProto
+
+from xdsl.dialects.builtin import TensorType
+from xdsl.frontend.onnx.elem_type import get_elem_type
+from xdsl.ir import Attribute
+
+
+def get_shape(shape: TensorShapeProto) -> tuple[int, ...]:
+    return tuple(dim.dim_value for dim in shape.dim)
+
+
+def get_tensor_type(tensor: TypeProto.Tensor) -> TensorType[Attribute]:
+    elem_type = get_elem_type(tensor.elem_type)
+    shape = get_shape(tensor.shape)
+    return TensorType(elem_type, shape)


### PR DESCRIPTION
Also adds onnx as an optional dependency, that doesn't get installed by default even with `-r requirements.txt`, and adds a unit test that gets skipped if onnx is not installed.