### PR TITLE
dialects: (memref_stream) add StridePattern

### DIFF
--- a/tests/filecheck/dialects/memref_stream/ops.mlir
+++ b/tests/filecheck/dialects/memref_stream/ops.mlir
@@ -20,11 +20,10 @@ memref_stream.write %val to %writable : f32
 %A, %B, %C, %D = "test.op"() : () -> (memref<2xf32>, memref<3xf32>, memref<3x2xf64>, f64)
 
 memref_stream.streaming_region {
-    bounds = [3, 2],
-    indexing_maps = [
-        affine_map<(d0, d1) -> (d0)>,
-        affine_map<(d0, d1) -> (d1)>,
-        affine_map<(d0, d1) -> (d0, d1)>
+    patterns = [
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0)>,
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d1)>,
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0, d1)>
     ]
 } ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs = {hello = "world"} {
 ^bb0(%a: !stream.readable<f32>, %b: !stream.readable<f32>, %c: !stream.writable<f64>):
@@ -32,13 +31,13 @@ memref_stream.streaming_region {
 }
 
 // CHECK-NEXT:            %A, %B, %C, %D = "test.op"() : () -> (memref<2xf32>, memref<3xf32>, memref<3x2xf64>, f64)
-// CHECK-NEXT:            memref_stream.streaming_region {bounds = [3, 2], indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs =  {"hello" = "world"} {
+// CHECK-NEXT:            memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0)>, #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d1)>, #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0, d1)>]} ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs =  {"hello" = "world"} {
 // CHECK-NEXT:            ^0(%a : !stream.readable<f32>, %b : !stream.readable<f32>, %c : !stream.writable<f64>):
 // CHECK-NEXT:              "test.op"(%a, %b, %c) : (!stream.readable<f32>, !stream.readable<f32>, !stream.writable<f64>) -> ()
 // CHECK-NEXT:            }
 
 // CHECK-GENERIC-NEXT:    %A, %B, %C, %D = "test.op"() : () -> (memref<2xf32>, memref<3xf32>, memref<3x2xf64>, f64)
-// CHECK-GENERIC-NEXT:    "memref_stream.streaming_region"(%A, %B, %C) <{"bounds" = [#builtin.int<3>, #builtin.int<2>], "indexing_maps" = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.streaming_region"(%A, %B, %C) <{"patterns" = [#memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0)>, #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d1)>, #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0, d1)>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^0(%a : !stream.readable<f32>, %b : !stream.readable<f32>, %c : !stream.writable<f64>):
 // CHECK-GENERIC-NEXT:      "test.op"(%a, %b, %c) : (!stream.readable<f32>, !stream.readable<f32>, !stream.writable<f64>) -> ()
 // CHECK-GENERIC-NEXT:    }) {"hello" = "world"} : (memref<2xf32>, memref<3xf32>, memref<3x2xf64>) -> ()

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
@@ -20,10 +20,9 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %zero_float = riscv.fcvt.d.w %c0 : (!riscv.reg<>) -> !riscv.freg<>
 
     memref_stream.streaming_region {
-      bounds = [1, 1, 6, 6, 1, 3, 3],
-      indexing_maps = [
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>,
-        affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+      patterns = [
+          #memref_stream.stride_pattern<ub = [1, 1, 6, 6, 1, 3, 3], index_map = (d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>,
+          #memref_stream.stride_pattern<ub = [1, 1, 6, 6, 1, 3, 3], index_map = (d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
       ]
     } ins(%X, %Y : memref<1x1x8x8xf64>, memref<1x1x3x3xf64>) {
     ^0(%x_stream : !stream.readable<f64>, %y_stream : !stream.readable<f64>):
@@ -115,10 +114,9 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %G_moved = builtin.unrealized_conversion_cast %G : memref<f64> to !riscv.reg<>
 
     memref_stream.streaming_region {
-      bounds = [128],
-      indexing_maps = [
-          affine_map<(m) -> (m)>,
-          affine_map<(m) -> (m)>
+      patterns = [
+          #memref_stream.stride_pattern<ub = [128], index_map = (d0) -> (d0)>,
+          #memref_stream.stride_pattern<ub = [128], index_map = (d0) -> (d0)>
       ]
     } ins(%X, %Y : memref<128xf64>, memref<128xf64>) {
     ^0(%x_stream : !stream.readable<f64>, %y_stream : !stream.readable<f64>):
@@ -186,11 +184,10 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %zero_float = riscv.fcvt.d.w %c0 : (!riscv.reg<>) -> !riscv.freg<>
 
     memref_stream.streaming_region {
-      bounds = [8, 8, 8],
-      indexing_maps = [
-          affine_map<(m, n, k) -> (m, k)>,
-          affine_map<(m, n, k) -> (k, n)>,
-          affine_map<(m, n) -> (m, n)>
+      patterns = [
+        #memref_stream.stride_pattern<ub = [8, 8, 8], index_map = (m, n, k) -> (m, k)>,
+        #memref_stream.stride_pattern<ub = [8, 8, 8], index_map = (m, n, k) -> (k, n)>,
+        #memref_stream.stride_pattern<ub = [8, 8], index_map = (m, n) -> (m, n)>
       ]
     } ins(%X, %W, %B : memref<8x8xf64>, memref<8x8xf64>, memref<8x8xf64>) {
     ^0(%x_stream : !stream.readable<f64>, %w_stream : !stream.readable<f64>, %b_stream : !stream.readable<f64>):
@@ -292,11 +289,10 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
       %c128 = riscv.li 128 : () -> !riscv.reg<>
 
       memref_stream.streaming_region {
-        bounds = [8, 16],
-        indexing_maps = [
-          affine_map<(d0, d1) -> (d0, d1)>,
-          affine_map<(d0, d1) -> (d0, d1)>,
-          affine_map<(d0, d1) -> (d0, d1)>
+        patterns = [
+          #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>,
+          #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>,
+          #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>
         ]
       } ins(%X, %Y : memref<8x16xf64>, memref<8x16xf64>) outs(%Z : memref<8x16xf64>) {
       ^0(%x_stream : !stream.readable<f64>, %y_stream : !stream.readable<f64>, %z_stream : !stream.writable<f64>):
@@ -349,9 +345,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %x = riscv.fmv.d %X_moved : (!riscv.freg<>) -> !riscv.freg<>
 
     memref_stream.streaming_region {
-      bounds = [16, 16],
-      indexing_maps = [
-          affine_map<(d0, d1) -> (d0, d1)>
+      patterns = [
+        #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>
       ]
     } outs(%Y : memref<16x16xf64>) {
     ^0(%y_stream : !stream.writable<f64>):
@@ -405,10 +400,9 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %c512 = riscv.li 512 : () -> !riscv.reg<>
 
     memref_stream.streaming_region {
-      bounds = [8, 8, 8],
-      indexing_maps = [
-          affine_map<(m, n, k) -> (m, k)>,
-          affine_map<(m, n, k) -> (k, n)>
+      patterns = [
+        #memref_stream.stride_pattern<ub = [8, 8, 8], index_map = (m, n, k) -> (m, k)>,
+        #memref_stream.stride_pattern<ub = [8, 8, 8], index_map = (m, n, k) -> (k, n)>
       ]
     } ins(%X, %Y : memref<8x8xf64>, memref<8x8xf64>) {
     ^0(%x_stream : !stream.readable<f64>, %y_stream : !stream.readable<f64>):
@@ -501,9 +495,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     %c512 = riscv.li 512 : () -> !riscv.reg<>
 
     memref_stream.streaming_region {
-      bounds = [1, 1, 7, 7, 3, 3],
-      indexing_maps = [
-          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2 * 2 + d4, d3 * 2 + d5)>
+      patterns = [
+        #memref_stream.stride_pattern<ub = [1, 1, 7, 7, 3, 3], index_map = (d0, d1, d2, d3, d4, d5) -> (d0, d1, d2 * 2 + d4, d3 * 2 + d5)>
       ]
     } ins(%X : memref<1x1x16x16xf64>) {
     ^0(%x_stream : !stream.readable<f64>):
@@ -577,10 +570,9 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     %zero_float = riscv.fcvt.d.w %zero_int : (!riscv.reg<zero>) -> !riscv.freg<>
 
     memref_stream.streaming_region {
-      bounds = [16, 16],
-      indexing_maps = [
-          affine_map<(d0, d1) -> (d0, d1)>,
-          affine_map<(d0, d1) -> (d0, d1)>
+      patterns = [
+          #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>,
+          #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>
       ]
     } ins(%X : memref<16x16xf64>) outs(%Y : memref<16x16xf64>) {
     ^0(%x_stream : !stream.readable<f64>, %y_stream : !stream.writable<f64>):
@@ -637,9 +629,8 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
     %c512 = riscv.li 512 : () -> !riscv.reg<>
 
     memref_stream.streaming_region {
-      bounds = [1, 1, 7, 7, 3, 3],
-      indexing_maps = [
-          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2 * 2 + d4, d3 * 2 + d5)>
+      patterns = [
+        #memref_stream.stride_pattern<ub = [1, 1, 7, 7, 3, 3], index_map = (d0, d1, d2, d3, d4, d5) -> (d0, d1, d2 * 2 + d4, d3 * 2 + d5)>
       ]
     } ins(%X : memref<1x1x16x16xf64>) {
     ^0(%x_stream : !stream.readable<f64>):

--- a/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
@@ -3,7 +3,13 @@
 // CHECK:       builtin.module {
 
   func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2 : memref<8x16xf64>) -> memref<8x16xf64> {
-    memref_stream.streaming_region {bounds = [8, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
+    memref_stream.streaming_region {
+      patterns = [
+        #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>,
+        #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>,
+        #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>
+    ]
+  } ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
     ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>, %2 : !stream.writable<f64>):
       memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
       ^1(%in : f64, %in_0 : f64, %out : f64):
@@ -14,7 +20,7 @@
     func.return %arg2 : memref<8x16xf64>
   }
 // CHECK-NEXT:    func.func public @dsum(%{{.*}} : memref<8x16xf64>, %{{.*}} : memref<8x16xf64>, %{{.*}} : memref<8x16xf64>) -> memref<8x16xf64> {
-// CHECK-NEXT:      memref_stream.streaming_region {bounds = [8, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%{{.*}}, %{{.*}} : memref<8x16xf64>, memref<8x16xf64>) outs(%{{.*}} : memref<8x16xf64>) {
+// CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%{{.*}}, %{{.*}} : memref<8x16xf64>, memref<8x16xf64>) outs(%{{.*}} : memref<8x16xf64>) {
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : !stream.readable<f64>, %{{.*}} : !stream.readable<f64>, %{{.*}} : !stream.writable<f64>):
 // CHECK-NEXT:        %{{.*}} = arith.constant 8 : index
 // CHECK-NEXT:        %{{.*}} = arith.constant 16 : index
@@ -34,7 +40,13 @@
 
   func.func public @relu(%arg0_1 : memref<16x16xf64>, %arg1_1 : memref<16x16xf64>) -> memref<16x16xf64> {
     %cst = arith.constant 0.000000e+00 : f64
-    memref_stream.streaming_region {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%arg0_1 : memref<16x16xf64>) outs(%arg1_1 : memref<16x16xf64>) {
+    memref_stream.streaming_region {
+      patterns = [
+        #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>,
+        #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>,
+        #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>
+    ]
+  } ins(%arg0_1 : memref<16x16xf64>) outs(%arg1_1 : memref<16x16xf64>) {
     ^2(%4 : !stream.readable<f64>, %5 : !stream.writable<f64>):
       memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : !stream.readable<f64>) outs(%5 : !stream.writable<f64>) {
       ^3(%in_1 : f64, %out_1 : f64):
@@ -46,7 +58,7 @@
   }
 // CHECK-NEXT:    func.func public @relu(%{{.*}} : memref<16x16xf64>, %{{.*}} : memref<16x16xf64>) -> memref<16x16xf64> {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:      memref_stream.streaming_region {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%{{.*}} : memref<16x16xf64>) outs(%{{.*}} : memref<16x16xf64>) {
+// CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%{{.*}} : memref<16x16xf64>) outs(%{{.*}} : memref<16x16xf64>) {
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : !stream.readable<f64>, %{{.*}} : !stream.writable<f64>):
 // CHECK-NEXT:        %{{.*}} = arith.constant 16 : index
 // CHECK-NEXT:        %{{.*}} = arith.constant 16 : index
@@ -67,9 +79,8 @@ func.func public @fill(%arg0 : memref<16x16xf64>) -> memref<16x16xf64> {
   // Scalar argument
   %zero = arith.constant 0.0 : f64
   memref_stream.streaming_region {
-    bounds = [16, 16],
-    indexing_maps = [
-      affine_map<(d0, d1) -> (d0, d1)>
+    patterns = [
+      #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>
     ]
   } outs(%arg0 : memref<16x16xf64>) {
   ^3(%7 : !stream.writable<f64>):
@@ -90,7 +101,7 @@ func.func public @fill(%arg0 : memref<16x16xf64>) -> memref<16x16xf64> {
 
 // CHECK-NEXT:    func.func public @fill(%{{.*}} : memref<16x16xf64>) -> memref<16x16xf64> {
 // CHECK-NEXT:      %{{.*}} = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:      memref_stream.streaming_region {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>]} outs(%{{.*}} : memref<16x16xf64>) {
+// CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>]} outs(%{{.*}} : memref<16x16xf64>) {
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : !stream.writable<f64>):
 // CHECK-NEXT:        %{{.*}} = arith.constant 16 : index
 // CHECK-NEXT:        %{{.*}} = arith.constant 16 : index

--- a/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
@@ -18,11 +18,10 @@ memref_stream.write %val to %writable : f32
 %A, %B, %C = "test.op"() : () -> (memref<2xf64>, memref<3xf64>, memref<3x2xf64>)
 
 memref_stream.streaming_region {
-    bounds = [3, 2],
-    indexing_maps = [
-        affine_map<(d0, d1) -> (d0)>,
-        affine_map<(d0, d1) -> (d1)>,
-        affine_map<(d0, d1) -> (d0, d1)>
+    patterns = [
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0)>,
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d1)>,
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0, d1)>
     ]
 } ins(%A, %B : memref<2xf64>, memref<3xf64>) outs(%C : memref<3x2xf64>) attrs = {hello = "world"} {
 ^bb0(%a: !stream.readable<f64>, %b: !stream.readable<f64>, %c: !stream.writable<f64>):
@@ -42,10 +41,9 @@ memref_stream.streaming_region {
 // CHECK-NEXT:  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
 
 memref_stream.streaming_region {
-    bounds = [3, 2],
-    indexing_maps = [
-        affine_map<(d0, d1) -> (d0, d1)>,
-        affine_map<(d0, d1) -> (d0, d1)>
+    patterns = [
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0, d1)>,
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0, d1)>
     ]
 } ins(%C, %C : memref<3x2xf64>, memref<3x2xf64>) {
 ^bb0(%c0: !stream.readable<f64>, %c1: !stream.readable<f64>):
@@ -66,10 +64,9 @@ memref_stream.streaming_region {
 // CHECK-NEXT:   %D, %E = "test.op"() : () -> (memref<1x1x8x8xf64>, memref<1x1x3x3xf64>)
 
 memref_stream.streaming_region {
-    bounds = [1, 1, 6, 6, 1, 3, 3],
-    indexing_maps = [
-    affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>,
-    affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
+    patterns = [
+        #memref_stream.stride_pattern<ub = [1, 1, 6, 6, 1, 3, 3], index_map = (d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>,
+        #memref_stream.stride_pattern<ub = [1, 1, 6, 6, 1, 3, 3], index_map = (d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>
     ]
 } ins(%D, %E : memref<1x1x8x8xf64>, memref<1x1x3x3xf64>) {
 ^0(%d_stream : !stream.readable<f64>, %e_stream : !stream.readable<f64>):
@@ -89,11 +86,10 @@ memref_stream.streaming_region {
 // CHECK-NEXT:   %F = "test.op"() : () -> memref<8x8xf64>
 
 memref_stream.streaming_region {
-    bounds = [8, 8, 8],
-    indexing_maps = [
-        affine_map<(m, n, k) -> (m, k)>,
-        affine_map<(m, n, k) -> (k, n)>,
-        affine_map<(m, n) -> (m, n)>
+    patterns = [
+        #memref_stream.stride_pattern<ub = [8, 8, 8], index_map = (m, n, k) -> (m, k)>,
+        #memref_stream.stride_pattern<ub = [8, 8, 8], index_map = (m, n, k) -> (k, n)>,
+        #memref_stream.stride_pattern<ub = [8, 8], index_map = (m, n) -> (m, n)>
     ]
 } ins(%F, %F, %F : memref<8x8xf64>, memref<8x8xf64>, memref<8x8xf64>) {
 ^0(%x_stream : !stream.readable<f64>, %w_stream : !stream.readable<f64>, %b_stream : !stream.readable<f64>):

--- a/tests/filecheck/transforms/memref_streamify.mlir
+++ b/tests/filecheck/transforms/memref_streamify.mlir
@@ -16,7 +16,7 @@ func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2
 }
 
 // CHECK-NEXT:    func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2 : memref<8x16xf64>) -> memref<8x16xf64> {
-// CHECK-NEXT:      memref_stream.streaming_region {bounds = [8, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
+// CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
 // CHECK-NEXT:      ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>, %2 : !stream.writable<f64>):
 // CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
 // CHECK-NEXT:        ^1(%in : f64, %in_0 : f64, %out : f64):
@@ -43,7 +43,7 @@ func.func public @relu(%arg0_1 : memref<16x16xf64>, %arg1_1 : memref<16x16xf64>)
 
 // CHECK-NEXT:    func.func public @relu(%arg0_1 : memref<16x16xf64>, %arg1_1 : memref<16x16xf64>) -> memref<16x16xf64> {
 // CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:      memref_stream.streaming_region {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]} ins(%arg0_1 : memref<16x16xf64>) outs(%arg1_1 : memref<16x16xf64>) {
+// CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%arg0_1 : memref<16x16xf64>) outs(%arg1_1 : memref<16x16xf64>) {
 // CHECK-NEXT:      ^2(%4 : !stream.readable<f64>, %5 : !stream.writable<f64>):
 // CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : !stream.readable<f64>) outs(%5 : !stream.writable<f64>) {
 // CHECK-NEXT:        ^3(%in_1 : f64, %out_1 : f64):

--- a/xdsl/dialects/snitch_stream.py
+++ b/xdsl/dialects/snitch_stream.py
@@ -74,6 +74,13 @@ class StridePattern(ParametrizedAttribute):
     ub: ParameterDef[ArrayAttr[IntAttr]]
     strides: ParameterDef[ArrayAttr[IntAttr]]
 
+    def __init__(
+        self,
+        ub: ParameterDef[ArrayAttr[IntAttr]],
+        strides: ParameterDef[ArrayAttr[IntAttr]],
+    ):
+        super().__init__((ub, strides))
+
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
         with parser.in_angle_brackets():
@@ -109,10 +116,8 @@ class StridePattern(ParametrizedAttribute):
         ub: Sequence[int], strides: Sequence[int]
     ) -> StridePattern:
         return StridePattern(
-            (
-                ArrayAttr(IntAttr(i) for i in ub),
-                ArrayAttr(IntAttr(i) for i in strides),
-            )
+            ArrayAttr(IntAttr(i) for i in ub),
+            ArrayAttr(IntAttr(i) for i in strides),
         )
 
     def rank(self):

--- a/xdsl/interpreters/tensor.py
+++ b/xdsl/interpreters/tensor.py
@@ -30,7 +30,8 @@ class TensorFunctions(InterpreterFunctions):
         xtype = xtype_for_el_type(result_type.element_type, interpreter.index_bitwidth)
         return (
             ShapedArray(
-                TypedPtr.new((0,) * math.prod(result_shape), xtype=xtype), result_shape
+                TypedPtr.new((0,) * math.prod(result_shape), xtype=xtype),
+                result_shape,
             ),
         )
 


### PR DESCRIPTION
In the context of imperfectly nested and/or interleaving loops, the streams are not able to reuse the same iteration bounds. . This PR adds a StridePattern to memref_stream, with pretty syntax.