### PR TITLE
dialects: (csl) Adding Constructors for `comptime_struct` and `color`, as well as some `layout` functions.

### DIFF
--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -47,6 +47,22 @@ csl.func @initialize() {
     %arg1, %arg2 = "test.op"() : () -> (i32, i16)
     %call_res = "csl.call"(%arg1, %arg2) <{callee = @func_with_args}> : (i32, i16) -> i32
 
+
+    %attr_struct = "csl.const_struct"() <{
+      items = {i = 42 : i32, f = 3.7 : f32 }
+    }> : () -> !csl.comptime_struct
+
+    %ssa_struct = "csl.const_struct"(%arg1, %arg2, %col) <{
+      ssa_fields = ["i32_", "i16_", "col"]
+    }> : (i32, i16, !csl.color) -> !csl.comptime_struct
+
+    %mixed_struct = "csl.const_struct"(%arg1, %arg2, %col) <{
+      ssa_fields = ["i32_", "i16_", "col"],
+      items = {i = 42 : i32, f = 3.7 : f32 }
+    }> : (i32, i16, !csl.color) -> !csl.comptime_struct
+
+    %col_1 = "csl.get_color"() <{id = 3 : i5}> : () -> !csl.color
+
   csl.return
 }
 }) {sym_name = "program"} :  () -> ()
@@ -90,6 +106,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %col = "test.op"() : () -> !csl.color
 // CHECK-NEXT:     %arg1_1, %arg2_1 = "test.op"() : () -> (i32, i16)
 // CHECK-NEXT:     %call_res = "csl.call"(%arg1_1, %arg2_1) <{"callee" = @func_with_args}> : (i32, i16) -> i32
+// CHECK-NEXT:     %attr_struct = "csl.const_struct"() <{"items" = {"i" = 42 : i32, "f" = 3.700000e+00 : f32}}> : () -> !csl.comptime_struct
+// CHECK-NEXT:     %ssa_struct = "csl.const_struct"(%arg1_1, %arg2_1, %col) <{"ssa_fields" = ["i32_", "i16_", "col"]}> : (i32, i16, !csl.color) -> !csl.comptime_struct
+// CHECK-NEXT:     %mixed_struct = "csl.const_struct"(%arg1_1, %arg2_1, %col) <{"ssa_fields" = ["i32_", "i16_", "col"], "items" = {"i" = 42 : i32, "f" = 3.700000e+00 : f32}}> : (i32, i16, !csl.color) -> !csl.comptime_struct
+// CHECK-NEXT:     %col_1 = "csl.get_color"() <{"id" = 3 : i5}> : () -> !csl.color
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -69,6 +69,12 @@ csl.func @initialize() {
 
 "csl.module"() <{kind = #csl<module_kind layout>}> ({
   csl.layout {
+    %x_dim, %y_dim = "test.op"() : () -> (i32, i32)
+    "csl.set_rectangle"(%x_dim, %y_dim) : (i32, i32) -> ()
+
+
+    %x_coord, %y_coord, %params = "test.op"() : () -> (i32, i32, !csl.comptime_struct)
+    "csl.set_tile_code"(%x_coord, %y_coord, %params) <{file = "pe_program.csl"}> : (i32, i32, !csl.comptime_struct) -> ()
   }
 }) {sym_name = "layout"} : () -> ()
 
