### PR TITLE
tests: Wrapped all %s that refer to paths with "

### DIFF
--- a/docs/Toy/examples/ast.toy
+++ b/docs/Toy/examples/ast.toy
@@ -1,4 +1,4 @@
-# RUN: python -m toy %s --emit=ast | filecheck %s
+# RUN: python -m toy "%s" --emit=ast | filecheck "%s"
 
 # User defined generic function that operates on unknown shaped arguments.
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/codegen.toy
+++ b/docs/Toy/examples/codegen.toy
@@ -1,4 +1,4 @@
-# RUN: python -m toy %s --emit=toy --ir | filecheck %s
+# RUN: python -m toy "%s" --emit=toy --ir | filecheck "%s"
 
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/interpret.toy
+++ b/docs/Toy/examples/interpret.toy
@@ -1,13 +1,13 @@
-# RUN: python -m toy %s --emit=toy | filecheck %s
-# RUN: python -m toy %s --emit=toy-opt | filecheck %s
-# RUN: python -m toy %s --emit=toy-inline | filecheck %s
-# RUN: python -m toy %s --emit=toy-infer-shapes | filecheck %s
-# RUN: python -m toy %s --emit=affine | filecheck %s
-# RUN: python -m toy %s --emit=scf | filecheck %s
-# RUN: python -m toy %s --emit=riscv | filecheck %s
-# RUN: python -m toy %s --emit=riscv-regalloc | filecheck %s
-# RUN: python -m toy %s --emit=riscv-lowered | filecheck %s
-# RUN: python -m toy %s --emit=riscv-asm | filecheck %s
+# RUN: python -m toy "%s" --emit=toy | filecheck "%s"
+# RUN: python -m toy "%s" --emit=toy-opt | filecheck "%s"
+# RUN: python -m toy "%s" --emit=toy-inline | filecheck "%s"
+# RUN: python -m toy "%s" --emit=toy-infer-shapes | filecheck "%s"
+# RUN: python -m toy "%s" --emit=affine | filecheck "%s"
+# RUN: python -m toy "%s" --emit=scf | filecheck "%s"
+# RUN: python -m toy "%s" --emit=riscv | filecheck "%s"
+# RUN: python -m toy "%s" --emit=riscv-regalloc | filecheck "%s"
+# RUN: python -m toy "%s" --emit=riscv-lowered | filecheck "%s"
+# RUN: python -m toy "%s" --emit=riscv-asm | filecheck "%s"
 
 # User defined generic function that operates on unknown shaped arguments
 def multiply_transpose(a, b) {

--- a/docs/Toy/examples/scalar.toy
+++ b/docs/Toy/examples/scalar.toy
@@ -1,4 +1,4 @@
-# RUN: python -m toy %s --emit=toy --ir | filecheck %s
+# RUN: python -m toy "%s" --emit=toy --ir | filecheck "%s"
 
 def main() {
   var a<2, 2> = 5.5;

--- a/docs/Toy/examples/tests/infer_shapes.mlir
+++ b/docs/Toy/examples/tests/infer_shapes.mlir
@@ -1,4 +1,4 @@
-// RUN: python -m toy %s --emit=toy-infer-shapes --ir | filecheck %s
+// RUN: python -m toy "%s" --emit=toy-infer-shapes --ir | filecheck "%s"
 
 "builtin.module"() ({
   "toy.func"() ({

--- a/docs/Toy/examples/tests/inline.mlir
+++ b/docs/Toy/examples/tests/inline.mlir
@@ -1,4 +1,4 @@
-// RUN: python -m toy %s --emit=toy-inline --ir | filecheck %s
+// RUN: python -m toy "%s" --emit=toy-inline --ir | filecheck "%s"
 
 builtin.module {
 // CHECK: builtin.module {

--- a/docs/Toy/examples/tests/optimise_toy.mlir
+++ b/docs/Toy/examples/tests/optimise_toy.mlir
@@ -1,4 +1,4 @@
-// RUN: python -m toy %s --emit=toy-opt --ir | filecheck %s
+// RUN: python -m toy "%s" --emit=toy-opt --ir | filecheck "%s"
 
 "builtin.module"() ({
 // CHECK:       builtin.module {

--- a/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
+++ b/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-riscv-scf-to-riscv-cf --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p convert-riscv-scf-to-riscv-cf --split-input-file "%s" | filecheck "%s"
 
 
 builtin.module {

--- a/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf_with_regalloc.mlir
+++ b/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf_with_regalloc.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-allocate-registers,convert-riscv-scf-to-riscv-cf %s | filecheck %s
+// RUN: xdsl-opt -p riscv-allocate-registers,convert-riscv-scf-to-riscv-cf "%s" | filecheck "%s"
 
 builtin.module {
     riscv_func.func @sum_range(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>) {

--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t csl %s | filecheck %s
+// RUN: xdsl-opt -t csl "%s" | filecheck "%s"
 
 "csl.module"() <{kind=#csl<module_kind program>}> ({
 

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file -p canonicalize %s | filecheck %s
+// RUN: xdsl-opt --split-input-file -p canonicalize "%s" | filecheck "%s"
 
 builtin.module {
   %i0, %i1, %i2 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<>)

--- a/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-arith-to-riscv,reconcile-unrealized-casts %s | filecheck %s
+// RUN: xdsl-opt -p convert-arith-to-riscv,reconcile-unrealized-casts "%s" | filecheck "%s"
 builtin.module {
     %lhsi32 = "arith.constant"() {value = 1 : i32} : () -> i32
     // CHECK: %{{.*}} = riscv.li 1 : () -> !riscv.reg<>

--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-func-to-riscv-func --split-input-file  %s | filecheck %s
+// RUN: xdsl-opt -p convert-func-to-riscv-func --split-input-file  "%s" | filecheck "%s"
 
 builtin.module {
     func.func @main() {

--- a/tests/filecheck/backend/riscv/convert_riscv_scf_for_to_frep.mlir
+++ b/tests/filecheck/backend/riscv/convert_riscv_scf_for_to_frep.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-riscv-scf-for-to-frep %s | filecheck %s
+// RUN: xdsl-opt -p convert-riscv-scf-for-to-frep "%s" | filecheck "%s"
 
 %i0 = riscv.get_register : () -> !riscv.reg<>
 %i1 = riscv.get_register : () -> !riscv.reg<>

--- a/tests/filecheck/backend/riscv/func_and_arith_to_riscv_asm_flow.mlir
+++ b/tests/filecheck/backend/riscv/func_and_arith_to_riscv_asm_flow.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-func-to-riscv-func,convert-snrt-to-riscv{cluster-num=2},convert-arith-to-riscv,reconcile-unrealized-casts,riscv-allocate-registers -t riscv-asm | filecheck %s
+// RUN: xdsl-opt "%s" -p convert-func-to-riscv-func,convert-snrt-to-riscv{cluster-num=2},convert-arith-to-riscv,reconcile-unrealized-casts,riscv-allocate-registers -t riscv-asm | filecheck "%s"
 
 
 func.func @test(%dst: i32, %src: i32) -> i32 {

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-memref-to-riscv  --split-input-file --verify-diagnostics %s | filecheck %s
+// RUN: xdsl-opt -p convert-memref-to-riscv  --split-input-file --verify-diagnostics "%s" | filecheck "%s"
 
 builtin.module {
     %v_f32, %v_f64, %v_i32, %r, %c, %m_f32, %m_f64, %m_i32, %m_scalar_i32 = "test.op"() : () -> (f32, f64, i32, index, index, memref<3x2xf32>, memref<3x2xf64>, memref<3xi32>, memref<i32>)

--- a/tests/filecheck/backend/riscv/memref_to_riscv_opt.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv_opt.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file -p convert-memref-to-riscv,reconcile-unrealized-casts,canonicalize %s | filecheck %s
+// RUN: xdsl-opt --split-input-file -p convert-memref-to-riscv,reconcile-unrealized-casts,canonicalize "%s" | filecheck "%s"
 
 // Test that a memref float store and load with constant indices optimise to a single operation
 

--- a/tests/filecheck/backend/riscv/print_format_to_riscv_debug.mlir
+++ b/tests/filecheck/backend/riscv/print_format_to_riscv_debug.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-print-format-to-riscv-debug %s | filecheck %s
+// RUN: xdsl-opt -p convert-print-format-to-riscv-debug "%s" | filecheck "%s"
 
 %i32, %i64, %f32, %f64 = "test.op"() : () -> (i32, i64, f32, f64)
 

--- a/tests/filecheck/backend/riscv/register_allocation_exclude_snitch.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_exclude_snitch.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s
-// RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive exclude_snitch_reserved=false}" %s | filecheck %s --check-prefix=CHECK-SNITCH-UNRESERVED
+// RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" "%s" | filecheck "%s"
+// RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive exclude_snitch_reserved=false}" "%s" | filecheck "%s" --check-prefix=CHECK-SNITCH-UNRESERVED
 
 riscv_func.func @main() {
   %stream = "test.op"() : () -> (!stream.readable<!riscv.freg<ft0>>)

--- a/tests/filecheck/backend/riscv/register_allocation_frep.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_frep.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE
-// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=0}" %s | filecheck %s --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE-J
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" "%s" | filecheck "%s" --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=0}" "%s" | filecheck "%s" --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE-J
 
 riscv_func.func @main() {
   %0 = riscv.li 6 : () -> !riscv.reg<>

--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-allocate-registers{allocation_strategy=LivenessBlockNaive} %s | filecheck %s
+// RUN: xdsl-opt -p riscv-allocate-registers{allocation_strategy=LivenessBlockNaive} "%s" | filecheck "%s"
 
 builtin.module {
   riscv_func.func @main() {

--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=2}" %s | filecheck %s
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=2}" "%s" | filecheck "%s"
 
 riscv_func.func @main() {
   %0 = riscv.li  6 : () -> !riscv.reg<>

--- a/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s --check-prefix=LIVE-BNAIVE
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" "%s" | filecheck "%s" --check-prefix=LIVE-BNAIVE
 
 riscv_func.func @main() {
   %0 = riscv.li 6 : () -> !riscv.reg<>

--- a/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
+++ b/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE
-// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=0}" %s | filecheck %s --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE-J
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" "%s" | filecheck "%s" --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE
+// RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=0}" "%s" | filecheck "%s" --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE-J
 
 riscv_func.func @external() -> ()
 

--- a/tests/filecheck/backend/riscv/verify.mlir
+++ b/tests/filecheck/backend/riscv/verify.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+// RUN: xdsl-opt --split-input-file --verify-diagnostics "%s" | filecheck "%s"
 
 %i1 = "test.op"() : () -> !riscv.reg<a1>
 %1 = riscv.li 1 : () -> !riscv.reg<>

--- a/tests/filecheck/backend/rvscf_lowering_labels.mlir
+++ b/tests/filecheck/backend/rvscf_lowering_labels.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-riscv-scf-to-labels --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p lower-riscv-scf-to-labels --split-input-file "%s" | filecheck "%s"
 
 // sum(range(arg0, arg1))
 

--- a/tests/filecheck/backend/rvscf_scf_lowering.mlir
+++ b/tests/filecheck/backend/rvscf_scf_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-scf-to-riscv-scf %s | filecheck %s
+// RUN: xdsl-opt -p convert-scf-to-riscv-scf "%s" | filecheck "%s"
 
 builtin.module {
   %c0 = arith.constant 0 : index

--- a/tests/filecheck/dce.mlir
+++ b/tests/filecheck/dce.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p dce | filecheck %s
+// RUN: xdsl-opt "%s" -p dce | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> i32

--- a/tests/filecheck/dialects/affine/invalid.mlir
+++ b/tests/filecheck/dialects/affine/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics --split-input-file | filecheck "%s"
 
 %N = "test.op"() : () -> index
 "affine.parallel"(%N) <{"lowerBoundsMap" = affine_map<(i) -> (i)>, "lowerBoundsGroups" = dense<1> : vector<1xi32>, "upperBoundsMap" = affine_map<()[s0] -> (s0)>, "upperBoundsGroups" = dense<1> : vector<1xi32>, "steps" = [1 : i64], "reductions" = []}> ({

--- a/tests/filecheck/dialects/arith/arith_cfg.mlir
+++ b/tests/filecheck/dialects/arith/arith_cfg.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s
+// RUN: xdsl-opt "%s"
 
 // This file tests that the parser does not assert in case the block
 // ordering seemingly indicates that an operand is not yet defined.

--- a/tests/filecheck/dialects/arith/arith_constant_fold_interp.mlir
+++ b/tests/filecheck/dialects/arith/arith_constant_fold_interp.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p constant-fold-interp | filecheck %s
+// RUN: xdsl-opt "%s" -p constant-fold-interp | filecheck "%s"
 
 // CHECK: builtin.module {
 

--- a/tests/filecheck/dialects/arith/arith_invalid.mlir
+++ b/tests/filecheck/dialects/arith/arith_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p canonicalize %s | filecheck %s
+// RUN: xdsl-opt -p canonicalize "%s" | filecheck "%s"
 
 %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
 %lhsvec, %rhsvec = "test.op"() : () -> (vector<4xf32>, vector<4xf32>)

--- a/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
+++ b/tests/filecheck/dialects/builtin/dense_array_invalid_dims.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics | filecheck "%s"
 
 "builtin.module" () {"test" = array<i32: "", 3>} ({
 })

--- a/tests/filecheck/dialects/builtin/dense_array_invalid_element.mlir
+++ b/tests/filecheck/dialects/builtin/dense_array_invalid_element.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics | filecheck "%s"
 
 "builtin.module" () {"test" = array<()->(): 2, 5, 2>} ({
 })

--- a/tests/filecheck/dialects/builtin/parse_with_location.mlir
+++ b/tests/filecheck/dialects/builtin/parse_with_location.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" --print-op-generic | filecheck "%s"
 // CHECK: module
 "builtin.module"() ({
   // CHECK: ^{{.*}}(%{{.*}}: i32):

--- a/tests/filecheck/dialects/comb/comb_ops_err.mlir
+++ b/tests/filecheck/dialects/comb/comb_ops_err.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics --parsing-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics --parsing-diagnostics --split-input-file | filecheck "%s"
 
 builtin.module {
     %a = "test.op"() : () -> i32

--- a/tests/filecheck/dialects/dmp/canonicalize.mlir
+++ b/tests/filecheck/dialects/dmp/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p canonicalize-dmp %s | filecheck %s
+// RUN: xdsl-opt -p canonicalize-dmp "%s" | filecheck "%s"
 
 builtin.module {
     %ref = "test.op"() : () -> (memref<1024x1024xf32>)

--- a/tests/filecheck/dialects/fsm/fsm_invalid.mlir
+++ b/tests/filecheck/dialects/fsm/fsm_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics --split-input-file | filecheck "%s"
 
 "fsm.machine"() ({
     ^bb0(%arg0: i1):

--- a/tests/filecheck/dialects/func/func_invalid.mlir
+++ b/tests/filecheck/dialects/func/func_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck "%s"
 
 builtin.module {
   func.func @cus_arg_rec(%0 : !test.type<"int">) -> !test.type<"int"> {

--- a/tests/filecheck/dialects/func/func_ops_generic.mlir
+++ b/tests/filecheck/dialects/func/func_ops_generic.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" --print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "func.func"() <{function_type = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), res_attrs = [{llvm.noalias}, {llvm.noalias}], sym_name = "arg_attrs", sym_visibility = "public"}> ({
 ^bb0(%arg0: tensor<8x8xf64>, %arg1: tensor<8x8xf64>):

--- a/tests/filecheck/dialects/gpu/invalid.mlir
+++ b/tests/filecheck/dialects/gpu/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics --parsing-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics --parsing-diagnostics --split-input-file | filecheck "%s"
 
 "builtin.module"()({
     "gpu.module"()({

--- a/tests/filecheck/dialects/hw/invalid.mlir
+++ b/tests/filecheck/dialects/hw/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   "test.op"() { "test" = #hw.innerNameRef<1> } : () -> ()

--- a/tests/filecheck/dialects/hw/invalid_instance.mlir
+++ b/tests/filecheck/dialects/hw/invalid_instance.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck "%s"
 
 hw.module @module() {
   hw.output

--- a/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
@@ -1,6 +1,6 @@
-// RUN: irdl-to-pyrdl %s | filecheck %s
-// RUN: irdl-to-pyrdl %s -o %t.py && cat %t.py | filecheck %s
-// RUN: irdl-to-pyrdl %s -o %t.py && python %t.py
+// RUN: irdl-to-pyrdl "%s" | filecheck "%s"
+// RUN: irdl-to-pyrdl "%s" -o "%t.py" && cat "%t.py" | filecheck "%s"
+// RUN: irdl-to-pyrdl "%s" -o "%t.py" && python "%t.py"
 
 // CHECK:      from xdsl.irdl import *
 // CHECK-NEXT: from xdsl.ir import *

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,4 +1,4 @@
-# RUN: coverage run %s | filecheck %s
+# RUN: coverage run "%s" | filecheck "%s"
 
 from xdsl.dialects.cmath import CMath
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl

--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck "%s"
 
 builtin.module {
     %f = "test.op"() : () -> !llvm.func<i32 (i32, ..., i32)>

--- a/tests/filecheck/dialects/memref/invalid_ops.mlir
+++ b/tests/filecheck/dialects/memref/invalid_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck "%s"
 
 builtin.module {
   "memref.global"() {"alignment" = 64 : i32, "sym_name" = "wrong_alignment_type", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/dialects/mpi/memref_compat.mlir
+++ b/tests/filecheck/dialects/mpi/memref_compat.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-mpi --print-op-generic %s
+// RUN: xdsl-opt -p lower-mpi --print-op-generic "%s"
 "builtin.module"() ({
     %ref = "memref.alloc"() {"alignment" = 32 : i64, "operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<100x14x14xf64>
     %buff, %count, %dtype = "mpi.unwrap_memref"(%ref) : (memref<100x14x14xf64>) -> (!llvm.ptr, i32, !mpi.datatype)

--- a/tests/filecheck/dialects/onnx/onnx_invalid.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt --verify-diagnostics --split-input-file "%s" | filecheck "%s"
 
 // Non-broadcastable operands are not allowed.
 

--- a/tests/filecheck/dialects/pdl/verifiers.mlir
+++ b/tests/filecheck/dialects/pdl/verifiers.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file --verify-diagnostics | filecheck "%s"
 
 pdl.pattern @NonConstantAttrInRewrite : benefit(0) {
     %op = pdl.operation "test.op"

--- a/tests/filecheck/dialects/printf/invalid.mlir
+++ b/tests/filecheck/dialects/printf/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file --verify-diagnostics | filecheck "%s"
 
 builtin.module {
     printf.print_format "This will fail {}"

--- a/tests/filecheck/dialects/printf/printf_to_llvm.mlir
+++ b/tests/filecheck/dialects/printf/printf_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p printf-to-llvm --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" -p printf-to-llvm --split-input-file | filecheck "%s"
 
 builtin.module {
     "func.func"() ({

--- a/tests/filecheck/dialects/riscv/frep_verification.mlir
+++ b/tests/filecheck/dialects/riscv/frep_verification.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+// RUN: xdsl-opt --split-input-file --verify-diagnostics "%s" | filecheck "%s"
 
 %i0 = "test.op"() : () -> !riscv.reg<>
 "riscv_snitch.frep_outer"(%i0) ({

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -t riscv-asm "%s" | filecheck "%s"
 
 "builtin.module"() ({
   riscv_func.func @main() {

--- a/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_cf/assembly_emission.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t riscv-asm %s | filecheck %s --match-full-lines
+// RUN: xdsl-opt -t riscv-asm "%s" | filecheck "%s" --match-full-lines
 
 %0 = riscv.get_register : () -> !riscv.reg<a0>
 %1 = riscv.get_register : () -> !riscv.reg<a1>

--- a/tests/filecheck/dialects/riscv_cf/canonicalize.mlir
+++ b/tests/filecheck/dialects/riscv_cf/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p canonicalize %s | filecheck %s
+// RUN: xdsl-opt -p canonicalize "%s" | filecheck "%s"
 
 riscv_func.func @at_least_once() {
     %one = riscv.li 1 : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/riscv_cf/verification.mlir
+++ b/tests/filecheck/dialects/riscv_cf/verification.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+// RUN: xdsl-opt --split-input-file --verify-diagnostics "%s" | filecheck "%s"
 
 %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<a2>, !riscv.reg<a3>, !riscv.reg<a2>, !riscv.reg<a3>)
 

--- a/tests/filecheck/dialects/riscv_debug/riscv_debug_ops.mlir
+++ b/tests/filecheck/dialects/riscv_debug/riscv_debug_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: XDSL_ROUNDTRIP
 // RUN: XDSL_GENERIC_ROUNDTRIP
-// RUN: xdsl-opt -t riscv-asm %s | filecheck %s --check-prefix=CHECK-ASM
+// RUN: xdsl-opt -t riscv-asm "%s" | filecheck "%s" --check-prefix=CHECK-ASM
 
 
 %0 = riscv.get_register : () -> !riscv.reg<a0>

--- a/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
+++ b/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-riscv-func %s | filecheck %s
+// RUN: xdsl-opt -p lower-riscv-func "%s" | filecheck "%s"
 
 "builtin.module"() ({
 // CHECK:      builtin.module {

--- a/tests/filecheck/dialects/riscv_func/lower_riscv_func_main.mlir
+++ b/tests/filecheck/dialects/riscv_func/lower_riscv_func_main.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-riscv-func{insert_exit_syscall=true} %s | filecheck %s
+// RUN: xdsl-opt -p lower-riscv-func{insert_exit_syscall=true} "%s" | filecheck "%s"
 
 "builtin.module"() ({
 // CHECK:      builtin.module {

--- a/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
+++ b/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --print-op-generic %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt --print-op-generic "%s" | xdsl-opt | filecheck "%s"
 
 builtin.module {
 

--- a/tests/filecheck/dialects/riscv_scf/loop_flatten.mlir
+++ b/tests/filecheck/dialects/riscv_scf/loop_flatten.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-scf-loop-flatten %s | filecheck %s
+// RUN: xdsl-opt -p riscv-scf-loop-flatten "%s" | filecheck "%s"
 
 // CHECK:       builtin.module {
 

--- a/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
+++ b/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-scf-loop-range-folding %s | filecheck %s
+// RUN: xdsl-opt -p riscv-scf-loop-range-folding "%s" | filecheck "%s"
 
 // CHECK:       builtin.module {
 

--- a/tests/filecheck/dialects/riscv_scf/verification.mlir
+++ b/tests/filecheck/dialects/riscv_scf/verification.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics | filecheck "%s"
 
 
 

--- a/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -t riscv-asm "%s" | filecheck "%s"
 
 
 riscv_func.func @main() {

--- a/tests/filecheck/dialects/riscv_snitch/verification.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/verification.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+// RUN: xdsl-opt --split-input-file --verify-diagnostics "%s" | filecheck "%s"
 
 
 %0, %init = "test.op"() : () -> (!riscv.reg<a0>, !riscv.freg<fa0>)

--- a/tests/filecheck/dialects/scf/canonicalize.mlir
+++ b/tests/filecheck/dialects/scf/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p canonicalize %s | filecheck %s
+// RUN: xdsl-opt -p canonicalize "%s" | filecheck "%s"
 %v0, %v1 = "test.op"() : () -> (index, index)
 
 %c0 = arith.constant 0 : index

--- a/tests/filecheck/dialects/scf/for_args_number.mlir
+++ b/tests/filecheck/dialects/scf/for_args_number.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/for_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_args_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics --split-input-file | filecheck "%s"
 
 "builtin.module"() ({
   %lbi = "test.op"() : () -> !test.type<"int">

--- a/tests/filecheck/dialects/scf/for_body_args_number.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_number.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index

--- a/tests/filecheck/dialects/scf/for_body_args_number_much.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_number_much.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index

--- a/tests/filecheck/dialects/scf/for_body_args_types.mlir
+++ b/tests/filecheck/dialects/scf/for_body_args_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index

--- a/tests/filecheck/dialects/scf/for_iv.mlir
+++ b/tests/filecheck/dialects/scf/for_iv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index

--- a/tests/filecheck/dialects/scf/for_yield.mlir
+++ b/tests/filecheck/dialects/scf/for_yield.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/for_yield_number.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_number.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index

--- a/tests/filecheck/dialects/scf/for_yield_types.mlir
+++ b/tests/filecheck/dialects/scf/for_yield_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index
   %ub = "arith.constant"() {"value" = 42 : index} : () -> index

--- a/tests/filecheck/dialects/scf/parallel_blocks_args_types.mlir
+++ b/tests/filecheck/dialects/scf/parallel_blocks_args_types.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/parallel_blocks_not_enough_reduce.mlir
+++ b/tests/filecheck/dialects/scf/parallel_blocks_not_enough_reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/parallel_bounds.mlir
+++ b/tests/filecheck/dialects/scf/parallel_bounds.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/parallel_iv.mlir
+++ b/tests/filecheck/dialects/scf/parallel_iv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/parallel_multiple_blocks.mlir
+++ b/tests/filecheck/dialects/scf/parallel_multiple_blocks.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/reduce_arg_type_missmatch.mlir
+++ b/tests/filecheck/dialects/scf/reduce_arg_type_missmatch.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/scf/reduce_return_type_missmatch.mlir
+++ b/tests/filecheck/dialects/scf/reduce_return_type_missmatch.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/dialects/seq/seq_invalid.mlir
+++ b/tests/filecheck/dialects/seq/seq_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --verify-diagnostics --parsing-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt --verify-diagnostics --parsing-diagnostics --split-input-file "%s" | filecheck "%s"
 
 builtin.module {
   %clk = "test.op"() : () -> (!seq.clock)

--- a/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p lower-snitch %s | filecheck %s
+// RUN: xdsl-opt -p lower-snitch "%s" | filecheck "%s"
 builtin.module {
   %addr = "test.op"() : () -> !riscv.reg<>
   %bound = riscv.li 9 : () -> !riscv.reg<>

--- a/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
+++ b/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-snitch-stream-to-snitch %s | filecheck %s
+// RUN: xdsl-opt -p convert-snitch-stream-to-snitch "%s" | filecheck "%s"
 
 // CHECK: builtin.module {
 

--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file --verify-diagnostics --parsing-diagnostics | filecheck "%s"
 
 builtin.module {
   func.func @mixed_bounds_2d(%in : !stencil.field<?x[-4,68]xf64>) {

--- a/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
+++ b/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
@@ -1,6 +1,6 @@
 // RUN: XDSL_ROUNDTRIP
-// RUN: xdsl-opt %s -p stencil-storage-materialization,stencil-shape-inference | filecheck %s --check-prefix SHAPE
-// RUN: xdsl-opt %s -p stencil-storage-materialization,stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck %s --check-prefix MLIR
+// RUN: xdsl-opt "%s" -p stencil-storage-materialization,stencil-shape-inference | filecheck "%s" --check-prefix SHAPE
+// RUN: xdsl-opt "%s" -p stencil-storage-materialization,stencil-shape-inference,convert-stencil-to-ll-mlir | filecheck "%s" --check-prefix MLIR
 
 func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?x?xf64>, %arg2: !stencil.field<?x?x?xf64>, %arg3: !stencil.field<?x?x?xf64>, %arg4: !stencil.field<?x?x?xf64>, %arg5: !stencil.field<?x?x?xf64>, %arg6: !stencil.field<?x?x?xf64>) attributes {stencil.program} {
   %0 = stencil.cast %arg0 : !stencil.field<?x?x?xf64> -> !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>

--- a/tests/filecheck/dialects/tensor/invalid_ops.mlir
+++ b/tests/filecheck/dialects/tensor/invalid_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt --verify-diagnostics --split-input-file "%s" | filecheck "%s"
 
 // Verification checks
 

--- a/tests/filecheck/dialects/vector/vector_broadcast_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_broadcast_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_createmask_indexing.mlir
+++ b/tests/filecheck/dialects/vector/vector_createmask_indexing.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_fma_res_acc_shape_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_acc_shape_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_fma_res_acc_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_acc_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_fma_res_lhs_shape_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_lhs_shape_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_fma_res_lhs_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_lhs_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_fma_res_rhs_shape_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_rhs_shape_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_fma_res_rhs_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_rhs_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_load_indexing.mlir
+++ b/tests/filecheck/dialects/vector/vector_load_indexing.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_load_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_load_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_maskedload_indexing.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedload_indexing.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_maskedload_memref_passthrough_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedload_memref_passthrough_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_maskedload_memref_res_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedload_memref_res_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_maskedstore_indexing.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedstore_indexing.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_maskedstore_memref_storevec_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_maskedstore_memref_storevec_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_store_indexing.mlir
+++ b/tests/filecheck/dialects/vector/vector_store_indexing.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/vector/vector_store_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_store_type_matching.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t x86-asm %s | filecheck %s
+// RUN: xdsl-opt -t x86-asm "%s" | filecheck "%s"
 
 %0 = x86.get_register : () -> !x86.reg<rax>
 %1 = x86.get_register : () -> !x86.reg<rdx>

--- a/tests/filecheck/frontend/dialects/affine.py
+++ b/tests/filecheck/frontend/dialects/affine.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.exception import CodeGenerationException

--- a/tests/filecheck/frontend/dialects/arith.py
+++ b/tests/filecheck/frontend/dialects/arith.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.dialects.builtin import f16, f32, f64, i1, i32, i64

--- a/tests/filecheck/frontend/dialects/builtin.py
+++ b/tests/filecheck/frontend/dialects/builtin.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 
 from xdsl.frontend.context import CodeContext

--- a/tests/filecheck/frontend/dialects/cf.py
+++ b/tests/filecheck/frontend/dialects/cf.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.dialects.builtin import i1, i32

--- a/tests/filecheck/frontend/dialects/func.py
+++ b/tests/filecheck/frontend/dialects/func.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.dialects.builtin import i32

--- a/tests/filecheck/frontend/dialects/invalid.py
+++ b/tests/filecheck/frontend/dialects/invalid.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.dialects.builtin import i1, i32, i64

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.dialects.builtin import f32, i1, i32, index

--- a/tests/filecheck/frontend/passes/desymref.mlir
+++ b/tests/filecheck/frontend/passes/desymref.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p frontend-desymrefy --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" -p frontend-desymrefy --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
 // CHECK: "builtin.module"() ({

--- a/tests/filecheck/frontend/programs/invalid.py
+++ b/tests/filecheck/frontend/programs/invalid.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.block import block
 from xdsl.frontend.const import Const

--- a/tests/filecheck/frontend/programs/programs.py
+++ b/tests/filecheck/frontend/programs/programs.py
@@ -1,4 +1,4 @@
-# RUN: python %s | filecheck %s
+# RUN: python "%s" | filecheck "%s"
 
 from xdsl.frontend.context import CodeContext
 from xdsl.frontend.program import FrontendProgram

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -5,15 +5,15 @@ config.test_source_root = os.path.dirname(__file__)
 xdsl_src = os.path.dirname(os.path.dirname(config.test_source_root))
 
 config.name = "xDSL"
-config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {xdsl_src}"])
+config.test_format = lit.formats.ShTest(preamble_commands=[f"cd \"{xdsl_src}\""])
 config.suffixes = ['.test', '.mlir', '.py']
 
 xdsl_opt = "xdsl/tools/xdsl-opt"
 xdsl_run = "xdsl/tools/xdsl_run.py"
 irdl_to_pyrdl = "xdsl/tools/irdl_to_pyrdl.py"
 
-config.substitutions.append(('XDSL_ROUNDTRIP', "xdsl-opt %s --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck %s"))
-config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "xdsl-opt %s --print-op-generic --split-input-file | filecheck %s --check-prefix=CHECK-GENERIC"))
+config.substitutions.append(('XDSL_ROUNDTRIP', "xdsl-opt \"%s\" --print-op-generic --split-input-file | xdsl-opt --split-input-file | filecheck \"%s\""))
+config.substitutions.append(("XDSL_GENERIC_ROUNDTRIP", "xdsl-opt \"%s\" --print-op-generic --split-input-file | filecheck \"%s\" --check-prefix=CHECK-GENERIC"))
 if "COVERAGE" in lit_config.params:
     config.substitutions.append(('xdsl-opt', f"coverage run {xdsl_opt}"))
     config.substitutions.append(('xdsl-run', f"coverage run {xdsl_run}"))

--- a/tests/filecheck/mlir-conversion/with-mlir/affine_map.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/affine_map.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --allow-unregistered-dialect | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope -mlir-print-op-generic | xdsl-opt --allow-unregistered-dialect
+// RUN: xdsl-opt "%s" --allow-unregistered-dialect | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope -mlir-print-op-generic | xdsl-opt --allow-unregistered-dialect
 
 "builtin.module"() ({
   "f"() {map = affine_map<(d0, d1, d2)[s0, s1] -> (d0, d1, d2 + s0 + s1)>} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/affinet_set.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/affinet_set.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --allow-unregistered-dialect %s | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope -mlir-print-op-generic | xdsl-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt --allow-unregistered-dialect "%s" | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope -mlir-print-op-generic | xdsl-opt --allow-unregistered-dialect | filecheck "%s"
 
 builtin.module {
     // CHECK:    "f1"() {"set" = affine_set<(d0) : ((d0 + -10) >= 0)>} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | xdsl-opt | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | xdsl-opt | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f64} : () -> f64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_conv.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f16} : () -> f16

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_fp_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 1.0 : f32} : () -> f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_ops_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_ops_custom.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck "%s"
 
 "builtin.module"() ({
   %lhsi1 = "test.op"() : () -> (i1)

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/bufferization/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/bufferization/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck "%s"
 
 module{
     %t = "bufferization.alloc_tensor"() <{"operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> tensor<10x20x30xf64>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/unrealized_conversion_cast.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/unrealized_conversion_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/cf/assert.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/cf/assert.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = true} : () -> i1

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt --print-op-generic "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck "%s"
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck "%s"
 
 builtin.module {
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/func/func_ops_generic.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt --print-op-generic "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "func.func"() <{function_type = (tensor<8x8xf64>, tensor<8x8xf64>) -> (tensor<8x8xf64>, tensor<8x8xf64>), res_attrs = [{llvm.noalias}, {llvm.noalias}], sym_name = "arg_attrs", sym_visibility = "public"}> ({
 ^bb0(%arg0: tensor<8x8xf64>, %arg1: tensor<8x8xf64>):

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/gpu/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
     "gpu.module"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/irdl/testd.irdl.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/irdl/testd.irdl.mlir
@@ -1,5 +1,5 @@
 // XFAIL: *
-// RUN: xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt "%s" --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck "%s"
 
 builtin.module {
   // CHECK: irdl.dialect @testd {

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/invalid_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/invalid_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt --verify-diagnostics --split-input-file "%s" | filecheck "%s"
 
 
 builtin.module {

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/linalg_on_memrefs.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/linalg_on_memrefs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-local-scope -mlir-print-op-generic | xdsl-opt
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-local-scope -mlir-print-op-generic | xdsl-opt
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck "%s"
 
 %0, %1 = "test.op"() : () -> (f32, memref<1x256xf32>)
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/arithmetic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/arithmetic.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt | filecheck "%s"
 
 builtin.module {
     %arg0, %arg1 = "test.op"() : () -> (i32, i32)

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/global.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 "builtin.module"() ({
   "llvm.mlir.global"() ({
   }) {"global_type" = !llvm.array<12 x i8>, "sym_name" = "str0", "linkage" = #llvm.linkage<"internal">, "addr_space" = 0 : i32, "constant", "value" = "Hello world!", "unnamed_addr" = 0 : i64} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
@@ -1,4 +1,4 @@
-/// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+/// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 %0 = "test.op"() : () -> i32
 %1 = "test.op"() : () -> i32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_func.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_func.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %cst = arith.constant {"truc" = !llvm.func<ptr<16> (i64, ...)>} 10 : i32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_pointer_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : i64} : () -> i64

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/llvm_types.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   // CHECK:   "builtin.module"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/canonicalize.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/canonicalize.mlir
@@ -1,4 +1,4 @@
-//RUN: xdsl-opt %s -p canonicalize | mlir-opt | filecheck %s
+//RUN: xdsl-opt "%s" -p canonicalize | mlir-opt | filecheck "%s"
 
 builtin.module {
     func.func @test(%ref: memref<72x72x72xf64>) {

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: mlir-opt "%s" --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_custom.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt --allow-unregistered-dialect --mlir-print-local-scope | filecheck "%s"
 
 func.func @memref_alloca_scope() {
 "memref.alloca_scope"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/memref_ops_mlir_conversion.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   "memref.global"() {"alignment" = 64 : i64, "sym_name" = "g_with_alignment", "type" = memref<1xindex>, "initial_value" = dense<0> : tensor<1xindex>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/subview_constructor.py
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/subview_constructor.py
@@ -1,4 +1,4 @@
-# RUN: python %s | mlir-opt | filecheck %s
+# RUN: python "%s" | mlir-opt | filecheck "%s"
 
 from xdsl.builder import Builder
 from xdsl.dialects import memref

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/ml_program/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/ml_program/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck "%s"
 
 ml_program.global private @global_same_type(dense<4> : tensor<4xi32>) : tensor<4xi32>
 ml_program.global private mutable @global_mutable_undef : tensor<?xi32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world-async.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world-async.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p lower-mpi | mlir-opt --convert-func-to-llvm --expand-strided-metadata --normalize-memrefs --memref-expand --fold-memref-alias-ops --finalize-memref-to-llvm --reconcile-unrealized-casts | filecheck %s
+// RUN: xdsl-opt "%s" -p lower-mpi | mlir-opt --convert-func-to-llvm --expand-strided-metadata --normalize-memrefs --memref-expand --fold-memref-alias-ops --finalize-memref-to-llvm --reconcile-unrealized-casts | filecheck "%s"
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/mpi/mpi-hello-world.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p lower-mpi | mlir-opt --convert-func-to-llvm --expand-strided-metadata --normalize-memrefs --memref-expand --fold-memref-alias-ops --finalize-memref-to-llvm --reconcile-unrealized-casts | filecheck %s
+// RUN: xdsl-opt "%s" -p lower-mpi | mlir-opt --convert-func-to-llvm --expand-strided-metadata --normalize-memrefs --memref-expand --fold-memref-alias-ops --finalize-memref-to-llvm --reconcile-unrealized-casts | filecheck "%s"
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/omp/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/omp/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck %s
+// RUN: xdsl-opt "%s" --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt | filecheck "%s"
 
 builtin.module {
   func.func @omp_parallel(%arg0 : memref<1xi32>, %arg1 : i1, %arg2 : i32) {

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_llvm.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p printf-to-llvm | mlir-opt --test-lower-to-llvm  | filecheck %s
+// RUN: xdsl-opt "%s" -p printf-to-llvm | mlir-opt --test-lower-to-llvm  | filecheck "%s"
 // this tests straight to llvmir to verify intended target compatibility
 
 builtin.module {

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_putchar.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_putchar.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p printf-to-putchar %s | mlir-opt --convert-math-to-funcs  --test-lower-to-llvm | mlir-cpu-runner --entry-point-result=void | filecheck %s
+// RUN: xdsl-opt -p printf-to-putchar "%s" | mlir-opt --convert-math-to-funcs  --test-lower-to-llvm | mlir-cpu-runner --entry-point-result=void | filecheck "%s"
 
 builtin.module{
     "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_custom.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt | filecheck "%s"
 
 %lb = arith.constant 0 : index
 %ub = arith.constant 42 : index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_custom_non_index_iv.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_custom_non_index_iv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt | filecheck "%s"
 
 %lb = arith.constant 0 : i32
 %ub = arith.constant 42 : i32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_generic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_generic.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_generic_non_index_iv.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/for_generic_non_index_iv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %lb = "arith.constant"() {"value" = 0 : i32} : () -> i32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/if.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = false} : () -> i1

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel_with_reduce.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/parallel_with_reduce.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "arith.constant"() {"value" = 0 : index} : () -> index

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/while_custom.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/scf/while_custom.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt | filecheck "%s"
 
 func.func @while() {
     %init = arith.constant 0 : i32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/hdiff.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | mlir-opt | filecheck %s
+// RUN: xdsl-opt "%s" -p convert-stencil-to-ll-mlir | mlir-opt | filecheck "%s"
 
 builtin.module {
   func.func @stencil_hdiff(%0 : !stencil.field<?x?x?xf64>, %1 : !stencil.field<?x?x?xf64>) {

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck "%s"
 
 %t1 = tensor.empty() : tensor<2x3xf32>
 %t2 = tensor.empty() : tensor<2xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt.mlir
@@ -1,18 +1,18 @@
 // Shorthand to use mlir-opt within an xDSL pipeline: will use
 // mlir-opt --allow-unregistered-dialect --mlir-print-op-generic -p builtin.pipeline(<input-pipeline>)
-// RUN: xdsl-opt %s -p mlir-opt[cse] --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" -p mlir-opt[cse] --print-op-generic | filecheck "%s"
 
 // The explicit syntax for the MLIROptPass, allowing full control over the used arguments
 // Here, using --mlir-disable-threading to disable threading in mlir-opt
-// RUN: xdsl-opt %s -p mlir-opt{arguments='--cse','--mlir-disable-threading','--mlir-print-op-generic'} --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" -p mlir-opt{arguments='--cse','--mlir-disable-threading','--mlir-print-op-generic'} --print-op-generic | filecheck "%s"
 
 // Here, using the generic argument to use xDSL's custom syntax printing to send IR to
 // MLIR.
-// RUN: xdsl-opt %s -p mlir-opt{generic=false\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
-// RUN: xdsl-opt %s -p mlir-opt{generic=true\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" -p mlir-opt{generic=false\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck "%s"
+// RUN: xdsl-opt "%s" -p mlir-opt{generic=true\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck "%s"
 
 // Check that manually passing an executable works
-// RUN: xdsl-opt %s -p mlir-opt{executable=mlir-opt\ generic=true\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" -p mlir-opt{executable=mlir-opt\ generic=true\ arguments='--cse','--mlir-print-op-generic'} --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
@@ -1,6 +1,6 @@
-// RUN: xdsl-opt %s -p mlir-opt{arguments='--hello','--mlir-print-op-generic'} --print-op-generic --verify-diagnostics | filecheck %s
-// RUN: xdsl-opt %s -p mlir-opt[this-probably-will-never-be-an-MLIR-pass-name] --print-op-generic --verify-diagnostics | filecheck %s
-// RUN: xdsl-opt %s -p mlir-opt{executable='"false"'} --print-op-generic --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" -p mlir-opt{arguments='--hello','--mlir-print-op-generic'} --print-op-generic --verify-diagnostics | filecheck "%s"
+// RUN: xdsl-opt "%s" -p mlir-opt[this-probably-will-never-be-an-MLIR-pass-name] --print-op-generic --verify-diagnostics | filecheck "%s"
+// RUN: xdsl-opt "%s" -p mlir-opt{executable='"false"'} --print-op-generic --verify-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/mlir-conversion/with-mlir/scope.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/scope.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s | xdsl-opt | filecheck %s
+// RUN: mlir-opt "%s" | xdsl-opt | filecheck "%s"
 
 module {
   func.func public @my_func() {

--- a/tests/filecheck/mlir-conversion/with-mlir/symbol_tests.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/symbol_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt %s | mlir-opt --mlir-print-op-generic > %t-2 && diff %t-1 %t-2
+// RUN: xdsl-opt "%s" | mlir-opt --mlir-print-op-generic > %t-1 && xdsl-opt "%s" | mlir-opt --mlir-print-op-generic > %t-2 && diff %t-1 %t-2
 
 // Tests if the non generic form can be printed.
 

--- a/tests/filecheck/mlir-conversion/with-mlir/unrealized_conv_cast.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/unrealized_conv_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | mlir-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt "%s" | mlir-opt --allow-unregistered-dialect | filecheck "%s"
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/parser-printer/affine_map.mlir
+++ b/tests/filecheck/parser-printer/affine_map.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --allow-unregistered-dialect %s | filecheck %s
+// RUN: xdsl-opt --allow-unregistered-dialect "%s" | filecheck "%s"
 
 builtin.module {
   // CHECK: "f1"() {"map" = affine_map<(d0) -> (d0)>} : () -> ()

--- a/tests/filecheck/parser-printer/affine_set.mlir
+++ b/tests/filecheck/parser-printer/affine_set.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --allow-unregistered-dialect %s | filecheck %s
+// RUN: xdsl-opt --allow-unregistered-dialect "%s" | filecheck "%s"
 
 builtin.module {
   // CHECK:    "f0"() {"set" = affine_set<(d0) : ((d0 + -10) >= 0)>} : () -> ()

--- a/tests/filecheck/parser-printer/aliases.mlir
+++ b/tests/filecheck/parser-printer/aliases.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file --parsing-diagnostics | filecheck "%s"
 
 !ii32 = i32
 #attr = 0 : !ii32

--- a/tests/filecheck/parser-printer/attribute_names.mlir
+++ b/tests/filecheck/parser-printer/attribute_names.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt --print-op-generic | filecheck "%s"
 
 builtin.module attributes {a = i32, _e = i32, "foo" = i32, _ = i32} {
 }

--- a/tests/filecheck/parser-printer/builtin_attrs.mlir
+++ b/tests/filecheck/parser-printer/builtin_attrs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   "func.func"() ({

--- a/tests/filecheck/parser-printer/escaped_characters.mlir
+++ b/tests/filecheck/parser-printer/escaped_characters.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/float_parsing.mlir
+++ b/tests/filecheck/parser-printer/float_parsing.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | filecheck "%s"
 
 
 "builtin.module"() ({

--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics --split-input-file | filecheck "%s"
 
 // A cyclic dependency
 

--- a/tests/filecheck/parser-printer/implicit_module.mlir
+++ b/tests/filecheck/parser-printer/implicit_module.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --print-op-generic --split-input-file %s | filecheck %s
+// RUN: xdsl-opt --print-op-generic --split-input-file "%s" | filecheck "%s"
 
 "builtin.module"() ({
   %0 = "test.op"() : () -> i32

--- a/tests/filecheck/parser-printer/invalid_dense_attr.mlir
+++ b/tests/filecheck/parser-printer/invalid_dense_attr.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics --split-input-file | filecheck "%s"
 
 "func.func"() ({}) {function_type = () -> (), value1 = dense<"0x0BAD"> : tensor<2xf16>, sym_name = "unsupported_float"} : () -> ()
 

--- a/tests/filecheck/parser-printer/operation_signature.mlir
+++ b/tests/filecheck/parser-printer/operation_signature.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics --split-input-file | filecheck "%s"
 
 // A correct operation
 

--- a/tests/filecheck/parser-printer/operation_with_properties.mlir
+++ b/tests/filecheck/parser-printer/operation_with_properties.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt "%s" --allow-unregistered-dialect | filecheck "%s"
 
 builtin.module {
 

--- a/tests/filecheck/parser-printer/parse_error.mlir
+++ b/tests/filecheck/parser-printer/parse_error.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics --split-input-file | filecheck "%s"
 
 "test.op"(abc) : () -> ()
 // CHECK: {{.*}}tests/filecheck/parser-printer/parse_error.mlir:3:10

--- a/tests/filecheck/parser-printer/region_name_clash.mlir
+++ b/tests/filecheck/parser-printer/region_name_clash.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt | filecheck "%s"
 
 // Check that SSA values and blocks can reuse names across regions
 

--- a/tests/filecheck/parser-printer/unregistered_dialect.mlir
+++ b/tests/filecheck/parser-printer/unregistered_dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect  | filecheck %s
+// RUN: xdsl-opt "%s" --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect  | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/value_tuple.mlir
+++ b/tests/filecheck/parser-printer/value_tuple.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt  | filecheck %s
+// RUN: xdsl-opt "%s" | xdsl-opt  | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/value_tuple_access_oob.mlir
+++ b/tests/filecheck/parser-printer/value_tuple_access_oob.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --allow-unregistered-dialect --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --allow-unregistered-dialect --parsing-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/value_tuple_wrong_number.mlir
+++ b/tests/filecheck/parser-printer/value_tuple_wrong_number.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --parsing-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --parsing-diagnostics | filecheck "%s"
 
 "builtin.module"() ({
 

--- a/tests/filecheck/parser-printer/verifier_error.mlir
+++ b/tests/filecheck/parser-printer/verifier_error.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt "%s" --verify-diagnostics | filecheck "%s"
 
 builtin.module {
     // Operation has an unexpected result

--- a/tests/filecheck/projects/riscv-backend-paper/add.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/add.mlir
@@ -1,7 +1,7 @@
-// RUN: xdsl-run %s | filecheck %s
-// RUN: xdsl-opt -p convert-linalg-to-loops %s | xdsl-run | filecheck %s
-// RUN: xdsl-opt %s -p convert-linalg-to-memref-stream | xdsl-run | filecheck %s
-// RUN: xdsl-opt %s -p convert-linalg-to-memref-stream,memref-streamify,convert-memref-stream-to-loops,convert-memref-stream-to-snitch,convert-arith-to-riscv,convert-func-to-riscv-func,convert-memref-to-riscv,convert-scf-to-riscv-scf,convert-print-format-to-riscv-debug,reconcile-unrealized-casts,snitch-allocate-registers | xdsl-run | filecheck %s
+// RUN: xdsl-run "%s" | filecheck "%s"
+// RUN: xdsl-opt -p convert-linalg-to-loops "%s" | xdsl-run | filecheck "%s"
+// RUN: xdsl-opt "%s" -p convert-linalg-to-memref-stream | xdsl-run | filecheck "%s"
+// RUN: xdsl-opt "%s" -p convert-linalg-to-memref-stream,memref-streamify,convert-memref-stream-to-loops,convert-memref-stream-to-snitch,convert-arith-to-riscv,convert-func-to-riscv-func,convert-memref-to-riscv,convert-scf-to-riscv-scf,convert-print-format-to-riscv-debug,reconcile-unrealized-casts,snitch-allocate-registers | xdsl-run | filecheck "%s"
 
 builtin.module {
     "memref.global"() {"sym_name" = "a", "type" = memref<2x3xf64>, "initial_value" = dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf64>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/projects/riscv-backend-paper/add_snitch_stream.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/add_snitch_stream.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-run %s | filecheck %s
+// RUN: xdsl-run "%s" | filecheck "%s"
 
 builtin.module {
   riscv.assembly_section ".data" {

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-linalg-to-memref-stream,memref-streamify,convert-memref-stream-to-loops,convert-memref-to-riscv,convert-scf-to-riscv-scf,convert-arith-to-riscv,convert-func-to-riscv-func,convert-memref-stream-to-snitch,reconcile-unrealized-casts,riscv-scf-loop-flatten,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-linalg-to-memref-stream,memref-streamify,convert-memref-stream-to-loops,convert-memref-to-riscv,convert-scf-to-riscv-scf,convert-arith-to-riscv,convert-func-to-riscv-func,convert-memref-stream-to-snitch,reconcile-unrealized-casts,riscv-scf-loop-flatten,test-lower-snitch-stream-to-asm -t riscv-asm "%s" | filecheck "%s"
 
 func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %X: memref<1x1x8x8xf64>,

--- a/tests/filecheck/projects/riscv-backend-paper/conv.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/conv.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-run %s | filecheck %s
-// RUN: xdsl-opt -p convert-linalg-to-loops %s | xdsl-run | filecheck %s
+// RUN: xdsl-run "%s" | filecheck "%s"
+// RUN: xdsl-opt -p convert-linalg-to-loops "%s" | xdsl-run | filecheck "%s"
 
 module {
     "memref.global"() {

--- a/tests/filecheck/projects/riscv-backend-paper/ddot_regalloc.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/ddot_regalloc.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-allocate-registers %s | filecheck %s
+// RUN: xdsl-opt -p riscv-allocate-registers "%s" | filecheck "%s"
 
 riscv.assembly_section ".text" {
     riscv.directive ".globl" "ddot"

--- a/tests/filecheck/projects/riscv-backend-paper/fill.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/fill.mlir
@@ -1,8 +1,8 @@
 
-// RUN: xdsl-run %s --symbol fill --args "4.0 : f64, dense<0.0> : tensor<16x16xf64>" --verbose | filecheck %s
+// RUN: xdsl-run "%s" --symbol fill --args "4.0 : f64, dense<0.0> : tensor<16x16xf64>" --verbose | filecheck "%s"
 
 // Currently doesn't work, need to add scalar arguments to memref_stream.generic
-// xdsl-opt %s -p convert-linalg-to-memref-stream | xdsl-run %s --symbol fill --args "4.0 : f64, dense<0.0> : memref<16x16xf64>" --verbose | filecheck %s
+// xdsl-opt "%s" -p convert-linalg-to-memref-stream | xdsl-run "%s" --symbol fill --args "4.0 : f64, dense<0.0> : memref<16x16xf64>" --verbose | filecheck "%s"
 
 module {
   func.func public @fill(%arg0: f64, %arg1: memref<16x16xf64>) -> memref<16x16xf64> {

--- a/tests/filecheck/projects/riscv-backend-paper/matmul.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/matmul.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-run  --args="dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]> : tensor<4x2xf64>, dense<[[0.0, 0.25, 0.5], [0.75, 1.0, 1.25]]> : tensor<2x3xf64>, dense<[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]> : tensor<4x3xf64>" --verbose %s | filecheck %s
-// RUN: xdsl-opt -p convert-linalg-to-loops %s | xdsl-run  --args="dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]> : tensor<4x2xf64>, dense<[[0.0, 0.25, 0.5], [0.75, 1.0, 1.25]]> : tensor<2x3xf64>, dense<[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]> : tensor<4x3xf64>" --verbose | filecheck %s
+// RUN: xdsl-run  --args="dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]> : tensor<4x2xf64>, dense<[[0.0, 0.25, 0.5], [0.75, 1.0, 1.25]]> : tensor<2x3xf64>, dense<[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]> : tensor<4x3xf64>" --verbose "%s" | filecheck "%s"
+// RUN: xdsl-opt -p convert-linalg-to-loops "%s" | xdsl-run  --args="dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]> : tensor<4x2xf64>, dense<[[0.0, 0.25, 0.5], [0.75, 1.0, 1.25]]> : tensor<2x3xf64>, dense<[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]> : tensor<4x3xf64>" --verbose | filecheck "%s"
 
 func.func @main(%A: memref<4x2xf64>, %B : memref<2x3xf64>, %C : memref<4x3xf64>) -> memref<4x3xf64> {
     linalg.generic {

--- a/tests/filecheck/projects/riscv-backend-paper/pres.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/pres.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -t riscv-asm "%s" | filecheck "%s"
 
 // A test that verifies that we can emit the target assembly for Snitch, below are the
 // versions of ssum (C=A+B where all have fixed size 128xf32) .

--- a/tests/filecheck/projects/riscv-backend-paper/relu.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/relu.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-run %s | filecheck %s
+// RUN: xdsl-run "%s" | filecheck "%s"
 
 builtin.module {
     "memref.global"() {"sym_name" = "a", "type" = memref<2x3xf64>, "initial_value" = dense<[[1.0, -1.0, 0.0], [2.0, -2.0, 0.0]]> : tensor<2x3xf64>, "sym_visibility" = "public"} : () -> ()

--- a/tests/filecheck/projects/riscv-backend-paper/relu_snitch_stream.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/relu_snitch_stream.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-run %s | filecheck %s
+// RUN: xdsl-run "%s" | filecheck "%s"
 
 builtin.module {
   riscv.assembly_section ".data" {

--- a/tests/filecheck/projects/riscv-backend-paper/source.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/source.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-linalg-to-memref-stream,memref-streamify
+// RUN: xdsl-opt "%s" -p convert-linalg-to-memref-stream,memref-streamify
 
 // A top-down lowering filecheck for some of our chosen kernels
 

--- a/tests/filecheck/runner/example.mlir
+++ b/tests/filecheck/runner/example.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-run %s | filecheck %s
+// RUN: xdsl-run "%s" | filecheck "%s"
 
 builtin.module {
   func.func @main() {

--- a/tests/filecheck/runner/factorial.mlir
+++ b/tests/filecheck/runner/factorial.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-run %s | filecheck %s
+// RUN: xdsl-run "%s" | filecheck "%s"
 
 builtin.module {
 

--- a/tests/filecheck/runner/riscv.mlir
+++ b/tests/filecheck/runner/riscv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-run %s --verbose | filecheck %s
+// RUN: xdsl-run "%s" --verbose | filecheck "%s"
 
 riscv_func.func @malloc(!riscv.reg<>) -> !riscv.reg<>
 

--- a/tests/filecheck/runner/riscv_scf.mlir
+++ b/tests/filecheck/runner/riscv_scf.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-run --verbose %s | filecheck %s
-// RUN: xdsl-run --verbose --symbol="sum_to" --args="6" %s | filecheck %s --check-prefix=CHECK-ARGS
+// RUN: xdsl-run --verbose "%s" | filecheck "%s"
+// RUN: xdsl-run --verbose --symbol="sum_to" --args="6" "%s" | filecheck "%s" --check-prefix=CHECK-ARGS
 
 builtin.module {
   func.func @sum_to(%0 : !riscv.reg<>) -> !riscv.reg<> {

--- a/tests/filecheck/runner/runner_args.mlir
+++ b/tests/filecheck/runner/runner_args.mlir
@@ -1,7 +1,7 @@
-// RUN: xdsl-run --symbol one --verbose %s | filecheck %s --check-prefix CHECK-ONE
-// RUN: xdsl-run --symbol two --verbose %s | filecheck %s --check-prefix CHECK-TWO
-// RUN: xdsl-run --symbol void --verbose %s | filecheck %s --check-prefix CHECK-VOID
-// RUN: xdsl-run --symbol tuple --verbose %s | filecheck %s --check-prefix CHECK-TUPLE
+// RUN: xdsl-run --symbol one --verbose "%s" | filecheck "%s" --check-prefix CHECK-ONE
+// RUN: xdsl-run --symbol two --verbose "%s" | filecheck "%s" --check-prefix CHECK-TWO
+// RUN: xdsl-run --symbol void --verbose "%s" | filecheck "%s" --check-prefix CHECK-VOID
+// RUN: xdsl-run --symbol tuple --verbose "%s" | filecheck "%s" --check-prefix CHECK-TUPLE
 
 module {
     func.func @one() -> i32 {

--- a/tests/filecheck/runner/with-wgpu/global_id_inc.mlir
+++ b/tests/filecheck/runner/with-wgpu/global_id_inc.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-run --wgpu --index-bitwidth=32 %s | filecheck %s
+// RUN: xdsl-run --wgpu --index-bitwidth=32 "%s" | filecheck "%s"
 
 builtin.module attributes {gpu.container_module} {
   "gpu.module"() ({

--- a/tests/filecheck/transforms/arith-add-fastmath.mlir
+++ b/tests/filecheck/transforms/arith-add-fastmath.mlir
@@ -1,7 +1,7 @@
-// RUN: xdsl-opt -p arith-add-fastmath %s | filecheck %s
-// RUN: xdsl-opt -p "arith-add-fastmath{flags=none}" %s | filecheck %s --check-prefix=NONE
-// RUN: xdsl-opt -p "arith-add-fastmath{flags=nnan}" %s | filecheck %s --check-prefix=SINGLE
-// RUN: xdsl-opt -p "arith-add-fastmath{flags=nnan,nsz}" %s | filecheck %s --check-prefix=DOUBLE
+// RUN: xdsl-opt -p arith-add-fastmath "%s" | filecheck "%s"
+// RUN: xdsl-opt -p "arith-add-fastmath{flags=none}" "%s" | filecheck "%s" --check-prefix=NONE
+// RUN: xdsl-opt -p "arith-add-fastmath{flags=nnan}" "%s" | filecheck "%s" --check-prefix=SINGLE
+// RUN: xdsl-opt -p "arith-add-fastmath{flags=nnan,nsz}" "%s" | filecheck "%s" --check-prefix=DOUBLE
 
 func.func public @foo1() {
   %lhs, %rhs = "test.op"() : () -> (f64, f64)

--- a/tests/filecheck/transforms/arith-add-immediate-zero.mlir
+++ b/tests/filecheck/transforms/arith-add-immediate-zero.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p canonicalize | filecheck %s
+// RUN: xdsl-opt "%s" -p canonicalize | filecheck "%s"
 
 func.func @hello(%n : i32) -> i32 {
   %two = arith.constant 0 : i32

--- a/tests/filecheck/transforms/arith-individual-rewrite-pattern-AdditionOfSameVariablesToMultiplyByTwo.mlir
+++ b/tests/filecheck/transforms/arith-individual-rewrite-pattern-AdditionOfSameVariablesToMultiplyByTwo.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p 'apply-individual-rewrite{matched_operation_index=2 operation_name="arith.addi" pattern_name="AdditionOfSameVariablesToMultiplyByTwo"}' | filecheck %s
+// RUN: xdsl-opt "%s" -p 'apply-individual-rewrite{matched_operation_index=2 operation_name="arith.addi" pattern_name="AdditionOfSameVariablesToMultiplyByTwo"}' | filecheck "%s"
 
 builtin.module {
   func.func @hello(%n : i32) -> i32 {

--- a/tests/filecheck/transforms/arith-individual-rewrite-patterns-DivisionOfSameVariableToOne.mlir
+++ b/tests/filecheck/transforms/arith-individual-rewrite-patterns-DivisionOfSameVariableToOne.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p 'apply-individual-rewrite{matched_operation_index=5 operation_name="arith.divui" pattern_name="DivisionOfSameVariableToOne"}' | filecheck %s
+// RUN: xdsl-opt "%s" -p 'apply-individual-rewrite{matched_operation_index=5 operation_name="arith.divui" pattern_name="DivisionOfSameVariableToOne"}' | filecheck "%s"
 
 builtin.module {
   func.func @hello(%n : i32) -> i32 {

--- a/tests/filecheck/transforms/convert-scf-to-openmp.mlir
+++ b/tests/filecheck/transforms/convert-scf-to-openmp.mlir
@@ -1,10 +1,10 @@
-// RUN: xdsl-opt -p convert-scf-to-openmp %s | filecheck %s
-// RUN: xdsl-opt -p "convert-scf-to-openmp{nested=true}" %s | filecheck %s --check-prefix NESTED
-// RUN: xdsl-opt -p "convert-scf-to-openmp{collapse=1}" %s | filecheck %s --check-prefix COLLAPSE
-// RUN: xdsl-opt -p "convert-scf-to-openmp{schedule=dynamic}" %s | filecheck %s --check-prefix DYNAMIC
-// RUN: xdsl-opt -p "convert-scf-to-openmp{chunk=4}" %s | filecheck %s --check-prefix CHUNK
+// RUN: xdsl-opt -p convert-scf-to-openmp "%s" | filecheck "%s"
+// RUN: xdsl-opt -p "convert-scf-to-openmp{nested=true}" "%s" | filecheck "%s" --check-prefix NESTED
+// RUN: xdsl-opt -p "convert-scf-to-openmp{collapse=1}" "%s" | filecheck "%s" --check-prefix COLLAPSE
+// RUN: xdsl-opt -p "convert-scf-to-openmp{schedule=dynamic}" "%s" | filecheck "%s" --check-prefix DYNAMIC
+// RUN: xdsl-opt -p "convert-scf-to-openmp{chunk=4}" "%s" | filecheck "%s" --check-prefix CHUNK
 // Check that a `collapse` greater than the loop depth doesn't crash
-// RUN: xdsl-opt -p "convert-scf-to-openmp{collapse=3}" %s
+// RUN: xdsl-opt -p "convert-scf-to-openmp{collapse=3}" "%s"
 
 builtin.module {
   func.func @parallel(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index) {

--- a/tests/filecheck/transforms/convert-snrt-to-riscv.mlir
+++ b/tests/filecheck/transforms/convert-snrt-to-riscv.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-snrt-to-riscv{cluster-num=2} | filecheck %s
+// RUN: xdsl-opt "%s" -p convert-snrt-to-riscv{cluster-num=2} | filecheck "%s"
 
 
 %global_core_base_hartid = "snrt.global_core_base_hartid"() : () -> i32

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p convert-stencil-to-ll-mlir | filecheck %s
+// RUN: xdsl-opt "%s" -p convert-stencil-to-ll-mlir | filecheck "%s"
 
 builtin.module {
 // CHECK: builtin.module {

--- a/tests/filecheck/transforms/convert_linalg_to_loops.mlir
+++ b/tests/filecheck/transforms/convert_linalg_to_loops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-linalg-to-loops %s | filecheck %s
+// RUN: xdsl-opt -p convert-linalg-to-loops "%s" | filecheck "%s"
 
 %A, %B, %C = "test.op"() : () -> (memref<f64>, memref<f64>, memref<f64>)
 %D, %E, %F = "test.op"() : () -> (memref<2x3xf64>, memref<3x4xf64>, memref<2x4xf64>)

--- a/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
+++ b/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-linalg-to-memref-stream %s | filecheck %s
+// RUN: xdsl-opt -p convert-linalg-to-memref-stream "%s" | filecheck "%s"
 
 %A, %B, %C = "test.op"() : () -> (memref<f64>, memref<f64>, memref<f64>)
 %D, %E, %F = "test.op"() : () -> (memref<2x3xf64>, memref<3x4xf64>, memref<2x4xf64>)

--- a/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-memref-stream-to-loops %s | filecheck %s
+// RUN: xdsl-opt -p convert-memref-stream-to-loops "%s" | filecheck "%s"
 
 // CHECK:       builtin.module {
 

--- a/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-memref-stream-to-snitch %s | filecheck %s
+// RUN: xdsl-opt -p convert-memref-stream-to-snitch "%s" | filecheck "%s"
 
 // CHECK:       builtin.module {
 

--- a/tests/filecheck/transforms/convert_onnx_to_linalg.mlir
+++ b/tests/filecheck/transforms/convert_onnx_to_linalg.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-onnx-to-linalg %s | filecheck %s
+// RUN: xdsl-opt -p convert-onnx-to-linalg "%s" | filecheck "%s"
 
 // CHECK:       builtin.module {
 

--- a/tests/filecheck/transforms/gpu-allocs.mlir
+++ b/tests/filecheck/transforms/gpu-allocs.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p memref-to-gpu | filecheck %s
+// RUN: xdsl-opt "%s" -p memref-to-gpu | filecheck "%s"
 
 func.func private @memref_test() {
   %12 = "test.op"() : () -> index

--- a/tests/filecheck/transforms/gpu-map-parallel-loops.mlir
+++ b/tests/filecheck/transforms/gpu-map-parallel-loops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p gpu-map-parallel-loops --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p gpu-map-parallel-loops --split-input-file "%s" | filecheck "%s"
 
 func.func @parallel_loop(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : index) {
   %0 = arith.constant 0 : index

--- a/tests/filecheck/transforms/individual_rewrite.mlir
+++ b/tests/filecheck/transforms/individual_rewrite.mlir
@@ -1,4 +1,4 @@
-// RUN:xdsl-opt %s -p 'apply-individual-rewrite{matched_operation_index=4 operation_name="riscv.add" pattern_name="AddImmediates"}'| filecheck %s
+// RUN:xdsl-opt "%s" -p 'apply-individual-rewrite{matched_operation_index=4 operation_name="riscv.add" pattern_name="AddImmediates"}'| filecheck "%s"
 
 %a = riscv.li 1 : () -> !riscv.reg<>
 %b = riscv.li 2 : () -> !riscv.reg<>

--- a/tests/filecheck/transforms/loop-hoist-memref/loop-nest.mlir
+++ b/tests/filecheck/transforms/loop-hoist-memref/loop-nest.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file -p loop-hoist-memref | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file -p loop-hoist-memref | filecheck "%s"
 
 func.func public @ddot(%arg0: memref<8xf64>, %arg1: memref<8xf64>, %arg2: memref<f64>) -> memref<f64> {
   %c0 = arith.constant 0 : index

--- a/tests/filecheck/transforms/loop-hoist-memref/single-loop-skipped.mlir
+++ b/tests/filecheck/transforms/loop-hoist-memref/single-loop-skipped.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file -p loop-hoist-memref | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file -p loop-hoist-memref | filecheck "%s"
 
 // skip loads from the same location
 func.func public @foo(%arg0: memref<8xf64>, %arg1: memref<8xf64>, %arg2: memref<f64>, %arg3: memref<f64>) -> memref<f64> {

--- a/tests/filecheck/transforms/loop-hoist-memref/single-loop.mlir
+++ b/tests/filecheck/transforms/loop-hoist-memref/single-loop.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --split-input-file -p loop-hoist-memref | filecheck %s
+// RUN: xdsl-opt "%s" --split-input-file -p loop-hoist-memref | filecheck "%s"
 
 // single load-store pair hoisting
 func.func public @foo(%arg0: memref<8xf64>, %arg1: memref<8xf64>, %arg2: memref<f64>) -> memref<f64> {

--- a/tests/filecheck/transforms/lower_affine.mlir
+++ b/tests/filecheck/transforms/lower_affine.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p lower-affine --allow-unregistered-dialect --print-op-generic | filecheck %s
+// RUN: xdsl-opt "%s" -p lower-affine --allow-unregistered-dialect --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   %v0, %m = "test.op"() : () -> (f32, memref<2x3xf32>)

--- a/tests/filecheck/transforms/memref_streamify.mlir
+++ b/tests/filecheck/transforms/memref_streamify.mlir
@@ -1,7 +1,7 @@
-// RUN: xdsl-opt -p memref-streamify %s | filecheck %s
+// RUN: xdsl-opt -p memref-streamify "%s" | filecheck "%s"
 
 // Check that streamfying twice does not make further changes
-// RUN: xdsl-opt -p memref-streamify,memref-streamify %s | filecheck %s
+// RUN: xdsl-opt -p memref-streamify,memref-streamify "%s" | filecheck "%s"
 
 
 // CHECK:       builtin.module {

--- a/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
+++ b/tests/filecheck/transforms/reconcile_unrealized_casts.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p reconcile-unrealized-casts | filecheck %s
+// RUN: xdsl-opt "%s" -p reconcile-unrealized-casts | filecheck "%s"
 
 builtin.module {
     // CHECK:  builtin.module {

--- a/tests/filecheck/transforms/riscv_cse.mlir
+++ b/tests/filecheck/transforms/riscv_cse.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p riscv-cse --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p riscv-cse --split-input-file "%s" | filecheck "%s"
 
 %a8 = riscv.li 8 : () -> !riscv.reg<>
 %b8 = riscv.li 8 : () -> !riscv.reg<>

--- a/tests/filecheck/transforms/scf-parallel-loop-tiling-partial.mlir
+++ b/tests/filecheck/transforms/scf-parallel-loop-tiling-partial.mlir
@@ -1,6 +1,6 @@
-// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,0,4}" | filecheck %s
-// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=0,4,4}" | filecheck %s --check-prefix CHECK-FIRST
-// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,4,0}" | filecheck %s --check-prefix CHECK-LAST
+// RUN: xdsl-opt "%s" -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,0,4}" | filecheck "%s"
+// RUN: xdsl-opt "%s" -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=0,4,4}" | filecheck "%s" --check-prefix CHECK-FIRST
+// RUN: xdsl-opt "%s" -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=4,4,0}" | filecheck "%s" --check-prefix CHECK-LAST
 
 func.func @tile_partial() {
   %zero = arith.constant 0 : index

--- a/tests/filecheck/transforms/scf-parallel-loop-tiling.mlir
+++ b/tests/filecheck/transforms/scf-parallel-loop-tiling.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=1,4}" --split-input-file | filecheck %s
+// RUN: xdsl-opt "%s" -p "scf-parallel-loop-tiling{parallel-loop-tile-sizes=1,4}" --split-input-file | filecheck "%s"
 
 func.func @parallel_loop(%arg0 : index, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : memref<?x?xf32>, %arg7 : memref<?x?xf32>, %arg8 : memref<?x?xf32>, %arg9 : memref<?x?xf32>) {
   "scf.parallel"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) <{"operandSegmentSizes" = array<i32: 2, 2, 2, 0>}> ({

--- a/tests/filecheck/transforms/snitch_register_allocation.mlir
+++ b/tests/filecheck/transforms/snitch_register_allocation.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p snitch-allocate-registers %s | filecheck %s
+// RUN: xdsl-opt -p snitch-allocate-registers "%s" | filecheck "%s"
 
 %ptr0, %ptr1, %ptr2 = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
 

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p stencil-shape-inference --verify-diagnostics --split-input-file %s | filecheck %s
+// RUN: xdsl-opt -p stencil-shape-inference --verify-diagnostics --split-input-file "%s" | filecheck "%s"
 
 builtin.module {
   func.func @different_input_offsets(%out : !stencil.field<[-4,68]xf64>, %left : !stencil.field<[-4,68]xf64>, %right : !stencil.field<[-4,68]xf64>) {

--- a/tests/filecheck/transforms/stencil-storage-materialization.mlir
+++ b/tests/filecheck/transforms/stencil-storage-materialization.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p stencil-storage-materialization | filecheck %s
+// RUN: xdsl-opt "%s" -p stencil-storage-materialization | filecheck "%s"
 
 // This should not change with the pass applied.
 

--- a/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
+++ b/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p "stencil-tensorize-z-dimension" | filecheck %s
+// RUN: xdsl-opt "%s" -p "stencil-tensorize-z-dimension" | filecheck "%s"
 
 builtin.module {
   func.func @gauss_seidel(%a : memref<1024x512x512xf32>, %b : memref<1024x512x512xf32>) {

--- a/tests/filecheck/transforms/stencil-unroll.mlir
+++ b/tests/filecheck/transforms/stencil-unroll.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p "stencil-unroll{unroll-factor=8,1}" | filecheck %s
+// RUN: xdsl-opt "%s" -p "stencil-unroll{unroll-factor=8,1}" | filecheck "%s"
 
   func.func @stencil_init_float(%0 : f64, %1 : !stencil.field<?x?x?xf64>) {
     %2 = stencil.cast %1 : !stencil.field<?x?x?xf64> -> !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>

--- a/tests/filecheck/version.mlir
+++ b/tests/filecheck/version.mlir
@@ -1,3 +1,3 @@
-// RUN: xdsl-opt --version | filecheck %s
+// RUN: xdsl-opt --version | filecheck "%s"
 
 //CHECK: xdsl-opt built from xdsl version {{.*}}

--- a/tests/filecheck/with-riscemu/riscv_emulation.mlir
+++ b/tests/filecheck/with-riscemu/riscv_emulation.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file -t riscemu %s | filecheck %s
+// RUN: xdsl-opt --split-input-file -t riscemu "%s" | filecheck "%s"
 
 builtin.module {
   riscv.directive ".globl" "main"

--- a/tests/filecheck/with-riscemu/rvscf_lowering_emu.mlir
+++ b/tests/filecheck/with-riscemu/rvscf_lowering_emu.mlir
@@ -1,5 +1,5 @@
-// RUN: xdsl-opt -p lower-riscv-scf-to-labels -t riscemu %s
-// RUN: xdsl-opt -p convert-riscv-scf-to-riscv-cf -t riscemu %s
+// RUN: xdsl-opt -p lower-riscv-scf-to-labels -t riscemu "%s"
+// RUN: xdsl-opt -p convert-riscv-scf-to-riscv-cf -t riscemu "%s"
 
 builtin.module {
   riscv_func.func @main() {

--- a/tests/filecheck/xdsl_opt/split_input.mlir
+++ b/tests/filecheck/xdsl_opt/split_input.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt --split-input-file %s | xdsl-opt --split-input-file --print-op-generic | filecheck %s
+// RUN: xdsl-opt --split-input-file "%s" | xdsl-opt --split-input-file --print-op-generic | filecheck "%s"
 
 "builtin.module"() ({
   ^0:


### PR DESCRIPTION
See issue #2598

Replaced all %s with "%s" inside .mlir, .toy and some .py. 
Wrapped some paths with \" in lit.cfg 
