### PR TITLE
transformations: Refine and enhance lowering Snitch runtime DMA operations to RISC-V

### DIFF
--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -59,21 +59,21 @@ builtin.module {
         // DMA Operations
         %dst_64 = arith.constant 100 : i64
         %src_64 = arith.constant 0 : i64
-        %size = arith.constant 100 : index
-        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, index) -> i32
-        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, index) -> i32
+        %size = arith.constant 100 : i32
+        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, i32) -> i32
+        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, i32) -> i32
         %dst_32 = arith.constant 100 : i32
         %src_32 = arith.constant 0 : i32
         %size_2 = arith.constant 100 : index
-        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (i32, i32, index) -> i32
-        // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size_2) : (i32, i32, index) -> i32
+        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size) : (i32, i32, i32) -> i32
+        // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size) : (i32, i32, i32) -> i32
         "snrt.dma_wait"(%transfer_id) : (i32) -> ()
         // CHECK: "snrt.dma_wait"(%transfer_id) : (i32) -> ()
         %repeat = arith.constant 1 : index
         %src_stride = arith.constant 1 : index
         %dst_stride = arith.constant 1 : index
-        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (i64, i64, index, index, index, index) -> i32
-        // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size, %repeat) : (i64, i64, index, index, index, index) -> i32
+        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) : (i64, i64, index, index, index, index) -> i32
+        // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) : (i64, i64, index, index, index, index) -> i32
         %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, index, index, index, index) -> i32
         // CHECK: transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, index, index, index, index) -> i32
         "snrt.dma_wait_all"() : () -> ()

--- a/tests/filecheck/transforms/convert-snrt-to-riscv-asm.mlir
+++ b/tests/filecheck/transforms/convert-snrt-to-riscv-asm.mlir
@@ -3,8 +3,19 @@
 "snrt.cluster_hw_barrier"() : () -> ()
 "snrt.ssr_disable"() : () -> ()
 
+%dst, %src, %size = "test.op"() : () -> (i64, i64, i32)
+%tx_id = "snrt.dma_start_1d_wideptr"(%dst, %src, %size) : (i64, i64, i32) -> i32
+
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   %0 = riscv.get_register : () -> !riscv.reg<zero>
 // CHECK-NEXT:   %1 = riscv.csrrs %0, 1986 : (!riscv.reg<zero>) -> !riscv.reg<zero>
 // CHECK-NEXT:   %2 = riscv.csrrci 1984, 1 : () -> !riscv.reg<>
+// CHECK-NEXT:   %dst, %src, %size = "test.op"() : () -> (i64, i64, i32)
+// CHECK-NEXT:   %tx_id, %tx_id_1 = builtin.unrealized_conversion_cast %dst : i64 to !riscv.reg<>, !riscv.reg<>
+// CHECK-NEXT:   %tx_id_2, %tx_id_3 = builtin.unrealized_conversion_cast %src : i64 to !riscv.reg<>, !riscv.reg<>
+// CHECK-NEXT:   %tx_id_4 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg<>
+// CHECK-NEXT:   riscv_snitch.dmsrc %tx_id_2, %tx_id_3 : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:   riscv_snitch.dmdst %tx_id, %tx_id_1 : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:   %tx_id_5 = riscv_snitch.dmcpyi %tx_id_4, 0 : (!riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:   %tx_id_6 = builtin.unrealized_conversion_cast %tx_id_5 : !riscv.reg<> to i32
 // CHECK-NEXT: }

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -14,7 +14,7 @@ from xdsl.irdl import (
     operand_def,
     prop_def,
     result_def,
-    var_operand_def,
+    var_operand_def, prop_def,
 )
 from xdsl.utils.exceptions import VerifyException
 

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -14,7 +14,7 @@ from xdsl.irdl import (
     operand_def,
     prop_def,
     result_def,
-    var_operand_def, prop_def,
+    var_operand_def,
 )
 from xdsl.utils.exceptions import VerifyException
 

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -312,7 +312,9 @@ class DmaStart1DBaseOperation(SnitchRuntimeBaseOperation, Generic[_T], ABC):
     T = Annotated[Attribute, ConstraintVar("T"), _T]
     dst: Operand = operand_def(_T)
     src: Operand = operand_def(_T)
-    size: Operand = operand_def(IndexType)
+    # Pylance was complaining about the below.
+    # size: Operand = operand_def(Annotated[Attribute, i32])
+    size: Operand = operand_def(i32)
     transfer_id: OpResult = result_def(tx_id)
 
     def __init__(

--- a/xdsl/transforms/snrt_to_riscv_asm.py
+++ b/xdsl/transforms/snrt_to_riscv_asm.py
@@ -160,6 +160,10 @@ class ConvertSnrtToRISCV(ModulePass):
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
-                [LowerClusterHWBarrier(), LowerSSRDisable(), LowerDMAStart1DWidePtr(),]
+                [
+                    LowerClusterHWBarrier(),
+                    LowerSSRDisable(),
+                    LowerDMAStart1DWidePtr(),
+                ]
             )
         ).rewrite_module(op)

