### PR TITLE
core: enabling pattern rewrite for subscripted ops

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -49,6 +49,8 @@ from xdsl.dialects.arith import (
 from xdsl.dialects.builtin import (
     AnyTensorType,
     AnyVectorType,
+    Float16Type,
+    Float32Type,
     FloatAttr,
     IndexType,
     IntegerType,
@@ -368,3 +370,17 @@ def test_extui_incorrect_bitwidth():
     # bitwidth of b has to be larger than the one of a
     with pytest.raises(VerifyException):
         _extui_op = ExtUIOp(a, i32).verify()
+
+
+def test_op():
+    one = Constant(FloatAttr(1.0, Float16Type()))
+    two = Constant(FloatAttr(2.0, Float32Type()))
+    addf = Addf(one, two)
+    assert isa(addf, BinaryOperation[Attribute])
+    # it'd be great if the following would pass
+    assert not isa(addf, BinaryOperation[Float16Type | Float32Type])
+    assert isa(addf, BinaryOperation)
+    assert isa(addf, FloatingPointLikeBinaryOp)
+    assert not isa(
+        addf, BinaryOperation[int]  # pyright: ignore [reportGeneralTypeIssues]
+    )

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -378,7 +378,7 @@ def test_op():
     addf = Addf(one, two)
     assert isa(addf, BinaryOperation[Attribute])
     # it'd be great if the following would pass
-    assert not isa(addf, BinaryOperation[Float16Type | Float32Type])
+    # assert not isa(addf, BinaryOperation[Float16Type | Float32Type])
     assert isa(addf, BinaryOperation)
     assert isa(addf, FloatingPointLikeBinaryOp)
     assert not isa(

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -1,8 +1,16 @@
 from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
+from xdsl.dialects.arith import (
+    Addf,
+    BinaryOperation,
+    Constant,
+    FloatingPointLikeBinaryOp,
+)
 from xdsl.dialects.builtin import (
     ArrayAttr,
     DictionaryAttr,
+    Float32Type,
+    FloatAttr,
     FloatData,
     IndexType,
     IntAttr,
@@ -395,3 +403,22 @@ def test_literal():
 
     assert not isa(1, Literal["1"])
     assert not isa("1", Literal[1])
+
+
+################################################################################
+# Op
+################################################################################
+
+
+def test_op():
+    one = Constant(FloatAttr(1.0, Float32Type()))
+    two = Constant(FloatAttr(2.0, Float32Type()))
+    addf = Addf(one, two)
+    assert isa(addf, BinaryOperation[Attribute])
+    assert isa(addf, BinaryOperation)
+    # assert isa(addf, BinaryOperation[Float32Type])
+    # assert not isa(addf, BinaryOperation[Float16Type])
+    assert isa(addf, FloatingPointLikeBinaryOp)
+    assert not isa(
+        addf, BinaryOperation[int]
+    )  # pyright: ignore [reportGeneralTypeIssues]

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -420,5 +420,5 @@ def test_op():
     # assert not isa(addf, BinaryOperation[Float16Type])
     assert isa(addf, FloatingPointLikeBinaryOp)
     assert not isa(
-        addf, BinaryOperation[int]
-    )  # pyright: ignore [reportGeneralTypeIssues]
+        addf, BinaryOperation[int]  # pyright: ignore [reportGeneralTypeIssues]
+    )

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -378,6 +378,8 @@ def op_type_rewrite_pattern(
     expected_types = (expected_type,)
     if get_origin(expected_type) in [Union, UnionType]:
         expected_types = get_args(expected_type)
+    elif (t := get_origin(expected_type)) is not None:
+        expected_types = (t,)
 
     if not all(issubclass(t, Operation) for t in expected_types):
         raise Exception(
@@ -387,7 +389,7 @@ def op_type_rewrite_pattern(
         )
 
     def impl(self: _RewritePatternT, op: Operation, rewriter: PatternRewriter) -> None:
-        if isinstance(op, expected_type):
+        if isa(op, expected_type):
             func(self, op, rewriter)
 
     return impl

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -1,9 +1,9 @@
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import TypeGuard, cast
 
 from attr import dataclass
 
-from xdsl.dialects.arith import Addf, Divf, FloatingPointLikeBinaryOp, Mulf, Subf
+from xdsl.dialects.arith import BinaryOperation
 from xdsl.dialects.builtin import (
     AnyFloat,
     ContainerType,
@@ -145,16 +145,16 @@ class AccessOpTensorize(RewritePattern):
 
 
 def arithBinaryOpTensorize(
-    type_constructor: Callable[..., FloatingPointLikeBinaryOp],
-    op: FloatingPointLikeBinaryOp,
+    op: BinaryOperation[Attribute],
     rewriter: PatternRewriter,
     /,
 ):
+    type_constructor = type(op)
     if is_tensor(op.result.type):
         return
     if is_tensor(op.lhs.type) and is_tensor(op.rhs.type):
         rewriter.replace_matched_op(
-            type_constructor(op.lhs, op.rhs, flags=None, result_type=op.lhs.type)
+            type_constructor(op.lhs, op.rhs, result_type=op.lhs.type)
         )
     elif is_tensor(op.lhs.type) and is_scalar(op.rhs.type):
         emptyop = EmptyOp((), op.lhs.type)
@@ -162,7 +162,7 @@ def arithBinaryOpTensorize(
         rewriter.insert_op_before(emptyop, op)
         rewriter.insert_op_before(fillop, op)
         rewriter.replace_matched_op(
-            type_constructor(op.lhs, fillop, flags=None, result_type=op.lhs.type)
+            type_constructor(op.lhs, fillop, result_type=op.lhs.type)
         )
     elif is_scalar(op.lhs.type) and is_tensor(op.rhs.type):
         emptyop = EmptyOp((), op.rhs.type)
@@ -170,32 +170,16 @@ def arithBinaryOpTensorize(
         rewriter.insert_op_before(emptyop, op)
         rewriter.insert_op_before(fillop, op)
         rewriter.replace_matched_op(
-            type_constructor(fillop, op.rhs, flags=None, result_type=op.rhs.type)
+            type_constructor(fillop, op.rhs, result_type=op.rhs.type)
         )
 
 
-class ArithAddfOpTensorize(RewritePattern):
+class ArithOpTensorize(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Addf, rewriter: PatternRewriter, /):
-        arithBinaryOpTensorize(Addf, op, rewriter)
-
-
-class ArithSubfOpTensorize(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Subf, rewriter: PatternRewriter, /):
-        arithBinaryOpTensorize(Subf, op, rewriter)
-
-
-class ArithMulfOpTensorize(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Mulf, rewriter: PatternRewriter, /):
-        arithBinaryOpTensorize(Mulf, op, rewriter)
-
-
-class ArithDivfOpTensorize(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Divf, rewriter: PatternRewriter, /):
-        arithBinaryOpTensorize(Divf, op, rewriter)
+    def match_and_rewrite(
+        self, op: BinaryOperation[Attribute], rewriter: PatternRewriter, /
+    ):
+        arithBinaryOpTensorize(op, rewriter)
 
 
 @dataclass(frozen=True)
@@ -323,40 +307,24 @@ class ExtractSliceOpUpdateShape(RewritePattern):
 
 
 def arithBinaryOpUpdateShape(
-    type_constructor: Callable[..., FloatingPointLikeBinaryOp],
-    op: FloatingPointLikeBinaryOp,
+    op: BinaryOperation[Attribute],
     rewriter: PatternRewriter,
     /,
 ):
+    type_constructor = type(op)
     if typ := get_required_result_type(op):
         if needs_update_shape(op.result.type, typ):
             rewriter.replace_matched_op(
-                type_constructor(op.lhs, op.rhs, flags=None, result_type=typ)
+                type_constructor(op.lhs, op.rhs, result_type=typ)
             )
 
 
-class ArithAddfOpUpdateShape(RewritePattern):
+class ArithOpUpdateShape(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Addf, rewriter: PatternRewriter, /):
-        arithBinaryOpUpdateShape(Addf, op, rewriter)
-
-
-class ArithSubfOpUpdateShape(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Subf, rewriter: PatternRewriter, /):
-        arithBinaryOpUpdateShape(Subf, op, rewriter)
-
-
-class ArithMulfOpUpdateShape(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Mulf, rewriter: PatternRewriter, /):
-        arithBinaryOpUpdateShape(Mulf, op, rewriter)
-
-
-class ArithDivfOpUpdateShape(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: Divf, rewriter: PatternRewriter, /):
-        arithBinaryOpUpdateShape(Divf, op, rewriter)
+    def match_and_rewrite(
+        self, op: BinaryOperation[Attribute], rewriter: PatternRewriter, /
+    ):
+        arithBinaryOpUpdateShape(op, rewriter)
 
 
 class EmptyOpUpdateShape(RewritePattern):
@@ -401,10 +369,7 @@ class StencilTensorizeZDimension(ModulePass):
             GreedyRewritePatternApplier(
                 [
                     AccessOpTensorize(),
-                    ArithAddfOpTensorize(),
-                    ArithMulfOpTensorize(),
-                    ArithSubfOpTensorize(),
-                    ArithDivfOpTensorize(),
+                    ArithOpTensorize(),
                 ]
             ),
             walk_reverse=False,
@@ -418,10 +383,7 @@ class StencilTensorizeZDimension(ModulePass):
                     ExtractSliceOpUpdateShape(),
                     EmptyOpUpdateShape(),
                     FillOpUpdateShape(),
-                    ArithAddfOpUpdateShape(),
-                    ArithSubfOpUpdateShape(),
-                    ArithMulfOpUpdateShape(),
-                    ArithDivfOpUpdateShape(),
+                    ArithOpUpdateShape(),
                 ]
             ),
             walk_reverse=True,

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -100,7 +100,7 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
 
         def extract_args(arg_t: type[Any]) -> type[Any]:
             if hasattr(arg_t, "__orig_bases__"):
-                return extract_args(types.get_original_bases(arg_t)[0])
+                return extract_args(arg_t.__orig_bases__[0])
             elif not isclass(arg_t) and isclass(get_args(arg_t)[0]):
                 return get_args(arg_t)[0]
             elif (


### PR DESCRIPTION
This PR enables the pattern rewriter to support matching things like:

```
@op_type_rewrite_pattern
def match_and_rewrite(
    self, op: BinaryOperation[Attribute], rewriter: PatternRewriter, /
):
   ....
```

Currently, matching is supported for un-subscripted types (like `BinaryOperation`) but pyright will note that there are incomplete type information. Adding subscripts (as shown above) will pass pyright checks and we'd like to support it by extending `isa` and by using `isa` rather than `isinstance` in the pattern rewriter.

An additional test function shows how `arith.Addf` is matched into the above type. It is an interesting case, because accessing the underlying type is not immediately straightforward, as several things need resolving:
* calling `get_args` will not work directly as it doesn't expose any args, instead we have to go to the superclass
* the superclass is a type alias which needs resolving
* the args are `Annotated` which evaluates to the type of its first param

It might be interesting to match `BinaryOperation[Float32Type]`, but note that it appears the operation does not actually appear to carry that type information.