### PR TITLE
ci: use old pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
-pytest<9.0
+pytest<8.1
 nbval<0.11
 filecheck<0.0.25
 lit<18.0.0


### PR DESCRIPTION
Our pattern is too coarse, the tests all passed locally, but broke with the new minor version.