### PR TITLE
dialects: (riscv) add index to registers

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,7 +1,7 @@
 import pytest
 
 from xdsl.dialects import riscv
-from xdsl.dialects.builtin import IntegerAttr, ModuleOp, Signedness, i32
+from xdsl.dialects.builtin import IntegerAttr, ModuleOp, NoneAttr, Signedness, i32
 from xdsl.ir import MLContext
 from xdsl.parser import Parser
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
@@ -28,7 +28,7 @@ def test_add_op():
     assert a2.type.index.data == 12
 
     # Registers that aren't predefined should not have an index.
-    assert riscv.IntRegisterType("j1").index is None
+    assert isinstance(riscv.IntRegisterType("j1").index, NoneAttr)
 
 
 def test_csr_op():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -1,7 +1,14 @@
 import pytest
 
 from xdsl.dialects import riscv
-from xdsl.dialects.builtin import IntegerAttr, ModuleOp, NoneAttr, Signedness, i32
+from xdsl.dialects.builtin import (
+    IntegerAttr,
+    ModuleOp,
+    NoneAttr,
+    Signedness,
+    i32,
+    IntAttr,
+)
 from xdsl.ir import MLContext
 from xdsl.parser import Parser
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
@@ -21,11 +28,11 @@ def test_add_op():
     assert isinstance(a1.type, riscv.IntRegisterType)
     assert isinstance(a2.type, riscv.IntRegisterType)
     assert a0.type.spelling.data == "a0"
-    assert a0.type.index.data == 10
+    assert a0.type.index == IntAttr(10)
     assert a1.type.spelling.data == "a1"
-    assert a1.type.index.data == 11
+    assert a1.type.index == IntAttr(11)
     assert a2.type.spelling.data == "a2"
-    assert a2.type.index.data == 12
+    assert a2.type.index == IntAttr(12)
 
     # Registers that aren't predefined should not have an index.
     assert isinstance(riscv.IntRegisterType("j1").index, NoneAttr)

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -20,9 +20,15 @@ def test_add_op():
     assert isinstance(a0.type, riscv.IntRegisterType)
     assert isinstance(a1.type, riscv.IntRegisterType)
     assert isinstance(a2.type, riscv.IntRegisterType)
-    assert a0.type.data == "a0"
-    assert a1.type.data == "a1"
-    assert a2.type.data == "a2"
+    assert a0.type.spelling.data == "a0"
+    assert a0.type.index.data == 10
+    assert a1.type.spelling.data == "a1"
+    assert a1.type.index.data == 11
+    assert a2.type.spelling.data == "a2"
+    assert a2.type.index.data == 12
+
+    # Registers that aren't predefined should not have an index.
+    assert riscv.IntRegisterType("j1").index is None
 
 
 def test_csr_op():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -2,12 +2,12 @@ import pytest
 
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
+    IntAttr,
     IntegerAttr,
     ModuleOp,
     NoneAttr,
     Signedness,
     i32,
-    IntAttr,
 )
 from xdsl.ir import MLContext
 from xdsl.parser import Parser

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
 from io import StringIO
-from typing import IO, Annotated, ClassVar, Generic, Literal, TypeAlias, TypeVar
+from typing import IO, Annotated, Generic, Literal, TypeAlias, TypeVar
 
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     IndexType,
+    IntAttr,
     IntegerAttr,
     IntegerType,
     ModuleOp,
+    NoneAttr,
     Signedness,
     StringAttr,
     UnitAttr,
