### PR TITLE
pip prod(deps): update pytest requirement from <8.1  to <8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ toml<0.11
 pytest-cov
 coverage<8.0.0
 ipykernel
-pytest<8.1
+pytest<8.2
 nbval<0.12
 filecheck<0.0.25
 lit<18.0.0


### PR DESCRIPTION
Follow up on #2291. I will save you dependabot!

Updates the requirements on [pytest](https://github.com/pytest-dev/pytest) to permit the latest version.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/1.0.0b3...8.1.0)

---
updated-dependencies:
- dependency-name: pytest
  dependency-type: direct:production
...