### PR TITLE
dialects: (riscv, x86) do not print empty <> for unallocated registers

### DIFF
--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -242,7 +242,7 @@ def test_riscv_parse_immediate_value():
     ctx = MLContext()
     ctx.load_dialect(riscv.RISCV)
 
-    prog = """riscv.jalr %0, 1.1, !riscv.reg<> : (!riscv.reg<>) -> ()"""
+    prog = """riscv.jalr %0, 1.1, !riscv.reg : (!riscv.reg) -> ()"""
     parser = Parser(ctx, prog)
     with pytest.raises(ParseError, match="Expected immediate"):
         parser.parse_operation()

--- a/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf_with_regalloc.mlir
+++ b/tests/filecheck/backend/convert_riscv_scf_to_riscv_cf_with_regalloc.mlir
@@ -2,15 +2,15 @@
 
 builtin.module {
     riscv_func.func @sum_range(%0 : !riscv.reg<a0>, %1 : !riscv.reg<a1>) {
-        %2 = riscv.li 1 : () -> !riscv.reg<>
-        %3 = riscv.li 0 : () -> !riscv.reg<>
-        %arg = riscv.mv %3 : (!riscv.reg<>) -> !riscv.reg<>
-        %4 = riscv_scf.for %5 : !riscv.reg<> = %0 to %1 step %2 iter_args(%6 = %arg) -> (!riscv.reg<>) {
-            %7 = riscv.add %5, %6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-            riscv_scf.yield %7 : !riscv.reg<>
+        %2 = riscv.li 1 : () -> !riscv.reg
+        %3 = riscv.li 0 : () -> !riscv.reg
+        %arg = riscv.mv %3 : (!riscv.reg) -> !riscv.reg
+        %4 = riscv_scf.for %5 : !riscv.reg = %0 to %1 step %2 iter_args(%6 = %arg) -> (!riscv.reg) {
+            %7 = riscv.add %5, %6 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+            riscv_scf.yield %7 : !riscv.reg
         }
-        %8 = riscv.mv %4 : (!riscv.reg<>) -> !riscv.reg<>
-        riscv_func.return %8 : !riscv.reg<>
+        %8 = riscv.mv %4 : (!riscv.reg) -> !riscv.reg
+        riscv_func.return %8 : !riscv.reg
     }
 }
 

--- a/tests/filecheck/backend/riscv/canonicalize.mlir
+++ b/tests/filecheck/backend/riscv/canonicalize.mlir
@@ -1,34 +1,34 @@
 // RUN: xdsl-opt --split-input-file -p canonicalize %s | filecheck %s
 
 builtin.module {
-  %i0, %i1, %i2 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<>)
+  %i0, %i1, %i2 = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg)
   %o0 = riscv.mv %i0 : (!riscv.reg<a0>) -> !riscv.reg<a0>
   %o1 = riscv.mv %i1 : (!riscv.reg<a1>) -> !riscv.reg<a2>
-  %o2 = riscv.mv %i2 : (!riscv.reg<>) -> !riscv.reg<>
-  "test.op"(%o0, %o1, %o2) : (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg<>) -> ()
+  %o2 = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg
+  "test.op"(%o0, %o1, %o2) : (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg) -> ()
 
-  %i3 = riscv.li 100 : () -> !riscv.reg<>
-  %i4 = riscv.mv %i3 : (!riscv.reg<>) -> !riscv.reg<>
-  %i5 = riscv.mv %i3 : (!riscv.reg<>) -> !riscv.reg<j0>
-  "test.op"(%i3, %i4, %i5) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<j0>) -> ()
+  %i3 = riscv.li 100 : () -> !riscv.reg
+  %i4 = riscv.mv %i3 : (!riscv.reg) -> !riscv.reg
+  %i5 = riscv.mv %i3 : (!riscv.reg) -> !riscv.reg<j0>
+  "test.op"(%i3, %i4, %i5) : (!riscv.reg, !riscv.reg, !riscv.reg<j0>) -> ()
 
-  %f0, %f1, %f2 = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg<>)
+  %f0, %f1, %f2 = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg)
   %fo0 = riscv.fmv.s %f0 : (!riscv.freg<fa0>) -> !riscv.freg<fa0>
   %fo1 = riscv.fmv.s %f1 : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
-  %fo2 = riscv.fmv.s %f2 : (!riscv.freg<>) -> !riscv.freg<>
+  %fo2 = riscv.fmv.s %f2 : (!riscv.freg) -> !riscv.freg
   %fo3 = riscv.fmv.d %f0 : (!riscv.freg<fa0>) -> !riscv.freg<fa0>
   %fo4 = riscv.fmv.d %f1 : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
-  %fo5 = riscv.fmv.d %f2 : (!riscv.freg<>) -> !riscv.freg<>
-  "test.op"(%fo0, %fo1, %fo2, %fo3, %fo4, %fo5) : (!riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg<>, !riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg<>) -> ()
+  %fo5 = riscv.fmv.d %f2 : (!riscv.freg) -> !riscv.freg
+  "test.op"(%fo0, %fo1, %fo2, %fo3, %fo4, %fo5) : (!riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg, !riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg) -> ()
 
   %zero = riscv.get_register : () -> !riscv.reg<zero>
-  %c0 = riscv.li 0 : () -> !riscv.reg<>
-  %c1 = riscv.li 1 : () -> !riscv.reg<>
-  %c2 = riscv.li 2 : () -> !riscv.reg<>
-  %c3 = riscv.li 3 : () -> !riscv.reg<>
+  %c0 = riscv.li 0 : () -> !riscv.reg
+  %c1 = riscv.li 1 : () -> !riscv.reg
+  %c2 = riscv.li 2 : () -> !riscv.reg
+  %c3 = riscv.li 3 : () -> !riscv.reg
 
   // Don't optimise out unused immediates
-  "test.op"(%zero, %c0, %c1, %c2, %c3) : (!riscv.reg<zero>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+  "test.op"(%zero, %c0, %c1, %c2, %c3) : (!riscv.reg<zero>, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
   %load_zero_zero = riscv.li 0 : () -> !riscv.reg<zero>
   "test.op"(%load_zero_zero) : (!riscv.reg<zero>) -> ()
@@ -36,42 +36,42 @@ builtin.module {
   %add_immediate_zero_reg = riscv.addi %zero, 1 : (!riscv.reg<zero>) -> !riscv.reg<a0>
   "test.op"(%add_immediate_zero_reg) : (!riscv.reg<a0>) -> ()
 
-  %multiply_immediates = riscv.mul %c2, %c3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %multiply_immediates = riscv.mul %c2, %c3 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%multiply_immediates) : (!riscv.reg<a0>) -> ()
 
-  %multiply_immediate_r0 = riscv.mul %c0, %i1 : (!riscv.reg<>, !riscv.reg<a1>) -> !riscv.reg<a0>
+  %multiply_immediate_r0 = riscv.mul %c0, %i1 : (!riscv.reg, !riscv.reg<a1>) -> !riscv.reg<a0>
   "test.op"(%multiply_immediate_r0) : (!riscv.reg<a0>) -> ()
 
-  %multiply_immediate_l0 = riscv.mul %i1, %c0 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
+  %multiply_immediate_l0 = riscv.mul %i1, %c0 : (!riscv.reg<a1>, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%multiply_immediate_l0) : (!riscv.reg<a0>) -> ()
 
-  %add_lhs_immediate = riscv.add %c2, %i2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %add_lhs_immediate = riscv.add %c2, %i2 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%add_lhs_immediate) : (!riscv.reg<a0>) -> ()
 
-  %add_rhs_immediate = riscv.add %i2, %c2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %add_rhs_immediate = riscv.add %i2, %c2 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%add_rhs_immediate) : (!riscv.reg<a0>) -> ()
 
-  %add_immediates = riscv.add %c2, %c3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %add_immediates = riscv.add %c2, %c3 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%add_immediates) : (!riscv.reg<a0>) -> ()
 
   %add_vars = riscv.add %i0, %i1 : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
   "test.op"(%add_vars) : (!riscv.reg<a0>) -> ()
 
-  %add_immediate_zero = riscv.addi %i2, 0 : (!riscv.reg<>) -> !riscv.reg<a0>
+  %add_immediate_zero = riscv.addi %i2, 0 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%add_immediate_zero) : (!riscv.reg<a0>) -> ()
 
-  %add_immediate_constant = riscv.addi %c2, 1 : (!riscv.reg<>) -> !riscv.reg<a0>
+  %add_immediate_constant = riscv.addi %c2, 1 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%add_immediate_constant) : (!riscv.reg<a0>) -> ()
 
   // Unchanged
-  %sub_lhs_immediate = riscv.sub %c2, %i2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %sub_lhs_immediate = riscv.sub %c2, %i2 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%sub_lhs_immediate) : (!riscv.reg<a0>) -> ()
 
   // Replace with addi
-  %sub_rhs_immediate = riscv.sub %i2, %c2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %sub_rhs_immediate = riscv.sub %i2, %c2 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%sub_rhs_immediate) : (!riscv.reg<a0>) -> ()
 
-  %sub_immediates = riscv.sub %c2, %c3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %sub_immediates = riscv.sub %c2, %c3 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%sub_immediates) : (!riscv.reg<a0>) -> ()
 
   // Unchanged
@@ -79,66 +79,66 @@ builtin.module {
   "test.op"(%add_vars) : (!riscv.reg<a0>) -> ()
 
   // Optimise out an arithmetic operation
-  %sub_add_immediate = riscv.sub %add_rhs_immediate, %i2 : (!riscv.reg<a0>, !riscv.reg<>) -> !riscv.reg<a0>
+  %sub_add_immediate = riscv.sub %add_rhs_immediate, %i2 : (!riscv.reg<a0>, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%sub_add_immediate) : (!riscv.reg<a0>) -> ()
 
-  %shift_left_immediate = riscv.slli %c2, 4 : (!riscv.reg<>) -> !riscv.reg<a0>
+  %shift_left_immediate = riscv.slli %c2, 4 : (!riscv.reg) -> !riscv.reg<a0>
   "test.op"(%shift_left_immediate) : (!riscv.reg<a0>) -> ()
 
-  %load_float_ptr = riscv.addi %i2, 8 : (!riscv.reg<>) -> !riscv.reg<>
-  %load_float_known_offset = riscv.flw %load_float_ptr, 4 : (!riscv.reg<>) -> !riscv.freg<fa0>
+  %load_float_ptr = riscv.addi %i2, 8 : (!riscv.reg) -> !riscv.reg
+  %load_float_known_offset = riscv.flw %load_float_ptr, 4 : (!riscv.reg) -> !riscv.freg<fa0>
   "test.op"(%load_float_known_offset) : (!riscv.freg<fa0>) -> ()
 
-  %load_double_ptr = riscv.addi %i2, 8 : (!riscv.reg<>) -> !riscv.reg<>
-  %load_double_known_offset = riscv.fld %load_double_ptr, 4 : (!riscv.reg<>) -> !riscv.freg<fa0>
+  %load_double_ptr = riscv.addi %i2, 8 : (!riscv.reg) -> !riscv.reg
+  %load_double_known_offset = riscv.fld %load_double_ptr, 4 : (!riscv.reg) -> !riscv.freg<fa0>
   "test.op"(%load_double_known_offset) : (!riscv.freg<fa0>) -> ()
 
-  %store_float_ptr = riscv.addi %i2, 8 : (!riscv.reg<>) -> !riscv.reg<>
-  riscv.fsw %store_float_ptr, %f2, 4 : (!riscv.reg<>, !riscv.freg<>) -> ()
+  %store_float_ptr = riscv.addi %i2, 8 : (!riscv.reg) -> !riscv.reg
+  riscv.fsw %store_float_ptr, %f2, 4 : (!riscv.reg, !riscv.freg) -> ()
 
-  %store_double_ptr = riscv.addi %i2, 8 : (!riscv.reg<>) -> !riscv.reg<>
-  riscv.fsd %store_double_ptr, %f2, 4 : (!riscv.reg<>, !riscv.freg<>) -> ()
+  %store_double_ptr = riscv.addi %i2, 8 : (!riscv.reg) -> !riscv.reg
+  riscv.fsd %store_double_ptr, %f2, 4 : (!riscv.reg, !riscv.freg) -> ()
 
   %add_lhs_rhs = riscv.add %i1, %i1 : (!riscv.reg<a1>, !riscv.reg<a1>) -> !riscv.reg<a0>
   "test.op"(%add_lhs_rhs) : (!riscv.reg<a0>) -> ()
 
-  %and_bitwise_zero_l0 = riscv.and %c1, %c0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %and_bitwise_zero_l0 = riscv.and %c1, %c0 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%and_bitwise_zero_l0) : (!riscv.reg<a0>) -> ()
 
-  %and_bitwise_zero_r0 = riscv.and %c0, %c1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+  %and_bitwise_zero_r0 = riscv.and %c0, %c1 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
   "test.op"(%and_bitwise_zero_r0) : (!riscv.reg<a0>) -> ()
 
   // scfgw immediates
-  %scfgw = riscv_snitch.scfgw %i1, %c1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<zero>
+  %scfgw = riscv_snitch.scfgw %i1, %c1 : (!riscv.reg<a1>, !riscv.reg) -> !riscv.reg<zero>
   "test.op"(%scfgw) : (!riscv.reg<zero>) -> ()
 }
 
 // CHECK: builtin.module {
-// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg<>)
+// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<a0>, !riscv.reg<a1>, !riscv.reg)
 // CHECK-NOT:    %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg<a0>
 // CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a1>) -> !riscv.reg<a2>
-// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   "test.op"(%i0, %o1, %o2) : (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg<>) -> ()
+// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   "test.op"(%i0, %o1, %o2) : (!riscv.reg<a0>, !riscv.reg<a2>, !riscv.reg) -> ()
 
-// CHECK-NEXT:   %i3 = riscv.li 100 : () -> !riscv.reg<>
-// CHECK-NEXT:   %i4 = riscv.mv %i3 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %i5 = riscv.mv %i3 : (!riscv.reg<>) -> !riscv.reg<j0>
-// CHECK-NEXT:   "test.op"(%i3, %i4, %i5) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<j0>) -> ()
+// CHECK-NEXT:   %i3 = riscv.li 100 : () -> !riscv.reg
+// CHECK-NEXT:   %i4 = riscv.mv %i3 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %i5 = riscv.mv %i3 : (!riscv.reg) -> !riscv.reg<j0>
+// CHECK-NEXT:   "test.op"(%i3, %i4, %i5) : (!riscv.reg, !riscv.reg, !riscv.reg<j0>) -> ()
 
-// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg<>)
+// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.freg<fa0>, !riscv.freg<fa1>, !riscv.freg)
 // CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
-// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg
 // CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa1>) -> !riscv.freg<fa2>
-// CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   "test.op"(%f0, %fo1, %fo2, %f0, %fo4, %fo5) : (!riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg<>, !riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg<>) -> ()
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   "test.op"(%f0, %fo1, %fo2, %f0, %fo4, %fo5) : (!riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg, !riscv.freg<fa0>, !riscv.freg<fa2>, !riscv.freg) -> ()
 
 // CHECK-NEXT:   %zero = riscv.get_register : () -> !riscv.reg<zero>
 // CHECK-NEXT:   %c0 = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %c0_1 = riscv.mv %c0 : (!riscv.reg<zero>) -> !riscv.reg<>
-// CHECK-NEXT:   %c1 = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:   %c2 = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:   %c3 = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:   "test.op"(%zero, %c0_1, %c1, %c2, %c3) : (!riscv.reg<zero>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:   %c0_1 = riscv.mv %c0 : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   %c1 = riscv.li 1 : () -> !riscv.reg
+// CHECK-NEXT:   %c2 = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:   %c3 = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:   "test.op"(%zero, %c0_1, %c1, %c2, %c3) : (!riscv.reg<zero>, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
 // CHECK-NEXT:   %load_zero_zero = riscv.get_register : () -> !riscv.reg<zero>
 // CHECK-NEXT:   "test.op"(%load_zero_zero) : (!riscv.reg<zero>) -> ()
