### PR TITLE
transformations: Add convert-snrt-to-riscv-asm pass to lower snrt ops to RISC-V dialect

### DIFF
--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -97,10 +97,9 @@ builtin.module {
         %i3 = arith.constant 107 : index
         "snrt.ssr_loop_4d"(%dm, %b0, %b1, %b2, %b3, %i0, %i1, %i2, %i3) {"operandSegmentSizes" = array<i32: 1, 4, 4>} : (i32, index, index, index, index, index, index, index, index) -> ()
         //CHECK: "snrt.ssr_loop_4d"(%dm, %b0, %b1, %b2, %b3, %i0, %i1, %i2, %i3) {"operandSegmentSizes" = array<i32: 1, 4, 4>} : (i32, index, index, index, index, index, index, index, index) -> ()
-        %dm2 = arith.constant 1 : i32
-        %count = arith.constant 20 : index
-        "snrt.ssr_repeat"(%dm2, %count) : (i32, index) -> ()
-        // CHECK: "snrt.ssr_repeat"(%dm2, %count) : (i32, index) -> ()
+        %count = arith.constant 20 : i32
+        "snrt.ssr_repeat"(%count) <{dm = 3 : i32}> : (i32) -> ()
+        // CHECK: "snrt.ssr_repeat"(%count) <{"dm" = 3 : i32}> : (i32) -> ()
         "snrt.ssr_enable"() : () -> ()
         // CHECK: "snrt.ssr_enable"() : () -> ()
         "snrt.ssr_disable"() : () -> ()
@@ -108,10 +107,10 @@ builtin.module {
         %dm3 = arith.constant 2 : i32
         %dim = arith.constant 1 : i32
         %ptr = arith.constant 0 : i32
-        "snrt.ssr_read"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
-        // CHECK: "snrt.ssr_read"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
-        "snrt.ssr_write"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
-        // CHECK: "snrt.ssr_write"(%dm3, %dim, %ptr) : (i32, i32, i32) -> ()
+        "snrt.ssr_read"(%ptr) <{dm = 0 : i32, dim = 1 : i32}> : (i32) -> ()
+        // CHECK: "snrt.ssr_read"(%ptr) <{"dm" = 0 : i32, "dim" = 1 : i32}> : (i32) -> ()
+        "snrt.ssr_write"(%ptr) <{dm = 0 : i32, dim = 1 : i32}> : (i32) -> ()
+        // CHECK: "snrt.ssr_write"(%ptr) <{"dm" = 0 : i32, "dim" = 1 : i32}> : (i32) -> ()
         "snrt.fpu_fence"() : () -> ()
         // CHECK: "snrt.fpu_fence"() : () -> ()
 

--- a/tests/filecheck/transforms/convert-snrt-to-riscv-asm.mlir
+++ b/tests/filecheck/transforms/convert-snrt-to-riscv-asm.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt %s -p convert-snrt-to-riscv-asm | filecheck %s
+
+"snrt.cluster_hw_barrier"() : () -> ()
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   %0 = riscv.get_register : () -> !riscv.reg<zero>
+// CHECK-NEXT:   %1 = riscv.csrrs %0, 1986 : (!riscv.reg<zero>) -> !riscv.reg<zero>
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-snrt-to-riscv-asm.mlir
+++ b/tests/filecheck/transforms/convert-snrt-to-riscv-asm.mlir
@@ -1,8 +1,10 @@
 // RUN: xdsl-opt %s -p convert-snrt-to-riscv-asm | filecheck %s
 
 "snrt.cluster_hw_barrier"() : () -> ()
+"snrt.ssr_disable"() : () -> ()
 
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   %0 = riscv.get_register : () -> !riscv.reg<zero>
 // CHECK-NEXT:   %1 = riscv.csrrs %0, 1986 : (!riscv.reg<zero>) -> !riscv.reg<zero>
+// CHECK-NEXT:   %2 = riscv.csrrci 1984, 1 : () -> !riscv.reg<>
 // CHECK-NEXT: }

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -353,6 +353,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return constant_fold_interp.ConstantFoldInterpPass
 
+    def get_convert_snrt_to_riscv():
+        from xdsl.transforms import snrt_to_riscv_asm
+
+        return snrt_to_riscv_asm.ConvertSnrtToRISCV
+
     def get_convert_stencil_to_ll_mlir():
         from xdsl.transforms.experimental import convert_stencil_to_ll_mlir
 
@@ -565,6 +570,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "convert-scf-to-openmp": get_convert_scf_to_openmp,
         "convert-scf-to-riscv-scf": get_convert_scf_to_riscv_scf,
         "convert-snitch-stream-to-snitch": get_convert_snitch_stream_to_snitch,
+        "convert-snrt-to-riscv-asm": get_convert_snrt_to_riscv,
         "convert-stencil-to-ll-mlir": get_convert_stencil_to_ll_mlir,
         "dce": get_dce,
         "distribute-stencil": get_distribute_stencil,

--- a/xdsl/transforms/snrt_to_riscv_asm.py
+++ b/xdsl/transforms/snrt_to_riscv_asm.py
@@ -1,13 +1,21 @@
-from xdsl.dialects import snitch_runtime, riscv, builtin
+from xdsl.dialects import builtin, riscv, snitch_runtime
 from xdsl.dialects.builtin import IntegerAttr
-from xdsl.ir import MLContext, Operation
-from xdsl.pattern_rewriter import RewritePattern, PatternRewriter, op_type_rewrite_pattern, GreedyRewritePatternApplier, PatternRewriteWalker
+from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
 
 
 class LowerClusterHWBarrier(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: snitch_runtime.ClusterHwBarrierOp, rewriter: PatternRewriter, /):
+    def match_and_rewrite(
+        self, op: snitch_runtime.ClusterHwBarrierOp, rewriter: PatternRewriter, /
+    ):
         """
         Lowers to:
 
@@ -16,20 +24,49 @@ class LowerClusterHWBarrier(RewritePattern):
             asm volatile("csrr x0, 0x7C2" ::: "memory");
         }
         """
-        rewriter.replace_matched_op([
-            zero := riscv.GetRegisterOp(riscv.Registers.ZERO),
-            riscv.CsrrsOp(
-                rd=riscv.Registers.ZERO,
-                rs1=zero,
-                csr=IntegerAttr(0x7C2, 12),
-            )
-        ], [])
+        rewriter.replace_matched_op(
+            [
+                zero := riscv.GetRegisterOp(riscv.Registers.ZERO),
+                riscv.CsrrsOp(
+                    rd=riscv.Registers.ZERO,
+                    rs1=zero,
+                    csr=IntegerAttr(0x7C2, 12),
+                ),
+            ],
+            [],
+        )
+
+
+class LowerSSRDisable(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: snitch_runtime.SsrDisableOp, rewriter: PatternRewriter, /
+    ):
+        """
+        Lowers to:
+
+            /// Disable SSR.
+            inline void snrt_ssr_disable() {
+            #ifdef __TOOLCHAIN_LLVM__
+                __builtin_ssr_disable();
+            #else
+                asm volatile("csrci 0x7C0, 1\n");
+            #endif
+            }
+
+        P.S. This specific rewrite ignores the LLVM case and goes
+                straight to the generic one.
+        """
+        rewriter.replace_matched_op(
+            [riscv.CsrrciOp(csr=IntegerAttr(0x7C0, 12), immediate=IntegerAttr(1, 4))],
+            [],
+        )
 
 
 class ConvertSnrtToRISCV(ModulePass):
     name = "convert-snrt-to-riscv-asm"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        PatternRewriteWalker(GreedyRewritePatternApplier([
-            LowerClusterHWBarrier(),
-        ])).rewrite_module(op)
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier([LowerClusterHWBarrier(), LowerSSRDisable()])
+        ).rewrite_module(op)

--- a/xdsl/transforms/snrt_to_riscv_asm.py
+++ b/xdsl/transforms/snrt_to_riscv_asm.py
@@ -1,0 +1,35 @@
+from xdsl.dialects import snitch_runtime, riscv, builtin
+from xdsl.dialects.builtin import IntegerAttr
+from xdsl.ir import MLContext, Operation
+from xdsl.pattern_rewriter import RewritePattern, PatternRewriter, op_type_rewrite_pattern, GreedyRewritePatternApplier, PatternRewriteWalker
+from xdsl.passes import ModulePass
+
+
+class LowerClusterHWBarrier(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: snitch_runtime.ClusterHwBarrierOp, rewriter: PatternRewriter, /):
+        """
+        Lowers to:
+
+        /// Synchronize cores in a cluster with a hardware barrier
+        inline void snrt_cluster_hw_barrier() {
+            asm volatile("csrr x0, 0x7C2" ::: "memory");
+        }
+        """
+        rewriter.replace_matched_op([
+            zero := riscv.GetRegisterOp(riscv.Registers.ZERO),
+            riscv.CsrrsOp(
+                rd=riscv.Registers.ZERO,
+                rs1=zero,
+                csr=IntegerAttr(0x7C2, 12),
+            )
+        ], [])
+
+
+class ConvertSnrtToRISCV(ModulePass):
+    name = "convert-snrt-to-riscv-asm"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(GreedyRewritePatternApplier([
+            LowerClusterHWBarrier(),
+        ])).rewrite_module(op)


### PR DESCRIPTION
Add `convert-snrt-to-riscv-asm` transformation that converts (some) snitch runtime ops into their assembly definitions.

This is part one of many, so more patterns coming up soon!
