### PR TITLE
core: Implement and use ConstraintContext

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -119,9 +119,15 @@
     "any_constraint = AnyAttr()\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "any_constraint.verify(i64, {})\n",
-    "any_constraint.verify(StringAttr(\"ga\"), {})"
+    "any_constraint.verify(i64)\n",
+    "any_constraint.verify(StringAttr(\"ga\"))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "220fe84d",
+   "metadata": {},
+   "source": []
   },
   {
    "attachments": {},
@@ -163,11 +169,11 @@
     "eq_constraint = EqAttrConstraint(i64)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "eq_constraint.verify(i64, {})\n",
+    "eq_constraint.verify(i64)\n",
     "\n",
     "# This will trigger an exception\n",
     "try:\n",
-    "    eq_constraint.verify(i32, {})\n",
+    "    eq_constraint.verify(i32)\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -213,12 +219,12 @@
     "base_constraint = BaseAttr(StringAttr)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "base_constraint.verify(StringAttr(\"ga\"), {})\n",
-    "base_constraint.verify(StringAttr(\"bu\"), {})\n",
+    "base_constraint.verify(StringAttr(\"ga\"))\n",
+    "base_constraint.verify(StringAttr(\"bu\"))\n",
     "\n",
     "# This will trigger an exception\n",
     "try:\n",
-    "    base_constraint.verify(i32, {})\n",
+    "    base_constraint.verify(i32)\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -240,7 +246,7 @@
    "source": [
     "# This too\n",
     "try:\n",
-    "    base_constraint.verify(IntAttr(3), {})\n",
+    "    base_constraint.verify(IntAttr(3))\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -316,15 +322,15 @@
     "or_constraint = AnyOf([i32, StringAttr])\n",
     "\n",
     "# This will pass without triggering an exception, since the first constraint is satisfied\n",
-    "or_constraint.verify(i32, {})\n",
+    "or_constraint.verify(i32)\n",
     "\n",
     "# This will pass without triggering an exception, since the second constraint is satisfied\n",
-    "or_constraint.verify(StringAttr(\"ga\"), {})\n",
-    "or_constraint.verify(StringAttr(\"bu\"), {})\n",
+    "or_constraint.verify(StringAttr(\"ga\"))\n",
+    "or_constraint.verify(StringAttr(\"bu\"))\n",
     "\n",
     "# This will trigger an exception, since none of the constraints are satisfied\n",
     "try:\n",
-    "    or_constraint.verify(i64, {})\n",
+    "    or_constraint.verify(i64)\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -369,12 +375,12 @@
     "param_constraint = ParamAttrConstraint(IntegerAttr, [IntAttr, i32])\n",
     "\n",
     "# This will pass without triggering an exception.\n",
-    "param_constraint.verify(IntegerAttr(IntAttr(42), i32), {})\n",
-    "param_constraint.verify(IntegerAttr(IntAttr(23), i32), {})\n",
+    "param_constraint.verify(IntegerAttr(IntAttr(42), i32))\n",
+    "param_constraint.verify(IntegerAttr(IntAttr(23), i32))\n",
     "\n",
     "# This will trigger an exception, since the attribute type is not the expected one\n",
     "try:\n",
-    "    param_constraint.verify(i64, {})\n",
+    "    param_constraint.verify(i64)\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -397,7 +403,7 @@
     "# This will trigger an exception, since the second parameter constraint is not satisfied\n",
     "\n",
     "try:\n",
-    "    param_constraint.verify(IntegerAttr(IntAttr(42), i64), {})\n",
+    "    param_constraint.verify(IntegerAttr(IntAttr(42), i64))\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -436,15 +442,15 @@
     }
    ],
    "source": [
-    "from xdsl.ir import Attribute\n",
     "from xdsl.irdl import VarConstraint\n",
+    "from xdsl.irdl.irdl import ConstraintContext\n",
     "\n",
     "var_constraint = VarConstraint(\"T\", BaseAttr(IntegerType))\n",
-    "constraint_variables: dict[str, Attribute] = {}\n",
+    "constraint_context = ConstraintContext()\n",
     "\n",
     "# The underlying constraint is not satisfied by the given attribute\n",
     "try:\n",
-    "    var_constraint.verify(IndexType(), constraint_variables)\n",
+    "    var_constraint.verify(IndexType(), constraint_context)\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -465,8 +471,8 @@
    ],
    "source": [
     "# The constraint sets the constraint variable if the attribute verifies\n",
-    "var_constraint.verify(i32, constraint_variables)\n",
-    "print(constraint_variables[\"T\"])"
+    "var_constraint.verify(i32, constraint_context)\n",
+    "print(constraint_context.variables[\"T\"])"
    ]
   },
   {
@@ -486,7 +492,7 @@
    "source": [
     "# Since the variable is set, the constraint can now only be satisfied by the same attribute\n",
     "try:\n",
-    "    var_constraint.verify(i64, constraint_variables)\n",
+    "    var_constraint.verify(i64, constraint_context)\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -537,21 +543,21 @@
     "        object.__setattr__(self, \"elem_constr\", attr_constr_coercion(constr))\n",
     "\n",
     "    # Check that an attribute satisfies the constraints\n",
-    "    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:\n",
+    "    def verify(self, attr: Attribute, constraint_context: ConstraintContext | None = None) -> None:\n",
     "        # We first check that the attribute is an ArrayAttr\n",
     "        if not isa(attr, ArrayAttr[Attribute]):\n",
     "            raise VerifyException(f\"expected attribute ArrayData but got {attr}\")\n",
     "\n",
     "        # We check the constraint for all elements in the array\n",
     "        for e in attr.data:\n",
-    "            self.elem_constr.verify(e, constraint_vars)\n",
+    "            self.elem_constr.verify(e, constraint_context)\n",
     "\n",
     "\n",
     "array_constraint = ArrayOfConstraint(IntAttr)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "array_constraint.verify(ArrayAttr([IntAttr(42)]), {})\n",
-    "array_constraint.verify(ArrayAttr([IntAttr(3), IntAttr(7)]), {})"
+    "array_constraint.verify(ArrayAttr([IntAttr(42)]))\n",
+    "array_constraint.verify(ArrayAttr([IntAttr(3), IntAttr(7)]))"
    ]
   },
   {
@@ -571,7 +577,7 @@
    "source": [
     "# This will trigger an exception, since the attribute is not an array\n",
     "try:\n",
-    "    array_constraint.verify(i32, {})\n",
+    "    array_constraint.verify(i32)\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -593,7 +599,7 @@
    "source": [
     "# This will trigger an exception, since the array contains attribute that do not satisfies the constraint\n",
     "try:\n",
-    "    array_constraint.verify(ArrayAttr([IntAttr(42), StringAttr(\"ga\")]), {})\n",
+    "    array_constraint.verify(ArrayAttr([IntAttr(42), StringAttr(\"ga\")]))\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -1517,8 +1523,14 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1517,14 +1517,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "name": "python",
-   "version": "3.11.9"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -124,12 +124,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "220fe84d",
-   "metadata": {},
-   "source": []
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "b44e60b8",

--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -113,14 +113,14 @@
     "# NBVAL_CHECK_OUTPUT\n",
     "\n",
     "from xdsl.dialects.builtin import IndexType, IntegerType, StringAttr, i64\n",
-    "from xdsl.irdl import AnyAttr\n",
+    "from xdsl.irdl import AnyAttr, ConstraintContext\n",
     "\n",
     "# Construct the constraint\n",
     "any_constraint = AnyAttr()\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "any_constraint.verify(i64)\n",
-    "any_constraint.verify(StringAttr(\"ga\"))"
+    "any_constraint.verify(i64, ConstraintContext())\n",
+    "any_constraint.verify(StringAttr(\"ga\"), ConstraintContext())"
    ]
   },
   {
@@ -163,11 +163,11 @@
     "eq_constraint = EqAttrConstraint(i64)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "eq_constraint.verify(i64)\n",
+    "eq_constraint.verify(i64, ConstraintContext())\n",
     "\n",
     "# This will trigger an exception\n",
     "try:\n",
-    "    eq_constraint.verify(i32)\n",
+    "    eq_constraint.verify(i32, ConstraintContext())\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -213,12 +213,12 @@
     "base_constraint = BaseAttr(StringAttr)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "base_constraint.verify(StringAttr(\"ga\"))\n",
-    "base_constraint.verify(StringAttr(\"bu\"))\n",
+    "base_constraint.verify(StringAttr(\"ga\"), ConstraintContext())\n",
+    "base_constraint.verify(StringAttr(\"bu\"), ConstraintContext())\n",
     "\n",
     "# This will trigger an exception\n",
     "try:\n",
-    "    base_constraint.verify(i32)\n",
+    "    base_constraint.verify(i32, ConstraintContext())\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -240,7 +240,7 @@
    "source": [
     "# This too\n",
     "try:\n",
-    "    base_constraint.verify(IntAttr(3))\n",
+    "    base_constraint.verify(IntAttr(3), ConstraintContext())\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -369,12 +369,12 @@
     "param_constraint = ParamAttrConstraint(IntegerAttr, [IntAttr, i32])\n",
     "\n",
     "# This will pass without triggering an exception.\n",
-    "param_constraint.verify(IntegerAttr(IntAttr(42), i32))\n",
-    "param_constraint.verify(IntegerAttr(IntAttr(23), i32))\n",
+    "param_constraint.verify(IntegerAttr(IntAttr(42), i32), ConstraintContext())\n",
+    "param_constraint.verify(IntegerAttr(IntAttr(23), i32), ConstraintContext())\n",
     "\n",
     "# This will trigger an exception, since the attribute type is not the expected one\n",
     "try:\n",
-    "    param_constraint.verify(i64)\n",
+    "    param_constraint.verify(i64, ConstraintContext())\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -397,7 +397,7 @@
     "# This will trigger an exception, since the second parameter constraint is not satisfied\n",
     "\n",
     "try:\n",
-    "    param_constraint.verify(IntegerAttr(IntAttr(42), i64))\n",
+    "    param_constraint.verify(IntegerAttr(IntAttr(42), i64), ConstraintContext())\n",
     "except VerifyException as e:\n",
     "    print(e)"
    ]
@@ -537,7 +537,7 @@
     "        object.__setattr__(self, \"elem_constr\", attr_constr_coercion(constr))\n",
     "\n",
     "    # Check that an attribute satisfies the constraints\n",
-    "    def verify(self, attr: Attribute, constraint_context: ConstraintContext | None = None) -> None:\n",
+    "    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:\n",
     "        # We first check that the attribute is an ArrayAttr\n",
     "        if not isa(attr, ArrayAttr[Attribute]):\n",
     "            raise VerifyException(f\"expected attribute ArrayData but got {attr}\")\n",
@@ -550,8 +550,8 @@
     "array_constraint = ArrayOfConstraint(IntAttr)\n",
     "\n",
     "# This will pass without triggering an exception\n",
-    "array_constraint.verify(ArrayAttr([IntAttr(42)]))\n",
-    "array_constraint.verify(ArrayAttr([IntAttr(3), IntAttr(7)]))"
+    "array_constraint.verify(ArrayAttr([IntAttr(42)]), ConstraintContext())\n",
+    "array_constraint.verify(ArrayAttr([IntAttr(3), IntAttr(7)]), ConstraintContext())"
    ]
   },
   {
@@ -571,7 +571,7 @@
    "source": [
     "# This will trigger an exception, since the attribute is not an array\n",
     "try:\n",
-    "    array_constraint.verify(i32)\n",
+    "    array_constraint.verify(i32, ConstraintContext())\n",
     "except Exception as e:\n",
     "    print(e)"
    ]
@@ -593,7 +593,9 @@
    "source": [
     "# This will trigger an exception, since the array contains attribute that do not satisfies the constraint\n",
     "try:\n",
-    "    array_constraint.verify(ArrayAttr([IntAttr(42), StringAttr(\"ga\")]))\n",
+    "    array_constraint.verify(\n",
+    "        ArrayAttr([IntAttr(42), StringAttr(\"ga\")]), ConstraintContext()\n",
+    "    )\n",
     "except Exception as e:\n",
     "    print(e)"
    ]

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -33,6 +33,7 @@ from xdsl.dialects.builtin import (
     i64,
 )
 from xdsl.ir import Attribute
+from xdsl.irdl import ConstraintContext
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -211,7 +212,7 @@ def test_vector_base_type_and_rank_constraint_verify():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i32, 2)
 
-    constraint.verify(vector_type)
+    constraint.verify(vector_type, ConstraintContext())
 
 
 def test_vector_base_type_and_rank_constraint_base_type_mismatch():
@@ -219,7 +220,7 @@ def test_vector_base_type_and_rank_constraint_base_type_mismatch():
     constraint = VectorBaseTypeAndRankConstraint(i64, 2)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, ConstraintContext())
     assert e.value.args[0] == "Expected vector type to be i64, got i32."
 
 
@@ -228,7 +229,7 @@ def test_vector_base_type_and_rank_constraint_rank_mismatch():
     constraint = VectorBaseTypeAndRankConstraint(i32, 3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, ConstraintContext())
     assert e.value.args[0] == "Expected vector rank to be 3, got 2."
 
 
@@ -241,7 +242,7 @@ memref<1x2xi32> should be of type VectorType.
 memref<1x2xi32> should be of type VectorType."""
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type)
+        constraint.verify(memref_type, ConstraintContext())
     assert e.value.args[0] == error_msg
 
 

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -161,7 +161,7 @@ def test_vector_rank_constraint_verify():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorRankConstraint(2)
 
-    constraint.verify(vector_type, {})
+    constraint.verify(vector_type)
 
 
 def test_vector_rank_constraint_rank_mismatch():
@@ -169,7 +169,7 @@ def test_vector_rank_constraint_rank_mismatch():
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type, {})
+        constraint.verify(vector_type)
     assert e.value.args[0] == "Expected vector rank to be 3, got 2."
 
 
@@ -178,7 +178,7 @@ def test_vector_rank_constraint_attr_mismatch():
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type, {})
+        constraint.verify(memref_type)
     assert e.value.args[0] == "memref<1x2xi32> should be of type VectorType."
 
 
@@ -186,7 +186,7 @@ def test_vector_base_type_constraint_verify():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeConstraint(i32)
 
-    constraint.verify(vector_type, {})
+    constraint.verify(vector_type)
 
 
 def test_vector_base_type_constraint_type_mismatch():
@@ -194,7 +194,7 @@ def test_vector_base_type_constraint_type_mismatch():
     constraint = VectorBaseTypeConstraint(i64)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type, {})
+        constraint.verify(vector_type)
     assert e.value.args[0] == "Expected vector type to be i64, got i32."
 
 
@@ -203,7 +203,7 @@ def test_vector_base_type_constraint_attr_mismatch():
     constraint = VectorBaseTypeConstraint(i32)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type, {})
+        constraint.verify(memref_type)
     assert e.value.args[0] == "memref<1x2xi32> should be of type VectorType."
 
 
@@ -211,7 +211,7 @@ def test_vector_base_type_and_rank_constraint_verify():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeAndRankConstraint(i32, 2)
 
-    constraint.verify(vector_type, {})
+    constraint.verify(vector_type)
 
 
 def test_vector_base_type_and_rank_constraint_base_type_mismatch():
@@ -219,7 +219,7 @@ def test_vector_base_type_and_rank_constraint_base_type_mismatch():
     constraint = VectorBaseTypeAndRankConstraint(i64, 2)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type, {})
+        constraint.verify(vector_type)
     assert e.value.args[0] == "Expected vector type to be i64, got i32."
 
 
@@ -228,7 +228,7 @@ def test_vector_base_type_and_rank_constraint_rank_mismatch():
     constraint = VectorBaseTypeAndRankConstraint(i32, 3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type, {})
+        constraint.verify(vector_type)
     assert e.value.args[0] == "Expected vector rank to be 3, got 2."
 
 
@@ -241,7 +241,7 @@ memref<1x2xi32> should be of type VectorType.
 memref<1x2xi32> should be of type VectorType."""
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type, {})
+        constraint.verify(memref_type)
     assert e.value.args[0] == error_msg
 
 

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -568,7 +568,7 @@ def test_informative_constraint():
         VerifyException,
         match="User-enlightening message.\nUnderlying verification failure: Expected attribute #none but got #builtin.int<1>",
     ):
