### PR TITLE
Dialects: (csl) Simplify DSD types in IR

### DIFF
--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -79,7 +79,6 @@ csl.func @initialize() {
     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
-    //%dsd_1d4 = "csl.set_dsd_length"(%u16, %dsd_1d3) : (ui16, !csl<dsd mem1d_dsd>) -> !csl<dsd mem1d_dsd>
     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 
     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl<dsd mem1d_dsd>

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -71,21 +71,22 @@ csl.func @initialize() {
     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 
-    %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-    %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
-    %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
-    %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
-    %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-    %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, memref<10xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) <{"elem_type" = f32}> : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-    %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, ui16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-    %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si8) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
+    %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3, 4], "offsets" = [1, 2]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+    %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl<dsd mem1d_dsd>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl<dsd mem1d_dsd>
+    %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
+    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
+    %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
+    //%dsd_1d4 = "csl.set_dsd_length"(%u16, %dsd_1d3) : (ui16, !csl<dsd mem1d_dsd>) -> !csl<dsd mem1d_dsd>
+    %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 
-    %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-    %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, tensor<510xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
+    %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl<dsd mem1d_dsd>
+    %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl<dsd mem1d_dsd>, tensor<510xf32>) -> !csl<dsd mem1d_dsd>
 
-    %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabin_dsd>, none>
-    %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabout_dsd>, none>
+    %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabin_dsd>
+    %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabout_dsd>
 
 
   csl.return
@@ -160,19 +161,19 @@ csl.func @initialize() {
 // CHECK-NEXT:     %scalar_ptr = "csl.addressof"(%scalar) : (i32) -> !csl.ptr<i32, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:     %many_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>
 // CHECK-NEXT:     %single_arr_ptr = "csl.addressof"(%arr) : (memref<10xf32>) -> !csl.ptr<memref<10xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
-// CHECK-NEXT:     %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
-// CHECK-NEXT:     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
-// CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl.dsd<#csl<dsd_kind mem4d_dsd>, f32>
-// CHECK-NEXT:     %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, memref<10xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) <{"elem_type" = f32}> : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, ui16) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, si8) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>, tensor<510xf32>) -> !csl.dsd<#csl<dsd_kind mem1d_dsd>, f32>
-// CHECK-NEXT:     %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabin_dsd>, none>
-// CHECK-NEXT:     %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl.dsd<#csl<dsd_kind fabout_dsd>, none>
+// CHECK-NEXT:     %dsd_1d = "csl.get_mem_dsd"(%arr, %scalar) : (memref<10xf32>, i32) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_2d = "csl.get_mem_dsd"(%arr, %scalar, %scalar) <{"strides" = [3 : i64, 4 : i64], "offsets" = [1 : i64, 2 : i64]}> : (memref<10xf32>, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_3d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
+// CHECK-NEXT:     %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl<dsd mem1d_dsd>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl<dsd mem1d_dsd>, tensor<510xf32>) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabin_dsd>
+// CHECK-NEXT:     %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabout_dsd>
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -77,7 +77,7 @@ csl.func @initialize() {
     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
     %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl<dsd mem1d_dsd>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl<dsd mem1d_dsd>
     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
-    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
+    %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) <{"elem_type" = f32}> : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 
@@ -166,7 +166,7 @@ csl.func @initialize() {
 // CHECK-NEXT:     %dsd_4d = "csl.get_mem_dsd"(%arr, %scalar, %scalar, %scalar, %scalar) : (memref<10xf32>, i32, i32, i32, i32) -> !csl<dsd mem4d_dsd>
 // CHECK-NEXT:     %dsd_1d1 = "csl.set_dsd_base_addr"(%dsd_1d, %many_arr_ptr) : (!csl<dsd mem1d_dsd>, !csl.ptr<f32, #csl<ptr_kind many>, #csl<ptr_const const>>) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:     %dsd_1d2 = "csl.set_dsd_base_addr"(%dsd_1d, %arr) : (!csl<dsd mem1d_dsd>, memref<10xf32>) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:     %dsd_1d3 = "csl.increment_dsd_offset"(%dsd_1d2, %int16) <{"elem_type" = f32}> : (!csl<dsd mem1d_dsd>, si16) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:     %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:     %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl<dsd mem1d_dsd>

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -816,7 +816,7 @@ class IncrementDsdOffsetOp(_ModifyDsdOp):
     op = operand_def(DsdType)
     offset = operand_def(IntegerType(16, Signedness.SIGNED))
 
-    def get_element_type(self):
+    def get_element_type(self) -> Float16Type | Float32Type | IntegerType | None:
         assert isinstance(self.op, OpResult)
         op = self.op.op
         while op:
@@ -827,7 +827,12 @@ class IncrementDsdOffsetOp(_ModifyDsdOp):
                 return None
             elif isinstance(op, GetMemDsdOp):
                 if isinstance(op.base_addr.type, ContainerType):
-                    return op.base_addr.type.get_element_type()
+                    assert isinstance(
+                        res := op.base_addr.type.get_element_type(),  # pyright: ignore [reportUnknownVariableType]
+                        Float16Type | Float32Type | IntegerType,
+                    )
+                    return res
+                    # return op.base_addr.type.get_element_type()
                 return None
         return None
 


### PR DESCRIPTION
Simplify DSD types in IR by not carrying around element type information. Since this is only needed for the printing of `@increment_dsd_offset()`, we can provide a helper method instead to retrieve this information.