### PR TITLE
dialects: Add accfg dialect operations

### DIFF
--- a/tests/dialects/test_accfg.py
+++ b/tests/dialects/test_accfg.py
@@ -1,0 +1,18 @@
+from xdsl.dialects import accfg, builtin, test
+from xdsl.dialects.builtin import StringAttr
+
+
+def test_acc_setup():
+    one, two = test.TestOp(result_types=[builtin.i32, builtin.i32]).results
+
+    setup1 = accfg.SetupOp([one, two], ["A", "B"], "acc1")
+    setup1.verify()
+
+    assert setup1.accelerator == StringAttr("acc1")
+
+    setup2 = accfg.SetupOp(setup1.values, ["A", "B"], setup1.accelerator, setup1)
+    setup2.verify()
+
+    assert setup2.accelerator == setup1.accelerator
+    assert isinstance(setup2.out_state.type, accfg.StateType)
+    assert setup2.out_state.type.accelerator == setup1.accelerator

--- a/tests/filecheck/dialects/accfg/accfg_ops.mlir
+++ b/tests/filecheck/dialects/accfg/accfg_ops.mlir
@@ -1,0 +1,43 @@
+// RUN: XDSL_ROUNDTRIP
+
+"accfg.accelerator"() <{
+    name               = @acc1,
+    fields             = {A=0x3c0, B=0x3c1},
+    launch_addr        = 0x3cf,
+    barrier            = 0x7c3
+}> : () -> ()
+
+func.func @test() {
+    %one, %two = "test.op"() : () -> (i32, i32)
+
+    %state = "accfg.setup"(%one, %two) <{
+        param_names = ["A", "B"],
+        accelerator = "acc1",
+        operandSegmentSizes = array<i32: 2, 0>
+    }> : (i32, i32) -> !accfg.state<"acc1">
+
+    %token = "accfg.launch"(%state) <{accelerator = "acc1"}>: (!accfg.state<"acc1">) -> !accfg.token<"acc1">
+
+    %state2 = "accfg.setup"(%one, %two, %state) <{
+        param_names = ["A", "B"],
+        accelerator = "acc1",
+        operandSegmentSizes = array<i32: 2, 1>
+    }> : (i32, i32, !accfg.state<"acc1">) -> !accfg.state<"acc1">
+
+    "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
+
+    func.return
+}
+
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   "accfg.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier" = 1987 : i64}> : () -> ()
+// CHECK-NEXT:   func.func @test() {
+// CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
+// CHECK-NEXT:     %state = "accfg.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !accfg.state<"acc1">
+// CHECK-NEXT:     %token = "accfg.launch"(%state) <{"accelerator" = "acc1"}> : (!accfg.state<"acc1">) -> !accfg.token<"acc1">
+// CHECK-NEXT:     %state2 = "accfg.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !accfg.state<"acc1">) -> !accfg.state<"acc1">
+// CHECK-NEXT:     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/tests/filecheck/dialects/accfg/accfg_ops.mlir
+++ b/tests/filecheck/dialects/accfg/accfg_ops.mlir
@@ -1,4 +1,5 @@
 // RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
 
 "accfg.accelerator"() <{
     name               = @acc1,
@@ -41,3 +42,18 @@ func.func @test() {
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+
+// CHECK-GENERIC-NEXT: "builtin.module"() ({
+// CHECK-GENERIC-NEXT:   "accfg.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier" = 1987 : i64}> : () -> ()
+// CHECK-GENERIC-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
+// CHECK-GENERIC-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
+// CHECK-GENERIC-NEXT:     %state = "accfg.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !accfg.state<"acc1">
+// CHECK-GENERIC-NEXT:     %token = "accfg.launch"(%state) <{"accelerator" = "acc1"}> : (!accfg.state<"acc1">) -> !accfg.token<"acc1">
+// CHECK-GENERIC-NEXT:     %state2 = "accfg.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !accfg.state<"acc1">) -> !accfg.state<"acc1">
+// CHECK-GENERIC-NEXT:     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
+// CHECK-GENERIC-NEXT:     "func.return"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()
+
+

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -71,6 +71,10 @@ class StateType(ParametrizedAttribute, TypeAttribute):
 
 
 class AcceleratorSymbolOpTrait(SymbolOpInterface):
+    """
+    Symbol op trait to define multiple accelerator names.
+    """
+
     def get_sym_attr_name(self, op: Operation) -> StringAttr | None:
         assert isinstance(op, AcceleratorOp)
         return StringAttr(op.name_prop.string_value())

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
     ArrayAttr,
     DictionaryAttr,
     IntegerAttr,
@@ -104,8 +105,8 @@ class AcceleratorOp(IRDLOperation):
         self,
         name: str | StringAttr | SymbolRefAttr,
         fields: dict[str, int] | DictionaryAttr,
-        launch: int | IntegerAttr,
-        barrier: int | IntegerAttr,
+        launch: int | AnyIntegerAttr,
+        barrier: int | AnyIntegerAttr,
     ):
         if not isinstance(fields, DictionaryAttr):
             fields = DictionaryAttr(
@@ -132,14 +133,14 @@ class AcceleratorOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        for name, val in self.fields.data.items():
+        for _, val in self.fields.data.items():
             if not isinstance(val, IntegerAttr):
                 raise VerifyException("fields must only contain IntegerAttr!")
 
     def field_names(self) -> tuple[str, ...]:
         return tuple(self.fields.data.keys())
 
-    def field_items(self) -> Iterable[tuple[str, IntegerAttr]]:
+    def field_items(self) -> Iterable[tuple[str, AnyIntegerAttr]]:
         for name, val in self.fields.data.items():
             assert isinstance(val, IntegerAttr)
             yield name, val

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    DictionaryAttr,
+    IntegerAttr,
+    StringAttr,
+    SymbolRefAttr,
+    i32,
+)
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    Operation,
+    ParametrizedAttribute,
+    SSAValue,
+    TypeAttribute,
+)
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    ParameterDef,
+    VerifyException,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    opt_operand_def,
+    prop_def,
+    result_def,
+    var_operand_def,
+)
+from xdsl.traits import SymbolOpInterface
+
+
+@irdl_attr_definition
+class TokenType(ParametrizedAttribute, TypeAttribute):
+    """
+    Async token type for managing synchronization between asynchronously
+    launched accelerators. You can use them to create def-use chains
+    between accfg.launch and accfg.await ops.
+    """
+
+    name = "accfg.token"
+
+    accelerator: ParameterDef[StringAttr]
+
+    def __init__(self, accelerator: str | StringAttr):
+        if not isinstance(accelerator, StringAttr):
+            accelerator = StringAttr(accelerator)
+        return super().__init__([accelerator])
+
+
+@irdl_attr_definition
+class StateType(ParametrizedAttribute, TypeAttribute):
+    """
+    State type to manage accelerator configuration state.
+    States are chained through the def-use chain to allow
+    deduplication of setup calls.
+    """
+
+    name = "accfg.state"
+
+    accelerator: ParameterDef[StringAttr]
+
+    def __init__(self, accelerator: str | StringAttr):
+        if not isinstance(accelerator, StringAttr):
+            accelerator = StringAttr(accelerator)
+        return super().__init__([accelerator])
+
+
+class AcceleratorSymbolOpTrait(SymbolOpInterface):
+    def get_sym_attr_name(self, op: Operation) -> StringAttr | None:
+        assert isinstance(op, AcceleratorOp)
+        return StringAttr(op.name_prop.string_value())
+
+
+@irdl_op_definition
+class AcceleratorOp(IRDLOperation):
+    """
+    Declares an accelerator that can be configured, launched, etc.
+    `fields` is a dictionary mapping accelerator configuration names to
+    registers addresses.
+    """
+
+    name = "accfg.accelerator"
+
+    traits = frozenset([AcceleratorSymbolOpTrait()])
+
+    name_prop = prop_def(SymbolRefAttr, prop_name="name")
+
+    fields = prop_def(DictionaryAttr)
+
+    launch_addr = prop_def(IntegerAttr)
+
+    barrier = prop_def(IntegerAttr)  # TODO: this will be reworked in a later version
+
+    def __init__(
+        self,
+        name: str | StringAttr | SymbolRefAttr,
+        fields: dict[str, int] | DictionaryAttr,
+        launch: int | IntegerAttr,
+        barrier: int | IntegerAttr,
+    ):
+        if not isinstance(fields, DictionaryAttr):
+            fields = DictionaryAttr(
+                {name: IntegerAttr(val, i32) for name, val in fields.items()}
+            )
+
+        super().__init__(
+            properties={
+                "name": (
+                    SymbolRefAttr(name) if not isinstance(name, SymbolRefAttr) else name
+                ),
+                "fields": fields,
+                "launch_addr": (
+                    IntegerAttr(launch, i32)
+                    if not isinstance(launch, IntegerAttr)
+                    else launch
+                ),
+                "barrier": (
+                    IntegerAttr(barrier, i32)
+                    if not isinstance(barrier, IntegerAttr)
+                    else barrier
+                ),
+            }
+        )
+
+    def verify_(self) -> None:
+        for name, val in self.fields.data.items():
+            if not isinstance(val, IntegerAttr):
+                raise VerifyException("fields must only contain IntegerAttr!")
+
+    def field_names(self) -> tuple[str, ...]:
+        return tuple(self.fields.data.keys())
+
+    def field_items(self) -> Iterable[tuple[str, IntegerAttr]]:
+        for name, val in self.fields.data.items():
+            assert isinstance(val, IntegerAttr)
+            yield name, val
+
+
+@irdl_op_definition
+class LaunchOp(IRDLOperation):
+    """
+    Launch an accelerator.
+    We assume that all values in configuration registers are consumed
+    by the accelerator at this point. This means that
+    the configuration registers to the accelerator can be reconfigured
+    safely after a launch op without interfering with the Accelerator.
+    """
+
+    name = "accfg.launch"
+
+    state = operand_def(StateType)
+
+    accelerator = prop_def(StringAttr)
+
+    token = result_def()
+
+    def __init__(self, state: SSAValue | Operation):
+        state_val: SSAValue = SSAValue.get(state)
+        if not isinstance(state_val.type, StateType):
+            raise ValueError("`state` SSA Value must be of type `accfg.state`!")
+        super().__init__(
+            operands=[state],
+            properties={"accelerator": state_val.type.accelerator},
+            result_types=[TokenType(state_val.type.accelerator)],
+        )
+
+    def verify_(self) -> None:
+        # that the state and my accelerator match
+        assert isinstance(self.state.type, StateType)
+        if self.state.type.accelerator != self.accelerator:
+            raise VerifyException(
+                "The state's accelerator does not match the launch accelerator!"
+            )
+        # that the token and my accelerator match
+        assert isinstance(self.token.type, TokenType)
+        if self.token.type.accelerator != self.accelerator:
+            raise VerifyException(
+                "The token's accelerator does not match the launch accelerator!"
+            )
+
+        # that the token is used
+        if len(self.token.uses) != 1 or not isinstance(
+            next(iter(self.token.uses)).operation, AwaitOp
+        ):
+            raise VerifyException("Launch token must be used by exactly one await op")
+        # TODO: allow use in control flow
+
+
+@irdl_op_definition
+class AwaitOp(IRDLOperation):
+    """
+    Wait until the launched operation finishes.
+    Awaits the token emitted by an accfg.launch operation.
+    """
+
+    name = "accfg.await"
+
+    token = operand_def(TokenType)
+
+    def __init__(self, token: SSAValue | Operation):
+        super().__init__(operands=[token])
+
+
+@irdl_op_definition
+class SetupOp(IRDLOperation):
+    """
+    accfg.setup writes values to a specific accelerators configuration and returns
+    a value representing the currently known state of that accelerator's config.
+
+    If accfg.setup is called without any parameters, the resulting state is the
+    "empty" state, that represents a state without known values.
+    """
+
+    name = "accfg.setup"
+
+    values = var_operand_def(Attribute)  # TODO: make more precise?
+    """
+    The actual values used to set up the CSRs
+    """
+
+    in_state = opt_operand_def(StateType)
+    """
+    The state produced by a previous accfg.setup
+    """
+
+    out_state = result_def(StateType)
+    """
+    The CSR state after the setup op modified it.
+    """
+
+    param_names = prop_def(ArrayAttr[StringAttr])
+    """
+    Maps the SSA values in `values` to accelerator parameter names
+    """
+
+    accelerator = prop_def(StringAttr)
+    """
+    Name of the accelerator this setup is for
+    """
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    def __init__(
+        self,
+        vals: list[SSAValue | Operation],
+        param_names: Iterable[str] | Iterable[StringAttr],
+        accelerator: str | StringAttr,
+        in_state: SSAValue | Operation | None = None,
+    ):
+        if not isinstance(accelerator, StringAttr):
+            accelerator = StringAttr(accelerator)
+
+        param_names_tuple: tuple[StringAttr, ...] = tuple(
+            StringAttr(name) if isinstance(name, str) else name for name in param_names
+        )
+
+        super().__init__(
+            operands=[vals, in_state],
+            properties={
+                "param_names": ArrayAttr(param_names_tuple),
+                "accelerator": accelerator,
+            },
+            result_types=[StateType(accelerator)],
+        )
+
+    def iter_params(self) -> Iterable[tuple[str, SSAValue]]:
+        return zip((p.data for p in self.param_names), self.values)
+
+    def verify_(self) -> None:
+        # that accelerator on input matches output
+        if self.in_state is not None:
+            if self.in_state.type != self.out_state.type:
+                raise VerifyException("Input and output state accelerators must match")
+        assert isinstance(self.out_state.type, StateType)
+        if self.accelerator != self.out_state.type.accelerator:
+            raise VerifyException(
+                "Output state accelerator and accelerator the "
+                "operations property must match"
+            )
+
+        # that len(values) == len(param_names)
+        if len(self.values) != len(self.param_names):
+            raise ValueError(
+                "Must have received same number of values as parameter names"
+            )
+
+
+ACCFG = Dialect(
+    "accfg",
+    [
+        AcceleratorOp,
+        SetupOp,
+        LaunchOp,
+        AwaitOp,
+    ],
+    [
+        StateType,
+        TokenType,
+    ],
+)

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -99,7 +99,15 @@ class AcceleratorOp(IRDLOperation):
 
     launch_addr = prop_def(IntegerAttr)
 
