### PR TITLE
transformations: stencil conversion fixes and improvements

### DIFF
--- a/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
+++ b/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
@@ -456,12 +456,12 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // MLIR-NEXT:      "scf.parallel"(%78, %79, %80, %84, %85, %86, %81, %82, %83) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
 // MLIR-NEXT:      ^2(%87 : index, %88 : index, %89 : index):
 // MLIR-NEXT:        %cst = arith.constant 0.000000e+00 : f64
-// MLIR-NEXT:        %cst_0 = arith.constant 1.000000e+00 : f64
+// MLIR-NEXT:        %cst_1 = arith.constant 1.000000e+00 : f64
 // MLIR-NEXT:        %90 = arith.constant -1 : index
 // MLIR-NEXT:        %91 = arith.addi %88, %90 : index
 // MLIR-NEXT:        %92 = memref.load %arg12[%87, %91, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
 // MLIR-NEXT:        %93 = arith.cmpf oeq, %92, %cst : f64
-// MLIR-NEXT:        %94 = arith.select %93, %cst_0, %cst : f64
+// MLIR-NEXT:        %94 = arith.select %93, %cst_1, %cst : f64
 // MLIR-NEXT:        %95 = memref.load %arg12[%87, %88, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
 // MLIR-NEXT:        %96 = arith.mulf %95, %94 : f64
 // MLIR-NEXT:        %97 = arith.addf %92, %96 : f64
@@ -476,7 +476,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // MLIR-NEXT:          %106 = memref.load %arg11[%87, %105, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
 // MLIR-NEXT:          %107 = arith.mulf %98, %106 : f64
 // MLIR-NEXT:          %108 = arith.subf %103, %107 : f64
-// MLIR-NEXT:          %109 = arith.subf %cst_0, %98 : f64
+// MLIR-NEXT:          %109 = arith.subf %cst_1, %98 : f64
 // MLIR-NEXT:          %110 = arith.mulf %109, %108 : f64
 // MLIR-NEXT:          scf.yield %110 : f64
 // MLIR-NEXT:        }, {
@@ -484,7 +484,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // MLIR-NEXT:          %112 = memref.load %arg11[%87, %88, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
 // MLIR-NEXT:          %113 = arith.mulf %98, %112 : f64
 // MLIR-NEXT:          %114 = arith.addf %111, %113 : f64
-// MLIR-NEXT:          %115 = arith.addf %cst_0, %98 : f64
+// MLIR-NEXT:          %115 = arith.addf %cst_1, %98 : f64
 // MLIR-NEXT:          %116 = arith.mulf %115, %114 : f64
 // MLIR-NEXT:          scf.yield %116 : f64
 // MLIR-NEXT:        }) : (i1) -> f64

--- a/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
+++ b/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
@@ -1,5 +1,6 @@
 // RUN: XDSL_ROUNDTRIP
 // RUN: xdsl-opt %s -p stencil-storage-materialization,stencil-shape-inference | filecheck %s --check-prefix SHAPE
