### PR TITLE
installation: Add ruff to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
               LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib";
               buildInputs = [
                 nodejs_22
+                ruff
               ];
             };
           }


### PR DESCRIPTION
The python installation of ruff doesn't work on nixos, so it'd be good to add it to the flake