### PR TITLE
dialects: (csl) Add csl.constants op and printing

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -56,6 +56,20 @@
     csl.return
   }
 
+  csl.func @constants() {
+    %inline_const = arith.constant 100 : i32
+
+    %1 = "csl.constants"(%const27, %const27) : (i16, i16) -> memref<?xi16>
+
+    %2 = "csl.constants"(%const27, %const27) <{is_const}> : (i16, i16) -> memref<?xi16>
+
+    %3 = "csl.constants"(%const27, %inline_const) <{is_const}> : (i16, i32) -> memref<?xi32>
+
+    %4 = "csl.constants"(%inline_const, %inline_const) <{is_const}> : (i32, i32) -> memref<?xi32>
+
+    csl.return
+  }
+
 
   csl.task @data_task(%arg: f32) attributes {kind = #csl<task_kind data>, id = 0 : i5} {
     csl.return
@@ -386,6 +400,14 @@ csl.func @builtins() {
 // CHECK-NEXT:   const castI16again : i16 = @as(i16, 0);
 // CHECK-NEXT:   const castI32again : i32 = @as(i32, @as(i16, 0.0));
 // CHECK-NEXT:   const castU32 : u32 = @as(u32, 0);
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT:
+// CHECK-NEXT: fn constants() void {
+// CHECK-NEXT:   var v0 : [const27]i16 = @constants(const27, const27);
+// CHECK-NEXT:   const v1 : [const27]i16 = @constants(const27, const27);
+// CHECK-NEXT:   const v2 : [const27]i32 = @constants(const27, 100);
+// CHECK-NEXT:   const v3 : [100]i32 = @constants(100, 100);
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT:

--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -404,10 +404,10 @@ csl.func @builtins() {
 // CHECK-NEXT: }
 // CHECK-NEXT:
 // CHECK-NEXT: fn constants() void {
-// CHECK-NEXT:   var v0 : [const27]i16 = @constants(const27, const27);
-// CHECK-NEXT:   const v1 : [const27]i16 = @constants(const27, const27);
-// CHECK-NEXT:   const v2 : [const27]i32 = @constants(const27, 100);
-// CHECK-NEXT:   const v3 : [100]i32 = @constants(100, 100);
+// CHECK-NEXT:   var v0 : [const27]i16 = @constants([const27]i16, const27);
+// CHECK-NEXT:   const v1 : [const27]i16 = @constants([const27]i16, const27);
+// CHECK-NEXT:   const v2 : [const27]i32 = @constants([const27]i32, 100);
+// CHECK-NEXT:   const v3 : [100]i32 = @constants([100]i32, 100);
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT:

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -15,6 +15,7 @@ csl.func @func_with_args(%arg1: i32, %arg2: i16) -> i32 {
 %c100 = arith.constant 100 : i32
 
 %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
+%zeros2 = "csl.constants"(%zero, %c100) <{is_const}> : (i32, i32) -> memref<?xi32>
 
 csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 0 : i5} {
   csl.return
@@ -329,6 +330,7 @@ csl.func @builtins() {
 // CHECK-NEXT:     %zero = arith.constant 0 : i32
 // CHECK-NEXT:     %c100 = arith.constant 100 : i32
 // CHECK-NEXT:     %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
+// CHECK-NEXT:     %zeros2 = "csl.constants"(%zero, %c100) <{"is_const"}> : (i32, i32) -> memref<?xi32>
 // CHECK-NEXT:     csl.task @local_task()  attributes {"kind" = #csl<task_kind local>, "id" = 0 : i5}{
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
@@ -561,6 +563,7 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:     %zero = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
 // CHECK-GENERIC-NEXT:     %c100 = "arith.constant"() <{"value" = 100 : i32}> : () -> i32
 // CHECK-GENERIC-NEXT:     %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
+// CHECK-GENERIC-NEXT:     %zeros2 = "csl.constants"(%zero, %c100) <{"is_const"}> : (i32, i32) -> memref<?xi32>
 // CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "local_task", "function_type" = () -> (), "kind" = #csl<task_kind local>, "id" = 0 : i5}> ({
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -11,6 +11,11 @@ csl.func @func_with_args(%arg1: i32, %arg2: i16) -> i32 {
 }
 
 
+%zero = arith.constant 0 : i32
+%c100 = arith.constant 100 : i32
+
+%zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
+
 csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 0 : i5} {
   csl.return
 }
@@ -321,6 +326,9 @@ csl.func @builtins() {
 // CHECK-NEXT:     csl.func @func_with_args(%arg1 : i32, %arg2 : i16) -> i32 {
 // CHECK-NEXT:       csl.return %arg1 : i32
 // CHECK-NEXT:     }
+// CHECK-NEXT:     %zero = arith.constant 0 : i32
+// CHECK-NEXT:     %c100 = arith.constant 100 : i32
+// CHECK-NEXT:     %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
 // CHECK-NEXT:     csl.task @local_task()  attributes {"kind" = #csl<task_kind local>, "id" = 0 : i5}{
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
@@ -550,6 +558,9 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:     ^0(%arg1 : i32, %arg2 : i16):
 // CHECK-GENERIC-NEXT:       "csl.return"(%arg1) : (i32) -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
+// CHECK-GENERIC-NEXT:     %zero = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     %c100 = "arith.constant"() <{"value" = 100 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
 // CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "local_task", "function_type" = () -> (), "kind" = #csl<task_kind local>, "id" = 0 : i5}> ({
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -513,7 +513,7 @@ class CslPrintContext:
                     res_name = self._get_variable_name_for(res)
                     kind = "const" if constness else "var"
                     self.print(
-                        f"{kind} {res_name} : {type} = @constants({self._var_use(size)}, {self._var_use(val)});"
+                        f"{kind} {res_name} : {type} = @constants({type}, {self._var_use(val)});"
                     )
                 case memref.Global(
                     sym_name=name, type=ty, initial_value=init, constant=const

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -9,7 +9,6 @@ from typing import IO, Literal, cast
 from xdsl.dialects import arith, csl, memref, scf
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    ContainerType,
     DenseIntOrFPElementsAttr,
     DictionaryAttr,
     Float16Type,
@@ -31,6 +30,7 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Block, Operation, OpResult, Region, SSAValue
 from xdsl.irdl import Operand
 from xdsl.traits import is_side_effect_free
+from xdsl.utils.hints import isa
 
 
 @dataclass
@@ -234,8 +234,10 @@ class CslPrintContext:
         that created the memref (e.g. memref.alloc, csl.constants, ...)
         """
         type = val.type
-        assert isinstance(type, MemRefType)
-        assert isinstance(val, OpResult), "The value provided to _memref_type_to_string must be an op result"
+        assert isa(type, MemRefType[Attribute])
+        assert isinstance(
+            val, OpResult
+        ), "The value provided to _memref_type_to_string must be an op result"
         dims: list[str] = []
         idx = 0
         for dim in type.get_shape():
@@ -245,7 +247,7 @@ class CslPrintContext:
             else:
                 dims.append(str(dim))
         dims_str = ",".join(dims)
-        return f"[{dims_str}]{self.mlir_type_to_csl_type(type.get_element_type())}"
+        return f"[{dims_str}]{self.mlir_type_to_csl_type(type.element_type)}"
 
     def mlir_type_to_csl_type(self, type_attr: Attribute) -> str:
         """
@@ -284,14 +286,14 @@ class CslPrintContext:
                 return f"u{width}"
             case IntegerType(width=IntAttr(data=width)):
                 return f"i{width}"
-            case MemRefType() as t:
-                if any(dim == -1 for dim in t.get_shape()):
+            case MemRefType(element_type=Attribute() as elem_t, shape=shape):
+                if any(dim.data == -1 for dim in shape):
                     raise ValueError(
                         "Can't print memrefs using mlir_type_to_csl_type if they have dynamic sizes. "
                         "Use _memref_type_to_string instead"
                     )
-                shape = ", ".join(str(s) for s in t.get_shape())
-                type = self.mlir_type_to_csl_type(t.get_element_type())
+                shape = ", ".join(str(s.data) for s in shape)
+                type = self.mlir_type_to_csl_type(elem_t)
                 return f"[{shape}]{type}"
             case csl.PtrType(type=ty, kind=kind, constness=const):
                 match kind.data:
@@ -504,11 +506,15 @@ class CslPrintContext:
                     self._print_or_promote_to_inline_expr(
                         res, f"@concat_structs({a_var}, {b_var})"
                     )
-                case csl.ConstantsOp(size=size, value=val, result=res, is_const=constness):
+                case csl.ConstantsOp(
+                    size=size, value=val, result=res, is_const=constness
+                ):
                     type = self._memref_type_to_string(res)
                     res_name = self._get_variable_name_for(res)
                     kind = "const" if constness else "var"
-                    self.print(f"{kind} {res_name} : {type} = @constants({self._var_use(size)}, {self._var_use(val)});")
+                    self.print(
+                        f"{kind} {res_name} : {type} = @constants({self._var_use(size)}, {self._var_use(val)});"
+                    )
                 case memref.Global(
                     sym_name=name, type=ty, initial_value=init, constant=const
                 ):

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -506,9 +506,7 @@ class CslPrintContext:
                     self._print_or_promote_to_inline_expr(
                         res, f"@concat_structs({a_var}, {b_var})"
                     )
-                case csl.ConstantsOp(
-                    size=size, value=val, result=res, is_const=constness
-                ):
+                case csl.ConstantsOp(value=val, result=res, is_const=constness):
                     type = self._memref_type_to_string(res)
                     res_name = self._get_variable_name_for(res)
                     kind = "const" if constness else "var"

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -427,7 +427,9 @@ class ConstantsOp(IRDLOperation):
     """
     Represents the @constants operation in CSL.
 
-    This can also be used to represent @zeros by passing a zero constant as the second argument.
+    This can also be used as a stand-in for @zeros by passing a zero constant as the second argument.
+
+    If is_const is present, it is printed with the `const` prefix, otherwise it's assumed `var` by the csl printer.
     """
 
     name = "csl.constants"

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -422,6 +422,31 @@ class ConstStructOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ConstantsOp(IRDLOperation):
+    """
+    Represents the @constants operation in CSL.
+
+    This can also be used to represent @zeros by passing a zero constant as the second argument.
+    """
+
+    name = "csl.constants"
+
+    T = Annotated[IntegerType | Float32Type | Float16Type, ConstraintVar("T")]
+
+    size = operand_def(IntegerType)
+
+    value = operand_def(T)
+
+    result = result_def(MemRefType[T])
+
+    def __init__(self, size: SSAValue | Operation, value: SSAValue | Operation):
+        super().__init__(
+            operands=[size, value],
+            result_types=[MemRefType(SSAValue.get(value).type, [-1])],
+        )
+
+
+@irdl_op_definition
 class GetColorOp(IRDLOperation):
     name = "csl.get_color"
 
@@ -1641,6 +1666,7 @@ CSL = Dialect(
         ClzOp,
         ConcatStructOp,
         ConstStructOp,
+        ConstantsOp,
         CslModuleOp,
         CtzOp,
         FabshOp,

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -14,6 +14,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Annotated, ClassVar, TypeAlias
 
+from xdsl.dialects import builtin
 from xdsl.dialects.builtin import (
     AnyFloatAttr,
     AnyIntegerAttr,
@@ -438,6 +439,8 @@ class ConstantsOp(IRDLOperation):
     value = operand_def(T)
 
     result = result_def(MemRefType[T])
+
+    is_const = opt_prop_def(builtin.UnitAttr)
 
     def __init__(self, size: SSAValue | Operation, value: SSAValue | Operation):
         super().__init__(


### PR DESCRIPTION
Add the `csl.constants` op to define constant-initialized arrays and printing for said operation.