### PR TITLE
transformations: (mlir-opt) Add option to specify mlir-opt binary in args

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
@@ -11,6 +11,9 @@
 // RUN: xdsl-opt %s -p mlir-opt{generic=false\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
 // RUN: xdsl-opt %s -p mlir-opt{generic=true\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
 
+// Check that manually passing an executable works
+// RUN: xdsl-opt %s -p mlir-opt{executable=mlir-opt\ generic=true\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
+
 "builtin.module"() ({
   "func.func"() ({
     %0 = "arith.constant"() {"value" = 1 : i32} : () -> i32

--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
@@ -1,5 +1,6 @@
 // RUN: xdsl-opt %s -p mlir-opt{arguments='--hello','--mlir-print-op-generic'} --print-op-generic --verify-diagnostics | filecheck %s
 // RUN: xdsl-opt %s -p mlir-opt[this-probably-will-never-be-an-MLIR-pass-name] --print-op-generic --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s -p mlir-opt{executable=cat} --print-op-generic --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s -p mlir-opt{arguments='--hello','--mlir-print-op-generic'} --print-op-generic --verify-diagnostics | filecheck %s
 // RUN: xdsl-opt %s -p mlir-opt[this-probably-will-never-be-an-MLIR-pass-name] --print-op-generic --verify-diagnostics | filecheck %s
-// RUN: xdsl-opt %s -p mlir-opt{executable=cat} --print-op-generic --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s -p mlir-opt{executable='"false"'} --print-op-generic --verify-diagnostics | filecheck %s
 
 "builtin.module"() ({
   "func.func"() ({

--- a/xdsl/transforms/mlir_opt.py
+++ b/xdsl/transforms/mlir_opt.py
@@ -21,12 +21,13 @@ class MLIROptPass(ModulePass):
 
     name = "mlir-opt"
 
+    executable: str = field(default="mlir-opt")
     generic: bool = field(default=True)
     arguments: tuple[str, ...] = field(default=())
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
-        if not shutil.which("mlir-opt"):
-            raise ValueError("mlir-opt is not available")
+        if not shutil.which(self.executable):
+            raise ValueError(f"{self.executable} is not available")
 
         stream = StringIO()
         printer = Printer(print_generic_format=self.generic, stream=stream)
@@ -35,7 +36,7 @@ class MLIROptPass(ModulePass):
         my_string = stream.getvalue()
 
         completed_process = subprocess.run(
-            ["mlir-opt", *self.arguments],
+            [self.executable, *self.arguments],
             input=my_string,
             stdout=subprocess.PIPE,
             text=True,


### PR DESCRIPTION
This adds the `executable` option to the `mlir-opt` pass that allows one to pass a custom executable (e.g. `mlir-opt-17`, or a path to a binary that is not in `PATH`).
