### PR TITLE
dialects: (builtin) Fix printing and parsing of `UnitAttr`

### DIFF
--- a/tests/filecheck/parser-printer/builtin_attrs.mlir
+++ b/tests/filecheck/parser-printer/builtin_attrs.mlir
@@ -8,12 +8,9 @@
 
   // CHECK: (index)
 
-  "func.func"() ({
-    ^bb0(%arg0: unit):
-    "func.return"() : () -> ()
-  }) {function_type = (unit) -> (), sym_name = "unit_type_func"} : () -> ()
+  "func.func"() ({}) {function_type = () -> (), sym_name = "unit_attr_func", unitarray = [unit]} : () -> ()
 
-  // CHECK: (unit)
+  // CHECK: "unitarray" = [unit]
 
   "func.func"() ({
     ^bb0(%arg0: i32, %arg1: i64, %arg2: i1):

--- a/tests/filecheck/parser-printer/builtin_attrs.mlir
+++ b/tests/filecheck/parser-printer/builtin_attrs.mlir
@@ -8,6 +8,12 @@
 
   // CHECK: (index)
 
+  "func.func"() ({
+    ^bb0(%arg0: unit):
+    "func.return"() : () -> ()
+  }) {function_type = (unit) -> (), sym_name = "unit_type_func"} : () -> ()
+
+  // CHECK: (unit)
 
   "func.func"() ({
     ^bb0(%arg0: i32, %arg1: i64, %arg2: i1):

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -595,7 +595,6 @@ class AttrParser(BaseParser):
             return BytesAttr(bytes_lit)
 
         attrs = (
-            self.parse_optional_unit_attr,
             self.parse_optional_builtin_int_or_float_attr,
             self._parse_optional_array_attr,
             self._parse_optional_symref_attr,
@@ -651,22 +650,6 @@ class AttrParser(BaseParser):
         offset = self._parse_int_or_question(" in stride offset")
         self._parse_token(Token.Kind.GREATER, "Expected '>' in end of stride attribute")
         return StridedLayoutAttr(strides, None if offset == "?" else offset)
-
-    def parse_optional_unit_attr(self) -> Attribute | None:
-        """
-        Parse a value of `unit` type.
-        unit-attribute ::= `unit`
-        """
-        if self._current_token.kind != Token.Kind.BARE_IDENT:
-            return None
-        name = self._current_token.span.text
-
-        # Unit type
-        if name == "unit":
-            self._consume_token()
-            return UnitAttr()
-
-        return None
 
     def _parse_optional_builtin_parametrized_attr(self) -> Attribute | None:
         if self._current_token.kind != Token.Kind.BARE_IDENT:
@@ -1267,6 +1250,7 @@ class AttrParser(BaseParser):
         Parse as integer or float type, if present.
           integer-or-float-type ::= index-type | integer-type | float-type
           index-type            ::= `index`
+          unit-attribute        ::= `unit`
           integer-type          ::= (`i` | `si` | `ui`) decimal-literal
           float-type            ::= `f16` | `f32` | `f64` | `f80` | `f128` | `bf16`
         """
@@ -1278,6 +1262,11 @@ class AttrParser(BaseParser):
         if name == "index":
             self._consume_token()
             return IndexType()
+
+        # Unit type
+        if name == "unit":
+            self._consume_token()
+            return UnitAttr()
 
         # Integer type
         if (match := self._builtin_integer_type_regex.match(name)) is not None:

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -661,7 +661,7 @@ class AttrParser(BaseParser):
             return None
         name = self._current_token.span.text
 
-        # Unit type
+        # Unit attribute
         if name == "unit":
             self._consume_token()
             return UnitAttr()

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -595,6 +595,7 @@ class AttrParser(BaseParser):
             return BytesAttr(bytes_lit)
 
         attrs = (
+            self.parse_optional_unit_attr,
             self.parse_optional_builtin_int_or_float_attr,
             self._parse_optional_array_attr,
             self._parse_optional_symref_attr,
@@ -650,6 +651,22 @@ class AttrParser(BaseParser):
         offset = self._parse_int_or_question(" in stride offset")
         self._parse_token(Token.Kind.GREATER, "Expected '>' in end of stride attribute")
         return StridedLayoutAttr(strides, None if offset == "?" else offset)
+
+    def parse_optional_unit_attr(self) -> Attribute | None:
+        """
+        Parse a value of `unit` type.
+        unit-attribute ::= `unit`
+        """
+        if self._current_token.kind != Token.Kind.BARE_IDENT:
+            return None
+        name = self._current_token.span.text
+
+        # Unit type
+        if name == "unit":
+            self._consume_token()
+            return UnitAttr()
+
+        return None
 
     def _parse_optional_builtin_parametrized_attr(self) -> Attribute | None:
         if self._current_token.kind != Token.Kind.BARE_IDENT:

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -595,6 +595,7 @@ class AttrParser(BaseParser):
             return BytesAttr(bytes_lit)
 
         attrs = (
+            self.parse_optional_unit_attr,
             self.parse_optional_builtin_int_or_float_attr,
             self._parse_optional_array_attr,
             self._parse_optional_symref_attr,
@@ -650,6 +651,22 @@ class AttrParser(BaseParser):
         offset = self._parse_int_or_question(" in stride offset")
         self._parse_token(Token.Kind.GREATER, "Expected '>' in end of stride attribute")
         return StridedLayoutAttr(strides, None if offset == "?" else offset)
+
+    def parse_optional_unit_attr(self) -> Attribute | None:
+        """
+        Parse a value of `unit` type.
+        unit-attribute ::= `unit`
+        """
+        if self._current_token.kind != Token.Kind.BARE_IDENT:
+            return None
+        name = self._current_token.span.text
+
+        # Unit type
+        if name == "unit":
+            self._consume_token()
+            return UnitAttr()
+
+        return None
 
     def _parse_optional_builtin_parametrized_attr(self) -> Attribute | None:
         if self._current_token.kind != Token.Kind.BARE_IDENT:
@@ -1250,7 +1267,6 @@ class AttrParser(BaseParser):
         Parse as integer or float type, if present.
           integer-or-float-type ::= index-type | integer-type | float-type
           index-type            ::= `index`
-          unit-attribute        ::= `unit`
           integer-type          ::= (`i` | `si` | `ui`) decimal-literal
           float-type            ::= `f16` | `f32` | `f64` | `f80` | `f128` | `bf16`
         """
@@ -1262,11 +1278,6 @@ class AttrParser(BaseParser):
         if name == "index":
             self._consume_token()
             return IndexType()
-
-        # Unit type
-        if name == "unit":
-            self._consume_token()
-            return UnitAttr()
 
         # Integer type
         if (match := self._builtin_integer_type_regex.match(name)) is not None:

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -398,6 +398,7 @@ class Printer:
 
     def print_attribute(self, attribute: Attribute) -> None:
         if isinstance(attribute, UnitAttr):
+            self.print("unit")
             return
 
         if isinstance(attribute, LocationAttr):


### PR DESCRIPTION
It's actually `unit` not the empty string.