### PR TITLE
dialects: (comb) Fix extract op

### DIFF
--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -58,6 +58,16 @@ def test_comb_extract_parse():
     ctx = MLContext()
     ctx.load_dialect(Comb)
     ctx.load_dialect(Test)
+
     with pytest.raises(ParseError) as e:
         Parser(ctx, r"%extract = comb.extract %a from 1 : (i32, i32) -> i4").parse_op()
     assert e.value.args[1] == "expected exactly one input and exactly one output types"
+
+    with pytest.raises(ParseError) as e:
+        Parser(
+            ctx, r'%extract = comb.extract %a from 1 : (i32) -> !test.type<"foo">'
+        ).parse_op()
+    assert (
+        e.value.args[1]
+        == "expected output to be an integer type, got '!test.type<\"foo\">'"
+    )

--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -52,3 +52,12 @@ def test_comb_concat_parse():
     with pytest.raises(ParseError) as e:
         Parser(ctx, r'%concat = comb.concat %a, %b : i32, !test.type<"foo">').parse_op()
     assert e.value.args[1] == "expected only integer types as input"
+
+
+def test_comb_extract_parse():
+    ctx = MLContext()
+    ctx.load_dialect(Comb)
+    ctx.load_dialect(Test)
+    with pytest.raises(ParseError) as e:
+        Parser(ctx, r"%extract = comb.extract %a from 1 : (i32, i32) -> i4").parse_op()
+    assert e.value.args[1] == "expected exactly one input and exactly one output types"

--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -1,11 +1,9 @@
 import pytest
 
 from xdsl.dialects.builtin import IntegerType, i32
-from xdsl.dialects.comb import Comb, ConcatOp, ICmpOp
-from xdsl.dialects.test import Test, TestOp, TestType
-from xdsl.ir import MLContext
-from xdsl.parser import Parser
-from xdsl.utils.exceptions import ParseError, VerifyException
+from xdsl.dialects.comb import ConcatOp, ICmpOp
+from xdsl.dialects.test import TestOp, TestType
+from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.test_value import TestSSAValue
 
 
@@ -43,31 +41,3 @@ def test_comb_concat_verifier():
 
     with pytest.raises(VerifyException):
         ConcatOp([a, b, c], IntegerType(2)).verify()
-
-
-def test_comb_concat_parse():
-    ctx = MLContext()
-    ctx.load_dialect(Comb)
-    ctx.load_dialect(Test)
-    with pytest.raises(ParseError) as e:
-        Parser(ctx, r'%concat = comb.concat %a, %b : i32, !test.type<"foo">').parse_op()
-    assert e.value.args[1] == "expected only integer types as input"
-
-
-def test_comb_extract_parse():
-    ctx = MLContext()
-    ctx.load_dialect(Comb)
-    ctx.load_dialect(Test)
-
-    with pytest.raises(ParseError) as e:
-        Parser(ctx, r"%extract = comb.extract %a from 1 : (i32, i32) -> i4").parse_op()
-    assert e.value.args[1] == "expected exactly one input and exactly one output types"
-
-    with pytest.raises(ParseError) as e:
-        Parser(
-            ctx, r'%extract = comb.extract %a from 1 : (i32) -> !test.type<"foo">'
-        ).parse_op()
-    assert (
-        e.value.args[1]
-        == "expected output to be an integer type, got '!test.type<\"foo\">'"
-    )

--- a/tests/filecheck/dialects/comb/comb_ops.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops.mlir
@@ -54,8 +54,8 @@
   %parity = comb.parity %lhsi1 : i1
   // CHECK-NEXT: %parity = comb.parity %lhsi1 : i1
 
-  %extract = comb.extract %lhsi32 from 1 : (i32) -> i32
-  // CHECK-NEXT: %extract = comb.extract %lhsi32 : i32
+  %extract = comb.extract %lhsi32 from 1 : (i32) -> i3
+  // CHECK-NEXT: %extract = comb.extract %lhsi32 from 1 : (i32) -> i3
 
   %concat = comb.concat %lhsi32, %rhsi32 : i32, i32
   // CHECK-NEXT: %concat = comb.concat %lhsi32, %rhsi32 : i32, i32

--- a/tests/filecheck/dialects/comb/comb_ops_err.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops_err.mlir
@@ -1,0 +1,7 @@
+// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
+
+builtin.module {
+    %a = "test.op"() : () -> i8
+    // CHECK: output width 6 is too large for input of width 8 (included low bit is at 6)
+    %extract = comb.extract %a from 6 : (i8) -> i6
+}