@@ -26,6 +28,7 @@ from xdsl.ir import (
     Dialect,
     Operation,
     OpResult,
+    ParametrizedAttribute,
     Region,
     SSAValue,
     TypeAttribute,
@@ -34,6 +37,7 @@ from xdsl.irdl import (
     IRDLOperation,
     Operand,
     OptSingleBlockRegion,
+    ParameterDef,
     VarOperand,
     VarOpResult,
     attr_def,
@@ -74,47 +78,63 @@ class FastMathFlagsAttr(FastMathAttrBase):
         super().__init__(flags)
 
 
-class RISCVRegisterType(Data[str], TypeAttribute, ABC):
+class RISCVRegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     """
     A RISC-V register type.
     """
 
-    _unallocated: ClassVar[Self | None] = None
+    index: ParameterDef[IntAttr | NoneAttr]
+    spelling: ParameterDef[StringAttr]
+
+    def __init__(self, spelling: str):
+        super().__init__(self._parameters_from_spelling(spelling))
+
+    @classmethod
+    def _parameters_from_spelling(
+        cls, spelling: str
+    ) -> tuple[IntAttr | NoneAttr, StringAttr]:
+        """
+        Returns the parameter list required to construct a register instance from the given spelling.
+        """
+        index_attr = NoneAttr()
+        index = cls.abi_index_by_name().get(spelling)
+        if index is not None:
+            index_attr = IntAttr(index)
+        return index_attr, StringAttr(spelling)
 
     @classmethod
     def unallocated(cls) -> Self:
-        if cls._unallocated is None:
-            cls._unallocated = cls("")
-        return cls._unallocated
+        return cls("")
 
     @property
     def register_name(self) -> str:
         """Returns name if allocated, raises ValueError if not"""
         if not self.is_allocated:
             raise ValueError("Cannot get name for unallocated register")
-        return self.data
+        return self.spelling.data
 
     @property
     def is_allocated(self) -> bool:
         """Returns true if a RISCV register is allocated, otherwise false"""
-        return bool(self.data)
+        return bool(self.spelling.data)
 
     @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> str:
+    def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
         with parser.in_angle_brackets():
             name = parser.parse_optional_identifier()
-            if name is None:
-                return ""
-            if not name.startswith("j"):
-                assert name in cls.abi_index_by_name(), f"{name}"
-            return name
+            if name is not None:
+                if not name.startswith("j"):
+                    assert name in cls.abi_index_by_name(), f"{name}"
+            else:
+                name = ""
+            return cls._parameters_from_spelling(name)
 
-    def print_parameter(self, printer: Printer) -> None:
+    def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
-            printer.print_string(self.data)
+            printer.print_string(self.spelling.data)
 
     def verify(self) -> None:
-        name = self.data
+        name = self.spelling.data
         if not self.is_allocated or name.startswith("j"):
             return
         if name not in type(self).abi_index_by_name():
@@ -136,6 +156,43 @@ class RISCVRegisterType(Data[str], TypeAttribute, ABC):
         raise NotImplementedError()
 
 
+RV32I_INDEX_BY_NAME = {
+    "zero": 0,
+    "ra": 1,
+    "sp": 2,
+    "gp": 3,
+    "tp": 4,
+    "t0": 5,
+    "t1": 6,
+    "t2": 7,
+    "fp": 8,
+    "s0": 8,
+    "s1": 9,
+    "a0": 10,
+    "a1": 11,
+    "a2": 12,
+    "a3": 13,
+    "a4": 14,
+    "a5": 15,
+    "a6": 16,
+    "a7": 17,
+    "s2": 18,
+    "s3": 19,
+    "s4": 20,
+    "s5": 21,
+    "s6": 22,
+    "s7": 23,
+    "s8": 24,
+    "s9": 25,
+    "s10": 26,
+    "s11": 27,
+    "t3": 28,
+    "t4": 29,
+    "t5": 30,
+    "t6": 31,
+}
+
+
 @irdl_attr_definition
 class IntRegisterType(RISCVRegisterType):
     """
@@ -150,47 +207,47 @@ class IntRegisterType(RISCVRegisterType):
 
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        return IntRegisterType.RV32I_INDEX_BY_NAME
+        return RV32I_INDEX_BY_NAME
 
     @classmethod
     def a_register(cls, index: int) -> IntRegisterType:
         return Registers.A[index]
 
-    RV32I_INDEX_BY_NAME = {
-        "zero": 0,
-        "ra": 1,
-        "sp": 2,
-        "gp": 3,
-        "tp": 4,
-        "t0": 5,
-        "t1": 6,
-        "t2": 7,
-        "fp": 8,
-        "s0": 8,
-        "s1": 9,
-        "a0": 10,
-        "a1": 11,
-        "a2": 12,
-        "a3": 13,
-        "a4": 14,
-        "a5": 15,
-        "a6": 16,
-        "a7": 17,
-        "s2": 18,
-        "s3": 19,
-        "s4": 20,
-        "s5": 21,
-        "s6": 22,
-        "s7": 23,
-        "s8": 24,
-        "s9": 25,
-        "s10": 26,
-        "s11": 27,
-        "t3": 28,
-        "t4": 29,
-        "t5": 30,
-        "t6": 31,
-    }
+
+RV32F_INDEX_BY_NAME = {
+    "ft0": 0,
+    "ft1": 1,
+    "ft2": 2,
+    "ft3": 3,
+    "ft4": 4,
+    "ft5": 5,
+    "ft6": 6,
+    "ft7": 7,
+    "fs0": 8,
+    "fs1": 9,
+    "fa0": 10,
+    "fa1": 11,
+    "fa2": 12,
+    "fa3": 13,
+    "fa4": 14,
+    "fa5": 15,
+    "fa6": 16,
+    "fa7": 17,
+    "fs2": 18,
+    "fs3": 19,
+    "fs4": 20,
+    "fs5": 21,
+    "fs6": 22,
+    "fs7": 23,
+    "fs8": 24,
+    "fs9": 25,
+    "fs10": 26,
+    "fs11": 27,
+    "ft8": 28,
+    "ft9": 29,
+    "ft10": 30,
+    "ft11": 31,
+}
 
 
 @irdl_attr_definition
@@ -207,46 +264,11 @@ class FloatRegisterType(RISCVRegisterType):
 
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        return FloatRegisterType.RV32F_INDEX_BY_NAME
+        return RV32F_INDEX_BY_NAME
 
     @classmethod
     def a_register(cls, index: int) -> FloatRegisterType:
         return Registers.FA[index]
-
-    RV32F_INDEX_BY_NAME = {
-        "ft0": 0,
-        "ft1": 1,
-        "ft2": 2,
-        "ft3": 3,
-        "ft4": 4,
-        "ft5": 5,
-        "ft6": 6,
-        "ft7": 7,
-        "fs0": 8,
-        "fs1": 9,
-        "fa0": 10,
-        "fa1": 11,
-        "fa2": 12,
-        "fa3": 13,
-        "fa4": 14,
-        "fa5": 15,
-        "fa6": 16,
-        "fa7": 17,
-        "fs2": 18,
-        "fs3": 19,
-        "fs4": 20,
-        "fs5": 21,
-        "fs6": 22,
-        "fs7": 23,
-        "fs8": 24,
-        "fs9": 25,
-        "fs10": 26,
-        "fs11": 27,
-        "ft8": 28,
-        "ft9": 29,
-        "ft10": 30,
-        "ft11": 31,
-    }
 
 
 RDInvT = TypeVar("RDInvT", bound=RISCVRegisterType)
@@ -1157,10 +1179,10 @@ class CsrReadWriteOperation(IRDLOperation, RISCVInstruction, ABC):
             return
         if not isinstance(self.rd.type, IntRegisterType):
             return
-        if self.rd.type.is_allocated and self.rd.type.data != "zero":
+        if self.rd.type.is_allocated and self.rd.type != Registers.ZERO:
             raise VerifyException(
                 "When in 'writeonly' mode, destination must be register x0 (a.k.a. 'zero'), "
-                f"not '{self.rd.type.data}'"
+                f"not '{self.rd.type.spelling.data}'"
             )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
@@ -1235,10 +1257,10 @@ class CsrBitwiseOperation(IRDLOperation, RISCVInstruction, ABC):
             return
         if not isinstance(self.rs1.type, IntRegisterType):
             return
-        if self.rs1.type.is_allocated and self.rs1.type.data != "zero":
+        if self.rs1.type.is_allocated and self.rs1.type != Registers.ZERO:
             raise VerifyException(
                 "When in 'readonly' mode, source must be register x0 (a.k.a. 'zero'), "
-                f"not '{self.rs1.type.data}'"
+                f"not '{self.rs1.type.spelling.data}'"
             )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
@@ -1311,10 +1333,10 @@ class CsrReadWriteImmOperation(IRDLOperation, RISCVInstruction, ABC):
             return
         if not isinstance(self.rd.type, IntRegisterType):
             return
-        if self.rd.type.is_allocated and self.rd.type.data != "zero":
+        if self.rd.type.is_allocated and self.rd.type != Registers.ZERO:
             raise VerifyException(
                 "When in 'writeonly' mode, destination must be register x0 (a.k.a. 'zero'), "
-                f"not '{self.rd.type.data}'"
+                f"not '{self.rd.type.spelling.data}'"
             )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -103,8 +103,9 @@ class RISCVRegisterType(ParametrizedAttribute, TypeAttribute, ABC):
         return index_attr, StringAttr(spelling)
 
     @classmethod
+    @abstractmethod
     def unallocated(cls) -> Self:
-        return cls("")
+        raise NotImplementedError()
 
     @property
     def register_name(self) -> str:
@@ -202,6 +203,10 @@ class IntRegisterType(RISCVRegisterType):
     name = "riscv.reg"
 
     @classmethod
+    def unallocated(cls) -> IntRegisterType:
+        return Registers.UNALLOCATED_INT
+
+    @classmethod
     def instruction_set_name(cls) -> str:
         return "RV32I"
 
@@ -259,6 +264,10 @@ class FloatRegisterType(RISCVRegisterType):
     name = "riscv.freg"
 
     @classmethod
+    def unallocated(cls) -> FloatRegisterType:
+        return Registers.UNALLOCATED_FLOAT
+
+    @classmethod
     def instruction_set_name(cls) -> str:
         return "RV32F"
 
@@ -280,6 +289,7 @@ RS2InvT = TypeVar("RS2InvT", bound=RISCVRegisterType)
 class Registers(ABC):
     """Namespace for named register constants."""
 
+    UNALLOCATED_INT = IntRegisterType("")
     ZERO = IntRegisterType("zero")
     RA = IntRegisterType("ra")
     SP = IntRegisterType("sp")
@@ -314,6 +324,7 @@ class Registers(ABC):
     T5 = IntRegisterType("t5")
     T6 = IntRegisterType("t6")
 
+    UNALLOCATED_FLOAT = FloatRegisterType("")
     FT0 = FloatRegisterType("ft0")
     FT1 = FloatRegisterType("ft1")
     FT2 = FloatRegisterType("ft2")


### PR DESCRIPTION
The identity of registers is currently defined by a string. This can be problematic as RISC-V registers have alternative spellings which are then considered as unequal.

This PR is a first step towards fixing that issue by adding an optional `index` parameter to the type. The idea is to have a unique index that identifies the register in the future if it is a predefined register. Non-predefined registers such as the infinite `j[0-9]+` registers set `index` to `None` to signal that the spelling should be used for equality.

A future PR will add the `__eq__` implementation after the representation has proven itself.

Part of https://github.com/xdslproject/xdsl/issues/1760