### PR TITLE
dialects: Add accfg deduplication pass

### DIFF
--- a/tests/filecheck/transforms/accfg-dedup.mlir
+++ b/tests/filecheck/transforms/accfg-dedup.mlir
@@ -1,0 +1,91 @@
+// RUN: xdsl-opt %s -p accfg-dedup | filecheck %s
+
+func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
+  %0 = arith.constant 0 : index
+  %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+  %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+  %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+  %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+
+  %5 = "accfg.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !accfg.state<"snax_hwpe_mult">
+  %6 = "accfg.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+  "accfg.await"(%6) : (!accfg.token<"snax_hwpe_mult">) -> ()
+
+  %7 = "test.op"() : () -> i1
+
+  %8, %9 = "scf.if"(%7) ({
+    %10 = "accfg.setup"(%1, %3, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !accfg.state<"snax_hwpe_mult">) -> !accfg.state<"snax_hwpe_mult">
+    %11 = "accfg.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+    "accfg.await"(%11) : (!accfg.token<"snax_hwpe_mult">) -> ()
+
+    %12 = "test.op"() : () -> i32
+    scf.yield %12, %10 : i32, !accfg.state<"snax_hwpe_mult">
+  }, {
+    %13 = "test.op"() : () -> i32
+
+    %14 = "accfg.setup"(%1, %2, %3, %4, %5) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !accfg.state<"snax_hwpe_mult">) -> !accfg.state<"snax_hwpe_mult">
+    %15 = "accfg.launch"(%14) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+    "accfg.await"(%15) : (!accfg.token<"snax_hwpe_mult">) -> ()
+
+    scf.yield %13, %14 : i32, !accfg.state<"snax_hwpe_mult">
+  }) : (i1) -> (i32, !accfg.state<"snax_hwpe_mult">)
+
+  "test.op"(%8) : (i32) -> ()
+
+  %16 = "accfg.setup"(%1, %3, %2, %4, %9) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 1>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index, !accfg.state<"snax_hwpe_mult">) -> !accfg.state<"snax_hwpe_mult">
+  %17 = "accfg.launch"(%16) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+  "accfg.await"(%17) : (!accfg.token<"snax_hwpe_mult">) -> ()
+
+  func.return
+}
+
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func public @simple_mult(%arg0 : memref<?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?xi32>) {
+// CHECK-NEXT:     %0 = arith.constant 0 : index
+// CHECK-NEXT:     %1 = "memref.extract_aligned_pointer_as_index"(%arg0) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %2 = "memref.extract_aligned_pointer_as_index"(%arg1) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %3 = "memref.extract_aligned_pointer_as_index"(%arg2) : (memref<?xi32>) -> index
+// CHECK-NEXT:     %4 = "memref.dim"(%arg0, %0) : (memref<?xi32>, index) -> index
+
+                   // Full setup:
+
+// CHECK-NEXT:     %5 = "accfg.setup"(%1, %2, %3, %4) <{"accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 4, 0>, "param_names" = ["A", "B", "O", "size"]}> : (index, index, index, index) -> !accfg.state<"snax_hwpe_mult">
+// CHECK-NEXT:     %6 = "accfg.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+// CHECK-NEXT:     "accfg.await"(%6) : (!accfg.token<"snax_hwpe_mult">) -> ()
+// CHECK-NEXT:     %7 = "test.op"() : () -> i1
+// CHECK-NEXT:     %8, %9 = "scf.if"(%7) ({
+
+                     // Elide A and O setups:
+
+// CHECK-NEXT:       %10 = "accfg.setup"(%3, %5) <{"param_names" = ["B"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !accfg.state<"snax_hwpe_mult">) -> !accfg.state<"snax_hwpe_mult">
+// CHECK-NEXT:       %11 = "accfg.launch"(%10) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+// CHECK-NEXT:       "accfg.await"(%11) : (!accfg.token<"snax_hwpe_mult">) -> ()
+// CHECK-NEXT:       %12 = "test.op"() : () -> i32
+
+                     // Hoisted into if, elided A, B
+
+// CHECK-NEXT:       %13 = "accfg.setup"(%2, %10) <{"param_names" = ["O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 1, 1>}> : (index, !accfg.state<"snax_hwpe_mult">) -> !accfg.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %12, %13 : i32, !accfg.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:       %14 = "test.op"() : () -> i32
+
+                     // Elide full setup op
+
+// CHECK-NEXT:       %15 = "accfg.launch"(%5) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+// CHECK-NEXT:       "accfg.await"(%15) : (!accfg.token<"snax_hwpe_mult">) -> ()
+
+                     // Hoisted into if, elided A
+
+// CHECK-NEXT:       %16 = "accfg.setup"(%3, %2, %5) <{"param_names" = ["B", "O"], "accelerator" = "snax_hwpe_mult", "operandSegmentSizes" = array<i32: 2, 1>}> : (index, index, !accfg.state<"snax_hwpe_mult">) -> !accfg.state<"snax_hwpe_mult">
+// CHECK-NEXT:       scf.yield %14, %16 : i32, !accfg.state<"snax_hwpe_mult">
+// CHECK-NEXT:     }) : (i1) -> (i32, !accfg.state<"snax_hwpe_mult">)
+// CHECK-NEXT:     "test.op"(%8) : (i32) -> ()
+
+                   // fully elided setup op
+
+// CHECK-NEXT:     %17 = "accfg.launch"(%9) <{"accelerator" = "snax_hwpe_mult"}> : (!accfg.state<"snax_hwpe_mult">) -> !accfg.token<"snax_hwpe_mult">
+// CHECK-NEXT:     "accfg.await"(%17) : (!accfg.token<"snax_hwpe_mult">) -> ()
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -309,6 +309,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     """Return the list of all available passes."""
 
+    def get_accfg_dedup():
+        from xdsl.transforms import accfg_dedup
+
+        return accfg_dedup.AccfgDeduplicate
+
     def get_arith_add_fastmath():
         from xdsl.transforms import arith_add_fastmath
 
@@ -555,6 +560,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         return test_lower_snitch_stream_to_asm.TestLowerSnitchStreamToAsm
 
     return {
+        "accfg-dedup": get_accfg_dedup,
         "arith-add-fastmath": get_arith_add_fastmath,
         "loop-hoist-memref": get_loop_hoist_memref,
         "canonicalize-dmp": get_canonicalize_dmp,

--- a/xdsl/transforms/accfg/trace_acc_state.py
+++ b/xdsl/transforms/accfg/trace_acc_state.py
@@ -41,7 +41,7 @@ def infer_state_of(state_var: SSAValue) -> State:
         # If the owner is an scf.if that has two possible setups
         # only update the state that is set in both possible setups
         case scf.If() as if_op:
-            return state_union(*infer_states_for_if(if_op, state_var))
+            return state_intersection(*infer_states_for_if(if_op, state_var))
         case Block():
             # TODO: maybe implement something here?
             return {}
@@ -70,5 +70,5 @@ def infer_states_for_if(op: scf.If, state: SSAValue) -> tuple[State, State]:
     return state_tuple
 
 
-def state_union(a: State, b: State) -> State:
-    return {k: a[k] for k in a if a[k] == b[k]}
+def state_intersection(a: State, b: State) -> State:
+    return {k: a[k] for k in a if a[k] == b.get(k)}

--- a/xdsl/transforms/accfg/trace_acc_state.py
+++ b/xdsl/transforms/accfg/trace_acc_state.py
@@ -57,7 +57,7 @@ def infer_states_for_if(op: scf.If, state: SSAValue) -> tuple[State, State]:
     assert state in op.results, "Expected state to be one of the scf.if results!"
     idx = op.results.index(state)
 
-    states = []
+    states: list[State] = []
     for region in op.regions:
         # we know the last op must be the yield
         yield_op = region.block.last_op
@@ -65,8 +65,9 @@ def infer_states_for_if(op: scf.If, state: SSAValue) -> tuple[State, State]:
         # we know the yield op has the same number of operands as the
         # scf.if has results, so [idx] must be defined
         states.append(infer_state_of(yield_op.operands[idx]))
-    assert len(states) == 2
-    return tuple(states)
+    state_tuple = tuple(states)
+    assert len(state_tuple) == 2
+    return state_tuple
 
 
 def state_union(a: State, b: State) -> State:

--- a/xdsl/transforms/accfg/trace_acc_state.py
+++ b/xdsl/transforms/accfg/trace_acc_state.py
@@ -1,0 +1,67 @@
+"""
+These inference helpers are used to figure out which values are
+present at which points in the IR.
+
+Example inference results:
+
+```
+accfg.setup(A = %1, B = %2)  // previous state = {}
+// ...
+accfg.setup(A = %3, C = %1)  // previous state = {A = %1, B = %2}
+```
+
+These inference passes walk the IR backwards.
+"""
+
+from xdsl.dialects import accfg, scf
+from xdsl.ir import Block, SSAValue
+
+State = dict[str, SSAValue]
+
+
+def infer_state_of(state_var: SSAValue) -> State:
+    """
+    Entrance function of the inference pass.
+
+    This walks up the def-use chain to compute all values
+    that are guaranteed to be set in this state.
+    """
+    owner = state_var.owner
+    match owner:
+        case accfg.SetupOp(in_state=None) as setup_op:
+            return {name: val for name, val in setup_op.iter_params()}
+        case accfg.SetupOp(in_state=st) as setup_op if st is not None:
+            in_state = infer_state_of(st)
+            in_state.update(dict(setup_op.iter_params()))
+            return in_state
+        case scf.If() as if_op:
+            return state_union(*infer_states_for_if(if_op, state_var))
+        case Block():
+            # TODO: maybe implement something here?
+            return {}
+        case _:
+            raise ValueError(f"Cannot infer state for op {owner.name}")
+
+
+def infer_states_for_if(op: scf.If, state: SSAValue) -> tuple[State, State]:
+    """
+    Walk both sides of the if/else block and return the computed
+    states for the given state SSA value (`state`)
+    """
+    assert state in op.results, "Expected state to be one of the scf.if results!"
+    idx = op.results.index(state)
+
+    states = []
+    for region in op.regions:
+        # we know the last op must be the yield
+        yield_op = region.block.last_op
+        assert isinstance(yield_op, scf.Yield)
+        # we know the yield op has the same number of operands as the
+        # scf.if has results, so [idx] must be defined
+        states.append(infer_state_of(yield_op.operands[idx]))
+    assert len(states) == 2
+    return tuple(states)
+
+
+def state_union(a: State, b: State) -> State:
+    return {k: a[k] for k in a if a[k] == b[k]}

--- a/xdsl/transforms/accfg_dedup.py
+++ b/xdsl/transforms/accfg_dedup.py
@@ -1,0 +1,154 @@
+from dataclasses import dataclass
+
+from xdsl.dialects import accfg, builtin, scf
+from xdsl.ir import MLContext, OpResult, SSAValue
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.transforms.accfg.trace_acc_state import infer_state_of
+
+
+class SimplifyRedundantSetupCalls(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: accfg.SetupOp, rewriter: PatternRewriter, /):
+        # Step 1: Figure out previous state
+        prev_state = infer_state_of(op.in_state) if op.in_state else {}
+
+        # Step 2: Filter setup parameters to remove calls that set the same value again
+        new_params: list[tuple[str, SSAValue]] = [
+            (name, val) for name, val in op.iter_params() if prev_state.get(name) != val
+        ]
+
+        # Step 3: If no new params remain, elide the whole op
+        if not new_params:
+            # This only happens when:
+            #  1) The operation has no input state, and
+            #  2) The operation has no parameters it sets
+            if op.in_state is None:
+                # in this case, we can't elide the operation if it's output state is
+                # used otherwise we would break stuff. So we just assume that a setup
+                # without parameters returns an "empty" state that assumes nothing.
+                return
+
+            op.out_state.replace_by(op.in_state)
+            rewriter.erase_matched_op()
+            return
+
+        # Step 4: If all parameters change, do nothing
+        if len(new_params) == len(op.param_names):
+            return
+
+        # Step 5: Replace matched op with reduced version
+        rewriter.replace_matched_op(
+            accfg.SetupOp(
+                [val for _, val in new_params],
+                [param for param, _ in new_params],
+                op.accelerator,
+                op.in_state,
+            )
+        )
+
+
+class HoistSetupCallsIntoConditionals(RewritePattern):
+    """
+    Hoists setup calls into preceeding scf.if blocks if possible.
+
+    This will never result in additional setup calls and only
+    reduced the number of fields that are set up.
+    (proof left as an exercise to the reader)
+
+    Things we need to worry about:
+
+    - we can't insert a setup op before the originally produced state.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: accfg.SetupOp, rewriter: PatternRewriter, /):
+        # do not apply if our in_state is not an scf.if
+        if op.in_state is None or not isinstance(op.in_state.owner, scf.If):
+            return
+        # grab some helper vars
+        old_in_state = op.in_state
+        assert isinstance(old_in_state, OpResult)
+
+        # Step 1: Check that it's legal to move:
+        # grab all launch op uses of the SSA value produced by the scf.if
+        # this will only find things that happen *after* the scf.if, so nothing
+        # inside the scf.if regions.
+        uses = tuple(
+            use for use in op.in_state.uses if isinstance(use.operation, accfg.LaunchOp)
+        )
+        # if we have some launch ops, we need to investigate further:
+        for use in uses:
+            # grab the launch operation
+            launch_op = use.operation
+            # check that it is in the same block (if not bail out)
+            # if it is not in the same block, it means that the launch is nested:
+            #   scf.if -> some_op { launch } -> setup
+            # properly inferring where the launch op is, is out of scope for now.
+            # we always bail out in this case so that we don't break things.
+            # TODO: better check this case?
+            if launch_op.parent_block() is not op.parent_block():
+                return
+            # if we share a block, figure out positions and compare:
+            block = launch_op.parent_block()
+            assert block is not None
+            # launch op index < our index => we have a launch between us and the if
+            # that means we can't hoist.
+            if block.get_operation_index(launch_op) < block.get_operation_index(op):
+                return
+
+        # Step 2: Clone the op into the end of both branches
+        for region in op.in_state.owner.regions:
+            # grab the yield op:
+            yield_op = region.block.last_op
+            assert isinstance(yield_op, scf.Yield)
+            new_in_state = yield_op.operands[old_in_state.index]
+
+            # insert a copy of the setup op but replace the
+            # original in_state with the yielded state of the region
+            rewriter.insert_op_before(
+                new_setup := op.clone(value_mapper={op.in_state: new_in_state}),
+                yield_op,
+            )
+            # replace the yield op with a new yield op that yields the
+            # newly produced state
+            rewriter.replace_op(
+                yield_op,
+                yield_op.clone(value_mapper={new_in_state: new_setup.out_state}),
+            )
+
+        # erase the op, replacing all uses of its out state by
+        # its in_state.
+        op.out_state.replace_by(op.in_state)
+        rewriter.erase_matched_op()
+
+
+@dataclass(frozen=True)
+class AccfgDeduplicate(ModulePass):
+    """
+    Reduce the number of parameters in setup calls by inferring previously
+    set up values and carefully moving setup calls around.
+    """
+
+    name = "accfg-dedup"
+
+    hoist: bool = True
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        patterns = [
+            SimplifyRedundantSetupCalls(),
+        ]
+
+        if self.hoist:
+            patterns.append(HoistSetupCallsIntoConditionals())
+
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(patterns),
+            walk_reverse=True,
+        ).rewrite_module(op)

--- a/xdsl/transforms/accfg_dedup.py
+++ b/xdsl/transforms/accfg_dedup.py
@@ -141,7 +141,7 @@ class AccfgDeduplicate(ModulePass):
     hoist: bool = True
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        patterns = [
+        patterns: list[RewritePattern] = [
             SimplifyRedundantSetupCalls(),
         ]
 


### PR DESCRIPTION
This adds an accelerator deduplication pass that removes unnecessary state setup by implementing an algorithm that  recursively infers the previous state.

To this extent, it also introduces a HoistSetupCallsIntoConditionals pass which, as its name suggests,
Hoists one setup call happening right after an scf.if block into conditionals, this will never result in more setups, but it might result in less, since there is only one previous state to perform deduplication with, and there are 2 if this setup call is not hoisted in.

@AntonLydike I'm currently opening this PR as draft since I'm having some issues with pyright and I seem unable to address them.
I think our type declarations are somewhat lacking, and we are not really defining what should be the outcome of the `infer_state_of` if there is no previous state?