### PR TITLE
transformations: add qref/qssa conversions

### DIFF
--- a/tests/filecheck/transforms/convert_qref_to_qssa.mlir
+++ b/tests/filecheck/transforms/convert_qref_to_qssa.mlir
@@ -1,0 +1,25 @@
+// RUN: xdsl-opt -p convert-qref-to-qssa %s | filecheck %s
+// RUN: xdsl-opt -p convert-qref-to-qssa,convert-qssa-to-qref %s | filecheck %s --check-prefix=CHECK-ROUNDTRIP
+
+%q0, %q1 = qref.alloc<2>
+qref.h %q0
+qref.cz %q1, %q0
+qref.cnot %q1, %q0
+%0 = qref.measure %q0
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %q0, %q1 = qssa.alloc<2>
+// CHECK-NEXT:    %q0_1 = qssa.h %q0
+// CHECK-NEXT:    %q1_1, %q0_2 = qssa.cz %q1, %q0_1
+// CHECK-NEXT:    %q1_2, %q0_3 = qssa.cnot %q1_1, %q0_2
+// CHECK-NEXT:    %0 = qssa.measure %q0_3
+// CHECK-NEXT:  }
+
+// CHECK-ROUNDTRIP:       builtin.module {
+// CHECK-ROUNDTRIP-NEXT:    %q0, %q1 = qref.alloc<2>
+// CHECK-ROUNDTRIP-NEXT:    qref.h %q0
+// CHECK-ROUNDTRIP-NEXT:    qref.cz %q1, %q0
+// CHECK-ROUNDTRIP-NEXT:    qref.cnot %q1, %q0
+// CHECK-ROUNDTRIP-NEXT:    %0 = qref.measure %q0
+// CHECK-ROUNDTRIP-NEXT:  }
+

--- a/tests/filecheck/transforms/convert_qssa_to_qref.mlir
+++ b/tests/filecheck/transforms/convert_qssa_to_qref.mlir
@@ -1,0 +1,25 @@
+// RUN: xdsl-opt -p convert-qssa-to-qref %s | filecheck %s
+// RUN: xdsl-opt -p convert-qssa-to-qref,convert-qref-to-qssa %s | filecheck %s --check-prefix=CHECK-ROUNDTRIP
+
+%q0, %q1 = qssa.alloc<2>
+%q2 = qssa.h %q0
+%q3, %q4 = qssa.cz %q1, %q2
+%q5, %q6 = qssa.cnot %q3, %q4
+%0 = qssa.measure %q6
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %q0, %q1 = qref.alloc<2>
+// CHECK-NEXT:    qref.h %q0
+// CHECK-NEXT:    qref.cz %q1, %q0
+// CHECK-NEXT:    qref.cnot %q1, %q0
+// CHECK-NEXT:    %0 = qref.measure %q0
+// CHECK-NEXT:  }
+
+// CHECK-ROUNDTRIP:       builtin.module {
+// CHECK-ROUNDTRIP-NEXT:    %q0, %q1 = qssa.alloc<2>
+// CHECK-ROUNDTRIP-NEXT:    %q0_1 = qssa.h %q0
+// CHECK-ROUNDTRIP-NEXT:    %q1_1, %q0_2 = qssa.cz %q1, %q0_1
+// CHECK-ROUNDTRIP-NEXT:    %q1_2, %q0_3 = qssa.cnot %q1_1, %q0_2
+// CHECK-ROUNDTRIP-NEXT:    %0 = qssa.measure %q0_3
+// CHECK-ROUNDTRIP-NEXT:  }
+

--- a/xdsl/dialects/qref.py
+++ b/xdsl/dialects/qref.py
@@ -31,10 +31,17 @@ qubit = QubitAttr()
 
 
 class QRefBase(IRDLOperation, ABC):
+    """
+    Base class for qref operations, with methods to help convert to the qssa dialect.
+
+    Invariant:
+    self.is_gate == self.ssa_op().is_gate
+    """
+
     @abstractmethod
     def ssa_op(self) -> qssa.QssaBase:
         """
-        Get corresponding qssa operation
+        Build corresponding qssa operation
         """
         raise NotImplementedError()
 
@@ -42,7 +49,10 @@ class QRefBase(IRDLOperation, ABC):
     @abstractmethod
     def is_gate(self) -> bool:
         """
-        Is this operation a gate
+        Is this operation a gate?
+        Qref gates represent standard quantum logic gates
+        They should have no results
+        The results of the generated gate must be rewired when converting to the qssa dialect
         """
         raise NotImplementedError()
 

