### PR TITLE
(dialects): csl_stencil apply op

### DIFF
--- a/tests/dialects/test_csl_stencil.py
+++ b/tests/dialects/test_csl_stencil.py
@@ -41,7 +41,6 @@ def test_access_patterns():
         ],
         result_types=[tens_t],
     )
-    # apply = ApplyOp.get((temp, temp), apply_op_region.detach_block(0), [typ])
 
     r0_t0_acc, r0_t1_acc, r1_t0_acc, r1_t1_acc = tuple(apply.get_accesses())
 

--- a/tests/dialects/test_csl_stencil.py
+++ b/tests/dialects/test_csl_stencil.py
@@ -1,0 +1,57 @@
+from xdsl.builder import Builder
+from xdsl.dialects.builtin import IntegerAttr, IntegerType, MemRefType, TensorType, f32
+from xdsl.dialects.csl.csl_stencil import AccessOp, ApplyOp
+from xdsl.dialects.stencil import IndexAttr, TempType
+from xdsl.ir import Region, SSAValue
+from xdsl.utils.test_value import TestSSAValue
+
+
+def test_access_patterns():
+    temp_t = TempType(5, f32)
+    temp = TestSSAValue(temp_t)
+    mref = TestSSAValue(mref_t := MemRefType(tens_t := TensorType(f32, (5,)), (4,)))
+
+    @Builder.implicit_region((mref_t, temp_t))
+    def region0(args: tuple[SSAValue, ...]):
+        t0, t1 = args
+        for x in (-1, 1):
+            AccessOp(t0, IndexAttr.get(x, 0), tens_t)
+        for y in (-1, 1):
+            AccessOp(t0, IndexAttr.get(0, y), tens_t)
+
+        AccessOp(t1, IndexAttr.get(1, 1), tens_t)
+        AccessOp(t1, IndexAttr.get(-1, -1), tens_t)
+
+    @Builder.implicit_region((temp_t, temp_t))
+    def region1(args: tuple[SSAValue, ...]):
+        t0, t1 = args
+        AccessOp(t0, IndexAttr.get(0, 0), tens_t)
+        AccessOp(t1, IndexAttr.get(0, 0), tens_t)
+
+    apply = ApplyOp(
+        operands=[temp, mref, []],
+        properties={
+            "swaps": None,
+            "topo": None,
+            "num_chunks": IntegerAttr(1, IntegerType(64)),
+        },
+        regions=[
+            Region(region0.detach_block(0)),
+            Region(region1.detach_block(0)),
+        ],
+        result_types=[tens_t],
+    )
+    # apply = ApplyOp.get((temp, temp), apply_op_region.detach_block(0), [typ])
+
+    r0_t0_acc, r0_t1_acc, r1_t0_acc, r1_t1_acc = tuple(apply.get_accesses())
+
+    assert r0_t0_acc.visual_pattern() == " X \nXOX\n X "
+    assert r0_t1_acc.visual_pattern() == "X  \n O \n  X"
+
+    assert not r0_t0_acc.is_diagonal
+    assert r0_t1_acc.is_diagonal
+
+    assert len(tuple(r0_t1_acc.get_diagonals())) == 2
+
+    assert r1_t0_acc.visual_pattern() == "X"
+    assert r1_t1_acc.visual_pattern() == "X"

--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -30,7 +30,7 @@ builtin.module {
   }
 }
 
-// CHECK-NEXT: builtin.module {
+// CHECK:      builtin.module {
 // CHECK-NEXT:   func.func @gauss_seidel_func(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
 // CHECK-NEXT:     %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:     %pref = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
@@ -59,8 +59,7 @@ builtin.module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
-
-// CHECK-GENERIC-NEXT: "builtin.module"() ({
+// CHECK-GENERIC:      "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   "func.func"() <{"sym_name" = "gauss_seidel_func", "function_type" = (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()}> ({
 // CHECK-GENERIC-NEXT:   ^0(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
 // CHECK-GENERIC-NEXT:     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
