### PR TITLE
core: Strip multi-digit suffixes in name_hint, not only single-digit.

### DIFF
--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -25,7 +25,7 @@ def test_var_mixed_builder():
     [
         "test",
         "-2",
-        "test_123",
+        "test123",
         "kebab-case-name",
         None,
     ],

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -319,7 +319,7 @@ class SSAValue(ABC):
         if SSAValue.is_valid_name(name):
             # Remove `_` followed by numbers at the end of the name
             if name is not None:
-                r1 = re.compile(r"(_\d)+$")
+                r1 = re.compile(r"(_\d+)+$")
                 if match := r1.search(name):
                     name = name[: match.start()]
             self._name = name


### PR DESCRIPTION
Forgot this last commit in #2545 

The initial fix only strips `_\d` (single-digit) suffixes, not `_\d+` (one-or-more digits) suffixes