### PR TITLE
Dialects: (csl) adding dsd ops

### DIFF
--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -84,6 +84,10 @@ csl.func @initialize() {
     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
     %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, tensor<510xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
 
+    %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabin_dsd>, none>
+    %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabout_dsd>, none>
+
+
   csl.return
 }
 
@@ -167,6 +171,8 @@ csl.func @initialize() {
 // CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si8) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
 // CHECK-NEXT:     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
 // CHECK-NEXT:     %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, tensor<510xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabin_dsd>, none>
+// CHECK-NEXT:     %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabout_dsd>, none>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -64,22 +64,25 @@ csl.func @initialize() {
     %col_1 = "csl.get_color"() <{id = 3 : i5}> : () -> !csl.color
 
 
-    %arr, %scalar = "test.op"() : () -> (memref<10xf32>, i32)
+    %arr, %scalar, %tens = "test.op"() : () -> (memref<10xf32>, i32, tensor<510xf32>)
     %int8, %int16, %u16 = "test.op"() : () -> (si8, si16, ui16)
 
     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 
-    %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
-    %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
-    %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
-    %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
-    %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
-    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
-    %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
-    %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
+    %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
+    %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
+    %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
+    %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, memref<10xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) <{"elem_type" = f32}> : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, ui16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si8) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
 
+    %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, tensor<510xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
 
   csl.return
 }
