### PR TITLE
core: unify (Pattern)Rewriter insertion and inlining APIs around InsertPoint

### DIFF
--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -59,7 +59,7 @@ def insert_alloc_and_dealloc(
 
     # Make sure to allocate at the beginning of the block.
     alloc = memref.Alloc.get(type.element_type, None, type.shape)
-    rewriter.insert_op_at_start(alloc, block)
+    rewriter.insert_op(alloc, InsertPoint.at_start(block))
 
     # Make sure to deallocate this alloc at the end of the block. This is fine as toy
     # functions have no control flow.

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -64,7 +64,7 @@ def insert_alloc_and_dealloc(
     # Make sure to deallocate this alloc at the end of the block. This is fine as toy
     # functions have no control flow.
     dealloc = memref.Dealloc.get(alloc)
-    rewriter.insert_op_before(dealloc, block.last_op)
+    rewriter.insert_op(dealloc, InsertPoint.before(block.last_op))
 
     return alloc
 
@@ -382,7 +382,7 @@ class ConstantOpLowering(RewritePattern):
         ]
 
         # Insert constants used before the alloc, not before matched operation
-        rewriter.insert_op_before(constants, alloc)
+        rewriter.insert_op(constants, InsertPoint.before(alloc))
 
         # Replace the constant by the stores, and its result by the allocated value
         rewriter.replace_matched_op(stores, (alloc.memref,))

--- a/docs/Toy/toy/rewrites/setup_riscv_pass.py
+++ b/docs/Toy/toy/rewrites/setup_riscv_pass.py
@@ -8,6 +8,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 class AddSections(RewritePattern):
@@ -27,7 +28,9 @@ class AddSections(RewritePattern):
         )
         data_section = riscv.AssemblySectionOp(".data", Region(Block()))
 
-        rewriter.insert_op_at_start((heap_section, data_section), op.body.block)
+        rewriter.insert_op(
+            (heap_section, data_section), InsertPoint.at_start(op.body.block)
+        )
 
 
 class SetupRiscvPass(ModulePass):

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -387,7 +387,7 @@ def test_insert_op_at_start():
         def match_and_rewrite(self, mod: ModuleOp, rewriter: PatternRewriter):
             new_cst = Constant.from_int_and_width(42, i32)
 
-            rewriter.insert_op_at_start(new_cst, mod.regions[0].blocks[0])
+            rewriter.insert_op(new_cst, InsertPoint.at_start(mod.regions[0].blocks[0]))
 
     rewrite_and_compare(
         prog,
@@ -1138,7 +1138,7 @@ def test_insert_same_block():
             )
 
             # Allocate before first use
-            rewriter.insert_op_at_start(alloc, block)
+            rewriter.insert_op(alloc, InsertPoint.at_start(block))
             # Deallocate after last use
             rewriter.insert_op(dealloc, InsertPoint.before(last_op))
             # Init instead of creating, and replace result with allocated value

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1140,7 +1140,7 @@ def test_insert_same_block():
             # Allocate before first use
             rewriter.insert_op_at_start(alloc, block)
             # Deallocate after last use
-            rewriter.insert_op_before(dealloc, last_op)
+            rewriter.insert_op(dealloc, InsertPoint.before(last_op))
             # Init instead of creating, and replace result with allocated value
             rewriter.replace_matched_op(init, alloc.res)
 

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -831,7 +831,7 @@ def test_inline_block_before():
 
                 if isinstance(first_op, test.TestOp):
                     inner_block = first_op.regs[0].blocks[0]
