### PR TITLE
interpreter: (memref_stream) add interpreter support for imperfect nesting

### DIFF
--- a/tests/interpreters/test_memref_stream_interpreter.py
+++ b/tests/interpreters/test_memref_stream_interpreter.py
@@ -1,8 +1,9 @@
 from xdsl.builder import ImplicitBuilder
-from xdsl.dialects import arith, linalg, memref_stream
+from xdsl.dialects import arith, memref_stream
 from xdsl.dialects.builtin import (
     AffineMapAttr,
     ArrayAttr,
+    Float32Type,
     IntAttr,
     MemRefType,
     ModuleOp,
@@ -48,9 +49,8 @@ def test_memref_stream_generic():
         ),
         ArrayAttr(
             (
-                linalg.IteratorTypeAttr.parallel(),
-                linalg.IteratorTypeAttr.parallel(),
-                linalg.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.parallel(),
             )
         ),
         ArrayAttr((IntAttr(2), IntAttr(3))),
@@ -59,6 +59,8 @@ def test_memref_stream_generic():
     with ImplicitBuilder(op.body) as (a, b):
         c = arith.Muli(a, b).result
         memref_stream.YieldOp(c)
+
+    op.verify()
 
     a = ShapedArray(TypedPtr.new_float64([1, 2, 3, 4, 5, 6]), [2, 3])
     b = ShapedArray(TypedPtr.new_float64([1, 4, 2, 5, 3, 6]), [3, 2])
@@ -99,9 +101,8 @@ def test_memref_stream_generic_scalar():
         ),
         ArrayAttr(
             (
-                linalg.IteratorTypeAttr.parallel(),
-                linalg.IteratorTypeAttr.parallel(),
-                linalg.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.parallel(),
             )
         ),
         ArrayAttr((IntAttr(2), IntAttr(3))),
@@ -110,6 +111,8 @@ def test_memref_stream_generic_scalar():
     with ImplicitBuilder(op.body) as (a, b):
         c = arith.Muli(a, b).result
         memref_stream.YieldOp(c)
+
+    op.verify()
 
     a = ShapedArray(TypedPtr.new_float64([1, 2, 3, 4, 5, 6]), [2, 3])
     b = 2
@@ -139,7 +142,7 @@ def test_memref_stream_generic_reduction():
                 AffineMapAttr(AffineMap.from_callable(lambda d0: ())),
             )
         ),
-        ArrayAttr((linalg.IteratorTypeAttr.reduction(),)),
+        ArrayAttr((memref_stream.IteratorTypeAttr.reduction(),)),
         ArrayAttr((IntAttr(3),)),
     )
 
@@ -148,6 +151,8 @@ def test_memref_stream_generic_reduction():
         new_acc = arith.Addi(sum, acc).result
         memref_stream.YieldOp(new_acc)
 
+    op.verify()
+
     a = ShapedArray(TypedPtr.new_float64([1, 2, 3]), [3])
     b = ShapedArray(TypedPtr.new_float64([4, 5, 6]), [3])
     c = ShapedArray(TypedPtr.new_float64([0]), [])
@@ -155,3 +160,52 @@ def test_memref_stream_generic_reduction():
     interpreter.run_op(op, (a, b, c))
 
     assert c.data == [32]
+
+
+def test_memref_stream_generic_imperfect_nesting():
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(MemrefStreamFunctions())
+    interpreter.register_implementations(ArithFunctions())
+
+    f32 = Float32Type()
+
+    op = memref_stream.GenericOp(
+        (
+            TestSSAValue(MemRefType(f32, [3, 2])),
+            TestSSAValue(MemRefType(f32, [2, 3])),
+        ),
+        (TestSSAValue(MemRefType(f32, [3, 3])),),
+        Region(Block(arg_types=(f32, f32, f32))),
+        ArrayAttr(
+            (
+                AffineMapAttr(AffineMap.from_callable(lambda n, m, k: (n, k))),
+                AffineMapAttr(AffineMap.from_callable(lambda n, m, k: (k, m))),
+                AffineMapAttr(AffineMap.from_callable(lambda n, m: (n, m))),
+            )
+        ),
+        ArrayAttr(
+            (
+                memref_stream.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.reduction(),
+            )
+        ),
+        ArrayAttr((IntAttr(3), IntAttr(3), IntAttr(2))),
+    )
+
+    with ImplicitBuilder(op.body) as (lhs, rhs, acc):
+        sum = arith.Mulf(lhs, rhs).result
+        new_acc = arith.Addf(sum, acc).result
+        memref_stream.YieldOp(new_acc)
+
+    op.verify()
+
+    a = ShapedArray(TypedPtr.new_float32([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]), [3, 2])
+    b = ShapedArray(TypedPtr.new_float32([4.0, 3.0, 5.0, 1.0, 2.0, 8.0]), [2, 3])
+    c = ShapedArray(TypedPtr.new_float32([0.0] * 9), [3, 3])
+
+    interpreter.run_op(op, (a, b, c))
+    assert c == ShapedArray(
+        TypedPtr.new_float32([6.0, 7.0, 21.0, 16.0, 17.0, 47.0, 26.0, 27.0, 73.0]),
+        [3, 3],
+    )

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -351,8 +351,23 @@ class GenericOp(IRDLOperation):
             regions=[body],
         )
 
