### PR TITLE
dialects: (x86) PR11 - RMI Operations

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -87,3 +87,8 @@ x86.mi.mov %0, 2, 8 : (!x86.reg<rax>) -> ()
 
 %rri_imul = x86.rri.imul %1, 2 : (!x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK: imul rax, rdx, 2
+
+%rmi_imul_no_offset = x86.rmi.imul %1, 2 : (!x86.reg<rdx>) -> !x86.reg<rax>
+// CHECK: imul rax, [rdx], 2
+%rmi_imul = x86.rmi.imul %1, 2, 8 : (!x86.reg<rdx>) -> !x86.reg<rax>
+// CHECK: imul rax, [rdx+8], 2

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -88,3 +88,8 @@ x86.mi.mov %0, 2, 8 : (!x86.reg<>) -> ()
 
 %rri_imul = x86.rri.imul %1, 2 : (!x86.reg<>) -> !x86.reg<>
 // CHECK-NEXT: %{{.*}} = x86.rri.imul %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
+
+%rmi_imul_no_offset = x86.rmi.imul %1, 2 : (!x86.reg<>) -> !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rmi.imul %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
+%rmi_imul = x86.rmi.imul %1, 2, 8 : (!x86.reg<>) ->  !x86.reg<>
+// CHECK-NEXT: %{{.*}} = x86.rmi.imul %{{.*}}, 2, 8 : (!x86.reg<>) -> !x86.reg<>

--- a/xdsl/dialects/x86/__init__.py
+++ b/xdsl/dialects/x86/__init__.py
@@ -30,6 +30,7 @@ from .ops import (
     RM_OrOp,
     RM_SubOp,
     RM_XorOp,
+    RMI_ImulOp,
     RR_AddOp,
     RR_AndOp,
     RR_ImulOp,
@@ -80,6 +81,7 @@ X86 = Dialect(
         MI_XorOp,
         MI_MovOp,
         RRI_ImulOP,
+        RMI_ImulOp,
         GetRegisterOp,
     ],
     [


### PR DESCRIPTION
Added support for operations with one destination register, one memory access and one immediate.