+// RUN: xdsl-opt %s -p stencil-storage-materialization,stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s --check-prefix MLIR
 
 func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?x?xf64>, %arg2: !stencil.field<?x?x?xf64>, %arg3: !stencil.field<?x?x?xf64>, %arg4: !stencil.field<?x?x?xf64>, %arg5: !stencil.field<?x?x?xf64>, %arg6: !stencil.field<?x?x?xf64>) attributes {stencil.program} {
   %0 = stencil.cast %arg0 : !stencil.field<?x?x?xf64> -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
@@ -351,3 +352,204 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // SHAPE-NEXT:      stencil.store %92 to %5 ([0, 0, 0] : [64, 64, 64]) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // SHAPE-NEXT:      func.return
 // SHAPE-NEXT:    }
+
+// MLIR:         func.func @fvtp2d_qi(%arg0 : memref<?x?x?xf64>, %arg1 : memref<?x?x?xf64>, %arg2 : memref<?x?x?xf64>, %arg3 : memref<?x?x?xf64>, %arg4 : memref<?x?x?xf64>, %arg5 : memref<?x?x?xf64>, %arg6 : memref<?x?x?xf64>)  attributes {"stencil.program"}{
+// MLIR-NEXT:      %0 = memref.alloc() : memref<64x67x64xf64>
+// MLIR-NEXT:      %1 = "memref.subview"(%0) <{"static_offsets" = array<i64: 0, 1, 0>, "static_sizes" = array<i64: 64, 67, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64x67x64xf64>) -> memref<64x67x64xf64, strided<[4288, 64, 1], offset: 64>>
+// MLIR-NEXT:      %2 = memref.alloc() : memref<64x66x64xf64>
+// MLIR-NEXT:      %arg9 = "memref.subview"(%2) <{"static_offsets" = array<i64: 0, 1, 0>, "static_sizes" = array<i64: 64, 66, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64x66x64xf64>) -> memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:      %3 = memref.alloc() : memref<64x66x64xf64>
+// MLIR-NEXT:      %arg10 = "memref.subview"(%3) <{"static_offsets" = array<i64: 0, 1, 0>, "static_sizes" = array<i64: 64, 66, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64x66x64xf64>) -> memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:      %4 = memref.alloc() : memref<64x66x64xf64>
+// MLIR-NEXT:      %arg11 = "memref.subview"(%4) <{"static_offsets" = array<i64: 0, 1, 0>, "static_sizes" = array<i64: 64, 66, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64x66x64xf64>) -> memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:      %5 = memref.alloc() : memref<64x66x64xf64>
+// MLIR-NEXT:      %arg12 = "memref.subview"(%5) <{"static_offsets" = array<i64: 0, 1, 0>, "static_sizes" = array<i64: 64, 66, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64x66x64xf64>) -> memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:      %6 = memref.alloc() : memref<64x65x64xf64>
+// MLIR-NEXT:      %arg9_1 = "memref.subview"(%6) <{"static_offsets" = array<i64: 0, 0, 0>, "static_sizes" = array<i64: 64, 65, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64x65x64xf64>) -> memref<64x65x64xf64, strided<[4160, 64, 1]>>
+// MLIR-NEXT:      %7 = "memref.cast"(%arg0) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// MLIR-NEXT:      %8 = "memref.cast"(%arg1) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// MLIR-NEXT:      %9 = "memref.cast"(%arg2) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// MLIR-NEXT:      %10 = "memref.cast"(%arg3) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// MLIR-NEXT:      %11 = "memref.cast"(%arg4) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// MLIR-NEXT:      %12 = "memref.cast"(%arg5) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// MLIR-NEXT:      %13 = "memref.subview"(%12) <{"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 64, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72x72x72xf64>) -> memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:      %14 = "memref.cast"(%arg6) : (memref<?x?x?xf64>) -> memref<72x72x72xf64>
+// MLIR-NEXT:      %15 = "memref.subview"(%14) <{"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 65, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72x72x72xf64>) -> memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:      %16 = "memref.subview"(%7) <{"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 70, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72x72x72xf64>) -> memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:      %17 = "memref.subview"(%8) <{"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 65, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72x72x72xf64>) -> memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:      %18 = "memref.subview"(%9) <{"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 64, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72x72x72xf64>) -> memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:      %19 = "memref.subview"(%10) <{"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 65, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72x72x72xf64>) -> memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:      %20 = "memref.subview"(%11) <{"static_offsets" = array<i64: 4, 4, 4>, "static_sizes" = array<i64: 64, 64, 64>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72x72x72xf64>) -> memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:      %21 = arith.constant 0 : index
+// MLIR-NEXT:      %22 = arith.constant -1 : index
+// MLIR-NEXT:      %23 = arith.constant 0 : index
+// MLIR-NEXT:      %24 = arith.constant 1 : index
+// MLIR-NEXT:      %25 = arith.constant 1 : index
+// MLIR-NEXT:      %26 = arith.constant 1 : index
+// MLIR-NEXT:      %27 = arith.constant 64 : index
+// MLIR-NEXT:      %28 = arith.constant 66 : index
+// MLIR-NEXT:      %29 = arith.constant 64 : index
+// MLIR-NEXT:      "scf.parallel"(%21, %22, %23, %27, %28, %29, %24, %25, %26) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
+// MLIR-NEXT:      ^0(%30 : index, %31 : index, %32 : index):
+// MLIR-NEXT:        %33 = arith.constant 1.000000e+00 : f64
+// MLIR-NEXT:        %34 = arith.constant 7.000000e+00 : f64
+// MLIR-NEXT:        %35 = arith.constant 1.200000e+01 : f64
+// MLIR-NEXT:        %36 = arith.divf %34, %35 : f64
+// MLIR-NEXT:        %37 = arith.divf %33, %35 : f64
+// MLIR-NEXT:        %38 = arith.constant -1 : index
+// MLIR-NEXT:        %39 = arith.addi %31, %38 : index
+// MLIR-NEXT:        %40 = memref.load %16[%30, %39, %32] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %41 = memref.load %16[%30, %31, %32] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %42 = arith.addf %40, %41 : f64
+// MLIR-NEXT:        %43 = arith.constant -2 : index
+// MLIR-NEXT:        %44 = arith.addi %31, %43 : index
+// MLIR-NEXT:        %45 = memref.load %16[%30, %44, %32] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %46 = arith.constant 1 : index
+// MLIR-NEXT:        %47 = arith.addi %31, %46 : index
+// MLIR-NEXT:        %48 = memref.load %16[%30, %47, %32] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %49 = arith.addf %45, %48 : f64
+// MLIR-NEXT:        %50 = arith.mulf %36, %42 : f64
+// MLIR-NEXT:        %51 = arith.mulf %37, %49 : f64
+// MLIR-NEXT:        %52 = arith.addf %50, %51 : f64
+// MLIR-NEXT:        memref.store %52, %1[%30, %31, %32] : memref<64x67x64xf64, strided<[4288, 64, 1], offset: 64>>
+// MLIR-NEXT:        scf.yield
+// MLIR-NEXT:      }) : (index, index, index, index, index, index, index, index, index) -> ()
+// MLIR-NEXT:      %53 = arith.constant 0 : index
+// MLIR-NEXT:      %54 = arith.constant -1 : index
+// MLIR-NEXT:      %55 = arith.constant 0 : index
+// MLIR-NEXT:      %56 = arith.constant 1 : index
+// MLIR-NEXT:      %57 = arith.constant 1 : index
+// MLIR-NEXT:      %58 = arith.constant 1 : index
+// MLIR-NEXT:      %59 = arith.constant 64 : index
+// MLIR-NEXT:      %60 = arith.constant 65 : index
+// MLIR-NEXT:      %61 = arith.constant 64 : index
+// MLIR-NEXT:      "scf.parallel"(%53, %54, %55, %59, %60, %61, %56, %57, %58) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
+// MLIR-NEXT:      ^1(%62 : index, %63 : index, %64 : index):
+// MLIR-NEXT:        %65 = arith.constant 0.000000e+00 : f64
+// MLIR-NEXT:        %66 = arith.constant 1.000000e+00 : f64
+// MLIR-NEXT:        %67 = memref.load %1[%62, %63, %64] : memref<64x67x64xf64, strided<[4288, 64, 1], offset: 64>>
+// MLIR-NEXT:        %68 = memref.load %16[%62, %63, %64] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %69 = arith.subf %67, %68 : f64
+// MLIR-NEXT:        %70 = arith.constant 1 : index
+// MLIR-NEXT:        %71 = arith.addi %63, %70 : index
+// MLIR-NEXT:        %72 = memref.load %1[%62, %71, %64] : memref<64x67x64xf64, strided<[4288, 64, 1], offset: 64>>
+// MLIR-NEXT:        %73 = arith.subf %72, %68 : f64
+// MLIR-NEXT:        %74 = arith.addf %69, %73 : f64
+// MLIR-NEXT:        %75 = arith.mulf %69, %73 : f64
+// MLIR-NEXT:        %76 = arith.cmpf olt, %75, %65 : f64
+// MLIR-NEXT:        %77 = arith.select %76, %66, %65 : f64
+// MLIR-NEXT:        memref.store %69, %arg9[%62, %63, %64] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:        memref.store %73, %arg10[%62, %63, %64] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:        memref.store %74, %arg11[%62, %63, %64] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:        memref.store %77, %arg12[%62, %63, %64] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:        scf.yield
+// MLIR-NEXT:      }) : (index, index, index, index, index, index, index, index, index) -> ()
+// MLIR-NEXT:      %78 = arith.constant 0 : index
+// MLIR-NEXT:      %79 = arith.constant 0 : index
+// MLIR-NEXT:      %80 = arith.constant 0 : index
+// MLIR-NEXT:      %81 = arith.constant 1 : index
+// MLIR-NEXT:      %82 = arith.constant 1 : index
+// MLIR-NEXT:      %83 = arith.constant 1 : index
+// MLIR-NEXT:      %84 = arith.constant 64 : index
+// MLIR-NEXT:      %85 = arith.constant 65 : index
+// MLIR-NEXT:      %86 = arith.constant 64 : index
+// MLIR-NEXT:      "scf.parallel"(%78, %79, %80, %84, %85, %86, %81, %82, %83) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
+// MLIR-NEXT:      ^2(%87 : index, %88 : index, %89 : index):
+// MLIR-NEXT:        %cst = arith.constant 0.000000e+00 : f64
+// MLIR-NEXT:        %cst_0 = arith.constant 1.000000e+00 : f64
+// MLIR-NEXT:        %90 = arith.constant -1 : index
+// MLIR-NEXT:        %91 = arith.addi %88, %90 : index
+// MLIR-NEXT:        %92 = memref.load %arg12[%87, %91, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:        %93 = arith.cmpf oeq, %92, %cst : f64
+// MLIR-NEXT:        %94 = arith.select %93, %cst_0, %cst : f64
+// MLIR-NEXT:        %95 = memref.load %arg12[%87, %88, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:        %96 = arith.mulf %95, %94 : f64
+// MLIR-NEXT:        %97 = arith.addf %92, %96 : f64
+// MLIR-NEXT:        %98 = memref.load %17[%87, %88, %89] : memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %99 = arith.cmpf ogt, %98, %cst : f64
+// MLIR-NEXT:        %100 = "scf.if"(%99) ({
+// MLIR-NEXT:          %101 = arith.constant -1 : index
+// MLIR-NEXT:          %102 = arith.addi %88, %101 : index
+// MLIR-NEXT:          %103 = memref.load %arg10[%87, %102, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:          %104 = arith.constant -1 : index
+// MLIR-NEXT:          %105 = arith.addi %88, %104 : index
+// MLIR-NEXT:          %106 = memref.load %arg11[%87, %105, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:          %107 = arith.mulf %98, %106 : f64
+// MLIR-NEXT:          %108 = arith.subf %103, %107 : f64
+// MLIR-NEXT:          %109 = arith.subf %cst_0, %98 : f64
+// MLIR-NEXT:          %110 = arith.mulf %109, %108 : f64
+// MLIR-NEXT:          scf.yield %110 : f64
+// MLIR-NEXT:        }, {
+// MLIR-NEXT:          %111 = memref.load %arg9[%87, %88, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:          %112 = memref.load %arg11[%87, %88, %89] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
+// MLIR-NEXT:          %113 = arith.mulf %98, %112 : f64
+// MLIR-NEXT:          %114 = arith.addf %111, %113 : f64
+// MLIR-NEXT:          %115 = arith.addf %cst_0, %98 : f64
+// MLIR-NEXT:          %116 = arith.mulf %115, %114 : f64
+// MLIR-NEXT:          scf.yield %116 : f64
+// MLIR-NEXT:        }) : (i1) -> f64
+// MLIR-NEXT:        %117 = arith.mulf %100, %97 : f64
+// MLIR-NEXT:        %118 = "scf.if"(%99) ({
+// MLIR-NEXT:          %119 = arith.constant -1 : index
+// MLIR-NEXT:          %120 = arith.addi %88, %119 : index
+// MLIR-NEXT:          %121 = memref.load %16[%87, %120, %89] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:          %122 = arith.addf %121, %117 : f64
+// MLIR-NEXT:          scf.yield %122 : f64
+// MLIR-NEXT:        }, {
+// MLIR-NEXT:          %123 = memref.load %16[%87, %88, %89] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:          %124 = arith.addf %123, %117 : f64
+// MLIR-NEXT:          scf.yield %124 : f64
+// MLIR-NEXT:        }) : (i1) -> f64
+// MLIR-NEXT:        memref.store %118, %15[%87, %88, %89] : memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        scf.yield
+// MLIR-NEXT:      }) : (index, index, index, index, index, index, index, index, index) -> ()
+// MLIR-NEXT:      %125 = arith.constant 0 : index
+// MLIR-NEXT:      %126 = arith.constant 0 : index
+// MLIR-NEXT:      %127 = arith.constant 0 : index
+// MLIR-NEXT:      %128 = arith.constant 1 : index
+// MLIR-NEXT:      %129 = arith.constant 1 : index
+// MLIR-NEXT:      %130 = arith.constant 1 : index
+// MLIR-NEXT:      %131 = arith.constant 64 : index
+// MLIR-NEXT:      %132 = arith.constant 65 : index
+// MLIR-NEXT:      %133 = arith.constant 64 : index
+// MLIR-NEXT:      "scf.parallel"(%125, %126, %127, %131, %132, %133, %128, %129, %130) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
+// MLIR-NEXT:      ^3(%134 : index, %135 : index, %136 : index):
+// MLIR-NEXT:        %137 = memref.load %19[%134, %135, %136] : memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %138 = memref.load %15[%134, %135, %136] : memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %139 = arith.mulf %137, %138 : f64
+// MLIR-NEXT:        memref.store %139, %arg9_1[%134, %135, %136] : memref<64x65x64xf64, strided<[4160, 64, 1]>>
+// MLIR-NEXT:        scf.yield
+// MLIR-NEXT:      }) : (index, index, index, index, index, index, index, index, index) -> ()
+// MLIR-NEXT:      %140 = arith.constant 0 : index
+// MLIR-NEXT:      %141 = arith.constant 0 : index
+// MLIR-NEXT:      %142 = arith.constant 0 : index
+// MLIR-NEXT:      %143 = arith.constant 1 : index
+// MLIR-NEXT:      %144 = arith.constant 1 : index
+// MLIR-NEXT:      %145 = arith.constant 1 : index
+// MLIR-NEXT:      %146 = arith.constant 64 : index
+// MLIR-NEXT:      %147 = arith.constant 64 : index
+// MLIR-NEXT:      %148 = arith.constant 64 : index
+// MLIR-NEXT:      "scf.parallel"(%140, %141, %142, %146, %147, %148, %143, %144, %145) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
+// MLIR-NEXT:      ^4(%149 : index, %150 : index, %151 : index):
+// MLIR-NEXT:        %152 = memref.load %16[%149, %150, %151] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %153 = memref.load %20[%149, %150, %151] : memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %154 = arith.mulf %152, %153 : f64
+// MLIR-NEXT:        %155 = memref.load %arg9_1[%149, %150, %151] : memref<64x65x64xf64, strided<[4160, 64, 1]>>
+// MLIR-NEXT:        %156 = arith.constant 1 : index
+// MLIR-NEXT:        %157 = arith.addi %150, %156 : index
+// MLIR-NEXT:        %158 = memref.load %arg9_1[%149, %157, %151] : memref<64x65x64xf64, strided<[4160, 64, 1]>>
+// MLIR-NEXT:        %159 = arith.subf %155, %158 : f64
+// MLIR-NEXT:        %160 = arith.addf %154, %159 : f64
+// MLIR-NEXT:        %161 = memref.load %18[%149, %150, %151] : memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        %162 = arith.divf %160, %161 : f64
+// MLIR-NEXT:        memref.store %162, %13[%149, %150, %151] : memref<64x64x64xf64, strided<[5184, 72, 1], offset: 21028>>
+// MLIR-NEXT:        scf.yield
+// MLIR-NEXT:      }) : (index, index, index, index, index, index, index, index, index) -> ()
+// MLIR-NEXT:      memref.dealloc %6 : memref<64x65x64xf64>
+// MLIR-NEXT:      memref.dealloc %5 : memref<64x66x64xf64>
+// MLIR-NEXT:      memref.dealloc %4 : memref<64x66x64xf64>
+// MLIR-NEXT:      memref.dealloc %3 : memref<64x66x64xf64>
+// MLIR-NEXT:      memref.dealloc %2 : memref<64x66x64xf64>
+// MLIR-NEXT:      memref.dealloc %0 : memref<64x67x64xf64>
+// MLIR-NEXT:      func.return
+// MLIR-NEXT:    }

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -354,8 +354,8 @@ builtin.module {
   }
 
 // CHECK:         func.func @stencil_two_stores(%134 : memref<72xf64>, %135 : memref<72xf64>, %136 : memref<72xf64>) {
-// CHECK-NEXT:      %137 = "memref.subview"(%135) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:      %138 = "memref.subview"(%136) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %137 = "memref.subview"(%136) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %138 = "memref.subview"(%135) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:      %139 = "memref.subview"(%134) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:      %140 = arith.constant 1 : index
 // CHECK-NEXT:      %141 = arith.constant 1 : index
@@ -365,7 +365,7 @@ builtin.module {
 // CHECK-NEXT:        %144 = arith.constant -1 : index
 // CHECK-NEXT:        %145 = arith.addi %143, %144 : index
 // CHECK-NEXT:        %146 = memref.load %139[%145] : memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        memref.store %146, %138[%143] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        memref.store %146, %137[%143] : memref<64xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:        scf.yield
 // CHECK-NEXT:      }) : (index, index, index) -> ()
 // CHECK-NEXT:      %147 = arith.constant 0 : index
@@ -375,8 +375,8 @@ builtin.module {
 // CHECK-NEXT:      ^10(%150 : index):
 // CHECK-NEXT:        %151 = arith.constant 1 : index
 // CHECK-NEXT:        %152 = arith.addi %150, %151 : index
-// CHECK-NEXT:        %153 = memref.load %138[%152] : memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        memref.store %153, %137[%150] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %153 = memref.load %137[%152] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        memref.store %153, %138[%150] : memref<64xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:        scf.yield
 // CHECK-NEXT:      }) : (index, index, index) -> ()
 // CHECK-NEXT:      func.return
@@ -641,8 +641,8 @@ func.func @if_lowering(%arg0_1 : f64, %b0 : !stencil.field<[0,7]x[0,7]x[0,7]xf64
   }
 
 // CHECK-NEXT:    func.func @if_lowering(%arg0_1 : f64, %b0 : memref<7x7x7xf64>, %b1 : memref<7x7x7xf64>)  attributes {"stencil.program"}{
-// CHECK-NEXT:      %b1_storeview = "memref.subview"(%b1) <{"static_offsets" = array<i64: 0, 0, 0>, "static_sizes" = array<i64: 7, 7, 7>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<7x7x7xf64>) -> memref<7x7x7xf64, strided<[49, 7, 1]>>
 // CHECK-NEXT:      %b0_storeview = "memref.subview"(%b0) <{"static_offsets" = array<i64: 0, 0, 0>, "static_sizes" = array<i64: 7, 7, 7>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<7x7x7xf64>) -> memref<7x7x7xf64, strided<[49, 7, 1]>>
+// CHECK-NEXT:      %b1_storeview = "memref.subview"(%b1) <{"static_offsets" = array<i64: 0, 0, 0>, "static_sizes" = array<i64: 7, 7, 7>, "static_strides" = array<i64: 1, 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<7x7x7xf64>) -> memref<7x7x7xf64, strided<[49, 7, 1]>>
 // CHECK-NEXT:      %259 = arith.constant 0 : index
 // CHECK-NEXT:      %260 = arith.constant 0 : index
 // CHECK-NEXT:      %261 = arith.constant 0 : index

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -744,6 +744,21 @@ class IndexOp(IRDLOperation):
 
     assembly_format = "$dim $offset attr-dict-with-keyword"
 
+    traits = frozenset([HasAncestor(ApplyOp)])
+
+    def get_apply(self):
+        """
+        Simple helper to get the parent apply and raise otherwise.
+        """
+        trait = cast(HasAncestor, self.get_trait(HasAncestor, (ApplyOp,)))
+        ancestor = trait.get_ancestor(self)
+        if ancestor is None:
+            raise ValueError(
+                "stencil.apply not found, this function should be called on"
+                "verified accesses only."
+            )
+        return cast(ApplyOp, ancestor)
+
 
 @irdl_op_definition
 class AccessOp(IRDLOperation):

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -1,7 +1,6 @@
-from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import product
-from typing import TypeVar, cast
+from typing import TypeVar
 from warnings import warn
 
 from xdsl.dialects import arith, builtin, memref, scf
@@ -9,7 +8,6 @@ from xdsl.dialects.builtin import (
     MemRefType,
     UnrealizedConversionCastOp,
 )
-from xdsl.dialects.func import FuncOp
 from xdsl.dialects.stencil import (
     AccessOp,
     ApplyOp,
@@ -97,7 +95,7 @@ def collectBlockArguments(number: int, block: Block):
 
 
 def update_return_target(
-    return_targets: dict[ReturnOp, list[SSAValue | None]],
+    return_targets: dict[ApplyOp, list[SSAValue | None]],
     old_target: SSAValue,
     new_target: SSAValue | None,
 ):
@@ -131,7 +129,7 @@ def _find_result_store(result: SSAValue) -> tuple[StoreResultOp, ...]:
 
 @dataclass
 class ReturnOpToMemref(RewritePattern):
-    return_target: dict[ReturnOp, list[SSAValue | None]]
+    return_target: dict[ApplyOp, list[SSAValue | None]]
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ReturnOp, rewriter: PatternRewriter, /):
@@ -139,13 +137,15 @@ class ReturnOpToMemref(RewritePattern):
         n_res = len(op.arg) // unroll_factor
 
         store_list: list[Operation] = []
-        parallel = op.parent_op()
-        assert isinstance(parallel, scf.ParallelOp)
+        apply = op.parent_op()
+        assert isinstance(apply, ApplyOp)
+        if op.unroll is not None:
+            apply.attributes["__unroll__"] = op.unroll
 
-        n_dims = len(parallel.lowerBound)
+        n_dims = apply.get_rank()
 
         for j in range(n_res):
-            target = self.return_target[op][j]
+            target = self.return_target[apply][j]
 
             unroll = op.unroll
             if unroll is None:
@@ -153,16 +153,25 @@ class ReturnOpToMemref(RewritePattern):
 
             for k, offset in enumerate(product(*(range(u) for u in unroll))):
                 arg = op.arg[j * unroll_factor + k]
-                assert (block := op.parent_block()) is not None
-                args = cast(list[SSAValue], collectBlockArguments(n_dims, block))
+                index_ops: list[Operation] = list(
+                    IndexOp(
+                        attributes={
+                            "dim": builtin.IntegerAttr.from_index_int_value(i),
+                            "offset": IndexAttr.get(*([0] * n_dims)),
+                        },
+                        result_types=[builtin.IndexType()],
+                    )
+                    for i in range(n_dims)
+                )
+                store_list += index_ops
 
                 for i in range(n_dims):
                     if offset[i] != 0:
                         constant_op = arith.Constant.from_int_and_width(
                             offset[i], builtin.IndexType()
                         )
-                        add_op = arith.Addi(args[i], constant_op)
-                        args[i] = add_op.results[0]
+                        add_op = arith.Addi(index_ops[i], constant_op)
+                        index_ops[i] = add_op
                         store_list.append(constant_op)
                         store_list.append(add_op)
 
@@ -171,7 +180,7 @@ class ReturnOpToMemref(RewritePattern):
                     for owner in result_owner:
                         if owner.arg:
                             if target is not None:
-                                store = memref.Store.get(owner.arg, target, args)
+                                store = memref.Store.get(owner.arg, target, index_ops)
                             else:
                                 store = list[Operation]()
                             rewriter.replace_op(
@@ -185,10 +194,11 @@ class ReturnOpToMemref(RewritePattern):
 
                 else:
                     if target is not None:
-                        store = memref.Store.get(arg, target, args)
+                        store = memref.Store.get(arg, target, index_ops)
                         store_list.append(store)
 
-        rewriter.replace_matched_op([*store_list])
+        rewriter.insert_op_before_matched_op([*store_list])
+        rewriter.erase_matched_op()
 
 
 def assert_subset(field: FieldType[Attribute], temp: TempType[Attribute]):
@@ -204,38 +214,6 @@ def assert_subset(field: FieldType[Attribute], temp: TempType[Attribute]):
             "The stencil computation requires a field with upper bound at least "
             f"{temp.bounds.ub}, got {field.bounds.ub}, max: {max(field.bounds.ub, temp.bounds.ub)}"
         )
-
-
-class IndexOpToLoopSSA(RewritePattern):
-    @staticmethod
-    def discover_enclosing_loops(op: Operation) -> Iterable[scf.For | scf.ParallelOp]:
-        parent_op = op.parent_op()
-        if parent_op is not None:
-            yield from IndexOpToLoopSSA.discover_enclosing_loops(parent_op)
-        if isa(op, scf.For) or isa(op, scf.ParallelOp):
-            yield op
-
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: IndexOp, rewriter: PatternRewriter, /):
-        enclosing_loops = list(IndexOpToLoopSSA.discover_enclosing_loops(op))
-        # The first block argument is the loop iterator
-        loop_op = enclosing_loops[0]
-        assert isa(loop_op, scf.For) or isa(loop_op, scf.ParallelOp)
-        assert len(loop_op.body.blocks) == 1
-        assert len(loop_op.body.block.args) >= 1
-        replacement_ssa = loop_op.body.block.args[op.dim.value.data]
-        offset = op.offset.array.data[op.dim.value.data].data
-        if offset == 0:
-            rewriter.replace_matched_op([], [replacement_ssa])
-        else:
-            rewriter.replace_matched_op(
-                [
-                    offset_op := arith.Constant.from_int_and_width(
-                        offset, builtin.IndexType()
-                    ),
-                    arith.Addi(replacement_ssa, offset_op),
-                ]
-            )
 
 
 class LoadOpToMemref(RewritePattern):
@@ -265,28 +243,26 @@ class LoadOpToMemref(RewritePattern):
         subview.result.name_hint = name
 
 
-def prepare_apply_body(op: ApplyOp, rewriter: PatternRewriter, dim: int):
+def prepare_apply_body(op: ApplyOp):
     # First replace all current arguments by their definition
     # and erase them from the block. (We are changing the op
     # to a loop, which has access to them either way)
     entry = op.region.block
 
-    for idx, arg in enumerate(entry.args):
-        arg_uses = set(arg.uses)
-        for use in arg_uses:
-            use.operation.operands[use.index] = op.args[idx]
+    for operand, arg in zip(op.operands, entry.args):
+        arg.replace_by(operand)
         entry.erase_arg(arg)
+    entry.add_op(scf.Yield())
+    for _ in range(op.get_rank()):
+        entry.insert_arg(builtin.IndexType(), 0)
 
-    for _ in range(dim):
-        rewriter.insert_block_argument(entry, 0, builtin.IndexType())
-
-    return rewriter.move_region_contents_to_new_regions(op.region)
+    return op.region.detach_block(entry)
 
 
 @dataclass
 class BufferOpToMemref(RewritePattern):
 
-    return_targets: dict[ReturnOp, list[SSAValue | None]]
+    return_targets: dict[ApplyOp, list[SSAValue | None]]
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: BufferOp, rewriter: PatternRewriter, /):
@@ -340,7 +316,7 @@ class BufferOpToMemref(RewritePattern):
 
 @dataclass
 class ApplyOpToParallel(RewritePattern):
-    return_targets: dict[ReturnOp, list[SSAValue | None]]
+    return_targets: dict[ApplyOp, list[SSAValue | None]]
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ApplyOp, rewriter: PatternRewriter, /):
@@ -349,15 +325,15 @@ class ApplyOpToParallel(RewritePattern):
         assert isinstance(res_type.bounds, StencilBoundsAttr)
 
         # Get this apply's ReturnOp
