### PR TITLE
core: replace BlockReverseOps with a Reversible conformance

### DIFF
--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -197,7 +197,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
             assert isinstance(iter_arg.type, IntRegisterType | FloatRegisterType)
             self.available_registers.reserve_register(iter_arg.type)
 
-        for op in loop.body.block.ops_reverse:
+        for op in reversed(loop.body.block.ops):
             self.process_operation(op)
 
         # Unreserve the loop carried variables for allocation outside of the body
@@ -260,7 +260,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
             assert isinstance(iter_arg.type, IntRegisterType | FloatRegisterType)
             self.available_registers.reserve_register(iter_arg.type)
 
-        for op in loop.body.block.ops_reverse:
+        for op in reversed(loop.body.block.ops):
             self.process_operation(op)
 
         # Unreserve the loop carried variables for allocation outside of the body
@@ -299,7 +299,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
         self.live_ins_per_block = live_ins_per_block(block)
         assert not self.live_ins_per_block[block]
-        for op in block.ops_reverse:
+        for op in reversed(block.ops):
             self.process_operation(op)
 
 
@@ -308,7 +308,7 @@ def _live_ins_per_block(
 ) -> OrderedSet[SSAValue]:
     res = OrderedSet[SSAValue]([])
 
-    for op in block.ops_reverse:
+    for op in reversed(block.ops):
         # Remove values defined in the block
         # We are traversing backwards, so cannot use the value removed here again
         res.difference_update(op.results)

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -624,7 +624,7 @@ class ApplyOpToHLS(RewritePattern):
             new_return_op.detach()
             new_return_op.erase()
 
-            for operation in new_apply_block.ops_reverse:
+            for operation in reversed(new_apply_block.ops):
                 op_index = new_apply_block.get_operation_index(operation)
                 if op_index not in operation_indices:
                     operation.detach()


### PR DESCRIPTION
Turns out there's a neat built-in way to get the expected behaviour.