### PR TITLE
dialects: (x86) - Reformats and changes in naming convention

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -4,23 +4,23 @@
 %1 = x86.get_register : () -> !x86.reg<rdx>
 %rsp = x86.get_register : () -> !x86.reg<rsp>
 
-%add = x86.add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%add = x86.rr_add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: add rax, rdx
-%sub = x86.sub %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%sub = x86.rr_sub %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: sub rax, rdx
-%imul = x86.imul %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%imul = x86.rr_imul %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: imul rax, rdx
-%and = x86.and %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%and = x86.rr_and %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: and rax, rdx
-%or = x86.or %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%or = x86.rr_or %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: or rax, rdx
-%xor = x86.xor %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%xor = x86.rr_xor %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: xor rax, rdx
-%mov = x86.mov %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%mov = x86.rr_mov %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: mov rax, rdx
-x86.push %0 : (!x86.reg<rax>) -> ()
+x86.r_push %0 : (!x86.reg<rax>) -> ()
 // CHECK: push rax
-%pop, %poprsp = x86.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<rax>, !x86.reg<rsp>)
+%pop, %poprsp = x86.r_pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<rax>, !x86.reg<rsp>)
 // CHECK: pop rax
-%not = x86.not %0 : (!x86.reg<rax>) -> !x86.reg<rax>
+%not = x86.r_not %0 : (!x86.reg<rax>) -> !x86.reg<rax>
 // CHECK: not rax

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -4,23 +4,23 @@
 %1 = x86.get_register : () -> !x86.reg<rdx>
 %rsp = x86.get_register : () -> !x86.reg<rsp>
 
-%add = x86.rr_add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%add = x86.rr.add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: add rax, rdx
-%sub = x86.rr_sub %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%sub = x86.rr.sub %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: sub rax, rdx
-%imul = x86.rr_imul %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%imul = x86.rr.imul %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: imul rax, rdx
-%and = x86.rr_and %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%and = x86.rr.and %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: and rax, rdx
-%or = x86.rr_or %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%or = x86.rr.or %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: or rax, rdx
-%xor = x86.rr_xor %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%xor = x86.rr.xor %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: xor rax, rdx
-%mov = x86.rr_mov %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%mov = x86.rr.mov %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: mov rax, rdx
-x86.r_push %0 : (!x86.reg<rax>) -> ()
+x86.r.push %0 : (!x86.reg<rax>) -> ()
 // CHECK: push rax
-%pop, %poprsp = x86.r_pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<rax>, !x86.reg<rsp>)
+%pop, %poprsp = x86.r.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<rax>, !x86.reg<rsp>)
 // CHECK: pop rax
-%not = x86.r_not %0 : (!x86.reg<rax>) -> !x86.reg<rax>
+%not = x86.r.not %0 : (!x86.reg<rax>) -> !x86.reg<rax>
 // CHECK: not rax

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -5,23 +5,23 @@
 %0, %1 = "test.op"() : () -> (!x86.reg<>, !x86.reg<>)
 %rsp = "test.op"() : () -> !x86.reg<rsp>
 
