### PR TITLE
interactive: add AvailablePass NamedTuple and move code to new file for cleanliness 1/3

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -15,6 +15,7 @@ from xdsl.dialects.builtin import (
     UnrealizedConversionCastOp,
 )
 from xdsl.interactive.app import InputApp
+from xdsl.interactive.get_condensed_passes import AvailablePass
 from xdsl.ir import Block, Region
 from xdsl.transforms import (
     individual_rewrite,
@@ -267,15 +268,51 @@ async def test_buttons():
 
         condensed_list = tuple(
             (
-                individual_rewrite.IndividualRewrite,
-                convert_arith_to_riscv.ConvertArithToRiscvPass,
-                convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass,
-                stencil_global_to_local.DistributeStencilPass,
-                hls_convert_stencil_to_ll_mlir.HLSConvertStencilToLLMLIRPass,
-                mlir_opt.MLIROptPass,
-                printf_to_llvm.PrintfToLLVM,
-                scf_parallel_loop_tiling.ScfParallelLoopTilingPass,
-                stencil_unroll.StencilUnrollPass,
+                AvailablePass(
+                    display_name="apply-individual-rewrite",
+                    module_pass=individual_rewrite.IndividualRewrite,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="convert-arith-to-riscv",
+                    module_pass=convert_arith_to_riscv.ConvertArithToRiscvPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="convert-func-to-riscv-func",
+                    module_pass=convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="distribute-stencil",
+                    module_pass=stencil_global_to_local.DistributeStencilPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="hls-convert-stencil-to-ll-mlir",
+                    module_pass=hls_convert_stencil_to_ll_mlir.HLSConvertStencilToLLMLIRPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="mlir-opt",
+                    module_pass=mlir_opt.MLIROptPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="printf-to-llvm",
+                    module_pass=printf_to_llvm.PrintfToLLVM,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="scf-parallel-loop-tiling",
+                    module_pass=scf_parallel_loop_tiling.ScfParallelLoopTilingPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="stencil-unroll",
+                    module_pass=stencil_unroll.StencilUnrollPass,
+                    pass_spec=None,
+                ),
             )
         )
 

--- a/xdsl/interactive/get_condensed_passes.py
+++ b/xdsl/interactive/get_condensed_passes.py
@@ -1,0 +1,47 @@
+from typing import NamedTuple
+
+from xdsl.dialects import builtin
+from xdsl.ir import MLContext
+from xdsl.passes import ModulePass
+from xdsl.tools.command_line_tool import get_all_dialects, get_all_passes
+from xdsl.transforms.mlir_opt import MLIROptPass
+from xdsl.utils.parse_pipeline import PipelinePassSpec
+
+ALL_PASSES = tuple(sorted((p_name, p()) for (p_name, p) in get_all_passes().items()))
+"""Contains the list of xDSL passes."""
+
+
+class AvailablePass(NamedTuple):
+    """
+    Type alias for the attributes that describe a pass, namely the display name of the
+    pass, the module pass and pass spec.
+    """
+
+    display_name: str
+    module_pass: type[ModulePass]
+    pass_spec: PipelinePassSpec | None
+
+
+def get_condensed_pass_list(input: builtin.ModuleOp) -> tuple[AvailablePass, ...]:
+    ctx = MLContext(True)
+
+    for dialect_name, dialect_factory in get_all_dialects().items():
+        ctx.register_dialect(dialect_name, dialect_factory)
+
+    selections: list[AvailablePass] = []
+    for _, value in ALL_PASSES:
+        if value is MLIROptPass:
+            # Always keep MLIROptPass as an option in condensed list
+            selections.append(AvailablePass(value.name, value, None))
+            continue
+        try:
+            cloned_module = input.clone()
+            cloned_ctx = ctx.clone()
+            value().apply(cloned_ctx, cloned_module)
+            if input.is_structurally_equivalent(cloned_module):
+                continue
+        except Exception:
+            pass
+        selections.append(AvailablePass(value.name, value, None))
+
+    return tuple(selections)


### PR DESCRIPTION
attempt to split t[his PR](https://github.com/xdslproject/xdsl/pull/2131/files#diff-6c0fd122274ca87c3f88d46a4abe86a2d09289633359f7c9830925aeb2137178L56) into smaller ones. 

PR 1 

1. Move "get_condensed_pass_list" and ALL_PASS variable to a separate file to reduce code in app.py
2. Introduce "AvailablePass" Named Tuple + adjust the function types/tests affected by this change.

