### PR TITLE
dialects: (linalg) add linalg.conv_2d_nchw_fchw

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -39,11 +39,11 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
     ins(%10, %11: tensor<1x1x4x4xf32>, tensor<3x3xf32>)
     outs(%12: tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
 
-%13, %14, %15, %16 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
+%13, %14, %15, %16 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>, tensor<1x1x3x3xf32>)
 
 %conv_2d_nchw = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
-            ins(%13, %14: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>)
-            outs(%15: tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+            ins(%13, %14, %15: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>)
+            outs(%16: tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 
 %sum_2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) {
 ^bb0(%in: f32, %in_0: f32, %out: f32):
@@ -77,8 +77,8 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
 // CHECK-NEXT:    %8 = linalg.matmul ins(%6#0, %6#1 : tensor<64x9216xf32>, tensor<9216x4096xf32>) outs(%7 : tensor<64x4096xf32>) -> tensor<64x4096xf32>
 // CHECK-NEXT:    %9:3 = "test.op"() : () -> (tensor<1x1x4x4xf32>, tensor<3x3xf32>, tensor<1x1x2x2xf32>)
 // CHECK-NEXT:    %10 = linalg.pooling_nchw_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%9#0, %9#1 : tensor<1x1x4x4xf32>, tensor<3x3xf32>) outs(%9#2 : tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
-// CHECK-NEXT:    %11:4 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
-// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1, %11#2 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) outs(%11#3 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-NEXT:    %11:4 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>, tensor<1x1x3x3xf32>)
+// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1, %11#2 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>) outs(%11#3 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 // CHECK-NEXT:    %{{.*}} = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %{{.*}} = arith.addf %in, %in_0 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -39,11 +39,11 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
     ins(%10, %11: tensor<1x1x4x4xf32>, tensor<3x3xf32>)
     outs(%12: tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
 
-%13, %14, %15, %16 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>, tensor<1x1x3x3xf32>)
+%13, %14, %15 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<1x1x3x3xf32>)
 
 %conv_2d_nchw = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
-            ins(%13, %14, %15: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>)
-            outs(%16: tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+            ins(%13, %14: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>)
+            outs(%15: tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 
 %sum_2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) {
 ^bb0(%in: f32, %in_0: f32, %out: f32):
@@ -77,8 +77,8 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
 // CHECK-NEXT:    %8 = linalg.matmul ins(%6#0, %6#1 : tensor<64x9216xf32>, tensor<9216x4096xf32>) outs(%7 : tensor<64x4096xf32>) -> tensor<64x4096xf32>
 // CHECK-NEXT:    %9:3 = "test.op"() : () -> (tensor<1x1x4x4xf32>, tensor<3x3xf32>, tensor<1x1x2x2xf32>)
 // CHECK-NEXT:    %10 = linalg.pooling_nchw_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%9#0, %9#1 : tensor<1x1x4x4xf32>, tensor<3x3xf32>) outs(%9#2 : tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
-// CHECK-NEXT:    %11:4 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>, tensor<1x1x3x3xf32>)
-// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1, %11#2 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<0xf32>) outs(%11#3 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-NEXT:    %11:3 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<1x1x3x3xf32>)
+// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>) outs(%11#2 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 // CHECK-NEXT:    %{{.*}} = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %{{.*}} = arith.addf %in, %in_0 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -39,11 +39,11 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
     ins(%10, %11: tensor<1x1x4x4xf32>, tensor<3x3xf32>)
     outs(%12: tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
 
-%13, %14, %15, %16 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
+%13, %14, %15 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<1x1x3x3xf32>)
 
 %conv_2d_nchw = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
-            ins(%13, %14, %15: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none)
-            outs(%16: tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+            ins(%13, %14: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>)
+            outs(%15: tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 
 %sum_2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) {
 ^bb0(%in: f32, %in_0: f32, %out: f32):
@@ -77,8 +77,8 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
 // CHECK-NEXT:    %8 = linalg.matmul ins(%6#0, %6#1 : tensor<64x9216xf32>, tensor<9216x4096xf32>) outs(%7 : tensor<64x4096xf32>) -> tensor<64x4096xf32>
 // CHECK-NEXT:    %9:3 = "test.op"() : () -> (tensor<1x1x4x4xf32>, tensor<3x3xf32>, tensor<1x1x2x2xf32>)
 // CHECK-NEXT:    %10 = linalg.pooling_nchw_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%9#0, %9#1 : tensor<1x1x4x4xf32>, tensor<3x3xf32>) outs(%9#2 : tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
-// CHECK-NEXT:    %11:4 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
-// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw  {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1, %11#2 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) outs(%11#3 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-NEXT:    %11:3 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<1x1x3x3xf32>)
+// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw  {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>) outs(%11#2 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 // CHECK-NEXT:    %{{.*}} = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %{{.*}} = arith.addf %in, %in_0 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -39,7 +39,7 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
     ins(%10, %11: tensor<1x1x4x4xf32>, tensor<3x3xf32>)
     outs(%12: tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
 
-%13, %14, %15 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<1x1x3x3xf32>)
+%13, %14, %15, %16 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
 
 %conv_2d_nchw = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
             ins(%13, %14: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>)
@@ -77,8 +77,8 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
 // CHECK-NEXT:    %8 = linalg.matmul ins(%6#0, %6#1 : tensor<64x9216xf32>, tensor<9216x4096xf32>) outs(%7 : tensor<64x4096xf32>) -> tensor<64x4096xf32>
 // CHECK-NEXT:    %9:3 = "test.op"() : () -> (tensor<1x1x4x4xf32>, tensor<3x3xf32>, tensor<1x1x2x2xf32>)
 // CHECK-NEXT:    %10 = linalg.pooling_nchw_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%9#0, %9#1 : tensor<1x1x4x4xf32>, tensor<3x3xf32>) outs(%9#2 : tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
-// CHECK-NEXT:    %11:3 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<1x1x3x3xf32>)
-// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>) outs(%11#2 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-NEXT:    %11:4 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
+// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1, %11#2 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) outs(%11#3 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 // CHECK-NEXT:    %{{.*}} = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %{{.*}} = arith.addf %in, %in_0 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -78,7 +78,7 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
 // CHECK-NEXT:    %9:3 = "test.op"() : () -> (tensor<1x1x4x4xf32>, tensor<3x3xf32>, tensor<1x1x2x2xf32>)
 // CHECK-NEXT:    %10 = linalg.pooling_nchw_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%9#0, %9#1 : tensor<1x1x4x4xf32>, tensor<3x3xf32>) outs(%9#2 : tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
 // CHECK-NEXT:    %11:3 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, tensor<1x1x3x3xf32>)
-// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw  {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>) outs(%11#2 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>) outs(%11#2 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 // CHECK-NEXT:    %{{.*}} = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %{{.*}} = arith.addf %in, %in_0 : f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -39,6 +39,12 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
     ins(%10, %11: tensor<1x1x4x4xf32>, tensor<3x3xf32>)
     outs(%12: tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
 
+%13, %14, %15, %16 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
+
+%conv_2d_nchw = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+            ins(%13, %14, %15: tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none)
+            outs(%16: tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+
 %sum_2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %2 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%2 : tensor<2x3xf32>) {
 ^bb0(%in: f32, %in_0: f32, %out: f32):
     %acc = arith.addf %in, %in_0 : f32
@@ -71,6 +77,8 @@ linalg.fill ins(%4 : f32) outs(%1 : memref<1x256xf32>)
 // CHECK-NEXT:    %8 = linalg.matmul ins(%6#0, %6#1 : tensor<64x9216xf32>, tensor<9216x4096xf32>) outs(%7 : tensor<64x4096xf32>) -> tensor<64x4096xf32>
 // CHECK-NEXT:    %9:3 = "test.op"() : () -> (tensor<1x1x4x4xf32>, tensor<3x3xf32>, tensor<1x1x2x2xf32>)
 // CHECK-NEXT:    %10 = linalg.pooling_nchw_max {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%9#0, %9#1 : tensor<1x1x4x4xf32>, tensor<3x3xf32>) outs(%9#2 : tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
+// CHECK-NEXT:    %11:4 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none, tensor<1x1x3x3xf32>)
+// CHECK-NEXT:    %12 = linalg.conv_2d_nchw_fchw  {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%11#0, %11#1, %11#2 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) outs(%11#3 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 // CHECK-NEXT:    %{{.*}} = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1#0, %1#0 : tensor<2x3xf32>, tensor<2x3xf32>) outs(%1#0 : tensor<2x3xf32>) {
 // CHECK-NEXT:    ^bb0(%in: f32, %in_0: f32, %out: f32):
 // CHECK-NEXT:      %{{.*}} = arith.addf %in, %in_0 : f32


### PR DESCRIPTION
resolves #2399
edit:  linalg.conv_2d_nchw_fchw accepts 3 total args not 4, meaning that the bias matrix from onnx.conv can't be added during, i think a linalg.add op will be required for lowering in that case  