@@ -149,16 +149,16 @@ builtin.module {
 // CHECK-NEXT:   %multiply_immediates = riscv.li 6 : () -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%multiply_immediates) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %multiply_immediate_r0 = riscv.mv %c0_1 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %multiply_immediate_r0 = riscv.mv %c0_1 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%multiply_immediate_r0) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %multiply_immediate_l0 = riscv.mv %c0_1 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %multiply_immediate_l0 = riscv.mv %c0_1 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%multiply_immediate_l0) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %add_lhs_immediate = riscv.addi %i2, 2 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %add_lhs_immediate = riscv.addi %i2, 2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_lhs_immediate) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %add_rhs_immediate = riscv.addi %i2, 2 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %add_rhs_immediate = riscv.addi %i2, 2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_rhs_immediate) : (!riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   %add_immediates = riscv.li 5 : () -> !riscv.reg<a0>
@@ -167,18 +167,18 @@ builtin.module {
 // CHECK-NEXT:   %add_vars = riscv.add %i0, %i1 : (!riscv.reg<a0>, !riscv.reg<a1>) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_vars) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %add_immediate_zero = riscv.mv %i2 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %add_immediate_zero = riscv.mv %i2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_immediate_zero) : (!riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   %add_immediate_constant = riscv.li 3 : () -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_immediate_constant) : (!riscv.reg<a0>) -> ()
 
   // Unchanged
-// CHECK-NEXT:   %sub_lhs_immediate = riscv.sub %c2, %i2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %sub_lhs_immediate = riscv.sub %c2, %i2 : (!riscv.reg, !riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%sub_lhs_immediate) : (!riscv.reg<a0>) -> ()
 
   // Replace with addi
-// CHECK-NEXT:   %sub_rhs_immediate = riscv.addi %i2, -2 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %sub_rhs_immediate = riscv.addi %i2, -2 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%sub_rhs_immediate) : (!riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   %sub_immediates = riscv.li -1 : () -> !riscv.reg<a0>
@@ -195,24 +195,24 @@ builtin.module {
 // CHECK-NEXT:   %shift_left_immediate = riscv.li 32 : () -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%shift_left_immediate) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %load_float_known_offset = riscv.flw %i2, 12 : (!riscv.reg<>) -> !riscv.freg<fa0>
+// CHECK-NEXT:   %load_float_known_offset = riscv.flw %i2, 12 : (!riscv.reg) -> !riscv.freg<fa0>
 // CHECK-NEXT:   "test.op"(%load_float_known_offset) : (!riscv.freg<fa0>) -> ()
 
-// CHECK-NEXT:   %load_double_known_offset = riscv.fld %i2, 12 : (!riscv.reg<>) -> !riscv.freg<fa0>
+// CHECK-NEXT:   %load_double_known_offset = riscv.fld %i2, 12 : (!riscv.reg) -> !riscv.freg<fa0>
 // CHECK-NEXT:   "test.op"(%load_double_known_offset) : (!riscv.freg<fa0>) -> ()
 
-// CHECK-NEXT:   riscv.fsw %i2, %f2, 12 : (!riscv.reg<>, !riscv.freg<>) -> ()
+// CHECK-NEXT:   riscv.fsw %i2, %f2, 12 : (!riscv.reg, !riscv.freg) -> ()
 
-// CHECK-NEXT:   riscv.fsd %i2, %f2, 12 : (!riscv.reg<>, !riscv.freg<>) -> ()
+// CHECK-NEXT:   riscv.fsd %i2, %f2, 12 : (!riscv.reg, !riscv.freg) -> ()
 
-// CHECK-NEXT:   %add_lhs_rhs = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:   %add_lhs_rhs_1 = riscv.mul %i1, %add_lhs_rhs : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %add_lhs_rhs = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:   %add_lhs_rhs_1 = riscv.mul %i1, %add_lhs_rhs : (!riscv.reg<a1>, !riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%add_lhs_rhs_1) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %and_bitwise_zero_l0 = riscv.mv %c0_1 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %and_bitwise_zero_l0 = riscv.mv %c0_1 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%and_bitwise_zero_l0) : (!riscv.reg<a0>) -> ()
 
-// CHECK-NEXT:   %and_bitwise_zero_r0 = riscv.mv %c0_1 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:   %and_bitwise_zero_r0 = riscv.mv %c0_1 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:   "test.op"(%and_bitwise_zero_r0) : (!riscv.reg<a0>) -> ()
 
 // CHECK-NEXT:   %scfgw = riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<zero>
@@ -222,129 +222,129 @@ builtin.module {
 
 // -----
 
-%0, %1 = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>)
+%0, %1 = "test.op"() : () -> (!riscv.freg, !riscv.freg)
 
 // should fuse
-%rmul0 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd0 = riscv.fadd.d %0, %rmul0 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul0 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd0 = riscv.fadd.d %0, %rmul0 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
 // same as above, but swapped addends
-%rmul0b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd0b = riscv.fadd.d %rmul0b, %0 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul0b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd0b = riscv.fadd.d %rmul0b, %0 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
 // same as above but allocated
-%rmul0_a = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd0_a = riscv.fadd.d %0, %rmul0_a fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<ft0>
+%rmul0_a = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd0_a = riscv.fadd.d %0, %rmul0_a fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg<ft0>
 
-%rmul0b_a = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd0b_a = riscv.fadd.d %rmul0b_a, %0 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<ft1>
+%rmul0b_a = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd0b_a = riscv.fadd.d %rmul0b_a, %0 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg<ft1>
 
 // both addends are results of multiplcation, if all else is the same we fuse with second operand
-%rmul0c0 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%rmul0c1 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd0c = riscv.fadd.d %rmul0c0, %rmul0c1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul0c0 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%rmul0c1 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd0c = riscv.fadd.d %rmul0c0, %rmul0c1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
 // should not fuse due to missing "contract" fastmath flag
-%rmul1 = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd1 = riscv.fadd.d %0, %rmul1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul1 = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd1 = riscv.fadd.d %0, %rmul1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-%rmul1b = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd1b = riscv.fadd.d %rmul1b, %0 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-
-// should not fuse due to missing "contract" fastmath flag
-%rmul2 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd2 = riscv.fadd.d %0, %rmul2 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-
-%rmul2b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd2b = riscv.fadd.d %rmul2b, %0 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul1b = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd1b = riscv.fadd.d %rmul1b, %0 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
 // should not fuse due to missing "contract" fastmath flag
-%rmul3 = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd3 = riscv.fadd.d %0, %rmul3 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul2 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd2 = riscv.fadd.d %0, %rmul2 : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-%rmul3b = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd3b = riscv.fadd.d %rmul3b, %0 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul2b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd2b = riscv.fadd.d %rmul2b, %0 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+
+// should not fuse due to missing "contract" fastmath flag
+%rmul3 = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd3 = riscv.fadd.d %0, %rmul3 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+
+%rmul3b = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd3b = riscv.fadd.d %rmul3b, %0 : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
 // should not fuse due to more than one uses
-%rmul4 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd4 = riscv.fadd.d %0, %rmul4 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul4 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd4 = riscv.fadd.d %0, %rmul4 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-%rmul4b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-%radd4b = riscv.fadd.d %rmul4b, %0 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+%rmul4b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%radd4b = riscv.fadd.d %rmul4b, %0 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
 // use multiplication result here to stop the fusion
-"test.op"(%rmul4) : (!riscv.freg<>) -> ()
-"test.op"(%rmul4b) : (!riscv.freg<>) -> ()
+"test.op"(%rmul4) : (!riscv.freg) -> ()
+"test.op"(%rmul4b) : (!riscv.freg) -> ()
 
 // use results here to avoid dead code elimination up the SSA chain
-"test.op"(%radd0) : (!riscv.freg<>) -> ()
-"test.op"(%radd0b) : (!riscv.freg<>) -> ()
+"test.op"(%radd0) : (!riscv.freg) -> ()
+"test.op"(%radd0b) : (!riscv.freg) -> ()
 "test.op"(%radd0_a) : (!riscv.freg<ft0>) -> ()
 "test.op"(%radd0b_a) : (!riscv.freg<ft1>) -> ()
-"test.op"(%radd0c) : (!riscv.freg<>) -> ()
-"test.op"(%radd1) : (!riscv.freg<>) -> ()
-"test.op"(%radd1b) : (!riscv.freg<>) -> ()
-"test.op"(%radd2) : (!riscv.freg<>) -> ()
-"test.op"(%radd2b) : (!riscv.freg<>) -> ()
-"test.op"(%radd3) : (!riscv.freg<>) -> ()
-"test.op"(%radd3b) : (!riscv.freg<>) -> ()
-"test.op"(%radd4) : (!riscv.freg<>) -> ()
-"test.op"(%radd4b) : (!riscv.freg<>) -> ()
+"test.op"(%radd0c) : (!riscv.freg) -> ()
+"test.op"(%radd1) : (!riscv.freg) -> ()
+"test.op"(%radd1b) : (!riscv.freg) -> ()
+"test.op"(%radd2) : (!riscv.freg) -> ()
+"test.op"(%radd2b) : (!riscv.freg) -> ()
+"test.op"(%radd3) : (!riscv.freg) -> ()
+"test.op"(%radd3b) : (!riscv.freg) -> ()
+"test.op"(%radd4) : (!riscv.freg) -> ()
+"test.op"(%radd4b) : (!riscv.freg) -> ()
 
 // CHECK:      builtin.module {
 
-// CHECK-NEXT:   %0, %1 = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>)
+// CHECK-NEXT:   %0, %1 = "test.op"() : () -> (!riscv.freg, !riscv.freg)
 
-// CHECK-NEXT:   %radd0 = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %radd0 = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %radd0b = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %radd0b = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %radd0_a = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<ft0>
+// CHECK-NEXT:   %radd0_a = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg<ft0>
 
-// CHECK-NEXT:   %radd0b_a = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<ft1>
+// CHECK-NEXT:   %radd0b_a = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg<ft1>
 
-// CHECK-NEXT:   %rmul0c0 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd0c = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul0c0 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd0c = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul1 = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd1 = riscv.fadd.d %0, %rmul1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul1 = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd1 = riscv.fadd.d %0, %rmul1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul1b = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd1b = riscv.fadd.d %rmul1b, %0 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul1b = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd1b = riscv.fadd.d %rmul1b, %0 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul2 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd2 = riscv.fadd.d %0, %rmul2 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul2 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd2 = riscv.fadd.d %0, %rmul2 : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul2b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd2b = riscv.fadd.d %rmul2b, %0 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul2b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd2b = riscv.fadd.d %rmul2b, %0 : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul3 = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd3 = riscv.fadd.d %0, %rmul3 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul3 = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd3 = riscv.fadd.d %0, %rmul3 : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul3b = riscv.fmul.d %0, %1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd3b = riscv.fadd.d %rmul3b, %0 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul3b = riscv.fmul.d %0, %1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd3b = riscv.fadd.d %rmul3b, %0 : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul4 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd4 = riscv.fadd.d %0, %rmul4 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul4 = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd4 = riscv.fadd.d %0, %rmul4 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   %rmul4b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %radd4b = riscv.fadd.d %rmul4b, %0 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+// CHECK-NEXT:   %rmul4b = riscv.fmul.d %0, %1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %radd4b = riscv.fadd.d %rmul4b, %0 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-// CHECK-NEXT:   "test.op"(%rmul4) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%rmul4b) : (!riscv.freg<>) -> ()
+// CHECK-NEXT:   "test.op"(%rmul4) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%rmul4b) : (!riscv.freg) -> ()
 
-// CHECK-NEXT:   "test.op"(%radd0) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd0b) : (!riscv.freg<>) -> ()
+// CHECK-NEXT:   "test.op"(%radd0) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd0b) : (!riscv.freg) -> ()
 // CHECK-NEXT:   "test.op"(%radd0_a) : (!riscv.freg<ft0>) -> ()
 // CHECK-NEXT:   "test.op"(%radd0b_a) : (!riscv.freg<ft1>) -> ()
-// CHECK-NEXT:   "test.op"(%radd0c) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd1) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd1b) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd2) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd2b) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd3) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd3b) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd4) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%radd4b) : (!riscv.freg<>) -> ()
+// CHECK-NEXT:   "test.op"(%radd0c) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd1) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd1b) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd2) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd2b) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd3) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd3b) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd4) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%radd4b) : (!riscv.freg) -> ()
 
 // CHECK-NEXT:  }

--- a/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
@@ -1,224 +1,224 @@
 // RUN: xdsl-opt -p convert-arith-to-riscv,reconcile-unrealized-casts %s | filecheck %s
 builtin.module {
     %lhsi32 = "arith.constant"() {value = 1 : i32} : () -> i32
-    // CHECK: %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
+    // CHECK: %{{.*}} = riscv.li 1 : () -> !riscv.reg
     %rhsi32 = "arith.constant"() {value = 2 : i32} : () -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 2 : () -> !riscv.reg
     %lhsindex = "arith.constant"() {value = 1 : index} : () -> index
-    // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg
     %rhsindex = "arith.constant"() {value = 2 : index} : () -> index
-    // CHECK-NEXT: %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 2 : () -> !riscv.reg
     %lhsf32 = "arith.constant"() {value = 1.000000e+00 : f32} : () -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.li 1065353216 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.w.x %lhsf32 : (!riscv.reg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 1065353216 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fmv.w.x %lhsf32 : (!riscv.reg) -> !riscv.freg
     %rhsf32 = "arith.constant"() {value = 2.000000e+00 : f32} : () -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.li 1073741824 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.w.x %rhsf32 : (!riscv.reg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 1073741824 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fmv.w.x %rhsf32 : (!riscv.reg) -> !riscv.freg
 
     %constf64zero = arith.constant 0.0 : f64
-    // CHECK-NEXT: %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.w %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 0 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.w %{{.*}} : (!riscv.reg) -> !riscv.freg
 
-    %lhsf64_reg, %rhsf64_reg = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>)
-    %lhsf64 = builtin.unrealized_conversion_cast %lhsf64_reg : !riscv.freg<> to f64
-    %rhsf64 = builtin.unrealized_conversion_cast %rhsf64_reg : !riscv.freg<> to f64
+    %lhsf64_reg, %rhsf64_reg = "test.op"() : () -> (!riscv.freg, !riscv.freg)
+    %lhsf64 = builtin.unrealized_conversion_cast %lhsf64_reg : !riscv.freg to f64
+    %rhsf64 = builtin.unrealized_conversion_cast %rhsf64_reg : !riscv.freg to f64
 
-    // CHECK-NEXT: %lhsf64_reg, %rhsf64_reg = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>)
+    // CHECK-NEXT: %lhsf64_reg, %rhsf64_reg = "test.op"() : () -> (!riscv.freg, !riscv.freg)
 
     %f64 = "arith.constant"() {value = 1234.5678 : f64} : () -> f64
     // CHECK-NEXT: %{{.*}} = riscv.get_register : () -> !riscv.reg<sp>
-    // CHECK-NEXT: %{{.*}} = riscv.li 1083394629 : () -> !riscv.reg<>
-    // CHECK-NEXT: riscv.sw %{{.*}}, %{{.*}}, -4 : (!riscv.reg<sp>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: %{{.*}} = riscv.li 1834810029 : () -> !riscv.reg<>
-    // CHECK-NEXT: riscv.sw %{{.*}}, %{{.*}}, -8 : (!riscv.reg<sp>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: %{{.*}} = riscv.fld %{{.*}}, -8 : (!riscv.reg<sp>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 1083394629 : () -> !riscv.reg
+    // CHECK-NEXT: riscv.sw %{{.*}}, %{{.*}}, -4 : (!riscv.reg<sp>, !riscv.reg) -> ()
+    // CHECK-NEXT: %{{.*}} = riscv.li 1834810029 : () -> !riscv.reg
+    // CHECK-NEXT: riscv.sw %{{.*}}, %{{.*}}, -8 : (!riscv.reg<sp>, !riscv.reg) -> ()
+    // CHECK-NEXT: %{{.*}} = riscv.fld %{{.*}}, -8 : (!riscv.reg<sp>) -> !riscv.freg
 
     %addi32 = "arith.addi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.add %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.add %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %addindex = "arith.addi"(%lhsindex, %rhsindex) : (index, index) -> index
-    // CHECK-NEXT: %{{.*}} = riscv.add %lhsindex, %rhsindex : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.add %lhsindex, %rhsindex : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     %subi32 = "arith.subi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.sub %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sub %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %subindex = "arith.subi"(%lhsindex, %rhsindex) : (index, index) -> index
-    // CHECK-NEXT: %{{.*}} = riscv.sub %lhsindex, %rhsindex : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sub %lhsindex, %rhsindex : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     %muli32 = "arith.muli"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.mul %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.mul %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %mulindex = "arith.muli"(%lhsindex, %rhsindex) : (index, index) -> index
-    // CHECK-NEXT: %{{.*}} = riscv.mul %lhsindex, %rhsindex : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.mul %lhsindex, %rhsindex : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     %divui32 = "arith.divui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.divu %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.divu %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %divsi32 = "arith.divsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.div %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.div %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     %remui = "arith.remui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.remu %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.remu %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %remsi = "arith.remsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.rem %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.rem %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     %andi32 = "arith.andi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.and %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.and %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %ori32 = "arith.ori"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.or %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.or %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %xori32 = "arith.xori"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.xor %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.xor %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     %shli32 = "arith.shli"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.sll %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sll %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %shrui32 = "arith.shrui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.srl %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.srl %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %shrsi32 = "arith.shrsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = riscv.sra %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sra %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     %cmpi0 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 0 : i32} : (i32, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.xor %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sltiu %cmpi0, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.xor %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.sltiu %cmpi0, 1 : (!riscv.reg) -> !riscv.reg
     %cmpi1 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 1 : i32} : (i32, i32) -> i1
     // CHECK-NEXT: %{{.*}} = riscv.get_register : () -> !riscv.reg<zero>
-    // CHECK-NEXT: %{{.*}}= riscv.xor %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sltu %cmpi1, %cmpi1_1 : (!riscv.reg<zero>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}}= riscv.xor %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.sltu %cmpi1, %cmpi1_1 : (!riscv.reg<zero>, !riscv.reg) -> !riscv.reg
     %cmpi2 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 2 : i32} : (i32, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.slt %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.slt %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %cmpi3 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 3 : i32} : (i32, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.slt %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpi3, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.slt %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpi3, 1 : (!riscv.reg) -> !riscv.reg
     %cmpi4 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 4 : i32} : (i32, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.sltu %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sltu %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %cmpi5 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 5 : i32} : (i32, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.sltu %lhsi32, %rhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpi5, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sltu %lhsi32, %rhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpi5, 1 : (!riscv.reg) -> !riscv.reg
     %cmpi6 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 6 : i32} : (i32, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.sltu %rhsi32, %lhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sltu %rhsi32, %lhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %cmpi7 = "arith.cmpi"(%lhsi32, %rhsi32) {"predicate" = 7 : i32} : (i32, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.sltu %rhsi32, %lhsi32 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpi7, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.sltu %rhsi32, %lhsi32 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpi7, 1 : (!riscv.reg) -> !riscv.reg
 
     %addf32 = "arith.addf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %subf32 = "arith.subf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %mulf32 = "arith.mulf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %divf32 = "arith.divf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %negf32 = "arith.negf"(%rhsf32) : (f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnjn.s %rhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsgnjn.s %rhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %minf32 = "arith.minimumf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %maxf32 = "arith.maximumf"(%lhsf32, %rhsf32) : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
     // tests with fastmath flags when set to "fast"
     %addf32_fm = "arith.addf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %subf32_fm = "arith.subf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %mulf32_fm = "arith.mulf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %divf32_fm = "arith.divf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %minf32_fm = "arith.minimumf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %maxf32_fm = "arith.maximumf"(%lhsf32, %rhsf32) {"fastmath" = #arith.fastmath<fast>} : (f32, f32) -> f32
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
     %addf64 = "arith.addf"(%lhsf64, %rhsf64) : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %subf64 = "arith.subf"(%lhsf64, %rhsf64) : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %mulf64 = "arith.mulf"(%lhsf64, %rhsf64) : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %divf64 = "arith.divf"(%lhsf64, %rhsf64) : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %minf64 = "arith.minimumf"(%lhsf64, %rhsf64) : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %maxf64 = "arith.maximumf"(%lhsf64, %rhsf64) : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
     // tests with fastmath flags when set to "fast"
     %addf64_fm = "arith.addf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %subf64_fm = "arith.subf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %mulf64_fm = "arith.mulf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %divf64_fm = "arith.divf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %minf64_fm = "arith.minimumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %maxf64_fm = "arith.maximumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<fast>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
     // tests with fastmath flags when set to "contract"
     %addf64_fm_contract = "arith.addf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %subf64_fm_contract = "arith.subf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %mulf64_fm_contract = "arith.mulf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %divf64_fm_contract = "arith.divf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %minf64_fm_contract = "arith.minimumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg, !riscv.freg) -> !riscv.freg
     %maxf64_fm_contract = "arith.maximumf"(%lhsf64, %rhsf64) {"fastmath" = #arith.fastmath<contract>} : (f64, f64) -> f64
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %lhsf64_reg, %rhsf64_reg fastmath<contract> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
     %sitofp32 = arith.sitofp %lhsi32 : i32 to f32
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %lhsi32 : (!riscv.reg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %lhsi32 : (!riscv.reg) -> !riscv.freg
     %fp32tosi = arith.fptosi %lhsf32 : f32 to i32
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %lhsf32_1 : (!riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %lhsf32_1 : (!riscv.freg) -> !riscv.reg
     %sitofp64 = arith.sitofp %lhsi32 : i32 to f64
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.w %lhsi32 : (!riscv.reg<>) -> !riscv.freg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.w %lhsi32 : (!riscv.reg) -> !riscv.freg
 
     %cmpf0 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 0 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 0 : () -> !riscv.reg
     %cmpf1 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 1 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
     %cmpf2 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 2 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
     %cmpf3 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 3 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
     %cmpf4 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 4 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
     %cmpf5 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 5 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
     %cmpf6 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 6 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.or %cmpf6_1, %cmpf6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.or %cmpf6_1, %cmpf6 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %cmpf7 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 7 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.and %cmpf7_1, %cmpf7 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.and %cmpf7_1, %cmpf7 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %cmpf8 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 8 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.or %cmpf8_1, %cmpf8 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf8_2, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.or %cmpf8_1, %cmpf8 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf8_2, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf9 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 9 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf9, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf9, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf10 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 10 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf10, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf10, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf11 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 11 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf11, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf11, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf12 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 12 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf12, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf12, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf13 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 13 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf13, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf13, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf14 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 14 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.and %cmpf14_1, %cmpf14 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf14_2, 1 : (!riscv.reg<>) -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.and %cmpf14_1, %cmpf14 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf14_2, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf15 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 15 : i32} : (f32, f32) -> i1
-    // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
+    // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg
     %index_cast = "arith.index_cast"(%lhsindex) : (index) -> i32
     // CHECK-NEXT: }
 }

--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -36,15 +36,15 @@ builtin.module {
 // CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @main() {
 // CHECK-NEXT:          %0, %1 = "test.op"() : () -> (i32, i32)
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg<>
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %1 : i32 to !riscv.reg<>
-// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a1>
+// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg
+// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %1 : i32 to !riscv.reg
+// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a1>
 // CHECK-NEXT:          %{{.*}}, %{{.*}} = riscv_func.call @foo(%{{.*}}, %{{.*}}) : (!riscv.reg<a0>, !riscv.reg<a1>) -> (!riscv.reg<a0>, !riscv.reg<a1>)
-// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a1>) -> !riscv.reg<>
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
+// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a1>) -> !riscv.reg
+// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:          riscv_func.return
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -52,15 +52,15 @@ builtin.module {
 // CHECK-NEXT:      riscv.directive ".globl" "foo"
 // CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.reg<a1>) -> (!riscv.reg<a0>, !riscv.reg<a1>) {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg1 : (!riscv.reg<a1>) -> !riscv.reg<>
-// CHECK-NEXT:        %arg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
+// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:        %{{.*}} = riscv.mv %arg1 : (!riscv.reg<a1>) -> !riscv.reg
+// CHECK-NEXT:        %arg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:        %res0, %res1 = "test.op"(%arg0_1, %arg1_1) : (i32, i32) -> (i32, i32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0 : i32 to !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res1 : i32 to !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
-// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a1>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0 : i32 to !riscv.reg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res1 : i32 to !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a1>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.reg<a0>, !riscv.reg<a1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -68,15 +68,15 @@ builtin.module {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_float"
 // CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) {
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg<>
-// CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg1 : (!riscv.freg<fa1>) -> !riscv.freg<>
-// CHECK-NEXT:        %farg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg1 : (!riscv.freg<fa1>) -> !riscv.freg
+// CHECK-NEXT:        %farg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
 // CHECK-NEXT:        %fres0, %fres1 = "test.op"(%farg0_1, %farg1_1) : (f32, f32) -> (f32, f32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres1 : f32 to !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa0>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa1>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres1 : f32 to !riscv.freg
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa1>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.freg<fa1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -84,15 +84,15 @@ builtin.module {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_int_float"
 // CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg<>
-// CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
+// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
 // CHECK-NEXT:        %fres0, %res0 = "test.op"(%arg0_1, %farg0_1) : (i32, f32) -> (f32, i32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0 : i32 to !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa0>
-// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0 : i32 to !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
+// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -100,15 +100,15 @@ builtin.module {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_int_double"
 // CHECK-NEXT:      riscv.directive ".p2align" "2"
 // CHECK-NEXT:      riscv_func.func @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to i32
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f64
+// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f64
 // CHECK-NEXT:        %{{.*}}, %{{.*}} = "test.op"(%{{.*}}, %{{.*}}) : (i32, f64) -> (f64, i32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : i32 to !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<fa0>
-// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : i32 to !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
+// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/tests/filecheck/backend/riscv/convert_riscv_scf_for_to_frep.mlir
+++ b/tests/filecheck/backend/riscv/convert_riscv_scf_for_to_frep.mlir
@@ -1,11 +1,11 @@
 // RUN: xdsl-opt -p convert-riscv-scf-for-to-frep %s | filecheck %s
 
-%i0 = riscv.get_register : () -> !riscv.reg<>
-%i1 = riscv.get_register : () -> !riscv.reg<>
-%i2 = riscv.get_register : () -> !riscv.reg<>
+%i0 = riscv.get_register : () -> !riscv.reg
+%i1 = riscv.get_register : () -> !riscv.reg
+%i2 = riscv.get_register : () -> !riscv.reg
 
-%c1 = riscv.li 1 : () -> !riscv.reg<>
-%c2 = riscv.li 2 : () -> !riscv.reg<>
+%c1 = riscv.li 1 : () -> !riscv.reg
+%c2 = riscv.li 2 : () -> !riscv.reg
 
 %readable = riscv_snitch.get_stream : !stream.readable<!riscv.freg<ft0>>
 %writable = riscv_snitch.get_stream : !stream.writable<!riscv.freg<ft1>>
@@ -32,8 +32,8 @@ riscv_scf.for %index0 : !riscv.reg<a4> = %i0 to %i1 step %c1 {
 // CHECK-NEXT:      %f5 = riscv.fadd.d %f4, %f4 : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
 // CHECK-NEXT:      riscv_snitch.write %f5 to %writable : !riscv.freg<ft1>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %res = riscv.sub %i1, %i0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    %res_1 = riscv.addi %res, -1 : (!riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:    %res = riscv.sub %i1, %i0 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %res_1 = riscv.addi %res, -1 : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:    %res_2 = riscv_snitch.frep_outer %res_1 iter_args(%f3 = %f0) -> (!riscv.freg<ft2>) {
 // CHECK-NEXT:      %{{.*}} = riscv.fadd.d %f3, %f3 : (!riscv.freg<ft2>, !riscv.freg<ft2>) -> !riscv.freg<ft2>
 // CHECK-NEXT:      riscv_snitch.frep_yield %{{.*}} : !riscv.freg<ft2>
@@ -75,13 +75,13 @@ riscv_scf.for %index3 : !riscv.reg<a4> = %i0 to %i1 step %c2 {
 
 riscv_scf.for %index4 : !riscv.reg<a4> = %i0 to %i1 step %c1 {
     %f4 = riscv_snitch.read from %readable : !riscv.freg<ft0>
-    %f5 = riscv.fcvt.s.w %i2 : (!riscv.reg<>) -> !riscv.freg<ft1>
+    %f5 = riscv.fcvt.s.w %i2 : (!riscv.reg) -> !riscv.freg<ft1>
     riscv_snitch.write %f5 to %writable : !riscv.freg<ft1>
 }
 
 // CHECK-NEXT:    riscv_scf.for %index4 : !riscv.reg<a4> = %i0 to %i1 step %c1 {
 // CHECK-NEXT:      %{{.*}} = riscv_snitch.read from %readable : !riscv.freg<ft0>
-// CHECK-NEXT:      %{{.*}} = riscv.fcvt.s.w %i2 : (!riscv.reg<>) -> !riscv.freg<ft1>
+// CHECK-NEXT:      %{{.*}} = riscv.fcvt.s.w %i2 : (!riscv.reg) -> !riscv.freg<ft1>
 // CHECK-NEXT:      riscv_snitch.write %{{.*}} to %writable : !riscv.freg<ft1>
 // CHECK-NEXT:    }
 

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -16,76 +16,76 @@ builtin.module {
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:     %v_f32, %v_f64, %v_i32, %r, %c, %m_f32, %m_f64, %m_i32, %m_scalar_i32 = "test.op"() : () -> (f32, f64, i32, index, index, memref<3x2xf32>, memref<3x2xf64>, memref<3xi32>, memref<i32>)
-// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %v_f32 : f32 to !riscv.freg<>
-// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg<>
-// CHECK-NEXT:   %2 = builtin.unrealized_conversion_cast %r : index to !riscv.reg<>
-// CHECK-NEXT:   %3 = builtin.unrealized_conversion_cast %c : index to !riscv.reg<>
-// CHECK-NEXT:   %4 = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:   %5 = riscv.mul %4, %2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %6 = riscv.add %5, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %7 = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:   %8 = riscv.mul %6, %7 {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %9 = riscv.add %1, %8 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   riscv.fsw %9, %0, 0 {"comment" = "store float value to memref of shape (3, 2)"} : (!riscv.reg<>, !riscv.freg<>) -> ()
-// CHECK-NEXT:   %10 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg<>
-// CHECK-NEXT:   %11 = builtin.unrealized_conversion_cast %r : index to !riscv.reg<>
-// CHECK-NEXT:   %12 = builtin.unrealized_conversion_cast %c : index to !riscv.reg<>
-// CHECK-NEXT:   %13 = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:   %14 = riscv.mul %13, %11 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %15 = riscv.add %14, %12 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %16 = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:   %17 = riscv.mul %15, %16 {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %18 = riscv.add %10, %17 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %x_f32 = riscv.flw %18, 0 {"comment" = "load float from memref of shape (3, 2)"} : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %x_f32_1 = builtin.unrealized_conversion_cast %x_f32 : !riscv.freg<> to f32
-// CHECK-NEXT:   %19 = builtin.unrealized_conversion_cast %v_i32 : i32 to !riscv.reg<>
-// CHECK-NEXT:   %20 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg<>
-// CHECK-NEXT:   %21 = builtin.unrealized_conversion_cast %c : index to !riscv.reg<>
-// CHECK-NEXT:   %22 = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:   %23 = riscv.mul %21, %22 {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %24 = riscv.add %20, %23 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   riscv.sw %24, %19, 0 {"comment" = "store int value to memref of shape (3,)"} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   %25 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg<>
-// CHECK-NEXT:   %26 = builtin.unrealized_conversion_cast %c : index to !riscv.reg<>
-// CHECK-NEXT:   %27 = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:   %28 = riscv.mul %26, %27 {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %29 = riscv.add %25, %28 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %x_i32 = riscv.lw %29, 0 {"comment" = "load word from memref of shape (3,)"} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %x_i32_1 = builtin.unrealized_conversion_cast %x_i32 : !riscv.reg<> to i32
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %v_f64 : f64 to !riscv.freg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %r : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %c : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   riscv.fsd %{{.*}}, %{{.*}}, 0 {"comment" = "store double value to memref of shape (3, 2)"} : (!riscv.reg<>, !riscv.freg<>) -> ()
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg<>
-// CHECK-NEXT:   %scalar_x_i32 = riscv.lw %{{.*}}, 0 {"comment" = "load word from memref of shape ()"} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %scalar_x_i32_1 = builtin.unrealized_conversion_cast %scalar_x_i32 : !riscv.reg<> to i32
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %scalar_x_i32_1 : i32 to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg<>
-// CHECK-NEXT:   riscv.sw %{{.*}}, %{{.*}}, 0 {"comment" = "store int value to memref of shape ()"} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %r : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %c : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %x_f64 = riscv.fld %{{.*}}, 0 {"comment" = "load double from memref of shape (3, 2)"} : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %x_f64_1 = builtin.unrealized_conversion_cast %x_f64 : !riscv.freg<> to f64
+// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %v_f32 : f32 to !riscv.freg
+// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg
+// CHECK-NEXT:   %2 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:   %3 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:   %4 = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:   %5 = riscv.mul %4, %2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %6 = riscv.add %5, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %7 = riscv.li 4 : () -> !riscv.reg
+// CHECK-NEXT:   %8 = riscv.mul %6, %7 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %9 = riscv.add %1, %8 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   riscv.fsw %9, %0, 0 {"comment" = "store float value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-NEXT:   %10 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg
+// CHECK-NEXT:   %11 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:   %12 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:   %13 = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:   %14 = riscv.mul %13, %11 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %15 = riscv.add %14, %12 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %16 = riscv.li 4 : () -> !riscv.reg
+// CHECK-NEXT:   %17 = riscv.mul %15, %16 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %18 = riscv.add %10, %17 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %x_f32 = riscv.flw %18, 0 {"comment" = "load float from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
+// CHECK-NEXT:   %x_f32_1 = builtin.unrealized_conversion_cast %x_f32 : !riscv.freg to f32
+// CHECK-NEXT:   %19 = builtin.unrealized_conversion_cast %v_i32 : i32 to !riscv.reg
+// CHECK-NEXT:   %20 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg
+// CHECK-NEXT:   %21 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:   %22 = riscv.li 4 : () -> !riscv.reg
+// CHECK-NEXT:   %23 = riscv.mul %21, %22 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %24 = riscv.add %20, %23 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   riscv.sw %24, %19, 0 {"comment" = "store int value to memref of shape (3,)"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   %25 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg
+// CHECK-NEXT:   %26 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:   %27 = riscv.li 4 : () -> !riscv.reg
+// CHECK-NEXT:   %28 = riscv.mul %26, %27 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %29 = riscv.add %25, %28 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %x_i32 = riscv.lw %29, 0 {"comment" = "load word from memref of shape (3,)"} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %x_i32_1 = builtin.unrealized_conversion_cast %x_i32 : !riscv.reg to i32
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %v_f64 : f64 to !riscv.freg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   riscv.fsd %{{.*}}, %{{.*}}, 0 {"comment" = "store double value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg
+// CHECK-NEXT:   %scalar_x_i32 = riscv.lw %{{.*}}, 0 {"comment" = "load word from memref of shape ()"} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %scalar_x_i32_1 = builtin.unrealized_conversion_cast %scalar_x_i32 : !riscv.reg to i32
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %scalar_x_i32_1 : i32 to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg
+// CHECK-NEXT:   riscv.sw %{{.*}}, %{{.*}}, 0 {"comment" = "store int value to memref of shape ()"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %x_f64 = riscv.fld %{{.*}}, 0 {"comment" = "load double from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
+// CHECK-NEXT:   %x_f64_1 = builtin.unrealized_conversion_cast %x_f64 : !riscv.freg to f64
 // CHECK-NEXT:   riscv.assembly_section ".data" {
 // CHECK-NEXT:       riscv.label "global"
 // CHECK-NEXT:       riscv.directive ".word" "0x0,0x3ff00000,0x0,0x40000000"
 // CHECK-NEXT:   }
-// CHECK-NEXT:   %{{.*}} riscv.li "global" : () -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to memref<2xi32>
+// CHECK-NEXT:   %{{.*}} riscv.li "global" : () -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to memref<2xi32>
 // CHECK-NEXT: }
 
 // -----
@@ -96,16 +96,16 @@ builtin.module {
 }
 
 // CHECK:       builtin.module {
-// CHECK-NEXT:    %m0 = riscv.li 4 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
-// CHECK-NEXT:    %m0_1 = riscv.mv %m0 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m0 = riscv.li 4 {"comment" = "memref alloc size"} : () -> !riscv.reg
+// CHECK-NEXT:    %m0_1 = riscv.mv %m0 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:    %m0_2 = riscv_func.call @malloc(%m0_1) : (!riscv.reg<a0>) -> !riscv.reg<a0>
-// CHECK-NEXT:    %m0_3 = riscv.mv %m0_2 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:    %m0_4 = builtin.unrealized_conversion_cast %m0_3 : !riscv.reg<> to memref<1x1xf32>
-// CHECK-NEXT:    %m1 = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg<>
-// CHECK-NEXT:    %m1_1 = riscv.mv %m1 : (!riscv.reg<>) -> !riscv.reg<a0>
+// CHECK-NEXT:    %m0_3 = riscv.mv %m0_2 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:    %m0_4 = builtin.unrealized_conversion_cast %m0_3 : !riscv.reg to memref<1x1xf32>
+// CHECK-NEXT:    %m1 = riscv.li 8 {"comment" = "memref alloc size"} : () -> !riscv.reg
+// CHECK-NEXT:    %m1_1 = riscv.mv %m1 : (!riscv.reg) -> !riscv.reg<a0>
 // CHECK-NEXT:    %m1_2 = riscv_func.call @malloc(%m1_1) : (!riscv.reg<a0>) -> !riscv.reg<a0>
-// CHECK-NEXT:    %m1_3 = riscv.mv %m1_2 : (!riscv.reg<a0>) -> !riscv.reg<>
-// CHECK-NEXT:    %m1_4 = builtin.unrealized_conversion_cast %m1_3 : !riscv.reg<> to memref<1x1xf64>
+// CHECK-NEXT:    %m1_3 = riscv.mv %m1_2 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:    %m1_4 = builtin.unrealized_conversion_cast %m1_3 : !riscv.reg to memref<1x1xf64>
 // CHECK-NEXT:    riscv_func.func private @malloc(!riscv.reg<a0>) -> !riscv.reg<a0>
 // CHECK-NEXT:  }
 

--- a/tests/filecheck/backend/riscv/memref_to_riscv_opt.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv_opt.mlir
@@ -3,40 +3,40 @@
 // Test that a memref float store and load with constant indices optimise to a single operation
 
 builtin.module {
-    %vf_reg, %vd_reg, %vi_reg, %mf_reg, %md_reg, %mi_reg = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-    %vf = builtin.unrealized_conversion_cast %vf_reg : !riscv.freg<> to f32
-    %vd = builtin.unrealized_conversion_cast %vd_reg : !riscv.freg<> to f64
-    %vi = builtin.unrealized_conversion_cast %vi_reg : !riscv.reg<> to i32
-    %mf = builtin.unrealized_conversion_cast %mf_reg : !riscv.reg<> to memref<3x2xf32>
-    %md = builtin.unrealized_conversion_cast %md_reg : !riscv.reg<> to memref<3x2xf64>
-    %mi = builtin.unrealized_conversion_cast %mi_reg : !riscv.reg<> to memref<3x2xi32>
-    %r_reg = riscv.li 1 : () -> !riscv.reg<>
-    %c_reg = riscv.li 1 : () -> !riscv.reg<>
-    %r = builtin.unrealized_conversion_cast %r_reg : !riscv.reg<> to index
-    %c = builtin.unrealized_conversion_cast %c_reg : !riscv.reg<> to index
+    %vf_reg, %vd_reg, %vi_reg, %mf_reg, %md_reg, %mi_reg = "test.op"() : () -> (!riscv.freg, !riscv.freg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg)
+    %vf = builtin.unrealized_conversion_cast %vf_reg : !riscv.freg to f32
+    %vd = builtin.unrealized_conversion_cast %vd_reg : !riscv.freg to f64
+    %vi = builtin.unrealized_conversion_cast %vi_reg : !riscv.reg to i32
+    %mf = builtin.unrealized_conversion_cast %mf_reg : !riscv.reg to memref<3x2xf32>
+    %md = builtin.unrealized_conversion_cast %md_reg : !riscv.reg to memref<3x2xf64>
+    %mi = builtin.unrealized_conversion_cast %mi_reg : !riscv.reg to memref<3x2xi32>
+    %r_reg = riscv.li 1 : () -> !riscv.reg
+    %c_reg = riscv.li 1 : () -> !riscv.reg
+    %r = builtin.unrealized_conversion_cast %r_reg : !riscv.reg to index
+    %c = builtin.unrealized_conversion_cast %c_reg : !riscv.reg to index
     "memref.store"(%vf, %mf, %r, %c) {"nontemporal" = false} : (f32, memref<3x2xf32>, index, index) -> ()
     %xf = "memref.load"(%mf, %r, %c) {"nontemporal" = false} : (memref<3x2xf32>, index, index) -> (f32)
     "memref.store"(%vd, %md, %r, %c) {"nontemporal" = false} : (f64, memref<3x2xf64>, index, index) -> ()
     %xd = "memref.load"(%md, %r, %c) {"nontemporal" = false} : (memref<3x2xf64>, index, index) -> (f64)
     "memref.store"(%vi, %mi, %r, %c) {"nontemporal" = false} : (i32, memref<3x2xi32>, index, index) -> ()
     %xi = "memref.load"(%mi, %r, %c) {"nontemporal" = false} : (memref<3x2xi32>, index, index) -> (i32)
-    %xf_reg = builtin.unrealized_conversion_cast %xf : f32 to !riscv.freg<>
-    %xd_reg = builtin.unrealized_conversion_cast %xd : f64 to !riscv.freg<>
-    %xi_reg = builtin.unrealized_conversion_cast %xi : i32 to !riscv.reg<>
-    "test.op"(%xf_reg) : (!riscv.freg<>) -> ()
-    "test.op"(%xd_reg) : (!riscv.freg<>) -> ()
-    "test.op"(%xi_reg) : (!riscv.reg<>) -> ()
+    %xf_reg = builtin.unrealized_conversion_cast %xf : f32 to !riscv.freg
+    %xd_reg = builtin.unrealized_conversion_cast %xd : f64 to !riscv.freg
+    %xi_reg = builtin.unrealized_conversion_cast %xi : i32 to !riscv.reg
+    "test.op"(%xf_reg) : (!riscv.freg) -> ()
+    "test.op"(%xd_reg) : (!riscv.freg) -> ()
+    "test.op"(%xi_reg) : (!riscv.reg) -> ()
 }
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   %vf_reg, %vd_reg, %vi_reg, %mf_reg, %md_reg, %mi_reg = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT:   riscv.fsw %mf_reg, %vf_reg, 12 {"comment" = "store float value to memref of shape (3, 2)"} : (!riscv.reg<>, !riscv.freg<>) -> ()
-// CHECK-NEXT:   %xf = riscv.flw %mf_reg, 12 {"comment" = "load float from memref of shape (3, 2)"} : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-NEXT:   riscv.fsd %md_reg, %vd_reg, 24 {"comment" = "store double value to memref of shape (3, 2)"} : (!riscv.reg<>, !riscv.freg<>) -> ()
-// CHECK-NEXT:   %xd = riscv.fld %md_reg, 24 {"comment" = "load double from memref of shape (3, 2)"} : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-NEXT:   riscv.sw %mi_reg, %vi_reg, 12 {"comment" = "store int value to memref of shape (3, 2)"} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   %xi = riscv.lw %mi_reg, 12 {"comment" = "load word from memref of shape (3, 2)"} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   "test.op"(%xf) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%xd) : (!riscv.freg<>) -> ()
-// CHECK-NEXT:   "test.op"(%xi) : (!riscv.reg<>) -> ()
+// CHECK-NEXT:   %vf_reg, %vd_reg, %vi_reg, %mf_reg, %md_reg, %mi_reg = "test.op"() : () -> (!riscv.freg, !riscv.freg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg)
+// CHECK-NEXT:   riscv.fsw %mf_reg, %vf_reg, 12 {"comment" = "store float value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-NEXT:   %xf = riscv.flw %mf_reg, 12 {"comment" = "load float from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
+// CHECK-NEXT:   riscv.fsd %md_reg, %vd_reg, 24 {"comment" = "store double value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-NEXT:   %xd = riscv.fld %md_reg, 24 {"comment" = "load double from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
+// CHECK-NEXT:   riscv.sw %mi_reg, %vi_reg, 12 {"comment" = "store int value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   %xi = riscv.lw %mi_reg, 12 {"comment" = "load word from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   "test.op"(%xf) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%xd) : (!riscv.freg) -> ()
+// CHECK-NEXT:   "test.op"(%xi) : (!riscv.reg) -> ()
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/print_format_to_riscv_debug.mlir
+++ b/tests/filecheck/backend/riscv/print_format_to_riscv_debug.mlir
@@ -8,9 +8,9 @@ printf.print_format "bitwidths {} {} {} {}", %i32 : i32, %i64 : i64, %f32 : f32,
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %i32, %i64, %f32, %f64 = "test.op"() : () -> (i32, i64, f32, f64)
 // CHECK-NEXT:   riscv_debug.printf "Hello world!" : () -> ()
-// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %i32 : i32 to !riscv.reg<>
-// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %i64 : i64 to !riscv.reg<>
-// CHECK-NEXT:   %2 = builtin.unrealized_conversion_cast %f32 : f32 to !riscv.freg<>
-// CHECK-NEXT:   %3 = builtin.unrealized_conversion_cast %f64 : f64 to !riscv.freg<>
-// CHECK-NEXT:   riscv_debug.printf %0, %1, %2, %3 "bitwidths {} {} {} {}" : (!riscv.reg<>, !riscv.reg<>, !riscv.freg<>, !riscv.freg<>) -> ()
+// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %i32 : i32 to !riscv.reg
+// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %i64 : i64 to !riscv.reg
+// CHECK-NEXT:   %2 = builtin.unrealized_conversion_cast %f32 : f32 to !riscv.freg
+// CHECK-NEXT:   %3 = builtin.unrealized_conversion_cast %f64 : f64 to !riscv.freg
+// CHECK-NEXT:   riscv_debug.printf %0, %1, %2, %3 "bitwidths {} {} {} {}" : (!riscv.reg, !riscv.reg, !riscv.freg, !riscv.freg) -> ()
 // CHECK-NEXT: }

--- a/tests/filecheck/backend/riscv/register_allocation_exclude_snitch.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_exclude_snitch.mlir
@@ -3,16 +3,16 @@
 
 riscv_func.func @main() {
   %stream = "test.op"() : () -> (!stream.readable<!riscv.freg<ft0>>)
-  %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>)
+  %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg, !riscv.freg, !riscv.freg)
   %read = riscv_snitch.read from %stream : !riscv.freg<ft0>
-  %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+  %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
   riscv_func.return
 }
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
 // CHECK-NEXT:      %stream = "test.op"() : () -> !stream.readable<!riscv.freg<ft0>>
-// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft4>, !riscv.freg<>)
+// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft4>, !riscv.freg)
 // CHECK-NEXT:      %read = riscv_snitch.read from %stream : !riscv.freg<ft0>
 // CHECK-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft3>, !riscv.freg<ft4>) -> !riscv.freg<ft3>
 // CHECK-NEXT:      riscv_func.return
@@ -22,7 +22,7 @@ riscv_func.func @main() {
 // CHECK-SNITCH-UNRESERVED:       builtin.module {
 // CHECK-SNITCH-UNRESERVED-NEXT:    riscv_func.func @main() {
 // CHECK-SNITCH-UNRESERVED-NEXT:      %stream = "test.op"() : () -> !stream.readable<!riscv.freg<ft0>>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg<>)
+// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg)
 // CHECK-SNITCH-UNRESERVED-NEXT:      %read = riscv_snitch.read from %stream : !riscv.freg<ft0>
 // CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft1>, !riscv.freg<ft2>) -> !riscv.freg<ft1>
 // CHECK-SNITCH-UNRESERVED-NEXT:      riscv_func.return
@@ -33,16 +33,16 @@ riscv_func.func @main() {
 
 riscv_func.func @main() {
   %stream, %val = "test.op"() : () -> (!stream.writable<!riscv.freg<ft0>>, !riscv.freg<ft0>)
-  %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>)
+  %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg, !riscv.freg, !riscv.freg)
   riscv_snitch.write %val to %stream : !riscv.freg<ft0>
-  %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+  %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
   riscv_func.return
 }
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv_func.func @main() {
 // CHECK-NEXT:      %stream, %val = "test.op"() : () -> (!stream.writable<!riscv.freg<ft0>>, !riscv.freg<ft0>)
-// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft4>, !riscv.freg<>)
+// CHECK-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft3>, !riscv.freg<ft4>, !riscv.freg)
 // CHECK-NEXT:      riscv_snitch.write %val to %stream : !riscv.freg<ft0>
 // CHECK-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft3>, !riscv.freg<ft4>) -> !riscv.freg<ft3>
 // CHECK-NEXT:      riscv_func.return
@@ -52,7 +52,7 @@ riscv_func.func @main() {
 // CHECK-SNITCH-UNRESERVED:       builtin.module {
 // CHECK-SNITCH-UNRESERVED-NEXT:    riscv_func.func @main() {
 // CHECK-SNITCH-UNRESERVED-NEXT:      %stream, %val = "test.op"() : () -> (!stream.writable<!riscv.freg<ft0>>, !riscv.freg<ft0>)
-// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg<>)
+// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg)
 // CHECK-SNITCH-UNRESERVED-NEXT:      riscv_snitch.write %val to %stream : !riscv.freg<ft0>
 // CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft1>, !riscv.freg<ft2>) -> !riscv.freg<ft1>
 // CHECK-SNITCH-UNRESERVED-NEXT:      riscv_func.return

--- a/tests/filecheck/backend/riscv/register_allocation_frep.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_frep.mlir
@@ -2,19 +2,19 @@
 // RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=0}" %s | filecheck %s --check-prefix=CHECK-LIVENESS-BLOCK-NAIVE-J
 
 riscv_func.func @main() {
-  %0 = riscv.li 6 : () -> !riscv.reg<>
+  %0 = riscv.li 6 : () -> !riscv.reg
   %1 = riscv.li 5 : () -> !riscv.reg<s0>
-  %2 = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
-  %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg<>
-  %4 = riscv.fadd.s %2, %3 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-  %5 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
+  %2 = riscv.fcvt.s.w %0 : (!riscv.reg) -> !riscv.freg
+  %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg
+  %4 = riscv.fadd.s %2, %3 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  %5 = riscv.add %0, %1 : (!riscv.reg, !riscv.reg<s0>) -> !riscv.reg
 
   riscv_snitch.frep_outer %0 {
   }
 
-  %7 = riscv_snitch.frep_outer %0 iter_args(%6 = %5) -> (!riscv.reg<>) {
-    %8 = riscv.mv %6 : (!riscv.reg<>) -> !riscv.reg<>
-    riscv_snitch.frep_yield %8 : !riscv.reg<>
+  %7 = riscv_snitch.frep_outer %0 iter_args(%6 = %5) -> (!riscv.reg) {
+    %8 = riscv.mv %6 : (!riscv.reg) -> !riscv.reg
+    riscv_snitch.frep_yield %8 : !riscv.reg
   }
   riscv_func.return
 }

--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive.mlir
@@ -2,41 +2,41 @@
 
 builtin.module {
   riscv_func.func @main() {
-    %0 = riscv.li 6 : () -> !riscv.reg<>
+    %0 = riscv.li 6 : () -> !riscv.reg
     %1 = riscv.li 5 : () -> !riscv.reg<s0>
-    %2 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
-    %3 = riscv.li 29 : () -> !riscv.reg<>
-    %4 = riscv.li 28 : () -> !riscv.reg<>
-    %5 = riscv.li 27 : () -> !riscv.reg<>
-    %6 = riscv.li 26 : () -> !riscv.reg<>
-    %7 = riscv.li 25 : () -> !riscv.reg<>
-    %8 = riscv.li 24 : () -> !riscv.reg<>
-    %9 = riscv.li 23 : () -> !riscv.reg<>
-    %10 = riscv.li 22 : () -> !riscv.reg<>
-    %11 = riscv.li 21 : () -> !riscv.reg<>
-    %12 = riscv.li 20 : () -> !riscv.reg<>
-    %13 = riscv.li 19 : () -> !riscv.reg<>
-    %14 = riscv.li 18 : () -> !riscv.reg<>
-    %15 = riscv.li 17 : () -> !riscv.reg<>
-    %16 = riscv.li 16 : () -> !riscv.reg<>
-    %17 = riscv.li 15 : () -> !riscv.reg<>
-    %18 = riscv.li 14 : () -> !riscv.reg<>
-    %19 = riscv.li 13 : () -> !riscv.reg<>
-    %20 = riscv.li 12 : () -> !riscv.reg<>
-    %21 = riscv.li 11 : () -> !riscv.reg<>
-    %22 = riscv.li 10 : () -> !riscv.reg<>
-    %23 = riscv.li 9 : () -> !riscv.reg<>
-    %24 = riscv.li 8 : () -> !riscv.reg<>
-    %25 = riscv.li 7 : () -> !riscv.reg<>
-    %26 = riscv.li 6 : () -> !riscv.reg<>
-    %27 = riscv.li 5 : () -> !riscv.reg<>
-    %28 = riscv.li 4 : () -> !riscv.reg<>
-    %29 = riscv.li 3 : () -> !riscv.reg<>
-    %30 = riscv.li 2 : () -> !riscv.reg<>
-    %31 = riscv.li 1 : () -> !riscv.reg<>
-    %32 = riscv.fcvt.s.w %30 : (!riscv.reg<>) -> !riscv.freg<>
-    %33 = riscv.fcvt.s.w %31 : (!riscv.reg<>) -> !riscv.freg<>
-    %34 = riscv.fadd.s %32, %33 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %2 = riscv.add %0, %1 : (!riscv.reg, !riscv.reg<s0>) -> !riscv.reg
+    %3 = riscv.li 29 : () -> !riscv.reg
+    %4 = riscv.li 28 : () -> !riscv.reg
+    %5 = riscv.li 27 : () -> !riscv.reg
+    %6 = riscv.li 26 : () -> !riscv.reg
+    %7 = riscv.li 25 : () -> !riscv.reg
+    %8 = riscv.li 24 : () -> !riscv.reg
+    %9 = riscv.li 23 : () -> !riscv.reg
+    %10 = riscv.li 22 : () -> !riscv.reg
+    %11 = riscv.li 21 : () -> !riscv.reg
+    %12 = riscv.li 20 : () -> !riscv.reg
+    %13 = riscv.li 19 : () -> !riscv.reg
+    %14 = riscv.li 18 : () -> !riscv.reg
+    %15 = riscv.li 17 : () -> !riscv.reg
+    %16 = riscv.li 16 : () -> !riscv.reg
+    %17 = riscv.li 15 : () -> !riscv.reg
+    %18 = riscv.li 14 : () -> !riscv.reg
+    %19 = riscv.li 13 : () -> !riscv.reg
+    %20 = riscv.li 12 : () -> !riscv.reg
+    %21 = riscv.li 11 : () -> !riscv.reg
+    %22 = riscv.li 10 : () -> !riscv.reg
+    %23 = riscv.li 9 : () -> !riscv.reg
+    %24 = riscv.li 8 : () -> !riscv.reg
+    %25 = riscv.li 7 : () -> !riscv.reg
+    %26 = riscv.li 6 : () -> !riscv.reg
+    %27 = riscv.li 5 : () -> !riscv.reg
+    %28 = riscv.li 4 : () -> !riscv.reg
+    %29 = riscv.li 3 : () -> !riscv.reg
+    %30 = riscv.li 2 : () -> !riscv.reg
+    %31 = riscv.li 1 : () -> !riscv.reg
+    %32 = riscv.fcvt.s.w %30 : (!riscv.reg) -> !riscv.freg
+    %33 = riscv.fcvt.s.w %31 : (!riscv.reg) -> !riscv.freg
+    %34 = riscv.fadd.s %32, %33 : (!riscv.freg, !riscv.freg) -> !riscv.freg
     riscv_func.return
   }
 }

--- a/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_liveness_block_naive_limited.mlir
@@ -1,21 +1,21 @@
 // RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive limit_registers=2}" %s | filecheck %s
 
 riscv_func.func @main() {
-  %0 = riscv.li  6 : () -> !riscv.reg<>
+  %0 = riscv.li  6 : () -> !riscv.reg
   %1 = riscv.li  5 : () -> !riscv.reg<s0>
-  %2 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
-  %3 = riscv.li  29 : () -> !riscv.reg<>
-  %4 = riscv.li  28 : () -> !riscv.reg<>
-  %5 = riscv.add %3, %4 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  %6 = riscv.li  26 : () -> !riscv.reg<>
-  %7 = riscv.li  25 : () -> !riscv.reg<>
-  %8 = riscv.li  24 : () -> !riscv.reg<>
-  %9 = riscv.li  23 : () -> !riscv.reg<>
-  %10 = riscv.li 2 : () -> !riscv.reg<>
-  %11 = riscv.li 1 : () -> !riscv.reg<>
-  %12 = riscv.fcvt.s.w %10 : (!riscv.reg<>) -> !riscv.freg<>
-  %13 = riscv.fcvt.s.w %11 : (!riscv.reg<>) -> !riscv.freg<>
-  %14 = riscv.fadd.s %12, %13 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+  %2 = riscv.add %0, %1 : (!riscv.reg, !riscv.reg<s0>) -> !riscv.reg
+  %3 = riscv.li  29 : () -> !riscv.reg
+  %4 = riscv.li  28 : () -> !riscv.reg
+  %5 = riscv.add %3, %4 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+  %6 = riscv.li  26 : () -> !riscv.reg
+  %7 = riscv.li  25 : () -> !riscv.reg
+  %8 = riscv.li  24 : () -> !riscv.reg
+  %9 = riscv.li  23 : () -> !riscv.reg
+  %10 = riscv.li 2 : () -> !riscv.reg
+  %11 = riscv.li 1 : () -> !riscv.reg
+  %12 = riscv.fcvt.s.w %10 : (!riscv.reg) -> !riscv.freg
+  %13 = riscv.fcvt.s.w %11 : (!riscv.reg) -> !riscv.freg
+  %14 = riscv.fadd.s %12, %13 : (!riscv.freg, !riscv.freg) -> !riscv.freg
   riscv_func.return
 }
 // CHECK:       builtin.module {

--- a/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
+++ b/tests/filecheck/backend/riscv/register_allocation_preallocated.mlir
@@ -1,12 +1,12 @@
 // RUN: xdsl-opt -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s --check-prefix=LIVE-BNAIVE
 
 riscv_func.func @main() {
-  %0 = riscv.li 6 : () -> !riscv.reg<>
+  %0 = riscv.li 6 : () -> !riscv.reg
   %1 = riscv.li 5 : () -> !riscv.reg<t0>
-  %3 = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
-  %4 = riscv.fcvt.s.w %1 : (!riscv.reg<t0>) -> !riscv.freg<>
-  %5 = riscv.fadd.s %3, %4 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-  %2 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<t0>) -> !riscv.reg<>
+  %3 = riscv.fcvt.s.w %0 : (!riscv.reg) -> !riscv.freg
+  %4 = riscv.fcvt.s.w %1 : (!riscv.reg<t0>) -> !riscv.freg
+  %5 = riscv.fadd.s %3, %4 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  %2 = riscv.add %0, %1 : (!riscv.reg, !riscv.reg<t0>) -> !riscv.reg
   riscv_func.return
 }
 

--- a/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
+++ b/tests/filecheck/backend/riscv/riscv_register_allocation.mlir
@@ -4,23 +4,23 @@
 riscv_func.func @external() -> ()
 
 riscv_func.func @main() {
-  %zero = riscv.li 0 : () -> !riscv.reg<>
-  %0 = riscv.li 6 : () -> !riscv.reg<>
+  %zero = riscv.li 0 : () -> !riscv.reg
+  %0 = riscv.li 6 : () -> !riscv.reg
   %1 = riscv.li 5 : () -> !riscv.reg<s0>
-  %2 = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
-  %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg<>
-  %4 = riscv.fadd.s %2, %3 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-  %5 = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<s0>) -> !riscv.reg<>
+  %2 = riscv.fcvt.s.w %0 : (!riscv.reg) -> !riscv.freg
+  %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg
+  %4 = riscv.fadd.s %2, %3 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  %5 = riscv.add %0, %1 : (!riscv.reg, !riscv.reg<s0>) -> !riscv.reg
 
-  riscv_scf.for %6 : !riscv.reg<> = %0 to %1 step %5 {
+  riscv_scf.for %6 : !riscv.reg = %0 to %1 step %5 {
   }
 
-  %7 = riscv_scf.for %8 : !riscv.reg<> = %0 to  %1 step %5 iter_args(%9 = %5) -> (!riscv.reg<>) {
-    %10 = riscv.mv %9 : (!riscv.reg<>) -> !riscv.reg<>
-    riscv_scf.yield %10 : !riscv.reg<>
+  %7 = riscv_scf.for %8 : !riscv.reg = %0 to  %1 step %5 iter_args(%9 = %5) -> (!riscv.reg) {
+    %10 = riscv.mv %9 : (!riscv.reg) -> !riscv.reg
+    riscv_scf.yield %10 : !riscv.reg
   }
 
-  %zero_0 = riscv.li 0 : () -> !riscv.reg<>
+  %zero_0 = riscv.li 0 : () -> !riscv.reg
   %zero_1 = riscv.li 0 : () -> !riscv.reg<a0>
 
   riscv_func.return

--- a/tests/filecheck/backend/riscv/verify.mlir
+++ b/tests/filecheck/backend/riscv/verify.mlir
@@ -1,26 +1,26 @@
 // RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
 
 %i1 = "test.op"() : () -> !riscv.reg<a1>
-%1 = riscv.li 1 : () -> !riscv.reg<>
+%1 = riscv.li 1 : () -> !riscv.reg
 
-%empty_0 = riscv_snitch.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<>
+%empty_0 = riscv_snitch.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg) -> !riscv.reg
 
-// CHECK: Operation does not verify: scfgw rd must be ZERO, got !riscv.reg<>
+// CHECK: Operation does not verify: scfgw rd must be ZERO, got !riscv.reg
 
 // -----
 
 %i1 = "test.op"() : () -> !riscv.reg<a1>
-%1 = riscv.li 1 : () -> !riscv.reg<>
-%wrong_0 = riscv_snitch.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg<>) -> !riscv.reg<t0>
+%1 = riscv.li 1 : () -> !riscv.reg
+%wrong_0 = riscv_snitch.scfgw %i1, %1 : (!riscv.reg<a1>, !riscv.reg) -> !riscv.reg<t0>
 
 // CHECK: Operation does not verify: scfgw rd must be ZERO, got !riscv.reg<t0>
 
 // -----
 
 %i1 = "test.op"() : () -> !riscv.reg<a1>
-%empty_1 = riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg<>
+%empty_1 = riscv_snitch.scfgwi %i1, 1 : (!riscv.reg<a1>) -> !riscv.reg
 
-// CHECK: Operation does not verify: scfgwi rd must be ZERO, got !riscv.reg<>
+// CHECK: Operation does not verify: scfgwi rd must be ZERO, got !riscv.reg
 
 // -----
 

--- a/tests/filecheck/backend/rvscf_scf_lowering.mlir
+++ b/tests/filecheck/backend/rvscf_scf_lowering.mlir
@@ -21,30 +21,30 @@ builtin.module {
 // CHECK-NEXT:   %i_in = arith.constant 42 : index
 // CHECK-NEXT:   %f32_in = arith.constant 2.100000e+01 : f32
 // CHECK-NEXT:   %f64_in = arith.constant 4.200000e+01 : f64
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg<>
-// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = riscv_scf.for %idx : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (!riscv.reg<>, !riscv.freg<>, !riscv.freg<>) {
-// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f64
-// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
-// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to index
-// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to index
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg
+// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %{{.*}}, %{{.*}}, %{{.*}} = riscv_scf.for %idx : !riscv.reg = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}, %{{.*}} = %{{.*}}) -> (!riscv.reg, !riscv.freg, !riscv.freg) {
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f64
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to index
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to index
 // CHECK-NEXT:     %{{.*}} = arith.addi %{{.*}}, %{{.*}} : index
-// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg<>
-// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg<>
-// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg<>
-// CHECK-NEXT:     riscv_scf.yield %{{.*}}, %{{.*}}, %{{.*}} : !riscv.reg<>, !riscv.freg<>, !riscv.freg<>
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : index to !riscv.reg
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg
+// CHECK-NEXT:     %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg
+// CHECK-NEXT:     riscv_scf.yield %{{.*}}, %{{.*}}, %{{.*}} : !riscv.reg, !riscv.freg, !riscv.freg
 // CHECK-NEXT:   }
-// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg<> to index
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f64
+// CHECK-NEXT:   %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to index
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f64
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/riscv/frep_verification.mlir
+++ b/tests/filecheck/dialects/riscv/frep_verification.mlir
@@ -1,8 +1,8 @@
 // RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
 
-%i0 = "test.op"() : () -> !riscv.reg<>
+%i0 = "test.op"() : () -> !riscv.reg
 "riscv_snitch.frep_outer"(%i0) ({
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
 
 // CHECK: expected a single block, but got 0 blocks
 
@@ -36,37 +36,37 @@ riscv_snitch.frep_outer %i0 {
 
 // -----
 
-%0 = "test.op"(): () -> !riscv.reg<>
+%0 = "test.op"(): () -> !riscv.reg
 
 "riscv_snitch.frep_outer"(%0) ({
 ^bb0:
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
 
 // CHECK: Operation riscv_snitch.frep_outer contains empty block in single-block region that expects at least a terminator
 
 
 // -----
 
-%0 = "test.op"(): () -> !riscv.reg<>
-%f0 = "test.op"(): () -> !riscv.freg<>
+%0 = "test.op"(): () -> !riscv.reg
+%f0 = "test.op"(): () -> !riscv.freg
 
 "riscv_snitch.frep_outer"(%0) ({
 ^bb0:
-    %f1 = "riscv.fadd.s"(%f0, %f0) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+    %f1 = "riscv.fadd.s"(%f0, %f0) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
 
 // CHECK: Operation riscv.fadd.s terminates block in single-block region but is not a terminator
 
 
 // -----
 
-%0 = "test.op"(): () -> !riscv.reg<>
-%f0 = "test.op"(): () -> !riscv.freg<>
+%0 = "test.op"(): () -> !riscv.reg
+%f0 = "test.op"(): () -> !riscv.freg
 
 "riscv_snitch.frep_outer"(%0) ({
 ^bb0:
-    %f1 = "riscv.fadd.s"(%f0, %f0) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %f1 = "riscv.fadd.s"(%f0, %f0) : (!riscv.freg, !riscv.freg) -> !riscv.freg
     "test.termop"() : () -> ()
-}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+}) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
 
 // CHECK: Operation does not verify: 'riscv_snitch.frep_outer' terminates with operation test.termop instead of riscv_snitch.frep_yield

--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -84,7 +84,7 @@
 
     riscv.ret
     // CHECK-NEXT: ret
-  ^0(%b00 : !riscv.reg<>, %b01 : !riscv.reg<>):
+  ^0(%b00 : !riscv.reg, %b01 : !riscv.reg):
 
 
     // Conditional Branch Instructions
@@ -156,7 +156,7 @@
     // CHECK-NEXT: ebreak
     riscv.ret
     // CHECK-NEXT: ret
-  ^1(%b10 : !riscv.reg<>, %b11 : !riscv.reg<>):
+  ^1(%b10 : !riscv.reg, %b11 : !riscv.reg):
 
     riscv.directive ".align" "2"
     // CHECK-NEXT: .align 2

--- a/tests/filecheck/dialects/riscv/riscv_ops.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_ops.mlir
@@ -3,57 +3,57 @@
 
 "builtin.module"() ({
   riscv_func.func @main() {
-    %0 = riscv.get_register : () -> !riscv.reg<>
-    %1 = riscv.get_register : () -> !riscv.reg<>
+    %0 = riscv.get_register : () -> !riscv.reg
+    %1 = riscv.get_register : () -> !riscv.reg
     // RV32I/RV64I: 2.4 Integer Computational Instructions
 
     // Integer Register-Immediate Instructions
-    %addi = riscv.addi %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK: %{{.*}} = riscv.addi %{{.*}}, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %slti = riscv.slti %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.slti %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %sltiu = riscv.sltiu %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sltiu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %andi = riscv.andi %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.andi %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %ori = riscv.ori %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.ori %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %xori = riscv.xori %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xori %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %slli = riscv.slli %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.slli %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %srli = riscv.srli %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.srli %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %srai = riscv.srai %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.srai %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %lui = riscv.lui 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lui 1 : () -> !riscv.reg<>
-    %auipc = riscv.auipc 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.auipc 1 : () -> !riscv.reg<>
-    %mv = riscv.mv %0 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK: %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<>) -> !riscv.reg<>
+    %addi = riscv.addi %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK: %{{.*}} = riscv.addi %{{.*}}, 1 : (!riscv.reg) -> !riscv.reg
+    %slti = riscv.slti %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.slti %0, 1 : (!riscv.reg) -> !riscv.reg
+    %sltiu = riscv.sltiu %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.sltiu %0, 1 : (!riscv.reg) -> !riscv.reg
+    %andi = riscv.andi %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.andi %0, 1 : (!riscv.reg) -> !riscv.reg
+    %ori = riscv.ori %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.ori %0, 1 : (!riscv.reg) -> !riscv.reg
+    %xori = riscv.xori %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %0, 1 : (!riscv.reg) -> !riscv.reg
+    %slli = riscv.slli %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.slli %0, 1 : (!riscv.reg) -> !riscv.reg
+    %srli = riscv.srli %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.srli %0, 1 : (!riscv.reg) -> !riscv.reg
+    %srai = riscv.srai %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.srai %0, 1 : (!riscv.reg) -> !riscv.reg
+    %lui = riscv.lui 1 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.lui 1 : () -> !riscv.reg
+    %auipc = riscv.auipc 1 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.auipc 1 : () -> !riscv.reg
+    %mv = riscv.mv %0 : (!riscv.reg) -> !riscv.reg
+    // CHECK: %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg
 
     // Integer Register-Register Operations
-    %add = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %slt = riscv.slt %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.slt %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %sltu = riscv.sltu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sltu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %and = riscv.and %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.and %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %or = riscv.or %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.or %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %xor = riscv.xor %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.xor %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %sll = riscv.sll %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sll %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %srl = riscv.srl %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.srl %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %sub = riscv.sub %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %sra = riscv.sra %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.sra %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    %add = riscv.add %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %slt = riscv.slt %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.slt %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %sltu = riscv.sltu %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.sltu %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %and = riscv.and %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.and %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %or = riscv.or %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.or %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %xor = riscv.xor %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xor %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %sll = riscv.sll %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.sll %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %srl = riscv.srl %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.srl %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %sub = riscv.sub %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %sra = riscv.sra %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.sra %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
     riscv.nop
     // CHECK-NEXT: riscv.nop
 
@@ -62,8 +62,8 @@
     // Unconditional Branch Instructions
     riscv.jal 1
     // CHECK-NEXT: riscv.jal 1
-    riscv.jal 1, !riscv.reg<>
-    // CHECK-NEXT: riscv.jal 1, !riscv.reg<>
+    riscv.jal 1, !riscv.reg
+    // CHECK-NEXT: riscv.jal 1, !riscv.reg
     riscv.jal "label"
     // CHECK-NEXT: riscv.jal "label"
 
@@ -72,77 +72,77 @@
     riscv.j "label"
     // CHECK-NEXT: riscv.j "label"
 
-    riscv.jalr %0, 1: (!riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.jalr %0, 1 : (!riscv.reg<>) -> ()
-    riscv.jalr %0, 1, !riscv.reg<> : (!riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.jalr %0, 1, !riscv.reg<> : (!riscv.reg<>) -> ()
-    riscv.jalr %0, "label" : (!riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.jalr %0, "label" : (!riscv.reg<>) -> ()
+    riscv.jalr %0, 1: (!riscv.reg) -> ()
+    // CHECK-NEXT: riscv.jalr %0, 1 : (!riscv.reg) -> ()
+    riscv.jalr %0, 1, !riscv.reg : (!riscv.reg) -> ()
+    // CHECK-NEXT: riscv.jalr %0, 1, !riscv.reg : (!riscv.reg) -> ()
+    riscv.jalr %0, "label" : (!riscv.reg) -> ()
+    // CHECK-NEXT: riscv.jalr %0, "label" : (!riscv.reg) -> ()
 
     riscv.ret
     // CHECK-NEXT: riscv.ret
-  ^0(%2 : !riscv.reg<>, %3 : !riscv.reg<>):
-  // CHECK-NEXT: ^0(%2 : !riscv.reg<>, %3 : !riscv.reg<>):
+  ^0(%2 : !riscv.reg, %3 : !riscv.reg):
+  // CHECK-NEXT: ^0(%2 : !riscv.reg, %3 : !riscv.reg):
 
     // Conditional Branch Instructions
-    riscv.beq %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.beq %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    riscv.bne %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bne %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    riscv.blt %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.blt %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    riscv.bge %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bge %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    riscv.bltu %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bltu %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    riscv.bgeu %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.bgeu %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
+    riscv.beq %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.beq %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.reg) -> ()
+    riscv.bne %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.bne %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.reg) -> ()
+    riscv.blt %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.blt %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.reg) -> ()
+    riscv.bge %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.bge %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.reg) -> ()
+    riscv.bltu %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.bltu %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.reg) -> ()
+    riscv.bgeu %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.bgeu %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.reg) -> ()
 
     // RV32I/RV64I: 2.6 Load and Store Instructions
 
-    %lb = riscv.lb %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lb %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %lbu = riscv.lbu %0, 1: (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lbu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %lh = riscv.lh %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lh %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %lhu = riscv.lhu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lhu %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    %lw = riscv.lw %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.lw %0, 1 : (!riscv.reg<>) -> !riscv.reg<>
-    riscv.sb %0, %1, 1: (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.sb %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    riscv.sh %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.sh %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    riscv.sw %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-    // CHECK-NEXT: riscv.sw %0, %1, 1 : (!riscv.reg<>, !riscv.reg<>) -> ()
+    %lb = riscv.lb %0, 1 : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.lb %0, 1 : (!riscv.reg) -> !riscv.reg
+    %lbu = riscv.lbu %0, 1: (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.lbu %0, 1 : (!riscv.reg) -> !riscv.reg
+    %lh = riscv.lh %0, 1 : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.lh %0, 1 : (!riscv.reg) -> !riscv.reg
+    %lhu = riscv.lhu %0, 1 : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.lhu %0, 1 : (!riscv.reg) -> !riscv.reg
+    %lw = riscv.lw %0, 1 : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.lw %0, 1 : (!riscv.reg) -> !riscv.reg
+    riscv.sb %0, %1, 1: (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.sb %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    riscv.sh %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.sh %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    riscv.sw %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
+    // CHECK-NEXT: riscv.sw %0, %1, 1 : (!riscv.reg, !riscv.reg) -> ()
 
     // RV32I/RV64I: 2.8 Control and Status Register Instructions
 
-    %csrrw_rw = riscv.csrrw %0 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrw %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    %csrrw_w = riscv.csrrw %0 1024, "w" : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrw %0, 1024, "w" : (!riscv.reg<>) -> !riscv.reg<>
-    %csrrs_rw = riscv.csrrs %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrs %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    %csrrs_r = riscv.csrrs %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrs %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
-    %csrrc_rw = riscv.csrrc %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrc %0, 1024 : (!riscv.reg<>) -> !riscv.reg<>
-    %csrrc_r = riscv.csrrc %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrc %0, 1024, "r" : (!riscv.reg<>) -> !riscv.reg<>
-    %csrrsi_rw = riscv.csrrsi 1024, 8 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrsi 1024, 8 : () -> !riscv.reg<>
-    %csrrsi_r = riscv.csrrsi 1024, 0 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrsi 1024, 0 : () -> !riscv.reg<>
-    %csrrci_rw = riscv.csrrci 1024, 8 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrci 1024, 8 : () -> !riscv.reg<>
-    %csrrci_r = riscv.csrrci 1024, 0 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrci 1024, 0 : () -> !riscv.reg<>
-    %csrrwi_rw = riscv.csrrwi 1024, 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrwi 1024, 1 : () -> !riscv.reg<>
-    %csrrwi_w = riscv.csrrwi 1024, 1, "w" : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.csrrwi 1024, 1, "w" : () -> !riscv.reg<>
+    %csrrw_rw = riscv.csrrw %0 1024 : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrw %0, 1024 : (!riscv.reg) -> !riscv.reg
+    %csrrw_w = riscv.csrrw %0 1024, "w" : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrw %0, 1024, "w" : (!riscv.reg) -> !riscv.reg
+    %csrrs_rw = riscv.csrrs %0, 1024 : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrs %0, 1024 : (!riscv.reg) -> !riscv.reg
+    %csrrs_r = riscv.csrrs %0, 1024, "r" : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrs %0, 1024, "r" : (!riscv.reg) -> !riscv.reg
+    %csrrc_rw = riscv.csrrc %0, 1024 : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrc %0, 1024 : (!riscv.reg) -> !riscv.reg
+    %csrrc_r = riscv.csrrc %0, 1024, "r" : (!riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrc %0, 1024, "r" : (!riscv.reg) -> !riscv.reg
+    %csrrsi_rw = riscv.csrrsi 1024, 8 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrsi 1024, 8 : () -> !riscv.reg
+    %csrrsi_r = riscv.csrrsi 1024, 0 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrsi 1024, 0 : () -> !riscv.reg
+    %csrrci_rw = riscv.csrrci 1024, 8 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrci 1024, 8 : () -> !riscv.reg
+    %csrrci_r = riscv.csrrci 1024, 0 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrci 1024, 0 : () -> !riscv.reg
+    %csrrwi_rw = riscv.csrrwi 1024, 1 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrwi 1024, 1 : () -> !riscv.reg
+    %csrrwi_w = riscv.csrrwi 1024, 1, "w" : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.csrrwi 1024, 1, "w" : () -> !riscv.reg
 
     // Machine Mode Privileged Instructions
     riscv.wfi
@@ -152,29 +152,29 @@
     // RV32M/RV64M: 7 “M” Standard Extension for Integer Multiplication and Division
 
     // Multiplication Operations
-    %mul = riscv.mul %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %mulh = riscv.mulh %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mulh %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %mulhsu = riscv.mulhsu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mulhsu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %mulhu = riscv.mulhu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.mulhu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    %mul = riscv.mul %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %mulh = riscv.mulh %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.mulh %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %mulhsu = riscv.mulhsu %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.mulhsu %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %mulhu = riscv.mulhu %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.mulhu %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     // Division Operations
-    %div = riscv.div %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.div %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %divu = riscv.divu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.divu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %rem = riscv.rem %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.rem %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %remu = riscv.remu %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.remu %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    %div = riscv.div %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.div %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %divu = riscv.divu %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.divu %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %rem = riscv.rem %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.rem %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %remu = riscv.remu %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.remu %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
     // Assembler pseudo-instructions
 
-    %li = riscv.li 1 : () -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
+    %li = riscv.li 1 : () -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.li 1 : () -> !riscv.reg
     // Environment Call and Breakpoints
     riscv.ecall
     // CHECK-NEXT: riscv.ecall
@@ -185,161 +185,161 @@
     riscv.directive ".align" "2"
     // CHECK-NEXT: riscv.directive ".align" "2"
     riscv.assembly_section ".text" attributes {"foo" = i32} {
-      %nested_li = riscv.li 1 : () -> !riscv.reg<>
+      %nested_li = riscv.li 1 : () -> !riscv.reg
     }
     // CHECK-NEXT:  riscv.assembly_section ".text" attributes {"foo" = i32} {
-    // CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
+    // CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg
     // CHECK-NEXT:  }
 
     riscv.assembly_section ".text" {
-      %nested_li = riscv.li 1 : () -> !riscv.reg<>
+      %nested_li = riscv.li 1 : () -> !riscv.reg
     }
     // CHECK-NEXT:  riscv.assembly_section ".text" {
-    // CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
+    // CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg
     // CHECK-NEXT:  }
 
     // Custom instruction
-    %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
-    // CHECK-NEXT:   %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
+    %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg)
+    // CHECK-NEXT:   %custom0, %custom1 = riscv.custom_assembly_instruction %0, %1 {"instruction_name" = "hello"} : (!riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg)
 
     // RV32F: 8 “F” Standard Extension for Single-Precision Floating-Point, Version 2.0
-    %f0 = riscv.get_float_register : () -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
-    %f1 = riscv.get_float_register : () -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
-    %f2 = riscv.get_float_register : () -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg<>
+    %f0 = riscv.get_float_register : () -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg
+    %f1 = riscv.get_float_register : () -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg
+    %f2 = riscv.get_float_register : () -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.get_float_register : () -> !riscv.freg
 
-    %fmv = riscv.fmv.s %f0 : (!riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+    %fmv = riscv.fmv.s %f0 : (!riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg
 
-    %fmadd_s = riscv.fmadd.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmsub_s = riscv.fmsub.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmsub.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fnmsub_s = riscv.fnmsub.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fnmsub.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fnmadd_s = riscv.fnmadd.s %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fnmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmadd_s = riscv.fmadd.s %f0, %f1, %f2 : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmsub_s = riscv.fmsub.s %f0, %f1, %f2 : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmsub.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    %fnmsub_s = riscv.fnmsub.s %f0, %f1, %f2 : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fnmsub.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    %fnmadd_s = riscv.fnmadd.s %f0, %f1, %f2 : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fnmadd.s %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fadd_s = riscv.fadd.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fsub_s = riscv.fsub.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmul_s = riscv.fmul.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fdiv_s = riscv.fdiv.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fadd_s = riscv.fadd.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fsub_s = riscv.fsub.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmul_s = riscv.fmul.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fdiv_s = riscv.fdiv.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fadd_s_fm = riscv.fadd.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fsub_s_fm = riscv.fsub.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmul_s_fm = riscv.fmul.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fdiv_s_fm = riscv.fdiv.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fadd_s_fm = riscv.fadd.s %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fsub_s_fm = riscv.fsub.s %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmul_s_fm = riscv.fmul.s %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fdiv_s_fm = riscv.fdiv.s %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fsqrt_s = riscv.fsqrt.s %f0 : (!riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsqrt.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+    %fsqrt_s = riscv.fsqrt.s %f0 : (!riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsqrt.s %{{.*}} : (!riscv.freg) -> !riscv.freg
 
-    %fsgnj_s = riscv.fsgnj.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnj.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fsgnjn_s = riscv.fsgnjn.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnjn.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fsgnjx_s = riscv.fsgnjx.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsgnjx.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fsgnj_s = riscv.fsgnj.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsgnj.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fsgnjn_s = riscv.fsgnjn.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsgnjn.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fsgnjx_s = riscv.fsgnjx.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsgnjx.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fmin_s = riscv.fmin.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmax_s = riscv.fmax.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmin_s = riscv.fmin.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmax_s = riscv.fmax.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fmin_s_fm = riscv.fmin.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmax_s_fm = riscv.fmax.s %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmin_s_fm = riscv.fmin.s %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmax_s_fm = riscv.fmax.s %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.s %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fcvt_w_s = riscv.fcvt.w.s %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
-    %fcvt_wu_s = riscv.fcvt.wu.s %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.wu.s %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
-    %fmv_x_w = riscv.fmv.x.w %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.x.w %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
+    %fcvt_w_s = riscv.fcvt.w.s %f0 : (!riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.w.s %{{.*}} : (!riscv.freg) -> !riscv.reg
+    %fcvt_wu_s = riscv.fcvt.wu.s %f0 : (!riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.wu.s %{{.*}} : (!riscv.freg) -> !riscv.reg
+    %fmv_x_w = riscv.fmv.x.w %f0 : (!riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fmv.x.w %{{.*}} : (!riscv.freg) -> !riscv.reg
 
-    %feq_s = riscv.feq.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.feq.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    %flt_s = riscv.flt.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flt.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    %fle_s = riscv.fle.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fle.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-    %fclass_s = riscv.fclass.s %f0 : (!riscv.freg<>) -> !riscv.reg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fclass.s %{{.*}} : (!riscv.freg<>) -> !riscv.reg<>
-    %fcvt_s_w = riscv.fcvt.s.w %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
-    %fcvt_s_wu = riscv.fcvt.s.wu %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.wu %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
-    %fmv_w_x = riscv.fmv.w.x %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.w.x %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
+    %feq_s = riscv.feq.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %flt_s = riscv.flt.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %fle_s = riscv.fle.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %fclass_s = riscv.fclass.s %f0 : (!riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.fclass.s %{{.*}} : (!riscv.freg) -> !riscv.reg
+    %fcvt_s_w = riscv.fcvt.s.w %0 : (!riscv.reg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.w %{{.*}} : (!riscv.reg) -> !riscv.freg
+    %fcvt_s_wu = riscv.fcvt.s.wu %0 : (!riscv.reg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.s.wu %{{.*}} : (!riscv.reg) -> !riscv.freg
+    %fmv_w_x = riscv.fmv.w.x %0 : (!riscv.reg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmv.w.x %{{.*}} : (!riscv.reg) -> !riscv.freg
 
-    %flw = riscv.flw %0, 1 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.flw %{{.*}}, 1 : (!riscv.reg<>) -> !riscv.freg<>
-    riscv.fsw %0, %f0, 1 : (!riscv.reg<>, !riscv.freg<>) -> ()
-    // CHECK-NEXT: riscv.fsw %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.freg<>) -> ()
+    %flw = riscv.flw %0, 1 : (!riscv.reg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.flw %{{.*}}, 1 : (!riscv.reg) -> !riscv.freg
+    riscv.fsw %0, %f0, 1 : (!riscv.reg, !riscv.freg) -> ()
+    // CHECK-NEXT: riscv.fsw %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.freg) -> ()
 
     // Vector Ops
-    %fld = riscv.fld %0, 1 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fld %{{.*}}, 1 : (!riscv.reg<>) -> !riscv.freg<>
-    riscv.fsd %0, %f0, 1 : (!riscv.reg<>, !riscv.freg<>) -> ()
-    // CHECK-NEXT: riscv.fsd %{{.*}}, %{{.*}}, 1 : (!riscv.reg<>, !riscv.freg<>) -> ()
+    %fld = riscv.fld %0, 1 : (!riscv.reg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fld %{{.*}}, 1 : (!riscv.reg) -> !riscv.freg
+    riscv.fsd %0, %f0, 1 : (!riscv.reg, !riscv.freg) -> ()
+    // CHECK-NEXT: riscv.fsd %{{.*}}, %{{.*}}, 1 : (!riscv.reg, !riscv.freg) -> ()
 
-    %fmv_d = riscv.fmv.d %f0 : (!riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
+    %fmv_d = riscv.fmv.d %f0 : (!riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg
 
-    %vfadd_s = riscv.vfadd.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.vfadd.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %vfmul_s = riscv.vfmul.s %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.vfmul.s %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %vfadd_s = riscv.vfadd.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.vfadd.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %vfmul_s = riscv.vfmul.s %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.vfmul.s %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
     // RV32F: 9 “D” Standard Extension for Double-Precision Floating-Point, Version 2.0
 
-    %fadd_d = riscv.fadd.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fsub_d = riscv.fsub.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmul_d = riscv.fmul.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fdiv_d = riscv.fdiv.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fadd_d = riscv.fadd.d %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fsub_d = riscv.fsub.d %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmul_d = riscv.fmul.d %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fdiv_d = riscv.fdiv.d %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fadd_d_fm = riscv.fadd.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fsub_d_fm = riscv.fsub.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmul_d_fm = riscv.fmul.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fdiv_d_fm = riscv.fdiv.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fadd_d_fm = riscv.fadd.d %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fadd.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fsub_d_fm = riscv.fsub.d %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fsub.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmul_d_fm = riscv.fmul.d %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmul.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fdiv_d_fm = riscv.fdiv.d %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fdiv.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fmadd_d = riscv.fmadd.d %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmsub_d = riscv.fmsub.d %f0, %f1, %f2 : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmsub.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmadd_d = riscv.fmadd.d %f0, %f1, %f2 : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmadd.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmsub_d = riscv.fmsub.d %f0, %f1, %f2 : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmsub.d %{{.*}}, %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fmin_d = riscv.fmin.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmax_d = riscv.fmax.d %f0, %f1 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmin_d = riscv.fmin.d %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmax_d = riscv.fmax.d %f0, %f1 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fmin_d_fm = riscv.fmin.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    %fmax_d_fm = riscv.fmax.d %f0, %f1 fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
+    %fmin_d_fm = riscv.fmin.d %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmin.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    %fmax_d_fm = riscv.fmax.d %f0, %f1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fmax.d %{{.*}}, %{{.*}} fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
-    %fcvt_d_w = riscv.fcvt.d.w %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.w %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
-    %fcvt_d_wu = riscv.fcvt.d.wu %0 : (!riscv.reg<>) -> !riscv.freg<>
-    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.wu %{{.*}} : (!riscv.reg<>) -> !riscv.freg<>
+    %fcvt_d_w = riscv.fcvt.d.w %0 : (!riscv.reg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.w %{{.*}} : (!riscv.reg) -> !riscv.freg
+    %fcvt_d_wu = riscv.fcvt.d.wu %0 : (!riscv.reg) -> !riscv.freg
+    // CHECK-NEXT: %{{.*}} = riscv.fcvt.d.wu %{{.*}} : (!riscv.reg) -> !riscv.freg
 
     // Terminate block
     riscv_func.return
@@ -348,145 +348,145 @@
 
 // CHECK-GENERIC: "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
-// CHECK-GENERIC-NEXT:     %0 = "riscv.get_register"() : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %1 = "riscv.get_register"() : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %addi = "riscv.addi"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %slti = "riscv.slti"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %sltiu = "riscv.sltiu"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %andi = "riscv.andi"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %ori = "riscv.ori"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %xori = "riscv.xori"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %slli = "riscv.slli"(%0) {"immediate" = 1 : ui5} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %srli = "riscv.srli"(%0) {"immediate" = 1 : ui5} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %srai = "riscv.srai"(%0) {"immediate" = 1 : ui5} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %lui = "riscv.lui"() {"immediate" = 1 : i20} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %auipc = "riscv.auipc"() {"immediate" = 1 : i20} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %mv = "riscv.mv"(%0) : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %add = "riscv.add"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %slt = "riscv.slt"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %sltu = "riscv.sltu"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %and = "riscv.and"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %or = "riscv.or"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %xor = "riscv.xor"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %sll = "riscv.sll"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %srl = "riscv.srl"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %sub = "riscv.sub"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %sra = "riscv.sra"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %0 = "riscv.get_register"() : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %1 = "riscv.get_register"() : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %addi = "riscv.addi"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %slti = "riscv.slti"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %sltiu = "riscv.sltiu"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %andi = "riscv.andi"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %ori = "riscv.ori"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %xori = "riscv.xori"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %slli = "riscv.slli"(%0) {"immediate" = 1 : ui5} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %srli = "riscv.srli"(%0) {"immediate" = 1 : ui5} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %srai = "riscv.srai"(%0) {"immediate" = 1 : ui5} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %lui = "riscv.lui"() {"immediate" = 1 : i20} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %auipc = "riscv.auipc"() {"immediate" = 1 : i20} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %mv = "riscv.mv"(%0) : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %add = "riscv.add"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %slt = "riscv.slt"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %sltu = "riscv.sltu"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %and = "riscv.and"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %or = "riscv.or"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %xor = "riscv.xor"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %sll = "riscv.sll"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %srl = "riscv.srl"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %sub = "riscv.sub"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %sra = "riscv.sra"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:     "riscv.nop"() : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.jal"() {"immediate" = 1 : si20} : () -> ()
-// CHECK-GENERIC-NEXT:     "riscv.jal"() {"immediate" = 1 : si20, "rd" = !riscv.reg<>} : () -> ()
+// CHECK-GENERIC-NEXT:     "riscv.jal"() {"immediate" = 1 : si20, "rd" = !riscv.reg} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.jal"() {"immediate" = #riscv.label<"label">} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.j"() {"immediate" = 1 : si20} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.j"() {"immediate" = #riscv.label<"label">} : () -> ()
-// CHECK-GENERIC-NEXT:     "riscv.jalr"(%0) {"immediate" = 1 : si12} : (!riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.jalr"(%0) {"immediate" = 1 : si12, "rd" = !riscv.reg<>} : (!riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.jalr"(%0) {"immediate" = #riscv.label<"label">} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.jalr"(%0) {"immediate" = 1 : si12} : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.jalr"(%0) {"immediate" = 1 : si12, "rd" = !riscv.reg} : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.jalr"(%0) {"immediate" = #riscv.label<"label">} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:     "riscv.ret"() : () -> ()
-// CHECK-GENERIC-NEXT:   ^0(%2 : !riscv.reg<>, %3 : !riscv.reg<>):
-// CHECK-GENERIC-NEXT:     "riscv.beq"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.bne"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.blt"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.bge"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.bltu"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.bgeu"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     %lb = "riscv.lb"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %lbu = "riscv.lbu"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %lh = "riscv.lh"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %lhu = "riscv.lhu"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %lw = "riscv.lw"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     "riscv.sb"(%0, %1) {"immediate" = 1 : i12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.sh"(%0, %1) {"immediate" = 1 : i12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv.sw"(%0, %1) {"immediate" = 1 : i12} : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     %csrrw_rw = "riscv.csrrw"(%0) {"csr" = 1024 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrw_w = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly"} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrs_rw = "riscv.csrrs"(%0) {"csr" = 1024 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrs_r = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly"} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrc_rw = "riscv.csrrc"(%0) {"csr" = 1024 : i32} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrc_r = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly"} : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrsi_rw = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrsi_r = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrci_rw = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrci_r = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 1 : i32} : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 1 : i32, "writeonly"} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:   ^0(%2 : !riscv.reg, %3 : !riscv.reg):
+// CHECK-GENERIC-NEXT:     "riscv.beq"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.bne"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.blt"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.bge"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.bltu"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.bgeu"(%0, %1) {"offset" = 1 : si12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     %lb = "riscv.lb"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %lbu = "riscv.lbu"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %lh = "riscv.lh"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %lhu = "riscv.lhu"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %lw = "riscv.lw"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     "riscv.sb"(%0, %1) {"immediate" = 1 : i12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.sh"(%0, %1) {"immediate" = 1 : i12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv.sw"(%0, %1) {"immediate" = 1 : i12} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     %csrrw_rw = "riscv.csrrw"(%0) {"csr" = 1024 : i32} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrw_w = "riscv.csrrw"(%0) {"csr" = 1024 : i32, "writeonly"} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrs_rw = "riscv.csrrs"(%0) {"csr" = 1024 : i32} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrs_r = "riscv.csrrs"(%0) {"csr" = 1024 : i32, "readonly"} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrc_rw = "riscv.csrrc"(%0) {"csr" = 1024 : i32} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrc_r = "riscv.csrrc"(%0) {"csr" = 1024 : i32, "readonly"} : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrsi_rw = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrsi_r = "riscv.csrrsi"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrci_rw = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 8 : i32} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrci_r = "riscv.csrrci"() {"csr" = 1024 : i32, "immediate" = 0 : i32} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrwi_rw = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 1 : i32} : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %csrrwi_w = "riscv.csrrwi"() {"csr" = 1024 : i32, "immediate" = 1 : i32, "writeonly"} : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:     "riscv.wfi"() : () -> ()
-// CHECK-GENERIC-NEXT:     %mul = "riscv.mul"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %mulh = "riscv.mulh"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %mulhsu = "riscv.mulhsu"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %mulhu = "riscv.mulhu"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %div = "riscv.div"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %divu = "riscv.divu"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %rem = "riscv.rem"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %remu = "riscv.remu"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %mul = "riscv.mul"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %mulh = "riscv.mulh"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %mulhsu = "riscv.mulhsu"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %mulhu = "riscv.mulhu"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %div = "riscv.div"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %divu = "riscv.divu"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %rem = "riscv.rem"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %remu = "riscv.remu"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:     "riscv.ecall"() : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.ebreak"() : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.directive"() {"directive" = ".bss"} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.directive"() {"directive" = ".align", "value" = "2"} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.assembly_section"() ({
-// CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text", "foo" = i32} : () -> ()
 // CHECK-GENERIC-NEXT:     "riscv.assembly_section"() ({
-// CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:       %nested_li = "riscv.li"() {"immediate" = 1 : i32} : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:     }) {"directive" = ".text"} : () -> ()
-// CHECK-GENERIC-NEXT:     %custom0, %custom1 = "riscv.custom_assembly_instruction"(%0, %1) {"instruction_name" = "hello"} : (!riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>)
-// CHECK-GENERIC-NEXT:     %f0 = "riscv.get_float_register"() : () -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %f1 = "riscv.get_float_register"() : () -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %f2 = "riscv.get_float_register"() : () -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmv = "riscv.fmv.s"(%f0) : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmadd_s = "riscv.fmadd.s"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmsub_s = "riscv.fmsub.s"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fnmsub_s = "riscv.fnmsub.s"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fnmadd_s = "riscv.fnmadd.s"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fadd_s = "riscv.fadd.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fsub_s = "riscv.fsub.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmul_s = "riscv.fmul.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fdiv_s = "riscv.fdiv.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fadd_s_fm = "riscv.fadd.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fsub_s_fm = "riscv.fsub.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmul_s_fm = "riscv.fmul.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fdiv_s_fm = "riscv.fdiv.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fsqrt_s = "riscv.fsqrt.s"(%f0) : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fsgnj_s = "riscv.fsgnj.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fsgnjn_s = "riscv.fsgnjn.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fsgnjx_s = "riscv.fsgnjx.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmin_s = "riscv.fmin.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmax_s = "riscv.fmax.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmin_s_fm = "riscv.fmin.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmax_s_fm = "riscv.fmax.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fcvt_w_s = "riscv.fcvt.w.s"(%f0) : (!riscv.freg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %fcvt_wu_s = "riscv.fcvt.wu.s"(%f0) : (!riscv.freg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %fmv_x_w = "riscv.fmv.x.w"(%f0) : (!riscv.freg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %feq_s = "riscv.feq.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %flt_s = "riscv.flt.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %fle_s = "riscv.fle.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %fclass_s = "riscv.fclass.s"(%f0) : (!riscv.freg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %fcvt_s_w = "riscv.fcvt.s.w"(%0) : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fcvt_s_wu = "riscv.fcvt.s.wu"(%0) : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmv_w_x = "riscv.fmv.w.x"(%0) : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %flw = "riscv.flw"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     "riscv.fsw"(%0, %f0) {"immediate" = 1 : i12} : (!riscv.reg<>, !riscv.freg<>) -> ()
-// CHECK-GENERIC-NEXT:     %fld = "riscv.fld"(%0) {"immediate" = 1 : i12} : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     "riscv.fsd"(%0, %f0) {"immediate" = 1 : i12} : (!riscv.reg<>, !riscv.freg<>) -> ()
-// CHECK-GENERIC-NEXT:     %fmv_d = "riscv.fmv.d"(%f0) : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %vfadd_s = "riscv.vfadd.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %vfmul_s = "riscv.vfmul.s"(%f0, %f1) : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fadd.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fsub.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fmul.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fdiv.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fadd.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fsub.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fmul.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fdiv.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmadd_d = "riscv.fmadd.d"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmsub_d = "riscv.fmsub.d"(%f0, %f1, %f2) : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmin_d = "riscv.fmin.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmax_d = "riscv.fmax.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmin_d_fm = "riscv.fmin.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT:     %fmax_d_fm = "riscv.fmax.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT: %{{.*}} = "riscv.fcvt.d.w"(%{{.*}}) : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-GENERIC-NEXT: %{{.*}} = "riscv.fcvt.d.wu"(%{{.*}}) : (!riscv.reg<>) -> !riscv.freg<>
+// CHECK-GENERIC-NEXT:     %custom0, %custom1 = "riscv.custom_assembly_instruction"(%0, %1) {"instruction_name" = "hello"} : (!riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg)
+// CHECK-GENERIC-NEXT:     %f0 = "riscv.get_float_register"() : () -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %f1 = "riscv.get_float_register"() : () -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %f2 = "riscv.get_float_register"() : () -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmv = "riscv.fmv.s"(%f0) : (!riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmadd_s = "riscv.fmadd.s"(%f0, %f1, %f2) : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmsub_s = "riscv.fmsub.s"(%f0, %f1, %f2) : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fnmsub_s = "riscv.fnmsub.s"(%f0, %f1, %f2) : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fnmadd_s = "riscv.fnmadd.s"(%f0, %f1, %f2) : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fadd_s = "riscv.fadd.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fsub_s = "riscv.fsub.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmul_s = "riscv.fmul.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fdiv_s = "riscv.fdiv.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fadd_s_fm = "riscv.fadd.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fsub_s_fm = "riscv.fsub.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmul_s_fm = "riscv.fmul.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fdiv_s_fm = "riscv.fdiv.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fsqrt_s = "riscv.fsqrt.s"(%f0) : (!riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fsgnj_s = "riscv.fsgnj.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fsgnjn_s = "riscv.fsgnjn.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fsgnjx_s = "riscv.fsgnjx.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmin_s = "riscv.fmin.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmax_s = "riscv.fmax.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmin_s_fm = "riscv.fmin.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmax_s_fm = "riscv.fmax.s"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fcvt_w_s = "riscv.fcvt.w.s"(%f0) : (!riscv.freg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %fcvt_wu_s = "riscv.fcvt.wu.s"(%f0) : (!riscv.freg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %fmv_x_w = "riscv.fmv.x.w"(%f0) : (!riscv.freg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %feq_s = "riscv.feq.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %flt_s = "riscv.flt.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %fle_s = "riscv.fle.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %fclass_s = "riscv.fclass.s"(%f0) : (!riscv.freg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %fcvt_s_w = "riscv.fcvt.s.w"(%0) : (!riscv.reg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fcvt_s_wu = "riscv.fcvt.s.wu"(%0) : (!riscv.reg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmv_w_x = "riscv.fmv.w.x"(%0) : (!riscv.reg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %flw = "riscv.flw"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     "riscv.fsw"(%0, %f0) {"immediate" = 1 : i12} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-GENERIC-NEXT:     %fld = "riscv.fld"(%0) {"immediate" = 1 : i12} : (!riscv.reg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     "riscv.fsd"(%0, %f0) {"immediate" = 1 : i12} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-GENERIC-NEXT:     %fmv_d = "riscv.fmv.d"(%f0) : (!riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %vfadd_s = "riscv.vfadd.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %vfmul_s = "riscv.vfmul.s"(%f0, %f1) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fadd.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fsub.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fmul.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fdiv.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fadd.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fsub.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fmul.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv.fdiv.d"(%{{.*}}, %{{.*}}) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmadd_d = "riscv.fmadd.d"(%f0, %f1, %f2) : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmsub_d = "riscv.fmsub.d"(%f0, %f1, %f2) : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmin_d = "riscv.fmin.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmax_d = "riscv.fmax.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmin_d_fm = "riscv.fmin.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:     %fmax_d_fm = "riscv.fmax.d"(%f0, %f1) {"fastmath" = #riscv.fastmath<fast>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT: %{{.*}} = "riscv.fcvt.d.w"(%{{.*}}) : (!riscv.reg) -> !riscv.freg
+// CHECK-GENERIC-NEXT: %{{.*}} = "riscv.fcvt.d.wu"(%{{.*}}) : (!riscv.reg) -> !riscv.freg
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "main", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/riscv_cf/canonicalize.mlir
+++ b/tests/filecheck/dialects/riscv_cf/canonicalize.mlir
@@ -1,60 +1,60 @@
 // RUN: xdsl-opt -p canonicalize %s | filecheck %s
 
 riscv_func.func @at_least_once() {
-    %one = riscv.li 1 : () -> !riscv.reg<>
-    %three = riscv.li 3 : () -> !riscv.reg<>
-    %0 = riscv.mv %one : (!riscv.reg<>) -> !riscv.reg<>
-    riscv_cf.bge %0 : !riscv.reg<>, %three : !riscv.reg<>, ^1(%0 : !riscv.reg<>), ^0(%0 : !riscv.reg<>)
-^0(%i : !riscv.reg<>):
+    %one = riscv.li 1 : () -> !riscv.reg
+    %three = riscv.li 3 : () -> !riscv.reg
+    %0 = riscv.mv %one : (!riscv.reg) -> !riscv.reg
+    riscv_cf.bge %0 : !riscv.reg, %three : !riscv.reg, ^1(%0 : !riscv.reg), ^0(%0 : !riscv.reg)
+^0(%i : !riscv.reg):
     riscv.label "scf_body_0_for"
-    "test.op"(%i) : (!riscv.reg<>) -> ()
-    %1 = riscv.add %i, %one : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    riscv_cf.blt %1 : !riscv.reg<>, %three : !riscv.reg<>, ^0(%1 : !riscv.reg<>), ^1(%1 : !riscv.reg<>)
-^1(%2 : !riscv.reg<>):
+    "test.op"(%i) : (!riscv.reg) -> ()
+    %1 = riscv.add %i, %one : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    riscv_cf.blt %1 : !riscv.reg, %three : !riscv.reg, ^0(%1 : !riscv.reg), ^1(%1 : !riscv.reg)
+^1(%2 : !riscv.reg):
     riscv.label "scf_body_end_0_for"
     riscv_func.return
 }
 riscv_func.func @never() {
-    %one = riscv.li 1 : () -> !riscv.reg<>
-    %three = riscv.li 3 : () -> !riscv.reg<>
-    %0 = riscv.mv %one : (!riscv.reg<>) -> !riscv.reg<>
-    riscv_cf.bge %three : !riscv.reg<>, %one : !riscv.reg<>, ^1(%0 : !riscv.reg<>), ^0(%0 : !riscv.reg<>)
-^0(%i : !riscv.reg<>):
+    %one = riscv.li 1 : () -> !riscv.reg
+    %three = riscv.li 3 : () -> !riscv.reg
+    %0 = riscv.mv %one : (!riscv.reg) -> !riscv.reg
+    riscv_cf.bge %three : !riscv.reg, %one : !riscv.reg, ^1(%0 : !riscv.reg), ^0(%0 : !riscv.reg)
+^0(%i : !riscv.reg):
     riscv.label "scf_body_0_for"
-    "test.op"(%i) : (!riscv.reg<>) -> ()
-    %1 = riscv.add %i, %one : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    riscv_cf.blt %1 : !riscv.reg<>, %three : !riscv.reg<>, ^0(%1 : !riscv.reg<>), ^1(%1 : !riscv.reg<>)
-^1(%2 : !riscv.reg<>):
+    "test.op"(%i) : (!riscv.reg) -> ()
+    %1 = riscv.add %i, %one : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    riscv_cf.blt %1 : !riscv.reg, %three : !riscv.reg, ^0(%1 : !riscv.reg), ^1(%1 : !riscv.reg)
+^1(%2 : !riscv.reg):
     riscv.label "scf_body_end_0_for"
     riscv_func.return
 }
 
 // CHECK:       riscv_func.func @at_least_once() {
-// CHECK-NEXT:    %one = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:    %three = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:    %0 = riscv.mv %one : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    riscv_cf.branch ^0(%0 : !riscv.reg<>) attributes {"comment" = "Constant folded riscv_cf.bge"}
-// CHECK-NEXT:  ^0(%i : !riscv.reg<>):
+// CHECK-NEXT:    %one = riscv.li 1 : () -> !riscv.reg
+// CHECK-NEXT:    %three = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:    %0 = riscv.mv %one : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv_cf.branch ^0(%0 : !riscv.reg) attributes {"comment" = "Constant folded riscv_cf.bge"}
+// CHECK-NEXT:  ^0(%i : !riscv.reg):
 // CHECK-NEXT:    riscv.label "scf_body_0_for"
-// CHECK-NEXT:    "test.op"(%i) : (!riscv.reg<>) -> ()
-// CHECK-NEXT:    %1 = riscv.addi %i, 1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    riscv_cf.blt %1 : !riscv.reg<>, %three : !riscv.reg<>, ^0(%1 : !riscv.reg<>), ^1(%1 : !riscv.reg<>)
-// CHECK-NEXT:  ^1(%2 : !riscv.reg<>):
+// CHECK-NEXT:    "test.op"(%i) : (!riscv.reg) -> ()
+// CHECK-NEXT:    %1 = riscv.addi %i, 1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv_cf.blt %1 : !riscv.reg, %three : !riscv.reg, ^0(%1 : !riscv.reg), ^1(%1 : !riscv.reg)
+// CHECK-NEXT:  ^1(%2 : !riscv.reg):
 // CHECK-NEXT:    riscv.label "scf_body_end_0_for"
 // CHECK-NEXT:    riscv_func.return
 // CHECK-NEXT:  }
 
 // CHECK-NEXT:  riscv_func.func @never() {
-// CHECK-NEXT:    %one = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:    %three = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.mv %one : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    riscv_cf.j ^{{\d+}}(%{{.*}} : !riscv.reg<>) attributes {"comment" = "Constant folded riscv_cf.bge"}
-// CHECK-NEXT:  ^{{\d+}}(%i : !riscv.reg<>):
+// CHECK-NEXT:    %one = riscv.li 1 : () -> !riscv.reg
+// CHECK-NEXT:    %three = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.mv %one : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv_cf.j ^{{\d+}}(%{{.*}} : !riscv.reg) attributes {"comment" = "Constant folded riscv_cf.bge"}
+// CHECK-NEXT:  ^{{\d+}}(%i : !riscv.reg):
 // CHECK-NEXT:    riscv.label "scf_body_0_for"
-// CHECK-NEXT:    "test.op"(%i) : (!riscv.reg<>) -> ()
-// CHECK-NEXT:    %{{\d+}} = riscv.addi %i, 1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    riscv_cf.blt %{{\d+}} : !riscv.reg<>, %three : !riscv.reg<>, ^{{\d+}}(%{{\d+}} : !riscv.reg<>), ^{{\d+}}(%{{\d+}} : !riscv.reg<>)
-// CHECK-NEXT:  ^{{\d+}}(%{{\d+}} : !riscv.reg<>):
+// CHECK-NEXT:    "test.op"(%i) : (!riscv.reg) -> ()
+// CHECK-NEXT:    %{{\d+}} = riscv.addi %i, 1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv_cf.blt %{{\d+}} : !riscv.reg, %three : !riscv.reg, ^{{\d+}}(%{{\d+}} : !riscv.reg), ^{{\d+}}(%{{\d+}} : !riscv.reg)
+// CHECK-NEXT:  ^{{\d+}}(%{{\d+}} : !riscv.reg):
 // CHECK-NEXT:    riscv.label "scf_body_end_0_for"
 // CHECK-NEXT:    riscv_func.return
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
+++ b/tests/filecheck/dialects/riscv_func/lower_riscv_func.mlir
@@ -18,18 +18,18 @@
 // CHECK-NEXT:     riscv.ecall
 
     riscv_func.func @main() {
-        %0 = riscv_func.call @get_one() : () -> !riscv.reg<>
-        %1 = riscv_func.call @get_one() : () -> !riscv.reg<>
-        %2 = riscv_func.call @add(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        riscv_func.call @my_print(%2) : (!riscv.reg<>) -> ()
+        %0 = riscv_func.call @get_one() : () -> !riscv.reg
+        %1 = riscv_func.call @get_one() : () -> !riscv.reg
+        %2 = riscv_func.call @add(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        riscv_func.call @my_print(%2) : (!riscv.reg) -> ()
         riscv_func.return
     }
 
 // CHECK-NEXT:    riscv_func.func @main() {
-// CHECK-NEXT:        %{{.*}} = riscv_func.call @get_one() : () -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv_func.call @get_one() : () -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv_func.call @add(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        riscv_func.call @my_print(%{{.*}}) : (!riscv.reg<>) -> ()
+// CHECK-NEXT:        %{{.*}} = riscv_func.call @get_one() : () -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv_func.call @get_one() : () -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv_func.call @add(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:        riscv_func.call @my_print(%{{.*}}) : (!riscv.reg) -> ()
 // CHECK-NEXT:        riscv_func.return
 // CHECK-NEXT:    }
 
@@ -43,23 +43,23 @@
 // CHECK-NEXT:   }
 
     riscv_func.func @get_one() {
-        %0 = riscv.li 1 : () -> !riscv.reg<>
-        riscv_func.return %0 : !riscv.reg<>
+        %0 = riscv.li 1 : () -> !riscv.reg
+        riscv_func.return %0 : !riscv.reg
     }
 
 // CHECK-NEXT:   riscv_func.func @get_one() {
-// CHECK-NEXT:       %{{\d+}} = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:       riscv_func.return %{{\d+}} : !riscv.reg<>
+// CHECK-NEXT:       %{{\d+}} = riscv.li 1 : () -> !riscv.reg
+// CHECK-NEXT:       riscv_func.return %{{\d+}} : !riscv.reg
 // CHECK-NEXT:   }
 
-    riscv_func.func @add(%arg0 : !riscv.reg<>, %arg1 : !riscv.reg<>) {
-        %res = riscv.add %arg0, %arg1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        riscv_func.return %res : !riscv.reg<>
+    riscv_func.func @add(%arg0 : !riscv.reg, %arg1 : !riscv.reg) {
+        %res = riscv.add %arg0, %arg1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        riscv_func.return %res : !riscv.reg
     }
 
-// CHECK-NEXT:   riscv_func.func @add(%arg0 : !riscv.reg<>, %arg1 : !riscv.reg<>) {
-// CHECK-NEXT:       %res = riscv.add %arg0, %arg1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:       riscv_func.return %res : !riscv.reg<>
+// CHECK-NEXT:   riscv_func.func @add(%arg0 : !riscv.reg, %arg1 : !riscv.reg) {
+// CHECK-NEXT:       %res = riscv.add %arg0, %arg1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:       riscv_func.return %res : !riscv.reg
 // CHECK-NEXT:   }
 
     riscv_func.func private @visibility_private() {

--- a/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
+++ b/tests/filecheck/dialects/riscv_func/riscv_func_ops.mlir
@@ -30,33 +30,33 @@ builtin.module {
    // CHECK-NEXT:   riscv_func.return
    // CHECK-NEXT: }
 
-  riscv_func.func @arg_rec(%0 : !riscv.reg<>) -> !riscv.reg<> {
-    %1 = riscv_func.call @arg_rec(%0) : (!riscv.reg<>) -> !riscv.reg<>
-    riscv_func.return %1 : !riscv.reg<>
+  riscv_func.func @arg_rec(%0 : !riscv.reg) -> !riscv.reg {
+    %1 = riscv_func.call @arg_rec(%0) : (!riscv.reg) -> !riscv.reg
+    riscv_func.return %1 : !riscv.reg
   }
 
-   // CHECK: riscv_func.func @arg_rec(%0 : !riscv.reg<>) -> !riscv.reg<> {
-   // CHECK-NEXT:   %{{.*}} = riscv_func.call @arg_rec(%{{.*}}) : (!riscv.reg<>) -> !riscv.reg<>
-   // CHECK-NEXT:   riscv_func.return %{{.*}} : !riscv.reg<>
+   // CHECK: riscv_func.func @arg_rec(%0 : !riscv.reg) -> !riscv.reg {
+   // CHECK-NEXT:   %{{.*}} = riscv_func.call @arg_rec(%{{.*}}) : (!riscv.reg) -> !riscv.reg
+   // CHECK-NEXT:   riscv_func.return %{{.*}} : !riscv.reg
    // CHECK-NEXT: }
 
-  riscv_func.func @arg_rec_block(!riscv.reg<>) -> !riscv.reg<> {
-  ^0(%2 : !riscv.reg<>):
-    %3 = riscv_func.call @arg_rec_block(%2) : (!riscv.reg<>) -> !riscv.reg<>
-    riscv_func.return %3 : !riscv.reg<>
+  riscv_func.func @arg_rec_block(!riscv.reg) -> !riscv.reg {
+  ^0(%2 : !riscv.reg):
+    %3 = riscv_func.call @arg_rec_block(%2) : (!riscv.reg) -> !riscv.reg
+    riscv_func.return %3 : !riscv.reg
   }
 
-  // CHECK: riscv_func.func @arg_rec_block(%{{\d+}} : !riscv.reg<>) -> !riscv.reg<> {
-  // CHECK-NEXT:   %{{\d+}} = riscv_func.call @arg_rec_block(%{{\d+}}) : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT:   riscv_func.return %{{\d+}} : !riscv.reg<>
+  // CHECK: riscv_func.func @arg_rec_block(%{{\d+}} : !riscv.reg) -> !riscv.reg {
+  // CHECK-NEXT:   %{{\d+}} = riscv_func.call @arg_rec_block(%{{\d+}}) : (!riscv.reg) -> !riscv.reg
+  // CHECK-NEXT:   riscv_func.return %{{\d+}} : !riscv.reg
   // CHECK-NEXT: }
 
-  riscv_func.func @multi_return_body(%a : !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>) {
-    riscv_func.return %a, %a : !riscv.reg<>, !riscv.reg<>
+  riscv_func.func @multi_return_body(%a : !riscv.reg) -> (!riscv.reg, !riscv.reg) {
+    riscv_func.return %a, %a : !riscv.reg, !riscv.reg
   }
 
-  // CHECK: riscv_func.func @multi_return_body(%a : !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>) {
-  // CHECK-NEXT:   riscv_func.return %a, %a : !riscv.reg<>, !riscv.reg<>
+  // CHECK: riscv_func.func @multi_return_body(%a : !riscv.reg) -> (!riscv.reg, !riscv.reg) {
+  // CHECK-NEXT:   riscv_func.return %a, %a : !riscv.reg, !riscv.reg
   // CHECK-NEXT: }
 
   riscv_func.func private @visibility_private() {

--- a/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
+++ b/tests/filecheck/dialects/riscv_scf/loop_range_folding.mlir
@@ -2,55 +2,55 @@
 
 // CHECK:       builtin.module {
 
-%lb, %ub, %step = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-%0, %1 = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT:    %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>)
+%lb, %ub, %step = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
+%0, %1 = "test.op"() : () -> (!riscv.reg, !riscv.reg)
+// CHECK-NEXT:    %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
+// CHECK-NEXT:    %{{.*}}, %{{.*}} = "test.op"() : () -> (!riscv.reg, !riscv.reg)
 
-riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
+riscv_scf.for %2 : !riscv.reg = %lb to %ub step %step {
     // mul by constant
-    %3 = riscv.li 3 : () -> !riscv.reg<>
-    %4 = riscv.mul %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    %3 = riscv.li 3 : () -> !riscv.reg
+    %4 = riscv.mul %2, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
     // add with constant
-    %5 = riscv.li 5 : () -> !riscv.reg<>
-    %6 = riscv.add %4, %5 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    "test.op"(%6) : (!riscv.reg<>) -> ()
+    %5 = riscv.li 5 : () -> !riscv.reg
+    %6 = riscv.add %4, %5 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    "test.op"(%6) : (!riscv.reg) -> ()
 }
-// CHECK-NEXT:    %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.li 5 : () -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
-// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:      %{{.*}} = riscv.li 5 : () -> !riscv.reg<>
-// CHECK-NEXT:      "test.op"(%{{.*}}) : (!riscv.reg<>) -> ()
+// CHECK-NEXT:    %{{.*}} = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.li 5 : () -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:      %{{.*}} = riscv.li 5 : () -> !riscv.reg
+// CHECK-NEXT:      "test.op"(%{{.*}}) : (!riscv.reg) -> ()
 // CHECK-NEXT:    }
 
 // Don't fold
-riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
+riscv_scf.for %2 : !riscv.reg = %lb to %ub step %step {
     // Two uses of mul -> can't fold
-    %3 = riscv.li 3 : () -> !riscv.reg<>
-    %4 = riscv.mul %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    "test.op"(%4, %2) : (!riscv.reg<>, !riscv.reg<>) -> ()
+    %3 = riscv.li 3 : () -> !riscv.reg
+    %4 = riscv.mul %2, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    "test.op"(%4, %2) : (!riscv.reg, !riscv.reg) -> ()
 }
-riscv_scf.for %2 : !riscv.reg<> = %lb to %ub step %step {
+riscv_scf.for %2 : !riscv.reg = %lb to %ub step %step {
     // Two uses of add -> can't fold
-    %3 = riscv.li 3 : () -> !riscv.reg<>
-    %4 = riscv.add %2, %3 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    "test.op"(%4, %2) : (!riscv.reg<>, !riscv.reg<>) -> ()
+    %3 = riscv.li 3 : () -> !riscv.reg
+    %4 = riscv.add %2, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    "test.op"(%4, %2) : (!riscv.reg, !riscv.reg) -> ()
 }
-// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
-// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:      %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:      %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:    }
-// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
-// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:      %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:      %{{.*}} = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:      %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 

--- a/tests/filecheck/dialects/riscv_scf/ops.mlir
+++ b/tests/filecheck/dialects/riscv_scf/ops.mlir
@@ -1,43 +1,43 @@
 // RUN: XDSL_ROUNDTRIP
 
-%lb = "riscv.li"() {"immediate" = 0: i32} : () -> !riscv.reg<>
-%ub = "riscv.li"() {"immediate" = 100: i32} : () -> !riscv.reg<>
-%step = "riscv.li"() {"immediate" = 1: i32} : () -> !riscv.reg<>
+%lb = "riscv.li"() {"immediate" = 0: i32} : () -> !riscv.reg
+%ub = "riscv.li"() {"immediate" = 100: i32} : () -> !riscv.reg
+%step = "riscv.li"() {"immediate" = 1: i32} : () -> !riscv.reg
 %acc = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<t0>
-riscv_scf.for %i : !riscv.reg<> = %lb to %ub step %step {
+riscv_scf.for %i : !riscv.reg = %lb to %ub step %step {
     "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
 }
-riscv_scf.rof %j : !riscv.reg<> = %ub down to %lb step %step {
+riscv_scf.rof %j : !riscv.reg = %ub down to %lb step %step {
     "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
 }
-%i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) {
-        %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        riscv_scf.condition(%cond : !riscv.reg<>) %i0, %ub_arg0, %step_arg0 : !riscv.reg<>, !riscv.reg<>, !riscv.reg<>
+%i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg, !riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg, !riscv.reg) {
+        %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        riscv_scf.condition(%cond : !riscv.reg) %i0, %ub_arg0, %step_arg0 : !riscv.reg, !riscv.reg, !riscv.reg
 } do {
-    ^1(%i1 : !riscv.reg<>, %ub_arg1 : !riscv.reg<>, %step_arg1 : !riscv.reg<>):
+    ^1(%i1 : !riscv.reg, %ub_arg1 : !riscv.reg, %step_arg1 : !riscv.reg):
         "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
-        %i_next = "riscv.add"(%i1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        "riscv_scf.yield"(%i_next, %ub_arg1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+        %i_next = "riscv.add"(%i1, %step_arg1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "riscv_scf.yield"(%i_next, %ub_arg1, %step_arg1) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 }
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   %lb = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %ub = riscv.li 100 : () -> !riscv.reg<>
-// CHECK-NEXT:   %step = riscv.li 1 : () -> !riscv.reg<>
+// CHECK-NEXT:   %lb = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:   %ub = riscv.li 100 : () -> !riscv.reg
+// CHECK-NEXT:   %step = riscv.li 1 : () -> !riscv.reg
 // CHECK-NEXT:   %acc = riscv.li 0 : () -> !riscv.reg<t0>
-// CHECK-NEXT:   riscv_scf.for %i : !riscv.reg<> = %lb to %ub step %step {
+// CHECK-NEXT:   riscv_scf.for %i : !riscv.reg = %lb to %ub step %step {
 // CHECK-NEXT:     %0 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:   }
-// CHECK-NEXT:   riscv_scf.rof %j : !riscv.reg<> = %ub down to %lb step %step {
+// CHECK-NEXT:   riscv_scf.rof %j : !riscv.reg = %ub down to %lb step %step {
 // CHECK-NEXT:     %1 = riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
 // CHECK-NEXT:   }
-// CHECK-NEXT:     %i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) {
-// CHECK-NEXT:             %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:             riscv_scf.condition(%cond : !riscv.reg<>) %i0, %ub_arg0, %step_arg0 : !riscv.reg<>, !riscv.reg<>, !riscv.reg<>
+// CHECK-NEXT:     %i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %ub_arg0 = %ub, %step_arg0 = %step) : (!riscv.reg, !riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg, !riscv.reg) {
+// CHECK-NEXT:             %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:             riscv_scf.condition(%cond : !riscv.reg) %i0, %ub_arg0, %step_arg0 : !riscv.reg, !riscv.reg, !riscv.reg
 // CHECK-NEXT:     } do {
-// CHECK-NEXT:         ^0(%i1 : !riscv.reg<>, %ub_arg1 : !riscv.reg<>, %step_arg1 : !riscv.reg<>):
+// CHECK-NEXT:         ^0(%i1 : !riscv.reg, %ub_arg1 : !riscv.reg, %step_arg1 : !riscv.reg):
 // CHECK-NEXT:             riscv.addi %acc, 1 : (!riscv.reg<t0>) -> !riscv.reg<t0>
-// CHECK-NEXT:             %i_next = riscv.add %i1, %step_arg1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:             riscv_scf.yield %i_next, %ub_arg1, %step_arg1 : !riscv.reg<>, !riscv.reg<>, !riscv.reg<>
+// CHECK-NEXT:             %i_next = riscv.add %i1, %step_arg1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:             riscv_scf.yield %i_next, %ub_arg1, %step_arg1 : !riscv.reg, !riscv.reg, !riscv.reg
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/riscv_scf/verification.mlir
+++ b/tests/filecheck/dialects/riscv_scf/verification.mlir
@@ -2,19 +2,19 @@
 
 
 
-%lb = "riscv.li"() {"immediate" = 0: i32} : () -> !riscv.reg<>
-%ub = "riscv.li"() {"immediate" = 100: i32} : () -> !riscv.reg<>
-%step = "riscv.li"() {"immediate" = 1: i32} : () -> !riscv.reg<>
+%lb = "riscv.li"() {"immediate" = 0: i32} : () -> !riscv.reg
+%ub = "riscv.li"() {"immediate" = 100: i32} : () -> !riscv.reg
+%step = "riscv.li"() {"immediate" = 1: i32} : () -> !riscv.reg
 %acc = "riscv.li"() {"immediate" = 0 : i32} : () -> !riscv.reg<t0>
 
-%i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %step_arg0 = %step) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) {
-    %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    riscv_scf.condition(%cond : !riscv.reg<>) %i0, %ub_arg0, %step_arg0 : !riscv.reg<>, !riscv.reg<>, !riscv.reg<>
+%i_last, %ub_last, %step_last = riscv_scf.while (%i0 = %lb, %step_arg0 = %step) : (!riscv.reg, !riscv.reg, !riscv.reg) -> (!riscv.reg, !riscv.reg, !riscv.reg) {
+    %cond = riscv.slt %i0, %ub_arg0 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    riscv_scf.condition(%cond : !riscv.reg) %i0, %ub_arg0, %step_arg0 : !riscv.reg, !riscv.reg, !riscv.reg
 } do {
-^1(%i1 : !riscv.reg<>, %ub_arg1 : !riscv.reg<>, %step_arg1 : !riscv.reg<>):
+^1(%i1 : !riscv.reg, %ub_arg1 : !riscv.reg, %step_arg1 : !riscv.reg):
     "riscv.addi"(%acc) {"immediate" = 1 : i12} : (!riscv.reg<t0>) -> !riscv.reg<t0>
-    %i_next = "riscv.add"(%i1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    "riscv_scf.yield"(%i_next, %ub_arg1, %step_arg1) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+    %i_next = "riscv.add"(%i1, %step_arg1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    "riscv_scf.yield"(%i_next, %ub_arg1, %step_arg1) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 }
 
 // CHECK: Mismatch between block argument count (2) and operand count (3)

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -2,27 +2,27 @@
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
 riscv_func.func @xfrep() {
-  %0 = riscv.get_register : () -> !riscv.reg<>
-  %1 = riscv.get_register : () -> !riscv.reg<>
+  %0 = riscv.get_register : () -> !riscv.reg
+  %1 = riscv.get_register : () -> !riscv.reg
 
   // RISC-V extensions
-  %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  // CHECK: %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
-  // CHECK-NEXT: %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg<>) -> !riscv.reg<zero>
+  %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  // CHECK: %scfgw = riscv_snitch.scfgw %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg) -> !riscv.reg<zero>
+  // CHECK-NEXT: %scfgwi_zero = riscv_snitch.scfgwi %0, 42 : (!riscv.reg) -> !riscv.reg<zero>
 
   riscv_snitch.frep_outer %0 {
-    %add_o = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    %add_o = riscv.add %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
   }
   // CHECK-NEXT:  riscv_snitch.frep_outer %0 {
-  // CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
   // CHECK-NEXT:  }
 
   riscv_snitch.frep_inner %0 {
-    %add_i = riscv.add %0, %1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+    %add_i = riscv.add %0, %1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
   }
   // CHECK-NEXT:  riscv_snitch.frep_inner %0 {
-  // CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+  // CHECK-NEXT:    %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
   // CHECK-NEXT:  }
 
   %readable = riscv_snitch.get_stream : !stream.readable<!riscv.freg<ft0>>
@@ -57,30 +57,30 @@ riscv_func.func @xfrep() {
 }
 
 riscv_func.func @xdma() {
-  %reg = riscv.get_register : () -> !riscv.reg<>
-  // CHECK: %reg = riscv.get_register : () -> !riscv.reg<>
+  %reg = riscv.get_register : () -> !riscv.reg
+  // CHECK: %reg = riscv.get_register : () -> !riscv.reg
 
 
-  riscv_snitch.dmsrc %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: riscv_snitch.dmsrc %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> ()
+  riscv_snitch.dmsrc %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
+  // CHECK-NEXT: riscv_snitch.dmsrc %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 
-  riscv_snitch.dmdst %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: riscv_snitch.dmdst %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> ()
+  riscv_snitch.dmdst %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
+  // CHECK-NEXT: riscv_snitch.dmdst %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
 
-  riscv_snitch.dmstr %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> ()
-  // CHECK-NEXT: riscv_snitch.dmstr %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> ()
-  riscv_snitch.dmrep %reg : (!riscv.reg<>) -> ()
-  // CHECK-NEXT: riscv_snitch.dmrep %reg : (!riscv.reg<>) -> ()
+  riscv_snitch.dmstr %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
+  // CHECK-NEXT: riscv_snitch.dmstr %reg, %reg : (!riscv.reg, !riscv.reg) -> ()
+  riscv_snitch.dmrep %reg : (!riscv.reg) -> ()
+  // CHECK-NEXT: riscv_snitch.dmrep %reg : (!riscv.reg) -> ()
 
-  %0 = riscv_snitch.dmcpy %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmcpy %reg, %reg : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-  %1 = riscv_snitch.dmstat %reg : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmstat %reg : (!riscv.reg<>) -> !riscv.reg<>
+  %0 = riscv_snitch.dmcpy %reg, %reg : (!riscv.reg, !riscv.reg) -> !riscv.reg
+  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmcpy %reg, %reg : (!riscv.reg, !riscv.reg) -> !riscv.reg
+  %1 = riscv_snitch.dmstat %reg : (!riscv.reg) -> !riscv.reg
+  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmstat %reg : (!riscv.reg) -> !riscv.reg
 
-  %2 = riscv_snitch.dmcpyi %reg, 0 : (!riscv.reg<>) -> !riscv.reg<>
-  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmcpyi %reg, 0 : (!riscv.reg<>) -> !riscv.reg<>
-  %3 = riscv_snitch.dmstati 0 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmstati 0 : () -> !riscv.reg<>
+  %2 = riscv_snitch.dmcpyi %reg, 0 : (!riscv.reg) -> !riscv.reg
+  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmcpyi %reg, 0 : (!riscv.reg) -> !riscv.reg
+  %3 = riscv_snitch.dmstati 0 : () -> !riscv.reg
+  // CHECK-NEXT: %{{\d+}} = riscv_snitch.dmstati 0 : () -> !riscv.reg
 
 
   riscv_func.return
@@ -89,18 +89,18 @@ riscv_func.func @xdma() {
 
 // CHECK-GENERIC-NEXT: "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
-// CHECK-GENERIC-NEXT:     %0 = "riscv.get_register"() : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %1 = "riscv.get_register"() : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %scfgw = "riscv_snitch.scfgw"(%0, %1) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-// CHECK-GENERIC-NEXT:     %scfgwi_zero = "riscv_snitch.scfgwi"(%0) {"immediate" = 42 : i12} : (!riscv.reg<>) -> !riscv.reg<zero>
+// CHECK-GENERIC-NEXT:     %0 = "riscv.get_register"() : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %1 = "riscv.get_register"() : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %scfgw = "riscv_snitch.scfgw"(%0, %1) : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+// CHECK-GENERIC-NEXT:     %scfgwi_zero = "riscv_snitch.scfgwi"(%0) {"immediate" = 42 : i12} : (!riscv.reg) -> !riscv.reg<zero>
 // CHECK-GENERIC-NEXT:    "riscv_snitch.frep_outer"(%{{.*}}) ({
-// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:    "riscv_snitch.frep_inner"(%{{.*}}) ({
-// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:      %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:        %readable = "riscv_snitch.get_stream"() : () -> !stream.readable<!riscv.freg<ft0>>
 // CHECK-GENERIC-NEXT:        %writable = "riscv_snitch.get_stream"() : () -> !stream.writable<!riscv.freg<ft1>>
 // CHECK-GENERIC-NEXT:        "riscv_snitch.frep_outer"(%0) ({
@@ -108,25 +108,25 @@ riscv_func.func @xdma() {
 // CHECK-GENERIC-NEXT:          %val1 = "riscv.fmv.d"(%val0) : (!riscv.freg<ft0>) -> !riscv.freg<ft1>
 // CHECK-GENERIC-NEXT:          "riscv_snitch.write"(%val1, %writable) : (!riscv.freg<ft1>, !stream.writable<!riscv.freg<ft1>>) -> ()
 // CHECK-GENERIC-NEXT:          "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:        }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:        }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
 // CHECK-GENERIC-NEXT:    %init = "test.op"() : () -> !riscv.freg<ft3>
 // CHECK-GENERIC-NEXT:    %z = "riscv_snitch.frep_outer"(%0, %init) ({
 // CHECK-GENERIC-NEXT:    ^0(%acc : !riscv.freg<ft3>):
 // CHECK-GENERIC-NEXT:      %res = "riscv.fadd.d"(%acc, %acc) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<ft3>, !riscv.freg<ft3>) -> !riscv.freg<ft3>
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_yield"(%res) : (!riscv.freg<ft3>) -> ()
-// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>, !riscv.freg<ft3>) -> !riscv.freg<ft3>
+// CHECK-GENERIC-NEXT:    }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg, !riscv.freg<ft3>) -> !riscv.freg<ft3>
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "xfrep", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
-// CHECK-GENERIC-NEXT:     %reg = "riscv.get_register"() : () -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     "riscv_snitch.dmsrc"(%reg, %reg) : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv_snitch.dmdst"(%reg, %reg) : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv_snitch.dmstr"(%reg, %reg) : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     "riscv_snitch.dmrep"(%reg) : (!riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmcpy"(%reg, %reg) : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmstat"(%reg) : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmcpyi"(%reg) <{"config" = 0 : ui5}> : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmstati"() <{"status" = 0 : ui5}> : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:     %reg = "riscv.get_register"() : () -> !riscv.reg
+// CHECK-GENERIC-NEXT:     "riscv_snitch.dmsrc"(%reg, %reg) : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv_snitch.dmdst"(%reg, %reg) : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv_snitch.dmstr"(%reg, %reg) : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     "riscv_snitch.dmrep"(%reg) : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmcpy"(%reg, %reg) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmstat"(%reg) : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmcpyi"(%reg) <{"config" = 0 : ui5}> : (!riscv.reg) -> !riscv.reg
+// CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmstati"() <{"status" = 0 : ui5}> : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "xdma", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/snitch/snitch_ops.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_ops.mlir
@@ -1,20 +1,20 @@
 // RUN: XDSL_ROUNDTRIP
 "builtin.module"() ({
-  %addr = "test.op"() : () -> !riscv.reg<>
-  %bound = "test.op"() : () -> !riscv.reg<>
-  %stride = "test.op"() : () -> !riscv.reg<>
-  %rep = "test.op"() : () -> !riscv.reg<>
+  %addr = "test.op"() : () -> !riscv.reg
+  %bound = "test.op"() : () -> !riscv.reg
+  %stride = "test.op"() : () -> !riscv.reg
+  %rep = "test.op"() : () -> !riscv.reg
   // Usual SSR setup sequence:
-  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #builtin.int<0>} : (!riscv.reg) -> ()
   "snitch.ssr_enable"() : () -> ()
   // CHECK-NEXT: "snitch.ssr_enable"() : () -> ()
   "snitch.ssr_disable"() : () -> ()

--- a/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
+++ b/tests/filecheck/dialects/snitch/snitch_to_riscv_lowering.mlir
@@ -1,38 +1,38 @@
 // RUN: xdsl-opt -p lower-snitch %s | filecheck %s
 builtin.module {
-  %addr = "test.op"() : () -> !riscv.reg<>
-  %bound = riscv.li 9 : () -> !riscv.reg<>
-  %stride = riscv.li 4 : () -> !riscv.reg<>
-  %rep = riscv.li 0 : () -> !riscv.reg<>
+  %addr = "test.op"() : () -> !riscv.reg
+  %bound = riscv.li 9 : () -> !riscv.reg
+  %stride = riscv.li 4 : () -> !riscv.reg
+  %rep = riscv.li 0 : () -> !riscv.reg
   // SSR setup sequence for dimension 0
-  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 64 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 192 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 768 : () -> !riscv.reg<>
-  // %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 896 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 64 : () -> !riscv.reg
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 192 : () -> !riscv.reg
+  // CHECK-NEXT: %{{.*}} riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 768 : () -> !riscv.reg
+  // %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 896 : () -> !riscv.reg
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
   // SSR setup sequence for dimension 3
-  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 160 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 288 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 864 : () -> !riscv.reg<>
-  // riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 992 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
-  "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #builtin.int<0>}: (!riscv.reg<>) -> ()
-  // CHECK: %{{.*}} = riscv.li 32 : () -> !riscv.reg<>
-  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %rep, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_bound"(%bound) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 160 : () -> !riscv.reg
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %bound, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_stride"(%stride) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 288 : () -> !riscv.reg
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %stride, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_source"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 864 : () -> !riscv.reg
+  // riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  "snitch.ssr_set_dimension_destination"(%addr) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<3>} : (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 992 : () -> !riscv.reg
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %addr, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
+  "snitch.ssr_set_stream_repetition"(%rep) {"dm" = #builtin.int<0>}: (!riscv.reg) -> ()
+  // CHECK: %{{.*}} = riscv.li 32 : () -> !riscv.reg
+  // CHECK-NEXT: %{{.*}} = riscv_snitch.scfgw %rep, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg<zero>
   // On/Off switching sequence
   "snitch.ssr_enable"() : () -> ()
   // CHECK: riscv.csrrsi 1984, 1

--- a/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
+++ b/tests/filecheck/dialects/snitch_stream/convert_snitch_stream_to_snitch.mlir
@@ -2,8 +2,8 @@
 
 // CHECK: builtin.module {
 
-%A, %B, %C = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
-// CHECK-NEXT:  %A, %B, %C = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+%A, %B, %C = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
+// CHECK-NEXT:  %A, %B, %C = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
 
 "snitch_stream.streaming_region"(%A, %B, %C) <{
     "stride_patterns" = [
@@ -15,60 +15,60 @@
 }> ({
 ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
     "test.op"() : () -> ()
-}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 24 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 4 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 5 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<2>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 480 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 160 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 40 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<2>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%A) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%B) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_destination"(%C) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg<>) -> ()
+}) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 24 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 4 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 5 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<1>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<2>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 480 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 160 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 40 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<1>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<2>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.sub %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%A) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%B) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<1>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_destination"(%C) {"dm" = #builtin.int<2>, "dimension" = #builtin.int<3>} : (!riscv.reg) -> ()
 // CHECK-NEXT:  %a_stream, %b_stream, %c_stream = "snitch.ssr_enable"() : () -> (!stream.readable<!riscv.freg<ft0>>, !stream.readable<!riscv.freg<ft1>>, !stream.writable<!riscv.freg<ft2>>)
 // CHECK-NEXT:  "test.op"() : () -> ()
 // CHECK-NEXT:  "snitch.ssr_disable"() : () -> ()
@@ -81,16 +81,16 @@
 }> ({
 ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.writable<!riscv.freg<ft1>>):
     "test.op"() : () -> ()
-}) : (!riscv.reg<>, !riscv.reg<>) -> ()
+}) : (!riscv.reg, !riscv.reg) -> ()
 
-// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%A) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-NEXT:  "snitch.ssr_set_dimension_destination"(%B) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg<>) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:  %{{.*}} = riscv.addi %{{.*}}, -1 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_bound"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_stride"(%{{.*}}) {"dm" = #builtin.int<31>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  %{{.*}} = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:  "snitch.ssr_set_dimension_source"(%A) {"dm" = #builtin.int<0>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-NEXT:  "snitch.ssr_set_dimension_destination"(%B) {"dm" = #builtin.int<1>, "dimension" = #builtin.int<0>} : (!riscv.reg) -> ()
 // CHECK-NEXT:  %{{.*}}, %{{.*}} = "snitch.ssr_enable"() : () -> (!stream.readable<!riscv.freg<ft0>>, !stream.writable<!riscv.freg<ft1>>)
 // CHECK-NEXT:  "test.op"() : () -> ()
 // CHECK-NEXT:  "snitch.ssr_disable"() : () -> ()

--- a/tests/filecheck/dialects/snitch_stream/ops.mlir
+++ b/tests/filecheck/dialects/snitch_stream/ops.mlir
@@ -1,45 +1,45 @@
 // RUN: XDSL_ROUNDTRIP
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
-%X, %Y, %Z = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+%X, %Y, %Z = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
 
 "snitch_stream.streaming_region"(%X, %Y, %Z) <{
     "stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>],
     "operandSegmentSizes" = array<i32: 2, 1>
 }> ({
 ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
-    %c5 = riscv.li 5 : () -> !riscv.reg<>
+    %c5 = riscv.li 5 : () -> !riscv.reg
     riscv_snitch.frep_outer %c5 {
         %a = riscv_snitch.read from %a_stream : !riscv.freg<ft0>
         %b = riscv_snitch.read from %b_stream : !riscv.freg<ft1>
         %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
         riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
     }
-}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+}) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
 
-// CHECK:       %X, %Y, %Z = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK:       %X, %Y, %Z = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
 // CHECK-NEXT:   "snitch_stream.streaming_region"(%X, %Y, %Z) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT:    ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
-// CHECK-NEXT:    %c5 = riscv.li 5 : () -> !riscv.reg<>
+// CHECK-NEXT:    %c5 = riscv.li 5 : () -> !riscv.reg
 // CHECK-NEXT:    riscv_snitch.frep_outer %c5 {
 // CHECK-NEXT:      %a = riscv_snitch.read from %a_stream : !riscv.freg<ft0>
 // CHECK-NEXT:      %b = riscv_snitch.read from %b_stream : !riscv.freg<ft1>
 // CHECK-NEXT:      %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
 // CHECK-NEXT:      riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:  }) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
 
-// CHECK-GENERIC:         %X, %Y, %Z = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-GENERIC:         %X, %Y, %Z = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
 // CHECK-GENERIC-NEXT:    "snitch_stream.streaming_region"(%X, %Y, %Z) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 16], strides = [128, 8]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
-// CHECK-GENERIC-NEXT:      %c5 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg<>
+// CHECK-GENERIC-NEXT:      %c5 = "riscv.li"() {"immediate" = 5 : i32} : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:      "riscv_snitch.frep_outer"(%c5) ({
 // CHECK-GENERIC-NEXT:        %a = "riscv_snitch.read"(%a_stream) : (!stream.readable<!riscv.freg<ft0>>) -> !riscv.freg<ft0>
 // CHECK-GENERIC-NEXT:        %b = "riscv_snitch.read"(%b_stream) : (!stream.readable<!riscv.freg<ft1>>) -> !riscv.freg<ft1>
 // CHECK-GENERIC-NEXT:        %c = "riscv.fadd.d"(%a, %b) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
 // CHECK-GENERIC-NEXT:        "riscv_snitch.write"(%c, %c_stream) : (!riscv.freg<ft2>, !stream.writable<!riscv.freg<ft2>>) -> ()
 // CHECK-GENERIC-NEXT:        "riscv_snitch.frep_yield"() : () -> ()
-// CHECK-GENERIC-NEXT:      }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg<>) -> ()
-// CHECK-GENERIC-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-GENERIC-NEXT:      }) {"stagger_mask" = #builtin.int<0>, "stagger_count" = #builtin.int<0>} : (!riscv.reg) -> ()
+// CHECK-GENERIC-NEXT:    }) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -153,164 +153,164 @@ func.func @funcyasm() {
     %4 = x86.get_register : () -> !x86.reg<rdx>
     %rflags = x86.rr.cmp %3, %4 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.rflags<rflags>
     // CHECK: cmp rax, rdx
-    
-    x86.s.jmp ^then(%arg : !x86.reg<>)
+
+    x86.s.jmp ^then(%arg : !x86.reg)
     // CHECK-NEXT: jmp then
-    ^then(%arg : !x86.reg<>):
+    ^then(%arg : !x86.reg):
     x86.label "then"
     // CHECK-NEXT: then:
-    x86.s.ja %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else(%arg2 : !x86.reg<>)
+    x86.s.ja %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else(%arg2 : !x86.reg)
     // CHECK-NEXT: ja then
-    ^else(%arg2 : !x86.reg<>):
+    ^else(%arg2 : !x86.reg):
     x86.label "else"
     // CHECK-NEXT: else:
-    x86.s.jae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else2(%arg3 : !x86.reg<>)
+    x86.s.jae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else2(%arg3 : !x86.reg)
     // CHECK-NEXT: jae then
-    ^else2(%arg3 : !x86.reg<>):
+    ^else2(%arg3 : !x86.reg):
     x86.label "else2"
     // CHECK-NEXT: else2:
-    x86.s.jb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else3(%arg4 : !x86.reg<>)
+    x86.s.jb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else3(%arg4 : !x86.reg)
     // CHECK-NEXT: jb then
-    ^else3(%arg4 : !x86.reg<>):
+    ^else3(%arg4 : !x86.reg):
     x86.label "else3"
     // CHECK-NEXT: else3:
-    x86.s.jbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else4(%arg5 : !x86.reg<>)
+    x86.s.jbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else4(%arg5 : !x86.reg)
     // CHECK-NEXT: jbe then
-    ^else4(%arg5 : !x86.reg<>):
+    ^else4(%arg5 : !x86.reg):
     x86.label "else4"
     // CHECK-NEXT: else4:
-    x86.s.jc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else5(%arg6 : !x86.reg<>)
+    x86.s.jc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else5(%arg6 : !x86.reg)
     // CHECK-NEXT: jc then
-    ^else5(%arg6 : !x86.reg<>):
+    ^else5(%arg6 : !x86.reg):
     x86.label "else5"
     // CHECK-NEXT: else5:
-    x86.s.je %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else6(%arg7 : !x86.reg<>)
+    x86.s.je %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else6(%arg7 : !x86.reg)
     // CHECK-NEXT: je then
-    ^else6(%arg7 : !x86.reg<>):
+    ^else6(%arg7 : !x86.reg):
     x86.label "else6"
     // CHECK-NEXT: else6:
-    x86.s.jg %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else7(%arg8 : !x86.reg<>)
+    x86.s.jg %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else7(%arg8 : !x86.reg)
     // CHECK-NEXT: jg then
-    ^else7(%arg8 : !x86.reg<>):
+    ^else7(%arg8 : !x86.reg):
     x86.label "else7"
     // CHECK-NEXT: else7:
-    x86.s.jge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else8(%arg9 : !x86.reg<>)
+    x86.s.jge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else8(%arg9 : !x86.reg)
     // CHECK-NEXT: jge then
-    ^else8(%arg9 : !x86.reg<>):
+    ^else8(%arg9 : !x86.reg):
     x86.label "else8"
     // CHECK-NEXT: else8:
-    x86.s.jl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else9(%arg10 : !x86.reg<>)
+    x86.s.jl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else9(%arg10 : !x86.reg)
     // CHECK-NEXT: jl then
-    ^else9(%arg10 : !x86.reg<>):
+    ^else9(%arg10 : !x86.reg):
     x86.label "else9"
     // CHECK-NEXT: else9:
-    x86.s.jle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else10(%arg11 : !x86.reg<>)
+    x86.s.jle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else10(%arg11 : !x86.reg)
     // CHECK-NEXT: jle then
-    ^else10(%arg11 : !x86.reg<>):
+    ^else10(%arg11 : !x86.reg):
     x86.label "else10"
     // CHECK-NEXT: else10:
-    x86.s.jna %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else11(%arg12 : !x86.reg<>)
+    x86.s.jna %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else11(%arg12 : !x86.reg)
     // CHECK-NEXT: jna then
-    ^else11(%arg12 : !x86.reg<>):
+    ^else11(%arg12 : !x86.reg):
     x86.label "else11"
     // CHECK-NEXT: else11:
-    x86.s.jnae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else12(%arg13 : !x86.reg<>)
+    x86.s.jnae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else12(%arg13 : !x86.reg)
     // CHECK-NEXT: jnae then
-    ^else12(%arg13 : !x86.reg<>):
+    ^else12(%arg13 : !x86.reg):
     x86.label "else12"
     // CHECK-NEXT: else12:
-    x86.s.jnb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else13(%arg14 : !x86.reg<>)
+    x86.s.jnb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else13(%arg14 : !x86.reg)
     // CHECK-NEXT: jnb then
-    ^else13(%arg14 : !x86.reg<>):
+    ^else13(%arg14 : !x86.reg):
     x86.label "else13"
     // CHECK-NEXT: else13:
-    x86.s.jnbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else14(%arg15 : !x86.reg<>)
+    x86.s.jnbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else14(%arg15 : !x86.reg)
     // CHECK-NEXT: jnbe then
-    ^else14(%arg15 : !x86.reg<>):
+    ^else14(%arg15 : !x86.reg):
     x86.label "else14"
     // CHECK-NEXT: else14:
-    x86.s.jnc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else15(%arg16 : !x86.reg<>)
+    x86.s.jnc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else15(%arg16 : !x86.reg)
     // CHECK-NEXT: jnc then
-    ^else15(%arg16 : !x86.reg<>):
+    ^else15(%arg16 : !x86.reg):
     x86.label "else15"
     // CHECK-NEXT: else15:
-    x86.s.jne %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else16(%arg17 : !x86.reg<>)
+    x86.s.jne %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else16(%arg17 : !x86.reg)
     // CHECK-NEXT: jne then
-    ^else16(%arg17 : !x86.reg<>):
+    ^else16(%arg17 : !x86.reg):
     x86.label "else16"
     // CHECK-NEXT: else16:
-    x86.s.jng %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else17(%arg18 : !x86.reg<>)
+    x86.s.jng %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else17(%arg18 : !x86.reg)
     // CHECK-NEXT: jng then
-    ^else17(%arg18 : !x86.reg<>):
+    ^else17(%arg18 : !x86.reg):
     x86.label "else17"
     // CHECK-NEXT: else17:
-    x86.s.jnge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else18(%arg19 : !x86.reg<>)
+    x86.s.jnge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else18(%arg19 : !x86.reg)
     // CHECK-NEXT: jnge then
-    ^else18(%arg19 : !x86.reg<>):
+    ^else18(%arg19 : !x86.reg):
     x86.label "else18"
     // CHECK-NEXT: else18:
-    x86.s.jnl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else19(%arg20 : !x86.reg<>)
+    x86.s.jnl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else19(%arg20 : !x86.reg)
     // CHECK-NEXT: jnl then
-    ^else19(%arg20 : !x86.reg<>):
+    ^else19(%arg20 : !x86.reg):
     x86.label "else19"
     // CHECK-NEXT: else19:
-    x86.s.jnle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else20(%arg21 : !x86.reg<>)
+    x86.s.jnle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else20(%arg21 : !x86.reg)
     // CHECK-NEXT: jnle then
-    ^else20(%arg21 : !x86.reg<>):
+    ^else20(%arg21 : !x86.reg):
     x86.label "else20"
     // CHECK-NEXT: else20:
-    x86.s.jno %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else21(%arg22 : !x86.reg<>)
+    x86.s.jno %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else21(%arg22 : !x86.reg)
     // CHECK-NEXT: jno then
-    ^else21(%arg22 : !x86.reg<>):
+    ^else21(%arg22 : !x86.reg):
     x86.label "else21"
     // CHECK-NEXT: else21:
-    x86.s.jnp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else22(%arg23 : !x86.reg<>)
+    x86.s.jnp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else22(%arg23 : !x86.reg)
     // CHECK-NEXT: jnp then
-    ^else22(%arg23 : !x86.reg<>):
+    ^else22(%arg23 : !x86.reg):
     x86.label "else22"
     // CHECK-NEXT: else22:
-    x86.s.jns %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else23(%arg24 : !x86.reg<>)
+    x86.s.jns %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else23(%arg24 : !x86.reg)
     // CHECK-NEXT: jns then
-    ^else23(%arg24 : !x86.reg<>):
+    ^else23(%arg24 : !x86.reg):
     x86.label "else23"
     // CHECK-NEXT: else23:
-    x86.s.jnz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else24(%arg25 : !x86.reg<>)
+    x86.s.jnz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else24(%arg25 : !x86.reg)
     // CHECK-NEXT: jnz then
-    ^else24(%arg25 : !x86.reg<>):
+    ^else24(%arg25 : !x86.reg):
     x86.label "else24"
     // CHECK-NEXT: else24:
-    x86.s.jo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else25(%arg26 : !x86.reg<>)
+    x86.s.jo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else25(%arg26 : !x86.reg)
     // CHECK-NEXT: jo then
-    ^else25(%arg26 : !x86.reg<>):
+    ^else25(%arg26 : !x86.reg):
     x86.label "else25"
     // CHECK-NEXT: else25:
-    x86.s.jp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else26(%arg27 : !x86.reg<>)
+    x86.s.jp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else26(%arg27 : !x86.reg)
     // CHECK-NEXT: jp then
-    ^else26(%arg27 : !x86.reg<>):
+    ^else26(%arg27 : !x86.reg):
     x86.label "else26"
     // CHECK-NEXT: else26:
-    x86.s.jpe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else27(%arg28 : !x86.reg<>)
+    x86.s.jpe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else27(%arg28 : !x86.reg)
     // CHECK-NEXT: jpe then
-    ^else27(%arg28 : !x86.reg<>):
+    ^else27(%arg28 : !x86.reg):
     x86.label "else27"
     // CHECK-NEXT: else27:
-    x86.s.jpo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else28(%arg29 : !x86.reg<>)
+    x86.s.jpo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else28(%arg29 : !x86.reg)
     // CHECK-NEXT: jpo then
-    ^else28(%arg29 : !x86.reg<>):
+    ^else28(%arg29 : !x86.reg):
     x86.label "else28"
     // CHECK-NEXT: else28:
-    x86.s.js %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else29(%arg30 : !x86.reg<>)
+    x86.s.js %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else29(%arg30 : !x86.reg)
     // CHECK-NEXT: js then
-    ^else29(%arg30 : !x86.reg<>):
+    ^else29(%arg30 : !x86.reg):
     x86.label "else29"
     // CHECK-NEXT: else29:
-    x86.s.jz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else30(%arg31 : !x86.reg<>)
+    x86.s.jz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else30(%arg31 : !x86.reg)
     // CHECK-NEXT: jz then
-    ^else30(%arg31 : !x86.reg<>):
+    ^else30(%arg31 : !x86.reg):
     x86.label "else30"
     // CHECK-NEXT: else30:
 
-    x86.s.jmp ^then(%arg : !x86.reg<>)
+    x86.s.jmp ^then(%arg : !x86.reg)
     // CHECK-NEXT: jmp then
 }
 

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -2,147 +2,147 @@
 %a = "test.op"() : () -> !x86.reg<rax>
 // CHECK: %{{.*}} = "test.op"() : () -> !x86.reg<rax>
 
-%0, %1 = "test.op"() : () -> (!x86.reg<>, !x86.reg<>)
+%0, %1 = "test.op"() : () -> (!x86.reg, !x86.reg)
 %rsp = "test.op"() : () -> !x86.reg<rsp>
 %rax = "test.op"() : () -> !x86.reg<rax>
 %rdx = "test.op"() : () -> !x86.reg<rdx>
 
-%rr_add = x86.rr.add %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK: %{{.*}} = x86.rr.add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rr_sub = x86.rr.sub %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr.sub %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rr_mul = x86.rr.imul %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr.imul %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rr_and = x86.rr.and %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr.and %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rr_or = x86.rr.or %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr.or %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rr_xor = x86.rr.xor %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr.xor %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rr_mov = x86.rr.mov %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rr.mov %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rr_cmp = x86.rr.cmp %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.rflags<rflags>
-// CHECK: %{{.*}} = x86.rr.cmp %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.rflags
+%rr_add = x86.rr.add %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK: %{{.*}} = x86.rr.add %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_sub = x86.rr.sub %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rr.sub %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_mul = x86.rr.imul %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rr.imul %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_and = x86.rr.and %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rr.and %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_or = x86.rr.or %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rr.or %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_xor = x86.rr.xor %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rr.xor %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_mov = x86.rr.mov %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rr.mov %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_cmp = x86.rr.cmp %0, %1 : (!x86.reg, !x86.reg) -> !x86.rflags<rflags>
+// CHECK: %{{.*}} = x86.rr.cmp %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.rflags
 
-%r_pushrsp = x86.r.push %rsp, %0 : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-// CHECK-NEXT: %{{.*}} = x86.r.push %rsp, %{{.*}} : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-%r_pop, %r_poprsp = x86.r.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r.pop %{{.*}} : (!x86.reg<rsp>) -> (!x86.reg<>, !x86.reg<rsp>)
-%r_not = x86.r.not %0 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.r.not %{{.*}} : (!x86.reg<>) -> !x86.reg<>
-%r_neg = x86.r.neg %0 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.r.neg %{{.*}} : (!x86.reg<>) -> !x86.reg<>
-%r_inc = x86.r.inc %0 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.r.inc %{{.*}} : (!x86.reg<>) -> !x86.reg<>
-%r_dec = x86.r.dec %0 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.r.dec %{{.*}} : (!x86.reg<>) -> !x86.reg<>
+%r_pushrsp = x86.r.push %rsp, %0 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+// CHECK-NEXT: %{{.*}} = x86.r.push %rsp, %{{.*}} : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+%r_pop, %r_poprsp = x86.r.pop %rsp : (!x86.reg<rsp>) -> (!x86.reg, !x86.reg<rsp>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r.pop %{{.*}} : (!x86.reg<rsp>) -> (!x86.reg, !x86.reg<rsp>)
+%r_not = x86.r.not %0 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.r.not %{{.*}} : (!x86.reg) -> !x86.reg
+%r_neg = x86.r.neg %0 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.r.neg %{{.*}} : (!x86.reg) -> !x86.reg
+%r_inc = x86.r.inc %0 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.r.inc %{{.*}} : (!x86.reg) -> !x86.reg
+%r_dec = x86.r.dec %0 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.r.dec %{{.*}} : (!x86.reg) -> !x86.reg
 
-%r_idiv_rdx, %r_idiv_rax = x86.r.idiv %0, %rdx, %rax : (!x86.reg<>, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r.idiv %{{.*}}, %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-%r_imul_rdx, %r_imul_rax = x86.r.imul %0, %rax : (!x86.reg<>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r.imul %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+%r_idiv_rdx, %r_idiv_rax = x86.r.idiv %0, %rdx, %rax : (!x86.reg, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r.idiv %{{.*}}, %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+%r_imul_rdx, %r_imul_rax = x86.r.imul %0, %rax : (!x86.reg, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.r.imul %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
 
-%rm_add_no_offset  = x86.rm.add %0, %1 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_add = x86.rm.add %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK: %{{.*}} = x86.rm.add %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_sub = x86.rm.sub %0, %1, -8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.sub %{{.*}}, %{{.*}}, -8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_imul = x86.rm.imul %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.imul %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_and = x86.rm.and %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.and %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_or = x86.rm.or %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.or %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_xor = x86.rm.xor %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.xor %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_mov = x86.rm.mov %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.mov %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-%rm_cmp = x86.rm.cmp %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.rflags<rflags>
-// CHECK-NEXT: %{{.*}} = x86.rm.cmp %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.rflags
-%rm_lea = x86.rm.lea %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.lea %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.reg<>
+%rm_add_no_offset  = x86.rm.add %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.add %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_add = x86.rm.add %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK: %{{.*}} = x86.rm.add %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_sub = x86.rm.sub %0, %1, -8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.sub %{{.*}}, %{{.*}}, -8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_imul = x86.rm.imul %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.imul %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_and = x86.rm.and %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.and %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_or = x86.rm.or %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.or %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_xor = x86.rm.xor %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.xor %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_mov = x86.rm.mov %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.mov %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_cmp = x86.rm.cmp %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.rflags<rflags>
+// CHECK-NEXT: %{{.*}} = x86.rm.cmp %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.rflags
+%rm_lea = x86.rm.lea %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.lea %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
 
-%ri_add = x86.ri.add %0, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.ri.add %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
-%ri_sub = x86.ri.sub %0, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.ri.sub %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
-%ri_and = x86.ri.and %0, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.ri.and %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
-%ri_or = x86.ri.or %0, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.ri.or %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
-%ri_xor = x86.ri.xor %0, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.ri.xor %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
-%ri_mov = x86.ri.mov %0, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.ri.mov %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
-%ri_cmp = x86.ri.cmp %0, 2 : (!x86.reg<>) -> !x86.rflags<rflags>
-// CHECK-NEXT: %{{.*}} = x86.ri.cmp %{{.*}}, 2 : (!x86.reg<>) -> !x86.rflags
+%ri_add = x86.ri.add %0, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.ri.add %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%ri_sub = x86.ri.sub %0, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.ri.sub %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%ri_and = x86.ri.and %0, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.ri.and %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%ri_or = x86.ri.or %0, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.ri.or %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%ri_xor = x86.ri.xor %0, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.ri.xor %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%ri_mov = x86.ri.mov %0, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.ri.mov %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%ri_cmp = x86.ri.cmp %0, 2 : (!x86.reg) -> !x86.rflags<rflags>
+// CHECK-NEXT: %{{.*}} = x86.ri.cmp %{{.*}}, 2 : (!x86.reg) -> !x86.rflags
 
-x86.mr.add %0, %1 : (!x86.reg<>, !x86.reg<>) -> ()
-// CHECK-NEXT: x86.mr.add %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> ()
-x86.mr.add %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-// CHECK-NEXT: x86.mr.add %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-x86.mr.sub %0, %1, -8 : (!x86.reg<>, !x86.reg<>) -> ()
-// CHECK-NEXT: x86.mr.sub %{{.*}}, %{{.*}}, -8 : (!x86.reg<>, !x86.reg<>) -> ()
-x86.mr.and %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-// CHECK-NEXT: x86.mr.and %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-x86.mr.or %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-// CHECK-NEXT: x86.mr.or %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-x86.mr.xor %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-// CHECK-NEXT: x86.mr.xor %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-x86.mr.mov %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-// CHECK-NEXT: x86.mr.mov %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> ()
-%mr.cmp = x86.mr.cmp %0, %1, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.rflags<rflags>
-// CHECK-NEXT: %{{.*}} = x86.mr.cmp %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<>) -> !x86.rflags
+x86.mr.add %0, %1 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.mr.add %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> ()
+x86.mr.add %0, %1, 8 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.mr.add %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> ()
+x86.mr.sub %0, %1, -8 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.mr.sub %{{.*}}, %{{.*}}, -8 : (!x86.reg, !x86.reg) -> ()
+x86.mr.and %0, %1, 8 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.mr.and %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> ()
+x86.mr.or %0, %1, 8 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.mr.or %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> ()
+x86.mr.xor %0, %1, 8 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.mr.xor %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> ()
+x86.mr.mov %0, %1, 8 : (!x86.reg, !x86.reg) -> ()
+// CHECK-NEXT: x86.mr.mov %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> ()
+%mr.cmp = x86.mr.cmp %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.rflags<rflags>
+// CHECK-NEXT: %{{.*}} = x86.mr.cmp %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.rflags
 
-x86.mi.add %0, 2 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.mi.add %{{.*}}, 2 : (!x86.reg<>) -> ()
-x86.mi.add %0, 2, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.mi.add %{{.*}}, 2, 8 : (!x86.reg<>) -> ()
-x86.mi.sub %0, 2, -8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.mi.sub %{{.*}}, 2, -8 : (!x86.reg<>) -> ()
-x86.mi.and %0, 2, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.mi.and %{{.*}}, 2, 8 : (!x86.reg<>) -> ()
-x86.mi.or %0, 2, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.mi.or %{{.*}}, 2, 8 : (!x86.reg<>) -> ()
-x86.mi.xor %0, 2, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.mi.xor %{{.*}}, 2, 8 : (!x86.reg<>) -> ()
-x86.mi.mov %0, 2, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.mi.mov %{{.*}}, 2, 8 : (!x86.reg<>) -> ()
-%mi_cmp = x86.mi.cmp %0, 2, 8 : (!x86.reg<>) -> !x86.rflags<rflags>
-// CHECK-NEXT: %{{.*}} = x86.mi.cmp %{{.*}}, 2, 8 : (!x86.reg<>) -> !x86.rflags
+x86.mi.add %0, 2 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.mi.add %{{.*}}, 2 : (!x86.reg) -> ()
+x86.mi.add %0, 2, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.mi.add %{{.*}}, 2, 8 : (!x86.reg) -> ()
+x86.mi.sub %0, 2, -8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.mi.sub %{{.*}}, 2, -8 : (!x86.reg) -> ()
+x86.mi.and %0, 2, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.mi.and %{{.*}}, 2, 8 : (!x86.reg) -> ()
+x86.mi.or %0, 2, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.mi.or %{{.*}}, 2, 8 : (!x86.reg) -> ()
+x86.mi.xor %0, 2, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.mi.xor %{{.*}}, 2, 8 : (!x86.reg) -> ()
+x86.mi.mov %0, 2, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.mi.mov %{{.*}}, 2, 8 : (!x86.reg) -> ()
+%mi_cmp = x86.mi.cmp %0, 2, 8 : (!x86.reg) -> !x86.rflags<rflags>
+// CHECK-NEXT: %{{.*}} = x86.mi.cmp %{{.*}}, 2, 8 : (!x86.reg) -> !x86.rflags
 
-%rri_imul = x86.rri.imul %1, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rri.imul %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
+%rri_imul = x86.rri.imul %1, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rri.imul %{{.*}}, 2 : (!x86.reg) -> !x86.reg
 
-%rmi_imul_no_offset = x86.rmi.imul %1, 2 : (!x86.reg<>) -> !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rmi.imul %{{.*}}, 2 : (!x86.reg<>) -> !x86.reg<>
-%rmi_imul = x86.rmi.imul %1, 2, 8 : (!x86.reg<>) ->  !x86.reg<>
-// CHECK-NEXT: %{{.*}} = x86.rmi.imul %{{.*}}, 2, 8 : (!x86.reg<>) -> !x86.reg<>
+%rmi_imul_no_offset = x86.rmi.imul %1, 2 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rmi.imul %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%rmi_imul = x86.rmi.imul %1, 2, 8 : (!x86.reg) ->  !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rmi.imul %{{.*}}, 2, 8 : (!x86.reg) -> !x86.reg
 
-%m_push_rsp = x86.m.push %rsp, %0 : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-// CHECK-NEXT: %{{.*}} = x86.m.push %rsp, %{{.*}} : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-%m_push_rsp2 = x86.m.push %rsp, %0, 8 : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-// CHECK-NEXT: %{{.*}} = x86.m.push %rsp, %{{.*}}, 8 : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-%m_pop_rsp = x86.m.pop %rsp, %0, 8 : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-// CHECK-NEXT: %{{.*}} = x86.m.pop %rsp, %{{.*}}, 8 : (!x86.reg<rsp>, !x86.reg<>) -> !x86.reg<rsp>
-x86.m.neg %0 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.m.neg %{{.*}} : (!x86.reg<>) -> ()
-x86.m.neg %0, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.m.neg %{{.*}}, 8 : (!x86.reg<>) -> ()
-x86.m.not %0, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.m.not %{{.*}}, 8 : (!x86.reg<>) -> ()
-x86.m.inc %0, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.m.inc %{{.*}}, 8 : (!x86.reg<>) -> ()
-x86.m.dec %0, 8 : (!x86.reg<>) -> ()
-// CHECK-NEXT: x86.m.dec %{{.*}}, 8 : (!x86.reg<>) -> ()
+%m_push_rsp = x86.m.push %rsp, %0 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+// CHECK-NEXT: %{{.*}} = x86.m.push %rsp, %{{.*}} : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+%m_push_rsp2 = x86.m.push %rsp, %0, 8 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+// CHECK-NEXT: %{{.*}} = x86.m.push %rsp, %{{.*}}, 8 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+%m_pop_rsp = x86.m.pop %rsp, %0, 8 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+// CHECK-NEXT: %{{.*}} = x86.m.pop %rsp, %{{.*}}, 8 : (!x86.reg<rsp>, !x86.reg) -> !x86.reg<rsp>
+x86.m.neg %0 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.m.neg %{{.*}} : (!x86.reg) -> ()
+x86.m.neg %0, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.m.neg %{{.*}}, 8 : (!x86.reg) -> ()
+x86.m.not %0, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.m.not %{{.*}}, 8 : (!x86.reg) -> ()
+x86.m.inc %0, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.m.inc %{{.*}}, 8 : (!x86.reg) -> ()
+x86.m.dec %0, 8 : (!x86.reg) -> ()
+// CHECK-NEXT: x86.m.dec %{{.*}}, 8 : (!x86.reg) -> ()
 
-%m_idiv_rdx, %m_idiv_rax = x86.m.idiv %0, %rdx, %rax : (!x86.reg<>, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.m.idiv %{{.*}}, %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-%m_idiv_rdx2, %m_idiv_rax2 = x86.m.idiv %0, %rdx, %rax, 8 : (!x86.reg<>, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.m.idiv %{{.*}}, %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-%m_imul_rdx, %m_imul_rax = x86.m.imul %0, %rax, 8 : (!x86.reg<>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
-// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.m.imul %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+%m_idiv_rdx, %m_idiv_rax = x86.m.idiv %0, %rdx, %rax : (!x86.reg, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.m.idiv %{{.*}}, %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+%m_idiv_rdx2, %m_idiv_rax2 = x86.m.idiv %0, %rdx, %rax, 8 : (!x86.reg, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.m.idiv %{{.*}}, %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg<rdx>, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+%m_imul_rdx, %m_imul_rax = x86.m.imul %0, %rax, 8 : (!x86.reg, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
+// CHECK-NEXT: %{{.*}}, %{{.*}} = x86.m.imul %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg<rax>) -> (!x86.reg<rdx>, !x86.reg<rax>)
 
 x86.directive ".text"
 // CHECK-NEXT: x86.directive ".text"
@@ -152,208 +152,208 @@ x86.label "label"
 // CHECK-NEXT: x86.label "label"
 
 func.func @funcyasm() {
-    %2, %3 = "test.op"() : () -> (!x86.reg<>, !x86.reg<>)
-    %rflags = x86.rr.cmp %2, %3 : (!x86.reg<>, !x86.reg<>) -> !x86.rflags<rflags>
-    // CHECK: %{{.*}} = x86.rr.cmp %{{.*}}, %{{.*}} : (!x86.reg<>, !x86.reg<>) -> !x86.rflags
-    
-    x86.s.jmp ^then(%arg : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jmp ^{{.+}}(%arg : !x86.reg<>)
-    ^then(%arg : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg : !x86.reg<>):
+    %2, %3 = "test.op"() : () -> (!x86.reg, !x86.reg)
+    %rflags = x86.rr.cmp %2, %3 : (!x86.reg, !x86.reg) -> !x86.rflags<rflags>
+    // CHECK: %{{.*}} = x86.rr.cmp %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.rflags
+
+    x86.s.jmp ^then(%arg : !x86.reg)
+    // CHECK-NEXT: x86.s.jmp ^{{.+}}(%arg : !x86.reg)
+    ^then(%arg : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg : !x86.reg):
     x86.label "then"
     // CHECK-NEXT: x86.label "then"
-    x86.s.ja %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else(%arg2 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.ja %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg2 : !x86.reg<>)
-    ^else(%arg2 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg2 : !x86.reg<>):
+    x86.s.ja %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else(%arg2 : !x86.reg)
+    // CHECK-NEXT: x86.s.ja %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg2 : !x86.reg)
+    ^else(%arg2 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg2 : !x86.reg):
     x86.label "else"
     // CHECK-NEXT: x86.label "else"
-    x86.s.jae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else2(%arg3 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jae %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg3 : !x86.reg<>)
-    ^else2(%arg3 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg3 : !x86.reg<>):
+    x86.s.jae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else2(%arg3 : !x86.reg)
+    // CHECK-NEXT: x86.s.jae %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg3 : !x86.reg)
+    ^else2(%arg3 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg3 : !x86.reg):
     x86.label "else2"
     // CHECK-NEXT: x86.label "else2"
-    x86.s.jb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else3(%arg4 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jb %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg4 : !x86.reg<>)
-    ^else3(%arg4 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg4 : !x86.reg<>):
+    x86.s.jb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else3(%arg4 : !x86.reg)
+    // CHECK-NEXT: x86.s.jb %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg4 : !x86.reg)
+    ^else3(%arg4 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg4 : !x86.reg):
     x86.label "else3"
     // CHECK-NEXT: x86.label "else3"
-    x86.s.jbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else4(%arg5 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jbe %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg5 : !x86.reg<>)
-    ^else4(%arg5 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg5 : !x86.reg<>):
+    x86.s.jbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else4(%arg5 : !x86.reg)
+    // CHECK-NEXT: x86.s.jbe %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg5 : !x86.reg)
+    ^else4(%arg5 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg5 : !x86.reg):
     x86.label "else4"
     // CHECK-NEXT: x86.label "else4"
-    x86.s.jc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else5(%arg6 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jc %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg6 : !x86.reg<>)
-    ^else5(%arg6 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg6 : !x86.reg<>):
+    x86.s.jc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else5(%arg6 : !x86.reg)
+    // CHECK-NEXT: x86.s.jc %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg6 : !x86.reg)
+    ^else5(%arg6 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg6 : !x86.reg):
     x86.label "else5"
     // CHECK-NEXT: x86.label "else5"
-    x86.s.je %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else6(%arg7 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.je %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg7 : !x86.reg<>)
-    ^else6(%arg7 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg7 : !x86.reg<>):
+    x86.s.je %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else6(%arg7 : !x86.reg)
+    // CHECK-NEXT: x86.s.je %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg7 : !x86.reg)
+    ^else6(%arg7 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg7 : !x86.reg):
     x86.label "else6"
     // CHECK-NEXT: x86.label "else6"
-    x86.s.jg %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else7(%arg8 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jg %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg8 : !x86.reg<>)
-    ^else7(%arg8 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg8 : !x86.reg<>):
+    x86.s.jg %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else7(%arg8 : !x86.reg)
+    // CHECK-NEXT: x86.s.jg %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg8 : !x86.reg)
+    ^else7(%arg8 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg8 : !x86.reg):
     x86.label "else7"
     // CHECK-NEXT: x86.label "else7"
-    x86.s.jge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else8(%arg9 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jge %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg9 : !x86.reg<>)
-    ^else8(%arg9 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg9 : !x86.reg<>):
+    x86.s.jge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else8(%arg9 : !x86.reg)
+    // CHECK-NEXT: x86.s.jge %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg9 : !x86.reg)
+    ^else8(%arg9 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg9 : !x86.reg):
     x86.label "else8"
     // CHECK-NEXT: x86.label "else8"
-    x86.s.jl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else9(%arg10 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jl %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg10 : !x86.reg<>)
-    ^else9(%arg10 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg10 : !x86.reg<>):
+    x86.s.jl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else9(%arg10 : !x86.reg)
+    // CHECK-NEXT: x86.s.jl %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg10 : !x86.reg)
+    ^else9(%arg10 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg10 : !x86.reg):
     x86.label "else9"
     // CHECK-NEXT: x86.label "else9"
-    x86.s.jle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else10(%arg11 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jle %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg11 : !x86.reg<>)
-    ^else10(%arg11 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg11 : !x86.reg<>):
+    x86.s.jle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else10(%arg11 : !x86.reg)
+    // CHECK-NEXT: x86.s.jle %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg11 : !x86.reg)
+    ^else10(%arg11 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg11 : !x86.reg):
     x86.label "else10"
     // CHECK-NEXT: x86.label "else10"
-    x86.s.jna %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else11(%arg12 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jna %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg12 : !x86.reg<>)
-    ^else11(%arg12 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg12 : !x86.reg<>):
+    x86.s.jna %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else11(%arg12 : !x86.reg)
+    // CHECK-NEXT: x86.s.jna %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg12 : !x86.reg)
+    ^else11(%arg12 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg12 : !x86.reg):
     x86.label "else11"
     // CHECK-NEXT: x86.label "else11"
-    x86.s.jnae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else12(%arg13 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnae %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg13 : !x86.reg<>)
-    ^else12(%arg13 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg13 : !x86.reg<>):
+    x86.s.jnae %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else12(%arg13 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnae %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg13 : !x86.reg)
+    ^else12(%arg13 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg13 : !x86.reg):
     x86.label "else12"
     // CHECK-NEXT: x86.label "else12"
-    x86.s.jnb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else13(%arg14 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnb %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg14 : !x86.reg<>)
-    ^else13(%arg14 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg14 : !x86.reg<>):
+    x86.s.jnb %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else13(%arg14 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnb %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg14 : !x86.reg)
+    ^else13(%arg14 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg14 : !x86.reg):
     x86.label "else13"
     // CHECK-NEXT: x86.label "else13"
-    x86.s.jnbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else14(%arg15 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnbe %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg15 : !x86.reg<>)
-    ^else14(%arg15 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg15 : !x86.reg<>):
+    x86.s.jnbe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else14(%arg15 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnbe %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg15 : !x86.reg)
+    ^else14(%arg15 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg15 : !x86.reg):
     x86.label "else14"
     // CHECK-NEXT: x86.label "else14"
-    x86.s.jnc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else15(%arg16 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnc %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg16 : !x86.reg<>)
-    ^else15(%arg16 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg16 : !x86.reg<>):
+    x86.s.jnc %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else15(%arg16 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnc %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg16 : !x86.reg)
+    ^else15(%arg16 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg16 : !x86.reg):
     x86.label "else15"
     // CHECK-NEXT: x86.label "else15"
-    x86.s.jne %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else16(%arg17 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jne %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg17 : !x86.reg<>)
-    ^else16(%arg17 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg17 : !x86.reg<>):
+    x86.s.jne %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else16(%arg17 : !x86.reg)
+    // CHECK-NEXT: x86.s.jne %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg17 : !x86.reg)
+    ^else16(%arg17 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg17 : !x86.reg):
     x86.label "else16"
     // CHECK-NEXT: x86.label "else16"
-    x86.s.jng %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else17(%arg18 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jng %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg18 : !x86.reg<>)
-    ^else17(%arg18 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg18 : !x86.reg<>):
+    x86.s.jng %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else17(%arg18 : !x86.reg)
+    // CHECK-NEXT: x86.s.jng %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg18 : !x86.reg)
+    ^else17(%arg18 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg18 : !x86.reg):
     x86.label "else17"
     // CHECK-NEXT: x86.label "else17"
-    x86.s.jnge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else18(%arg19 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnge %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg19 : !x86.reg<>)
-    ^else18(%arg19 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg19 : !x86.reg<>):
+    x86.s.jnge %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else18(%arg19 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnge %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg19 : !x86.reg)
+    ^else18(%arg19 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg19 : !x86.reg):
     x86.label "else18"
     // CHECK-NEXT: x86.label "else18"
-    x86.s.jnl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else19(%arg20 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnl %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg20 : !x86.reg<>)
-    ^else19(%arg20 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg20 : !x86.reg<>):
+    x86.s.jnl %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else19(%arg20 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnl %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg20 : !x86.reg)
+    ^else19(%arg20 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg20 : !x86.reg):
     x86.label "else19"
     // CHECK-NEXT: x86.label "else19"
-    x86.s.jnle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else20(%arg21 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnle %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg21 : !x86.reg<>)
-    ^else20(%arg21 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg21 : !x86.reg<>):
+    x86.s.jnle %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else20(%arg21 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnle %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg21 : !x86.reg)
+    ^else20(%arg21 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg21 : !x86.reg):
     x86.label "else20"
     // CHECK-NEXT: x86.label "else20"
-    x86.s.jno %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else21(%arg22 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jno %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg22 : !x86.reg<>)
-    ^else21(%arg22 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg22 : !x86.reg<>):
+    x86.s.jno %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else21(%arg22 : !x86.reg)
+    // CHECK-NEXT: x86.s.jno %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg22 : !x86.reg)
+    ^else21(%arg22 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg22 : !x86.reg):
     x86.label "else21"
     // CHECK-NEXT: x86.label "else21"
-    x86.s.jnp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else22(%arg23 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnp %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg23 : !x86.reg<>)
-    ^else22(%arg23 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg23 : !x86.reg<>):
+    x86.s.jnp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else22(%arg23 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnp %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg23 : !x86.reg)
+    ^else22(%arg23 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg23 : !x86.reg):
     x86.label "else22"
     // CHECK-NEXT: x86.label "else22"
-    x86.s.jns %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else23(%arg24 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jns %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg24 : !x86.reg<>)
-    ^else23(%arg24 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg24 : !x86.reg<>):
+    x86.s.jns %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else23(%arg24 : !x86.reg)
+    // CHECK-NEXT: x86.s.jns %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg24 : !x86.reg)
+    ^else23(%arg24 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg24 : !x86.reg):
     x86.label "else23"
     // CHECK-NEXT: x86.label "else23"
-    x86.s.jnz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else24(%arg25 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jnz %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg25 : !x86.reg<>)
-    ^else24(%arg25 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg25 : !x86.reg<>):
+    x86.s.jnz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else24(%arg25 : !x86.reg)
+    // CHECK-NEXT: x86.s.jnz %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg25 : !x86.reg)
+    ^else24(%arg25 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg25 : !x86.reg):
     x86.label "else24"
     // CHECK-NEXT: x86.label "else24"
-    x86.s.jo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else25(%arg26 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jo %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg26 : !x86.reg<>)
-    ^else25(%arg26 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg26 : !x86.reg<>):
+    x86.s.jo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else25(%arg26 : !x86.reg)
+    // CHECK-NEXT: x86.s.jo %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg26 : !x86.reg)
+    ^else25(%arg26 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg26 : !x86.reg):
     x86.label "else25"
     // CHECK-NEXT: x86.label "else25"
-    x86.s.jp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else26(%arg27 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jp %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg27 : !x86.reg<>)
-    ^else26(%arg27 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg27 : !x86.reg<>):
+    x86.s.jp %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else26(%arg27 : !x86.reg)
+    // CHECK-NEXT: x86.s.jp %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg27 : !x86.reg)
+    ^else26(%arg27 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg27 : !x86.reg):
     x86.label "else26"
     // CHECK-NEXT: x86.label "else26"
-    x86.s.jpe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else27(%arg28 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jpe %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg28 : !x86.reg<>)
-    ^else27(%arg28 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg28 : !x86.reg<>):
+    x86.s.jpe %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else27(%arg28 : !x86.reg)
+    // CHECK-NEXT: x86.s.jpe %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg28 : !x86.reg)
+    ^else27(%arg28 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg28 : !x86.reg):
     x86.label "else27"
     // CHECK-NEXT: x86.label "else27"
-    x86.s.jpo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else28(%arg29 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jpo %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg29 : !x86.reg<>)
-    ^else28(%arg29 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg29 : !x86.reg<>):
+    x86.s.jpo %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else28(%arg29 : !x86.reg)
+    // CHECK-NEXT: x86.s.jpo %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg29 : !x86.reg)
+    ^else28(%arg29 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg29 : !x86.reg):
     x86.label "else28"
     // CHECK-NEXT: x86.label "else28"
-    x86.s.js %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else29(%arg30 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.js %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg30 : !x86.reg<>)
-    ^else29(%arg30 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg30 : !x86.reg<>):
+    x86.s.js %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else29(%arg30 : !x86.reg)
+    // CHECK-NEXT: x86.s.js %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg30 : !x86.reg)
+    ^else29(%arg30 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg30 : !x86.reg):
     x86.label "else29"
     // CHECK-NEXT: x86.label "else29"
-    x86.s.jz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg<>), ^else30(%arg31 : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jz %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg<>), ^{{.+}}(%arg31 : !x86.reg<>)
-    ^else30(%arg31 : !x86.reg<>):
-    // CHECK-NEXT: ^{{.+}}(%arg31 : !x86.reg<>):
+    x86.s.jz %rflags : !x86.rflags<rflags>, ^then(%arg : !x86.reg), ^else30(%arg31 : !x86.reg)
+    // CHECK-NEXT: x86.s.jz %rflags : !x86.rflags<rflags>, ^{{.+}}(%arg : !x86.reg), ^{{.+}}(%arg31 : !x86.reg)
+    ^else30(%arg31 : !x86.reg):
+    // CHECK-NEXT: ^{{.+}}(%arg31 : !x86.reg):
     x86.label "else30"
     // CHECK-NEXT: x86.label "else30"
 
-    x86.s.jmp ^then(%arg : !x86.reg<>)
-    // CHECK-NEXT: x86.s.jmp ^{{.+}}(%arg : !x86.reg<>)
+    x86.s.jmp ^then(%arg : !x86.reg)
+    // CHECK-NEXT: x86.s.jmp ^{{.+}}(%arg : !x86.reg)
 }
 
-%zmm0, %zmm1, %zmm2 = "test.op"() : () -> (!x86.avxreg<>, !x86.avxreg<>, !x86.avxreg<>)
+%zmm0, %zmm1, %zmm2 = "test.op"() : () -> (!x86.avxreg, !x86.avxreg, !x86.avxreg)
 
-%rrr_vfmadd231pd = x86.rrr.vfmadd231pd %zmm0, %zmm1, %zmm2 : (!x86.avxreg<>, !x86.avxreg<>, !x86.avxreg<>) -> !x86.avxreg<>
-// CHECK: %{{.*}} = x86.rrr.vfmadd231pd %{{.*}}, %{{.*}}, %{{.*}} : (!x86.avxreg<>, !x86.avxreg<>, !x86.avxreg<>) -> !x86.avxreg<>
-%rr_vmovapd = x86.rr.vmovapd %zmm0, %zmm1 : (!x86.avxreg<>, !x86.avxreg<>) -> !x86.avxreg<>
-// CHECK-NEXT: x86.rr.vmovapd %{{.*}}, %{{.*}} : (!x86.avxreg<>, !x86.avxreg<>) -> !x86.avxreg<>
-x86.mr.vmovapd %0, %zmm1, 8 : (!x86.reg<>, !x86.avxreg<>) -> ()
-// CHECK-NEXT: x86.mr.vmovapd %{{.*}}, %{{.*}}, 8 : (!x86.reg<>, !x86.avxreg<>) -> ()
-%rm_vbroadcastsd = x86.rm.vbroadcastsd %zmm1, %0, 8 : (!x86.avxreg<>, !x86.reg<>) -> !x86.avxreg<>
-// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, %{{.*}}, 8 : (!x86.avxreg<>, !x86.reg<>) -> !x86.avxreg<>
+%rrr_vfmadd231pd = x86.rrr.vfmadd231pd %zmm0, %zmm1, %zmm2 : (!x86.avxreg, !x86.avxreg, !x86.avxreg) -> !x86.avxreg
+// CHECK: %{{.*}} = x86.rrr.vfmadd231pd %{{.*}}, %{{.*}}, %{{.*}} : (!x86.avxreg, !x86.avxreg, !x86.avxreg) -> !x86.avxreg
+%rr_vmovapd = x86.rr.vmovapd %zmm0, %zmm1 : (!x86.avxreg, !x86.avxreg) -> !x86.avxreg
+// CHECK-NEXT: x86.rr.vmovapd %{{.*}}, %{{.*}} : (!x86.avxreg, !x86.avxreg) -> !x86.avxreg
+x86.mr.vmovapd %0, %zmm1, 8 : (!x86.reg, !x86.avxreg) -> ()
+// CHECK-NEXT: x86.mr.vmovapd %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.avxreg) -> ()
+%rm_vbroadcastsd = x86.rm.vbroadcastsd %zmm1, %0, 8 : (!x86.avxreg, !x86.reg) -> !x86.avxreg
+// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, %{{.*}}, 8 : (!x86.avxreg, !x86.reg) -> !x86.avxreg

--- a/tests/filecheck/projects/riscv-backend-paper/add_snitch_stream.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/add_snitch_stream.mlir
@@ -13,30 +13,30 @@ builtin.module {
     riscv.directive ".globl" "main"
     riscv.directive ".p2align" "2"
     riscv_func.func @main() {
-      %A = riscv.li "a" : () -> !riscv.reg<>
-      %B = riscv.li "b" : () -> !riscv.reg<>
-      %C = riscv.li "c" : () -> !riscv.reg<>
+      %A = riscv.li "a" : () -> !riscv.reg
+      %B = riscv.li "b" : () -> !riscv.reg
+      %C = riscv.li "c" : () -> !riscv.reg
       "snitch_stream.streaming_region"(%A, %B, %C) <{
         "stride_patterns" = [#snitch_stream.stride_pattern<ub = [2, 3], strides = [24, 8]>],
         "operandSegmentSizes" = array<i32: 2, 1>
       }> ({
       ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.readable<!riscv.freg<ft1>>, %c_stream : !stream.writable<!riscv.freg<ft2>>):
-          %c5 = riscv.li 5 : () -> !riscv.reg<>
+          %c5 = riscv.li 5 : () -> !riscv.reg
           riscv_snitch.frep_outer %c5 {
               %a = riscv_snitch.read from %a_stream : !riscv.freg<ft0>
               %b = riscv_snitch.read from %b_stream : !riscv.freg<ft1>
               %c = riscv.fadd.d %a, %b : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
               riscv_snitch.write %c to %c_stream : !riscv.freg<ft2>
           }
-      }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
-      %5 = riscv.mv %C : (!riscv.reg<>) -> !riscv.reg<>
-      %v0 = riscv.fld %5, 0 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v1 = riscv.fld %C, 8 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v2 = riscv.fld %C, 16 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v3 = riscv.fld %C, 24 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v4 = riscv.fld %C, 32 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v5 = riscv.fld %C, 40 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      riscv_debug.printf %v0, %v1, %v2, %v3, %v4, %v5 "[[{}, {}, {}], [{}, {}, {}]]" : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>, !riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> ()
+      }) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
+      %5 = riscv.mv %C : (!riscv.reg) -> !riscv.reg
+      %v0 = riscv.fld %5, 0 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v1 = riscv.fld %C, 8 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v2 = riscv.fld %C, 16 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v3 = riscv.fld %C, 24 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v4 = riscv.fld %C, 32 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v5 = riscv.fld %C, 40 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      riscv_debug.printf %v0, %v1, %v2, %v3, %v4, %v5 "[[{}, {}, {}], [{}, {}, {}]]" : (!riscv.freg, !riscv.freg, !riscv.freg, !riscv.freg, !riscv.freg, !riscv.freg) -> ()
       riscv_func.return
     }
   }

--- a/tests/filecheck/projects/riscv-backend-paper/ddot_regalloc.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/ddot_regalloc.mlir
@@ -4,23 +4,23 @@ riscv.assembly_section ".text" {
     riscv.directive ".globl" "ddot"
     riscv.directive ".p2align" "2"
     riscv_func.func @ddot(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.reg<a2>) {
-        %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg<>
-        %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg<>
-        %Z_moved = riscv.mv %Z : (!riscv.reg<a2>) -> !riscv.reg<>
-        %init = riscv.fld %Z_moved, 0 : (!riscv.reg<>) -> !riscv.freg<>
-        %lb = riscv.li 0 : () -> !riscv.reg<>
-        %ub = riscv.li 1024 : () -> !riscv.reg<>
-        %c8 = riscv.li 8 : () -> !riscv.reg<>
-        %res = riscv_scf.for %i : !riscv.reg<> = %lb to %ub step %c8 iter_args(%acc_in = %init) -> (!riscv.freg<>) {
-            %x_ptr = riscv.add %X_moved, %i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-            %x = riscv.fld %x_ptr, 0 : (!riscv.reg<>) -> !riscv.freg<>
-            %y_ptr = riscv.add %Y_moved, %i : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-            %y = riscv.fld %y_ptr, 0 : (!riscv.reg<>) -> !riscv.freg<>
-            %xy = riscv.fmul.d %x, %y : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-            %acc_out = riscv.fadd.d %acc_in, %xy : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-            riscv_scf.yield %acc_out : !riscv.freg<>
+        %X_moved = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg
+        %Y_moved = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg
+        %Z_moved = riscv.mv %Z : (!riscv.reg<a2>) -> !riscv.reg
+        %init = riscv.fld %Z_moved, 0 : (!riscv.reg) -> !riscv.freg
+        %lb = riscv.li 0 : () -> !riscv.reg
+        %ub = riscv.li 1024 : () -> !riscv.reg
+        %c8 = riscv.li 8 : () -> !riscv.reg
+        %res = riscv_scf.for %i : !riscv.reg = %lb to %ub step %c8 iter_args(%acc_in = %init) -> (!riscv.freg) {
+            %x_ptr = riscv.add %X_moved, %i : (!riscv.reg, !riscv.reg) -> !riscv.reg
+            %x = riscv.fld %x_ptr, 0 : (!riscv.reg) -> !riscv.freg
+            %y_ptr = riscv.add %Y_moved, %i : (!riscv.reg, !riscv.reg) -> !riscv.reg
+            %y = riscv.fld %y_ptr, 0 : (!riscv.reg) -> !riscv.freg
+            %xy = riscv.fmul.d %x, %y : (!riscv.freg, !riscv.freg) -> !riscv.freg
+            %acc_out = riscv.fadd.d %acc_in, %xy : (!riscv.freg, !riscv.freg) -> !riscv.freg
+            riscv_scf.yield %acc_out : !riscv.freg
         }
-        riscv.fsd %Z_moved, %res, 0 : (!riscv.reg<>, !riscv.freg<>) -> ()
+        riscv.fsd %Z_moved, %res, 0 : (!riscv.reg, !riscv.freg) -> ()
         riscv_func.return
     }
 }

--- a/tests/filecheck/projects/riscv-backend-paper/relu_snitch_stream.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/relu_snitch_stream.mlir
@@ -13,33 +13,33 @@ builtin.module {
     riscv.directive ".globl" "main"
     riscv.directive ".p2align" "2"
     riscv_func.func @main() {
-      %A = riscv.li "a" : () -> !riscv.reg<>
-      %B = riscv.li "b" : () -> !riscv.reg<>
+      %A = riscv.li "a" : () -> !riscv.reg
+      %B = riscv.li "b" : () -> !riscv.reg
       %zero = riscv.get_register : () -> !riscv.reg<sp>
-      %zero_1 = riscv.li 0 : () -> !riscv.reg<>
-      riscv.sw %zero, %zero_1, -4 : (!riscv.reg<sp>, !riscv.reg<>) -> ()
-      %zero_2 = riscv.li 0 : () -> !riscv.reg<>
-      riscv.sw %zero, %zero_2, -8 : (!riscv.reg<sp>, !riscv.reg<>) -> ()
-      %zero_3 = riscv.fld %zero, -8 : (!riscv.reg<sp>) -> !riscv.freg<>
+      %zero_1 = riscv.li 0 : () -> !riscv.reg
+      riscv.sw %zero, %zero_1, -4 : (!riscv.reg<sp>, !riscv.reg) -> ()
+      %zero_2 = riscv.li 0 : () -> !riscv.reg
+      riscv.sw %zero, %zero_2, -8 : (!riscv.reg<sp>, !riscv.reg) -> ()
+      %zero_3 = riscv.fld %zero, -8 : (!riscv.reg<sp>) -> !riscv.freg
       "snitch_stream.streaming_region"(%A, %B) <{
         "stride_patterns" = [#snitch_stream.stride_pattern<ub = [2, 3], strides = [24, 8]>],
         "operandSegmentSizes" = array<i32: 1, 1>
       }> ({
       ^0(%a_stream : !stream.readable<!riscv.freg<ft0>>, %b_stream : !stream.writable<!riscv.freg<ft1>>):
-        %c5 = riscv.li 5 : () -> !riscv.reg<>
+        %c5 = riscv.li 5 : () -> !riscv.reg
         riscv_snitch.frep_outer %c5 {
           %a = riscv_snitch.read from %a_stream : !riscv.freg<ft0>
-          %b = riscv.fmax.d %a, %zero_3 : (!riscv.freg<ft0>, !riscv.freg<>) -> !riscv.freg<ft1>
+          %b = riscv.fmax.d %a, %zero_3 : (!riscv.freg<ft0>, !riscv.freg) -> !riscv.freg<ft1>
           riscv_snitch.write %b to %b_stream : !riscv.freg<ft1>
         }
-      }) : (!riscv.reg<>, !riscv.reg<>) -> ()
-      %v0 = riscv.fld %B, 0 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v1 = riscv.fld %B, 8 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v2 = riscv.fld %B, 16 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v3 = riscv.fld %B, 24 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v4 = riscv.fld %B, 32 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      %v5 = riscv.fld %B, 40 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg<>) -> !riscv.freg<>
-      riscv_debug.printf %v0, %v1, %v2, %v3, %v4, %v5 "[[{}, {}, {}], [{}, {}, {}]]" : (!riscv.freg<>, !riscv.freg<>, !riscv.freg<>, !riscv.freg<>, !riscv.freg<>, !riscv.freg<>) -> ()
+      }) : (!riscv.reg, !riscv.reg) -> ()
+      %v0 = riscv.fld %B, 0 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v1 = riscv.fld %B, 8 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v2 = riscv.fld %B, 16 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v3 = riscv.fld %B, 24 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v4 = riscv.fld %B, 32 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      %v5 = riscv.fld %B, 40 {"comment" = "load double from memref of shape (2, 3)"} : (!riscv.reg) -> !riscv.freg
+      riscv_debug.printf %v0, %v1, %v2, %v3, %v4, %v5 "[[{}, {}, {}], [{}, {}, {}]]" : (!riscv.freg, !riscv.freg, !riscv.freg, !riscv.freg, !riscv.freg, !riscv.freg) -> ()
       riscv_func.return
 
     }

--- a/tests/filecheck/runner/riscv.mlir
+++ b/tests/filecheck/runner/riscv.mlir
@@ -1,23 +1,23 @@
 // RUN: xdsl-run %s --verbose | filecheck %s
 
-riscv_func.func @malloc(!riscv.reg<>) -> !riscv.reg<>
+riscv_func.func @malloc(!riscv.reg) -> !riscv.reg
 
-riscv_func.func @putchar(!riscv.reg<>) -> !riscv.reg<>
+riscv_func.func @putchar(!riscv.reg) -> !riscv.reg
 
-riscv_func.func @free(!riscv.reg<>) -> ()
+riscv_func.func @free(!riscv.reg) -> ()
 
 riscv_func.func @main() -> () {
-    %33 = riscv.li 33 : () -> !riscv.reg<>
-    %newline = riscv.li 10 : () -> !riscv.reg<>
-    %ptr = riscv_func.call @malloc(%33) : (!riscv.reg<>) -> !riscv.reg<>
-    riscv.sw %ptr, %33, 0 : (!riscv.reg<>, !riscv.reg<>) -> ()
+    %33 = riscv.li 33 : () -> !riscv.reg
+    %newline = riscv.li 10 : () -> !riscv.reg
+    %ptr = riscv_func.call @malloc(%33) : (!riscv.reg) -> !riscv.reg
+    riscv.sw %ptr, %33, 0 : (!riscv.reg, !riscv.reg) -> ()
 
-    %res = riscv.lw %ptr, 0 : (!riscv.reg<>) -> !riscv.reg<>
+    %res = riscv.lw %ptr, 0 : (!riscv.reg) -> !riscv.reg
 
-    %nothing = riscv_func.call @putchar(%res) : (!riscv.reg<>) -> !riscv.reg<>
-    %nothing2 = riscv_func.call @putchar(%newline) : (!riscv.reg<>) -> !riscv.reg<>
+    %nothing = riscv_func.call @putchar(%res) : (!riscv.reg) -> !riscv.reg
+    %nothing2 = riscv_func.call @putchar(%newline) : (!riscv.reg) -> !riscv.reg
 
-    riscv_func.call @free(%ptr) : (!riscv.reg<>) -> ()
+    riscv_func.call @free(%ptr) : (!riscv.reg) -> ()
 
     riscv_func.return
 }

--- a/tests/filecheck/runner/riscv_scf.mlir
+++ b/tests/filecheck/runner/riscv_scf.mlir
@@ -2,20 +2,20 @@
 // RUN: xdsl-run --verbose --symbol="sum_to" --args="6" %s | filecheck %s --check-prefix=CHECK-ARGS
 
 builtin.module {
-  func.func @sum_to(%0 : !riscv.reg<>) -> !riscv.reg<> {
-    %1 = riscv.li 0 : () -> !riscv.reg<>
-    %2 = riscv.li 1 : () -> !riscv.reg<>
-    %3 = riscv.li 0 : () -> !riscv.reg<>
-    %4 = riscv_scf.for %5 : !riscv.reg<> = %1 to %0 step %2 iter_args(%6 = %3) -> (!riscv.reg<>) {
-      %7 = riscv.add %5, %6 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-      riscv_scf.yield %7 : !riscv.reg<>
+  func.func @sum_to(%0 : !riscv.reg) -> !riscv.reg {
+    %1 = riscv.li 0 : () -> !riscv.reg
+    %2 = riscv.li 1 : () -> !riscv.reg
+    %3 = riscv.li 0 : () -> !riscv.reg
+    %4 = riscv_scf.for %5 : !riscv.reg = %1 to %0 step %2 iter_args(%6 = %3) -> (!riscv.reg) {
+      %7 = riscv.add %5, %6 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+      riscv_scf.yield %7 : !riscv.reg
     }
-    func.return %4 : !riscv.reg<>
+    func.return %4 : !riscv.reg
   }
-  func.func @main() -> !riscv.reg<> {
-    %c5 = riscv.li 5 : () -> !riscv.reg<>
-    %res = func.call @sum_to(%c5) : (!riscv.reg<>) -> !riscv.reg<>
-    return %res : !riscv.reg<>
+  func.func @main() -> !riscv.reg {
+    %c5 = riscv.li 5 : () -> !riscv.reg
+    %res = func.call @sum_to(%c5) : (!riscv.reg) -> !riscv.reg
+    return %res : !riscv.reg
   }
 }
 

--- a/tests/filecheck/transforms/convert-snrt-to-riscv.mlir
+++ b/tests/filecheck/transforms/convert-snrt-to-riscv.mlir
@@ -35,63 +35,63 @@
 
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   %global_core_base_hartid = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %global_core_base_hartid_1 = builtin.unrealized_conversion_cast %global_core_base_hartid : !riscv.reg<> to i32
+// CHECK-NEXT:   %global_core_base_hartid = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:   %global_core_base_hartid_1 = builtin.unrealized_conversion_cast %global_core_base_hartid : !riscv.reg to i32
 // CHECK-NEXT:   %global_core_idx = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %global_core_idx_1 = riscv.csrrs %global_core_idx, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg<>
-// CHECK-NEXT:   %global_core_idx_2 = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %global_core_idx_3 = riscv.sub %global_core_idx_1, %global_core_idx_2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %global_core_idx_4 = builtin.unrealized_conversion_cast %global_core_idx_3 : !riscv.reg<> to i32
-// CHECK-NEXT:   %global_core_num = riscv.li 18 : () -> !riscv.reg<>
-// CHECK-NEXT:   %global_core_num_1 = builtin.unrealized_conversion_cast %global_core_num : !riscv.reg<> to i32
+// CHECK-NEXT:   %global_core_idx_1 = riscv.csrrs %global_core_idx, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   %global_core_idx_2 = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:   %global_core_idx_3 = riscv.sub %global_core_idx_1, %global_core_idx_2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %global_core_idx_4 = builtin.unrealized_conversion_cast %global_core_idx_3 : !riscv.reg to i32
+// CHECK-NEXT:   %global_core_num = riscv.li 18 : () -> !riscv.reg
+// CHECK-NEXT:   %global_core_num_1 = builtin.unrealized_conversion_cast %global_core_num : !riscv.reg to i32
 // CHECK-NEXT:   %gcluster_core_idx = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %gcluster_core_idx_1 = riscv.csrrs %gcluster_core_idx, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg<>
-// CHECK-NEXT:   %gcluster_core_idx_2 = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %gcluster_core_idx_3 = riscv.sub %gcluster_core_idx_1, %gcluster_core_idx_2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %gcluster_core_idx_4 = builtin.unrealized_conversion_cast %gcluster_core_idx_3 : !riscv.reg<> to i32
-// CHECK-NEXT:   %gcluster_core_idx_5 = riscv.li 9 : () -> !riscv.reg<>
-// CHECK-NEXT:   %gcluster_core_idx_6 = builtin.unrealized_conversion_cast %gcluster_core_idx_5 : !riscv.reg<> to i32
+// CHECK-NEXT:   %gcluster_core_idx_1 = riscv.csrrs %gcluster_core_idx, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   %gcluster_core_idx_2 = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:   %gcluster_core_idx_3 = riscv.sub %gcluster_core_idx_1, %gcluster_core_idx_2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %gcluster_core_idx_4 = builtin.unrealized_conversion_cast %gcluster_core_idx_3 : !riscv.reg to i32
+// CHECK-NEXT:   %gcluster_core_idx_5 = riscv.li 9 : () -> !riscv.reg
+// CHECK-NEXT:   %gcluster_core_idx_6 = builtin.unrealized_conversion_cast %gcluster_core_idx_5 : !riscv.reg to i32
 // CHECK-NEXT:   %gcluster_core_idx_7 = arith.remsi %gcluster_core_idx_4, %gcluster_core_idx_6 : i32
-// CHECK-NEXT:   %cluster_core_num = riscv.li 9 : () -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_core_num_1 = builtin.unrealized_conversion_cast %cluster_core_num : !riscv.reg<> to i32
-// CHECK-NEXT:   %cluster_compute_core_num = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_compute_core_num_1 = builtin.unrealized_conversion_cast %cluster_compute_core_num : !riscv.reg<> to i32
-// CHECK-NEXT:   %cluster_dm_core_num = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_dm_core_num_1 = builtin.unrealized_conversion_cast %cluster_dm_core_num : !riscv.reg<> to i32
-// CHECK-NEXT:   %cluster_idx = riscv.li 9 : () -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_idx_1 = builtin.unrealized_conversion_cast %cluster_idx : !riscv.reg<> to i32
+// CHECK-NEXT:   %cluster_core_num = riscv.li 9 : () -> !riscv.reg
+// CHECK-NEXT:   %cluster_core_num_1 = builtin.unrealized_conversion_cast %cluster_core_num : !riscv.reg to i32
+// CHECK-NEXT:   %cluster_compute_core_num = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:   %cluster_compute_core_num_1 = builtin.unrealized_conversion_cast %cluster_compute_core_num : !riscv.reg to i32
+// CHECK-NEXT:   %cluster_dm_core_num = riscv.li 1 : () -> !riscv.reg
+// CHECK-NEXT:   %cluster_dm_core_num_1 = builtin.unrealized_conversion_cast %cluster_dm_core_num : !riscv.reg to i32
+// CHECK-NEXT:   %cluster_idx = riscv.li 9 : () -> !riscv.reg
+// CHECK-NEXT:   %cluster_idx_1 = builtin.unrealized_conversion_cast %cluster_idx : !riscv.reg to i32
 // CHECK-NEXT:   %cluster_idx_2 = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %cluster_idx_3 = riscv.csrrs %cluster_idx_2, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_idx_4 = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_idx_5 = riscv.sub %cluster_idx_3, %cluster_idx_4 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_idx_6 = builtin.unrealized_conversion_cast %cluster_idx_5 : !riscv.reg<> to i32
-// CHECK-NEXT:   %cluster_idx_7 = builtin.unrealized_conversion_cast %cluster_idx_1 : i32 to !riscv.reg<>
-// CHECK-NEXT:   %cluster_idx_8 = builtin.unrealized_conversion_cast %cluster_idx_6 : i32 to !riscv.reg<>
-// CHECK-NEXT:   %cluster_idx_9 = riscv.div %cluster_idx_8, %cluster_idx_7 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_idx_10 = builtin.unrealized_conversion_cast %cluster_idx_9 : !riscv.reg<> to i32
-// CHECK-NEXT:   %cluster_num = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:   %cluster_num_1 = builtin.unrealized_conversion_cast %cluster_num : !riscv.reg<> to i32
+// CHECK-NEXT:   %cluster_idx_3 = riscv.csrrs %cluster_idx_2, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   %cluster_idx_4 = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:   %cluster_idx_5 = riscv.sub %cluster_idx_3, %cluster_idx_4 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %cluster_idx_6 = builtin.unrealized_conversion_cast %cluster_idx_5 : !riscv.reg to i32
+// CHECK-NEXT:   %cluster_idx_7 = builtin.unrealized_conversion_cast %cluster_idx_1 : i32 to !riscv.reg
+// CHECK-NEXT:   %cluster_idx_8 = builtin.unrealized_conversion_cast %cluster_idx_6 : i32 to !riscv.reg
+// CHECK-NEXT:   %cluster_idx_9 = riscv.div %cluster_idx_8, %cluster_idx_7 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %cluster_idx_10 = builtin.unrealized_conversion_cast %cluster_idx_9 : !riscv.reg to i32
+// CHECK-NEXT:   %cluster_num = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:   %cluster_num_1 = builtin.unrealized_conversion_cast %cluster_num : !riscv.reg to i32
 // CHECK-NEXT:   %is_compute_core = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %is_compute_core_1 = riscv.csrrs %is_compute_core, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg<>
-// CHECK-NEXT:   %is_compute_core_2 = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %is_compute_core_3 = riscv.sub %is_compute_core_1, %is_compute_core_2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %is_compute_core_4 = builtin.unrealized_conversion_cast %is_compute_core_3 : !riscv.reg<> to i32
-// CHECK-NEXT:   %is_compute_core_5 = riscv.li 9 : () -> !riscv.reg<>
-// CHECK-NEXT:   %is_compute_core_6 = builtin.unrealized_conversion_cast %is_compute_core_5 : !riscv.reg<> to i32
+// CHECK-NEXT:   %is_compute_core_1 = riscv.csrrs %is_compute_core, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   %is_compute_core_2 = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:   %is_compute_core_3 = riscv.sub %is_compute_core_1, %is_compute_core_2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %is_compute_core_4 = builtin.unrealized_conversion_cast %is_compute_core_3 : !riscv.reg to i32
+// CHECK-NEXT:   %is_compute_core_5 = riscv.li 9 : () -> !riscv.reg
+// CHECK-NEXT:   %is_compute_core_6 = builtin.unrealized_conversion_cast %is_compute_core_5 : !riscv.reg to i32
 // CHECK-NEXT:   %is_compute_core_7 = arith.remsi %is_compute_core_4, %is_compute_core_6 : i32
-// CHECK-NEXT:   %is_compute_core_8 = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:   %is_compute_core_9 = builtin.unrealized_conversion_cast %is_compute_core_8 : !riscv.reg<> to i32
+// CHECK-NEXT:   %is_compute_core_8 = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:   %is_compute_core_9 = builtin.unrealized_conversion_cast %is_compute_core_8 : !riscv.reg to i32
 // CHECK-NEXT:   %is_compute_core_10 = arith.cmpi slt, %is_compute_core_7, %is_compute_core_9 : i32
 // CHECK-NEXT:   %is_dm_core = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %is_dm_core_1 = riscv.csrrs %is_dm_core, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg<>
-// CHECK-NEXT:   %is_dm_core_2 = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:   %is_dm_core_3 = riscv.sub %is_dm_core_1, %is_dm_core_2 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %is_dm_core_4 = builtin.unrealized_conversion_cast %is_dm_core_3 : !riscv.reg<> to i32
-// CHECK-NEXT:   %is_dm_core_5 = riscv.li 9 : () -> !riscv.reg<>
-// CHECK-NEXT:   %is_dm_core_6 = builtin.unrealized_conversion_cast %is_dm_core_5 : !riscv.reg<> to i32
+// CHECK-NEXT:   %is_dm_core_1 = riscv.csrrs %is_dm_core, 3860, "r" : (!riscv.reg<zero>) -> !riscv.reg
+// CHECK-NEXT:   %is_dm_core_2 = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:   %is_dm_core_3 = riscv.sub %is_dm_core_1, %is_dm_core_2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %is_dm_core_4 = builtin.unrealized_conversion_cast %is_dm_core_3 : !riscv.reg to i32
+// CHECK-NEXT:   %is_dm_core_5 = riscv.li 9 : () -> !riscv.reg
+// CHECK-NEXT:   %is_dm_core_6 = builtin.unrealized_conversion_cast %is_dm_core_5 : !riscv.reg to i32
 // CHECK-NEXT:   %is_dm_core_7 = arith.remsi %is_dm_core_4, %is_dm_core_6 : i32
-// CHECK-NEXT:   %is_dm_core_8 = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:   %is_dm_core_9 = builtin.unrealized_conversion_cast %is_dm_core_8 : !riscv.reg<> to i32
+// CHECK-NEXT:   %is_dm_core_8 = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:   %is_dm_core_9 = builtin.unrealized_conversion_cast %is_dm_core_8 : !riscv.reg to i32
 // CHECK-NEXT:   %is_dm_core_10 = arith.cmpi sge, %is_dm_core_7, %is_dm_core_9 : i32
 
 
@@ -100,58 +100,58 @@
 // CHECK-NEXT:   %1 = riscv.csrrs %0, 1986 : (!riscv.reg<zero>) -> !riscv.reg<zero>
 
                  // Lowering of ssr_disable
-// CHECK-NEXT:   %2 = riscv.csrrci 1984, 1 : () -> !riscv.reg<>
+// CHECK-NEXT:   %2 = riscv.csrrci 1984, 1 : () -> !riscv.reg
 // CHECK-NEXT:   %dst, %src, %size = "test.op"() : () -> (i32, i32, i32)
 
                  // Lowering for dma_start_1d
 // CHECK-NEXT:   %tx_id = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %tx_id_1 = builtin.unrealized_conversion_cast %dst : i32 to !riscv.reg<>
-// CHECK-NEXT:   %tx_id_2 = builtin.unrealized_conversion_cast %src : i32 to !riscv.reg<>
-// CHECK-NEXT:   %tx_id_3 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg<>
-// CHECK-NEXT:   riscv_snitch.dmsrc %tx_id_2, %tx_id : (!riscv.reg<>, !riscv.reg<zero>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmdst %tx_id_1, %tx_id : (!riscv.reg<>, !riscv.reg<zero>) -> ()
-// CHECK-NEXT:   %tx_id_4 = riscv_snitch.dmcpyi %tx_id_3, 0 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %tx_id_5 = builtin.unrealized_conversion_cast %tx_id_4 : !riscv.reg<> to i32
+// CHECK-NEXT:   %tx_id_1 = builtin.unrealized_conversion_cast %dst : i32 to !riscv.reg
+// CHECK-NEXT:   %tx_id_2 = builtin.unrealized_conversion_cast %src : i32 to !riscv.reg
+// CHECK-NEXT:   %tx_id_3 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg
+// CHECK-NEXT:   riscv_snitch.dmsrc %tx_id_2, %tx_id : (!riscv.reg, !riscv.reg<zero>) -> ()
+// CHECK-NEXT:   riscv_snitch.dmdst %tx_id_1, %tx_id : (!riscv.reg, !riscv.reg<zero>) -> ()
+// CHECK-NEXT:   %tx_id_4 = riscv_snitch.dmcpyi %tx_id_3, 0 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %tx_id_5 = builtin.unrealized_conversion_cast %tx_id_4 : !riscv.reg to i32
 
 // CHECK-NEXT:   %dst_wide, %src_wide = "test.op"() : () -> (i64, i64)
 
                  // Lowering of dma_start_1d_wideptr
-// CHECK-NEXT:   %tx_id2, %tx_id2_1 = builtin.unrealized_conversion_cast %dst_wide : i64 to !riscv.reg<>, !riscv.reg<>
-// CHECK-NEXT:   %tx_id2_2, %tx_id2_3 = builtin.unrealized_conversion_cast %src_wide : i64 to !riscv.reg<>, !riscv.reg<>
-// CHECK-NEXT:   %tx_id2_4 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg<>
-// CHECK-NEXT:   riscv_snitch.dmsrc %tx_id2_2, %tx_id2_3 : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmdst %tx_id2, %tx_id2_1 : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   %tx_id2_5 = riscv_snitch.dmcpyi %tx_id2_4, 0 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %tx_id2_6 = builtin.unrealized_conversion_cast %tx_id2_5 : !riscv.reg<> to i32
+// CHECK-NEXT:   %tx_id2, %tx_id2_1 = builtin.unrealized_conversion_cast %dst_wide : i64 to !riscv.reg, !riscv.reg
+// CHECK-NEXT:   %tx_id2_2, %tx_id2_3 = builtin.unrealized_conversion_cast %src_wide : i64 to !riscv.reg, !riscv.reg
+// CHECK-NEXT:   %tx_id2_4 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg
+// CHECK-NEXT:   riscv_snitch.dmsrc %tx_id2_2, %tx_id2_3 : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   riscv_snitch.dmdst %tx_id2, %tx_id2_1 : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   %tx_id2_5 = riscv_snitch.dmcpyi %tx_id2_4, 0 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %tx_id2_6 = builtin.unrealized_conversion_cast %tx_id2_5 : !riscv.reg to i32
 
 // CHECK-NEXT:   %dst_stride, %src_stride, %repeat = "test.op"() : () -> (i32, i32, i32)
 
                  // Lowering for dma_start_2d_wideptr
-// CHECK-NEXT:   %3, %4 = builtin.unrealized_conversion_cast %dst_wide : i64 to !riscv.reg<>, !riscv.reg<>
-// CHECK-NEXT:   %5, %6 = builtin.unrealized_conversion_cast %src_wide : i64 to !riscv.reg<>, !riscv.reg<>
-// CHECK-NEXT:   %7 = builtin.unrealized_conversion_cast %src_stride : i32 to !riscv.reg<>
-// CHECK-NEXT:   %8 = builtin.unrealized_conversion_cast %dst_stride : i32 to !riscv.reg<>
-// CHECK-NEXT:   %9 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg<>
-// CHECK-NEXT:   %10 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg<>
-// CHECK-NEXT:   riscv_snitch.dmsrc %5, %6 : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmdst %3, %4 : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmstr %7, %8 : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmrep %10 : (!riscv.reg<>) -> ()
-// CHECK-NEXT:   %tx_id3 = riscv_snitch.dmcpyi %9, 2 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %tx_id3_1 = builtin.unrealized_conversion_cast %tx_id3 : !riscv.reg<> to i32
+// CHECK-NEXT:   %3, %4 = builtin.unrealized_conversion_cast %dst_wide : i64 to !riscv.reg, !riscv.reg
+// CHECK-NEXT:   %5, %6 = builtin.unrealized_conversion_cast %src_wide : i64 to !riscv.reg, !riscv.reg
+// CHECK-NEXT:   %7 = builtin.unrealized_conversion_cast %src_stride : i32 to !riscv.reg
+// CHECK-NEXT:   %8 = builtin.unrealized_conversion_cast %dst_stride : i32 to !riscv.reg
+// CHECK-NEXT:   %9 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg
+// CHECK-NEXT:   %10 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg
+// CHECK-NEXT:   riscv_snitch.dmsrc %5, %6 : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   riscv_snitch.dmdst %3, %4 : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   riscv_snitch.dmstr %7, %8 : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   riscv_snitch.dmrep %10 : (!riscv.reg) -> ()
+// CHECK-NEXT:   %tx_id3 = riscv_snitch.dmcpyi %9, 2 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %tx_id3_1 = builtin.unrealized_conversion_cast %tx_id3 : !riscv.reg to i32
 
                  // Lowering for dma_start_2d
 // CHECK-NEXT:   %11 = riscv.get_register : () -> !riscv.reg<zero>
-// CHECK-NEXT:   %12 = builtin.unrealized_conversion_cast %dst : i32 to !riscv.reg<>
-// CHECK-NEXT:   %13 = builtin.unrealized_conversion_cast %src : i32 to !riscv.reg<>
-// CHECK-NEXT:   %14 = builtin.unrealized_conversion_cast %src_stride : i32 to !riscv.reg<>
-// CHECK-NEXT:   %15 = builtin.unrealized_conversion_cast %dst_stride : i32 to !riscv.reg<>
-// CHECK-NEXT:   %16 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg<>
-// CHECK-NEXT:   %17 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg<>
-// CHECK-NEXT:   riscv_snitch.dmsrc %13, %11 : (!riscv.reg<>, !riscv.reg<zero>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmdst %12, %11 : (!riscv.reg<>, !riscv.reg<zero>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmstr %14, %15 : (!riscv.reg<>, !riscv.reg<>) -> ()
-// CHECK-NEXT:   riscv_snitch.dmrep %17 : (!riscv.reg<>) -> ()
-// CHECK-NEXT:   %tx_id4 = riscv_snitch.dmcpyi %16, 2 : (!riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:   %tx_id4_1 = builtin.unrealized_conversion_cast %tx_id4 : !riscv.reg<> to i32
+// CHECK-NEXT:   %12 = builtin.unrealized_conversion_cast %dst : i32 to !riscv.reg
+// CHECK-NEXT:   %13 = builtin.unrealized_conversion_cast %src : i32 to !riscv.reg
+// CHECK-NEXT:   %14 = builtin.unrealized_conversion_cast %src_stride : i32 to !riscv.reg
+// CHECK-NEXT:   %15 = builtin.unrealized_conversion_cast %dst_stride : i32 to !riscv.reg
+// CHECK-NEXT:   %16 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg
+// CHECK-NEXT:   %17 = builtin.unrealized_conversion_cast %size : i32 to !riscv.reg
+// CHECK-NEXT:   riscv_snitch.dmsrc %13, %11 : (!riscv.reg, !riscv.reg<zero>) -> ()
+// CHECK-NEXT:   riscv_snitch.dmdst %12, %11 : (!riscv.reg, !riscv.reg<zero>) -> ()
+// CHECK-NEXT:   riscv_snitch.dmstr %14, %15 : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:   riscv_snitch.dmrep %17 : (!riscv.reg) -> ()
+// CHECK-NEXT:   %tx_id4 = riscv_snitch.dmcpyi %16, 2 : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:   %tx_id4_1 = builtin.unrealized_conversion_cast %tx_id4 : !riscv.reg to i32
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_snitch.mlir
@@ -8,13 +8,13 @@
 memref_stream.write %val to %writable : f32
 
 // CHECK-NEXT:    %readable, %writable = "test.op"() : () -> (!stream.readable<f32>, !stream.writable<f32>)
-// CHECK-NEXT:    %val = builtin.unrealized_conversion_cast %readable : !stream.readable<f32> to !stream.readable<!riscv.freg<>>
-// CHECK-NEXT:    %{{.*}} = riscv_snitch.read from %val : !riscv.freg<>
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg<> to f32
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %writable : !stream.writable<f32> to !stream.writable<!riscv.freg<>>
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg<>
-// CHECK-NEXT:    %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:    riscv_snitch.write %{{.*}} to %{{.*}} : !riscv.freg<>
+// CHECK-NEXT:    %val = builtin.unrealized_conversion_cast %readable : !stream.readable<f32> to !stream.readable<!riscv.freg>
+// CHECK-NEXT:    %{{.*}} = riscv_snitch.read from %val : !riscv.freg
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %writable : !stream.writable<f32> to !stream.writable<!riscv.freg>
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f32 to !riscv.freg
+// CHECK-NEXT:    %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:    riscv_snitch.write %{{.*}} to %{{.*}} : !riscv.freg
 
 %A, %B, %C = "test.op"() : () -> (memref<2xf64>, memref<3xf64>, memref<3x2xf64>)
 
@@ -30,16 +30,16 @@ memref_stream.streaming_region {
 }
 
 // CHECK-NEXT:  %A, %B, %C = "test.op"() : () -> (memref<2xf64>, memref<3xf64>, memref<3x2xf64>)
-// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %A : memref<2xf64> to !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %B : memref<3xf64> to !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg<>
+// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %A : memref<2xf64> to !riscv.reg
+// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %B : memref<3xf64> to !riscv.reg
+// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg
 // CHECK-NEXT:    "snitch_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [3, 2], strides = [8, 0]>, #snitch_stream.stride_pattern<ub = [3, 2], strides = [0, 8]>, #snitch_stream.stride_pattern<ub = [6], strides = [8]>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
-// CHECK-NEXT:  ^0(%a : !stream.readable<!riscv.freg<>>, %b : !stream.readable<!riscv.freg<>>, %c : !stream.writable<!riscv.freg<>>):
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %a : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %b : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c : !stream.writable<!riscv.freg<>> to !stream.writable<f64>
+// CHECK-NEXT:  ^0(%a : !stream.readable<!riscv.freg>, %b : !stream.readable<!riscv.freg>, %c : !stream.writable<!riscv.freg>):
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %a : !stream.readable<!riscv.freg> to !stream.readable<f64>
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %b : !stream.readable<!riscv.freg> to !stream.readable<f64>
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c : !stream.writable<!riscv.freg> to !stream.writable<f64>
 // CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}, %{{.*}}) : (!stream.readable<f64>, !stream.readable<f64>, !stream.writable<f64>) -> ()
-// CHECK-NEXT:  }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:  }) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
 memref_stream.streaming_region {
     patterns = [
@@ -51,14 +51,14 @@ memref_stream.streaming_region {
     "test.op"(%c0, %c1) : (!stream.readable<f64>, !stream.readable<f64>) -> ()
 }
 
-// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg<>
-// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg<>
+// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg
+// CHECK-NEXT:  %{{.*}} = builtin.unrealized_conversion_cast %C : memref<3x2xf64> to !riscv.reg
 // CHECK-NEXT:    "snitch_stream.streaming_region"(%{{.*}}, %{{.*}}) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [6], strides = [8]>], "operandSegmentSizes" = array<i32: 2, 0>}> ({
-// CHECK-NEXT:  ^{{.*}}(%c0 : !stream.readable<!riscv.freg<>>, %c1 : !stream.readable<!riscv.freg<>>):
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c0 : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c1 : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
+// CHECK-NEXT:  ^{{.*}}(%c0 : !stream.readable<!riscv.freg>, %c1 : !stream.readable<!riscv.freg>):
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c0 : !stream.readable<!riscv.freg> to !stream.readable<f64>
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %c1 : !stream.readable<!riscv.freg> to !stream.readable<f64>
 // CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!stream.readable<f64>, !stream.readable<f64>) -> ()
-// CHECK-NEXT:  }) : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:  }) : (!riscv.reg, !riscv.reg) -> ()
 
 
 %D, %E = "test.op"() : () -> (memref<1x1x8x8xf64>, memref<1x1x3x3xf64>)
@@ -74,14 +74,14 @@ memref_stream.streaming_region {
     "test.op"(%d_stream, %e_stream) : (!stream.readable<f64>, !stream.readable<f64>) -> ()
 }
 
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<1x1x8x8xf64> to !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<1x1x3x3xf64> to !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<1x1x8x8xf64> to !riscv.reg
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<1x1x3x3xf64> to !riscv.reg
 // CHECK-NEXT:    "snitch_stream.streaming_region"(%{{.*}}, %{{.*}}) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [6, 6, 3, 3], strides = [64, 8, 64, 8]>, #snitch_stream.stride_pattern<ub = [36, 3, 3], strides = [0, 24, 8]>], "operandSegmentSizes" = array<i32: 2, 0>}> ({
-// CHECK-NEXT:    ^{{.*}}(%{{.*}} : !stream.readable<!riscv.freg<>>, %{{.*}} : !stream.readable<!riscv.freg<>>):
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
+// CHECK-NEXT:    ^{{.*}}(%{{.*}} : !stream.readable<!riscv.freg>, %{{.*}} : !stream.readable<!riscv.freg>):
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg> to !stream.readable<f64>
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg> to !stream.readable<f64>
 // CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}) : (!stream.readable<f64>, !stream.readable<f64>) -> ()
-// CHECK-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:    }) : (!riscv.reg, !riscv.reg) -> ()
 
 %F = "test.op"() : () -> memref<8x8xf64>
 // CHECK-NEXT:   %F = "test.op"() : () -> memref<8x8xf64>
@@ -97,16 +97,16 @@ memref_stream.streaming_region {
     "test.op"(%x_stream, %w_stream, %b_stream) : (!stream.readable<f64>, !stream.readable<f64>, !stream.readable<f64>) -> ()
 }
 
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<8x8xf64> to !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<8x8xf64> to !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<8x8xf64> to !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<8x8xf64> to !riscv.reg
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<8x8xf64> to !riscv.reg
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<8x8xf64> to !riscv.reg
 // CHECK-NEXT:    "snitch_stream.streaming_region"(%{{.*}}, %{{.*}}, %{{.*}}) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [8, 8, 8], strides = [64, 0, 8]>, #snitch_stream.stride_pattern<ub = [8, 8, 8], strides = [0, 8, 64]>, #snitch_stream.stride_pattern<ub = [64], strides = [8]>], "operandSegmentSizes" = array<i32: 3, 0>}> ({
-// CHECK-NEXT:    ^{{.*}}(%{{.*}} : !stream.readable<!riscv.freg<>>, %{{.*}} : !stream.readable<!riscv.freg<>>, %{{.*}} : !stream.readable<!riscv.freg<>>):
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg<>> to !stream.readable<f64>
+// CHECK-NEXT:    ^{{.*}}(%{{.*}} : !stream.readable<!riscv.freg>, %{{.*}} : !stream.readable<!riscv.freg>, %{{.*}} : !stream.readable<!riscv.freg>):
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg> to !stream.readable<f64>
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg> to !stream.readable<f64>
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.readable<!riscv.freg> to !stream.readable<f64>
 // CHECK-NEXT:      "test.op"(%{{.*}}, %{{.*}}, %{{.*}}) : (!stream.readable<f64>, !stream.readable<f64>, !stream.readable<f64>) -> ()
-// CHECK-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:    }) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
 %G, %H = "test.op"() : () -> (f64, memref<16x16xf64>)
 // CHECK-NEXT:   %G, %H = "test.op"() : () -> (f64, memref<16x16xf64>)
@@ -125,19 +125,19 @@ memref_stream.streaming_region {
     }
 }
 
-// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<16x16xf64> to !riscv.reg<>
+// CHECK-NEXT:    %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : memref<16x16xf64> to !riscv.reg
 // CHECK-NEXT:    "snitch_stream.streaming_region"(%{{.*}}) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [256], strides = [8]>], "operandSegmentSizes" = array<i32: 0, 1>}> ({
-// CHECK-NEXT:    ^{{.*}}(%{{.*}} : !stream.writable<!riscv.freg<>>):
-// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.writable<!riscv.freg<>> to !stream.writable<f64>
+// CHECK-NEXT:    ^{{.*}}(%{{.*}} : !stream.writable<!riscv.freg>):
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.writable<!riscv.freg> to !stream.writable<f64>
 // CHECK-NEXT:      %{{.*}} = arith.constant 0 : i32
 // CHECK-NEXT:      %{{.*}} = arith.constant 1 : i32
 // CHECK-NEXT:      %{{.*}} = arith.constant 256 : i32
 // CHECK-NEXT:      scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} : i32 {
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.writable<f64> to !stream.writable<!riscv.freg<>>
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:        riscv_snitch.write %{{.*}} to %{{.*}} : !riscv.freg<>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !stream.writable<f64> to !stream.writable<!riscv.freg>
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:        riscv_snitch.write %{{.*}} to %{{.*}} : !riscv.freg
 // CHECK-NEXT:      }
-// CHECK-NEXT:    }) : (!riscv.reg<>) -> ()
+// CHECK-NEXT:    }) : (!riscv.reg) -> ()
 
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/individual_rewrite.mlir
+++ b/tests/filecheck/transforms/individual_rewrite.mlir
@@ -1,16 +1,16 @@
 // RUN:xdsl-opt %s -p 'apply-individual-rewrite{matched_operation_index=4 operation_name="riscv.add" pattern_name="AddImmediates"}'| filecheck %s
 
-%a = riscv.li 1 : () -> !riscv.reg<>
-%b = riscv.li 2 : () -> !riscv.reg<>
-%c = riscv.li 3 : () -> !riscv.reg<>
-%d = riscv.add %a, %b : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-%e = riscv.add %b, %c : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+%a = riscv.li 1 : () -> !riscv.reg
+%b = riscv.li 2 : () -> !riscv.reg
+%c = riscv.li 3 : () -> !riscv.reg
+%d = riscv.add %a, %b : (!riscv.reg, !riscv.reg) -> !riscv.reg
+%e = riscv.add %b, %c : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
 
 //CHECK:         builtin.module {
-// CHECK-NEXT:       %a = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:       %b = riscv.li 2 : () -> !riscv.reg<>
-// CHECK-NEXT:       %c = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:       %d = riscv.li 3 : () -> !riscv.reg<>
-// CHECK-NEXT:       %e = riscv.add %b, %c : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
+// CHECK-NEXT:       %a = riscv.li 1 : () -> !riscv.reg
+// CHECK-NEXT:       %b = riscv.li 2 : () -> !riscv.reg
+// CHECK-NEXT:       %c = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:       %d = riscv.li 3 : () -> !riscv.reg
+// CHECK-NEXT:       %e = riscv.add %b, %c : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:     }

--- a/tests/filecheck/transforms/riscv_cse.mlir
+++ b/tests/filecheck/transforms/riscv_cse.mlir
@@ -1,85 +1,85 @@
 // RUN: xdsl-opt -p riscv-cse --split-input-file %s | filecheck %s
 
-%a8 = riscv.li 8 : () -> !riscv.reg<>
-%b8 = riscv.li 8 : () -> !riscv.reg<>
-%c8 = riscv.li 8 : () -> !riscv.reg<>
+%a8 = riscv.li 8 : () -> !riscv.reg
+%b8 = riscv.li 8 : () -> !riscv.reg
+%c8 = riscv.li 8 : () -> !riscv.reg
 
-%a7 = riscv.li 7 : () -> !riscv.reg<>
-%b7 = riscv.li 7 : () -> !riscv.reg<>
+%a7 = riscv.li 7 : () -> !riscv.reg
+%b7 = riscv.li 7 : () -> !riscv.reg
 
 riscv.assembly_section ".text" {
-    %d8 = riscv.li 8 : () -> !riscv.reg<>
-    %e8 = riscv.li 8 : () -> !riscv.reg<>
+    %d8 = riscv.li 8 : () -> !riscv.reg
+    %e8 = riscv.li 8 : () -> !riscv.reg
 }
 
-%f8 = riscv.li 8 : () -> !riscv.reg<>
+%f8 = riscv.li 8 : () -> !riscv.reg
 
 // CHECK:       builtin.module {
-// CHECK-NEXT:    %a8 = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:    %a7 = riscv.li 7 : () -> !riscv.reg<>
+// CHECK-NEXT:    %a8 = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:    %a7 = riscv.li 7 : () -> !riscv.reg
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      %d8 = riscv.li 8 : () -> !riscv.reg<>
+// CHECK-NEXT:      %d8 = riscv.li 8 : () -> !riscv.reg
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 // -----
 
-%0, %1, %2 = "test.op"() : () -> (!stream.readable<!riscv.freg<>>, !stream.readable<!riscv.freg<>>, !riscv.reg<>)
+%0, %1, %2 = "test.op"() : () -> (!stream.readable<!riscv.freg>, !stream.readable<!riscv.freg>, !riscv.reg)
 
-%8 = riscv.li 8 : () -> !riscv.reg<>
-%9 = riscv.li 8 : () -> !riscv.reg<>
-%10 = riscv.li 8 : () -> !riscv.reg<>
-%11 = riscv.li 0 : () -> !riscv.reg<>
-%12 = riscv.li 1 : () -> !riscv.reg<>
-riscv_scf.for %13 : !riscv.reg<> = %11 to %8 step %12 {
-    riscv_scf.for %14 : !riscv.reg<> = %11 to %9 step %12 {
-        %15 = riscv.li 8 : () -> !riscv.reg<>
-        %16 = riscv.mul %15, %13 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        %17 = riscv.add %16, %14 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        %18 = riscv.li 8 : () -> !riscv.reg<>
-        %19 = riscv.mul %17, %18 {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        %20 = riscv.add %2, %19 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        %21 = riscv.fld %20, 0 {"comment" = "load double from memref of shape (8, 8)"} : (!riscv.reg<>) -> !riscv.freg<>
-        %22 = riscv.fmv.d %21 : (!riscv.freg<>) -> !riscv.freg<>
-        %23 = riscv_scf.for %24 : !riscv.reg<> = %11 to %10 step %12 iter_args(%25 = %22) -> (!riscv.freg<>) {
-            %26 = riscv_snitch.read from %0 : !riscv.freg<>
-            %27 = riscv_snitch.read from %1 : !riscv.freg<>
-            %28 = riscv.fmul.d %26, %27 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-            %29 = riscv.fadd.d %21, %26 : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-            riscv_scf.yield %29 : !riscv.freg<>
+%8 = riscv.li 8 : () -> !riscv.reg
+%9 = riscv.li 8 : () -> !riscv.reg
+%10 = riscv.li 8 : () -> !riscv.reg
+%11 = riscv.li 0 : () -> !riscv.reg
+%12 = riscv.li 1 : () -> !riscv.reg
+riscv_scf.for %13 : !riscv.reg = %11 to %8 step %12 {
+    riscv_scf.for %14 : !riscv.reg = %11 to %9 step %12 {
+        %15 = riscv.li 8 : () -> !riscv.reg
+        %16 = riscv.mul %15, %13 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        %17 = riscv.add %16, %14 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        %18 = riscv.li 8 : () -> !riscv.reg
+        %19 = riscv.mul %17, %18 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        %20 = riscv.add %2, %19 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        %21 = riscv.fld %20, 0 {"comment" = "load double from memref of shape (8, 8)"} : (!riscv.reg) -> !riscv.freg
+        %22 = riscv.fmv.d %21 : (!riscv.freg) -> !riscv.freg
+        %23 = riscv_scf.for %24 : !riscv.reg = %11 to %10 step %12 iter_args(%25 = %22) -> (!riscv.freg) {
+            %26 = riscv_snitch.read from %0 : !riscv.freg
+            %27 = riscv_snitch.read from %1 : !riscv.freg
+            %28 = riscv.fmul.d %26, %27 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+            %29 = riscv.fadd.d %21, %26 : (!riscv.freg, !riscv.freg) -> !riscv.freg
+            riscv_scf.yield %29 : !riscv.freg
         }
-        %30 = riscv.li 8 : () -> !riscv.reg<>
-        %31 = riscv.mul %30, %13 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        %32 = riscv.add %31, %14 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        %33 = riscv.li 8 : () -> !riscv.reg<>
-        %34 = riscv.mul %32, %33 {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        %35 = riscv.add %2, %34 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-        riscv.fsd %35, %23, 0 {"comment" = "store double value to memref of shape (8, 8)"} : (!riscv.reg<>, !riscv.freg<>) -> ()
+        %30 = riscv.li 8 : () -> !riscv.reg
+        %31 = riscv.mul %30, %13 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        %32 = riscv.add %31, %14 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        %33 = riscv.li 8 : () -> !riscv.reg
+        %34 = riscv.mul %32, %33 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        %35 = riscv.add %2, %34 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        riscv.fsd %35, %23, 0 {"comment" = "store double value to memref of shape (8, 8)"} : (!riscv.reg, !riscv.freg) -> ()
     }
 }
 
 // CHECK:       builtin.module {
-// CHECK-NEXT:    %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!stream.readable<!riscv.freg<>>, !stream.readable<!riscv.freg<>>, !riscv.reg<>)
-// CHECK-NEXT:    %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.li 0 : () -> !riscv.reg<>
-// CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg<>
-// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
-// CHECK-NEXT:      riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} {
-// CHECK-NEXT:        %{{.*}} = riscv.li 8 : () -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-// CHECK-NEXT:        %{{.*}} = riscv.fld %{{.*}}, 0 {"comment" = "load double from memref of shape (8, 8)"} : (!riscv.reg<>) -> !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:        %{{.*}} = riscv_scf.for %{{.*}} : !riscv.reg<> = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (!riscv.freg<>) {
-// CHECK-NEXT:          %{{.*}} = riscv_snitch.read from %{{.*}} : !riscv.freg<>
-// CHECK-NEXT:          %{{.*}} = riscv_snitch.read from %{{.*}} : !riscv.freg<>
-// CHECK-NEXT:          %{{.*}} = riscv.fmul.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:          %{{.*}} = riscv.fadd.d %{{.*}}, %{{.*}} : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-// CHECK-NEXT:          riscv_scf.yield %{{.*}} : !riscv.freg<>
+// CHECK-NEXT:    %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (!stream.readable<!riscv.freg>, !stream.readable<!riscv.freg>, !riscv.reg)
+// CHECK-NEXT:    %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.li 0 : () -> !riscv.reg
+// CHECK-NEXT:    %{{.*}} = riscv.li 1 : () -> !riscv.reg
+// CHECK-NEXT:    riscv_scf.for %{{.*}} : !riscv.reg = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:      riscv_scf.for %{{.*}} : !riscv.reg = %{{.*}} to %{{.*}} step %{{.*}} {
+// CHECK-NEXT:        %{{.*}} = riscv.li 8 : () -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:        %{{.*}} = riscv.fld %{{.*}}, 0 {"comment" = "load double from memref of shape (8, 8)"} : (!riscv.reg) -> !riscv.freg
+// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg
+// CHECK-NEXT:        %{{.*}} = riscv_scf.for %{{.*}} : !riscv.reg = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (!riscv.freg) {
+// CHECK-NEXT:          %{{.*}} = riscv_snitch.read from %{{.*}} : !riscv.freg
+// CHECK-NEXT:          %{{.*}} = riscv_snitch.read from %{{.*}} : !riscv.freg
+// CHECK-NEXT:          %{{.*}} = riscv.fmul.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:          %{{.*}} = riscv.fadd.d %{{.*}}, %{{.*}} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-NEXT:          riscv_scf.yield %{{.*}} : !riscv.freg
 // CHECK-NEXT:        }
-// CHECK-NEXT:        riscv.fsd %{{.*}}, %{{.*}}, 0 {"comment" = "store double value to memref of shape (8, 8)"} : (!riscv.reg<>, !riscv.freg<>) -> ()
+// CHECK-NEXT:        riscv.fsd %{{.*}}, %{{.*}}, 0 {"comment" = "store double value to memref of shape (8, 8)"} : (!riscv.reg, !riscv.freg) -> ()
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/snitch_register_allocation.mlir
+++ b/tests/filecheck/transforms/snitch_register_allocation.mlir
@@ -1,33 +1,33 @@
 // RUN: xdsl-opt -p snitch-allocate-registers %s | filecheck %s
 
-%ptr0, %ptr1, %ptr2 = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+%ptr0, %ptr1, %ptr2 = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
 
 "snitch_stream.streaming_region"(%ptr0, %ptr1, %ptr2) <{
     "stride_patterns" = [#snitch_stream.stride_pattern<ub = [], strides = []>],
     "operandSegmentSizes" = array<i32: 2, 1>
 }> ({
-^0(%s0 : !stream.readable<!riscv.freg<>>, %s1 : !stream.readable<!riscv.freg<>>, %s2 : !stream.writable<!riscv.freg<>>):
-    %c5 = riscv.li 5 : () -> !riscv.reg<>
+^0(%s0 : !stream.readable<!riscv.freg>, %s1 : !stream.readable<!riscv.freg>, %s2 : !stream.writable<!riscv.freg>):
+    %c5 = riscv.li 5 : () -> !riscv.reg
     riscv_snitch.frep_outer %c5 {
-        %x = riscv_snitch.read from %s0 : !riscv.freg<>
-        %y = riscv_snitch.read from %s1 : !riscv.freg<>
-        %r = riscv.fadd.d %x, %y : (!riscv.freg<>, !riscv.freg<>) -> !riscv.freg<>
-        riscv_snitch.write %r to %s2 : !riscv.freg<>
+        %x = riscv_snitch.read from %s0 : !riscv.freg
+        %y = riscv_snitch.read from %s1 : !riscv.freg
+        %r = riscv.fadd.d %x, %y : (!riscv.freg, !riscv.freg) -> !riscv.freg
+        riscv_snitch.write %r to %s2 : !riscv.freg
     }
-}) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+}) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
 // CHECK: builtin.module {
 
-// CHECK-NEXT:    %ptr0, %ptr1, %ptr2 = "test.op"() : () -> (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>)
+// CHECK-NEXT:    %ptr0, %ptr1, %ptr2 = "test.op"() : () -> (!riscv.reg, !riscv.reg, !riscv.reg)
 // CHECK-NEXT:    "snitch_stream.streaming_region"(%ptr0, %ptr1, %ptr2) <{"stride_patterns" = [#snitch_stream.stride_pattern<ub = [], strides = []>], "operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-NEXT:    ^0(%s0 : !stream.readable<!riscv.freg<ft0>>, %s1 : !stream.readable<!riscv.freg<ft1>>, %s2 : !stream.writable<!riscv.freg<ft2>>):
-// CHECK-NEXT:      %c5 = riscv.li 5 : () -> !riscv.reg<>
+// CHECK-NEXT:      %c5 = riscv.li 5 : () -> !riscv.reg
 // CHECK-NEXT:      riscv_snitch.frep_outer %c5 {
 // CHECK-NEXT:        %x = riscv_snitch.read from %s0 : !riscv.freg<ft0>
 // CHECK-NEXT:        %y = riscv_snitch.read from %s1 : !riscv.freg<ft1>
 // CHECK-NEXT:        %r = riscv.fadd.d %x, %y : (!riscv.freg<ft0>, !riscv.freg<ft1>) -> !riscv.freg<ft2>
 // CHECK-NEXT:        riscv_snitch.write %r to %s2 : !riscv.freg<ft2>
 // CHECK-NEXT:      }
-// CHECK-NEXT:    }) : (!riscv.reg<>, !riscv.reg<>, !riscv.reg<>) -> ()
+// CHECK-NEXT:    }) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
 
 // CHECK-NEXT: }

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -181,16 +181,16 @@ async def test_buttons():
     riscv.directive ".globl" "hello"
     riscv.directive ".p2align" "2"
     riscv_func.func @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> {
-      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg<>
-      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg<> to index
-      %two = riscv.li 2 : () -> !riscv.reg<>
-      %two_1 = builtin.unrealized_conversion_cast %two : !riscv.reg<> to index
-      %res = builtin.unrealized_conversion_cast %n_1 : index to !riscv.reg<>
-      %res_1 = builtin.unrealized_conversion_cast %two_1 : index to !riscv.reg<>
-      %res_2 = riscv.mul %res, %res_1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-      %res_3 = builtin.unrealized_conversion_cast %res_2 : !riscv.reg<> to index
-      %1 = builtin.unrealized_conversion_cast %res_3 : index to !riscv.reg<>
-      %2 = riscv.mv %1 : (!riscv.reg<>) -> !riscv.reg<a0>
+      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
+      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
+      %two = riscv.li 2 : () -> !riscv.reg
+      %two_1 = builtin.unrealized_conversion_cast %two : !riscv.reg to index
+      %res = builtin.unrealized_conversion_cast %n_1 : index to !riscv.reg
+      %res_1 = builtin.unrealized_conversion_cast %two_1 : index to !riscv.reg
+      %res_2 = riscv.mul %res, %res_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+      %res_3 = builtin.unrealized_conversion_cast %res_2 : !riscv.reg to index
+      %1 = builtin.unrealized_conversion_cast %res_3 : index to !riscv.reg
+      %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
       riscv_func.return %2 : !riscv.reg<a0>
     }
   }
@@ -212,12 +212,12 @@ async def test_buttons():
     riscv.directive ".globl" "hello"
     riscv.directive ".p2align" "2"
     riscv_func.func @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> {
-      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg<>
-      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg<> to index
+      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
+      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
       %two = arith.constant 2 : index
       %res = arith.muli %n_1, %two : index
-      %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg<>
-      %2 = riscv.mv %1 : (!riscv.reg<>) -> !riscv.reg<a0>
+      %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg
+      %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
       riscv_func.return %2 : !riscv.reg<a0>
     }
   }
@@ -393,12 +393,12 @@ async def test_passes():
     riscv.directive ".globl" "hello"
     riscv.directive ".p2align" "2"
     riscv_func.func @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> {
-      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg<>
-      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg<> to index
+      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
+      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
       %two = arith.constant 2 : index
       %res = arith.muli %n_1, %two : index
-      %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg<>
-      %2 = riscv.mv %1 : (!riscv.reg<>) -> !riscv.reg<a0>
+      %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg
+      %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
       riscv_func.return %2 : !riscv.reg<a0>
     }
   }

--- a/tests/interactive/test_pass_metrics.py
+++ b/tests/interactive/test_pass_metrics.py
@@ -88,12 +88,12 @@ def test_get_diff_operation_count():
     # get output module
     output_text = """builtin.module {
   func.func @hello(%n : index) -> index {
-    %two = riscv.li 2 : () -> !riscv.reg<>
-    %two_1 = builtin.unrealized_conversion_cast %two : !riscv.reg<> to index
-    %res = builtin.unrealized_conversion_cast %n : index to !riscv.reg<>
-    %res_1 = builtin.unrealized_conversion_cast %two_1 : index to !riscv.reg<>
-    %res_2 = riscv.mul %res, %res_1 : (!riscv.reg<>, !riscv.reg<>) -> !riscv.reg<>
-    %res_3 = builtin.unrealized_conversion_cast %res_2 : !riscv.reg<> to index
+    %two = riscv.li 2 : () -> !riscv.reg
+    %two_1 = builtin.unrealized_conversion_cast %two : !riscv.reg to index
+    %res = builtin.unrealized_conversion_cast %n : index to !riscv.reg
+    %res_1 = builtin.unrealized_conversion_cast %two_1 : index to !riscv.reg
+    %res_2 = riscv.mul %res, %res_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %res_3 = builtin.unrealized_conversion_cast %res_2 : !riscv.reg to index
     func.return %res_3 : index
   }
 }

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -284,7 +284,7 @@ def test_riscv_interpreter():
     get_non_zero = riscv.GetRegisterOp(riscv.IntRegisterType.unallocated())
     with pytest.raises(
         InterpretationError,
-        match="Cannot get value for unallocated register !riscv.reg<>",
+        match="Cannot get value for unallocated register !riscv.reg",
     ):
         interpreter.run_op(get_non_zero, ())
 

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -67,8 +67,9 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
         raise NotImplementedError()
 
     def print_parameters(self, printer: Printer) -> None:
-        with printer.in_angle_brackets():
-            printer.print_string(self.spelling.data)
+        if self.spelling.data:
+            with printer.in_angle_brackets():
+                printer.print_string(self.spelling.data)
 
     def verify(self) -> None:
         raise NotImplementedError()

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -82,14 +82,14 @@ class RISCVRegisterType(RegisterType):
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
-        with parser.in_angle_brackets():
-            name = parser.parse_optional_identifier()
-            if name is not None:
-                if not name.startswith("j"):
-                    assert name in cls.abi_index_by_name(), f"{name}"
-            else:
-                name = ""
-            return cls._parameters_from_spelling(name)
+        if parser.parse_optional_punctuation("<") is not None:
+            name = parser.parse_identifier()
+            parser.parse_punctuation(">")
+            if not name.startswith("j"):
+                assert name in cls.abi_index_by_name(), f"{name}"
+        else:
+            name = ""
+        return cls._parameters_from_spelling(name)
 
     def verify(self) -> None:
         name = self.spelling.data

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -18,14 +18,14 @@ class X86RegisterType(RegisterType):
 
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
-        with parser.in_angle_brackets():
-            name = parser.parse_optional_identifier()
-            if name is not None:
-                if not name.startswith("e") and not name.startswith("r"):
-                    assert name in cls.abi_index_by_name(), f"{name}"
-            else:
-                name = ""
-            return cls._parameters_from_spelling(name)
+        if parser.parse_optional_punctuation("<") is not None:
+            name = parser.parse_identifier()
+            parser.parse_punctuation(">")
+            if not name.startswith("e") and not name.startswith("r"):
+                assert name in cls.abi_index_by_name(), f"{name}"
+        else:
+            name = ""
+        return cls._parameters_from_spelling(name)
 
     def verify(self) -> None:
         name = self.spelling.data


### PR DESCRIPTION
I think this removes quite a bit of noise when reading the IR.

Note that the code changes are the three bottom files at the bottom of the files view, the rest is filecheck changes.