### PR TITLE
core: Add optional attributes to declarative assembly format

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -390,6 +390,37 @@ def test_prop_name(program: str, generic_program: str):
     "program, generic_program",
     [
         (
+            "test.optional_property",
+            '"test.optional_property"() : () -> ()',
+        ),
+        (
+            "test.optional_property prop i32",
+            '"test.optional_property"() <{"prop" = i32}> : () -> ()',
+        ),
+    ],
+)
+def test_optional_property(program: str, generic_program: str):
+    """Test the parsing of optional operands"""
+
+    @irdl_op_definition
+    class OptionalPropertyOp(IRDLOperation):
+        name = "test.optional_property"
+        prop = opt_prop_def(Attribute)
+
+        assembly_format = "(`prop` $prop^)? attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(OptionalPropertyOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
             "test.optional_attribute",
             '"test.optional_attribute"() : () -> ()',
         ),

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -32,6 +32,7 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
+    opt_attr_def,
     opt_operand_def,
     opt_prop_def,
     opt_result_def,
@@ -383,6 +384,37 @@ def test_prop_name(program: str, generic_program: str):
 
     check_equivalence(program, generic_program, ctx)
     check_roundtrip(program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            "test.optional_attribute",
+            '"test.optional_attribute"() : () -> ()',
+        ),
+        (
+            "test.optional_attribute attr i32",
+            '"test.optional_attribute"() {"attr" = i32} : () -> ()',
+        ),
+    ],
+)
+def test_optional_attribute(program: str, generic_program: str):
+    """Test the parsing of optional operands"""
+
+    @irdl_op_definition
+    class OptionalAttributeOp(IRDLOperation):
+        name = "test.optional_attribute"
+        attr = opt_attr_def(Attribute)
+
+        assembly_format = "(`attr` $attr^)? attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(OptionalAttributeOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
 
 
 ################################################################################

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -721,6 +721,36 @@ class AttributeVariable(FormatDirective):
             printer.print_attribute(op.attributes[self.attr_name])
 
 
+class OptionalAttributeVariable(AttributeVariable, OptionalVariable):
+    """
+    An optional attribute variable, with the following format:
+      operand-directive ::= ( percent-ident )?
+    The directive will request a space to be printed after.
+    """
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        if attribute := parser.parse_optional_attribute():
+            if self.is_property:
+                state.properties[self.attr_name] = attribute
+            else:
+                state.attributes[self.attr_name] = attribute
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        if self.is_property:
+            attr = op.properties.get(self.attr_name)
+        else:
+            attr = op.attributes.get(self.attr_name)
+        if attr:
+            printer.print_attribute(attr)
+            state.should_emit_space = True
+            state.last_was_punctuation = False
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return getattr(op, self.attr_name) is not None
+
+
 @dataclass(frozen=True)
 class WhitespaceDirective(FormatDirective):
     """

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -18,6 +18,7 @@ from xdsl.irdl import (
     OptAttributeDef,
     OptionalDef,
     OptOperandDef,
+    OptPropertyDef,
     OptResultDef,
     ParsePropInAttrDict,
     VariadicDef,
@@ -359,8 +360,13 @@ class FormatParser(BaseParser):
                         )
                     self.seen_attributes.add(attr_name)
 
-            match self.op_def.attributes.get(attr_name):
-                case OptAttributeDef():
+            attr_def = (
+                self.op_def.properties.get(attr_name)
+                if attr_or_prop == "property"
+                else self.op_def.attributes.get(attr_name)
+            )
+            match attr_def:
+                case OptAttributeDef() | OptPropertyDef():
                     return OptionalAttributeVariable(
                         variable_name, attr_or_prop == "property"
                     )

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -15,6 +15,7 @@ from xdsl.ir import Attribute
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     OpDef,
+    OptAttributeDef,
     OptionalDef,
     OptOperandDef,
     OptResultDef,
@@ -33,6 +34,7 @@ from xdsl.irdl.declarative_assembly_format import (
     OperandOrResult,
     OperandTypeDirective,
     OperandVariable,
+    OptionalAttributeVariable,
     OptionalGroupDirective,
     OptionallyParsableDirective,
     OptionalOperandTypeDirective,
@@ -357,7 +359,13 @@ class FormatParser(BaseParser):
                         )
                     self.seen_attributes.add(attr_name)
 
-            return AttributeVariable(variable_name, attr_or_prop == "property")
+            match self.op_def.attributes.get(attr_name):
+                case OptAttributeDef():
+                    return OptionalAttributeVariable(
+                        variable_name, attr_or_prop == "property"
+                    )
+                case _:
+                    return AttributeVariable(variable_name, attr_or_prop == "property")
 
         self.raise_error(
             "expected variable to refer to an operand, "


### PR DESCRIPTION
I was going to suggest the missing optional `$inner_sym` attr on #2404 but realised optional attributes don’t exist yet in the declarative format. It seemed a rather trivial extension so here’s my shot at it, let me know if something misses/feels wrong.