### PR TITLE
transformations: (riscv-scf-loop-range-folding) add riscv.add support

### DIFF
--- a/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
+++ b/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
@@ -1,47 +1,56 @@
 // RUN: xdsl-opt -p riscv-scf-loop-range-folding %s | filecheck %s
 
-%0, %1, %2, %3 = "test.op"() : () -> (!riscv.freg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-%c0 = riscv.li 0 : () -> !riscv.reg<>
-%c64 = riscv.li 64 : () -> !riscv.reg<>
-%c1 = riscv.li 1 : () -> !riscv.reg<>
+// CHECK:       builtin.module {
 
-riscv_scf.for %arg4 : !riscv.reg<> = %c0 to %c64 step %c1 {
-    %4 = riscv.li 4 : () -> !riscv.reg<>
-    %5 = riscv.mul %arg4, %4 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    "test.op"(%5) : (!riscv.reg<>) -> ()
-    %6 = riscv.li 4 : () -> !riscv.reg<>
-    %7 = riscv.mul %arg4, %6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    "test.op"(%7) : (!riscv.reg<>) -> ()
+%lb, %ub, %step = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+%0, %1 = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>)
+// CHECK-NEXT:    %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>)
+
+riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
+    // mul by constant
+    %3 = riscv.li 3 : () -> !riscv.reg<>
+    %4 = riscv.mul %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // add with constant
+    %5 = riscv.li 5 : () -> !riscv.reg<>
+    %6 = riscv.add %4, %5 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    "test.op"(%6) : (!riscv.reg<>) -> ()
 }
+// CHECK-NEXT:    %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = riscv.li 5 : () -> !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
+// CHECK-NEXT:      %{{.*}} = riscv.li 5 : () -> !riscv.reg<>
+// CHECK-NEXT:      "test.op"(%{{.*}}) : (!riscv.reg<>) -> ()
+// CHECK-NEXT:    }
 
-// Don't hoist multiplication by different constants
-riscv_scf.for %arg4 : !riscv.reg<> = %c0 to %c64 step %c1 {
-    %4 = riscv.li 4 : () -> !riscv.reg<>
-    %5 = riscv.mul %arg4, %4 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %6 = riscv.li 5 : () -> !riscv.reg<>
-    %7 = riscv.mul %arg4, %6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// Don't fold
+riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
+    // Two uses mul
+    %3 = riscv.li 3 : () -> !riscv.reg<>
+    %4 = riscv.mul %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    "test.op"(%4, %2) : (!riscv.reg<>, !riscv.reg<>) -> ()
 }
+riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
+    // Two uses add
+    %3 = riscv.li 3 : () -> !riscv.reg<>
+    %4 = riscv.add %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    "test.op"(%4, %2) : (!riscv.reg<>, !riscv.reg<>) -> ()
+}
+// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
+// CHECK-NEXT:      %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
+// CHECK-NEXT:      %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
 
-
-// CHECK:           builtin.module {
-// CHECK-NEXT:        %0, %1, %2, %3 = "test.op"() : () -> (!riscv.freg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT:        %c0 = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:        %c64 = riscv.li 64 : () -> !riscv.reg<>
-// CHECK-NEXT:        %c1 = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.mul %c0, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.mul %c64, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.mul %c1, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        riscv_scf.for %arg4 : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
-// CHECK-NEXT:            %{{.*}} = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:            "test.op"(%{{.*}}) : (!riscv.reg<>) -> ()
-// CHECK-NEXT:            %{{.*}} = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:            "test.op"(%{{.*}}) : (!riscv.reg<>) -> ()
-// CHECK-NEXT:        }
-// CHECK-NEXT:        riscv_scf.for %{{.*}} : !riscv.reg<> = %c0 to %c64 step %c1 {
-// CHECK-NEXT:            %{{.*}} = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:            %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:            %{{.*}} = riscv.li 5 : () -> !riscv.reg<>
-// CHECK-NEXT:            %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        }
-// CHECK-NEXT:      }

--- a/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
+++ b/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
@@ -31,13 +31,13 @@ riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
 
 // Don't fold
 riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
