### PR TITLE
core: Fix xDSL printing multiple values with the same name.

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -48,7 +48,7 @@ func.func @initialize() {
 }
 
 
-// CHECK-NEXT: //unknown op Global("memref.global"() <{"sym_name" = "A", "sym_visibility" = "public", "type" = memref<24xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
+// CHECK:      //unknown op Global("memref.global"() <{"sym_name" = "A", "sym_visibility" = "public", "type" = memref<24xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
 // CHECK-NEXT: //unknown op Global("memref.global"() <{"sym_name" = "x", "sym_visibility" = "public", "type" = memref<6xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
 // CHECK-NEXT: //unknown op Global("memref.global"() <{"sym_name" = "b", "sym_visibility" = "public", "type" = memref<4xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
 // CHECK-NEXT: //unknown op Global("memref.global"() <{"sym_name" = "y", "sym_visibility" = "public", "type" = memref<4xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())
@@ -69,15 +69,15 @@ func.func @initialize() {
 // CHECK-NEXT:     //unknown op Store(memref.store %idx_f32, %A[%idx_index] : memref<24xf32>)
 // CHECK-NEXT:     //unknown op Yield(scf.yield)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   const ub_6 : i16 = 6;
+// CHECK-NEXT:   const ub2 : i16 = 6;
 // CHECK-NEXT:   for(@range(i16, lb, ub, step)) |j| {
 // CHECK-NEXT:     const val : f32 = 1.0;
 // CHECK-NEXT:     //unknown op IndexCastOp(%j_idx = "arith.index_cast"(%j) : (i16) -> index)
 // CHECK-NEXT:     //unknown op Store(memref.store %val, %x[%j_idx] : memref<6xf32>)
 // CHECK-NEXT:     //unknown op Yield(scf.yield)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   const ub_4 : i16 = 6;
-// CHECK-NEXT:   for(@range(i16, lb, ub_4, step)) |i| {
+// CHECK-NEXT:   const ub3 : i16 = 6;
+// CHECK-NEXT:   for(@range(i16, lb, ub3, step)) |i| {
 // CHECK-NEXT:     const c2 : f32 = 2.0;
 // CHECK-NEXT:     const c0 : f32 = 0.0;
 // CHECK-NEXT:     //unknown op IndexCastOp(%i_idx = "arith.index_cast"(%i) : (i16) -> index)

--- a/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
+++ b/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
@@ -42,8 +42,8 @@ riscv_func.func @main() {
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        %{{\d+}} = riscv.mv %9 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:        riscv_scf.yield %{{\d+}} : !riscv.reg<t0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      }
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %zero_0 = riscv.li 0 : () -> !riscv.reg<zero>
-//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %zero_1 = riscv.li 0 : () -> !riscv.reg<a0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %zero_1 = riscv.li 0 : () -> !riscv.reg<zero>
+//   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      %zero_2 = riscv.li 0 : () -> !riscv.reg<a0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:      riscv_func.return
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:    }
 //   CHECK-LIVENESS-BLOCK-NAIVE-NEXT:  }
@@ -64,8 +64,8 @@ riscv_func.func @main() {
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:        %{{\d+}} = riscv.mv %9 : (!riscv.reg<j0>) -> !riscv.reg<j0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:        riscv_scf.yield %{{\d+}} : !riscv.reg<j0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      }
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %zero_0 = riscv.li 0 : () -> !riscv.reg<zero>
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %zero_1 = riscv.li 0 : () -> !riscv.reg<a0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %zero_1 = riscv.li 0 : () -> !riscv.reg<zero>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %zero_2 = riscv.li 0 : () -> !riscv.reg<a0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      riscv_func.return
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:    }
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:  }

