### PR TITLE
dialects: (builtin) Fix bound computation crash for i0

### DIFF
--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -35,6 +35,8 @@
     %x15 = "arith.constant"() {"value" = 0 : i64, "test" = loc(unknown)} : () -> i64
     // CHECK:  "test" = none
     %x16 = "arith.constant"() {"value" = 0 : i64, "test" = none} : () -> i64
+    // CHECK:  "test" = 0 : i0
+    %x17 = "arith.constant"() {"value" = 0 : i64, "test" = 0 : i0} : () -> i64
     "func.return"() : () -> ()
   }) {"function_type" = () -> (), "sym_name" = "builtin"} : () -> ()
   "test.op"() {"value"= {"one"=1 : i64, "two"=2 : i64, "three"="three"}} : () -> ()

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -312,10 +312,10 @@ class Signedness(Enum):
         """
         match self:
             case Signedness.SIGNLESS:
-                min_value = -(1 << (bitwidth - 1))
+                min_value = -((1 << bitwidth) >> 1)
                 max_value = 1 << bitwidth
             case Signedness.SIGNED:
-                min_value = -(1 << (bitwidth - 1))
+                min_value = -((1 << bitwidth) >> 1)
                 max_value = 1 << (bitwidth - 1)
             case Signedness.UNSIGNED:
                 min_value = 0


### PR DESCRIPTION
The previous logic to compute the lower signed bound for i0 integers attempted to compute `1 << -1` which Python does not like. This change translates the intuitive meaning of `1 << -1` into `1 >> 1` for the zero bitwidth case.