-    // Two uses mul
+    // Two uses of mul -> can't fold
     %3 = riscv.li 3 : () -> !riscv.reg<>
     %4 = riscv.mul %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     "test.op"(%4, %2) : (!riscv.reg<>, !riscv.reg<>) -> ()
 }
 riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
-    // Two uses add
+    // Two uses of add -> can't fold
     %3 = riscv.li 3 : () -> !riscv.reg<>
     %4 = riscv.add %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
     "test.op"(%4, %2) : (!riscv.reg<>, !riscv.reg<>) -> ()

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -29,11 +29,9 @@ class HoistIndexTimesConstant(RewritePattern):
 
             if user.rs1 is index:
                 if (imm := get_constant_value(user.rs2)) is None:
-                    # One of the uses is not a addition with constant, bail
                     return
             else:
                 if (imm := get_constant_value(user.rs1)) is None:
-                    # One of the uses is not a addition with constant, bail
                     return
 
             constant = imm.value.data

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -24,21 +24,22 @@ class HoistIndexTimesConstant(RewritePattern):
 
             user = next(iter(index.uses)).operation
 
+            if not isinstance(user, riscv.AddOp | riscv.MulOp):
+                return
+
+            if user.rs1 is index:
+                if (imm := get_constant_value(user.rs2)) is None:
+                    # One of the uses is not a addition with constant, bail
+                    return
+            else:
+                if (imm := get_constant_value(user.rs1)) is None:
+                    # One of the uses is not a addition with constant, bail
+                    return
+
+            constant = imm.value.data
+
             match user:
                 case riscv.AddOp():
-                    add_op = user
-
-                    if add_op.rs1 is index:
-                        if (imm := get_constant_value(add_op.rs2)) is None:
-                            # One of the uses is not a addition with constant, bail
-                            return
-                    else:
-                        if (imm := get_constant_value(add_op.rs1)) is None:
-                            # One of the uses is not a addition with constant, bail
-                            return
-
-                    constant = imm.value.data
-
                     # All the uses are multiplications by a constant, we can fold
                     rewriter.insert_op_before_matched_op(
                         [
@@ -51,23 +52,7 @@ class HoistIndexTimesConstant(RewritePattern):
                             ),
                         ]
                     )
-
-                    op.operands[0] = new_lb.rd
-                    op.operands[1] = new_ub.rd
                 case riscv.MulOp():
-                    mul_op = user
-
-                    if mul_op.rs1 is index:
-                        if (imm := get_constant_value(mul_op.rs2)) is None:
-                            # One of the uses is not a multiplication by constant, bail
-                            return
-                    else:
-                        if (imm := get_constant_value(mul_op.rs1)) is None:
-                            # One of the uses is not a multiplication by constant, bail
-                            return
-
-                    constant = imm.value.data
-
                     # All the uses are multiplications by a constant, we can fold
                     rewriter.insert_op_before_matched_op(
                         [
@@ -84,13 +69,10 @@ class HoistIndexTimesConstant(RewritePattern):
                         ]
                     )
 
-                    op.operands[0] = new_lb.rd
-                    op.operands[1] = new_ub.rd
                     op.operands[2] = new_step.rd
 
-                case _:
-                    return
-
+            op.operands[0] = new_lb.rd
+            op.operands[1] = new_ub.rd
             rewriter.replace_op(user, [], [index])
 
 

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -7,6 +7,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
 
 
 class HoistIndexTimesConstant(RewritePattern):
@@ -14,61 +15,83 @@ class HoistIndexTimesConstant(RewritePattern):
     def match_and_rewrite(self, op: riscv_scf.ForOp, rewriter: PatternRewriter) -> None:
         index = op.body.block.args[0]
 
-        uses: list[riscv.MulOp] = []
-        constant: int | None = None
-        for use in index.uses:
-            if not isinstance(mul_op := use.operation, riscv.MulOp):
-                # One of the uses is not a multiplication, bail
+        # Fold until a fixed point is reached
+        while True:
+            if len(index.uses) != 1:
+                # If the induction variable is used more than once, we can't fold its
+                # arith ops into the loop range
                 return
 