--- a/xdsl/dialects/qref.py
+++ b/xdsl/dialects/qref.py
@@ -21,7 +21,7 @@ from xdsl.printer import Printer
 @irdl_attr_definition
 class QubitAttr(ParametrizedAttribute, TypeAttribute):
     """
-    Reference to a qubit
+    Reference to a qubit.
     """
 
     name = "qref.qubit"
@@ -41,7 +41,7 @@ class QRefBase(IRDLOperation, ABC):
     @abstractmethod
     def ssa_op(self) -> qssa.QssaBase:
         """
-        Build corresponding qssa operation
+        Build corresponding qssa operation.
         """
         raise NotImplementedError()
 
@@ -50,9 +50,9 @@ class QRefBase(IRDLOperation, ABC):
     def is_gate(self) -> bool:
         """
         Is this operation a gate?
-        Qref gates represent standard quantum logic gates
-        They should have no results
-        The results of the generated gate must be rewired when converting to the qssa dialect
+        Qref gates represent standard quantum logic gates.
+        They should have no results.
+        The results of the generated gate must be rewired when converting to the qssa dialect.
         """
         raise NotImplementedError()
 

--- a/xdsl/dialects/qssa.py
+++ b/xdsl/dialects/qssa.py
@@ -21,7 +21,7 @@ from xdsl.printer import Printer
 @irdl_attr_definition
 class QubitAttr(ParametrizedAttribute, TypeAttribute):
     """
-    Type for a single qubit
+    Type for a single qubit.
     """
 
     name = "qssa.qubit"
@@ -41,7 +41,7 @@ class QssaBase(IRDLOperation, ABC):
     @abstractmethod
     def ref_op(self) -> qref.QRefBase:
         """
-        Build corresponding qref operation
+        Build corresponding qref operation.
         """
         raise NotImplementedError()
 

--- a/xdsl/dialects/qssa.py
+++ b/xdsl/dialects/qssa.py
@@ -31,6 +31,13 @@ qubit = QubitAttr()
 
 
 class QssaBase(IRDLOperation, ABC):
+    """
+    Base class for qssa operations, with methods to help convert to the qref dialect.
+
+    Invariant:
+    self.is_gate == self.ref_op().is_gate
+    """
+
     @abstractmethod
     def ref_op(self) -> qref.QRefBase:
         """
@@ -42,11 +49,12 @@ class QssaBase(IRDLOperation, ABC):
     @abstractmethod
     def is_gate(self) -> bool:
         """
