### PR TITLE
install: Consistently use VENV_DIR variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ TESTS_COVERAGE_FILE = ${COVERAGE_FILE}.tests
 .ONESHELL:
 
 # these targets don't produce files:
-.PHONY: venv clean filecheck pytest pytest-nb tests-toy tests rerun-notebooks precommit-install precommit black pyright
+.PHONY: ${VENV_DIR}/ clean filecheck pytest pytest-nb tests-toy tests rerun-notebooks precommit-install precommit black pyright
 .PHONY: coverage coverage-tests coverage-filecheck-tests coverage-report-html coverage-report-md
 
 # set up the venv with all dependencies for development
-venv: requirements.txt
+${VENV_DIR}/: requirements.txt
 	python3 -m venv ${VENV_DIR}
 	. ${VENV_DIR}/bin/activate
 	python3 -m pip --require-virtualenv install -r requirements.txt


### PR DESCRIPTION
Currently the makefile interchangeably uses `venv` and `${VENV_DIR}` to refer to the virtual environment install directory. This change replaces all instances with the variable.

This allows to have e.g. 2 versions side-by-side:
```sh
$ make  # unchanged, builds into ./venv/
$ git checkout some-other-branch
$ make VENV_DIR=other-venv  # builds into ./other-venv/ without overwriting ./venv/
```

The trailing slash on the target name means you can use a hidden directory (e.g., `make VENV_DIR=.venv`) without the target being confused for a special Makefile target (`.c.o`, `.PHONY`, etc).
