### PR TITLE
transformations: do not insert affine.apply ops when streaming

### DIFF
--- a/xdsl/transforms/convert_memref_stream_to_loops.py
+++ b/xdsl/transforms/convert_memref_stream_to_loops.py
@@ -2,9 +2,7 @@ from collections.abc import Sequence
 
 from xdsl.context import MLContext
 from xdsl.dialects import memref, memref_stream, stream
-from xdsl.dialects.builtin import (
-    ModuleOp,
-)
+from xdsl.dialects.builtin import AffineMapAttr, ModuleOp
 from xdsl.ir import Operation, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -16,34 +14,49 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.rewriter import InsertPoint
 from xdsl.transforms.loop_nest_lowering_utils import (
+    indices_for_map,
     rewrite_generic_to_imperfect_loops,
     rewrite_generic_to_loops,
 )
 
 
-def load(
+def insert_load(
     source: SSAValue,
-    indices: Sequence[SSAValue],
+    affine_map_attr: AffineMapAttr,
+    ind_vars: Sequence[SSAValue],
     rewriter: PatternRewriter,
-    insert_point: InsertPoint,
+    insertion_point: InsertPoint,
 ) -> SSAValue:
     if isinstance(source.type, memref.MemRefType):
+        indices = indices_for_map(
+            rewriter, insertion_point, affine_map_attr.data, ind_vars
+        )
         op = memref.Load.get(source, indices)
     elif isinstance(source.type, stream.ReadableStreamType):
         op = memref_stream.ReadOp(source)
     else:
         return source
-    rewriter.insert_op(op, insert_point)
+    rewriter.insert_op(op, insertion_point)
     return op.res
 
 
-def store(
-    value: SSAValue, destination: SSAValue, indices: Sequence[SSAValue]
+def insert_store(
+    value: SSAValue,
+    destination: SSAValue,
+    affine_map_attr: AffineMapAttr,
+    ind_vars: Sequence[SSAValue],
+    rewriter: PatternRewriter,
+    insertion_point: InsertPoint,
 ) -> Operation:
     if isinstance(destination.type, memref.MemRefType):
-        return memref.Store.get(value, destination, indices)
+        indices = indices_for_map(
+            rewriter, insertion_point, affine_map_attr.data, ind_vars
+        )
+        op = memref.Store.get(value, destination, indices)
     else:
-        return memref_stream.WriteOp(value, destination)
+        op = memref_stream.WriteOp(value, destination)
+    rewriter.insert_op(op, insertion_point)
+    return op
 
 
 class LowerGenericOpPattern(RewritePattern):
@@ -69,8 +82,8 @@ class LowerGenericOpPattern(RewritePattern):
                 op.body.block.args[ins_count:],
                 op.body.block.args[:ins_count],
                 op.body.block,
-                load,
-                store,
+                insert_load,
+                insert_store,
             )
         else:
             rewrite_generic_to_loops(
@@ -82,8 +95,8 @@ class LowerGenericOpPattern(RewritePattern):
                 op.operands,
                 op.outputs,
                 op.body.block,
-                load,
-                store,
+                insert_load,
+                insert_store,
             )
 
 

--- a/xdsl/transforms/loop_nest_lowering_utils.py
+++ b/xdsl/transforms/loop_nest_lowering_utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Sequence
 from itertools import compress
+from typing import TypeAlias
 
 from xdsl.dialects import affine, arith, scf
 from xdsl.dialects.builtin import AffineMapAttr, IndexType, IntegerAttr
@@ -60,6 +61,31 @@ def indices_for_map(
             output_indices.append(apply_op.result)
 
     return output_indices
+
+
+INSERT_LOAD: TypeAlias = Callable[
+    [
+        SSAValue,
+        AffineMapAttr,
+        Sequence[SSAValue],
+        PatternRewriter,
+        InsertPoint,
+    ],
+    SSAValue,
+]
+
+
+INSERT_STORE: TypeAlias = Callable[
+    [
+        SSAValue,
+        SSAValue,
+        AffineMapAttr,
+        Sequence[SSAValue],
+        PatternRewriter,
+        InsertPoint,
+    ],
+    Operation,
+]
 
 
 def _insert_loop_nest(
@@ -131,9 +157,7 @@ def _insert_load_ops(
     affine_map_attrs: Sequence[AffineMapAttr],
     operands: Sequence[SSAValue],
     args: Sequence[BlockArgument],
-    load: Callable[
-        [SSAValue, Sequence[SSAValue], PatternRewriter, InsertPoint], SSAValue
-    ],
+    insert_load: INSERT_LOAD,
 ) -> Sequence[tuple[int, SSAValue]]:
     """
     Inserts the load operations at the specified insertion point.
@@ -143,6 +167,8 @@ def _insert_load_ops(
     The `args` are the block arguments corresponding to the use of the load; if there are
     no uses, the loads are not inserted.
     The `affine_map_attrs`, `operands`, and `args` must have the same length.
+    Returns a tuple of integers indicating the locations of the returned values, and
+    the values themselves.
     """
     res: list[tuple[int, SSAValue]] = []
     for i, (affine_map_attr, operand, arg) in enumerate(
@@ -150,9 +176,13 @@ def _insert_load_ops(
     ):
         if not arg.uses:
             continue
-        affine_map = affine_map_attr.data
-        indices = indices_for_map(rewriter, insertion_point, affine_map, ind_vars)
-        res_val = load(operand, indices, rewriter, insertion_point)
+        res_val = insert_load(
+            operand,
+            affine_map_attr,
+            ind_vars,
+            rewriter,
+            insertion_point,
+        )
         res.append((i, res_val))
     return res
 
@@ -164,7 +194,7 @@ def _insert_store_ops(
     output_indexing_maps: Sequence[AffineMapAttr],
     yield_operands: Sequence[SSAValue],
     output_operands: Sequence[SSAValue],
-    store: Callable[[SSAValue, SSAValue, Sequence[SSAValue]], Operation],
+    insert_store: INSERT_STORE,
 ):
     """
     Inserts the store operations at the specified insertion point.
@@ -178,10 +208,9 @@ def _insert_store_ops(
     for affine_map_attr, yield_value, ref in zip(
         output_indexing_maps, yield_operands, output_operands, strict=True
     ):
-        affine_map = affine_map_attr.data
-        indices = indices_for_map(rewriter, insertion_point, affine_map, ind_vars)
-        store_op = store(yield_value, ref, indices)
-        rewriter.insert_op(store_op, insertion_point)
+        insert_store(
+            yield_value, ref, affine_map_attr, ind_vars, rewriter, insertion_point
+        )
 
 
 def rewrite_generic_to_loops(
@@ -193,10 +222,8 @@ def rewrite_generic_to_loops(
     load_operands: Sequence[SSAValue],
     store_operands: Sequence[SSAValue],
     block: Block,
-    load: Callable[
-        [SSAValue, Sequence[SSAValue], PatternRewriter, InsertPoint], SSAValue
-    ],
-    store: Callable[[SSAValue, SSAValue, Sequence[SSAValue]], Operation],
+    insert_load: INSERT_LOAD,
+    insert_store: INSERT_STORE,
 ) -> None:
     # Create loop nest lb (0), step (1), and ubs
     # ubs are calculated from affine maps and memref dimensions
@@ -227,7 +254,7 @@ def rewrite_generic_to_loops(
             load_indexing_maps,
             load_operands,
             block.args,
-            load,
+            insert_load,
         )
 
         for i, val in loaded_values:
@@ -251,7 +278,7 @@ def rewrite_generic_to_loops(
             store_indexing_maps,
             yield_op.operands,
             store_operands,
-            store,
+            insert_store,
         )
 
         return ()
@@ -283,10 +310,8 @@ def rewrite_generic_to_imperfect_loops(
     outer_load_block_args: Sequence[BlockArgument],
     inner_load_block_args: Sequence[BlockArgument],
     block: Block,
-    load: Callable[
-        [SSAValue, Sequence[SSAValue], PatternRewriter, InsertPoint], SSAValue
-    ],
-    store: Callable[[SSAValue, SSAValue, Sequence[SSAValue]], Operation],
+    insert_load: INSERT_LOAD,
+    insert_store: INSERT_STORE,
 ) -> None:
     # Create loop nest lb (0), step (1), and ubs
     # ubs are calculated from affine maps and memref dimensions
@@ -323,7 +348,7 @@ def rewrite_generic_to_imperfect_loops(
             outer_load_indexing_maps,
             outer_load_operands,
             outer_load_block_args,
-            load,
+            insert_load,
         )
 
         def inner_make_body(
@@ -340,7 +365,7 @@ def rewrite_generic_to_imperfect_loops(
                 inner_load_indexing_maps,
                 inner_load_operands,
                 inner_load_block_args,
-                load,
+                insert_load,
             )
 
             # Replace block argument use with iter args
@@ -390,7 +415,7 @@ def rewrite_generic_to_imperfect_loops(
             store_indexing_maps,
             inner_loop_nest_results,
             store_operands,
-            store,
+            insert_store,
         )
 
         return ()


### PR DESCRIPTION
We encode the affine map constraints in the streaming region setup, so we don't need the results of the affine.apply operation, unlike in the memref.load case. We could dce them away, but it feels better to not insert them in the first place.