### PR TITLE
dialects: (LLVM) Fix use of attributes dict when dialect specifies prop_def

### DIFF
--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -821,7 +821,7 @@ class ExtractValueOp(IRDLOperation):
     ):
         super().__init__(
             operands=[container],
-            attributes={
+            properties={
                 "position": position,
             },
             result_types=[result_type],
@@ -850,7 +850,7 @@ class InsertValueOp(IRDLOperation):
     ):
         super().__init__(
             operands=[container, value],
-            attributes={
+            properties={
                 "position": position,
             },
             result_types=[container.type],


### PR DESCRIPTION
Fixes use of attributes dict when dialect specifies prop_def for:
llvm.extractvalue
llvm.insertvalue

Seems like a bug left over from #1874 
