### PR TITLE
(bug): update add op lowering to check for -1 not 1

### DIFF
--- a/xdsl/transforms/convert_onnx_to_linalg.py
+++ b/xdsl/transforms/convert_onnx_to_linalg.py
@@ -41,7 +41,7 @@ class AddOpLowering(RewritePattern):
             lhs_shape = lhs_type.get_shape()
             rhs_shape = rhs_type.get_shape()
 
-            if 1 in lhs_shape or 1 in rhs_shape:
+            if -1 in lhs_shape or -1 in rhs_shape:
                 raise NotImplementedError()
 
         rewriter.replace_matched_op(


### PR DESCRIPTION
 ONNX denotes broadcastable dimensions with `-1,` whereas MLIR does with `?.` This PR fixes the bug where `1` was used instead of `-1`.
