### PR TITLE
dialects: (linalg) add attributes to linalg.pooling_nchw_max and base class for pooling ops 

### DIFF
--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -677,6 +677,8 @@ class MaxPoolOp(IRDLOperation):
 
     def __init__(
         self,
+        dilations: Attribute,
+        strides: Attribute,
         inputs: Sequence[SSAValue],
         outputs: Sequence[SSAValue] = (),
         res: Sequence[Attribute] | None = None,
@@ -686,6 +688,10 @@ class MaxPoolOp(IRDLOperation):
         else:
             result_types = res
         super().__init__(
+            attributes={
+                "dilations": dilations,
+                "strides": strides,
+            },
             operands=(inputs, outputs),
             result_types=result_types,
         )

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -691,7 +691,7 @@ class PoolingOpsBase(IRDLOperation, ABC):
 
 
 @irdl_op_definition
-class PoolingNCHWMaxOp(PoolingOpsBase):
+class PoolingNchwMaxOp(PoolingOpsBase):
     """
     Performs max pooling
 
@@ -711,7 +711,7 @@ Linalg = Dialect(
         MulOp,
         TransposeOp,
         MatmulOp,
-        PoolingNCHWMaxOp,
+        PoolingNchwMaxOp,
     ],
     [
         IteratorTypeAttr,

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC
 from collections.abc import Sequence
 from enum import auto
 from typing import cast
@@ -649,16 +650,8 @@ class MatmulOp(IRDLOperation):
         )
 
 
-@irdl_op_definition
-class MaxPoolOp(IRDLOperation):
-    """
-    Performs max pooling
-
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgpooling_nchw_max-linalgpoolingnchwmaxop
-
-    """
-
-    name = "linalg.pooling_nchw_max"
+class PoolingOpsBase(IRDLOperation, ABC):
+    """Base class for linalg pooling operations."""
 
     inputs = var_operand_def()
     outputs = var_operand_def(AnyShapedType())
@@ -697,6 +690,16 @@ class MaxPoolOp(IRDLOperation):
         )
 
 
+@irdl_op_definition
+class PoolingNCHWMaxOp(PoolingOpsBase):
+    """
+    Performs max pooling
+    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgpooling_nchw_max-linalgpoolingnchwmaxop
+    """
+
+    name = "linalg.pooling_nchw_max"
+
+
 Linalg = Dialect(
     "linalg",
     [
@@ -707,7 +710,7 @@ Linalg = Dialect(
         MulOp,
         TransposeOp,
         MatmulOp,
-        MaxPoolOp,
+        PoolingNCHWMaxOp,
     ],
     [
         IteratorTypeAttr,

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -694,6 +694,7 @@ class PoolingOpsBase(IRDLOperation, ABC):
 class PoolingNCHWMaxOp(PoolingOpsBase):
     """
     Performs max pooling
+
     See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgpooling_nchw_max-linalgpoolingnchwmaxop
     """
 


### PR DESCRIPTION
This PR adds the key attributes `dilations` and `strides` to the `init`, which was omitted, and also we make an abstract superclass so we can subclass per permutation when adding future pooling operations 