### PR TITLE
transformations: (test-lower-snitch-stream-to-asm) remove riscv-cse

### DIFF
--- a/xdsl/transforms/test_lower_snitch_stream_to_asm.py
+++ b/xdsl/transforms/test_lower_snitch_stream_to_asm.py
@@ -10,7 +10,6 @@ from xdsl.passes import ModulePass, PipelinePass
 from xdsl.transforms.canonicalize import CanonicalizePass
 from xdsl.transforms.convert_riscv_scf_for_to_frep import ConvertRiscvScfForToFrepPass
 from xdsl.transforms.lower_snitch import LowerSnitchPass
-from xdsl.transforms.riscv_cse import RiscvCommonSubexpressionElimination
 from xdsl.transforms.riscv_register_allocation import RISCVRegisterAllocation
 from xdsl.transforms.riscv_scf_loop_range_folding import RiscvScfLoopRangeFoldingPass
 from xdsl.transforms.snitch_register_allocation import SnitchRegisterAllocation
@@ -27,7 +26,6 @@ class TestLowerSnitchStreamToAsm(ModulePass):
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PipelinePass(
             (
-                RiscvCommonSubexpressionElimination(),
                 ConvertRiscvScfForToFrepPass(),
                 SnitchRegisterAllocation(),
                 ConvertSnitchStreamToSnitch(),


### PR DESCRIPTION
riscv-cse is currently buggy, this removes it from the pipeline until the bugs get fixed

#2384 