### PR TITLE
dialects: (riscv) mark assembly region as isolated from above

### DIFF
--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -83,14 +83,14 @@ builtin.module {
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_int_float"
 // CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @foo_int_float(%arg0_2 : !riscv.reg<a0>, %farg0_2 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0_2 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:        %arg0_3 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0_2 : (!riscv.freg<fa0>) -> !riscv.freg<>
-// CHECK-NEXT:        %farg0_3 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
-// CHECK-NEXT:        %fres0_1, %res0_1 = "test.op"(%arg0_3, %farg0_3) : (i32, f32) -> (f32, i32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0_1 : f32 to !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0_1 : i32 to !riscv.reg<>
+// CHECK-NEXT:      riscv_func.func @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
+// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
+// CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg<>
+// CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
+// CHECK-NEXT:        %fres0, %res0 = "test.op"(%arg0_1, %farg0_1) : (i32, f32) -> (f32, i32)
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg<>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0 : i32 to !riscv.reg<>
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa0>
 // CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
@@ -99,9 +99,9 @@ builtin.module {
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_int_double"
 // CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @foo_int_double(%arg0_4 : !riscv.reg<a0>, %farg0_4 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0_4 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %30 : !riscv.reg<> to i32
+// CHECK-NEXT:      riscv_func.func @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
+// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg<>
 // CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f64
 // CHECK-NEXT:        %{{.*}}, %{{.*}} = "test.op"(%{{.*}}, %{{.*}}) : (i32, f64) -> (f64, i32)

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -161,9 +161,11 @@
     riscv.directive ".align" "2"
     // CHECK-NEXT: .align 2
     riscv.assembly_section ".text" {
-      %nested_addi = riscv.addi %1, 1 : (!riscv.reg<j1>) -> !riscv.reg<j1>
+      %inner = riscv.li 5 : () -> !riscv.reg<j1>
+      %nested_addi = riscv.addi %inner, 1 : (!riscv.reg<j1>) -> !riscv.reg<j1>
     }
     // CHECK-NEXT:  .text
+    // CHECK-NEXT:  li j1, 5
     // CHECK-NEXT:  addi j1, j1, 1
     riscv.label "label0"
     // CHECK-NEXT: label0:

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -427,7 +427,7 @@
 // CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text", "foo" = i32} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.assembly_section"() ({
-// CHECK-GENERIC-NEXT:       %nested_li_1 = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text"} : () -> ()
 // CHECK-GENERIC-NEXT:     %custom0, %custom1 = "riscv.custom_assembly_instruction"(%0, %1) {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
 // CHECK-GENERIC-NEXT:     %f0 = "riscv.get_float_register"() : () -> !riscv.freg<>

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -52,6 +52,7 @@ from xdsl.printer import Printer
 from xdsl.traits import (
     ConstantLike,
     HasCanonicalisationPatternsTrait,
+    IsolatedFromAbove,
     IsTerminator,
     NoTerminator,
     Pure,
@@ -2623,7 +2624,7 @@ class AssemblySectionOp(IRDLOperation, RISCVOp):
     directive: StringAttr = attr_def(StringAttr)
     data: Region = region_def("single_block")
 
-    traits = frozenset([NoTerminator()])
+    traits = frozenset([NoTerminator(), IsolatedFromAbove()])
 
     def __init__(
         self,


### PR DESCRIPTION
Mostly impacts SSA counters in filechecks, and one assembly printing test.