### PR TITLE
core: add Hasher and HashableModule

### DIFF
--- a/tests/utils/test_hashable_module.py
+++ b/tests/utils/test_hashable_module.py
@@ -1,0 +1,33 @@
+from collections.abc import Iterable
+
+from xdsl.builder import ImplicitBuilder
+from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.dialects.test import TestOp
+from xdsl.utils.hashable_module import HashableModule
+
+
+def m(labels: Iterable[str]):
+    module = ModuleOp([])
+    with ImplicitBuilder(module.body):
+        for label in labels:
+            TestOp(attributes={"label": StringAttr(label)})
+    return module
+
+
+def test_hashable_module():
+    assert HashableModule(ModuleOp([])) == HashableModule(ModuleOp([]))
+    assert hash(HashableModule(ModuleOp([]))) == hash(HashableModule(ModuleOp([])))
+
+    a0 = m("a")
+    a1 = m("a")
+
+    assert HashableModule(a0) == HashableModule(a1)
+    assert hash(HashableModule(a0)) == hash(HashableModule(a1))
+
+    abra0 = m("abra")
+    abra1 = m("abra")
+
+    assert HashableModule(abra0) == HashableModule(abra1)
+    assert hash(HashableModule(abra0)) == hash(HashableModule(abra1))
+
+    assert HashableModule(a0) != HashableModule(abra1)

--- a/tests/utils/test_hashable_module.py
+++ b/tests/utils/test_hashable_module.py
@@ -6,7 +6,7 @@ from xdsl.dialects.test import TestOp
 from xdsl.utils.hashable_module import HashableModule
 
 
-def m(labels: Iterable[str]):
+def _gen_module(labels: Iterable[str]):
     module = ModuleOp([])
     with ImplicitBuilder(module.body):
         for label in labels:
@@ -18,14 +18,14 @@ def test_hashable_module():
     assert HashableModule(ModuleOp([])) == HashableModule(ModuleOp([]))
     assert hash(HashableModule(ModuleOp([]))) == hash(HashableModule(ModuleOp([])))
 
-    a0 = m("a")
-    a1 = m("a")
+    a0 = _gen_module("a")
+    a1 = _gen_module("a")
 
     assert HashableModule(a0) == HashableModule(a1)
     assert hash(HashableModule(a0)) == hash(HashableModule(a1))
 
-    abra0 = m("abra")
-    abra1 = m("abra")
+    abra0 = _gen_module("abra")
+    abra1 = _gen_module("abra")
 
     assert HashableModule(abra0) == HashableModule(abra1)
     assert hash(HashableModule(abra0)) == hash(HashableModule(abra1))

--- a/tests/utils/test_hasher.py
+++ b/tests/utils/test_hasher.py
@@ -1,0 +1,16 @@
+from xdsl.utils.hasher import Hasher
+
+
+def test_hasher():
+    h = Hasher()
+    h.combine(1)
+    hash1 = h.hash
+    h.combine(2)
+
+    j = Hasher(seed=hash1)
+
+    assert h.hash != j.hash
+
+    j.combine(2)
+
+    assert h.hash == j.hash

--- a/xdsl/utils/hashable_module.py
+++ b/xdsl/utils/hashable_module.py
@@ -1,0 +1,31 @@
+from collections.abc import Hashable
+from dataclasses import dataclass
+
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.utils.hasher import Hasher
+
+
+@dataclass(frozen=True)
+class HashableModule(Hashable):
+    """
+    A class wrapping a ModuleOp, that forwards to structural equality checking for `==`.
+    The module in this class should not be mutated.
+    """
+
+    module: ModuleOp
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(
+            other, HashableModule
+        ) and self.module.is_structurally_equivalent(other.module)
+
+    def __hash__(self) -> int:
+        """
+        The hash of the module is a hash of the ordered combination of operation names.
+        As most transformations on IR modify at least one operation, this should be enough
+        to minimise collisions.
+        """
+        hasher = Hasher()
+        for op in self.module.walk():
+            hasher.combine(op.name)
+        return hasher.hash

--- a/xdsl/utils/hasher.py
+++ b/xdsl/utils/hasher.py
@@ -3,8 +3,7 @@ from collections.abc import Hashable
 
 class Hasher:
     """
-    A helper class that accumulates hash values over time. The value depends on the order
-    in which hash values are mixed into `self`.
+    A helper class that accumulates hash values over time.
     """
 
     hash: int
@@ -13,12 +12,7 @@ class Hasher:
         self.hash = seed
 
     def combine_hash(self, other_hash: int) -> None:
-        """
-        boost's hash combine function
-
-        https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
-        """
-        self.hash ^= other_hash + 0x9E3779B9 + (self.hash << 6) + (self.hash >> 2)
+        self.hash ^= other_hash
 
     def combine(self, other: Hashable) -> None:
         self.combine_hash(hash(other))

--- a/xdsl/utils/hasher.py
+++ b/xdsl/utils/hasher.py
@@ -11,8 +11,5 @@ class Hasher:
     def __init__(self, *, seed: int = 0):
         self.hash = seed
 
-    def combine_hash(self, other_hash: int) -> None:
-        self.hash ^= other_hash
-
     def combine(self, other: Hashable) -> None:
-        self.combine_hash(hash(other))
+        self.hash = hash((self.hash, other))

--- a/xdsl/utils/hasher.py
+++ b/xdsl/utils/hasher.py
@@ -1,0 +1,24 @@
+from collections.abc import Hashable
+
+
+class Hasher:
+    """
+    A helper class that accumulates hash values over time. The value depends on the order
+    in which hash values are mixed into `self`.
+    """
+
+    hash: int
+
+    def __init__(self, *, seed: int = 0):
+        self.hash = seed
+
+    def combine_hash(self, other_hash: int) -> None:
+        """
+        boost's hash combine function
+
+        https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
+        """
+        self.hash ^= other_hash + 0x9E3779B9 + (self.hash << 6) + (self.hash >> 2)
+
+    def combine(self, other: Hashable) -> None:
+        self.combine_hash(hash(other))


### PR DESCRIPTION
These utils are planned to be used in `xdsl-gui`, but may well be useful outside of that project. The Hasher contains logic I've used a lot before, it seems to work well enough. In the future, we might want a more efficient way to compute equality/inequality for modules, but we might as well add a working helper class now and optimise later.