### PR TITLE
core: Implement TypedAttribute, leverage in declarative assembly format.

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -18,6 +18,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     NoneAttr,
     Signedness,
+    StringAttr,
 )
 from xdsl.ir import (
     Attribute,
@@ -26,6 +27,7 @@ from xdsl.ir import (
     ParametrizedAttribute,
     SpacedOpaqueSyntaxAttribute,
     StrEnum,
+    TypedAttribute,
 )
 from xdsl.irdl import (
     AnyAttr,
@@ -201,6 +203,33 @@ def test_identifier_enum_guard():
             EnumAttribute[TestNonIdentifierEnum]
         ):
             name = "test.non_identifier_enum"
+
+
+################################################################################
+# Typed Attribute
+################################################################################
+
+
+def test_typed_attribute():
+    with pytest.raises(
+        PyRDLAttrDefinitionError,
+        match="TypedAttribute TypedAttr should have a 'type' parameter.",
+    ):
+
+        @irdl_attr_definition
+        class TypedAttr(TypedAttribute[Attribute]):
+            name = "test.typed"
+
+    with pytest.raises(
+        Exception,
+        match="A TypedAttribute `type` parameter must be of the same type as the type variable in the TypedAttribute base class.",
+    ):
+
+        @irdl_attr_definition
+        class TypedAttrBis(TypedAttribute[IntegerAttr]):
+            name = "test.typed"
+
+            type: ParameterDef[StringAttr]
 
 
 ################################################################################

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -217,7 +217,9 @@ def test_typed_attribute():
     ):
 
         @irdl_attr_definition
-        class TypedAttr(TypedAttribute[Attribute]):
+        class TypedAttr(  # pyright: ignore[reportUnusedClass]
+            TypedAttribute[Attribute]
+        ):
             name = "test.typed"
 
     with pytest.raises(
@@ -226,7 +228,9 @@ def test_typed_attribute():
     ):
 
         @irdl_attr_definition
-        class TypedAttrBis(TypedAttribute[IntegerAttr]):
+        class TypedAttrBis(  # pyright: ignore[reportUnusedClass]
+            TypedAttribute[IntegerAttr[IndexType]]
+        ):
             name = "test.typed"
 
             type: ParameterDef[StringAttr]

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -7,7 +7,7 @@ from typing import Annotated, Generic, TypeVar
 
 import pytest
 
-from xdsl.dialects.builtin import ModuleOp
+from xdsl.dialects.builtin import IntAttr, IntegerAttr, IntegerType, ModuleOp
 from xdsl.dialects.test import Test, TestType
 from xdsl.ir import (
     Attribute,
@@ -24,6 +24,7 @@ from xdsl.irdl import (
     ConstraintVar,
     EqAttrConstraint,
     IRDLOperation,
+    ParamAttrConstraint,
     ParameterDef,
     ParsePropInAttrDict,
     VarOperand,
@@ -480,6 +481,38 @@ def test_optional_attribute(program: str, generic_program: str):
 
     ctx = MLContext()
     ctx.load_op(OptionalAttributeOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            "test.typed_attr 3",
+            '"test.typed_attr"() {"attr" = 3 : i32} : () -> ()',
+        ),
+    ],
+)
+def test_typed_attribute_variable(program: str, generic_program: str):
+    """Test the parsing of optional operands"""
+
+    @irdl_op_definition
+    class TypedAttributeOp(IRDLOperation):
+        name = "test.typed_attr"
+        attr: IntegerAttr[IntegerType] = attr_def(
+            ParamAttrConstraint(
+                IntegerAttr,
+                [IntAttr, IntegerType(32)],
+            )
+        )
+
+        assembly_format = "$attr attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(TypedAttributeOp)
     ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -7,7 +7,7 @@ from typing import Annotated, Generic, TypeVar
 
 import pytest
 