-    barrier = prop_def(IntegerAttr)  # TODO: this will be reworked in a later version
+    # TODO: the barrier field will likely be changed in the future
+
+    # The exact translation of accfg.await is not final,
+    # and as such the information required for this on the accfg.accelerator
+    # op will probably change again in the future.
+    # We're looking into ways of generalizing this aspect currently,
+    # but this is a thing that actually works for snitch now.
+
+    barrier = prop_def(IntegerAttr)
 
     def __init__(
         self,
@@ -274,7 +282,7 @@ class SetupOp(IRDLOperation):
         )
 
     def iter_params(self) -> Iterable[tuple[str, SSAValue]]:
-        return zip((p.data for p in self.param_names), self.values)
+        return zip((p.data for p in self.param_names), self.values, strict=True)
 
     def verify_(self) -> None:
         # that accelerator on input matches output

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
@@ -252,7 +252,7 @@ class SetupOp(IRDLOperation):
 
     def __init__(
         self,
-        vals: list[SSAValue | Operation],
+        vals: Sequence[SSAValue | Operation],
         param_names: Iterable[str] | Iterable[StringAttr],
         accelerator: str | StringAttr,
         in_state: SSAValue | Operation | None = None,

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -14,6 +14,11 @@ from xdsl.utils.exceptions import ParseError
 def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
     """Returns all available dialects."""
 
+    def get_accfg():
+        from xdsl.dialects.accfg import ACCFG
+
+        return ACCFG
+
     def get_affine():
         from xdsl.dialects.affine import Affine
 
@@ -250,6 +255,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         return X86
 
     return {
+        "accfg": get_accfg,
         "affine": get_affine,
         "aie": get_aie,
         "air": get_air,


### PR DESCRIPTION
This PR adds the accfg dialect that @AntonLydike and me designed during a very productive week in Leuven

Accfg dialect contains ops to minimize setup in register-set-up accelerators.
Either through registers connected to a CPU core (like control and status registers) or memory mapped io (like setting registers over an AXI bus).

All operations are documented with docstrings.

Thanks for your reviews!