-        Is this operation a gate
+        Is this operation a gate?
+        Qssa gates represent standard quantum logic gates
+        They should have an equal number of qubit-typed operands and results
+        Their results must be rewired when converting to the qref dialect
         """
         raise NotImplementedError()
-
-    pass
 
 
 @irdl_op_definition

--- a/xdsl/dialects/qssa.py
+++ b/xdsl/dialects/qssa.py
@@ -61,16 +61,6 @@ class QssaBase(IRDLOperation, ABC):
 class QubitAllocOp(QssaBase):
     name = "qssa.alloc"
 
-    def ref_op(self) -> qref.QRefAllocOp:
-        return qref.QRefAllocOp.create(
-            result_types=[qref.qubit] * self.num_qubits,
-            attributes=self.attributes,
-        )
-
-    @property
-    def is_gate(self) -> bool:
-        return False
-
     res: VarOpResult = var_result_def(qubit)
 
     def __init__(self, num_qubits: int):
@@ -99,21 +89,20 @@ class QubitAllocOp(QssaBase):
 
         printer.print_op_attributes(self.attributes)
 
-
-@irdl_op_definition
-class HGateOp(QssaBase):
-    name = "qssa.h"
-
-    def ref_op(self) -> qref.HGateOp:
-        return qref.HGateOp.create(
-            operands=self.operands,
-            result_types=(),
+    def ref_op(self) -> qref.QRefAllocOp:
+        return qref.QRefAllocOp.create(
+            result_types=[qref.qubit] * self.num_qubits,
             attributes=self.attributes,
         )
 
     @property
     def is_gate(self) -> bool:
-        return True
+        return False
+
+
+@irdl_op_definition
+class HGateOp(QssaBase):
+    name = "qssa.h"
 
     input = operand_def(qubit)
 
@@ -127,10 +116,37 @@ class HGateOp(QssaBase):
             result_types=(qubit,),
         )
 
+    def ref_op(self) -> qref.HGateOp:
+        return qref.HGateOp.create(
+            operands=self.operands,
+            result_types=(),
+            attributes=self.attributes,
+        )
+
+    @property
+    def is_gate(self) -> bool:
+        return True
+
 
 @irdl_op_definition
 class CNotGateOp(QssaBase):
     name = "qssa.cnot"
+
+    in1 = operand_def(qubit)
+
+    in2 = operand_def(qubit)
+
+    out1 = result_def(qubit)
+
+    out2 = result_def(qubit)
+
+    assembly_format = "$in1 `,` $in2 attr-dict"
+
+    def __init__(self, in1: SSAValue, in2: SSAValue):
+        super().__init__(
+            operands=(in1, in2),
+            result_types=(qubit, qubit),
+        )
 
     def ref_op(self) -> qref.CNotGateOp:
         return qref.CNotGateOp.create(
@@ -143,6 +159,11 @@ class CNotGateOp(QssaBase):
     def is_gate(self) -> bool:
         return True
 
+
+@irdl_op_definition
+class CZGateOp(QssaBase):
+    name = "qssa.cz"
+
     in1 = operand_def(qubit)
 
     in2 = operand_def(qubit)
@@ -158,11 +179,6 @@ class CNotGateOp(QssaBase):
             operands=(in1, in2),
             result_types=(qubit, qubit),
         )
-
-
-@irdl_op_definition
-class CZGateOp(QssaBase):
-    name = "qssa.cz"
 
     def ref_op(self) -> qref.CZGateOp:
         return qref.CZGateOp.create(
@@ -175,37 +191,10 @@ class CZGateOp(QssaBase):
     def is_gate(self) -> bool:
         return True
 
-    in1 = operand_def(qubit)
-
-    in2 = operand_def(qubit)
-
-    out1 = result_def(qubit)
-
-    out2 = result_def(qubit)
-
-    assembly_format = "$in1 `,` $in2 attr-dict"
-
-    def __init__(self, in1: SSAValue, in2: SSAValue):
-        super().__init__(
-            operands=(in1, in2),
-            result_types=(qubit, qubit),
-        )
-
 
 @irdl_op_definition
 class MeasureOp(QssaBase):
     name = "qssa.measure"
-
-    def ref_op(self) -> qref.MeasureOp:
-        return qref.MeasureOp.create(
-            operands=self.operands,
-            result_types=(IntegerType(1),),
-            attributes=self.attributes,
-        )
-
-    @property
-    def is_gate(self) -> bool:
-        return False
 
     input = operand_def(qubit)
 
@@ -218,6 +207,17 @@ class MeasureOp(QssaBase):
             operands=[input],
             result_types=[IntegerType(1)],
         )
+
+    def ref_op(self) -> qref.MeasureOp:
+        return qref.MeasureOp.create(
+            operands=self.operands,
+            result_types=(IntegerType(1),),
+            attributes=self.attributes,
+        )
+
+    @property
+    def is_gate(self) -> bool:
+        return False
 
 
 QSSA = Dialect(

--- a/xdsl/dialects/qssa.py
+++ b/xdsl/dialects/qssa.py
@@ -50,9 +50,9 @@ class QssaBase(IRDLOperation, ABC):
     def is_gate(self) -> bool:
         """
         Is this operation a gate?
