### PR TITLE
ci: use a separate workflow for codecov upload

### DIFF
--- a/.github/workflows/ci-codecov.yml
+++ b/.github/workflows/ci-codecov.yml
@@ -1,0 +1,32 @@
+# This workflow will install MLIR, Python dependencies, run tests and lint with a single version of Python
+
+name: CI - Codecov
+
+on:
+  # Trigger the workflow after ci-mlir completes
+  workflow_run:
+    workflows: [CI - Python-based Testing]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: xdsl
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.10'
+      uses: Wandalen/wretry.action@v1
+      with:
+        action: codecov/codecov-action@v4
+        attempt_delay: 10000
+        attempt_limit: 10
+        with: |
+          fail_ci_if_error: true
+          verbose: true
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-codecov.yml
+++ b/.github/workflows/ci-codecov.yml
@@ -1,25 +1,21 @@
-# This workflow will install MLIR, Python dependencies, run tests and lint with a single version of Python
-
 name: CI - Codecov
 
 on:
   # Trigger the workflow after ci-mlir completes
   workflow_run:
-    workflows: [CI - Python-based Testing]
-    types:
-      - completed
+    workflows: [CI - MLIR-based Testing]
+    types: [completed]
 
 jobs:
-  build:
+  upload-codecov:
     runs-on: ubuntu-20.04
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v4
       with:
         path: xdsl
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.10'
       uses: Wandalen/wretry.action@v1
       with:
         action: codecov/codecov-action@v4

--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -119,16 +119,3 @@ jobs:
         coverage combine --append
         coverage report
         coverage xml
-
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.10'
-      uses: Wandalen/wretry.action@v1
-      with:
-        action: codecov/codecov-action@v4
-        attempt_delay: 10000
-        attempt_limit: 10
-        with: |
-          fail_ci_if_error: true
-          verbose: true
-          files: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
My understanding is that actions that are triggered by the workflow_run action are run with secrets enabled.