### PR TITLE
core: add insert_op_at_location to PatternRewriter

### DIFF
--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -94,8 +94,7 @@ class PatternRewriter(PatternRewriterListener):
         op = (op,) if isinstance(op, Operation) else op
         if not op:
             return
-        for op_ in op:
-            Rewriter.insert_op_at_location(op_, insertion_point)
+        Rewriter.insert_ops_at_location(op, insertion_point)
 
         for op_ in op:
             self.handle_operation_insertion(op_)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -8,7 +8,7 @@ from functools import wraps
 from types import UnionType
 from typing import TypeVar, Union, final, get_args, get_origin
 
-from xdsl.builder import Builder, BuilderListener, InsertPoint
+from xdsl.builder import BuilderListener, InsertPoint
 from xdsl.dialects.builtin import ArrayAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
@@ -91,11 +91,11 @@ class PatternRewriter(PatternRewriterListener):
     ):
         """Insert operations at a certain location in a block."""
         self.has_done_action = True
-        op = [op] if isinstance(op, Operation) else op
+        op = (op,) if isinstance(op, Operation) else op
         if not op:
             return
         for op_ in op:
-            Builder(insertion_point).insert(op_)
+            Rewriter.insert_op_at_location(op_, insertion_point)
 
         for op_ in op:
             self.handle_operation_insertion(op_)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -14,7 +14,7 @@ from typing import (
     get_origin,
 )
 
-from xdsl.builder import BuilderListener
+from xdsl.builder import Builder, BuilderListener, InsertPoint
 from xdsl.dialects.builtin import ArrayAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
@@ -92,60 +92,47 @@ class PatternRewriter(PatternRewriterListener):
     has_done_action: bool = field(default=False, init=False)
     """Has the rewriter done any action during the current match."""
 
-    def insert_op_before_matched_op(self, op: Operation | Sequence[Operation]):
-        """Insert operations before the matched operation."""
-        self.insert_op_before(op, self.current_operation)
-
-    def insert_op_after_matched_op(self, op: Operation | Sequence[Operation]):
-        """Insert operations after the matched operation."""
-        self.insert_op_after(op, self.current_operation)
-
-    def insert_op_at_end(self, op: Operation | Sequence[Operation], block: Block):
-        """Insert operations at the end of a block."""
+    def insert_op_at_location(
+        self, op: Operation | Sequence[Operation], insertion_point: InsertPoint
+    ):
+        """Insert operations at a certain location in a block."""
         self.has_done_action = True
         op = [op] if isinstance(op, Operation) else op
         if len(op) == 0:
             return
-        block.add_ops(op)
+        for op_ in op:
+            Builder(insertion_point).insert(op_)
+
         for op_ in op:
             self.handle_operation_insertion(op_)
 
+    def insert_op_before_matched_op(self, op: Operation | Sequence[Operation]):
+        """Insert operations before the matched operation."""
+        self.insert_op_at_location(op, InsertPoint.before(self.current_operation))
+
+    def insert_op_after_matched_op(self, op: Operation | Sequence[Operation]):
+        """Insert operations after the matched operation."""
+        self.insert_op_at_location(op, InsertPoint.after(self.current_operation))
+
+    def insert_op_at_end(self, op: Operation | Sequence[Operation], block: Block):
+        """Insert operations at the end of a block."""
+        self.insert_op_at_location(op, InsertPoint.at_end(block))
+
     def insert_op_at_start(self, op: Operation | Sequence[Operation], block: Block):
         """Insert operations at the start of a block."""
-        if (first_op := block.first_op) is not None:
-            self.insert_op_before(op, first_op)
-        else:
-            self.insert_op_at_end(op, block)
+        self.insert_op_at_location(op, InsertPoint.at_start(block))
 
     def insert_op_before(
         self, op: Operation | Sequence[Operation], target_op: Operation
     ):
         """Insert operations before an operation."""