-        Qssa gates represent standard quantum logic gates
-        They should have an equal number of qubit-typed operands and results
-        Their results must be rewired when converting to the qref dialect
+        Qssa gates represent standard quantum logic gates.
+        They should have an equal number of qubit-typed operands and results.
+        Their results must be rewired when converting to the qref dialect.
         """
         raise NotImplementedError()
 

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -236,6 +236,16 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return convert_print_format_to_riscv_debug.ConvertPrintFormatToRiscvDebugPass
 
+    def get_convert_qref_to_qssa():
+        from xdsl.transforms import convert_qref_to_qssa
+
+        return convert_qref_to_qssa.ConvertQRefToQssa
+
+    def get_convert_qssa_to_qref():
+        from xdsl.transforms import convert_qssa_to_qref
+
+        return convert_qssa_to_qref.ConvertQssaToQRef
+
     def get_scf_parallel_loop_tiling():
         from xdsl.transforms import scf_parallel_loop_tiling
 
@@ -324,6 +334,8 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "convert-onnx-to-linalg": get_convert_onnx_to_linalg,
         "convert-memref-stream-to-snitch": get_convert_memref_stream_to_snitch,
         "convert-print-format-to-riscv-debug": get_convert_print_format_to_riscv_debug,
+        "convert-qref-to-qssa": get_convert_qref_to_qssa,
+        "convert-qssa-to-qref": get_convert_qssa_to_qref,
         "convert-riscv-scf-for-to-frep": get_convert_riscv_scf_for_to_frep,
         "convert-riscv-scf-to-riscv-cf": get_convert_riscv_scf_to_riscv_cf,
         "convert-scf-to-openmp": get_convert_scf_to_openmp,

--- a/xdsl/transforms/convert_qref_to_qssa.py
+++ b/xdsl/transforms/convert_qref_to_qssa.py
@@ -13,9 +13,9 @@ from xdsl.pattern_rewriter import (
 
 class ConvertQRefToQssaPattern(RewritePattern):
     """
-    Replaces a qref operation by its qssa counterpart
+    Replaces a qref operation by its qssa counterpart.
     If the operation is a gate, then subsequent uses of its operands should instead be given
-    the results of the new operation
+    the results of the new operation.
     """
 
     @op_type_rewrite_pattern
@@ -45,8 +45,8 @@ class ConvertQRefToQssaPattern(RewritePattern):
 
 class ConvertQRefToQssa(ModulePass):
     """
