### PR TITLE
misc: (Makefile) Fix coverage reports to depend on coverage generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ htmlcov/
 .tox/
 .nox/
 .coverage
+.coveragepart.*
 .coverage.*
 .coverage_pytest
 .coverage_filecheck

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
+.coverage_pytest
+.coverage_filecheck
 .cache
 nosetests.xml
 coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ black:
 coverage: coverage-tests coverage-filecheck-tests
 	coverage combine --append
 
+conditional-coverage:
+	if ! [[ -e .coverage ]]; then make coverage; fi
+
 # run coverage over tests
 coverage-tests:
 	COVERAGE_FILE=${TESTS_COVERAGE_FILE} pytest -W error --cov --cov-config=.coveragerc
@@ -87,9 +90,9 @@ coverage-filecheck-tests:
 	lit -v tests/filecheck/ -DCOVERAGE
 
 # generate html coverage report
-coverage-report-html: coverage
+coverage-report-html: conditional-coverage
 	coverage html
 
 # generate markdown coverage report
-coverage-report-md: coverage
+coverage-report-md: conditional-coverage
 	coverage report --format=markdown

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TESTS_COVERAGE_FILE = ${COVERAGE_FILE}.tests
 
 # these targets don't produce files:
 .PHONY: ${VENV_DIR}/ clean filecheck pytest pytest-nb tests-toy tests rerun-notebooks precommit-install precommit black pyright
+.PHONY: coverage coverage-pytest-tests coverage-filecheck-tests coverage-report-html coverage-report-md
 
 # set up the venv with all dependencies for development
 ${VENV_DIR}/: requirements.txt
@@ -77,18 +78,27 @@ black:
 .coverage: .coverage_pytest .coverage_filecheck
 	coverage combine --keep .coverage_pytest .coverage_filecheck
 
-# run coverage over tests
 .coverage_pytest:
+	make coverage-pytest-tests
+
+.coverage_filecheck:
+	make coverage-filecheck-tests
+
+coverage: coverage-pytest-tests coverage-filecheck-tests
+	coverage combine --keep .coverage_pytest .coverage_filecheck
+
+# run coverage over tests
+coverage-pytest-tests:
 	COVERAGE_FILE=${TESTS_COVERAGE_FILE} pytest -W error --cov --cov-config=.coveragerc
 	coverage combine --append --data-file=.coverage_pytest ${TESTS_COVERAGE_FILE}
 
 # run coverage over filecheck tests
-.coverage_filecheck:
+coverage-filecheck-tests:
 	lit -v tests/filecheck/ -DCOVERAGE
 	coverage combine --append --data-file=.coverage_filecheck .coverage.*
 
 # generate html coverage report
-htmlcov/index.html: .coverage
+coverage-report-html: .coverage
 	coverage html
 
 # generate markdown coverage report

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ coverage-filecheck-tests:
 	lit -v tests/filecheck/ -DCOVERAGE
 
 # generate html coverage report
-coverage-report-html:
+coverage-report-html: coverage
 	coverage html
 
 # generate markdown coverage report
-coverage-report-md:
+coverage-report-md: coverage
 	coverage report --format=markdown


### PR DESCRIPTION
Making the coverage reporting targets depend on the coverage generating ones.

The big disadvantage of this is that now, you will always run the test suite when wanting to report the coverage. I am open for suggestions on how to circumvent that.
