### PR TITLE
dialects: (hw) Add InnerRefNamespaceTrait to HWModuleOp

### DIFF
--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -120,12 +120,12 @@ def test_inner_symbol_table_interface():
     no_trait_circ = TestOp(regions=[[mod_no_trait_circ, OutputOp()]])
     with pytest.raises(
         VerifyException,
-        match="Operation module with trait InnerSymbolTableTrait must have a parent with trait InnerRefNamespaceTrait",
+        match="Operation module with trait InnerSymbolTableTrait must have a parent with trait InnerRefNamespaceLike",
     ):
         mod_no_trait_circ.verify()
     with pytest.raises(
         VerifyException,
-        match="Operation module with trait InnerSymbolTableTrait must have a parent with trait InnerRefNamespaceTrait",
+        match="Operation module with trait InnerSymbolTableTrait must have a parent with trait InnerRefNamespaceLike",
     ):
         no_trait_circ.verify()
 


### PR DESCRIPTION
This requires `InnerRefNamespaceLike`.
We use `abc.ABC` to reimplement the upstream mechanics of implementing this with `isa<InnerRefNamespaceLike>` and `InnerRefNamespaceLike::classof()`

Fixes #2402