### PR TITLE
dialects: Factor out sym_visibility parsing in all dialects

### DIFF
--- a/xdsl/dialects/ml_program.py
+++ b/xdsl/dialects/ml_program.py
@@ -85,16 +85,7 @@ class Global(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> Self:
         attrs = parser.parse_optional_attr_dict()
-        if parser.parse_optional_keyword("public"):
-            sym_visibility = StringAttr("public")
-        elif parser.parse_optional_keyword("nested"):
-            sym_visibility = StringAttr("nested")
-        elif parser.parse_optional_keyword("private"):
-            sym_visibility = StringAttr("private")
-        else:
-            parser.raise_error(
-                "Expected 'public', 'private', or 'nested'",
-            )
+        sym_visibility = parser.parse_visibility_keyword()
 
         if parser.parse_optional_keyword("mutable"):
             is_mutable = UnitAttr()

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -177,15 +177,7 @@ class FuncOp(IRDLOperation, riscv.RISCVOp):
 
     @classmethod
     def parse(cls, parser: Parser) -> FuncOp:
-        # Parse visibility keyword if present
-        if parser.parse_optional_keyword("public"):
-            visibility = "public"
-        elif parser.parse_optional_keyword("nested"):
-            visibility = "nested"
-        elif parser.parse_optional_keyword("private"):
-            visibility = "private"
-        else:
-            visibility = None
+        visibility = parser.parse_optional_visibility_keyword()
         (
             name,
             input_types,


### PR DESCRIPTION
I had forgotten to do this on existing dialects other than func.