### PR TITLE
core: Allow to parse string enums

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from io import StringIO
 from typing import cast
 
@@ -882,3 +883,35 @@ def test_parse_visibility(keyword: str, expected: StringAttr | None):
             parser.parse_visibility_keyword()
     else:
         assert parser.parse_visibility_keyword() == expected
+
+class MyEnum(StrEnum):
+    A = "a"
+    B = "b"
+    C = "c"
+
+@pytest.mark.parametrize(
+        "keyword, expected",
+        [
+            ("a", MyEnum.A),
+            ("b", MyEnum.B),
+            ("c", MyEnum.C),
+            ("cc", None),
+        ],
+)
+def test_parse_str_enum(keyword: str, expected: MyEnum | None):
+    assert Parser(MLContext(), keyword).parse_optional_str_enum(MyEnum) == expected
+
+    parser = Parser(MLContext(), keyword)
+    if expected is None:
+        with pytest.raises(ParseError, match="Expected `a`, `b`, or `c`"):
+            parser.parse_str_enum(MyEnum)
+    else:
+        assert parser.parse_str_enum(MyEnum) == expected
+
+class MySingletonEnum(StrEnum):
+    A = "a"
+
+def test_parse_singleton_enum_fail():
+    parser = Parser(MLContext(), "b")
+    with pytest.raises(ParseError, match="Expected `a`"):
+        parser.parse_str_enum(MySingletonEnum)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -608,17 +608,7 @@ class EnumAttribute(Data[EnumType]):
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> EnumType:
-        enum_type = cls.enum_type
-
-        val = parser.parse_identifier()
-        if val not in enum_type.__members__.values():
-            enum_values = list(enum_type)
-            if len(enum_values) == 1:
-                parser.raise_error(f"Expected `{enum_values[0]}`.")
-            parser.raise_error(
-                f"Expected `{'`, `'.join(enum_values[:-1])}` or `{enum_values[-1]}`."
-            )
-        return cast(EnumType, enum_type(val))
+        return cast(EnumType, parser.parse_str_enum(cls.enum_type))
 
 
 @dataclass(frozen=True, init=False)

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -6,11 +6,12 @@ that is inherited from the different parsers used in xDSL.
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
-from enum import Enum, StrEnum
+from enum import Enum
 from typing import NoReturn, TypeVar, overload
 
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Lexer, Position, Span, StringLiteral, Token
+from xdsl.utils.str_enum import StrEnum
 
 
 @dataclass(init=False)
@@ -544,7 +545,9 @@ class BaseParser:
         enum_values = tuple(enum_type)
         if len(enum_values) == 1:
             self.raise_error(f"Expected `{enum_values[0]}`.")
-        self.raise_error(f"Expected `{'`, `'.join(enum_values[:-1])}` or `{enum_values[-1]}`.")
+        self.raise_error(
+            f"Expected `{'`, `'.join(enum_values[:-1])}`, or `{enum_values[-1]}`."
+        )
 
     def parse_optional_str_enum(self, enum_type: type[_EnumType]) -> _EnumType | None:
         """Parse a string enum value, if present."""

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -6,7 +6,7 @@ that is inherited from the different parsers used in xDSL.
 from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import NoReturn, TypeVar, overload
 
 from xdsl.utils.exceptions import ParseError
@@ -34,6 +34,7 @@ class ParserState:
 
 
 _AnyInvT = TypeVar("_AnyInvT")
+_EnumType = TypeVar("_EnumType", bound=StrEnum)
 
 
 @dataclass
@@ -534,3 +535,26 @@ class BaseParser:
         kind = Token.Kind.get_punctuation_kind_from_spelling(punctuation)
         self._parse_token(kind, f"Expected '{punctuation}'" + context_msg)
         return punctuation
+
+    def parse_str_enum(self, enum_type: type[_EnumType]) -> _EnumType:
+        """Parse a string enum value."""
+        result = self.parse_optional_str_enum(enum_type)
+        if result is not None:
+            return result
+        enum_values = tuple(enum_type)
+        if len(enum_values) == 1:
+            self.raise_error(f"Expected `{enum_values[0]}`.")
+        self.raise_error(f"Expected `{'`, `'.join(enum_values[:-1])}` or `{enum_values[-1]}`.")
+
+    def parse_optional_str_enum(self, enum_type: type[_EnumType]) -> _EnumType | None:
+        """Parse a string enum value, if present."""
+
+        if self._current_token.kind != Token.Kind.BARE_IDENT:
+            return None
+
+        val = self._current_token.text
+        if val not in enum_type.__members__.values():
+            return None
+
+        self._consume_token(Token.Kind.BARE_IDENT)
+        return enum_type(val)


### PR DESCRIPTION
Add support in the parser to parse an `StrEnum`.
It parses a bare identifier, and check if it is part of the `StrEnum`.