### PR TITLE
dialects: (snitch_stream) replace stride pattern op with attribute

### DIFF
--- a/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
+++ b/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
@@ -5,32 +5,35 @@
 %A, %B, %C = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 // CHECK-NEXT:  %A, %B, %C = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 
-%sp1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<1>
+%sp1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<1>
+%sp2 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>], "strides" = [#builtin.int<24>, #builtin.int<8>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<2>
+%sp4 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>, #builtin.int<4>, #builtin.int<5>], "strides" = [#builtin.int<480>, #builtin.int<160>, #builtin.int<40>, #builtin.int<8>], "dm" = #builtin.int<2>} : () -> !snitch_stream.stride_pattern_type<4>
+
+
+"snitch_stream.streaming_region"(%A, %B, %C, %sp1, %sp2, %sp4) <{"operandSegmentSizes" = array<i32: 2, 1, 3>}> ({
+^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
+    "test.op"() : () -> ()
+}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<1>, !snitch_stream.stride_pattern_type<2>, !snitch_stream.stride_pattern_type<4>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
-
-%sp2 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>], "strides" = [#builtin.int<24>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
 // CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 24 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-
-
-%sp4 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>, #builtin.int<4>, #builtin.int<5>], "strides" = [#builtin.int<480>, #builtin.int<160>, #builtin.int<40>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<4>
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 4 : () -> !riscv.reg<>
@@ -43,47 +46,49 @@
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<2>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<2>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<2>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<2>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-
-
-"snitch_stream.streaming_region"(%A, %B, %C, %sp2) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
-^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
-    %c5 = riscv.li 5 : () -> !riscv.reg<>
-    riscv_snitch.frep_outer %c5 {
-        %a = riscv_snitch.read from %a_stream : !riscv.freg<ft0>
-        %b = riscv_snitch.read from %b_stream : !riscv.freg<ft1>
-        %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
-        riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
-    }
-}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%A) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%A) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%B) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_destination"(%C) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_destination"(%C) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
 // CHECK-NEXT:  %a_stream, %b_stream, %c_stream = "snitch.ssr_enable"() : () -> (!stream.readable<!riscv.freg<ft0>>, !stream.readable<!riscv.freg<ft1>>, !stream.writable<!riscv.freg<ft2>>)
-// CHECK-NEXT:  %{{.*}} = riscv.li 5 : () -> !riscv.reg<>
-// CHECK-NEXT:  riscv_snitch.frep_outer %{{.*}} {
-// CHECK-NEXT:    %a = riscv_snitch.read from %a_stream : !riscv.freg<ft0>
-// CHECK-NEXT:    %b = riscv_snitch.read from %b_stream : !riscv.freg<ft1>
-// CHECK-NEXT:    %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
-// CHECK-NEXT:    riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
-// CHECK-NEXT:  }
+// CHECK-NEXT:  "test.op"() : () -> ()
+// CHECK-NEXT:  "snitch.ssr_disable"() : () -> ()
+
+
+%sp1_31 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<1>
+
+"snitch_stream.streaming_region"(%A, %B, %sp1_31) <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> ({
+^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.writable<!riscv.freg<ft1>>):
+    "test.op"() : () -> ()
+}) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<1>) -> ()
+
+// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
+// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
+// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%A) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_destination"(%B) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  %{{.*}}, %{{.*}} = "snitch.ssr_enable"() : () -> (!stream.readable<!riscv.freg<ft0>>, !stream.writable<!riscv.freg<ft1>>)
+// CHECK-NEXT:  "test.op"() : () -> ()
 // CHECK-NEXT:  "snitch.ssr_disable"() : () -> ()
 
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
+++ b/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
@@ -5,15 +5,17 @@
 %A, %B, %C = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 // CHECK-NEXT:  %A, %B, %C = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 
