### PR TITLE
transformations: Implement and test `memref-to-gpu`.

### DIFF
--- a/tests/filecheck/transforms/gpu-allocs.mlir
+++ b/tests/filecheck/transforms/gpu-allocs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p gpu-allocs | filecheck %s
+// RUN: xdsl-opt %s -p memref-to-gpu | filecheck %s
 
 func.func private @memref_test() {
   %12 = "test.op"() : () -> index

--- a/tests/filecheck/transforms/gpu-allocs.mlir
+++ b/tests/filecheck/transforms/gpu-allocs.mlir
@@ -1,0 +1,29 @@
+// RUN: xdsl-opt %s -p gpu-allocs | filecheck %s
+
+func.func private @memref_test() {
+  %12 = "test.op"() : () -> index
+  %13 = "test.op"() : () -> index
+  %14 = "test.op"() : () -> index
+  %10 = memref.alloc() : memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
+  %15 = memref.alloc(%12) {"alignment" = 0} : memref<?xindex>
+  %16 = memref.alloc(%12, %13, %14) {"alignment" = 0} : memref<?x?x?xindex>
+  memref.dealloc %10 : memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
+  memref.dealloc %15 : memref<?xindex>
+  memref.dealloc %16 : memref<?x?x?xindex>
+  func.return
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func private @memref_test() {
+// CHECK-NEXT:      %0 = "test.op"() : () -> index
+// CHECK-NEXT:      %1 = "test.op"() : () -> index
+// CHECK-NEXT:      %2 = "test.op"() : () -> index
+// CHECK-NEXT:      %3 = "gpu.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
+// CHECK-NEXT:      %4 = "gpu.alloc"(%0) <{"operandSegmentSizes" = array<i32: 0, 1, 0>}> : (index) -> memref<?xindex>
+// CHECK-NEXT:      %5 = "gpu.alloc"(%0, %1, %2) <{"operandSegmentSizes" = array<i32: 0, 3, 0>}> : (index, index, index) -> memref<?x?x?xindex>
+// CHECK-NEXT:      "gpu.dealloc"(%3) {"operandSegmentSizes" = array<i32: 0, 1>} : (memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>) -> ()
+// CHECK-NEXT:      "gpu.dealloc"(%4) {"operandSegmentSizes" = array<i32: 0, 1>} : (memref<?xindex>) -> ()
+// CHECK-NEXT:      "gpu.dealloc"(%5) {"operandSegmentSizes" = array<i32: 0, 1>} : (memref<?x?x?xindex>) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -390,6 +390,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return DesymrefyPass
 
+    def get_gpu_allocs():
+        from xdsl.transforms import gpu_allocs
+
+        return gpu_allocs.GpuAllocsPass
+
     def get_gpu_map_parallel_loops():
         from xdsl.transforms import gpu_map_parallel_loops
 
@@ -591,6 +596,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "distribute-stencil": get_distribute_stencil,
         "dmp-to-mpi": get_lower_halo_to_mpi,
         "frontend-desymrefy": get_desymrefy,
+        "gpu-allocs": get_gpu_allocs,
         "gpu-map-parallel-loops": get_gpu_map_parallel_loops,
         "hls-convert-stencil-to-ll-mlir": get_hls_convert_stencil_to_ll_mlir,
         "apply-individual-rewrite": get_individual_rewrite,

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -393,7 +393,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
     def get_gpu_allocs():
         from xdsl.transforms import gpu_allocs
 
-        return gpu_allocs.GpuAllocsPass
+        return gpu_allocs.MemrefToGPUPass
 
     def get_gpu_map_parallel_loops():
         from xdsl.transforms import gpu_map_parallel_loops
@@ -596,7 +596,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "distribute-stencil": get_distribute_stencil,
         "dmp-to-mpi": get_lower_halo_to_mpi,
         "frontend-desymrefy": get_desymrefy,
-        "gpu-allocs": get_gpu_allocs,
+        "memref-to-gpu": get_gpu_allocs,
         "gpu-map-parallel-loops": get_gpu_map_parallel_loops,
         "hls-convert-stencil-to-ll-mlir": get_hls_convert_stencil_to_ll_mlir,
         "apply-individual-rewrite": get_individual_rewrite,

--- a/xdsl/transforms/gpu_allocs.py
+++ b/xdsl/transforms/gpu_allocs.py
@@ -1,0 +1,43 @@
+from xdsl.dialects import gpu, memref
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.ir import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class GpuAllocPattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Alloc, rewriter: PatternRewriter, /):
+        rewriter.replace_matched_op(
+            gpu.AllocOp.build(
+                operands=[None, op.dynamic_sizes, op.symbol_operands],
+                result_types=[op.memref.type, None],
+            )
+        )
+
+
+class GpuDellocPattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Dealloc, rewriter: PatternRewriter, /):
+        rewriter.replace_matched_op(gpu.DeallocOp(op.memref))
+
+
+class GpuAllocsPass(ModulePass):
+    name = "gpu-allocs"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        walker = PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    GpuAllocPattern(),
+                    GpuDellocPattern(),
+                ]
+            )
+        )
+        walker.rewrite_module(op)

--- a/xdsl/transforms/gpu_allocs.py
+++ b/xdsl/transforms/gpu_allocs.py
@@ -28,8 +28,8 @@ class GpuDellocPattern(RewritePattern):
         rewriter.replace_matched_op(gpu.DeallocOp(op.memref))
 
 
-class GpuAllocsPass(ModulePass):
-    name = "gpu-allocs"
+class MemrefToGPUPass(ModulePass):
+    name = "memref-to-gpu"
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
         walker = PatternRewriteWalker(


### PR DESCRIPTION
This new pass converts all `memref.(de)alloc`s to `gpu.(de)alloc`s.

The motivation is that my stencil conversion is now completely target-agnostic, except for allocations, for which there currently exists no way to express transparently and select a platform later, for example.

It is very rough at this point; i.e., could extend to more targets, or to more settings, but is good enough for what I want to do with it at the moment :slightly_smiling_face: 