### PR TITLE
dialects: (seq) Add ConstClockOp

### DIFF
--- a/tests/filecheck/dialects/seq/seq_invalid.mlir
+++ b/tests/filecheck/dialects/seq/seq_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt --verify-diagnostics --parsing-diagnostics --split-input-file %s | filecheck %s
 
 builtin.module {
   %clk = "test.op"() : () -> (!seq.clock)
@@ -27,4 +27,11 @@ builtin.module {
 
   // CHECK: Both reset and reset_value must be set when one is
   %compreg_reset = "seq.compreg"(%data, %clk, %data) {"operandSegmentSizes" = array<i32: 1, 1, 0, 1, 0>} : (i14, !seq.clock, i14) -> i14
+}
+
+// -----
+
+builtin.module {
+  // CHECK: Expected either low or high clock value
+  %clock = seq.const_clock foobar
 }

--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -18,4 +18,11 @@ builtin.module {
   // CHECK: %compreg_all = seq.compreg %data, %clk reset %bool, %data powerOn %on : i14
   %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
   // CHECK: %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
+
+  %const_low = seq.const_clock low
+  // CHECK: %const_low = seq.const_clock low
+  %const_high = seq.const_clock high
+  // CHECK: %const_high = seq.const_clock high
+  %const_low_foo = seq.const_clock low {"foo"}
+  // CHECK: %const_low_foo = seq.const_clock low {"foo"}
 }

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -4,6 +4,7 @@ CIRCT’s seq dialect
 [1] https://circt.llvm.org/docs/Dialects/Seq/
 """
 
+from enum import Enum
 from typing import Annotated
 
 from xdsl.dialects.builtin import (
@@ -14,7 +15,7 @@ from xdsl.dialects.builtin import (
     i1,
 )
 from xdsl.dialects.hw import InnerSymAttr
-from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
+from xdsl.ir import Attribute, Data, Dialect, Operation, OpResult, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     ConstraintVar,
@@ -29,7 +30,7 @@ from xdsl.irdl import (
     opt_operand_def,
     result_def,
 )
-from xdsl.parser import Parser
+from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
 
@@ -135,13 +136,82 @@ class CompRegOp(IRDLOperation):
             raise VerifyException("Both reset and reset_value must be set when one is")
 
 
+class ClockConstAttrData(Enum):
+    LOW = 0
+    HIGH = 1
+
+
+@irdl_attr_definition
+class ClockConstAttr(Data[ClockConstAttrData]):
+    """
+    Clock constant.
+
+    This attribute diverges slightly from the upstream implementation
+    as xDSL does not allow completely unstructured parsing and printing
+    of attributes (for good reasons).
+    """
+
+    name = "seq.clock_constant"
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> ClockConstAttrData:
+        with parser.in_angle_brackets():
+            return ClockConstAttr.parse_parameter_free_standing(parser)
+
+    @classmethod
+    def parse_parameter_free_standing(cls, parser: AttrParser) -> ClockConstAttrData:
+        if parser.parse_optional_keyword("low") is not None:
+            return ClockConstAttrData.LOW
+        if parser.parse_optional_keyword("high") is not None:
+            return ClockConstAttrData.HIGH
+        parser.raise_error("Expected either low or high clock value")
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            self.print_parameter_free_standing(printer)
+
+    def print_parameter_free_standing(self, printer: Printer) -> None:
+        match self.data:
+            case ClockConstAttrData.LOW:
+                printer.print("low")
+            case ClockConstAttrData.HIGH:
+                printer.print("high")
+
+
+@irdl_op_definition
+class ConstClockOp(IRDLOperation):
+    """
+    The constant operation produces a constant clock value.
+    """
+
+    name = "seq.const_clock"
+
+    value: ClockConstAttr = attr_def(ClockConstAttr)
+    result: OpResult = result_def(clock)
+
+    @classmethod
+    def parse(cls, parser: Parser) -> "ConstClockOp":
+        value = ClockConstAttr(ClockConstAttr.parse_parameter_free_standing(parser))
+        attrs = parser.parse_optional_attr_dict_with_reserved_attr_names(("value",))
+        attrs_data = attrs.data if attrs is not None else {}
+        attrs_data["value"] = value
+        return ConstClockOp.create(attributes=attrs_data, result_types=[clock])
+
+    def print(self, printer: Printer):
+        printer.print(" ")
+        self.value.print_parameter_free_standing(printer)
+        printer.print_op_attributes(self.attributes, reserved_attr_names=("value",))
+
+
 Seq = Dialect(
     "seq",
     [
         ClockDivider,
         CompRegOp,
+        ConstClockOp,
     ],
     [
         ClockType,
+        ClockConstAttr,
     ],
 )


### PR DESCRIPTION
This PR adds the const clock operation. Because of the arguably very cursed way MLIR handles attribute parsing, we cannot reproduce the convenient structure upstream uses to easily parse the clock value. Instead, I set up a way for the attribute to expose this unstructured parsing for custom parsers.