### PR TITLE
core: Implement first cases of assembly format optional groups

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1285,3 +1285,36 @@ def test_optional_group_variadic_result_anchor(
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "format, error",
+    (
+        ("()?", "An optional group cannot be empty"),
+        ("(`keyword`)?", "Every optional group must have an anchor."),
+        (
+            "($args^ type($rets)^)?",
+            "An optional group can only have one anchor.",
+        ),
+        ("(`keyword`^)?", "An optional group's anchor must be an achorable directive."),
+        (
+            "($mandatory_arg^)?",
+            "First element of an optional group must be optionally parsable.",
+        ),
+    ),
+)
+def test_optional_group_checkers(format: str, error: str):
+    with pytest.raises(
+        PyRDLOpDefinitionError,
+        match=error,
+    ):
+
+        @irdl_op_definition
+        class WrongOptionalGroupOp(IRDLOperation):
+            name = "test.wrong_optional_group"
+
+            args = var_operand_def()
+            rets = var_result_def()
+            mandatory_arg = operand_def()
+
+            assembly_format = format

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1310,7 +1310,7 @@ def test_optional_group_checkers(format: str, error: str):
     ):
 
         @irdl_op_definition
-        class WrongOptionalGroupOp(IRDLOperation):
+        class WrongOptionalGroupOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.wrong_optional_group"
 
             args = var_operand_def()

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -357,17 +357,26 @@ class AttrDictDirective(FormatDirective):
 
 
 @dataclass(frozen=True)
-class OperandVariable(FormatDirective):
+class VariableDirective(FormatDirective, ABC):
+    """
+    A variable directive, with the following format:
+      variable-directive ::= dollar-ident
+    The directive will request a space to be printed after.
+    """
+
+    name: str
+    """The variable name. This is only used for error message reporting."""
+    index: int
+    """Index of the variable(operand or result) definition."""
+
+
+@dataclass(frozen=True)
+class OperandVariable(VariableDirective):
     """
     An operand variable, with the following format:
       operand-directive ::= dollar-ident
     The directive will request a space to be printed after.
     """
-
-    name: str
-    """The operand name. This is only used for error message reporting."""
-    index: int
-    """Index of the operand definition."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
         operand = parser.parse_unresolved_operand()
@@ -431,17 +440,12 @@ class OptionalOperandVariable(OperandVariable, VariadicLikeVariable):
 
 
 @dataclass(frozen=True)
-class OperandTypeDirective(TypeDirective):
+class OperandTypeDirective(TypeDirective, VariableDirective):
     """
     An operand variable type directive, with the following format:
       operand-type-directive ::= type(dollar-ident)
     The directive will request a space to be printed right after.
     """
-
-    name: str
-    """The operand name. This is only used for error message reporting."""
-    index: int
-    """Index of the operand definition."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
         type = parser.parse_type()
@@ -505,18 +509,13 @@ class OptionalOperandTypeDirective(OperandTypeDirective, VariadicLikeTypeDirecti
 
 
 @dataclass(frozen=True)
-class ResultVariable(FormatDirective):
+class ResultVariable(VariableDirective):
     """
     An result variable, with the following format:
       result-directive ::= dollar-ident
     This directive can not be used for parsing and printing directly, as result
     parsing is not handled by the custom operation parser.
     """
-
-    name: str
-    """The result name. This is only used for error message reporting."""
-    index: int
-    """Index of the result definition."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
         assert (
@@ -575,17 +574,12 @@ class OptionalResultVariable(ResultVariable, VariadicLikeVariable):
 
 
 @dataclass(frozen=True)
-class ResultTypeDirective(TypeDirective):
+class ResultTypeDirective(TypeDirective, VariableDirective):
     """
     A result variable type directive, with the following format:
       result-type-directive ::= type(dollar-ident)
     The directive will request a space to be printed right after.
     """
-
-    name: str
-    """The result name. This is only used for error message reporting."""
-    index: int
-    """Index of the result definition."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
         type = parser.parse_type()

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -429,22 +429,23 @@ class FormatParser(BaseParser):
             then_elements += (self.parse_directive(),)
             if self.parse_optional_keyword("^"):
                 if anchor is not None:
-                    self.raise_error("multiple anchors in a group")
+                    self.raise_error("An optional group can only have one anchor.")
                 anchor = then_elements[-1]
         self.parse_punctuation("?")
 
-        if anchor is None:
-            self.raise_error("no anchor in a group")
         if not then_elements:
-            self.raise_error("empty group")
+            self.raise_error("An optional group cannot be empty")
+        if anchor is None:
+            self.raise_error("Every optional group must have an anchor.")
         # TODO: allow attribute and region variables when implemented.
         if not isinstance(then_elements[0], OptionallyParsableDirective):
             self.raise_error(
-                "first then-element of a group must be a litteral, operand, region or"
-                "attribute"
+                "First element of an optional group must be optionally parsable."
             )
         if not isinstance(anchor, AnchorableDirective):
-            self.raise_error("anchor must be an anchorable directive")
+            self.raise_error(
+                "An optional group's anchor must be an achorable directive."
+            )
 
         return OptionalGroupDirective(anchor, then_elements[0], then_elements[1:])
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -79,7 +79,7 @@ class FormatLexer(Lexer):
 
         # We parse '`', `\\` and '$' as a BARE_IDENT.
         # This is a hack to reuse the MLIR lexer.
-        if current_char in ("`", "$", "\\"):
+        if current_char in ("`", "$", "\\", "^"):
             self._consume_chars()
             return self._form_token(Token.Kind.BARE_IDENT, start_pos)
         return super().lex()

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -39,6 +39,7 @@ from xdsl.irdl.declarative_assembly_format import (
     PunctuationDirective,
     ResultTypeDirective,
     ResultVariable,
+    TypeDirective,
     VariadicLikeFormatDirective,
     VariadicLikeTypeDirective,
     VariadicLikeVariable,
@@ -167,7 +168,9 @@ class FormatParser(BaseParser):
                     self.raise_error(
                         "A variadic type directive cannot be followed by another variadic type directive."
                     )
-                case VariadicLikeVariable(), VariadicLikeVariable():
+                case VariadicLikeVariable(), VariadicLikeVariable() if not (
+                    isinstance(a, TypeDirective) or isinstance(b, TypeDirective)
+                ):
                     self.raise_error(
                         "A variadic operand variable cannot be followed by another variadic operand variable."
                     )


### PR DESCRIPTION
This covers optional groups with no else group, only literal first then element, and optional/variadic operand/result/type anchors. I think this is the most widely used, it enables the typical `` (`(` $variadic_operand`)`)?``