--- a/tests/filecheck/dialects/comb/comb_ops_err.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops_err.mlir
@@ -1,4 +1,29 @@
-// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt %s --verify-diagnostics --parsing-diagnostics --split-input-file | filecheck %s
+
+builtin.module {
+    %a = "test.op"() : () -> i32
+    %b = "test.op"() : () -> !test.type<"foo">
+    // CHECK: expected only integer types as input
+    %concat = comb.concat %a, %b : i32, !test.type<"foo">
+}
+
+// -----
+
+builtin.module {
+    %a = "test.op"() : () -> i32
+    // CHECK: expected output to be an integer type, got '!test.type<"foo">'
+    %extract = comb.extract %a from 1 : (i32) -> !test.type<"foo">
+}
+
+// -----
+
+builtin.module {
+    %a = "test.op"() : () -> i32
+    // CHECK: expected exactly one input and exactly one output types
+    %extract = comb.extract %a from 1 : (i32, i32) -> i4
+}
+
+// -----
 
 builtin.module {
     %a = "test.op"() : () -> i8

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -364,7 +364,12 @@ class ParityOp(IRDLOperation):
 class ExtractOp(IRDLOperation):
     """
     Extract a range of bits into a smaller value, low_bit
-    specifies the lowest bit included.
+    specifies the lowest bit included. Result is the size
+    of the value to extract.
+
+    |-----------------|   input
+           l              low bit
+           <-------->     result
     """
 
     name = "comb.extract"
@@ -376,14 +381,31 @@ class ExtractOp(IRDLOperation):
     result: OpResult = result_def(IntegerType)
 
     def __init__(
-        self, operand: Operation | SSAValue, low_bit: IntegerAttr[IntegerType]
+        self,
+        operand: Operation | SSAValue,
+        low_bit: IntegerAttr[IntegerType],
+        result: Attribute,
     ):
         operand = SSAValue.get(operand)
         return super().__init__(
             attributes={"low_bit": low_bit},
             operands=[operand],
-            result_types=[operand.type],
+            result_types=[result],
         )
+
+    def verify_(self) -> None:
+        assert isinstance(self.input.type, IntegerType)
+        assert isinstance(self.result.type, IntegerType)
+        if (
+            self.low_bit.value.data + self.result.type.width.data
+            > self.input.type.width.data + 1
+        ):
+            raise VerifyException(
+                f"output width {self.result.type.width.data} is "
+                f"too large for input of width "
+                f"{self.input.type.width.data} (included low bit "
+                f"is at {self.low_bit.value.data})"
+            )
 
     @classmethod
     def parse(cls, parser: Parser):
@@ -392,14 +414,18 @@ class ExtractOp(IRDLOperation):
         bit = parser.parse_integer()
         parser.parse_punctuation(":")
         result_type = parser.parse_function_type()
+        if len(result_type.inputs.data) != 1 or len(result_type.outputs.data) != 1:
+            parser.raise_error(
+                "expected exactly one input and exactly one output types"
+            )
         (op,) = parser.resolve_operands([op], result_type.inputs.data, parser.pos)
-        return cls(op, IntegerAttr(bit, 32))
+        return cls(op, IntegerAttr(bit, 32), result_type.outputs.data[0])
 
     def print(self, printer: Printer):
         printer.print(" ")
         printer.print_ssa_value(self.input)
-        printer.print(" : ")
-        printer.print(self.result.type)
+        printer.print(f" from {self.low_bit.value.data} : ")
+        printer.print_function_type([self.input.type], [self.result.type])
 
 
 def _get_sum_of_int_width(int_types: Sequence[Attribute]) -> int | None:

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -384,7 +384,7 @@ class ExtractOp(IRDLOperation):
         self,
         operand: Operation | SSAValue,
         low_bit: IntegerAttr[IntegerType],
-        result: Attribute,
+        result: IntegerType,
     ):
         operand = SSAValue.get(operand)
         return super().__init__(
@@ -417,6 +417,10 @@ class ExtractOp(IRDLOperation):
         if len(result_type.inputs.data) != 1 or len(result_type.outputs.data) != 1:
             parser.raise_error(
                 "expected exactly one input and exactly one output types"
+            )
+        if not isinstance(result_type.outputs.data[0], IntegerType):
+            parser.raise_error(
+                f"expected output to be an integer type, got '{result_type.outputs.data[0]}'"
             )
         (op,) = parser.resolve_operands([op], result_type.inputs.data, parser.pos)
         return cls(op, IntegerAttr(bit, 32), result_type.outputs.data[0])

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -386,13 +386,13 @@ class ExtractOp(IRDLOperation):
         self,
         operand: Operation | SSAValue,
         low_bit: IntegerAttr[IntegerType],
-        result: IntegerType,
+        result_type: IntegerType,
     ):
         operand = SSAValue.get(operand)
         return super().__init__(
             attributes={"low_bit": low_bit},
             operands=[operand],
-            result_types=[result],
+            result_types=[result_type],
         )
 
     def verify_(self) -> None:

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -4,6 +4,8 @@ compiler IR for combinational logic. It is designed to be easy to analyze and
 transform, and be a flexible and extensible substrate that may be extended with
 higher level dialects mixed into it.
 
+Up to date as of CIRCT commit `2e23cda6c2cbedb118b92fab755f1e36d80b13f5`.
+
 [1] https://circt.llvm.org/docs/Dialects/Comb/
 """
 


### PR DESCRIPTION
The constructor, parser and printer of the comb extract op are incorrect. This PR fixes it and adds a verifier.