### PR TITLE
(minor): allow csl_stencil.access to operate on own data

### DIFF
--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -9,8 +9,8 @@ builtin.module {
       %4 = arith.constant 1.666600e-01 : f32
       %5 = csl_stencil.access %3[1, 0] : memref<4xtensor<510xf32>>
       %6 = csl_stencil.access %3[-1, 0] : memref<4xtensor<510xf32>>
-      %7 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %8 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %7 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %8 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
       %9 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
       %10 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
       %11 = csl_stencil.access %3[0, 1] : memref<4xtensor<510xf32>>
@@ -38,8 +38,8 @@ builtin.module {
 // CHECK-NEXT:       %4 = arith.constant 1.666600e-01 : f32
 // CHECK-NEXT:       %5 = csl_stencil.access %3[1, 0] : memref<4xtensor<510xf32>>
 // CHECK-NEXT:       %6 = csl_stencil.access %3[-1, 0] : memref<4xtensor<510xf32>>
-// CHECK-NEXT:       %7 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %8 = stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %7 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %8 = csl_stencil.access %2[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %9 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %10 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %11 = csl_stencil.access %3[0, 1] : memref<4xtensor<510xf32>>
@@ -70,8 +70,8 @@ builtin.module {
 // CHECK-GENERIC-NEXT:       %4 = "arith.constant"() <{"value" = 1.666600e-01 : f32}> : () -> f32
 // CHECK-GENERIC-NEXT:       %5 = "csl_stencil.access"(%3) <{"offset" = #stencil.index[1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %6 = "csl_stencil.access"(%3) <{"offset" = #stencil.index[-1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
-// CHECK-GENERIC-NEXT:       %7 = "stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
-// CHECK-GENERIC-NEXT:       %8 = "stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-GENERIC-NEXT:       %7 = "csl_stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-GENERIC-NEXT:       %8 = "csl_stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
 // CHECK-GENERIC-NEXT:       %9 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %10 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %11 = "csl_stencil.access"(%3) <{"offset" = #stencil.index[0, 1], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<510xf32>>) -> tensor<510xf32>

--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -70,8 +70,8 @@ builtin.module {
 // CHECK-GENERIC-NEXT:       %4 = "arith.constant"() <{"value" = 1.666600e-01 : f32}> : () -> f32
 // CHECK-GENERIC-NEXT:       %5 = "csl_stencil.access"(%3) <{"offset" = #stencil.index[1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %6 = "csl_stencil.access"(%3) <{"offset" = #stencil.index[-1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<510xf32>>) -> tensor<510xf32>
-// CHECK-GENERIC-NEXT:       %7 = "csl_stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
-// CHECK-GENERIC-NEXT:       %8 = "csl_stencil.access"(%2) {"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]} : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-GENERIC-NEXT:       %7 = "csl_stencil.access"(%2) <{"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-GENERIC-NEXT:       %8 = "csl_stencil.access"(%2) <{"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
 // CHECK-GENERIC-NEXT:       %9 = "tensor.extract_slice"(%7) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %10 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %11 = "csl_stencil.access"(%3) <{"offset" = #stencil.index[0, 1], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<510xf32>>) -> tensor<510xf32>

--- a/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
@@ -41,9 +41,9 @@ builtin.module {
 // CHECK-NEXT:       %5 = arith.constant 1.666600e-01 : f32
 // CHECK-NEXT:       %6 = csl_stencil.access %4[1, 0] : memref<4xtensor<510xf32>>
 // CHECK-NEXT:       %7 = csl_stencil.access %4[-1, 0] : memref<4xtensor<510xf32>>
-// CHECK-NEXT:       %8 = stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %8 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %9 = "tensor.extract_slice"(%8) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %10 = stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %10 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %11 = "tensor.extract_slice"(%10) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %12 = csl_stencil.access %4[0, 1] : memref<4xtensor<510xf32>>
 // CHECK-NEXT:       %13 = csl_stencil.access %4[0, -1] : memref<4xtensor<510xf32>>

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -145,7 +145,7 @@ class AccessOp(IRDLOperation):
         self,
         op: Operand,
         offset: stencil.IndexAttr,
-        result_type: TensorType[Attribute] | stencil.TempType[Attribute],
+        result_type: TensorType[Attribute],
         offset_mapping: stencil.IndexAttr | None = None,
     ):
         super().__init__(

--- a/xdsl/transforms/stencil_to_csl_stencil.py
+++ b/xdsl/transforms/stencil_to_csl_stencil.py
@@ -39,7 +39,7 @@ class ConvertAccessOpFromPrefetchPattern(RewritePattern):
 
         # translate access to own data, which operates on stencil.TempType
         if tuple(op.offset) == (0, 0):
-            assert isa(op.res.type, stencil.TempType)
+            assert isa(op.res.type, stencil.TensorType)
             rewriter.replace_matched_op(
                 csl_stencil.AccessOp(
                     op=op.temp,

--- a/xdsl/transforms/stencil_to_csl_stencil.py
+++ b/xdsl/transforms/stencil_to_csl_stencil.py
@@ -36,7 +36,10 @@ class ConvertAccessOpFromPrefetchPattern(RewritePattern):
         assert len(op.offset) == 2
         if op.temp != op.get_apply().region.block.args[self.arg_index]:
             return
+
+        # translate access to own data, which operates on stencil.TempType
         if tuple(op.offset) == (0, 0):
+            assert isa(op.res.type, stencil.TempType)
             rewriter.replace_matched_op(
                 csl_stencil.AccessOp(
                     op=op.temp,
@@ -46,6 +49,7 @@ class ConvertAccessOpFromPrefetchPattern(RewritePattern):
                 )
             )
             return
+
         prefetched_arg = op.get_apply().region.block.args[-1]
         assert isa(m_type := prefetched_arg.type, memref.MemRefType[Attribute])
         assert isa(t_type := m_type.get_element_type(), TensorType[Attribute])

--- a/xdsl/transforms/stencil_to_csl_stencil.py
+++ b/xdsl/transforms/stencil_to_csl_stencil.py
@@ -34,10 +34,17 @@ class ConvertAccessOpFromPrefetchPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: stencil.AccessOp, rewriter: PatternRewriter, /):
         assert len(op.offset) == 2
-        if (
-            tuple(op.offset) == (0, 0)
-            or op.temp != op.get_apply().region.block.args[self.arg_index]
-        ):
+        if op.temp != op.get_apply().region.block.args[self.arg_index]:
+            return
+        if tuple(op.offset) == (0, 0):
+            rewriter.replace_matched_op(
+                csl_stencil.AccessOp(
+                    op=op.temp,
+                    offset=op.offset,
+                    offset_mapping=op.offset_mapping,
+                    result_type=op.res.type,
+                )
+            )
             return
         prefetched_arg = op.get_apply().region.block.args[-1]
         assert isa(m_type := prefetched_arg.type, memref.MemRefType[Attribute])


### PR DESCRIPTION
Follow-up from #2766

The original plan was to lower `stencil.access` to `csl_stencil.access` if and only if the access is to neighbour data (i.e. prefetched), while accesses to own data were supposed to remain `stencil.access` without being lowered.

This runs into the very practical problem, that `stencil.access` can only exist within a `stencil.apply` op - which we also want to lower, but this cannot be done with `stencil.access` ops.