### PR TITLE
backend: (riscv) fix scf to riscv scf lowering

### DIFF
--- a/tests/filecheck/backend/rvscf_scf_lowering.mlir
+++ b/tests/filecheck/backend/rvscf_scf_lowering.mlir
@@ -1,15 +1,16 @@
 // RUN: xdsl-opt -p convert-scf-to-riscv-scf %s | filecheck %s
 
 builtin.module {
-  %0 = arith.constant 0 : index
-  %1 = arith.constant 10 : index
-  %2 = arith.constant 1 : index
-  %3 = arith.constant 0 : index
-  %4 = "scf.for"(%0, %1, %2, %3) ({
-  ^0(%5 : index, %6 : index):
-    %7 = arith.addi %5, %6 : index
-    "scf.yield"(%7) : (index) -> ()
-  }) : (index, index, index, index) -> index
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %i_in = arith.constant 42 : index
+  %f_in = arith.constant 42.0 : f64
+
+  %i_out, %f_out = scf.for %idx = %c0 to %c10 step %c1 iter_args(%i_acc = %i_in, %f_acc = %f_in) -> (index, f64) {
+    %res = arith.addi %idx, %i_acc : index
+    scf.yield %res, %f_acc : index, f64
+  }
 }
 
 // CHECK:      builtin.module {

--- a/tests/filecheck/backend/rvscf_scf_lowering.mlir
+++ b/tests/filecheck/backend/rvscf_scf_lowering.mlir
@@ -5,30 +5,43 @@ builtin.module {
   %c10 = arith.constant 10 : index
   %c1 = arith.constant 1 : index
   %i_in = arith.constant 42 : index
-  %f_in = arith.constant 42.0 : f64
+  %f32_in = arith.constant 21.0 : f32
+  %f64_in = arith.constant 42.0 : f64
 
-  %i_out, %f_out = scf.for %idx = %c0 to %c10 step %c1 iter_args(%i_acc = %i_in, %f_acc = %f_in) -> (index, f64) {
+  %i_out, %f32_out, %f64_out = scf.for %idx = %c0 to %c10 step %c1 iter_args(%i_acc = %i_in, %f32_acc = %f32_in, %f64_acc = %f64_in) -> (index, f32, f64) {
     %res = arith.addi %idx, %i_acc : index
-    scf.yield %res, %f_acc : index, f64
+    scf.yield %res, %f32_acc, %f64_acc : index, f32, f64
   }
 }
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   %0 = arith.constant 0 : index
-// CHECK-NEXT:   %1 = arith.constant 10 : index
-// CHECK-NEXT:   %2 = arith.constant 1 : index
-// CHECK-NEXT:   %3 = arith.constant 0 : index
-// CHECK-NEXT:   %4 = builtin.unrealized_conversion_cast %0 : index to !riscv.reg<>
-// CHECK-NEXT:   %5 = builtin.unrealized_conversion_cast %1 : index to !riscv.reg<>
-// CHECK-NEXT:   %6 = builtin.unrealized_conversion_cast %2 : index to !riscv.reg<>
-// CHECK-NEXT:   %7 = builtin.unrealized_conversion_cast %3 : index to !riscv.reg<>
-// CHECK-NEXT:   %8 = riscv.mv %7 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %9 = riscv_scf.for %10 : !riscv.reg<> = %4 to %5 step %6 iter_args(%11 = %8) -> (!riscv.reg<>) {
-// CHECK-NEXT:     %12 = builtin.unrealized_conversion_cast %11 : !riscv.reg<> to index
-// CHECK-NEXT:     %13 = builtin.unrealized_conversion_cast %10 : !riscv.reg<> to index
-// CHECK-NEXT:     %14 = arith.addi %13, %12 : index
-// CHECK-NEXT:     %15 = builtin.unrealized_conversion_cast %14 : index to !riscv.reg<>
-// CHECK-NEXT:     riscv_scf.yield %15 : !riscv.reg<>
+// CHECK-NEXT:   %c0 = arith.constant 0 : index
+// CHECK-NEXT:   %c10 = arith.constant 10 : index
+// CHECK-NEXT:   %c1 = arith.constant 1 : index
+// CHECK-NEXT:   %i_in = arith.constant 42 : index
+// CHECK-NEXT:   %f32_in = arith.constant 2.100000e+01 : f32
+// CHECK-NEXT:   %f64_in = arith.constant 4.200000e+01 : f64
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg<>
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg<>
+// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = riscv_scf.for %idx : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (!riscv.reg<>, !riscv.freg<>, !riscv.freg<>) {
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f64
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to index
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to index
+// CHECK-NEXT:     %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg<>
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg<>
+// CHECK-NEXT:     riscv_scf.yield %{{.*}}, %{{.*}}, %{{.*}} : !riscv.reg<>, !riscv.freg<>, !riscv.freg<>
 // CHECK-NEXT:   }
-// CHECK-NEXT:   %16 = builtin.unrealized_conversion_cast %9 : !riscv.reg<> to index
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to index
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f64
 // CHECK-NEXT: }

--- a/xdsl/backend/riscv/lowering/convert_scf_to_riscv_scf.py
+++ b/xdsl/backend/riscv/lowering/convert_scf_to_riscv_scf.py
@@ -22,7 +22,9 @@ class ScfForLowering(RewritePattern):
         lb, ub, step, *args = cast_operands_to_regs(rewriter)
         new_region = rewriter.move_region_contents_to_new_regions(op.body)
         cast_block_args_to_regs(new_region.block, rewriter)
-        mv_ops, values = move_to_unallocated_regs(args, tuple(arg.type for arg in args))
+        mv_ops, values = move_to_unallocated_regs(
+            args, tuple(arg.type for arg in op.iter_args)
+        )
         rewriter.insert_op_before_matched_op(mv_ops)
         cast_matched_op_results(rewriter)
         rewriter.replace_matched_op(riscv_scf.ForOp(lb, ub, step, values, new_region))


### PR DESCRIPTION
I accidentally used the new register types, as opposed to the old fp types, which prevents us from picking the correct move instruction, I added this to the lowering test.