### PR TITLE
dialects: (seq) Finish `seq.compreg` optionals

### DIFF
--- a/tests/filecheck/dialects/seq/seq_invalid.mlir
+++ b/tests/filecheck/dialects/seq/seq_invalid.mlir
@@ -15,7 +15,7 @@ builtin.module {
   %bool = "test.op"() : () -> i1
 
   // CHECK: Both reset and reset_value must be set when one is
-  %compreg_reset = "seq.compreg"(%data, %clk, %bool) {"operandSegmentSizes" = array<i32: 1, 1, 1, 0>} : (i14, !seq.clock, i1) -> i14
+  %compreg_reset = "seq.compreg"(%data, %clk, %bool) {"operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>} : (i14, !seq.clock, i1) -> i14
 }
 
 // -----
@@ -26,5 +26,5 @@ builtin.module {
   %bool = "test.op"() : () -> i1
 
   // CHECK: Both reset and reset_value must be set when one is
-  %compreg_reset = "seq.compreg"(%data, %clk, %data) {"operandSegmentSizes" = array<i32: 1, 1, 0, 1>} : (i14, !seq.clock, i14) -> i14
+  %compreg_reset = "seq.compreg"(%data, %clk, %data) {"operandSegmentSizes" = array<i32: 1, 1, 0, 1, 0>} : (i14, !seq.clock, i14) -> i14
 }

--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -11,4 +11,6 @@ builtin.module {
   // CHECK: %compreg = seq.compreg %data, %clk : i14
   %compreg_reset = seq.compreg %data, %clk reset %bool, %data : i14
   // CHECK: %compreg_reset = seq.compreg %data, %clk reset %bool, %data : i14
+  %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
+  // CHECK: %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
 }

--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -3,6 +3,7 @@
 builtin.module {
   %clk = "test.op"() : () -> (!seq.clock)
   %data = "test.op"() : () -> i14
+  %on = "test.op"() : () -> i14
   %bool = "test.op"() : () -> i1
 
   %div_clk = seq.clock_div %clk by 4
@@ -11,6 +12,10 @@ builtin.module {
   // CHECK: %compreg = seq.compreg %data, %clk : i14
   %compreg_reset = seq.compreg %data, %clk reset %bool, %data : i14
   // CHECK: %compreg_reset = seq.compreg %data, %clk reset %bool, %data : i14
+  %compreg_poweron = seq.compreg %data, %clk powerOn %on : i14
+  // CHECK: %compreg_poweron = seq.compreg %data, %clk powerOn %on : i14
+  %compreg_all = seq.compreg %data, %clk reset %bool, %data powerOn %on : i14
+  // CHECK: %compreg_all = seq.compreg %data, %clk reset %bool, %data powerOn %on : i14
   %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
   // CHECK: %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
 }

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -13,6 +13,7 @@ from xdsl.dialects.builtin import (
     TypeAttribute,
     i1,
 )
+from xdsl.dialects.hw import InnerSymAttr
 from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
@@ -24,6 +25,7 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
+    opt_attr_def,
     opt_operand_def,
     result_def,
 )
@@ -93,6 +95,7 @@ class CompRegOp(IRDLOperation):
 
     DataType = Annotated[Attribute, ConstraintVar("DataType")]
 
+    inner_sym = opt_attr_def(InnerSymAttr)
     input = operand_def(DataType)
     clk = operand_def(clock)
     reset = opt_operand_def(i1)
@@ -102,7 +105,7 @@ class CompRegOp(IRDLOperation):
     irdl_options = [AttrSizedOperandSegments()]
 
     assembly_format = (
-        "$input `,` $clk (`reset` $reset^ `,` $reset_value)? attr-dict "
+        "(`sym` $inner_sym^)? $input `,` $clk (`reset` $reset^ `,` $reset_value)? attr-dict "
         "`:` type($input)"
     )
 

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -100,13 +100,16 @@ class CompRegOp(IRDLOperation):
     clk = operand_def(clock)
     reset = opt_operand_def(i1)
     reset_value = opt_operand_def(DataType)
+    power_on_value = opt_operand_def(DataType)
     data = result_def(DataType)
 
     irdl_options = [AttrSizedOperandSegments()]
 
     assembly_format = (
-        "(`sym` $inner_sym^)? $input `,` $clk (`reset` $reset^ `,` $reset_value)? attr-dict "
-        "`:` type($input)"
+        "(`sym` $inner_sym^)? $input `,` $clk "
+        "(`reset` $reset^ `,` $reset_value)? "
+        "(`powerOn` $power_on_value^)? "
+        "attr-dict `:` type($input)"
     )
 
     def __init__(
@@ -114,6 +117,7 @@ class CompRegOp(IRDLOperation):
         input: SSAValue,
         clk: SSAValue,
         reset: tuple[SSAValue, SSAValue] | None = None,
+        power_on_value: SSAValue | None = None,
     ):
         super().__init__(
             operands=[
@@ -121,14 +125,13 @@ class CompRegOp(IRDLOperation):
                 clk,
                 reset[0] if reset is not None else None,
                 reset[1] if reset is not None else None,
+                power_on_value,
             ],
             result_types=[input.type],
         )
 
     def verify_(self):
-        if (self.reset is not None and self.reset_value is None) or (
-            self.reset_value is not None and self.reset is None
-        ):
+        if (self.reset is None) != (self.reset_value is None):
             raise VerifyException("Both reset and reset_value must be set when one is")
 
 


### PR DESCRIPTION
Now #2448 and #2407 are in we can finally complete what was left out of #2404:
- an optional attribute `inner_sym` 
- the second optional operand `powerOn`