### PR TITLE
installation: Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ docs/ret.xdsl
 
 # asv
 .asv
+
+# direnv
+.direnv
+.envrc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1714906307,
+        "narHash": "sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0=",
+        "path": "/nix/store/3pif36ks3f56py4wb1dkq6sh0nkf3ygj-source",
+        "rev": "25865a40d14b3f9cf19f19b924e2ab4069b09588",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "XDSL devshell";
+  description = "xDSL devshell";
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "XDSL devshell";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        in
+          {
+            devShells.default = with pkgs; mkShell {
+              LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib";
+              buildInputs = [
+                nodejs_22
+              ];
+            };
+          }
+    );
+}


### PR DESCRIPTION
Makes the following two changes to make building easier on nixos:
- Adds direnv files to gitignore
- Adds a basic flake that allows `make tests` to be run

@AntonLydike
