### PR TITLE
interpreter: remove deallocated property on RawPtr

### DIFF
--- a/xdsl/interpreters/riscv_libc.py
+++ b/xdsl/interpreters/riscv_libc.py
@@ -51,8 +51,6 @@ class RiscvLibcFunctions(InterpreterFunctions):
     ) -> PythonValues:
         assert len(args) == 1
         assert isinstance(args[0], RawPtr)
-        buff: RawPtr = args[0]
-        buff.deallocate()
         return ()
 
     @impl_external("putchar")


### PR DESCRIPTION
This was never leveraged or tested, and I'm not sure that it's safe to have in the general case. If a user implements some sort of custom allocator that uses one large RawPtr instance, then the whole thing shouldn't be deallocated just because a part of it was.