### PR TITLE
core: Fix printing of non-identifier symbols

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     FunctionType,
     IntAttr,
     IntegerType,
+    SymbolRefAttr,
     UnitAttr,
     i32,
 )
@@ -787,3 +788,23 @@ def test_print_properties_as_attributes_safeguard():
         match="Properties sym_name would overwrite the attributes of the same names.",
     ):
         assert_print_op(parsed, retro_prog, None, print_properties_as_attributes=True)
+
+
+@pytest.mark.parametrize(
+    "attr,expected",
+    [
+        (SymbolRefAttr("foo"), "@foo"),
+        (SymbolRefAttr("weird name!!"), '@"weird name!!"'),
+        (
+            SymbolRefAttr("weird nested", ["yes", "very nested"]),
+            '@"weird nested"::@yes::@"very nested"',
+        ),
+    ],
+)
+def test_symbol_ref(attr: SymbolRefAttr, expected: str):
+    ctx = MLContext()
+    ctx.load_dialect(Builtin)
+
+    printed = StringIO()
+    Printer(printed).print_attribute(attr)
+    assert printed.getvalue() == expected

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -67,6 +67,7 @@ from xdsl.ir import (
 )
 from xdsl.traits import IsTerminator
 from xdsl.utils.diagnostic import Diagnostic
+from xdsl.utils.lexer import Lexer
 
 indentNumSpaces = 2
 
@@ -357,6 +358,16 @@ class Printer:
     def print_string_literal(self, string: str):
         self.print(json.dumps(string))
 
+    def print_identifier_or_string_literal(self, string: str):
+        """
+        Prints the provided string as an identifier if it is one,
+        and as a string literal otherwise.
+        """
+        if Lexer.bare_identifier_regex.fullmatch(string) is None:
+            self.print_string_literal(string)
+            return
+        self.print(string)
+
     def print_bytes_literal(self, bytestring: bytes):
         self.print('"')
         for byte in bytestring:
@@ -415,9 +426,11 @@ class Printer:
             return
 
         if isinstance(attribute, SymbolRefAttr):
-            self.print(f"@{attribute.root_reference.data}")
+            self.print("@")
+            self.print_identifier_or_string_literal(attribute.root_reference.data)
             for ref in attribute.nested_references.data:
-                self.print(f"::@{ref.data}")
+                self.print("::@")
+                self.print_identifier_or_string_literal(ref.data)
             return
 
         if isinstance(attribute, IntegerAttr):

--- a/xdsl/utils/lexer.py
+++ b/xdsl/utils/lexer.py
@@ -506,7 +506,9 @@ class Lexer:
             f"Unexpected character: {current_char}",
         )
 
-    bare_identifier_suffix_regex = re.compile(r"[a-zA-Z0-9_$.]*")
+    IDENTIFIER_SUFFIX = r"[a-zA-Z0-9_$.]*"
+    bare_identifier_regex = re.compile(r"[a-zA-Z_]" + IDENTIFIER_SUFFIX)
+    bare_identifier_suffix_regex = re.compile(IDENTIFIER_SUFFIX)
 
     def _lex_bare_identifier(self, start_pos: Position) -> Token:
         """


### PR DESCRIPTION
Symbol names are not required to be identifiers, and in that case they should be printed as `@"non-identifier name"`, but xDSL would print them as `@non-identifier name`. This PR fixes this behavior.