### PR TITLE
dialects: add arith canoncialization pattern "AdditionOfSameVariablesToMultiplybyTwo"

### DIFF
--- a/tests/filecheck/transforms/arith-addition-of-same-variables-to-multiply-by-two.mlir
+++ b/tests/filecheck/transforms/arith-addition-of-same-variables-to-multiply-by-two.mlir
@@ -1,17 +1,17 @@
 // RUN: xdsl-opt %s -p canonicalize | filecheck %s
 
 func.func @hello(%n : i32) -> i32 {
-  %one = arith.constant 2 : i32
-  %res = arith.addi %one, %one : i32
+  %two = arith.constant 3 : i32
+  %res = arith.addi %two, %two : i32
   func.return %res : i32
 }
 
-
 //CHECK:         builtin.module {
 // CHECK-NEXT:     func.func @hello(%n : i32) -> i32 {
-// CHECK-NEXT:       %one = arith.constant 2 : i32
-// CHECK-NEXT:       %res = arith.muli %one, 2 : i32
-// CHECK-NEXT:       func.return %n : i32
+// CHECK-NEXT:       %two = arith.constant 3 : i32
+// CHECK-NEXT:       %res = arith.constant 2 : i32
+// CHECK-NEXT:       %res_1 = arith.muli %two, %res : i32
+// CHECK-NEXT:       func.return %res_1 : i32
 // CHECK-NEXT:     }
 // CHECK-NEXT:  }
 

--- a/tests/filecheck/transforms/arith-addition-of-same-variables-to-multiply-by-two.mlir
+++ b/tests/filecheck/transforms/arith-addition-of-same-variables-to-multiply-by-two.mlir
@@ -1,0 +1,18 @@
+// RUN: xdsl-opt %s -p canonicalize | filecheck %s
+
+func.func @hello(%n : i32) -> i32 {
+  %one = arith.constant 2 : i32
+  %res = arith.addi %one, %one : i32
+  func.return %res : i32
+}
+
+
+//CHECK:         builtin.module {
+// CHECK-NEXT:     func.func @hello(%n : i32) -> i32 {
+// CHECK-NEXT:       %one = arith.constant 2 : i32
+// CHECK-NEXT:       %res = arith.muli %one, 2 : i32
+// CHECK-NEXT:       func.return %n : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:  }
+
+

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -267,9 +267,15 @@ IntegerBinaryOp = BinaryOperation[IntegerType]
 class AddiOpHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl.transforms.canonicalization_patterns.arith import AddImmediateZero
+        from xdsl.transforms.canonicalization_patterns.arith import (
+            AddImmediateZero,
+            AdditionOfSameVariablesToMultiplyByTwo,
+        )
 
-        return (AddImmediateZero(),)
+        return (
+            AddImmediateZero(),
+            AdditionOfSameVariablesToMultiplyByTwo(),
+        )
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -5,7 +5,6 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.utils.hints import isa
 
 
 class AddImmediateZero(RewritePattern):
@@ -23,11 +22,10 @@ class AdditionOfSameVariablesToMultiplyByTwo(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.Addi, rewriter: PatternRewriter) -> None:
         if op.lhs == op.rhs:
-            rd = arith.cast(arith.IntegerType, op.lhs.type)
-            assert isa(op.lhs.type, IntegerType | IndexType)
+            assert isinstance(op.lhs.type, IntegerType | IndexType)
             rewriter.replace_matched_op(
                 [
                     li_op := arith.Constant(IntegerAttr(2, op.lhs.type)),
-                    arith.Muli(op.lhs, li_op, rd),
+                    arith.Muli(op.lhs, li_op),
                 ]
             )

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -1,10 +1,11 @@
 from xdsl.dialects import arith
-from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.builtin import IndexType, IntegerAttr, IntegerType
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.utils.hints import isa
 
 
 class AddImmediateZero(RewritePattern):
@@ -16,3 +17,17 @@ class AddImmediateZero(RewritePattern):
             and value.value.data == 0
         ):
             rewriter.replace_matched_op([], [op.rhs])
+
+
+class AdditionOfSameVariablesToMultiplyByTwo(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: arith.Addi, rewriter: PatternRewriter) -> None:
+        if op.lhs == op.rhs:
+            rd = arith.cast(arith.IntegerType, op.lhs.type)
+            assert isa(op.lhs.type, IntegerType | IndexType)
+            rewriter.replace_matched_op(
+                [
+                    li_op := arith.Constant(IntegerAttr(2, op.lhs.type)),
+                    arith.Muli(op.lhs, li_op, rd),
+                ]
+            )


### PR DESCRIPTION
This arith rewrite pattern does the following:

`a + a -> a * 2`

Update: @math-fehr says we may not want to merge "bad" rewrite patterns. Please see [this PR](https://github.com/xdslproject/xdsl/pull/2167) as a potential solution.