-        constr.verify(IntAttr(1))
+        constr.verify(IntAttr(1), ConstraintContext())
     assert constr.get_resolved_variables() == set()
     assert constr.get_unique_base() == NoneAttr
 
@@ -630,7 +630,7 @@ class DataListAttr(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         attr = cast(ListData[Attribute], attr)
         for e in attr.data:

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -33,6 +33,7 @@ from xdsl.irdl import (
     AnyAttr,
     AttrConstraint,
     BaseAttr,
+    ConstraintContext,
     ConstraintVar,
     GenericData,
     MessageConstraint,
@@ -347,7 +348,11 @@ def test_union_constraint_fail():
 
 
 class PositiveIntConstr(AttrConstraint):
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self,
+        attr: Attribute,
+        constraint_context: ConstraintContext | None = None,
+    ) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(
                 f"Expected {IntData.name} attribute, but got {attr.name}."
@@ -563,7 +568,7 @@ def test_informative_constraint():
         VerifyException,
         match="User-enlightening message.\nUnderlying verification failure: Expected attribute #none but got #builtin.int<1>",
     ):
-        constr.verify(IntAttr(1), {})
+        constr.verify(IntAttr(1))
     assert constr.get_resolved_variables() == set()
     assert constr.get_unique_base() == NoneAttr
 
@@ -622,10 +627,14 @@ class DataListAttr(AttrConstraint):
 
     elem_constr: AttrConstraint
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self,
+        attr: Attribute,
+        constraint_context: ConstraintContext | None = None,
+    ) -> None:
         attr = cast(ListData[Attribute], attr)
         for e in attr.data:
