### PR TITLE
dialects: (x86) PR5_3 - single operand instructions - source and destination 

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -22,3 +22,5 @@ x86.push %0 : (!x86.reg<rax>) -> ()
 // CHECK: push rax
 %pop, %poprsp = x86.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<rax>, !x86.reg<rsp>)
 // CHECK: pop rax
+%not = x86.not %0 : (!x86.reg<rax>) -> !x86.reg<rax>
+// CHECK: not rax

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -23,3 +23,5 @@ x86.push %0 : (!x86.reg<>) -> ()
 // CHECK-NEXT: x86.push %{{.*}} : (!x86.reg<>)
 %pop, %poprsp = x86.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
 // CHECK-NEXT: %{{.*}}, %{{.*}} = x86.pop %{{.*}} : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
+%not = x86.not %0 : (!x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.not %{{.*}} : (!x86.reg<>) -> !x86.reg<>

--- a/xdsl/dialects/x86/__init__.py
+++ b/xdsl/dialects/x86/__init__.py
@@ -6,6 +6,7 @@ from .ops import (
     GetRegisterOp,
     ImulOp,
     MovOp,
+    NotOp,
     OrOp,
     PopOp,
     PushOp,
@@ -26,6 +27,7 @@ X86 = Dialect(
         MovOp,
         PushOp,
         PopOp,
+        NotOp,
         GetRegisterOp,
     ],
     [

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
 from io import StringIO
-from typing import IO, Generic, TypeAlias, TypeVar
+from typing import IO, Annotated, Generic, TypeAlias, TypeVar
 
 from typing_extensions import Self
 
@@ -18,6 +18,7 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.irdl import (
+    ConstraintVar,
     IRDLOperation,
     irdl_op_definition,
     operand_def,
@@ -360,6 +361,48 @@ class PopOp(ROperationDst[GeneralRegisterType]):
     """
 
     name = "x86.pop"
+
+
+class ROperationSrcDst(Generic[R1InvT], SingleOperandInstruction):
+    """
+    A base class for x86 operations that have one register acting as both source and destination.
+    """
+
+    T = Annotated[GeneralRegisterType, ConstraintVar("T")]
+    source = operand_def(R1InvT)
+    destination = result_def(R1InvT)
+
+    def __init__(
+        self,
+        source: Operation | SSAValue | None = None,
+        *,
+        comment: str | StringAttr | None = None,
+        destination: R1InvT | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[source],
+            attributes={
+                "comment": comment,
+            },
+            result_types=[destination],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return (self.source,)
+
+
+@irdl_op_definition
+class NotOp(ROperationSrcDst[GeneralRegisterType]):
+    """
+    bitwise not of r1, stored in r1
+    x[r1] = ~x[r1]
+    https://www.felixcloutier.com/x86/not
+    """
+
+    name = "x86.not"
 
 
 # region Assembly printing


### PR DESCRIPTION
re-implementing the changes from #2456 after a merge conflict proved too annoying to handle. The changes have already been approved and I made sure that there were no errors during the copy-paste process.