-%sp1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<1>
-%sp2 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>], "strides" = [#builtin.int<24>, #builtin.int<8>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<2>
-%sp4 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>, #builtin.int<4>, #builtin.int<5>], "strides" = [#builtin.int<480>, #builtin.int<160>, #builtin.int<40>, #builtin.int<8>], "dm" = #builtin.int<2>} : () -> !snitch_stream.stride_pattern_type<4>
-
-
-"snitch_stream.streaming_region"(%A, %B, %C, %sp1, %sp2, %sp4) <{"operandSegmentSizes" = array<i32: 2, 1, 3>}> ({
+"snitch_stream.streaming_region"(%A, %B, %C) <{
+    "stride_patterns" = [
+        #snitch_stream.stride_pattern<ub = [2], strides = [8]>,
+        #snitch_stream.stride_pattern<ub = [2, 3], strides = [24, 8]>,
+        #snitch_stream.stride_pattern<ub = [2, 3, 4, 5], strides = [480, 160, 40, 8]>
+    ],
+    "operandSegmentSizes" = array<i32: 2, 1>
+}> ({
 ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
     "test.op"() : () -> ()
-}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<1>, !snitch_stream.stride_pattern_type<2>, !snitch_stream.stride_pattern_type<4>) -> ()
+}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 // CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
@@ -71,13 +73,15 @@
 // CHECK-NEXT:  "test.op"() : () -> ()
 // CHECK-NEXT:  "snitch.ssr_disable"() : () -> ()
 
-
-%sp1_31 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<1>
-
-"snitch_stream.streaming_region"(%A, %B, %sp1_31) <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> ({
+"snitch_stream.streaming_region"(%A, %B) <{
+    "stride_patterns" = [
+        #snitch_stream.stride_pattern<ub = [2], strides = [8]>
+    ],
+    "operandSegmentSizes" = array<i32: 1, 1>
+}> ({
 ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.writable<!riscv.freg<ft1>>):
     "test.op"() : () -> ()
-}) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<1>) -> ()
+}) : (!riscv.reg<>, !riscv.reg<>) -> ()
 
 // CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/snitch_stream/ops.mlir
+++ b/tests/filecheck/dialects/snitch_stream/ops.mlir
@@ -3,6 +3,8 @@
 
 %X, %Y, %Z, %n = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 