--- a/tests/filecheck/dialects/air/air_ops.mlir
+++ b/tests/filecheck/dialects/air/air_ops.mlir
@@ -121,39 +121,39 @@ module {
 // CHECK-NEXT:       %alloc = memref.alloc() {"alignment" = 64 : i64} : memref<64x64xi32>
 // CHECK-NEXT:       "air.execute_terminator"(%alloc) : (memref<64x64xi32>) -> ()
 // CHECK-NEXT:     }) : () -> (!air.async.token, memref<64x64xi32>)
-// CHECK-NEXT:     %async_token_0 = "air.execute"(%async_token) ({
+// CHECK-NEXT:     %async_token_1 = "air.execute"(%async_token) ({
 // CHECK-NEXT:       %alloc_1 = memref.alloc() {"alignment" = 64 : i64} : memref<64x64xi32>
 // CHECK-NEXT:       "air.execute_terminator"(%alloc_1) : (memref<64x64xi32>) -> ()
 // CHECK-NEXT:     }) : (!air.async.token) -> !air.async.token
-// CHECK-NEXT:     %async_token_1, %results_2 = "air.execute"() ({
+// CHECK-NEXT:     %async_token_2, %results_1 = "air.execute"() ({
 // CHECK-NEXT:       %alloc_2 = memref.alloc() {"alignment" = 64 : i64} : memref<64x64xi32>
 // CHECK-NEXT:       "air.execute_terminator"(%alloc_2) : (memref<64x64xi32>) -> ()
 // CHECK-NEXT:     }) : () -> (!air.async.token, memref<64x64xi32>)
-// CHECK-NEXT:     %async_token_3 = "air.execute"(%async_token_1, %async_token_0) ({
+// CHECK-NEXT:     %async_token_3 = "air.execute"(%async_token_2, %async_token_1) ({
 // CHECK-NEXT:       %alloc_3 = memref.alloc() {"alignment" = 64 : i64} : memref<64x64xi32>
 // CHECK-NEXT:       "air.execute_terminator"(%alloc_3) : (memref<64x64xi32>) -> ()
 // CHECK-NEXT:     }) : (!air.async.token, !air.async.token) -> !air.async.token
-// CHECK-NEXT:     %0 = air.wait_all async 
+// CHECK-NEXT:     %0 = air.wait_all async
 // CHECK-NEXT:     %1 = scf.for %arg3 = %c0 to %c128 step %c32 iter_args(%arg4 = %0) -> (!air.async.token) {
 // CHECK-NEXT:       %2 = air.channel.put async[%arg4] @channel_0[] (%arg0[%c0, %arg3] [%c32, %c32] [%c128, %c1]) {"id" = 1 : i32} : (memref<64x128xi32>)
 // CHECK-NEXT:       scf.yield %2 : !air.async.token
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %3 = air.wait_all async 
+// CHECK-NEXT:     %3 = air.wait_all async
 // CHECK-NEXT:     %4 = scf.for %arg3_1 = %c0 to %c128 step %c32 iter_args(%arg4_1 = %3) -> (!air.async.token) {
 // CHECK-NEXT:       %5 = air.channel.put async[%arg4_1] @channel_1[] (%arg0[%c32, %arg3_1] [%c32, %c32] [%c128, %c1]) {"id" = 2 : i32} : (memref<64x128xi32>)
 // CHECK-NEXT:       scf.yield %5 : !air.async.token
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %6 = air.wait_all async 
+// CHECK-NEXT:     %6 = air.wait_all async
 // CHECK-NEXT:     %7 = scf.for %arg3_2 = %c0 to %c128 step %c32 iter_args(%arg4_2 = %6) -> (!air.async.token) {
 // CHECK-NEXT:       %8 = air.channel.put async[%arg4_2] @channel_2[] (%arg1[%arg3_2, %c0] [%c32, %c32] [%c64, %c1]) {"id" = 3 : i32} : (memref<128x64xi32>)
 // CHECK-NEXT:       scf.yield %8 : !air.async.token
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %9 = air.wait_all async 
+// CHECK-NEXT:     %9 = air.wait_all async
 // CHECK-NEXT:     %10 = scf.for %arg3_3 = %c0 to %c128 step %c32 iter_args(%arg4_3 = %9) -> (!air.async.token) {
 // CHECK-NEXT:       %11 = air.channel.put async[%arg4_3] @channel_3[] (%arg1[%arg3_3, %c32] [%c32, %c32] [%c64, %c1]) {"id" = 4 : i32} : (memref<128x64xi32>)
 // CHECK-NEXT:       scf.yield %11 : !air.async.token
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %12 = air.channel.get async[%async_token_3] @channel_4[] (%results_2[] [%c32, %c32] [%c64, %c1]) {"id" = 5 : i32} : (memref<64x64xi32>)
+// CHECK-NEXT:     %12 = air.channel.get async[%async_token_3] @channel_4[] (%results_1[] [%c32, %c32] [%c64, %c1]) {"id" = 5 : i32} : (memref<64x64xi32>)
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -3,15 +3,15 @@
 %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
 %lhsvec, %rhsvec = "test.op"() : () -> (vector<4xf32>, vector<4xf32>)
 
-%addf_0 = arith.addf %lhsf32, %rhsf32 : f32
+%addf = arith.addf %lhsf32, %rhsf32 : f32
 %addf_1 = arith.addf %lhsf32, %rhsf32 : f32
-%addf_vector_0 = arith.addf %lhsvec, %rhsvec : vector<4xf32>
+%addf_vector = arith.addf %lhsvec, %rhsvec : vector<4xf32>
 %addf_vector_1 = arith.addf %lhsvec, %rhsvec : vector<4xf32>
 
-"test.op"(%addf_0, %addf_vector_0) : (f32, vector<4xf32>) -> ()
+"test.op"(%addf, %addf_vector) : (f32, vector<4xf32>) -> ()
 
 // CHECK:        %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
 // CHECK-NEXT:   %lhsvec, %rhsvec = "test.op"() : () -> (vector<4xf32>, vector<4xf32>)
-// CHECK-NEXT:   %addf_0 = arith.addf %lhsf32, %rhsf32 : f32
-// CHECK-NEXT:   %addf_vector_0 = arith.addf %lhsvec, %rhsvec : vector<4xf32>
-// CHECK-NEXT:   "test.op"(%addf_0, %addf_vector_0) : (f32, vector<4xf32>) -> ()
+// CHECK-NEXT:   %addf = arith.addf %lhsf32, %rhsf32 : f32
+// CHECK-NEXT:   %addf_vector = arith.addf %lhsvec, %rhsvec : vector<4xf32>
+// CHECK-NEXT:   "test.op"(%addf, %addf_vector) : (f32, vector<4xf32>) -> ()

--- a/tests/filecheck/dialects/onnx/onnx_ops.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_ops.mlir
@@ -33,35 +33,35 @@
 %res_gemm = "onnx.Gemm"(%t9, %t10, %t11) {onnx_node_name = "/Gemm"}: (tensor<2x2xf32>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
 // CHECK: %res_gemm = onnx.Gemm(%t9, %t10, %t11) {"onnx_node_name" = "/Gemm"} : (tensor<2x2xf32>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
 
-%res_gemm_2 = "onnx.Gemm"(%t12, %t13, %t14) {onnx_node_name = "/Gemm"}: (tensor<5x3xf32>, tensor<3x2xf32>, tensor<5x2xf32>) -> tensor<5x2xf32>
-// CHECK: %res_gemm_2 = onnx.Gemm(%t12, %t13, %t14) {"onnx_node_name" = "/Gemm"} : (tensor<5x3xf32>, tensor<3x2xf32>, tensor<5x2xf32>) -> tensor<5x2xf32>
+%res_gemm_1 = "onnx.Gemm"(%t12, %t13, %t14) {onnx_node_name = "/Gemm"}: (tensor<5x3xf32>, tensor<3x2xf32>, tensor<5x2xf32>) -> tensor<5x2xf32>
+// CHECK: %res_gemm_1 = onnx.Gemm(%t12, %t13, %t14) {"onnx_node_name" = "/Gemm"} : (tensor<5x3xf32>, tensor<3x2xf32>, tensor<5x2xf32>) -> tensor<5x2xf32>
 
 %res_reshape = "onnx.Reshape"(%t15, %t16) {onnx_node_name = "/Reshape", "allowzero" = 1 : i64}: (tensor<48x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
 //CHECK: res_reshape = onnx.Reshape(%t15, %t16) {"onnx_node_name" = "/Reshape", "allowzero" = 1 : i64} : (tensor<48x256x64xf32>, tensor<3xi64>) -> tensor<48x256x64xf32>
 
-%res_reshape_2 = "onnx.Reshape"(%t17, %t18) {onnx_node_name = "/Reshape"}: (tensor<1x2x3x4x5xf32>, tensor<5xi64>) -> tensor<1x120xf32>
-//CHECK: %res_reshape_2 = onnx.Reshape(%t17, %t18) {"onnx_node_name" = "/Reshape"} : (tensor<1x2x3x4x5xf32>, tensor<5xi64>) -> tensor<1x120xf32>
+%res_reshape_1 = "onnx.Reshape"(%t17, %t18) {onnx_node_name = "/Reshape"}: (tensor<1x2x3x4x5xf32>, tensor<5xi64>) -> tensor<1x120xf32>
+//CHECK: %res_reshape_1 = onnx.Reshape(%t17, %t18) {"onnx_node_name" = "/Reshape"} : (tensor<1x2x3x4x5xf32>, tensor<5xi64>) -> tensor<1x120xf32>
 
 %res_abs = "onnx.Abs"(%t19) {onnx_node_name = "/Abs"}: (tensor<10x10xf32>) -> tensor<10x10xf32>
 // CHECK: %res_abs = onnx.Abs(%t19) {"onnx_node_name" = "/Abs"} : (tensor<10x10xf32>) -> tensor<10x10xf32>
 
-%res_conv_1 = "onnx.Conv"(%t20, %t21, %t22) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [1 : i64, 1 : i64, 1: i64, 1 : i64]}: (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x5x5xf32>
-//CHECK: %res_conv_1 = onnx.Conv(%t20, %t21, %t22) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [1 : i64, 1 : i64, 1 : i64, 1 : i64]} : (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x5x5xf32>
+%res_conv = "onnx.Conv"(%t20, %t21, %t22) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [1 : i64, 1 : i64, 1: i64, 1 : i64]}: (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x5x5xf32>
+//CHECK: %res_conv = onnx.Conv(%t20, %t21, %t22) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [1 : i64, 1 : i64, 1 : i64, 1 : i64]} : (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x5x5xf32>
 
-%res_conv_2 = "onnx.Conv"(%t20, %t21, %t22) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0: i64, 0 : i64]}: (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
-//CHECK: %res_conv_2 = onnx.Conv(%t20, %t21, %t22) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]} : (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
+%res_conv_1 = "onnx.Conv"(%t20, %t21, %t22) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0: i64, 0 : i64]}: (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
+//CHECK: %res_conv_1 = onnx.Conv(%t20, %t21, %t22) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]} : (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
 
-%res_conv_3 = "onnx.Conv"(%t20, %t21, %t22) {onnx_node_name = "/Conv", "auto_pad" = "SAME_LOWER", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0: i64, 0 : i64]}: (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
-//CHECK: %res_conv_3 = onnx.Conv(%t20, %t21, %t22) {"onnx_node_name" = "/Conv", "auto_pad" = "SAME_LOWER", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]} : (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
+%res_conv_2 = "onnx.Conv"(%t20, %t21, %t22) {onnx_node_name = "/Conv", "auto_pad" = "SAME_LOWER", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0: i64, 0 : i64]}: (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
+//CHECK: %res_conv_2 = onnx.Conv(%t20, %t21, %t22) {"onnx_node_name" = "/Conv", "auto_pad" = "SAME_LOWER", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]} : (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
 
-%res_conv_4 = "onnx.Conv"(%t23, %t24, %t25) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 1 : i64, 1 : i64, 1 : i64]}: (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x3xf32>
-//CHECK: %res_conv_4 = onnx.Conv(%t23, %t24, %t25) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 1 : i64, 1 : i64, 1 : i64]} : (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x3xf32>
+%res_conv_3 = "onnx.Conv"(%t23, %t24, %t25) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 1 : i64, 1 : i64, 1 : i64]}: (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x3xf32>
+//CHECK: %res_conv_3 = onnx.Conv(%t23, %t24, %t25) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 1 : i64, 1 : i64, 1 : i64]} : (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x3xf32>
 
-%res_conv_5 = "onnx.Conv"(%t23, %t24, %t25) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]}: (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x2xf32>
-//CHECK: %res_conv_5 = onnx.Conv(%t23, %t24, %t25) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]} : (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x2xf32>
+%res_conv_4 = "onnx.Conv"(%t23, %t24, %t25) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]}: (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x2xf32>
+//CHECK: %res_conv_4 = onnx.Conv(%t23, %t24, %t25) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64]} : (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x2xf32>
 
-%res_conv_6 = "onnx.Conv"(%t23, %t24, %t25) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 0 : i64, 1 : i64, 0 : i64]}: (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x2xf32>
-//CHECK: %res_conv_6 = onnx.Conv(%t23, %t24, %t25) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 0 : i64, 1 : i64, 0 : i64]} : (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x2xf32>
+%res_conv_5 = "onnx.Conv"(%t23, %t24, %t25) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 0 : i64, 1 : i64, 0 : i64]}: (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x2xf32>
+//CHECK: %res_conv_5 = onnx.Conv(%t23, %t24, %t25) {"onnx_node_name" = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [2 : i64, 2 : i64], "pads" = [1 : i64, 0 : i64, 1 : i64, 0 : i64]} : (tensor<1x1x7x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x4x2xf32>
 
 %res_max_pool_single_out = "onnx.MaxPoolSingleOut"(%t26) {onnx_node_name = "/MaxPoolSingleOut", "auto_pad" = "VALID", "ceil_mode" = 0 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64], "storage_order" = 0 : i64, "strides" = [1 : i64, 1 : i64]}: (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
 //CHECK: %res_max_pool_single_out = onnx.MaxPoolSingleOut(%t26) {"onnx_node_name" = "/MaxPoolSingleOut", "auto_pad" = "VALID", "ceil_mode" = 0 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64], "storage_order" = 0 : i64, "strides" = [1 : i64, 1 : i64]} : (tensor<5x5x32x32xf32>) -> tensor<5x5x30x30xf32>
@@ -69,14 +69,14 @@
 "onnx.EntryPoint"() {onnx_node_name = "/EntryPoint", "func" = @main_graph} : () -> ()
 //CHECK: "onnx.EntryPoint"() {"onnx_node_name" = "/EntryPoint", "func" = @main_graph} : () -> ()
 
-%res_constant_1 = onnx.Constant dense<1> : tensor<1xi64>
-//CHECK: %res_constant_1 = onnx.Constant dense<1> : tensor<1xi64>
+%res_constant = onnx.Constant dense<1> : tensor<1xi64>
+//CHECK: %res_constant = onnx.Constant dense<1> : tensor<1xi64>
 
-%res_constant_2 = onnx.Constant dense<[5, 5, 16, 2]> : tensor<4xi64>
-//CHECK: %res_constant_2 = onnx.Constant dense<[5, 5, 16, 2]> : tensor<4xi64>
+%res_constant_1 = onnx.Constant dense<[5, 5, 16, 2]> : tensor<4xi64>
+//CHECK: %res_constant_1 = onnx.Constant dense<[5, 5, 16, 2]> : tensor<4xi64>
 
-%res_gemm_3 = "onnx.Gemm"(%t27, %t28, %t29) {onnx_node_name = "/Gemm", "alpha" = 1.000000e+00 : f32, "beta" = 1.000000e+00 : f32, "transA" = 0 : si64, "transB" = 1 : si64}: (tensor<1x320xf32>, tensor<50x320xf32>, tensor<50xf32>) -> tensor<1x50xf32>
-// CHECK:  %res_gemm_3 = onnx.Gemm(%t27, %t28, %t29) {"onnx_node_name" = "/Gemm", "alpha" = 1.000000e+00 : f32, "beta" = 1.000000e+00 : f32, "transA" = 0 : si64, "transB" = 1 : si64} : (tensor<1x320xf32>, tensor<50x320xf32>, tensor<50xf32>) -> tensor<1x50xf32>
+%res_gemm_2 = "onnx.Gemm"(%t27, %t28, %t29) {onnx_node_name = "/Gemm", "alpha" = 1.000000e+00 : f32, "beta" = 1.000000e+00 : f32, "transA" = 0 : si64, "transB" = 1 : si64}: (tensor<1x320xf32>, tensor<50x320xf32>, tensor<50xf32>) -> tensor<1x50xf32>
+// CHECK:  %res_gemm_2 = onnx.Gemm(%t27, %t28, %t29) {"onnx_node_name" = "/Gemm", "alpha" = 1.000000e+00 : f32, "beta" = 1.000000e+00 : f32, "transA" = 0 : si64, "transB" = 1 : si64} : (tensor<1x320xf32>, tensor<50x320xf32>, tensor<50xf32>) -> tensor<1x50xf32>
 
 %res_matmul = "onnx.MatMul"(%t9, %t10) {onnx_node_name = "/MatMul"}: (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
 // CHECK: %res_matmul = onnx.MatMul(%t9, %t10) {"onnx_node_name" = "/MatMul"} : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>

--- a/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
+++ b/tests/filecheck/dialects/snitch_runtime/snitch_runtime_ops.mlir
@@ -57,25 +57,25 @@ builtin.module {
         // CHECK: %{{.*}}, %{{.*}} = "snrt.zero_memory"() : () -> (i64, i64)
 
         // DMA Operations
-        %dst_64 = arith.constant 100 : i64
-        %src_64 = arith.constant 0 : i64
+        %dst_i64 = arith.constant 100 : i64
+        %src_i64 = arith.constant 0 : i64
         %size = arith.constant 100 : i32
-        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, i32) -> i32
-        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_64, %src_64, %size) : (i64, i64, i32) -> i32
-        %dst_32 = arith.constant 100 : i32
-        %src_32 = arith.constant 0 : i32
-        %size_2 = arith.constant 100 : i32
-        %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size) : (i32, i32, i32) -> i32
-        // CHECK: %transfer_id_2 = "snrt.dma_start_1d"(%dst_32, %src_32, %size) : (i32, i32, i32) -> i32
+        %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_i64, %src_i64, %size) : (i64, i64, i32) -> i32
+        // CHECK: %transfer_id = "snrt.dma_start_1d_wideptr"(%dst_i64, %src_i64, %size) : (i64, i64, i32) -> i32
+        %dst_i32 = arith.constant 100 : i32
+        %src_i32 = arith.constant 0 : i32
+        %size_1 = arith.constant 100 : i32
+        %transfer_id_1 = "snrt.dma_start_1d"(%dst_i32, %src_i32, %size) : (i32, i32, i32) -> i32
+        // CHECK: %transfer_id_1 = "snrt.dma_start_1d"(%dst_i32, %src_i32, %size) : (i32, i32, i32) -> i32
         "snrt.dma_wait"(%transfer_id) : (i32) -> ()
         // CHECK: "snrt.dma_wait"(%transfer_id) : (i32) -> ()
         %repeat = arith.constant 1 : i32
         %src_stride = arith.constant 1 : i32
         %dst_stride = arith.constant 1 : i32
