### PR TITLE
misc: Create a devcontainer for container setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "Dev container",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11",
+      "installJupyterlab": true
+    }
+  },
+  // We want all dependencies except wgpu since that fails on the default container
+	"postCreateCommand": "python -m pip install -r requirements.txt && python -m pip uninstall wgpu"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,5 +8,5 @@
     }
   },
   // We want all dependencies except wgpu since that fails on the default container
-	"postCreateCommand": "python -m pip install -r requirements.txt && python -m pip uninstall wgpu"
+  "postCreateCommand": "python -m pip install -e .[gui,riscv,dev]"
 }


### PR DESCRIPTION
wgpu breaks the container, we probably want to have a dual docker + devcontainer setup going, I'll keep a list of tasks here to keep track of work:

 - [ ] migrate the dev requirements to pyproj
 - [ ] don't install wgpu by default for dev reqs