### PR TITLE
api: Fixed builtin.DenseArrayBase not supporting IndexType

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -17,6 +17,7 @@ from xdsl.dialects.builtin import (
     Float128Type,
     FloatAttr,
     FloatData,
+    IndexType,
     IntAttr,
     MemRefType,
     NoneAttr,
@@ -88,9 +89,15 @@ def test_DenseArrayBase_verifier_failure():
     )
 
     with pytest.raises(VerifyException) as err:
+        DenseArrayBase([IndexType(), ArrayAttr([FloatData(0.0)])])
+    assert err.value.args[0] == (
+        "dense array of integer or index element type " "should only contain integers"
+    )
+
+    with pytest.raises(VerifyException) as err:
         DenseArrayBase([i32, ArrayAttr([FloatData(0.0)])])
     assert err.value.args[0] == (
-        "dense array of integer element type " "should only contain integers"
+        "dense array of integer or index element type " "should only contain integers"
     )
 
 
@@ -283,3 +290,6 @@ def test_dense_as_tuple():
 
     ints = DenseArrayBase.from_list(i32, [1, 1, 2, 3, 5, 8])
     assert ints.as_tuple() == (1, 1, 2, 3, 5, 8)
+
+    indices = DenseArrayBase.from_list(IndexType(), [1, 1, 2, 3, 5, 8])
+    assert indices.as_tuple() == (1, 1, 2, 3, 5, 8)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1046,15 +1046,15 @@ class DenseResourceAttr(ParametrizedAttribute):
 class DenseArrayBase(ParametrizedAttribute):
     name = "array"
 
-    elt_type: ParameterDef[IntegerType | AnyFloat]
+    elt_type: ParameterDef[IntegerType | IndexType | AnyFloat]
     data: ParameterDef[ArrayAttr[IntAttr] | ArrayAttr[FloatData]]
 
     def verify(self):
-        if isinstance(self.elt_type, IntegerType):
+        if isinstance(self.elt_type, IntegerType | IndexType):
             for d in self.data.data:
                 if isinstance(d, FloatData):
                     raise VerifyException(
-                        "dense array of integer element type "
+                        "dense array of integer or index element type "
                         "should only contain integers"
                     )
         else:


### PR DESCRIPTION
api: Fixed builtin.DenseArrayBase not supporting IndexType as element type
Fixes issue #2604 