### PR TITLE
dialects: (pdl) Fix printer and parser for PDL range type

### DIFF
--- a/tests/filecheck/dialects/pdl/mlir-tests.mlir
+++ b/tests/filecheck/dialects/pdl/mlir-tests.mlir
@@ -164,20 +164,20 @@ builtin.module {
 builtin.module {
   pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
     %types = pdl.types
-    %root = pdl.operation -> (%types : !pdl.range<!pdl.type>)
+    %root = pdl.operation -> (%types : !pdl.range<type>)
     pdl.rewrite %root {
       %otherTypes = pdl.types : [i32, i64]
-      %newOp = pdl.operation "foo.op" -> (%types, %otherTypes : !pdl.range<!pdl.type>, !pdl.range<!pdl.type>)
+      %newOp = pdl.operation "foo.op" -> (%types, %otherTypes : !pdl.range<type>, !pdl.range<type>)
     }
   }
 }
 
 // CHECK:      pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
 // CHECK-NEXT:   %types = pdl.types
-// CHECK-NEXT:   %root = pdl.operation -> (%types : !pdl.range<!pdl.type>)
+// CHECK-NEXT:   %root = pdl.operation -> (%types : !pdl.range<type>)
 // CHECK-NEXT:   pdl.rewrite %root {
 // CHECK-NEXT:     %otherTypes = pdl.types : [i32, i64]
-// CHECK-NEXT:     %newOp = pdl.operation "foo.op" -> (%types, %otherTypes : !pdl.range<!pdl.type>, !pdl.range<!pdl.type>)
+// CHECK-NEXT:     %newOp = pdl.operation "foo.op" -> (%types, %otherTypes : !pdl.range<type>, !pdl.range<type>)
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
@@ -219,9 +219,9 @@ builtin.module {
   pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
     %types = pdl.types
     %operands = pdl.operands : %types
-    %root = pdl.operation (%operands : !pdl.range<!pdl.value>)
+    %root = pdl.operation (%operands : !pdl.range<value>)
     pdl.rewrite %root {
-      %newOp = pdl.operation "foo.op" -> (%types : !pdl.range<!pdl.type>)
+      %newOp = pdl.operation "foo.op" -> (%types : !pdl.range<type>)
     }
   }
 }