-            self.elem_constr.verify(e, constraint_vars)
+            self.elem_constr.verify(e, constraint_context)
 
 
 @irdl_attr_definition

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -11,6 +11,7 @@ from xdsl.irdl import (
     AnyOf,
     AttrConstraint,
     BaseAttr,
+    ConstraintContext,
     EqAttrConstraint,
     ParamAttrConstraint,
     ParameterDef,
@@ -66,7 +67,7 @@ def test_eq_attr_verify():
     """Check that an EqAttrConstraint verifies the expected attribute"""
     bool_true = BoolData(True)
     eq_true_constraint = EqAttrConstraint(bool_true)
-    eq_true_constraint.verify(bool_true, {})
+    eq_true_constraint.verify(bool_true)
 
 
 def test_eq_attr_verify_wrong_parameters_fail():
@@ -78,7 +79,7 @@ def test_eq_attr_verify_wrong_parameters_fail():
     bool_false = BoolData(False)
     eq_true_constraint = EqAttrConstraint(bool_true)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(bool_false, {})
+        eq_true_constraint.verify(bool_false)
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {bool_false}")
 
 
@@ -91,7 +92,7 @@ def test_eq_attr_verify_wrong_base_fail():
     int_zero = IntData(0)
     eq_true_constraint = EqAttrConstraint(bool_true)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(int_zero, {})
+        eq_true_constraint.verify(int_zero)
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {int_zero}")
 
 
@@ -101,8 +102,8 @@ def test_base_attr_verify():
     base attribute.
     """
     eq_true_constraint = BaseAttr(BoolData)
-    eq_true_constraint.verify(BoolData(True), {})
-    eq_true_constraint.verify(BoolData(False), {})
+    eq_true_constraint.verify(BoolData(True))
+    eq_true_constraint.verify(BoolData(False))
 
 
 def test_base_attr_verify_wrong_base_fail():
@@ -113,7 +114,7 @@ def test_base_attr_verify_wrong_base_fail():
     eq_true_constraint = BaseAttr(BoolData)
     int_zero = IntData(0)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(int_zero, {})
+        eq_true_constraint.verify(int_zero)
     assert e.value.args[0] == (
         f"{int_zero} should be of base attribute {BoolData.name}"
     )
@@ -122,16 +123,20 @@ def test_base_attr_verify_wrong_base_fail():
 def test_any_attr_verify():
     """Check that an AnyAttr verifies any attribute."""
     any_constraint = AnyAttr()
-    any_constraint.verify(BoolData(True), {})
-    any_constraint.verify(BoolData(False), {})
-    any_constraint.verify(IntData(0), {})
+    any_constraint.verify(BoolData(True))
+    any_constraint.verify(BoolData(False))
+    any_constraint.verify(IntData(0))
 
 
 @dataclass(frozen=True)
 class LessThan(AttrConstraint):
     bound: int
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self,
+        attr: Attribute,
+        constraint_context: ConstraintContext | None = None,
+    ) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
         if attr.data >= self.bound:
@@ -142,7 +147,11 @@ class LessThan(AttrConstraint):
 class GreaterThan(AttrConstraint):
     bound: int
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self,
+        attr: Attribute,
+        constraint_context: ConstraintContext | None = None,
+    ) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(f"{attr} should be of base attribute {IntData.name}")
         if attr.data <= self.bound:
@@ -157,10 +166,10 @@ def test_anyof_verify():
     verify.
     """
     constraint = AnyOf([LessThan(0), GreaterThan(10)])
-    constraint.verify(IntData(-1), {})
-    constraint.verify(IntData(-10), {})
-    constraint.verify(IntData(11), {})
-    constraint.verify(IntData(100), {})
+    constraint.verify(IntData(-1))
+    constraint.verify(IntData(-10))
+    constraint.verify(IntData(11))
+    constraint.verify(IntData(100))
 
 
 def test_anyof_verify_fail():
@@ -174,11 +183,11 @@ def test_anyof_verify_fail():
     ten = IntData(10)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(zero, {})
+        constraint.verify(zero)
     assert e.value.args[0] == f"Unexpected attribute {zero}"
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(ten, {})
+        constraint.verify(ten)
     assert e.value.args[0] == f"Unexpected attribute {ten}"
 
 
@@ -188,9 +197,9 @@ def test_allof_verify():
     verify.
     """
     constraint = AllOf((LessThan(10), GreaterThan(0)))
-    constraint.verify(IntData(1), {})
-    constraint.verify(IntData(9), {})
-    constraint.verify(IntData(5), {})
+    constraint.verify(IntData(1))
+    constraint.verify(IntData(9))
+    constraint.verify(IntData(5))
 
 
 def test_allof_verify_fail():
@@ -201,11 +210,11 @@ def test_allof_verify_fail():
     constraint = AllOf((LessThan(10), GreaterThan(0)))
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(10), {})
+        constraint.verify(IntData(10))
     assert e.value.args[0] == f"{IntData(10)} should hold a value less than 10"
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(0), {})
+        constraint.verify(IntData(0))
     assert e.value.args[0] == f"{IntData(0)} should hold a value greater than 0"
 
 
@@ -217,7 +226,7 @@ def test_allof_verify_multiple_failures():
     constraint = AllOf((LessThan(5), GreaterThan(8)))
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(7), {})
+        constraint.verify(IntData(7))
     assert (
         e.value.args[0]
         == f"The following constraints were not satisfied:\n{IntData(7)} should hold a value less than 5\n{IntData(7)} should hold a value greater than 8"
@@ -229,8 +238,8 @@ def test_param_attr_verify():
     constraint = ParamAttrConstraint(
         DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
     )
-    constraint.verify(DoubleParamAttr([bool_true, IntData(0)]), {})
-    constraint.verify(DoubleParamAttr([bool_true, IntData(42)]), {})
+    constraint.verify(DoubleParamAttr([bool_true, IntData(0)]))
+    constraint.verify(DoubleParamAttr([bool_true, IntData(42)]))
 
 
 def test_param_attr_verify_base_fail():
@@ -239,7 +248,7 @@ def test_param_attr_verify_base_fail():
         DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
     )
     with pytest.raises(VerifyException) as e:
-        constraint.verify(bool_true, {})
+        constraint.verify(bool_true)
     assert e.value.args[0] == (
         f"{bool_true} should be of base attribute {DoubleParamAttr.name}"
     )
@@ -250,7 +259,7 @@ def test_param_attr_verify_params_num_params_fail():
     constraint = ParamAttrConstraint(DoubleParamAttr, [EqAttrConstraint(bool_true)])
     attr = DoubleParamAttr([bool_true, IntData(0)])
     with pytest.raises(VerifyException) as e:
-        constraint.verify(attr, {})
+        constraint.verify(attr)
     assert e.value.args[0] == ("1 parameters expected, but got 2")
 
 
@@ -262,13 +271,13 @@ def test_param_attr_verify_params_fail():
     )
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(DoubleParamAttr([bool_true, bool_false]), {})
+        constraint.verify(DoubleParamAttr([bool_true, bool_false]))
     assert e.value.args[0] == (
         f"{bool_false} should be of base attribute {IntData.name}"
     )
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(DoubleParamAttr([bool_false, IntData(0)]), {})
+        constraint.verify(DoubleParamAttr([bool_false, IntData(0)]))
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {bool_false}")
 
 
@@ -277,13 +286,13 @@ def test_constraint_vars_success():
 
     constraint = VarConstraint("T", AnyOf([BoolData(False), IntData(0)]))
 
-    constraint_vars: dict[str, Attribute] = {}
-    constraint.verify(BoolData(False), constraint_vars)
-    constraint.verify(BoolData(False), constraint_vars)
+    constraint_context = ConstraintContext()
+    constraint.verify(BoolData(False), constraint_context)
+    constraint.verify(BoolData(False), constraint_context)
 
-    constraint_vars: dict[str, Attribute] = {}
-    constraint.verify(IntData(0), constraint_vars)
-    constraint.verify(IntData(0), constraint_vars)
+    constraint_context = ConstraintContext()
+    constraint.verify(IntData(0), constraint_context)
+    constraint.verify(IntData(0), constraint_context)
 
 
 def test_constraint_vars_fail_different():
@@ -291,11 +300,11 @@ def test_constraint_vars_fail_different():
 
     constraint = VarConstraint("T", AnyOf([BoolData(False), IntData(0)]))
 
-    constraint_vars: dict[str, Attribute] = {}
-    constraint.verify(IntData(0), constraint_vars)
+    constraint_context = ConstraintContext()
+    constraint.verify(IntData(0), constraint_context)
 
     with pytest.raises(VerifyException):
-        constraint.verify(BoolData(False), constraint_vars)
+        constraint.verify(BoolData(False), constraint_context)
 
 
 def test_constraint_vars_fail_underlying_constraint():
@@ -307,4 +316,4 @@ def test_constraint_vars_fail_underlying_constraint():
     constraint = VarConstraint("T", AnyOf([BoolData(False), IntData(0)]))
 
     with pytest.raises(VerifyException):
-        constraint.verify(IntData(1), {})
+        constraint.verify(IntData(1))

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -67,7 +67,7 @@ def test_eq_attr_verify():
     """Check that an EqAttrConstraint verifies the expected attribute"""
     bool_true = BoolData(True)
     eq_true_constraint = EqAttrConstraint(bool_true)
-    eq_true_constraint.verify(bool_true)
+    eq_true_constraint.verify(bool_true, ConstraintContext())
 
 
 def test_eq_attr_verify_wrong_parameters_fail():
@@ -79,7 +79,7 @@ def test_eq_attr_verify_wrong_parameters_fail():
     bool_false = BoolData(False)
     eq_true_constraint = EqAttrConstraint(bool_true)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(bool_false)
+        eq_true_constraint.verify(bool_false, ConstraintContext())
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {bool_false}")
 
 
@@ -92,7 +92,7 @@ def test_eq_attr_verify_wrong_base_fail():
     int_zero = IntData(0)
     eq_true_constraint = EqAttrConstraint(bool_true)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(int_zero)
+        eq_true_constraint.verify(int_zero, ConstraintContext())
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {int_zero}")
 
 
@@ -102,8 +102,8 @@ def test_base_attr_verify():
     base attribute.
     """
     eq_true_constraint = BaseAttr(BoolData)
-    eq_true_constraint.verify(BoolData(True))
-    eq_true_constraint.verify(BoolData(False))
+    eq_true_constraint.verify(BoolData(True), ConstraintContext())
+    eq_true_constraint.verify(BoolData(False), ConstraintContext())
 
 
 def test_base_attr_verify_wrong_base_fail():
@@ -114,7 +114,7 @@ def test_base_attr_verify_wrong_base_fail():
     eq_true_constraint = BaseAttr(BoolData)
     int_zero = IntData(0)
     with pytest.raises(VerifyException) as e:
-        eq_true_constraint.verify(int_zero)
+        eq_true_constraint.verify(int_zero, ConstraintContext())
     assert e.value.args[0] == (
         f"{int_zero} should be of base attribute {BoolData.name}"
     )
@@ -123,9 +123,9 @@ def test_base_attr_verify_wrong_base_fail():
 def test_any_attr_verify():
     """Check that an AnyAttr verifies any attribute."""
     any_constraint = AnyAttr()
-    any_constraint.verify(BoolData(True))
-    any_constraint.verify(BoolData(False))
-    any_constraint.verify(IntData(0))
+    any_constraint.verify(BoolData(True), ConstraintContext())
+    any_constraint.verify(BoolData(False), ConstraintContext())
+    any_constraint.verify(IntData(0), ConstraintContext())
 
 
 @dataclass(frozen=True)
@@ -166,10 +166,10 @@ def test_anyof_verify():
     verify.
     """
     constraint = AnyOf([LessThan(0), GreaterThan(10)])
-    constraint.verify(IntData(-1))
-    constraint.verify(IntData(-10))
-    constraint.verify(IntData(11))
-    constraint.verify(IntData(100))
+    constraint.verify(IntData(-1), ConstraintContext())
+    constraint.verify(IntData(-10), ConstraintContext())
+    constraint.verify(IntData(11), ConstraintContext())
+    constraint.verify(IntData(100), ConstraintContext())
 
 
 def test_anyof_verify_fail():
@@ -183,11 +183,11 @@ def test_anyof_verify_fail():
     ten = IntData(10)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(zero)
+        constraint.verify(zero, ConstraintContext())
     assert e.value.args[0] == f"Unexpected attribute {zero}"
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(ten)
+        constraint.verify(ten, ConstraintContext())
     assert e.value.args[0] == f"Unexpected attribute {ten}"
 
 
@@ -197,9 +197,9 @@ def test_allof_verify():
     verify.
     """
     constraint = AllOf((LessThan(10), GreaterThan(0)))
-    constraint.verify(IntData(1))
-    constraint.verify(IntData(9))
-    constraint.verify(IntData(5))
+    constraint.verify(IntData(1), ConstraintContext())
+    constraint.verify(IntData(9), ConstraintContext())
+    constraint.verify(IntData(5), ConstraintContext())
 
 
 def test_allof_verify_fail():
@@ -210,11 +210,11 @@ def test_allof_verify_fail():
     constraint = AllOf((LessThan(10), GreaterThan(0)))
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(10))
+        constraint.verify(IntData(10), ConstraintContext())
     assert e.value.args[0] == f"{IntData(10)} should hold a value less than 10"
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(0))
+        constraint.verify(IntData(0), ConstraintContext())
     assert e.value.args[0] == f"{IntData(0)} should hold a value greater than 0"
 
 
