### PR TITLE
dialects: (memref_stream) Add an inits field to memref_stream.generic [1/3]

### DIFF
--- a/tests/filecheck/dialects/memref_stream/ops.mlir
+++ b/tests/filecheck/dialects/memref_stream/ops.mlir
@@ -50,18 +50,19 @@ memref_stream.generic {
         affine_map<(d0, d1) -> (d1)>,
         affine_map<(d0, d1) -> (d0, d1)>
     ],
-    iterator_types = ["parallel", "parallel"]
+    iterator_types = ["parallel", "parallel"],
+    inits = [unit]
 } ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs = {hello = "world"} {
 ^bb0(%arg3: f32, %arg4: f32):
     memref_stream.yield %arg3 : f32
 }
 
-// CHECK-NEXT:          memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs =  {"hello" = "world"} {
+// CHECK-NEXT:          memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], inits = [unit]} ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs =  {"hello" = "world"} {
 // CHECK-NEXT:          ^1(%arg3 : f32, %arg4 : f32):
 // CHECK-NEXT:            memref_stream.yield %arg3 : f32
 // CHECK-NEXT:          }
 
-// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%A, %B, %C) <{"bounds" = [#builtin.int<3>, #builtin.int<2>], "indexing_maps" = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%A, %B, %C) <{"bounds" = [#builtin.int<3>, #builtin.int<2>], "inits" = [unit], "indexing_maps" = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^1(%arg3 : f32, %arg4 : f32):
 // CHECK-GENERIC-NEXT:      "memref_stream.yield"(%arg3) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) {"hello" = "world"} : (memref<2xf32>, memref<3xf32>, memref<3x2xf64>) -> ()
@@ -72,21 +73,56 @@ memref_stream.generic {
         affine_map<(d0, d1) -> ()>,
         affine_map<(d0, d1) -> (d0, d1)>
     ],
-    iterator_types = ["parallel", "parallel"]
+    iterator_types = ["parallel", "parallel"],
+    inits = [unit]
 } ins(%D : f64) outs(%C : memref<3x2xf64>) {
 ^bb0(%d : f64, %c : f64):
     memref_stream.yield %d : f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%D : f64) outs(%C : memref<3x2xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], inits = [unit]} ins(%D : f64) outs(%C : memref<3x2xf64>) {
 // CHECK-NEXT:    ^2(%d : f64, %c_1 : f64):
 // CHECK-NEXT:      memref_stream.yield %d : f64
 // CHECK-NEXT:    }
 
-// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%D, %C) <{"bounds" = [#builtin.int<3>, #builtin.int<2>], "indexing_maps" = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 1, 1>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%D, %C) <{"bounds" = [#builtin.int<3>, #builtin.int<2>], "inits" = [unit], "indexing_maps" = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 1, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^2(%d : f64, %c_1 : f64):
 // CHECK-GENERIC-NEXT:      "memref_stream.yield"(%d) : (f64) -> ()
 // CHECK-GENERIC-NEXT:    }) : (f64, memref<3x2xf64>) -> ()
+
+%E, %F, %G = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
+// CHECK-NEXT:            %E, %F, %G = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
+// CHECK-GENERIC-NEXT:    %E, %F, %G = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
+
+memref_stream.generic {
+    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    indexing_maps = [
+        affine_map<(d0, d1, d2) -> (d0, d2)>,
+        affine_map<(d0, d1, d2) -> (d2, d1)>,
+        affine_map<(d0, d1) -> (d0, d1)>
+    ],
+    iterator_types = ["parallel", "parallel", "reduction"],
+    inits = [0.000000e+00 : f64]
+} ins(%E, %F : memref<4x2xf64>, memref<2x3xf64>) outs(%G : memref<4x3xf64>) {
+^0(%e : f64, %f : f64, %acc_old : f64):
+    %prod = arith.mulf %e, %f : f64
+    %acc_new = arith.addf %acc_old, %prod : f64
+    linalg.yield %acc_new : f64
+}
+
+// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], inits = [0.000000e+00 : f64]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}} : memref<4x3xf64>) {
+// CHECK-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
+// CHECK-NEXT:      %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f64
+// CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f64
+// CHECK-NEXT:      linalg.yield %{{.*}} : f64
+// CHECK-NEXT:    }
+
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}) <{"bounds" = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], "inits" = [0.000000e+00 : f64], "indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f64) -> ()
+// CHECK-GENERIC-NEXT:    }) : (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>) -> ()
 
 // CHECK-NEXT:          }
 // CHECK-GENERIC-NEXT:  }) : () -> ()

