### PR TITLE
interactive: change input text so you can see example of a rewrite on gui launch 

### DIFF
--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -107,10 +107,10 @@ class InputApp(App[None]):
     """
 
     INITIAL_IR_TEXT = """
-        func.func @hello(%n : index) -> index {
-          %two = arith.constant 2 : index
-          %res = arith.muli %n, %two : index
-          func.return %res : index
+        func.func @hello(%n : i32) -> i32 {
+          %two = arith.constant 0 : i32
+          %res = arith.addi %two, %n : i32
+          func.return %res : i32
         }
         """
 


### PR DESCRIPTION
Changed input text to be an example where you can see an example of rewrite on gui launch. A canonicalizaiton pattern for Add Immediate Zero was pushed, and thats why this example will show a rewrite and the other one did not (no rewrite defined yet). Still need to add more rewrite patterns --> next PR's. 