@@ -226,7 +226,7 @@ def test_allof_verify_multiple_failures():
     constraint = AllOf((LessThan(5), GreaterThan(8)))
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(IntData(7))
+        constraint.verify(IntData(7), ConstraintContext())
     assert (
         e.value.args[0]
         == f"The following constraints were not satisfied:\n{IntData(7)} should hold a value less than 5\n{IntData(7)} should hold a value greater than 8"
@@ -238,8 +238,8 @@ def test_param_attr_verify():
     constraint = ParamAttrConstraint(
         DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
     )
-    constraint.verify(DoubleParamAttr([bool_true, IntData(0)]))
-    constraint.verify(DoubleParamAttr([bool_true, IntData(42)]))
+    constraint.verify(DoubleParamAttr([bool_true, IntData(0)]), ConstraintContext())
+    constraint.verify(DoubleParamAttr([bool_true, IntData(42)]), ConstraintContext())
 
 
 def test_param_attr_verify_base_fail():
@@ -248,7 +248,7 @@ def test_param_attr_verify_base_fail():
         DoubleParamAttr, [EqAttrConstraint(bool_true), BaseAttr(IntData)]
     )
     with pytest.raises(VerifyException) as e:
-        constraint.verify(bool_true)
+        constraint.verify(bool_true, ConstraintContext())
     assert e.value.args[0] == (
         f"{bool_true} should be of base attribute {DoubleParamAttr.name}"
     )
