### PR TITLE
transformations: Switch MPI lowering to use llvm.mlir.zero

### DIFF
--- a/tests/dialects/test_mpi_lowering.py
+++ b/tests/dialects/test_mpi_lowering.py
@@ -55,10 +55,10 @@ def test_lower_mpi_init():
     nullop, call = ops
 
     assert isinstance(call, func.Call)
-    assert isinstance(nullop, llvm.NullOp)
+    assert isinstance(nullop, llvm.ZeroOp)
     assert call.callee.string_value() == "MPI_Init"
     assert len(call.arguments) == 2
-    assert all(arg == nullop.nullptr for arg in call.arguments)
+    assert all(arg == nullop.res for arg in call.arguments)
 
 
 def test_lower_mpi_finalize():

--- a/xdsl/transforms/lower_mpi.py
+++ b/xdsl/transforms/lower_mpi.py
@@ -329,7 +329,7 @@ class LowerMpiInit(_MPIToLLVMRewriteBase):
         We currently don't model any argument passing to `MPI_Init()` and pass two nullptrs.
         """
         return [
-            nullptr := llvm.NullOp(),
+            nullptr := llvm.ZeroOp(result_types=[llvm.LLVMPointerType.opaque()]),
             func.Call(self._mpi_name(op), [nullptr, nullptr], [i32]),
         ], []
 


### PR DESCRIPTION
The currently used NullOp isn't defined in MLIR anymore; this was not caught on DeVito's side as we don't use MPI_Init from the xDSL compiled code there...

closes #2523