-        body_block = op.region.blocks[0]
-        return_op = next(o for o in body_block.ops if isinstance(o, ReturnOp))
-        unroll = return_op.unroll
+        unroll = op.attributes.get("__unroll__", None)
+        if unroll is not None:
+            assert isinstance(unroll, IndexAttr)
+            unroll = list(u for u in unroll)
 
-        dim = res_type.get_num_dims()
-        body = prepare_apply_body(op, rewriter, dim)
-        body.block.add_op(scf.Yield())
+        rank = op.get_rank()
+        body = prepare_apply_body(op)
         if unroll is None:
-            unroll = [1] * dim
+            unroll = [1] * rank
         else:
             unroll = [i for i in unroll]
 
@@ -391,14 +367,25 @@ class ApplyOpToParallel(RewritePattern):
             lower_bounds=lowerBounds,
             upper_bounds=upperBounds,
             steps=tiled_steps,
-            body=Region(),
+            body=Region(body),
         )
-
-        p.body.insert_block(body.detach_block(0), 0)
+        for index in body.walk():
+            if isinstance(index, IndexOp):
+                offset = list(index.offset)
+                ops: list[Operation] = []
+                res: list[SSAValue] = [body.args[index.dim.value.data]]
+                if offset[index.dim.value.data] != 0:
+                    ops = [
+                        cst := arith.Constant.from_int_and_width(
+                            offset[index.dim.value.data], builtin.IndexType()
+                        ),
+                        add := arith.Addi(body.args[index.dim.value.data], cst),
+                    ]
+                    res = [add.result]
+                rewriter.replace_op(index, ops, res)
 
         # Get the maybe updated results
