### PR TITLE
core: Fix bug in pattern rewriter when ErasedSSAValue is present

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1341,6 +1341,38 @@ def test_inline_region_at_end():
     )
 
 
+def test_erased_ssavalue():
+    prog = """\
+builtin.module {
+  "test.op"() ({
+    %0 = "test.op"() : () -> i32
+    "test.op"(%0) : (i32) -> ()
+  }) : () -> ()
+}
+  """
+
+    expected = """\
+"builtin.module"() ({
+  "test.op"() ({
+  ^0:
+  }) : () -> ()
+}) : () -> ()
+"""
+
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: test.TestOp, rewriter: PatternRewriter):
+            if op.results or op.operands:
+                rewriter.erase_matched_op(safe_erase=False)
+
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=True),
+        op_removed=2,
+    )
+
+
 def test_type_conversion():
     """Test rewriter on ops without results"""
     prog = """\

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -20,6 +20,7 @@ from xdsl.ir import (
     Attribute,
     Block,
     BlockArgument,
+    ErasedSSAValue,
     Operation,
     ParametrizedAttribute,
     Region,
@@ -647,7 +648,11 @@ class PatternRewriteWalker:
         have more canonicalization opportunities.
         """
         for operand in operands:
-            if len(operand.uses) == 1 and isinstance((op := operand.owner), Operation):
+            if (
+                len(operand.uses) == 1
+                and not isinstance(operand, ErasedSSAValue)
+                and isinstance((op := operand.owner), Operation)
+            ):
                 self._worklist.push(op)
 
     def _handle_operation_insertion(self, op: Operation) -> None:


### PR DESCRIPTION
When an operation is deleted, the pattern rewriter adds its operands with 1 use to the worklist of operations to change.
This change checks that these operands are not `ErasedSSAValue`, otherwise an erased operation would be added to the worklist.

I'm starting to think that the `ErasedSSAValue` design is bad, I'll be thinking of a way to change this.