### PR TITLE
misc: Small refactor to `PatternRewriter.replace_op`

### DIFF
--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -193,16 +193,15 @@ class PatternRewriter(PatternRewriterListener):
         Otherwise, replace its uses with ErasedSSAValue.
         """
         self.has_done_action = True
+
         if isinstance(new_ops, Operation):
-            new_ops = [new_ops]
+            new_ops = (new_ops,)
 
         # First, insert the new operations before the matched operation
         self.insert_op(new_ops, InsertPoint.before(op))
 
-        if isinstance(new_ops, Operation):
-            new_ops = [new_ops]
         if new_results is None:
-            new_results = [] if len(new_ops) == 0 else new_ops[-1].results
+            new_results = [] if not new_ops else new_ops[-1].results
 
         if len(op.results) != len(new_results):
             raise ValueError(

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -201,7 +201,7 @@ class PatternRewriter(PatternRewriterListener):
         self.insert_op(new_ops, InsertPoint.before(op))
 
         if new_results is None:
-            new_results = [] if not new_ops else new_ops[-1].results
+            new_results = new_ops[-1].results if new_ops else []
 
         if len(op.results) != len(new_results):
             raise ValueError(


### PR DESCRIPTION
Slight code cleanup for the replace_op function, removing duplicate check of the type of `new_ops`, and making a couple of things more pythony