### PR TITLE
testing: Ignore missing sources warning in pyright.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 reportImportCycles = false
+reportMissingModuleSource = false
 enableTypeIgnoreComments = false
 typeCheckingMode = "strict"
 "include" = ["docs", "xdsl", "tests", "bench"]


### PR DESCRIPTION
Importing a dialect from a `.irdl` file now raises Pyright warnings about not finding the source file but only the type stubs, which is expected. Disable this warning to avoid the noise