### PR TITLE
dialects: Add optional result to stencil.store to forward the stored values with halo

### DIFF
--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -247,13 +247,13 @@ builtin.module {
 // CHECK-NEXT:        %6 = stencil.access %5[0] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %6 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %7 = stencil.store %4 to %1 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<?xf64>
-// CHECK-NEXT:      %8 = stencil.apply(%9 = %7 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
-// CHECK-NEXT:        %10 = stencil.access %9[0] : !stencil.temp<?xf64>
-// CHECK-NEXT:        stencil.return %10 : f64
+// CHECK-NEXT:      %5 = stencil.store %4 to %1 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<?xf64>
+// CHECK-NEXT:      %6 = stencil.apply(%7 = %5 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+// CHECK-NEXT:        %8 = stencil.access %7[0] : !stencil.temp<?xf64>
+// CHECK-NEXT:        stencil.return %8 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %11 = stencil.combine 0 at 11 lower = (%7 : !stencil.temp<?xf64>) upper = (%8 : !stencil.temp<?xf64>) : !stencil.temp<?xf64>
-// CHECK-NEXT:      stencil.store %11 to %2 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      %7 = stencil.combine 0 at 11 lower = (%5 : !stencil.temp<?xf64>) upper = (%6 : !stencil.temp<?xf64>) : !stencil.temp<?xf64>
+// CHECK-NEXT:      stencil.store %7 to %2 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -219,3 +219,41 @@ builtin.module {
 // CHECK-NEXT:      stencil.store %5 to %3 ([0, 0] : [64, 64]) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
+
+// -----
+
+builtin.module {
+  func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %11 : !stencil.field<[-4,68]xf64>) {
+    %2 = stencil.load %0 : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
+    %3 = stencil.apply(%4 = %2 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+      %5 = stencil.access %4[0] : !stencil.temp<?xf64>
+      stencil.return %5 : f64
+    }
+    %6 = stencil.store %3 to %1 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<?xf64>
+    %7 = stencil.apply(%8 = %6 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+      %9 = stencil.access %8[0] : !stencil.temp<?xf64>
+      stencil.return %9 : f64
+    }
+    %10 = stencil.combine 0 at 11 lower = (%6 : !stencil.temp<?xf64>) upper = (%7 : !stencil.temp<?xf64>) : !stencil.temp<?xf64>
+    stencil.store %10 to %11 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    func.return
+  }
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %2 : !stencil.field<[-4,68]xf64>) {
+// CHECK-NEXT:      %3 = stencil.load %0 : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
+// CHECK-NEXT:      %4 = stencil.apply(%5 = %3 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+// CHECK-NEXT:        %6 = stencil.access %5[0] : !stencil.temp<?xf64>
+// CHECK-NEXT:        stencil.return %6 : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %7 = stencil.store %4 to %1 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<?xf64>
+// CHECK-NEXT:      %8 = stencil.apply(%9 = %7 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+// CHECK-NEXT:        %10 = stencil.access %9[0] : !stencil.temp<?xf64>
+// CHECK-NEXT:        stencil.return %10 : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %11 = stencil.combine 0 at 11 lower = (%7 : !stencil.temp<?xf64>) upper = (%8 : !stencil.temp<?xf64>) : !stencil.temp<?xf64>
+// CHECK-NEXT:      stencil.store %11 to %2 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -241,7 +241,7 @@ builtin.module {
 }
 
 // CHECK:       builtin.module {