-    def get_static_loop_ranges(self) -> tuple[int, ...]:
-        return tuple(bound.data for bound in self.bounds)
+    def get_static_loop_ranges(
+        self,
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """
+        This operation can represent two sets of perfectly nested loops, or one.
+        If it is one, then the first element of the returned tuple has all the loop
+        bounds, and the second is empty.
+        If there are two, then the first element of the returned tuple has the outer
+        bounds, and the second the inner.
+        """
+        output_maps = self.indexing_maps.data[len(self.inputs) :]
+        # min_dims will equal len(self.iterator_types) in the perfect nest case
+        min_dims = min(m.data.num_dims for m in output_maps)
+        return (
+            tuple(bound.data for bound in self.bounds.data[:min_dims]),
+            tuple(bound.data for bound in self.bounds.data[min_dims:]),
+        )
 
     def print(self, printer: Printer):
         printer.print_string(" {bounds = ")

--- a/xdsl/interpreters/memref_stream.py
+++ b/xdsl/interpreters/memref_stream.py
@@ -31,23 +31,66 @@ class MemrefStreamFunctions(InterpreterFunctions):
         indexing_maps = tuple(attr.data for attr in op.indexing_maps)
         output_indexing_maps = indexing_maps[inputs_count:]
 
-        loop_ranges = op.get_static_loop_ranges()
+        outer_ubs, inner_ubs = op.get_static_loop_ranges()
 
-        for indices in product(*(range(loop_range) for loop_range in loop_ranges)):
-            loop_args = tuple(
-                (
-                    (cast(ShapedArray[Any], i)).load(indexing_map.eval(indices, ()))
-                    if isinstance(i, ShapedArray)
-                    else i
+        if inner_ubs:
+            inputs: tuple[ShapedArray[float] | float, ...] = args[:inputs_count]
+            input_indexing_maps = indexing_maps[:inputs_count]
+            for outer_indices in product(*(range(outer_ub) for outer_ub in outer_ubs)):
+                output_loop_args = tuple(
+                    (
+                        (cast(ShapedArray[Any], o)).load(
+                            indexing_map.eval(outer_indices, ())
+                        )
+                    )
+                    for o, indexing_map in zip(
+                        outputs, output_indexing_maps, strict=True
+                    )
                 )
-                for i, indexing_map in zip(args, indexing_maps, strict=True)
-            )
-            loop_results = interpreter.run_ssacfg_region(op.body, loop_args, "for_loop")
-            for res, indexing_map in zip(
-                loop_results, output_indexing_maps, strict=True
-            ):
-                result_indices = indexing_map.eval(indices, ())
-                outputs[0].store(result_indices, res)
+                for inner_indices in product(
+                    *(range(inner_ub) for inner_ub in inner_ubs)
+                ):
+                    input_loop_args = tuple(
+                        (
+                            (cast(ShapedArray[Any], i)).load(
+                                indexing_map.eval(outer_indices + inner_indices, ())
+                            )
+                            if isinstance(i, ShapedArray)
+                            else i
+                        )
+                        for i, indexing_map in zip(
+                            inputs, input_indexing_maps, strict=True
+                        )
+                    )
+
+                    loop_results = interpreter.run_ssacfg_region(
+                        op.body, input_loop_args + output_loop_args, "for_loop"
+                    )
+                    output_loop_args = loop_results
+                print(output_loop_args, output_indexing_maps, outputs)
+                for res, indexing_map, output in zip(
+                    output_loop_args, output_indexing_maps, outputs, strict=True
+                ):
+                    result_indices = indexing_map.eval(outer_indices, ())
+                    output.store(result_indices, res)
+        else:
+            for indices in product(*(range(outer_ub) for outer_ub in outer_ubs)):
+                loop_args = tuple(
+                    (
+                        (cast(ShapedArray[Any], i)).load(indexing_map.eval(indices, ()))
+                        if isinstance(i, ShapedArray)
+                        else i
+                    )
+                    for i, indexing_map in zip(args, indexing_maps, strict=True)
+                )
+                loop_results = interpreter.run_ssacfg_region(
+                    op.body, loop_args, "for_loop"
+                )
+                for res, indexing_map, output in zip(
+                    loop_results, output_indexing_maps, outputs, strict=True
+                ):
+                    result_indices = indexing_map.eval(indices, ())
+                    output.store(result_indices, res)
 
         return ()
 

--- a/xdsl/transforms/convert_memref_stream_to_loops.py
+++ b/xdsl/transforms/convert_memref_stream_to_loops.py
@@ -50,16 +50,15 @@ class LowerGenericOpPattern(RewritePattern):
     def match_and_rewrite(
         self, op: memref_stream.GenericOp, rewriter: PatternRewriter
     ) -> None:
-        ubs = op.get_static_loop_ranges()
-        outer_bound_count = min(len(ubs), *(m.data.num_dims for m in op.indexing_maps))
-        if outer_bound_count != len(ubs):
+        outer_ubs, inner_ubs = op.get_static_loop_ranges()
+        if inner_ubs:
             # Imperfectly nested
             ins_count = len(op.inputs)
             rewrite_generic_to_imperfect_loops(
                 rewriter,
                 InsertPoint.before(op),
-                ubs[:outer_bound_count],
-                ubs[outer_bound_count:],
+                outer_ubs,
+                inner_ubs,
                 op.indexing_maps.data[ins_count:],
                 op.indexing_maps.data[:ins_count],
                 op.indexing_maps.data[ins_count:],
@@ -76,7 +75,7 @@ class LowerGenericOpPattern(RewritePattern):
             rewrite_generic_to_loops(
                 rewriter,
                 InsertPoint.before(op),
-                ubs,
+                outer_ubs,
                 op.indexing_maps.data,
                 op.indexing_maps.data[-len(op.outputs) :],
                 op.operands,


### PR DESCRIPTION
This makes it a little easier to test for miscompilations in our flow from linalg to snitch