### PR TITLE
core: make ModulePass frozen

### DIFF
--- a/tests/test_parse_spec_format.py
+++ b/tests/test_parse_spec_format.py
@@ -19,51 +19,51 @@ def test_pass_parser():
         PipelinePassSpec(
             "mlir-opt",
             {
-                "arguments": [
+                "arguments": (
                     "--mlir-print-op-generic",
                     "--allow-unregistered-dialect",
                     "-p",
                     "builtin.module(cse)",
-                ]
+                )
             },
         ),
         PipelinePassSpec("pass-1", {}),
         PipelinePassSpec(
             "pass-2",
             {
-                "arg1": [1],
-                "arg2": ["test", "test2", 3],
-                "arg3": ["test-str,2,3"],
-                "arg-4": [-3.44e-11],
-                "no-val-arg": [],
+                "arg1": (1,),
+                "arg2": ("test", "test2", 3),
+                "arg3": ("test-str,2,3",),
+                "arg-4": (-3.44e-11,),
+                "no-val-arg": (),
             },
         ),
         PipelinePassSpec(
             "mlir-opt",
             {
-                "arguments": [
+                "arguments": (
                     "--mlir-print-op-generic",
                     "--allow-unregistered-dialect",
                     "-p",
                     "builtin.module(cse)",
-                ]
+                )
             },
         ),
         PipelinePassSpec(
             "pass-3",
             {
-                "thing": ["2d-grid"],
+                "thing": ("2d-grid",),
             },
         ),
         PipelinePassSpec(
             "mlir-opt",
             {
-                "arguments": [
+                "arguments": (
                     "--mlir-print-op-generic",
                     "--allow-unregistered-dialect",
                     "-p",
                     "builtin.module(cse)",
-                ]
+                )
             },
         ),
     ]
@@ -76,17 +76,21 @@ def test_pass_parser():
         PipelinePassSpec(
             "pass-2",
             {
-                "arg1": [1],
-                "arg2": ["test", "test2", 3],
-                "arg3": ["test-str,2,3"],
-                "arg-4": [-3.44e-11],
-                "no-val-arg": [],
+                "arg1": (1,),
+                "arg2": (
+                    "test",
+                    "test2",
+                    3,
+                ),
+                "arg3": ("test-str,2,3",),
+                "arg-4": (-3.44e-11,),
+                "no-val-arg": (),
             },
         ),
         PipelinePassSpec(
             "pass-3",
             {
-                "thing": ["2d-grid"],
+                "thing": ("2d-grid",),
             },
         ),
     ],

--- a/tests/test_pass_from_spec.py
+++ b/tests/test_pass_from_spec.py
@@ -10,13 +10,13 @@ from xdsl.passes import ModulePass
 from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
-@dataclass
+@dataclass(frozen=True)
 class CustomPass(ModulePass):
     name = "custom-pass"
 
     number: int | float
 
-    int_list: list[int]
+    int_list: tuple[int, ...]
 
     non_init_thing: int = field(init=False)
 
@@ -32,7 +32,7 @@ class CustomPass(ModulePass):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class EmptyPass(ModulePass):
     name = "empty"
 
@@ -40,7 +40,7 @@ class EmptyPass(ModulePass):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimplePass(ModulePass):
     name = "simple"
 
@@ -56,17 +56,17 @@ def test_pass_instantiation():
         PipelinePassSpec(
             name="custom-pass",
             args={
-                "number": [2],
-                "int-list": [1, 2, 3],
-                "str-thing": ["hello world"],
-                "literal": ["maybe"]
+                "number": (2,),
+                "int-list": (1, 2, 3),
+                "str-thing": ("hello world",),
+                "literal": ("maybe",),
                 # "optional" was left out here, as it is optional
             },
         )
     )
 
     assert p.number == 2
-    assert p.int_list == [1, 2, 3]
+    assert p.int_list == (1, 2, 3)
     assert p.str_thing == "hello world"
     assert p.nullable_str is None
     assert p.literal == "maybe"
