### PR TITLE
core: Add UseDefChain Traits

### DIFF
--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -717,7 +717,7 @@ class ReduceOp(IRDLOperation):
 
     body: Region = region_def("single_block")
 
-    traits = frozenset([HasParent(ParallelOp), ReduceOpUseDefChainTrait()])
+    traits = frozenset([ReduceOpUseDefChainTrait()])
 
     def __init__(
         self,

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -478,7 +478,9 @@ class UseDefChainTrait(OpTrait):
     def get_operands_leading_to_block_argument(arg: BlockArgument) -> set[Use]:
         op = arg.owner.parent_op()
         if op is None:
-            raise ValueError("Cannot trace operands leading to a block argument if block has no owning operation.")
+            raise ValueError(
+                "Cannot trace operands leading to a block argument if block has no owning operation."
+            )
         uses = {
             use
             for trait in UseDefChainTrait._get_traits_for(op)


### PR DESCRIPTION
Add HasAncestor Trait
 - Constrain the op such that another Op is its transitive parent (before reaching ModuleOp)
 - Has a weak mode that allows also allows None to the be transitive parent such that it is valid to not yet have the op in a larger piece of IR

Add UseDefChain Trait
 - Provides a mechanism to follow use-def chains through control flow primitives
 - Implemented for scf as an example