### PR TITLE
interactive: remove passes that raise errors from condensed list

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -20,16 +20,12 @@ from xdsl.ir import Block, Region
 from xdsl.transforms import (
     canonicalize,
     individual_rewrite,
-    mlir_opt,
     printf_to_llvm,
-    scf_parallel_loop_tiling,
-    stencil_unroll,
     test_lower_linalg_to_snitch,
 )
 from xdsl.transforms.experimental import (
     hls_convert_stencil_to_ll_mlir,
 )
-from xdsl.transforms.experimental.dmp import stencil_global_to_local
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
 
@@ -271,11 +267,6 @@ async def test_buttons():
         condensed_list = tuple(
             (
                 AvailablePass(
-                    display_name="apply-individual-rewrite",
-                    module_pass=individual_rewrite.IndividualRewrite,
-                    pass_spec=None,
-                ),
-                AvailablePass(
                     display_name="convert-arith-to-riscv",
                     module_pass=convert_arith_to_riscv.ConvertArithToRiscvPass,
                     pass_spec=None,
@@ -286,33 +277,13 @@ async def test_buttons():
                     pass_spec=None,
                 ),
                 AvailablePass(
-                    display_name="distribute-stencil",
-                    module_pass=stencil_global_to_local.DistributeStencilPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
                     display_name="hls-convert-stencil-to-ll-mlir",
                     module_pass=hls_convert_stencil_to_ll_mlir.HLSConvertStencilToLLMLIRPass,
                     pass_spec=None,
                 ),
                 AvailablePass(
-                    display_name="mlir-opt",
-                    module_pass=mlir_opt.MLIROptPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
                     display_name="printf-to-llvm",
                     module_pass=printf_to_llvm.PrintfToLLVM,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="scf-parallel-loop-tiling",
-                    module_pass=scf_parallel_loop_tiling.ScfParallelLoopTilingPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="stencil-unroll",
-                    module_pass=stencil_unroll.StencilUnrollPass,
                     pass_spec=None,
                 ),
             )
@@ -357,11 +328,6 @@ async def test_rewrites():
         condensed_list = tuple(
             (
                 AvailablePass(
-                    display_name="apply-individual-rewrite",
-                    module_pass=individual_rewrite.IndividualRewrite,
-                    pass_spec=None,
-                ),
-                AvailablePass(
                     display_name="canonicalize",
                     module_pass=canonicalize.CanonicalizePass,
                     pass_spec=None,
@@ -377,33 +343,13 @@ async def test_rewrites():
                     pass_spec=None,
                 ),
                 AvailablePass(
-                    display_name="distribute-stencil",
-                    module_pass=stencil_global_to_local.DistributeStencilPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
                     display_name="hls-convert-stencil-to-ll-mlir",
                     module_pass=hls_convert_stencil_to_ll_mlir.HLSConvertStencilToLLMLIRPass,
                     pass_spec=None,
                 ),
                 AvailablePass(
-                    display_name="mlir-opt",
-                    module_pass=mlir_opt.MLIROptPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
                     display_name="printf-to-llvm",
                     module_pass=printf_to_llvm.PrintfToLLVM,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="scf-parallel-loop-tiling",
-                    module_pass=scf_parallel_loop_tiling.ScfParallelLoopTilingPass,
-                    pass_spec=None,
-                ),
-                AvailablePass(
-                    display_name="stencil-unroll",
-                    module_pass=stencil_unroll.StencilUnrollPass,
                     pass_spec=None,
                 ),
                 AvailablePass(

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -50,11 +50,7 @@ def apply_passes_to_module(
     return module
 
 
-def get_condensed_pass_list(input: builtin.ModuleOp) -> tuple[AvailablePass, ...]:
-    """
-    Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
-    change the ModuleOp.
-    """
+def iter_condensed_passes(input: builtin.ModuleOp):
     ctx = MLContext(True)
 
     for dialect_name, dialect_factory in get_all_dialects().items():
@@ -72,8 +68,14 @@ def get_condensed_pass_list(input: builtin.ModuleOp) -> tuple[AvailablePass, ...
             value().apply(cloned_ctx, cloned_module)
             if input.is_structurally_equivalent(cloned_module):
                 continue
+            yield AvailablePass(value.name, value, None), cloned_ctx
         except Exception:
             pass
-        selections.append(AvailablePass(value.name, value, None))
 
-    return tuple(selections)
+
+def get_condensed_pass_list(input: builtin.ModuleOp) -> tuple[AvailablePass, ...]:
+    """
+    Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
+    change the ModuleOp.
+    """
+    return tuple(ap for ap, _ in iter_condensed_passes(input))

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -68,7 +68,7 @@ def iter_condensed_passes(input: builtin.ModuleOp):
             value().apply(cloned_ctx, cloned_module)
             if input.is_structurally_equivalent(cloned_module):
                 continue
-            yield AvailablePass(value.name, value, None), cloned_ctx
+            yield AvailablePass(value.name, value, None), cloned_module
         except Exception:
             pass
 


### PR DESCRIPTION
I have a feeling this should have been the case from the get-go. The main reason to condense is to show the available transformations, to make it quick and easy to go towards your target. There are three reasons why a pass might fail:
1. it's mlir-opt and it has weird stdout/stderr behaviour that breaks textual
2. it's a pass that requires parameters to run
3. it actually fails

I would say that none of these are useful by themselves to show in the "quick and easy" list. If the user knows to use a certain pass, they can always "uncondense" and pick the pass that they want, possibly with the parameters they're interested int. The passes that currently require parameters should probably either provide default parameters or provide a range of options to try in the future, but that can be done by another PR.