@@ -79,16 +79,16 @@ def test_pass_instantiation():
 @pytest.mark.parametrize(
     "spec, error_msg",
     (
-        (PipelinePassSpec("wrong", {"a": [1]}), "Cannot create Pass simple"),
+        (PipelinePassSpec("wrong", {"a": (1,)}), "Cannot create Pass simple"),
         (PipelinePassSpec("simple", {}), 'requires argument "a"'),
         (
-            PipelinePassSpec("simple", {"a": [1], "no": []}),
+            PipelinePassSpec("simple", {"a": (1,), "no": ()}),
             'Provided arguments ["no"] not found in expected pass arguments ["a", "b"]',
         ),
-        (PipelinePassSpec("simple", {"a": []}), "Argument must contain a value"),
-        (PipelinePassSpec("simple", {"a": ["test"]}), "Incompatible types"),
+        (PipelinePassSpec("simple", {"a": ()}), "Argument must contain a value"),
+        (PipelinePassSpec("simple", {"a": ("test",)}), "Incompatible types"),
         (
-            PipelinePassSpec("simple", {"a": ["test"], "literal": ["definitely"]}),
+            PipelinePassSpec("simple", {"a": ("test",), "literal": ("definitely",)}),
             "Incompatible types",
         ),
     ),

--- a/tests/test_pass_to_arg_and_types_str.py
+++ b/tests/test_pass_to_arg_and_types_str.py
@@ -8,7 +8,7 @@ from xdsl.ir import MLContext
 from xdsl.passes import ModulePass, get_pass_argument_names_and_types
 
 
-@dataclass
+@dataclass(frozen=True)
 class CustomPass(ModulePass):
     name = "custom-pass"
 
@@ -16,7 +16,7 @@ class CustomPass(ModulePass):
 
     single_number: int
 
-    int_list: list[int]
+    int_list: tuple[int, ...]
 
     non_init_thing: int = field(init=False)
 
@@ -32,7 +32,7 @@ class CustomPass(ModulePass):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class EmptyPass(ModulePass):
     name = "empty"
 
@@ -40,7 +40,7 @@ class EmptyPass(ModulePass):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimplePass(ModulePass):
     name = "simple"
 
@@ -56,7 +56,7 @@ class SimplePass(ModulePass):
     "str_arg, pass_arg",
     (
         (
-            """number=int|float single_number=int int_list=list[int] non_init_thing=int str_thing=str nullable_str=str|None literal=no optional_bool=false""",
+            """number=int|float single_number=int int_list=tuple[int, ...] non_init_thing=int str_thing=str nullable_str=str|None literal=no optional_bool=false""",
             CustomPass,
         ),
         ("", EmptyPass),

--- a/tests/test_pass_to_spec.py
+++ b/tests/test_pass_to_spec.py
@@ -8,17 +8,17 @@ from xdsl.passes import ModulePass
 from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
-@dataclass
+@dataclass(frozen=True)
 class CustomPass(ModulePass):
     name = "custom-pass"
 
     number: int
 
-    int_list: list[int]
+    int_list: tuple[int, ...]
 
     str_thing: str | None
 
-    list_str: list[str] = field(default_factory=list)
+    list_str: tuple[str, ...] = field(default=())
 
     optional_bool: bool = False
 
@@ -26,7 +26,7 @@ class CustomPass(ModulePass):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class EmptyPass(ModulePass):
     name = "empty"
 
@@ -34,11 +34,11 @@ class EmptyPass(ModulePass):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimplePass(ModulePass):
     name = "simple"
 
-    a: list[float]
+    a: tuple[float, ...]
     b: int
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
@@ -49,22 +49,22 @@ class SimplePass(ModulePass):
     "test_pass, test_spec",
     (
         (
-            CustomPass(3, [1, 2], None, ["clown", "season"]),
+            CustomPass(3, (1, 2), None, ("clown", "season")),
             PipelinePassSpec(
                 "custom-pass",
                 {
-                    "number": [3],
-                    "int_list": [1, 2],
-                    "str_thing": [],
-                    "list_str": ["clown", "season"],
-                    "optional_bool": [False],
+                    "number": (3,),
+                    "int_list": (1, 2),
+                    "str_thing": (),
+                    "list_str": ("clown", "season"),
+                    "optional_bool": (False,),
                 },
             ),
         ),
         (EmptyPass(), PipelinePassSpec("empty", {})),
         (
-            SimplePass([3.14, 2.13], 2),
-            PipelinePassSpec("simple", {"a": [3.14, 2.13], "b": [2]}),
+            SimplePass((3.14, 2.13), 2),
+            PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
         ),
     ),
 )

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -41,10 +41,10 @@ def apply_passes_to_module(
     Function that takes a ModuleOp, an MLContext and a pass_pipeline (consisting of a type[ModulePass] and PipelinePassSpec), applies the pass(es) to the ModuleOp and returns the new ModuleOp.
     """
     pipeline = PipelinePass(
-        passes=[
+        passes=tuple(
             module_pass.from_pass_spec(pipeline_pass_spec)
             for module_pass, pipeline_pass_spec in pass_pipeline
-        ]
+        )
     )
     pipeline.apply(ctx, module)
     return module

--- a/xdsl/interactive/rewrites.py
+++ b/xdsl/interactive/rewrites.py
@@ -37,9 +37,9 @@ def convert_indexed_individual_rewrites_to_available_pass(
         rewrite_spec = PipelinePassSpec(
             name=rewrite_pass.name,
             args={
-                "matched_operation_index": [op_idx],
-                "operation_name": [op_name],
-                "pattern_name": [pat_name],
+                "matched_operation_index": (op_idx,),
+                "operation_name": (op_name,),
+                "pattern_name": (pat_name,),
             },
         )
         op = list(current_module.walk())[op_idx]

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -17,7 +17,7 @@ from xdsl.utils.parse_pipeline import (
 ModulePassT = TypeVar("ModulePassT", bound="ModulePass")
 
 
-@dataclass
+@dataclass(frozen=True)
 class ModulePass(ABC):
     """
     A Pass is a named rewrite pass over an IR module that can accept arguments.
@@ -31,18 +31,19 @@ class ModulePass(ABC):
     In order to make a pass accept arguments, it must be a dataclass. Furthermore,
     only the following types are supported as argument types:
 
-    Base types:             int | float | bool | string
-    Lists of base types:    list[int], list[int|float], list[int] | list[float]
-    Top-level optional:      ... | None
+    Base types:                int | float | bool | string
+    N-tuples of base types:
+        tuple[int, ...], tuple[int|float, ...], tuple[int, ...] | tuple[float, ...]
+    Top-level optional:        ... | None
 
     Pass arguments on the CLI are formatted as follows:
 
     CLI arg                             Mapped to class field
     -------------------------           ------------------------------
-    my-pass{arg-1=1}                    arg_1: int = 1
-    my-pass{arg-1}                      arg_1: int | None = None
-    my-pass{arg-1=1,2,3}                arg_1: list[int] = [1, 2, 3]
-    my-pass{arg-1=true}                 arg_1: bool | None = True
+    my-pass{arg-1=1}                    arg_1: int             = 1
+    my-pass{arg-1}                      arg_1: int | None      = None
+    my-pass{arg-1=1,2,3}                arg_1: tuple[int, ...] = (1, 2, 3)
+    my-pass{arg-1=true}                 arg_1: bool | None     = True
     """
 
     name: ClassVar[str]
@@ -124,9 +125,9 @@ class ModulePass(ABC):
 
             val = getattr(self, op_field.name)
             if val is None:
-                arg_dict.update({op_field.name: []})
+                arg_dict.update({op_field.name: ()})
             elif isinstance(val, PassArgElementType):
-                arg_dict.update({op_field.name: [getattr(self, op_field.name)]})
+                arg_dict.update({op_field.name: (getattr(self, op_field.name),)})
             else:
                 arg_dict.update({op_field.name: getattr(self, op_field.name)})
 
@@ -143,9 +144,11 @@ def get_pass_argument_names_and_types(arg: type[ModulePassT]) -> str:
 
     return " ".join(
         [
-            f"{field.name}={type_repr(field.type)}"
-            if not hasattr(arg, field.name)
-            else f"{field.name}={str(getattr(arg, field.name)).lower()}"
+            (
+                f"{field.name}={type_repr(field.type)}"
+                if not hasattr(arg, field.name)
+                else f"{field.name}={str(getattr(arg, field.name)).lower()}"
+            )
             for field in dataclasses.fields(arg)
         ]
     )
@@ -157,9 +160,9 @@ def _empty_callback(
     return
 
 
-@dataclass
+@dataclass(frozen=True)
 class PipelinePass(ModulePass):
-    passes: list[ModulePass]
+    passes: tuple[ModulePass, ...]
     callback: Callable[[ModulePass, builtin.ModuleOp, ModulePass], None] = field(
         default=_empty_callback
     )
@@ -200,8 +203,8 @@ def _convert_pass_arg_to_type(
     value,      dest_type,      result
     []          int | None      None
     [1]         int | None      1
-    [1]         list[int]       [1]
-    [1,2]       list[int]       [1,2]
+    [1]         tuple[int, ...] (1,)
+    [1,2]       tuple[int, ...] (1,2)
     [1,2]       int | None      Error
     []          int             Error
 
@@ -221,7 +224,7 @@ def _convert_pass_arg_to_type(
     if len(value) == 1 and isa(value[0], dest_type):
         return value[0]
 
-    # then check if array value is okay
+    # then check if n-tuple value is okay
     if isa(value, dest_type):
         return value
 

--- a/xdsl/transforms/convert_onnx_to_linalg.py
+++ b/xdsl/transforms/convert_onnx_to_linalg.py
@@ -144,7 +144,7 @@ class ReshapeOpLowering(RewritePattern):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConvertOnnxToLinalgPass(ModulePass):
     name = "convert-onnx-to-linalg"
 

--- a/xdsl/transforms/convert_scf_to_openmp.py
+++ b/xdsl/transforms/convert_scf_to_openmp.py
@@ -92,7 +92,7 @@ class ConvertParallel(RewritePattern):
         rewriter.replace_matched_op(parallel)
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConvertScfToOpenMPPass(ModulePass):
     """
     Convert `scf.parallel` loops to `omp.wsloop` constructs for parallel execution.

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -493,7 +493,7 @@ class StencilTypeConversion(TypeConversionPattern):
         return StencilToMemRefType(typ)
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConvertStencilToLLMLIRPass(ModulePass):
     name = "convert-stencil-to-ll-mlir"
 

--- a/xdsl/transforms/experimental/dmp/decompositions.py
+++ b/xdsl/transforms/experimental/dmp/decompositions.py
@@ -8,7 +8,7 @@ from xdsl.dialects.experimental import dmp
 
 @dataclass
 class DomainDecompositionStrategy(ABC):
-    def __init__(self, _: list[int]):
+    def __init__(self, _: tuple[int, ...]):
         pass
 
     @abstractmethod

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -416,11 +416,13 @@ class MpiLoopInvariantCodeMotion:
 
     def rewrite(
         self,
-        op: memref.Alloc
-        | mpi.CommRank
-        | mpi.AllocateTypeOp
-        | mpi.UnwrapMemrefOp
-        | mpi.Init,
+        op: (
+            memref.Alloc
+            | mpi.CommRank
+            | mpi.AllocateTypeOp
+            | mpi.UnwrapMemrefOp
+            | mpi.Init
+        ),
         rewriter: Rewriter,
         /,
     ):
@@ -620,14 +622,14 @@ class DmpSwapShapeInference:
                 self.match_and_rewrite(op)
 
 
-@dataclass
+@dataclass(frozen=True)
 class DmpDecompositionPass(ModulePass, ABC):
     """
     Represents a pass that takes a strategy as input
     """
 
 
-@dataclass
+@dataclass(frozen=True)
 class DistributeStencilPass(DmpDecompositionPass):
     """
     Decompose a stencil to apply to a local domain.
@@ -642,7 +644,7 @@ class DistributeStencilPass(DmpDecompositionPass):
         "3d-grid": GridSlice3d,
     }
 
-    slices: list[int]
+    slices: tuple[int, ...]
     """
     Number of slices to decompose the input into
     """
@@ -681,7 +683,7 @@ class DistributeStencilPass(DmpDecompositionPass):
         DmpSwapShapeInference(strategy).apply(op)
 
 
-@dataclass
+@dataclass(frozen=True)
 class LowerHaloToMPI(ModulePass):
     name = "dmp-to-mpi"
 

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -1255,7 +1255,7 @@ class QualifyInterfacesPass(RewritePattern):
             self.declared_coeff_func = True
 
 
-@dataclass
+@dataclass(frozen=True)
 class HLSConvertStencilToLLMLIRPass(ModulePass):
     name = "hls-convert-stencil-to-ll-mlir"
 

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -484,7 +484,7 @@ class GetHLSStreamInDataflow(RewritePattern):
         dataflow.body.blocks[0].insert_op_before(op, hls_yield)
 
 
-@dataclass
+@dataclass(frozen=True)
 class LowerHLSPass(ModulePass):
     name = "lower-hls"
 

--- a/xdsl/transforms/experimental/replace_incompatible_fpga.py
+++ b/xdsl/transforms/experimental/replace_incompatible_fpga.py
@@ -70,7 +70,7 @@ class ReplaceAbsOpByXilinxMath(RewritePattern):
         rewriter.replace_matched_op([call])
 
 
-@dataclass
+@dataclass(frozen=True)
 class ReplaceIncompatibleFPGA(ModulePass):
     name = "replace-incompatible-fpga"
 

--- a/xdsl/transforms/individual_rewrite.py
+++ b/xdsl/transforms/individual_rewrite.py
@@ -83,7 +83,7 @@ instances.
 """
 
 
-@dataclass
+@dataclass(frozen=True)
 class IndividualRewrite(ModulePass):
     """
     Module pass representing the application of an individual rewrite pattern to a module.

--- a/xdsl/transforms/loop_hoist_memref.py
+++ b/xdsl/transforms/loop_hoist_memref.py
@@ -187,7 +187,7 @@ class LoopHoistMemref(RewritePattern):
         rewriter.erase_op(for_op)
 
 
-@dataclass
+@dataclass(frozen=True)
 class LoopHoistMemrefPass(ModulePass):
     name = "loop-hoist-memref"
 

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -824,7 +824,7 @@ class LowerMpiGatherOp(_MPIToLLVMRewriteBase):
         ], []
 
 
-@dataclass
+@dataclass(frozen=True)
 class LowerMPIPass(ModulePass):
     name = "lower-mpi"
 

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -75,7 +75,7 @@ class InsertExitSyscallOp(RewritePattern):
         rewriter.insert_op_before(riscv_func.SyscallOp(EXIT), op)
 
 
-@dataclass
+@dataclass(frozen=True)
 class LowerRISCVFunc(ModulePass):
     name = "lower-riscv-func"
 

--- a/xdsl/transforms/lower_snitch.py
+++ b/xdsl/transforms/lower_snitch.py
@@ -245,7 +245,7 @@ class LowerSsrDisable(RewritePattern):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class LowerSnitchPass(ModulePass):
     name = "lower-snitch"
 

--- a/xdsl/transforms/memref_streamify.py
+++ b/xdsl/transforms/memref_streamify.py
@@ -87,7 +87,7 @@ class StreamifyGenericOpPattern(RewritePattern):
         rewriter.erase_matched_op()
 
 
-@dataclass
+@dataclass(frozen=True)
 class MemrefStreamifyPass(ModulePass):
     """
     Converts a memref generic on memrefs to a memref generic on streams, by moving it into

--- a/xdsl/transforms/mlir_opt.py
+++ b/xdsl/transforms/mlir_opt.py
@@ -12,7 +12,7 @@ from xdsl.printer import Printer
 from xdsl.utils.exceptions import DiagnosticException
 
 
-@dataclass
+@dataclass(frozen=True)
 class MLIROptPass(ModulePass):
     """
     A pass for calling the `mlir-opt` tool with specified parameters. Will fail if
@@ -22,7 +22,7 @@ class MLIROptPass(ModulePass):
     name = "mlir-opt"
 
     generic: bool = field(default=True)
-    arguments: list[str] = field(default_factory=list)
+    arguments: tuple[str, ...] = field(default=())
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
         if not shutil.which("mlir-opt"):

--- a/xdsl/transforms/riscv_cse.py
+++ b/xdsl/transforms/riscv_cse.py
@@ -38,7 +38,7 @@ def cse(rewriter: Rewriter, block: Block) -> None:
                 op_by_operands[operands] = op
 
 
-@dataclass
+@dataclass(frozen=True)
 class RiscvCommonSubexpressionElimination(ModulePass):
     """
     Eliminates common sub-expressions on unallocated registers per block.

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -7,7 +7,7 @@ from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
 
 
-@dataclass
+@dataclass(frozen=True)
 class RISCVRegisterAllocation(ModulePass):
     """
     Allocates unallocated registers in the module.

--- a/xdsl/transforms/scf_parallel_loop_tiling.py
+++ b/xdsl/transforms/scf_parallel_loop_tiling.py
@@ -133,11 +133,11 @@ class ScfParallelLoopTilingPattern(RewritePattern):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class ScfParallelLoopTilingPass(ModulePass):
     name = "scf-parallel-loop-tiling"
 
-    parallel_loop_tile_sizes: list[int]
+    parallel_loop_tile_sizes: tuple[int, ...]
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
         walker = PatternRewriteWalker(

--- a/xdsl/transforms/snitch_register_allocation.py
+++ b/xdsl/transforms/snitch_register_allocation.py
@@ -78,7 +78,7 @@ class AllocateRiscvSnitchWriteRegisters(RewritePattern):
         op.value.type = stream_type.element_type
 
 
-@dataclass
+@dataclass(frozen=True)
 class SnitchRegisterAllocation(ModulePass):
     """
     Allocates unallocated registers for snitch operations.

--- a/xdsl/transforms/stencil_unroll.py
+++ b/xdsl/transforms/stencil_unroll.py
@@ -54,7 +54,7 @@ def offseted_block_clone(apply: ApplyOp, unroll_offset: Sequence[int]):
 
 @dataclass
 class StencilUnrollPattern(RewritePattern):
-    unroll_factor: list[int]
+    unroll_factor: tuple[int, ...]
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
@@ -79,7 +79,7 @@ class StencilUnrollPattern(RewritePattern):
         unroll = self.unroll_factor
         if len(unroll) < dim:
             # If unroll factors list is shorter than the dim, fill with ones from the front
-            unroll = [1] * (dim - len(unroll)) + unroll
+            unroll = (1,) * (dim - len(unroll)) + unroll
         elif len(unroll) > dim:
             # If unroll factors list is longer than the dim, pop from the front to keep
             # similar semantics
@@ -114,11 +114,11 @@ class StencilUnrollPattern(RewritePattern):
         rewriter.replace_matched_op(new_apply)
 
 
-@dataclass
+@dataclass(frozen=True)
 class StencilUnrollPass(ModulePass):
     name = "stencil-unroll"
 
-    unroll_factor: list[int]
+    unroll_factor: tuple[int, ...]
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         walker = PatternRewriteWalker(

--- a/xdsl/transforms/test_lower_linalg_to_snitch.py
+++ b/xdsl/transforms/test_lower_linalg_to_snitch.py
@@ -26,7 +26,7 @@ class TestLowerLinalgToSnitchPass(ModulePass):
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PipelinePass(
-            [
+            (
                 RiscvCommonSubexpressionElimination(),
                 ConvertRiscvScfForToFrepPass(),
                 SnitchRegisterAllocation(),
@@ -39,5 +39,5 @@ class TestLowerLinalgToSnitchPass(ModulePass):
                 CanonicalizePass(),
                 ConvertRiscvScfToRiscvCfPass(),
                 CanonicalizePass(),
-            ]
+            )
         ).apply(ctx, op)

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -238,7 +238,7 @@ class xDSLOptMain(CommandLineTool):
                 print("\n\n\n")
 
         self.pipeline = PipelinePass(
-            list(
+            tuple(
                 pass_type.from_pass_spec(spec)
                 for pass_type, spec in PipelinePass.build_pipeline_tuples(
                     self.available_passes, parse_pipeline(self.args.passes)


### PR DESCRIPTION
Mainly through using n-tuples instead of lists.

This makes it much easier to reason about pass pipelines in general, but also for the interactive app specifically. If we can assume that all passes are immutable, we don't have to reconstruct them every time just to be safe.