### PR TITLE
installation: replace MANIFEST with pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include versioneer.py
-include xdsl/_version.py
-include requirements.txt requirements-optional.txt
-include xdsl/py.typed
-include xdsl/interactive/*.tcss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ xdsl-gui = "xdsl.interactive.app:main"
 [tool.setuptools]
 platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
-package-data = { "xdsl" = ["py.typed"] }
+
+[tool.setuptools.package-data]
+xdsl = ["py.typed", "interactive/*.tcss", "_version.py", "interactive/*.tcss"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel", "versioneer[toml]"]


### PR DESCRIPTION
https://devcodef1.com/news/1042633/replacing-manifest-in-with-pyproject-toml

It looks like this is the recommended setup, centralises one more aspect of our configuration. I ran `pip install .[extras]` in a new venv and it seems to work, correctly bundling the tcss files.