### PR TITLE
interactive: add rewrite functionality to gui tool 3/3

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -18,18 +18,20 @@ from xdsl.interactive.app import InputApp
 from xdsl.interactive.get_condensed_passes import AvailablePass
 from xdsl.ir import Block, Region
 from xdsl.transforms import (
+    canonicalize,
     individual_rewrite,
     mlir_opt,
     printf_to_llvm,
     scf_parallel_loop_tiling,
     stencil_unroll,
+    test_lower_linalg_to_snitch,
 )
 from xdsl.transforms.experimental import (
     hls_convert_stencil_to_ll_mlir,
 )
 from xdsl.transforms.experimental.dmp import stencil_global_to_local
 from xdsl.utils.exceptions import ParseError
-from xdsl.utils.parse_pipeline import PipelinePassSpec
+from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
 
 
 @pytest.mark.asyncio()
@@ -327,6 +329,130 @@ async def test_buttons():
         await pilot.pause()
         # assert after "Condense Button" is clicked that the state changes accordingly
         assert app.condense_mode is False
+
+
+@pytest.mark.asyncio()
+async def test_rewrites():
+    """Test rewrite application has the desired result."""
+    async with InputApp().run_test() as pilot:
+        app = cast(InputApp, pilot.app)
+        # clear preloaded code and unselect preselected pass
+        app.input_text_area.clear()
+
+        await pilot.pause()
+        # Testing a pass
+        app.input_text_area.insert(
+            """
+        func.func @hello(%n : i32) -> i32 {
+  %two = arith.constant 0 : i32
+  %res = arith.addi %two, %n : i32
+  func.return %res : i32
+}
+        """
+        )
+
+        # press "Condense" button
+        await pilot.click("#condense_button")
+
+        condensed_list = tuple(
+            (
+                AvailablePass(
+                    display_name="apply-individual-rewrite",
+                    module_pass=individual_rewrite.IndividualRewrite,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="canonicalize",
+                    module_pass=canonicalize.CanonicalizePass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="convert-arith-to-riscv",
+                    module_pass=convert_arith_to_riscv.ConvertArithToRiscvPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="convert-func-to-riscv-func",
+                    module_pass=convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="distribute-stencil",
+                    module_pass=stencil_global_to_local.DistributeStencilPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="hls-convert-stencil-to-ll-mlir",
+                    module_pass=hls_convert_stencil_to_ll_mlir.HLSConvertStencilToLLMLIRPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="mlir-opt",
+                    module_pass=mlir_opt.MLIROptPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="printf-to-llvm",
+                    module_pass=printf_to_llvm.PrintfToLLVM,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="scf-parallel-loop-tiling",
+                    module_pass=scf_parallel_loop_tiling.ScfParallelLoopTilingPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="stencil-unroll",
+                    module_pass=stencil_unroll.StencilUnrollPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="test-lower-linalg-to-snitch",
+                    module_pass=test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass,
+                    pass_spec=None,
+                ),
+                AvailablePass(
+                    display_name="Addi(%res = arith.addi %two, %n : i32):arith.addi:AddImmediateZero",
+                    module_pass=individual_rewrite.IndividualRewrite,
+                    pass_spec=list(
+                        parse_pipeline(
+                            'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddImmediateZero"}'
+                        )
+                    )[0],
+                ),
+            )
+        )
+
+        await pilot.pause()
+        # assert after "Condense Button" is clicked that the state and get_condensed_pass list change accordingly
+        assert app.condense_mode is True
+        assert app.available_pass_list == condensed_list
+
+        # Select a rewrite
+        app.pass_pipeline = (
+            *app.pass_pipeline,
+            (
+                individual_rewrite.IndividualRewrite,
+                list(
+                    parse_pipeline(
+                        'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddImmediateZero"}'
+                    )
+                )[0],
+            ),
+        )
+
+        # assert that pass selection affected Output Text Area
+        await pilot.pause()
+        assert (
+            app.output_text_area.text
+            == """builtin.module {
+  func.func @hello(%n : i32) -> i32 {
+    %two = arith.constant 0 : i32
+    func.return %n : i32
+  }
+}
+"""
+        )
 
 
 @pytest.mark.asyncio()

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -18,20 +18,18 @@ from xdsl.interactive.app import InputApp
 from xdsl.interactive.get_condensed_passes import AvailablePass
 from xdsl.ir import Block, Region
 from xdsl.transforms import (
-    canonicalize,
     individual_rewrite,
     mlir_opt,
     printf_to_llvm,
     scf_parallel_loop_tiling,
     stencil_unroll,
-    test_lower_linalg_to_snitch,
 )
 from xdsl.transforms.experimental import (
     hls_convert_stencil_to_ll_mlir,
 )
 from xdsl.transforms.experimental.dmp import stencil_global_to_local
 from xdsl.utils.exceptions import ParseError
