### PR TITLE
backend: (csl) Added printing for `param`,  `comptime_struct` and some builtins

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -246,10 +246,15 @@ csl.func @gemv() {
 // CHECK-NEXT: fn args_no_return(a : i32, b : i32) void {
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
-// CHECK-NEXT: //unknown op ConstStructOp(%empty_struct = "csl.const_struct"() : () -> !csl.comptime_struct)
-// CHECK-NEXT: //unknown op ConstStructOp(%attribute_struct = "csl.const_struct"() <{"items" = {"hello" = 1.230000e+02 : f32}}> : () -> !csl.comptime_struct)
+// CHECK-NEXT: const empty_struct : comptime_struct = .{
+// CHECK-NEXT: };
+// CHECK-NEXT: const attribute_struct : comptime_struct = .{
+// CHECK-NEXT:   .hello = 123.0,
+// CHECK-NEXT: };
 // CHECK-NEXT: const const27 : i16 = 27;
-// CHECK-NEXT: //unknown op ConstStructOp(%ssa_struct = "csl.const_struct"(%const27) <{"ssa_fields" = ["val"]}> : (i16) -> !csl.comptime_struct)
+// CHECK-NEXT: const ssa_struct : comptime_struct = .{
+// CHECK-NEXT:   .val = const27,
+// CHECK-NEXT: };
 // CHECK-NEXT: const no_param_import : imported_module = @import_module("<mod>");
 // CHECK-NEXT: const param_import : imported_module = @import_module("<mod>", ssa_struct);
 // CHECK-NEXT: param_import.foo();
@@ -332,9 +337,10 @@ csl.func @gemv() {
 // CHECK-NEXT: comptime {
 // CHECK-NEXT:   @export_symbol(args_no_return, "args_no_return");
 // CHECK-NEXT: }
-// CHECK-NEXT: //unknown op GetColorOp(%col = "csl.get_color"() <{"id" = 15 : i5}> : () -> !csl.color)
-// CHECK-NEXT: //unknown op RpcOp("csl.rpc"(%col) : (!csl.color) -> ())
-
+// CHECK-NEXT: const col : color = @get_color(15);
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @rpc(@get_data_task_id(col));
+// CHECK-NEXT: }
 // CHECK-NEXT: var A : [24]f32 = @constants([24]f32, 0);
 // CHECK-NEXT: var x : [6]f32 = @constants([6]f32, 0);
 // CHECK-NEXT: var b : [4]f32 = @constants([4]f32, 0);
@@ -398,18 +404,20 @@ csl.func @gemv() {
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT: // >>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<< //
-// CHECK-NEXT: //unknown op ParamOp(%p1 = "csl.param"() <{"param_name" = "param_1"}> : () -> i32)
-// CHECK-NEXT: //unknown op ParamOp(%p2 = "csl.param"() <{"param_name" = "param_2", "init_value" = 1.300000e+00 : f16}> : () -> f16)
+// CHECK-NEXT: param param_1 : i32;
+// CHECK-NEXT: param param_2 : f16 = 1.3;
 // CHECK-NEXT: layout {
 // CHECK-NEXT:   const x_dim : i32 = 4;
 // CHECK-NEXT:   const y_dim : i32 = 6;
-// CHECK-NEXT:   //unknown op SetRectangleOp("csl.set_rectangle"(%x_dim, %y_dim) : (i32, i32) -> ())
+// CHECK-NEXT:   @set_rectangle(x_dim, y_dim);
 // CHECK-NEXT:   const x_coord0 : i32 = 0;
 // CHECK-NEXT:   const y_coord : i32 = 0;
-// CHECK-NEXT:   //unknown op SetTileCodeOp("csl.set_tile_code"(%x_coord0, %y_coord) <{"file" = "file.csl"}> : (i32, i32) -> ())
-// CHECK-NEXT:   //unknown op ConstStructOp(%params = "csl.const_struct"() <{"items" = {"hello" = 123 : i32}}> : () -> !csl.comptime_struct)
+// CHECK-NEXT:   @set_tile_code(x_coord0, y_coord, "file.csl", )
+// CHECK-NEXT:   const params : comptime_struct = .{
+// CHECK-NEXT:     .hello = 123
+// CHECK-NEXT:   };
 // CHECK-NEXT:   const x_coord1 : i32 = 1;
-// CHECK-NEXT:   //unknown op SetTileCodeOp("csl.set_tile_code"(%x_coord1, %y_coord, %params) <{"file" = "file.csl"}> : (i32, i32, !csl.comptime_struct) -> ())
+// CHECK-NEXT:   @set_tile_code(x_coord1, y_coord, "file.csl", params);
 // CHECK-NEXT:   @export_name("ptr_name", [*]f32, true);
 // CHECK-NEXT:   @export_name("another_ptr", [*]const i32, false);
 // CHECK-NEXT:   @export_name("no_args_no_return", fn() void, );

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -418,6 +418,13 @@ class CslPrintContext:
                             # If specified, get mutability as true/false from python bool
                             mut = str(val[1]).lower() if val[1] is not None else ""
                             inner.print(f'@export_name("{name}", {ty}, {mut});')
+                case csl.ParamOp(init_value=init, param_name=name, res=res):
+                    if init is None:
+                        init = ""
+                    else:
+                        init = f" = { self.attribute_value_to_str(init)}"
+                    ty = self.mlir_type_to_csl_type(res.type)
+                    self.print(f"param {name.data} : {ty}{init};")
                 case csl.ConstStructOp(
                     items=items, ssa_fields=fields, ssa_values=values, res=res
                 ):

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -274,21 +274,6 @@ class CslPrintContext:
             case _:
                 return f"<!unknown value {attr}>"
 
-    def attribute_type_to_str(self, attr: Attribute) -> str:
-        """
-        Takes a value-carrying attribute and (IntegerAttr, FloatAttr, etc.)
-        and converts it to a csl expression representing the value's type (f32, u16, ...)
-        """
-        match attr:
-            case IntAttr():
-                return "<!indeterminate IntAttr type>"
-            case IntegerAttr(type=(IntegerType() | IndexType()) as int_t):
-                return self.mlir_type_to_csl_type(int_t)
-            case FloatAttr(type=(Float16Type() | Float32Type()) as float_t):
-                return self.mlir_type_to_csl_type(float_t)
-            case _:
-                return f"<!unknown type of {attr}>"
-
     def print_block(self, body: Block):
         """
         Walks over a block and prints every operation in the block.

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -6,8 +6,10 @@ from typing import IO, Literal, cast
 
 from xdsl.dialects import arith, csl, memref, scf
 from xdsl.dialects.builtin import (
+    ArrayAttr,
     ContainerType,
     DenseIntOrFPElementsAttr,
+    DictionaryAttr,
     Float16Type,
     Float32Type,
     FloatAttr,
@@ -197,8 +199,14 @@ class CslPrintContext:
         - float types: f16, f32
         - pointers: [*]f32
         - arrays: [64]f32
+        - function: fn(i32) f16
+        - color
+        - comptime_struct
+        - imported_module
+        - type
+        - comptime_string
 
-        This method does not yet support all the types and will be expanded as needed later.
+        This method supports all of these except type and comptime_string
         """
         match type_attr:
             case csl.ComptimeStructType():
@@ -240,6 +248,8 @@ class CslPrintContext:
                 args = map(self.mlir_type_to_csl_type, inp)
                 ret = self.mlir_type_to_csl_type(out.data[0]) if len(out) else "void"
                 return f"fn({', '.join(args)}) {ret}"
+            case csl.ColorType():
+                return "color"
             case _:
                 return f"<!unknown type {type_attr}>"
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -440,6 +440,25 @@ class CslPrintContext:
                         v = self._get_variable_name_for(v)
                         self.print(f".{k.data} = {v},", prefix=self._INDENT)
                     self.print("};")
+                case csl.SetTileCodeOp(
+                    file=file, x_coord=x_coord, y_coord=y_coord, params=params
+                ):
+                    file = self.attribute_value_to_str(file)
+                    x = self._get_variable_name_for(x_coord)
+                    y = self._get_variable_name_for(y_coord)
+                    params = self._get_variable_name_for(params) if params else ""
+                    self.print(f"@set_tile_code({x}, {y}, {file}, {params});")
+                case csl.SetRectangleOp(x_dim=x_dim, y_dim=y_dim):
+                    x = self._get_variable_name_for(x_dim)
+                    y = self._get_variable_name_for(y_dim)
+                    self.print(f"@set_rectangle({x}, {y});")
+                case csl.GetColorOp(id=id, res=res):
+                    id = self.attribute_value_to_str(id)
+                    self.print(f"{self._var_use(res)} = @get_color({id});")
+                case csl.RpcOp(id=id):
+                    id = self._get_variable_name_for(id)
+                    with self.descend("comptime") as inner:
+                        inner.print(f"@rpc(@get_data_task_id({id}));")
                 case anyop:
                     self.print(f"unknown op {anyop}", prefix="//")
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -418,6 +418,21 @@ class CslPrintContext:
                             # If specified, get mutability as true/false from python bool
                             mut = str(val[1]).lower() if val[1] is not None else ""
                             inner.print(f'@export_name("{name}", {ty}, {mut});')
+                case csl.ConstStructOp(
+                    items=items, ssa_fields=fields, ssa_values=values, res=res
+                ):
+                    items = items or DictionaryAttr({})
+                    fields = fields or ArrayAttr([])
+                    # First print the fields defined by attributes
+                    self.print(f"{self._var_use(res)} = .{{")
+                    for k, v in items.data.items():
+                        v = self.attribute_value_to_str(v)
+                        self.print(f".{k} = {v},", prefix=self._INDENT)
+                    # Then the fields defined by operands, with their corresponding names
+                    for k, v in zip(fields.data, values):
+                        v = self._get_variable_name_for(v)
+                        self.print(f".{k.data} = {v},", prefix=self._INDENT)
+                    self.print("};")
                 case anyop:
                     self.print(f"unknown op {anyop}", prefix="//")
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -261,10 +261,16 @@ class CslPrintContext:
         match attr:
             case IntAttr(data=val):
                 return str(val)
+            case IntegerAttr(
+                value=val, type=IntegerType(width=IntAttr(data=width))
+            ) if width == 1:
+                return str(bool(val.data)).lower()
             case IntegerAttr(value=val):
                 return str(val.data)
             case FloatAttr(value=val):
                 return str(val.data)
+            case StringAttr() as s:
+                return f'"{s.data}"'
             case _:
                 return f"<!unknown value {attr}>"
 


### PR DESCRIPTION
This PR adds

* Types
    + `csl.color`
* Attributes
    + Boolean attribute
    + String attribute
* Operations
    + `csl.param`
    + `csl.const_struct`
    + `csl.set_tile_code`
    + `csl.set_rectangle`
    + `csl.get_color`
    + `csl.rpc`

It adds the last changes made in #2592, which can be closed when this is merged.