-        %transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) : (i64, i64, i32, i32, i32, i32) -> i32
-        // CHECK: transfer_id_3 = "snrt.dma_start_2d_wideptr"(%dst_64, %src_64, %dst_stride, %src_stride, %size_2, %repeat) : (i64, i64, i32, i32, i32, i32) -> i32
-        %transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, i32, i32, i32, i32) -> i32
-        // CHECK: transfer_id_4 = "snrt.dma_start_2d"(%dst_32, %src_32, %dst_stride, %src_stride, %size_2, %repeat) : (i32, i32, i32, i32, i32, i32) -> i32
+        %transfer_id_2 = "snrt.dma_start_2d_wideptr"(%dst_i64, %src_i64, %dst_stride, %src_stride, %size_1, %repeat) : (i64, i64, i32, i32, i32, i32) -> i32
+        // CHECK: transfer_id_2 = "snrt.dma_start_2d_wideptr"(%dst_i64, %src_i64, %dst_stride, %src_stride, %size_1, %repeat) : (i64, i64, i32, i32, i32, i32) -> i32
+        %transfer_id_3 = "snrt.dma_start_2d"(%dst_i32, %src_i32, %dst_stride, %src_stride, %size_1, %repeat) : (i32, i32, i32, i32, i32, i32) -> i32
+        // CHECK: transfer_id_3 = "snrt.dma_start_2d"(%dst_i32, %src_i32, %dst_stride, %src_stride, %size_1, %repeat) : (i32, i32, i32, i32, i32, i32) -> i32
         "snrt.dma_wait_all"() : () -> ()
         // CHECK: "snrt.dma_wait_all"() : () -> ()
 

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -278,7 +278,7 @@ builtin.module {
   }
 
 // CHECK:         func.func @neg_bounds(%in : memref<64xf64>, %out_1 : memref<64xf64>) {
