### PR TITLE
dialects: (hw) Revert HWModuleOp's usage of InnerRefNamespaceTrait

### DIFF
--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -235,7 +235,7 @@ class InnerRefUserOpInterfaceTrait(OpTrait):
 
 @dataclass(frozen=True)
 class InnerRefNamespaceTrait(OpTrait):
-    """Trait for operations defining a new scope for InnerRef’s. Operations with this trait must be a SymbolTable."""
+    """Trait for operations defining a new scope for InnerRef's. Operations with this trait must be a SymbolTable."""
 
     def verify(self, op: Operation):
         if not op.has_trait(trait := SymbolTable):
@@ -637,8 +637,6 @@ class HWModuleOp(IRDLOperation):
             (
                 SymbolOpInterface(),
                 IsolatedFromAbove(),
-                InnerRefNamespaceTrait(),
-                SymbolTable(),
                 SingleBlockImplicitTerminator(OutputOp),
             )
         )


### PR DESCRIPTION
While upstream MLIR decouples SymbolTables from operations, this is not the case in xDSL. As such, whenever one wants to reuse symbol table functionality, they have to declare an operation as a SymbolTable op. This was done on HWModuleOp to reuse SymbolTable functionality for the InnerSymbolTable, but in contrast to how it is done in upstream CIRCT, this thus requires the InnerSymbolTable to be a regular SymbolTable. This in turn blocks regular symbol referencing outside of the InnerSymbolTable.

This PR reverts this change for now. This should be reimplemented once xDSL supports decoupled symbol tables (or InnerRefNamespaceTrait is updated accordingly).