### PR TITLE
dialects: (linalg) allow for empty results in linalg.fill custom format

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -20,6 +20,7 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 %4 = arith.constant 0.000000e+00 : f32
 
 %fill = linalg.fill ins(%4 : f32) outs(%2 : tensor<2x3xf32>) -> tensor<2x3xf32>
+linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
 
 %mul = linalg.mul ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%3 : tensor<2x3xf32>) -> tensor<2x3xf32>
 
@@ -55,6 +56,7 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 // CHECK-NEXT:    %2 = linalg.add ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#1 : tensor<2x3xf32>) -> tensor<2x3xf32>
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:    %3 = linalg.fill ins(%cst : f32) outs(%1#0 : tensor<2x3xf32>) -> tensor<2x3xf32>
+// CHECK-NEXT:    linalg.fill ins(%cst : f32) outs(%0#1 : memref<1x256xf32>)
 // CHECK-NEXT:    %4 = linalg.mul  ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#1 : tensor<2x3xf32>) -> tensor<2x3xf32>
 // CHECK-NEXT:    %5:2 = "test.op"() : () -> (tensor<16x64xf32>, tensor<64x16xf32>)
 // CHECK-NEXT:    %transposed  = linalg.transpose ins(%5#0 : tensor<16x64xf32>) outs(%5#1 : tensor<64x16xf32>) permutation = [1, 0]

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -420,6 +420,10 @@ class FillOp(IRDLOperation):
     """
     Fills the output tensor with the given value.
 
+    Works for arbitrary ranked output tensors since the operation performs scalar accesses
+    only and is thus rank polymorphic. Numeric casting is performed on the value operand,
+    promoting it to the same data type as the output.
+
     See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgfill-linalgfillop
     """
 
@@ -432,7 +436,7 @@ class FillOp(IRDLOperation):
 
     assembly_format = (
         "`ins` `(` $inputs `:` type($inputs) `)` ` ` "
-        "`outs` `(` $outputs `:` type($outputs) `)` `->` type($res) attr-dict"
+        "`outs` `(` $outputs `:` type($outputs) `)` (`->` type($res)^)? attr-dict"
     )
 
     irdl_options = [AttrSizedOperandSegments(as_property=True), ParsePropInAttrDict()]


### PR DESCRIPTION
Fixes #2228: linalg.fill shouldn't have a fixed result

CC @gabrielrodcanal 