### PR TITLE
dialects: (memref) canonicalize removes unused memref allocs

### DIFF
--- a/tests/filecheck/dialects/memref/canonicalize.mlir
+++ b/tests/filecheck/dialects/memref/canonicalize.mlir
@@ -12,7 +12,7 @@ memref.dealloc %alloc0 : memref<1xf64>
 memref.dealloc %alloc1 : memref<2xf64>
 // CHECK-NEXT:    %alloc1 = memref.alloc() : memref<2xf64>
 // CHECK-NEXT:    "test.op"(%alloc1) : (memref<2xf64>) -> ()
-// CHECK-NEXT:    memref.dealloc alloc1 : memref<2xf64>
+// CHECK-NEXT:    memref.dealloc %alloc1 : memref<2xf64>
 
 
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/memref/canonicalize.mlir
+++ b/tests/filecheck/dialects/memref/canonicalize.mlir
@@ -1,0 +1,18 @@
+// RUN: xdsl-opt -p canonicalize %s | filecheck %s
+
+// CHECK:       builtin.module {
+
+
+%alloc0 = memref.alloc() : memref<1xf64>
+%alloc1 = memref.alloc() : memref<2xf64>
+
+"test.op"(%alloc1) : (memref<2xf64>) -> ()
+
+memref.dealloc %alloc0 : memref<1xf64>
+memref.dealloc %alloc1 : memref<2xf64>
+// CHECK-NEXT:    %alloc1 = memref.alloc() : memref<2xf64>
+// CHECK-NEXT:    "test.op"(%alloc1) : (memref<2xf64>) -> ()
+// CHECK-NEXT:    memref.dealloc alloc1 : memref<2xf64>
+
+
+// CHECK-NEXT:  }

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -135,6 +135,15 @@ class Store(IRDLOperation):
         return cls(operands=[value, ref, indices])
 
 
+class AllocOpHasCanonicalizationPatterns(HasCanonicalisationPatternsTrait):
+
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.memref import ElideUnusedAlloc
+
+        return (ElideUnusedAlloc(),)
+
+
 @irdl_op_definition
 class Alloc(IRDLOperation):
     name = "memref.alloc"
@@ -148,6 +157,8 @@ class Alloc(IRDLOperation):
     alignment: AnyIntegerAttr | None = opt_prop_def(AnyIntegerAttr)
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    traits = frozenset((AllocOpHasCanonicalizationPatterns(),))
 
     def __init__(
         self,

--- a/xdsl/transforms/canonicalization_patterns/memref.py
+++ b/xdsl/transforms/canonicalization_patterns/memref.py
@@ -67,3 +67,13 @@ class MemrefSubviewOfSubviewFolding(RewritePattern):
                 return
 
         rewriter.replace_matched_op(new_op)
+
+
+class ElideUnusedAlloc(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: memref.Alloc, rewriter: PatternRewriter, /):
+        if len(op.memref.uses) == 1 and isinstance(
+            only_use := tuple(op.memref.uses)[0].operation, memref.Dealloc
+        ):
+            rewriter.erase_op(only_use)
+            rewriter.erase_matched_op()


### PR DESCRIPTION
We need to add this to remove the bogus empty tensor used solely for its shape in linalg pools