### PR TITLE
core: Block inlining API improvements

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -957,13 +957,12 @@ def test_inline_block_after():
   %0 = "test.op"() : () -> !test.type<"int">
   %1 = "test.op"() ({
     %2 = "test.op"() ({
-    ^0:
     }, {
-    ^1:
+    ^0:
     }) : () -> !test.type<"int">
     %3 = "test.op"() : () -> !test.type<"int">
   }, {
-  ^2:
+  ^1:
   }) : () -> !test.type<"int">
 }) : () -> ()
 """
@@ -1009,12 +1008,11 @@ def test_inline_block_after_matched():
   %0 = "test.op"() : () -> !test.type<"int">
   %1 = "test.op"() ({
     %2 = "test.op"() ({
-    ^0:
     }, {
-    ^1:
+    ^0:
     }) : () -> !test.type<"int">
   }, {
-  ^2:
+  ^1:
   }) : () -> !test.type<"int">
   %3 = "test.op"() : () -> !test.type<"int">
 }) : () -> ()

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -213,7 +213,6 @@ def test_inline_block_after():
   %0 = "test.op"() : () -> !test.type<"int">
   %1 = "test.op"() : () -> !test.type<"int">
   "test.op"() ({
-  ^0:
   }) : () -> ()
 }) : () -> ()
 """

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -241,28 +241,34 @@ class PatternRewriter(PatternRewriterListener):
         self._replace_all_uses_with(arg, None, safe_erase=safe_erase)
         arg.block.erase_arg(arg, safe_erase)
 
-    def inline_block_at_end(self, block: Block, target_block: Block):
+    def inline_block_at_end(
+        self, block: Block, target_block: Block, arg_values: Sequence[SSAValue] = ()
+    ):
         """
         Move the block operations to the end of another block.
         This block should not be a parent of the block to move to.
         """
         self.has_done_action = True
-        Rewriter.inline_block_at_end(block, target_block)
+        Rewriter.inline_block_at_end(block, target_block, arg_values=arg_values)
 
-    def inline_block_at_start(self, block: Block, target_block: Block):
+    def inline_block_at_start(
+        self, block: Block, target_block: Block, arg_values: Sequence[SSAValue] = ()
+    ):
         """
         Move the block operations to the start of another block.
         This block should not be a parent of the block to move to.
         """
         self.has_done_action = True
-        Rewriter.inline_block_at_start(block, target_block)
+        Rewriter.inline_block_at_start(block, target_block, arg_values)
 
-    def inline_block_before_matched_op(self, block: Block):
+    def inline_block_before_matched_op(
+        self, block: Block, arg_values: Sequence[SSAValue] = ()
+    ):
         """
         Move the block operations before the matched operation.
         The block should not be a parent of the operation.
         """
-        self.inline_block_before(block, self.current_operation)
+        self.inline_block_before(block, self.current_operation, arg_values=arg_values)
 
     def inline_block_before(
         self, block: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
@@ -274,20 +280,24 @@ class PatternRewriter(PatternRewriterListener):
         self.has_done_action = True
         Rewriter.inline_block_before(block, op, arg_values=arg_values)
 
-    def inline_block_after_matched_op(self, block: Block):
+    def inline_block_after_matched_op(
+        self, block: Block, arg_values: Sequence[SSAValue] = ()
+    ):
         """
         Move the block operations after the matched operation.
         The block should not be a parent of the operation.
         """
-        self.inline_block_after(block, self.current_operation)
+        self.inline_block_after(block, self.current_operation, arg_values=arg_values)
 
-    def inline_block_after(self, block: Block, op: Operation):
+    def inline_block_after(
+        self, block: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
+    ):
         """
         Move the block operations after the given operation.
         The block should not be a parent of the operation.
         """
         self.has_done_action = True
-        Rewriter.inline_block_after(block, op)
+        Rewriter.inline_block_after(block, op, arg_values=arg_values)
 
     def move_region_contents_to_new_regions(self, region: Region) -> Region:
         """Move the region blocks to a new region."""


### PR DESCRIPTION
The block argument replacement was added to the core function, but only to one of the API ones. This PR adds it to all of them.

Also minor tweaks:
- Block inlining currently asserts the inlined block is part of a region, only to detach it. Switch to simply detaching it if attached.
- Block inlining currently asserts that the right number of block argument replacement values is passed. Switch to just not do argument replacement if no such values are passed.