### PR TITLE
transformations: linalg.generic to loops uses InsertPoint

### DIFF
--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -251,6 +251,18 @@ class PatternRewriter(PatternRewriterListener):
         self._replace_all_uses_with(arg, None, safe_erase=safe_erase)
         arg.block.erase_arg(arg, safe_erase)
 
+    def inline_block_at_location(
+        self,
+        block: Block,
+        insertion_point: InsertPoint,
+        arg_values: Sequence[SSAValue] = (),
+    ):
+        """
+        Move the block operations to the specified insertion point.
+        """
+        self.has_done_action = True
+        Rewriter.inline_block_at_location(block, insertion_point, arg_values=arg_values)
+
     def inline_block_at_end(
         self, block: Block, target_block: Block, arg_values: Sequence[SSAValue] = ()
     ):

--- a/xdsl/transforms/convert_linalg_to_loops.py
+++ b/xdsl/transforms/convert_linalg_to_loops.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 
 from xdsl.dialects import linalg, memref
 from xdsl.dialects.builtin import MemRefType, ModuleOp
-from xdsl.ir import MLContext, Operation, SSAValue
+from xdsl.ir import MLContext, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -11,6 +11,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.transforms.loop_nest_lowering_utils import rewrite_generic_to_loops
 
 
@@ -18,11 +19,11 @@ def load(
     value: SSAValue,
     indices: Sequence[SSAValue],
     rewriter: PatternRewriter,
-    insertion_target: Operation,
+    insertion_target: InsertPoint,
 ) -> SSAValue:
     if isinstance(value.type, MemRefType):
         op = memref.Load.get(value, indices)
-        rewriter.insert_op_before(op, insertion_target)
+        rewriter.insert_op_at_location(op, insertion_target)
         return op.res
     else:
         return value

--- a/xdsl/transforms/convert_memref_stream_to_loops.py
+++ b/xdsl/transforms/convert_memref_stream_to_loops.py
@@ -13,6 +13,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.rewriter import InsertPoint
 from xdsl.transforms.loop_nest_lowering_utils import rewrite_generic_to_loops
 
 
@@ -20,7 +21,7 @@ def load(
     source: SSAValue,
     indices: Sequence[SSAValue],
     rewriter: PatternRewriter,
-    target_op: Operation,
+    insert_point: InsertPoint,
 ) -> SSAValue:
     if isinstance(source.type, memref.MemRefType):
         op = memref.Load.get(source, indices)
@@ -28,7 +29,7 @@ def load(
         op = memref_stream.ReadOp(source)
     else:
         return source
-    rewriter.insert_op_before(op, target_op)
+    rewriter.insert_op_at_location(op, insert_point)
     return op.res
 
 


### PR DESCRIPTION
A small refactor that makes some upcoming PRs less messy.

Note stacked PR.