### PR TITLE
dialects: (x86) PR8 - MR Operations

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -56,3 +56,18 @@ x86.r.push %0 : (!x86.reg<rax>) -> ()
 // CHECK: xor rax, 2
 %ri_mov = x86.ri.mov %0, 2 : (!x86.reg<rax>) -> !x86.reg<rax>
 // CHECK: mov rax, 2
+
+x86.mr.add %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> ()
+// CHECK: add [rax], rdx
+x86.mr.add %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> ()
+// CHECK: add [rax+8], rdx
+x86.mr.sub %0, %1, -8 : (!x86.reg<rax>, !x86.reg<rdx>) -> ()
+// CHECK: sub [rax-8], rdx
+x86.mr.and %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> ()
+// CHECK: and [rax+8], rdx
+x86.mr.or %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> ()
+// CHECK: or [rax+8], rdx
+x86.mr.xor %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> ()
+// CHECK: xor [rax+8], rdx
+x86.mr.mov %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> ()
+// CHECK: mov [rax+8], rdx

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -57,3 +57,18 @@ x86.r.push %0 : (!x86.reg<>) -> ()
 // CHECK-NEXT: %{{.*}} = x86.ri.xor %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
 %ri_mov = x86.ri.mov %0, 2 : (!x86.reg<>) -> !x86.reg<>
 // CHECK-NEXT: %{{.*}} = x86.ri.mov %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
+
+x86.mr.add %0, %1 : (!x86.reg<>, !x86.reg<>) -> ()
+// CHECK-NEXT: x86.mr.add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> ()
+x86.mr.add %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+// CHECK-NEXT: x86.mr.add %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+x86.mr.sub %0, %1, -8 : (!x86.reg<>, !x86.reg<>) -> ()
+// CHECK-NEXT: x86.mr.sub %{{.*}}, %{{.*}}, -8 : (!x86.reg<>, !x86.reg<>) -> ()
+x86.mr.and %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+// CHECK-NEXT: x86.mr.and %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+x86.mr.or %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+// CHECK-NEXT: x86.mr.or %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+x86.mr.xor %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+// CHECK-NEXT: x86.mr.xor %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+x86.mr.mov %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
+// CHECK-NEXT: x86.mr.mov %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()

