### PR TITLE
core: Make location parsing public

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -851,5 +851,5 @@ def test_properties_retrocompatibility():
 
 def test_parse_location():
     ctx = MLContext()
-    attr = Parser(ctx, "loc(unknown)").parse_attribute()
+    attr = Parser(ctx, "loc(unknown)").parse_optional_location()
     assert attr == LocationAttr()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,6 +10,7 @@ from xdsl.dialects.builtin import (
     IntAttr,
     IntegerAttr,
     IntegerType,
+    LocationAttr,
     StringAttr,
     SymbolRefAttr,
     i32,
@@ -846,3 +847,9 @@ def test_properties_retrocompatibility():
         VerifyException, match="Operation does not verify: property second expected"
     ):
         wrong_op.verify()
+
+
+def test_parse_location():
+    ctx = MLContext()
+    attr = Parser(ctx, "loc(unknown)").parse_attribute()
+    assert attr == LocationAttr()

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -606,7 +606,7 @@ class AttrParser(BaseParser):
             self.parse_optional_builtin_int_or_float_attr,
             self._parse_optional_array_attr,
             self._parse_optional_symref_attr,
-            self._parse_optional_location,
+            self.parse_optional_location,
             self._parse_optional_builtin_dict_attr,
             self.parse_optional_type,
             self._parse_optional_builtin_parametrized_attr,
@@ -1079,7 +1079,7 @@ class AttrParser(BaseParser):
 
         return SymbolRefAttr(sym_root, ArrayAttr(refs))
 
-    def _parse_optional_location(self) -> LocationAttr | None:
+    def parse_optional_location(self) -> LocationAttr | None:
         """
         Parse a location attribute, if present.
           location ::= `loc` `(` `unknown` `)`

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -200,7 +200,7 @@ class Parser(AttrParser):
             ).span
             self.parse_punctuation(":")
             arg_type = self.parse_attribute()
-            self._parse_optional_location()
+            self.parse_optional_location()
 
             # Insert the block argument in the block, and register it in the parser
             block_arg = block.insert_arg(arg_type, len(block.args))
@@ -866,7 +866,7 @@ class Parser(AttrParser):
         # Parse function type
         func_type = self.parse_function_type()
 
-        self._parse_optional_location()
+        self.parse_optional_location()
 
         operands = self.resolve_operands(args, func_type.inputs.data, func_type_pos)
 


### PR DESCRIPTION
For some reason when I added location parsing I made it protected. This PR makes it public.