-            uses.append(mul_op)
+            user = next(iter(index.uses)).operation
 
-            if mul_op.rs1 is index:
-                if not isinstance(li_op := mul_op.rs2.owner, riscv.LiOp):
-                    # One of the uses is not a multiplication by constant, bail
+            match user:
+                case riscv.AddOp():
+                    add_op = user
+
+                    if add_op.rs1 is index:
+                        if (imm := get_constant_value(add_op.rs2)) is None:
+                            # One of the uses is not a addition with constant, bail
+                            return
+                    else:
+                        if (imm := get_constant_value(add_op.rs1)) is None:
+                            # One of the uses is not a addition with constant, bail
+                            return
+
+                    constant = imm.value.data
+
+                    # All the uses are multiplications by a constant, we can fold
+                    rewriter.insert_op_before_matched_op(
+                        [
+                            shift := riscv.LiOp(constant),
+                            new_lb := riscv.AddOp(
+                                op.lb, shift, rd=riscv.IntRegisterType.unallocated()
+                            ),
+                            new_ub := riscv.AddOp(
+                                op.ub, shift, rd=riscv.IntRegisterType.unallocated()
+                            ),
+                        ]
+                    )
+
+                    op.operands[0] = new_lb.rd
+                    op.operands[1] = new_ub.rd
+                case riscv.MulOp():
+                    mul_op = user
+
+                    if mul_op.rs1 is index:
+                        if (imm := get_constant_value(mul_op.rs2)) is None:
+                            # One of the uses is not a multiplication by constant, bail
+                            return
+                    else:
+                        if (imm := get_constant_value(mul_op.rs1)) is None:
+                            # One of the uses is not a multiplication by constant, bail
+                            return
+
+                    constant = imm.value.data
+
+                    # All the uses are multiplications by a constant, we can fold
+                    rewriter.insert_op_before_matched_op(
+                        [
+                            factor := riscv.LiOp(constant),
+                            new_lb := riscv.MulOp(
+                                op.lb, factor, rd=riscv.IntRegisterType.unallocated()
+                            ),
+                            new_ub := riscv.MulOp(
+                                op.ub, factor, rd=riscv.IntRegisterType.unallocated()
+                            ),
+                            new_step := riscv.MulOp(
+                                op.step, factor, rd=riscv.IntRegisterType.unallocated()
+                            ),
+                        ]
+                    )
+
+                    op.operands[0] = new_lb.rd
+                    op.operands[1] = new_ub.rd
+                    op.operands[2] = new_step.rd
+
+                case _:
                     return
-            else:
-                if not isinstance(li_op := mul_op.rs1.owner, riscv.LiOp):
-                    # One of the uses is not a multiplication by constant, bail
-                    return
 
-            if not isinstance(imm := li_op.immediate, builtin.IntegerAttr):
-                # One of the constants is not an integer, bail
-                return
-
-            if constant is None:
-                constant = imm.value.data
-            else:
-                if constant != imm.value.data:
-                    # Not all constants are equal, bail
-                    return
-
-        if constant is None:
-            # No uses, bail
-            return
-
-        # All the uses are multiplications by a constant, we can fold
-        rewriter.insert_op_before_matched_op(
-            [
-                factor := riscv.LiOp(constant),
-                new_lb := riscv.MulOp(
-                    op.lb, factor, rd=riscv.IntRegisterType.unallocated()
-                ),
-                new_ub := riscv.MulOp(
-                    op.ub, factor, rd=riscv.IntRegisterType.unallocated()
-                ),
-                new_step := riscv.MulOp(
-                    op.step, factor, rd=riscv.IntRegisterType.unallocated()
-                ),
-            ]
-        )
-
-        op.operands[0] = new_lb.rd
-        op.operands[1] = new_ub.rd
-        op.operands[2] = new_step.rd
-
-        for mul_op in uses:
-            rewriter.replace_op(mul_op, [], [index])
+            rewriter.replace_op(user, [], [index])
 
 
 class RiscvScfLoopRangeFoldingPass(ModulePass):


### PR DESCRIPTION
We currently only support folding multiplications, this adds folding addition into the loop bounds.