-        new_results: list[SSAValue | None] = []
-        new_results = self.return_targets[return_op]
+        new_results = self.return_targets[op]
         # Replace with the loop and necessary constants.
         assert isa(boilerplate_ops, list[Operation])
         rewriter.insert_op_before_matched_op([*boilerplate_ops, p])
@@ -413,20 +400,24 @@ class AccessOpToMemref(RewritePattern):
         assert isa(temp, TempType[Attribute])
         assert isinstance(temp.bounds, StencilBoundsAttr)
 
-        # Make pyright happy with the fact that this op has to be in
-        # a block.
-        assert (block := op.parent_block()) is not None
-
         memref_offset = op.offset
 
-        block_args = block.args
         mapping = (
             op.offset_mapping
             if op.offset_mapping is not None
             else range(len(memref_offset))
         )
 
-        args = [block_args[i] for i in mapping]
+        args = [
+            IndexOp(
+                attributes={
+                    "dim": builtin.IntegerAttr.from_index_int_value(i),
+                    "offset": IndexAttr.get(*([0] * op.get_apply().get_rank())),
+                },
+                result_types=[builtin.IndexType()],
+            )
+            for i in mapping
+        ]
 
         off_const_ops: list[Operation] = []
         memref_load_args: list[BlockArgument | OpResult] = []