--- a/tests/filecheck/dialects/memref_stream/verify.mlir
+++ b/tests/filecheck/dialects/memref_stream/verify.mlir
@@ -9,7 +9,8 @@ memref_stream.generic {
         affine_map<(d0, d1, d2) -> (d1, d2)>,
         affine_map<(d0, d1, d2) -> (d0, d2)>
     ],
-    iterator_types = ["parallel", "reduction", "parallel"]
+    iterator_types = ["parallel", "reduction", "parallel"],
+    inits = [unit]
 } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C : memref<4x3xf64>) {
 ^0(%a : f64, %b : f64, %acc_old : f64):
     %prod = arith.mulf %a, %b : f64
@@ -29,7 +30,8 @@ memref_stream.generic {
         affine_map<(d0, d1, d2) -> (d0, d1)>,
         affine_map<(d0, d1, d2) -> (d1, d2)>
     ],
-    iterator_types = ["parallel", "parallel", "reduction"]
+    iterator_types = ["parallel", "parallel", "reduction"],
+    inits = [unit]
 } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C : memref<4x3xf64>) {
 ^0(%a : f64, %b : f64, %acc_old : f64):
     %prod = arith.mulf %a, %b : f64
@@ -50,7 +52,8 @@ memref_stream.generic {
         affine_map<(d0, d1, d2) -> (d1, d2)>,
         affine_map<(d0, d1, d2, d3) -> (d0, d2)>
     ],
-    iterator_types = ["parallel", "parallel", "reduction"]
+    iterator_types = ["parallel", "parallel", "reduction"],
+    inits = [unit]
 } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C : memref<4x3xf64>) {
 ^0(%a : f64, %b : f64, %acc_old : f64):
     %prod = arith.mulf %a, %b : f64
@@ -71,7 +74,8 @@ memref_stream.generic {
         affine_map<(d0, d1, d2) -> (d1, d2)>,
         affine_map<(d0, d1, d2, d3) -> (d0, d2)>
     ],
-    iterator_types = ["parallel", "parallel", "reduction"]
+    iterator_types = ["parallel", "parallel", "reduction"],
+    inits = [unit]
 } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C : memref<4x3xf64>) {
 ^0(%a : f64, %b : f64, %acc_old : f64):
     %prod = arith.mulf %a, %b : f64
@@ -93,7 +97,8 @@ memref_stream.generic {
         affine_map<(d0, d1, d2) -> (d0, d2)>,
         affine_map<(d0, d1) -> (d0, d1)>
     ],
-    iterator_types = ["parallel", "parallel", "reduction"]
+    iterator_types = ["parallel", "parallel", "reduction"],
+    inits = [unit, unit]
 } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C, %D : memref<4x3xf64>, memref<4x3xf64>) {
 ^0(%a : f64, %b : f64, %acc_old0 : f64, %acc_old1 : f64):
     %prod = arith.mulf %a, %b : f64

--- a/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
+++ b/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
@@ -22,7 +22,7 @@ linalg.generic {
     %acc_new = arith.addf %acc_old, %prod : f64
     linalg.yield %acc_new : f64
 }
-// CHECK-NEXT:      memref_stream.generic {bounds = [], indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []} ins(%A, %B : memref<f64>, memref<f64>) outs(%C : memref<f64>) {
+// CHECK-NEXT:      memref_stream.generic {bounds = [], indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = [], inits = [unit]} ins(%A, %B : memref<f64>, memref<f64>) outs(%C : memref<f64>) {
 // CHECK-NEXT:      ^0(%a : f64, %b : f64, %acc_old : f64):
 // CHECK-NEXT:        %prod = arith.mulf %a, %b : f64
 // CHECK-NEXT:        %acc_new = arith.addf %acc_old, %prod : f64
@@ -44,7 +44,7 @@ linalg.generic {
     linalg.yield %acc_new : f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<2>, #builtin.int<3>, #builtin.int<4>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%D, %E : memref<2x3xf64>, memref<3x4xf64>) outs(%F : memref<2x4xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<2>, #builtin.int<3>, #builtin.int<4>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>], iterator_types = ["parallel", "parallel", "reduction"], inits = [unit]} ins(%D, %E : memref<2x3xf64>, memref<3x4xf64>) outs(%F : memref<2x4xf64>) {
 // CHECK-NEXT:    ^1(%d : f64, %e : f64, %acc_old_1 : f64):
 // CHECK-NEXT:      %prod_1 = arith.mulf %d, %e : f64
 // CHECK-NEXT:      %acc_new_1 = arith.addf %acc_old_1, %prod_1 : f64
@@ -65,7 +65,7 @@ linalg.generic {
     linalg.yield %acc_new : f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> ((d0 + d1))>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%G, %H : memref<4xf64>, memref<2xf64>) outs(%I : memref<3xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> ((d0 + d1))>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"], inits = [unit]} ins(%G, %H : memref<4xf64>, memref<2xf64>) outs(%I : memref<3xf64>) {
 // CHECK-NEXT:    ^2(%g : f64, %h : f64, %acc_old_2 : f64):
 // CHECK-NEXT:      %prod_2 = arith.mulf %g, %h : f64
 // CHECK-NEXT:      %acc_new_2 = arith.addf %acc_old_2, %prod_2 : f64

--- a/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
@@ -11,7 +11,7 @@
     ]
   } ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
     ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>, %2 : !stream.writable<f64>):
