### PR TITLE
testing: rename test-lower-linalg-to-snitch to test-lower-snitch-stream-to-asm

### DIFF
--- a/tests/filecheck/projects/riscv-backend-paper/conv_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/conv_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
 // x[ M x K ]
 // y[ K x N ]

--- a/tests/filecheck/projects/riscv-backend-paper/ddot_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/ddot_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
 
   func.func @ddot(

--- a/tests/filecheck/projects/riscv-backend-paper/dense_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/dense_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
 
   // * Inputs:  x[ M x K ]

--- a/tests/filecheck/projects/riscv-backend-paper/dsum_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/dsum_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
     func.func @dsum(
       %arg0 : memref<8x16xf64>,

--- a/tests/filecheck/projects/riscv-backend-paper/fill_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/fill_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
   // y[ 16 x 16 ]
   func.func @fill(

--- a/tests/filecheck/projects/riscv-backend-paper/matmul_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/matmul_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
 
 // x[ M x K ]

--- a/tests/filecheck/projects/riscv-backend-paper/max_pool_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/max_pool_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
 // x[ M x K ]
 // y[ K x N ]

--- a/tests/filecheck/projects/riscv-backend-paper/relu_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/relu_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
   func.func public @relu(%X: memref<16x16xf64>, %Y: memref<16x16xf64>) {
     %X_moved = builtin.unrealized_conversion_cast %X : memref<16x16xf64> to !riscv.reg<>

--- a/tests/filecheck/projects/riscv-backend-paper/sum_pool_target.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/sum_pool_target.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-linalg-to-snitch -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
 // x[ M x K ]
 // y[ K x N ]

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -329,8 +329,8 @@ async def test_rewrites():
                     pass_spec=None,
                 ),
                 AvailablePass(
-                    display_name="test-lower-linalg-to-snitch",
-                    module_pass=test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass,
+                    display_name="test-lower-snitch-stream-to-asm",
+                    module_pass=test_lower_linalg_to_snitch.TestLowerSnitchStreamToAsm,
                     pass_spec=None,
                 ),
                 AvailablePass(

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -525,7 +525,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     def get_test_lower_linalg_to_snitch():
         from xdsl.transforms import test_lower_linalg_to_snitch
 
-        return test_lower_linalg_to_snitch.TestLowerLinalgToSnitchPass
+        return test_lower_linalg_to_snitch.TestLowerSnitchStreamToAsm
 
     return {
         "arith-add-fastmath": get_arith_add_fastmath,
@@ -575,7 +575,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "stencil-shape-inference": get_stencil_shape_inference,
         "stencil-storage-materialization": get_stencil_storage_materialization,
         "stencil-unroll": get_stencil_unroll,
-        "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
+        "test-lower-snitch-stream-to-asm": get_test_lower_linalg_to_snitch,
     }
 
 

--- a/xdsl/transforms/test_lower_linalg_to_snitch.py
+++ b/xdsl/transforms/test_lower_linalg_to_snitch.py
@@ -16,13 +16,13 @@ from xdsl.transforms.riscv_scf_loop_range_folding import RiscvScfLoopRangeFoldin
 from xdsl.transforms.snitch_register_allocation import SnitchRegisterAllocation
 
 
-class TestLowerLinalgToSnitchPass(ModulePass):
+class TestLowerSnitchStreamToAsm(ModulePass):
     """
     A compiler pass used for testing of the lowering from ML kernels defined as
-    linalg.generic operations to riscv-assemby leveraging Snitch cores.
+    snitch_stream + riscv operations to riscv-assemby leveraging Snitch cores.
     """
 
-    name = "test-lower-linalg-to-snitch"
+    name = "test-lower-snitch-stream-to-asm"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PipelinePass(


### PR DESCRIPTION
The main idea is that we want to keep a part of this stable, since we still have some tests defined as snitch_stream in the RISC-V backend paper experiments. I'd like to propose having two passes, one for linalg to snitch stream, and a second for lowering snitch stream down to assembly.