### PR TITLE
core: Handling true and false literals in DenseBaseAttr

### DIFF
--- a/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
+++ b/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
@@ -3,4 +3,4 @@
 "builtin.module" () {"test" = array<i32: "", 3>} ({
 })
 
-// CHECK: integer or float literal expected
+// CHECK: integer, boolean or float literal expected

--- a/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
+++ b/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
@@ -3,4 +3,4 @@
 "builtin.module" () {"test" = array<i32: "", 3>} ({
 })
 
-// CHECK: integer, boolean or float literal expected
+// CHECK: integer, boolean, or float literal expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -757,57 +757,65 @@ def test_parse_optional_int_error(text: str, allow_boolean: bool, allow_negative
 
 
 @pytest.mark.parametrize(
-    "text, expected_value",
+    "text, allow_boolean, expected_value",
     [
-        ("42", 42),
-        ("-1", -1),
-        ("true", None),
-        ("false", None),
-        ("0x1a", 26),
-        ("-0x1a", -26),
-        ("0.", 0.0),
-        ("1.", 1.0),
-        ("0.2", 0.2),
-        ("38.1243", 38.1243),
-        ("92.54e43", 92.54e43),
-        ("92.5E43", 92.5e43),
-        ("43.3e-54", 43.3e-54),
-        ("32.E+25", 32.0e25),
+        ("42", False, 42),
+        ("-1", False, -1),
+        ("true", False, None),
+        ("false", False, None),
+        ("0x1a", False, 26),
+        ("-0x1a", False, -26),
+        ("0.", False, 0.0),
+        ("1.", False, 1.0),
+        ("0.2", False, 0.2),
+        ("38.1243", False, 38.1243),
+        ("92.54e43", False, 92.54e43),
+        ("92.5E43", False, 92.5e43),
+        ("43.3e-54", False, 43.3e-54),
+        ("32.E+25", False, 32.0e25),
+        ("true", True, 1),
+        ("false", True, 0),
+        ("42", True, 42),
+        ("0.2", True, 0.2),
     ],
 )
-def test_parse_number(text: str, expected_value: int | float | None):
+def test_parse_number(
+    text: str, allow_boolean: bool, expected_value: int | float | None
+):
     parser = Parser(MLContext(), text)
-    assert parser.parse_optional_number() == expected_value
+    assert parser.parse_optional_number(allow_boolean=allow_boolean) == expected_value
 
     parser = Parser(MLContext(), text)
     if expected_value is None:
         with pytest.raises(ParseError):
             parser.parse_number()
     else:
-        assert parser.parse_number() == expected_value
+        assert parser.parse_number(allow_boolean=allow_boolean) == expected_value
 
 
 @pytest.mark.parametrize(
-    "text",
+    "text, allow_boolean",
     [
-        ("-false"),
-        ("-true"),
-        ("-k"),
-        ("-("),
+        ("-false", False),
+        ("-true", False),
+        ("-false", True),
+        ("-true", True),
+        ("-k", False),
+        ("-(", False),
     ],
 )
-def test_parse_number_error(text: str):
+def test_parse_number_error(text: str, allow_boolean: bool):
     """
     Test that parsing a negative without an
     integer or a float after raise an error.
     """
     parser = Parser(MLContext(), text)
     with pytest.raises(ParseError):
-        parser.parse_optional_number()
+        parser.parse_optional_number(allow_boolean=allow_boolean)
 
     parser = Parser(MLContext(), text)
     with pytest.raises(ParseError):
-        parser.parse_number()
+        parser.parse_number(allow_boolean=allow_boolean)
 
 
 @irdl_op_definition

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -718,7 +718,7 @@ def test_densearray_attr():
     """Test that a DenseArrayAttr can be parsed and then printed."""
 
     prog = """
-"func.func"() <{"sym_name" = "test", "function_type" = i64, "sym_visibility" = "private", "unit_attr"}> {"arg_attrs" = array<i1: false, true>, "other_attr" = array<i32: 19, 23, 55>} : () -> ()
+"func.func"() <{"sym_name" = "test", "function_type" = i64, "sym_visibility" = "private", "unit_attr"}> {"bool_attrs" = array<i1: false, true>, "int_attr" = array<i32: 19, 23, 55>, "float_attr" = array<f32: 0.34>} : () -> ()
     """
 
     ctx = MLContext()

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -714,6 +714,23 @@ def test_dictionary_attr():
     assert_print_op(parsed, prog, None)
 
 
