### PR TITLE
ci: update actions from node 16 to node 20

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -20,8 +20,8 @@ jobs:
         python-version: ['3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
-        
+    - uses: actions/checkout@v5
+
     - name: Install native dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
@@ -29,7 +29,7 @@ jobs:
         version: 1.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ['3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
 
     - name: Install native dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -22,7 +22,7 @@ jobs:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
       MLIR-Version: 98e674c9f16d677d95c67bc130e267fae331e43c
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: xdsl
 
@@ -59,7 +59,7 @@ jobs:
 
     - name: Checkout MLIR
       if: steps.cache-binary.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: llvm/llvm-project.git
         path: llvm-project

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         path: xdsl
-        
+
     - name: Install native dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
@@ -33,7 +33,7 @@ jobs:
         version: 1.0
 
     - name: Python Setup
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -51,7 +51,7 @@ jobs:
 
     - name: Cache binaries
       id: cache-binary
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: llvm-project/build
         key: binaries-${{ runner.os }}-${{ env.MLIR-Version }}

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ['3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Upgrade pip

--- a/.github/workflows/ci-pyright-fails.yml
+++ b/.github/workflows/ci-pyright-fails.yml
@@ -22,7 +22,7 @@ jobs:
       PYRIGHT_VERSION: 1.0
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-pyright-fails.yml
+++ b/.github/workflows/ci-pyright-fails.yml
@@ -22,9 +22,9 @@ jobs:
       PYRIGHT_VERSION: 1.0
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout xDSL
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           path: xdsl
 

--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout xDSL
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: xdsl
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Restore cached Pyodide tree
         id: cache-pyodide
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: pyodide
           key: pyodide

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
-pytest<8.1
+pytest<9.0
 nbval<0.11
 filecheck<0.0.25
 lit<18.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
-pytest<9.0
+pytest<8.1
 nbval<0.11
 filecheck<0.0.25
 lit<18.0.0


### PR DESCRIPTION
The CI gave me a warning and a link to this website, listing the actions updated in this PR:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.