-      memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
+      memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], inits = [unit]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
       ^1(%in : f64, %in_0 : f64, %out : f64):
         %3 = arith.addf %in, %in_0 : f64
         memref_stream.yield %3 : f64
@@ -48,7 +48,7 @@
     ]
   } ins(%arg0_1 : memref<16x16xf64>) outs(%arg1_1 : memref<16x16xf64>) {
     ^2(%4 : !stream.readable<f64>, %5 : !stream.writable<f64>):
-      memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : !stream.readable<f64>) outs(%5 : !stream.writable<f64>) {
+      memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], inits = [unit]} ins(%4 : !stream.readable<f64>) outs(%5 : !stream.writable<f64>) {
       ^3(%in_1 : f64, %out_1 : f64):
         %6 = arith.maximumf %in_1, %cst : f64
         memref_stream.yield %6 : f64
@@ -90,7 +90,8 @@ func.func public @fill(%arg0 : memref<16x16xf64>) -> memref<16x16xf64> {
             affine_map<(d0, d1) -> ()>,
             affine_map<(d0, d1) -> (d0, d1)>
         ],
-        iterator_types = ["parallel", "parallel"]
+        iterator_types = ["parallel", "parallel"],
+        inits = [unit]
     } ins(%zero : f64) outs(%7 : !stream.writable<f64>) {
     ^4(%in: f64, %out: f64):
         memref_stream.yield %in : f64
@@ -131,7 +132,8 @@ func.func @main(%A : memref<4x2xf64>, %B : memref<2x3xf64>, %C : memref<4x3xf64>
           affine_map<(d0, d1, d2) -> (d2, d1)>,
           affine_map<(d0, d1) -> (d0, d1)>
         ],
-        iterator_types = ["parallel", "parallel", "reduction"]
+        iterator_types = ["parallel", "parallel", "reduction"],
+        inits = [unit]
       } ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%C : memref<4x3xf64>) {
       ^1(%a : f64, %b : f64, %acc_old : f64):
         %prod = arith.mulf %a, %b : f64
@@ -179,7 +181,8 @@ func.func @elide_affine(%A : memref<6xf64>, %B : memref<f64>) -> memref<f64> {
           affine_map<(d0, d1) -> (d0 * 3 + d1)>,
           affine_map<(d0, d1) -> ()>
         ],
-        iterator_types = ["parallel", "reduction"]
+        iterator_types = ["parallel", "reduction"],
+        inits = [unit]
       } ins(%0 : !stream.readable<f64>) outs(%B : memref<f64>) {
       ^1(%a : f64, %acc_old : f64):
         %acc_new = arith.addf %acc_old, %a : f64
@@ -220,7 +223,8 @@ func.func @nested_imperfect(%A : memref<2x3x4xf64>, %B : memref<f64>) -> memref<
           affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
           affine_map<() -> ()>
         ],
