### PR TITLE
transformations: add malloc to riscv function call lowering

### DIFF
--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -94,7 +94,13 @@ builtin.module {
     %m = "memref.alloc"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<1x1xf32>
 }
 
-// CHECK:      Lowering memref.alloc not implemented yet
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %m = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
+// CHECK-NEXT:    %m_1 = riscv.mv %m : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m_2 = riscv_func.call @malloc(%m_1) : (!riscv.reg<a0>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m_3 = builtin.unrealized_conversion_cast %m_2 : !riscv.reg<a0> to memref<1x1xf32>
+// CHECK-NEXT:    riscv_func.func private @malloc(!riscv.reg<a0>) -> !riscv.reg<a0>
+// CHECK-NEXT:  }
 
 // -----
 

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -98,7 +98,8 @@ builtin.module {
 // CHECK-NEXT:    %m = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
 // CHECK-NEXT:    %m_1 = riscv.mv %m : (!riscv.reg<>) -> !riscv.reg<a0>
 // CHECK-NEXT:    %m_2 = riscv_func.call @malloc(%m_1) : (!riscv.reg<a0>) -> !riscv.reg<a0>
-// CHECK-NEXT:    %m_3 = builtin.unrealized_conversion_cast %m_2 : !riscv.reg<a0> to memref<1x1xf32>
+// CHECK-NEXT:    %m_3 = riscv.mv %m_2 : (!riscv.reg<a0>) -> !riscv.reg<>
+// CHECK-NEXT:    %m_4 = builtin.unrealized_conversion_cast %m_3 : !riscv.reg<> to memref<1x1xf32>
 // CHECK-NEXT:    riscv_func.func private @malloc(!riscv.reg<a0>) -> !riscv.reg<a0>
 // CHECK-NEXT:  }
 

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -91,15 +91,21 @@ builtin.module {
 // -----
 
 builtin.module {
-    %m = "memref.alloc"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<1x1xf32>
+    %m0 = "memref.alloc"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<1x1xf32>
+    %m1 = "memref.alloc"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<1x1xf64>
 }
 
 // CHECK:       builtin.module {
-// CHECK-NEXT:    %m = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
-// CHECK-NEXT:    %m_1 = riscv.mv %m : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:    %m_2 = riscv_func.call @malloc(%m_1) : (!riscv.reg<a0>) -> !riscv.reg<a0>
-// CHECK-NEXT:    %m_3 = riscv.mv %m_2 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:    %m_4 = builtin.unrealized_conversion_cast %m_3 : !riscv.reg<> to memref<1x1xf32>
+// CHECK-NEXT:    %m0 = riscv.li 4 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
+// CHECK-NEXT:    %m0_1 = riscv.mv %m0 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m0_2 = riscv_func.call @malloc(%m0_1) : (!riscv.reg<a0>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m0_3 = riscv.mv %m0_2 : (!riscv.reg<a0>) -> !riscv.reg<>
+// CHECK-NEXT:    %m0_4 = builtin.unrealized_conversion_cast %m0_3 : !riscv.reg<> to memref<1x1xf32>
+// CHECK-NEXT:    %m1 = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
+// CHECK-NEXT:    %m1_1 = riscv.mv %m1 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m1_2 = riscv_func.call @malloc(%m1_1) : (!riscv.reg<a0>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m1_3 = riscv.mv %m1_2 : (!riscv.reg<a0>) -> !riscv.reg<>
+// CHECK-NEXT:    %m1_4 = builtin.unrealized_conversion_cast %m1_3 : !riscv.reg<> to memref<1x1xf64>
 // CHECK-NEXT:    riscv_func.func private @malloc(!riscv.reg<a0>) -> !riscv.reg<a0>
 // CHECK-NEXT:  }
 

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -47,7 +47,8 @@ class ConvertMemrefAllocOp(RewritePattern):
                     (move_op.rd,),
                     (riscv.Registers.A0,),
                 ),
-                UnrealizedConversionCastOp.get(call.ress, (op.memref.type,)),
+                move_op := riscv.MVOp(call.ress[0], rd=riscv.Registers.UNALLOCATED_INT),
+                UnrealizedConversionCastOp.get((move_op.rd,), (op.memref.type,)),
             )
         )
 

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -36,18 +36,14 @@ def bitwidth_of_type(type_attribute: Attribute) -> int:
     """
     Returns the width of an element type in bits, or raises ValueError for unknown inputs.
     """
-    match type_attribute:
-        case IntegerType():
-            bitwidth = type_attribute.width.data
-            return bitwidth
-        case Float32Type():
-            return 32
-        case Float64Type():
-            return 64
-        case _:
-            raise NotImplementedError(
-                f"Unsupported memref element type for riscv lowering: {type_attribute}"
-            )
+    if isinstance(type_attribute, AnyFloat):
+        return type_attribute.get_bitwidth
+    elif isinstance(type_attribute, IntegerType):
+        return type_attribute.width.data
+    else:
+        raise NotImplementedError(
+            f"Unsupported memref element type for riscv lowering: {type_attribute}"
+        )
 
 
 class ConvertMemrefAllocOp(RewritePattern):


### PR DESCRIPTION
This seems to be similar to what `--finalize-memref-to-llvm` does.