### PR TITLE
core: Spacing fix in EnumAttribute and OpaqueSyntaxAttribute

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -596,7 +596,7 @@ class EnumAttribute(Data[EnumType]):
 
     @final
     def print_parameter(self, printer: Printer) -> None:
-        printer.print(" ", self.data.value)
+        printer.print(self.data.value)
 
     @final
     @classmethod

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -678,6 +678,7 @@ class Printer:
 
         if isinstance(attribute, OpaqueSyntaxAttribute):
             self.print(attribute.name.replace(".", "<", 1))
+            self.print(" ")
         else:
             self.print(attribute.name)
 


### PR DESCRIPTION
Enables:
- #2249

A mistake slipped in because all initial EnumAttributes where OpaqueSyntaxAttribute. linalg.IteratorType is the first one not to, hence the fix.