### PR TITLE
core: Remove redundant output from IRDLOperation's verification error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/ret.mlir
 
 # PyBuilder
 .pybuilder/

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -971,7 +971,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Operation does not verify: arith.addi32 operation does not verify\n",
+      "Operation does not verify: result at position 0 does not verify!\n",
+      "Expected attribute i32 but got i64\n",
       "\n",
       "%0 = \"arith.addi32\"(%1, %1) : (i32, i32) -> i64\n",
       "\n",
@@ -1042,7 +1043,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Operation does not verify: binary_op operation does not verify\n",
+      "Operation does not verify: result at position 0 does not verify!\n",
+      "attribute i32 expected from variable 'T', but got i64\n",
       "\n",
       "%0 = \"binary_op\"(%1, %1) : (i32, i32) -> i64\n",
       "\n",
@@ -1469,7 +1471,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Operation does not verify: arith.addi operation does not verify\n",
+      "Operation does not verify: result at position 0 does not verify!\n",
+      "attribute i32 expected from variable 'T', but got i64\n",
       "\n",
       "%0 = \"arith.addi\"(%1, %1) : (i32, i32) -> i64\n",
       "\n",

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -971,7 +971,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Operation does not verify: result at position 0 does not verify!\n",
+      "Operation does not verify: result at position 0 does not verify:\n",
       "Expected attribute i32 but got i64\n",
       "\n",
       "%0 = \"arith.addi32\"(%1, %1) : (i32, i32) -> i64\n",
@@ -1043,7 +1043,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Operation does not verify: result at position 0 does not verify!\n",
+      "Operation does not verify: result at position 0 does not verify:\n",
       "attribute i32 expected from variable 'T', but got i64\n",
       "\n",
       "%0 = \"binary_op\"(%1, %1) : (i32, i32) -> i64\n",
@@ -1471,7 +1471,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Operation does not verify: result at position 0 does not verify!\n",
+      "Operation does not verify: result at position 0 does not verify:\n",
       "attribute i32 expected from variable 'T', but got i64\n",
       "\n",
       "%0 = \"arith.addi\"(%1, %1) : (i32, i32) -> i64\n",

--- a/docs/ret.mlir
+++ b/docs/ret.mlir
@@ -1,6 +1,0 @@
-builtin.module {
-  %0 = arith.constant 1 : i32
-  %1 = arith.constant 2 : i32
-  %2 = arith.addi %0, %1 : i32
-}
-

--- a/docs/ret.mlir
+++ b/docs/ret.mlir
@@ -1,0 +1,6 @@
+builtin.module {
+  %0 = arith.constant 1 : i32
+  %1 = arith.constant 2 : i32
+  %2 = arith.addi %0, %1 : i32
+}
+

