### PR TITLE
dialects: stencil: more canonicalization

### DIFF
--- a/tests/filecheck/dialects/stencil/canonicalize.mlir
+++ b/tests/filecheck/dialects/stencil/canonicalize.mlir
@@ -16,8 +16,7 @@ func.func @dup_operand(%f : !stencil.field<[0,64]xf64>, %of1 : !stencil.field<[0
 // CHECK-NEXT:      %t = stencil.load %f : !stencil.field<[0,64]xf64> -> !stencil.temp<?xf64>
 // CHECK-NEXT:      %o1, %o1_1 = stencil.apply(%one = %t : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>, !stencil.temp<?xf64>) {
 // CHECK-NEXT:        %0 = stencil.access %one[0] : !stencil.temp<?xf64>
-// CHECK-NEXT:        %1 = stencil.access %one[0] : !stencil.temp<?xf64>
-// CHECK-NEXT:        stencil.return %0, %1 : f64, f64
+// CHECK-NEXT:        stencil.return %0, %0 : f64, f64
 // CHECK-NEXT:      }
 // CHECK-NEXT:      stencil.store %o1 to %of1 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>
 // CHECK-NEXT:      stencil.store %o1_1 to %of2 ([0] : [64]) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -385,10 +385,15 @@ class ApplyOpHasCanonicalizationPatternsTrait(HasCanonicalisationPatternsTrait):
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.stencil import (
             RedundantOperands,
+            UnusedOperands,
             UnusedResults,
         )
 
-        return (RedundantOperands(), UnusedResults())
+        return (
+            RedundantOperands(),
+            UnusedResults(),
+            UnusedOperands(),
+        )
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/stencil.py
@@ -57,13 +57,11 @@ class UnusedOperands(RewritePattern):
 
         new = stencil.ApplyOp.get(
             operands,
-            new_block := Block(arg_types=bbargs_type),
+            block := Block(arg_types=bbargs_type),
             [cast(stencil.TempType[Attribute], r.type) for r in op.res],
         )
 
-        rewriter.inline_block_at_start(
-            op.region.detach_block(0), new.region.block, new_block.args
-        )
+        rewriter.inline_block_at_start(op.region.block, block, block.args)
         rewriter.replace_matched_op(new)
 
 

--- a/xdsl/transforms/canonicalization_patterns/stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/stencil.py
@@ -7,6 +7,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.transforms.common_subexpression_elimination import cse
 
 
 class RedundantOperands(RewritePattern):
@@ -30,13 +31,38 @@ class RedundantOperands(RewritePattern):
         if not found_duplicate:
             return
 
+        bbargs = op.region.block.args
+        for i, a in enumerate(bbargs):
+            if rbargs[i] == i:
+                continue
+            a.replace_by(bbargs[rbargs[i]])
+
+        cse(op.region.block)
+
+
+class UnusedOperands(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: stencil.ApplyOp, rewriter: PatternRewriter) -> None:
+        op_args = op.region.block.args
+        unused = {a for a in op_args if not a.uses}
+        if not unused:
+            return
+        bbargs = [a for a in op_args if a not in unused]
+        bbargs_type = [a.type for a in bbargs]
+        operands = [a for i, a in enumerate(op.args) if op_args[i] not in unused]
+
+        for arg in unused:
+            op.region.block.erase_arg(arg)
+
         new = stencil.ApplyOp.get(
-            unique_operands,
-            block := Block(arg_types=[uo.type for uo in unique_operands]),
+            operands,
+            new_block := Block(arg_types=bbargs_type),
             [cast(stencil.TempType[Attribute], r.type) for r in op.res],
         )
+
         rewriter.inline_block_at_start(
-            op.region.block, block, [block.args[i] for i in rbargs]
+            op.region.detach_block(0), new.region.block, new_block.args
         )
         rewriter.replace_matched_op(new)
 


### PR DESCRIPTION
Stencil canonicalization now takes care of dropping unused operands.
Also leverage CSE after removing duplicated operands to simplify the body accordingly (i.e., get rid of now duplicated accesses)