### PR TITLE
dialects: (riscv) Make riscv.get_register pure

### DIFF
--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -2840,7 +2840,7 @@ class GetAnyRegisterOperation(Generic[RDInvT], IRDLOperation, RISCVOp):
 
     res: OpResult = result_def(RDInvT)
 
-    traits = frozenset((RegisterAllocatedMemoryEffect(),))
+    traits = frozenset((Pure(),))
 
     def __init__(
         self,


### PR DESCRIPTION
This makes `get_register` pure, as it should be.

The op never reads/writes and is safe to DCE and CSE.