### PR TITLE
core: move InsertPoint to Rewriter [NFC]

### DIFF
--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Sequence
 from itertools import product
 from typing import TypeAlias, TypeVar, cast
 
-from xdsl.builder import Builder, InsertPoint
+from xdsl.builder import Builder
 from xdsl.dialects import affine, arith, func, memref, printf
 from xdsl.dialects.builtin import (
     AffineMapAttr,
@@ -30,6 +30,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 from ..dialects import toy
 

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -1,10 +1,11 @@
 import pytest
 
-from xdsl.builder import Builder, InsertPoint
+from xdsl.builder import Builder
 from xdsl.dialects.arith import Constant
 from xdsl.dialects.builtin import IntAttr, i32, i64
 from xdsl.dialects.scf import If
 from xdsl.ir import Block, BlockArgument, Operation, Region
+from xdsl.rewriter import InsertPoint
 
 
 def test_insertion_point_constructors():

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -9,59 +9,7 @@ from typing import ClassVar, TypeAlias, overload
 
 from xdsl.dialects.builtin import ArrayAttr
 from xdsl.ir import Attribute, Block, BlockArgument, Operation, OperationInvT, Region
-from xdsl.rewriter import Rewriter
-
-
-@dataclass(frozen=True)
-class InsertPoint:
-    """
-    An insert point.
-    It is either a point before an operation, or at the end of a block.
-
-    https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder_1_1InsertPoint.html
-    """
-
-    block: Block
-    """The block where the insertion point is in."""
-
-    insert_before: Operation | None = field(default=None)
-    """
-    The insertion point is right before this operation.
-    If the operation is None, the insertion point is at the end of the block.
-    """
-
-    def __post_init__(self) -> None:
-        # Check that the insertion point is valid.
-        # An insertion point can only be invalid if `insert_before` is an `Operation`,
-        # and its parent is not `block`.
-        if self.insert_before is not None:
-            if self.insert_before.parent is not self.block:
-                raise ValueError("Insertion point must be in the builder's `block`")
-
-    @staticmethod
-    def before(op: Operation) -> InsertPoint:
-        """Gets the insertion point before an operation."""
-        if (block := op.parent_block()) is None:
-            raise ValueError("Operation insertion point must have a parent block")
-        return InsertPoint(block, op)
-
-    @staticmethod
-    def after(op: Operation) -> InsertPoint:
-        """Gets the insertion point after an operation."""
-        block = op.parent_block()
-        if block is None:
-            raise ValueError("Operation insertion point must have a parent block")
-        return InsertPoint(block, op.next_op)
-
-    @staticmethod
-    def at_start(block: Block) -> InsertPoint:
-        """Gets the insertion point at the start of a block."""
-        return InsertPoint(block, block.ops.first)
-
-    @staticmethod
-    def at_end(block: Block) -> InsertPoint:
-        """Gets the insertion point at the end of a block."""
-        return InsertPoint(block)
+from xdsl.rewriter import InsertPoint, Rewriter
 
 
 @dataclass(eq=False)

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -1,6 +1,61 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 
 from xdsl.ir import Block, BlockArgument, Operation, Region, SSAValue
+
+
+@dataclass(frozen=True)
+class InsertPoint:
+    """
+    An insert point.
+    It is either a point before an operation, or at the end of a block.
+
+    https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder_1_1InsertPoint.html
+    """
+
+    block: Block
+    """The block where the insertion point is in."""
+
+    insert_before: Operation | None = field(default=None)
+    """
+    The insertion point is right before this operation.
+    If the operation is None, the insertion point is at the end of the block.
+    """
+
+    def __post_init__(self) -> None:
+        # Check that the insertion point is valid.
+        # An insertion point can only be invalid if `insert_before` is an `Operation`,
+        # and its parent is not `block`.
+        if self.insert_before is not None:
+            if self.insert_before.parent is not self.block:
+                raise ValueError("Insertion point must be in the builder's `block`")
+
+    @staticmethod
+    def before(op: Operation) -> InsertPoint:
+        """Gets the insertion point before an operation."""
+        if (block := op.parent_block()) is None:
+            raise ValueError("Operation insertion point must have a parent block")
+        return InsertPoint(block, op)
+
+    @staticmethod
+    def after(op: Operation) -> InsertPoint:
+        """Gets the insertion point after an operation."""
+        block = op.parent_block()
+        if block is None:
+            raise ValueError("Operation insertion point must have a parent block")
+        return InsertPoint(block, op.next_op)
+
+    @staticmethod
+    def at_start(block: Block) -> InsertPoint:
+        """Gets the insertion point at the start of a block."""
+        return InsertPoint(block, block.ops.first)
+
+    @staticmethod
+    def at_end(block: Block) -> InsertPoint:
+        """Gets the insertion point at the end of a block."""
+        return InsertPoint(block)
 
 
 class Rewriter:


### PR DESCRIPTION
I'd like to add some helpers to Rewriter to leverage `InsertPoint`, and right now this would involve a circular reference. Between `Rewriter` and `Builder`, it feels like `InsertPoint` is closer in abstraction to `Rewriter` anyway.