### PR TITLE
dialects: (csl) add modules

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -1,5 +1,7 @@
 // RUN: xdsl-opt -t csl %s | filecheck %s
 
+"csl.module"() <{kind=#csl<module_kind program>}> ({
+
 "memref.global"() {"sym_name" = "A", "type" = memref<24xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
 "memref.global"() {"sym_name" = "x", "type" = memref<6xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
 "memref.global"() {"sym_name" = "b", "type" = memref<4xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
@@ -57,6 +59,7 @@ csl.func @initialize() {
 
   csl.return
 }
+}) {sym_name = "program"} : () -> ()
 
 
 // CHECK:      //unknown op Global("memref.global"() <{"sym_name" = "A", "sym_visibility" = "public", "type" = memref<24xf32>, "initial_value" = dense<0> : tensor<1xindex>}> : () -> ())

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -1,10 +1,12 @@
 // RUN: XDSL_ROUNDTRIP
 
+"csl.module"() <{kind = #csl<module_kind program>}> ({
+
+%thing = "csl.import_module"() <{module = "<thing>"}> : () -> !csl.imported_module
+
 csl.func @initialize() {
 
     %lb, %ub = "test.op"() : () -> (i16, i16)
-
-    %thing = "csl.import_module"() <{module = "<thing>"}> : () -> !csl.imported_module
 
     "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> ()
 
@@ -21,12 +23,19 @@ csl.func @initialize() {
 
   csl.return
 }
+}) {sym_name = "program"} :  () -> ()
+
+"csl.module"() <{kind = #csl<module_kind layout>}> ({
+  csl.layout {
+  }
+}) {sym_name = "layout"} : () -> ()
 
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   csl.func @initialize() {
+// CHECK-NEXT: "csl.module"() <{"kind" = #csl<module_kind program>}> ({
+// CHECK-NEXT: %thing = "csl.import_module"() <{"module" = "<thing>"}> : () -> !csl.imported_module
+// CHECK-NEXT: csl.func @initialize() {
 // CHECK-NEXT:     %lb, %ub = "test.op"() : () -> (i16, i16)
-// CHECK-NEXT:     %thing = "csl.import_module"() <{"module" = "<thing>"}> : () -> !csl.imported_module
 // CHECK-NEXT:     "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func", "operandSegmentSizes" = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> ()
 // CHECK-NEXT:     %res = "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func", "operandSegmentSizes" = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> i32
 // CHECK-NEXT:     %0 = "csl.member_access"(%thing) <{"field" = "some_field"}> : (!csl.imported_module) -> !csl.comptime_struct
@@ -37,4 +46,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %col = "test.op"() : () -> !csl.color
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
+// CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()
+// CHECK-NEXT: "csl.module"() <{"kind" = #csl<module_kind layout>}> ({
+// CHECK-NEXT: csl.layout {
+// CHECK-NEXT:   ^0:
+// CHECK-NEXT: }
+// CHECK-NEXT: }) {"sym_name" = "layout"} : () -> ()
 // CHECK-NEXT: }

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -214,6 +214,6 @@ def print_to_csl(prog: ModuleOp, output: IO[str]):
     Takes a module op and prints it to the given output stream.
     """
     ctx = CslPrintContext(output)
-    for mod in  prog.body.block.ops:
+    for mod in prog.body.block.ops:
         assert isinstance(mod, csl.CslModuleOp)
         ctx.print_block(mod.body.block)

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -214,4 +214,6 @@ def print_to_csl(prog: ModuleOp, output: IO[str]):
     Takes a module op and prints it to the given output stream.
     """
     ctx = CslPrintContext(output)
-    ctx.print_block(prog.body.block)
+    for mod in  prog.body.block.ops:
+        assert isinstance(mod, csl.CslModuleOp)
+        ctx.print_block(mod.body.block)

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -389,6 +389,29 @@ class ReturnOp(IRDLOperation):
             )
 
 
+@irdl_op_definition
+class LayoutOp(IRDLOperation):
+    name = "csl.layout"
+
+    body: Region = region_def()
+
+    traits = frozenset([NoTerminator(), InModuleKind(ModuleKind.LAYOUT)])
+
+    def __init__(self, ops: Sequence[Operation] | Region):
+        if not isinstance(ops, Region):
+            ops = Region(Block(ops))
+        if len(ops.blocks) == 0:
+            ops = Region(Block([]))
+        super().__init__(regions=[ops])
+
+    @classmethod
+    def parse(cls, parser: Parser) -> LayoutOp:
+        return cls(parser.parse_region())
+
+    def print(self, printer: Printer):
+        printer.print(" ", self.body)
+
+
 CSL = Dialect(
     "csl",
     [


### PR DESCRIPTION
* Added `CslModuleOp` to separate program from layout
* Added `LayoutOp` to specify the `layout` block
* Added traits to ensure ops are in correct module types.