### PR TITLE
core: (irdl) Allow ClassVar with all uppercase name

### DIFF
--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -1,3 +1,4 @@
+# do not include 'from __future__ import annotations' in this file
 from typing import ClassVar
 
 import pytest

--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import pytest
 
 from xdsl.dialects.builtin import StringAttr, SymbolRefAttr, i32
@@ -18,6 +20,8 @@ from xdsl.dialects.irdl import (
     TypeOp,
 )
 from xdsl.ir import Block, Region
+from xdsl.irdl import IRDLOperation, irdl_op_definition
+from xdsl.utils.exceptions import PyRDLOpDefinitionError
 from xdsl.utils.test_value import TestSSAValue
 
 
@@ -142,3 +146,24 @@ def test_qualified_name(op_type: type[OperationOp | TypeOp | AttributeOp]):
     dialect = DialectOp("mydialect", Region(Block([op])))
     dialect.verify()
     assert op.qualified_name == "mydialect.myname"
+
+
+class MyOpWithClassVar(IRDLOperation):
+    name = "test.has_class_var"
+
+    VAR: ClassVar[str] = "hello_world"
+
+
+class MyOpWithClassVarInvalid(IRDLOperation):
+    name = "test.has_class_var"
+
+    var: ClassVar[str] = "hello_world"
+
+
+def testClassVarOnOp():
+    irdl_op_definition(MyOpWithClassVar)
+
+
+def testClassVarOnOpInvalid():
+    with pytest.raises(PyRDLOpDefinitionError, match="is neither a"):
+        irdl_op_definition(MyOpWithClassVarInvalid)

--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -160,10 +160,10 @@ class MyOpWithClassVarInvalid(IRDLOperation):
     var: ClassVar[str] = "hello_world"
 
 
-def testClassVarOnOp():
+def test_class_var_on_op():
     irdl_op_definition(MyOpWithClassVar)
 
 
-def testClassVarOnOpInvalid():
+def test_class_var_on_op_invalid():
     with pytest.raises(PyRDLOpDefinitionError, match="is neither a"):
         irdl_op_definition(MyOpWithClassVarInvalid)

--- a/tests/dialects/test_irdl_with_annotations.py
+++ b/tests/dialects/test_irdl_with_annotations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# do not remove 'from __future__ import annotations'
 from typing import ClassVar
 
 import pytest

--- a/tests/dialects/test_irdl_with_annotations.py
+++ b/tests/dialects/test_irdl_with_annotations.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+
+from xdsl.irdl import IRDLOperation, irdl_op_definition
+from xdsl.utils.exceptions import PyRDLOpDefinitionError
+
+
+class MyOpWithClassVar(IRDLOperation):
+    name = "test.has_class_var"
+
+    VAR: ClassVar[str] = "hello_world"
+
+
+class MyOpWithClassVarInvalid(IRDLOperation):
+    name = "test.has_class_var"
+
+    var: ClassVar[str] = "hello_world"
+
+
+def test_class_var_on_op():
+    irdl_op_definition(MyOpWithClassVar)
+
+
+def test_class_var_on_op_invalid():
+    with pytest.raises(PyRDLOpDefinitionError, match="is neither a"):
+        irdl_op_definition(MyOpWithClassVarInvalid)

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1487,7 +1487,13 @@ class OpDef:
                 if (
                     field_name in annotations
                     and field_name.isupper()
-                    and get_origin(annotations[field_name]) is ClassVar
+                    and (
+                        get_origin(annotations[field_name]) is ClassVar
+                        or (
+                            isinstance(annotations[field_name], str)
+                            and annotations[field_name].startswith("ClassVar")
+                        )
+                    )
                 ):
                     continue
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1486,7 +1486,7 @@ class OpDef:
                 if (
                     field_name in annotations
                     and field_name.isupper()
-                    and annotations[field_name].startswith("ClassVar[")
+                    and get_origin(annotations[field_name]) is ClassVar
                 ):
                     continue
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1447,7 +1447,8 @@ class OpDef:
                 "operand_def(<Constraint>), results with "
                 "result_def(<Constraint>), regions with "
                 "region_def(), attributes with "
-                "attr_def(<Constraint>), and properties with prop_def(<Constraint>)"
+                "attr_def(<Constraint>), properties with prop_def(<Constraint>), "
+                "and constants (indicated by uppercase field names) as ClassVar."
             )
 
         op_def = OpDef(pyrdl_def.name)

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1483,6 +1483,12 @@ class OpDef:
                 if field_name in field_names:
                     # already registered value for field name
                     continue
+                if (
+                    field_name in annotations
+                    and field_name.isupper()
+                    and annotations[field_name].startswith("ClassVar[")
+                ):
+                    continue
 
                 value = clsdict[field_name]
 


### PR DESCRIPTION
This change makes IRDL accept non-irdl fields on `@irdl_op_definition` decorated classes, if they are all uppercase and annotated as `ClassVar`.
