### PR TITLE
dialects: (memref_stream) add a verifier for order of iterator types in memref_stream.generic

### DIFF
--- a/tests/filecheck/dialects/memref_stream/verify.mlir
+++ b/tests/filecheck/dialects/memref_stream/verify.mlir
@@ -1,0 +1,21 @@
+// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
+
+%A, %B, %C = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
+
+memref_stream.generic {
+    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    indexing_maps = [
+        affine_map<(d0, d1, d2) -> (d0, d1)>,
+        affine_map<(d0, d1, d2) -> (d1, d2)>,
+        affine_map<(d0, d1, d2) -> (d0, d2)>
+    ],
+    iterator_types = ["parallel", "reduction", "parallel"]
+} ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C : memref<4x3xf64>) {
+^0(%a : f64, %b : f64, %acc_old : f64):
+    %prod = arith.mulf %a, %b : f64
+    %acc_new = arith.addf %acc_old, %prod : f64
+    memref_stream.yield %acc_new : f64
+}
+
+// CHECK: Operation does not verify: Unexpected order of iterator types: ['parallel', 'reduction', 'parallel']
+

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -522,12 +522,10 @@ class GenericOp(IRDLOperation):
         return generic
 
     def verify_(self) -> None:
-        # Iterator types are in the expected order
+        # Parallel iterator types must preceed reduction iterators
         iterator_types = self.iterator_types.data
-        if not all(
-            a.data <= b.data for a, b in zip(iterator_types, iterator_types[1:])
-        ):
-
+        num_parallel = iterator_types.count(IteratorTypeAttr.parallel())
+        if IteratorTypeAttr.parallel() in iterator_types[num_parallel:]:
             raise VerifyException(
                 f"Unexpected order of iterator types: {[it.data.value for it in iterator_types]}"
             )

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -521,6 +521,17 @@ class GenericOp(IRDLOperation):
 
         return generic
 
+    def verify_(self) -> None:
+        # Iterator types are in the expected order
+        iterator_types = self.iterator_types.data
+        if not all(
+            a.data <= b.data for a, b in zip(iterator_types, iterator_types[1:])
+        ):
+
+            raise VerifyException(
+                f"Unexpected order of iterator types: {[it.data.value for it in iterator_types]}"
+            )
+
 
 @irdl_op_definition
 class YieldOp(AbstractYieldOperation[Attribute]):


### PR DESCRIPTION
fixes #2679
