### PR TITLE
dialects: Add NoMemoryEffects to memref and snitch_runtime dialect ops

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/canonicalize.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/memref/canonicalize.mlir
@@ -17,7 +17,9 @@ builtin.module {
             "operandSegmentSizes" = array<i32: 1, 0, 0, 0>
         }> : (memref<34x66x64xf64, strided<[5184, 72, 1], offset: 21028>>) -> memref<64x64xf64, strided<[72, 1], offset: 181732>>
 
-        func.return
+        "test.op"(%5, %33) : (memref<34x66x64xf64, strided<[5184, 72, 1], offset: 21028>>, memref<64x64xf64, strided<[72, 1], offset: 181732>>) -> ()
+
+        return
     }
 }
 //CHECK:      %subview = memref.subview %arg0[4, 4, 4] [34, 66, 64] [1, 1, 1] : memref<72x72x72xf64> to memref<34x66x64xf64, strided<[5184, 72, 1], offset: 21028>>

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -58,6 +58,7 @@ from xdsl.traits import (
     HasParent,
     IsTerminator,
     SymbolOpInterface,
+    NoMemoryEffect,
 )
 from xdsl.utils.bitwise_casts import is_power_of_two
 from xdsl.utils.deprecation import deprecated_constructor
@@ -379,6 +380,10 @@ class GetGlobal(IRDLOperation):
     memref: OpResult = result_def(MemRefType[Attribute])
     name_: SymbolRefAttr = prop_def(SymbolRefAttr, prop_name="name")
 
+    traits = frozenset([NoMemoryEffect()])
+
+    assembly_format = "$name `:` type($memref) attr-dict"
+
     def __init__(self, name: str | SymbolRefAttr, return_type: Attribute):
         if isinstance(name, str):
             name = SymbolRefAttr(name)
@@ -388,8 +393,6 @@ class GetGlobal(IRDLOperation):
     @staticmethod
     def get(name: str | SymbolRefAttr, return_type: Attribute) -> GetGlobal:
         return GetGlobal(name, return_type)
-
-    assembly_format = "$name `:` type($memref) attr-dict"
 
     # TODO how to verify the types, as the global might be defined in another
     # compilation unit
@@ -459,6 +462,8 @@ class Dim(IRDLOperation):
 
     result: OpResult = result_def(IndexType)
 
+    traits = frozenset([NoMemoryEffect()])
+
     @staticmethod
     def from_source_and_index(
         source: SSAValue | Operation, index: SSAValue | Operation
@@ -473,6 +478,8 @@ class Rank(IRDLOperation):
     source: Operand = operand_def(MemRefType[Attribute])
 
     rank: OpResult = result_def(IndexType)
+
+    traits = frozenset([NoMemoryEffect()])
 
     @staticmethod
     def from_memref(memref: Operation | SSAValue):
@@ -491,6 +498,8 @@ class AlterShapeOp(IRDLOperation):
     assembly_format = (
         "$src $reassociation attr-dict `:` type($src) `into` type($result)"
     )
+
+    traits = frozenset([NoMemoryEffect()])
 
 
 @irdl_op_definition
@@ -518,6 +527,8 @@ class ExtractAlignedPointerAsIndexOp(IRDLOperation):
     source: Operand = operand_def(MemRefType)
 
     aligned_pointer: OpResult = result_def(IndexType)
+
+    traits = frozenset([NoMemoryEffect()])
 
     @staticmethod
     def get(source: SSAValue | Operation):
@@ -551,7 +562,7 @@ class Subview(IRDLOperation):
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
-    traits = frozenset((MemrefHasCanonicalizationPatternsTrait(),))
+    traits = frozenset((MemrefHasCanonicalizationPatternsTrait(), NoMemoryEffect()))
 
     @staticmethod
     def from_static_parameters(
@@ -623,6 +634,8 @@ class Cast(IRDLOperation):
     source: Operand = operand_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
     dest: OpResult = result_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
 
+    traits = frozenset([NoMemoryEffect()])
+
     @staticmethod
     def get(
         source: SSAValue | Operation,
@@ -637,6 +650,8 @@ class MemorySpaceCast(IRDLOperation):
 
     source = operand_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
     dest = result_def(MemRefType[Attribute] | UnrankedMemrefType[Attribute])
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(
         self,

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -27,13 +27,7 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.ir import (
-    Attribute,
-    Dialect,
-    Operation,
-    OpResult,
-    SSAValue,
-)
+from xdsl.ir import Attribute, Dialect, Operation, OpResult, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     ConstraintVar,
@@ -57,8 +51,8 @@ from xdsl.traits import (
     HasCanonicalisationPatternsTrait,
     HasParent,
     IsTerminator,
-    SymbolOpInterface,
     NoMemoryEffect,
+    SymbolOpInterface,
 )
 from xdsl.utils.bitwise_casts import is_power_of_two
 from xdsl.utils.deprecation import deprecated_constructor

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -17,6 +17,7 @@ from xdsl.irdl import (
     var_operand_def,
 )
 from xdsl.utils.exceptions import VerifyException
+from xdsl.traits import Pure, NoMemoryEffect
 
 # Transfer ID
 tx_id = i32
@@ -45,6 +46,8 @@ class SnitchRuntimeGetInfo(SnitchRuntimeBaseOperation, ABC):
 
     result: OpResult = result_def(i32)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def __init__(
         self,
     ):
@@ -57,6 +60,8 @@ class SnitchRuntimeGetInfoBool(SnitchRuntimeBaseOperation, ABC):
     """
 
     result: OpResult = result_def(i1)
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(
         self,
@@ -265,6 +270,8 @@ class GetMemoryInfoBaseOperation(SnitchRuntimeBaseOperation, ABC):
 
     slice_begin: OpResult = result_def(slice_t_begin)
     slice_end: OpResult = result_def(slice_t_end)
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(
         self,

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -16,8 +16,8 @@ from xdsl.irdl import (
     result_def,
     var_operand_def,
 )
+from xdsl.traits import NoMemoryEffect
 from xdsl.utils.exceptions import VerifyException
-from xdsl.traits import Pure, NoMemoryEffect
 
 # Transfer ID
 tx_id = i32


### PR DESCRIPTION
This PR adds `NoMemoryEffects` trait to ops from the memref and snitch_runtime dialect that should have them.

