### PR TITLE
core: Factor out visibility keyword parsing

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -853,3 +853,24 @@ def test_parse_location():
     ctx = MLContext()
     attr = Parser(ctx, "loc(unknown)").parse_optional_location()
     assert attr == LocationAttr()
+
+
+@pytest.mark.parametrize(
+    "keyword,expected",
+    [
+        ("public", StringAttr("public")),
+        ("nested", StringAttr("nested")),
+        ("private", StringAttr("private")),
+        ("privateeee", None),
+        ("unknown", None),
+    ],
+)
+def test_parse_visibility(keyword: str, expected: StringAttr | None):
+    assert Parser(MLContext(), keyword).parse_optional_visibility_keyword() == expected
+
+    parser = Parser(MLContext(), keyword)
+    if expected is None:
+        with pytest.raises(ParseError):
+            parser.parse_visibility_keyword()
+    else:
+        assert parser.parse_visibility_keyword() == expected

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -115,15 +115,7 @@ class FuncOp(IRDLOperation):
 
     @classmethod
     def parse(cls, parser: Parser) -> FuncOp:
-        # Parse visibility keyword if present
-        if parser.parse_optional_keyword("public"):
-            visibility = "public"
-        elif parser.parse_optional_keyword("nested"):
-            visibility = "nested"
-        elif parser.parse_optional_keyword("private"):
-            visibility = "private"
-        else:
-            visibility = None
+        visibility = parser.parse_optional_visibility_keyword()
 
         (
             name,

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -1028,6 +1028,27 @@ class AttrParser(BaseParser):
             element = self._parse_tensor_literal_element()
             return [element], []
 
+    def parse_optional_visibility_keyword(self) -> StringAttr | None:
+        """
+        Parses the visibility keyword of a symbol if present.
+        """
+        if self.parse_optional_keyword("public"):
+            return StringAttr("public")
+        elif self.parse_optional_keyword("nested"):
+            return StringAttr("nested")
+        elif self.parse_optional_keyword("private"):
+            return StringAttr("private")
+        else:
+            return None
+
+    def parse_visibility_keyword(self) -> StringAttr:
+        """
+        Parses the visibility keyword of a symbol.
+        """
+        return self.expect(
+            self.parse_optional_visibility_keyword, "expect symbol visibility keyword"
+        )
+
     def parse_optional_symbol_name(self) -> StringAttr | None:
         """
         Parse an @-identifier if present, and return its name (without the '@') in a


### PR DESCRIPTION
This PR factors out the parsing of visibility keyword into core (like in MLIR) as visibility keywords are a property of the symbol infrastructure. While the symbol lookup in xDSL does not take it into account yet, it is useful to have it be part of the symbol infrastructure itself as those keywords are used in many places (for example, in func.func or hw.module).