### PR TITLE
backend: (csl) Add csl dialect

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -5,10 +5,21 @@
 "memref.global"() {"sym_name" = "b", "type" = memref<4xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
 "memref.global"() {"sym_name" = "y", "type" = memref<4xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
 
-func.func @initialize() {
+%thing = "csl.import_module"() <{module = "<thing>"}> : () -> !csl.comptime_struct
+
+csl.func @initialize() {
   %lb = arith.constant   0 : i16
   %ub = arith.constant  24 : i16
   %step = arith.constant 1 : i16
+
+  // call without result
+  "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.comptime_struct, i16, i16) -> ()
+
+  // call with result
+  %res = "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.comptime_struct, i16, i16) -> (i32)
+
+  // member access
+  %11 = "csl.member_access"(%thing) <{field = "some_field"}> : (!csl.comptime_struct) -> !csl.comptime_struct
 
   %0 = arith.constant 3.14 : f32
   %v0 = arith.constant 2.718 : f16
@@ -28,7 +39,7 @@ func.func @initialize() {
 
   %ub_6 = arith.constant 6 : i16
 
-  scf.for %j = %lb to %ub step %step {
+  scf.for %j = %lb to %ub_6 step %step {
     %val = arith.constant 1.0 : f32
     %j_idx = "arith.index_cast"(%j) : (i16) -> index
     memref.store %val, %x[%j_idx] : memref<6xf32>
@@ -44,7 +55,7 @@ func.func @initialize() {
     memref.store %c0, %y[%i_idx] : memref<4xf32>
   }
 
-  func.return
+  csl.return
 }
 
 
@@ -52,32 +63,40 @@ func.func @initialize() {
 // CHECK-NEXT: //unknown op Global("memref.global"() <{"sym_name" = "x", "sym_visibility" = "public", "type" = memref<6xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
 // CHECK-NEXT: //unknown op Global("memref.global"() <{"sym_name" = "b", "sym_visibility" = "public", "type" = memref<4xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
 // CHECK-NEXT: //unknown op Global("memref.global"() <{"sym_name" = "y", "sym_visibility" = "public", "type" = memref<4xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
+// CHECK-NEXT: const thing : comptime_struct = @import_module("<thing>");
+// CHECK-NEXT:
 // CHECK-NEXT: fn initialize() {
 // CHECK-NEXT:   const lb : i16 = 0;
 // CHECK-NEXT:   const ub : i16 = 24;
 // CHECK-NEXT:   const step : i16 = 1;
-// CHECK-NEXT:   const v0 : f32 = 3.14;
-// CHECK-NEXT:   const v01 : f16 = 2.718;
+// CHECK-NEXT:   thing.some_func(lb, ub);
+// CHECK-NEXT:   const res : i32 = thing.some_func(lb, ub);
+// CHECK-NEXT:   const v0 : comptime_struct = thing.some_field;
+// CHECK-NEXT:   const v1 : f32 = 3.14;
+// CHECK-NEXT:   const v02 : f16 = 2.718;
 // CHECK-NEXT:   const u32cst : u32 = 44;
 // CHECK-NEXT:   //unknown op GetGlobal(%A = memref.get_global @A : memref<24xf32>)
 // CHECK-NEXT:   //unknown op GetGlobal(%x = memref.get_global @x : memref<6xf32>)
 // CHECK-NEXT:   //unknown op GetGlobal(%b = memref.get_global @b : memref<4xf32>)
 // CHECK-NEXT:   //unknown op GetGlobal(%y = memref.get_global @y : memref<4xf32>)
+// CHECK-NEXT:
 // CHECK-NEXT:   for(@range(i16, lb, ub, step)) |idx| {
 // CHECK-NEXT:     //unknown op SIToFPOp(%idx_f32 = arith.sitofp %idx : i16 to f32
 // CHECK-NEXT:     //unknown op IndexCastOp(%idx_index = "arith.index_cast"(%idx) : (i16) -> index)
 // CHECK-NEXT:     //unknown op Store(memref.store %idx_f32, %A[%idx_index] : memref<24xf32>)
 // CHECK-NEXT:     //unknown op Yield(scf.yield)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   const ub2 : i16 = 6;
-// CHECK-NEXT:   for(@range(i16, lb, ub, step)) |j| {
+// CHECK-NEXT:   const ub3 : i16 = 6;
+// CHECK-NEXT:
+// CHECK-NEXT:   for(@range(i16, lb, ub3, step)) |j| {
 // CHECK-NEXT:     const val : f32 = 1.0;
 // CHECK-NEXT:     //unknown op IndexCastOp(%j_idx = "arith.index_cast"(%j) : (i16) -> index)
 // CHECK-NEXT:     //unknown op Store(memref.store %val, %x[%j_idx] : memref<6xf32>)
 // CHECK-NEXT:     //unknown op Yield(scf.yield)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   const ub3 : i16 = 6;
-// CHECK-NEXT:   for(@range(i16, lb, ub3, step)) |i| {
+// CHECK-NEXT:   const ub4 : i16 = 6;
+// CHECK-NEXT:
+// CHECK-NEXT:   for(@range(i16, lb, ub4, step)) |i| {
 // CHECK-NEXT:     const c2 : f32 = 2.0;
 // CHECK-NEXT:     const c0 : f32 = 0.0;
 // CHECK-NEXT:     //unknown op IndexCastOp(%i_idx = "arith.index_cast"(%i) : (i16) -> index)
@@ -85,5 +104,5 @@ func.func @initialize() {
 // CHECK-NEXT:     //unknown op Store(memref.store %c0, %y[%i_idx] : memref<4xf32>)
 // CHECK-NEXT:     //unknown op Yield(scf.yield)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   //unknown op Return(func.return)
+// CHECK-NEXT:   return;
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -1,0 +1,28 @@
+// RUN: XDSL_ROUNDTRIP
+
+csl.func @initialize() {
+
+    %lb, %ub = "test.op"() : () -> (i16, i16)
+
+    %thing = "csl.import_module"() <{module = "<thing>"}> : () -> !csl.comptime_struct
+
+    "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.comptime_struct, i16, i16) -> ()
+
+    %res = "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.comptime_struct, i16, i16) -> (i32)
+
+    %11 = "csl.member_access"(%thing) <{field = "some_field"}> : (!csl.comptime_struct) -> !csl.comptime_struct
+
+  csl.return
+}
+
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   csl.func @initialize() {
+// CHECK-NEXT:     %lb, %ub = "test.op"() : () -> (i16, i16)
+// CHECK-NEXT:     %thing = "csl.import_module"() <{"module" = "<thing>"}> : () -> !csl.comptime_struct
+// CHECK-NEXT:     "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func", "operandSegmentSizes" = array<i32: 1, 2>}> : (!csl.comptime_struct, i16, i16) -> ()
+// CHECK-NEXT:     %res = "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func", "operandSegmentSizes" = array<i32: 1, 2>}> : (!csl.comptime_struct, i16, i16) -> i32
+// CHECK-NEXT:     %0 = "csl.member_access"(%thing) <{"field" = "some_field"}> : (!csl.comptime_struct) -> !csl.comptime_struct
+// CHECK-NEXT:     csl.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import IO
 
-from xdsl.dialects import arith, func, scf
+from xdsl.dialects import arith, csl, scf
 from xdsl.dialects.builtin import (
     Float16Type,
     Float32Type,
@@ -29,14 +29,14 @@ class CslPrintContext:
 
     _prefix: str = field(default="")
 
-    def print(self, text: str, prefix: str = ""):
+    def print(self, text: str, prefix: str = "", end: str = "\n"):
         """
         Print `text` line by line, prefixed by self._prefix and prefix.
         """
         for l in text.split("\n"):
-            print(self._prefix + prefix + l, file=self.output)
+            print(self._prefix + prefix + l, file=self.output, end=end)
 
-    def _get_variable_name_for(self, val: SSAValue) -> str:
+    def _get_variable_name_for(self, val: SSAValue, hint: str | None = None) -> str:
         """
         Get an assigned variable name for a given SSA Value
         """
@@ -44,8 +44,12 @@ class CslPrintContext:
             return self.variables[val]
 
         taken_names = set(self.variables.values())
-        if val.name_hint is not None and val.name_hint not in taken_names:
-            name = val.name_hint
+
+        if hint is None:
+            hint = val.name_hint
+
+        if hint is not None and hint not in taken_names:
+            name = hint
         else:
             prefix = "v" if val.name_hint is None else val.name_hint
 
@@ -71,6 +75,8 @@ class CslPrintContext:
         This method does not yet support all the types and will be expanded as needed later.
         """
         match type_attr:
+            case csl.ComptimeStructType():
+                return "comptime_struct"
             case Float16Type():
                 return "f16"
             case Float32Type():
@@ -108,6 +114,8 @@ class CslPrintContext:
         match attr:
             case IntAttr():
                 return "<!indeterminate IntAttr type>"
+            case csl.ComptimeStructType():
+                return "comptime_struct"
             case IntegerAttr(type=(IntegerType() | IndexType()) as int_t):
                 return self.mlir_type_to_csl_type(int_t)
             case FloatAttr(type=(Float16Type() | Float32Type()) as float_t):
@@ -133,17 +141,51 @@ class CslPrintContext:
                     self.print(
                         f"const {self._get_variable_name_for(r)} : {type_name} = {value_str};"
                     )
-                case func.FuncOp(sym_name=name, body=bdy, function_type=ftyp) if len(
+                case csl.ImportModuleConstOp(module=module, params=params, result=res):
+                    name = self._get_variable_name_for(res)
+
+                    params_str = ""
+                    if params is not None:
+                        params_str = f", {self._get_variable_name_for(params)}"
+
+                    self.print(
+                        f'const {name} : comptime_struct = @import_module("{module.data}"{params_str});'
+                    )
+                case csl.MemberCallOp(
+                    struct=struct, field=field, args=args, result=res
+                ):
+                    args = ", ".join(self._get_variable_name_for(arg) for arg in args)
+                    struct_var = self._get_variable_name_for(struct)
+
+                    text = ""
+                    if res is not None:
+                        name = self._get_variable_name_for(res)
+                        text += (
+                            f"const {name} : {self.mlir_type_to_csl_type(res.type)} = "
+                        )
+
+                    self.print(f"{text}{struct_var}.{field.data}({args});")
+                case csl.MemberAccessOp(struct=struct, field=field, result=res):
+                    name = self._get_variable_name_for(res)
+                    struct_var = self._get_variable_name_for(struct)
+                    self.print(
+                        f"const {name} : {self.mlir_type_to_csl_type(res.type)} = {struct_var}.{field.data};"
+                    )
+                case csl.FuncOp(sym_name=name, body=bdy, function_type=ftyp) if len(
                     ftyp.inputs
                 ) == 0 and len(ftyp.outputs) == 0:
                     # only functions without input / outputs supported for now.
-                    self.print(f"fn {name.data}() {{")
+                    self.print(f"\nfn {name.data}() {{")
                     self.descend().print_block(bdy.block)
                     self.print("}")
+                case csl.ReturnOp(ret_val=None):
+                    self.print("return;")
+                case csl.ReturnOp(ret_val=val) if val is not None:
+                    self.print(f"return {self._get_variable_name_for(val)};")
                 case scf.For(lb=lower, ub=upper, step=stp, body=bdy):
                     idx, *_ = bdy.block.args
                     self.print(
-                        f"for(@range({self.mlir_type_to_csl_type(idx.type)}, {self._get_variable_name_for(lower)}, {self._get_variable_name_for(upper)}, {self._get_variable_name_for(stp)})) |{self._get_variable_name_for(idx)}| {{"
+                        f"\nfor(@range({self.mlir_type_to_csl_type(idx.type)}, {self._get_variable_name_for(lower)}, {self._get_variable_name_for(upper)}, {self._get_variable_name_for(stp)})) |{self._get_variable_name_for(idx)}| {{"
                     )
                     self.descend().print_block(bdy.block)
                     self.print("}")

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from xdsl.dialects import func
+from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, FunctionType, StringAttr
+from xdsl.dialects.utils import (
+    parse_func_op_like,
+    parse_return_op_like,
+    print_func_op_like,
+    print_return_op_like,
+)
+from xdsl.ir import (
+    Attribute,
+    Block,
+    Dialect,
+    Operation,
+    Region,
+    SSAValue,
+    TypeAttribute,
+)
+from xdsl.irdl import (
+    AttrSizedOperandSegments,
+    IRDLOperation,
+    ParametrizedAttribute,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    opt_operand_def,
+    opt_prop_def,
+    opt_result_def,
+    prop_def,
+    region_def,
+    result_def,
+    var_operand_def,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.traits import HasParent, IsTerminator, SymbolOpInterface
+from xdsl.utils.exceptions import VerifyException
+
+
+@irdl_attr_definition
+class ComptimeStructType(ParametrizedAttribute, TypeAttribute):
+    """
+    Represents a compile time struct.
+
+    The type makes no guarantees on the fields available.
+    """
+
+    name = "csl.comptime_struct"
+
+
+@irdl_op_definition
+class ImportModuleConstOp(IRDLOperation):
+    """
+    Equivalent to an `const <va_name> = @import_module("<module_name>", <params>)` call.
+    """
+
+    name = "csl.import_module"
+
+    module = prop_def(StringAttr)
+
+    params = opt_operand_def(ComptimeStructType)
+
+    result = result_def(ComptimeStructType)
+
+
+@irdl_op_definition
+class MemberAccessOp(IRDLOperation):
+    """
+    Access a member of a struct and assigna a new variable.
+    """
+
+    name = "csl.member_access"
+
+    struct = operand_def(ComptimeStructType)
+
+    field = prop_def(StringAttr)
+
+    result = result_def(Attribute)
+
+
+@irdl_op_definition
+class MemberCallOp(IRDLOperation):
+    """
+    Call a member of a struct, optionally assign a value to the result.
+    """
+
+    name = "csl.member_call"
+
+    struct = operand_def(ComptimeStructType)
+
+    field = prop_def(StringAttr)
+
+    args = var_operand_def(Attribute)
+
+    result = opt_result_def(Attribute)
+
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+
+@irdl_op_definition
+class FuncOp(IRDLOperation):
+    """
+    Almost the same as func.func, but only has one result, and is not isolated from above.
+
+    We dropped IsolatedFromAbove because CSL functions often times access global parameters
+    or constants.
+    """
+
+    name = "csl.func"
+
+    body: Region = region_def()
+    sym_name: StringAttr = prop_def(StringAttr)
+    function_type: FunctionType = prop_def(FunctionType)
+    arg_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
+    res_attrs = opt_prop_def(ArrayAttr[DictionaryAttr])
+
+    traits = frozenset([SymbolOpInterface(), func.FuncOpCallableInterface()])
+
+    def __init__(
+        self,
+        name: str,
+        function_type: FunctionType | tuple[Sequence[Attribute], Attribute | None],
+        region: Region | type[Region.DEFAULT] = Region.DEFAULT,
+        *,
+        arg_attrs: ArrayAttr[DictionaryAttr] | None = None,
+        res_attrs: ArrayAttr[DictionaryAttr] | None = None,
+    ):
+        if isinstance(function_type, tuple):
+            inputs, output = function_type
+            function_type = FunctionType.from_lists(inputs, [output] if output else [])
+        if len(function_type.outputs) > 1:
+            raise ValueError("Can't have a csl.function return more than one value!")
+        if not isinstance(region, Region):
+            region = Region(Block(arg_types=function_type.inputs))
+        properties: dict[str, Attribute | None] = {
+            "sym_name": StringAttr(name),
+            "function_type": function_type,
+            "arg_attrs": arg_attrs,
+            "res_attrs": res_attrs,
+        }
+        super().__init__(properties=properties, regions=[region])
+
+    def verify_(self) -> None:
+        # If this is an empty region (external function), then return
+        if len(self.body.blocks) == 0:
+            return
+
+        entry_block: Block = self.body.blocks[0]
+        block_arg_types = [arg.type for arg in entry_block.args]
+        if self.function_type.inputs.data != tuple(block_arg_types):
+            raise VerifyException(
+                "Expected entry block arguments to have the same types as the function "
+                "input types"
+            )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> FuncOp:
+        (
+            name,
+            input_types,
+            return_types,
+            region,
+            extra_attrs,
+            arg_attrs,
+        ) = parse_func_op_like(
+            parser, reserved_attr_names=("sym_name", "function_type", "sym_visibility")
+        )
+
+        assert len(return_types) <= 1, "csl.func can't have more than one result type!"
+
+        func = cls(
+            name=name,
+            function_type=(input_types, return_types[0] if return_types else None),
+            region=region,
+            arg_attrs=arg_attrs,
+        )
+        if extra_attrs is not None:
+            func.attributes |= extra_attrs.data
+        return func
+
+    def print(self, printer: Printer):
+        print_func_op_like(
+            printer,
+            self.sym_name,
+            self.function_type,
+            self.body,
+            self.attributes,
+            arg_attrs=self.arg_attrs,
+            reserved_attr_names=(
+                "sym_name",
+                "function_type",
+                "sym_visibility",
+                "arg_attrs",
+            ),
+        )
+
+
+@irdl_op_definition
+class ReturnOp(IRDLOperation):
+    """
+    Return for CSL operations such as functions and tasks.
+    """
+
+    name = "csl.return"
+
+    ret_val = opt_operand_def(Attribute)
+
+    traits = frozenset([HasParent(FuncOp), IsTerminator()])
+
+    def __init__(self, return_val: SSAValue | Operation | None = None):
+        super().__init__(operands=[return_val])
+
+    def verify_(self) -> None:
+        func_op = self.parent_op()
+        assert isinstance(func_op, FuncOp)
+
+        if tuple(func_op.function_type.outputs) != tuple(
+            val.type for val in self.operands
+        ):
+            raise VerifyException(
+                "Expected arguments to have the same types as the function output types"
+            )
+
+    def print(self, printer: Printer):
+        print_return_op_like(printer, self.attributes, self.operands)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> ReturnOp:
+        attrs, args = parse_return_op_like(parser)
+        op = ReturnOp(*args)
+        op.attributes.update(attrs)
+        return op
+
+
+CSL = Dialect(
+    "csl",
+    [
+        FuncOp,
+        ReturnOp,
+        ImportModuleConstOp,
+        MemberCallOp,
+        MemberAccessOp,
+    ],
+    [
+        ComptimeStructType,
+    ],
+)

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -65,6 +65,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return Comb
 
+    def get_csl():
+        from xdsl.dialects.csl import CSL
+
+        return CSL
+
     def get_dmp():
         from xdsl.dialects.experimental.dmp import DMP
 
@@ -271,6 +276,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "cf": get_cf,
         "cmath": get_cmath,
         "comb": get_comb,
+        "csl": get_csl,
         "dmp": get_dmp,
         "fir": get_fir,
         "fsm": get_fsm,


### PR DESCRIPTION
Adds the first few ops for the CSL dialect, currently only a function op, module imports and struct accesses.