### PR TITLE
dialects: (comb) Fix concat op

### DIFF
--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -1,9 +1,11 @@
 import pytest
 
 from xdsl.dialects.builtin import IntegerType, i32
-from xdsl.dialects.comb import ConcatOp, ICmpOp
-from xdsl.dialects.test import TestOp, TestType
-from xdsl.utils.exceptions import VerifyException
+from xdsl.dialects.comb import Comb, ConcatOp, ICmpOp
+from xdsl.dialects.test import Test, TestOp, TestType
+from xdsl.ir import MLContext
+from xdsl.parser import Parser
+from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
 
@@ -41,3 +43,12 @@ def test_comb_concat_verifier():
 
     with pytest.raises(VerifyException):
         ConcatOp([a, b, c], IntegerType(2)).verify()
+
+
+def test_comb_concat_parse():
+    ctx = MLContext()
+    ctx.load_dialect(Comb)
+    ctx.load_dialect(Test)
+    with pytest.raises(ParseError) as e:
+        Parser(ctx, r'%concat = comb.concat %a, %b : i32, !test.type<"foo">').parse_op()
+    assert e.value.args[1] == "expected only integer types as input"

--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -20,17 +20,17 @@ def test_icmp_incorrect_comparison():
 
 
 def test_comb_concat_builder():
-    a = TestOp(result_types=[IntegerType(5)])
-    b = TestOp(result_types=[IntegerType(3)])
-    c = TestOp(result_types=[IntegerType(1)])
-    foo = TestOp(result_types=[TestType("foo")])
+    a = TestSSAValue(IntegerType(5))
+    b = TestSSAValue(IntegerType(3))
+    c = TestSSAValue(IntegerType(1))
+    foo = TestSSAValue(TestType("foo"))
 
-    concat = ConcatOp.from_int_values([a.results[0], b.results[0], c.results[0]])
+    concat = ConcatOp.from_int_values([a, b, c])
     assert concat is not None
     assert isinstance(concat.result.type, IntegerType)
     assert concat.result.type.width.data == 9
 
-    bad_concat = ConcatOp.from_int_values([a.results[0], foo.results[0]])
+    bad_concat = ConcatOp.from_int_values([a, foo])
     assert bad_concat is None
 
 

--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -1,7 +1,10 @@
 import pytest
 
-from xdsl.dialects.builtin import i32
-from xdsl.dialects.comb import ICmpOp
+from typing import cast
+
+from xdsl.dialects.builtin import i32, IntegerType
+from xdsl.dialects.comb import ICmpOp, ConcatOp
+from xdsl.dialects.test import TestOp, TestType
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
@@ -14,3 +17,29 @@ def test_icmp_incorrect_comparison():
         # 'slet' is an invalid comparison operation
         _icmp_op = ICmpOp(a, b, "slet")
     assert e.value.args[0] == "Unknown comparison mnemonic: slet"
+
+
+def test_comb_concat_builder():
+    a = TestOp(result_types=[IntegerType(5)])
+    b = TestOp(result_types=[IntegerType(3)])
+    c = TestOp(result_types=[IntegerType(1)])
+    foo = TestOp(result_types=[TestType("foo")])
+
+    concat = ConcatOp.from_int_values([a.results[0], b.results[0], c.results[0]])
+    assert concat is not None
+    assert isinstance(concat.result.type, IntegerType)
+    assert concat.result.type.width.data == 9
+
+    bad_concat = ConcatOp.from_int_values([a.results[0], foo.results[0]])
+    assert bad_concat is None
+
+
+def test_comb_concat_verifier():
+    a = TestOp(result_types=[IntegerType(5)])
+    b = TestOp(result_types=[IntegerType(3)])
+    c = TestOp(result_types=[IntegerType(1)])
+
+    ConcatOp([a, b, c], IntegerType(9)).verify()
+
+    with pytest.raises(VerifyException):
+        ConcatOp([a, b, c], IntegerType(2)).verify()

--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -2,8 +2,8 @@ import pytest
 
 from typing import cast
 
-from xdsl.dialects.builtin import i32, IntegerType
-from xdsl.dialects.comb import ICmpOp, ConcatOp
+from xdsl.dialects.builtin import IntegerType, i32
+from xdsl.dialects.comb import ConcatOp, ICmpOp
 from xdsl.dialects.test import TestOp, TestType
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue

--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -1,7 +1,5 @@
 import pytest
 
-from typing import cast
-
 from xdsl.dialects.builtin import IntegerType, i32
 from xdsl.dialects.comb import ConcatOp, ICmpOp
 from xdsl.dialects.test import TestOp, TestType

--- a/tests/filecheck/dialects/comb/comb_ops.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops.mlir
@@ -57,8 +57,8 @@
   %extract = comb.extract %lhsi32 from 1 : (i32) -> i32
   // CHECK-NEXT: %extract = comb.extract %lhsi32 : i32
 
-  %concat = comb.concat %lhsi32, %rhsi32 : i32
-  // CHECK-NEXT: %concat = comb.concat %lhsi32, %rhsi32 : i32
+  %concat = comb.concat %lhsi32, %rhsi32 : i32, i32
+  // CHECK-NEXT: %concat = comb.concat %lhsi32, %rhsi32 : i32, i32
 
   %mux = comb.mux %lhsi1, %lhsi32, %rhsi32 : i32
   // CHECK-NEXT: %mux = comb.mux %lhsi1, %lhsi32, %rhsi32 : i32

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -402,6 +402,19 @@ class ExtractOp(IRDLOperation):
         printer.print(self.result.type)
 
 
+def _get_sum_of_int_width(int_types: Sequence[Attribute]) -> int | None:
+    """
+    Gets the sum of the width of the provided integer types. Returns None
+    if one of the provided attributes is not an integer type.
+    """
+    sum_of_width = 0
+    for typ in int_types:
+        if not isinstance(typ, IntegerType):
+            return None
+        sum_of_width += typ.width.data
+    return sum_of_width
+
+
 @irdl_op_definition
 class ConcatOp(IRDLOperation):
     """
@@ -422,18 +435,14 @@ class ConcatOp(IRDLOperation):
         Concatenates the provided values, in order. Returns None if the provided
         values are not integers.
         """
-        sum_of_width = 0
-        for arg in inputs:
-            if not isinstance(arg.type, IntegerType):
-                return None
-            sum_of_width += arg.type.width.data
+        sum_of_width = _get_sum_of_int_width([inp.type for inp in inputs])
+        if sum_of_width is None:
+            return None
         return ConcatOp(inputs, IntegerType(sum_of_width))
 
     def verify_(self) -> None:
-        sum_of_width = 0
-        for arg in self.inputs:
-            assert isinstance(arg.type, IntegerType)
-            sum_of_width += arg.type.width.data
+        sum_of_width = _get_sum_of_int_width([inp.type for inp in self.inputs])
+        assert sum_of_width is not None
         assert isinstance(self.result.type, IntegerType)
         if sum_of_width != self.result.type.width.data:
             raise VerifyException(
@@ -448,17 +457,20 @@ class ConcatOp(IRDLOperation):
             parser.Delimiter.NONE, parser.parse_unresolved_operand
         )
         parser.parse_punctuation(":")
-        result_type = parser.parse_type()
-        inputs = parser.resolve_operands(
-            inputs, len(inputs) * [result_type], parser.pos
+        input_types = parser.parse_comma_separated_list(
+            parser.Delimiter.NONE, parser.parse_type
         )
-        return cls.create(operands=inputs, result_types=[result_type])
+        sum_of_width = _get_sum_of_int_width(input_types)
+        if sum_of_width is None:
+            parser.raise_error("expected only integer types as input")
+        inputs = parser.resolve_operands(inputs, input_types, parser.pos)
+        return cls.create(operands=inputs, result_types=[IntegerType(sum_of_width)])
 
     def print(self, printer: Printer):
         printer.print(" ")
         printer.print_list(self.inputs, printer.print_ssa_value)
         printer.print(" : ")
-        printer.print(self.result.type)
+        printer.print_list([inp.type for inp in self.inputs], printer.print_attribute)
 
 
 @irdl_op_definition


### PR DESCRIPTION
The constructor, parser and printer of the comb concat op are incorrect. This PR fixes it, adds a useful builder for the concat operation and adds a verifier.