### PR TITLE
dialects: (seq) Add CompRegOp

### DIFF
--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -2,6 +2,13 @@
 
 builtin.module {
   %clk = "test.op"() : () -> (!seq.clock)
+  %data = "test.op"() : () -> i14
+  %bool = "test.op"() : () -> i1
+
   %div_clk = seq.clock_div %clk by 4
   // CHECK:      %div_clk = seq.clock_div %clk by 4
+  %compreg = seq.compreg %data, %clk : i14
+  // CHECK: %compreg = seq.compreg %data, %clk : i14
+  %compreg_reset = seq.compreg %data, %clk reset %bool, %data : i14
+  // CHECK: %compreg_reset = seq.compreg %data, %clk reset %bool, %data : i14
 }


### PR DESCRIPTION
This op allows modeling registers. This is for now a very basic implementation which only partially matches the CompRegOp upstream. But it should be enough for many practical uses already!