### PR TITLE
transformations: simplify stride patterns when lowering memref_stream

### DIFF
--- a/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
@@ -33,7 +33,7 @@ memref_stream.streaming_region {
 // CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %A : memref<2xf64> to !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %B : memref<3xf64> to !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg<>
-// CHECK-NEXT:    "snitch_stream.streaming_region"(%2, %3, %4) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [2, 3], strides = [0, 8]>, #snitch_stream.stride_pattern<ub = [2, 3], strides = [8, 0]>, #snitch_stream.stride_pattern<ub = [2, 3], strides = [8, 16]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-NEXT:    "snitch_stream.streaming_region"(%2, %3, %4) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [2, 3], strides = [0, 8]>, #snitch_stream.stride_pattern<ub = [2, 3], strides = [8, 0]>, #snitch_stream.stride_pattern<ub = [6], strides = [8]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT:  ^0(%a : !stream.readable<!riscv.freg<>>, %b : !stream.readable<!riscv.freg<>>, %c : !stream.writable<!riscv.freg<>>):
 // CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %a : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
 // CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %b : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
@@ -54,7 +54,7 @@ memref_stream.streaming_region {
 
 // CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg<>
 // CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg<>
-// CHECK-NEXT:    "snitch_stream.streaming_region"(%{{.*}}, %{{.*}}) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [2, 3], strides = [8, 16]>], "operandSegmentSizes" = array<i32: 2, 0>}> ({
+// CHECK-NEXT:    "snitch_stream.streaming_region"(%{{.*}}, %{{.*}}) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [6], strides = [8]>], "operandSegmentSizes" = array<i32: 2, 0>}> ({
 // CHECK-NEXT:  ^{{.*}}(%c0 : !stream.readable<!riscv.freg<>>, %c1 : !stream.readable<!riscv.freg<>>):
 // CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c0 : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
 // CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c1 : !stream.readable<!riscv.freg<>> to !stream.readable<f64>

--- a/tests/interpreters/test_snitch_stream_interpreter.py
+++ b/tests/interpreters/test_snitch_stream_interpreter.py
@@ -24,6 +24,25 @@ def test_stride_pattern_offsets():
     ).offsets() == tuple(range(24))
 
 
+def test_simplify_stride_pattern():
+    assert snitch_stream.StridePattern.from_bounds_and_strides(
+        (4, 3, 2), (1, 4, 12)
+    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides((24,), (1,))
+    assert snitch_stream.StridePattern.from_bounds_and_strides(
+        (2, 3), (8, 16)
+    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides((6,), (8,))
+    assert snitch_stream.StridePattern.from_bounds_and_strides(
+        (2, 3), (0, 8)
+    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides(
+        (2, 3), (0, 8)
+    )
+    assert snitch_stream.StridePattern.from_bounds_and_strides(
+        (2, 3), (8, 0)
+    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides(
+        (2, 3), (8, 0)
+    )
+
+
 def test_snitch_stream_interpreter():
     register = riscv.IntRegisterType.unallocated()
 

--- a/tests/interpreters/test_snitch_stream_interpreter.py
+++ b/tests/interpreters/test_snitch_stream_interpreter.py
@@ -26,6 +26,9 @@ def test_stride_pattern_offsets():
 
 def test_simplify_stride_pattern():
     assert snitch_stream.StridePattern.from_bounds_and_strides(
+        (24,), (1,)
+    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides((24,), (1,))
+    assert snitch_stream.StridePattern.from_bounds_and_strides(
         (4, 3, 2), (1, 4, 12)
     ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides((24,), (1,))
     assert snitch_stream.StridePattern.from_bounds_and_strides(

--- a/tests/interpreters/test_snitch_stream_interpreter.py
+++ b/tests/interpreters/test_snitch_stream_interpreter.py
@@ -1,3 +1,5 @@
+import pytest
+
 from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import riscv, riscv_snitch, snitch_stream, stream
 from xdsl.dialects.builtin import ArrayAttr, ModuleOp
@@ -9,41 +11,41 @@ from xdsl.ir import Block, Region
 from xdsl.utils.test_value import TestSSAValue
 
 
-def test_stride_pattern_offsets():
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (6,), (1,)
-    ).offsets() == tuple(range(6))
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (6,), (2,)
-    ).offsets() == tuple(range(0, 12, 2))
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (2, 3), (1, 2)
-    ).offsets() == tuple(range(6))
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (2, 3, 4), (1, 2, 6)
-    ).offsets() == tuple(range(24))
+@pytest.mark.parametrize(
+    "ub, strides, offsets",
+    [
+        ((6,), (1,), tuple(range(6))),
+        ((6,), (2,), tuple(range(0, 12, 2))),
+        ((2, 3), (1, 2), tuple(range(6))),
+        ((2, 3, 4), (1, 2, 6), tuple(range(24))),
+    ],
+)
+def test_stride_pattern_offsets(
+    ub: tuple[int, ...], strides: tuple[int, ...], offsets: tuple[int, ...]
+):
+    assert (
+        snitch_stream.StridePattern.from_bounds_and_strides(ub, strides).offsets()
+        == offsets
+    )
 
 
-def test_simplify_stride_pattern():
+@pytest.mark.parametrize(
+    "inputs, outputs",
+    [
+        (((24,), (1,)), ((24,), (1,))),
+        (((4, 3, 2), (1, 4, 12)), ((24,), (1,))),
+        (((2, 3), (8, 16)), ((6,), (8,))),
+        (((2, 3), (0, 8)), ((2, 3), (0, 8))),
+        (((2, 3), (8, 0)), ((2, 3), (8, 0))),
+    ],
+)
+def test_simplify_stride_pattern(
+    inputs: tuple[tuple[int, ...], tuple[int, ...]],
+    outputs: tuple[tuple[int, ...], tuple[int, ...]],
+):
     assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (24,), (1,)
-    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides((24,), (1,))
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (4, 3, 2), (1, 4, 12)
-    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides((24,), (1,))
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (2, 3), (8, 16)
-    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides((6,), (8,))
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (2, 3), (0, 8)
-    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides(
-        (2, 3), (0, 8)
-    )
-    assert snitch_stream.StridePattern.from_bounds_and_strides(
-        (2, 3), (8, 0)
-    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides(
-        (2, 3), (8, 0)
-    )
+        *inputs
+    ).simplified() == snitch_stream.StridePattern.from_bounds_and_strides(*outputs)
 
 
 def test_snitch_stream_interpreter():

--- a/xdsl/interpreters/snitch_stream.py
+++ b/xdsl/interpreters/snitch_stream.py
@@ -1,11 +1,6 @@
-from collections.abc import Sequence
+from collections.abc import Iterator
 from dataclasses import dataclass
-from functools import reduce
-from itertools import accumulate
-from operator import mul
 from typing import Any
-
-from typing_extensions import Self
 
 from xdsl.dialects import snitch_stream
 from xdsl.interpreter import (
@@ -20,134 +15,29 @@ from xdsl.interpreters.stream import (
     ReadableStream,
     WritableStream,
 )
-from xdsl.ir.affine import AffineExpr, AffineMap
-
-
-def indexing_map_from_bounds(bounds: Sequence[int]) -> AffineMap:
-    """
-    Given a set of upper bounds of the nested loop, creates a map that represents the
-    values of the loop iterators.
-
-    e.g.:
-    ```
-    for i in range(2):
-        for j in range(3):
-            print(i, j) # -> (0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)
-
-    map = indexing_map_from_bounds([3, 2])
-
-    for k in range(6):
-        print(map.eval(k)) # -> (0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)
-    ```
-    """
-    divs = tuple(accumulate(bounds, mul, initial=1))[-2::-1]
-    return AffineMap(
-        1,
-        0,
-        tuple(
-            (
-                AffineExpr.dimension(0).floor_div(div) % bound
-                if div != 1
-                else AffineExpr.dimension(0) % bound
-            )
-            for bound, div in zip(reversed(bounds), divs, strict=True)
-        ),
-    )
-
-
-def offset_map_from_strides(strides: Sequence[int]) -> AffineMap:
-    """
-    Given a set of offsets for each bound of the nested loop, creates a map that
-    represents the offset from the base_ptr that the stream will fetch.
-
-    e.g.:
-    ```
-    my_list = [1, 2, 3, 4, 5, 6]
-    strides = [1, 3]
-    for i in range(2):
-        for j in range(3):
-            k = i * 3 + j
-            el = my_list[k]
-            print(el) # -> 1, 2, 3, 4, 5, 6
-
-    map = offset_map_from_strides([1, 3])
-
-    for i in range(2):
-        for j in range(3):
-            k = map.eval(i, j)
-            el = my_list[k]
-            print(el) # -> 1, 2, 3, 4, 5, 6
-    ```
-    """
-    if not strides:
-        # Return empty map to avoid reducing over an empty sequence
-        return AffineMap(1, 0, ())
-
-    return AffineMap(
-        len(strides),
-        0,
-        (
-            reduce(
-                lambda acc, m: acc + m,
-                (
-                    AffineExpr.dimension(i) * stride
-                    for i, stride in enumerate(reversed(strides))
-                ),
-            ),
-        ),
-    )
-
-
-@dataclass
-class StridePattern:
-    """
-    Defines the upper bounds and strides for the stride pattern, conceptually from the
-    innermost loop outwards.
-    """
-
-    ub: list[int]
-    strides: list[int]
-
-    @property
-    def offset_expr(self) -> AffineExpr:
-        """
-        Creates the map that represents the offset that the stream will read from or write
-        to at register access "i".
-        """
-        indexing_map = indexing_map_from_bounds(self.ub)
-        offset_map = offset_map_from_strides(self.strides)
-        result_map = offset_map.compose(indexing_map)
-        return result_map.results[0]
-
-    @classmethod
-    def from_attr(cls, attr: snitch_stream.StridePattern) -> Self:
-        return cls(
-            [ub.data for ub in attr.ub],
-            [stride.data for stride in attr.strides],
-        )
 
 
 @dataclass
 class StridedPointerInputStream(ReadableStream[float]):
-    offset_expr: AffineExpr
+    offset_iter: Iterator[int]
     pointer: RawPtr
     index = -1
 
     def read(self) -> float:
         self.index += 1
-        offset = self.offset_expr.eval((self.index,), ())
+        offset = next(self.offset_iter)
         return (self.pointer + offset).float64[0]
 
 
 @dataclass
 class StridedPointerOutputStream(WritableStream[float]):
     index = -1
-    offset_expr: AffineExpr
+    offset_iter: Iterator[int]
     pointer: RawPtr
 
     def write(self, value: float) -> None:
         self.index += 1
-        offset = self.offset_expr.eval((self.index,), ())
+        offset = next(self.offset_iter)
         (self.pointer + offset).float64[0] = value
 
 
@@ -167,24 +57,21 @@ class SnitchStreamFunctions(InterpreterFunctions):
             input_stream_count : input_stream_count + output_stream_count
         ]
 
-        stride_patterns = tuple(
-            StridePattern.from_attr(pattern) for pattern in op.stride_patterns
-        )
-        if len(stride_patterns) == 1:
-            pattern = stride_patterns[0]
+        if len(op.stride_patterns) == 1:
+            pattern = op.stride_patterns.data[0]
             input_stride_patterns = (pattern,) * input_stream_count
             output_stride_patterns = (pattern,) * output_stream_count
         else:
-            input_stride_patterns = stride_patterns[:input_stream_count]
-            output_stride_patterns = stride_patterns[input_stream_count:]
+            input_stride_patterns = op.stride_patterns.data[:input_stream_count]
+            output_stride_patterns = op.stride_patterns.data[input_stream_count:]
 
         input_streams = tuple(
-            StridedPointerInputStream(pat.offset_expr, ptr)
+            StridedPointerInputStream(pat.offset_iter(), ptr)
             for pat, ptr in zip(input_stride_patterns, input_pointers, strict=True)
         )
 
         output_streams = tuple(
-            StridedPointerOutputStream(pat.offset_expr, ptr)
+            StridedPointerOutputStream(pat.offset_iter(), ptr)
             for pat, ptr in zip(output_stride_patterns, output_pointers, strict=True)
         )
 

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -111,7 +111,7 @@ class StreamOpLowering(RewritePattern):
         stride_patterns = tuple(
             snitch_stream.StridePattern.from_bounds_and_strides(
                 bounds[::-1], strides[::-1]
-            )
+            ).simplified()
             for strides in all_strides
         )
         if len(set(stride_patterns)) == 1:


### PR DESCRIPTION
Note stacked PR

When lowering convolutions, we run out of stream dimensions, hence this PR, which lowers the number of dimensions in the stream. In a future PR, we'll only convert a memref operand to a `generic` to a stream when we know that the stride pattern will be less than some parameter. For now, we just convert first and then hope for the best.