### PR TITLE
dialects: Add memref.extract_strided_metadata op

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -9,6 +9,7 @@ from xdsl.dialects.builtin import (
     IntAttr,
     IntegerType,
     MemRefType,
+    NoneAttr,
     StridedLayoutAttr,
     UnrankedMemrefType,
     i32,
@@ -23,6 +24,7 @@ from xdsl.dialects.memref import (
     DmaStartOp,
     DmaWaitOp,
     ExtractAlignedPointerAsIndexOp,
+    ExtractStridedMetaDataOp,
     Load,
     MemorySpaceCast,
     Store,
@@ -279,6 +281,26 @@ def test_memref_matmul_verify():
 
     # check that it verifies correctly
     module.verify()
+
+
+def test_memref_extract_strided_metadata():
+    # input type
+    el_type = i32
+    alignment = 8
+    shape = [10, 10, 10]
+    strides = [1, 2, 2]
+    offset = None  # Dynamic offset
+    layout = StridedLayoutAttr(strides, offset)
+    memory_space = IntAttr(1)
+    alloc = Alloc.get(
+        el_type, alignment, shape, layout=layout, memory_space=memory_space
+    )
+    assert isa(alloc.memref.type, MemRefType[Attribute])
+
+    extract_op = ExtractStridedMetaDataOp.from_source_memref(alloc, alloc.memref.type)
+    # output type is expected to have no layout information, and no shape
+    expected_type = MemRefType(el_type, [], NoneAttr(), memory_space=memory_space)
+    assert extract_op.results[0].type == expected_type
 
 
 def test_memref_subview_constant_parameters():

--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -27,6 +27,7 @@ builtin.module {
     %9 = "memref.memory_space_cast"(%5) : (memref<10x2xindex>) -> memref<10x2xindex, 1: i32>
     %10 = memref.alloc() : memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
     %11 = "memref.alloca"() {"operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
+    %base_buffer, %offset, %sizes:2, %strides:2 = "memref.extract_strided_metadata"(%11) {"resultSegmentSizes" = array<i32: 1, 1, 2, 2>}: (memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>) -> (memref<index>, index, index, index, index, index)
     %12, %13, %14 = "test.op"() : () -> (index, index, index)
     %15 = memref.alloc(%12) {"alignment" = 0} : memref<?xindex>
     %16 = memref.alloc(%12, %13, %14) {"alignment" = 0} : memref<?x?x?xindex>
@@ -74,6 +75,7 @@ builtin.module {
 // CHECK-NEXT:     %{{.*}} = "memref.memory_space_cast"(%{{.*}}) : (memref<10x2xindex>) -> memref<10x2xindex, 1 : i32>
 // CHECK-NEXT:     %{{.*}} = memref.alloc() : memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
 // CHECK-NEXT:     %{{.*}} = "memref.alloca"() <{"operandSegmentSizes" = array<i32: 0, 0>}> : () -> memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>
+// CHECK-NEXT:     %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} = "memref.extract_strided_metadata"(%{{.*}}) {"resultSegmentSizes" = array<i32: 1, 1, 2, 2>} : (memref<64x64xindex, strided<[2, 4], offset: 6>, 2 : i32>) -> (memref<index>, index, index, index, index, index)
 // CHECK-NEXT:     %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (index, index, index)
 // CHECK-NEXT:     %{{.*}} = memref.alloc(%{{.*}}) {"alignment" = 0 : i64} : memref<?xindex>
 // CHECK-NEXT:     %{{.*}} = memref.alloc(%{{.*}}, %{{.*}}, %{{.*}}) {"alignment" = 0 : i64} : memref<?x?x?xindex>

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -513,6 +513,10 @@ class ExpandShapeOp(AlterShapeOp):
 
 @irdl_op_definition
 class ExtractStridedMetaDataOp(IRDLOperation):
+    """
+    https://mlir.llvm.org/docs/Dialects/MemRef/#memrefextract_strided_metadata-memrefextractstridedmetadataop
+    """
+
     name = "memref.extract_strided_metadata"
 
     source: Operand = operand_def(MemRefType)
@@ -528,6 +532,10 @@ class ExtractStridedMetaDataOp(IRDLOperation):
     def from_source_memref(
         source: SSAValue | Operation, source_type: MemRefType[Attribute]
     ):
+        """
+        Create an ExtractStridedMetaDataOp that extracts the metadata from the
+        operation (source) that produces a memref.
+        """
         source_shape = source_type.get_shape()
         # Return a rank zero memref with the memref type
         base_buffer_type = MemRefType(
@@ -537,11 +545,12 @@ class ExtractStridedMetaDataOp(IRDLOperation):
             source_type.memory_space,
         )
         offset_type = IndexType()
-        strides_type = [IndexType() for _ in source_shape]
-        sizes_type = [IndexType() for _ in source_shape]
+        # There are as many strides/sizes as there are shape dimensions
+        strides_type = [IndexType()] * len(source_shape)
+        sizes_type = [IndexType()] * len(source_shape)
         return_type = [base_buffer_type, offset_type, strides_type, sizes_type]
         return ExtractStridedMetaDataOp.build(
-            operands=[source], result_types=[*return_type]
+            operands=[source], result_types=return_type
         )
 
 


### PR DESCRIPTION
I'm adding the memref.extract_strided_metadataop because I need an op to fetch the dynamic offset created by a subview, and otherwise I can not do  that. 
https://mlir.llvm.org/docs/Dialects/MemRef/#memrefextract_strided_metadata-memrefextractstridedmetadataop