### PR TITLE
rewriting: Extend TypeConversionPattern annotation

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1497,3 +1497,46 @@ def test_type_conversion():
         op_replaced=4,
         op_modified=4,
     )
+
+    class RewriteMaybe(TypeConversionPattern):
+        @attr_type_rewrite_pattern
+        def convert_type(self, typ: IntegerType) -> IndexType | None:
+            return IndexType() if typ.width.data >= 8 else None
+
+    prog = """\
+"builtin.module"() ({
+  "func.func"() ({
+  ^0(%arg : i6):
+  }) : () -> ()
+  %0 = "test.op"() {"nested" = memref<*xi4>} : () -> i6
+  %1 = "test.op"() {"type" = () -> memref<*xi32>} : () -> f32
+  %2 = "test.op"() <{"prop" = memref<*xi4>}> : () -> i32
+  %3 = "test.op"(%0, %1) : (i6, f32) -> memref<*xi32>
+  %4 = "arith.addi"(%0, %0) : (i6, i6) -> i6
+  "func.return"() : () -> ()
+}) : () -> ()
+"""
+
+    expected = """\
+"builtin.module"() ({
+  "func.func"() ({
+  ^0(%arg : i6):
+  }) : () -> ()
+  %0 = "test.op"() {"nested" = memref<*xi4>} : () -> i6
+  %1 = "test.op"() {"type" = () -> memref<*xindex>} : () -> f32
+  %2 = "test.op"() <{"prop" = memref<*xi4>}> : () -> index
+  %3 = "test.op"(%0, %1) : (i6, f32) -> memref<*xindex>
+  %4 = "arith.addi"(%0, %0) : (i6, i6) -> i6
+  "func.return"() : () -> ()
+}) : () -> ()
+"""
+
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(RewriteMaybe(recursive=True), apply_recursively=True),
+        op_inserted=3,
+        op_removed=3,
+        op_replaced=3,
+        op_modified=1,
+    )

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -498,7 +498,7 @@ _ConvertedT = TypeVar("_ConvertedT", bound=Attribute)
 
 
 def attr_type_rewrite_pattern(
-    func: Callable[[_TypeConversionPatternT, _AttributeT], _ConvertedT]
+    func: Callable[[_TypeConversionPatternT, _AttributeT], _ConvertedT | None]
 ) -> Callable[[_TypeConversionPatternT, Attribute], Attribute | None]:
     """
     This function is intended to be used as a decorator on a TypeConversionPattern


### PR DESCRIPTION
I found it was a little bit odd that this decorator did not allow the option for conversion to still be skipped even though the type matches the expected one. This change should be benign I expect?