### PR TITLE
core: Implement unqualified attributes in declarative syntax.

### DIFF
--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -1,4 +1,5 @@
 // RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
 
 builtin.module {
   %clk = "test.op"() : () -> (!seq.clock)
@@ -18,6 +19,7 @@ builtin.module {
   // CHECK: %compreg_all = seq.compreg %data, %clk reset %bool, %data powerOn %on : i14
   %compreg_sym = seq.compreg sym @foo %data, %clk : i14
   // CHECK: %compreg_sym = seq.compreg sym @foo %data, %clk : i14
+  // CHECK-GENERIC:    %compreg_sym = "seq.compreg"(%data, %clk) {"inner_sym" = #hw<innerSym@foo>, "operandSegmentSizes" = array<i32: 1, 1, 0, 0, 0>} : (i14, !seq.clock) -> i14
 
   %const_low = seq.const_clock low
   // CHECK: %const_low = seq.const_clock low

--- a/tests/filecheck/dialects/seq/seq_ops.mlir
+++ b/tests/filecheck/dialects/seq/seq_ops.mlir
@@ -16,8 +16,8 @@ builtin.module {
   // CHECK: %compreg_poweron = seq.compreg %data, %clk powerOn %on : i14
   %compreg_all = seq.compreg %data, %clk reset %bool, %data powerOn %on : i14
   // CHECK: %compreg_all = seq.compreg %data, %clk reset %bool, %data powerOn %on : i14
-  %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
-  // CHECK: %compreg_sym = seq.compreg sym #hw<innerSym@foo> %data, %clk : i14
+  %compreg_sym = seq.compreg sym @foo %data, %clk : i14
+  // CHECK: %compreg_sym = seq.compreg sym @foo %data, %clk : i14
 
   %const_low = seq.const_clock low
   // CHECK: %const_low = seq.const_clock low

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -727,6 +727,7 @@ class AttributeVariable(FormatDirective):
     is_property: bool
     """Should this attribute be put in the attribute or property dictionary."""
     unique_base: type[Attribute] | None
+    """The known base class of the Attribute, if any."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
         builtin_attributes = Builtin.attributes

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -15,7 +15,6 @@ from xdsl.dialects.builtin import Builtin
 from xdsl.ir import (
     Attribute,
     Data,
-    OpaqueSyntaxAttribute,
     ParametrizedAttribute,
     SSAValue,
 )
@@ -731,18 +730,14 @@ class AttributeVariable(FormatDirective):
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
         builtin_attributes = Builtin.attributes
-        if (
-            self.unique_base is None
-            or self.unique_base in builtin_attributes
-            or issubclass(self.unique_base, OpaqueSyntaxAttribute)
-        ):
+        if self.unique_base is None or self.unique_base in builtin_attributes:
             attr = parser.parse_attribute()
         else:
             if issubclass(self.unique_base, ParametrizedAttribute):
-                attr = self.unique_base(self.unique_base.parse_parameters(parser))
+                attr = self.unique_base.new(self.unique_base.parse_parameters(parser))
             elif issubclass(self.unique_base, Data):
                 unique_base = cast(type[Data[Any]], self.unique_base)
-                attr = unique_base(unique_base.parse_parameter(parser))
+                attr = unique_base.new(unique_base.parse_parameter(parser))
             else:
                 raise ValueError("Attributes must be Data or ParameterizedAttribute!")
         if self.is_property:
@@ -762,11 +757,7 @@ class AttributeVariable(FormatDirective):
             attr = op.attributes[self.name]
 
         builtin_attributes = Builtin.attributes
-        if (
-            self.unique_base is None
-            or self.unique_base in builtin_attributes
-            or issubclass(self.unique_base, OpaqueSyntaxAttribute)
-        ):
+        if self.unique_base is None or self.unique_base in builtin_attributes:
             printer.print_attribute(attr)
         else:
             if isinstance(attr, ParametrizedAttribute):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -11,7 +11,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
-from xdsl.dialects.builtin import Builtin
 from xdsl.ir import (
     Attribute,
     Data,
@@ -730,8 +729,7 @@ class AttributeVariable(FormatDirective):
     """The known base class of the Attribute, if any."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
-        builtin_attributes = Builtin.attributes
-        if self.unique_base is None or self.unique_base in builtin_attributes:
+        if self.unique_base is None:
             attr = parser.parse_attribute()
         else:
             if issubclass(self.unique_base, ParametrizedAttribute):
@@ -757,8 +755,7 @@ class AttributeVariable(FormatDirective):
         else:
             attr = op.attributes[self.name]
 
-        builtin_attributes = Builtin.attributes
-        if self.unique_base is None or self.unique_base in builtin_attributes:
+        if self.unique_base is None:
             printer.print_attribute(attr)
         else:
             if isinstance(attr, ParametrizedAttribute):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -13,6 +13,7 @@ from itertools import pairwise
 
 from xdsl.ir import Attribute
 from xdsl.irdl import (
+    AttributeDef,
     AttrSizedOperandSegments,
     OpDef,
     OptAttributeDef,
@@ -21,6 +22,7 @@ from xdsl.irdl import (
     OptPropertyDef,
     OptResultDef,
     ParsePropInAttrDict,
+    PropertyDef,
     VariadicDef,
     VarOperandDef,
     VarResultDef,
@@ -369,10 +371,18 @@ class FormatParser(BaseParser):
             match attr_def:
                 case OptAttributeDef() | OptPropertyDef():
                     return OptionalAttributeVariable(
-                        variable_name, attr_or_prop == "property"
+                        variable_name,
+                        attr_or_prop == "property",
+                        attr_def.constr.get_unique_base(),
                     )
-                case _:
-                    return AttributeVariable(variable_name, attr_or_prop == "property")
+                case AttributeDef() | PropertyDef():
+                    return AttributeVariable(
+                        variable_name,
+                        attr_or_prop == "property",
+                        attr_def.constr.get_unique_base(),
+                    )
+                case None:
+                    pass
 
         self.raise_error(
             "expected variable to refer to an operand, "

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -11,18 +11,16 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from itertools import pairwise
 
+from xdsl.dialects.builtin import Builtin
 from xdsl.ir import Attribute
 from xdsl.irdl import (
-    AttributeDef,
+    AttrOrPropDef,
     AttrSizedOperandSegments,
     OpDef,
-    OptAttributeDef,
     OptionalDef,
     OptOperandDef,
-    OptPropertyDef,
     OptResultDef,
     ParsePropInAttrDict,
-    PropertyDef,
     VariadicDef,
     VarOperandDef,
     VarResultDef,
@@ -368,21 +366,20 @@ class FormatParser(BaseParser):
                 if attr_or_prop == "property"
                 else self.op_def.attributes.get(attr_name)
             )
-            match attr_def:
-                case OptAttributeDef() | OptPropertyDef():
-                    return OptionalAttributeVariable(
-                        variable_name,
-                        attr_or_prop == "property",
-                        attr_def.constr.get_unique_base(),
-                    )
-                case AttributeDef() | PropertyDef():
-                    return AttributeVariable(
-                        variable_name,
-                        attr_or_prop == "property",
-                        attr_def.constr.get_unique_base(),
-                    )
-                case None:
-                    pass
+            if isinstance(attr_def, AttrOrPropDef):
+                unique_base = attr_def.constr.get_unique_base()
+                # Always qualify builtin attributes
+                # This is technically an approximation, but appears to be good enough
+                # for xDSL right now.
+                if unique_base is not None and unique_base in Builtin.attributes:
+                    unique_base = None
+                variable_type = (
+                    OptionalAttributeVariable
+                    if isinstance(attr_def, OptionalDef)
+                    else AttributeVariable
+                )
+                is_property = attr_or_prop == "property"
+                return variable_type(variable_name, is_property, unique_base)
 
         self.raise_error(
             "expected variable to refer to an operand, "


### PR DESCRIPTION
Those were currently using qualified attribute syntax (i.e., wrapping the parameters in the attribute's name).
This is not the intended behaviour: when parsing/printing a known attribute type, it should only print and parse its parameters.
The fully-qualified case is implemented upstream by an explicit wrapper (`qualified($attr)`) and could be added if needed; I see it is mostly used by the LLVM dialect upstream.