-// CHECK-NEXT:      %out_1_storeview = "memref.subview"(%out_1) <{"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
+// CHECK-NEXT:      %out_storeview = "memref.subview"(%out_1) <{"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
 // CHECK-NEXT:      %in_loadview = "memref.subview"(%in) <{"static_offsets" = array<i64: 32>, "static_sizes" = array<i64: 32>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<64xf64>) -> memref<32xf64, strided<[1], offset: 32>>
 // CHECK-NEXT:      %110 = arith.constant -16 : index
 // CHECK-NEXT:      %111 = arith.constant 1 : index
@@ -286,7 +286,7 @@ builtin.module {
 // CHECK-NEXT:      "scf.parallel"(%110, %112, %111) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
 // CHECK-NEXT:      ^6(%113 : index):
 // CHECK-NEXT:        %val = memref.load %in_loadview[%113] : memref<32xf64, strided<[1], offset: 32>>
-// CHECK-NEXT:        memref.store %val, %out_1_storeview[%113] : memref<32xf64, strided<[1], offset: 32>>
+// CHECK-NEXT:        memref.store %val, %out_storeview[%113] : memref<32xf64, strided<[1], offset: 32>>
 // CHECK-NEXT:        scf.yield
 // CHECK-NEXT:      }) : (index, index, index) -> ()
 // CHECK-NEXT:      func.return
@@ -382,19 +382,19 @@ builtin.module {
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
-  func.func @apply_kernel(%69 : !stencil.field<[-2,13]x[-2,13]xf32>, %70 : !stencil.field<[-2,13]x[-2,13]xf32>, %timers : !llvm.ptr)  attributes {"param_names" = ["u_vec_0", "u_vec_1", "timers"]}{
+  func.func @apply_kernel(%69 : !stencil.field<[-2,13]x[-2,13]xf32>, %70 : !stencil.field<[-2,13]x[-2,13]xf32>, %timers : !llvm.ptr)  attributes {"param_names" = ["u_vec_1", "u_vec", "timers"]}{
     %71 = "gpu.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> memref<15x15xf32>
-    %u_vec_1 = builtin.unrealized_conversion_cast %71 : memref<15x15xf32> to !stencil.field<[-2,13]x[-2,13]xf32>
+    %u_vec = builtin.unrealized_conversion_cast %71 : memref<15x15xf32> to !stencil.field<[-2,13]x[-2,13]xf32>
     %72 = builtin.unrealized_conversion_cast %70 : !stencil.field<[-2,13]x[-2,13]xf32> to memref<15x15xf32>
     "gpu.memcpy"(%71, %72) {"operandSegmentSizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
     %73 = "gpu.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> memref<15x15xf32>
-    %u_vec_0 = builtin.unrealized_conversion_cast %73 : memref<15x15xf32> to !stencil.field<[-2,13]x[-2,13]xf32>
+    %u_vec_1 = builtin.unrealized_conversion_cast %73 : memref<15x15xf32> to !stencil.field<[-2,13]x[-2,13]xf32>
     %74 = builtin.unrealized_conversion_cast %69 : !stencil.field<[-2,13]x[-2,13]xf32> to memref<15x15xf32>
     "gpu.memcpy"(%73, %74) {"operandSegmentSizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
     %time_m_1 = arith.constant 0 : index
     %time_M_1 = arith.constant 10 : index
     %step_1 = arith.constant 1 : index
-    %75, %76 = scf.for %time_1 = %time_m_1 to %time_M_1 step %step_1 iter_args(%t0 = %u_vec_0, %t1 = %u_vec_1) -> (!stencil.field<[-2,13]x[-2,13]xf32>, !stencil.field<[-2,13]x[-2,13]xf32>) {
+    %75, %76 = scf.for %time_1 = %time_m_1 to %time_M_1 step %step_1 iter_args(%t0 = %u_vec_1, %t1 = %u_vec) -> (!stencil.field<[-2,13]x[-2,13]xf32>, !stencil.field<[-2,13]x[-2,13]xf32>) {
       %t0_temp = stencil.load %t0 : !stencil.field<[-2,13]x[-2,13]xf32> -> !stencil.temp<[0,11]x[0,11]xf32>
       %t1_result = stencil.apply(%t0_buff = %t0_temp : !stencil.temp<[0,11]x[0,11]xf32>) -> (!stencil.temp<[0,11]x[0,11]xf32>) {
         %77 = stencil.access %t0_buff[0, 0] : !stencil.temp<[0,11]x[0,11]xf32>
@@ -406,19 +406,19 @@ builtin.module {
     func.return
   }
 
-// CHECK:         func.func @apply_kernel(%154 : memref<15x15xf32>, %155 : memref<15x15xf32>, %timers : !llvm.ptr)  attributes {"param_names" = ["u_vec_0", "u_vec_1", "timers"]}{
+// CHECK:         func.func @apply_kernel(%154 : memref<15x15xf32>, %155 : memref<15x15xf32>, %timers : !llvm.ptr)  attributes {"param_names" = ["u_vec_1", "u_vec", "timers"]}{
 // CHECK-NEXT:      %156 = "gpu.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> memref<15x15xf32>
-// CHECK-NEXT:      %u_vec_1 = builtin.unrealized_conversion_cast %156 : memref<15x15xf32> to memref<15x15xf32>
+// CHECK-NEXT:      %u_vec = builtin.unrealized_conversion_cast %156 : memref<15x15xf32> to memref<15x15xf32>
 // CHECK-NEXT:      %157 = builtin.unrealized_conversion_cast %155 : memref<15x15xf32> to memref<15x15xf32>
 // CHECK-NEXT:      "gpu.memcpy"(%156, %157) {"operandSegmentSizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
 // CHECK-NEXT:      %158 = "gpu.alloc"() <{"operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> memref<15x15xf32>
-// CHECK-NEXT:      %u_vec_0 = builtin.unrealized_conversion_cast %158 : memref<15x15xf32> to memref<15x15xf32>
+// CHECK-NEXT:      %u_vec_1 = builtin.unrealized_conversion_cast %158 : memref<15x15xf32> to memref<15x15xf32>
 // CHECK-NEXT:      %159 = builtin.unrealized_conversion_cast %154 : memref<15x15xf32> to memref<15x15xf32>
 // CHECK-NEXT:      "gpu.memcpy"(%158, %159) {"operandSegmentSizes" = array<i32: 0, 1, 1>} : (memref<15x15xf32>, memref<15x15xf32>) -> ()
 // CHECK-NEXT:      %time_m_1 = arith.constant 0 : index
 // CHECK-NEXT:      %time_M_1 = arith.constant 10 : index
 // CHECK-NEXT:      %step_1 = arith.constant 1 : index
-// CHECK-NEXT:      %160, %161 = scf.for %time_1 = %time_m_1 to %time_M_1 step %step_1 iter_args(%t0 = %u_vec_0, %t1 = %u_vec_1) -> (memref<15x15xf32>, memref<15x15xf32>) {
+// CHECK-NEXT:      %160, %161 = scf.for %time_1 = %time_m_1 to %time_M_1 step %step_1 iter_args(%t0 = %u_vec_1, %t1 = %u_vec) -> (memref<15x15xf32>, memref<15x15xf32>) {
 // CHECK-NEXT:        %t1_storeview = "memref.subview"(%t1) <{"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
 // CHECK-NEXT:        %t0_loadview = "memref.subview"(%t0) <{"static_offsets" = array<i64: 2, 2>, "static_sizes" = array<i64: 11, 11>, "static_strides" = array<i64: 1, 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<15x15xf32>) -> memref<11x11xf32, strided<[15, 1], offset: 32>>
 // CHECK-NEXT:        %162 = arith.constant 0 : index
@@ -575,10 +575,10 @@ builtin.module {
 // CHECK-NEXT:      "scf.parallel"(%232, %233, %234, %238, %239, %240, %235, %236, %237) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
 // CHECK-NEXT:      ^14(%241 : index, %242 : index, %z_1 : index):
 // CHECK-NEXT:        %x_1 = arith.constant 1 : index
-// CHECK-NEXT:        %x_1_1 = arith.addi %241, %x_1 : index
+// CHECK-NEXT:        %x_2 = arith.addi %241, %x_1 : index
 // CHECK-NEXT:        %y_1 = arith.constant -1 : index
-// CHECK-NEXT:        %y_1_1 = arith.addi %242, %y_1 : index
-// CHECK-NEXT:        %xy_1 = arith.addi %x_1_1, %y_1_1 : index
+// CHECK-NEXT:        %y_2 = arith.addi %242, %y_1 : index
+// CHECK-NEXT:        %xy_1 = arith.addi %x_2, %y_2 : index
 // CHECK-NEXT:        %xyz_1 = arith.addi %xy_1, %z_1 : index
 // CHECK-NEXT:        memref.store %xyz_1, %231[%241, %242, %z_1] : memref<64x64x64xindex, strided<[4096, 64, 1]>>
 // CHECK-NEXT:        scf.yield

--- a/tests/filecheck/transforms/convert_onnx_to_linalg.mlir
+++ b/tests/filecheck/transforms/convert_onnx_to_linalg.mlir
@@ -30,10 +30,10 @@
 
 // CHECK-NEXT:   %t27 = "test.op"() : () -> tensor<3x4xf64>
 // CHECK-NEXT:   %res_relu_3 = tensor.empty() : tensor<3x4xf64>
-// CHECK-NEXT:   %res_relu_3_1 = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:   %res_relu_3_2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%t27 : tensor<3x4xf64>) outs(%res_relu_3 : tensor<3x4xf64>) {
+// CHECK-NEXT:   %res_relu_4 = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:   %res_relu_5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%t27 : tensor<3x4xf64>) outs(%res_relu_3 : tensor<3x4xf64>) {
 // CHECK-NEXT:   ^1(%3 : f64, %4 : f64):
-// CHECK-NEXT:     %5 = arith.maximumf %3, %res_relu_3_1 : f64
+// CHECK-NEXT:     %5 = arith.maximumf %3, %res_relu_4 : f64
 // CHECK-NEXT:     linalg.yield %5 : f64
 // CHECK-NEXT:   } -> tensor<3x4xf64>
 
@@ -61,9 +61,9 @@
 
 
 // CHECK-NEXT:  %t8, %t9, %t10 = "test.op"() : () -> (tensor<5x3xf32>, tensor<3x2xf32>, tensor<5x2xf32>)
-// CHECK-NEXT:  %res_gemm_1 = tensor.empty() : tensor<5x2xf32>
-// CHECK-NEXT:  %res_gemm_1_1 = linalg.matmul ins(%t8, %t9 : tensor<5x3xf32>, tensor<3x2xf32>) outs(%res_gemm_1 : tensor<5x2xf32>) -> tensor<5x2xf32>
-// CHECK-NEXT:  %res_gemm_1_2 = linalg.add ins(%res_gemm_1_1, %t10 : tensor<5x2xf32>, tensor<5x2xf32>) outs(%res_gemm_1_1 : tensor<5x2xf32>) -> tensor<5x2xf32>
+// CHECK-NEXT:  %res_gemm_3 = tensor.empty() : tensor<5x2xf32>
+// CHECK-NEXT:  %res_gemm_4 = linalg.matmul ins(%t8, %t9 : tensor<5x3xf32>, tensor<3x2xf32>) outs(%res_gemm_3 : tensor<5x2xf32>) -> tensor<5x2xf32>
+// CHECK-NEXT:  %res_gemm_5 = linalg.add ins(%res_gemm_4, %t10 : tensor<5x2xf32>, tensor<5x2xf32>) outs(%res_gemm_4 : tensor<5x2xf32>) -> tensor<5x2xf32>
 
 
 %t11, %t12, %t13 = "test.op"(): () -> (tensor<10x5xf32>, tensor<10x3xf32>, tensor<5x3xf32>)
@@ -77,9 +77,9 @@
 // CHECK-NEXT:  %11 = linalg.mul ins(%10, %9 : f32, tensor<5x10xf32>) outs(%9 : tensor<5x10xf32>) -> tensor<5x10xf32>
 // CHECK-NEXT:  %12 = arith.constant 5.000000e-01 : f32
 // CHECK-NEXT:  %13 = linalg.mul ins(%12, %t13 : f32, tensor<5x3xf32>) outs(%t13 : tensor<5x3xf32>) -> tensor<5x3xf32>
-// CHECK-NEXT:  %res_gemm_2 = tensor.empty() : tensor<5x3xf32>
-// CHECK-NEXT:  %res_gemm_2_1 = linalg.matmul ins(%11, %t12 : tensor<5x10xf32>, tensor<10x3xf32>) outs(%res_gemm_2 : tensor<5x3xf32>) -> tensor<5x3xf32>
-// CHECK-NEXT:  %res_gemm_2_2 = linalg.add ins(%res_gemm_2_1, %13 : tensor<5x3xf32>, tensor<5x3xf32>) outs(%res_gemm_2_1 : tensor<5x3xf32>) -> tensor<5x3xf32>
+// CHECK-NEXT:  %res_gemm_6 = tensor.empty() : tensor<5x3xf32>
+// CHECK-NEXT:  %res_gemm_7 = linalg.matmul ins(%11, %t12 : tensor<5x10xf32>, tensor<10x3xf32>) outs(%res_gemm_6 : tensor<5x3xf32>) -> tensor<5x3xf32>
+// CHECK-NEXT:  %res_gemm_8 = linalg.add ins(%res_gemm_7, %13 : tensor<5x3xf32>, tensor<5x3xf32>) outs(%res_gemm_7 : tensor<5x3xf32>) -> tensor<5x3xf32>
 
 %t26 = "test.op"(): () ->  (tensor<1x16x14x14xf32>)
 %res_max_pool_single_out = "onnx.MaxPoolSingleOut"(%t26) {onnx_node_name = "/MaxPoolSingleOut", "auto_pad" = "NOTSET", "ceil_mode" = 0 : si64, "kernel_shape" = [3 : i64, 3 : i64],  "dilations" = [1 : i64, 1 : i64],  "pads" = [0 : i64, 0 : i64, 0 : i64, 0 : i64],  "storage_order" = 0 : si64, strides = [3 : i64, 3 : i64]} : (tensor<1x16x14x14xf32>) -> tensor<1x16x4x4xf32>
@@ -95,22 +95,22 @@
 %res_conv_2 = "onnx.Conv"(%t20, %t21, %t22) {onnx_node_name = "/Conv", "auto_pad" = "NOTSET", "group" = 1 : i64, "kernel_shape" = [3 : i64, 3 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0: i64, 0 : i64]}: (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none) -> tensor<1x1x3x3xf32>
 
 // CHECK-NEXT:  %t20, %t21, %t22 = "test.op"() : () -> (tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>, none)
-// CHECK-NEXT:  %res_conv_2 = tensor.empty() : tensor<1x1x3x3xf32>
-// CHECK-NEXT:  %res_conv_2_1 = linalg.conv_2d_nchw_fchw {"dilations" = dense<1> : tensor<2xi64>, "strides" = dense<1> : tensor<2xi64>} ins(%t20, %t21 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>) outs(%res_conv_2 : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
+// CHECK-NEXT:  %res_conv = tensor.empty() : tensor<1x1x3x3xf32>
+// CHECK-NEXT:  %res_conv_1 = linalg.conv_2d_nchw_fchw {"dilations" = dense<1> : tensor<2xi64>, "strides" = dense<1> : tensor<2xi64>} ins(%t20, %t21 : tensor<1x1x5x5xf32>, tensor<1x1x3x3xf32>) outs(%res_conv : tensor<1x1x3x3xf32>) -> tensor<1x1x3x3xf32>
 
 %t23, %t24, %t25 = "test.op"() : () -> (tensor<1x8x14x14xf32>, tensor<16x8x5x5xf32>, tensor<16xf32>)
 %res_conv_3 = "onnx.Conv"(%t23, %t24, %t25) {onnx_node_name = "/Conv", "auto_pad" = "SAME_UPPER", "group" = 1 : i64, "kernel_shape" = [5 : i64, 5 : i64], "dilations" = [1 : i64, 1 : i64], "strides" = [1 : i64, 1 : i64], "pads" = [0 : i64, 0 : i64, 0: i64, 0 : i64]} : (tensor<1x8x14x14xf32>, tensor<16x8x5x5xf32>, tensor<16xf32>) -> tensor<1x16x14x14xf32>
 
 // CHECK-NEXT:   %t23, %t24, %t25 = "test.op"() : () -> (tensor<1x8x14x14xf32>, tensor<16x8x5x5xf32>, tensor<16xf32>)
-// CHECK-NEXT:   %res_conv_3 = tensor.empty() : tensor<1x16x14x14xf32>
-// CHECK-NEXT:   %res_conv_3_1 = linalg.conv_2d_nchw_fchw {"dilations" = dense<1> : tensor<2xi64>, "strides" = dense<1> : tensor<2xi64>} ins(%t23, %t24 : tensor<1x8x14x14xf32>, tensor<16x8x5x5xf32>) outs(%res_conv_3 : tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
-// CHECK-NEXT:   %res_conv_3_2 = linalg.add ins(%t25 : tensor<16xf32>) outs(%res_conv_3_1 : tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
+// CHECK-NEXT:   %res_conv_2 = tensor.empty() : tensor<1x16x14x14xf32>
+// CHECK-NEXT:   %res_conv_3 = linalg.conv_2d_nchw_fchw {"dilations" = dense<1> : tensor<2xi64>, "strides" = dense<1> : tensor<2xi64>} ins(%t23, %t24 : tensor<1x8x14x14xf32>, tensor<16x8x5x5xf32>) outs(%res_conv_2 : tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
+// CHECK-NEXT:   %res_conv_4 = linalg.add ins(%t25 : tensor<16xf32>) outs(%res_conv_3 : tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
 
 %res_constant = "onnx.Constant"() {onnx_node_name = "/Constant", "value" = dense<1> : tensor<1xi64>}: () -> tensor<1xi64>
 %res_constant_2 = "onnx.Constant"() {onnx_node_name = "/Constant", "value" = dense<2.0> : tensor<1x5xf32>} : () -> tensor<1x5xf32>
 
 // CHECK-NEXT: %res_constant = ml_program.global_load_const @onnx_constant_1 : tensor<1xi64>
-// CHECK-NEXT: %res_constant_2 = ml_program.global_load_const @onnx_constant_2 : tensor<1x5xf32>
+// CHECK-NEXT: %res_constant_1 = ml_program.global_load_const @onnx_constant_2 : tensor<1x5xf32>
 // CHECK-NEXT: ml_program.global private @onnx_constant_1(dense<1> : tensor<1xi64>) : tensor<1xi64>
 // CHECK-NEXT: ml_program.global private @onnx_constant_2(dense<2.000000e+00> : tensor<1x5xf32>) : tensor<1x5xf32>
 

--- a/tests/filecheck/transforms/memref_streamify.mlir
+++ b/tests/filecheck/transforms/memref_streamify.mlir
@@ -19,8 +19,8 @@ func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2
 // CHECK-NEXT:      memref_stream.streaming_region {bounds = [8, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
 // CHECK-NEXT:      ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>, %2 : !stream.writable<f64>):
 // CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
-// CHECK-NEXT:        ^1(%in : f64, %in_0 : f64, %out : f64):
-// CHECK-NEXT:          %3 = arith.addf %in, %in_0 : f64
+// CHECK-NEXT:        ^1(%in : f64, %in_1 : f64, %out : f64):
+// CHECK-NEXT:          %3 = arith.addf %in, %in_1 : f64
 // CHECK-NEXT:          memref_stream.yield %3 : f64
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
@@ -46,8 +46,8 @@ func.func public @relu(%arg0_1 : memref<16x16xf64>, %arg1_1 : memref<16x16xf64>)
 // CHECK-NEXT:      memref_stream.streaming_region {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%arg0_1 : memref<16x16xf64>) outs(%arg1_1 : memref<16x16xf64>) {
 // CHECK-NEXT:      ^2(%4 : !stream.readable<f64>, %5 : !stream.writable<f64>):
 // CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : !stream.readable<f64>) outs(%5 : !stream.writable<f64>) {
-// CHECK-NEXT:        ^3(%in_1 : f64, %out_1 : f64):
-// CHECK-NEXT:          %6 = arith.maximumf %in_1, %cst : f64
+// CHECK-NEXT:        ^3(%in_2 : f64, %out_1 : f64):
+// CHECK-NEXT:          %6 = arith.maximumf %in_2, %cst : f64
 // CHECK-NEXT:          memref_stream.yield %6 : f64
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/tests/filecheck/transforms/stencil-storage-materialization.mlir
+++ b/tests/filecheck/transforms/stencil-storage-materialization.mlir
@@ -47,8 +47,8 @@ builtin.module{
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %midt_1 = stencil.buffer %midt : !stencil.temp<?xf64>
 // CHECK-NEXT:      %outt_1 = stencil.apply(%midb = %midt_1 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
-// CHECK-NEXT:        %v_2 = stencil.access %midb[-1] : !stencil.temp<?xf64>
-// CHECK-NEXT:        stencil.return %v_2 : f64
+// CHECK-NEXT:        %v_1 = stencil.access %midb[-1] : !stencil.temp<?xf64>
+// CHECK-NEXT:        stencil.return %v_1 : f64
 // CHECK-NEXT:      }
 // CHECK-NEXT:      stencil.store %outt_1 to %out_1 ([0] : [68]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
@@ -73,14 +73,14 @@ builtin.module{
 
 // CHECK:         func.func @stored_copy(%in_2 : !stencil.field<[-4,68]xf64>, %midout : !stencil.field<[-4,68]xf64>, %out_2 : !stencil.field<[-4,68]xf64>) {
 // CHECK-NEXT:      %int_2 = stencil.load %in_2 : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
-// CHECK-NEXT:      %midt_1 = stencil.apply(%inb_2 = %int_2 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
-// CHECK-NEXT:        %v_3 = stencil.access %inb_2[-1] : !stencil.temp<?xf64>
-// CHECK-NEXT:        stencil.return %v_3 : f64
+// CHECK-NEXT:      %midt_2 = stencil.apply(%inb_1 = %int_2 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+// CHECK-NEXT:        %v_2 = stencil.access %inb_1[-1] : !stencil.temp<?xf64>
+// CHECK-NEXT:        stencil.return %v_2 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %midt_1 to %midout ([0] : [68]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
-// CHECK-NEXT:      %outt_2 = stencil.apply(%midb_1 = %midt_1 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
-// CHECK-NEXT:        %v_4 = stencil.access %midb_1[-1] : !stencil.temp<?xf64>
-// CHECK-NEXT:        stencil.return %v_4 : f64
+// CHECK-NEXT:      stencil.store %midt_2 to %midout ([0] : [68]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      %outt_2 = stencil.apply(%midb_1 = %midt_2 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+// CHECK-NEXT:        %v_3 = stencil.access %midb_1[-1] : !stencil.temp<?xf64>
+// CHECK-NEXT:        stencil.return %v_3 : f64
 // CHECK-NEXT:      }
 // CHECK-NEXT:      stencil.store %outt_2 to %out_2 ([0] : [68]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -347,7 +347,11 @@ def test_print_custom_name():
 
 def test_print_clashing_names():
     """
-    Test name clash stuff
+    Test the printer's value name printing logic's robustness against clashing names.
+
+    This example now expects to print names i, i_1, i_2; it used to print i, i_1, i_1,
+    printing a duplicate name for two values, meaning invalid IR as input for both MLIR
+    and xDSL.
     """
 
     expected = """\

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -5,6 +5,7 @@ from io import StringIO
 import pytest
 from conftest import assert_print_op
 
+from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import test
 from xdsl.dialects.arith import Addi, Arith, Constant
 from xdsl.dialects.builtin import (
@@ -12,6 +13,7 @@ from xdsl.dialects.builtin import (
     FunctionType,
     IntAttr,
     IntegerType,
+    ModuleOp,
     SymbolRefAttr,
     UnitAttr,
     i32,
@@ -339,6 +341,34 @@ def test_print_custom_name():
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()
+
+    assert_print_op(module, expected, None)
+
+
+def test_print_clashing_names():
+    """
+    Test name clash stuff
+    """
+
+    expected = """\
+"builtin.module"() ({
+  %i = "test.op"() : () -> i32
+  %i_1 = "test.op"() : () -> i32
+  %i_2 = "test.op"() : () -> i32
+}) : () -> ()
+"""
+
+    ctx = MLContext()
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Builtin)
+
+    with ImplicitBuilder((module := ModuleOp([])).body):
+        i = test.TestOp.create(result_types=[i32])
+        i.results[0].name_hint = "i"
+        j = test.TestOp.create(result_types=[i32])
+        j.results[0].name_hint = "i"
+        k = test.TestOp.create(result_types=[i32])
+        k.results[0].name_hint = "i_1"
 
     assert_print_op(module, expected, None)
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -317,6 +317,11 @@ class SSAValue(ABC):
     def name_hint(self, name: str | None):
         # only allow valid names
         if SSAValue.is_valid_name(name):
+            # Remove `_` followed by numbers at the end of the name
+            if name is not None:
+                r1 = re.compile(r"(_\d)+$")
+                if match := r1.search(name):
+                    name = name[: match.start()]
             self._name = name
         else:
             raise ValueError(

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -241,11 +242,15 @@ class Printer:
         if value in self._ssa_values:
             name = self._ssa_values[value]
         elif value.name_hint:
-            curr_ind = self._ssa_names.get(value.name_hint, 0)
+            r1 = re.compile(r"_[0-9]+$")
+            name_hint = value.name_hint
+            if match := r1.search(name_hint):
+                name_hint = name_hint[: match.start()]
+            curr_ind = self._ssa_names.get(name_hint, 0)
             suffix = f"_{curr_ind}" if curr_ind != 0 else ""
-            name = f"{value.name_hint}{suffix}"
+            name = f"{name_hint}{suffix}"
             self._ssa_values[value] = name
-            self._ssa_names[value.name_hint] = curr_ind + 1
+            self._ssa_names[name_hint] = curr_ind + 1
         else:
             name = self._get_new_valid_name_id()
             self._ssa_values[value] = name

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -242,15 +241,11 @@ class Printer:
         if value in self._ssa_values:
             name = self._ssa_values[value]
         elif value.name_hint:
-            r1 = re.compile(r"_[0-9]+$")
-            name_hint = value.name_hint
-            if match := r1.search(name_hint):
-                name_hint = name_hint[: match.start()]
-            curr_ind = self._ssa_names.get(name_hint, 0)
+            curr_ind = self._ssa_names.get(value.name_hint, 0)
             suffix = f"_{curr_ind}" if curr_ind != 0 else ""
-            name = f"{name_hint}{suffix}"
+            name = f"{value.name_hint}{suffix}"
             self._ssa_values[value] = name
-            self._ssa_names[name_hint] = curr_ind + 1
+            self._ssa_names[value.name_hint] = curr_ind + 1
         else:
             name = self._get_new_valid_name_id()
             self._ssa_values[value] = name


### PR DESCRIPTION
Found this adorable little fundamental crack while working on the OEC kernels.

xDSL is currently still able to print distinct values using the same name; which is a big no no no.

## Headlines:

Basically our brave printer, willing to honor user-friendly name hints given to values, deduplicates value names when a given name_hint clashes with a previously printed name, by adding a `_1`, `_2`, or ... to the name.

Func fact is, if the printer already printed `%v` twice, i.e., actually printed them as `%v` and `%v_1`, it only sees `%v_1` printed as a deduplication of `v`. So if the next value is hinted as `v_1`, then no problem seen, and the printer will print the three ***distinct*** values as `%v`, `%v_1`, and `%v_1` again :warning: 

Here is @math-fehr 's solution: just strip all suffixes in the form of underscore+number from name_hints, always. The rationale being, they would be printed with those again, in order, anyway.
More importantly, this makes xDSL unable (to the best of our knowledge again :smiling_face_with_tear:) to print invalid IR :tada: 