### PR TITLE
transformations: scf-parallel-loop-tiling fixes.

### DIFF
--- a/tests/filecheck/transforms/scf-parallel-loop-tiling-partial.mlir
+++ b/tests/filecheck/transforms/scf-parallel-loop-tiling-partial.mlir
@@ -1,6 +1,6 @@
-// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,0,4}" --split-input-file | filecheck %s
-// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=0,4,4}" --split-input-file | filecheck %s --check-prefix CHECK-FIRST
-// COM: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,4,0}" --split-input-file | filecheck %s --check-prefix CHECK-LAST
+// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,0,4}" | filecheck %s
+// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=0,4,4}" | filecheck %s --check-prefix CHECK-FIRST
+// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,4,0}" | filecheck %s --check-prefix CHECK-LAST
 
 func.func @tile_partial() {
   %zero = arith.constant 0 : index
@@ -84,3 +84,68 @@ func.func @tile_partial() {
 // CHECK-LAST-NEXT:   }) : (index, index, index, index, index, index) -> ()
 // CHECK-LAST-NEXT:   func.return
 // CHECK-LAST-NEXT: }
+
+func.func @tile_partial_1d() {
+  %zero = arith.constant 0 : index
+  %one = arith.constant 1 : index
+  %size = arith.constant 64 : index
+    "scf.parallel"(%zero, %size, %one) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+    ^5(%arg1: index):
+    scf.yield
+    }) : (index, index, index) -> ()
+  func.return
+}
+
+// CHECK:         func.func @tile_partial_1d() {
+// CHECK-NEXT:      %zero_1 = arith.constant 0 : index
+// CHECK-NEXT:      %one_1 = arith.constant 1 : index
+// CHECK-NEXT:      %size_1 = arith.constant 64 : index
+// CHECK-NEXT:      %11 = arith.constant 0 : index
+// CHECK-NEXT:      %12 = arith.constant 4 : index
+// CHECK-NEXT:      %13 = arith.muli %one_1, %12 : index
+// CHECK-NEXT:      "scf.parallel"(%zero_1, %size_1, %13) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-NEXT:      ^2(%14 : index):
+// CHECK-NEXT:        %15 = "affine.min"(%12, %size_1, %14) <{"map" = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-NEXT:        "scf.parallel"(%11, %15, %one_1) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-NEXT:        ^3(%arg1 : index):
+// CHECK-NEXT:          %16 = arith.addi %14, %arg1 : index
+// CHECK-NEXT:          scf.yield
+// CHECK-NEXT:        }) : (index, index, index) -> ()
+// CHECK-NEXT:        scf.yield
+// CHECK-NEXT:      }) : (index, index, index) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// CHECK-FIRST:         func.func @tile_partial_1d() {
+// CHECK-FIRST-NEXT:      %zero_1 = arith.constant 0 : index
+// CHECK-FIRST-NEXT:      %one_1 = arith.constant 1 : index
+// CHECK-FIRST-NEXT:      %size_1 = arith.constant 64 : index
+// CHECK-FIRST-NEXT:      "scf.parallel"(%zero_1, %size_1, %one_1) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-FIRST-NEXT:      ^2(%arg1 : index):
+// CHECK-FIRST-NEXT:        scf.yield
+// CHECK-FIRST-NEXT:      }) : (index, index, index) -> ()
+// CHECK-FIRST-NEXT:      func.return
+// CHECK-FIRST-NEXT:    }
+// CHECK-FIRST-NEXT:  }
+
+// CHECK-LAST:         func.func @tile_partial_1d() {
+// CHECK-LAST-NEXT:      %zero_1 = arith.constant 0 : index
+// CHECK-LAST-NEXT:      %one_1 = arith.constant 1 : index
+// CHECK-LAST-NEXT:      %size_1 = arith.constant 64 : index
+// CHECK-LAST-NEXT:      %11 = arith.constant 0 : index
+// CHECK-LAST-NEXT:      %12 = arith.constant 4 : index
+// CHECK-LAST-NEXT:      %13 = arith.muli %one_1, %12 : index
+// CHECK-LAST-NEXT:      "scf.parallel"(%zero_1, %size_1, %13) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-LAST-NEXT:      ^2(%14 : index):
+// CHECK-LAST-NEXT:        %15 = "affine.min"(%12, %size_1, %14) <{"map" = affine_map<(d0, d1, d2) -> (d0, (d1 + (d2 * -1)))>}> : (index, index, index) -> index
+// CHECK-LAST-NEXT:        "scf.parallel"(%11, %15, %one_1) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-LAST-NEXT:        ^3(%arg1 : index):
+// CHECK-LAST-NEXT:          %16 = arith.addi %14, %arg1 : index
+// CHECK-LAST-NEXT:          scf.yield
+// CHECK-LAST-NEXT:        }) : (index, index, index) -> ()
+// CHECK-LAST-NEXT:        scf.yield
+// CHECK-LAST-NEXT:      }) : (index, index, index) -> ()
+// CHECK-LAST-NEXT:      func.return
+// CHECK-LAST-NEXT:    }
+// CHECK-LAST-NEXT:  }

--- a/xdsl/transforms/scf_parallel_loop_tiling.py
+++ b/xdsl/transforms/scf_parallel_loop_tiling.py
@@ -27,7 +27,9 @@ class ScfParallelLoopTilingPattern(RewritePattern):
         lower = op.lowerBound
         upper = op.upperBound
         step = op.step
-
+        # The pass is meant to work on any parallel loop with any nu;ber of tile sizes.
+        # For a loop of dimension N, either use the N first tile sizes or use them all
+        # and fill the rest with 1.
         tile_sizes_v = self.tile_sizes[: len(lower)] + (1,) * (
             len(lower) - len(self.tile_sizes)
         )

--- a/xdsl/transforms/scf_parallel_loop_tiling.py
+++ b/xdsl/transforms/scf_parallel_loop_tiling.py
@@ -28,10 +28,9 @@ class ScfParallelLoopTilingPattern(RewritePattern):
         upper = op.upperBound
         step = op.step
 
-        # fill the tile sizes with ones
-        tile_sizes_v = list(self.tile_sizes)
-        for _ in range(len(tile_sizes_v), len(lower)):
-            tile_sizes_v.append(1)
+        tile_sizes_v = self.tile_sizes[: len(lower)] + (1,) * (
+            len(lower) - len(self.tile_sizes)
+        )
 
         zero = arith.Constant(IntegerAttr.from_index_int_value(0))
         tile_sizes_v = {i: s for i, s in enumerate(tile_sizes_v) if s != 0}
@@ -40,6 +39,8 @@ class ScfParallelLoopTilingPattern(RewritePattern):
             for i, s in tile_sizes_v.items()
         }
         tiled_dims = sorted(tile_sizes.keys())
+        if not tiled_dims:
+            return
         outter_lower = [lower[d] for d in tiled_dims]
         outter_upper = [upper[d] for d in tiled_dims]
         outter_step = [arith.Muli(step[d], tile_sizes[d]) for d in tiled_dims]


### PR DESCRIPTION
- If we figure out there's nothing to tile, bail out.
- Drop extra tile sizes if we're tiling a lower-dimensional loop nest.