-    Converts uses of the qref dialect to the qssa dialect in a module
-    Inverse to the "convert-qssa-to-qref" pass
+    Converts uses of the qref dialect to the qssa dialect in a module.
+    Inverse to the "convert-qssa-to-qref" pass.
     """
 
     name = "convert-qref-to-qssa"

--- a/xdsl/transforms/convert_qref_to_qssa.py
+++ b/xdsl/transforms/convert_qref_to_qssa.py
@@ -1,0 +1,46 @@
+from xdsl.context import MLContext
+from xdsl.dialects import builtin
+from xdsl.dialects.qref import QRefBase
+from xdsl.dialects.qssa import QssaBase
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class QRefToQssaRewritePattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: QRefBase, rewriter: PatternRewriter):
+        # Create replacement operation
+        new_op: QssaBase = op.ssa_op()
+        # For gates there are no results to replace
+        new_results = () if new_op.is_gate else new_op.results
+
+        rewriter.replace_matched_op(new_op, new_results)
+
+        if not new_op.is_gate:
+            return
+
+        # For gates we replace any other occurences of the original operands
+        # with the results of the new operation
+
+        old_operands = tuple(new_op.operands)
+
+        # We do this by replacing all uses of the operand...
+        for operand, result in zip(op.operands, new_op.results):
+            operand.replace_by(result)
+
+        # and then resetting the operands of the new operation
+        new_op.operands = old_operands
+
+
+class ConvertQRefToQssa(ModulePass):
+    name = "convert-qref-to-qssa"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            QRefToQssaRewritePattern(), apply_recursively=False
+        ).rewrite_op(op)

--- a/xdsl/transforms/convert_qref_to_qssa.py
+++ b/xdsl/transforms/convert_qref_to_qssa.py
@@ -11,7 +11,7 @@ from xdsl.pattern_rewriter import (
 )
 
 
-class QRefToQssaRewritePattern(RewritePattern):
+class ConvertQRefToQssaPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: QRefBase, rewriter: PatternRewriter):
         # Create replacement operation
@@ -42,5 +42,5 @@ class ConvertQRefToQssa(ModulePass):
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
         PatternRewriteWalker(
-            QRefToQssaRewritePattern(), apply_recursively=False
+            ConvertQRefToQssaPattern(), apply_recursively=False
         ).rewrite_op(op)

--- a/xdsl/transforms/convert_qref_to_qssa.py
+++ b/xdsl/transforms/convert_qref_to_qssa.py
@@ -12,6 +12,12 @@ from xdsl.pattern_rewriter import (
 
 
 class ConvertQRefToQssaPattern(RewritePattern):
+    """
+    Replaces a qref operation by its qssa counterpart
+    If the operation is a gate, then subsequent uses of its operands should instead be given
+    the results of the new operation
+    """
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: QRefBase, rewriter: PatternRewriter):
         # Create replacement operation
@@ -38,6 +44,11 @@ class ConvertQRefToQssaPattern(RewritePattern):
 
 
 class ConvertQRefToQssa(ModulePass):
+    """
+    Converts uses of the qref dialect to the qssa dialect in a module
+    Inverse to the "convert-qssa-to-qref" pass
+    """
+
     name = "convert-qref-to-qssa"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:

--- a/xdsl/transforms/convert_qssa_to_qref.py
+++ b/xdsl/transforms/convert_qssa_to_qref.py
@@ -1,0 +1,26 @@
+from xdsl.context import MLContext
+from xdsl.dialects import builtin
+from xdsl.dialects.qssa import QssaBase
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class QssaToQRefRewritePattern(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: QssaBase, rewriter: PatternRewriter):
+        # For gates the results of the original operation should be replaced by its operands
+        new_results = op.operands if op.is_gate else None
+
+        rewriter.replace_matched_op(op.ref_op(), new_results)
+
+
+class ConvertQssaToQRef(ModulePass):
+    name = "convert-qssa-to-qref"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(QssaToQRefRewritePattern()).rewrite_op(op)

--- a/xdsl/transforms/convert_qssa_to_qref.py
+++ b/xdsl/transforms/convert_qssa_to_qref.py
@@ -11,6 +11,11 @@ from xdsl.pattern_rewriter import (
 
 
 class ConvertQssaToQRefPattern(RewritePattern):
+    """
+    Replaces a qssa operation by its qref counterpart
+    Must rewire the results of the original operation if it is a gate
+    """
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: QssaBase, rewriter: PatternRewriter):
         # For gates the results of the original operation should be replaced by its operands
@@ -20,6 +25,11 @@ class ConvertQssaToQRefPattern(RewritePattern):
 
 
 class ConvertQssaToQRef(ModulePass):
+    """
+    Converts uses of the qssa dialect to the qref dialect in a module
+    Inverse to the "convert-qref-to-qssa" pass
+    """
+
     name = "convert-qssa-to-qref"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:

--- a/xdsl/transforms/convert_qssa_to_qref.py
+++ b/xdsl/transforms/convert_qssa_to_qref.py
@@ -10,7 +10,7 @@ from xdsl.pattern_rewriter import (
 )
 
 
-class QssaToQRefRewritePattern(RewritePattern):
+class ConvertQssaToQRefPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: QssaBase, rewriter: PatternRewriter):
         # For gates the results of the original operation should be replaced by its operands
@@ -23,4 +23,4 @@ class ConvertQssaToQRef(ModulePass):
     name = "convert-qssa-to-qref"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        PatternRewriteWalker(QssaToQRefRewritePattern()).rewrite_op(op)
+        PatternRewriteWalker(ConvertQssaToQRefPattern()).rewrite_op(op)

--- a/xdsl/transforms/convert_qssa_to_qref.py
+++ b/xdsl/transforms/convert_qssa_to_qref.py
@@ -12,8 +12,8 @@ from xdsl.pattern_rewriter import (
 
 class ConvertQssaToQRefPattern(RewritePattern):
     """
-    Replaces a qssa operation by its qref counterpart
-    Must rewire the results of the original operation if it is a gate
+    Replaces a qssa operation by its qref counterpart.
+    Must rewire the results of the original operation if it is a gate.
     """
 
     @op_type_rewrite_pattern
@@ -26,8 +26,8 @@ class ConvertQssaToQRefPattern(RewritePattern):
 
 class ConvertQssaToQRef(ModulePass):
     """
-    Converts uses of the qssa dialect to the qref dialect in a module
-    Inverse to the "convert-qref-to-qssa" pass
+    Converts uses of the qssa dialect to the qref dialect in a module.
+    Inverse to the "convert-qref-to-qssa" pass.
     """
 
     name = "convert-qssa-to-qref"


### PR DESCRIPTION
Built on top of #2768 

Adds two passes which convert back and forth between the qssa and qref dialects. Also adds filecheck tests that test each pass and roundtrip of the passes

I think the `convert-qref-to-qssa` is particularly hacky, with the saving the old operands of the operation into a tuple, running replace on the operands and then inserting back the old ones. Would be keen to hear better ways to achieve the same behaviour