--- a/xdsl/transforms/snrt_to_riscv_asm.py
+++ b/xdsl/transforms/snrt_to_riscv_asm.py
@@ -1,4 +1,4 @@
-from xdsl.dialects import builtin, riscv, snitch_runtime
+from xdsl.dialects import builtin, riscv, riscv_snitch, snitch_runtime
 from xdsl.dialects.builtin import IntegerAttr
 from xdsl.ir import MLContext
 from xdsl.passes import ModulePass
@@ -63,10 +63,103 @@ class LowerSSRDisable(RewritePattern):
         )
 
 
+class LowerDMAStart1DWidePtr(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: snitch_runtime.DmaStart1DWideptrOp, rewriter: PatternRewriter, /
+    ):
+        """
+        Lowers to:
+
+        /// Initiate an asynchronous 1D DMA transfer with wide 64-bit pointers.
+        inline snrt_dma_txid_t snrt_dma_start_1d_wideptr(uint64_t dst, uint64_t src,
+                                                        size_t size) {
+            // Current DMA does not allow transfers with size == 0 (blocks)
+            // TODO(colluca) remove this check once new DMA is integrated
+            if (size > 0) {
+                register uint32_t reg_dst_low asm("a0") = dst >> 0;    // 10
+                register uint32_t reg_dst_high asm("a1") = dst >> 32;  // 11
+                register uint32_t reg_src_low asm("a2") = src >> 0;    // 12
+                register uint32_t reg_src_high asm("a3") = src >> 32;  // 13
+                register uint32_t reg_size asm("a4") = size;           // 14
+
+                // dmsrc a2, a3
+                asm volatile(
+                    ".word (0b0000000 << 25) | \
+                        (     (13) << 20) | \
+                        (     (12) << 15) | \
+                        (    0b000 << 12) | \
+                        (0b0101011 <<  0)   \n" ::"r"(reg_src_high),
+                    "r"(reg_src_low));
+
+                // dmdst a0, a1
+                asm volatile(
+                    ".word (0b0000001 << 25) | \
+                        (     (11) << 20) | \
+                        (     (10) << 15) | \
+                        (    0b000 << 12) | \
+                        (0b0101011 <<  0)   \n" ::"r"(reg_dst_high),
+                    "r"(reg_dst_low));
+
+                // dmcpyi a0, a4, 0b00
+                register uint32_t reg_txid asm("a0");  // 10
+                asm volatile(
+                    ".word (0b0000010 << 25) | \
+                        (  0b00000 << 20) | \
+                        (     (14) << 15) | \
+                        (    0b000 << 12) | \
+                        (     (10) <<  7) | \
+                        (0b0101011 <<  0)   \n"
+                    : "=r"(reg_txid)
+                    : "r"(reg_size));
+
+                return reg_txid;
+            } else {
+                return -1;
+            }
+        }
+
+        P.S. We only implement taking the top branch for now.
+        """
+        reg_t = riscv.IntRegisterType.unallocated()
+        rewriter.replace_matched_op(
+            [
+                # "Take an ui64 and split it in two 32 bit-wide RISC-V registers"
+                split_i64_dst := builtin.UnrealizedConversionCastOp.get(
+                    [op.dst],
+                    [reg_t, reg_t],
+                ),
+                # "Take an ui64 and split it in two 32 bit-wide RISC-V registers"
+                split_i64_src := builtin.UnrealizedConversionCastOp.get(
+                    [op.src],
+                    [reg_t, reg_t],
+                ),
+                # "Convert an IR-level i32 to a RISC-V register"
+                i32_size := builtin.UnrealizedConversionCastOp.get(
+                    [op.size],
+                    [reg_t],
+                ),
+                riscv_snitch.DMSourceOp(
+                    split_i64_src.results[0], split_i64_src.results[1]
+                ),
+                riscv_snitch.DMDestinationOp(
+                    split_i64_dst.results[0], split_i64_dst.results[1]
+                ),
+                copy_imm := riscv_snitch.DMCopyImmOp(i32_size, 0),
+                tx_id := builtin.UnrealizedConversionCastOp.get(
+                    [copy_imm], [builtin.i32]
+                ),
+            ],
+            new_results=tx_id.results,
+        )
+
+
 class ConvertSnrtToRISCV(ModulePass):
     name = "convert-snrt-to-riscv-asm"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(
-            GreedyRewritePatternApplier([LowerClusterHWBarrier(), LowerSSRDisable()])
+            GreedyRewritePatternApplier(
+                [LowerClusterHWBarrier(), LowerSSRDisable(), LowerDMAStart1DWidePtr()]
+            )
         ).rewrite_module(op)

--- a/xdsl/transforms/snrt_to_riscv_asm.py
+++ b/xdsl/transforms/snrt_to_riscv_asm.py
@@ -160,6 +160,6 @@ class ConvertSnrtToRISCV(ModulePass):
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
-                [LowerClusterHWBarrier(), LowerSSRDisable(), LowerDMAStart1DWidePtr()]
+                [LowerClusterHWBarrier(), LowerSSRDisable(), LowerDMAStart1DWidePtr(),]
             )
         ).rewrite_module(op)


### PR DESCRIPTION
This PR partially initializes a transformation for lowering DMA-related operations to RISC-V dialect.

Specifically, `xdsl/transforms/snrt_to_riscv_asm.py` is enriched with the `LowerDMAStart1DWidePtr` class. There's some more stuff in there, detailed in [another (closed) PR](https://github.com/xdslproject/xdsl/pull/2411).