### PR TITLE
dialects: (comb) Accept non-integer types in mux

### DIFF
--- a/tests/filecheck/dialects/comb/comb_ops.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops.mlir
@@ -8,6 +8,7 @@
   %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
   %lhsf64, %rhsf64 = "test.op"() : () -> (f64, f64)
   %lhsvec, %rhsvec = "test.op"() : () -> (vector<4xf32>, vector<4xf32>)
+  %lhstest, %rhstest = "test.op"() : () -> (!test.type<"test">, !test.type<"test">)
 
   %add = comb.add %lhsi32, %rhsi32 : i32
   // CHECK: %add = comb.add %lhsi32, %rhsi32 : i32
@@ -71,6 +72,9 @@
 
   %mux = comb.mux %lhsi1, %lhsi32, %rhsi32 : i32
   // CHECK-NEXT: %mux = comb.mux %lhsi1, %lhsi32, %rhsi32 : i32
+
+  %mux_exotic = comb.mux %lhsi1, %lhstest, %rhstest : !test.type<"test">
+  // CHECK-NEXT: %mux_exotic = comb.mux %lhsi1, %lhstest, %rhstest : !test.type<"test">
 
   %replicate = comb.replicate %lhsi32 : (i32) -> i64
   // CHECK-NEXT: %replicate = comb.replicate %lhsi32 : (i32) -> i64

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -555,7 +555,7 @@ class MuxOp(IRDLOperation):
 
     name = "comb.mux"
 
-    T = Annotated[IntegerType, ConstraintVar("T")]
+    T = Annotated[Attribute, ConstraintVar("T")]
 
     cond: Operand = operand_def(IntegerType(1))
     true_value: Operand = operand_def(T)

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -14,7 +14,7 @@ from collections.abc import Sequence
 from typing import Annotated
 
 from xdsl.dialects.builtin import IntegerAttr, IntegerType, UnitAttr, i32, i64
-from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
+from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue, TypeAttribute
 from xdsl.irdl import (
     ConstraintVar,
     IRDLOperation,
@@ -555,7 +555,7 @@ class MuxOp(IRDLOperation):
 
     name = "comb.mux"
 
-    T = Annotated[Attribute, ConstraintVar("T")]
+    T = Annotated[TypeAttribute, ConstraintVar("T")]
 
     cond: Operand = operand_def(IntegerType(1))
     true_value: Operand = operand_def(T)


### PR DESCRIPTION
Upstream CIRCT accepts any type in a mux. This fixes parity in xDSL.