--- a/tests/filecheck/dialects/onnx/onnx_invalid.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_invalid.mlir
@@ -23,7 +23,7 @@ builtin.module {
 builtin.module {
   %t0, %t1 = "test.op"() : () -> (f32, tensor<2x4xf32>)
 
-  // CHECK: operand at position 0 does not verify!
+  // CHECK: operand at position 0 does not verify:
   // CHECK: f32 should be of base attribute tensor
   %res_mul =  "onnx.Mul"(%t0, %t1) {onnx_node_name = "/Mul"} : (f32, tensor<2x4xf32>) -> tensor<2x4xf32>
 }
@@ -33,7 +33,7 @@ builtin.module {
 builtin.module {
   %t0, %t1 = "test.op"() : () -> (tensor<2x4xf32>, tensor<2x4xi32>)
 
-  // CHECK: operand at position 1 does not verify!
+  // CHECK: operand at position 1 does not verify:
   // CHECK: attribute f32 expected from variable 'T', but got i32
   %res_div =  "onnx.Div"(%t0, %t1) {onnx_node_name = "/Div"} : (tensor<2x4xf32>, tensor<2x4xi32>) -> tensor<2x4xf32>
 }
@@ -43,7 +43,7 @@ builtin.module {
 builtin.module {
   %t0 = "test.op"() : () -> (tensor<2x4xf32>)
 
-  // CHECK: operand at position 1 does not verify!
+  // CHECK: operand at position 1 does not verify:
   // CHECK: Operation does not verify: Mismatch between operand type and res type of onnx.Relu
   %res_relu =  "onnx.Relu"(%t0) {onnx_node_name = "/Relu"} : (tensor<2x4xf32>) -> tensor<3x4xf32>
 }
@@ -62,7 +62,7 @@ builtin.module {
 builtin.module {
   %t0, %t1, %t2 = "test.op"() : () -> (f32, tensor<2x4xf32>,tensor<2x4xf32>)
 
-  // CHECK: operand at position 0 does not verify!
+  // CHECK: operand at position 0 does not verify:
   // CHECK: f32 should be of base attribute tensor
   %res_gemm=  "onnx.Gemm"(%t0, %t1, %t2) {onnx_node_name = "/Gemm"} : (f32, tensor<2x4xf32>, tensor<2x4xf32>) -> tensor<2x4xf32>
 }
@@ -81,7 +81,7 @@ builtin.module {
 builtin.module {
   %t0, %t1, %t2 = "test.op"() : () -> (tensor<2x4xf32>, tensor<2x4xi32>, tensor<2x4xf32>)
 
-  // CHECK: operand at position 1 does not verify!
+  // CHECK: operand at position 1 does not verify:
   // CHECK: attribute f32 expected from variable 'T', but got i32
   %res_gemm =  "onnx.Gemm"(%t0, %t1, %t2) {onnx_node_name = "/Gemm"} : (tensor<2x4xf32>, tensor<2x4xi32>, tensor<2x4xf32>) -> tensor<2x4xf32>
 
@@ -116,7 +116,7 @@ builtin.module {
 builtin.module {
   %t0, %t1 = "test.op"() : () -> (f32, tensor<2x4xi64>)
 
-  // CHECK: operand at position 0 does not verify!
+  // CHECK: operand at position 0 does not verify:
   // CHECK: f32 should be of base attribute tensor
   %res_reshape =  "onnx.Reshape"(%t0, %t1) {onnx_node_name = "/Reshape"} : (f32, tensor<2x4xi64>) -> tensor<2x4xi64>
 }
@@ -126,7 +126,7 @@ builtin.module {
 builtin.module {
     %t0, %t1 = "test.op"() : () -> (tensor<4x3x2xf32>, tensor<1xi64>)
 
-  // CHECK: result at position 0 does not verify!
+  // CHECK: result at position 0 does not verify:
   // CHECK: attribute f32 expected from variable 'T', but got i32
   %res_reshape = "onnx.Reshape"(%t0, %t1) {"onnx_node_name" = "/Reshape"} : (tensor<4x3x2xf32>, tensor<1xi64>) -> tensor<4x3x2xi32>
 }
@@ -136,7 +136,7 @@ builtin.module {
 builtin.module {
     %t0, %t1 = "test.op"() : () -> (tensor<6x9x5xf32>, tensor<3xi64>)
 
-  // CHECK: result at position 0 does not verify!
+  // CHECK: result at position 0 does not verify:
   // CHECK: Operation does not verify: Input tensor's shape and output tensor's shape must have the same number of elements
   %res_reshape = "onnx.Reshape"(%t0, %t1) {"onnx_node_name" = "/Reshape"} : (tensor<6x9x5xf32>, tensor<3xi64>) -> tensor<6x9xf32>
 }
@@ -155,7 +155,7 @@ builtin.module {
 builtin.module {
     %t0, %t1 = "test.op"() : () -> (tensor<6x9x5xf32>, tensor<3xi64>)
 
-  // CHECK: result at position 0 does not verify!
+  // CHECK: result at position 0 does not verify:
   // CHECK:  vector<6x9x5xf32> should be of base attribute tensor
   %res_reshape = "onnx.Reshape"(%t0, %t1) {"onnx_node_name" = "/Reshape"} : (tensor<6x9x5xf32>, tensor<3xi64>) -> vector<6x9x5xf32>
 }
@@ -165,7 +165,7 @@ builtin.module {
 builtin.module {
     %t0, %t1 = "test.op"() : () -> (vector<6x9x5xf32>, tensor<3xi64>)
 
-  // CHECK: operand at position 0 does not verify!
+  // CHECK: operand at position 0 does not verify:
   // CHECK:  vector<6x9x5xf32> should be of base attribute tensor
   %res_reshape = "onnx.Reshape"(%t0, %t1) {"onnx_node_name" = "/Reshape"} : (vector<6x9x5xf32>, tensor<3xi64>) -> tensor<6x9x5xf32>
 }
@@ -206,7 +206,7 @@ builtin.module {
 builtin.module {
   %t0,%t1,%t2 = "test.op"(): () ->  (f32, tensor<1x1x3x3xf32>, none)
 
-  // CHECK: operand at position 0 does not verify!
+  // CHECK: operand at position 0 does not verify:
   // CHECK: f32 should be of base attribute tensor
   %res_conv =  "onnx.Conv"(%t0, %t1, %t2) {onnx_node_name = "/Conv"} : (f32, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
 }
@@ -216,7 +216,7 @@ builtin.module {
 builtin.module {
     %t0,%t1,%t2 = "test.op"(): () ->  (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none)
 
-  // CHECK: result at position 0 does not verify!
+  // CHECK: result at position 0 does not verify:
   // CHECK: attribute f32 expected from variable 'T', but got i32
   %res_conv = "onnx.Conv"(%t0, %t1, %t2) {"onnx_node_name" = "/Conv"} : (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xi32>
 
@@ -368,7 +368,7 @@ builtin.module {
 builtin.module {
   %t0 = "test.op"(): () ->  (f32)
 
-  // CHECK: operand at position 0 does not verify!
+  // CHECK: operand at position 0 does not verify:
   // CHECK: Unexpected attribute f32
   %res_max_pool_single_out =  "onnx.MaxPoolSingleOut"(%t0) {onnx_node_name = "/MaxPoolSingleOut"} : (f32) -> tensor<5x5x32x32xf32>
 }
@@ -378,7 +378,7 @@ builtin.module {
 builtin.module {
     %t0= "test.op"(): () ->  (tensor<5x5x32x32xf32>)
 
-  // CHECK: result at position 0 does not verify!
+  // CHECK: result at position 0 does not verify:
   // CHECK: Unexpected attribute tensor<5x5x32x32xi32>
   %res_max_pool_single_out = "onnx.MaxPoolSingleOut"(%t0) {"onnx_node_name" = "/MaxPoolSingleOut"} : (tensor<5x5x32x32xf32>) -> tensor<5x5x32x32xi32>
 

--- a/tests/filecheck/dialects/scf/parallel_multiple_blocks.mlir
+++ b/tests/filecheck/dialects/scf/parallel_multiple_blocks.mlir
@@ -12,5 +12,5 @@
   }) {"operandSegmentSizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 }) : () -> ()
 
-// CHECK:      Operation does not verify: region at position 0 does not verify!
+// CHECK:      Operation does not verify: region at position 0 does not verify:
 // CHECK-NEXT: expected a single block, but got 2 blocks

--- a/tests/filecheck/dialects/scf/parallel_multiple_blocks.mlir
+++ b/tests/filecheck/dialects/scf/parallel_multiple_blocks.mlir
@@ -12,4 +12,5 @@
   }) {"operandSegmentSizes" = array<i32: 1, 1, 1, 0>} : (index, index, index) -> ()
 }) : () -> ()
 
-// CHECK: scf.parallel operation does not verify
+// CHECK:      Operation does not verify: region at position 0 does not verify!
+// CHECK-NEXT: expected a single block, but got 2 blocks

--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -41,7 +41,7 @@ builtin.module {
 builtin.module {
   %t0, %t1 = "test.op"() : () -> (f32, tensor<1xi32>)
 
-  // CHECK: operand at position 0 does not verify!
+  // CHECK: operand at position 0 does not verify:
   // CHECK: f32 should be of base attribute tensor
   %res_reshape =  tensor.reshape %t0(%t1)  : (f32, tensor<1xi32>) -> tensor<4xf32>
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -851,10 +851,9 @@ def test_op_custom_verify_is_done_last():
     a = Constant.from_int_and_width(1, i32)
     # CustomVerify expects a i64, not i32
     b = CustomVerify.get(a.result)
-    with pytest.raises(Exception) as e:
+    with pytest.raises(VerifyException) as e:
         b.verify()
-    assert e.value.args[0] != "Custom Verification Check"
-    assert "test.custom_verify_op operation does not verify" in e.value.args[0]
+    assert "Custom Verification Check" not in e.value.args[0]
 
 
 def test_block_walk():

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1822,7 +1822,7 @@ def irdl_op_verify_arg_list(
             error(
                 op,
                 f"{get_construct_name(construct)} at position "
-                f"{arg_idx} does not verify!\n{e}",
+                f"{arg_idx} does not verify:\n{e}",
                 e,
             )
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 def error(op: Operation, msg: str, e: Exception):
     diag = Diagnostic()
     diag.add_message(op, msg)
-    diag.raise_exception(f"{op.name} operation does not verify", op, type(e), e)
+    diag.raise_exception(msg, op, type(e), e)
 
 
 class IRDLAnnotations(Enum):


### PR DESCRIPTION
Minor refactor of error reporting, removing superfluous intermediary messages from IRDL.
More importantly, this was capturing the error thrown by constraints, forcing users to scroll back to the underlying exception; this enables to directly print messages as seen in:
- #2482 