### PR TITLE
misc: irdl loading fixes

### DIFF
--- a/tests/filecheck/dialects/irdl/cmath_irdl_loading.py
+++ b/tests/filecheck/dialects/irdl/cmath_irdl_loading.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
     f = open("tests/filecheck/dialects/cmath/cmath_ops.mlir")
     parser = Parser(ctx, f.read())
     module = parser.parse_module()
+    module.verify()
     print(module)
 
 # CHECK:       builtin.module {

--- a/tests/filecheck/dialects/irdl/cmath_irdl_loading.py
+++ b/tests/filecheck/dialects/irdl/cmath_irdl_loading.py
@@ -40,15 +40,15 @@ if __name__ == "__main__":
     print(module)
 
 # CHECK:       builtin.module {
-# CHECK-NEXT:    func.func @conorm(%p : #cmath.complex<f32>, %q : #cmath.complex<f32>) -> f32 {
-# CHECK-NEXT:      %norm_p = "cmath.norm"(%p) : (#cmath.complex<f32>) -> f32
-# CHECK-NEXT:      %norm_q = "cmath.norm"(%q) : (#cmath.complex<f32>) -> f32
+# CHECK-NEXT:    func.func @conorm(%p : !cmath.complex<f32>, %q : !cmath.complex<f32>) -> f32 {
+# CHECK-NEXT:      %norm_p = "cmath.norm"(%p) : (!cmath.complex<f32>) -> f32
+# CHECK-NEXT:      %norm_q = "cmath.norm"(%q) : (!cmath.complex<f32>) -> f32
 # CHECK-NEXT:      %pq = arith.mulf %norm_p, %norm_q : f32
 # CHECK-NEXT:      func.return %pq : f32
 # CHECK-NEXT:    }
-# CHECK-NEXT:    func.func @conorm2(%a : #cmath.complex<f32>, %b : #cmath.complex<f32>) -> f32 {
-# CHECK-NEXT:      %ab = "cmath.mul"(%a, %b) : (#cmath.complex<f32>, #cmath.complex<f32>) -> #cmath.complex<f32>
-# CHECK-NEXT:      %conorm = "cmath.norm"(%ab) : (#cmath.complex<f32>) -> f32
+# CHECK-NEXT:    func.func @conorm2(%a : !cmath.complex<f32>, %b : !cmath.complex<f32>) -> f32 {
+# CHECK-NEXT:      %ab = "cmath.mul"(%a, %b) : (!cmath.complex<f32>, !cmath.complex<f32>) -> !cmath.complex<f32>
+# CHECK-NEXT:      %conorm = "cmath.norm"(%ab) : (!cmath.complex<f32>) -> f32
 # CHECK-NEXT:      func.return %conorm : f32
 # CHECK-NEXT:    }
 # CHECK-NEXT:  }

--- a/xdsl/interpreters/irdl.py
+++ b/xdsl/interpreters/irdl.py
@@ -17,8 +17,10 @@ from xdsl.irdl import (
     EqAttrConstraint,
     IRDLOperation,
     OpDef,
+    OperandDef,
     ParamAttrConstraint,
     ParamAttrDef,
+    ResultDef,
     VarConstraint,
     get_accessors_from_op_def,
     get_accessors_from_param_attr_def,
@@ -168,7 +170,7 @@ class IRDLFunctions(InterpreterFunctions):
         op_op = cast(irdl.OperationOp, op.parent_op())
         op_name = op_op.qualified_name
         self._get_op_def(interpreter, op_name).operands = list(
-            (f"o{i}", a) for i, a in enumerate(args)
+            (f"o{i}", OperandDef(a)) for i, a in enumerate(args)
         )
         return ()
 
@@ -179,7 +181,7 @@ class IRDLFunctions(InterpreterFunctions):
         op_op = cast(irdl.OperationOp, op.parent_op())
         op_name = op_op.qualified_name
         self._get_op_def(interpreter, op_name).results = list(
-            (f"r{i}", a) for i, a in enumerate(args)
+            (f"r{i}", ResultDef(a)) for i, a in enumerate(args)
         )
         return ()
 
@@ -192,6 +194,7 @@ class IRDLFunctions(InterpreterFunctions):
         interpreter.run_ssacfg_region(op.body, ())
         op_def = self._get_op_def(interpreter, name)
         op_type = self.get_op(interpreter, name)
+
         to_inject = get_accessors_from_op_def(op_def, None)
         for k, v in to_inject.items():
             setattr(op_type, k, v)

--- a/xdsl/interpreters/irdl.py
+++ b/xdsl/interpreters/irdl.py
@@ -9,7 +9,7 @@ from xdsl.interpreter import (
     impl,
     register_impls,
 )
-from xdsl.ir import Attribute, Dialect, Operation, ParametrizedAttribute
+from xdsl.ir import Attribute, Dialect, Operation, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (
     AnyAttr,
     AnyOf,
@@ -236,7 +236,7 @@ class IRDLFunctions(InterpreterFunctions):
                         type.__new__(
                             type(ParametrizedAttribute),
                             entry.sym_name.data,
-                            ParametrizedAttribute.__mro__,
+                            (TypeAttribute, *ParametrizedAttribute.__mro__),
                             dict(ParametrizedAttribute.__dict__)
                             | {"name": entry.qualified_name},
                         )

--- a/xdsl/interpreters/irdl.py
+++ b/xdsl/interpreters/irdl.py
@@ -222,10 +222,9 @@ class IRDLFunctions(InterpreterFunctions):
             match entry:
                 case irdl.OperationOp():
                     operations.append(
-                        type.__new__(
-                            type(IRDLOperation),
+                        type(IRDLOperation)(
                             entry.sym_name.data,
-                            IRDLOperation.__mro__,
+                            (IRDLOperation,),
                             dict(IRDLOperation.__dict__)
                             | {"name": entry.qualified_name},
                         )
@@ -233,10 +232,9 @@ class IRDLFunctions(InterpreterFunctions):
 
                 case irdl.TypeOp():
                     attributes.append(
-                        type.__new__(
-                            type(ParametrizedAttribute),
+                        type(ParametrizedAttribute)(
                             entry.sym_name.data,
-                            (TypeAttribute, *ParametrizedAttribute.__mro__),
+                            (TypeAttribute, ParametrizedAttribute),
                             dict(ParametrizedAttribute.__dict__)
                             | {"name": entry.qualified_name},
                         )

--- a/xdsl/irdl/irdl.py
+++ b/xdsl/irdl/irdl.py
@@ -2505,7 +2505,11 @@ def get_accessors_from_op_def(
 
         new_attrs["verify_"] = verify_
     else:
-        new_attrs["verify_"] = op_def.verify
+
+        def verify_(self: IRDLOperation):
+            op_def.verify(self)
+
+        new_attrs["verify_"] = verify_
 
     return new_attrs
 


### PR DESCRIPTION
Some fixes on the irdl loading boilerplate introduced in:
- #2654 

Fixes:
  - Properly wrap operand and result constraints in OperandDef / ResultDef. @math-fehr I'm not sure how variadicity/optionality works on the irdl dialect. Is it another op or an attribute on those ones?
  - Use cleaner type constructors: Not sure why, but those over the top __new__ calls had undesired side effects. Those don't and just are cleaner!
  - Cleaner baseclassing (don't fetch the full `__mro__`, let the Python type machinery handle it properly
  - Makes types types!