### PR TITLE
[RFC] misc: implement PatternUnfoldListener

### DIFF
--- a/xdsl/utils/diagnostic.py
+++ b/xdsl/utils/diagnostic.py
@@ -16,14 +16,9 @@ class Diagnostic:
         """Add a message to an operation."""
         self.op_messages.setdefault(op, []).append(message)
 
-    def raise_exception(
-        self,
-        message: str,
-        ir: IRNode,
-        exception_type: type[Exception] = DiagnosticException,
-        underlying_error: Exception | None = None,
-    ) -> NoReturn:
-        """Raise an exception, that will also print all messages in the IR."""
+    def get_output(self, ir: IRNode) -> str:
+        """Get all messages in the IR."""
+
         from xdsl.printer import Printer
 
         f = StringIO()
@@ -39,4 +34,17 @@ class Diagnostic:
         else:
             assert "xDSL internal error: get_toplevel_object returned unknown construct"
 
-        raise exception_type(message + "\n\n" + f.getvalue()) from underlying_error
+        return f.getvalue()
+
+    def raise_exception(
+        self,
+        message: str,
+        ir: IRNode,
+        exception_type: type[Exception] = DiagnosticException,
+        underlying_error: Exception | None = None,
+    ) -> NoReturn:
+        """Raise an exception, that will also print all messages in the IR."""
+
+        raise exception_type(
+            message + "\n\n" + self.get_output(ir)
+        ) from underlying_error

--- a/xdsl/utils/listeners/pattern_unfold_listener.py
+++ b/xdsl/utils/listeners/pattern_unfold_listener.py
@@ -1,0 +1,72 @@
+from collections.abc import Sequence
+
+from xdsl.ir import Block, BlockArgument, Operation, OpResult, SSAValue
+from xdsl.pattern_rewriter import PatternRewriterListener
+from xdsl.utils.diagnostic import Diagnostic
+
+
+def print_operation_insertion(op: Operation):
+    d = Diagnostic()
+    d.add_message(op, "Operation inserted")
+    print(d.get_output(op))
+
+
+def print_operation_removal(op: Operation):
+    d = Diagnostic()
+    d.add_message(op, "Removing this operation")
+    print(d.get_output(op))
+
+
+def print_operation_replacement(op: Operation, new_results: Sequence[SSAValue | None]):
+    d = Diagnostic()
+    if len(op.results) == len(new_results):
+        for new_r, old_r in zip(new_results, op.results):
+            if new_r is not None:
+                if isinstance(new_r, OpResult):
+                    owner = new_r.owner
+                    d.add_message(
+                        owner,
+                        f"Result #{new_r.index} is replacing result #{old_r.index}.",
+                    )
+                elif isinstance(new_r, BlockArgument):
+                    block = new_r.owner
+                    region = block.parent
+                    if region is None:
+                        continue
+                    owner = region.parent
+                    if owner is None:
+                        continue
+                    d.add_message(
+                        owner,
+                        f"Argument #{new_r.index} of block #{region.get_block_index(block)} is replacing result #{old_r.index}.",
+                    )
+
+    d.add_message(op, "Replacing this operation")
+
+    print(d.get_output(op))
+
+
+def print_operation_modification(op: Operation):
+    d = Diagnostic()
+    d.add_message(op, "Modifying this operation")
+    print(d.get_output(op))
+
+
+def print_block_creation(b: Block):
+    d = Diagnostic()
+    op = b.parent_op()
+    if op is not None:
+        d.add_message(op, "Block created")
+    print(d.get_output(b))
+
+
+class PatternUnfoldListener(PatternRewriterListener):
+
+    def __init__(self):
+        super().__init__(
+            operation_insertion_handler=[print_operation_insertion],
+            block_creation_handler=[print_block_creation],
+            operation_removal_handler=[print_operation_removal],
+            operation_modification_handler=[print_operation_modification],
+            operation_replacement_handler=[print_operation_replacement],
+        )

--- a/xdsl/utils/listeners/pattern_unfold_listener.py
+++ b/xdsl/utils/listeners/pattern_unfold_listener.py
@@ -62,11 +62,28 @@ def print_block_creation(b: Block):
 
 class PatternUnfoldListener(PatternRewriterListener):
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        insertion: bool = True,
+        removal: bool = True,
+        modification: bool = True,
+        replacement: bool = True,
+        block_creation: bool = True,
+    ):
+        operation_insertion_handler = [print_operation_insertion] if insertion else []
+        operation_removal_handler = [print_operation_removal] if removal else []
+        operation_modification_handler = (
+            [print_operation_modification] if modification else []
+        )
+        operation_replacement_handler = (
+            [print_operation_replacement] if replacement else []
+        )
+        block_creation_handler = [print_block_creation] if block_creation else []
         super().__init__(
-            operation_insertion_handler=[print_operation_insertion],
-            block_creation_handler=[print_block_creation],
-            operation_removal_handler=[print_operation_removal],
-            operation_modification_handler=[print_operation_modification],
-            operation_replacement_handler=[print_operation_replacement],
+            operation_insertion_handler=operation_insertion_handler,
+            block_creation_handler=block_creation_handler,
+            operation_removal_handler=operation_removal_handler,
+            operation_modification_handler=operation_modification_handler,
+            operation_replacement_handler=operation_replacement_handler,
         )


### PR DESCRIPTION
Currently confused by some behaviour of a pattern-based pass I'm working on, I wrote this to be able to see the steps done in order.

I think it would make sense to expose this as a CLI option of `xdsl-opt` directly, but getting there requires extra plumbing AFAIU.
Meanwhile, what do people think? This can be used in development by adding it directly to the pass you're working on.