### PR TITLE
dialects: Add LLVM InlineAsm op

### DIFF
--- a/tests/filecheck/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/dialects/llvm/inline_asm.mlir
@@ -1,0 +1,16 @@
+// RUN: XDSL_ROUNDTRIP
+
+%0 = "test.op"() : () -> i32
+%1 = "test.op"() : () -> i32
+"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r"}> {has_side_effect} : (i32, i32) -> ()
+
+%2 = "test.op"() : () -> vector<8xf32>
+%3 = "test.op"() : () -> vector<8xf32>
+%4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x"}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+
+// CHECK: %0 = "test.op"() : () -> i32
+// CHECK-NEXT: 1 = "test.op"() : () -> i32
+// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{"asm_string" = "csrw $0, $1", "constraints" = "i, r"}> {"has_side_effect"} : (i32, i32) -> ()
+// CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{"asm_dialect" = 1 : i64, "asm_string" = "vaddps $0, $1, $2", "constraints" = "=x,x,x"}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
@@ -1,0 +1,16 @@
+/// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+
+%0 = "test.op"() : () -> i32
+%1 = "test.op"() : () -> i32
+"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r"}> {has_side_effect} : (i32, i32) -> ()
+
+%2 = "test.op"() : () -> vector<8xf32>
+%3 = "test.op"() : () -> vector<8xf32>
+%4 = "llvm.inline_asm"(%2, %3) <{asm_dialect = 1 : i64, asm_string = "vaddps $0, $1, $2", constraints = "=x,x,x"}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>
+
+// CHECK: %0 = "test.op"() : () -> i32
+// CHECK-NEXT: 1 = "test.op"() : () -> i32
+// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{"asm_string" = "csrw $0, $1", "constraints" = "i, r"}> {"has_side_effect"} : (i32, i32) -> ()
+// CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{"asm_dialect" = 1 : i64, "asm_string" = "vaddps $0, $1, $2", "constraints" = "=x,x,x"}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -723,7 +723,6 @@ class InlineAsmOp(IRDLOperation):
 
     name = "llvm.inline_asm"
 
-    # operands_, because is already defined?
     operands_: VarOperand = var_operand_def()
 
     res: OptOpResult = opt_result_def()
@@ -733,7 +732,7 @@ class InlineAsmOp(IRDLOperation):
     # 0 for AT&T inline assembly dialect
     # 1 for Intel inline assembly dialect
     # In this context dialect does not refer to an MLIR dialect
-    asm_dialect = opt_prop_def(IntegerAttr[IntegerType])
+    asm_dialect = opt_prop_def(IntegerAttr[Annotated[IntegerType, IntegerType(64)]])
 
     asm_string: StringAttr = prop_def(StringAttr)
     constraints: StringAttr = prop_def(StringAttr)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -740,6 +740,32 @@ class InlineAsmOp(IRDLOperation):
     has_side_effects: UnitAttr | None = opt_prop_def(UnitAttr)
     is_align_stack: UnitAttr | None = opt_prop_def(UnitAttr)
 
+    def __init__(
+        self,
+        operands_: list[SSAValue | Operation],
+        res_types: list[Attribute],
+        asm_string: str,
+        constraints: str,
+        asm_dialect: int = 0,
+        has_side_effects: bool = False,
+        is_align_stack: bool = False,
+    ):
+        props: dict[str, Attribute] = {
+            "asm_string": StringAttr(asm_string),
+            "constraints": StringAttr(constraints),
+            "asm_dialect": IntegerAttr.from_int_and_width(asm_dialect, 64),
+        }
+        if has_side_effects:
+            props["has_side_effects"] = UnitAttr()
+        if is_align_stack:
+            props["is_align_stack"] = UnitAttr()
+
+        super().__init__(
+            operands=operands_,
+            properties=props,
+            result_types=res_types,
+        )
+
 
 @irdl_op_definition
 class PtrToIntOp(IRDLOperation):

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -714,6 +714,13 @@ class IntToPtrOp(IRDLOperation):
 
 @irdl_op_definition
 class InlineAsmOp(IRDLOperation):
+    """
+    https://mlir.llvm.org/docs/Dialects/LLVM/#llvminline_asm-llvminlineasmop
+
+    To see what each field means, have a look at:
+    https://llvm.org/docs/LangRef.html#inline-assembler-expressions
+    """
+
     name = "llvm.inline_asm"
 
     # operands_, because is already defined?
@@ -723,6 +730,9 @@ class InlineAsmOp(IRDLOperation):
 
     # note: in MLIR upstream this is implemented as AsmDialectAttr;
     # which is an instantiation of an LLVM_EnumAttr
+    # 0 for AT&T inline assembly dialect
+    # 1 for Intel inline assembly dialect
+    # In this context dialect does not refer to an MLIR dialect
     asm_dialect = opt_prop_def(IntegerAttr[IntegerType])
 
     asm_string: StringAttr = prop_def(StringAttr)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -713,6 +713,25 @@ class IntToPtrOp(IRDLOperation):
 
 
 @irdl_op_definition
+class InlineAsmOp(IRDLOperation):
+    name = "llvm.inline_asm"
+
+    # operands_, because is already defined?
+    operands_: VarOperand = var_operand_def()
+
+    res: OptOpResult = opt_result_def()
+
+    # note: in MLIR upstream this is implemented as AsmDialectAttr;
+    # which is an instantiation of an LLVM_EnumAttr
+    asm_dialect = opt_prop_def(IntegerAttr[IntegerType])
+
+    asm_string: StringAttr = prop_def(StringAttr)
+    constraints: StringAttr = prop_def(StringAttr)
+    has_side_effects: UnitAttr | None = opt_prop_def(UnitAttr)
+    is_align_stack: UnitAttr | None = opt_prop_def(UnitAttr)
+
+
+@irdl_op_definition
 class PtrToIntOp(IRDLOperation):
     name = "llvm.ptrtoint"
 
@@ -1271,6 +1290,7 @@ LLVM = Dialect(
         AShrOp,
         ExtractValueOp,
         InsertValueOp,
+        InlineAsmOp,
         UndefOp,
         AllocaOp,
         GEPOp,


### PR DESCRIPTION
This PR attempts to add the LLVM InlineAsm op, which allows to bake in inline assembly from within MLIR.

Some things I noted while making this:
* The docs mention this:
   > The InlineAsmOp mirrors the underlying LLVM semantics with a notable exception: the embedded asm_string is not    allowed to define or reference any symbol or any global variable: only the operands of the op may be read, written, or    referenced. Attempting to define or reference any symbol or any global behavior is considered undefined behavior at    this time.
   
   I'm assuming this means that this constraint is never actually checked/verified :sweat_smile: ?
* There's an additional attribute to select the inline assembly dialect (not dialect in context of MLIR, choices are AT&T or Intel). I just implemented this as an `IntegerAttr`, is that okay? It looked like `Linkage` (prior to this PR) was/is implemented differently from upstream in a similar way?

Currently I have only implemented round-trip tests.

Happy to add any other tests if required.

CC @jorendumoulin 