@@ -440,48 +431,46 @@ class AccessOpToMemref(RewritePattern):
                 memref_load_args.append(add_op.results[0])
                 off_const_ops += [constant_op, add_op]
             else:
-                memref_load_args.append(arg)
+                memref_load_args.append(arg.idx)
 
         load = memref.Load.get(op.temp, memref_load_args)
 
+        rewriter.insert_op_before_matched_op(args)
         rewriter.replace_matched_op([*off_const_ops, load], [load.res])
 
 
 @dataclass
 class StencilStoreToSubview(RewritePattern):
-    return_targets: dict[ReturnOp, list[SSAValue | None]]
+    return_targets: dict[ApplyOp, list[SSAValue | None]]
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: FuncOp, rewriter: PatternRewriter, /):
-        stores = [o for o in op.walk() if isinstance(o, StoreOp)]
+    def match_and_rewrite(self, op: StoreOp, rewriter: PatternRewriter, /):
+        field = op.field
+        assert isa(field.type, FieldType[Attribute])
+        assert isa(field.type.bounds, StencilBoundsAttr)
+        temp = op.temp
+        assert isa(temp.type, TempType[Attribute])
+        offsets = [i for i in -field.type.bounds.lb]
+        sizes = [i for i in temp.type.get_shape()]
+        subview = memref.Subview.from_static_parameters(
+            field,
+            StencilToMemRefType(field.type),
+            offsets,
+            sizes,
+            [1] * len(sizes),
+        )
+        name = None
+        if subview.source.name_hint:
+            name = subview.source.name_hint + "_storeview"
+        subview.result.name_hint = name
+        if isinstance(field.owner, Operation):
+            rewriter.insert_op_after(subview, field.owner)
+        else:
+            rewriter.insert_op_at_start(subview, field.owner)
 
