### PR TITLE
dialects: make linalg.IteratorType an EnumAttribute

### DIFF
--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from enum import Enum
+from enum import auto
 from typing import cast
 
 from typing_extensions import Self
@@ -39,14 +39,15 @@ from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import IsTerminator
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.str_enum import StrEnum
 
 
-class IteratorType(Enum):
+class IteratorType(StrEnum):
     "Iterator type for linalg trait"
 
-    PARALLEL = "parallel"
-    REDUCTION = "reduction"
-    WINDOW = "window"
+    PARALLEL = auto()
+    REDUCTION = auto()
+    WINDOW = auto()
 
 
 @irdl_attr_definition
@@ -200,9 +201,7 @@ class Generic(IRDLOperation):
         printer.print_string(", iterator_types = [")
         printer.print_list(
             self.iterator_types,
-            lambda iterator_type: printer.print_string_literal(
-                iterator_type.data.value
-            ),
+            lambda iterator_type: printer.print_string_literal(iterator_type.data),
         )
         printer.print_string("]")
         if self.doc:

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -19,7 +19,7 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.utils import (
     AbstractYieldOperation,
 )
-from xdsl.ir import Attribute, Data, Dialect, Region, SSAValue
+from xdsl.ir import Attribute, Dialect, EnumAttribute, Region, SSAValue
 from xdsl.ir.affine import AffineMap
 from xdsl.irdl import (
     AttrSizedOperandSegments,
@@ -51,7 +51,7 @@ class IteratorType(StrEnum):
 
 
 @irdl_attr_definition
-class IteratorTypeAttr(Data[IteratorType]):
+class IteratorTypeAttr(EnumAttribute[IteratorType]):
     name = "linalg.iterator_type"
 
     @classmethod
@@ -69,24 +69,11 @@ class IteratorTypeAttr(Data[IteratorType]):
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> IteratorType:
         with parser.in_angle_brackets():
-            if parser.parse_optional_keyword("parallel") is not None:
-                return IteratorType.PARALLEL
-            if parser.parse_optional_keyword("reduction") is not None:
-                return IteratorType.REDUCTION
-            if parser.parse_optional_keyword("window") is not None:
-                return IteratorType.WINDOW
-            parser.raise_error("`parallel`, `reduction` or `window` expected")
+            return super().parse_parameter(parser)
 
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
-            data = self.data
-            match data:
-                case IteratorType.PARALLEL:
-                    printer.print_string("parallel")
-                case IteratorType.REDUCTION:
-                    printer.print_string("reduction")
-                case IteratorType.WINDOW:
-                    printer.print_string("window")
+            super().print_parameter(printer)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -256,9 +256,7 @@ class GenericOp(IRDLOperation):
         printer.print_string(", iterator_types = [")
         printer.print_list(
             self.iterator_types,
-            lambda iterator_type: printer.print_string_literal(
-                iterator_type.data.value
-            ),
+            lambda iterator_type: printer.print_string_literal(iterator_type.data),
         )
         printer.print_string("]")
         printer.print_string("}")

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -15,7 +15,6 @@ from typing import (
     Protocol,
     TypeVar,
     cast,
-    final,
     get_args,
     get_origin,
     overload,
@@ -594,11 +593,9 @@ class EnumAttribute(Data[EnumType]):
 
         cls.enum_type = enum_type
 
-    @final
     def print_parameter(self, printer: Printer) -> None:
         printer.print(self.data.value)
 
-    @final
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> EnumType:
         enum_type = cls.enum_type

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -596,7 +596,7 @@ class EnumAttribute(Data[EnumType]):
 
     @final
     def print_parameter(self, printer: Printer) -> None:
-        printer.print(" ", self.data.value)
+        printer.print(self.data.value)
 
     @final
     @classmethod

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -678,6 +678,7 @@ class Printer:
 
         if isinstance(attribute, OpaqueSyntaxAttribute):
             self.print(attribute.name.replace(".", "<", 1))
+            self.print(" ")
         else:
             self.print(attribute.name)
 


### PR DESCRIPTION
Stacked on:
- #2248 

Just a little reuse.
Had to remove the `@final` to add brackets.
@math-fehr, do you still believe those brackets belong in individual attributes? Is there an MLIR attribute that does not use them in non-opaque syntax?
