### PR TITLE
dialects: (llvm) Fix constructor for llvm.InlineAsmOp

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -7,6 +7,7 @@ from xdsl.dialects.builtin import IntegerType, UnitAttr, i32
 from xdsl.ir import Attribute
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.test_value import TestSSAValue
 
 
 @pytest.mark.parametrize(
@@ -242,3 +243,21 @@ def test_variadic_func():
     p = Printer(stream=io)
     p.print_attribute(func_type)
     assert io.getvalue() == """!llvm.func<void (...)>"""
+
+
+def test_inline_assembly_op():
+    a, b, c = (
+        TestSSAValue(builtin.i32),
+        TestSSAValue(builtin.i32),
+        TestSSAValue(builtin.i32),
+    )
+
+    op = llvm.InlineAsmOp(
+        [a, b, c],
+        [builtin.i32],
+        "nop",
+        "I, I, I, =r",
+        has_side_effects=True,
+    )
+
+    op.verify()

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -253,11 +253,35 @@ def test_inline_assembly_op():
     )
 
     op = llvm.InlineAsmOp(
-        [a, b, c],
-        [builtin.i32],
         "nop",
         "I, I, I, =r",
+        [a, b, c],
+        [builtin.i32],
         has_side_effects=True,
     )
+    op.verify()
 
+    op = llvm.InlineAsmOp(
+        "nop",
+        "I, I, I, =r",
+        [a, b, c],
+        [],
+        has_side_effects=True,
+    )
+    op.verify()
+
+    op = llvm.InlineAsmOp(
+        "nop",
+        "I, I, I, =r",
+        [a, b, c],
+        has_side_effects=True,
+    )
+    op.verify()
+
+    op = llvm.InlineAsmOp(
+        "nop",
+        "I, I, I, =r",
+        [],
+        has_side_effects=True,
+    )
     op.verify()

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -743,10 +743,10 @@ class InlineAsmOp(IRDLOperation):
 
     def __init__(
         self,
-        operands: list[SSAValue | Operation],
-        res_types: list[Attribute],
         asm_string: str,
         constraints: str,
+        operands: Sequence[SSAValue | Operation],
+        res_types: Sequence[Attribute] | None = None,
         asm_dialect: int = 0,
         has_side_effects: bool = False,
         is_align_stack: bool = False,
@@ -762,11 +762,14 @@ class InlineAsmOp(IRDLOperation):
             "is_align_stack": UnitAttr() if is_align_stack else None,
         }
 
+        if res_types is None:
+            res_types = []
+
         super().__init__(
             operands=[operands],
             attributes=attrs,
             properties=props,
-            result_types=res_types,
+            result_types=[res_types],
         )
 
 

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -743,7 +743,7 @@ class InlineAsmOp(IRDLOperation):
 
     def __init__(
         self,
-        operands_: list[SSAValue | Operation],
+        operands: list[SSAValue | Operation],
         res_types: list[Attribute],
         asm_string: str,
         constraints: str,
@@ -763,7 +763,7 @@ class InlineAsmOp(IRDLOperation):
         }
 
         super().__init__(
-            operands=operands_,
+            operands=[operands],
             attributes=attrs,
             properties=props,
             result_types=res_types,

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -6,13 +6,7 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import wraps
 from types import UnionType
-from typing import (
-    TypeVar,
-    Union,
-    final,
-    get_args,
-    get_origin,
-)
+from typing import TypeVar, Union, final, get_args, get_origin
 
 from xdsl.builder import BuilderListener
 from xdsl.dialects.builtin import ArrayAttr, ModuleOp
@@ -217,7 +211,7 @@ class PatternRewriter(PatternRewriterListener):
         if new_results is None:
             new_results = [] if len(new_ops) == 0 else new_ops[-1].results
 
-        if len(op.results) != len(new_results):
+        if len(op.results) != len(new_results) and safe_erase:
             raise ValueError(
                 f"Expected {len(op.results)} new results, but got {len(new_results)}"
             )


### PR DESCRIPTION
Fixes a small bug in the constructor of the inline assembly op.
