### PR TITLE
dialects: Implement `stencil.combine`

### DIFF
--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -52,7 +52,7 @@ builtin.module {
   }
 }
 
-// CHECK: Expected stencil.buffer to buffer a stencil.apply's output, got Block(_args=(<BlockArgument[!stencil.temp<[0,68]xf64>] index: 0, uses: 1>,), num_ops=2)
+// CHECK: Expected stencil.buffer to buffer a stencil.apply or stencil.combine's output, got Block(_args=(<BlockArgument[!stencil.temp<[0,68]xf64>] index: 0, uses: 1>,), num_ops=2)
 
 // -----
 

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -147,7 +147,8 @@ builtin.module {
       %14 = "stencil.access"(%13) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%14) : (f64) -> ()
     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-    "stencil.store"(%12, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+    %2 = "stencil.combine"(%15, %12) {dim=0, index=11, operandSegmentSizes = array<i32:1,1,0,0>} : (!stencil.temp<?xf64>, !stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+    "stencil.store"(%2, %1) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
     func.return
   }
 }
@@ -166,7 +167,8 @@ builtin.module {
 // CHECK-NEXT:       %9 = "stencil.access"(%8) {"offset" = #stencil.index<0>} : (!stencil.temp<?xf64>) -> f64
 // CHECK-NEXT:       "stencil.return"(%9) : (f64) -> ()
 // CHECK-NEXT:     }) : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
-// CHECK-NEXT:     "stencil.store"(%7, %1) {"lb" = #stencil.index<0, 0>, "ub" = #stencil.index<64, 64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
+// CHECK-NEXT:      %10 = "stencil.combine"(%6, %7) {"dim" = 0 : i64, "index" = 11 : i64, "operandSegmentSizes" = array<i32: 1, 1, 0, 0>} : (!stencil.temp<?xf64>, !stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+// CHECK-NEXT:      "stencil.store"(%10, %1) {"lb" = #stencil.index<0>, "ub" = #stencil.index<64>} : (!stencil.temp<?xf64>, !stencil.field<[-4,68]xf64>) -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -225,22 +225,22 @@ func.func @dyn_access(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x
 
 func.func @combine(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?x?xf64>) attributes {stencil.program} {
   %0 = "stencil.cast"(%arg0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
-    %1 = "stencil.cast"(%arg1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
-    %2 = "stencil.load"(%0) : (!stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> !stencil.temp<?x?x?xf64>
-    %3 = "stencil.apply"(%2) ( {
-    ^bb0(%arg2: !stencil.temp<?x?x?xf64>):
-      %6 = "stencil.access"(%arg2) {offset = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %7 = "stencil.store_result"(%6) : (f64) -> !stencil.result<f64>
-      "stencil.return"(%7) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    %4 = "stencil.apply"(%2) ( {
-    ^bb0(%arg2: !stencil.temp<?x?x?xf64>):
-      %6 = "stencil.access"(%arg2) {offset = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
-      %7 = "stencil.store_result"(%6) : (f64) -> !stencil.result<f64>
-      "stencil.return"(%7) : (!stencil.result<f64>) -> ()
-    }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    %5 = "stencil.combine"(%3, %4) {dim = 0 : i64, index = 32 : i64, operandSegmentSizes = array<i32:1, 1, 0, 0>} : (!stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
-    "stencil.store"(%5, %1) {lb = #stencil.index<0, 0, 0>, ub = #stencil.index<64, 64, 60>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> ()
+  %1 = "stencil.cast"(%arg1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+  %2 = "stencil.load"(%0) : (!stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> !stencil.temp<?x?x?xf64>
+  %3 = "stencil.apply"(%2) ( {
+  ^bb0(%arg2: !stencil.temp<?x?x?xf64>):
+    %6 = "stencil.access"(%arg2) {offset = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+    %7 = "stencil.store_result"(%6) : (f64) -> !stencil.result<f64>
+    "stencil.return"(%7) : (!stencil.result<f64>) -> ()
+  }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  %4 = "stencil.apply"(%2) ( {
+  ^bb0(%arg2: !stencil.temp<?x?x?xf64>):
+    %6 = "stencil.access"(%arg2) {offset = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+    %7 = "stencil.store_result"(%6) : (f64) -> !stencil.result<f64>
+    "stencil.return"(%7) : (!stencil.result<f64>) -> ()
+  }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  %5 = "stencil.combine"(%3, %4) {dim = 0 : i64, index = 32 : i64, operandSegmentSizes = array<i32:1, 1, 0, 0>} : (!stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  "stencil.store"(%5, %1) {lb = #stencil.index<0, 0, 0>, ub = #stencil.index<64, 64, 60>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> ()
   return
 }
 
@@ -263,6 +263,76 @@ func.func @combine(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?x?
 // CHECK-NEXT:      }) : (!stencil.temp<[0,32]x[0,64]x[0,60]xf64>) -> !stencil.temp<[32,64]x[0,64]x[0,60]xf64>
 // CHECK-NEXT:      %9 = "stencil.combine"(%3, %6) {"dim" = 0 : i64, "index" = 32 : i64, "operandSegmentSizes" = array<i32: 1, 1, 0, 0>} : (!stencil.temp<[0,32]x[0,64]x[0,60]xf64>, !stencil.temp<[32,64]x[0,64]x[0,60]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,60]xf64>
 // CHECK-NEXT:      "stencil.store"(%9, %1) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 60>} : (!stencil.temp<[0,64]x[0,64]x[0,60]xf64>, !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// -----
+
+func.func @buffer(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?x?xf64>) attributes {stencil.program} {
+  %0 = "stencil.cast"(%arg0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+  %1 = "stencil.cast"(%arg1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+  %2 = "stencil.apply"() ( {
+    %cst = arith.constant 1.0 : f64
+    %9 = "stencil.store_result"(%cst) : (f64) -> !stencil.result<f64>
+    "stencil.return"(%9) : (!stencil.result<f64>) -> ()
+  }) : () -> !stencil.temp<?x?x?xf64>
+  %3 = "stencil.apply"() ( {
+    %cst = arith.constant 1.0 : f64
+    %9 = "stencil.store_result"(%cst) : (f64) -> !stencil.result<f64>
+    "stencil.return"(%9) : (!stencil.result<f64>) -> ()
+  }) : () -> !stencil.temp<?x?x?xf64>
+  %4:2 = "stencil.combine"(%2, %2, %3) {dim = 0 : i64, index = 32 : i64, operandSegmentSizes = array<i32:1, 1, 0, 1>} : (!stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>) -> (!stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>)
+  %5 = "stencil.buffer"(%4#0) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  %6 = "stencil.buffer"(%4#1) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  %7 = "stencil.apply"(%5) ( {
+  ^bb0(%arg2: !stencil.temp<?x?x?xf64>):  // no predecessors
+    %9 = "stencil.access"(%arg2) {offset = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+    %10 = "stencil.store_result"(%9) : (f64) -> !stencil.result<f64>
+    "stencil.return"(%10) : (!stencil.result<f64>) -> ()
+  }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  %8 = "stencil.apply"(%6) ( {
+  ^bb0(%arg2: !stencil.temp<?x?x?xf64>):  // no predecessors
+    %9 = "stencil.access"(%arg2) {offset = #stencil.index<0, 0, 0>} : (!stencil.temp<?x?x?xf64>) -> f64
+    %10 = "stencil.store_result"(%9) : (f64) -> !stencil.result<f64>
+    "stencil.return"(%10) : (!stencil.result<f64>) -> ()
+  }) : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  "stencil.store"(%7, %0) {lb = #stencil.index<0, 0, 0>, ub = #stencil.index<64, 64, 60>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> ()
+  "stencil.store"(%8, %1) {lb = #stencil.index<48, 0, 0>, ub = #stencil.index<64, 64, 60>} : (!stencil.temp<?x?x?xf64>, !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> ()
+  return
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @buffer(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<?x?x?xf64>)  attributes {"stencil.program"}{
+// CHECK-NEXT:      %0 = "stencil.cast"(%arg0) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      %1 = "stencil.cast"(%arg1) : (!stencil.field<?x?x?xf64>) -> !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      %2 = "stencil.apply"() ({
+// CHECK-NEXT:        %cst = arith.constant 1.000000e+00 : f64
+// CHECK-NEXT:        %3 = "stencil.store_result"(%cst) : (f64) -> !stencil.result<f64>
+// CHECK-NEXT:        "stencil.return"(%3) : (!stencil.result<f64>) -> ()
+// CHECK-NEXT:      }) : () -> !stencil.temp<[0,64]x[0,64]x[0,60]xf64>
+// CHECK-NEXT:      %4 = "stencil.apply"() ({
+// CHECK-NEXT:        %cst_1 = arith.constant 1.000000e+00 : f64
+// CHECK-NEXT:        %5 = "stencil.store_result"(%cst_1) : (f64) -> !stencil.result<f64>
+// CHECK-NEXT:        "stencil.return"(%5) : (!stencil.result<f64>) -> ()
+// CHECK-NEXT:      }) : () -> !stencil.temp<[32,64]x[0,64]x[0,60]xf64>
+// CHECK-NEXT:      %6, %7 = "stencil.combine"(%2, %2, %4) {"dim" = 0 : i64, "index" = 32 : i64, "operandSegmentSizes" = array<i32: 1, 1, 0, 1>} : (!stencil.temp<[0,64]x[0,64]x[0,60]xf64>, !stencil.temp<[0,64]x[0,64]x[0,60]xf64>, !stencil.temp<[32,64]x[0,64]x[0,60]xf64>) -> (!stencil.temp<[0,64]x[0,64]x[0,60]xf64>, !stencil.temp<[48,64]x[0,64]x[0,60]xf64>)
+// CHECK-NEXT:      %8 = "stencil.buffer"(%6) : (!stencil.temp<[0,64]x[0,64]x[0,60]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,60]xf64>
+// CHECK-NEXT:      %9 = "stencil.buffer"(%7) : (!stencil.temp<[48,64]x[0,64]x[0,60]xf64>) -> !stencil.temp<[48,64]x[0,64]x[0,60]xf64>
+// CHECK-NEXT:      %10 = "stencil.apply"(%8) ({
+// CHECK-NEXT:      ^0(%arg2 : !stencil.temp<[0,64]x[0,64]x[0,60]xf64>):
+// CHECK-NEXT:        %11 = "stencil.access"(%arg2) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[0,64]x[0,64]x[0,60]xf64>) -> f64
+// CHECK-NEXT:        %12 = "stencil.store_result"(%11) : (f64) -> !stencil.result<f64>
+// CHECK-NEXT:        "stencil.return"(%12) : (!stencil.result<f64>) -> ()
+// CHECK-NEXT:      }) : (!stencil.temp<[0,64]x[0,64]x[0,60]xf64>) -> !stencil.temp<[0,64]x[0,64]x[0,60]xf64>
+// CHECK-NEXT:      %13 = "stencil.apply"(%9) ({
+// CHECK-NEXT:      ^1(%arg2_1 : !stencil.temp<[48,64]x[0,64]x[0,60]xf64>):
+// CHECK-NEXT:        %14 = "stencil.access"(%arg2_1) {"offset" = #stencil.index<0, 0, 0>} : (!stencil.temp<[48,64]x[0,64]x[0,60]xf64>) -> f64
+// CHECK-NEXT:        %15 = "stencil.store_result"(%14) : (f64) -> !stencil.result<f64>
+// CHECK-NEXT:        "stencil.return"(%15) : (!stencil.result<f64>) -> ()
+// CHECK-NEXT:      }) : (!stencil.temp<[48,64]x[0,64]x[0,60]xf64>) -> !stencil.temp<[48,64]x[0,64]x[0,60]xf64>
+// CHECK-NEXT:      "stencil.store"(%10, %0) {"lb" = #stencil.index<0, 0, 0>, "ub" = #stencil.index<64, 64, 60>} : (!stencil.temp<[0,64]x[0,64]x[0,60]xf64>, !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> ()
+// CHECK-NEXT:      "stencil.store"(%13, %1) {"lb" = #stencil.index<48, 0, 0>, "ub" = #stencil.index<64, 64, 60>} : (!stencil.temp<[48,64]x[0,64]x[0,60]xf64>, !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>) -> ()
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -20,6 +20,7 @@ from xdsl.ir import (
     TypeAttribute,
 )
 from xdsl.irdl import (
+    AttrSizedOperandSegments,
     IRDLOperation,
     Operand,
     ParameterDef,
@@ -438,6 +439,34 @@ class CastOp(IRDLOperation):
             raise VerifyException(
                 "If input shape is not dynamic, it must be the same as output"
             )
+
+
+@irdl_op_definition
+class CombineOp(IRDLOperation):
+    """
+    Combines the results computed on a lower with the results computed on
+    an upper domain. The operation combines the domain at a given index/offset
+    in a given dimension. Optional extra operands allow to combine values
+    that are only written / defined on the lower or upper subdomain. The result
+    values have the order upper/lower, lowerext, upperext.
+
+    Example:
+      %result = stencil.combine 2 at 11 lower = (%0 : !stencil.temp<?x?x?xf64>) upper = (%1 : !stencil.temp<?x?x?xf64>) lowerext = (%2 : !stencil.temp<?x?x?xf64>): !stencil.temp<?x?x?xf64>, !stencil.temp<?x?x?xf64>
+    """
+
+    name = "stencil.combine"
+
+    dim = attr_def(AnyIntegerAttr)
+    index = attr_def(AnyIntegerAttr)
+    lower = var_operand_def(TempType)
+    upper = var_operand_def(TempType)
+    lowerext = var_operand_def(TempType)
+    upperext = var_operand_def(TempType)
+    lb = opt_attr_def(IndexAttr)
+    ub = opt_attr_def(IndexAttr)
+    _results = var_result_def(TempType)
+
+    irdl_options = [AttrSizedOperandSegments()]
 
 
 @irdl_op_definition
@@ -924,6 +953,7 @@ Stencil = Dialect(
     "stencil",
     [
         CastOp,
+        CombineOp,
         DynAccessOp,
         ExternalLoadOp,
         ExternalStoreOp,

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -464,7 +464,7 @@ class CombineOp(IRDLOperation):
     upperext = var_operand_def(TempType)
     lb = opt_attr_def(IndexAttr)
     ub = opt_attr_def(IndexAttr)
-    _results = var_result_def(TempType)
+    results_ = var_result_def(TempType)
 
     irdl_options = [AttrSizedOperandSegments()]
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -732,9 +732,9 @@ class BufferOp(IRDLOperation):
                 f"Expected operand and result type to be equal, got ({self.temp.type}) "
                 f"-> {self.res.type}"
             )
-        if not isinstance(self.temp.owner, ApplyOp):
+        if not isinstance(self.temp.owner, ApplyOp | CombineOp):
             raise VerifyException(
-                f"Expected stencil.buffer to buffer a stencil.apply's output, got "
+                f"Expected stencil.buffer to buffer a stencil.apply or stencil.combine's output, got "
                 f"{self.temp.owner}"
             )
         if any(not isinstance(use.operation, BufferOp) for use in self.temp.uses):

--- a/xdsl/transforms/experimental/stencil_shape_inference.py
+++ b/xdsl/transforms/experimental/stencil_shape_inference.py
@@ -68,46 +68,103 @@ class CombineOpShapeInference(RewritePattern):
     def match_and_rewrite(self, op: CombineOp, rewriter: PatternRewriter, /):
         # Get each result group
         combined_res = op.results_[0 : len(op.lower)]
-        op.results_[len(op.lower) : len(op.lower) + len(op.lowerext)]
-        op.results_[len(op.lower) + len(op.lowerext) :]
+        lowerext_res = op.results_[len(op.lower) : len(op.lower) + len(op.lowerext)]
+        upperext_res = op.results_[len(op.lower) + len(op.lowerext) :]
 
-        # Handle combined results
-        for c, l, u in zip(combined_res, op.lower, op.upper, strict=True):
+        # Handle combined lower results
+        for c, l in zip(combined_res, op.lower, strict=True):
             c_type = cast(TempType[Attribute], c.type)
             assert isinstance(c_type.bounds, StencilBoundsAttr)
             # Get the inferred bounds on the combined result
             c_bounds = c_type.bounds
             assert isa(l.type, TempType[Attribute])
+
+            # Recover existing bounds on the lower and upper input if any
+            lb = None
+            ub = None
+            if isinstance(l.type.bounds, StencilBoundsAttr):
+                lb = l.type.bounds.lb
+                ub = l.type.bounds.ub
+
+            # Compute the new extreme bounds as usual.
+            lb = IndexAttr.min(c_bounds.lb, lb)
+            # Compute the combine bounds
+            c_bound_c = list(c_bounds.ub)
+            c_bound_c[op.dim.value.data] = op.index.value.data
+            c_bound = IndexAttr.get(*c_bound_c)
+            ub = IndexAttr.max(c_bound, ub)
+            bounds = StencilBoundsAttr(zip(lb, ub))
+            l.type = TempType(bounds, l.type.element_type)
+        # Handle combined upper results
+        for c, u in zip(combined_res, op.upper, strict=True):
+            c_type = cast(TempType[Attribute], c.type)
+            assert isinstance(c_type.bounds, StencilBoundsAttr)
+            # Get the inferred bounds on the combined result
+            c_bounds = c_type.bounds
             assert isa(u.type, TempType[Attribute])
 
             # Recover existing bounds on the lower and upper input if any
-            l_lb = None
-            l_ub = None
-            if isinstance(l.type.bounds, StencilBoundsAttr):
-                l_lb = l.type.bounds.lb
-                l_ub = l.type.bounds.ub
-            u_lb = None
-            u_ub = None
+            lb = None
+            ub = None
             if isinstance(u.type.bounds, StencilBoundsAttr):
-                u_lb = u.type.bounds.lb
-                u_ub = u.type.bounds.ub
+                lb = u.type.bounds.lb
+                ub = u.type.bounds.ub
 
             # Compute the new extreme bounds as usual.
-            l_lb = IndexAttr.min(c_bounds.lb, l_lb)
-            u_ub = IndexAttr.max(c_bounds.ub, u_ub)
+            ub = IndexAttr.max(c_bounds.ub, ub)
             # Compute the combine bounds
-            u_c_bound_c = list(c_bounds.lb)
-            u_c_bound_c[op.dim.value.data] = op.index.value.data
-            l_c_bound_c = list(c_bounds.ub)
-            l_c_bound_c[op.dim.value.data] = op.index.value.data
-            u_c_bound = IndexAttr.get(*u_c_bound_c)
-            l_c_bound = IndexAttr.get(*l_c_bound_c)
-            l_ub = IndexAttr.max(l_c_bound, l_ub)
-            u_lb = IndexAttr.min(u_c_bound, u_lb)
-            l_bounds = StencilBoundsAttr(zip(l_lb, l_ub))
-            u_bounds = StencilBoundsAttr(zip(u_lb, u_ub))
-            l.type = TempType(l_bounds, l.type.element_type)
-            u.type = TempType(u_bounds, u.type.element_type)
+            c_bound_c = list(c_bounds.lb)
+            c_bound_c[op.dim.value.data] = op.index.value.data
+            c_bound = IndexAttr.get(*c_bound_c)
+            lb = IndexAttr.min(c_bound, lb)
+            bounds = StencilBoundsAttr(zip(lb, ub))
+            u.type = TempType(bounds, u.type.element_type)
+
+        # Handle lowerext results
+        for r, o in zip(lowerext_res, op.lowerext, strict=True):
+            assert isa(o.type, TempType[Attribute])
+            assert isa(r.type, TempType[Attribute])
+            r_bounds = r.type.bounds
+            assert isinstance(r_bounds, StencilBoundsAttr)
+            # Recover existing bounds on the upperext input if any
+            lb = None
+            ub = None
+            if isinstance(o.type.bounds, StencilBoundsAttr):
+                lb = o.type.bounds.lb
+                ub = o.type.bounds.ub
+
+            ub_c = list(r_bounds.lb)
+            ub_c[op.dim.value.data] = op.index.value.data
+
+            ub_c = IndexAttr.get(*ub_c)
+
+            lb = IndexAttr.min(r_bounds.lb, lb)
+            ub = IndexAttr.max(ub_c, ub)
+
+            o.type = TempType(StencilBoundsAttr(zip(lb, ub)), o.type.element_type)
+
+        # Handle upperext results
+        for r, o in zip(upperext_res, op.upperext, strict=True):
+            assert isa(o.type, TempType[Attribute])
+            assert isa(r.type, TempType[Attribute])
+            r_bounds = r.type.bounds
+            assert isinstance(r_bounds, StencilBoundsAttr)
+            # Recover existing bounds on the upperext input if any
+            lb = None
+            ub = None
+            if isinstance(o.type.bounds, StencilBoundsAttr):
+                lb = o.type.bounds.lb
+                ub = o.type.bounds.ub
+
+            lb_c = list(r_bounds.lb)
+            lb_c[op.dim.value.data] = op.index.value.data
+
+            lb_c = IndexAttr.get(*lb_c)
+
+            lb = IndexAttr.min(lb_c, lb)
+            ub = IndexAttr.max(r_bounds.ub, ub)
+
+            o.type = TempType(StencilBoundsAttr(zip(lb, ub)), o.type.element_type)
 
 
 class LoadOpShapeInference(RewritePattern):


### PR DESCRIPTION
And implement support in verifiers and shape inference.
No support in the existing lowering is implemented yet, as this operation is not meant to be lowered directly but handled by dedicated passes; so will implement those separately.