-        for store in stores:
-            field = store.field
-            assert isa(field.type, FieldType[Attribute])
-            assert isa(field.type.bounds, StencilBoundsAttr)
-            temp = store.temp
-            assert isa(temp.type, TempType[Attribute])
-            offsets = [i for i in -field.type.bounds.lb]
-            sizes = [i for i in temp.type.get_shape()]
-            subview = memref.Subview.from_static_parameters(
-                field,
-                StencilToMemRefType(field.type),
-                offsets,
-                sizes,
-                [1] * len(sizes),
-            )
-            name = None
-            if subview.source.name_hint:
-                name = subview.source.name_hint + "_storeview"
-            subview.result.name_hint = name
-            if isinstance(field.owner, Operation):
-                rewriter.insert_op_after(subview, field.owner)
-            else:
-                rewriter.insert_op_at_start(subview, field.owner)
+        rewriter.erase_matched_op()
 
-            rewriter.erase_op(store)
-
-            update_return_target(self.return_targets, field, subview.result)
+        update_return_target(self.return_targets, field, subview.result)
 
 
 class TrivialExternalLoadOpCleanup(RewritePattern):
@@ -556,7 +545,7 @@ def _get_use_target(use: Use) -> SSAValue | None:
 
 
 def return_target_analysis(module: builtin.ModuleOp):
