### PR TITLE
dialects: (csl) set_tile_code fix traits

### DIFF
--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -64,6 +64,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import (
+    HasAncestor,
     HasParent,
     IsolatedFromAbove,
     IsTerminator,
@@ -701,7 +702,7 @@ class SetRectangleOp(IRDLOperation):
 class SetTileCodeOp(IRDLOperation):
     name = "csl.set_tile_code"
 
-    traits = frozenset([HasParent(LayoutOp)])
+    traits = frozenset([HasAncestor(LayoutOp)])
 
     file = prop_def(StringAttr)
 


### PR DESCRIPTION
`set_tile_code` does not have to be a direct child of `layout`, e.g. it can be used in a loop. But it does have to occur in a `layout`.

_NOTE_: the parameter to `set_tile_code` is specified as `ComptimeStructType`, not `StructLike`. This is semantically correct (though undocumented), i.e. you can't do this:

```zig
const my_params = @import_module("my_params.csl")
...
@set_tile_code(..., my_params);
```