+def test_densearray_attr():
+    """Test that a DenseArrayAttr can be parsed and then printed."""
+
+    prog = """
+"func.func"() <{"sym_name" = "test", "function_type" = i64, "sym_visibility" = "private", "unit_attr"}> {"arg_attrs" = array<i1: false, true>, "other_attr" = array<i32: 19, 23, 55>} : () -> ()
+    """
+
+    ctx = MLContext()
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Func)
+
+    parser = Parser(ctx, prog)
+    parsed = parser.parse_op()
+
+    assert_print_op(parsed, prog, None)
+
+
 def test_print_function_type():
     io = StringIO()
     printer = Printer(stream=io)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -883,7 +883,9 @@ class AttrParser(BaseParser):
 
         self.parse_characters(":", " in dense array")
 
-        values = self.parse_comma_separated_list(self.Delimiter.NONE, self.parse_number)
+        values = self.parse_comma_separated_list(
+            self.Delimiter.NONE, self.parse_integer
+        )
         self.parse_characters(">", " in dense array")
 
         return DenseArrayBase.from_list(element_type, values)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -894,8 +894,19 @@ class AttrParser(BaseParser):
         if None in values:
             assert values.count(None) == len(values)
             values = self.parse_comma_separated_list(
-                self.Delimiter.NONE, self.parse_integer
+                self.Delimiter.NONE, self.parse_optional_integer
             )
+        if None in values:
+            raise ParseError(
+                name,
+                "integer, boolean or float literal expected",
+            )
+
+        # This is needed to keep pyright happy, to remove the None from the lists
+        # types (from parse_optional_number) as this is not compatible with the
+        # types of DenseArrayBase.from_list
+        values = cast(list[int | float], values)
+
         self.parse_characters(">", " in dense array")
 
         return DenseArrayBase.from_list(element_type, values)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -884,8 +884,18 @@ class AttrParser(BaseParser):
         self.parse_characters(":", " in dense array")
 
         values = self.parse_comma_separated_list(
-            self.Delimiter.NONE, self.parse_integer
+            self.Delimiter.NONE, self.parse_optional_number
         )
+        # parse_number will handle integers and floats, but not true/false as integers,
+        # whereas parse_integer is integer only (not floats) but handles true/false as
+        # integers. Therefore we try with parse_optional_number first, and if
+        # this can not parse we try with parse_integer. There is a single type,
+        # so if one parsed entry is None then all should be
+        if None in values:
+            assert values.count(None) == len(values)
+            values = self.parse_comma_separated_list(
+                self.Delimiter.NONE, self.parse_integer
+            )
         self.parse_characters(">", " in dense array")
 
         return DenseArrayBase.from_list(element_type, values)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -884,28 +884,8 @@ class AttrParser(BaseParser):
         self.parse_characters(":", " in dense array")
 
         values = self.parse_comma_separated_list(
-            self.Delimiter.NONE, self.parse_optional_number
+            self.Delimiter.NONE, lambda: self.parse_number(allow_boolean=True)
         )
-        # parse_number will handle integers and floats, but not true/false as integers,
-        # whereas parse_integer is integer only (not floats) but handles true/false as
-        # integers. Therefore we try with parse_optional_number first, and if
-        # this can not parse we try with parse_integer. There is a single type,
-        # so if one parsed entry is None then all should be
-        if None in values:
-            assert values.count(None) == len(values)
-            values = self.parse_comma_separated_list(
-                self.Delimiter.NONE, self.parse_optional_integer
-            )
-        if None in values:
-            raise ParseError(
-                name,
-                "integer, boolean or float literal expected",
-            )
-
-        # This is needed to keep pyright happy, to remove the None from the lists
-        # types (from parse_optional_number) as this is not compatible with the
-        # types of DenseArrayBase.from_list
-        values = cast(list[int | float], values)
 
         self.parse_characters(">", " in dense array")
 

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -350,7 +350,7 @@ class BaseParser:
             "Expected integer literal" + context_msg,
         )
 
