### PR TITLE
dialects: (comb) Fix lowBit case in extract op

### DIFF
--- a/tests/filecheck/dialects/comb/comb_ops.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops.mlir
@@ -66,6 +66,9 @@
   %extract = comb.extract %lhsi32 from 1 : (i32) -> i3
   // CHECK-NEXT: %extract = comb.extract %lhsi32 from 1 : (i32) -> i3
 
+  %extract_generic = "comb.extract"(%lhsi32) {"lowBit" = 1 : i32} : (i32) -> i3
+  // CHECK-NEXT: %extract_generic = comb.extract %lhsi32 from 1 : (i32) -> i3
+
   %concat = comb.concat %lhsi32, %rhsi32 : i32, i32
   // CHECK-NEXT: %concat = comb.concat %lhsi32, %rhsi32 : i32, i32
 

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -391,7 +391,7 @@ class ExtractOp(IRDLOperation):
 
     input: Operand = operand_def(IntegerType)
     low_bit: IntegerAttr[Annotated[IntegerType, i32]] = attr_def(
-        IntegerAttr[Annotated[IntegerType, i32]]
+        IntegerAttr[Annotated[IntegerType, i32]], attr_name="lowBit"
     )
     result: OpResult = result_def(IntegerType)
 
@@ -403,7 +403,7 @@ class ExtractOp(IRDLOperation):
     ):
         operand = SSAValue.get(operand)
         return super().__init__(
-            attributes={"low_bit": low_bit},
+            attributes={"lowBit": low_bit},
             operands=[operand],
             result_types=[result_type],
         )


### PR DESCRIPTION
Upstream expects `lowBit` casing.