### PR TITLE
Refix spacing

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -16,8 +16,8 @@ from xdsl.ir import (
     Attribute,
     Data,
     EnumAttribute,
-    OpaqueSyntaxAttribute,
     ParametrizedAttribute,
+    SpacedOpaqueSyntaxAttribute,
     StrEnum,
 )
 from xdsl.irdl import (
@@ -158,7 +158,7 @@ class TestNonIdentifierEnum(StrEnum):
 
 
 @irdl_attr_definition
-class EnumData(EnumAttribute[TestEnum], OpaqueSyntaxAttribute):
+class EnumData(EnumAttribute[TestEnum], SpacedOpaqueSyntaxAttribute):
     name = "test.enum"
 
 

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -23,11 +23,11 @@ from xdsl.ir import (
     Block,
     Dialect,
     EnumAttribute,
-    OpaqueSyntaxAttribute,
     Operation,
     OpResult,
     ParametrizedAttribute,
     Region,
+    SpacedOpaqueSyntaxAttribute,
     SSAValue,
     StrEnum,
     TypeAttribute,
@@ -100,17 +100,17 @@ class ProcessorEnum(StrEnum):
 
 
 @irdl_attr_definition
-class AllReduceOpAttr(EnumAttribute[AllReduceOpEnum], OpaqueSyntaxAttribute):
+class AllReduceOpAttr(EnumAttribute[AllReduceOpEnum], SpacedOpaqueSyntaxAttribute):
     name = "gpu.all_reduce_op"
 
 
 @irdl_attr_definition
-class DimensionAttr(EnumAttribute[DimensionEnum], OpaqueSyntaxAttribute):
+class DimensionAttr(EnumAttribute[DimensionEnum], SpacedOpaqueSyntaxAttribute):
     name = "gpu.dim"
 
 
 @irdl_attr_definition
-class ProcessorAttr(EnumAttribute[ProcessorEnum], OpaqueSyntaxAttribute):
+class ProcessorAttr(EnumAttribute[ProcessorEnum], SpacedOpaqueSyntaxAttribute):
     name = "gpu.processor"
 
 
@@ -533,17 +533,21 @@ class LaunchOp(IRDLOperation):
         if len(blockSize) != 3:
             raise ValueError(f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
         operands = [
-            []
-            if asyncDependencies is None
-            else [SSAValue.get(a) for a in asyncDependencies]
+            (
+                []
+                if asyncDependencies is None
+                else [SSAValue.get(a) for a in asyncDependencies]
+            )
         ]
 
         operands += [SSAValue.get(gs) for gs in gridSize]
         operands += [SSAValue.get(bs) for bs in blockSize]
         operands += [
-            []
-            if dynamicSharedMemorySize is None
-            else [SSAValue.get(dynamicSharedMemorySize)]
+            (
+                []
+                if dynamicSharedMemorySize is None
+                else [SSAValue.get(dynamicSharedMemorySize)]
+            )
         ]
         super().__init__(
             operands=operands,

--- a/xdsl/dialects/omp.py
+++ b/xdsl/dialects/omp.py
@@ -10,7 +10,13 @@ from xdsl.dialects.builtin import (
     i32,
 )
 from xdsl.dialects.utils import AbstractYieldOperation
-from xdsl.ir import Attribute, Dialect, EnumAttribute, OpaqueSyntaxAttribute, StrEnum
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    EnumAttribute,
+    SpacedOpaqueSyntaxAttribute,
+    StrEnum,
+)
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     IRDLOperation,
@@ -42,17 +48,19 @@ class OrderKind(StrEnum):
 
 
 @irdl_attr_definition
-class ScheduleKindAttr(EnumAttribute[ScheduleKind], OpaqueSyntaxAttribute):
+class ScheduleKindAttr(EnumAttribute[ScheduleKind], SpacedOpaqueSyntaxAttribute):
     name = "omp.schedulekind"
 
 
 @irdl_attr_definition
-class ScheduleModifierAttr(EnumAttribute[ScheduleModifier], OpaqueSyntaxAttribute):
+class ScheduleModifierAttr(
+    EnumAttribute[ScheduleModifier], SpacedOpaqueSyntaxAttribute
+):
     name = "omp.sched_mod"
 
 
 @irdl_attr_definition
-class OrderKindAttr(EnumAttribute[OrderKind], OpaqueSyntaxAttribute):
+class OrderKindAttr(EnumAttribute[OrderKind], SpacedOpaqueSyntaxAttribute):
     name = "omp.orderkind"
 
 
@@ -91,7 +99,7 @@ class ProcBindKindEnum(StrEnum):
     Spread = auto()
 
 
-class ProcBindKindAttr(EnumAttribute[ProcBindKindEnum], OpaqueSyntaxAttribute):
+class ProcBindKindAttr(EnumAttribute[ProcBindKindEnum], SpacedOpaqueSyntaxAttribute):
     name = "omp.procbindkind"
 
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -497,6 +497,16 @@ class OpaqueSyntaxAttribute(Attribute):
     pass
 
 
+class SpacedOpaqueSyntaxAttribute(OpaqueSyntaxAttribute):
+    """
+    This class should only be inherited by classes inheriting Attribute.
+    This class is only used for printing attributes in the opaque form,
+    as described at https://mlir.llvm.org/docs/LangRef/#dialect-attribute-values.
+    """
+
+    pass
+
+
 DataElement = TypeVar("DataElement", covariant=True)
 
 AttributeCovT = TypeVar("AttributeCovT", bound=Attribute, covariant=True)
@@ -554,7 +564,7 @@ class EnumAttribute(Data[EnumType]):
         First = auto()
         Second = auto()
 
-    class MyEnumAttribute(EnumAttribute[MyEnum], OpaqueSyntaxAttribute):
+    class MyEnumAttribute(EnumAttribute[MyEnum], SpacedOpaqueSyntaxAttribute):
         name = "example.my_enum"
     ```
     To use this attribute suffices to have a textual representation

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -61,6 +61,7 @@ from xdsl.ir import (
     Operation,
     ParametrizedAttribute,
     Region,
+    SpacedOpaqueSyntaxAttribute,
     SSAValue,
     TypeAttribute,
 )
@@ -678,7 +679,8 @@ class Printer:
 
         if isinstance(attribute, OpaqueSyntaxAttribute):
             self.print(attribute.name.replace(".", "<", 1))
-            self.print(" ")
+            if isinstance(attribute, SpacedOpaqueSyntaxAttribute):
+                self.print(" ")
         else:
             self.print(attribute.name)
 


### PR DESCRIPTION
- #2248 

Was merged a bit fast; I realized meanwhile that not all opaque syntax attributes have this spacing :smiling_face_with_tear: Best example in:
- #2251

With the attribute `#hw<innerSym@sym>` :smiling_face_with_tear: 

So I'm introducing `SpacedOpaqueSyntaxAttribute` for this common behaviour, but we need attributes to be able to use opaque syntax without hardcoding this spacing.