-        if target_op.parent is None:
-            raise Exception("Cannot insert operations before toplevel operation.")
-        target_block = target_op.parent
-        self.has_done_action = True
-        op = [op] if isinstance(op, Operation) else op
-        if len(op) == 0:
-            return
-        target_block.insert_ops_before(op, target_op)
-        for op_ in op:
-            self.handle_operation_insertion(op_)
+        self.insert_op_at_location(op, InsertPoint.before(target_op))
 
     def insert_op_after(
         self, op: Operation | Sequence[Operation], target_op: Operation
     ):
         """Insert operations after an operation."""
-        if target_op.parent is None:
-            raise Exception("Cannot insert operations after toplevel operation.")
-        target_block = target_op.parent
-        self.has_done_action = True
-        ops = [op] if isinstance(op, Operation) else op
-        if len(ops) == 0:
-            return
-        target_block.insert_ops_after(ops, target_op)
-        for op_ in ops:
-            self.handle_operation_insertion(op_)
+        self.insert_op_at_location(op, InsertPoint.after(target_op))
 
     def erase_matched_op(self, safe_erase: bool = True):
         """

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -98,7 +98,7 @@ class PatternRewriter(PatternRewriterListener):
         """Insert operations at a certain location in a block."""
         self.has_done_action = True
         op = [op] if isinstance(op, Operation) else op
-        if len(op) == 0:
+        if not op:
             return
         for op_ in op:
             Builder(insertion_point).insert(op_)

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -253,22 +253,22 @@ class Rewriter:
         region.insert_block(block_list, pos)
 
     @staticmethod
-    def insert_op_at_location(op: Operation, insertion_point: InsertPoint):
+    def insert_ops_at_location(ops: Sequence[Operation], insertion_point: InsertPoint):
         """Insert operations at a certain location in a block."""
         if insertion_point.insert_before is not None:
-            insertion_point.block.insert_op_before(op, insertion_point.insert_before)
+            insertion_point.block.insert_ops_before(ops, insertion_point.insert_before)
         else:
-            insertion_point.block.add_op(op)
+            insertion_point.block.add_ops(ops)
 
     @staticmethod
     def insert_op_after(op: Operation, new_op: Operation):
         """Inserts a new operation after another operation."""
-        Rewriter.insert_op_at_location(new_op, InsertPoint.after(op))
+        Rewriter.insert_ops_at_location((new_op,), InsertPoint.after(op))
 
     @staticmethod
     def insert_op_before(op: Operation, new_op: Operation):
         """Inserts a new operation before another operation."""
-        Rewriter.insert_op_at_location(new_op, InsertPoint.before(op))
+        Rewriter.insert_ops_at_location((new_op,), InsertPoint.before(op))
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -253,18 +253,22 @@ class Rewriter:
         region.insert_block(block_list, pos)
 
     @staticmethod
+    def insert_op_at_location(op: Operation, insertion_point: InsertPoint):
+        """Insert operations at a certain location in a block."""
+        if insertion_point.insert_before is not None:
+            insertion_point.block.insert_op_before(op, insertion_point.insert_before)
+        else:
+            insertion_point.block.add_op(op)
+
+    @staticmethod
     def insert_op_after(op: Operation, new_op: Operation):
         """Inserts a new operation after another operation."""
-        if op.parent is None:
-            raise Exception("Cannot insert an operation after a toplevel operation")
-        op.parent.insert_ops_after((new_op,), op)
+        Rewriter.insert_op_at_location(new_op, InsertPoint.after(op))
 
     @staticmethod
     def insert_op_before(op: Operation, new_op: Operation):
         """Inserts a new operation before another operation."""
-        if op.parent is None:
-            raise Exception("Cannot insert an operation before a toplevel operation")
-        op.parent.insert_ops_before((new_op,), op)
+        Rewriter.insert_op_at_location(new_op, InsertPoint.before(op))
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:


### PR DESCRIPTION
I'm messing about with some helpers that pass around what are effectively insertion points, this functionality makes that code simpler. It also feels like a general entropy minimising step.