### PR TITLE
dialects: (csl) Added operations to manage symbols

### DIFF
--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -84,6 +84,9 @@ csl.func @initialize() {
   type = !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
 }> : (!csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>) -> ()
 
+%rpc_col = "test.op"() : () -> !csl.color
+"csl.rpc"(%rpc_col) : (!csl.color) -> ()
+
 }) {sym_name = "program"} :  () -> ()
 
 "csl.module"() <{kind = #csl<module_kind layout>}> ({
@@ -145,6 +148,8 @@ csl.func @initialize() {
 // CHECK-NEXT: "csl.export"() <{"var_name" = @initialize, "type" = () -> ()}> : () -> ()
 // CHECK-NEXT: "csl.export"() <{"var_name" = @global_ptr, "type" = !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>}> : () -> ()
 // CHECK-NEXT: "csl.export"(%other_global_ptr) <{"var_name" = "some_name", "type" = !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>}> : (!csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>) -> ()
+// CHECK-NEXT: %rpc_col = "test.op"() : () -> !csl.color
+// CHECK-NEXT: "csl.rpc"(%rpc_col) : (!csl.color) -> ()
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()
 // CHECK-NEXT: "csl.module"() <{"kind" = #csl<module_kind layout>}> ({
 // CHECK-NEXT: csl.layout {

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -71,8 +71,19 @@ csl.func @initialize() {
     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 
 
+
   csl.return
 }
+
+%other_global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
+
+"csl.export"() <{var_name = @initialize, type = () -> ()}> : () -> ()
+"csl.export"() <{var_name = @global_ptr, type = !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>}> : () -> ()
+"csl.export"(%other_global_ptr) <{
+  var_name = "some_name",
+  type = !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
+}> : (!csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>) -> ()
+
 }) {sym_name = "program"} :  () -> ()
 
 "csl.module"() <{kind = #csl<module_kind layout>}> ({
@@ -130,6 +141,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
+// CHECK-NEXT: %other_global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
+// CHECK-NEXT: "csl.export"() <{"var_name" = @initialize, "type" = () -> ()}> : () -> ()
+// CHECK-NEXT: "csl.export"() <{"var_name" = @global_ptr, "type" = !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>}> : () -> ()
+// CHECK-NEXT: "csl.export"(%other_global_ptr) <{"var_name" = "some_name", "type" = !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>}> : (!csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>) -> ()
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()
 // CHECK-NEXT: "csl.module"() <{"kind" = #csl<module_kind layout>}> ({
 // CHECK-NEXT: csl.layout {

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -63,6 +63,14 @@ csl.func @initialize() {
 
     %col_1 = "csl.get_color"() <{id = 3 : i5}> : () -> !csl.color
 
+
+    %arr, %scalar = "test.op"() : () -> (memref<10xf32>, i32)
+
+    %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
+    %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
+    %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
+
+
   csl.return
 }
 }) {sym_name = "program"} :  () -> ()
@@ -116,6 +124,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %ssa_struct = "csl.const_struct"(%arg1_1, %arg2_1, %col) <{"ssa_fields" = ["i32_", "i16_", "col"]}> : (i32, i16, !csl.color) -> !csl.comptime_struct
 // CHECK-NEXT:     %mixed_struct = "csl.const_struct"(%arg1_1, %arg2_1, %col) <{"ssa_fields" = ["i32_", "i16_", "col"], "items" = {"i" = 42 : i32, "f" = 3.700000e+00 : f32}}> : (i32, i16, !csl.color) -> !csl.comptime_struct
 // CHECK-NEXT:     %col_1 = "csl.get_color"() <{"id" = 3 : i5}> : () -> !csl.color