@@ -259,7 +259,7 @@ def test_param_attr_verify_params_num_params_fail():
     constraint = ParamAttrConstraint(DoubleParamAttr, [EqAttrConstraint(bool_true)])
     attr = DoubleParamAttr([bool_true, IntData(0)])
     with pytest.raises(VerifyException) as e:
-        constraint.verify(attr)
+        constraint.verify(attr, ConstraintContext())
     assert e.value.args[0] == ("1 parameters expected, but got 2")
 
 
@@ -271,13 +271,15 @@ def test_param_attr_verify_params_fail():
     )
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(DoubleParamAttr([bool_true, bool_false]))
+        constraint.verify(DoubleParamAttr([bool_true, bool_false]), ConstraintContext())
     assert e.value.args[0] == (
         f"{bool_false} should be of base attribute {IntData.name}"
     )
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(DoubleParamAttr([bool_false, IntData(0)]))
+        constraint.verify(
+            DoubleParamAttr([bool_false, IntData(0)]), ConstraintContext()
+        )
     assert e.value.args[0] == (f"Expected attribute {bool_true} but got {bool_false}")
 
 
@@ -316,4 +318,4 @@ def test_constraint_vars_fail_underlying_constraint():
     constraint = VarConstraint("T", AnyOf([BoolData(False), IntData(0)]))
 
     with pytest.raises(VerifyException):
