### PR TITLE
dialects: (x86) PR19 - move assembly helpers to separate class

### DIFF
--- a/xdsl/dialects/x86/__init__.py
+++ b/xdsl/dialects/x86/__init__.py
@@ -1,9 +1,9 @@
 from xdsl.ir import Dialect
 
+from .attributes import LabelAttr
 from .ops import (
     DirectiveOp,
     GetRegisterOp,
-    LabelAttr,
     LabelOp,
     M_IDivOp,
     M_ImulOp,

--- a/xdsl/dialects/x86/assembly.py
+++ b/xdsl/dialects/x86/assembly.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-from io import StringIO
-from typing import IO, TypeAlias
+from typing import TypeAlias
 
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     IndexType,
     IntegerAttr,
     IntegerType,
-    ModuleOp,
     StringAttr,
 )
-from xdsl.dialects.func import FuncOp
 from xdsl.ir import (
     SSAValue,
 )
@@ -72,25 +69,6 @@ def assembly_line(
         code += f" {arg_str}"
     code = append_comment(code, comment)
     return code
-
-
-def print_assembly(module: ModuleOp, output: IO[str]) -> None:
-    from .ops import X86Op  # Avoid circular import
-
-    for op in module.body.walk():
-        if isinstance(op, FuncOp):
-            print(f"{op.sym_name.data}:", file=output)
-            continue
-        assert isinstance(op, X86Op), f"{op}"
-        asm = op.assembly_line()
-        if asm is not None:
-            print(asm, file=output)
-
-
-def x86_code(module: ModuleOp) -> str:
-    stream = StringIO()
-    print_assembly(module, stream)
-    return stream.getvalue()
 
 
 def parse_immediate_value(

--- a/xdsl/dialects/x86/assembly.py
+++ b/xdsl/dialects/x86/assembly.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from io import StringIO
+from typing import IO, TypeAlias
+
+from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
+    IndexType,
+    IntegerAttr,
+    IntegerType,
+    ModuleOp,
+    StringAttr,
+)
+from xdsl.dialects.func import FuncOp
+from xdsl.ir import (
+    SSAValue,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.utils.hints import isa
+
+from .attributes import LabelAttr
+from .register import GeneralRegisterType, RFLAGSRegisterType
+
+AssemblyInstructionArg: TypeAlias = (
+    AnyIntegerAttr | SSAValue | GeneralRegisterType | str | int | LabelAttr
+)
+
+
+def append_comment(line: str, comment: StringAttr | None) -> str:
+    if comment is None:
+        return line
+
+    padding = " " * max(0, 48 - len(line))
+
+    return f"{line}{padding} # {comment.data}"
+
+
+def assembly_arg_str(arg: AssemblyInstructionArg) -> str:
+    if isa(arg, AnyIntegerAttr):
+        return f"{arg.value.data}"
+    elif isinstance(arg, int):
+        return f"{arg}"
+    elif isinstance(arg, str):
+        return arg
+    elif isinstance(arg, GeneralRegisterType):
+        return arg.register_name
+    elif isinstance(arg, RFLAGSRegisterType):
+        return arg.register_name
+    elif isinstance(arg, LabelAttr):
+        return arg.data
+    else:
+        if isinstance(arg.type, GeneralRegisterType):
+            reg = arg.type.register_name
+            return reg
+        elif isinstance(arg.type, RFLAGSRegisterType):
+            reg = arg.type.register_name
+            return reg
+        else:
+            assert False, f"{arg.type}"
+
+
+def assembly_line(
+    name: str,
+    arg_str: str,
+    comment: StringAttr | None = None,
+    is_indented: bool = True,
+) -> str:
+    code = "    " if is_indented else ""
+    code += name
+    if arg_str:
+        code += f" {arg_str}"
+    code = append_comment(code, comment)
+    return code
+
+
+def print_assembly(module: ModuleOp, output: IO[str]) -> None:
+    from .ops import X86Op  # Avoid circular import
+
+    for op in module.body.walk():
+        if isinstance(op, FuncOp):
+            print(f"{op.sym_name.data}:", file=output)
+            continue
+        assert isinstance(op, X86Op), f"{op}"
+        asm = op.assembly_line()
+        if asm is not None:
+            print(asm, file=output)
+
+
+def x86_code(module: ModuleOp) -> str:
+    stream = StringIO()
+    print_assembly(module, stream)
+    return stream.getvalue()
+
+
+def parse_immediate_value(
+    parser: Parser, integer_type: IntegerType | IndexType
+) -> IntegerAttr[IntegerType | IndexType] | LabelAttr:
+    return parser.expect(
+        lambda: parse_optional_immediate_value(parser, integer_type),
+        "Expected immediate",
+    )
+
+
+def parse_optional_immediate_value(
+    parser: Parser, integer_type: IntegerType | IndexType
+) -> IntegerAttr[IntegerType | IndexType] | LabelAttr | None:
+    """
+    Parse an optional immediate value. If an integer is parsed, an integer attr with the specified type is created.
+    """
+    if (immediate := parser.parse_optional_integer()) is not None:
+        return IntegerAttr(immediate, integer_type)
+    if (immediate := parser.parse_optional_str_literal()) is not None:
+        return LabelAttr(immediate)
+
+
+def print_immediate_value(printer: Printer, immediate: AnyIntegerAttr | LabelAttr):
+    match immediate:
+        case IntegerAttr():
+            printer.print(immediate.value.data)
+        case LabelAttr():
+            printer.print_string_literal(immediate.data)
+
+
+def memory_access_str(
+    register: AssemblyInstructionArg, offset: AnyIntegerAttr | None
+) -> str:
+    register_str = assembly_arg_str(register)
+    if offset is not None:
+        offset_str = assembly_arg_str(offset)
+        if offset.value.data > 0:
+            mem_acc_str = f"[{register_str}+{offset_str}]"
+        else:
+            mem_acc_str = f"[{register_str}{offset_str}]"
+    else:
+        mem_acc_str = f"[{register_str}]"
+    return mem_acc_str
+
+
+def print_type_pair(printer: Printer, value: SSAValue) -> None:
+    printer.print_ssa_value(value)
+    printer.print_string(" : ")
+    printer.print_attribute(value.type)
+
+
+def parse_type_pair(parser: Parser) -> SSAValue:
+    unresolved = parser.parse_unresolved_operand()
+    parser.parse_punctuation(":")
+    type = parser.parse_type()
+    return parser.resolve_operand(unresolved, type)

--- a/xdsl/dialects/x86/attributes.py
+++ b/xdsl/dialects/x86/attributes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from xdsl.ir import (
-    Data,
+    Data
 )
 from xdsl.irdl import (
     irdl_attr_definition

--- a/xdsl/dialects/x86/attributes.py
+++ b/xdsl/dialects/x86/attributes.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-from xdsl.ir import (
-    Data
-)
-from xdsl.irdl import (
-    irdl_attr_definition
-)
+from xdsl.ir import Data
+from xdsl.irdl import irdl_attr_definition
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 

--- a/xdsl/dialects/x86/attributes.py
+++ b/xdsl/dialects/x86/attributes.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from xdsl.ir import (
+    Data,
+)
+from xdsl.irdl import (
+    irdl_attr_definition,
+)
+from xdsl.parser import AttrParser
+from xdsl.printer import Printer
+
+
+@irdl_attr_definition
+class LabelAttr(Data[str]):
+    name = "x86.label"
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> str:
+        with parser.in_angle_brackets():
+            return parser.parse_str_literal()
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string_literal(self.data)

--- a/xdsl/dialects/x86/attributes.py
+++ b/xdsl/dialects/x86/attributes.py
@@ -4,7 +4,7 @@ from xdsl.ir import (
     Data,
 )
 from xdsl.irdl import (
-    irdl_attr_definition,
+    irdl_attr_definition
 )
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer


### PR DESCRIPTION
I moved most of the printing and parsing methods to a separate file as per issue #2377. I also moved the LabelAttr to attributes.py because it was needed in both .assembly and .ops + it seemed to make sense.

I left the print_assembly and x86_code in .ops as otherwise it would create a circular import. 