### PR TITLE
dialects: (hw) Add `InnerSymAttr` attributes to HW dialect.

### DIFF
--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -310,3 +310,16 @@ def test_inner_sym_attr():
     assert aggregate_sym_attr.get_sym_name() == StringAttr(
         "sym"
     ), "InnerSymAttr for aggregate types should return name with field ID 0"
+
+    for inner, expected_field_id in zip(aggregate_sym_attr, [0, 1, 2]):
+        assert (
+            inner.field_id.data == expected_field_id
+        ), "InnerSymAttr should allow iterating its properties in order"
+
+    aggregate_without_nested = aggregate_sym_attr.erase(2)
+    assert (
+        aggregate_without_nested.get_sym_if_exists(2) is None
+    ), "InnerSymAttr removal should work"
+    assert (
+        len(aggregate_without_nested) == 2
+    ), "InnerSymAttr removal should correctly change length"

--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -11,8 +11,10 @@ from xdsl.dialects.hw import (
     InnerRefAttr,
     InnerRefNamespaceTrait,
     InnerRefUserOpInterfaceTrait,
+    InnerSymAttr,
     InnerSymbolTableCollection,
     InnerSymbolTableTrait,
+    InnerSymPropertiesAttr,
     InnerSymTarget,
 )
 from xdsl.dialects.test import TestOp
@@ -278,3 +280,33 @@ def test_inner_ref_attr():
     assert (
         ref.get_module().data == "mod2"
     ), "Name of the referenced module should be returned correctly"
+
+
+def test_inner_sym_attr():
+    """
+    Test inner symbol attributes
+    """
+    invalid_sym_attr = InnerSymAttr()
+    assert (
+        invalid_sym_attr.get_sym_name() is None
+    ), "Invalid InnerSymAttr should return no name"
+
+    sym_attr = InnerSymAttr("sym")
+    assert sym_attr.get_sym_name() == StringAttr(
+        "sym"
+    ), "InnerSymAttr for “ground” type should return name"
+
+    with pytest.raises(VerifyException, match=r"inner symbol cannot have empty name"):
+        InnerSymAttr("")
+
+    aggregate_sym_attr = InnerSymAttr(
+        [
+            InnerSymPropertiesAttr("sym", 0, "public"),
+            InnerSymPropertiesAttr("other", 1, "private"),
+            InnerSymPropertiesAttr("yet_another", 2, "nested"),
+        ]
+    )
+
+    assert aggregate_sym_attr.get_sym_name() == StringAttr(
+        "sym"
+    ), "InnerSymAttr for aggregate types should return name with field ID 0"

