### PR TITLE
transformations: Make mlir-opt pass take the top-level module attributes into account.

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
@@ -5,11 +5,11 @@
     %0 = "arith.constant"() {"value" = 1 : i32} : () -> i32
     "func.return"() : () -> ()
   }) {function_type = () -> (), sym_name = "do_nothing"} : () -> ()
-}) : () -> ()
+}) {"gpu.container_module"} : () -> ()
 
 
 // CHECK:         "builtin.module"() ({
 // CHECK-NEXT:      "func.func"() <{"function_type" = () -> (), "sym_name" = "do_nothing"}> ({
 // CHECK-NEXT:        "func.return"() : () -> ()
 // CHECK-NEXT:      }) : () -> ()
-// CHECK-NEXT:    }) : () -> ()
+// CHECK-NEXT:    }) {"gpu.container_module"} : () -> ()

--- a/xdsl/transforms/mlir_opt.py
+++ b/xdsl/transforms/mlir_opt.py
@@ -53,5 +53,6 @@ class MLIROptPass(ModulePass):
             rewriter = PatternRewriter(op)
             op.detach_region(op.body)
             op.add_region(rewriter.move_region_contents_to_new_regions(new_module.body))
+            op.attributes = new_module.attributes
         except Exception as e:
             raise DiagnosticException("Error executing mlir-opt pass") from e


### PR DESCRIPTION
Phew this one got me running in circles!
Had a case where using our `mlir-opt` pass was arong, because it currently just discards any attributes on the parsed top-level module.