-        constraint.verify(IntData(1))
+        constraint.verify(IntData(1), ConstraintContext())

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -39,6 +39,7 @@ from xdsl.irdl import (
     AnyAttr,
     AnyOf,
     AttrConstraint,
+    ConstraintContext,
     GenericData,
     IRDLOperation,
     MessageConstraint,
@@ -82,7 +83,9 @@ class ShapedType(ABC):
 
 
 class AnyShapedType(AttrConstraint):
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
         if not isinstance(attr, ShapedType):
             raise Exception(f"expected type ShapedType but got {attr}")
 
@@ -117,11 +120,13 @@ class ArrayOfConstraint(AttrConstraint):
     def __init__(self, constr: Attribute | type[Attribute] | AttrConstraint):
         object.__setattr__(self, "elem_constr", attr_constr_coercion(constr))
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
         if not isinstance(attr, ArrayAttr):
             raise VerifyException(f"expected ArrayData attribute, but got {attr}")
         for e in cast(ArrayAttr[Attribute], attr).data:
-            self.elem_constr.verify(e, constraint_vars)
+            self.elem_constr.verify(e, constraint_context)
 
 
 @irdl_attr_definition
@@ -243,7 +248,9 @@ class EmptyArrayAttrConstraint(AttrConstraint):
     Constrain attribute to be empty ArrayData
     """
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
         if not isinstance(attr, ArrayAttr):
             raise VerifyException(f"expected ArrayData attribute, but got {attr}")
         attr = cast(ArrayAttr[Attribute], attr)
@@ -803,12 +810,14 @@ class ContainerOf(AttrConstraint):
     ) -> None:
         object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
         if isinstance(attr, VectorType) or isinstance(attr, TensorType):
             attr = cast(VectorType[Attribute] | TensorType[Attribute], attr)
-            self.elem_constr.verify(attr.element_type, constraint_vars)
+            self.elem_constr.verify(attr.element_type, constraint_context)
         else:
-            self.elem_constr.verify(attr, constraint_vars)
+            self.elem_constr.verify(attr, constraint_context)
 
 
 VectorOrTensorOf: TypeAlias = (
@@ -831,7 +840,9 @@ class VectorRankConstraint(AttrConstraint):
     expected_rank: int
     """The expected vector rank."""
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
         if not isinstance(attr, VectorType):
             raise VerifyException(f"{attr} should be of type VectorType.")
         if attr.get_num_dims() != self.expected_rank:
@@ -849,7 +860,9 @@ class VectorBaseTypeConstraint(AttrConstraint):
     expected_type: Attribute
     """The expected vector base type."""
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
         if not isinstance(attr, VectorType):
             raise VerifyException(f"{attr} should be of type VectorType.")
         attr = cast(VectorType[Attribute], attr)
@@ -871,14 +884,16 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
     expected_rank: int
     """The expected vector rank."""
 
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
         constraint = AllOf(
             (
                 VectorBaseTypeConstraint(self.expected_type),
                 VectorRankConstraint(self.expected_rank),
             )
         )
-        constraint.verify(attr, constraint_vars)
+        constraint.verify(attr, constraint_context)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -120,9 +120,7 @@ class ArrayOfConstraint(AttrConstraint):
     def __init__(self, constr: Attribute | type[Attribute] | AttrConstraint):
         object.__setattr__(self, "elem_constr", attr_constr_coercion(constr))
 
-    def verify(
-        self, attr: Attribute, constraint_context: ConstraintContext | None = None
-    ) -> None:
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         if not isinstance(attr, ArrayAttr):
             raise VerifyException(f"expected ArrayData attribute, but got {attr}")
         for e in cast(ArrayAttr[Attribute], attr).data:
@@ -813,9 +811,7 @@ class ContainerOf(AttrConstraint):
     ) -> None:
         object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
 
-    def verify(
-        self, attr: Attribute, constraint_context: ConstraintContext | None = None
-    ) -> None:
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         if isinstance(attr, VectorType) or isinstance(attr, TensorType):
             attr = cast(VectorType[Attribute] | TensorType[Attribute], attr)
             self.elem_constr.verify(attr.element_type, constraint_context)
@@ -887,9 +883,7 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
     expected_rank: int
     """The expected vector rank."""
 
-    def verify(
-        self, attr: Attribute, constraint_context: ConstraintContext | None = None
-    ) -> None:
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         constraint = AllOf(
             (
                 VectorBaseTypeConstraint(self.expected_type),

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -32,6 +32,7 @@ from xdsl.irdl import (
     AnyOf,
     AttrSizedOperandSegments,
     BaseAttr,
+    ConstraintContext,
     ConstraintVar,
     IRDLOperation,
     MessageConstraint,
@@ -1127,16 +1128,21 @@ class BufferOp(IRDLOperation):
 
 
 class TensorIgnoreSizeConstraint(VarConstraint):
-    def verify(self, attr: Attribute, constraint_vars: dict[str, Attribute]) -> None:
-        if self.name in constraint_vars:
+    def verify(
+        self, attr: Attribute, constraint_context: ConstraintContext | None = None
+    ) -> None:
+        constraint_context = constraint_context or ConstraintContext()
+        if self.name in constraint_context.variables:
             if (
                 isa(attr, TensorType[Attribute])
-                and isinstance(other := constraint_vars[self.name], TensorType)
+                and isinstance(
+                    other := constraint_context.variables[self.name], TensorType
+                )
                 and len(attr.get_shape()) == len(other.get_shape())
                 and attr.get_element_type() == other.get_element_type()
             ):
                 return
-        super().verify(attr, constraint_vars)
+        super().verify(attr, constraint_context)
 
 
 @irdl_op_definition

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -17,6 +17,7 @@ from xdsl.ir import Attribute, TypedAttribute
 from xdsl.irdl import (
     AttrOrPropDef,
     AttrSizedOperandSegments,
+    ConstraintContext,
     OpDef,
     OptionalDef,
     OptOperandDef,
@@ -383,7 +384,7 @@ class FormatParser(BaseParser):
                             unique_base.get_type_index()
                         ]
                         if type_constraint.can_infer(set()):
-                            unique_type = type_constraint.infer()
+                            unique_type = type_constraint.infer(ConstraintContext())
                 if (
                     unique_base is not None
                     and unique_base in Builtin.attributes

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -383,7 +383,7 @@ class FormatParser(BaseParser):
                             unique_base.get_type_index()
                         ]
                         if type_constraint.can_infer(set()):
-                            unique_type = type_constraint.infer({})
+                            unique_type = type_constraint.infer()
                 if (
                     unique_base is not None
                     and unique_base in Builtin.attributes

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -105,7 +105,7 @@ class AttrConstraint(ABC):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         """
         Check if the attribute satisfies the constraint,
@@ -128,7 +128,7 @@ class AttrConstraint(ABC):
         # By default, we cannot infer anything.
         return False
 
-    def infer(self, constraint_context: ConstraintContext | None = None) -> Attribute:
+    def infer(self, constraint_context: ConstraintContext) -> Attribute:
         """
         Infer the attribute given the constraint variables that are already set.
 
@@ -161,9 +161,8 @@ class VarConstraint(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
-        constraint_context = constraint_context or ConstraintContext()
         if self.name in constraint_context.variables:
             if attr != constraint_context.variables[self.name]:
                 raise VerifyException(
@@ -180,7 +179,7 @@ class VarConstraint(AttrConstraint):
     def can_infer(self, constraint_names: set[str]) -> bool:
         return self.name in constraint_names
 
-    def infer(self, constraint_context: ConstraintContext | None = None) -> Attribute:
+    def infer(self, constraint_context: ConstraintContext) -> Attribute:
         constraint_context = constraint_context or ConstraintContext()
         if self.name not in constraint_context.variables:
             raise ValueError(f"Cannot infer attribute from constraint {self}")
@@ -215,7 +214,7 @@ class EqAttrConstraint(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         if attr != self.attr:
             raise VerifyException(f"Expected attribute {self.attr} but got {attr}")
@@ -223,7 +222,7 @@ class EqAttrConstraint(AttrConstraint):
     def can_infer(self, constraint_names: set[str]) -> bool:
         return True
 
-    def infer(self, constraint_context: ConstraintContext | None = None) -> Attribute:
+    def infer(self, constraint_context: ConstraintContext) -> Attribute:
         return self.attr
 
     def get_unique_base(self) -> type[Attribute] | None:
@@ -240,7 +239,7 @@ class BaseAttr(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         if not isinstance(attr, self.attr):
             raise VerifyException(
@@ -276,7 +275,7 @@ class AnyAttr(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         pass
 
@@ -345,7 +344,7 @@ class AllOf(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         exc_bucket: list[VerifyException] = []
 
@@ -414,7 +413,7 @@ class ParamAttrConstraint(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         if not isinstance(attr, self.base_attr):
             raise VerifyException(
@@ -462,7 +461,7 @@ class MessageConstraint(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         try:
             return self.constr.verify(attr, constraint_context)
@@ -481,7 +480,7 @@ class MessageConstraint(AttrConstraint):
     def can_infer(self, constraint_names: set[str]) -> bool:
         return self.constr.can_infer(constraint_names)
 
-    def infer(self, constraint_context: ConstraintContext | None = None) -> Attribute:
+    def infer(self, constraint_context: ConstraintContext) -> Attribute:
         return self.constr.infer(constraint_context)
 
 
@@ -491,7 +490,7 @@ class RangeConstraint(ABC):
     def verify(
         self,
         attrs: Sequence[Attribute],
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         """
         Check if the range satisfies the constraint, or raise an exception otherwise.
@@ -515,7 +514,7 @@ class RangeConstraint(ABC):
         return False
 
     def infer(
-        self, length: int, constraint_context: ConstraintContext | None = None
+        self, length: int, constraint_context: ConstraintContext
     ) -> list[Attribute]:
         """
         Infer the range given the constraint variables that are already set.
@@ -538,7 +537,7 @@ class RangeOf(RangeConstraint):
     def verify(
         self,
         attrs: Sequence[Attribute],
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         for a in attrs:
             self.constr.verify(a, constraint_context)
@@ -550,7 +549,7 @@ class RangeOf(RangeConstraint):
         return self.constr.can_infer(constraint_names)
 
     def infer(
-        self, length: int, constraint_context: ConstraintContext | None = None
+        self, length: int, constraint_context: ConstraintContext
     ) -> list[Attribute]:
         return [self.constr.infer(constraint_context)] * length
 
@@ -566,7 +565,7 @@ class SingleOf(RangeConstraint):
     def verify(
         self,
         attrs: Sequence[Attribute],
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         if len(attrs) != 1:
             raise VerifyException(f"Expected a single attribute, got {len(attrs)}")
@@ -579,7 +578,7 @@ class SingleOf(RangeConstraint):
         return self.constr.can_infer(constraint_names)
 
     def infer(
-        self, length: int, constraint_context: ConstraintContext | None = None
+        self, length: int, constraint_context: ConstraintContext
     ) -> list[Attribute]:
         return [self.constr.infer(constraint_context)]
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1748,7 +1748,7 @@ class OpDef:
         irdl_op_verify_arg_list(op, self, VarIRConstruct.RESULT, constraint_context)
 
         # Verify regions.
-        irdl_op_verify_regions(op, self, constraint_vars)
+        irdl_op_verify_regions(op, self, constraint_context)
 
         # Verify successors.
         get_variadic_sizes(op, self, VarIRConstruct.SUCCESSOR)
@@ -2041,7 +2041,7 @@ def get_operand_result_or_region(
 
 
 def irdl_op_verify_regions(
-    op: Operation, op_def: OpDef, constraint_vars: dict[str, Attribute]
+    op: Operation, op_def: OpDef, constraint_context: ConstraintContext
 ):
     get_variadic_sizes(op, op_def, VarIRConstruct.REGION)
     for i, (region, (name, region_def)) in enumerate(zip(op.regions, op_def.regions)):
@@ -2053,7 +2053,7 @@ def irdl_op_verify_regions(
         if len(region.blocks) > 0:
             entry_args_types = tuple(a.type for a in region.blocks[0].args)
             try:
-                region_def.entry_args.verify(entry_args_types, constraint_vars)
+                region_def.entry_args.verify(entry_args_types, constraint_context)
             except Exception as e:
                 error(
                     op,

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -1616,13 +1616,7 @@ class OpDef:
                 ) -> RangeConstraint:
                     if isinstance(pyrdl_constr, RangeConstraint):
                         return pyrdl_constr
-                    return RangeOf(
-                        _irdl_list_to_attr_constraint(
-                            (pyrdl_constr,),
-                            allow_type_var=True,
-                            type_var_mapping=type_var_mapping,
-                        )
-                    )
+                    return RangeOf(get_constraint(pyrdl_constr))
 
                 field_names.add(field_name)
 

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -84,7 +84,7 @@ class IRDLAnnotations(Enum):
 @dataclass
 class ConstraintContext:
     """
-    Context for constraint variables.
+    Contains the assignment of constraint variables.
     """
 
     variables: dict[str, Attribute] = field(default_factory=dict)

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -88,7 +88,7 @@ class ConstraintContext:
     """
 
     variables: dict[str, Attribute] = field(default_factory=dict)
-    """The constraint variables."""
+    """The assignment of constraint variables."""
 
     def copy(self):
         return ConstraintContext(self.variables.copy())

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -21,6 +21,8 @@ _T = TypeVar("_T")
 
 
 def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
+    from xdsl.irdl import ConstraintContext
+
     """
     Check if `arg` is of the type described by `hint`.
     For now, only lists, dictionaries, unions,
@@ -89,7 +91,7 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
     if (origin is not None) and issubclass(origin, GenericData | ParametrizedAttribute):
         constraint = irdl_to_attr_constraint(hint)
         try:
-            constraint.verify(arg)
+            constraint.verify(arg, ConstraintContext())
             return True
         except VerifyException:
             return False

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -89,7 +89,7 @@ def isa(arg: Any, hint: type[_T]) -> TypeGuard[_T]:
     if (origin is not None) and issubclass(origin, GenericData | ParametrizedAttribute):
         constraint = irdl_to_attr_constraint(hint)
         try:
-            constraint.verify(arg, {})
+            constraint.verify(arg)
             return True
         except VerifyException:
             return False


### PR DESCRIPTION
Just define ConstraintContext to encapsulate the constraint variables used in verification and inference.
Also, define a default value for this argument in verification, to verify with an empty context.