--- a/tests/filecheck/dialects/hw/hw_ops.mlir
+++ b/tests/filecheck/dialects/hw/hw_ops.mlir
@@ -2,10 +2,10 @@
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
 "builtin.module"() ({
-  "test.op"() { "test" = #hw.inner_name_ref<@Foo::@Bar> } : () -> ()
-  // CHECK:  "test.op"() {"test" = #hw.inner_name_ref<@Foo::@Bar>} : () -> ()
+  "test.op"() { "test" = #hw.innerNameRef<@Foo::@Bar> } : () -> ()
+  // CHECK:  "test.op"() {"test" = #hw.innerNameRef<@Foo::@Bar>} : () -> ()
 }) : () -> ()
 
 // CHECK-GENERIC: "builtin.module"() ({
-// CHECK-GENERIC-NEXT:   "test.op"() {"test" = #hw.inner_name_ref<@Foo::@Bar>} : () -> ()
+// CHECK-GENERIC-NEXT:   "test.op"() {"test" = #hw.innerNameRef<@Foo::@Bar>} : () -> ()
 // CHECK-GENERIC-NEXT: })

--- a/tests/filecheck/dialects/hw/hw_ops.mlir
+++ b/tests/filecheck/dialects/hw/hw_ops.mlir
@@ -1,11 +1,12 @@
 // RUN: XDSL_ROUNDTRIP
-// RUN: XDSL_GENERIC_ROUNDTRIP
 
 "builtin.module"() ({
   "test.op"() { "test" = #hw.innerNameRef<@Foo::@Bar> } : () -> ()
   // CHECK:  "test.op"() {"test" = #hw.innerNameRef<@Foo::@Bar>} : () -> ()
-}) : () -> ()
 
-// CHECK-GENERIC: "builtin.module"() ({
-// CHECK-GENERIC-NEXT:   "test.op"() {"test" = #hw.innerNameRef<@Foo::@Bar>} : () -> ()
-// CHECK-GENERIC-NEXT: })
+  "test.op"() { "test" = #hw<innerSym[<@x_1,4,public>, <@y,5,public>]> } : () -> ()
+  // CHECK-NEXT:  "test.op"() {"test" = #hw<innerSym[<@x_1,4,public>, <@y,5,public>]>} : () -> ()
+
+  "test.op"() { "test" = #hw<innerSym@sym> } : () -> ()
+  // CHECK-NEXT:  "test.op"() {"test" = #hw<innerSym@sym>} : () -> ()
+}) : () -> ()

--- a/tests/filecheck/dialects/hw/invalid.mlir
+++ b/tests/filecheck/dialects/hw/invalid.mlir
@@ -21,3 +21,11 @@
 }) : () -> ()
 
 // CHECK:  Expected a module and symbol reference
+
+// -----
+
+"builtin.module"() ({
+  "test.op"() { "test" = #hw.innerSym[<@x_1,4,foo>, <@y,5,bar>] } : () -> ()
+}) : () -> ()
+
+// CHECK:  Expected "public", "private", or "nested"

--- a/tests/filecheck/dialects/hw/invalid.mlir
+++ b/tests/filecheck/dialects/hw/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck %s
 
 "builtin.module"() ({
-  "test.op"() { "test" = #hw.inner_name_ref<1> } : () -> ()
+  "test.op"() { "test" = #hw.innerNameRef<1> } : () -> ()
 }) : () -> ()
 
 // CHECK:  Expected a module and symbol reference
@@ -9,7 +9,7 @@
 // -----
 
 "builtin.module"() ({
-  "test.op"() { "test" = #hw.inner_name_ref<@Foo> } : () -> ()
+  "test.op"() { "test" = #hw.innerNameRef<@Foo> } : () -> ()
 }) : () -> ()
 
 // CHECK:  Expected a module and symbol reference
@@ -17,7 +17,7 @@
 // -----
 
 "builtin.module"() ({
-  "test.op"() { "test" = #hw.inner_name_ref<@Foo::@Bar::@Baz> } : () -> ()
+  "test.op"() { "test" = #hw.innerNameRef<@Foo::@Bar::@Baz> } : () -> ()
 }) : () -> ()
 
 // CHECK:  Expected a module and symbol reference

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -353,10 +353,13 @@ class InnerSymAttr(
             syms = ArrayAttr(syms)
         super().__init__([syms])
 
-    def get_sym_if_exists(self, field_id: int) -> StringAttr | None:
+    def get_sym_if_exists(self, field_id: IntAttr | int) -> StringAttr | None:
         """Get the inner sym name for field_id, if it exists."""
+        if not isinstance(field_id, IntAttr):
+            field_id = IntAttr(field_id)
+
         for prop in self.props:
-            if field_id == prop.field_id.data:
+            if field_id == prop.field_id:
                 return prop.sym_name
 
     def get_sym_name(self) -> StringAttr | None:
@@ -371,8 +374,10 @@ class InnerSymAttr(
         """Iterator for all the InnerSymPropertiesAttr."""
         return iter(self.props)
 
-    def erase(self, field_id: int) -> "InnerSymAttr":
+    def erase(self, field_id: IntAttr | int) -> "InnerSymAttr":
         """Return an InnerSymAttr with the inner symbol for the specified field_id removed."""
+        if not isinstance(field_id, IntAttr):
+            field_id = IntAttr(field_id)
         return InnerSymAttr([prop for prop in self.props if prop.field_id != field_id])
 
     @classmethod

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -72,7 +72,7 @@ class InnerSymTarget:
 class InnerRefAttr(ParametrizedAttribute):
     """This works like a symbol reference, but to a name inside a module."""
 
-    name = "hw.inner_name_ref"
+    name = "hw.innerNameRef"
     module_ref: ParameterDef[FlatSymbolRefAttr]
     # NB. upstream defines as “name” which clashes with Attribute.name
     sym_name: ParameterDef[StringAttr]

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -6,10 +6,14 @@ It currently implements minimal types and operations for the symbols and inner s
 [2] https://circt.llvm.org/docs/RationaleSymbols/
 """
 
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import InitVar, dataclass, field
+from typing import overload
 
 from xdsl.dialects.builtin import (
+    ArrayAttr,
     FlatSymbolRefAttr,
+    IntAttr,
     ParameterDef,
     StringAttr,
     SymbolRefAttr,
@@ -17,6 +21,7 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import (
     Attribute,
     Dialect,
+    OpaqueSyntaxAttribute,
     Operation,
     ParametrizedAttribute,
 )
@@ -248,10 +253,163 @@ class InnerRefNamespace:
         self.inner_sym_tables = InnerSymbolTableCollection(inner_ref_ns_op)
 
 
+@irdl_attr_definition
+class InnerSymPropertiesAttr(ParametrizedAttribute):
+    name = "hw.innerSymProps"
+
+    # NB. upstream defines as “name” which clashes with Attribute.name
+    sym_name: ParameterDef[StringAttr]
+    field_id: ParameterDef[IntAttr]
+    sym_visibility: ParameterDef[StringAttr]
+
+    def __init__(
+        self,
+        sym: str | StringAttr,
+        field_id: int | IntAttr = 0,
+        sym_visibility: str | StringAttr = "public",
+    ) -> None:
+        if isinstance(sym, str):
+            sym = StringAttr(sym)
+        if isinstance(field_id, int):
+            field_id = IntAttr(field_id)
+        if isinstance(sym_visibility, str):
+            sym_visibility = StringAttr(sym_visibility)
+        super().__init__([sym, field_id, sym_visibility])
+
+    @classmethod
+    def parse_parameters(
+        cls, parser: AttrParser
+    ) -> tuple[StringAttr, IntAttr, StringAttr]:
+        parser.parse_punctuation("<")
+        sym_name = parser.parse_symbol_name()
+        parser.parse_punctuation(",")
+        field_id = parser.parse_integer(allow_negative=False, allow_boolean=False)
+        parser.parse_punctuation(",")
+        sym_visibility = parser.parse_identifier()
+        if sym_visibility not in {"public", "private", "nested"}:
+            parser.raise_error('Expected "public", "private", or "nested"')
+        parser.parse_punctuation(">")
+        return (sym_name, IntAttr(field_id), StringAttr(sym_visibility))
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print_string("<@")
+        printer.print_string(self.sym_name.data)
+        printer.print_string(",")
+        printer.print_string(str(self.field_id.data))
+        printer.print_string(",")
+        printer.print_string(self.sym_visibility.data)
+        printer.print_string(">")
+
+    def verify(self):
+        if not self.sym_name or not self.sym_name.data:
+            raise VerifyException("inner symbol cannot have empty name")
+
+
+@irdl_attr_definition
+class InnerSymAttr(
+    ParametrizedAttribute, Iterable[InnerSymPropertiesAttr], OpaqueSyntaxAttribute
+):
+    """Inner symbol definition
+
+    Defines the properties of an inner_sym attribute. It specifies the symbol name and symbol
+    visibility for each field ID. For any ground types, there are no subfields and the field ID is 0.
+    For aggregate types, a unique field ID is assigned to each field by visiting them in a
+    depth-first pre-order.
+
+    The custom assembly format ensures that for ground types, only `@<sym_name>` is printed.
+    """
+
+    name = "hw.innerSym"
+
+    props: ParameterDef[ArrayAttr[InnerSymPropertiesAttr]]
+
+    @overload
+    def __init__(self) -> None:
+        # Create an empty array, represents an invalid InnerSym.
+        ...
+
+    @overload
+    def __init__(self, syms: str | StringAttr) -> None: ...
+
+    @overload
+    def __init__(
+        self, syms: Sequence[InnerSymPropertiesAttr] | ArrayAttr[InnerSymPropertiesAttr]
+    ) -> None: ...
+
+    def __init__(
+        self,
+        syms: (
+            str
+            | StringAttr
+            | Sequence[InnerSymPropertiesAttr]
+            | ArrayAttr[InnerSymPropertiesAttr]
+        ) = [],
+    ) -> None:
+        if isinstance(syms, str | StringAttr):
+            syms = [InnerSymPropertiesAttr(syms)]
+        if not isinstance(syms, ArrayAttr):
+            syms = ArrayAttr(syms)
+        super().__init__([syms])
+
+    def get_sym_if_exists(self, field_id: int) -> StringAttr | None:
+        """Get the inner sym name for field_id, if it exists."""
+        for prop in self.props:
+            if field_id == prop.field_id.data:
+                return prop.sym_name
+
+    def get_sym_name(self) -> StringAttr | None:
+        """Get the inner sym name for field_id=0, if it exists."""
+        return self.get_sym_if_exists(0)
+
+    def __len__(self) -> int:
+        """Get the number of inner symbols defined."""
+        return len(self.props)
+
+    def __iter__(self) -> Iterator[InnerSymPropertiesAttr]:
+        """Iterator for all the InnerSymPropertiesAttr."""
+        return iter(self.props)
+
+    def erase(self, field_id: int) -> "InnerSymAttr":
+        """Return an InnerSymAttr with the inner symbol for the specified field_id removed."""
+        return InnerSymAttr([prop for prop in self.props if prop.field_id != field_id])
+
+    @classmethod
+    def parse_parameters(
+        cls, parser: AttrParser
+    ) -> list[ArrayAttr[InnerSymPropertiesAttr]]:
+        if (sym_name := parser.parse_optional_symbol_name()) is not None:
+            return [ArrayAttr([InnerSymPropertiesAttr(sym_name, 0, "public")])]
+
+        data = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE,
+            lambda: InnerSymPropertiesAttr.parse_parameters(parser),
+        )
+        return [ArrayAttr(InnerSymPropertiesAttr(*tup) for tup in data)]
+
+    def print_parameters(self, printer: Printer):
+        if (
+            len(self) == 1
+            and (sym_name := self.get_sym_name()) is not None
+            and self.props.data[0].sym_visibility.data == "public"
+            and self.props.data[0].field_id.data == 0
+        ):
+            printer.print_string("@")
+            printer.print_string(sym_name.data)
+        else:
+            printer.print_string("[")
+            printer.print_list(
+                sorted(self.props, key=lambda prop: prop.field_id.data),
+                lambda prop: prop.print_parameters(printer),
+            )
+            printer.print_string("]")
+
+
 HW = Dialect(
     "hw",
     [],
     [
         InnerRefAttr,
+        InnerSymPropertiesAttr,
+        InnerSymAttr,
     ],
 )

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -329,12 +329,14 @@ class InnerSymAttr(
         ...
 
     @overload
-    def __init__(self, syms: str | StringAttr) -> None: ...
+    def __init__(self, syms: str | StringAttr) -> None:
+        ...
 
     @overload
     def __init__(
         self, syms: Sequence[InnerSymPropertiesAttr] | ArrayAttr[InnerSymPropertiesAttr]
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def __init__(
         self,


### PR DESCRIPTION
Another hopefully manageable chunk of HW, which introduces the symbol attributes. These are used in many circt dialects (e.g., seq) to define the names then referenced by the `InnerRefAttr`s and the like.

This is [the bit of the symbol rationale](https://circt.llvm.org/docs/RationaleSymbols/#inner-symbol) that gives details.

This PR also includes a small fix on the tests, simplifying the test file and undoing the over-correction of camel case to snake case on symbol mnemonics (we want those to be compatible with CIRCT).

Thanks a lot to @PapyChacal for all the help in deciphering where CIRCT hides the symbol attr tests.