### PR TITLE
backend: (csl) Rework printing logic for printing individual modules

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -315,7 +315,7 @@ csl.func @builtins() {
   csl.return
 }
 
-}) {sym_name = "program"} : () -> ()
+}) {sym_name = "program.csl"} : () -> ()
 
 
 "csl.module"() <{kind=#csl<module_kind layout>}> ({
@@ -333,11 +333,12 @@ csl.func @builtins() {
 
     %params = "csl.const_struct"(){items = {hello = 123 : i32}} : () -> !csl.comptime_struct
     %x_coord1 = arith.constant 1 : i32
-    "csl.set_tile_code"(%x_coord1, %y_coord, %params) <{file = "file.csl"}> : (i32, i32, !csl.comptime_struct) -> ()
+    "csl.set_tile_code"(%x_coord1, %y_coord, %params) <{file = "program.csl"}> : (i32, i32, !csl.comptime_struct) -> ()
 
   }
-}) {sym_name = "layout"} : () -> ()
+}) {sym_name = "layout.csl"} : () -> ()
 
+// CHECK-NEXT: // FILE: program.csl
 // CHECK-NEXT:
 // CHECK-NEXT: fn no_args_no_return() void {
 // CHECK-NEXT:   return;
@@ -617,7 +618,8 @@ csl.func @builtins() {
 // CHECK-NEXT:   @xp162fs(dest_dsd, src_dsd1);
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
-// CHECK-NEXT: // >>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<< //
+// CHECK-NEXT: // -----
+// CHECK-NEXT: // FILE: layout.csl
 // CHECK-NEXT: param param_1 : i32;
 // CHECK-NEXT: param param_2 : f16 = 1.3;
 // CHECK-NEXT: layout {
@@ -626,12 +628,12 @@ csl.func @builtins() {
 // CHECK-NEXT:   @set_rectangle(x_dim, y_dim);
 // CHECK-NEXT:   const x_coord0 : i32 = 0;
 // CHECK-NEXT:   const y_coord : i32 = 0;
-// CHECK-NEXT:   @set_tile_code(x_coord0, y_coord, "file.csl", )
+// CHECK-NEXT:   @set_tile_code(x_coord0, y_coord, "file.csl", );
 // CHECK-NEXT:   const params : comptime_struct = .{
 // CHECK-NEXT:     .hello = 123
 // CHECK-NEXT:   };
 // CHECK-NEXT:   const x_coord1 : i32 = 1;
-// CHECK-NEXT:   @set_tile_code(x_coord1, y_coord, "file.csl", params);
+// CHECK-NEXT:   @set_tile_code(x_coord1, y_coord, "program.csl", params);
 // CHECK-NEXT:   @export_name("ptr_name", [*]f32, true);
 // CHECK-NEXT:   @export_name("another_ptr", [*]const i32, false);
 // CHECK-NEXT:   @export_name("no_args_no_return", fn() void, );

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -604,11 +604,16 @@ class CslPrintContext:
 
 
 def get_csl_modules_in_module_op(module: ModuleOp) -> Iterable[csl.CslModuleOp]:
+    layouts = []
     for op in module.body.ops:
         if isinstance(op, csl.CslModuleOp):
+            if op.kind == csl.ModuleKind.LAYOUT:
+                layouts.append(op)
+                continue
             yield op
         else:
             warnings.warn("Expected all top-level operations to be `csl.module` ops!")
+    yield from layouts
 
 
 def print_to_csl(prog: ModuleOp, output: IO[str]):

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -604,7 +604,7 @@ class CslPrintContext:
 
 
 def get_csl_modules_in_module_op(module: ModuleOp) -> Iterable[csl.CslModuleOp]:
-    layouts = []
+    layouts: list[csl.CslModuleOp] = []
     for op in module.body.ops:
         if isinstance(op, csl.CslModuleOp):
             if op.kind == csl.ModuleKind.LAYOUT:


### PR DESCRIPTION
This PR addresses a few minor details in csl printing QOL:

- Remove the requirement of there being exactly two csl modules (one layout and one program)
- Change the divider to the standard file-split divider
- Print the file name at the start of each file block