### PR TITLE
core: Allowing overload of ClassVar from superclass

### DIFF
--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -168,3 +168,19 @@ def test_class_var_on_op():
 def test_class_var_on_op_invalid():
     with pytest.raises(PyRDLOpDefinitionError, match="is neither a"):
         irdl_op_definition(MyOpWithClassVarInvalid)
+
+
+class MySuperWithClassVarDef(IRDLOperation):
+    name = "test.super_has_class_var"
+
+    VAR: ClassVar[str]
+
+
+class MySubWithClassVarOverload(MySuperWithClassVarDef):
+    name = "test.super_has_class_var"
+
+    VAR: ClassVar[str] = "hello_world"
+
+
+def test_class_var_on_super():
+    irdl_op_definition(MySubWithClassVarOverload)

--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -183,4 +183,5 @@ class MySubWithClassVarOverload(MySuperWithClassVarDef):
 
 
 def test_class_var_on_super():
+    irdl_op_definition(MySuperWithClassVarDef)
     irdl_op_definition(MySubWithClassVarOverload)

--- a/tests/dialects/test_irdl_with_annotations.py
+++ b/tests/dialects/test_irdl_with_annotations.py
@@ -28,3 +28,19 @@ def test_class_var_on_op():
 def test_class_var_on_op_invalid():
     with pytest.raises(PyRDLOpDefinitionError, match="is neither a"):
         irdl_op_definition(MyOpWithClassVarInvalid)
+
+
+class MySuperWithClassVarDef(IRDLOperation):
+    name = "test.super_has_class_var"
+
+    VAR: ClassVar[str]
+
+
+class MySubWithClassVarOverload(MySuperWithClassVarDef):
+    name = "test.super_has_class_var"
+
+    VAR: ClassVar[str] = "hello_world"
+
+
+def test_class_var_on_super():
+    irdl_op_definition(MySubWithClassVarOverload)

--- a/tests/dialects/test_irdl_with_annotations.py
+++ b/tests/dialects/test_irdl_with_annotations.py
@@ -43,4 +43,5 @@ class MySubWithClassVarOverload(MySuperWithClassVarDef):
 
 
 def test_class_var_on_super():
+    irdl_op_definition(MySuperWithClassVarDef)
     irdl_op_definition(MySubWithClassVarOverload)

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1472,6 +1472,14 @@ class OpDef:
             annotations = parent_cls.__annotations__
 
             for field_name in annotations:
+                if field_name.isupper() and (
+                    get_origin(annotations[field_name]) is ClassVar
+                    or (
+                        isinstance(annotations[field_name], str)
+                        and annotations[field_name].startswith("ClassVar")
+                    )
+                ):
+                    continue
                 if field_name not in clsdict:
                     raise wrong_field_exception(field_name)
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1451,6 +1451,15 @@ class OpDef:
                 "and constants (indicated by uppercase field names) as ClassVar."
             )
 
+        def is_const_classvar(field_name: str, annotations: dict[str, Any]) -> bool:
+            return field_name.isupper() and (
+                get_origin(annotations[field_name]) is ClassVar
+                or (
+                    isinstance(annotations[field_name], str)
+                    and annotations[field_name].startswith("ClassVar")
+                )
+            )
+
         op_def = OpDef(pyrdl_def.name)
 
         # If an operation subclass overrides a superclass field, only keep the definition
@@ -1472,13 +1481,7 @@ class OpDef:
             annotations = parent_cls.__annotations__
 
             for field_name in annotations:
-                if field_name.isupper() and (
-                    get_origin(annotations[field_name]) is ClassVar
-                    or (
-                        isinstance(annotations[field_name], str)
-                        and annotations[field_name].startswith("ClassVar")
-                    )
-                ):
+                if is_const_classvar(field_name, annotations):
                     continue
                 if field_name not in clsdict:
                     raise wrong_field_exception(field_name)
@@ -1492,16 +1495,8 @@ class OpDef:
                 if field_name in field_names:
                     # already registered value for field name
                     continue
-                if (
-                    field_name in annotations
-                    and field_name.isupper()
-                    and (
-                        get_origin(annotations[field_name]) is ClassVar
-                        or (
-                            isinstance(annotations[field_name], str)
-                            and annotations[field_name].startswith("ClassVar")
-                        )
-                    )
+                if field_name in annotations and is_const_classvar(
+                    field_name, annotations
                 ):
                     continue
 


### PR DESCRIPTION
This is to enhance PR [#2687](https://github.com/xdslproject/xdsl/pull/2687), which allowed uppercase `ClassVar` fields on ops.

This PR adds support for the case that an uppercase `ClassVar` is defined (without a value) in a superclass and assigned a value in a subclass. This is confirmed by performing the same check as in the other PR.