+"test.op"() {"pat" = #snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>} : () -> ()
+
 %pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
 
 "snitch_stream.streaming_region"(%X, %Y, %Z, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
@@ -18,7 +20,8 @@
 
 
 // CHECK:       %X, %Y, %Z, %n = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT:       %pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
+// CHECK-NEXT:  "test.op"() {"pat" = #snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>} : () -> ()
+// CHECK-NEXT:  %pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
 // CHECK-NEXT:  "snitch_stream.streaming_region"(%X, %Y, %Z, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
 // CHECK-NEXT:  ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
 // CHECK-NEXT:    %c5 = riscv.li 5 : () -> !riscv.reg<>
@@ -31,7 +34,8 @@
 // CHECK-NEXT:  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
 
 
-// CHECK-GENERIC:       %X, %Y, %Z, %n = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-GENERIC:         %X, %Y, %Z, %n = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-GENERIC-NEXT:    "test.op"() {"pat" = #snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>} : () -> ()
 // CHECK-GENERIC-NEXT:    %pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
 // CHECK-GENERIC-NEXT:    "snitch_stream.streaming_region"(%X, %Y, %Z, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):

--- a/tests/filecheck/dialects/snitch_stream/ops.mlir
+++ b/tests/filecheck/dialects/snitch_stream/ops.mlir
@@ -1,13 +1,12 @@
 // RUN: XDSL_ROUNDTRIP
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
-%X, %Y, %Z, %n = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+%X, %Y, %Z = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 
-"test.op"() {"pat" = #snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>} : () -> ()
-
-%pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
-
-"snitch_stream.streaming_region"(%X, %Y, %Z, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+"snitch_stream.streaming_region"(%X, %Y, %Z) <{
+    "stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>],
+    "operandSegmentSizes" = array<i32: 2, 1>
+}> ({
 ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
     %c5 = riscv.li 5 : () -> !riscv.reg<>
     riscv_snitch.frep_outer %c5 {
@@ -16,14 +15,12 @@
         %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
         riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
     }
-}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 
 
-// CHECK:       %X, %Y, %Z, %n = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT:  "test.op"() {"pat" = #snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>} : () -> ()
-// CHECK-NEXT:  %pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
-// CHECK-NEXT:  "snitch_stream.streaming_region"(%X, %Y, %Z, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
-// CHECK-NEXT:  ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
+// CHECK:       %X, %Y, %Z = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-NEXT:   "snitch_stream.streaming_region"(%X, %Y, %Z) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:    ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
 // CHECK-NEXT:    %c5 = riscv.li 5 : () -> !riscv.reg<>
 // CHECK-NEXT:    riscv_snitch.frep_outer %c5 {
 // CHECK-NEXT:      %a = riscv_snitch.read from %a_stream : !riscv.freg<ft0>
@@ -31,13 +28,11 @@
 // CHECK-NEXT:      %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
 // CHECK-NEXT:      riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+// CHECK-NEXT:  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 
 
-// CHECK-GENERIC:         %X, %Y, %Z, %n = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-GENERIC-NEXT:    "test.op"() {"pat" = #snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>} : () -> ()
-// CHECK-GENERIC-NEXT:    %pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
-// CHECK-GENERIC-NEXT:    "snitch_stream.streaming_region"(%X, %Y, %Z, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+// CHECK-GENERIC:         %X, %Y, %Z = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-GENERIC-NEXT:    "snitch_stream.streaming_region"(%X, %Y, %Z) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
 // CHECK-GENERIC-NEXT:      %c5 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_outer"(%c5) ({
@@ -47,4 +42,4 @@
 // CHECK-GENERIC-NEXT:        "riscv_snitch.write"(%c, %c_stream) : (!riscv.freg<ft2>, !stream.writable<!riscv.freg<ft2>>) -> ()
 // CHECK-GENERIC-NEXT:        "riscv_snitch.frep_yield"() : () -> ()
 // CHECK-GENERIC-NEXT:      }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+// CHECK-GENERIC-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()

--- a/tests/filecheck/projects/riscv-backend-paper/add_snitch_stream.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/add_snitch_stream.mlir
@@ -16,8 +16,10 @@ builtin.module {
       %A = riscv.li "a" : () -> !riscv.reg<>
       %B = riscv.li "b" : () -> !riscv.reg<>
       %C = riscv.li "c" : () -> !riscv.reg<>
-      %pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>], "strides" = [#builtin.int<24>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
-      "snitch_stream.streaming_region"(%A, %B, %C, %pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+      "snitch_stream.streaming_region"(%A, %B, %C) <{
+        "stride_patterns" = [#snitch_stream.stride_pattern<ub = [2, 3], strides = [24, 8]>],
+        "operandSegmentSizes" = array<i32: 2, 1>
+      }> ({
       ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
           %c5 = riscv.li 5 : () -> !riscv.reg<>
           riscv_snitch.frep_outer %c5 {
@@ -26,7 +28,7 @@ builtin.module {
               %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
               riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
           }
-      }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+      }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
       %5 = riscv.mv %C : (!riscv.reg<>) -> !riscv.reg<>
       %v0 = riscv.fld %5, 0 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
       %v1 = riscv.fld %C, 8 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>

--- a/tests/filecheck/projects/riscv-backend-paper/conv_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/conv_target.mlir
@@ -22,10 +22,13 @@ riscv_func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
     %zero_float = riscv.fcvt.d.w %c0 : (!riscv.reg<>) -> !riscv.freg<>
 
-    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<6>, #builtin.int<6>], "strides" = [#builtin.int<8>, #builtin.int<64>, #builtin.int<8>, #builtin.int<64>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<4>
-    %stride_pattern_1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<6>, #builtin.int<6>], "strides" = [#builtin.int<8>, #builtin.int<24>, #builtin.int<0>, #builtin.int<0>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<4>
-
-    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern_0, %stride_pattern_1) <{"operandSegmentSizes" = array<i32: 2, 0, 2>}> ({
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved) <{
+      "stride_patterns" = [
+        #snitch_stream.stride_pattern<ub = [3, 3, 6, 6], strides = [8, 64, 8, 64]>,
+        #snitch_stream.stride_pattern<ub = [3, 3, 6, 6], strides = [8, 24, 0, 0]>
+      ],
+      "operandSegmentSizes" = array<i32: 2, 0>
+    }> ({
     ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
       %c288 = riscv.li 288 : () -> !riscv.reg<>
       riscv_scf.for %z_i : !riscv.reg<> = %c0 to %c288 step %c8 {
@@ -43,7 +46,7 @@ riscv_func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
         riscv_scf.yield
       }
-    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<4>, !snitch_stream.stride_pattern_type<4>) -> ()
+    }) : (!riscv.reg<>, !riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/projects/riscv-backend-paper/ddot_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/ddot_target.mlir
@@ -13,9 +13,10 @@ riscv.assembly_section ".text" {
     %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
     %G_moved = riscv.mv %G : (!riscv.reg<a2>) -> !riscv.reg<>
 
-    %stride_pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<128>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<1>
-
-    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern) <{"operandSegmentSizes" = array<i32: 2, 0, 1>}> ({
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved) <{
+      "stride_patterns" = [#snitch_stream.stride_pattern<ub = [128], strides = [8]>],
+      "operandSegmentSizes" = array<i32: 2, 0>
+    }> ({
     ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
         %init = riscv.fld %G_moved, 0 : (!riscv.reg<>) -> !riscv.freg<>
 
@@ -30,7 +31,7 @@ riscv.assembly_section ".text" {
         }
 
         riscv.fsd %G_moved, %g, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
-    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<1>) -> ()
+    }) : (!riscv.reg<>, !riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/projects/riscv-backend-paper/dense_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/dense_target.mlir
@@ -26,13 +26,14 @@ riscv.assembly_section ".text" {
 
     %zero_float = riscv.fcvt.d.w %c0 : (!riscv.reg<>) -> !riscv.freg<>
 
-    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<8>, #builtin.int<0>, #builtin.int<64>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<3>
-
-    %stride_pattern_1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<64>, #builtin.int<8>, #builtin.int<0>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<3>
-
-    %stride_pattern_2 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<8>, #builtin.int<64>], "dm" = #builtin.int<2>} : () -> !snitch_stream.stride_pattern_type<2>
-
-    "snitch_stream.streaming_region"(%X_moved, %W_moved, %B_moved, %stride_pattern_0, %stride_pattern_1, %stride_pattern_2) <{"operandSegmentSizes" = array<i32: 3, 0, 3>}> ({
+    "snitch_stream.streaming_region"(%X_moved, %W_moved, %B_moved) <{
+      "stride_patterns" = [
+        #snitch_stream.stride_pattern<ub = [8, 8, 8], strides = [8, 0, 64]>,
+        #snitch_stream.stride_pattern<ub = [8, 8, 8], strides = [64, 8, 0]>,
+        #snitch_stream.stride_pattern<ub = [8, 8], strides = [8, 64]>
+      ],
+      "operandSegmentSizes" = array<i32: 3, 0>
+    }> ({
     ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %W_stream : !stream.readable<!riscv.freg<ft1>>, %B_stream : !stream.readable<!riscv.freg<ft2>>):
       riscv_scf.for %y_i : !riscv.reg<> = %c0 to %c512 step %c8 {
         %Y_dest = riscv.add %Y_moved, %y_i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
@@ -53,7 +54,7 @@ riscv.assembly_section ".text" {
 
         riscv_scf.yield
       }
-    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<3>, !snitch_stream.stride_pattern_type<3>, !snitch_stream.stride_pattern_type<2>) -> ()
+    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/projects/riscv-backend-paper/dsum_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/dsum_target.mlir
@@ -7,11 +7,13 @@
       %0 = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
       %1 = riscv.mv %arg1 : (!riscv.reg<a1>) -> !riscv.reg<>
       %2 = riscv.mv %arg2 : (!riscv.reg<a2>) -> !riscv.reg<>
-      %3 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
       %c0 = riscv.li 0 : () -> !riscv.reg<>
       %c1 = riscv.li 1 : () -> !riscv.reg<>
       %c128 = riscv.li 128 : () -> !riscv.reg<>
-      "snitch_stream.streaming_region"(%0, %1, %2, %3) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+      "snitch_stream.streaming_region"(%0, %1, %2) <{
+        "stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>],
+        "operandSegmentSizes" = array<i32: 2, 1>
+      }> ({
       ^0(%5 : !stream.readable<!riscv.freg<ft0>>, %6 : !stream.readable<!riscv.freg<ft1>>, %7 : !stream.writable<!riscv.freg<ft2>>):
         riscv_scf.for %i : !riscv.reg<> = %c0 to %c128 step %c1 {
           %9 = riscv_snitch.read from %5 : !riscv.freg<ft0>
@@ -20,7 +22,7 @@
           riscv_snitch.write %11 to %7 : !riscv.freg<ft2>
           riscv_scf.yield
         }
-      }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+      }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
       %12 = riscv.mv %2 : (!riscv.reg<>) -> !riscv.reg<a0>
       riscv_func.return %12 : !riscv.reg<a0>
     }

--- a/tests/filecheck/projects/riscv-backend-paper/fill_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/fill_target.mlir
@@ -14,9 +14,10 @@ riscv.assembly_section ".text" {
 
     %x = riscv.fmv.d %X_moved : (!riscv.freg<>) -> !riscv.freg<>
 
-    %stride_pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<256>], "strides" = [#builtin.int<8>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<1>
-
-    "snitch_stream.streaming_region"(%Y_moved, %stride_pattern) <{"operandSegmentSizes" = array<i32: 0, 1, 1>}> ({
+    "snitch_stream.streaming_region"(%Y_moved) <{
+      "stride_patterns" = [#snitch_stream.stride_pattern<ub = [256], strides=[8]>],
+      "operandSegmentSizes" = array<i32: 0, 1>
+    }> ({
     ^bb0(%Y_stream : !stream.writable<!riscv.freg<ft0>>):
       %c0 = riscv.li 0 : () -> !riscv.reg<>
       %c1 = riscv.li 1 : () -> !riscv.reg<>
@@ -25,7 +26,7 @@ riscv.assembly_section ".text" {
         %y = riscv.fmv.d %x : (!riscv.freg<>) -> !riscv.freg<ft0>
         riscv_snitch.write %y to %Y_stream : !riscv.freg<ft0>
       }
-    }) : (!riscv.reg<>, !snitch_stream.stride_pattern_type<1>) -> ()
+    }) : (!riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/projects/riscv-backend-paper/matmul_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/matmul_target.mlir
@@ -21,11 +21,13 @@ riscv.assembly_section ".text" {
     %c8 = riscv.li 8 : () -> !riscv.reg<>
     %c512 = riscv.li 512 : () -> !riscv.reg<>
 
-    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<8>, #builtin.int<0>, #builtin.int<64>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<3>
-
-    %stride_pattern_1 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<8>, #builtin.int<8>, #builtin.int<8>], "strides" = [#builtin.int<64>, #builtin.int<8>, #builtin.int<0>], "dm" = #builtin.int<1>} : () -> !snitch_stream.stride_pattern_type<3>
-
-    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern_0, %stride_pattern_1) <{"operandSegmentSizes" = array<i32: 2, 0, 2>}> ({
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved) <{
+      "stride_patterns" = [
+        #snitch_stream.stride_pattern<ub = [8, 8, 8], strides = [8, 0, 64]>,
+        #snitch_stream.stride_pattern<ub = [8, 8, 8], strides = [64, 8, 0]>
+      ],
+      "operandSegmentSizes" = array<i32: 2, 0>
+    }> ({
     ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
       riscv_scf.for %g_i : !riscv.reg<> = %c0 to %c512 step %c8 {
         %G_dest = riscv.add %G_moved, %g_i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
@@ -42,7 +44,7 @@ riscv.assembly_section ".text" {
 
         riscv_scf.yield
       }
-    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<3>, !snitch_stream.stride_pattern_type<3>) -> ()
+    }) : (!riscv.reg<>, !riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/projects/riscv-backend-paper/max_pool_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/max_pool_target.mlir
@@ -19,9 +19,10 @@ riscv_func.func public @pooling_nchw_max_d1_s2_3x3(
     %c9 = riscv.li 9 : () -> !riscv.reg<>
     %c512 = riscv.li 512 : () -> !riscv.reg<>
 
-    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<7>, #builtin.int<7>], "strides" = [#builtin.int<8>, #builtin.int<128>, #builtin.int<16>, #builtin.int<256>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<4>
-
-    "snitch_stream.streaming_region"(%X_moved, %stride_pattern_0) <{"operandSegmentSizes" = array<i32: 1, 0, 1>}> ({
+    "snitch_stream.streaming_region"(%X_moved) <{
+      "stride_patterns" = [#snitch_stream.stride_pattern<ub = [3, 3, 7, 7], strides = [8, 128, 16, 256]>],
+      "operandSegmentSizes" = array<i32: 1, 0>
+    }> ({
     ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
       %c392 = riscv.li 392 : () -> !riscv.reg<>
       riscv_scf.for %y_i : !riscv.reg<> = %c0 to %c392 step %c8 {
@@ -38,7 +39,7 @@ riscv_func.func public @pooling_nchw_max_d1_s2_3x3(
 
         riscv_scf.yield
       }
-    }) : (!riscv.reg<>, !snitch_stream.stride_pattern_type<4>) -> ()
+    }) : (!riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/projects/riscv-backend-paper/relu_snitch_stream.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/relu_snitch_stream.mlir
@@ -21,8 +21,10 @@ builtin.module {
       %zero_2 = riscv.li 0 : () -> !riscv.reg<>
       riscv.sw %zero, %zero_2, -8 : (!riscv.reg<sp>, !riscv.reg<>) -> ()
       %zero_3 = riscv.fld %zero, -8 : (!riscv.reg<sp>) -> !riscv.freg<>
-      %stride_pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<2>, #builtin.int<3>], "strides" = [#builtin.int<24>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
-      "snitch_stream.streaming_region"(%A, %B, %stride_pattern, %stride_pattern) <{"operandSegmentSizes" = array<i32: 1, 1, 2>}> ({
+      "snitch_stream.streaming_region"(%A, %B) <{
+        "stride_patterns" = [#snitch_stream.stride_pattern<ub = [2, 3], strides = [24, 8]>],
+        "operandSegmentSizes" = array<i32: 1, 1>
+      }> ({
       ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.writable<!riscv.freg<ft1>>):
         %c5 = riscv.li 5 : () -> !riscv.reg<>
         riscv_snitch.frep_outer %c5 {
@@ -30,7 +32,7 @@ builtin.module {
           %b = riscv.fmax.d %a, %zero_3 : (!riscv.freg<ft0>, !riscv.freg<>) -> !riscv.freg<ft1>
           riscv_snitch.write %b to %b_stream : !riscv.freg<ft1>
         }
-      }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>, !snitch_stream.stride_pattern_type<2>) -> ()
+      }) : (!riscv.reg<>, !riscv.reg<>) -> ()
       %v0 = riscv.fld %B, 0 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
       %v1 = riscv.fld %B, 8 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
       %v2 = riscv.fld %B, 16 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>

--- a/tests/filecheck/projects/riscv-backend-paper/relu_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/relu_target.mlir
@@ -10,9 +10,10 @@ riscv.assembly_section ".text" {
     %zero_int = riscv.get_register : () -> !riscv.reg<zero>
     %zero_float = riscv.fcvt.d.w %zero_int : (!riscv.reg<zero>) -> !riscv.freg<>
 
-    %stride_pattern = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<16>, #builtin.int<16>], "strides" = [#builtin.int<128>, #builtin.int<8>], "dm" = #builtin.int<31>} : () -> !snitch_stream.stride_pattern_type<2>
-
-    "snitch_stream.streaming_region"(%X_moved, %Y_moved, %stride_pattern) <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> ({
+    "snitch_stream.streaming_region"(%X_moved, %Y_moved) <{
+      "stride_patterns" = [#snitch_stream.stride_pattern<ub = [16, 16], strides = [128, 8]>],
+      "operandSegmentSizes" = array<i32: 1, 1>
+    }> ({
     ^0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.writable<!riscv.freg<ft1>>):
       %c0 = riscv.li 0 : () -> !riscv.reg<>
       %c1 = riscv.li 1 : () -> !riscv.reg<>
@@ -22,7 +23,7 @@ riscv.assembly_section ".text" {
         %y = riscv.fmax.d %x, %zero_float : (!riscv.freg<ft0>, !riscv.freg<>) -> !riscv.freg<ft1>
         riscv_snitch.write %y to %Y_stream : !riscv.freg<ft1>
       }
-    }) : (!riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+    }) : (!riscv.reg<>, !riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/projects/riscv-backend-paper/sum_pool_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/sum_pool_target.mlir
@@ -19,9 +19,10 @@ riscv_func.func public @pooling_nchw_sum_d1_s2_3x3(
     %c9 = riscv.li 9 : () -> !riscv.reg<>
     %c512 = riscv.li 512 : () -> !riscv.reg<>
 
-    %stride_pattern_0 = "snitch_stream.stride_pattern"() {"ub" = [#builtin.int<3>, #builtin.int<3>, #builtin.int<7>, #builtin.int<7>], "strides" = [#builtin.int<8>, #builtin.int<128>, #builtin.int<16>, #builtin.int<256>], "dm" = #builtin.int<0>} : () -> !snitch_stream.stride_pattern_type<4>
-
-    "snitch_stream.streaming_region"(%X_moved, %stride_pattern_0) <{"operandSegmentSizes" = array<i32: 1, 0, 1>}> ({
+    "snitch_stream.streaming_region"(%X_moved) <{
+      "stride_patterns" = [#snitch_stream.stride_pattern<ub = [3, 3, 7, 7], strides = [8, 128, 16, 256]>],
+      "operandSegmentSizes" = array<i32: 1, 0>
+    }> ({
     ^bb0(%X_stream : !stream.readable<!riscv.freg<ft0>>, %Y_stream : !stream.readable<!riscv.freg<ft1>>):
       %c392 = riscv.li 392 : () -> !riscv.reg<>
       riscv_scf.for %y_i : !riscv.reg<> = %c0 to %c392 step %c8 {
@@ -39,7 +40,7 @@ riscv_func.func public @pooling_nchw_sum_d1_s2_3x3(
         riscv_scf.yield
       }
 
-    }) : (!riscv.reg<>, !snitch_stream.stride_pattern_type<4>) -> ()
+    }) : (!riscv.reg<>) -> ()
 
     riscv_func.return
   }

--- a/tests/filecheck/transforms/snitch_register_allocation.mlir
+++ b/tests/filecheck/transforms/snitch_register_allocation.mlir
@@ -1,8 +1,11 @@
 // RUN: xdsl-opt -p snitch-allocate-registers %s | filecheck %s
 
-%ptr0, %ptr1, %ptr2, %stride_pattern = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>)
+%ptr0, %ptr1, %ptr2 = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 
-"snitch_stream.streaming_region"(%ptr0, %ptr1, %ptr2, %stride_pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+"snitch_stream.streaming_region"(%ptr0, %ptr1, %ptr2) <{
+    "stride_patterns" = [#snitch_stream.stride_pattern<ub = [], strides = []>],
+    "operandSegmentSizes" = array<i32: 2, 1>
+}> ({
 ^0(%s0 : !stream.readable<!riscv.freg<>>, %s1 : !stream.readable<!riscv.freg<>>, %s2 : !stream.writable<!riscv.freg<>>):
     %c5 = riscv.li 5 : () -> !riscv.reg<>
     riscv_snitch.frep_outer %c5 {
@@ -11,12 +14,12 @@
         %r = riscv.fadd.d %x, %y : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
         riscv_snitch.write %r to %s2 : !riscv.freg<>
     }
-}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 
 // CHECK: builtin.module {
 
-// CHECK-NEXT:    %ptr0, %ptr1, %ptr2, %stride_pattern = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>)
-// CHECK-NEXT:    "snitch_stream.streaming_region"(%ptr0, %ptr1, %ptr2, %stride_pattern) <{"operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+// CHECK-NEXT:    %ptr0, %ptr1, %ptr2 = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-NEXT:    "snitch_stream.streaming_region"(%ptr0, %ptr1, %ptr2) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [], strides = []>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT:    ^0(%s0 : !stream.readable<!riscv.freg<ft0>>, %s1 : !stream.readable<!riscv.freg<ft1>>, %s2 : !stream.writable<!riscv.freg<ft2>>):
 // CHECK-NEXT:      %c5 = riscv.li 5 : () -> !riscv.reg<>
 // CHECK-NEXT:      riscv_snitch.frep_outer %c5 {
@@ -25,6 +28,6 @@
 // CHECK-NEXT:        %r = riscv.fadd.d %x, %y : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
 // CHECK-NEXT:        riscv_snitch.write %r to %s2 : !riscv.freg<ft2>
 // CHECK-NEXT:      }
-// CHECK-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !snitch_stream.stride_pattern_type<2>) -> ()
+// CHECK-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 
 // CHECK-NEXT: }

--- a/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
+++ b/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
@@ -17,6 +17,84 @@ from xdsl.pattern_rewriter import (
 )
 
 
+def insert_stride_pattern_ops(
+    rewriter: PatternRewriter,
+    target_op: Operation,
+    ub: builtin.ArrayAttr[builtin.IntAttr],
+    strides: builtin.ArrayAttr[builtin.IntAttr],
+    dm: builtin.IntAttr,
+):
+    # reference implementation:
+    # https://github.com/pulp-platform/snitch/blob/d026f47843f0ea6c269244c4e6851e0e09141ec3/sw/snRuntime/src/ssr.h#L73
+    #
+    # 4d loop reproduced here:
+    #
+    # // Configure an SSR data mover for a 4D loop nest.
+    # // b0: Inner-most bound (limit of loop)
+    # // b3: Outer-most bound (limit of loop)
+    # // s0: increment size of inner-most loop
+    # inline void snrt_ssr_loop_4d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
+    #                              size_t b2, size_t b3, size_t s0, size_t s1,
+    #                              size_t s2, size_t s3) {
+    #     --b0;
+    #     --b1;
+    #     --b2;
+    #     --b3;
+    #     write_ssr_cfg(REG_BOUNDS + 0, dm, b0);
+    #     write_ssr_cfg(REG_BOUNDS + 1, dm, b1);
+    #     write_ssr_cfg(REG_BOUNDS + 2, dm, b2);
+    #     write_ssr_cfg(REG_BOUNDS + 3, dm, b3);
+    #     size_t a = 0;
+    #     write_ssr_cfg(REG_STRIDES + 0, dm, s0 - a);
+    #     a += s0 * b0;
+    #     write_ssr_cfg(REG_STRIDES + 1, dm, s1 - a);
+    #     a += s1 * b1;
+    #     write_ssr_cfg(REG_STRIDES + 2, dm, s2 - a);
+    #     a += s2 * b2;
+    #     write_ssr_cfg(REG_STRIDES + 3, dm, s3 - a);
+    #     a += s3 * b3;
+    # }
+
+    rank = len(ub)
+    if rank > 4:
+        raise NotImplementedError(
+            "Only 1d, 2d, 3d, or 4d loop stride patterns are supported"
+        )
+
+    ints = tuple(builtin.IntAttr(i) for i in range(rank))
+
+    b_ops = tuple(riscv.LiOp(b.data) for b in ub)
+    s_ops = tuple(riscv.LiOp(s.data) for s in strides)
+    new_b_ops = tuple(riscv.AddiOp(b_op.rd, -1) for b_op in b_ops)
+    set_bound_ops = tuple(
+        snitch.SsrSetDimensionBoundOp(new_b_op, dm, i)
+        for (i, new_b_op) in zip(ints, new_b_ops)
+    )
+
+    new_ops: list[Operation] = [
+        *b_ops,
+        *s_ops,
+        *new_b_ops,
+        *set_bound_ops,
+        snitch.SsrSetDimensionStrideOp(s_ops[0], dm, ints[0]),
+        a_op := riscv.LiOp(0, rd=riscv.IntRegisterType.unallocated()),
+    ]
+
+    for i in range(1, rank):
+        a_inc_op = riscv.MulOp(
+            new_b_ops[i - 1], s_ops[i - 1], rd=riscv.IntRegisterType.unallocated()
+        )
+        new_a_op = riscv.AddOp(a_op, a_inc_op, rd=riscv.IntRegisterType.unallocated())
+        stride_op = riscv.SubOp(
+            s_ops[i], new_a_op, rd=riscv.IntRegisterType.unallocated()
+        )
+        set_stride_op = snitch.SsrSetDimensionStrideOp(stride_op.rd, dm, ints[i])
+        new_ops.extend((a_inc_op, new_a_op, stride_op, set_stride_op))
+        a_op = new_a_op
+
+    rewriter.insert_op_before(new_ops, target_op)
+
+
 class LowerStridePatternOp(RewritePattern):
     """
     Lower a stride pattern to snrt_ssr_loop_2d.
@@ -26,77 +104,7 @@ class LowerStridePatternOp(RewritePattern):
     def match_and_rewrite(
         self, op: snitch_stream.StridePatternOp, rewriter: PatternRewriter, /
     ):
-        # reference implementation:
-        # https://github.com/pulp-platform/snitch/blob/d026f47843f0ea6c269244c4e6851e0e09141ec3/sw/snRuntime/src/ssr.h#L73
-        #
-        # 4d loop reproduced here:
-        #
-        # // Configure an SSR data mover for a 4D loop nest.
-        # // b0: Inner-most bound (limit of loop)
-        # // b3: Outer-most bound (limit of loop)
-        # // s0: increment size of inner-most loop
-        # inline void snrt_ssr_loop_4d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
-        #                              size_t b2, size_t b3, size_t s0, size_t s1,
-        #                              size_t s2, size_t s3) {
-        #     --b0;
-        #     --b1;
-        #     --b2;
-        #     --b3;
-        #     write_ssr_cfg(REG_BOUNDS + 0, dm, b0);
-        #     write_ssr_cfg(REG_BOUNDS + 1, dm, b1);
-        #     write_ssr_cfg(REG_BOUNDS + 2, dm, b2);
-        #     write_ssr_cfg(REG_BOUNDS + 3, dm, b3);
-        #     size_t a = 0;
-        #     write_ssr_cfg(REG_STRIDES + 0, dm, s0 - a);
-        #     a += s0 * b0;
-        #     write_ssr_cfg(REG_STRIDES + 1, dm, s1 - a);
-        #     a += s1 * b1;
-        #     write_ssr_cfg(REG_STRIDES + 2, dm, s2 - a);
-        #     a += s2 * b2;
-        #     write_ssr_cfg(REG_STRIDES + 3, dm, s3 - a);
-        #     a += s3 * b3;
-        # }
-
-        rank = len(op.ub)
-        if rank > 4:
-            raise NotImplementedError(
-                "Only 1d, 2d, 3d, or 4d loop stride patterns are supported"
-            )
-
-        ints = tuple(builtin.IntAttr(i) for i in range(rank))
-
-        b_ops = tuple(riscv.LiOp(b.data) for b in op.ub.data)
-        s_ops = tuple(riscv.LiOp(s.data) for s in op.strides.data)
-        new_b_ops = tuple(riscv.AddiOp(b_op.rd, -1) for b_op in b_ops)
-        set_bound_ops = tuple(
-            snitch.SsrSetDimensionBoundOp(new_b_op, op.dm, i)
-            for (i, new_b_op) in zip(ints, new_b_ops)
-        )
-
-        new_ops: list[Operation] = [
-            *b_ops,
-            *s_ops,
-            *new_b_ops,
-            *set_bound_ops,
-            snitch.SsrSetDimensionStrideOp(s_ops[0], op.dm, ints[0]),
-            a_op := riscv.LiOp(0, rd=riscv.IntRegisterType.unallocated()),
-        ]
-
-        for i in range(1, rank):
-            a_inc_op = riscv.MulOp(
-                new_b_ops[i - 1], s_ops[i - 1], rd=riscv.IntRegisterType.unallocated()
-            )
-            new_a_op = riscv.AddOp(
-                a_op, a_inc_op, rd=riscv.IntRegisterType.unallocated()
-            )
-            stride_op = riscv.SubOp(
-                s_ops[i], new_a_op, rd=riscv.IntRegisterType.unallocated()
-            )
-            set_stride_op = snitch.SsrSetDimensionStrideOp(stride_op.rd, op.dm, ints[i])
-            new_ops.extend((a_inc_op, new_a_op, stride_op, set_stride_op))
-            a_op = new_a_op
-
-        rewriter.insert_op_before_matched_op(new_ops)
+        insert_stride_pattern_ops(rewriter, op, op.ub, op.strides, op.dm)
         rewriter.erase_matched_op()
 
 


### PR DESCRIPTION
PR 4/4 of replacing the snitch_stream.stride_pattern op with an attribute

The operation is removed, and the stride pattern is specified as an attribute on the streaming region op. When lowering the streaming region, the dm is inferred.

Note that the assembly that is returned by our lowering is entirely unchanged after this refactor.