### PR TITLE
rewriting: Fix TypeConversionPattern recursive support for DictionaryAttr

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1576,6 +1576,34 @@ def test_type_conversion():
         op_modified=1,
     )
 
+    prog = """\
+"builtin.module"() ({
+  "test.op"() {"dict_nest" = {"hello" = i32}} : () -> ()
+}) : () -> ()
+"""
+
+    expected_recursive = """
+"builtin.module"() ({
+  "test.op"() {"dict_nest" = {"hello" = index}} : () -> ()
+}) : () -> ()
+"""
+
+    rewrite_and_compare(
+        prog,
+        prog,
+        PatternRewriteWalker(RewriteMaybe(recursive=False)),
+        expect_rewrite=False,
+    )
+
+    rewrite_and_compare(
+        prog,
+        expected_recursive,
+        PatternRewriteWalker(RewriteMaybe(recursive=True)),
+        op_inserted=1,
+        op_removed=1,
+        op_replaced=1,
+    )
+
 
 def test_no_change():
     """Test that doing nothing successfully does not report doing something."""

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1591,14 +1591,14 @@ def test_type_conversion():
     rewrite_and_compare(
         prog,
         prog,
-        PatternRewriteWalker(RewriteMaybe(recursive=False)),
+        PatternRewriteWalker(Rewrite(recursive=False)),
         expect_rewrite=False,
     )
 
     rewrite_and_compare(
         prog,
         expected_recursive,
-        PatternRewriteWalker(RewriteMaybe(recursive=True)),
+        PatternRewriteWalker(Rewrite(recursive=True)),
         op_inserted=1,
         op_removed=1,
         op_replaced=1,

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -9,7 +9,7 @@ from types import UnionType
 from typing import TypeVar, Union, final, get_args, get_origin
 
 from xdsl.builder import BuilderListener, InsertPoint
-from xdsl.dialects.builtin import ArrayAttr, ModuleOp
+from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, ModuleOp
 from xdsl.ir import (
     Attribute,
     Block,
@@ -440,6 +440,9 @@ class TypeConversionPattern(RewritePattern):
                 inp = type(typ).new(parameters)
             if isa(typ, ArrayAttr[Attribute]):
                 parameters = tuple(self._convert_type_rec(p) or p for p in typ)
+                inp = type(typ).new(parameters)
+            if isa(typ, DictionaryAttr):
+                parameters = {k: self._convert_type_rec(v) for k, v in typ.data.items()}
                 inp = type(typ).new(parameters)
         converted = self.convert_type(inp)
         return converted if converted is not None else inp


### PR DESCRIPTION
The documentation of `TypeConversionPattern` claims it supports attribute dictionaries, but does not walk them recursively. This PR fixes this behavior.