### PR TITLE
backend: (csl) printing for functions, tasks and layout related things

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -1,6 +1,92 @@
 // RUN: xdsl-opt -t csl %s | filecheck %s
 
 "csl.module"() <{kind=#csl<module_kind program>}> ({
+  // csl.func, csl.return
+  csl.func @no_args_no_return() {
+    csl.return
+  }
+
+  csl.func @no_args_return() -> f32 {
+    %c = arith.constant 5.0 : f32
+    csl.return %c : f32
+  }
+
+  csl.func @args_no_return(%a: i32, %b: i32) {
+    csl.return
+  }
+
+  // csl.const_struct
+  %empty_struct = "csl.const_struct"() : () -> !csl.comptime_struct
+  %attribute_struct = "csl.const_struct"() <{items = {hello = 123 : f32}}> : () -> !csl.comptime_struct
+  %const27 = arith.constant 27 : i16
+  %ssa_struct = "csl.const_struct"(%const27) <{ssa_fields = ["val"]}> : (i16) -> !csl.comptime_struct
+
+  %no_param_import = "csl.import_module"() <{module = "<mod>"}> : () -> !csl.imported_module
+  %param_import = "csl.import_module"(%ssa_struct) <{module = "<mod>"}> : (!csl.comptime_struct) -> !csl.imported_module
+
+  "csl.member_call"(%param_import) <{field = "foo"}> : (!csl.imported_module) -> ()
+  "csl.member_call"(%param_import, %const27) <{field = "bar"}> : (!csl.imported_module, i16) -> ()
+  %val2 = "csl.member_call"(%param_import) <{field = "baz"}> : (!csl.imported_module) -> (f32)
+
+  %val3 = "csl.member_access"(%param_import) <{field = "f"}> :  (!csl.imported_module) -> (i32)
+
+
+  csl.func @main() {
+    "csl.call"() <{callee = @no_args_no_return}> : () -> ()
+    "csl.call"(%val3, %val3) <{callee = @args_no_return}> : (i32, i32) -> ()
+    %ret = "csl.call"() <{callee = @no_args_return}> : () -> (f32)
+
+    csl.return
+  }
+
+
+  csl.task @data_task(%arg: f32) attributes {kind = #csl<task_kind data>, id = 0 : i5} {
+    csl.return
+  }
+
+  csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 1 : i5} {
+    csl.return
+  }
+
+  // TODO(dk949): control_task
+
+
+  "memref.global"() {"sym_name" = "uninit_array", "type" = memref<10xf32>, "sym_visibility" = "public", "initial_value"} : () -> ()
+  "memref.global"() {"sym_name" = "global_array", "type" = memref<10xf32>, "sym_visibility" = "public", "initial_value" = dense<4.2> : tensor<1xf32>} : () -> ()
+  "memref.global"() {"sym_name" = "const_array", "type" = memref<10xi32>, "sym_visibility" = "public", "constant", "initial_value" = dense<10> : tensor<1xi32>} : () -> ()
+
+
+  %uninit_array = memref.get_global @uninit_array : memref<10xf32>
+  %global_array = memref.get_global @global_array : memref<10xf32>
+  %const_array = memref.get_global @const_array : memref<10xi32>
+
+  %uninit_ptr = "csl.addressof"(%uninit_array) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const var>>
+  %global_ptr = "csl.addressof"(%global_array) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const var>>
+  %const_ptr  = "csl.addressof"(%const_array) : (memref<10xi32>) -> !csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const const>>
+
+  %ptr_to_arr = "csl.addressof"(%uninit_array) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const var>>
+  %ptr_to_val = "csl.addressof"(%const27) : (i16) -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const const>>
+
+
+  "csl.export"(%global_ptr) <{
+    type = !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const var>>,
+    var_name = "ptr_name"
+  }> : (!csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const var>>) -> ()
+
+  "csl.export"(%const_ptr) <{
+    type = !csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const const>>,
+    var_name = "another_ptr"
+  }> : (!csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> ()
+
+  "csl.export"() <{type = () -> (), var_name = @no_args_no_return}> : () -> ()
+
+  "csl.export"() <{type = (i32, i32) -> (), var_name = @args_no_return}> : () -> ()
+
+    %col  = "csl.get_color"() <{id = 15 : i5}> : () -> !csl.color
+
+    "csl.rpc"(%col) : (!csl.color) -> ()
+
+
 
 "memref.global"() {"sym_name" = "A", "type" = memref<24xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
 "memref.global"() {"sym_name" = "x", "type" = memref<6xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
@@ -8,6 +94,7 @@
 "memref.global"() {"sym_name" = "y", "type" = memref<4xf32>, "sym_visibility" = "public", "initial_value" = dense<0> : tensor<1xindex>} : () -> ()
 
 %thing = "csl.import_module"() <{module = "<thing>"}> : () -> !csl.imported_module
+
 
 csl.func @initialize() {
   %lb = arith.constant   0 : i16
@@ -97,13 +184,101 @@ csl.func @gemv() {
 }) {sym_name = "program"} : () -> ()
 
 
+"csl.module"() <{kind=#csl<module_kind layout>}> ({
+  %p1 = "csl.param"() <{param_name = "param_1"}> : () -> i32
+  %p2 = "csl.param"() <{param_name = "param_2", init_value = 1.3 : f16}> : () -> f16
+
+  csl.layout {
+    %x_dim = arith.constant 4 : i32
+    %y_dim = arith.constant 6 : i32
+    "csl.set_rectangle"(%x_dim, %y_dim) : (i32, i32) -> ()
+
+    %x_coord0 = arith.constant 0 : i32
+    %y_coord = arith.constant 0 : i32
+    "csl.set_tile_code"(%x_coord0, %y_coord) <{file = "file.csl"}> : (i32, i32) -> ()
+
+    %params = "csl.const_struct"(){items = {hello = 123 : i32}} : () -> !csl.comptime_struct
+    %x_coord1 = arith.constant 1 : i32
+    "csl.set_tile_code"(%x_coord1, %y_coord, %params) <{file = "file.csl"}> : (i32, i32, !csl.comptime_struct) -> ()
+
+  }
+}) {sym_name = "layout"} : () -> ()
+
+// CHECK-NEXT:
+// CHECK-NEXT: fn no_args_no_return() void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: fn no_args_return() f32 {
+// CHECK-NEXT:   const c : f32 = 5.0;
+// CHECK-NEXT:   return c;
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: fn args_no_return(a : i32, b : i32) void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT: //unknown op ConstStructOp(%empty_struct = "csl.const_struct"() : () -> !csl.comptime_struct)
+// CHECK-NEXT: //unknown op ConstStructOp(%attribute_struct = "csl.const_struct"() <{"items" = {"hello" = 1.230000e+02 : f32}}> : () -> !csl.comptime_struct)
+// CHECK-NEXT: const const27 : i16 = 27;
+// CHECK-NEXT: //unknown op ConstStructOp(%ssa_struct = "csl.const_struct"(%const27) <{"ssa_fields" = ["val"]}> : (i16) -> !csl.comptime_struct)
+// CHECK-NEXT: const no_param_import : imported_module = @import_module("<mod>");
+// CHECK-NEXT: const param_import : imported_module = @import_module("<mod>", ssa_struct);
+// CHECK-NEXT: param_import.foo();
+// CHECK-NEXT: param_import.bar(const27);
+// CHECK-NEXT: const val2 : f32 = param_import.baz();
+// CHECK-NEXT: const val3 : i32 = param_import.f;
+// CHECK-NEXT:
+// CHECK-NEXT: fn main() void {
+// CHECK-NEXT:   no_args_no_return();
+// CHECK-NEXT:   args_no_return(val3, val3);
+// CHECK-NEXT:   const ret : f32 = no_args_return();
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: task data_task(arg : f32) void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @bind_data_task(data_task, @get_data_task_id(@get_color(0)));
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: task local_task() void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @bind_local_task(local_task, @get_local_task_id(1));
+// CHECK-NEXT: }
+// CHECK-NEXT: var uninit_array : [10]f32;
+// CHECK-NEXT: var global_array : [10]f32 = @constants([10]f32, 4.2);
+// CHECK-NEXT: const const_array : [10]i32 = @constants([10]i32, 10);
+
+// CHECK-NEXT: //unknown op AddressOfOp(%uninit_ptr = "csl.addressof"(%uninit_array) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const var>>)
+// CHECK-NEXT: //unknown op AddressOfOp(%global_ptr = "csl.addressof"(%global_array) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const var>>)
+// CHECK-NEXT: //unknown op AddressOfOp(%const_ptr = "csl.addressof"(%const_array) : (memref<10xi32>) -> !csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const const>>)
+// CHECK-NEXT: //unknown op AddressOfOp(%ptr_to_arr = "csl.addressof"(%uninit_array) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const var>>)
+// CHECK-NEXT: //unknown op AddressOfOp(%ptr_to_val = "csl.addressof"(%const27) : (i16) -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const const>>)
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @export_symbol(global_ptr, "ptr_name");
+// CHECK-NEXT: }
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @export_symbol(const_ptr, "another_ptr");
+// CHECK-NEXT: }
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @export_symbol(no_args_no_return, "no_args_no_return");
+// CHECK-NEXT: }
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @export_symbol(args_no_return, "args_no_return");
+// CHECK-NEXT: }
+// CHECK-NEXT: //unknown op GetColorOp(%col = "csl.get_color"() <{"id" = 15 : i5}> : () -> !csl.color)
+// CHECK-NEXT: //unknown op RpcOp("csl.rpc"(%col) : (!csl.color) -> ())
+
 // CHECK-NEXT: var A : [24]f32 = @constants([24]f32, 0);
 // CHECK-NEXT: var x : [6]f32 = @constants([6]f32, 0);
 // CHECK-NEXT: var b : [4]f32 = @constants([4]f32, 0);
 // CHECK-NEXT: var y : [4]f32 = @constants([4]f32, 0);
 // CHECK-NEXT: const thing : imported_module = @import_module("<thing>");
 // CHECK-NEXT:
-// CHECK-NEXT: fn initialize() {
+// CHECK-NEXT: fn initialize() void {
 // CHECK-NEXT:   const lb : i16 = 0;
 // CHECK-NEXT:   const ub : i16 = 24;
 // CHECK-NEXT:   const step : i16 = 1;
@@ -138,7 +313,7 @@ csl.func @gemv() {
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT:
-// CHECK-NEXT: fn gemv() {
+// CHECK-NEXT: fn gemv() void {
 // CHECK-NEXT:   const lb : i32 = 0;
 // CHECK-NEXT:   const step : i32 = 1;
 // CHECK-NEXT:   const ub : i32 = 6;
@@ -162,4 +337,23 @@ csl.func @gemv() {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
+// CHECK-NEXT: // >>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<< //
+// CHECK-NEXT: //unknown op ParamOp(%p1 = "csl.param"() <{"param_name" = "param_1"}> : () -> i32)
+// CHECK-NEXT: //unknown op ParamOp(%p2 = "csl.param"() <{"param_name" = "param_2", "init_value" = 1.300000e+00 : f16}> : () -> f16)
+// CHECK-NEXT: layout {
+// CHECK-NEXT:   const x_dim : i32 = 4;
+// CHECK-NEXT:   const y_dim : i32 = 6;
+// CHECK-NEXT:   //unknown op SetRectangleOp("csl.set_rectangle"(%x_dim, %y_dim) : (i32, i32) -> ())
+// CHECK-NEXT:   const x_coord0 : i32 = 0;
+// CHECK-NEXT:   const y_coord : i32 = 0;
+// CHECK-NEXT:   //unknown op SetTileCodeOp("csl.set_tile_code"(%x_coord0, %y_coord) <{"file" = "file.csl"}> : (i32, i32) -> ())
+// CHECK-NEXT:   //unknown op ConstStructOp(%params = "csl.const_struct"() <{"items" = {"hello" = 123 : i32}}> : () -> !csl.comptime_struct)
+// CHECK-NEXT:   const x_coord1 : i32 = 1;
+// CHECK-NEXT:   //unknown op SetTileCodeOp("csl.set_tile_code"(%x_coord1, %y_coord, %params) <{"file" = "file.csl"}> : (i32, i32, !csl.comptime_struct) -> ())
+// CHECK-NEXT:   @export_name("ptr_name", <!unknown value !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const var>>>, true);
+// CHECK-NEXT:   @export_name("another_ptr", <!unknown value !csl.ptr<i32, #csl<ptr_kind many>, #csl<ptr_const const>>>, false);
+// CHECK-NEXT:   @export_name("no_args_no_return", <!unknown value () -> ()>, );
+// CHECK-NEXT:   @export_name("args_no_return", <!unknown value (i32, i32) -> ()>, );
+// CHECK-NEXT: }
+
 // CHECK-EMPTY:

--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -48,7 +48,21 @@
     csl.return
   }
 
-  // TODO(dk949): control_task
+  csl.task @control_task() attributes {kind = #csl<task_kind control>, id = 42 : i6} {
+    csl.return
+  }
+
+  csl.task @data_task_no_bind(%arg: f32) attributes {kind = #csl<task_kind data>} {
+    csl.return
+  }
+
+  csl.task @local_task_no_bind() attributes {kind = #csl<task_kind local>} {
+    csl.return
+  }
+
+  csl.task @control_task_no_bind() attributes {kind = #csl<task_kind control>} {
+    csl.return
+  }
 
 
   "memref.global"() {"sym_name" = "uninit_array", "type" = memref<10xf32>, "sym_visibility" = "public", "initial_value"} : () -> ()
@@ -247,6 +261,25 @@ csl.func @gemv() {
 // CHECK-NEXT: }
 // CHECK-NEXT: comptime {
 // CHECK-NEXT:   @bind_local_task(local_task, @get_local_task_id(1));
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: task control_task() void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @bind_control_task(control_task, @get_control_task_id(42));
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: task data_task_no_bind(arg0 : f32) void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: task local_task_no_bind() void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: task control_task_no_bind() void {
+// CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT: var uninit_array : [10]f32;
 // CHECK-NEXT: var global_array : [10]f32 = @constants([10]f32, 4.2);

--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -317,9 +317,9 @@ csl.func @gemv() {
 // CHECK-NEXT:   const step : i16 = 1;
 // CHECK-NEXT:   thing.some_func(lb, ub);
 // CHECK-NEXT:   const res : i32 = thing.some_func(lb, ub);
-// CHECK-NEXT:   const v0 : comptime_struct = thing.some_field;
-// CHECK-NEXT:   const v1 : f32 = 3.14;
-// CHECK-NEXT:   const v02 : f16 = 2.718;
+// CHECK-NEXT:   const v1 : comptime_struct = thing.some_field;
+// CHECK-NEXT:   const v2 : f32 = 3.14;
+// CHECK-NEXT:   const v0 : f16 = 2.718;
 // CHECK-NEXT:   const u32cst : u32 = 44;
 // CHECK-NEXT:
 // CHECK-NEXT:   for(@range(i16, lb, ub, step)) |idx| {
@@ -350,11 +350,11 @@ csl.func @gemv() {
 // CHECK-NEXT:   const lb : i32 = 0;
 // CHECK-NEXT:   const step : i32 = 1;
 // CHECK-NEXT:   const ub : i32 = 6;
-// CHECK-NEXT:   const ub0 : i32 = 4;
+// CHECK-NEXT:   const ub1 : i32 = 4;
 // CHECK-NEXT:
-// CHECK-NEXT:   for(@range(i32, lb, ub0, step)) |i| {
+// CHECK-NEXT:   for(@range(i32, lb, ub1, step)) |i| {
 // CHECK-NEXT:     const tmp : f32 = 0.0;
-// CHECK-NEXT:     var tmp1 : f32 = tmp;
+// CHECK-NEXT:     var tmp2 : f32 = tmp;
 // CHECK-NEXT:
 // CHECK-NEXT:     for(@range(i32, lb, ub, step)) |j| {
 // CHECK-NEXT:       //unknown op Muli(%ix6 = arith.muli %i, %ub : index)

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -103,6 +103,10 @@ class CslPrintContext:
     def _print_bind_task(
         self, name: str, kind: csl.TaskKind, id: csl.ColorIdAttr | None
     ):
+        """
+        Generate a call to `@bind_<kind>_task` if task ID was specified as a
+        property of the task. Otherwise we assume binding will be done at runtime.
+        """
         if id is None:
             return
         with self._in_block("comptime"):

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -72,7 +72,7 @@ class CslPrintContext:
             if len(ftyp.outputs) == 0
             else self.mlir_type_to_csl_type(ftyp.outputs.data[0])
         )
-        self.print(f"{introducer} {name.data}({args}) {ret} {{")
+        self.print(f"\n{introducer} {name.data}({args}) {ret} {{")
         self.descend().print_block(bdy.block)
         self.print("}")
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -60,7 +60,7 @@ class CslPrintContext:
         self.print("}")
         pass
 
-    def _task_or_fn(
+    def _print_task_or_fn(
         self, introducer: str, name: StringAttr, bdy: Region, ftyp: FunctionType
     ):
         args = ", ".join(
@@ -81,7 +81,9 @@ class CslPrintContext:
             return f"@get_color({id})"
         return str(id)
 
-    def _bind_task(self, name: str, kind: csl.TaskKind, id: csl.ColorIdAttr | None):
+    def _print_bind_task(
+        self, name: str, kind: csl.TaskKind, id: csl.ColorIdAttr | None
+    ):
         if id is None:
             return
         with self._in_block("comptime"):
@@ -266,10 +268,10 @@ class CslPrintContext:
                 case csl.TaskOp(
                     sym_name=name, body=bdy, function_type=ftyp, kind=kind, id=id
                 ):
-                    self._task_or_fn("task", name, bdy, ftyp)
-                    self._bind_task(name.data, kind.data, id)
+                    self._print_task_or_fn("task", name, bdy, ftyp)
+                    self._print_bind_task(name.data, kind.data, id)
                 case csl.FuncOp(sym_name=name, body=bdy, function_type=ftyp):
-                    self._task_or_fn("fn", name, bdy, ftyp)
+                    self._print_task_or_fn("fn", name, bdy, ftyp)
                 case csl.ReturnOp(ret_val=None):
                     self.print("return;")
                 case csl.ReturnOp(ret_val=val) if val is not None:

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -89,7 +89,7 @@ class CslPrintContext:
         self.descend().print_block(bdy.block)
         self.print("}")
 
-    def _wrapp_task_id(self, kind: csl.TaskKind, id: int) -> str:
+    def _wrap_task_id(self, kind: csl.TaskKind, id: int) -> str:
         """
         When using `@get_<kind>_tadk_id`, data task IDs have to be wrapped in
         `@get_color`. Local and control task IDs  just get passed directly.
@@ -111,7 +111,7 @@ class CslPrintContext:
             return
         with self._in_block("comptime"):
             self.print(
-                f"@bind_{kind.value}_task({name}, @get_{kind.value}_task_id({self._wrapp_task_id(kind, id.value.data)}));"
+                f"@bind_{kind.value}_task({name}, @get_{kind.value}_task_id({self._wrap_task_id(kind, id.value.data)}));"
             )
 
     def _memref_global_init(self, init: Attribute, type: str) -> str:

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -114,7 +114,11 @@ class CslPrintContext:
                 f"@bind_{kind.value}_task({name}, @get_{kind.value}_task_id({self._wrapp_task_id(kind, id.value.data)}));"
             )
 
-    def _memref_global_init(self, init: Attribute, type: str):
+    def _memref_global_init(self, init: Attribute, type: str) -> str:
+        """
+        Generate an initialisation expression (@constants) for global arrays.
+        Expects the memref.global initial_value property.
+        """
         match init:
             case UnitAttr():
                 return ""

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -370,6 +370,13 @@ class CslPrintContext:
 
 
 def _get_layout_program(module: ModuleOp) -> tuple[csl.CslModuleOp, csl.CslModuleOp]:
+    """
+    Get the layout and program `csl.module`s from the top level `builtin.module`.
+
+    Makes sure there is exactly 1 layout and 1 program `csl.module`.
+
+    Returns layout first, then program.
+    """
     ops_list = list(module.body.block.ops)
     assert all(
         isinstance(mod, csl.CslModuleOp) for mod in ops_list

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -89,7 +89,13 @@ class CslPrintContext:
         self.descend().print_block(bdy.block)
         self.print("}")
 
-    def _wrapp_task_id(self, kind: csl.TaskKind, id: int):
+    def _wrapp_task_id(self, kind: csl.TaskKind, id: int) -> str:
+        """
+        When using `@get_<kind>_tadk_id`, data task IDs have to be wrapped in
+        `@get_color`. Local and control task IDs  just get passed directly.
+
+        Returns wrapped ID as a string.
+        """
         if kind == csl.TaskKind.DATA:
             return f"@get_color({id})"
         return str(id)

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -24,7 +24,7 @@ from xdsl.dialects.builtin import (
     TypeAttribute,
     UnitAttr,
 )
-from xdsl.ir import Attribute, Block, BlockOps, Region, SSAValue
+from xdsl.ir import Attribute, Block, Region, SSAValue
 
 
 @dataclass
@@ -352,8 +352,8 @@ class CslPrintContext:
         )
 
 
-def _get_layout_program(ops: BlockOps) -> tuple[csl.CslModuleOp, csl.CslModuleOp]:
-    ops_list = list(ops)
+def _get_layout_program(module: ModuleOp) -> tuple[csl.CslModuleOp, csl.CslModuleOp]:
+    ops_list = list(module.body.block.ops)
     assert all(
         isinstance(mod, csl.CslModuleOp) for mod in ops_list
     ), "Expected all top level ops to be csl.module"
@@ -377,7 +377,7 @@ def print_to_csl(prog: ModuleOp, output: IO[str]):
     Takes a module op and prints it to the given output stream.
     """
     ctx = CslPrintContext(output)
-    layout, program = _get_layout_program(prog.body.block.ops)
+    layout, program = _get_layout_program(prog)
     ctx.print_block(program.body.block)
     ctx.print(ctx.DIVIDER)
     ctx.print_block(layout.body.block)

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -68,7 +68,7 @@ class CslPrintContext:
 
     def _print_task_or_fn(
         self,
-        kind: Literal["fn"] | Literal["task"],
+        kind: Literal["fn", "task"],
         name: StringAttr,
         bdy: Region,
         ftyp: FunctionType,

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -52,6 +52,12 @@ class CslPrintContext:
 
     @contextmanager
     def _in_block(self, block_name: str):
+        """
+        To be used in a `with` statement.
+        Surrounds everything in the `with` with curly braces and .
+
+        This is used instead of descend when
+        """
         self.print(f"{block_name} {{")
         old_prefix = self._prefix
         self._prefix += self._INDENT

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -50,22 +50,6 @@ class CslPrintContext:
         for l in text.split("\n"):
             print(self._prefix + prefix + l, file=self.output, end=end)
 
-    @contextmanager
-    def _in_block(self, block_name: str):
-        """
-        To be used in a `with` statement.
-        Surrounds everything in the `with` with curly braces and .
-
-        This is used instead of descend when
-        """
-        self.print(f"{block_name} {{")
-        old_prefix = self._prefix
-        self._prefix += self._INDENT
-        yield
-        self._prefix = old_prefix
-        self.print("}")
-        pass
-
     def _print_task_or_fn(
         self,
         kind: Literal["fn", "task"],

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -323,6 +323,14 @@ class CslPrintContext:
                         export_val = name
                     with self._in_block("comptime"):
                         self.print(f"@export_symbol({export_val}, {q_name});")
+                case csl.LayoutOp(body=bdy):
+                    with self._in_block("layout"):
+                        self.print_block(bdy.block)
+                        for name, val in self._symbols_to_export.items():
+                            ty = self.attribute_value_to_str(val[0])
+                            # If specified, get mutability as true/false from python bool
+                            mut = str(val[1]).lower() if val[1] is not None else ""
+                            self.print(f'@export_name("{name}", {ty}, {mut});')
                 case anyop:
                     self.print(f"unknown op {anyop}", prefix="//")
 


### PR DESCRIPTION
Printing for:
* `csl.call`
* `csl.task`
* `csl.func`
    * Merged with `csl.task`
* `csl.export`
* `csl.layout`

Also introduces a divider between the program and layout, for ease of filechecking and splitting