@@ -115,7 +121,10 @@ csl.func @initialize() {
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()
 // CHECK-NEXT: "csl.module"() <{"kind" = #csl<module_kind layout>}> ({
 // CHECK-NEXT: csl.layout {
-// CHECK-NEXT:   ^0:
+// CHECK-NEXT:   x_dim, %y_dim = "test.op"() : () -> (i32, i32)
+// CHECK-NEXT:   "csl.set_rectangle"(%x_dim, %y_dim) : (i32, i32) -> ()
+// CHECK-NEXT:   %x_coord, %y_coord, %params = "test.op"() : () -> (i32, i32, !csl.comptime_struct)
+// CHECK-NEXT:   "csl.set_tile_code"(%x_coord, %y_coord, %params) <{"file" = "pe_program.csl"}> : (i32, i32, !csl.comptime_struct) -> ()
 // CHECK-NEXT: }
 // CHECK-NEXT: }) {"sym_name" = "layout"} : () -> ()
 // CHECK-NEXT: }

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -621,6 +621,16 @@ class CallOp(IRDLOperation):
 
 
 @irdl_op_definition
+class SetRectangleOp(IRDLOperation):
+    name = "csl.set_rectangle"
+
+    traits = frozenset([HasParent(LayoutOp)])
+
+    x_dim = operand_def(IntegerType)
+    y_dim = operand_def(IntegerType)
+
+
+@irdl_op_definition
 class SetTileCodeOp(IRDLOperation):
     name = "csl.set_tile_code"
 
@@ -647,6 +657,7 @@ CSL = Dialect(
         TaskOp,
         ConstStructOp,
         GetColorOp,
+        SetRectangleOp,
         SetTileCodeOp,
     ],
     [

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
@@ -272,6 +272,12 @@ class ColorType(ParametrizedAttribute, TypeAttribute):
     name = "csl.color"
 
 
+ColorIdAttr: TypeAlias = (
+    IntegerAttr[Annotated[IntegerType, IntegerType(5)]]
+    | IntegerAttr[Annotated[IntegerType, IntegerType(6)]]
+)
+
+
 @irdl_op_definition
 class CslModuleOp(IRDLOperation):
     """
@@ -416,7 +422,7 @@ class TaskOp(_FuncBase):
     name = "csl.task"
 
     kind = prop_def(TaskKindAttr)
-    id = opt_prop_def(IntegerAttr[IntegerType])
+    id = opt_prop_def(ColorIdAttr)
 
     traits = frozenset([InModuleKind(ModuleKind.PROGRAM)])
 
@@ -429,7 +435,7 @@ class TaskOp(_FuncBase):
         task_kind: TaskKindAttr | TaskKind,
         arg_attrs: ArrayAttr[DictionaryAttr] | None = None,
         res_attrs: ArrayAttr[DictionaryAttr] | None = None,
-        id: IntegerAttr[IntegerType] | int | None,
+        id: ColorIdAttr | int | None,
     ):
         properties, region = self._props_region(
             name, function_type, region, arg_attrs=arg_attrs, res_attrs=res_attrs
@@ -496,7 +502,7 @@ class TaskOp(_FuncBase):
         ):
             parser.raise_error(f"{cls.name} expected kind attribute")
         id = extra_attrs.data.get("id")
-        if id is not None and not isa(id, IntegerAttr[IntegerType]):
+        if id is not None and not isa(id, ColorIdAttr):
             parser.raise_error(f"{cls.name} expected kind attribute")
 
         assert (

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -317,6 +317,28 @@ class ImportModuleConstOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ConstStructOp(IRDLOperation):
+    name = "csl.const_struct"
+
+    items = opt_prop_def(DictionaryAttr)
+    ssa_fields = opt_prop_def(ArrayAttr[StringAttr])
+    ssa_values = var_operand_def()
+    res = result_def(ComptimeStructType)
+
+    def verify_(self) -> None:
+        if self.ssa_fields is None:
+            if len(self.ssa_values) == 0:
+                return super().verify_()
+        else:
+            if len(self.ssa_values) == len(self.ssa_fields):
+                return super().verify_()
+
+        raise VerifyException(
+            "Number of ssa_fields has to match the number of arguments"
+        )
+
+
+@irdl_op_definition
 class MemberAccessOp(IRDLOperation):
     """
     Access a member of a struct and assigna a new variable.
@@ -602,6 +624,7 @@ CSL = Dialect(
         LayoutOp,
         CallOp,
         TaskOp,
+        ConstStructOp,
     ],
     [
         ComptimeStructType,

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -339,6 +339,14 @@ class ConstStructOp(IRDLOperation):
 
 
 @irdl_op_definition
+class GetColorOp(IRDLOperation):
+    name = "csl.get_color"
+
+    id = prop_def(ColorIdAttr)
+    res = result_def(ColorType)
+
+
+@irdl_op_definition
 class MemberAccessOp(IRDLOperation):
     """
     Access a member of a struct and assigna a new variable.
@@ -625,6 +633,7 @@ CSL = Dialect(
         CallOp,
         TaskOp,
         ConstStructOp,
+        GetColorOp,
     ],
     [
         ComptimeStructType,

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -620,6 +620,19 @@ class CallOp(IRDLOperation):
     # TODO(dk949): verify that if Call is used outside of a csl.func or csl.task it has a result
 
 
+@irdl_op_definition
+class SetTileCodeOp(IRDLOperation):
+    name = "csl.set_tile_code"
+
+    traits = frozenset([HasParent(LayoutOp)])
+
+    file = prop_def(StringAttr)
+
+    x_coord = operand_def(IntegerType)
+    y_coord = operand_def(IntegerType)
+    params = opt_operand_def(ComptimeStructType)
+
+
 CSL = Dialect(
     "csl",
     [
@@ -634,6 +647,7 @@ CSL = Dialect(
         TaskOp,
         ConstStructOp,
         GetColorOp,
+        SetTileCodeOp,
     ],
     [
         ComptimeStructType,


### PR DESCRIPTION
This PR adds: 
* `csl.const_struct`
    * `comptime_struct` literal constructor
* `csl.get_color`
    * Corresponds to `@get_color` in CSL
* `csl.set_rectangle`
    * Corresponds to `@set_rectangle` in CSL
* `csl.set_tile_code`
    * Corresponds to `@set_tile_code` in CSL