### PR TITLE
transformations: add "generic" parameter to MLIROptPass

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
@@ -1,4 +1,6 @@
 // RUN: xdsl-opt %s -p mlir-opt{arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
+// RUN: xdsl-opt %s -p mlir-opt{generic=false\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
+// RUN: xdsl-opt %s -p mlir-opt{generic=true\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/xdsl/transforms/mlir_opt.py
+++ b/xdsl/transforms/mlir_opt.py
@@ -21,6 +21,7 @@ class MLIROptPass(ModulePass):
 
     name = "mlir-opt"
 
+    generic: bool = field(default=True)
     arguments: list[str] = field(default_factory=list)
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
@@ -28,7 +29,7 @@ class MLIROptPass(ModulePass):
             raise ValueError("mlir-opt is not available")
 
         stream = StringIO()
-        printer = Printer(print_generic_format=True, stream=stream)
+        printer = Printer(print_generic_format=self.generic, stream=stream)
         printer.print(op)
 
         my_string = stream.getvalue()


### PR DESCRIPTION
Fixes #2120

I'm not sure how to test this, we need to somehow intercept that the syntax passed to mlir-opt is in a certain format, but we pass it along directly... I think just testing that it works with true, false, and nothing is enough for now.