-from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
+from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 @pytest.mark.asyncio()
@@ -329,130 +327,6 @@ async def test_buttons():
         await pilot.pause()
         # assert after "Condense Button" is clicked that the state changes accordingly
         assert app.condense_mode is False
-
-
-@pytest.mark.asyncio()
-async def test_rewrites():
-    """Test rewrite application has the desired result."""
-    async with InputApp().run_test() as pilot:
-        app = cast(InputApp, pilot.app)
-        # clear preloaded code and unselect preselected pass
-        app.input_text_area.clear()
-
-        await pilot.pause()
-        # Testing a pass
-        app.input_text_area.insert(
-            """
-        func.func @hello(%n : i32) -> i32 {
-  %two = arith.constant 0 : i32
-  %res = arith.addi %two, %n : i32
-  func.return %res : i32
-}
-        """
-        )
-
-        # press "Condense" button
-        await pilot.click("#condense_button")
-
-        condensed_list = tuple(
-            (
-                AvailablePass(
-                    display_name="apply-individual-rewrite",
-                    module_pass=individual_rewrite.IndividualRewrite,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="canonicalize",
-                    module_pass=canonicalize.CanonicalizePass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="convert-arith-to-riscv",
-                    module_pass=convert_arith_to_riscv.ConvertArithToRiscvPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="convert-func-to-riscv-func",
-                    module_pass=convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="distribute-stencil",
-                    module_pass=stencil_global_to_local.DistributeStencilPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="hls-convert-stencil-to-ll-mlir",
-                    module_pass=hls_convert_stencil_to_ll_mlir.HLSConvertStencilToLLMLIRPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="mlir-opt",
-                    module_pass=mlir_opt.MLIROptPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="printf-to-llvm",
-                    module_pass=printf_to_llvm.PrintfToLLVM,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="scf-parallel-loop-tiling",
-                    module_pass=scf_parallel_loop_tiling.ScfParallelLoopTilingPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="stencil-unroll",
-                    module_pass=stencil_unroll.StencilUnrollPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="test-lower-linalg-to-snitch",
-                    module_pass=test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="Addi(%res = arith.addi %two, %n : i32):arith.addi:AddImmediateZero",
-                    module_pass=individual_rewrite.IndividualRewrite,
-                    pass_spec=list(
-                        parse_pipeline(
-                            'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddImmediateZero"}'
-                        )
-                    )[0],
-                ),
-            )
-        )
-
-        await pilot.pause()
-        # assert after "Condense Button" is clicked that the state and get_condensed_pass list change accordingly
-        assert app.condense_mode is True
-        assert app.available_pass_list == condensed_list
-
-        # Select a rewrite
-        app.pass_pipeline = (
-            *app.pass_pipeline,
-            (
-                individual_rewrite.IndividualRewrite,
-                list(
-                    parse_pipeline(
-                        'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddImmediateZero"}'
-                    )
-                )[0],
-            ),
-        )
-
-        # assert that pass selection affected Output Text Area
-        await pilot.pause()
-        assert (
-            app.output_text_area.text
-            == """builtin.module {
-  func.func @hello(%n : i32) -> i32 {
-    %two = arith.constant 0 : i32
-    func.return %n : i32
-  }
-}
-"""
-        )
 
 
 @pytest.mark.asyncio()

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -222,7 +222,7 @@ class InputApp(App[None]):
         # initialize ListView to contain the pass options
         for n, module_pass in ALL_PASSES:
             self.passes_list_view.append(
-                PassListItem(Label(n), module_pass=module_pass, name=n)
+                PassListItem(Label(n), module_pass=module_pass, pass_spec=None, name=n)
             )
 
         # initialize GUI with either specified input text or default example