-    return_targets: dict[ReturnOp, list[SSAValue | None]] = {}
+    return_targets: dict[ApplyOp, list[SSAValue | None]] = {}
 
     for op in module.walk():
         if not isinstance(op, ReturnOp):
@@ -565,7 +554,7 @@ def return_target_analysis(module: builtin.ModuleOp):
         apply = op.parent_op()
         assert isinstance(apply, ApplyOp)
 
-        return_targets[op] = []
+        return_targets[apply] = []
         for res in list(apply.res):
             store = [
                 use
@@ -582,7 +571,7 @@ def return_target_analysis(module: builtin.ModuleOp):
             else:
                 field = _get_use_target(store[0])
 
-            return_targets[op].append(field)
+            return_targets[apply].append(field)
 
     return return_targets
 
@@ -604,7 +593,7 @@ class ConvertStencilToLLMLIRPass(ModulePass):
     name = "convert-stencil-to-ll-mlir"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        return_targets: dict[ReturnOp, list[SSAValue | None]] = return_target_analysis(
+        return_targets: dict[ApplyOp, list[SSAValue | None]] = return_target_analysis(
             op
         )
 
@@ -618,13 +607,13 @@ class ConvertStencilToLLMLIRPass(ModulePass):
                     LoadOpToMemref(),
                     AccessOpToMemref(),
                     ReturnOpToMemref(return_targets),
-                    IndexOpToLoopSSA(),
                     TrivialExternalLoadOpCleanup(),
                     TrivialExternalStoreOpCleanup(),
                 ]
             ),
             apply_recursively=True,
             walk_reverse=True,
