### PR TITLE
dialects: (comb) Fix icmp parser/printer discrepancy and 2-state semantics modelling

### DIFF
--- a/tests/filecheck/dialects/comb/comb_ops.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops.mlir
@@ -48,14 +48,20 @@
   %xor = comb.xor %lhsi32, %rhsi32 : i32
   // CHECK-NEXT: %xor = comb.xor %lhsi32, %rhsi32 : i32
 
-  %icmp = "comb.icmp"(%lhsi1, %rhsi1) {"predicate" = 2 : i64, "two_state"} : (i1, i1) -> i1
-  // CHECK-NEXT: %icmp = comb.icmp slt %lhsi1, %rhsi1 : i1
+  %icmp = "comb.icmp"(%lhsi1, %rhsi1) {"predicate" = 2 : i64, "twoState"} : (i1, i1) -> i1
+  // CHECK-NEXT: %icmp = comb.icmp bin slt %lhsi1, %rhsi1 : i1
 
   %icmp2 = comb.icmp eq %lhsi1, %rhsi1 : i1
   // CHECK-NEXT: %icmp2 = comb.icmp eq %lhsi1, %rhsi1 : i1
 
+  %icmp_bin = comb.icmp bin eq %lhsi1, %rhsi1 : i1
+  // CHECK-NEXT: %icmp_bin = comb.icmp bin eq %lhsi1, %rhsi1 : i1
+
   %parity = comb.parity %lhsi1 : i1
   // CHECK-NEXT: %parity = comb.parity %lhsi1 : i1
+
+  %parity_bin = comb.parity bin %lhsi1 : i1
+  // CHECK-NEXT: %parity_bin = comb.parity bin %lhsi1 : i1
 
   %extract = comb.extract %lhsi32 from 1 : (i32) -> i3
   // CHECK-NEXT: %extract = comb.extract %lhsi32 from 1 : (i32) -> i3

--- a/tests/filecheck/dialects/comb/comb_ops.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops.mlir
@@ -49,7 +49,10 @@
   // CHECK-NEXT: %xor = comb.xor %lhsi32, %rhsi32 : i32
 
   %icmp = "comb.icmp"(%lhsi1, %rhsi1) {"predicate" = 2 : i64, "two_state"} : (i1, i1) -> i1
-  // CHECK-NEXT: %icmp = comb.icmp slt, %lhsi1, %rhsi1 : i1
+  // CHECK-NEXT: %icmp = comb.icmp slt %lhsi1, %rhsi1 : i1
+
+  %icmp2 = comb.icmp eq %lhsi1, %rhsi1 : i1
+  // CHECK-NEXT: %icmp2 = comb.icmp eq %lhsi1, %rhsi1 : i1
 
   %parity = comb.parity %lhsi1 : i1
   // CHECK-NEXT: %parity = comb.parity %lhsi1 : i1

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -303,7 +303,6 @@ class ICmpOp(IRDLOperation, ABC):
     @classmethod
     def parse(cls, parser: Parser):
         arg = parser.parse_identifier()
-        parser.parse_punctuation(",")
         operand1 = parser.parse_unresolved_operand()
         parser.parse_punctuation(",")
         operand2 = parser.parse_unresolved_operand()
@@ -318,7 +317,6 @@ class ICmpOp(IRDLOperation, ABC):
     def print(self, printer: Printer):
         printer.print(" ")
         printer.print_string(ICMP_COMPARISON_OPERATIONS[self.predicate.value.data])
-        printer.print(", ")
         printer.print_operand(self.lhs)
         printer.print(", ")
         printer.print_operand(self.rhs)

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -258,7 +258,7 @@ class ICmpOp(IRDLOperation, ABC):
     rhs: Operand = operand_def(T)
     result: OpResult = result_def(IntegerType(1))
 
-    two_state: UnitAttr = attr_def(UnitAttr)
+    two_state: UnitAttr | None = opt_attr_def(UnitAttr, attr_name="twoState")
 
     @staticmethod
     def _get_comparison_predicate(
@@ -274,6 +274,7 @@ class ICmpOp(IRDLOperation, ABC):
         operand1: Operation | SSAValue,
         operand2: Operation | SSAValue,
         arg: int | str | IntegerAttr[IntegerType],
+        has_two_state_semantics: bool = False,
     ):
         operand1 = SSAValue.get(operand1)
         operand2 = SSAValue.get(operand2)
@@ -294,14 +295,20 @@ class ICmpOp(IRDLOperation, ABC):
             arg = ICmpOp._get_comparison_predicate(arg, cmpi_comparison_operations)
         if not isinstance(arg, IntegerAttr):
             arg = IntegerAttr.from_int_and_width(arg, 64)
+
+        attrs: dict[str, Attribute] = {"predicate": arg}
+        if has_two_state_semantics:
+            attrs["twoState"] = UnitAttr()
+
         return super().__init__(
             operands=[operand1, operand2],
             result_types=[IntegerType(1)],
-            attributes={"predicate": arg},
+            attributes=attrs,
         )
 
     @classmethod
     def parse(cls, parser: Parser):
+        has_two_state_semantics = parser.parse_optional_keyword("bin") is not None
         arg = parser.parse_identifier()
         operand1 = parser.parse_unresolved_operand()
         parser.parse_punctuation(",")
@@ -312,11 +319,14 @@ class ICmpOp(IRDLOperation, ABC):
             [operand1, operand2], 2 * [input_type], parser.pos
         )
 
-        return cls(operand1, operand2, arg)
+        return cls(operand1, operand2, arg, has_two_state_semantics)
 
     def print(self, printer: Printer):
         printer.print(" ")
+        if self.two_state is not None:
+            printer.print("bin ")
         printer.print_string(ICMP_COMPARISON_OPERATIONS[self.predicate.value.data])
+        printer.print(" ")
         printer.print_operand(self.lhs)
         printer.print(", ")
         printer.print_operand(self.rhs)
@@ -333,28 +343,33 @@ class ParityOp(IRDLOperation):
     input: Operand = operand_def(IntegerType)
     result: OpResult = result_def(IntegerType(1))
 
-    two_state: UnitAttr | None = opt_attr_def(UnitAttr)
+    two_state: UnitAttr | None = opt_attr_def(UnitAttr, attr_name="twoState")
 
     def __init__(
         self, operand: Operation | SSAValue, two_state: UnitAttr | None = None
     ):
         operand = SSAValue.get(operand)
         return super().__init__(
-            attributes={"two_state": two_state},
+            attributes={"twoState": two_state},
             operands=[operand],
             result_types=[operand.type],
         )
 
     @classmethod
     def parse(cls, parser: Parser):
+        two_state = None
+        if parser.parse_optional_keyword("bin") is not None:
+            two_state = UnitAttr()
         op = parser.parse_unresolved_operand()
         parser.parse_punctuation(":")
         result_type = parser.parse_type()
         op = parser.resolve_operand(op, result_type)
-        return cls(op)
+        return cls(op, two_state)
 
     def print(self, printer: Printer):
         printer.print(" ")
+        if self.two_state is not None:
+            printer.print("bin ")
         printer.print_ssa_value(self.input)
         printer.print(" : ")
         printer.print(self.result.type)


### PR DESCRIPTION
The printer and parser of the ICmp operation were emitting/expecting an extra comma that is not present in the original dialect.