--- a/xdsl/dialects/x86/__init__.py
+++ b/xdsl/dialects/x86/__init__.py
@@ -2,6 +2,12 @@ from xdsl.ir import Dialect
 
 from .ops import (
     GetRegisterOp,
+    MR_AddOp,
+    MR_AndOp,
+    MR_MovOp,
+    MR_OrOp,
+    MR_SubOp,
+    MR_XorOp,
     R_NotOp,
     R_PopOp,
     R_PushOp,
@@ -56,6 +62,12 @@ X86 = Dialect(
         RI_OrOp,
         RI_XorOp,
         RI_MovOp,
+        MR_AddOp,
+        MR_SubOp,
+        MR_AndOp,
+        MR_OrOp,
+        MR_XorOp,
+        MR_MovOp,
         GetRegisterOp,
     ],
     [

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -713,7 +713,16 @@ class M_MR_Operation(Generic[R1InvT, R2InvT], IRDLOperation, X86Instruction, ABC
         )
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        return self.r1, self.r2
+        destination = _assembly_arg_str(self.r1)
+        if self.offset is not None:
+            offset = _assembly_arg_str(self.offset)
+            if self.offset.value.data > 0:
+                destination = f"[{destination}+{offset}]"
+            else:
+                destination = f"[{destination}{offset}]"
+        else:
+            destination = f"[{destination}]"
+        return destination, self.r2
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -730,27 +739,6 @@ class M_MR_Operation(Generic[R1InvT, R2InvT], IRDLOperation, X86Instruction, ABC
         if self.offset is not None:
             _print_immediate_value(printer, self.offset)
         return {"offset"}
-
-    def assembly_line(self) -> str | None:
-        instruction_name = self.assembly_instruction_name()
-        destination = _assembly_arg_str(self.r1)
-        source = _assembly_arg_str(self.r2)
-        if self.offset is not None:
-            offset = _assembly_arg_str(self.offset)
-            if self.offset.value.data > 0:
-                return _assembly_line(
-                    instruction_name,
-                    f"[{destination}+{offset}], {source}",
-                    self.comment,
-                )
-            else:
-                return _assembly_line(
-                    instruction_name, f"[{destination}{offset}], {source}", self.comment
-                )
-        else:
-            return _assembly_line(
-                instruction_name, f"[{destination}], {source}", self.comment
-            )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -681,6 +681,144 @@ class RI_MovOp(R_RI_Operation[GeneralRegisterType]):
     name = "x86.ri.mov"
 
 
+class M_MR_Operation(Generic[R1InvT, R2InvT], IRDLOperation, X86Instruction, ABC):
+    """
+    A base class for x86 operations that have one memory reference and one register.
+    """
+
+    r1 = operand_def(R1InvT)
+    r2 = operand_def(R2InvT)
+    offset: AnyIntegerAttr | None = opt_attr_def(AnyIntegerAttr)
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        r2: Operation | SSAValue,
+        offset: int | AnyIntegerAttr | None,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(offset, int):
+            offset = IntegerAttr(offset, 64)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1, r2],
+            attributes={
+                "offset": offset,
+                "comment": comment,
+            },
+            result_types=[],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return self.r1, self.r2
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        temp = _parse_optional_immediate_value(
+            parser, IntegerType(64, Signedness.SIGNED)
+        )
+        if temp is not None:
+            attributes["offset"] = temp
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        if self.offset is not None:
+            _print_immediate_value(printer, self.offset)
+        return {"offset"}
+
+    def assembly_line(self) -> str | None:
+        instruction_name = self.assembly_instruction_name()
+        destination = _assembly_arg_str(self.r1)
+        source = _assembly_arg_str(self.r2)
+        if self.offset is not None:
+            offset = _assembly_arg_str(self.offset)
+            if self.offset.value.data > 0:
+                return _assembly_line(
+                    instruction_name,
+                    f"[{destination}+{offset}], {source}",
+                    self.comment,
+                )
+            else:
+                return _assembly_line(
+                    instruction_name, f"[{destination}{offset}], {source}", self.comment
+                )
+        else:
+            return _assembly_line(
+                instruction_name, f"[{destination}], {source}", self.comment
+            )
+
+
+@irdl_op_definition
+class MR_AddOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
+    """
+    Adds the value from r2 to the memory location pointed to by r1.
+    [x[r1]] = [x[r1]] + x[r2]
+    https://www.felixcloutier.com/x86/add
+    """
+
+    name = "x86.mr.add"
+
+
+@irdl_op_definition
+class MR_SubOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
+    """
+    Subtracts the value from r2 from the memory location pointed to by r1.
+    [x[r1]] = [x[r1]] - x[r2]
+    https://www.felixcloutier.com/x86/sub
+    """
+
+    name = "x86.mr.sub"
+
+
+@irdl_op_definition
+class MR_AndOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
+    """
+    bitwise and of [r1] and r2
+    [x[r1]] = [x[r1]] & x[r2]
+    https://www.felixcloutier.com/x86/and
+    """
+
+    name = "x86.mr.and"
+
+
+@irdl_op_definition
+class MR_OrOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
+    """
+    bitwise or of [r1] and r2
+    [x[r1]] = [x[r1]] | x[r2]
+    https://www.felixcloutier.com/x86/or
+    """
+
+    name = "x86.mr.or"
+
+
+@irdl_op_definition
+class MR_XorOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
+    """
+    bitwise xor of [r1] and r2
+    [x[r1]] = [x[r1]] ^ x[r2]
+    https://www.felixcloutier.com/x86/xor
+    """
+
+    name = "x86.mr.xor"
+
+
+@irdl_op_definition
+class MR_MovOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
+    """
+    Copies the value from r2 into the memory location pointed to by r1.
+    [x[r1]] = x[r2]
+    https://www.felixcloutier.com/x86/mov
+    """
+
+    name = "x86.mr.mov"
+
+
 # region Assembly printing
 def _append_comment(line: str, comment: StringAttr | None) -> str:
     if comment is None:


### PR DESCRIPTION
Added support for operations that have one memory access and one register operand. The result is saved to the memory location.