### PR TITLE
dialects: (hw) Add `hw.module` and `hw.output` operations

### DIFF
--- a/tests/filecheck/dialects/hw/hw_module.mlir
+++ b/tests/filecheck/dialects/hw/hw_module.mlir
@@ -7,7 +7,7 @@
 // CHECK-NEXT: hw.output %{{[^ ]*}}, %{{[^ ]*}} : i1, i1
 // CHECK-NEXT: }
 // CHECK-GENERIC: "hw.module"() ({
-// CHECK-GENERIC-NEXT: ^0(%{{[^ ]*}} : i1, %{{[^ ]*}} : i1, %{{[^ ]*}} : i32):
+// CHECK-GENERIC-NEXT: ^{{[^(]*}}(%{{[^ ]*}} : i1, %{{[^ ]*}} : i1, %{{[^ ]*}} : i32):
 // CHECK-GENERIC-NEXT:   "hw.output"(%{{[^ ]*}}, %{{[^ ]*}}) : (i1, i1) -> ()
 // CHECK-GENERIC-NEXT: }) {"sym_name" = "custom_basic", "module_type" = !hw.modty<input a : i1, output nameOfPortInSV : i1, output "" : i1, input customName : i1, input "very custom name" : i32>, "parameters" = []} : () -> ()
 hw.module @custom_basic(in %a_foo a: i1, out nameOfPortInSV: i1, out "": i1, in %b customName: i1, in %c "very custom name": i32) {
@@ -40,7 +40,7 @@ hw.module @"wack name!!"() {
 // CHECK-NEXT: hw.output %{{[^ ]*}}, %{{[^ ]*}} : i1, i1
 // CHECK-NEXT: }
 // CHECK-GENERIC: "hw.module"() ({
-// CHECK-GENERIC-NEXT: ^{{.*}}(%{{[^ ]*}} : i1, %{{[^ ]*}} : i1, %{{[^ ]*}} : i32):
+// CHECK-GENERIC-NEXT: ^{{[^(]*}}(%{{[^ ]*}} : i1, %{{[^ ]*}} : i1, %{{[^ ]*}} : i32):
 // CHECK-GENERIC-NEXT:   "hw.output"(%{{[^ ]*}}, %{{[^ ]*}}) : (i1, i1) -> ()
 // CHECK-GENERIC-NEXT: }) {"sym_name" = "generic_basic", "module_type" = !hw.modty<input a : i1, output nameOfPortInSV : i1, output "" : i1, input customName : i1, input "very custom name" : i32>, "parameters" = []} : () -> ()
 "hw.module"() ({

--- a/tests/filecheck/dialects/hw/hw_module.mlir
+++ b/tests/filecheck/dialects/hw/hw_module.mlir
@@ -1,0 +1,67 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+// Custom format input tests
+
+// CHECK: hw.module @custom_basic(in %{{[^ ]*}} a: i1, out nameOfPortInSV: i1, out "": i1, in %{{[^ ]*}} customName: i1, in %{{[^ ]*}} "very custom name": i32) {
+// CHECK-NEXT: hw.output %{{[^ ]*}}, %{{[^ ]*}} : i1, i1
+// CHECK-NEXT: }
+// CHECK-GENERIC: "hw.module"() ({
+// CHECK-GENERIC-NEXT: ^0(%{{[^ ]*}} : i1, %{{[^ ]*}} : i1, %{{[^ ]*}} : i32):
+// CHECK-GENERIC-NEXT:   "hw.output"(%{{[^ ]*}}, %{{[^ ]*}}) : (i1, i1) -> ()
+// CHECK-GENERIC-NEXT: }) {"sym_name" = "custom_basic", "module_type" = !hw.modty<input a : i1, output nameOfPortInSV : i1, output "" : i1, input customName : i1, input "very custom name" : i32>, "parameters" = []} : () -> ()
+hw.module @custom_basic(in %a_foo a: i1, out nameOfPortInSV: i1, out "": i1, in %b customName: i1, in %c "very custom name": i32) {
+  hw.output %a_foo, %b: i1, i1
+}
+
+// CHECK: hw.module @custom_param<p1: i42, "p2 with wack name": i1>() {
+// CHECK-NEXT: hw.output
+// CHECK-NEXT: }
+// CHECK-GENERIC: "hw.module"() ({
+// CHECK-GENERIC-NEXT:   "hw.output"() : () -> ()
+// CHECK-GENERIC-NEXT: }) {"sym_name" = "custom_param", "module_type" = !hw.modty<>, "parameters" = [#hw.param.decl<"p1": i42>, #hw.param.decl<"p2 with wack name": i1>]} : () -> ()
+hw.module @custom_param<p1: i42, "p2 with wack name": i1>() {
+  hw.output
+}
+
+// CHECK: hw.module @"wack name!!"() {
+// CHECK-NEXT: hw.output
+// CHECK-NEXT: }
+// CHECK-GENERIC: "hw.module"() ({
+// CHECK-GENERIC:   "hw.output"() : () -> ()
+// CHECK-GENERIC: }) {"sym_name" = "wack name!!", "module_type" = !hw.modty<>, "parameters" = []} : () -> ()
+hw.module @"wack name!!"() {
+  hw.output
+}
+
+// Generic format input tests
+
+// CHECK: hw.module @generic_basic(in %{{[^ ]*}} a: i1, out nameOfPortInSV: i1, out "": i1, in %{{[^ ]*}} customName: i1, in %{{[^ ]*}} "very custom name": i32) {
+// CHECK-NEXT: hw.output %{{[^ ]*}}, %{{[^ ]*}} : i1, i1
+// CHECK-NEXT: }
+// CHECK-GENERIC: "hw.module"() ({
+// CHECK-GENERIC-NEXT: ^{{.*}}(%{{[^ ]*}} : i1, %{{[^ ]*}} : i1, %{{[^ ]*}} : i32):
+// CHECK-GENERIC-NEXT:   "hw.output"(%{{[^ ]*}}, %{{[^ ]*}}) : (i1, i1) -> ()
+// CHECK-GENERIC-NEXT: }) {"sym_name" = "generic_basic", "module_type" = !hw.modty<input a : i1, output nameOfPortInSV : i1, output "" : i1, input customName : i1, input "very custom name" : i32>, "parameters" = []} : () -> ()
+"hw.module"() ({
+  ^0(%a_foo : i1, %b : i1, %c: i32):
+    "hw.output"(%a_foo, %b) : (i1, i1) -> ()
+  }) {
+    "sym_name" = "generic_basic",
+    "module_type" = !hw.modty<input a : i1, output nameOfPortInSV : i1, output "" : i1, input customName : i1, input "very custom name" : i32>,
+    "parameters" = []
+  } : () -> ()
+
+// CHECK: hw.module @generic_param<p1: i42, "p2 with wack name": i1>() {
+// CHECK-NEXT: hw.output
+// CHECK-NEXT: }
+// CHECK-GENERIC: "hw.module"() ({
+// CHECK-GENERIC-NEXT:   "hw.output"() : () -> ()
+// CHECK-GENERIC-NEXT: }) {"sym_name" = "generic_param", "module_type" = !hw.modty<>, "parameters" = [#hw.param.decl<"p1": i42>, #hw.param.decl<"p2 with wack name": i1>]} : () -> ()
+"hw.module"() ({
+  "hw.output"() : () -> ()
+}) {
+  "sym_name" = "generic_param",
+  "module_type" = !hw.modty<>, 
+  "parameters" = [#hw.param.decl<"p1": i42>, #hw.param.decl<"p2 with wack name": i1>]
+} : () -> ()

--- a/tests/filecheck/dialects/hw/hw_module.mlir
+++ b/tests/filecheck/dialects/hw/hw_module.mlir
@@ -35,13 +35,14 @@ hw.module @"wack name!!"() {
 }
 
 // CHECK: hw.module @name_preserve(in %preserve: i8)
-// CHECK-GENERIC: {"sym_name" = "name_preserve", "module_type" = !hw.modty<input preserve: i8>, "parameters" = []} : () -> ()
+// CHECK-GENERIC: {"sym_name" = "name_preserve", "module_type" = !hw.modty<input preserve : i8>, "parameters" = []} : () -> ()
 hw.module @name_preserve(in %preserve: i8) {
   hw.output
 }
 
-// CHECK: hw.module @more_attrs(in %preserve: i8) attributes {"foo"} {
-hw.module @more_attrs(in %preserve: i8) attributes {"foo"} {
+// CHECK: hw.module @more_attrs() attributes {"foo"} {
+// CHECK-GENERIC: }) {"sym_name" = "more_attrs", "module_type" = !hw.modty<>, "parameters" = [], "foo"} : () -> ()
+hw.module @more_attrs() attributes {"foo"} {
   hw.output
 }
 

--- a/tests/filecheck/dialects/hw/hw_module.mlir
+++ b/tests/filecheck/dialects/hw/hw_module.mlir
@@ -28,8 +28,8 @@ hw.module @custom_param<p1: i42, "p2 with wack name": i1>() {
 // CHECK-NEXT: hw.output
 // CHECK-NEXT: }
 // CHECK-GENERIC: "hw.module"() ({
-// CHECK-GENERIC:   "hw.output"() : () -> ()
-// CHECK-GENERIC: }) {"sym_name" = "wack name!!", "module_type" = !hw.modty<>, "parameters" = []} : () -> ()
+// CHECK-GENERIC-NEXT:   "hw.output"() : () -> ()
+// CHECK-GENERIC-NEXT: }) {"sym_name" = "wack name!!", "module_type" = !hw.modty<>, "parameters" = []} : () -> ()
 hw.module @"wack name!!"() {
   hw.output
 }

--- a/tests/filecheck/dialects/hw/hw_module.mlir
+++ b/tests/filecheck/dialects/hw/hw_module.mlir
@@ -34,6 +34,18 @@ hw.module @"wack name!!"() {
   hw.output
 }
 
+// CHECK: hw.module @name_preserve(in %preserve: i8)
+// CHECK-GENERIC: {"sym_name" = "name_preserve", "module_type" = !hw.modty<input preserve: i8>, "parameters" = []} : () -> ()
+hw.module @name_preserve(in %preserve: i8) {
+  hw.output
+}
+
+// CHECK: hw.module @more_attrs(in %preserve: i8) attributes {"foo"} {
+hw.module @more_attrs(in %preserve: i8) attributes {"foo"} {
+  hw.output
+}
+
+
 // Generic format input tests
 
 // CHECK: hw.module @generic_basic(in %{{[^ ]*}} a: i1, out nameOfPortInSV: i1, out "": i1, in %{{[^ ]*}} customName: i1, in %{{[^ ]*}} "very custom name": i32) {

--- a/tests/filecheck/dialects/hw/hw_ops.mlir
+++ b/tests/filecheck/dialects/hw/hw_ops.mlir
@@ -9,4 +9,6 @@
 
   "test.op"() { "test" = #hw<innerSym@sym> } : () -> ()
   // CHECK-NEXT:  "test.op"() {"test" = #hw<innerSym@sym>} : () -> ()
+
+  "test.op"() { "test" = #hw.direction<input> } : () -> ()
 }) : () -> ()

--- a/tests/filecheck/dialects/hw/invalid.mlir
+++ b/tests/filecheck/dialects/hw/invalid.mlir
@@ -29,3 +29,112 @@
 }) : () -> ()
 
 // CHECK:  Expected "public", "private", or "nested"
+
+// -----
+
+hw.module @bad_dir(hgry %a: i1) {
+  hw.output
+}
+
+// CHECK: invalid port direction
+
+// -----
+
+hw.module @bad_name(out 9auh: i1) {
+  %res = "test.op"() : () -> i1
+  hw.output %res : i1
+}
+
+// CHECK: expected identifier or string literal as port name
+
+// -----
+
+hw.module @bad_param<9: i1>() {
+  hw.output
+}
+
+// CHECK: expected parameter name
+
+// -----
+
+hw.module @default_values_not_supported<param: i1 = 0>() {
+  hw.output
+}
+
+// CHECK: default values for parameters are not yet supported
+
+// -----
+
+hw.module @parameter_not_of_type<param: "foo">() {
+  hw.output
+}
+
+// CHECK: expected type attribute for parameter
+
+// -----
+
+hw.module @double_param<param: i1, param: i1>() {
+  hw.output
+}
+
+// CHECK: module has two parameters of same name
+
+// -----
+
+"builtin.module"() ({
+  "hw.module"() ({
+  ^0:
+    "hw.output"() : () -> ()
+  }) {"sym_name" = "too_few_args", "module_type" = !hw.modty<input a : i32>, "parameters" = []} : () -> ()
+}) : () -> ()
+
+// CHECK: missing block arguments in module block
+
+// -----
+
+"builtin.module"() ({
+  "hw.module"() ({
+  ^0(%a: i32, %b: i32):
+    "hw.output"() : () -> ()
+  }) {"sym_name" = "too_many_args", "module_type" = !hw.modty<input a : i32>, "parameters" = []} : () -> ()
+}) : () -> ()
+
+// CHECK: too many block arguments in module block
+
+// -----
+
+"builtin.module"() ({
+  "hw.module"() ({
+  ^0(%a: i8):
+    "hw.output"() : () -> ()
+  }) {"sym_name" = "wrong_arg", "module_type" = !hw.modty<input a : i32>, "parameters" = []} : () -> ()
+}) : () -> ()
+
+// CHECK: input-like port #0 has inconsistent type with its matching module block argument (expected i32, block argument is of type i8)
+
+// -----
+
+"builtin.module"() ({
+  "hw.module"() ({
+    "hw.output"() : () -> ()
+  }) {"sym_name" = "bad_port_name", "module_type" = !hw.modty<output 9foo : i32>, "parameters" = []} : () -> ()
+}) : () -> ()
+
+// CHECK: expected port name as identifier or string litteral
+
+// -----
+
+hw.module @wrong_amount_output(out foo : i8) {
+  hw.output
+}
+
+// CHECK: wrong amount of output values (expected 1, got 0)
+
+// -----
+
+hw.module @bad_output_type(out foo : i8, out bar : i32) {
+  %res = arith.constant 0 : i32
+  hw.output %res, %res : i32, i32
+}
+
+// CHECK: output #0 is of unexpected type (expected i8, got i32)

--- a/tests/filecheck/dialects/hw/invalid.mlir
+++ b/tests/filecheck/dialects/hw/invalid.mlir
@@ -120,7 +120,7 @@ hw.module @double_param<param: i1, param: i1>() {
   }) {"sym_name" = "bad_port_name", "module_type" = !hw.modty<output 9foo : i32>, "parameters" = []} : () -> ()
 }) : () -> ()
 
-// CHECK: expected port name as identifier or string litteral
+// CHECK: expected port name as identifier or string literal
 
 // -----
 

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -780,7 +780,13 @@ class ModuleOp(IRDLOperation):
 
         printer.print_list(self.module_type.ports.data, print_port)
 
-        printer.print(") ")
+        printer.print(")")
+        printer.print_op_attributes(
+            self.attributes,
+            reserved_attr_names=_MODULE_OP_ATTRS_HANDLED_BY_CUSTOM_FORMAT,
+            print_keyword=True,
+        )
+        printer.print(" ")
         printer.print_region(self.body, print_entry_block_args=False)
 
 
@@ -807,13 +813,13 @@ class OutputOp(IRDLOperation):
 
         if len(expected_results) != len(self.inputs):
             raise VerifyException(
-                f"module expected {len(expected_results)} outputs, got {len(self.inputs)}"
+                f"wrong amount of output values (expected {len(expected_results)}, got {len(self.inputs)})"
             )
 
         for i, (got, expected) in enumerate(zip(self.inputs, expected_results)):
             if got.type != expected:
                 raise VerifyException(
-                    f"output {i} is of unexpected type: expected {expected}, got {got.type}"
+                    f"output #{i} is of unexpected type (expected {expected}, got {got.type})"
                 )
 
     @classmethod

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -624,6 +624,7 @@ class HWModuleOp(IRDLOperation):
 
     body: SingleBlockRegion = region_def("single_block")
 
+    # TODO: add InnerSymbolTableTrait (https://github.com/xdslproject/xdsl/issues/2402)
     traits = traits_def(
         lambda: frozenset(
             (

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -1,6 +1,6 @@
 """
 This is a stub of CIRCT’s hw dialect.
-Up to date as of commit `TODO`
+Follows definitions as of CIRCT commit `f8c7faec1e8447521a1ea9a0836b6923a132c79e`.
 
 [1] https://circt.llvm.org/docs/Dialects/HW/
 [2] https://circt.llvm.org/docs/RationaleSymbols/

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -43,7 +43,6 @@ from xdsl.dialects.builtin import (
     Signedness,
     StridedLayoutAttr,
     StringAttr,
-    SymbolNameAttr,
     SymbolRefAttr,
     TensorType,
     UnitAttr,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -43,6 +43,7 @@ from xdsl.dialects.builtin import (
     Signedness,
     StridedLayoutAttr,
     StringAttr,
+    SymbolNameAttr,
     SymbolRefAttr,
     TensorType,
     UnitAttr,


### PR DESCRIPTION
This PR introduces the `hw.module` and its companion `hw.output` from CIRCT, while adding various small enhancements to the general infrastructure to accommodate them. ModuleOps are used to specify self-contained hardware modules, akin to functions in software.

A `hw.module` looks like the following:
```
hw.module @name<param1: i1, param2: i2>(in %a: i8, in %b: i9, out c: i8) {
  %res = arith.constant 0 : i8
  hw.output %res : i8
}
```
While hardware modules have similar semantics to functions, both inputs and outputs in `hw.module` are defined within the parenthesis, as *ports*. This is because some ports may be both input and output in CIRCT (currently not supported). Modules can optionally receive static parameters (in the example, `param1` and `param2`). Those are akin to C++ value templates or Rust const generics, and are useful to factor similar modules together.

`DirectionAttr`, `ModulePort` and `ModuleType` are defined to represent the type of a module and its ports. `ParamDeclAttr` is an attribute to represent the parameter definitions on the module.

The `hw.output` operation is the terminator for `hw.module`, setting the value of the output ports.

cc @superlopuh @math-fehr 