+// CHECK-NEXT:     %arr, %scalar = "test.op"() : () -> (memref<10xf32>, i32)
+// CHECK-NEXT:     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
+// CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
+// CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -90,6 +90,8 @@ csl.func @initialize() {
 }) {sym_name = "program"} :  () -> ()
 
 "csl.module"() <{kind = #csl<module_kind layout>}> ({
+  %comp_const = "csl.param"() <{param_name = "comp_constant"}> : () -> i32
+  %comp_const_with_def = "csl.param"() <{param_name = "comp_constant", init_value = 1 : i32}> : () -> i32
   csl.layout {
     %x_dim, %y_dim = "test.op"() : () -> (i32, i32)
     "csl.set_rectangle"(%x_dim, %y_dim) : (i32, i32) -> ()
@@ -152,6 +154,8 @@ csl.func @initialize() {
 // CHECK-NEXT: "csl.rpc"(%rpc_col) : (!csl.color) -> ()
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()
 // CHECK-NEXT: "csl.module"() <{"kind" = #csl<module_kind layout>}> ({
+// CHECK-NEXT:  %comp_const = "csl.param"() <{"param_name" = "comp_constant"}> : () -> i32
+// CHECK-NEXT:  %comp_const_with_def = "csl.param"() <{"param_name" = "comp_constant", "init_value" = 1 : i32}> : () -> i32
 // CHECK-NEXT: csl.layout {
 // CHECK-NEXT:   x_dim, %y_dim = "test.op"() : () -> (i32, i32)
 // CHECK-NEXT:   "csl.set_rectangle"(%x_dim, %y_dim) : (i32, i32) -> ()

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -75,11 +75,10 @@ csl.func @initialize() {
   csl.return
 }
 
-%other_global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
+%global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
 
 "csl.export"() <{var_name = @initialize, type = () -> ()}> : () -> ()
-"csl.export"() <{var_name = @global_ptr, type = !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>}> : () -> ()
-"csl.export"(%other_global_ptr) <{
+"csl.export"(%global_ptr) <{
   var_name = "some_name",
   type = !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
 }> : (!csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>) -> ()
@@ -146,10 +145,9 @@ csl.func @initialize() {
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
-// CHECK-NEXT: %other_global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
+// CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
 // CHECK-NEXT: "csl.export"() <{"var_name" = @initialize, "type" = () -> ()}> : () -> ()
-// CHECK-NEXT: "csl.export"() <{"var_name" = @global_ptr, "type" = !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>}> : () -> ()
-// CHECK-NEXT: "csl.export"(%other_global_ptr) <{"var_name" = "some_name", "type" = !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>}> : (!csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>) -> ()
+// CHECK-NEXT: "csl.export"(%global_ptr) <{"var_name" = "some_name", "type" = !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>}> : (!csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>) -> ()
 // CHECK-NEXT: %rpc_col = "test.op"() : () -> !csl.color
 // CHECK-NEXT: "csl.rpc"(%rpc_col) : (!csl.color) -> ()
 // CHECK-NEXT: }) {"sym_name" = "program"} :  () -> ()

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -736,6 +736,21 @@ class AddressOfOp(IRDLOperation):
         return super().verify_()
 
 
+@irdl_op_definition
+class RpcOp(IRDLOperation):
+    """
+    represents a call to `@rpc`
+
+    When printing should wrap id in `@get_data_task_id`
+    """
+
+    name = "csl.rpc"
+
+    traits = frozenset([InModuleKind(ModuleKind.PROGRAM)])
+
+    id = operand_def(ColorType)
+
+
 CSL = Dialect(
     "csl",
     [
@@ -754,6 +769,7 @@ CSL = Dialect(
         SetTileCodeOp,
         AddressOfOp,
         SymbolExportOp,
+        RpcOp,
     ],
     [
         ComptimeStructType,

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -688,6 +688,10 @@ class SymbolExportOp(IRDLOperation):
                 raise VerifyException(
                     "When passing var_name as a string, operand also has to be supplied"
                 )
+            if not isinstance(self.type, PtrType):
+                raise VerifyException(
+                    "When passing operand and name as string, type has to be a pointer type"
+                )
             if self.value.type != self.type:
                 raise VerifyException(
                     "Type of the operand has to match the type property"
@@ -696,6 +700,10 @@ class SymbolExportOp(IRDLOperation):
             if self.value is not None:
                 raise VerifyException(
                     "When passing var_name as a symbol, operand cannot be supplied"
+                )
+            if not isinstance(self.type, FunctionType):
+                raise VerifyException(
+                    "When passing a symbol, type has to be a function type"
                 )
 
         return super().verify_()

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -716,6 +716,19 @@ class AddressOfOp(IRDLOperation):
     res = result_def(PtrType)
 
     def _verify_memref_addr(self, val_ty: MemRefType[Attribute], res_ty: PtrType):
+        """
+        Verify that if the address of a memref is taken, the resulting pointer is either:
+            A single pointer to the array type or
+            A many pointer to the array element type
+        E.g.
+            const x: [10]f32;
+            const arr_ptr: *[10]f32 = &x;
+            const elem_ptr: [*]f32 = &x;
+            // const invalid: [*]i32 = &x;
+            // const invalid: *f32 = &x;
+            // const invalid: [*][10]f32 = &x;
+        """
+
         res_elem_ty = res_ty.get_element_type()
         if res_elem_ty == val_ty.get_element_type():
             if res_ty.kind.data != PtrKind.MANY:


### PR DESCRIPTION
This PR adds:

* `csl.addressof`
    * Take address of a value (required for `csl.export`)
* `csl.export`
    * Exports symbol by ssa value and name (as a string) or by symbol name
* `csl.rpc`
    * equivalend to `@rpc` in the language
    * _NOTE:_ I thought `@rpc` was going away in SDK 1.1, but now I can't find a reference to it in the documentation.
* `csl.param`
    * Module import parameters (with optional default values)