### PR TITLE
dialects: (csl) Added call op and tasks

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -15,10 +15,10 @@ csl.func @initialize() {
   %step = arith.constant 1 : i16
 
   // call without result
-  "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> ()
+  "csl.member_call"(%thing, %lb, %ub) <{field = "some_func"}> : (!csl.imported_module, i16, i16) -> ()
 
   // call with result
-  %res = "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> (i32)
+  %res = "csl.member_call"(%thing, %lb, %ub) <{field = "some_func"}> : (!csl.imported_module, i16, i16) -> (i32)
 
   // member access
   %11 = "csl.member_access"(%thing) <{field = "some_field"}> : (!csl.imported_module) -> !csl.comptime_struct

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -4,13 +4,33 @@
 
 %thing = "csl.import_module"() <{module = "<thing>"}> : () -> !csl.imported_module
 
+csl.func @func_with_args(%arg1: i32, %arg2: i16) -> i32 {
+
+  csl.return %arg1 : i32
+}
+
+
+csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 0 : i5} {
+  csl.return
+}
+csl.task @data_task(%a: i32) attributes {kind = #csl<task_kind data>, id = 1 : i5} {
+  csl.return
+}
+csl.task @control_task() attributes {kind = #csl<task_kind control>, id = 2 : i6} {
+  csl.return
+}
+csl.task @control_task_args(%a: i32) attributes {kind = #csl<task_kind control>, id = 2 : i6} {
+  csl.return
+}
+
+
 csl.func @initialize() {
 
     %lb, %ub = "test.op"() : () -> (i16, i16)
 
-    "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> ()
+    "csl.member_call"(%thing, %lb, %ub) <{field = "some_func"}> : (!csl.imported_module, i16, i16) -> ()
 
-    %res = "csl.member_call"(%thing, %lb, %ub) <{field = "some_func", operandSegmentSizes = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> (i32)
+    %res = "csl.member_call"(%thing, %lb, %ub) <{field = "some_func"}> : (!csl.imported_module, i16, i16) -> (i32)
 
     %11 = "csl.member_access"(%thing) <{field = "some_field"}> : (!csl.imported_module) -> !csl.comptime_struct
 
@@ -20,6 +40,9 @@ csl.func @initialize() {
     %many_var = "test.op"() : () -> !csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const var>>
 
     %col = "test.op"() : () -> !csl.color
+
+    %arg1, %arg2 = "test.op"() : () -> (i32, i16)
+    %call_res = "csl.call"(%arg1, %arg2) <{callee = @func_with_args}> : (i32, i16) -> i32
 
   csl.return
 }
@@ -34,16 +57,33 @@ csl.func @initialize() {
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT: "csl.module"() <{"kind" = #csl<module_kind program>}> ({
 // CHECK-NEXT: %thing = "csl.import_module"() <{"module" = "<thing>"}> : () -> !csl.imported_module
+// CHECK-NEXT: csl.func @func_with_args(%arg1 : i32, %arg2 : i16) -> i32 {
+// CHECK-NEXT:   csl.return %arg1 : i32
+// CHECK-NEXT: }
+// CHECK-NEXT: csl.task @local_task()  attributes {"kind" = #csl<task_kind local>, "id" = 0 : i5}{
+// CHECK-NEXT:   csl.return
+// CHECK-NEXT: }
+// CHECK-NEXT: csl.task @data_task(%a : i32) attributes {"kind" = #csl<task_kind data>, "id" = 1 : i5}{
+// CHECK-NEXT:   csl.return
+// CHECK-NEXT: }
+// CHECK-NEXT: csl.task @control_task() attributes {"kind" = #csl<task_kind control>, "id" = 2 : i6}{
+// CHECK-NEXT:   csl.return
+// CHECK-NEXT: }
+// CHECK-NEXT: csl.task @control_task_args(%a_1 : i32) attributes {"kind" = #csl<task_kind control>, "id" = 2 : i6}{
+// CHECK-NEXT:   csl.return
+// CHECK-NEXT: }
 // CHECK-NEXT: csl.func @initialize() {
 // CHECK-NEXT:     %lb, %ub = "test.op"() : () -> (i16, i16)
-// CHECK-NEXT:     "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func", "operandSegmentSizes" = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> ()
-// CHECK-NEXT:     %res = "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func", "operandSegmentSizes" = array<i32: 1, 2>}> : (!csl.imported_module, i16, i16) -> i32
+// CHECK-NEXT:     "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func"}> : (!csl.imported_module, i16, i16) -> ()
+// CHECK-NEXT:     %res = "csl.member_call"(%thing, %lb, %ub) <{"field" = "some_func"}> : (!csl.imported_module, i16, i16) -> i32
 // CHECK-NEXT:     %0 = "csl.member_access"(%thing) <{"field" = "some_field"}> : (!csl.imported_module) -> !csl.comptime_struct
 // CHECK-NEXT:     %single_const = "test.op"() : () -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_var = "test.op"() : () -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const var>>
 // CHECK-NEXT:     %many_const = "test.op"() : () -> !csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %many_var = "test.op"() : () -> !csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const var>>
 // CHECK-NEXT:     %col = "test.op"() : () -> !csl.color
+// CHECK-NEXT:     %arg1_1, %arg2_1 = "test.op"() : () -> (i32, i16)
+// CHECK-NEXT:     %call_res = "csl.call"(%arg1_1, %arg2_1) <{"callee" = @func_with_args}> : (i32, i16) -> i32
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -22,6 +22,9 @@ csl.task @control_task() attributes {kind = #csl<task_kind control>, id = 2 : i6
 csl.task @control_task_args(%a: i32) attributes {kind = #csl<task_kind control>, id = 2 : i6} {
   csl.return
 }
+csl.task @runtime_bound_local_task() attributes {kind = #csl<task_kind local>} {
+  csl.return
+}
 
 
 csl.func @initialize() {
@@ -70,6 +73,9 @@ csl.func @initialize() {
 // CHECK-NEXT:   csl.return
 // CHECK-NEXT: }
 // CHECK-NEXT: csl.task @control_task_args(%a_1 : i32) attributes {"kind" = #csl<task_kind control>, "id" = 2 : i6}{
+// CHECK-NEXT:   csl.return
+// CHECK-NEXT: }
+// CHECK-NEXT: csl.task @runtime_bound_local_task() attributes {"kind" = #csl<task_kind local>}{
 // CHECK-NEXT:   csl.return
 // CHECK-NEXT: }
 // CHECK-NEXT: csl.func @initialize() {

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -9,6 +9,7 @@ This is meant to be used in conjunction with the `-t csl` printing option to gen
 
 from __future__ import annotations
 
+from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TypeAlias
@@ -88,7 +89,7 @@ class TaskKind(StrEnum):
     CONTROL = "control"
 
 
-class _FuncBase(IRDLOperation):
+class _FuncBase(IRDLOperation, ABC):
     """
     Base class for the shared functionalty of FuncOp and TaskOp
     """

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -13,7 +13,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TypeAlias
 
-from xdsl.dialects import func
 from xdsl.dialects.builtin import (
     ArrayAttr,
     ContainerType,
@@ -21,6 +20,7 @@ from xdsl.dialects.builtin import (
     FunctionType,
     ModuleOp,
     StringAttr,
+    SymbolRefAttr,
 )
 from xdsl.dialects.utils import parse_func_op_like, print_func_op_like
 from xdsl.ir import (
@@ -35,7 +35,6 @@ from xdsl.ir import (
     TypeAttribute,
 )
 from xdsl.irdl import (
-    AttrSizedOperandSegments,
     IRDLOperation,
     ParameterDef,
     ParametrizedAttribute,
@@ -257,8 +256,6 @@ class MemberCallOp(IRDLOperation):
 
     result = opt_result_def(Attribute)
 
-    irdl_options = [AttrSizedOperandSegments(as_property=True)]
-
 
 @irdl_op_definition
 class FuncOp(IRDLOperation):
@@ -412,6 +409,25 @@ class LayoutOp(IRDLOperation):
         printer.print(" ", self.body)
 
 
+@irdl_op_definition
+class CallOp(IRDLOperation):
+    """
+    Call a regular function or task by name
+    """
+
+    name = "csl.call"
+
+    callee = prop_def(SymbolRefAttr)
+    args = var_operand_def(Attribute)
+    result = opt_result_def(Attribute)
+
+    # TODO(dk949): verify that callee corresponds to a real symbol
+
+    # TODO(dk949): verify that function type of callee matches args and result
+
+    # TODO(dk949): verify that if Call is used outside of a csl.func or csl.task it has a result
+
+
 CSL = Dialect(
     "csl",
     [
@@ -422,6 +438,7 @@ CSL = Dialect(
         MemberAccessOp,
         CslModuleOp,
         LayoutOp,
+        CallOp,
     ],
     [
         ComptimeStructType,

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -473,8 +473,6 @@ class TaskOp(IRDLOperation, _FuncBase):
             case TaskKind.LOCAL:
                 if len(self.function_type.inputs.data) != 0:
                     raise VerifyException("Local tasks cannot have input argumentd")
-                if self.id is not None and self.id.value.data > 31:
-                    raise VerifyException()
             case TaskKind.DATA:
                 if not (0 < len(self.function_type.inputs.data) < 5):
                     raise VerifyException(

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -18,11 +18,11 @@ from xdsl.dialects.builtin import (
     ContainerType,
     DictionaryAttr,
     FunctionType,
+    IntegerAttr,
+    IntegerType,
     ModuleOp,
     StringAttr,
     SymbolRefAttr,
-    IntegerAttr,
-    IntegerType,
 )
 from xdsl.dialects.utils import parse_func_op_like, print_func_op_like
 from xdsl.ir import (
@@ -63,8 +63,8 @@ from xdsl.traits import (
     SymbolOpInterface,
 )
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.str_enum import StrEnum
 from xdsl.utils.hints import isa
+from xdsl.utils.str_enum import StrEnum
 
 
 class PtrKind(StrEnum):

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -88,7 +88,7 @@ class TaskKind(StrEnum):
     CONTROL = "control"
 
 
-class FuncBase:
+class _FuncBase:
     """
     Base class for the shared functionalty of FuncOp and TaskOp
     """
@@ -349,7 +349,7 @@ class MemberCallOp(IRDLOperation):
 
 
 @irdl_op_definition
-class FuncOp(IRDLOperation, FuncBase):
+class FuncOp(IRDLOperation, _FuncBase):
     """
     Almost the same as func.func, but only has one result, and is not isolated from above.
 
@@ -374,7 +374,7 @@ class FuncOp(IRDLOperation, FuncBase):
         super().__init__(properties=properties, regions=[region])
 
     def verify_(self) -> None:
-        FuncBase._verify(self)
+        _FuncBase._verify(self)
 
     @classmethod
     def parse(cls, parser: Parser) -> FuncOp:
@@ -404,11 +404,11 @@ class FuncOp(IRDLOperation, FuncBase):
         return func
 
     def print(self, printer: Printer):
-        FuncBase._print(self, printer)
+        _FuncBase._print(self, printer)
 
 
 @irdl_op_definition
-class TaskOp(IRDLOperation, FuncBase):
+class TaskOp(IRDLOperation, _FuncBase):
     """
     Represents a task in CSL. All three types of task are represented by this Op.
 
@@ -455,7 +455,7 @@ class TaskOp(IRDLOperation, FuncBase):
         super().__init__(properties=properties, regions=[region])
 
     def verify_(self) -> None:
-        FuncBase._verify(self)
+        _FuncBase._verify(self)
         if len(self.function_type.outputs.data) != 0:
             raise VerifyException(f"{self.name} cannot have return values")
 
@@ -518,7 +518,7 @@ class TaskOp(IRDLOperation, FuncBase):
         return task
 
     def print(self, printer: Printer):
-        FuncBase._print(self, printer)
+        _FuncBase._print(self, printer)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -282,8 +282,6 @@ class CslModuleOp(IRDLOperation):
     Separates layout module from program module
     """
 
-    # TODO(dk949): This should also probably handle csl `param`s
-
     name = "csl.module"
     body: Region = region_def("single_block")
     kind = prop_def(ModuleKindAttr)
@@ -460,7 +458,6 @@ class TaskOp(IRDLOperation, _FuncBase):
         if len(self.function_type.outputs.data) != 0:
             raise VerifyException(f"{self.name} cannot have return values")
 
-        # TODO(dk949): Need to check at some point that we're not reusing the same color multiple times
         if (
             self.id is not None
             and self.id.type.width.data != self.kind.get_color_bits()
@@ -587,10 +584,6 @@ class CallOp(IRDLOperation):
     callee = prop_def(SymbolRefAttr)
     args = var_operand_def(Attribute)
     result = opt_result_def(Attribute)
-
-    # TODO(dk949): verify that callee corresponds to a real symbol
-
-    # TODO(dk949): verify that function type of callee matches args and result
 
     # TODO(dk949): verify that if Call is used outside of a csl.func or csl.task it has a result
 

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -407,7 +407,7 @@ class FuncOp(IRDLOperation, _FuncBase):
     def print(self, printer: Printer):
         _FuncBase._print(self, printer)
 
-    def _get_name(self):
+    def _get_name(self) -> str:
         return self.name
 
     def _get_attribs_and_props(self) -> dict[str, Attribute]:
@@ -529,7 +529,7 @@ class TaskOp(IRDLOperation, _FuncBase):
     def print(self, printer: Printer):
         _FuncBase._print(self, printer)
 
-    def _get_name(self):
+    def _get_name(self) -> str:
         return self.name
 
     def _get_attribs_and_props(self) -> dict[str, Attribute]:


### PR DESCRIPTION
* The three kinds of tasks
  * Tasks carry IDs they will be bound to (by the printer, coming in future PR)
* `csl.call`, for tasks and functions
* Removed `AttrSizedOperandSegments` from `csl.member_call` following a discussion with @AntonLydike 