### PR TITLE
backend: (csl) Add printing some scf and memref features

### DIFF
--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -21,6 +21,7 @@ from xdsl.ir import Attribute, Block, SSAValue
 
 @dataclass
 class CslPrintContext:
+    _INDEX = "i32"
     output: IO[str]
 
     variables: dict[SSAValue, str] = field(default_factory=dict)
@@ -100,6 +101,8 @@ class CslPrintContext:
                 return "f16"
             case Float32Type():
                 return "f32"
+            case IndexType():
+                return self._INDEX
             case IntegerType(
                 width=IntAttr(data=width),
                 signedness=SignednessAttr(data=Signedness.UNSIGNED),


### PR DESCRIPTION
Add csl backend support for the following operations:
* `scf.For`
* `scf.yield`
* `memref.global`
* `memref.get_global`

Also added the following types:
* `memref`
* `index`