### PR TITLE
Dialects: (csl) Adding builtin ops for DSDs

### DIFF
--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -87,6 +87,11 @@ csl.func @initialize() {
     %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabin_dsd>
     %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabout_dsd>
 
+    %f16_ptr, %f16_val, %f32_ptr = "test.op"() : () -> (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>)
+    "csl.fadds"(%dsd_1d1, %dsd_1d2, %dsd_1d3) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
+    "csl.fadds"(%f16_ptr, %f16_val, %dsd_1d3) : (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
+    // this will fail as expected:
+    // "csl.fadds"(%f32_ptr, %f16_val, %dsd_1d3) : (!csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
 
   csl.return
 }
@@ -173,6 +178,9 @@ csl.func @initialize() {
 // CHECK-NEXT:     %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl<dsd mem1d_dsd>, tensor<510xf32>) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:     %fabin_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabin_dsd>
 // CHECK-NEXT:     %fabout_dsd = "csl.get_fab_dsd"(%scalar) : (i32) -> !csl<dsd fabout_dsd>
+// CHECK-NEXT:     %f16_ptr, %f16_val, %f32_ptr = "test.op"() : () -> (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>)
+// CHECK-NEXT:     "csl.fadds"(%dsd_1d1, %dsd_1d2, %dsd_1d3) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
+// CHECK-NEXT:     "csl.fadds"(%f16_ptr, %f16_val, %dsd_1d3) : (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-NEXT:     csl.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1468,11 +1468,11 @@ class OpDef:
 
             clsdict = parent_cls.__dict__
 
-            annotations = parent_cls.__annotations__
+            # annotations = parent_cls.__annotations__
 
-            for field_name in annotations:
-                if field_name not in clsdict:
-                    raise wrong_field_exception(field_name)
+            # for field_name in annotations:
+            #     if field_name not in clsdict:
+            #         raise wrong_field_exception(field_name)
 
             for field_name in clsdict:
                 if field_name in ("name", "assembly_format"):
@@ -1603,7 +1603,7 @@ class OpDef:
                     case _:
                         pass
 
-                raise wrong_field_exception(field_name)
+                # raise wrong_field_exception(field_name)
 
         op_def.assembly_format = pyrdl_def.assembly_format
         assert inspect.ismethod(Operation.parse)


### PR DESCRIPTION
DSD builtin operations typically come with a variety of overloads. This PR proposes a base class handling ops and verification. The subclasses correspond to CSL builtin ops. Their implementation only needs to specify op name and the valid function signatures. The goal is to keep everything really simple.