### PR TITLE
interpreter: add infrastructure to collect interpreter traces

### DIFF
--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Callable, Generator, Iterable
 from dataclasses import dataclass, field
 from typing import (
@@ -413,6 +414,17 @@ class Interpreter:
     the `register_functions` method.
     """
 
+    class Watcher:
+        """
+        Base class for observing the operations that are interpreted during a run.
+        """
+
+        def will_interpret_op(self, op: Operation, args: PythonValues) -> None:
+            ...
+
+        def did_interpret_op(self, op: Operation, results: PythonValues) -> None:
+            ...
+
     module: ModuleOp
     _impls: _InterpreterFunctionImpls = field(default_factory=_InterpreterFunctionImpls)
     _ctx: InterpreterContext = field(
@@ -426,6 +438,7 @@ class Interpreter:
     """
     Runtime data associated with an interpreter functions implementation.
     """
+    watcher: Watcher = field(default=Watcher())
 
     @property
     def symbol_table(self) -> dict[str, Operation]:
@@ -482,6 +495,12 @@ class Interpreter:
         """
         self._impls.register_from(impls, override=override)
 
+    def _run_op(self, op: Operation, inputs: PythonValues) -> OpImplResult:
+        self.watcher.will_interpret_op(op, inputs)
+        result = self._impls.run(self, op, inputs)
+        self.watcher.did_interpret_op(op, result.values)
+        return result
+
     def run_op(self, op: Operation | str, inputs: PythonValues) -> PythonValues:
         """
         Calls the implementation for the given operation.
@@ -489,8 +508,7 @@ class Interpreter:
         if isinstance(op, str):
             op = self.get_op_for_symbol(op)
 
-        result = self._impls.run(self, op, inputs)
-        return result.values
+        return self._run_op(op, inputs).values
 
     def call_op(self, op: Operation | str, inputs: PythonValues) -> PythonValues:
         """
@@ -545,7 +563,7 @@ class Interpreter:
 
             while op is not None:
                 inputs = self.get_values(op.operands)
-                result = self._impls.run(self, op, inputs)
+                result = self._run_op(op, inputs)
                 self.interpreter_assert(
                     len(op.results) == len(result.values),
                     f"Incorrect number of results for op {op.name}, expected {len(op.results)} but got {len(result.values)}",
@@ -620,6 +638,18 @@ class Interpreter:
         """Raise InterpretationError if condition is not satisfied."""
         if not condition:
             raise InterpretationError(f"AssertionError: ({self._ctx})({message})")
+
+
+@dataclass
+class OpCounter(Interpreter.Watcher):
+    """
+    Counts the number of times that an op has been run by the interpreter.
+    """
+
+    ops: Counter[str] = field(default_factory=Counter)
+
+    def will_interpret_op(self, op: Operation, args: PythonValues) -> None:
+        self.ops[op.name] += 1
 
 
 PythonValues: TypeAlias = tuple[Any, ...]


### PR DESCRIPTION
Adds a no-op base observer class, and a subclass to count the number of ops executed during an interpreter run. This will let us gather basic statistics about some code on given inputs, hopefully giving us a hint at the performance.