-// CHECK-NEXT:    func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %2 : !stencil.field<[-4,68]xf64>) {
+// CHECK-NEXT:    func.func private @stencil_forwarding_store(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %2 : !stencil.field<[-4,68]xf64>) {
 // CHECK-NEXT:      %3 = stencil.load %0 : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
 // CHECK-NEXT:      %4 = stencil.apply(%5 = %3 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
 // CHECK-NEXT:        %6 = stencil.access %5[0] : !stencil.temp<?xf64>

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -223,7 +223,7 @@ builtin.module {
 // -----
 
 builtin.module {
-  func.func private @stencil_buffer(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %11 : !stencil.field<[-4,68]xf64>) {
+  func.func private @stencil_forwarding_store(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %11 : !stencil.field<[-4,68]xf64>) {
     %2 = stencil.load %0 : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
     %3 = stencil.apply(%4 = %2 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
       %5 = stencil.access %4[0] : !stencil.temp<?xf64>

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -840,4 +840,47 @@ func.func @buffered_combine(%115 : !stencil.field<?x?xf64>) {
   }
 
 }
+
+// CHECK-NEXT:    func.func private @stencil_forwarding_store(%346 : memref<72xf64>, %347 : memref<72xf64>, %348 : memref<72xf64>) {
+// CHECK-NEXT:      %349 = "memref.subview"(%347) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %350 = "memref.subview"(%348) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %351 = "memref.subview"(%346) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 66>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %352 = arith.constant 0 : index
+// CHECK-NEXT:      %353 = arith.constant 1 : index
+// CHECK-NEXT:      %354 = arith.constant 64 : index
+// CHECK-NEXT:      "scf.parallel"(%352, %354, %353) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-NEXT:      ^23(%355 : index):
+// CHECK-NEXT:        %356 = arith.constant -1 : index
+// CHECK-NEXT:        %357 = arith.addi %355, %356 : index
+// CHECK-NEXT:        %358 = memref.load %351[%357] : memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %359 = memref.load %351[%355] : memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %360 = arith.constant 1 : index
+// CHECK-NEXT:        %361 = arith.addi %355, %360 : index
+// CHECK-NEXT:        %362 = memref.load %351[%361] : memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %363 = arith.addf %358, %359 : f64
+// CHECK-NEXT:        %364 = arith.addf %362, %363 : f64
+// CHECK-NEXT:        memref.store %364, %349[%355] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        scf.yield
+// CHECK-NEXT:      }) : (index, index, index) -> ()
+// CHECK-NEXT:      %365 = "memref.subview"(%347) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %366 = arith.constant 0 : index
+// CHECK-NEXT:      %367 = arith.constant 1 : index
+// CHECK-NEXT:      %368 = arith.constant 64 : index
+// CHECK-NEXT:      "scf.parallel"(%366, %368, %367) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-NEXT:      ^24(%369 : index):
+// CHECK-NEXT:        %370 = arith.constant -1 : index
+// CHECK-NEXT:        %371 = arith.addi %369, %370 : index
+// CHECK-NEXT:        %372 = memref.load %365[%371] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %373 = memref.load %365[%369] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %374 = arith.constant 1 : index
+// CHECK-NEXT:        %375 = arith.addi %369, %374 : index
+// CHECK-NEXT:        %376 = memref.load %365[%375] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %377 = arith.addf %372, %373 : f64
+// CHECK-NEXT:        %378 = arith.addf %376, %377 : f64
+// CHECK-NEXT:        memref.store %378, %350[%369] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        scf.yield
+// CHECK-NEXT:      }) : (index, index, index) -> ()
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -815,7 +815,29 @@ func.func @buffered_combine(%115 : !stencil.field<?x?xf64>) {
 // CHECK-NEXT:      }) : (index, index, index, index, index, index) -> ()
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
-  
+
+  func.func private @stencil_forwarding_store(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %2 : !stencil.field<[-4,68]xf64>) {
+    %3 = stencil.load %0 : !stencil.field<[-4,68]xf64> -> !stencil.temp<[-1,65]xf64>
+    %4 = stencil.apply(%5 = %3 : !stencil.temp<[-1,65]xf64>) -> (!stencil.temp<[0,64]xf64>) {
+      %6 = stencil.access %5[-1] : !stencil.temp<[-1,65]xf64>
+      %7 = stencil.access %5[0] : !stencil.temp<[-1,65]xf64>
+      %8 = stencil.access %5[1] : !stencil.temp<[-1,65]xf64>
+      %9 = arith.addf %6, %7 : f64
+      %10 = arith.addf %8, %9 : f64
+      stencil.return %10 : f64
+    }
+    %11 = stencil.store %4 to %1 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<[-1,65]xf64>
+    %12 = stencil.apply(%13 = %11 : !stencil.temp<[-1,65]xf64>) -> (!stencil.temp<[0,64]xf64>) {
+      %14 = stencil.access %13[-1] : !stencil.temp<[-1,65]xf64>
+      %15 = stencil.access %13[0] : !stencil.temp<[-1,65]xf64>
+      %16 = stencil.access %13[1] : !stencil.temp<[-1,65]xf64>
+      %17 = arith.addf %14, %15 : f64
+      %18 = arith.addf %16, %17 : f64
+      stencil.return %18 : f64
+    }
+    stencil.store %12 to %2 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
+    func.return
+  }
 
 }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -841,43 +841,43 @@ func.func @buffered_combine(%115 : !stencil.field<?x?xf64>) {
 
 }
 
-// CHECK-NEXT:    func.func private @stencil_forwarding_store(%346 : memref<72xf64>, %347 : memref<72xf64>, %348 : memref<72xf64>) {
-// CHECK-NEXT:      %349 = "memref.subview"(%347) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:      %350 = "memref.subview"(%348) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:      %351 = "memref.subview"(%346) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 66>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<66xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:      %352 = arith.constant 0 : index
-// CHECK-NEXT:      %353 = arith.constant 1 : index
-// CHECK-NEXT:      %354 = arith.constant 64 : index
-// CHECK-NEXT:      "scf.parallel"(%352, %354, %353) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
-// CHECK-NEXT:      ^23(%355 : index):
-// CHECK-NEXT:        %356 = arith.constant -1 : index
-// CHECK-NEXT:        %357 = arith.addi %355, %356 : index
-// CHECK-NEXT:        %358 = memref.load %351[%357] : memref<66xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        %359 = memref.load %351[%355] : memref<66xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        %360 = arith.constant 1 : index
-// CHECK-NEXT:        %361 = arith.addi %355, %360 : index
-// CHECK-NEXT:        %362 = memref.load %351[%361] : memref<66xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        %363 = arith.addf %358, %359 : f64
-// CHECK-NEXT:        %364 = arith.addf %362, %363 : f64
-// CHECK-NEXT:        memref.store %364, %349[%355] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK:         func.func private @stencil_forwarding_store(%0 : memref<72xf64>, %1 : memref<72xf64>, %2 : memref<72xf64>) {
+// CHECK-NEXT:      %3 = "memref.subview"(%1) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %4 = "memref.subview"(%2) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %5 = "memref.subview"(%0) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 66>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %6 = arith.constant 0 : index
+// CHECK-NEXT:      %7 = arith.constant 1 : index
+// CHECK-NEXT:      %8 = arith.constant 64 : index
+// CHECK-NEXT:      "scf.parallel"(%6, %8, %7) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-NEXT:      ^0(%9 : index):
+// CHECK-NEXT:        %10 = arith.constant -1 : index
+// CHECK-NEXT:        %11 = arith.addi %9, %10 : index
+// CHECK-NEXT:        %12 = memref.load %5[%11] : memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %13 = memref.load %5[%9] : memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %14 = arith.constant 1 : index
+// CHECK-NEXT:        %15 = arith.addi %9, %14 : index
+// CHECK-NEXT:        %16 = memref.load %5[%15] : memref<66xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %17 = arith.addf %12, %13 : f64
+// CHECK-NEXT:        %18 = arith.addf %16, %17 : f64
+// CHECK-NEXT:        memref.store %18, %3[%9] : memref<64xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:        scf.yield
 // CHECK-NEXT:      }) : (index, index, index) -> ()
-// CHECK-NEXT:      %365 = "memref.subview"(%347) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:      %366 = arith.constant 0 : index
-// CHECK-NEXT:      %367 = arith.constant 1 : index
-// CHECK-NEXT:      %368 = arith.constant 64 : index
-// CHECK-NEXT:      "scf.parallel"(%366, %368, %367) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
-// CHECK-NEXT:      ^24(%369 : index):
-// CHECK-NEXT:        %370 = arith.constant -1 : index
-// CHECK-NEXT:        %371 = arith.addi %369, %370 : index
-// CHECK-NEXT:        %372 = memref.load %365[%371] : memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        %373 = memref.load %365[%369] : memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        %374 = arith.constant 1 : index
-// CHECK-NEXT:        %375 = arith.addi %369, %374 : index
-// CHECK-NEXT:        %376 = memref.load %365[%375] : memref<64xf64, strided<[1], offset: 4>>
-// CHECK-NEXT:        %377 = arith.addf %372, %373 : f64
-// CHECK-NEXT:        %378 = arith.addf %376, %377 : f64
-// CHECK-NEXT:        memref.store %378, %350[%369] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %19 = "memref.subview"(%1) <{"static_offsets" = array<i64: 4>, "static_sizes" = array<i64: 64>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (memref<72xf64>) -> memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:      %20 = arith.constant 0 : index
+// CHECK-NEXT:      %21 = arith.constant 1 : index
+// CHECK-NEXT:      %22 = arith.constant 64 : index
+// CHECK-NEXT:      "scf.parallel"(%20, %22, %21) <{"operandSegmentSizes" = array<i32: 1, 1, 1, 0>}> ({
+// CHECK-NEXT:      ^1(%23 : index):
+// CHECK-NEXT:        %24 = arith.constant -1 : index
+// CHECK-NEXT:        %25 = arith.addi %23, %24 : index
+// CHECK-NEXT:        %26 = memref.load %19[%25] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %27 = memref.load %19[%23] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %28 = arith.constant 1 : index
+// CHECK-NEXT:        %29 = arith.addi %23, %28 : index
+// CHECK-NEXT:        %30 = memref.load %19[%29] : memref<64xf64, strided<[1], offset: 4>>
+// CHECK-NEXT:        %31 = arith.addf %26, %27 : f64
+// CHECK-NEXT:        %32 = arith.addf %30, %31 : f64
+// CHECK-NEXT:        memref.store %32, %4[%23] : memref<64xf64, strided<[1], offset: 4>>
 // CHECK-NEXT:        scf.yield
 // CHECK-NEXT:      }) : (index, index, index) -> ()
 // CHECK-NEXT:      func.return

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -366,16 +366,16 @@ builtin.module {
 // CHECK-NEXT:        %10 = arith.addf %8, %9 : f64
 // CHECK-NEXT:        stencil.return %10 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %11 = stencil.store %4 to %1 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<[-1,65]xf64>
-// CHECK-NEXT:      %12 = stencil.apply(%13 = %11 : !stencil.temp<[-1,65]xf64>) -> (!stencil.temp<[0,64]xf64>) {
-// CHECK-NEXT:        %14 = stencil.access %13[-1] : !stencil.temp<[-1,65]xf64>
-// CHECK-NEXT:        %15 = stencil.access %13[0] : !stencil.temp<[-1,65]xf64>
-// CHECK-NEXT:        %16 = stencil.access %13[1] : !stencil.temp<[-1,65]xf64>
-// CHECK-NEXT:        %17 = arith.addf %14, %15 : f64
-// CHECK-NEXT:        %18 = arith.addf %16, %17 : f64
-// CHECK-NEXT:        stencil.return %18 : f64
+// CHECK-NEXT:      %5 = stencil.store %4 to %1 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:      %6 = stencil.apply(%7 = %5 : !stencil.temp<[-1,65]xf64>) -> (!stencil.temp<[0,64]xf64>) {
+// CHECK-NEXT:        %8 = stencil.access %7[-1] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %9 = stencil.access %7[0] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %10 = stencil.access %7[1] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %11 = arith.addf %8, %9 : f64
+// CHECK-NEXT:        %12 = arith.addf %10, %11 : f64
+// CHECK-NEXT:        stencil.return %12 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %12 to %2 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %6 to %2 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -77,7 +77,7 @@ builtin.module {
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
-//-----
+// -----
 
 builtin.module {
   func.func @stencil_hdiff(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>) {
@@ -355,4 +355,27 @@ builtin.module {
   }
 }
 
-// CHECK-NEXT: NOPE
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func private @stencil_forwarding_store(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %2 : !stencil.field<[-4,68]xf64>) {
+// CHECK-NEXT:      %3 = stencil.load %0 : !stencil.field<[-4,68]xf64> -> !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:      %4 = stencil.apply(%5 = %3 : !stencil.temp<[-1,65]xf64>) -> (!stencil.temp<[0,64]xf64>) {
+// CHECK-NEXT:        %6 = stencil.access %5[-1] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %7 = stencil.access %5[0] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %8 = stencil.access %5[1] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %9 = arith.addf %6, %7 : f64
+// CHECK-NEXT:        %10 = arith.addf %8, %9 : f64
+// CHECK-NEXT:        stencil.return %10 : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %11 = stencil.store %4 to %1 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:      %12 = stencil.apply(%13 = %11 : !stencil.temp<[-1,65]xf64>) -> (!stencil.temp<[0,64]xf64>) {
+// CHECK-NEXT:        %14 = stencil.access %13[-1] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %15 = stencil.access %13[0] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %16 = stencil.access %13[1] : !stencil.temp<[-1,65]xf64>
+// CHECK-NEXT:        %17 = arith.addf %14, %15 : f64
+// CHECK-NEXT:        %18 = arith.addf %16, %17 : f64
+// CHECK-NEXT:        stencil.return %18 : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      stencil.store %12 to %2 ([0] : [64]) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -77,7 +77,7 @@ builtin.module {
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
-// -----
+//-----
 
 builtin.module {
   func.func @stencil_hdiff(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>) {
@@ -327,3 +327,32 @@ func.func @buffer(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<?x?x
 // CHECK-NEXT:      stencil.store %14 to %2 ([48, 0, 0] : [64, 64, 60]) : !stencil.temp<[48,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
+
+// -----
+
+builtin.module {
+  func.func private @stencil_forwarding_store(%0 : !stencil.field<[-4,68]xf64>, %1 : !stencil.field<[-4,68]xf64>, %11 : !stencil.field<[-4,68]xf64>) {
+    %2 = stencil.load %0 : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
+    %3 = stencil.apply(%4 = %2 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+      %5 = stencil.access %4[-1] : !stencil.temp<?xf64>
+      %12 = stencil.access %4[0] : !stencil.temp<?xf64>
+      %13 = stencil.access %4[1] : !stencil.temp<?xf64>
+      %17 = arith.addf %5, %12 : f64
+      %18 = arith.addf %13, %17 : f64
+      stencil.return %18 : f64
+    }
+    %6 = stencil.store %3 to %1 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64> with_halo : !stencil.temp<?xf64>
+    %7 = stencil.apply(%8 = %6 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+      %14 = stencil.access %8[-1] : !stencil.temp<?xf64>
+      %15 = stencil.access %8[0] : !stencil.temp<?xf64>
+      %16 = stencil.access %8[1] : !stencil.temp<?xf64>
+      %19 = arith.addf %14, %15 : f64
+      %20 = arith.addf %16, %19 : f64
+      stencil.return %20 : f64
+    }
+    stencil.store %7 to %11 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    func.return
+  }
+}
+
+// CHECK-NEXT: NOPE


### PR DESCRIPTION
This enables further stencil computations to act on the stored values, but also on out-of-computed-bounds ones, read from the stored-to buffer.
Otherwise, those would have to be somehow loaded from the field. But one cannot load and store from the same field!