### PR TITLE
docs: Change link to pr title formatting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Make sure to follow the steps in the checklist below *before* you submit this PR
 ## Checklist before you submit this PR:
 
  - [ ] If your PR is not ready for review, open it as a draft instead.
- - [ ] Make sure your PR title follows the [guidelines](https://github.com/xdslproject/xdsl/wiki/Tags-for-commit-messages-and-PR-titles)
+ - [ ] Make sure your PR title follows the [guidelines](https://github.com/xdslproject/xdsl/wiki#commit-and-pr-message-formatting)
  - [ ] Add some tags to categorize the PR, if able.
  - [ ] Request review from people you *know* have to sign off on these changes, you can leave it blank for now if you are not sure or don't have the rights to request reviews.
  - [ ] Tag people you wish to get feedback from (using @\<username>), they will then sort out the reviewers.


### PR DESCRIPTION
Changes the link to point to the new PR naming guidelines section of the wiki