@@ -265,9 +265,14 @@ class InputApp(App[None]):
         """
         if old_pass_list != new_pass_list:
             self.passes_list_view.clear()
-            for _, value, _ in new_pass_list:
+            for pass_name, value, value_spec in new_pass_list:
                 self.passes_list_view.append(
-                    PassListItem(Label(value.name), module_pass=value, name=value.name)
+                    PassListItem(
+                        Label(pass_name),
+                        module_pass=value,
+                        pass_spec=value_spec,
+                        name=value.name,
+                    )
                 )
 
     def get_pass_arguments(self, selected_pass_value: type[ModulePass]) -> None:
@@ -327,7 +332,7 @@ class InputApp(App[None]):
         """
         list_item = event.item
         assert isinstance(list_item, PassListItem)
-        self.get_pass_arguments(list_item.module_pass)
+        self.get_pass_arguments(list_item.module_pass, list_item.pass_spec)
 
     def watch_pass_pipeline(self) -> None:
         """

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -30,6 +30,7 @@ from textual.widgets import (
 
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.interactive.add_arguments_screen import AddArguments
+from xdsl.interactive.get_all_possible_rewrites import get_all_possible_rewrites
 from xdsl.interactive.get_condensed_passes import (
     ALL_PASSES,
     AvailablePass,
@@ -46,6 +47,7 @@ from xdsl.parser import Parser
 from xdsl.passes import ModulePass, PipelinePass, get_pass_argument_names_and_types
 from xdsl.printer import Printer
 from xdsl.tools.command_line_tool import get_all_dialects, get_all_passes
+from xdsl.transforms import individual_rewrite
 from xdsl.utils.exceptions import PassPipelineParseError
 from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
 
@@ -249,10 +251,37 @@ class InputApp(App[None]):
             case Exception():
                 return ()
             case ModuleOp():
+                # transform rewrites into passes
+                rewrites = get_all_possible_rewrites(
+                    self.current_module,
+                    individual_rewrite.REWRITE_BY_NAMES,
+                )
+                rewrites_as_pass_list: tuple[AvailablePass, ...] = ()
+                for op_idx, (op_name, pat_name) in rewrites:
+                    rewrite_pass = individual_rewrite.IndividualRewrite
+                    rewrite_spec_arg_str = f'matched_operation_index={op_idx} operation_name="{op_name}" pattern_name={pat_name}'
+                    rewrite_spec = list(
+                        parse_pipeline(f"{rewrite_pass.name}{{{rewrite_spec_arg_str}}}")
+                    )[0]
+                    op = list(self.current_module.walk())[op_idx]
+                    rewrites_as_pass_list = (
+                        *rewrites_as_pass_list,
+                        (
+                            AvailablePass(
+                                f"{op}:{op_name}:{pat_name}", rewrite_pass, rewrite_spec
+                            )
+                        ),
+                    )
+
+                # merge rewrite passes with "other" pass list
                 if self.condense_mode:
-                    return get_condensed_pass_list(self.current_module)
+                    pass_list = get_condensed_pass_list(self.current_module)
+                    return pass_list + rewrites_as_pass_list
                 else:
-                    return tuple(AvailablePass(p.name, p, None) for _, p in ALL_PASSES)
+                    pass_list = tuple(
+                        AvailablePass(p.name, p, None) for _, p in ALL_PASSES
+                    )
+                    return pass_list + rewrites_as_pass_list
 
     def watch_available_pass_list(
         self,
@@ -275,7 +304,11 @@ class InputApp(App[None]):
                     )
                 )
 
-    def get_pass_arguments(self, selected_pass_value: type[ModulePass]) -> None:
+    def get_pass_arguments(
+        self,
+        selected_pass_value: type[ModulePass],
+        selected_pass_spec: PipelinePassSpec | None,
+    ) -> None:
         """
         This function facilitates user input of pass concatenated_arg_val by navigating
         to the AddArguments screen, and subsequently parses the returned string upon
@@ -306,7 +339,7 @@ class InputApp(App[None]):
                 self.push_screen(screen, add_pass_with_arguments_to_pass_pipeline)
 
         # if selected_pass_value has arguments, push screen
