### PR TITLE
dialects: (llvm) Fix elem_type bug in GEPOp builder

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -152,6 +152,7 @@ def test_llvm_getelementptr_op():
     )
 
     assert "elem_type" in gep2.properties
+    assert gep2.elem_type == builtin.i32
     assert "inbounds" not in gep2.properties
     assert gep2.result.type == ptr_type
     assert len(gep1.rawConstantIndices.data) == 1

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -622,8 +622,7 @@ class GEPOp(IRDLOperation):
         if not ptr_type.is_typed():
             if pointee_type is None:
                 raise ValueError("Opaque types must have a pointee type passed")
-            # opaque input ptr => opaque output ptr
-            props["elem_type"] = LLVMPointerType.opaque()
+            props["elem_type"] = pointee_type
 
         if inbounds:
             props["inbounds"] = UnitAttr()


### PR DESCRIPTION
There seems to have been a misunderstanding on the meaning of the element type in the llvm.getelementptr implementation in xDSL.