### PR TITLE
dialects: (gpu) Adding `gpu.wait` op

### DIFF
--- a/tests/dialects/test_gpu.py
+++ b/tests/dialects/test_gpu.py
@@ -29,8 +29,8 @@ from xdsl.dialects.gpu import (
     SubgroupIdOp,
     SubgroupSizeOp,
     TerminatorOp,
-    WaitOp,
     ThreadIdOp,
+    WaitOp,
     YieldOp,
 )
 from xdsl.ir import Block, Operation, Region, SSAValue
@@ -100,8 +100,7 @@ def test_all_reduce():
 
     @Builder.implicit_region
     def body():
-        sum = Operation.clone(arith.Addi(
-            body_block.args[0], body_block.args[1]))
+        sum = Operation.clone(arith.Addi(body_block.args[0], body_block.args[1]))
         YieldOp([sum])
 
     all_reduce_body = AllReduceOp.from_body(body, init)
@@ -144,8 +143,7 @@ def test_dealloc():
     assert alloc.asyncToken is not None  # For pyright
 
     dealloc = DeallocOp(
-        buffer=alloc.result, async_dependencies=[
-            alloc.asyncToken], is_async=True
+        buffer=alloc.result, async_dependencies=[alloc.asyncToken], is_async=True
     )
 
     assert dealloc.asyncToken is not None
@@ -231,8 +229,7 @@ def test_func():
 
     body = Region(Block([ReturnOp([])]))
 
-    func = FuncOp(kernel, (inputs, []), body, True,
-                  known_block_size, known_grid_size)
+    func = FuncOp(kernel, (inputs, []), body, True, known_block_size, known_grid_size)
 
     assert isinstance(func, FuncOp)
     assert func.kernel == builtin.UnitAttr()
@@ -407,13 +404,16 @@ def test_terminator():
 def test_wait():
     waitOp = WaitOp()
 
-    assert isinstance(waitOp,  WaitOp)
+    assert isinstance(waitOp, WaitOp)
     assert waitOp.asyncToken is not None
     assert isinstance(waitOp.asyncToken.type, AsyncTokenType)
 
-    waitOpWithDep = WaitOp(waitOp)
+    waitOp1 = WaitOp()
+
+    waitOpWithDep = WaitOp([waitOp, waitOp1])
     assert waitOpWithDep.asyncToken is not None
     assert waitOpWithDep.asyncDependencies[0] is waitOp.asyncToken
+    assert waitOpWithDep.asyncDependencies[1] is waitOp1.asyncToken
 
 
 def test_yield():

