### PR TITLE
dialects: [arith] Add extended multiplication operations

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -31,6 +31,8 @@ from xdsl.dialects.arith import (
     MinSI,
     MinUI,
     Mulf,
+    MulSIExtended,
+    MulUIExtended,
     Negf,
     OrI,
     RemSI,
@@ -170,6 +172,26 @@ def test_addui_extend(
         with pytest.raises((VerifyException, ValueError)):
             op = AddUIExtended(lhs, rhs, attributes, sum_type)
             op.verify()
+
+
+@pytest.mark.parametrize("op_type", [MulSIExtended, MulUIExtended])
+def test_mul_extended(op_type: type[MulSIExtended | MulUIExtended]):
+    lhs = TestSSAValue(i32)
+    rhs = TestSSAValue(i32)
+
+    op = op_type(lhs, rhs)
+
+    assert op.lhs == lhs
+    assert op.rhs == rhs
+    assert op.low.type == i32
+    assert op.high.type == i32
+
+    op2 = op_type(lhs, rhs, i64)
+
+    assert op2.lhs == lhs
+    assert op2.rhs == rhs
+    assert op2.low.type == i64
+    assert op2.high.type == i64
 
 
 class Test_float_arith_construction:

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -178,4 +178,16 @@
 
   // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i32, i1
   // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.addui_extended %{{.*}}, %{{.*}} : i64, i1
+
+  %low_ui, %high_ui = arith.mului_extended %lhsi32, %rhsi32 : i32
+  %low_ui_index, %high_ui_index = arith.mului_extended %lhsindex, %rhsindex : index
+
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.mului_extended %{{.*}}, %{{.*}} : i32
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.mului_extended %{{.*}}, %{{.*}} : index
+
+  %low_si, %high_si = arith.mulsi_extended %lhsi32, %rhsi32 : i32
+  %low_si_index, %high_si_index = arith.mulsi_extended %lhsindex, %rhsindex : index
+
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.mulsi_extended %{{.*}}, %{{.*}} : i32
+  // CHECK-NEXT: %{{.*}}, %{{.*}} = arith.mulsi_extended %{{.*}}, %{{.*}} : index
 }) : () -> ()

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -357,6 +357,47 @@ class Muli(SignlessIntegerBinaryOp):
     traits = frozenset([Pure()])
 
 
+class MulExtendedBase(IRDLOperation):
+    """Base class for extended multiplication operations."""
+
+    T = Annotated[Attribute, ConstraintVar("T"), signlessIntegerLike]
+
+    lhs: Operand = operand_def(T)
+    rhs: Operand = operand_def(T)
+    low: OpResult = result_def(T)
+    high: OpResult = result_def(T)
+
+    traits = frozenset([Pure()])
+
+    def __init__(
+        self,
+        operand1: SSAValue,
+        operand2: SSAValue,
+        result_type: Attribute | None = None,
+    ):
+        if result_type is None:
+            result_type = SSAValue.get(operand1).type
+        super().__init__(
+            operands=[operand1, operand2], result_types=[result_type, result_type]
+        )
+
+    assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs)"
+
+
+@irdl_op_definition
+class MulUIExtended(MulExtendedBase):
+    """Extended unsigned integer multiplication operation."""
+
+    name = "arith.mului_extended"
+
+
+@irdl_op_definition
+class MulSIExtended(MulExtendedBase):
+    """Extended unsigned integer multiplication operation."""
+
+    name = "arith.mulsi_extended"
+
+
 @irdl_op_definition
 class Subi(SignlessIntegerBinaryOp):
     name = "arith.subi"
@@ -1066,6 +1107,8 @@ Arith = Dialect(
         AddUIExtended,
         Subi,
         Muli,
+        MulUIExtended,
+        MulSIExtended,
         DivUI,
         DivSI,
         FloorDivSI,


### PR DESCRIPTION
Add the `mului_extended` and `mulsi_extended` from the `arith` dialect in MLIR