### PR TITLE
backend: (csl) Slightly rework printer to promote certain values to inline expressions

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -350,8 +350,7 @@ csl.func @builtins() {
 // CHECK-NEXT: }
 // CHECK-NEXT:
 // CHECK-NEXT: fn no_args_return() f32 {
-// CHECK-NEXT:   const c : f32 = 5.0;
-// CHECK-NEXT:   return c;
+// CHECK-NEXT:   return 5.0;
 // CHECK-NEXT: }
 // CHECK-NEXT:
 // CHECK-NEXT: fn args_no_return(a : i32, b : i32) void {
@@ -372,27 +371,21 @@ csl.func @builtins() {
 // CHECK-NEXT: param_import.foo();
 // CHECK-NEXT: param_import.bar(const27);
 // CHECK-NEXT: const val2 : f32 = param_import.baz();
-// CHECK-NEXT: const val3 : i32 = param_import.f;
 // CHECK-NEXT:
 // CHECK-NEXT: fn main() void {
 // CHECK-NEXT:   no_args_no_return();
-// CHECK-NEXT:   args_no_return(val3, val3);
+// CHECK-NEXT:   args_no_return(param_import.f, param_import.f);
 // CHECK-NEXT:   const ret : f32 = no_args_return();
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT:
 // CHECK-NEXT: fn casts() void {
-// CHECK-NEXT:   const constI32 : i32 = 0;
-// CHECK-NEXT:   const constU16 : u16 = 0;
-// CHECK-NEXT:   const constF32 : f32 = 0.0;
-// CHECK-NEXT:   const castIndex : i32 = @as(i32, constU16);
-// CHECK-NEXT:   const castF16 : f16 = @as(f16, constI32);
-// CHECK-NEXT:   const castI16 : i16 = @as(i16, constF32);
-// CHECK-NEXT:   const castF32 : f32 = @as(f32, castF16);
-// CHECK-NEXT:   const castF16again : f16 = @as(f16, constF32);
-// CHECK-NEXT:   const castI16again : i16 = @as(i16, constI32);
-// CHECK-NEXT:   const castI32again : i32 = @as(i32, castI16);
-// CHECK-NEXT:   const castU32 : u32 = @as(u32, constU16);
+// CHECK-NEXT:   const castIndex : i32 = @as(i32, 0);
+// CHECK-NEXT:   const castF32 : f32 = @as(f32, @as(f16, 0));
+// CHECK-NEXT:   const castF16again : f16 = @as(f16, 0.0);
+// CHECK-NEXT:   const castI16again : i16 = @as(i16, 0);
+// CHECK-NEXT:   const castI32again : i32 = @as(i32, @as(i16, 0.0));
+// CHECK-NEXT:   const castU32 : u32 = @as(u32, 0);
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT:
@@ -431,7 +424,6 @@ csl.func @builtins() {
 // CHECK-NEXT: var uninit_array : [10]f32;
 // CHECK-NEXT: var global_array : [10]f32 = @constants([10]f32, 4.2);
 // CHECK-NEXT: const const_array : [10]i32 = @constants([10]i32, 10);
-
 // CHECK-NEXT: var uninit_ptr : [*]f32 = &uninit_array;
 // CHECK-NEXT: var global_ptr : [*]f32 = &global_array;
 // CHECK-NEXT: const const_ptr : [*]const i32 = &const_array;
@@ -449,10 +441,8 @@ csl.func @builtins() {
 // CHECK-NEXT: comptime {
 // CHECK-NEXT:   @export_symbol(args_no_return, "args_no_return");
 // CHECK-NEXT: }
-// CHECK-NEXT: const cst15 : i32 = 15;
-// CHECK-NEXT: const col : color = @get_color(cst15);
 // CHECK-NEXT: comptime {
-// CHECK-NEXT:   @rpc(@get_data_task_id(col));
+// CHECK-NEXT:   @rpc(@get_data_task_id(@get_color(15)));
 // CHECK-NEXT: }
 // CHECK-NEXT: var A : [24]f32 = @constants([24]f32, 0);
 // CHECK-NEXT: var x : [6]f32 = @constants([6]f32, 0);
@@ -461,77 +451,54 @@ csl.func @builtins() {
 // CHECK-NEXT: const thing : imported_module = @import_module("<thing>");
 // CHECK-NEXT:
 // CHECK-NEXT: fn initialize() void {
-// CHECK-NEXT:   const lb : i16 = 0;
-// CHECK-NEXT:   const ub : i16 = 24;
-// CHECK-NEXT:   const step : i16 = 1;
-// CHECK-NEXT:   thing.some_func(lb, ub);
-// CHECK-NEXT:   const res : i32 = thing.some_func(lb, ub);
+// CHECK-NEXT:   thing.some_func(0, 24);
+// CHECK-NEXT:   const res : i32 = thing.some_func(0, 24);
 // CHECK-NEXT:   const v1 : comptime_struct = thing.some_field;
 // CHECK-NEXT:   const v2 : f32 = 3.14;
 // CHECK-NEXT:   const v0 : f16 = 2.718;
 // CHECK-NEXT:   const u32cst : u32 = 44;
 // CHECK-NEXT:
-// CHECK-NEXT:   for(@range(i16, lb, ub, step)) |idx| {
-// CHECK-NEXT:     const idx_f32 : f32 = @as(f32, idx);
-// CHECK-NEXT:     const idx_index : i32 = @as(i32, idx);
-// CHECK-NEXT:     A[idx_index] = idx_f32;
+// CHECK-NEXT:   for(@range(i16, 0, 24, 1)) |idx| {
+// CHECK-NEXT:     A[@as(i32, idx)] = @as(f32, idx);
 // CHECK-NEXT:   }
-// CHECK-NEXT:   const ub3 : i16 = 6;
 // CHECK-NEXT:
-// CHECK-NEXT:   for(@range(i16, lb, ub3, step)) |j| {
-// CHECK-NEXT:     const val : f32 = 1.0;
-// CHECK-NEXT:     const j_idx : i32 = @as(i32, j);
-// CHECK-NEXT:     x[j_idx] = val;
+// CHECK-NEXT:   for(@range(i16, 0, 6, 1)) |j| {
+// CHECK-NEXT:     x[@as(i32, j)] = 1.0;
 // CHECK-NEXT:   }
-// CHECK-NEXT:   const ub4 : i16 = 6;
 // CHECK-NEXT:
-// CHECK-NEXT:   for(@range(i16, lb, ub4, step)) |i| {
-// CHECK-NEXT:     const c2 : f32 = 2.0;
-// CHECK-NEXT:     const c0 : f32 = 0.0;
-// CHECK-NEXT:     const i_idx : i32 = @as(i32, i);
-// CHECK-NEXT:     b[i_idx] = c2;
-// CHECK-NEXT:     y[i_idx] = c0;
+// CHECK-NEXT:   for(@range(i16, 0, 6, 1)) |i| {
+// CHECK-NEXT:     b[@as(i32, i)] = 2.0;
+// CHECK-NEXT:     y[@as(i32, i)] = 0.0;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT:
 // CHECK-NEXT: fn gemv() void {
-// CHECK-NEXT:   const lb : i32 = 0;
-// CHECK-NEXT:   const step : i32 = 1;
-// CHECK-NEXT:   const ub : i32 = 6;
-// CHECK-NEXT:   const ub1 : i32 = 4;
 // CHECK-NEXT:
-// CHECK-NEXT:   for(@range(i32, lb, ub1, step)) |i| {
-// CHECK-NEXT:     const tmp : f32 = 0.0;
-// CHECK-NEXT:     var tmp2 : f32 = tmp;
+// CHECK-NEXT:   for(@range(i32, 0, 4, 1)) |i| {
+// CHECK-NEXT:     var tmp : f32 = 0.0;
 // CHECK-NEXT:
-// CHECK-NEXT:     for(@range(i32, lb, ub, step)) |j| {
-// CHECK-NEXT:       const ix6 : i32 = i * ub;
-// CHECK-NEXT:       const ix6pj : i32 = ix6 +  j;
-// CHECK-NEXT:       const Axx : f32 = (A[ix6pj]) * (x[j]);
-// CHECK-NEXT:       tmp2 = tmp2 + Axx;
+// CHECK-NEXT:     for(@range(i32, 0, 6, 1)) |j| {
+// CHECK-NEXT:       tmp = tmp + ((A[((i * 6) + j)]) * (x[j]));
 // CHECK-NEXT:     }
-// CHECK-NEXT:     const tmp_plus_bi : f32 =  tmp2 + (b[i]);
-// CHECK-NEXT:     y[i] = tmp_plus_bi;
+// CHECK-NEXT:     y[i] = (tmp + (b[i]));
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT:
 // CHECK-NEXT: fn ctrlflow() void {
-// CHECK-NEXT:   const v1 : bool = false;
-// CHECK-NEXT:   const v2 : bool = true;
 // CHECK-NEXT:   const i32_value : i32 = 100;
-// CHECK-NEXT:   if (v1) {
-// CHECK-NEXT:     const v3 : i32 = 2;
+// CHECK-NEXT:   if (false) {
+// CHECK-NEXT:     const v1 : i32 = 2;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   else {
-// CHECK-NEXT:     const v3 : i32 = 3;
+// CHECK-NEXT:     const v1 : i32 = 3;
 // CHECK-NEXT:   }
-// CHECK-NEXT:   if (v2) {
-// CHECK-NEXT:     const v3 : i32 = 4;
+// CHECK-NEXT:   if (true) {
+// CHECK-NEXT:     const v1 : i32 = 4;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   var i32ret : i32;
-// CHECK-NEXT:   if (v1) {
+// CHECK-NEXT:   if (false) {
 // CHECK-NEXT:     i32ret = 111;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   else {
@@ -541,15 +508,13 @@ csl.func @builtins() {
 // CHECK-NEXT: }
 // CHECK-NEXT:
 // CHECK-NEXT: fn builtins() void {
-// CHECK-NEXT:   const i8_value : i8 = 10;
 // CHECK-NEXT:   const i16_value : i16 = 10;
 // CHECK-NEXT:   const u16_value : u16 = 12;
 // CHECK-NEXT:   const i32_value : i32 = 100;
 // CHECK-NEXT:   const u32_value : u32 = 120;
 // CHECK-NEXT:   const f16_value : f16 = 7.0;
 // CHECK-NEXT:   const f32_value : f32 = 8.0;
-// CHECK-NEXT:   const three : i16 = 3;
-// CHECK-NEXT:   const col1 : color = @get_color(three);
+// CHECK-NEXT:   const col : color = @get_color(3);
 // CHECK-NEXT:   var f16_pointer : *f16 = &f16_value;
 // CHECK-NEXT:   var f32_pointer : *f32 = &f32_value;
 // CHECK-NEXT:   var i16_pointer : *i16 = &i16_value;
@@ -571,7 +536,7 @@ csl.func @builtins() {
 // CHECK-NEXT:   const dsd_1d2 : mem1d_dsd = @set_dsd_base_addr(dest_dsd, A);
 // CHECK-NEXT:   const dsd_1d3 : mem1d_dsd = @increment_dsd_offset(dsd_1d2, i16_value, f32);
 // CHECK-NEXT:   const dsd_1d4 : mem1d_dsd = @set_dsd_length(dsd_1d3, u16_value);
-// CHECK-NEXT:   const dsd_1d5 : mem1d_dsd = @set_dsd_stride(dsd_1d4, i8_value);
+// CHECK-NEXT:   const dsd_1d5 : mem1d_dsd = @set_dsd_stride(dsd_1d4, 10);
 // CHECK-NEXT:   const fabin_dsd : fabin_dsd = @get_dsd(fabin_dsd, .{
 // CHECK-NEXT:     .extent = i32_value,
 // CHECK-NEXT:     .input_queue = @get_input_queue(0),
@@ -629,24 +594,16 @@ csl.func @builtins() {
 // CHECK-NEXT: // -----
 // CHECK-NEXT: // FILE: layout.csl
 // CHECK-NEXT: param param_1 : i32;
-// CHECK-NEXT: const init : f16 = 3.14;
-// CHECK-NEXT: param param_2 : f16 = init;
+// CHECK-NEXT: param param_2 : f16 = 3.14;
 // CHECK-NEXT: layout {
-// CHECK-NEXT:   const x_dim : i32 = 4;
-// CHECK-NEXT:   const y_dim : i32 = 6;
-// CHECK-NEXT:   @set_rectangle(x_dim, y_dim);
-// CHECK-NEXT:   const x_coord0 : i32 = 0;
-// CHECK-NEXT:   const y_coord : i32 = 0;
-// CHECK-NEXT:   @set_tile_code(x_coord0, y_coord, "file.csl", );
+// CHECK-NEXT:   @set_rectangle(4, 6);
+// CHECK-NEXT:   @set_tile_code(0, 0, "file.csl", );
 // CHECK-NEXT:   const params : comptime_struct = .{
-// CHECK-NEXT:     .hello = 123
+// CHECK-NEXT:     .hello = 123,
 // CHECK-NEXT:   };
-// CHECK-NEXT:   const x_coord1 : i32 = 1;
-// CHECK-NEXT:   @set_tile_code(x_coord1, y_coord, "program.csl", params);
+// CHECK-NEXT:   @set_tile_code(1, 0, "program.csl", params);
 // CHECK-NEXT:   @export_name("ptr_name", [*]f32, true);
 // CHECK-NEXT:   @export_name("another_ptr", [*]const i32, false);
 // CHECK-NEXT:   @export_name("no_args_no_return", fn() void, );
 // CHECK-NEXT:   @export_name("args_no_return", fn(i32, i32) void, );
 // CHECK-NEXT: }
-
-// CHECK-EMPTY:

--- a/xdsl/dialects/csl.py
+++ b/xdsl/dialects/csl.py
@@ -69,6 +69,7 @@ from xdsl.traits import (
     HasParent,
     IsolatedFromAbove,
     IsTerminator,
+    NoMemoryEffect,
     NoTerminator,
     OpTrait,
     SymbolOpInterface,
@@ -381,6 +382,8 @@ class ImportModuleConstOp(IRDLOperation):
 class ConstStructOp(IRDLOperation):
     name = "csl.const_struct"
 
+    traits = frozenset([NoMemoryEffect()])
+
     items = opt_prop_def(DictionaryAttr)
     ssa_fields = opt_prop_def(ArrayAttr[StringAttr])
     ssa_values = var_operand_def()
@@ -403,6 +406,8 @@ class ConstStructOp(IRDLOperation):
 class GetColorOp(IRDLOperation):
     name = "csl.get_color"
 
+    traits = frozenset([NoMemoryEffect()])
+
     id = operand_def(IntegerType)
     res = result_def(ColorType)
 
@@ -414,6 +419,8 @@ class MemberAccessOp(IRDLOperation):
     """
 
     name = "csl.member_access"
+
+    traits = frozenset([NoMemoryEffect()])
 
     struct = operand_def(StructLike)
 
@@ -1397,6 +1404,8 @@ class AddressOfOp(IRDLOperation):
     value = operand_def()
     res = result_def(PtrType)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def _verify_memref_addr(self, val_ty: MemRefType[Attribute], res_ty: PtrType):
         """
         Verify that if the address of a memref is taken, the resulting pointer is either:
@@ -1492,6 +1501,8 @@ class SignednessCastOp(IRDLOperation):
     """
     Cast that throws away signedness attributes
     """
+
+    traits = frozenset([NoMemoryEffect()])
 
     name = "csl.mlir.signedness_cast"
 


### PR DESCRIPTION
This patch makes the printer promote certain values to inlined expressions (e.g. not creating a new `const x = 5;` variable for an `arith.constant` operation, or for arithmetic expressions.

This is for now applied very carefully to a select few operations. Some checks are performed, such as that the value is not referenced at any point using the `AddressOf`operation, that the operation that produced the value is pure, and more.