-%add = x86.rr_add %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK: %{{.*}} = x86.rr_add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%sub = x86.rr_sub %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr_sub %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%mul = x86.rr_imul %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr_imul %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%and = x86.rr_and %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr_and %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%or = x86.rr_or %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr_or %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%xor = x86.rr_xor %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr_xor %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%mov = x86.rr_mov %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr_mov %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-x86.r_push %0 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.r_push %{{.*}} : (!x86.reg<>)
-%pop, %poprsp = x86.r_pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r_pop %{{.*}} : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
-%not = x86.r_not %0 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.r_not %{{.*}} : (!x86.reg<>) -> !x86.reg<>
+%add = x86.rr.add %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK: %{{.*}} = x86.rr.add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%sub = x86.rr.sub %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr.sub %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%mul = x86.rr.imul %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr.imul %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%and = x86.rr.and %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr.and %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%or = x86.rr.or %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr.or %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%xor = x86.rr.xor %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr.xor %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%mov = x86.rr.mov %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr.mov %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+x86.r.push %0 : (!x86.reg<>) -> ()
+// CHECK-NEXT: x86.r.push %{{.*}} : (!x86.reg<>)
+%pop, %poprsp = x86.r.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r.pop %{{.*}} : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
+%not = x86.r.not %0 : (!x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.r.not %{{.*}} : (!x86.reg<>) -> !x86.reg<>

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -5,23 +5,23 @@
 %0, %1 = "test.op"() : () -> (!x86.reg<>, !x86.reg<>)
 %rsp = "test.op"() : () -> !x86.reg<rsp>
 
-%add = x86.add %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK: %{{.*}} = x86.add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%sub = x86.sub %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.sub %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%mul = x86.imul %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.imul %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%and = x86.and %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.and %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%or = x86.or %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.or %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%xor = x86.xor %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.xor %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%mov = x86.mov %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.mov %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-x86.push %0 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.push %{{.*}} : (!x86.reg<>)
-%pop, %poprsp = x86.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.pop %{{.*}} : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
-%not = x86.not %0 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.not %{{.*}} : (!x86.reg<>) -> !x86.reg<>
+%add = x86.rr_add %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK: %{{.*}} = x86.rr_add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%sub = x86.rr_sub %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr_sub %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%mul = x86.rr_imul %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr_imul %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%and = x86.rr_and %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr_and %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%or = x86.rr_or %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr_or %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%xor = x86.rr_xor %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr_xor %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%mov = x86.rr_mov %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rr_mov %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+x86.r_push %0 : (!x86.reg<>) -> ()
+// CHECK-NEXT: x86.r_push %{{.*}} : (!x86.reg<>)
+%pop, %poprsp = x86.r_pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r_pop %{{.*}} : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
+%not = x86.r_not %0 : (!x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.r_not %{{.*}} : (!x86.reg<>) -> !x86.reg<>

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -152,7 +152,7 @@ class X86Instruction(X86Op):
 
     def assembly_line(self) -> str | None:
         # default assembly code generator
-        instruction_name = self.assembly_instruction_name().split("_", 1)[-1]
+        instruction_name = self.assembly_instruction_name()
         arg_str = ", ".join(
             _assembly_arg_str(arg)
             for arg in self.assembly_line_args()
@@ -202,7 +202,7 @@ class AddOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     https://www.felixcloutier.com/x86/add
     """
 
-    name = "x86.rr_add"
+    name = "x86.rr.add"
 
 
 @irdl_op_definition
@@ -213,7 +213,7 @@ class SubOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     https://www.felixcloutier.com/x86/sub
     """
 
-    name = "x86.rr_sub"
+    name = "x86.rr.sub"
 
 
 @irdl_op_definition
@@ -224,7 +224,7 @@ class ImulOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     https://www.felixcloutier.com/x86/imul
     """
 
-    name = "x86.rr_imul"
+    name = "x86.rr.imul"
 
 
 @irdl_op_definition
@@ -235,7 +235,7 @@ class AndOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     https://www.felixcloutier.com/x86/and
     """
 
-    name = "x86.rr_and"
+    name = "x86.rr.and"
 
 
 @irdl_op_definition
@@ -246,7 +246,7 @@ class OrOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     https://www.felixcloutier.com/x86/or
     """
 
-    name = "x86.rr_or"
+    name = "x86.rr.or"
 
 
 @irdl_op_definition
@@ -257,7 +257,7 @@ class XorOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     https://www.felixcloutier.com/x86/xor
     """
 
-    name = "x86.rr_xor"
+    name = "x86.rr.xor"
 
 
 @irdl_op_definition
@@ -268,7 +268,7 @@ class MovOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     https://www.felixcloutier..com/x86/mov
     """
 
-    name = "x86.rr_mov"
+    name = "x86.rr.mov"
 
 
 class M_R_Operation(Generic[R1InvT], IRDLOperation, X86Instruction, ABC):
@@ -306,7 +306,7 @@ class PushOp(M_R_Operation[GeneralRegisterType]):
     https://www.felixcloutier.com/x86/push
     """
 
-    name = "x86.r_push"
+    name = "x86.r.push"
 
 
 class R_M_Operation(Generic[R1InvT], IRDLOperation, X86Instruction, ABC):
@@ -348,7 +348,7 @@ class PopOp(R_M_Operation[GeneralRegisterType]):
     https://www.felixcloutier.com/x86/pop
     """
 
-    name = "x86.r_pop"
+    name = "x86.r.pop"
 
 
 class R_R_Operation(Generic[R1InvT], IRDLOperation, X86Instruction, ABC):
@@ -390,7 +390,7 @@ class NotOp(R_R_Operation[GeneralRegisterType]):
     https://www.felixcloutier.com/x86/not
     """
 
-    name = "x86.r_not"
+    name = "x86.r.not"
 
 
 # region Assembly printing

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -152,7 +152,7 @@ class X86Instruction(X86Op):
 
     def assembly_line(self) -> str | None:
         # default assembly code generator
-        instruction_name = self.assembly_instruction_name()
+        instruction_name = self.assembly_instruction_name().split("_", 1)[-1]
         arg_str = ", ".join(
             _assembly_arg_str(arg)
             for arg in self.assembly_line_args()
@@ -161,19 +161,7 @@ class X86Instruction(X86Op):
         return _assembly_line(instruction_name, arg_str, self.comment)
 
 
-class SingleOperandInstruction(IRDLOperation, X86Instruction, ABC):
-    """
-    Base class for instructions that take a single operand.
-    """
-
-
-class DoubleOperandInstruction(IRDLOperation, X86Instruction, ABC):
-    """
-    Base class for instructions that take two operands.
-    """
-
-
-class RROperation(Generic[R1InvT, R2InvT], DoubleOperandInstruction):
+class R_RR_Operation(Generic[R1InvT, R2InvT], IRDLOperation, X86Instruction, ABC):
     """
     A base class for x86 operations that have two registers.
     """
@@ -207,83 +195,83 @@ class RROperation(Generic[R1InvT, R2InvT], DoubleOperandInstruction):
 
 
 @irdl_op_definition
-class AddOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
+class AddOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Adds the registers r1 and r2 and stores the result in r1.
     x[r1] = x[r1] + x[r2]
     https://www.felixcloutier.com/x86/add
     """
 
-    name = "x86.add"
+    name = "x86.rr_add"
 
 
 @irdl_op_definition
-class SubOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
+class SubOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     subtracts r2 from r1 and stores the result in r1.
     x[r1] = x[r1] - x[r2]
     https://www.felixcloutier.com/x86/sub
     """
 
-    name = "x86.sub"
+    name = "x86.rr_sub"
 
 
 @irdl_op_definition
-class ImulOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
+class ImulOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Multiplies the registers r1 and r2 and stores the result in r1.
     x[r1] = x[r1] * x[r2]
     https://www.felixcloutier.com/x86/imul
     """
 
-    name = "x86.imul"
+    name = "x86.rr_imul"
 
 
 @irdl_op_definition
-class AndOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
+class AndOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     bitwise and of r1 and r2, stored in r1
     x[r1] = x[r1] & x[r2]
     https://www.felixcloutier.com/x86/and
     """
 
-    name = "x86.and"
+    name = "x86.rr_and"
 
 
 @irdl_op_definition
-class OrOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
+class OrOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     bitwise or of r1 and r2, stored in r1
     x[r1] = x[r1] | x[r2]
     https://www.felixcloutier.com/x86/or
     """
 
-    name = "x86.or"
+    name = "x86.rr_or"
 
 
 @irdl_op_definition
-class XorOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
+class XorOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     bitwise xor of r1 and r2, stored in r1
     x[r1] = x[r1] ^ x[r2]
     https://www.felixcloutier.com/x86/xor
     """
 
-    name = "x86.xor"
+    name = "x86.rr_xor"
 
 
 @irdl_op_definition
-class MovOp(RROperation[GeneralRegisterType, GeneralRegisterType]):
+class MovOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Copies the value of r1 into r2.
     x[r1] = x[r2]
     https://www.felixcloutier..com/x86/mov
     """
 
-    name = "x86.mov"
+    name = "x86.rr_mov"
 
 
-class ROperationSrc(Generic[R1InvT], SingleOperandInstruction):
+class M_R_Operation(Generic[R1InvT], IRDLOperation, X86Instruction, ABC):
     """
     A base class for x86 operations that have one source register.
     """
@@ -312,16 +300,16 @@ class ROperationSrc(Generic[R1InvT], SingleOperandInstruction):
 
 
 @irdl_op_definition
-class PushOp(ROperationSrc[GeneralRegisterType]):
+class PushOp(M_R_Operation[GeneralRegisterType]):
     """
     Decreases %rsp and places r1 at the new memory location pointed to by %rsp.
     https://www.felixcloutier.com/x86/push
     """
 
-    name = "x86.push"
+    name = "x86.r_push"
 
 
-class ROperationDst(Generic[R1InvT], SingleOperandInstruction):
+class R_M_Operation(Generic[R1InvT], IRDLOperation, X86Instruction, ABC):
     """
     A base class for x86 operations that have one destination register.
     """
@@ -354,16 +342,16 @@ class ROperationDst(Generic[R1InvT], SingleOperandInstruction):
 
 
 @irdl_op_definition
-class PopOp(ROperationDst[GeneralRegisterType]):
+class PopOp(R_M_Operation[GeneralRegisterType]):
     """
     Copies the value at the top of the stack into r1 and increases %rsp.
     https://www.felixcloutier.com/x86/pop
     """
 
-    name = "x86.pop"
+    name = "x86.r_pop"
 
 
-class ROperationSrcDst(Generic[R1InvT], SingleOperandInstruction):
+class R_R_Operation(Generic[R1InvT], IRDLOperation, X86Instruction, ABC):
     """
     A base class for x86 operations that have one register acting as both source and destination.
     """
@@ -395,14 +383,14 @@ class ROperationSrcDst(Generic[R1InvT], SingleOperandInstruction):
 
 
 @irdl_op_definition
-class NotOp(ROperationSrcDst[GeneralRegisterType]):
+class NotOp(R_R_Operation[GeneralRegisterType]):
     """
     bitwise not of r1, stored in r1
     x[r1] = ~x[r1]
     https://www.felixcloutier.com/x86/not
     """
 
-    name = "x86.not"
+    name = "x86.r_not"
 
 
 # region Assembly printing


### PR DESCRIPTION
I've done some changes to the naming conventions following the suggestions of @tarinduj. This includes removing the single/doubleOperand parent classes (issue #2466), writing the class names in the format [Result]-[Operands]-Operation, and changing the individual names of the operations to prepare for the different configurations those instructions can exist in. The prefix signifies the type of the operand passed into the assembly instruction and is removed during assembly emission.