-    def parse_optional_number(self, allow_boolean: bool = False) -> int | float | None:
+    def parse_optional_number(self, *, allow_boolean: bool = False) -> int | float | None:
         """
         Parse a (possibly negative) integer or float literal, if present.
         Can optionally parse 'true' or 'false' into 1 and 0.

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -350,7 +350,9 @@ class BaseParser:
             "Expected integer literal" + context_msg,
         )
 
-    def parse_optional_number(self, *, allow_boolean: bool = False) -> int | float | None:
+    def parse_optional_number(
+        self, *, allow_boolean: bool = False
+    ) -> int | float | None:
         """
         Parse a (possibly negative) integer or float literal, if present.
         Can optionally parse 'true' or 'false' into 1 and 0.

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -350,8 +350,11 @@ class BaseParser:
             "Expected integer literal" + context_msg,
         )
 
-    def parse_optional_number(self) -> int | float | None:
-        """Parse a (possibly negative) integer or float literal, if present."""
+    def parse_optional_number(self, allow_boolean: bool = False) -> int | float | None:
+        """
+        Parse a (possibly negative) integer or float literal, if present.
+        Can optionally parse 'true' or 'false' into 1 and 0.
+        """
 
         is_negative = self._parse_optional_token(Token.Kind.MINUS) is not None
 
@@ -368,13 +371,23 @@ class BaseParser:
 
         if is_negative:
             self.raise_error("Expected integer or float literal after '-'")
+
+        if allow_boolean and (value := self.parse_optional_boolean()) is not None:
+            return 1 if value else 0
+
         return None
 
-    def parse_number(self, context_msg: str = "") -> int | float:
-        """Parse a (possibly negative) integer or float literal."""
+    def parse_number(
+        self, allow_boolean: bool = False, context_msg: str = ""
+    ) -> int | float:
+        """
+        Parse a (possibly negative) integer or float literal.
+        Can optionally parse 'true' or 'false' into 1 and 0.
+        """
         return self.expect(
-            lambda: self.parse_optional_number(),
-            "integer or float literal expected" + context_msg,
+            lambda: self.parse_optional_number(allow_boolean=allow_boolean),
+            f"integer{', boolean,' if allow_boolean else ''} or float literal expected"
+            + context_msg,
         )
 
     def parse_optional_str_literal(self) -> str | None:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -51,6 +51,7 @@ from xdsl.dialects.builtin import (
     UnregisteredAttr,
     UnregisteredOp,
     VectorType,
+    i1,
 )
 from xdsl.ir import (
     Attribute,
@@ -125,6 +126,7 @@ class Printer:
                 self.print_op(arg)
                 self._print_new_line()
                 continue
+
             text = str(arg)
             self.print_string(text)
 
@@ -484,7 +486,14 @@ class Printer:
                 self.print(">")
                 return
             self.print(": ")
-            self.print_list(data.data, lambda x: self.print(x.data))
+            # There is a bug in MLIR which will segfault when parsing DenseArrayBase type i1 as 0 or 1,
+            # therefore we need to print these as false and true
+            if attribute.elt_type == i1:
+                self.print_list(
+                    data.data, lambda x: self.print("true" if x.data == 1 else "false")
+                )
+            else:
+                self.print_list(data.data, lambda x: self.print(x.data))
             self.print(">")
             return
 


### PR DESCRIPTION
This PR firstly will enabling parsing of true and false string literals of type i1 to 1 and 0 respectively for DenseBaseAttr (previously true or false strings resulted in an error, but MLIR can output these as type i1).

This also works around an issue with MLIR, where MLIR will segfault in DenseArrayElementParser when it parses 0 and 1 as type i1, as it expects the false and true strings instead.