### PR TITLE
interactive : remove bug that happens when argument screen is cleared and entered

### DIFF
--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -5,7 +5,7 @@ from textual.screen import Screen
 from textual.widgets import Button, TextArea
 
 
-class AddArguments(Screen[str]):
+class AddArguments(Screen[str | None]):
     """
     Screen called when selected pass has arguments requiring user input.
     """
@@ -36,7 +36,7 @@ class AddArguments(Screen[str]):
 
     @on(Button.Pressed, "#quit_screen_button")
     def exit_screen(self, event: Button.Pressed) -> None:
-        self.dismiss("")
+        self.dismiss(None)
 
     @on(Button.Pressed, "#clear_input_screen_button")
     def clear_text_area(self, event: Button.Pressed) -> None:

--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -36,7 +36,7 @@ class AddArguments(Screen[str]):
 
     @on(Button.Pressed, "#quit_screen_button")
     def exit_screen(self, event: Button.Pressed) -> None:
-        self.dismiss()
+        self.dismiss("")
 
     @on(Button.Pressed, "#clear_input_screen_button")
     def clear_text_area(self, event: Button.Pressed) -> None:

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -364,7 +364,9 @@ class InputApp(App[None]):
         screen dismissal and appends the pass to the pass_pipeline variable.
         """
 
-        def add_pass_with_arguments_to_pass_pipeline(concatenated_arg_val: str) -> None:
+        def add_pass_with_arguments_to_pass_pipeline(
+            concatenated_arg_val: str | None,
+        ) -> None:
             """
             Called when AddArguments Screen is dismissed. This function attempts to parse
             the returned string, and if successful, adds it to the pass_pipeline variable.
@@ -373,11 +375,7 @@ class InputApp(App[None]):
             """
             try:
                 # if screen was dismissed and user 1) cleared the screen 2) made no changes
-                if (
-                    concatenated_arg_val == ""
-                    or concatenated_arg_val
-                    == get_pass_argument_names_and_types(selected_pass_value)
-                ):
+                if concatenated_arg_val is None:
                     return
 
                 new_pass_with_arguments = list(

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -372,6 +372,14 @@ class InputApp(App[None]):
             Parse Error.
             """
             try:
+                # if screen was dismissed and user 1) cleared the screen 2) made no changes
+                if (
+                    concatenated_arg_val == ""
+                    or concatenated_arg_val
+                    == get_pass_argument_names_and_types(selected_pass_value)
+                ):
+                    return
+
                 new_pass_with_arguments = list(
                     parse_pipeline(
                         f"{selected_pass_value.name}{{{concatenated_arg_val}}}"


### PR DESCRIPTION
When pressing a pass that requires argument input, a new screen pops up. when you press "clear" (i.e. clear the screen) and then press "enter" (i.e. dismiss the screen) --> causes error. 

this should fix it. 