-from xdsl.dialects.builtin import IntAttr, IntegerAttr, IntegerType, ModuleOp
+from xdsl.dialects.builtin import IntegerAttr, IntegerType, ModuleOp, i32
 from xdsl.dialects.test import Test, TestType
 from xdsl.ir import (
     Attribute,
@@ -24,7 +24,6 @@ from xdsl.irdl import (
     ConstraintVar,
     EqAttrConstraint,
     IRDLOperation,
-    ParamAttrConstraint,
     ParameterDef,
     ParsePropInAttrDict,
     VarOperand,
@@ -503,10 +502,7 @@ def test_typed_attribute_variable(program: str, generic_program: str):
     class TypedAttributeOp(IRDLOperation):
         name = "test.typed_attr"
         attr: IntegerAttr[IntegerType] = attr_def(
-            ParamAttrConstraint(
-                IntegerAttr,
-                [IntAttr, IntegerType(32)],
-            )
+            IntegerAttr[Annotated[IntegerType, i32]]
         )
 
         assembly_format = "$attr attr-dict"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -31,6 +31,7 @@ from xdsl.ir import (
     Region,
     SSAValue,
     TypeAttribute,
+    TypedAttribute,
 )
 from xdsl.ir.affine import AffineMap, AffineSet
 from xdsl.irdl import (
@@ -400,7 +401,10 @@ AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
 
 
 @irdl_attr_definition
-class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
+class IntegerAttr(
+    Generic[_IntegerAttrType],
+    TypedAttribute[IntegerType | IndexType],
+):
     name = "integer"
     value: ParameterDef[IntAttr]
     type: ParameterDef[_IntegerAttrType]
@@ -446,6 +450,20 @@ class IntegerAttr(Generic[_IntegerAttrType], ParametrizedAttribute):
                 f"type {self.type} which supports values in the "
                 f"range [{min_value}, {max_value})"
             )
+
+    @staticmethod
+    def get_type_parameter_index():
+        return 1
+
+    def get_type(self):
+        return self.type
+
+    @classmethod
+    def parse_with_type(cls, parser: AttrParser, type: IntegerType | IndexType):
+        return cls(parser.parse_integer(allow_boolean=(type == i1)), type)
+
+    def print_without_type(self, printer: Printer):
+        return printer.print(self.value.data)
 
 
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -390,9 +390,7 @@ class IndexType(ParametrizedAttribute):
     name = "index"
 
 
-_IntegerAttrType = TypeVar(
-    "_IntegerAttrType", bound=IntegerType | IndexType, covariant=True
-)
+_IntegerAttrType = TypeVar("_IntegerAttrType", bound=IntegerType | IndexType)
 
 AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
     Attribute, AnyOf([IndexType, SignlessIntegerConstraint])
@@ -403,7 +401,7 @@ AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
 @irdl_attr_definition
 class IntegerAttr(
     Generic[_IntegerAttrType],
-    TypedAttribute[IntegerType | IndexType],
+    TypedAttribute[_IntegerAttrType],
 ):
     name = "integer"
     value: ParameterDef[IntAttr]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -393,7 +393,6 @@ class IndexType(ParametrizedAttribute):
 _IntegerAttrType = TypeVar(
     "_IntegerAttrType", bound=IntegerType | IndexType, covariant=True
 )
-
 AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
     Attribute, AnyOf([IndexType, SignlessIntegerConstraint])
 ]
@@ -452,8 +451,16 @@ class IntegerAttr(
             )
 
     @classmethod
-    def parse_with_type(cls, parser: AttrParser, type: IntegerType | IndexType):
-        return cls(parser.parse_integer(allow_boolean=(type == i1)), type)
+    def parse_with_type(
+        cls: type[IntegerAttr[_IntegerAttrType]],
+        parser: AttrParser,
+        type: Attribute,
+    ) -> IntegerAttr[_IntegerAttrType]:
+        assert isinstance(type, IntegerType) or isinstance(type, IndexType)
+        return cast(
+            IntegerAttr[_IntegerAttrType],
+            IntegerAttr(parser.parse_integer(allow_boolean=(type == i1)), type),
+        )
 
     def print_without_type(self, printer: Printer):
         return printer.print(self.value.data)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -451,13 +451,6 @@ class IntegerAttr(
                 f"range [{min_value}, {max_value})"
             )
 
-    @staticmethod
-    def get_type_parameter_index():
-        return 1
-
-    def get_type(self):
-        return self.type
-
     @classmethod
     def parse_with_type(cls, parser: AttrParser, type: IntegerType | IndexType):
         return cls(parser.parse_integer(allow_boolean=(type == i1)), type)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -390,7 +390,9 @@ class IndexType(ParametrizedAttribute):
     name = "index"
 
 
-_IntegerAttrType = TypeVar("_IntegerAttrType", bound=IntegerType | IndexType)
+_IntegerAttrType = TypeVar(
+    "_IntegerAttrType", bound=IntegerType | IndexType, covariant=True
+)
 
 AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
     Attribute, AnyOf([IndexType, SignlessIntegerConstraint])

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -671,16 +671,7 @@ class TypedAttribute(ParametrizedAttribute, Generic[AttributeInvT], ABC):
     An attribute with a type.
     """
 
-    @staticmethod
-    @abstractmethod
-    def get_type_parameter_index() -> int: ...
-
-    @abstractmethod
-    def get_type(self) -> AttributeInvT:
-        """
-        Get the type of the attribute.
-        """
-        ...
+    type_index: ClassVar[int]
 
     @classmethod
     @abstractmethod

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -666,7 +666,7 @@ class ParametrizedAttribute(Attribute):
         super()._verify()
 
 
-class TypedAttribute(ParametrizedAttribute, Generic[AttributeInvT], ABC):
+class TypedAttribute(ParametrizedAttribute, Generic[AttributeCovT], ABC):
     """
     An attribute with a type.
     """
@@ -675,8 +675,11 @@ class TypedAttribute(ParametrizedAttribute, Generic[AttributeInvT], ABC):
     def get_type_index() -> int: ...
 
     @classmethod
-    @abstractmethod
-    def parse_with_type(cls, parser: AttrParser, type: AttributeInvT) -> Self:
+    def parse_with_type(
+        cls: type[TypedAttribute[AttributeInvT]],
+        parser: AttrParser,
+        type: AttributeInvT,
+    ) -> type[TypedAttribute[AttributeInvT]]:
         """
         Parse the attribute with the given type.
         """

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -676,10 +676,10 @@ class TypedAttribute(ParametrizedAttribute, Generic[AttributeCovT], ABC):
 
     @classmethod
     def parse_with_type(
-        cls: type[TypedAttribute[AttributeInvT]],
+        cls: type[TypedAttribute[AttributeCovT]],
         parser: AttrParser,
-        type: AttributeInvT,
-    ) -> type[TypedAttribute[AttributeInvT]]:
+        type: Attribute,
+    ) -> TypedAttribute[AttributeCovT]:
         """
         Parse the attribute with the given type.
         """

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -666,6 +666,34 @@ class ParametrizedAttribute(Attribute):
         super()._verify()
 
 
+class TypedAttribute(ParametrizedAttribute, Generic[AttributeInvT], ABC):
+    """
+    An attribute with a type.
+    """
+
+    @staticmethod
+    @abstractmethod
+    def get_type_parameter_index() -> int: ...
+
+    @abstractmethod
+    def get_type(self) -> AttributeInvT:
+        """
+        Get the type of the attribute.
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def parse_with_type(cls, parser: AttrParser, type: AttributeInvT) -> Self:
+        """
+        Parse the attribute with the given type.
+        """
+        ...
+
+    @abstractmethod
+    def print_without_type(self, printer: Printer): ...
+
+
 @dataclass(init=False)
 class IRNode(ABC):
     def is_ancestor(self, op: IRNode) -> bool:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -671,7 +671,8 @@ class TypedAttribute(ParametrizedAttribute, Generic[AttributeInvT], ABC):
     An attribute with a type.
     """
 
-    type_index: ClassVar[int]
+    @staticmethod
+    def get_type_index() -> int: ...
 
     @classmethod
     @abstractmethod

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -753,7 +753,7 @@ class AttributeVariable(FormatDirective):
             )
             attr = unique_base.new(unique_base.parse_parameter(parser))
         else:
-            raise ValueError("Attributes must be Data or ParameterizedAttribute!")
+            raise ValueError("Attributes must be Data or ParameterizedAttribute.")
         if self.is_property:
             state.properties[self.name] = attr
         else:

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -729,6 +729,7 @@ class AttributeVariable(FormatDirective):
     unique_base: type[Attribute] | None
     """The known base class of the Attribute, if any."""
     unique_type: Attribute | None
+    """The known type of the Attribute, if any."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:
         unique_base = self.unique_base

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -377,7 +377,9 @@ class FormatParser(BaseParser):
                 if unique_base is not None and issubclass(unique_base, TypedAttribute):
                     constr = attr_def.constr
                     if isinstance(constr, ParamAttrConstraint):
-                        type_constraint = constr.param_constrs[unique_base.type_index]
+                        type_constraint = constr.param_constrs[
+                            unique_base.get_type_index()
+                        ]
                         if type_constraint.can_infer(set()):
                             unique_type = type_constraint.infer({})
                 if (

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -377,6 +377,7 @@ class FormatParser(BaseParser):
                 if unique_base is not None and issubclass(unique_base, TypedAttribute):
                     constr = attr_def.constr
                     # TODO: generalize.
+                    # https://github.com/xdslproject/xdsl/issues/2499
                     if isinstance(constr, ParamAttrConstraint):
                         type_constraint = constr.param_constrs[
                             unique_base.get_type_index()

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -376,6 +376,7 @@ class FormatParser(BaseParser):
                 unique_type = None
                 if unique_base is not None and issubclass(unique_base, TypedAttribute):
                     constr = attr_def.constr
+                    # TODO: generalize.
                     if isinstance(constr, ParamAttrConstraint):
                         type_constraint = constr.param_constrs[
                             unique_base.get_type_index()

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -377,9 +377,7 @@ class FormatParser(BaseParser):
                 if unique_base is not None and issubclass(unique_base, TypedAttribute):
                     constr = attr_def.constr
                     if isinstance(constr, ParamAttrConstraint):
-                        type_constraint = constr.param_constrs[
-                            unique_base.get_type_parameter_index()
-                        ]
+                        type_constraint = constr.param_constrs[unique_base.type_index]
                         if type_constraint.can_infer(set()):
                             unique_type = type_constraint.infer({})
                 if (

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -2286,9 +2286,6 @@ def irdl_param_attr_get_param_type_hints(cls: type[_PAttrT]) -> list[tuple[str, 
     for field_name, field_type in get_type_hints(cls, include_extras=True).items():
         if field_name == "name" or field_name == "parameters":
             continue
-        # Allow type_index as defined by TypedAttribute
-        if issubclass(cls, TypedAttribute) and field_name == "type_index":
-            continue
 
         origin: Any | None = cast(Any | None, get_origin(field_type))
         args = get_args(field_type)
@@ -2359,6 +2356,7 @@ class ParamAttrDef:
 
         param_hints = irdl_param_attr_get_param_type_hints(pyrdl_def)
         if issubclass(pyrdl_def, TypedAttribute):
+            pyrdl_def = cast(type[TypedAttribute[Attribute]], pyrdl_def)
             try:
                 param_names = [name for name, _ in param_hints]
                 type_index = param_names.index("type")
@@ -2423,7 +2421,7 @@ def irdl_param_attr_definition(cls: type[_PAttrT]) -> type[_PAttrT]:
     if issubclass(cls, TypedAttribute):
         parameter_names: tuple[str] = tuple(zip(*attr_def.parameters))[0]
         type_index = parameter_names.index("type")
-        new_fields["type_index"] = type_index
+        new_fields["get_type_index"] = lambda: type_index
 
     cls = cast(type[_PAttrT], cls)
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -2368,9 +2368,6 @@ class ParamAttrDef:
             typed_hint = param_hints[type_index][1]
             if get_origin(typed_hint) is Annotated:
                 typed_hint = get_args(typed_hint)[0]
-            # import pdb
-
-            # pdb.set_trace()
             type_var = get_type_var_mapping(pyrdl_def)[1][AttributeCovT]
 
             if typed_hint != type_var:

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -2412,6 +2412,8 @@ def irdl_param_attr_definition(cls: type[_PAttrT]) -> type[_PAttrT]:
                 f"TypedAttribute {cls.__name__} should have a 'type' parameter."
             )
 
+    cls = cast(type[_PAttrT], cls)
+
     @classmethod
     def get_irdl_definition(cls: type[_PAttrT]):
         return attr_def

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -26,6 +26,7 @@ from typing import (
 
 from xdsl.ir import (
     Attribute,
+    AttributeCovT,
     AttributeInvT,
     Block,
     Data,
@@ -2367,7 +2368,10 @@ class ParamAttrDef:
             typed_hint = param_hints[type_index][1]
             if get_origin(typed_hint) is Annotated:
                 typed_hint = get_args(typed_hint)[0]
-            type_var = get_type_var_mapping(pyrdl_def)[1][AttributeInvT]
+            # import pdb
+
+            # pdb.set_trace()
+            type_var = get_type_var_mapping(pyrdl_def)[1][AttributeCovT]
 
             if typed_hint != type_var:
                 raise ValueError(

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1064,7 +1064,7 @@ def opt_result_def(
 
 
 def prop_def(
-    constraint: type[AttributeInvT] | TypeVar,
+    constraint: type[AttributeInvT] | TypeVar | AttrConstraint,
     *,
     prop_name: str | None = None,
     default: None = None,
@@ -1076,7 +1076,7 @@ def prop_def(
 
 
 def opt_prop_def(
-    constraint: type[AttributeInvT] | TypeVar,
+    constraint: type[AttributeInvT] | TypeVar | AttrConstraint,
     *,
     prop_name: str | None = None,
     default: None = None,
@@ -1088,7 +1088,7 @@ def opt_prop_def(
 
 
 def attr_def(
-    constraint: type[AttributeInvT] | TypeVar,
+    constraint: type[AttributeInvT] | TypeVar | AttrConstraint,
     *,
     attr_name: str | None = None,
     default: None = None,
@@ -1102,7 +1102,7 @@ def attr_def(
 
 
 def opt_attr_def(
-    constraint: type[AttributeInvT] | TypeVar,
+    constraint: type[AttributeInvT] | TypeVar | AttrConstraint,
     *,
     attr_name: str | None = None,
     default: None = None,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -447,8 +447,8 @@ class Printer:
                 self.print("false" if attribute.value.data == 0 else "true")
                 return
 
-            width = attribute.parameters[0]
-            attr_type = attribute.parameters[1]
+            width = attribute.value
+            attr_type = attribute.type
             assert isinstance(width, IntAttr)
             self.print(width.data)
             self.print(" : ")


### PR DESCRIPTION
Implement TypedAttribute, a baseclass for attributes having a type attribute :upside_down_face: Mirroring the MLIR interface.
This is useful for the declarative assembly format, where when referencing an integer of a known type, we want to parse and print it with its type elided.