### PR TITLE
Fix typing-extensions version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Mathieu Fehr", email = "mathieu.fehr@ed.ac.uk" }]
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "immutabledict<4.2.1",
-    "typing-extensions>=4.7,<5",
+    "typing-extensions>=4.7,<4.12",
     "ordered-set==4.1.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
typing-extensions 4.12 is causing our CI to fail.
Restricting it will make the CI pass while we are identifying the issue