### PR TITLE
core: Make print_ssa_value return chosen name

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -42,6 +42,7 @@ from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.utils.diagnostic import Diagnostic
 from xdsl.utils.exceptions import DiagnosticException, ParseError
+from xdsl.utils.test_value import TestSSAValue
 
 
 def test_simple_forgotten_op():
@@ -787,3 +788,28 @@ def test_print_properties_as_attributes_safeguard():
         match="Properties sym_name would overwrite the attributes of the same names.",
     ):
         assert_print_op(parsed, retro_prog, None, print_properties_as_attributes=True)
+
+
+def test_get_printed_name():
+    ctx = MLContext()
+    ctx.load_dialect(Builtin)
+
+    printer = Printer()
+    val = TestSSAValue(i32)
+
+    # Test printing without constraints
+    printer.stream = StringIO()
+    picked_name = printer.print_ssa_value(val)
+    assert f"%{picked_name}" == printer.stream.getvalue()
+
+    # Test printing when name has already been picked
+    printer.stream = StringIO()
+    picked_name = printer.print_ssa_value(val)
+    assert f"%{picked_name}" == printer.stream.getvalue()
+
+    # Test printing with name hint
+    val = TestSSAValue(i32)
+    val.name_hint = "foo"
+    printed = StringIO()
+    picked_name = Printer(printed).print_ssa_value(val)
+    assert f"%{picked_name}" == printed.getvalue()

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -176,7 +176,7 @@ class Printer:
     V = TypeVar("V")
 
     def print_list(
-        self, elems: Iterable[T], print_fn: Callable[[T], None], delimiter: str = ", "
+        self, elems: Iterable[T], print_fn: Callable[[T], Any], delimiter: str = ", "
     ) -> None:
         for i, elem in enumerate(elems):
             if i:
@@ -226,12 +226,14 @@ class Printer:
         self.print_list(op.results, self.print)
         self.print(" = ")
 
-    def print_ssa_value(self, value: SSAValue) -> None:
+    def print_ssa_value(self, value: SSAValue) -> str:
         """
         Print an SSA value in the printer. This assigns a name to the value if the value
         does not have one in the current printing context.
         If the value has a name hint, it will use it as a prefix, and otherwise assign
         a number as the name. Numbers are assigned in order.
+
+        Returns the name used for printing the value.
         """
         if value in self._ssa_values:
             name = self._ssa_values[value]
@@ -246,6 +248,7 @@ class Printer:
             self._ssa_values[value] = name
 
         self.print(f"%{name}")
+        return name
 
     def print_operand(self, operand: SSAValue) -> None:
         self.print_ssa_value(operand)


### PR DESCRIPTION
Sometimes it is useful to know when printing what name has been chosen to print an SSA value (for example when SSA value names should map to names in an interface like in CIRCT's hardware modules). This PR introduces this feature to the printer. This also adjusts the type bounds on `print_list` so it remains happy with having `print_ssa_value` as its argument.