### PR TITLE
dialects: (x86) PR3 - Assembly emission

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -1,0 +1,7 @@
+// RUN: xdsl-opt -t x86-asm %s | filecheck %s
+
+%0 = x86.get_register : () -> !x86.reg<rax>
+%1 = x86.get_register : () -> !x86.reg<rdx>
+
+%add = x86.add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+// CHECK: add rax, rdx

--- a/xdsl/dialects/x86/__init__.py
+++ b/xdsl/dialects/x86/__init__.py
@@ -1,12 +1,13 @@
 from xdsl.ir import Dialect
 
-from .ops import AddOp
+from .ops import AddOp, GetRegisterOp
 from .register import GeneralRegisterType
 
 X86 = Dialect(
     "x86",
     [
         AddOp,
+        GetRegisterOp,
     ],
     [
         GeneralRegisterType,

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
-from typing import Generic, TypeAlias, TypeVar
+from io import StringIO
+from typing import IO, Generic, TypeAlias, TypeVar
 
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
+    ModuleOp,
     StringAttr,
 )
 from xdsl.ir import (
@@ -19,10 +21,12 @@ from xdsl.irdl import (
     IRDLOperation,
     irdl_op_definition,
     operand_def,
+    opt_attr_def,
     result_def,
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.hints import isa
 
 from .register import GeneralRegisterType, X86RegisterType
 
@@ -34,6 +38,10 @@ class X86Op(Operation, ABC):
     """
     Base class for operations that can be a part of x86 assembly printing.
     """
+
+    @abstractmethod
+    def assembly_line(self) -> str | None:
+        raise NotImplementedError()
 
     @classmethod
     def parse(cls, parser: Parser) -> Self:
@@ -121,6 +129,36 @@ class X86Instruction(X86Op):
     The name of the operation will be used as the x86 assembly instruction name.
     """
 
+    comment: StringAttr | None = opt_attr_def(StringAttr)
+    """
+    An optional comment that will be printed along with the instruction.
+    """
+
+    @abstractmethod
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        """
+        The arguments to the instruction, in the order they should be printed in the
+        assembly.
+        """
+        raise NotImplementedError()
+
+    def assembly_instruction_name(self) -> str:
+        """
+        By default, the name of the instruction is the same as the name of the operation.
+        """
+
+        return self.name.split(".", 1)[-1]
+
+    def assembly_line(self) -> str | None:
+        # default assembly code generator
+        instruction_name = self.assembly_instruction_name()
+        arg_str = ", ".join(
+            _assembly_arg_str(arg)
+            for arg in self.assembly_line_args()
+            if arg is not None
+        )
+        return _assembly_line(instruction_name, arg_str, self.comment)
+
 
 class DoubleOperandInstruction(IRDLOperation, X86Instruction, ABC):
     """
@@ -157,6 +195,9 @@ class RROperation(Generic[R1InvT, R2InvT], DoubleOperandInstruction):
             result_types=[result],
         )
 
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return self.r1, self.r2
+
 
 @irdl_op_definition
 class AddOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
@@ -167,3 +208,58 @@ class AddOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
     """
 
     name = "x86.add"
+
+
+# region Assembly printing
+def _append_comment(line: str, comment: StringAttr | None) -> str:
+    if comment is None:
+        return line
+
+    padding = " " * max(0, 48 - len(line))
+
+    return f"{line}{padding} # {comment.data}"
+
+
+def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
+    if isa(arg, AnyIntegerAttr):
+        return f"{arg.value.data}"
+    elif isinstance(arg, int):
+        return f"{arg}"
+    elif isinstance(arg, str):
+        return arg
+    elif isinstance(arg, GeneralRegisterType):
+        return arg.register_name
+    else:
+        if isinstance(arg.type, GeneralRegisterType):
+            reg = arg.type.register_name
+            return reg
+        else:
+            assert False, f"{arg.type}"
+
+
+def _assembly_line(
+    name: str,
+    arg_str: str,
+    comment: StringAttr | None = None,
+    is_indented: bool = True,
+) -> str:
+    code = "    " if is_indented else ""
+    code += name
+    if arg_str:
+        code += f" {arg_str}"
+    code = _append_comment(code, comment)
+    return code
+
+
+def print_assembly(module: ModuleOp, output: IO[str]) -> None:
+    for op in module.body.walk():
+        assert isinstance(op, X86Op), f"{op}"
+        asm = op.assembly_line()
+        if asm is not None:
+            print(asm, file=output)
+
+
+def x86_code(module: ModuleOp) -> str:
+    stream = StringIO()
+    print_assembly(module, stream)
+    return stream.getvalue()

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -265,6 +265,9 @@ def x86_code(module: ModuleOp) -> str:
     return stream.getvalue()
 
 
+# endregion
+
+
 class GetAnyRegisterOperation(Generic[R1InvT], IRDLOperation, X86Op):
     """
     This instruction allows us to create an SSAValue for a given register name.

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -263,3 +263,25 @@ def x86_code(module: ModuleOp) -> str:
     stream = StringIO()
     print_assembly(module, stream)
     return stream.getvalue()
+
+
+class GetAnyRegisterOperation(Generic[R1InvT], IRDLOperation, X86Op):
+    """
+    This instruction allows us to create an SSAValue for a given register name.
+    """
+
+    result = result_def(R1InvT)
+
+    def __init__(
+        self,
+        register_type: R1InvT,
+    ):
+        super().__init__(result_types=[register_type])
+
+    def assembly_line(self) -> str | None:
+        return None
+
+
+@irdl_op_definition
+class GetRegisterOp(GetAnyRegisterOperation[GeneralRegisterType]):
+    name = "x86.get_register"

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -6,8 +6,8 @@ from importlib.metadata import version
 from io import StringIO
 from typing import IO
 
+from xdsl.dialects import riscv, x86
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.dialects.riscv import print_assembly, riscv_code
 from xdsl.ir import MLContext
 from xdsl.passes import ModulePass, PipelinePass
 from xdsl.printer import Printer
@@ -201,7 +201,10 @@ class xDSLOptMain(CommandLineTool):
             print("\n", file=output)
 
         def _output_riscv_asm(prog: ModuleOp, output: IO[str]):
-            print_assembly(prog, output)
+            riscv.print_assembly(prog, output)
+
+        def _output_x86_asm(prog: ModuleOp, output: IO[str]):
+            x86.ops.print_assembly(prog, output)
 
         def _emulate_riscv(prog: ModuleOp, output: IO[str]):
             # import only if running riscv emulation
@@ -211,12 +214,13 @@ class xDSLOptMain(CommandLineTool):
                 print("Please install optional dependencies to run riscv emulation")
                 return
 
-            code = riscv_code(prog)
+            code = riscv.riscv_code(prog)
             with redirect_stdout(output):
                 run_riscv(code, unlimited_regs=True, verbosity=0)
 
         self.available_targets["mlir"] = _output_mlir
         self.available_targets["riscv-asm"] = _output_riscv_asm
+        self.available_targets["x86-asm"] = _output_x86_asm
         self.available_targets["riscemu"] = _emulate_riscv
 
     def setup_pipeline(self):


### PR DESCRIPTION
I've re-added the printing functionality with a filecheck to test it. I have temporarily brought back the get_register method to get the PR out, so please let me know what's the better way to do it. test.op no longer works when a particular register needs to be specified (it fails an assertion error during the printing). Riscv did it by starting off with operations that don't need register arguments, but I don't have those yet. 

