### PR TITLE
transformations: (riscv_func) handle external function declarations

### DIFF
--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -26,6 +26,8 @@ builtin.module {
         %fres0, %res0 = "test.op"(%arg0, %farg0) : (i32, f64) -> (f64, i32)
         func.return %fres0, %res0 : f64, i32
     }
+
+    func.func @external(%arg0 : i32, %farg0 : f64) -> (f64, i32)
 }
 
 // CHECK:       builtin.module {
@@ -109,5 +111,10 @@ builtin.module {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
 // CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv.assembly_section ".text" {
+// CHECK-NEXT:      riscv.directive ".globl" "external"
+// CHECK-NEXT:      riscv.directive ".p2align" "2"
+// CHECK-NEXT:      riscv_func.func @external(!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>)
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -94,12 +94,7 @@ builtin.module {
     %m = "memref.alloc"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<1x1xf32>
 }
 
-// CHECK:       builtin.module {
-// CHECK-NEXT:    %m = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
-// CHECK-NEXT:    %m_1 = riscv_func.call @malloc(%m) : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    %m_2 = builtin.unrealized_conversion_cast %m_1 : !riscv.reg<> to memref<1x1xf32>
-// CHECK-NEXT:    riscv_func.func private @malloc() -> !riscv.reg<>
-// CHECK-NEXT:  }
+// CHECK:      Lowering memref.alloc not implemented yet
 
 // -----
 

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -94,7 +94,12 @@ builtin.module {
     %m = "memref.alloc"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<1x1xf32>
 }
 
-// CHECK:      Lowering memref.alloc not implemented yet
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %m = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
+// CHECK-NEXT:    %m_1 = riscv_func.call @malloc(%m) : (!riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:    %m_2 = builtin.unrealized_conversion_cast %m_1 : !riscv.reg<> to memref<1x1xf32>
+// CHECK-NEXT:    riscv_func.func private @malloc() -> !riscv.reg<>
+// CHECK-NEXT:  }
 
 // -----
 

--- a/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
+++ b/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
@@ -27,10 +27,13 @@ class LowerFuncOp(RewritePattern):
         if len(op.function_type.outputs.data) > 2:
             raise ValueError("Cannot lower func.func with more than 2 outputs")
 
-        first_block = op.body.blocks[0]
-        cast_block_args_from_a_regs(first_block, rewriter)
+        if op.body.blocks:
+            first_block = op.body.blocks[0]
+            cast_block_args_from_a_regs(first_block, rewriter)
 
-        input_types = [arg.type for arg in first_block.args]
+            input_types = [arg.type for arg in first_block.args]
+        else:
+            input_types = tuple(a_regs_for_types(op.function_type.inputs.data))
         result_types = list(a_regs_for_types(op.function_type.outputs.data))
 
         new_func = riscv_func.FuncOp(


### PR DESCRIPTION
I'm not 100% sure what the lowering should be. Godbolt seems to drop external function declarations, should we skip them during assembly printing?