### PR TITLE
(dialect+transform): stencil to new csl_stencil dialect and transform

### DIFF
--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -1,0 +1,63 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+builtin.module {
+  func.func @gauss_seidel_func(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
+    %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+    %pref = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "size" = 510, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> (memref<4xtensor<510xf32>>)
+    %1 = stencil.apply(%2 = %0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3 = %pref : memref<4xtensor<510xf32>>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) {
+      %4 = arith.constant 1.666600e-01 : f32
+      %5 = csl_stencil.access %3[1, 0] : memref<4xtensor<510xf32>>
+      %6 = csl_stencil.access %3[-1, 0] : memref<4xtensor<510xf32>>
+      %7 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %8 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %9 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %10 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %11 = csl_stencil.access %3[0, 1] : memref<4xtensor<510xf32>>
+      %12 = csl_stencil.access %3[0, -1] : memref<4xtensor<510xf32>>
+      %13 = arith.addf %12, %11 : tensor<510xf32>
+      %14 = arith.addf %13, %10 : tensor<510xf32>
+      %15 = arith.addf %14, %9 : tensor<510xf32>
+      %16 = arith.addf %15, %6 : tensor<510xf32>
+      %17 = arith.addf %16, %5 : tensor<510xf32>
+      %18 = tensor.empty() : tensor<510xf32>
+      %19 = linalg.fill ins(%4 : f32) outs(%18 : tensor<510xf32>) -> tensor<510xf32>
+      %20 = arith.mulf %17, %19 : tensor<510xf32>
+      stencil.return %20 : tensor<510xf32>
+    }
+    stencil.store %1 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    func.return
+  }
+}
+
+
+// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   "func.func"() <{"sym_name" = "gauss_seidel_func", "function_type" = (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()}> ({
+// CHECK-NEXT:   ^0(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
+// CHECK-NEXT:     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:     %pref = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "size" = 510 : i64, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
+// CHECK-NEXT:     %1 = "stencil.apply"(%0, %pref) ({
+// CHECK-NEXT:     ^1(%2 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3 : memref<4xtensor<510xf32>>):
+// CHECK-NEXT:       %4 = "arith.constant"() <{"value" = 1.666600e-01 : f32}> : () -> f32
+// CHECK-NEXT:       %5 = "csl_stencil.access"(%3) {"offset" = #stencil.index[1, 0], "offset_mapping" = #stencil.index[0, 1]} : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
+// CHECK-NEXT:       %6 = "csl_stencil.access"(%3) {"offset" = #stencil.index[-1, 0], "offset_mapping" = #stencil.index[0, 1]} : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
+// CHECK-NEXT:       %7 = "stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-NEXT:       %8 = "stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-NEXT:       %9 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %10 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %11 = "csl_stencil.access"(%3) {"offset" = #stencil.index[0, 1], "offset_mapping" = #stencil.index[0, 1]} : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
+// CHECK-NEXT:       %12 = "csl_stencil.access"(%3) {"offset" = #stencil.index[0, -1], "offset_mapping" = #stencil.index[0, 1]} : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
+// CHECK-NEXT:       %13 = "arith.addf"(%12, %11) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %14 = "arith.addf"(%13, %10) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %15 = "arith.addf"(%14, %9) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %16 = "arith.addf"(%15, %6) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %17 = "arith.addf"(%16, %5) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %18 = "tensor.empty"() : () -> tensor<510xf32>
+// CHECK-NEXT:       %19 = "linalg.fill"(%4, %18) <{"operandSegmentSizes" = array<i32: 1, 1>}> : (f32, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %20 = "arith.mulf"(%17, %19) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       "stencil.return"(%20) : (tensor<510xf32>) -> ()
+// CHECK-NEXT:     }) : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, memref<4xtensor<510xf32>>) -> !stencil.temp<[0,1]x[0,1]xtensor<510xf32>>
+// CHECK-NEXT:     "stencil.store"(%1, %b) {"bounds" = #stencil.bounds[0, 0] : [1, 1]} : (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()
+// CHECK-NEXT:     "func.return"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/csl/stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/dialects/csl/stencil-to-csl-stencil.mlir
@@ -1,0 +1,63 @@
+// RUN: xdsl-opt %s -p "stencil-to-csl-stencil" | filecheck %s
+
+builtin.module {
+  func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
+    %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+    "dmp.swap"(%0) {"topo" = #dmp.topo<1022x510>, "swaps" = [#dmp.exchange<at [1, 0, 0] size [1, 1, 510] source offset [-1, 0, 0] to [1, 0, 0]>, #dmp.exchange<at [-1, 0, 0] size [1, 1, 510] source offset [1, 0, 0] to [-1, 0, 0]>, #dmp.exchange<at [0, 1, 0] size [1, 1, 510] source offset [0, -1, 0] to [0, 1, 0]>, #dmp.exchange<at [0, -1, 0] size [1, 1, 510] source offset [0, 1, 0] to [0, -1, 0]>]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> ()
+    %1 = stencil.apply(%2 = %0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) {
+      %3 = arith.constant 1.666600e-01 : f32
+      %4 = stencil.access %2[1, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %5 = "tensor.extract_slice"(%4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %6 = stencil.access %2[-1, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %7 = "tensor.extract_slice"(%6) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %8 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %9 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %10 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %11 = "tensor.extract_slice"(%10) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %12 = stencil.access %2[0, 1] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %13 = "tensor.extract_slice"(%12) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %14 = stencil.access %2[0, -1] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %15 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %16 = arith.addf %15, %13 : tensor<510xf32>
+      %17 = arith.addf %16, %11 : tensor<510xf32>
+      %18 = arith.addf %17, %9 : tensor<510xf32>
+      %19 = arith.addf %18, %7 : tensor<510xf32>
+      %20 = arith.addf %19, %5 : tensor<510xf32>
+      %21 = tensor.empty() : tensor<510xf32>
+      %22 = linalg.fill ins(%3 : f32) outs(%21 : tensor<510xf32>) -> tensor<510xf32>
+      %23 = arith.mulf %20, %22 : tensor<510xf32>
+      stencil.return %23 : tensor<510xf32>
+    }
+    stencil.store %1 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    func.return
+  }
+}
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
+// CHECK-NEXT:     %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:     %1 = "csl_stencil.prefetch"(%0) <{"size" = 510 : i64, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
+// CHECK-NEXT:     %2 = stencil.apply(%3 = %0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %4 = %1 : memref<4xtensor<510xf32>>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) {
+// CHECK-NEXT:       %5 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:       %6 = csl_stencil.access %4[1, 0] : memref<4xtensor<510xf32>>
+// CHECK-NEXT:       %7 = csl_stencil.access %4[-1, 0] : memref<4xtensor<510xf32>>
+// CHECK-NEXT:       %8 = stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %9 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %10 = stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %11 = "tensor.extract_slice"(%10) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %12 = csl_stencil.access %4[0, 1] : memref<4xtensor<510xf32>>
+// CHECK-NEXT:       %13 = csl_stencil.access %4[0, -1] : memref<4xtensor<510xf32>>
+// CHECK-NEXT:       %14 = arith.addf %13, %12 : tensor<510xf32>
+// CHECK-NEXT:       %15 = arith.addf %14, %11 : tensor<510xf32>
+// CHECK-NEXT:       %16 = arith.addf %15, %9 : tensor<510xf32>
+// CHECK-NEXT:       %17 = arith.addf %16, %7 : tensor<510xf32>
+// CHECK-NEXT:       %18 = arith.addf %17, %6 : tensor<510xf32>
+// CHECK-NEXT:       %19 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:       %20 = linalg.fill ins(%5 : f32) outs(%19 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %21 = arith.mulf %18, %20 : tensor<510xf32>
+// CHECK-NEXT:       stencil.return %21 : tensor<510xf32>
+// CHECK-NEXT:     }
+// CHECK-NEXT:     stencil.store %2 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -61,6 +61,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return CSL
 
+    def get_csl_stencil():
+        from xdsl.dialects.csl_.csl_stencil import CSL_STENCIL
+
+        return CSL_STENCIL
+
     def get_dmp():
         from xdsl.dialects.experimental.dmp import DMP
 
@@ -273,6 +278,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "cmath": get_cmath,
         "comb": get_comb,
         "csl": get_csl,
+        "csl_stencil": get_csl_stencil,
         "dmp": get_dmp,
         "fir": get_fir,
         "fsm": get_fsm,

--- a/xdsl/dialects/csl_/csl_stencil.py
+++ b/xdsl/dialects/csl_/csl_stencil.py
@@ -1,0 +1,270 @@
+from collections.abc import Sequence
+from itertools import pairwise
+from typing import Annotated, cast
+
+from xdsl.dialects import builtin, memref, stencil
+from xdsl.dialects.builtin import IntegerAttr, IntegerType, TensorType
+from xdsl.dialects.experimental import dmp
+from xdsl.ir import Attribute, Dialect, Operation, ParametrizedAttribute, SSAValue
+from xdsl.irdl import (
+    ConstraintVar,
+    IRDLOperation,
+    Operand,
+    ParameterDef,
+    attr_def,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    opt_attr_def,
+    opt_prop_def,
+    prop_def,
+    result_def,
+)
+from xdsl.parser import AttrParser, Parser
+from xdsl.printer import Printer
+from xdsl.traits import HasAncestor, Pure
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
+
+
+@irdl_attr_definition
+class ExchangeDeclarationAttr(ParametrizedAttribute):
+    """
+    A simplified version of dmp.exchange, from which it should be lowered
+    """
+
+    name = "csl_stencil.exchange"
+
+    neighbor_: ParameterDef[builtin.DenseArrayBase]
+
+    def __init__(
+        self,
+        neighbor: Sequence[int],
+    ):
+        data_type = builtin.i64
+        super().__init__(
+            [
+                builtin.DenseArrayBase.from_list(data_type, neighbor),
+            ]
+        )
+
+    @classmethod
+    def from_dmp_exch_decl_attr(cls, src: dmp.ExchangeDeclarationAttr):
+        return cls(src.neighbor)
+
+    @property
+    def neighbor(self) -> tuple[int, ...]:
+        data = self.neighbor_.as_tuple()
+        assert isa(data, tuple[int, ...])
+        return data
+
+    def print_parameters(self, printer: Printer) -> None:
+        printer.print_string(f"<to {list(self.neighbor)}>")
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> list[Attribute]:
+        parser.parse_characters("<")
+        parser.parse_characters("to")
+        to = parser.parse_comma_separated_list(
+            parser.Delimiter.SQUARE, parser.parse_integer
+        )
+        parser.parse_characters(">")
+
+        return [builtin.DenseArrayBase.from_list(builtin.i64, to)]
+
+
+@irdl_op_definition
+class PrefetchOp(IRDLOperation):
+    """
+    An op to indicate buffer prefetches.
+    """
+
+    name = "csl_stencil.prefetch"
+
+    input_stencil: Operand = operand_def(
+        stencil.TempType[Attribute] | memref.MemRefType[Attribute]
+    )
+
+    swaps: builtin.ArrayAttr[ExchangeDeclarationAttr] | None = opt_prop_def(
+        builtin.ArrayAttr[ExchangeDeclarationAttr]
+    )
+
+    size = prop_def(IntegerAttr[IntegerType])
+
+    topo: dmp.RankTopoAttr | None = opt_prop_def(dmp.RankTopoAttr)
+
+    result = result_def(memref.MemRefType)
+
+    def __init__(
+        self,
+        input_stencil: SSAValue | Operation,
+        size: IntegerAttr[IntegerType],
+        topo: dmp.RankTopoAttr | None = None,
+        swaps: Sequence[ExchangeDeclarationAttr] = [],
+        result_type: memref.MemRefType[Attribute] | None = None,
+    ):
+        # if result_type is None:
+        #
+        #     result_type = builtin.TensorType()
+        super().__init__(
+            operands=[input_stencil],
+            properties={"size": size, "topo": topo, "swaps": builtin.ArrayAttr(swaps)},
+            result_types=[result_type],
+        )
+
+
+@irdl_op_definition
+class AccessOp(IRDLOperation):
+    """
+    A CSL stencil access that operates on data prefetched by `csl_stencil.prefetch`
+    """
+
+    T = Annotated[Attribute, ConstraintVar("T")]
+
+    name = "csl_stencil.access"
+    op: Operand = operand_def(memref.MemRefType)
+    offset: stencil.IndexAttr = attr_def(stencil.IndexAttr)
+    offset_mapping = opt_attr_def(stencil.IndexAttr)
+    result = result_def(TensorType)
+
+    traits = frozenset([HasAncestor(stencil.ApplyOp), Pure()])
+
+    def __init__(
+        self,
+        op: Operand,
+        offset: stencil.IndexAttr,
+        result_type: TensorType[Attribute],
+        offset_mapping: stencil.IndexAttr | None = None,
+    ):
+        super().__init__(
+            operands=[op],
+            attributes={"offset": offset, "offset_mapping": offset_mapping},
+            result_types=[result_type],
+        )
+
+    def print(self, printer: Printer):
+        printer.print(" ")
+        printer.print_operand(self.op)
+        printer.print_op_attributes(
+            self.attributes,
+            reserved_attr_names={"offset", "offset_mapping"},
+            print_keyword=True,
+        )
+
+        mapping = self.offset_mapping
+        if mapping is None:
+            mapping = range(len(self.offset))
+        offset = list(self.offset)
+
+        printer.print("[")
+        index = 0
+        for i in range(len(self.offset)):
+            if i in mapping:
+                printer.print(offset[index])
+                index += 1
+            else:
+                printer.print("_")
+            if i != len(self.offset) - 1:
+                printer.print(", ")
+        printer.print("]")
+
+        printer.print_string(" : ")
+        printer.print_attribute(self.op.type)
+
+    @classmethod
+    def parse(cls, parser: Parser):
+        temp = parser.parse_operand()
+
+        index = 0
+        offset = list[int]()
+        offset_mapping = list[int]()
+        parser.parse_punctuation("[")
+        while True:
+            o = parser.parse_optional_integer()
+            if o is None:
+                parser.parse_characters("_")
+            else:
+                offset.append(o)
+                offset_mapping.append(index)
+            if parser.parse_optional_punctuation("]"):
+                break
+            parser.parse_punctuation(",")
+            index += 1
+
+        attrs = parser.parse_optional_attr_dict_with_keyword(
+            {"offset", "offset_mapping"}
+        )
+        attrs = attrs.data if attrs else dict[str, Attribute]()
+        attrs["offset"] = stencil.IndexAttr.get(*offset)
+        if offset_mapping:
+            attrs["offset_mapping"] = stencil.IndexAttr.get(*offset_mapping)
+        parser.parse_punctuation(":")
+        res_type = parser.parse_attribute()
+        if not isa(res_type, memref.MemRefType[Attribute]):
+            parser.raise_error("Expected return type to be a memref")
+        return cls.build(
+            operands=[temp], result_types=[res_type.element_type], attributes=attrs
+        )
+
+    def verify_(self) -> None:
+        assert isa(self.op.type, memref.MemRefType[Attribute])
+        assert self.result.type == self.op.type.get_element_type()
+
+        # As promised by HasAncestor(ApplyOp)
+        trait = cast(HasAncestor, AccessOp.get_trait(HasAncestor, (stencil.ApplyOp,)))
+        apply = trait.get_ancestor(self)
+        assert isinstance(apply, stencil.ApplyOp)
+
+        # TODO This should be handled by infra, having a way to verify things on ApplyOp
+        # **before** its children.
+        # cf https://github.com/xdslproject/xdsl/issues/1112
+        apply.verify_()
+
+        if self.offset_mapping is not None and len(self.offset_mapping) != len(
+            self.offset
+        ):
+            raise VerifyException(
+                f"Expected stencil.access offset mapping be of length {len(self.offset)} "
+                f"to match the provided offsets, but it is {len(self.offset_mapping)} "
+                f"instead"
+            )
+
+        if self.offset_mapping is not None:
+            prev_offset = None
+            for prev_offset, offset in pairwise(self.offset_mapping):
+                if prev_offset >= offset:
+                    raise VerifyException(
+                        "Offset mapping in stencil.access must be strictly increasing."
+                        "increasing"
+                    )
+            for offset in self.offset_mapping:
+                if offset >= apply.get_rank():
+                    raise VerifyException(
+                        f"Offset mappings in stencil.access must be within the rank of the "
+                        f"apply, got {offset} >= {apply.get_rank()}"
+                    )
+
+    def get_apply(self):
+        """
+        Simple helper to get the parent apply and raise otherwise.
+        """
+        trait = cast(HasAncestor, self.get_trait(HasAncestor, (stencil.ApplyOp,)))
+        ancestor = trait.get_ancestor(self)
+        if ancestor is None:
+            raise ValueError(
+                "stencil.apply not found, this function should be called on"
+                "verified accesses only."
+            )
+        return cast(stencil.ApplyOp, ancestor)
+
+
+CSL_STENCIL = Dialect(
+    "csl_stencil",
+    [
+        PrefetchOp,
+        AccessOp,
+    ],
+    [
+        ExchangeDeclarationAttr,
+    ],
+)

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -293,6 +293,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return stencil_tensorize_z_dimension.StencilTensorizeZDimension
 
+    def get_stencil_to_csl_stencil():
+        from xdsl.transforms.experimental import stencil_to_csl_stencil
+
+        return stencil_to_csl_stencil.StencilToCslStencilPass
+
     def get_stencil_unroll():
         from xdsl.transforms import stencil_unroll
 
@@ -359,6 +364,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "stencil-shape-inference": get_stencil_shape_inference,
         "stencil-storage-materialization": get_stencil_storage_materialization,
         "stencil-tensorize-z-dimension": get_stencil_tensorize_z_dimension,
+        "stencil-to-csl-stencil": get_stencil_to_csl_stencil,
         "stencil-unroll": get_stencil_unroll,
         "test-lower-snitch-stream-to-asm": get_test_lower_snitch_stream_to_asm,
     }

--- a/xdsl/transforms/experimental/stencil_to_csl_stencil.py
+++ b/xdsl/transforms/experimental/stencil_to_csl_stencil.py
@@ -1,0 +1,160 @@
+from collections.abc import Sequence
+
+from attr import dataclass
+
+from xdsl.context import MLContext
+from xdsl.dialects import memref, stencil, tensor
+from xdsl.dialects.builtin import IntegerAttr, IntegerType, ModuleOp, TensorType
+from xdsl.dialects.csl_ import csl_stencil
+from xdsl.dialects.experimental import dmp
+from xdsl.ir import Attribute, OpResult
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.utils.hints import isa
+
+
+@dataclass(frozen=True)
+class ApplyOpAddPrefetch(RewritePattern):
+
+    prefetch_op: csl_stencil.PrefetchOp
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: stencil.ApplyOp, rewriter: PatternRewriter, /):
+
+        pass
+
+
+@dataclass(frozen=True)
+class AccessOpFromPrefetch(RewritePattern):
+
+    # index of the stencil access to be replaced by the prefetched buffer in the last arg
+    arg_index: int
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: stencil.AccessOp, rewriter: PatternRewriter, /):
+        assert len(op.offset) == 2
+        if tuple(op.offset) == (0, 0):
+            return
+        prefetched_arg = op.get_apply().region.block.args[-1]
+        assert isa(m_type := prefetched_arg.type, memref.MemRefType[Attribute])
+        assert isa(t_type := m_type.get_element_type(), TensorType[Attribute])
+
+        csl_access_op = csl_stencil.AccessOp(
+            op=prefetched_arg,
+            offset=op.offset,
+            offset_mapping=op.offset_mapping,
+            result_type=t_type,
+        )
+
+        # if the matched op is immediately followed by tensor.ExtractSliceOps to remove ghost cells, replace both
+        if len(op.res.uses) == 1 and isinstance(
+            use := list(op.res.uses)[0].operation, tensor.ExtractSliceOp
+        ):
+            rewriter.replace_op(use, csl_access_op)
+            rewriter.erase_op(op)
+        else:
+            rewriter.replace_matched_op(csl_access_op)
+
+
+@dataclass(frozen=True)
+class SwapToPrefetch(RewritePattern):
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: dmp.SwapOp, rewriter: PatternRewriter, /):
+        if op.swaps is None or len(op.swaps) == 0:
+            rewriter.erase_matched_op(False)
+            return
+        assert isinstance(op.input_stencil, OpResult)
+        # currently only works for 3-dimensional stencils
+        assert all(len(swap.size) == 3 for swap in op.swaps)
+        # dmp should decompose from (x,y,z) to (1,1,z)
+        assert all(swap.size[:2] == (1, 1) for swap in op.swaps)
+        # check that size is uniform
+        uniform_size = op.swaps.data[0].size[2]
+        assert all(swap.size[2] == uniform_size for swap in op.swaps)
+
+        assert isa(
+            op.input_stencil.type,
+            memref.MemRefType[Attribute] | stencil.TempType[Attribute],
+        )
+        assert isa(
+            t_type := op.input_stencil.type.get_element_type(), TensorType[Attribute]
+        )
+
+        # when translating swaps, remove third dimension
+        prefetch_op = csl_stencil.PrefetchOp(
+            input_stencil=op.input_stencil.op,
+            size=IntegerAttr(uniform_size, IntegerType(64)),
+            topo=op.topo,
+            swaps=[
+                csl_stencil.ExchangeDeclarationAttr(swap.neighbor[:2])
+                for swap in op.swaps
+            ],
+            result_type=memref.MemRefType(
+                TensorType(t_type.get_element_type(), (uniform_size,)),
+                (len(op.swaps),),
+            ),
+        )
+
+        # replace dmp.swap (`replace_matched_op` does not work because `prefetch` produces a result)
+        # rewriter.insert_op(prefetch_op, InsertPoint.before(op))
+
+        # a dirty hack to get around a check that prevents me from replacing a no-results op with an n-results op
+        rewriter.replace_matched_op(prefetch_op, new_results=[])
+
+        # rewrite stencil.apply
+        for use in op.input_stencil.uses:
+            if not isinstance(use.operation, stencil.ApplyOp):
+                continue
+            apply_op = use.operation
+            arg_idx = apply_op.args.index(op.input_stencil)
+
+            apply_op.region.block.insert_arg(
+                prefetch_op.result.type, len(apply_op.args)
+            )
+            r_types = [r.type for r in apply_op.results]
+            assert isa(r_types, Sequence[stencil.TempType[Attribute]])
+            new_apply_op = stencil.ApplyOp.get(
+                list(apply_op.args) + [prefetch_op.result],
+                apply_op.region.clone(),
+                r_types,
+            )
+            rewriter.replace_op(apply_op, new_apply_op)
+
+            nested_rewriter = PatternRewriteWalker(
+                GreedyRewritePatternApplier(
+                    [
+                        AccessOpFromPrefetch(arg_idx),
+                    ]
+                ),
+                walk_reverse=False,
+                apply_recursively=True,
+            )
+
+            nested_rewriter.rewrite_op(new_apply_op)
+
+        # erase dmp.swap
+        # rewriter.erase_matched_op(False)
+
+
+@dataclass(frozen=True)
+class StencilToCslStencilPass(ModulePass):
+    name = "stencil-to-csl-stencil"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        module_pass = PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    SwapToPrefetch(),
+                ]
+            ),
+            walk_reverse=False,
+            apply_recursively=False,
+        )
+        module_pass.rewrite_module(op)


### PR DESCRIPTION
Introduces an intermediate dialect with ops:
* `csl_stencil.prefetch` to indicate prefetched buffer transfers
* `csl_stencil.access` performs a `stencil.access` to a prefetched buffer

The `stencil-to-csl-stencil` transform:
* lowers `dmp.swap` to `csl_stencil.prefetch`
* adds prefetched buffers to signature of `stencil.apply`
* lowers `stencil.access` to `csl_stencil.access` iff they are accesses to prefetched buffers

For a more detailed description see the document in #2747. This PR implements Step 1 outlined there.