@@ -148,19 +151,22 @@ csl.func @initialize() {
 // CHECK-NEXT:     %ssa_struct = "csl.const_struct"(%arg1_1, %arg2_1, %col) <{"ssa_fields" = ["i32_", "i16_", "col"]}> : (i32, i16, !csl.color) -> !csl.comptime_struct
 // CHECK-NEXT:     %mixed_struct = "csl.const_struct"(%arg1_1, %arg2_1, %col) <{"ssa_fields" = ["i32_", "i16_", "col"], "items" = {"i" = 42 : i32, "f" = 3.700000e+00 : f32}}> : (i32, i16, !csl.color) -> !csl.comptime_struct
 // CHECK-NEXT:     %col_1 = "csl.get_color"() <{"id" = 3 : i5}> : () -> !csl.color
-// CHECK-NEXT:     %arr, %scalar = "test.op"() : () -> (memref<10xf32>, i32)
+// CHECK-NEXT:     %arr, %scalar, %tens = "test.op"() : () -> (memref<10xf32>, i32, tensor<510xf32>)
 // CHECK-NEXT:     %int8, %int16, %u16 = "test.op"() : () -> (si8, si16, ui16)
 // CHECK-NEXT:     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
-// CHECK-NEXT:     %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
-// CHECK-NEXT:     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
-// CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
-// CHECK-NEXT:     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
+// CHECK-NEXT:     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
+// CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
+// CHECK-NEXT:     %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, memref<10xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) <{"elem_type" = f32}> : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, ui16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si8) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+// CHECK-NEXT:     %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, tensor<510xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -74,6 +74,10 @@ csl.func @initialize() {
     %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
+    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
+    %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
+    %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
 
 
   csl.return
@@ -151,6 +155,10 @@ csl.func @initialize() {
 // CHECK-NEXT:     %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -65,6 +65,7 @@ csl.func @initialize() {
 
 
     %arr, %scalar = "test.op"() : () -> (memref<10xf32>, i32)
+    %int8, %int16, %u16 = "test.op"() : () -> (si8, si16, ui16)
 
     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
@@ -75,9 +76,9 @@ csl.func @initialize() {
     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
-    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
-    %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
-    %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
+    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
+    %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
+    %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 
 
   csl.return
@@ -148,6 +149,7 @@ csl.func @initialize() {
 // CHECK-NEXT:     %mixed_struct = "csl.const_struct"(%arg1_1, %arg2_1, %col) <{"ssa_fields" = ["i32_", "i16_", "col"], "items" = {"i" = 42 : i32, "f" = 3.700000e+00 : f32}}> : (i32, i16, !csl.color) -> !csl.comptime_struct
 // CHECK-NEXT:     %col_1 = "csl.get_color"() <{"id" = 3 : i5}> : () -> !csl.color
 // CHECK-NEXT:     %arr, %scalar = "test.op"() : () -> (memref<10xf32>, i32)
+// CHECK-NEXT:     %int8, %int16, %u16 = "test.op"() : () -> (si8, si16, ui16)
 // CHECK-NEXT:     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
@@ -156,9 +158,9 @@ csl.func @initialize() {
 // CHECK-NEXT:     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %scalar) : (!csl<dsd mem1d_dsd>, i32) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -28,6 +28,7 @@ from xdsl.dialects.builtin import (
     IntegerType,
     MemRefType,
     ModuleOp,
+    Signedness,
     StringAttr,
     SymbolRefAttr,
 )
@@ -807,7 +808,7 @@ class IncrementDsdOffsetOp(IRDLOperation):
     name = "csl.increment_dsd_offset"
 
     op = operand_def(DsdType)
-    offset = operand_def(IntegerType)
+    offset = operand_def(IntegerType(16, Signedness.SIGNED))
     result = result_def(DsdType)
 
     def verify_(self) -> None:
@@ -832,7 +833,7 @@ class SetDsdLengthOp(IRDLOperation):
 
     name = "csl.set_dsd_length"
     op = operand_def(DsdType)
-    length = operand_def(IntegerType)
+    length = operand_def(IntegerType(16, Signedness.UNSIGNED))
     result = result_def(DsdType)
 
     def verify_(self) -> None:
@@ -858,7 +859,7 @@ class SetDsdStrideOp(IRDLOperation):
 
     name = "csl.set_dsd_stride"
     op = operand_def(DsdType)
-    stride = operand_def(IntegerType)
+    stride = operand_def(IntegerType(8, Signedness.SIGNED))
     result = result_def(DsdType)
 
     def verify_(self) -> None:

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -287,10 +287,10 @@ DsdElementType: TypeAlias = (
     NoneType
     | Float16Type
     | Float32Type
-    | IntegerAttr[Annotated[IntegerType, IntegerType(16, Signedness.SIGNED)]]
-    | IntegerAttr[Annotated[IntegerType, IntegerType(16, Signedness.UNSIGNED)]]
-    | IntegerAttr[Annotated[IntegerType, IntegerType(32, Signedness.SIGNED)]]
-    | IntegerAttr[Annotated[IntegerType, IntegerType(32, Signedness.UNSIGNED)]]
+    | Annotated[IntegerType, IntegerType(16, Signedness.SIGNED)]
+    | Annotated[IntegerType, IntegerType(16, Signedness.UNSIGNED)]
+    | Annotated[IntegerType, IntegerType(32, Signedness.SIGNED)]
+    | Annotated[IntegerType, IntegerType(32, Signedness.UNSIGNED)]
 )
 
 
@@ -759,7 +759,7 @@ class GetFabDsdOp(_GetDsdOp):
     });
     """
 
-    name = "csl.get_fabin_dsd"
+    name = "csl.get_fab_dsd"
     fabric_color = opt_prop_def(ColorIdAttr)
     control = opt_prop_def(BoolAttr)
     wavelet_index_offset = opt_prop_def(AnyIntegerAttr)


### PR DESCRIPTION
Implementing support for CSL builtins that modify DSDs:

`@set_dsd_base_addr(input_dsd, base_addr)`
`@increment_dsd_offset(input_dsd, offset, elem_type)`
`@set_dsd_length(input_dsd, length)`
`@set_dsd_stride(input_dsd, stride)`

Each of these ops only works with specific DSD types, which is handled in the `verify_` method.

Added additional tests and support for `tensor` type as basis for mem dsds.