--- a/tests/filecheck/dialects/gpu/ops.mlir
+++ b/tests/filecheck/dialects/gpu/ops.mlir
@@ -11,6 +11,8 @@ builtin.module attributes {"gpu.container_module"} {
             "gpu.host_register"(%unranked) : (memref<*xi32>) -> ()
             "gpu.host_unregister"(%unranked) : (memref<*xi32>) -> ()
 
+            %wait_token = "gpu.wait"() : () -> !gpu.async.token
+
             %threadidx = "gpu.thread_id"() {"dimension" = #gpu<dim x>} : () -> index
             %threadidy = "gpu.thread_id"() {"dimension" = #gpu<dim y>} : () -> index
             %threadidz = "gpu.thread_id"() {"dimension" = #gpu<dim z>} : () -> index
@@ -88,6 +90,8 @@ builtin.module attributes {"gpu.container_module"} {
 // CHECK-NEXT:             %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x10xi32>) -> memref<*xi32>
 // CHECK-NEXT:             "gpu.host_register"(%{{.*}}) : (memref<*xi32>) -> ()
 // CHECK-NEXT:             "gpu.host_unregister"(%{{.*}}) : (memref<*xi32>) -> ()
+
+ // CHECK-NEXT:            %{{.*}} = "gpu.wait"() : () -> !gpu.async.token
 
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() <{"dimension" = #gpu<dim x>}> : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() <{"dimension" = #gpu<dim y>}> : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
@@ -11,6 +11,8 @@
             "gpu.host_register"(%unranked) : (memref<*xi32>) -> ()
             "gpu.host_unregister"(%unranked) : (memref<*xi32>) -> ()
 
+            %wait_token = "gpu.wait"() : () -> !gpu.async.token
+
             %threadidx = "gpu.thread_id"() {"dimension" = #gpu<dim x>} : () -> index
             %threadidy = "gpu.thread_id"() {"dimension" = #gpu<dim y>} : () -> index
             %threadidz = "gpu.thread_id"() {"dimension" = #gpu<dim z>} : () -> index
@@ -87,6 +89,8 @@
 // CHECK-NEXT:             %{{.*}} = "memref.cast"(%{{.*}}) : (memref<10x10xi32>) -> memref<*xi32>
 // CHECK-NEXT:             "gpu.host_register"(%{{.*}}) : (memref<*xi32>) -> ()
 // CHECK-NEXT:             "gpu.host_unregister"(%{{.*}}) : (memref<*xi32>) -> ()
+
+ // CHECK-NEXT:            %{{.*}} = "gpu.wait"() : () -> !gpu.async.token
 
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() <{"dimension" = #gpu<dim x>}> : () -> index
 // CHECK-NEXT:             %{{.*}} = "gpu.thread_id"() <{"dimension" = #gpu<dim y>}> : () -> index

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -799,7 +799,7 @@ GPU = Dialect(
         YieldOp,
     ],
     [
-        AsyncTokenType
+        AsyncTokenType,
         AllReduceOpAttr,
         DimensionAttr,
         ProcessorAttr,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -799,6 +799,7 @@ GPU = Dialect(
         YieldOp,
     ],
     [
+        AsyncTokenType
         AllReduceOpAttr,
         DimensionAttr,
         ProcessorAttr,

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -188,8 +188,7 @@ class AllocOp(IRDLOperation):
             [SSAValue.get(e) for e in dynamic_sizes] if dynamic_sizes else []
         )
         async_dependencies_vals: list[SSAValue] = (
-            [SSAValue.get(e)
-             for e in async_dependencies] if async_dependencies else []
+            [SSAValue.get(e) for e in async_dependencies] if async_dependencies else []
         )
         attributes: dict[str, Attribute] = (
             {"hostShared": UnitAttr()} if host_shared else {}
@@ -284,8 +283,7 @@ class BlockDimOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[
-            IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -295,8 +293,7 @@ class BlockIdOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[
-            IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -358,8 +355,7 @@ class MemcpyOp(IRDLOperation):
 class ModuleEndOp(IRDLOperation):
     name = "gpu.module_end"
 
-    traits = traits_def(lambda: frozenset(
-        [IsTerminator(), HasParent(ModuleOp)]))
+    traits = traits_def(lambda: frozenset([IsTerminator(), HasParent(ModuleOp)]))
 
     def __init__(self):
         super().__init__()
@@ -400,8 +396,7 @@ class FuncOp(IRDLOperation):
         DenseArrayBase, attr_name="gpu.known_grid_size"
     )
 
-    traits = frozenset(
-        [IsolatedFromAbove(), HasParent(ModuleOp), SymbolOpInterface()])
+    traits = frozenset([IsolatedFromAbove(), HasParent(ModuleOp), SymbolOpInterface()])
 
     def __init__(
         self,
@@ -417,8 +412,7 @@ class FuncOp(IRDLOperation):
             function_type = FunctionType.from_lists(inputs, outputs)
         if not isinstance(region, Region):
             region = Region(Block(arg_types=function_type.inputs))
-        attributes: dict[str, Attribute | None] = {
-            "sym_name": StringAttr(name)}
+        attributes: dict[str, Attribute | None] = {"sym_name": StringAttr(name)}
         properties: dict[str, Attribute | None] = {
             "function_type": function_type,
         }
@@ -432,8 +426,7 @@ class FuncOp(IRDLOperation):
             )
         if kernel:
             properties["kernel"] = UnitAttr()
-        super().__init__(properties=properties,
-                         attributes=attributes, regions=[region])
+        super().__init__(properties=properties, attributes=attributes, regions=[region])
 
     def verify_(self):
         entry_block: Block = self.body.blocks[0]
@@ -445,8 +438,7 @@ class FuncOp(IRDLOperation):
                 "function input types"
             )
         if (self.kernel is not None) and (len(self.function_type.outputs) != 0):
-            raise VerifyException(
-                "Expected void return type for kernel function")
+            raise VerifyException("Expected void return type for kernel function")
 
 
 @irdl_op_definition
@@ -456,8 +448,7 @@ class GlobalIdOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[
-            IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -467,8 +458,7 @@ class GridDimOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[
-            IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -539,11 +529,9 @@ class LaunchOp(IRDLOperation):
         dynamicSharedMemorySize: SSAValue | Operation | None = None,
     ):
         if len(gridSize) != 3:
-            raise ValueError(
-                f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
+            raise ValueError(f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
         if len(blockSize) != 3:
-            raise ValueError(
-                f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
+            raise ValueError(f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
         operands = [
             (
                 []
@@ -644,11 +632,9 @@ class LaunchFuncOp(IRDLOperation):
         dynamicSharedMemorySize: SSAValue | Operation | None = None,
     ):
         if len(gridSize) != 3:
-            raise ValueError(
-                f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
+            raise ValueError(f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
         if len(blockSize) != 3:
-            raise ValueError(
-                f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
+            raise ValueError(f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
         clusterSizeOperands: Sequence[
             SSAValue | Operation | Sequence[SSAValue | Operation]
         ]
@@ -741,8 +727,7 @@ class ThreadIdOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[
-            IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -755,8 +740,10 @@ class WaitOp(IRDLOperation):
         self,
         async_dependencies: Sequence[SSAValue | Operation] | None = None,
     ):
-        super().__init__(operands=[async_dependencies],
-                         result_types=[[AsyncTokenType()]],)
+        super().__init__(
+            operands=[async_dependencies],
+            result_types=[[AsyncTokenType()]],
+        )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/gpu.py
+++ b/xdsl/dialects/gpu.py
@@ -188,7 +188,8 @@ class AllocOp(IRDLOperation):
             [SSAValue.get(e) for e in dynamic_sizes] if dynamic_sizes else []
         )
         async_dependencies_vals: list[SSAValue] = (
-            [SSAValue.get(e) for e in async_dependencies] if async_dependencies else []
+            [SSAValue.get(e)
+             for e in async_dependencies] if async_dependencies else []
         )
         attributes: dict[str, Attribute] = (
             {"hostShared": UnitAttr()} if host_shared else {}
@@ -283,7 +284,8 @@ class BlockDimOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[
+            IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -293,7 +295,8 @@ class BlockIdOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[
+            IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -355,7 +358,8 @@ class MemcpyOp(IRDLOperation):
 class ModuleEndOp(IRDLOperation):
     name = "gpu.module_end"
 
-    traits = traits_def(lambda: frozenset([IsTerminator(), HasParent(ModuleOp)]))
+    traits = traits_def(lambda: frozenset(
+        [IsTerminator(), HasParent(ModuleOp)]))
 
     def __init__(self):
         super().__init__()
@@ -396,7 +400,8 @@ class FuncOp(IRDLOperation):
         DenseArrayBase, attr_name="gpu.known_grid_size"
     )
 
-    traits = frozenset([IsolatedFromAbove(), HasParent(ModuleOp), SymbolOpInterface()])
+    traits = frozenset(
+        [IsolatedFromAbove(), HasParent(ModuleOp), SymbolOpInterface()])
 
     def __init__(
         self,
@@ -412,7 +417,8 @@ class FuncOp(IRDLOperation):
             function_type = FunctionType.from_lists(inputs, outputs)
         if not isinstance(region, Region):
             region = Region(Block(arg_types=function_type.inputs))
-        attributes: dict[str, Attribute | None] = {"sym_name": StringAttr(name)}
+        attributes: dict[str, Attribute | None] = {
+            "sym_name": StringAttr(name)}
         properties: dict[str, Attribute | None] = {
             "function_type": function_type,
         }
@@ -426,7 +432,8 @@ class FuncOp(IRDLOperation):
             )
         if kernel:
             properties["kernel"] = UnitAttr()
-        super().__init__(properties=properties, attributes=attributes, regions=[region])
+        super().__init__(properties=properties,
+                         attributes=attributes, regions=[region])
 
     def verify_(self):
         entry_block: Block = self.body.blocks[0]
@@ -438,7 +445,8 @@ class FuncOp(IRDLOperation):
                 "function input types"
             )
         if (self.kernel is not None) and (len(self.function_type.outputs) != 0):
-            raise VerifyException("Expected void return type for kernel function")
+            raise VerifyException(
+                "Expected void return type for kernel function")
 
 
 @irdl_op_definition
@@ -448,7 +456,8 @@ class GlobalIdOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[
+            IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -458,7 +467,8 @@ class GridDimOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[
+            IndexType()], properties={"dimension": dim})
 
 
 @irdl_op_definition
@@ -529,9 +539,11 @@ class LaunchOp(IRDLOperation):
         dynamicSharedMemorySize: SSAValue | Operation | None = None,
     ):
         if len(gridSize) != 3:
-            raise ValueError(f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
+            raise ValueError(
+                f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
         if len(blockSize) != 3:
-            raise ValueError(f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
+            raise ValueError(
+                f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
         operands = [
             (
                 []
@@ -632,9 +644,11 @@ class LaunchFuncOp(IRDLOperation):
         dynamicSharedMemorySize: SSAValue | Operation | None = None,
     ):
         if len(gridSize) != 3:
-            raise ValueError(f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
+            raise ValueError(
+                f"LaunchOp must have 3 gridSizes, got {len(gridSize)}")
         if len(blockSize) != 3:
-            raise ValueError(f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
+            raise ValueError(
+                f"LaunchOp must have 3 blockSizes, got {len(blockSize)}")
         clusterSizeOperands: Sequence[
             SSAValue | Operation | Sequence[SSAValue | Operation]
         ]
@@ -727,7 +741,22 @@ class ThreadIdOp(IRDLOperation):
     result: OpResult = result_def(IndexType)
 
     def __init__(self, dim: DimensionAttr):
-        super().__init__(result_types=[IndexType()], properties={"dimension": dim})
+        super().__init__(result_types=[
+            IndexType()], properties={"dimension": dim})
+
+
+@irdl_op_definition
+class WaitOp(IRDLOperation):
+    name = "gpu.wait"
+    asyncDependencies: VarOperand = var_operand_def(AsyncTokenType)
+    asyncToken: OptOpResult = opt_result_def(AsyncTokenType)
+
+    def __init__(
+        self,
+        async_dependencies: Sequence[SSAValue | Operation] | None = None,
+    ):
+        super().__init__(operands=[async_dependencies],
+                         result_types=[[AsyncTokenType()]],)
 
 
 @irdl_op_definition
@@ -779,6 +808,7 @@ GPU = Dialect(
         SubgroupSizeOp,
         TerminatorOp,
         ThreadIdOp,
+        WaitOp,
         YieldOp,
     ],
     [


### PR DESCRIPTION
This pull request adds the `gpu.wait` op for GPU asynchronous execution. The `gpu.wait` op generates a token that can be used to enable asynchronous execution combined with other operations in `gpu` dialect.