@@ -229,9 +229,9 @@ builtin.module {
 // CHECK:       pdl.pattern @infer_type_from_type_used_in_match : benefit(1) {
 // CHECK-NEXT:    %types = pdl.types
 // CHECK-NEXT:    %operands = pdl.operands : %types
-// CHECK-NEXT:    %root = pdl.operation (%operands : !pdl.range<!pdl.value>)
+// CHECK-NEXT:    %root = pdl.operation (%operands : !pdl.range<value>)
 // CHECK-NEXT:    pdl.rewrite %root {
-// CHECK-NEXT:      %newOp = pdl.operation "foo.op" -> (%types : !pdl.range<!pdl.type>)
+// CHECK-NEXT:      %newOp = pdl.operation "foo.op" -> (%types : !pdl.range<type>)
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 

--- a/tests/filecheck/dialects/pdl/pdl_operand.mlir
+++ b/tests/filecheck/dialects/pdl/pdl_operand.mlir
@@ -27,7 +27,7 @@ pdl.pattern @unboundedOperands : benefit(1) {
   // Unbounded operands
   %operands = pdl.operands
   
-  %root = pdl.operation(%operands : !pdl.range<!pdl.value>)
+  %root = pdl.operation(%operands : !pdl.range<value>)
   pdl.rewrite %root with "test_rewriter"(%root : !pdl.operation)
 }
 
@@ -39,7 +39,7 @@ pdl.pattern @boundedOperands : benefit(1) {
   %types = pdl.types : [i32, i64, i1]
   %operands = pdl.operands : %types
   
-  %root = pdl.operation(%operands : !pdl.range<!pdl.value>)
+  %root = pdl.operation(%operands : !pdl.range<value>)
   pdl.rewrite %root with "test_rewriter"(%root : !pdl.operation)
 }
 

--- a/tests/filecheck/dialects/pdl/pdl_operation.mlir
+++ b/tests/filecheck/dialects/pdl/pdl_operation.mlir
@@ -21,12 +21,12 @@ pdl.pattern @boundedOperation : benefit(1) {
   %attr2 = pdl.attribute
 
   // A bound operation
-  %root = pdl.operation "test.test"(%operand, %operands : !pdl.value, !pdl.range<!pdl.value>)
+  %root = pdl.operation "test.test"(%operand, %operands : !pdl.value, !pdl.range<value>)
                         {"value1" = %attr, "value2" = %attr2}
-                        -> (%types, %type : !pdl.range<!pdl.type>, !pdl.type)
+                        -> (%types, %type : !pdl.range<type>, !pdl.type)
 
   pdl.rewrite %root with "test_rewriter"(%root : !pdl.operation)
 }
 
 // CHECK: @boundedOperation
-// CHECK: %{{.*}} = pdl.operation "test.test" (%{{.*}}, %{{.*}} : !pdl.value, !pdl.range<!pdl.value>) {"value1" = %{{.*}}, "value2" = %{{.*}}} -> (%{{.*}}, %{{.*}} : !pdl.range<!pdl.type>, !pdl.type)
+// CHECK: %{{.*}} = pdl.operation "test.test" (%{{.*}}, %{{.*}} : !pdl.value, !pdl.range<value>) {"value1" = %{{.*}}, "value2" = %{{.*}}} -> (%{{.*}}, %{{.*}} : !pdl.range<type>, !pdl.type)

--- a/tests/filecheck/dialects/pdl/pdl_range.mlir
+++ b/tests/filecheck/dialects/pdl/pdl_range.mlir
@@ -1,36 +1,41 @@
 // RUN: XDSL_ROUNDTRIP
 
+// CHECK: "test.op"() : () -> (!pdl.range<operation>, !pdl.range<attribute>)
+"test.op"() : () -> (!pdl.range<operation>, !pdl.range<attribute>)
+
 pdl.pattern @emptyRanges : benefit(1) {
 // CHECK: @emptyRanges
-  %types = pdl.range : !pdl.range<type>
-// CHECK: %{{.*}} = pdl.range : !pdl.range<type>
-  %values = pdl.range : !pdl.range<value>
-// CHECK: %{{.*}} = pdl.range : !pdl.range<value>
+  %root = pdl.operation
+  pdl.rewrite %root {
+    %types = pdl.range : !pdl.range<type>
+  // CHECK: %{{.*}} = pdl.range : !pdl.range<type>
+    %values = pdl.range : !pdl.range<value>
+  // CHECK: %{{.*}} = pdl.range : !pdl.range<value>
 
-  %root = pdl.operation (%values: !pdl.range<value>) -> (%types: !pdl.range<type>)
-  pdl.rewrite %root with "test_rewriter"
+    %rep = pdl.operation "test.op" (%values: !pdl.range<value>) -> (%types: !pdl.range<type>)
+  }
 }
 
 
 pdl.pattern @nonEmptyRanges : benefit(1) {
 // CHECK: @nonEmptyRanges
   %type1 = pdl.type : !pdl.type
-  %type1_range = pdl.range %type1 : !pdl.type
-// CHECK: %{{.*}} = pdl.range %{{.*}} : !pdl.type
   %type2 = pdl.type : !pdl.type
-  %types = pdl.range %type1_range, %type2 : !pdl.range<type>, !pdl.type
-// CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<type>, !pdl.type
-
   %value1 = pdl.operand : %type1
-  %value1_range = pdl.range %value1 : !pdl.value
-// CHECK: %{{.*}} = pdl.range %{{.*}} : !pdl.value
   %value2 = pdl.operand : %type2
-  %values = pdl.range %value1_range, %value2 : !pdl.range<value>, !pdl.value
-// CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<value>, !pdl.value
+  
+  %root = pdl.operation (%value1, %value2: !pdl.value, !pdl.value)
+  pdl.rewrite %root {
+    %type1_range = pdl.range %type1 : !pdl.type
+  // CHECK: %{{.*}} = pdl.range %{{.*}} : !pdl.type
+    %types = pdl.range %type1_range, %type2 : !pdl.range<type>, !pdl.type
+  // CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<type>, !pdl.type
 
-  %root = pdl.operation (%values: !pdl.range<value>) -> (%types: !pdl.range<type>)
-  pdl.rewrite %root with "test_rewriter"
+    %value1_range = pdl.range %value1 : !pdl.value
+  // CHECK: %{{.*}} = pdl.range %{{.*}} : !pdl.value
+    %values = pdl.range %value1_range, %value2 : !pdl.range<value>, !pdl.value
+  // CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<value>, !pdl.value
+
+    %rep = pdl.operation "test.op" (%values: !pdl.range<value>) -> (%types: !pdl.range<type>)
+  }
 }
-
-
-

--- a/tests/filecheck/dialects/pdl/pdl_range.mlir
+++ b/tests/filecheck/dialects/pdl/pdl_range.mlir
@@ -2,12 +2,12 @@
 
 pdl.pattern @emptyRanges : benefit(1) {
 // CHECK: @emptyRanges
-  %types = pdl.range : !pdl.range<!pdl.type>
-// CHECK: %{{.*}} = pdl.range : !pdl.range<!pdl.type>
-  %values = pdl.range : !pdl.range<!pdl.value>
-// CHECK: %{{.*}} = pdl.range : !pdl.range<!pdl.value>
+  %types = pdl.range : !pdl.range<type>
+// CHECK: %{{.*}} = pdl.range : !pdl.range<type>
+  %values = pdl.range : !pdl.range<value>
+// CHECK: %{{.*}} = pdl.range : !pdl.range<value>
 
-  %root = pdl.operation (%values: !pdl.range<!pdl.value>) -> (%types: !pdl.range<!pdl.type>)
+  %root = pdl.operation (%values: !pdl.range<value>) -> (%types: !pdl.range<type>)
   pdl.rewrite %root with "test_rewriter"
 }
 
@@ -18,17 +18,17 @@ pdl.pattern @nonEmptyRanges : benefit(1) {
   %type1_range = pdl.range %type1 : !pdl.type
 // CHECK: %{{.*}} = pdl.range %{{.*}} : !pdl.type
   %type2 = pdl.type : !pdl.type
-  %types = pdl.range %type1_range, %type2 : !pdl.range<!pdl.type>, !pdl.type
-// CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<!pdl.type>, !pdl.type
+  %types = pdl.range %type1_range, %type2 : !pdl.range<type>, !pdl.type
+// CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<type>, !pdl.type
 
   %value1 = pdl.operand : %type1
   %value1_range = pdl.range %value1 : !pdl.value
 // CHECK: %{{.*}} = pdl.range %{{.*}} : !pdl.value
   %value2 = pdl.operand : %type2
-  %values = pdl.range %value1_range, %value2 : !pdl.range<!pdl.value>, !pdl.value
-// CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<!pdl.value>, !pdl.value
+  %values = pdl.range %value1_range, %value2 : !pdl.range<value>, !pdl.value
+// CHECK: %{{.*}} = pdl.range %{{.*}}, %{{.*}} : !pdl.range<value>, !pdl.value
 
-  %root = pdl.operation (%values: !pdl.range<!pdl.value>) -> (%types: !pdl.range<!pdl.type>)
+  %root = pdl.operation (%values: !pdl.range<value>) -> (%types: !pdl.range<type>)
   pdl.rewrite %root with "test_rewriter"
 }
 

--- a/tests/filecheck/dialects/pdl/pdl_result.mlir
+++ b/tests/filecheck/dialects/pdl/pdl_result.mlir
@@ -2,7 +2,7 @@
 
 pdl.pattern @extractResult : benefit(1) {
   %types = pdl.types
-  %root = pdl.operation -> (%types : !pdl.range<!pdl.type>)
+  %root = pdl.operation -> (%types : !pdl.range<type>)
   %result = pdl.result 1 of %root
 
   pdl.rewrite %root with "test_rewriter"
@@ -13,7 +13,7 @@ pdl.pattern @extractResult : benefit(1) {
 
 pdl.pattern @extractAllResults : benefit(1) {
   %types = pdl.types
-  %root = pdl.operation -> (%types : !pdl.range<!pdl.type>)
+  %root = pdl.operation -> (%types : !pdl.range<type>)
   %result = pdl.results of %root
 
   pdl.rewrite %root with "test_rewriter"
@@ -24,8 +24,8 @@ pdl.pattern @extractAllResults : benefit(1) {
 
 pdl.pattern @extractOneResultRange : benefit(1) {
   %types = pdl.types
-  %root = pdl.operation -> (%types : !pdl.range<!pdl.type>)
-  %result = pdl.results 1 of %root -> !pdl.range<!pdl.value>
+  %root = pdl.operation -> (%types : !pdl.range<type>)
+  %result = pdl.results 1 of %root -> !pdl.range<value>
 
   pdl.rewrite %root with "test_rewriter"
 }

--- a/tests/filecheck/dialects/pdl/pdl_type.mlir
+++ b/tests/filecheck/dialects/pdl/pdl_type.mlir
@@ -26,7 +26,7 @@ pdl.pattern @unboundedTypes : benefit(1) {
   // Unbounded types
   %type = pdl.types
   
-  %root = pdl.operation -> (%type : !pdl.range<!pdl.type>)
+  %root = pdl.operation -> (%type : !pdl.range<type>)
   pdl.rewrite %root with "test_rewriter"(%root : !pdl.operation)
 }
 
@@ -37,7 +37,7 @@ pdl.pattern @knownTypes : benefit(1) {
   // Known types
   %type = pdl.types : [i32, i64]
   
-  %root = pdl.operation -> (%type : !pdl.range<!pdl.type>)
+  %root = pdl.operation -> (%type : !pdl.range<type>)
   pdl.rewrite %root with "test_rewriter"(%root : !pdl.operation)
 }
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -40,6 +40,7 @@ from xdsl.irdl import (
     prop_def,
     region_def,
     result_def,
+    traits_def,
     var_operand_def,
     var_result_def,
 )
@@ -642,6 +643,8 @@ class RangeOp(IRDLOperation):
     name = "pdl.range"
     arguments: VarOperand = var_operand_def(AnyPDLType | RangeType[AnyPDLType])
     result: OpResult = result_def(RangeType[AnyPDLType])
+
+    traits = traits_def(lambda: frozenset([HasParent(RewriteOp)]))
 
     def verify_(self) -> None:
         def get_type_or_elem_type(arg: SSAValue) -> Attribute:

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -43,7 +43,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.parser import Parser, AttrParser
+from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.traits import HasParent, IsTerminator, NoTerminator, OptionalSymbolOpInterface
 from xdsl.utils.exceptions import VerifyException

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -44,6 +44,7 @@ from xdsl.irdl import (
     var_result_def,
 )
 from xdsl.parser import Parser
+from xdsl.parser.attribute_parser import AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import HasParent, IsTerminator, NoTerminator, OptionalSymbolOpInterface
 from xdsl.utils.exceptions import VerifyException
@@ -147,6 +148,33 @@ class RangeType(Generic[_RangeT], ParametrizedAttribute, TypeAttribute):
 
     def __init__(self, element_type: _RangeT):
         super().__init__([element_type])
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
+        parser.parse_punctuation("<")
+        if parser.parse_optional_keyword("attribute") is not None:
+            element_type = AttributeType()
+        elif parser.parse_optional_keyword("operation") is not None:
+            element_type = OperationType()
+        elif parser.parse_optional_keyword("type") is not None:
+            element_type = TypeType()
+        elif parser.parse_optional_keyword("value") is not None:
+            element_type = ValueType()
+        else:
+            parser.raise_error("expected PDL element type for range")
+        parser.parse_punctuation(">")
+        return [element_type]
+
+    def print_parameters(self, printer: Printer) -> None:
+        match self.element_type:
+            case AttributeType():
+                printer.print("<attribute>")
+            case OperationType():
+                printer.print("<operation>")
+            case TypeType():
+                printer.print("<type>")
+            case ValueType():
+                printer.print("<value>")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -43,8 +43,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.parser import Parser
-from xdsl.parser.attribute_parser import AttrParser
+from xdsl.parser import Parser, AttrParser
 from xdsl.printer import Printer
 from xdsl.traits import HasParent, IsTerminator, NoTerminator, OptionalSymbolOpInterface
 from xdsl.utils.exceptions import VerifyException


### PR DESCRIPTION
It turns out PDL range types are not printed and parsed the natural way in MLIR, so this PR makes xDSL consistent with the MLIR implementation.