### PR TITLE
core: Expect Data's carride type to be Hashable.

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -125,7 +125,7 @@ def test_simple_data():
 
 
 @irdl_attr_definition
-class IntListData(Data[list[int]]):
+class IntListData(Data[tuple[int, ...]]):
     """
     An attribute holding a list of integers.
     """
@@ -133,7 +133,7 @@ class IntListData(Data[list[int]]):
     name = "test.int_list"
 
     @classmethod
-    def parse_parameter(cls, parser: AttrParser) -> list[int]:
+    def parse_parameter(cls, parser: AttrParser) -> tuple[int]:
         raise NotImplementedError()
 
     def print_parameter(self, printer: Printer) -> None:
@@ -145,7 +145,7 @@ class IntListData(Data[list[int]]):
 
 def test_non_class_data():
     """Test the definition of a Data with a non-class parameter."""
-    attr = IntListData([0, 1, 42])
+    attr = IntListData((0, 1, 42))
     stream = StringIO()
     p = Printer(stream=stream)
     p.print_attribute(attr)

--- a/xdsl/ir/affine/affine_expr.py
+++ b/xdsl/ir/affine/affine_expr.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from xdsl.ir.affine import AffineMap
 
 
-@dataclass()
+@dataclass(frozen=True)
 class AffineExpr:
     """
     An AffineExpr models an affine expression, which is a linear combination of
@@ -288,7 +288,7 @@ class AffineBinaryOpKind(Enum):
                 return "ceildiv"
 
 
-@dataclass
+@dataclass(frozen=True)
 class AffineBinaryOpExpr(AffineExpr):
     """An affine expression storage node representing a binary operation."""
 
@@ -305,7 +305,7 @@ class AffineBinaryOpExpr(AffineExpr):
         yield from self.rhs.dfs()
 
 
-@dataclass
+@dataclass(frozen=True)
 class AffineDimExpr(AffineExpr):
     """An affine expression storage node representing a dimension."""
 
@@ -315,7 +315,7 @@ class AffineDimExpr(AffineExpr):
         return f"d{self.position}"
 
 
-@dataclass
+@dataclass(frozen=True)
 class AffineSymExpr(AffineExpr):
     """An affine expression storage node representing a symbol."""
 
@@ -325,7 +325,7 @@ class AffineSymExpr(AffineExpr):
         return f"s{self.position}"
 
 
-@dataclass
+@dataclass(frozen=True)
 class AffineConstantExpr(AffineExpr):
     """An affine expression storage node representing a constant."""
 

--- a/xdsl/ir/affine/affine_set.py
+++ b/xdsl/ir/affine/affine_set.py
@@ -35,7 +35,7 @@ class AffineConstraintExpr:
         return f"{self.lhs} {self.kind.value} {self.rhs}"
 
 
-@dataclass
+@dataclass(frozen=True)
 class AffineSet:
     """
     AffineMap represents a map from a set of dimensions and symbols to a

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from io import StringIO
 from itertools import chain
@@ -547,6 +547,12 @@ class Data(Generic[DataElement], Attribute, ABC):
     def print_parameter(self, printer: Printer) -> None:
         """Print the attribute parameter."""
 
+    def __hash__(self) -> int:
+        if isinstance(self.data, Hashable):
+            return hash((type(self), self.data))
+        else:
+            return super().__hash__()
+
 
 EnumType = TypeVar("EnumType", bound=StrEnum)
 
@@ -669,6 +675,9 @@ class ParametrizedAttribute(Attribute):
         attr_def = t.get_irdl_definition()
         attr_def.verify(self)
         super()._verify()
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.parameters))
 
 
 class TypedAttribute(ParametrizedAttribute, Generic[AttributeCovT], ABC):

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -551,7 +551,7 @@ class Data(Generic[DataElement], Attribute, ABC):
         if isinstance(self.data, Hashable):
             return hash((type(self), self.data))
         else:
-            return super().__hash__()
+            return id(self)
 
 
 EnumType = TypeVar("EnumType", bound=StrEnum)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -506,7 +506,7 @@ class SpacedOpaqueSyntaxAttribute(OpaqueSyntaxAttribute):
     pass
 
 
-DataElement = TypeVar("DataElement", covariant=True)
+DataElement = TypeVar("DataElement", covariant=True, bound=Hashable)
 
 AttributeCovT = TypeVar("AttributeCovT", bound=Attribute, covariant=True)
 AttributeInvT = TypeVar("AttributeInvT", bound=Attribute)
@@ -546,12 +546,6 @@ class Data(Generic[DataElement], Attribute, ABC):
     @abstractmethod
     def print_parameter(self, printer: Printer) -> None:
         """Print the attribute parameter."""
-
-    def __hash__(self) -> int:
-        if isinstance(self.data, Hashable):
-            return hash((type(self), self.data))
-        else:
-            return id(self)
 
 
 EnumType = TypeVar("EnumType", bound=StrEnum)
@@ -675,9 +669,6 @@ class ParametrizedAttribute(Attribute):
         attr_def = t.get_irdl_definition()
         attr_def.verify(self)
         super()._verify()
-
-    def __hash__(self) -> int:
-        return hash((type(self), self.parameters))
 
 
 class TypedAttribute(ParametrizedAttribute, Generic[AttributeCovT], ABC):

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -2468,12 +2468,10 @@ def irdl_attr_definition(cls: TypeAttributeInvT) -> TypeAttributeInvT:
         data_class = cast(type[Data[Any]], cls)
         data_metaclass = cast(ABCMeta, data_class.__class__)
         irdled = runtime_final(
-            dataclass(frozen=True)(
-                data_metaclass(
-                    cls.__name__,
-                    (cls, *cls.__bases__),
-                    dict(cls.__dict__),
-                )
+            data_metaclass(
+                cls.__name__,
+                (cls, *cls.__bases__),
+                dict(cls.__dict__),
             )
         )
         return cast(TypeAttributeInvT, irdled)


### PR DESCRIPTION
Rationale reminder:
We already made `Data` a frozen dataclass, which force-provides a specific `hash` implementation assuming the data element is washable. Though we do not enforce this anywhere and it ungracefully crashes on non-compliant cases.

Also:
- Accordingly freeze AffineExpr constructs.
- Use `tuple` instead of `list` in a test-intended Data attribute.
- Tidy up the `@irdl_attr_definition` Data case:
  - Do not throw away base classes
  - Then no need to refreeze it? This silently overwrites a lot of stuff the user might want to provide on their specific Data attribute. It just needs to be Hashable, the read-only `data` part is already enforced by the `Data` base class, now carried through.
  - It typechecks :exploding_head: 