-        iterator_types = ["reduction", "reduction", "reduction"]
+        iterator_types = ["reduction", "reduction", "reduction"],
+        inits = [unit]
       } ins(%0 : !stream.readable<f64>) outs(%B : memref<f64>) {
       ^1(%a : f64, %acc_old : f64):
         %acc_new = arith.addf %acc_old, %a : f64

--- a/tests/filecheck/transforms/memref_stream_unnest_out_parameters.mlir
+++ b/tests/filecheck/transforms/memref_stream_unnest_out_parameters.mlir
@@ -10,7 +10,8 @@ memref_stream.generic {
         affine_map<(d0, d1, d2) -> (d2, d1)>,
         affine_map<(d0, d1, d2) -> (d0, d1)>
     ],
-    iterator_types = ["parallel", "parallel", "reduction"]
+    iterator_types = ["parallel", "parallel", "reduction"],
+    inits = [unit]
 } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C : memref<4x3xf64>) {
 ^0(%a : f64, %b : f64, %acc_old : f64):
     %prod = arith.mulf %a, %b : f64
@@ -20,7 +21,7 @@ memref_stream.generic {
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}} : memref<4x3xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], inits = [unit]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}} : memref<4x3xf64>) {
 // CHECK-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
 // CHECK-NEXT:      %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f64
 // CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f64

--- a/tests/filecheck/transforms/memref_streamify.mlir
+++ b/tests/filecheck/transforms/memref_streamify.mlir
@@ -10,7 +10,8 @@ func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2
     memref_stream.generic {
         bounds = [#builtin.int<8>, #builtin.int<16>],
         indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
-        iterator_types = ["parallel", "parallel"]
+        iterator_types = ["parallel", "parallel"],
+        inits = [unit]
     } ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
     ^0(%in : f64, %in_0 : f64, %out : f64):
         %0 = arith.addf %in, %in_0 : f64
@@ -22,7 +23,7 @@ func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2
 // CHECK-NEXT:    func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2 : memref<8x16xf64>) -> memref<8x16xf64> {
 // CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
 // CHECK-NEXT:      ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>, %2 : !stream.writable<f64>):
-// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
+// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], inits = [unit]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
 // CHECK-NEXT:        ^1(%in : f64, %in_1 : f64, %out : f64):
 // CHECK-NEXT:          %3 = arith.addf %in, %in_1 : f64
 // CHECK-NEXT:          memref_stream.yield %3 : f64
@@ -36,7 +37,8 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
     memref_stream.generic {
         bounds = [#builtin.int<16>, #builtin.int<16>],
         indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
-        iterator_types = ["parallel", "parallel"]
+        iterator_types = ["parallel", "parallel"],
+        inits = [unit]
     } ins(%arg0 : memref<16x16xf64>) outs(%arg1 : memref<16x16xf64>) {
     ^1(%in_1 : f64, %out_1 : f64):
         %1 = arith.maximumf %in_1, %cst : f64
@@ -49,7 +51,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
 // CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%arg0 : memref<16x16xf64>) outs(%arg1 : memref<16x16xf64>) {
 // CHECK-NEXT:      ^0(%0 : !stream.readable<f64>, %1 : !stream.writable<f64>):
-// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : !stream.readable<f64>) outs(%1 : !stream.writable<f64>) {
+// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], inits = [unit]} ins(%0 : !stream.readable<f64>) outs(%1 : !stream.writable<f64>) {
 // CHECK-NEXT:        ^1(%in : f64, %out : f64):
 // CHECK-NEXT:          %2 = arith.maximumf %in, %cst : f64
 // CHECK-NEXT:          memref_stream.yield %2 : f64
@@ -68,7 +70,8 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
             affine_map<(d0, d1) -> ()>,
             affine_map<(d0, d1) -> (d0, d1)>
         ],
-        iterator_types = ["parallel", "parallel"]
+        iterator_types = ["parallel", "parallel"],
+        inits = [unit]
     } ins(%X : f64) outs(%Y : memref<16x16xf64>) {
     ^bb0(%d : f64, %c : f64):
         memref_stream.yield %d : f64
@@ -80,7 +83,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
 // CHECK-NEXT:    func.func @fill(%{{.*}} : f64, %{{.*}} : memref<16x16xf64>) {
 // CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>]} outs(%{{.*}} : memref<16x16xf64>) {
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : !stream.writable<f64>):
-// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%{{.*}} : f64) outs(%{{.*}} : !stream.writable<f64>) {
+// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], inits = [unit]} ins(%{{.*}} : f64) outs(%{{.*}} : !stream.writable<f64>) {
 // CHECK-NEXT:        ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64):
 // CHECK-NEXT:          memref_stream.yield %{{.*}} : f64
 // CHECK-NEXT:        }

--- a/xdsl/transforms/convert_linalg_to_memref_stream.py
+++ b/xdsl/transforms/convert_linalg_to_memref_stream.py
@@ -1,10 +1,6 @@
 from xdsl.context import MLContext
 from xdsl.dialects import linalg, memref_stream
-from xdsl.dialects.builtin import (
-    ArrayAttr,
-    IntAttr,
-    ModuleOp,
-)
+from xdsl.dialects.builtin import ArrayAttr, IntAttr, ModuleOp, UnitAttr
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -47,6 +43,7 @@ class ConvertGenericOpPattern(RewritePattern):
                 op.inputs,
                 op.outputs,
                 rewriter.move_region_contents_to_new_regions(op.body),
+                ArrayAttr(tuple(UnitAttr() for _ in range(len(op.outputs)))),
                 op.indexing_maps,
                 iterator_types,
                 bounds,

--- a/xdsl/transforms/convert_memref_stream_to_loops.py
+++ b/xdsl/transforms/convert_memref_stream_to_loops.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 
 from xdsl.context import MLContext
 from xdsl.dialects import memref, memref_stream, stream
-from xdsl.dialects.builtin import AffineMapAttr, ModuleOp
+from xdsl.dialects.builtin import AffineMapAttr, ModuleOp, UnitAttr
 from xdsl.ir import Operation, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -64,6 +64,9 @@ class LowerGenericOpPattern(RewritePattern):
     def match_and_rewrite(
         self, op: memref_stream.GenericOp, rewriter: PatternRewriter
     ) -> None:
+        if any(not isinstance(init, UnitAttr) for init in op.inits):
+            raise NotImplementedError("Operation has inits that are not UnitAttr")
+
         outer_ubs, inner_ubs = op.get_static_loop_ranges()
         if inner_ubs:
             # Imperfectly nested


### PR DESCRIPTION
This is PR 1/3 that introduces constant initialisation to our kernel representations. This PR adds the new attribute, and adds NotImplemented to the streamification and lowering to loops, which are handled in the next two pull requests.

Note stacked PR.