### PR TITLE
dialects: (csl) Data structure descriptors

### DIFF
--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -70,10 +70,10 @@ csl.func @initialize() {
     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 
-    %dsd_1d = "csl.get_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
-    %dsd_2d = "csl.get_dsd"(%arr, %scalar, %scalar) : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
-    %dsd_3d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
-    %dsd_4d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_1d = "csl.get_dsd"(%arr) <{"sizes" = [10]}> : (memref<10xf32>) -> !csl<dsd mem1d_dsd>
+    %dsd_2d = "csl.get_dsd"(%arr) <{"sizes" = [10,10], "strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
+    %dsd_3d = "csl.get_dsd"(%arr) <{"sizes" = [10,10,10]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
+    %dsd_4d = "csl.get_dsd"(%arr) <{"sizes" = [10,10,10,10]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
 
 
   csl.return
@@ -148,7 +148,7 @@ csl.func @initialize() {
 // CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %dsd_1d = "csl.get_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_2d = "csl.get_dsd"(%arr, %scalar, %scalar) : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_2d = "csl.get_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i16, 4 :i 16], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>'
 // CHECK-NEXT:     %dsd_3d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     %dsd_4d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     csl.return

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -147,6 +147,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
+// CHECK-NEXT:     %dsd_1d = "csl.get_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_2d = "csl.get_dsd"(%arr, %scalar, %scalar) : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_3d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_4d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -70,6 +70,10 @@ csl.func @initialize() {
     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 
+    %dsd_1d = "csl.get_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
+    %dsd_2d = "csl.get_dsd"(%arr, %scalar, %scalar) : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_3d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_4d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 
 
   csl.return

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -70,10 +70,10 @@ csl.func @initialize() {
     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 
-    %dsd_1d = "csl.get_dsd"(%arr) <{"sizes" = [10]}> : (memref<10xf32>) -> !csl<dsd mem1d_dsd>
-    %dsd_2d = "csl.get_dsd"(%arr) <{"sizes" = [10,10], "strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
-    %dsd_3d = "csl.get_dsd"(%arr) <{"sizes" = [10,10,10]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
-    %dsd_4d = "csl.get_dsd"(%arr) <{"sizes" = [10,10,10,10]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
+    %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
+    %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 
 
   csl.return
@@ -147,10 +147,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
-// CHECK-NEXT:     %dsd_1d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64]}> : (memref<10xf32>) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_2d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64, 10 : i64], "strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
-// CHECK-NEXT:     %dsd_3d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64, 10 : i64, 10 : i64]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
-// CHECK-NEXT:     %dsd_4d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64, 10 : i64, 10 : i64, 10 : i64]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -147,10 +147,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
-// CHECK-NEXT:     %dsd_1d = "csl.get_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_2d = "csl.get_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i16, 4 :i 16], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>'
-// CHECK-NEXT:     %dsd_3d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
-// CHECK-NEXT:     %dsd_4d = "csl.get_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_1d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64]}> : (memref<10xf32>) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_2d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64, 10 : i64], "strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_3d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64, 10 : i64, 10 : i64]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_4d = "csl.get_dsd"(%arr) <{"sizes" = [10 : i64, 10 : i64, 10 : i64, 10 : i64]}> : (memref<10xf32>) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -281,9 +281,6 @@ class DsdType(EnumAttribute[DsdKind], TypeAttribute, SpacedOpaqueSyntaxAttribute
 
     name = "csl.dsd"
 
-    def get_element_type(self) -> DsdKind:
-        return self.data
-
 
 @irdl_attr_definition
 class ColorType(ParametrizedAttribute, TypeAttribute):
@@ -699,10 +696,7 @@ class GetDsdOp(IRDLOperation):
             raise VerifyException("DSD can have at most 4 dimensions")
         if not isinstance(self.result.type, DsdType):
             raise VerifyException("DSD type is not DsdType")
-        if (
-            len(self.sizes) > 1
-            and self.result.type.get_element_type() == DsdKind.mem1d_dsd
-        ):
+        if len(self.sizes) > 1 and self.result.type.data == DsdKind.mem1d_dsd:
             raise VerifyException(
                 "DSD with more than 1 dimension cannot be of type mem1d_dsd"
             )

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -274,7 +274,7 @@ class PtrType(ParametrizedAttribute, TypeAttribute, ContainerType[Attribute]):
 
 
 @irdl_attr_definition
-class DsdType(EnumAttribute[DsdKind], TypeAttribute):
+class DsdType(EnumAttribute[DsdKind], TypeAttribute, SpacedOpaqueSyntaxAttribute):
     """
     Represents a DSD in CSL.
     """


### PR DESCRIPTION
A basic implementation of dsd types and the `@get_dsd`. Custom array index expressions are not yet supported, and the current version should be understood (and printed) as accessing `A[i,j,k]` according to the number of dimensions and generate induction vars accordingly.