### PR TITLE
core: More informative rewrite errors.

### DIFF
--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -748,7 +748,14 @@ class PatternRewriteWalker:
             rewriter.current_operation = op
 
             # Apply the pattern on the operation
-            self.pattern.match_and_rewrite(op, rewriter)
+            try:
+                self.pattern.match_and_rewrite(op, rewriter)
+            except Exception as err:
+                op.emit_error(
+                    f"Error while applying pattern: {str(err)}",
+                    exception_type=type(err),
+                    underlying_error=err,
+                )
             rewriter_has_done_action |= rewriter.has_done_action
 
             # If the worklist is empty, we are done


### PR DESCRIPTION
xDSL currently bails out completely on the first exception raised while rewriting.
This changes this behaviour by capturing the said exception and printing it in the IR's context, just like verification errors.
Thus, when reading the error, the user can see the state of the IR at the point where a specific pattern failed, making it easier to reason about fixes or improvements IMO.

This is mostly intended to help while *developing* patterns, not any statement on the "should they even fail" topic.