@@ -87,6 +86,120 @@ builtin.module {
 // CHECK-GENERIC-NEXT:       "stencil.return"(%20) : (tensor<510xf32>) -> ()
 // CHECK-GENERIC-NEXT:     }) : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, memref<4xtensor<510xf32>>) -> !stencil.temp<[0,1]x[0,1]xtensor<510xf32>>
 // CHECK-GENERIC-NEXT:     "stencil.store"(%1, %b) {"bounds" = #stencil.bounds[0, 0] : [1, 1]} : (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()
+// CHECK-GENERIC-NEXT:     "func.return"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()
+
+// -----
+
+builtin.module {
+  func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
+    %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+
+    %1 = tensor.empty() : tensor<510xf32>
+    %2 = csl_stencil.apply(%3 = %0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %empty_res = %1 : tensor<510xf32>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+      ^0(%recv : memref<4xtensor<255xf32>>, %offset : index, %iter_arg : tensor<510xf32>):
+        // reduces chunks from neighbours into one chunk (clear_recv_buf_cb)
+        %4 = csl_stencil.access %recv[1, 0] : memref<4xtensor<255xf32>>
+        %5 = csl_stencil.access %recv[-1, 0] : memref<4xtensor<255xf32>>
+        %6 = csl_stencil.access %recv[0, 1] : memref<4xtensor<255xf32>>
+        %7 = csl_stencil.access %recv[0, -1] : memref<4xtensor<255xf32>>
+
+        %8 = arith.addf %4, %5 : tensor<255xf32>
+        %9 = arith.addf %8, %6 : tensor<255xf32>
+        %10 = arith.addf %9, %7 : tensor<255xf32>
+
+        %11 = "tensor.insert_slice"(%10, %iter_arg, %offset) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+        csl_stencil.yield %11 : tensor<510xf32>
+      }, {
+      ^0(%3 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv : tensor<510xf32>):
+        // takes combined chunks and applies further compute (communicate_cb)
+        %12 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+        %13 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+        %14 = "tensor.extract_slice"(%12) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+        %15 = "tensor.extract_slice"(%13) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+
+        %16 = arith.addf %rcv, %14 : tensor<510xf32>
+        %17 = arith.addf %16, %15 : tensor<510xf32>
+
+        %18 = arith.constant 1.666600e-01 : f32
+        %19 = tensor.empty() : tensor<510xf32>
+        %20 = linalg.fill ins(%18 : f32) outs(%19 : tensor<510xf32>) -> tensor<510xf32>
+        %21 = arith.mulf %17, %20 : tensor<510xf32>
+
+        csl_stencil.yield %21 : tensor<510xf32>
+      })
+
+    stencil.store %2 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    func.return
+  }
+}
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
+// CHECK-NEXT:     %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:     %1 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:     %2 = csl_stencil.apply(%3 = %0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %iter_arg = %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+// CHECK-NEXT:     ^0(%recv : memref<4xtensor<255xf32>>, %offset : index, %iter_arg : tensor<510xf32>):
+// CHECK-NEXT:       %4 = csl_stencil.access %recv[1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %5 = csl_stencil.access %recv[-1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %6 = csl_stencil.access %recv[0, 1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %7 = csl_stencil.access %recv[0, -1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %8 = arith.addf %4, %5 : tensor<255xf32>
+// CHECK-NEXT:       %9 = arith.addf %8, %6 : tensor<255xf32>
+// CHECK-NEXT:       %10 = arith.addf %9, %7 : tensor<255xf32>
+// CHECK-NEXT:       %11 = "tensor.insert_slice"(%10, %iter_arg, %offset) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield %11 : tensor<510xf32>
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:     ^1(%3 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv : tensor<510xf32>):
+// CHECK-NEXT:       %12 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %13 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %14 = "tensor.extract_slice"(%12) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %15 = "tensor.extract_slice"(%13) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %16 = arith.addf %rcv, %14 : tensor<510xf32>
+// CHECK-NEXT:       %17 = arith.addf %16, %15 : tensor<510xf32>
+// CHECK-NEXT:       %18 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:       %19 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:       %20 = linalg.fill ins(%18 : f32) outs(%19 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %21 = arith.mulf %17, %20 : tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield %21 : tensor<510xf32>
+// CHECK-NEXT:     })
+// CHECK-NEXT:     stencil.store %2 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     func.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// CHECK-GENERIC:      "builtin.module"() ({
+// CHECK-GENERIC-NEXT:   "func.func"() <{"sym_name" = "gauss_seidel", "function_type" = (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()}> ({
+// CHECK-GENERIC-NEXT:   ^0(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
+// CHECK-GENERIC-NEXT:     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-GENERIC-NEXT:     %1 = "tensor.empty"() : () -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:     %2 = "csl_stencil.apply"(%0, %1) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "num_chunks" = 2 : i64}> ({
+// CHECK-GENERIC-NEXT:     ^1(%recv : memref<4xtensor<255xf32>>, %offset : index, %iter_arg : tensor<510xf32>):
+// CHECK-GENERIC-NEXT:       %3 = "csl_stencil.access"(%recv) <{"offset" = #stencil.index[1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<255xf32>>) -> tensor<255xf32>
+// CHECK-GENERIC-NEXT:       %4 = "csl_stencil.access"(%recv) <{"offset" = #stencil.index[-1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<255xf32>>) -> tensor<255xf32>
+// CHECK-GENERIC-NEXT:       %5 = "csl_stencil.access"(%recv) <{"offset" = #stencil.index[0, 1], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<255xf32>>) -> tensor<255xf32>
+// CHECK-GENERIC-NEXT:       %6 = "csl_stencil.access"(%recv) <{"offset" = #stencil.index[0, -1], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<255xf32>>) -> tensor<255xf32>
+// CHECK-GENERIC-NEXT:       %7 = "arith.addf"(%3, %4) <{"fastmath" = #arith.fastmath<none>}> : (tensor<255xf32>, tensor<255xf32>) -> tensor<255xf32>
+// CHECK-GENERIC-NEXT:       %8 = "arith.addf"(%7, %5) <{"fastmath" = #arith.fastmath<none>}> : (tensor<255xf32>, tensor<255xf32>) -> tensor<255xf32>
+// CHECK-GENERIC-NEXT:       %9 = "arith.addf"(%8, %6) <{"fastmath" = #arith.fastmath<none>}> : (tensor<255xf32>, tensor<255xf32>) -> tensor<255xf32>
+// CHECK-GENERIC-NEXT:       %10 = "tensor.insert_slice"(%9, %iter_arg, %offset) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       "csl_stencil.yield"(%10) : (tensor<510xf32>) -> ()
+// CHECK-GENERIC-NEXT:     }, {
+// CHECK-GENERIC-NEXT:     ^2(%11 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv : tensor<510xf32>):
+// CHECK-GENERIC-NEXT:       %12 = "csl_stencil.access"(%11) <{"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-GENERIC-NEXT:       %13 = "csl_stencil.access"(%11) <{"offset" = #stencil.index[0, 0], "offset_mapping" = #stencil.index[0, 1]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<512xf32>
+// CHECK-GENERIC-NEXT:       %14 = "tensor.extract_slice"(%12) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       %15 = "tensor.extract_slice"(%13) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       %16 = "arith.addf"(%rcv, %14) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       %17 = "arith.addf"(%16, %15) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       %18 = "arith.constant"() <{"value" = 1.666600e-01 : f32}> : () -> f32
+// CHECK-GENERIC-NEXT:       %19 = "tensor.empty"() : () -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       %20 = "linalg.fill"(%18, %19) <{"operandSegmentSizes" = array<i32: 1, 1>}> : (f32, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       %21 = "arith.mulf"(%17, %20) <{"fastmath" = #arith.fastmath<none>}> : (tensor<510xf32>, tensor<510xf32>) -> tensor<510xf32>
+// CHECK-GENERIC-NEXT:       "csl_stencil.yield"(%21) : (tensor<510xf32>) -> ()
+// CHECK-GENERIC-NEXT:     }) : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, tensor<510xf32>) -> !stencil.temp<[0,1]x[0,1]xtensor<510xf32>>
+// CHECK-GENERIC-NEXT:     "stencil.store"(%2, %b) {"bounds" = #stencil.bounds[0, 0] : [1, 1]} : (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()
 // CHECK-GENERIC-NEXT:     "func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -174,7 +174,7 @@ builtin.module {
 // CHECK-GENERIC-NEXT:   ^0(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
 // CHECK-GENERIC-NEXT:     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-GENERIC-NEXT:     %1 = "tensor.empty"() : () -> tensor<510xf32>