-                    rewriter.inline_block_before(inner_block, first_op)
+                    rewriter.inline_block(inner_block, InsertPoint.before(first_op))
 
     rewrite_and_compare(
         prog,
@@ -870,7 +870,9 @@ def test_inline_block_at_before_when_op_is_matched_op():
         @op_type_rewrite_pattern
         def match_and_rewrite(self, matched_op: test.TestOp, rewriter: PatternRewriter):
             if matched_op.regs and matched_op.regs[0].blocks:
-                rewriter.inline_block_before(matched_op.regs[0].blocks[0], matched_op)
+                rewriter.inline_block(
+                    matched_op.regs[0].blocks[0], InsertPoint.before(matched_op)
+                )
 
     rewrite_and_compare(
         prog,
@@ -924,8 +926,8 @@ def test_inline_block_before_with_args():
 
                 if isinstance(first_op, test.TestOp):
                     inner_block = first_op.regs[0].blocks[0]
-                    rewriter.inline_block_before(
-                        inner_block, first_op, outer_block.args
+                    rewriter.inline_block(
+                        inner_block, InsertPoint.before(first_op), outer_block.args
                     )
 
     rewrite_and_compare(
@@ -977,7 +979,7 @@ def test_inline_block_after():
                 if first_op is not None and isinstance(first_op, test.TestOp):
                     if first_op.regs and first_op.regs[0].blocks:
                         inner_block = first_op.regs[0].blocks[0]
-                        rewriter.inline_block_after(inner_block, first_op)
+                        rewriter.inline_block(inner_block, InsertPoint.after(first_op))
 
     rewrite_and_compare(
         prog,
@@ -1028,7 +1030,9 @@ def test_inline_block_after_matched():
                 if first_op is not None and isinstance(first_op, test.TestOp):
                     if first_op.regs and first_op.regs[0].blocks:
                         inner_block = first_op.regs[0].blocks[0]
-                        rewriter.inline_block_after(inner_block, matched_op)
+                        rewriter.inline_block(
+                            inner_block, InsertPoint.after(matched_op)
+                        )
 
     rewrite_and_compare(
         prog,

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -28,6 +28,7 @@ from xdsl.pattern_rewriter import (
     attr_type_rewrite_pattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.utils.hints import isa
 
 
@@ -415,7 +416,7 @@ def test_insert_op_before():
 
             first_op = mod.ops.first
             assert first_op is not None
-            rewriter.insert_op_before(new_cst, first_op)
+            rewriter.insert_op(new_cst, InsertPoint.before(first_op))
 
     rewrite_and_compare(
         prog,
@@ -444,7 +445,7 @@ def test_insert_op_after():
 
             first_op = mod.ops.first
             assert first_op is not None
-            rewriter.insert_op_after(new_cst, first_op)
+            rewriter.insert_op(new_cst, InsertPoint.after(first_op))
 
     rewrite_and_compare(
         prog,
@@ -1071,7 +1072,7 @@ def test_move_region_contents_to_new_regions():
             new_region = rewriter.move_region_contents_to_new_regions(old_op.regions[0])
             res_types = [r.type for r in old_op.results]
             new_op = test.TestOp.create(result_types=res_types, regions=[new_region])
-            rewriter.insert_op_after(new_op, old_op)
+            rewriter.insert_op(new_op, InsertPoint.after(old_op))
 
     rewrite_and_compare(
         prog,

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -8,7 +8,7 @@ from xdsl.dialects.arith import Addi, Arith, Constant
 from xdsl.dialects.builtin import Builtin, Float32Type, Float64Type, ModuleOp, i32, i64
 from xdsl.ir import Block, MLContext, Region
 from xdsl.parser import Parser
-from xdsl.rewriter import Rewriter
+from xdsl.rewriter import InsertPoint, Rewriter
 
 
 def rewrite_and_compare(
@@ -159,7 +159,7 @@ def test_inline_block_at_end():
         module_block = module.regions[0].blocks[0]
         test_block = test_op.regions[0].blocks[0]
 
-        rewriter.inline_block_at_end(test_block, module_block)
+        rewriter.inline_block_at_location(test_block, InsertPoint.at_end(module_block))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -191,7 +191,7 @@ def test_inline_block_before():
         test_op = next(ops_iter)
         test_block = test_op.regions[0].blocks[0]
 
-        rewriter.inline_block_before(test_block, test_op)
+        rewriter.inline_block_at_location(test_block, InsertPoint.before(test_op))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -223,7 +223,7 @@ def test_inline_block_after():
         test_op = next(ops_iter)
         test_block = test_op.regions[0].blocks[0]
 
-        rewriter.inline_block_after(test_block, constant_op)
+        rewriter.inline_block_at_location(test_block, InsertPoint.after(constant_op))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -335,7 +335,7 @@ def test_insert_op_before():
         constant = Constant.from_int_and_width(34, i64)
         first_op = module.regions[0].blocks[0].first_op
         assert first_op is not None
-        rewriter.insert_op_before(first_op, constant)
+        rewriter.insert_ops_at_location((constant,), InsertPoint.before(first_op))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -359,7 +359,7 @@ def test_insert_op_after():
         constant = Constant.from_int_and_width(34, i64)
         first_op = module.regions[0].blocks[0].first_op
         assert first_op is not None
-        rewriter.insert_op_after(first_op, constant)
+        rewriter.insert_ops_at_location((constant,), InsertPoint.after(first_op))
 
     rewrite_and_compare(prog, expected, transformation)
 

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -335,7 +335,7 @@ def test_insert_op_before():
         constant = Constant.from_int_and_width(34, i64)
         first_op = module.regions[0].blocks[0].first_op
         assert first_op is not None
-        rewriter.insert_ops_at_location((constant,), InsertPoint.before(first_op))
+        rewriter.insert_ops((constant,), InsertPoint.before(first_op))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -359,7 +359,7 @@ def test_insert_op_after():
         constant = Constant.from_int_and_width(34, i64)
         first_op = module.regions[0].blocks[0].first_op
         assert first_op is not None
-        rewriter.insert_ops_at_location((constant,), InsertPoint.after(first_op))
+        rewriter.insert_ops((constant,), InsertPoint.after(first_op))
 
     rewrite_and_compare(prog, expected, transformation)
 

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -335,7 +335,7 @@ def test_insert_op_before():
         constant = Constant.from_int_and_width(34, i64)
         first_op = module.regions[0].blocks[0].first_op
         assert first_op is not None
-        rewriter.insert_ops((constant,), InsertPoint.before(first_op))
+        rewriter.insert_op(constant, InsertPoint.before(first_op))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -359,7 +359,7 @@ def test_insert_op_after():
         constant = Constant.from_int_and_width(34, i64)
         first_op = module.regions[0].blocks[0].first_op
         assert first_op is not None
-        rewriter.insert_ops((constant,), InsertPoint.after(first_op))
+        rewriter.insert_op(constant, InsertPoint.after(first_op))
 
     rewrite_and_compare(prog, expected, transformation)
 

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -159,7 +159,7 @@ def test_inline_block_at_end():
         module_block = module.regions[0].blocks[0]
         test_block = test_op.regions[0].blocks[0]
 
-        rewriter.inline_block_at_location(test_block, InsertPoint.at_end(module_block))
+        rewriter.inline_block(test_block, InsertPoint.at_end(module_block))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -191,7 +191,7 @@ def test_inline_block_before():
         test_op = next(ops_iter)
         test_block = test_op.regions[0].blocks[0]
 
-        rewriter.inline_block_at_location(test_block, InsertPoint.before(test_op))
+        rewriter.inline_block(test_block, InsertPoint.before(test_op))
 
     rewrite_and_compare(prog, expected, transformation)
 
@@ -223,7 +223,7 @@ def test_inline_block_after():
         test_op = next(ops_iter)
         test_block = test_op.regions[0].blocks[0]
 
-        rewriter.inline_block_at_location(test_block, InsertPoint.after(constant_op))
+        rewriter.inline_block(test_block, InsertPoint.after(constant_op))
 
     rewrite_and_compare(prog, expected, transformation)
 

--- a/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
+++ b/xdsl/backend/riscv/lowering/convert_riscv_scf_to_riscv_cf.py
@@ -7,6 +7,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 class LowerRiscvScfForPattern(RewritePattern):
@@ -124,7 +125,7 @@ class LowerRiscvScfForPattern(RewritePattern):
 
         # Move lb to new register to initialize the iv.
         # Skip for loop if condition is not satisfied at start.
-        rewriter.insert_op_at_end(
+        rewriter.insert_op(
             (
                 mv_op := riscv.MVOp(op.lb, rd=iv_reg),
                 riscv_cf.BgeOp(
@@ -136,12 +137,12 @@ class LowerRiscvScfForPattern(RewritePattern):
                     first_body_block,
                 ),
             ),
-            init_block,
+            InsertPoint.at_end(init_block),
         )
 
         # Insert label at the start of the first body block.
-        rewriter.insert_op_at_start(
-            riscv.LabelOp(f"scf_body_{suffix}"), first_body_block
+        rewriter.insert_op(
+            riscv.LabelOp(f"scf_body_{suffix}"), InsertPoint.at_start(first_body_block)
         )
 
         # Replace operation by arguments to the newly end block.

--- a/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
+++ b/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
@@ -12,6 +12,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 def insert_stride_pattern_ops(
@@ -94,7 +95,7 @@ def insert_stride_pattern_ops(
         new_ops.extend((a_inc_op, new_a_op, stride_op, set_stride_op))
         a_op = new_a_op
 
-    rewriter.insert_op_before(new_ops, target_op)
+    rewriter.insert_op(new_ops, InsertPoint.before(target_op))
 
 
 class LowerStreamingRegionOp(RewritePattern):

--- a/xdsl/backend/riscv/lowering/utils.py
+++ b/xdsl/backend/riscv/lowering/utils.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from xdsl.dialects import builtin, riscv
 from xdsl.ir import Attribute, Block, Operation, SSAValue
 from xdsl.pattern_rewriter import PatternRewriter
+from xdsl.rewriter import InsertPoint
 
 
 def register_type_for_type(
@@ -225,7 +226,7 @@ def cast_block_args_from_a_regs(block: Block, rewriter: PatternRewriter):
         arg.replace_by(cast_op.results[0])
         move_op.operands[0] = arg
 
-    rewriter.insert_op_at_start(new_ops, block)
+    rewriter.insert_op(new_ops, InsertPoint.at_start(block))
 
 
 def cast_block_args_to_regs(block: Block, rewriter: PatternRewriter):
@@ -235,11 +236,11 @@ def cast_block_args_to_regs(block: Block, rewriter: PatternRewriter):
     """
 
     for arg in block.args:
-        rewriter.insert_op_at_start(
+        rewriter.insert_op(
             new_val := builtin.UnrealizedConversionCastOp(
                 operands=[arg], result_types=[arg.type]
             ),
-            block,
+            InsertPoint.at_start(block),
         )
 
         arg.type = register_type_for_type(arg.type).unallocated()

--- a/xdsl/backend/riscv/riscv_scf_to_asm.py
+++ b/xdsl/backend/riscv/riscv_scf_to_asm.py
@@ -9,6 +9,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 def get_register_ops_from_values(
@@ -83,7 +84,7 @@ class LowerRiscvScfToLabels(RewritePattern):
         # Replace args of the body with operations that get the registers bound
         # to them.
         for get_target_register in get_register_ops_from_values(body.args):
-            body.insert_op_before(get_target_register, body.first_op)
+            rewriter.insert_op(get_target_register, InsertPoint.at_start(body))
 
         # Also replace the loop results directly with the registers bound to them.
         for get_target_register in get_register_ops_from_values(op.results):

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -251,18 +251,6 @@ class PatternRewriter(PatternRewriterListener):
         self._replace_all_uses_with(arg, None, safe_erase=safe_erase)
         arg.block.erase_arg(arg, safe_erase)
 
-    def inline_block_at_location(
-        self,
-        block: Block,
-        insertion_point: InsertPoint,
-        arg_values: Sequence[SSAValue] = (),
-    ):
-        """
-        Move the block operations to the specified insertion point.
-        """
-        self.has_done_action = True
-        Rewriter.inline_block_at_location(block, insertion_point, arg_values=arg_values)
-
     def inline_block_at_end(
         self, block: Block, target_block: Block, arg_values: Sequence[SSAValue] = ()
     ):

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -257,7 +257,7 @@ class PatternRewriter(PatternRewriterListener):
         self._replace_all_uses_with(arg, None, safe_erase=safe_erase)
         arg.block.erase_arg(arg, safe_erase)
 
-    def inline_block_at_location(
+    def inline_block(
         self,
         block: Block,
         insertion_point: InsertPoint,
@@ -267,7 +267,7 @@ class PatternRewriter(PatternRewriterListener):
         Move the block operations to the specified insertion point.
         """
         self.has_done_action = True
-        Rewriter.inline_block_at_location(block, insertion_point, arg_values=arg_values)
+        Rewriter.inline_block(block, insertion_point, arg_values=arg_values)
 
     def inline_block_at_end(
         self, block: Block, target_block: Block, arg_values: Sequence[SSAValue] = ()
@@ -276,7 +276,7 @@ class PatternRewriter(PatternRewriterListener):
         Move the block operations to the end of another block.
         This block should not be a parent of the block to move to.
         """
-        self.inline_block_at_location(
+        self.inline_block(
             block, InsertPoint.at_end(target_block), arg_values=arg_values
         )
 
@@ -287,7 +287,7 @@ class PatternRewriter(PatternRewriterListener):
         Move the block operations to the start of another block.
         This block should not be a parent of the block to move to.
         """
-        self.inline_block_at_location(
+        self.inline_block(
             block, InsertPoint.at_start(target_block), arg_values=arg_values
         )
 
@@ -307,9 +307,7 @@ class PatternRewriter(PatternRewriterListener):
         Move the block operations before the given operation.
         The block should not be a parent of the operation.
         """
-        self.inline_block_at_location(
-            block, InsertPoint.before(op), arg_values=arg_values
-        )
+        self.inline_block(block, InsertPoint.before(op), arg_values=arg_values)
 
     def inline_block_after_matched_op(
         self, block: Block, arg_values: Sequence[SSAValue] = ()
@@ -327,9 +325,7 @@ class PatternRewriter(PatternRewriterListener):
         Move the block operations after the given operation.
         The block should not be a parent of the operation.
         """
-        self.inline_block_at_location(
-            block, InsertPoint.after(op), arg_values=arg_values
-        )
+        self.inline_block(block, InsertPoint.after(op), arg_values=arg_values)
 
     def move_region_contents_to_new_regions(self, region: Region) -> Region:
         """Move the region blocks to a new region."""

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -269,6 +269,7 @@ class PatternRewriter(PatternRewriterListener):
         self.has_done_action = True
         Rewriter.inline_block(block, insertion_point, arg_values=arg_values)
 
+    @deprecated("Please use `inline_block` instead")
     def inline_block_at_end(
         self, block: Block, target_block: Block, arg_values: Sequence[SSAValue] = ()
     ):
@@ -280,6 +281,7 @@ class PatternRewriter(PatternRewriterListener):
             block, InsertPoint.at_end(target_block), arg_values=arg_values
         )
 
+    @deprecated("Please use `inline_block` instead")
     def inline_block_at_start(
         self, block: Block, target_block: Block, arg_values: Sequence[SSAValue] = ()
     ):
@@ -298,8 +300,11 @@ class PatternRewriter(PatternRewriterListener):
         Move the block operations before the matched operation.
         The block should not be a parent of the operation.
         """
-        self.inline_block_before(block, self.current_operation, arg_values=arg_values)
+        self.inline_block(
+            block, InsertPoint.before(self.current_operation), arg_values=arg_values
+        )
 
+    @deprecated("Please use `inline_block` instead")
     def inline_block_before(
         self, block: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
     ):
@@ -316,8 +321,11 @@ class PatternRewriter(PatternRewriterListener):
         Move the block operations after the matched operation.
         The block should not be a parent of the operation.
         """
-        self.inline_block_after(block, self.current_operation, arg_values=arg_values)
+        self.inline_block(
+            block, InsertPoint.after(self.current_operation), arg_values=arg_values
+        )
 
+    @deprecated("Please use `inline_block` instead")
     def inline_block_after(
         self, block: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
     ):

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -8,6 +8,8 @@ from functools import wraps
 from types import UnionType
 from typing import TypeVar, Union, final, get_args, get_origin
 
+from typing_extensions import deprecated
+
 from xdsl.builder import BuilderListener
 from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, ModuleOp
 from xdsl.ir import (
@@ -87,7 +89,7 @@ class PatternRewriter(PatternRewriterListener):
     has_done_action: bool = field(default=False, init=False)
     """Has the rewriter done any action during the current match."""
 
-    def insert_op_at_location(
+    def insert_op(
         self, op: Operation | Sequence[Operation], insertion_point: InsertPoint
     ):
         """Insert operations at a certain location in a block."""
@@ -95,38 +97,39 @@ class PatternRewriter(PatternRewriterListener):
         op = (op,) if isinstance(op, Operation) else op
         if not op:
             return
-        Rewriter.insert_ops_at_location(op, insertion_point)
+        Rewriter.insert_ops(op, insertion_point)
 
         for op_ in op:
             self.handle_operation_insertion(op_)
 
     def insert_op_before_matched_op(self, op: Operation | Sequence[Operation]):
         """Insert operations before the matched operation."""
-        self.insert_op_at_location(op, InsertPoint.before(self.current_operation))
+        self.insert_op(op, InsertPoint.before(self.current_operation))
 
     def insert_op_after_matched_op(self, op: Operation | Sequence[Operation]):
         """Insert operations after the matched operation."""
-        self.insert_op_at_location(op, InsertPoint.after(self.current_operation))
+        self.insert_op(op, InsertPoint.after(self.current_operation))
 
     def insert_op_at_end(self, op: Operation | Sequence[Operation], block: Block):
         """Insert operations at the end of a block."""
-        self.insert_op_at_location(op, InsertPoint.at_end(block))
+        self.insert_op(op, InsertPoint.at_end(block))
 
     def insert_op_at_start(self, op: Operation | Sequence[Operation], block: Block):
         """Insert operations at the start of a block."""
-        self.insert_op_at_location(op, InsertPoint.at_start(block))
+        self.insert_op(op, InsertPoint.at_start(block))
 
     def insert_op_before(
         self, op: Operation | Sequence[Operation], target_op: Operation
     ):
         """Insert operations before an operation."""
-        self.insert_op_at_location(op, InsertPoint.before(target_op))
+        self.insert_op(op, InsertPoint.before(target_op))
 
+    @deprecated("Please use `insert_op` instead")
     def insert_op_after(
         self, op: Operation | Sequence[Operation], target_op: Operation
     ):
         """Insert operations after an operation."""
-        self.insert_op_at_location(op, InsertPoint.after(target_op))
+        self.insert_op(op, InsertPoint.after(target_op))
 
     def erase_matched_op(self, safe_erase: bool = True):
         """

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -110,10 +110,12 @@ class PatternRewriter(PatternRewriterListener):
         """Insert operations after the matched operation."""
         self.insert_op(op, InsertPoint.after(self.current_operation))
 
+    @deprecated("Please use `insert_op` instead")
     def insert_op_at_end(self, op: Operation | Sequence[Operation], block: Block):
         """Insert operations at the end of a block."""
         self.insert_op(op, InsertPoint.at_end(block))
 
+    @deprecated("Please use `insert_op` instead")
     def insert_op_at_start(self, op: Operation | Sequence[Operation], block: Block):
         """Insert operations at the start of a block."""
         self.insert_op(op, InsertPoint.at_start(block))

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -97,7 +97,7 @@ class PatternRewriter(PatternRewriterListener):
         op = (op,) if isinstance(op, Operation) else op
         if not op:
             return
-        Rewriter.insert_ops(op, insertion_point)
+        Rewriter.insert_op(op, insertion_point)
 
         for op_ in op:
             self.handle_operation_insertion(op_)

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -118,6 +118,7 @@ class PatternRewriter(PatternRewriterListener):
         """Insert operations at the start of a block."""
         self.insert_op(op, InsertPoint.at_start(block))
 
+    @deprecated("Please use `insert_op` instead")
     def insert_op_before(
         self, op: Operation | Sequence[Operation], target_op: Operation
     ):
@@ -194,7 +195,7 @@ class PatternRewriter(PatternRewriterListener):
             new_ops = [new_ops]
 
         # First, insert the new operations before the matched operation
-        self.insert_op_before(new_ops, op)
+        self.insert_op(new_ops, InsertPoint.before(op))
 
         if isinstance(new_ops, Operation):
             new_ops = [new_ops]

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -268,13 +268,13 @@ class Rewriter:
         else:
             insertion_point.block.add_ops(ops)
 
-    @deprecated("Please use `insert_op_at_location` instead")
+    @deprecated("Please use `insert_ops` instead")
     @staticmethod
     def insert_op_after(op: Operation, new_op: Operation):
         """Inserts a new operation after another operation."""
         Rewriter.insert_ops((new_op,), InsertPoint.after(op))
 
-    @deprecated("Please use `insert_op_at_location` instead")
+    @deprecated("Please use `insert_ops` instead")
     @staticmethod
     def insert_op_before(op: Operation, new_op: Operation):
         """Inserts a new operation before another operation."""

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -257,24 +257,27 @@ class Rewriter:
         region.insert_block(block_list, pos)
 
     @staticmethod
-    def insert_ops(ops: Sequence[Operation], insertion_point: InsertPoint):
+    def insert_op(
+        op_or_ops: Operation | Sequence[Operation], insertion_point: InsertPoint
+    ):
         """Insert operations at a certain location in a block."""
+        ops = (op_or_ops,) if isinstance(op_or_ops, Operation) else op_or_ops
         if insertion_point.insert_before is not None:
             insertion_point.block.insert_ops_before(ops, insertion_point.insert_before)
         else:
             insertion_point.block.add_ops(ops)
 
-    @deprecated("Please use `insert_ops` instead")
+    @deprecated("Please use `insert_op` instead")
     @staticmethod
     def insert_op_after(op: Operation, new_op: Operation):
         """Inserts a new operation after another operation."""
-        Rewriter.insert_ops((new_op,), InsertPoint.after(op))
+        Rewriter.insert_op(new_op, InsertPoint.after(op))
 
-    @deprecated("Please use `insert_ops` instead")
+    @deprecated("Please use `insert_op` instead")
     @staticmethod
     def insert_op_before(op: Operation, new_op: Operation):
         """Inserts a new operation before another operation."""
-        Rewriter.insert_ops((new_op,), InsertPoint.before(op))
+        Rewriter.insert_op(new_op, InsertPoint.before(op))
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -120,7 +120,7 @@ class Rewriter:
         block.erase_op(op, safe_erase=safe_erase)
 
     @staticmethod
-    def inline_block_at_location(
+    def inline_block(
         source: Block, insertion_point: InsertPoint, arg_values: Sequence[SSAValue] = ()
     ):
         """
@@ -179,7 +179,7 @@ class Rewriter:
             parent_region.detach_block(source)
         source.erase()
 
-    @deprecated("Please use `inline_block_at_location` instead")
+    @deprecated("Please use `inline_block` instead")
     @staticmethod
     def inline_block_at_end(
         inlined_block: Block, extended_block: Block, arg_values: Sequence[SSAValue] = ()
@@ -189,11 +189,11 @@ class Rewriter:
         This block should not be a parent of the block to move to.
         The block operations should not use the block arguments.
         """
-        Rewriter.inline_block_at_location(
+        Rewriter.inline_block(
             inlined_block, InsertPoint.at_end(extended_block), arg_values=arg_values
         )
 
-    @deprecated("Please use `inline_block_at_location` instead")
+    @deprecated("Please use `inline_block` instead")
     @staticmethod
     def inline_block_at_start(
         inlined_block: Block, extended_block: Block, arg_values: Sequence[SSAValue] = ()
@@ -203,20 +203,18 @@ class Rewriter:
         This block should not be a parent of the block to move to.
         The block operations should not use the block arguments.
         """
-        Rewriter.inline_block_at_location(
+        Rewriter.inline_block(
             inlined_block, InsertPoint.at_start(extended_block), arg_values=arg_values
         )
 
-    @deprecated("Please use `inline_block_at_location` instead")
+    @deprecated("Please use `inline_block` instead")
     @staticmethod
     def inline_block_before(
         source: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
     ):
-        Rewriter.inline_block_at_location(
-            source, InsertPoint.before(op), arg_values=arg_values
-        )
+        Rewriter.inline_block(source, InsertPoint.before(op), arg_values=arg_values)
 
-    @deprecated("Please use `inline_block_at_location` instead")
+    @deprecated("Please use `inline_block` instead")
     @staticmethod
     def inline_block_after(
         block: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
@@ -226,9 +224,7 @@ class Rewriter:
         The block should not be a parent of the operation.
         The block operations should not use the block arguments.
         """
-        Rewriter.inline_block_at_location(
-            block, InsertPoint.after(op), arg_values=arg_values
-        )
+        Rewriter.inline_block(block, InsertPoint.after(op), arg_values=arg_values)
 
     @staticmethod
     def insert_block_after(block: Block | list[Block], target: Block):

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
+from typing_extensions import deprecated
+
 from xdsl.ir import Block, Operation, Region, SSAValue
 
 
@@ -177,6 +179,57 @@ class Rewriter:
             parent_region.detach_block(source)
         source.erase()
 
+    @deprecated("Please use `inline_block_at_location` instead")
+    @staticmethod
+    def inline_block_at_end(
+        inlined_block: Block, extended_block: Block, arg_values: Sequence[SSAValue] = ()
+    ):
+        """
+        Move the block operations to the end of another block.
+        This block should not be a parent of the block to move to.
+        The block operations should not use the block arguments.
+        """
+        Rewriter.inline_block_at_location(
+            inlined_block, InsertPoint.at_end(extended_block), arg_values=arg_values
+        )
+
+    @deprecated("Please use `inline_block_at_location` instead")
+    @staticmethod
+    def inline_block_at_start(
+        inlined_block: Block, extended_block: Block, arg_values: Sequence[SSAValue] = ()
+    ):
+        """
+        Move the block operations to the start of another block.
+        This block should not be a parent of the block to move to.
+        The block operations should not use the block arguments.
+        """
+        Rewriter.inline_block_at_location(
+            inlined_block, InsertPoint.at_start(extended_block), arg_values=arg_values
+        )
+
+    @deprecated("Please use `inline_block_at_location` instead")
+    @staticmethod
+    def inline_block_before(
+        source: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
+    ):
+        Rewriter.inline_block_at_location(
+            source, InsertPoint.before(op), arg_values=arg_values
+        )
+
+    @deprecated("Please use `inline_block_at_location` instead")
+    @staticmethod
+    def inline_block_after(
+        block: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
+    ):
+        """
+        Move the block operations after another operation.
+        The block should not be a parent of the operation.
+        The block operations should not use the block arguments.
+        """
+        Rewriter.inline_block_at_location(
+            block, InsertPoint.after(op), arg_values=arg_values
+        )
+
     @staticmethod
     def insert_block_after(block: Block | list[Block], target: Block):
         """
@@ -214,6 +267,18 @@ class Rewriter:
             insertion_point.block.insert_ops_before(ops, insertion_point.insert_before)
         else:
             insertion_point.block.add_ops(ops)
+
+    @deprecated("Please use `insert_op_at_location` instead")
+    @staticmethod
+    def insert_op_after(op: Operation, new_op: Operation):
+        """Inserts a new operation after another operation."""
+        Rewriter.insert_ops_at_location((new_op,), InsertPoint.after(op))
+
+    @deprecated("Please use `insert_op_at_location` instead")
+    @staticmethod
+    def insert_op_before(op: Operation, new_op: Operation):
+        """Inserts a new operation before another operation."""
+        Rewriter.insert_ops_at_location((new_op,), InsertPoint.before(op))
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -178,53 +178,6 @@ class Rewriter:
         source.erase()
 
     @staticmethod
-    def inline_block_at_end(
-        inlined_block: Block, extended_block: Block, arg_values: Sequence[SSAValue] = ()
-    ):
-        """
-        Move the block operations to the end of another block.
-        This block should not be a parent of the block to move to.
-        The block operations should not use the block arguments.
-        """
-        Rewriter.inline_block_at_location(
-            inlined_block, InsertPoint.at_end(extended_block), arg_values=arg_values
-        )
-
-    @staticmethod
-    def inline_block_at_start(
-        inlined_block: Block, extended_block: Block, arg_values: Sequence[SSAValue] = ()
-    ):
-        """
-        Move the block operations to the start of another block.
-        This block should not be a parent of the block to move to.
-        The block operations should not use the block arguments.
-        """
-        Rewriter.inline_block_at_location(
-            inlined_block, InsertPoint.at_start(extended_block), arg_values=arg_values
-        )
-
-    @staticmethod
-    def inline_block_before(
-        source: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
-    ):
-        Rewriter.inline_block_at_location(
-            source, InsertPoint.before(op), arg_values=arg_values
-        )
-
-    @staticmethod
-    def inline_block_after(
-        block: Block, op: Operation, arg_values: Sequence[SSAValue] = ()
-    ):
-        """
-        Move the block operations after another operation.
-        The block should not be a parent of the operation.
-        The block operations should not use the block arguments.
-        """
-        Rewriter.inline_block_at_location(
-            block, InsertPoint.after(op), arg_values=arg_values
-        )
-
-    @staticmethod
     def insert_block_after(block: Block | list[Block], target: Block):
         """
         Insert one or multiple blocks after another block.
@@ -261,16 +214,6 @@ class Rewriter:
             insertion_point.block.insert_ops_before(ops, insertion_point.insert_before)
         else:
             insertion_point.block.add_ops(ops)
-
-    @staticmethod
-    def insert_op_after(op: Operation, new_op: Operation):
-        """Inserts a new operation after another operation."""
-        Rewriter.insert_ops_at_location((new_op,), InsertPoint.after(op))
-
-    @staticmethod
-    def insert_op_before(op: Operation, new_op: Operation):
-        """Inserts a new operation before another operation."""
-        Rewriter.insert_ops_at_location((new_op,), InsertPoint.before(op))
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -261,7 +261,7 @@ class Rewriter:
         region.insert_block(block_list, pos)
 
     @staticmethod
-    def insert_ops_at_location(ops: Sequence[Operation], insertion_point: InsertPoint):
+    def insert_ops(ops: Sequence[Operation], insertion_point: InsertPoint):
         """Insert operations at a certain location in a block."""
         if insertion_point.insert_before is not None:
             insertion_point.block.insert_ops_before(ops, insertion_point.insert_before)
@@ -272,13 +272,13 @@ class Rewriter:
     @staticmethod
     def insert_op_after(op: Operation, new_op: Operation):
         """Inserts a new operation after another operation."""
-        Rewriter.insert_ops_at_location((new_op,), InsertPoint.after(op))
+        Rewriter.insert_ops((new_op,), InsertPoint.after(op))
 
     @deprecated("Please use `insert_op_at_location` instead")
     @staticmethod
     def insert_op_before(op: Operation, new_op: Operation):
         """Inserts a new operation before another operation."""
-        Rewriter.insert_ops_at_location((new_op,), InsertPoint.before(op))
+        Rewriter.insert_ops((new_op,), InsertPoint.before(op))
 
     @staticmethod
     def move_region_contents_to_new_regions(region: Region) -> Region:

--- a/xdsl/transforms/canonicalization_patterns/scf.py
+++ b/xdsl/transforms/canonicalization_patterns/scf.py
@@ -8,6 +8,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 class SimplifyTrivialLoops(RewritePattern):
@@ -73,7 +74,7 @@ def replace_op_with_region(
     block = region.block
     terminator = block.last_op
     assert terminator is not None
-    rewriter.inline_block_before(block, op, args)
+    rewriter.inline_block(block, InsertPoint.before(op), args)
     rewriter.replace_op(op, (), terminator.operands)
     rewriter.erase_op(terminator)
 

--- a/xdsl/transforms/canonicalization_patterns/stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/stencil.py
@@ -7,6 +7,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.transforms.common_subexpression_elimination import cse
 
 
@@ -61,7 +62,7 @@ class UnusedOperands(RewritePattern):
             [cast(stencil.TempType[Attribute], r.type) for r in op.res],
         )
 
-        rewriter.inline_block_at_start(op.region.block, block, block.args)
+        rewriter.inline_block(op.region.block, InsertPoint.at_start(block), block.args)
         rewriter.replace_matched_op(new)
 
 

--- a/xdsl/transforms/convert_linalg_to_loops.py
+++ b/xdsl/transforms/convert_linalg_to_loops.py
@@ -11,6 +11,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.transforms.loop_nest_lowering_utils import rewrite_generic_to_loops
 
 
@@ -22,7 +23,7 @@ def load(
 ) -> SSAValue:
     if isinstance(value.type, MemRefType):
         op = memref.Load.get(value, indices)
-        rewriter.insert_op_before(op, insertion_target)
+        rewriter.insert_op(op, InsertPoint.before(insertion_target))
         return op.res
     else:
         return value

--- a/xdsl/transforms/convert_memref_stream_to_loops.py
+++ b/xdsl/transforms/convert_memref_stream_to_loops.py
@@ -13,6 +13,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.transforms.loop_nest_lowering_utils import rewrite_generic_to_loops
 
 
@@ -28,7 +29,7 @@ def load(
         op = memref_stream.ReadOp(source)
     else:
         return source
-    rewriter.insert_op_before(op, target_op)
+    rewriter.insert_op(op, InsertPoint.before(target_op))
     return op.res
 
 

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -34,6 +34,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 class ReadOpLowering(RewritePattern):
@@ -155,9 +156,9 @@ class StreamOpLowering(RewritePattern):
         for i in reversed(range(len(stream_types))):
             arg = new_body.args[i]
             stream_type = stream_types[i]
-            rewriter.insert_op_at_start(
+            rewriter.insert_op(
                 cast_op := builtin.UnrealizedConversionCastOp.get((arg,), (arg.type,)),
-                new_body,
+                InsertPoint.at_start(new_body),
             )
             arg.replace_by(cast_op.results[0])
             cast_op.operands = (arg,)

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -299,8 +299,8 @@ class BufferOpToMemref(RewritePattern):
             [1] * temp_t.get_num_dims(),
         )
 
-        rewriter.insert_op_before(alloc, first_op)
-        rewriter.insert_op_before(view, first_op)
+        rewriter.insert_op(alloc, InsertPoint.before(first_op))
+        rewriter.insert_op(view, InsertPoint.before(first_op))
 
         update_return_target(self.return_targets, op.temp, view.result)
 
@@ -311,7 +311,7 @@ class BufferOpToMemref(RewritePattern):
             rewriter.erase_matched_op()
             return
 
-        rewriter.insert_op_before(dealloc, last_op)
+        rewriter.insert_op(dealloc, InsertPoint.before(last_op))
         rewriter.replace_matched_op([], [view.result])
 
 

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -49,6 +49,7 @@ from xdsl.pattern_rewriter import (
     attr_type_rewrite_pattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -306,7 +307,7 @@ class BufferOpToMemref(RewritePattern):
         dealloc = memref.Dealloc.get(alloc.memref)
 
         if not op.res.uses:
-            rewriter.insert_op_after(dealloc, op)
+            rewriter.insert_op_after_matched_op(dealloc)
             rewriter.erase_matched_op()
             return
 
@@ -464,7 +465,7 @@ class StencilStoreToSubview(RewritePattern):
             name = subview.source.name_hint + "_storeview"
         subview.result.name_hint = name
         if isinstance(field.owner, Operation):
-            rewriter.insert_op_after(subview, field.owner)
+            rewriter.insert_op(subview, InsertPoint.after(field.owner))
         else:
             rewriter.insert_op_at_start(subview, field.owner)
 

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -467,7 +467,7 @@ class StencilStoreToSubview(RewritePattern):
         if isinstance(field.owner, Operation):
             rewriter.insert_op(subview, InsertPoint.after(field.owner))
         else:
-            rewriter.insert_op_at_start(subview, field.owner)
+            rewriter.insert_op(subview, InsertPoint.at_start(field.owner))
 
         rewriter.erase_matched_op()
 

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -440,7 +440,7 @@ class MpiLoopInvariantCodeMotion:
             op.ref.owner, memref.Alloc
         ):
             op.detach()
-            rewriter.insert_ops_at_location((op,), InsertPoint.after(op.ref.owner))
+            rewriter.insert_ops((op,), InsertPoint.after(op.ref.owner))
             return
 
         base = op
@@ -472,14 +472,12 @@ class MpiLoopInvariantCodeMotion:
             block = parent.regions[0].blocks[-1]
             return_op = block.last_op
             assert return_op is not None
-            rewriter.insert_ops_at_location(
-                (mpi.Finalize(),), InsertPoint.before(return_op)
-            )
+            rewriter.insert_ops((mpi.Finalize(),), InsertPoint.before(return_op))
 
         ops = list(collect_args_recursive(op))
         for found_op in ops:
             found_op.detach()
-            rewriter.insert_ops_at_location((found_op,), InsertPoint.before(base))
+            rewriter.insert_ops((found_op,), InsertPoint.before(base))
 
     def get_matcher(
         self,

--- a/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
+++ b/xdsl/transforms/experimental/dmp/stencil_global_to_local.py
@@ -440,7 +440,7 @@ class MpiLoopInvariantCodeMotion:
             op.ref.owner, memref.Alloc
         ):
             op.detach()
-            rewriter.insert_ops((op,), InsertPoint.after(op.ref.owner))
+            rewriter.insert_op(op, InsertPoint.after(op.ref.owner))
             return
 
         base = op
@@ -472,12 +472,12 @@ class MpiLoopInvariantCodeMotion:
             block = parent.regions[0].blocks[-1]
             return_op = block.last_op
             assert return_op is not None
-            rewriter.insert_ops((mpi.Finalize(),), InsertPoint.before(return_op))
+            rewriter.insert_op(mpi.Finalize(), InsertPoint.before(return_op))
 
         ops = list(collect_args_recursive(op))
         for found_op in ops:
             found_op.detach()
-            rewriter.insert_ops((found_op,), InsertPoint.before(base))
+            rewriter.insert_op(found_op, InsertPoint.before(base))
 
     def get_matcher(
         self,

--- a/xdsl/transforms/experimental/function_constant_pinning.py
+++ b/xdsl/transforms/experimental/function_constant_pinning.py
@@ -89,13 +89,15 @@ class FunctionConstantPinning(RewritePattern):
                 # detatch the function
                 function_remainder.detach()
                 # re-insert it inside the else block of the if statement
-                rewriter.insert_op_at_end(function_remainder, dest_block)
+                rewriter.insert_op(function_remainder, InsertPoint.at_end(dest_block))
                 # go to next op
                 function_remainder = next_op
                 next_op = function_remainder.next_op
 
         # insert a yield that yields the return values
-        rewriter.insert_op_at_end(scf.Yield(*function_remainder.operands), dest_block)
+        rewriter.insert_op(
+            scf.Yield(*function_remainder.operands), InsertPoint.at_end(dest_block)
+        )
         # return the results of the scf.if
         rewriter.replace_op(function_remainder, func.Return(*scf_if.results))
 

--- a/xdsl/transforms/experimental/function_constant_pinning.py
+++ b/xdsl/transforms/experimental/function_constant_pinning.py
@@ -11,6 +11,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.traits import SymbolTable
 
 PIN_CONSTANT_VALS = "pin_to_constants"
@@ -52,7 +53,7 @@ class FunctionConstantPinning(RewritePattern):
         # insert the specialized function after the generic function (the one we matched on)
         rewriter.insert_op_after_matched_op(new_func)
         # insert a compare to the value we specialize and, and branch on if we are equal
-        rewriter.insert_op_after(
+        rewriter.insert_op(
             [
                 cst := arith.Constant(val, split_op.results[0].type),
                 is_eq := arith.Cmpi(split_op.results[0], cst, "eq"),
@@ -74,7 +75,7 @@ class FunctionConstantPinning(RewritePattern):
                     Region(dest_block := Block()),
                 ),
             ],
-            split_op,
+            InsertPoint.after(split_op),
         )
 
         # iterate over the remainder of the function:

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -61,6 +61,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.transforms.experimental.convert_stencil_to_ll_mlir import (
     AccessOpToMemref,
     CastOpToMemref,
@@ -871,7 +872,7 @@ class StencilStoreToSubview(RewritePattern):
                 name = subview.source.name_hint + "_storeview"
             subview.result.name_hint = name
             if isinstance(field.owner, Operation):
-                rewriter.insert_op_after(subview, field.owner)
+                rewriter.insert_op(subview, InsertPoint.after(field.owner))
             else:
                 rewriter.insert_op_at_start(subview, field.owner)
 

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -1015,7 +1015,9 @@ class GroupLoadsUnderSameDataflow(RewritePattern):
 
                 for data_stream in self.data_streams:
                     data_stream.op.detach()
-                    rewriter.insert_op_before(data_stream.op, parent_dataflow)
+                    rewriter.insert_op(
+                        data_stream.op, InsertPoint.before(parent_dataflow)
+                    )
 
 
 @dataclass

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -355,7 +355,7 @@ def add_read_write_ops(
         stream_to_write: BlockArgument = op.region.block.args[arg_index_write]
         write_op = HLSStreamWrite(stencil_return_vals[stencil_idx], stream_to_write)
 
-        rewriter.insert_op_at_end(write_op, op.region.block)
+        rewriter.insert_op(write_op, InsertPoint.at_end(op.region.block))
 
     for arg_index_read in indices_stream_to_read:
         stream_to_read = op.region.block.args[arg_index_read]
@@ -363,7 +363,7 @@ def add_read_write_ops(
         read_op = HLSStreamRead(stream_to_read)
         read_op.attributes["write_data"] = IntAttr(1)
 
-        rewriter.insert_op_at_start(read_op, op.region.block)
+        rewriter.insert_op(read_op, InsertPoint.at_start(op.region.block))
 
 
 def transform_apply_into_loop(
@@ -874,7 +874,7 @@ class StencilStoreToSubview(RewritePattern):
             if isinstance(field.owner, Operation):
                 rewriter.insert_op(subview, InsertPoint.after(field.owner))
             else:
-                rewriter.insert_op_at_start(subview, field.owner)
+                rewriter.insert_op(subview, InsertPoint.at_start(field.owner))
 
             rewriter.erase_op(store)
 
@@ -1234,14 +1234,18 @@ class QualifyInterfacesPass(RewritePattern):
                     call_interface_func = func.Call(
                         interface_func_name, [op.body.blocks[0].args[arg_idx]], []
                     )
-                    rewriter.insert_op_at_start(call_interface_func, op.body.blocks[0])
+                    rewriter.insert_op(
+                        call_interface_func, InsertPoint.at_start(op.body.blocks[0])
+                    )
 
                     bundle_idx += 1
                 else:
                     call_interface_func = llvm.CallOp(
                         self.interface_coeff_func_name, op.body.blocks[0].args[arg_idx]
                     )
-                    rewriter.insert_op_at_start(call_interface_func, op.body.blocks[0])
+                    rewriter.insert_op(
+                        call_interface_func, InsertPoint.at_start(op.body.blocks[0])
+                    )
                     self.called_coeff_func = True
 
                 arg_idx += 1

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -43,6 +43,7 @@ from xdsl.pattern_rewriter import (
     attr_type_rewrite_pattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.utils.hints import isa
 
 
@@ -140,7 +141,7 @@ class AccessOpTensorize(RewritePattern):
         extract = ExtractSliceOp.from_static_parameters(
             a, [z_offset], element_t.get_shape()
         )
-        rewriter.insert_op_before(a, op)
+        rewriter.insert_op(a, InsertPoint.before(op))
         rewriter.replace_matched_op(extract)
 
 
@@ -159,16 +160,16 @@ def arithBinaryOpTensorize(
     elif is_tensor(op.lhs.type) and is_scalar(op.rhs.type):
         emptyop = EmptyOp((), op.lhs.type)
         fillop = FillOp((op.rhs,), (emptyop,), (op.lhs.type,))
-        rewriter.insert_op_before(emptyop, op)
-        rewriter.insert_op_before(fillop, op)
+        rewriter.insert_op(emptyop, InsertPoint.before(op))
+        rewriter.insert_op(fillop, InsertPoint.before(op))
         rewriter.replace_matched_op(
             type_constructor(op.lhs, fillop, flags=None, result_type=op.lhs.type)
         )
     elif is_scalar(op.lhs.type) and is_tensor(op.rhs.type):
         emptyop = EmptyOp((), op.rhs.type)
         fillop = FillOp((op.lhs,), (emptyop,), (op.rhs.type,))
-        rewriter.insert_op_before(emptyop, op)
-        rewriter.insert_op_before(fillop, op)
+        rewriter.insert_op(emptyop, InsertPoint.before(op))
+        rewriter.insert_op(fillop, InsertPoint.before(op))
         rewriter.replace_matched_op(
             type_constructor(fillop, op.rhs, flags=None, result_type=op.rhs.type)
         )

--- a/xdsl/transforms/loop_hoist_memref.py
+++ b/xdsl/transforms/loop_hoist_memref.py
@@ -11,6 +11,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 def find_same_target_store(load: memref.Load):
@@ -181,7 +182,7 @@ class LoopHoistMemref(RewritePattern):
             memref.Store.get(new_for_op.res[idx], store.memref, store.indices)
             for idx, store in enumerate(load_store_pairs.values())
         ]
-        rewriter.insert_op_after(new_stores, for_op)
+        rewriter.insert_op(new_stores, InsertPoint.after(for_op))
 
         rewriter.insert_op_before(new_for_op, for_op)
         rewriter.erase_op(for_op)

--- a/xdsl/transforms/loop_hoist_memref.py
+++ b/xdsl/transforms/loop_hoist_memref.py
@@ -133,7 +133,7 @@ class LoopHoistMemref(RewritePattern):
 
         # hoist new loads before the current loop
         new_loads = [load.clone() for load in load_store_pairs.keys()]
-        rewriter.insert_op_before(new_loads, for_op)
+        rewriter.insert_op(new_loads, InsertPoint.before(for_op))
 
         new_body = Region()
         block_map: dict[Block, Block] = {}
@@ -184,7 +184,7 @@ class LoopHoistMemref(RewritePattern):
         ]
         rewriter.insert_op(new_stores, InsertPoint.after(for_op))
 
-        rewriter.insert_op_before(new_for_op, for_op)
+        rewriter.insert_op(new_for_op, InsertPoint.before(for_op))
         rewriter.erase_op(for_op)
 
 

--- a/xdsl/transforms/loop_nest_lowering_utils.py
+++ b/xdsl/transforms/loop_nest_lowering_utils.py
@@ -148,7 +148,7 @@ def rewrite_generic_to_loops(
     while op.body.block.args:
         rewriter.erase_block_argument(op.body.block.args[0])
 
-    rewriter.inline_block_before(op.body.block, insertion_target)
+    rewriter.inline_block(op.body.block, InsertPoint.before(insertion_target))
 
     # Erase generic
 

--- a/xdsl/transforms/lower_riscv_func.py
+++ b/xdsl/transforms/lower_riscv_func.py
@@ -72,7 +72,7 @@ class InsertExitSyscallOp(RewritePattern):
             return
 
         EXIT = 93
-        rewriter.insert_op_before(riscv_func.SyscallOp(EXIT), op)
+        rewriter.insert_op_before_matched_op(riscv_func.SyscallOp(EXIT))
 
 
 @dataclass(frozen=True)

--- a/xdsl/transforms/memref_streamify.py
+++ b/xdsl/transforms/memref_streamify.py
@@ -14,6 +14,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 
 
 @dataclass
@@ -80,7 +81,7 @@ class StreamifyGenericOpPattern(RewritePattern):
         for stream_index, (index, _) in enumerate(streamed_operand_indices):
             new_operands[index] = new_body.args[stream_index]
 
-        rewriter.insert_op_at_end(
+        rewriter.insert_op(
             memref_stream.GenericOp(
                 new_operands[:input_count],
                 new_operands[input_count:],
@@ -89,7 +90,7 @@ class StreamifyGenericOpPattern(RewritePattern):
                 op.iterator_types,
                 op.bounds,
             ),
-            new_body,
+            InsertPoint.at_end(new_body),
         )
         rewriter.erase_matched_op()
 


### PR DESCRIPTION
This reduces the surface area of the Rewriter and PatternRewriter. Note that it doesn't modify the `matched_op` helpers, partially so that the diff doesn't baloon, and partially because I think they are actually quite helpful as they are. At least I'd love to talk about the matched_op helpers separately from this PR, if possible.

Resolves #859 