-        if fields(selected_pass_value):
+        if fields(selected_pass_value) and selected_pass_spec is None:
             # generates a string containing the concatenated_arg_val and types of the selected pass and initializes the AddArguments Screen to contain the string
             self.push_screen(
                 AddArguments(
@@ -319,10 +352,16 @@ class InputApp(App[None]):
             )
         else:
             # add the selected pass to pass_pipeline
-            self.pass_pipeline = (
-                *self.pass_pipeline,
-                (selected_pass_value, selected_pass_value().pipeline_pass_spec()),
-            )
+            if selected_pass_spec is None:
+                self.pass_pipeline = (
+                    *self.pass_pipeline,
+                    (selected_pass_value, selected_pass_value().pipeline_pass_spec()),
+                )
+            else:
+                self.pass_pipeline = (
+                    *self.pass_pipeline,
+                    (selected_pass_value, selected_pass_spec),
+                )
 
     @on(ListView.Selected)
     def update_pass_pipeline(self, event: ListView.Selected) -> None:

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -222,7 +222,7 @@ class InputApp(App[None]):
         # initialize ListView to contain the pass options
         for n, module_pass in ALL_PASSES:
             self.passes_list_view.append(
-                PassListItem(Label(n), module_pass=module_pass, pass_spec=None, name=n)
+                PassListItem(Label(n), module_pass=module_pass, name=n)
             )
 
         # initialize GUI with either specified input text or default example
@@ -265,14 +265,9 @@ class InputApp(App[None]):
         """
         if old_pass_list != new_pass_list:
             self.passes_list_view.clear()
-            for pass_name, value, value_spec in new_pass_list:
+            for _, value, _ in new_pass_list:
                 self.passes_list_view.append(
-                    PassListItem(
-                        Label(pass_name),
-                        module_pass=value,
-                        pass_spec=value_spec,
-                        name=value.name,
-                    )
+                    PassListItem(Label(value.name), module_pass=value, name=value.name)
                 )
 
     def get_pass_arguments(self, selected_pass_value: type[ModulePass]) -> None:
@@ -332,7 +327,7 @@ class InputApp(App[None]):
         """
         list_item = event.item
         assert isinstance(list_item, PassListItem)
-        self.get_pass_arguments(list_item.module_pass, list_item.pass_spec)
+        self.get_pass_arguments(list_item.module_pass)
 
     def watch_pass_pipeline(self) -> None:
         """

--- a/xdsl/interactive/pass_list_item.py
+++ b/xdsl/interactive/pass_list_item.py
@@ -2,21 +2,25 @@ from textual.widget import Widget
 from textual.widgets import ListItem
 
 from xdsl.passes import ModulePass
+from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 class PassListItem(ListItem):
     module_pass: type[ModulePass]
+    pass_spec: PipelinePassSpec | None
 
     def __init__(
         self,
         *children: Widget,
         module_pass: type[ModulePass],
+        pass_spec: PipelinePassSpec | None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
         disabled: bool = False,
     ):
         self.module_pass = module_pass
+        self.pass_spec = pass_spec
         super().__init__(
             *children, name=name, id=id, classes=classes, disabled=disabled
         )

--- a/xdsl/interactive/pass_list_item.py
+++ b/xdsl/interactive/pass_list_item.py
@@ -2,25 +2,21 @@ from textual.widget import Widget
 from textual.widgets import ListItem
 
 from xdsl.passes import ModulePass
-from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 class PassListItem(ListItem):
     module_pass: type[ModulePass]
-    pass_spec: PipelinePassSpec | None
 
     def __init__(
         self,
         *children: Widget,
         module_pass: type[ModulePass],
-        pass_spec: PipelinePassSpec | None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
         disabled: bool = False,
     ):
         self.module_pass = module_pass
-        self.pass_spec = pass_spec
         super().__init__(
             *children, name=name, id=id, classes=classes, disabled=disabled
         )


### PR DESCRIPTION
attempt to split t[his PR](https://github.com/xdslproject/xdsl/pull/2131/files#diff-6c0fd122274ca87c3f88d46a4abe86a2d09289633359f7c9830925aeb2137178L56) into smaller ones.

PR 3

- adjust compute_available_pass_list to compute all_possible_rewrites for given module and wrap them in an "individual rewrite pass" i.e. rewrites now passes
- adjust get_pass_arguments function accordingly
- add a test that makes sure rewrite functionality in gui tool works