-// CHECK-GENERIC-NEXT:     %2 = "csl_stencil.apply"(%0, %1) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "num_chunks" = 2 : i64}> ({
+// CHECK-GENERIC-NEXT:     %2 = "csl_stencil.apply"(%0, %1) <{"num_chunks" = 2 : i64, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> ({
 // CHECK-GENERIC-NEXT:     ^1(%recv : memref<4xtensor<255xf32>>, %offset : index, %iter_arg : tensor<510xf32>):
 // CHECK-GENERIC-NEXT:       %3 = "csl_stencil.access"(%recv) <{"offset" = #stencil.index[1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<255xf32>>) -> tensor<255xf32>
 // CHECK-GENERIC-NEXT:       %4 = "csl_stencil.access"(%recv) <{"offset" = #stencil.index[-1, 0], "offset_mapping" = #stencil.index[0, 1]}> : (memref<4xtensor<255xf32>>) -> tensor<255xf32>

--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -97,7 +97,7 @@ builtin.module {
     %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 
     %1 = tensor.empty() : tensor<510xf32>
-    %2 = csl_stencil.apply(%3 = %0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %empty_res = %1 : tensor<510xf32>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+    %2 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
       ^0(%recv : memref<4xtensor<255xf32>>, %offset : index, %iter_arg : tensor<510xf32>):
         // reduces chunks from neighbours into one chunk (clear_recv_buf_cb)
         %4 = csl_stencil.access %recv[1, 0] : memref<4xtensor<255xf32>>
@@ -139,21 +139,21 @@ builtin.module {
 // CHECK-NEXT:   func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
 // CHECK-NEXT:     %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:     %1 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:     %2 = csl_stencil.apply(%3 = %0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %iter_arg = %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+// CHECK-NEXT:     %2 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
 // CHECK-NEXT:     ^0(%recv : memref<4xtensor<255xf32>>, %offset : index, %iter_arg : tensor<510xf32>):
-// CHECK-NEXT:       %4 = csl_stencil.access %recv[1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %5 = csl_stencil.access %recv[-1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %6 = csl_stencil.access %recv[0, 1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %7 = csl_stencil.access %recv[0, -1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %8 = arith.addf %4, %5 : tensor<255xf32>
+// CHECK-NEXT:       %3 = csl_stencil.access %recv[1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %4 = csl_stencil.access %recv[-1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %5 = csl_stencil.access %recv[0, 1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %6 = csl_stencil.access %recv[0, -1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %7 = arith.addf %3, %4 : tensor<255xf32>
+// CHECK-NEXT:       %8 = arith.addf %7, %5 : tensor<255xf32>
 // CHECK-NEXT:       %9 = arith.addf %8, %6 : tensor<255xf32>
-// CHECK-NEXT:       %10 = arith.addf %9, %7 : tensor<255xf32>
-// CHECK-NEXT:       %11 = "tensor.insert_slice"(%10, %iter_arg, %offset) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
-// CHECK-NEXT:       csl_stencil.yield %11 : tensor<510xf32>
+// CHECK-NEXT:       %10 = "tensor.insert_slice"(%9, %iter_arg, %offset) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield %10 : tensor<510xf32>
 // CHECK-NEXT:     }, {
-// CHECK-NEXT:     ^1(%3 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv : tensor<510xf32>):
-// CHECK-NEXT:       %12 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %13 = csl_stencil.access %3[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:     ^1(%11 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %rcv : tensor<510xf32>):
+// CHECK-NEXT:       %12 = csl_stencil.access %11[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %13 = csl_stencil.access %11[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
 // CHECK-NEXT:       %14 = "tensor.extract_slice"(%12) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %15 = "tensor.extract_slice"(%13) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %16 = arith.addf %rcv, %14 : tensor<510xf32>

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -1,11 +1,21 @@
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from itertools import pairwise
 from typing import cast
 
 from xdsl.dialects import builtin, memref, stencil
-from xdsl.dialects.builtin import TensorType
+from xdsl.dialects.builtin import IndexType, IntegerAttr, TensorType
 from xdsl.dialects.experimental import dmp
-from xdsl.ir import Attribute, Dialect, Operation, ParametrizedAttribute, SSAValue
+from xdsl.dialects.utils import AbstractYieldOperation
+from xdsl.ir import (
+    Attribute,
+    Block,
+    BlockArgument,
+    Dialect,
+    Operation,
+    ParametrizedAttribute,
+    Region,
+    SSAValue,
+)
 from xdsl.irdl import (
     IRDLOperation,
     Operand,
@@ -15,11 +25,22 @@ from xdsl.irdl import (
     operand_def,
     opt_prop_def,
     prop_def,
+    region_def,
     result_def,
+    traits_def,
+    var_operand_def,
+    var_result_def,
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.traits import HasAncestor, Pure
+from xdsl.traits import (
+    HasAncestor,
+    HasParent,
+    IsolatedFromAbove,
+    IsTerminator,
+    Pure,
+    RecursiveMemoryEffect,
+)
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 
@@ -122,6 +143,248 @@ class PrefetchOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ApplyOp(IRDLOperation):
+    """
+    This operation combines a `csl_stencil.prefetch` (symmetric buffer communication across a given stencil shape)
+    with a `stencil.apply` (a stencil function plus parameters and applies the stencil function to the output temp).
+
+    As communication may be done in chunks, this operation provides two regions for computation:
+      - the `chunk_reduce` region to reduce a chunk of data received from several neighbours to one chunk of data.
+        this region is invoked once per communicated chunks and effectively acts as a loop body.
+        It uses `iter_arg` to concatenate the chunks
+      - the `post_process` region (invoked once when communication has finished) that takes the concatenated
+        chunk of the `chunk_reduce` region and applies any further processing here - for instance, it may handle
+        the computation of 'own' (non-communicated) or otherwise prefetched data
+
+    Further fields:
+      - `communicated_stencil` - the stencil to communicate (send and receive)
+      - `args`  - arguments to the stencil computation, may include other prefetched buffers
+      - `topo`  - as received from `csl_stencil.prefetch`/`dmp.swap`
+      - `swaps` - a set of neighbouring points in the stencil, whose value we wish to retain
+                  (note, these are not guaranteed to be lowered as true point-to-point communication, and
+                  redundant communication should be irgnored)
+
+    Function signatures:
+    Before lowering (from `csl_stencil.prefetch` and `stencil.apply`):
+        %pref = csl_stencil.prefetch(%communicated_stencil : stencil.Temp)
+        stencil.apply( ..some args.. , %communicated_stencil, ..some more args.., %pref)
+
+    After lowering:
+        op:             csl_stencil.apply(%communicated_stencil, %iter_arg, chunk_reduce_args..., post_process_args...)
+        chunk_reduce:   block_args(slice of type(%pref), %offset, %iter_arg, args...)
+        post_process:   block_args(%communicated_stencil, %iter_arg, args...)
+
+    Note, that %pref can be dropped (as communication is done by the op rather than before the op),
+    and that a new %iter_arg is required, an empty tensor which is filled by `chunk_reduce` and
+    consumed by `post_process`
+    """
+
+    name = "csl_stencil.apply"
+
+    communicated_stencil = operand_def(
+        stencil.TempType[Attribute] | memref.MemRefType[Attribute]
+    )
+
+    iter_arg = operand_def(TensorType[Attribute])
+
+    args = var_operand_def(Attribute)
+
+    chunk_reduce = region_def()
+    post_process = region_def()
+
+    swaps = prop_def(builtin.ArrayAttr[ExchangeDeclarationAttr])
+
+    topo = opt_prop_def(dmp.RankTopoAttr)
+
+    num_chunks = prop_def(IntegerAttr)
+
+    res = var_result_def(stencil.TempType)
+
+    traits = frozenset([IsolatedFromAbove(), RecursiveMemoryEffect()])
+
+    def print(self, printer: Printer):
+        def print_assign_argument(args: tuple[BlockArgument, SSAValue, Attribute]):
+            printer.print(args[0])
+            printer.print(" = ")
+            printer.print(args[1])
+            printer.print(" : ")
+            printer.print(args[2])
+
+        printer.print("(")
+        args = [self.communicated_stencil, self.iter_arg, *self.args]
+        block_args = (
+            self.post_process.block.args[0],
+            self.chunk_reduce.block.args[2],
+            *self.chunk_reduce.block.args[3:],
+            *self.post_process.block.args[2:],
+        )
+        printer.print_list(
+            zip(block_args, args, (a.type for a in args)),
+            print_assign_argument,
+        )
+        printer.print(") -> (")
+        printer.print_list((r.type for r in self.res), printer.print_attribute)
+        printer.print(") ")
+        printer.print_op_attributes(self.attributes, print_keyword=True)
+        printer.print("(")
+        printer.print_region(self.chunk_reduce, print_entry_block_args=True)
+        printer.print(", ")
+        printer.print_region(self.post_process, print_entry_block_args=True)
+        printer.print(")")
+
+    @classmethod
+    def parse(cls, parser: Parser):
+        def parse_assign_args():
+            arg = parser.parse_argument(expect_type=False)
+            parser.parse_punctuation("=")
+            value = parser.parse_operand()
+            parser.parse_punctuation(":")
+            type = parser.parse_attribute()
+            arg = arg.resolve(type)
+            return arg, value
+
+        assign_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, parse_assign_args
+        )
+        operands: list[SSAValue]
+        operands = [o for _, o in assign_args]  # should we discard args here?
+
+        props = parser.parse_optional_properties_dict()
+        topo = props["topo"] if "topo" in props else None
+        swaps = props["swaps"]
+        num_chunks = props["num_chunks"]
+
+        parser.parse_punctuation("->")
+        result_types = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, parser.parse_attribute
+        )
+        attrs = parser.parse_optional_attr_dict_with_keyword()
+        if attrs is not None:
+            attrs = attrs.data
+        parser.parse_punctuation("(")
+        chunk_reduce = parser.parse_region()
+        parser.parse_punctuation(",")
+        post_process = parser.parse_region()
+        parser.parse_punctuation(")")
+        return cls(
+            operands=[operands[0], operands[1], operands[2:]],
+            result_types=[result_types],
+            regions=[chunk_reduce, post_process],
+            properties={"topo": topo, "swaps": swaps, "num_chunks": num_chunks},
+            attributes=attrs,
+        )
+
+    @staticmethod
+    def get(
+        args: Sequence[SSAValue] | Sequence[Operation],
+        body: Block | Region,
+        result_types: Sequence[stencil.TempType[Attribute]],
+    ):
+        assert len(result_types) > 0
+
+        if isinstance(body, Block):
+            body = Region(body)
+
+        return ApplyOp.build(
+            operands=[list(args)],
+            regions=[body],
+            result_types=[result_types],
+        )
+
+    def verify_(self) -> None:
+        # typecheck op arguments
+        if (
+            len(self.chunk_reduce.block.args) < 3
+            or len(self.post_process.block.args) < 2
+        ):
+            raise VerifyException("Missing required block args on region")
+        op_args = (
+            self.post_process.block.args[0],
+            self.chunk_reduce.block.args[2],
+            *self.chunk_reduce.block.args[3:],
+            *self.post_process.block.args[2:],
+        )
+        for operand, argument in zip(self.operands, op_args):
+            if operand.type != argument.type:
+                raise VerifyException(
+                    f"Expected argument type of {type(self)} to match operand type, got {argument.type} != {operand.type} at index {argument.index}"
+                )
+
+        # typecheck required (only) block arguments
+        assert isa(self.iter_arg.type, TensorType[Attribute])
+        chunk_reduce_req_types = [
+            memref.MemRefType(
+                TensorType(
+                    self.iter_arg.type.get_element_type(),
+                    (self.iter_arg.type.get_shape()[0] // self.num_chunks.value.data,),
+                ),
+                (len(self.swaps),),
+            ),
+            IndexType(),
+            self.iter_arg.type,
+        ]
+        post_process_req_types = [
+            self.communicated_stencil.type,
+            self.iter_arg.type,
+        ]
+        for arg, expected_type in zip(
+            self.chunk_reduce.block.args, chunk_reduce_req_types
+        ):
+            if arg.type != expected_type:
+                raise VerifyException(
+                    f"Unexpected block argument type of chunk_reduce, got {arg.type} != {expected_type} at index {arg.index}"
+                )
+        for arg, expected_type in zip(
+            self.post_process.block.args, post_process_req_types
+        ):
+            if arg.type != expected_type:
+                raise VerifyException(
+                    f"Unexpected block argument type of post_process, got {arg.type} != {expected_type} at index {arg.index}"
+                )
+
+        if len(self.res) < 1:
+            raise VerifyException(
+                f"Expected stencil.apply to have at least 1 result, got {len(self.res)}"
+            )
+        res_type = cast(stencil.TempType[Attribute], self.res[0].type)
+        for other in self.res[1:]:
+            other = cast(stencil.TempType[Attribute], other.type)
+            if res_type.bounds != other.bounds:
+                raise VerifyException("Expected all output types bounds to be equals.")
+
+    def get_rank(self) -> int:
+        res_type = self.res[0].type
+        assert isa(res_type, stencil.TempType[Attribute])
+        return res_type.get_num_dims()
+
+    def get_accesses(self) -> Iterable[stencil.AccessPattern]:
+        """
+        Return the access patterns of each input.
+
+         - An offset is a tuple describing a relative access
+         - An access pattern is a class wrappoing a sequence of offsets
+         - This method returns an access pattern for each stencil
+           field of the apply operation.
+        """
+        # iterate over the block arguments
+        for arg in self.chunk_reduce.block.args:
+            accesses: list[tuple[int, ...]] = []
+            # walk the uses of the argument
+            for use in arg.uses:
+                # filter out all non access ops
+                if not isinstance(use.operation, AccessOp):
+                    continue
+                access: AccessOp = use.operation
+                # grab the offsets as a tuple[int, ...]
+                offsets = tuple(access.offset)
+                # account for offset_mappings:
+                if access.offset_mapping is not None:
+                    offsets = tuple(offsets[i] for i in access.offset_mapping)
+                accesses.append(offsets)
+            yield stencil.AccessPattern(tuple(accesses))
+
+
+@irdl_op_definition
 class AccessOp(IRDLOperation):
     """
     A CSL stencil access that operates on own data or data prefetched from neighbors via `csl_stencil.prefetch`
@@ -139,7 +402,7 @@ class AccessOp(IRDLOperation):
     offset_mapping = opt_prop_def(stencil.IndexAttr)
     result = result_def(TensorType)
 
-    traits = frozenset([HasAncestor(stencil.ApplyOp), Pure()])
+    traits = frozenset([HasAncestor(stencil.ApplyOp, ApplyOp), Pure()])  # todo
 
     def __init__(
         self,
@@ -234,9 +497,11 @@ class AccessOp(IRDLOperation):
                 )
 
         # As promised by HasAncestor(ApplyOp)
-        trait = cast(HasAncestor, AccessOp.get_trait(HasAncestor, (stencil.ApplyOp,)))
+        trait = cast(
+            HasAncestor, AccessOp.get_trait(HasAncestor, (stencil.ApplyOp, ApplyOp))
+        )
         apply = trait.get_ancestor(self)
-        assert isinstance(apply, stencil.ApplyOp)
+        assert isinstance(apply, stencil.ApplyOp | ApplyOp)
 
         # TODO This should be handled by infra, having a way to verify things on ApplyOp
         # **before** its children.
@@ -281,11 +546,20 @@ class AccessOp(IRDLOperation):
         return cast(stencil.ApplyOp, ancestor)
 
 
+@irdl_op_definition
+class YieldOp(AbstractYieldOperation[Attribute]):
+    name = "csl_stencil.yield"
+
+    traits = traits_def(lambda: frozenset([IsTerminator(), HasParent(ApplyOp), Pure()]))
+
+
 CSL_STENCIL = Dialect(
     "csl_stencil",
     [
         PrefetchOp,
         AccessOp,
+        ApplyOp,
+        YieldOp,
     ],
     [
         ExchangeDeclarationAttr,

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -200,28 +200,6 @@ class ApplyOp(IRDLOperation):
 
     traits = frozenset([IsolatedFromAbove(), RecursiveMemoryEffect()])
 
-    # def __init__(
-    #     self,
-    #     communicated_stencil: stencil.TempType[Attribute] | memref.MemRefType[Attribute],
-    #     iter_arg: TensorType[Attribute],
-    #     args: Sequence[Attribute],
-    #
-    #
-    #     args: Sequence[SSAValue] | Sequence[Operation],
-    #     body: Block | Region,
-    #     result_types: Sequence[stencil.TempType[Attribute]],
-    # ):
-    #     assert len(result_types) > 0
-    #
-    #     if isinstance(body, Block):
-    #         body = Region(body)
-    #
-    #     return ApplyOp.build(
-    #         operands=[list(args)],
-    #         regions=[body],
-    #         result_types=[result_types],
-    #     )
-
     def print(self, printer: Printer):
         def print_arg(arg: tuple[SSAValue, Attribute]):
             printer.print(arg[0])


### PR DESCRIPTION
This PR implements the `csl_stencil.apply` op as outlined in Step 2 of #2747 

This operation combines a `csl_stencil.prefetch` (symmetric buffer communication across a given stencil shape) with a `stencil.apply`. Please see the doc string of the op for a detailed description.