+            walk_regions_first=True,
         )
         the_one_pass.rewrite_module(op)
         type_pass = PatternRewriteWalker(

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -370,7 +370,7 @@ def transform_apply_into_loop(
 ):
     dim: int = ndim
     assert dim == 3
-    body = prepare_apply_body(op, rewriter, dim)
+    body = prepare_apply_body(op, rewriter)
 
     body.block.add_op(scf.Yield())
 

--- a/xdsl/transforms/experimental/stencil_storage_materialization.py
+++ b/xdsl/transforms/experimental/stencil_storage_materialization.py
@@ -41,6 +41,8 @@ class ApplyOpMaterialization(RewritePattern):
                 new_res.append(out)
         if buffers:
             rewriter.replace_matched_op([clone, *buffers], new_res)
+        else:
+            clone.erase()
 
 
 class StencilStorageMaterializationPass(ModulePass):


### PR DESCRIPTION
Some improvements on the conversion:
- Stop relying on explicit loop indices for accesses and returns; `stencil.index` is modelling just that, use it instead as a proxy.
- `stencil.apply` now simply creates its own loop indices and replaces `stencil.index`s appropriately.
- split `stencil.store` in its own pattern rather than a loop, didn;t serve any purpose at this point - resulting in the minor recording of subviews.
- Accessorily fix a corner-case bug when not cleaning up the unused cloned op in storage materialization.

As can be seen on the tests, it's a nonfunctional change on whatever was tested, but the current passes did not work on a proper open earth compiler kernel. It now does :tada: