### PR TITLE
interactive: fix bug - do not allow users to be able to select root node to be added to the pass pipeline

### DIFF
--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -411,6 +411,10 @@ class InputApp(App[None]):
         if selected_pass.data is None:
             return
 
+        # block ability to select root (i.e. add root pass to the pipeline)
+        if selected_pass.is_root:
+            return
+
         # get instance
         selected_pass_value, selected_pass_spec = selected_pass.data
 


### PR DESCRIPTION
Small bug in the code. Selecting root node of tree of passes adds node to pass pipeline - this is not allowed. 