### PR TITLE
core: update parser rules to decide on memref layout or memory space attribute

### DIFF
--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -517,7 +517,7 @@ class AttrParser(BaseParser):
         memory_or_layout = self.parse_attribute()
 
         # If there is both a memory space and a layout, we know that the
-        # layout is the second one
+        # layout is the first one
         if self.parse_optional_punctuation(",") is not None:
             memory_space = self.parse_attribute()
             return MemRefType(type, shape, memory_or_layout, memory_space)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -522,7 +522,7 @@ class AttrParser(BaseParser):
             memory_space = self.parse_attribute()
             return MemRefType(type, shape, memory_or_layout, memory_space)
 
-        # Otherwise, there is a single argument, so we check based the attribute type.
+        # Otherwise, there is a single argument, so we check based on the attribute type.
         # MLIR bases itself on the `MemRefLayoutAttrInterface`, which we do not support.
         # Therefore, integers and strings are considered to be memory spaces,
         # other attributes are considered to be layout attributes.

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -528,7 +528,9 @@ class AttrParser(BaseParser):
         # other attributes are considered to be layout attributes.
 
         # If the argument is an integer or a string, it is a memory space
-        if isa(memory_or_layout, AnyIntegerAttr) or isinstance(memory_or_layout, StringAttr):
+        if isa(memory_or_layout, AnyIntegerAttr) or isinstance(
+            memory_or_layout, StringAttr
+        ):
             return MemRefType(type, shape, memory_space=memory_or_layout)
 
         # Else, it is a memory layout


### PR DESCRIPTION
This PR changes the way the parser decides on whether an attribute of a memref is a layout or a memory space.
My main motivation for this is that I want to use `StringAttr` attributes as memory spaces.
This decision is difficult in xdsl because it lacks the `MemRefLayoutAttrInterface` of mlir.

The current decision flow is as follows:

- If there are two attributes, first is layout and second is memory_space
- Else, if the attribute is an integer, it is a memory space
- Else, if the attribute is a stridedlayout or affinemap layout, it is a layout
- Else, throw an error

My problems with this approach are:

1. We can only use integers as memory spaces. This is causing some headaches over at `snax-mlir`. See [here](https://discourse.llvm.org/t/rfc-memref-memory-shape-as-attribute/2229), for a discussion on this in MLIR. They extended the memory space to be allowed as _any_ attribute.
2. The parsing behaviour is different when using either one or both attributes: for example, my custom layout attribute is completely valid according to xdsl, as long as I also specify a memory space for the memref. Otherwise, it is checked to be either a stridedlayout or affinemap, which it isn't, and then considered to be an invalid attribute.

Therefore, I suggest to extend the memory space to integers and strings, as these are the most widely used attribute types for this, and to remove the subsequent check on memory layout, as this obstructs the use of custom layout attributes