### PR TITLE
backend: (riscv) correctly handle f64 moves when lowering

### DIFF
--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -21,6 +21,11 @@ builtin.module {
         %fres0, %res0 = "test.op"(%arg0, %farg0) : (i32, f32) -> (f32, i32)
         func.return %fres0, %res0 : f32, i32
     }
+
+    func.func @foo_int_double(%arg0 : i32, %farg0 : f64) -> (f64, i32) {
+        %fres0, %res0 = "test.op"(%arg0, %farg0) : (i32, f64) -> (f64, i32)
+        func.return %fres0, %res0 : f64, i32
+    }
 }
 
 // CHECK:       builtin.module {
@@ -85,6 +90,22 @@ builtin.module {
 // CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0_1 : f32 to !riscv.freg<>
 // CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0_1 : i32 to !riscv.reg<>
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa0>
+// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv.assembly_section ".text" {
+// CHECK-NEXT:      riscv.directive ".globl" "foo_int_double"
+// CHECK-NEXT:      riscv.directive ".p2align" "2"
+// CHECK-NEXT:      riscv_func.func @foo_int_double(%arg0_4 : !riscv.reg<a0>, %farg0_4 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
+// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0_4 : (!riscv.reg<a0>) -> !riscv.reg<>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %30 : !riscv.reg<> to i32
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg<>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f64
+// CHECK-NEXT:        %{{.*}}, %{{.*}} = "test.op"(%{{.*}}, %{{.*}}) : (i32, f64) -> (f64, i32)
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg<>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : i32 to !riscv.reg<>
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa0>
 // CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
 // CHECK-NEXT:      }

--- a/xdsl/backend/riscv/lowering/convert_scf_to_riscv_scf.py
+++ b/xdsl/backend/riscv/lowering/convert_scf_to_riscv_scf.py
@@ -22,7 +22,7 @@ class ScfForLowering(RewritePattern):
         lb, ub, step, *args = cast_operands_to_regs(rewriter)
         new_region = rewriter.move_region_contents_to_new_regions(op.body)
         cast_block_args_to_regs(new_region.block, rewriter)
-        mv_ops, values = move_to_unallocated_regs(args)
+        mv_ops, values = move_to_unallocated_regs(args, tuple(arg.type for arg in args))
         rewriter.insert_op_before_matched_op(mv_ops)
         cast_matched_op_results(rewriter)
         rewriter.replace_matched_op(riscv_scf.ForOp(lb, ub, step, values, new_region))

--- a/xdsl/backend/riscv/lowering/utils.py
+++ b/xdsl/backend/riscv/lowering/utils.py
@@ -42,24 +42,36 @@ def cast_to_regs(values: Iterable[SSAValue]) -> tuple[list[Operation], list[SSAV
 
 
 def move_ops_for_value(
-    value: SSAValue, rd: riscv.RISCVRegisterType
+    value: SSAValue, value_type: Attribute, rd: riscv.RISCVRegisterType
 ) -> tuple[Operation, SSAValue]:
     """
     Returns the operation that moves the value from the input to a new register.
+    In order to disambiguate which floating point move should be used (fmv.s vs fmv.d),
+    the floating point type in question must be passed
     """
 
     if isinstance(rd, riscv.IntRegisterType):
         mv_op = riscv.MVOp(value, rd=rd)
         return mv_op, mv_op.rd
     elif isinstance(rd, riscv.FloatRegisterType):
-        mv_op = riscv.FMVOp(value, rd=rd)
+        match value_type:
+            case builtin.Float64Type():
+                mv_op = riscv.FMvDOp(value, rd=rd)
+            case builtin.Float32Type():
+                mv_op = riscv.FMVOp(value, rd=rd)
+            case _:
+                raise NotImplementedError(
+                    f"Move operation for float register containing value of type {value.type} is not implemented"
+                )
         return mv_op, mv_op.rd
     else:
         raise NotImplementedError(f"Unsupported register type for move op: {rd}")
 
 
 def move_to_regs(
-    values: Iterable[SSAValue], reg_types: Iterable[riscv.RISCVRegisterType]
+    values: Iterable[SSAValue],
+    value_types: Iterable[Attribute],
+    reg_types: Iterable[riscv.RISCVRegisterType],
 ) -> tuple[list[Operation], list[SSAValue]]:
     """
     Return move operations to `a` registers (a0, a1, ... | fa0, fa1, ...).
@@ -68,8 +80,10 @@ def move_to_regs(
     new_ops = list[Operation]()
     new_values = list[SSAValue]()
 
-    for value, register_type in zip(values, reg_types):
-        move_op, new_value = move_ops_for_value(value, register_type)
+    for value, value_type, register_type in zip(
+        values, value_types, reg_types, strict=True
+    ):
+        move_op, new_value = move_ops_for_value(value, value_type, register_type)
         new_ops.append(move_op)
         new_values.append(new_value)
 
@@ -97,15 +111,17 @@ def a_regs(values: Iterable[SSAValue]) -> Iterator[riscv.RISCVRegisterType]:
 
 def move_to_a_regs(
     values: Iterable[SSAValue],
+    value_types: Iterable[Attribute],
 ) -> tuple[list[Operation], list[SSAValue]]:
     """
     Return move operations to `a` registers (a0, a1, ... | fa0, fa1, ...).
     """
-    return move_to_regs(values, a_regs(values))
+    return move_to_regs(values, value_types, a_regs(values))
 
 
 def move_to_unallocated_regs(
     values: Iterable[SSAValue],
+    value_types: Iterable[Attribute],
 ) -> tuple[list[Operation], list[SSAValue]]:
     """
     Return move operations to `a` registers (a0, a1, ... | fa0, fa1, ...).
@@ -114,9 +130,11 @@ def move_to_unallocated_regs(
     new_ops = list[Operation]()
     new_values = list[SSAValue]()
 
-    for value in values:
+    for value, value_type in zip(values, value_types, strict=True):
         register_type = register_type_for_type(value.type)
-        move_op, new_value = move_ops_for_value(value, register_type.unallocated())
+        move_op, new_value = move_ops_for_value(
+            value, value_type, register_type.unallocated()
+        )
         new_ops.append(move_op)
         new_values.append(new_value)
 
@@ -194,7 +212,9 @@ def cast_block_args_from_a_regs(block: Block, rewriter: PatternRewriter):
 
     for arg in block.args:
         register_type = register_type_for_type(arg.type)
-        move_op, new_value = move_ops_for_value(arg, register_type.unallocated())
+        move_op, new_value = move_ops_for_value(
+            arg, arg.type, register_type.unallocated()
+        )
         cast_op = builtin.UnrealizedConversionCastOp.get((new_value,), (arg.type,))
         new_ops.append(move_op)
         new_ops.append(cast_op)


### PR DESCRIPTION
We currently incorrectly insert fmv.s when moving float registers, even when the actual value stored is f64. This is usually at the boundary between the standard and riscv dimensions, where the combination of casting to a register type and moving to/from an "a" register loses the relevant type information. This PR amends some helpers in the riscv backend to take into account the floating-point type of the operand when moving floating point values.