### PR TITLE
core: Make SSAValue hashable

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -372,6 +372,12 @@ class SSAValue(ABC):
             )
         self.replace_by(ErasedSSAValue(self.type, self))
 
+    def __hash__(self):
+        """
+        Make SSAValue hashable. Two SSA Values are never the same, therefore
+        the use of `id` is allowed here.
+        """
+        return id(self)
 
 @dataclass
 class OpResult(SSAValue):

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -379,6 +379,7 @@ class SSAValue(ABC):
         """
         return id(self)
 
+
 @dataclass
 class OpResult(SSAValue):
     """A reference to an SSA variable defined by an operation result."""

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -283,7 +283,7 @@ class Use:
     """The index of the operand using the value in the operation."""
 
 
-@dataclass
+@dataclass(eq=False)
 class SSAValue(ABC):
     """
     A reference to an SSA variable.
@@ -383,7 +383,7 @@ class SSAValue(ABC):
         return self is other
 
 
-@dataclass
+@dataclass(eq=False)
 class OpResult(SSAValue):
     """A reference to an SSA variable defined by an operation result."""
 
@@ -401,7 +401,7 @@ class OpResult(SSAValue):
         return f"<{self.__class__.__name__}[{self.type}] index: {self.index}, operation: {self.op.name}, uses: {len(self.uses)}>"
 
 
-@dataclass
+@dataclass(eq=False)
 class BlockArgument(SSAValue):
     """A reference to an SSA variable defined by a basic block argument."""
 
@@ -419,7 +419,7 @@ class BlockArgument(SSAValue):
         return f"<{self.__class__.__name__}[{self.type}] index: {self.index}, uses: {len(self.uses)}>"
 
 
-@dataclass
+@dataclass(eq=False)
 class ErasedSSAValue(SSAValue):
     """
     An erased SSA variable.

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -379,6 +379,9 @@ class SSAValue(ABC):
         """
         return id(self)
 
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
 
 @dataclass
 class OpResult(SSAValue):
@@ -396,12 +399,6 @@ class OpResult(SSAValue):
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}[{self.type}] index: {self.index}, operation: {self.op.name}, uses: {len(self.uses)}>"
-
-    def __eq__(self, other: object) -> bool:
-        return self is other
-
-    def __hash__(self) -> int:
-        return id(self)
 
 
 @dataclass
@@ -421,12 +418,6 @@ class BlockArgument(SSAValue):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}[{self.type}] index: {self.index}, uses: {len(self.uses)}>"
 
-    def __eq__(self, other: object) -> bool:
-        return self is other
-
-    def __hash__(self) -> int:
-        return id(self)
-
 
 @dataclass
 class ErasedSSAValue(SSAValue):
@@ -440,9 +431,6 @@ class ErasedSSAValue(SSAValue):
     @property
     def owner(self) -> Operation | Block:
         return self.old_value.owner
-
-    def __hash__(self) -> int:
-        return hash(id(self))
 
 
 A = TypeVar("A", bound="Attribute")

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -22,7 +22,7 @@ from xdsl.utils.exceptions import MultipleSpansParseError
 from xdsl.utils.lexer import Input, Lexer, Span, Token
 
 
-@dataclass
+@dataclass(eq=False)
 class ForwardDeclaredValue(SSAValue):
     """
     An SSA value that is used before it is defined.

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -33,12 +33,6 @@ class ForwardDeclaredValue(SSAValue):
     def owner(self) -> Operation | Block:
         assert False, "Forward declared values do not have an owner"
 
-    def __eq__(self, other: object) -> bool:
-        return self is other
-
-    def __hash__(self) -> int:
-        return id(self)
-
 
 @dataclass
 class UnresolvedOperand:

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -5,9 +5,3 @@ class TestSSAValue(SSAValue):
     @property
     def owner(self) -> Operation | Block:
         assert False, "Attempting to get the owner of a `TestSSAValue`"
-
-    def __eq__(self, other: object) -> bool:
-        return self is other
-
-    def __hash__(self) -> int:
-        return id(self)


### PR DESCRIPTION
This PR makes `SSAValue` hashable so that pyright will stop complaining when I use it in the `value_mapper` dict of `Operation.clone`.

The hash of an SSA Value is it's `id`, which should be safe as two SSA Values are only the same if they are literally the same value.