### PR TITLE
testing: Extract linalg to snitch pipeline to test passes in bottom-up

### DIFF
--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-linalg-to-memref-stream,memref-stream-infer-fill,memref-stream-unnest-out-parameters,memref-stream-fold-fill,memref-stream-generalize-fill,memref-streamify,convert-memref-stream-to-loops,canonicalize,scf-for-loop-flatten,convert-memref-to-riscv,convert-scf-to-riscv-scf,convert-arith-to-riscv,convert-func-to-riscv-func,convert-memref-stream-to-snitch,reconcile-unrealized-casts,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
+// RUN: xdsl-opt -p convert-linalg-to-memref-stream,test-optimise-memref-stream,test-lower-memref-stream-to-snitch-stream,test-lower-snitch-stream-to-asm -t riscv-asm %s | filecheck %s
 
 func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %X: memref<1x1x8x8xf64>,

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -5,7 +5,10 @@ from xdsl.backend.riscv.lowering import (
 from xdsl.interactive.get_all_available_passes import get_available_pass_list
 from xdsl.interactive.passes import AvailablePass
 from xdsl.interactive.rewrites import individual_rewrite
-from xdsl.transforms import reconcile_unrealized_casts
+from xdsl.transforms import (
+    reconcile_unrealized_casts,
+    test_lower_memref_stream_to_snitch_stream,
+)
 from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
@@ -35,6 +38,11 @@ def test_get_all_available_passes():
             AvailablePass(
                 display_name="reconcile-unrealized-casts",
                 module_pass=reconcile_unrealized_casts.ReconcileUnrealizedCastsPass,
+                pass_spec=None,
+            ),
+            AvailablePass(
+                display_name="test-lower-memref-stream-to-snitch-stream",
+                module_pass=test_lower_memref_stream_to_snitch_stream.TestLowerMemrefStreamToSnitchStream,
                 pass_spec=None,
             ),
         )

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -328,6 +328,18 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return test_lower_snitch_stream_to_asm.TestLowerSnitchStreamToAsm
 
+    def get_test_lower_memref_stream_to_snitch_stream():
+        from xdsl.transforms import test_lower_memref_stream_to_snitch_stream
+
+        return (
+            test_lower_memref_stream_to_snitch_stream.TestLowerMemrefStreamToSnitchStream
+        )
+
+    def get_test_optimise_memref_stream():
+        from xdsl.transforms import test_optimise_memref_stream
+
+        return test_optimise_memref_stream.TestOptimiseMemrefStream
+
     return {
         "arith-add-fastmath": get_arith_add_fastmath,
         "loop-hoist-memref": get_loop_hoist_memref,
@@ -391,6 +403,8 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "stencil-to-csl-stencil": get_stencil_to_csl_stencil,
         "stencil-unroll": get_stencil_unroll,
         "test-lower-snitch-stream-to-asm": get_test_lower_snitch_stream_to_asm,
+        "test-lower-memref-stream-to-snitch-stream": get_test_lower_memref_stream_to_snitch_stream,
+        "test-optimise-memref-stream": get_test_optimise_memref_stream,
     }
 
 

--- a/xdsl/transforms/test_lower_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/test_lower_memref_stream_to_snitch_stream.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+
+from xdsl.backend.riscv.lowering.convert_arith_to_riscv import ConvertArithToRiscvPass
+from xdsl.backend.riscv.lowering.convert_func_to_riscv_func import (
+    ConvertFuncToRiscvFuncPass,
+)
+from xdsl.backend.riscv.lowering.convert_memref_to_riscv import ConvertMemrefToRiscvPass
+from xdsl.backend.riscv.lowering.convert_scf_to_riscv_scf import ConvertScfToRiscvPass
+from xdsl.passes import ModulePass, PipelinePass
+from xdsl.transforms.canonicalize import CanonicalizePass
+from xdsl.transforms.convert_memref_stream_to_snitch_stream import (
+    ConvertMemrefStreamToSnitch,
+)
+from xdsl.transforms.reconcile_unrealized_casts import ReconcileUnrealizedCastsPass
+
+TEST_LOWER_MEMREF_STREAM_TO_SNITCH_STREAM: tuple[ModulePass, ...] = (
+    CanonicalizePass(),
+    ConvertMemrefToRiscvPass(),
+    ConvertScfToRiscvPass(),
+    ConvertArithToRiscvPass(),
+    ConvertFuncToRiscvFuncPass(),
+    ConvertMemrefStreamToSnitch(),
+    ReconcileUnrealizedCastsPass(),
+)
+
+
+@dataclass(frozen=True)
+class TestLowerMemrefStreamToSnitchStream(PipelinePass):
+    """
+    A compiler pass used for testing of the lowering from ML kernels defined as
+    memref_stream to snitch_stream + riscv.
+    """
+
+    name = "test-lower-memref-stream-to-snitch-stream"
+
+    passes: tuple[ModulePass, ...] = TEST_LOWER_MEMREF_STREAM_TO_SNITCH_STREAM

--- a/xdsl/transforms/test_lower_snitch_stream_to_asm.py
+++ b/xdsl/transforms/test_lower_snitch_stream_to_asm.py
@@ -15,6 +15,7 @@ from xdsl.transforms.riscv_scf_loop_range_folding import RiscvScfLoopRangeFoldin
 from xdsl.transforms.snitch_register_allocation import SnitchRegisterAllocation
 
 TEST_LOWER_SNITCH_STREAM_TO_ASM_PASSES: tuple[ModulePass, ...] = (
+    CanonicalizePass(),
     ConvertRiscvScfForToFrepPass(),
     SnitchRegisterAllocation(),
     ConvertSnitchStreamToSnitch(),

--- a/xdsl/transforms/test_optimise_memref_stream.py
+++ b/xdsl/transforms/test_optimise_memref_stream.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+from xdsl.passes import ModulePass, PipelinePass
+from xdsl.transforms.canonicalize import CanonicalizePass
+from xdsl.transforms.convert_memref_stream_to_loops import (
+    ConvertMemrefStreamToLoopsPass,
+)
+from xdsl.transforms.memref_stream_fold_fill import MemrefStreamFoldFillPass
+from xdsl.transforms.memref_stream_generalize_fill import MemrefStreamGeneralizeFillPass
+from xdsl.transforms.memref_stream_infer_fill import MemrefStreamInferFillPass
+from xdsl.transforms.memref_stream_unnest_out_parameters import (
+    MemrefStreamUnnestOutParametersPass,
+)
+from xdsl.transforms.memref_streamify import MemrefStreamifyPass
+from xdsl.transforms.scf_for_loop_flatten import ScfForLoopFlattenPass
+
+TEST_OPTIMISE_MEMREF_STREAM: tuple[ModulePass, ...] = (
+    MemrefStreamInferFillPass(),
+    MemrefStreamUnnestOutParametersPass(),
+    MemrefStreamFoldFillPass(),
+    MemrefStreamGeneralizeFillPass(),
+    MemrefStreamifyPass(),
+    ConvertMemrefStreamToLoopsPass(),
+    CanonicalizePass(),
+    ScfForLoopFlattenPass(),
+)
+
+
+@dataclass(frozen=True)
+class TestOptimiseMemrefStream(PipelinePass):
+    """
+    A compiler pass used for testing the optimization of memref streams.
+    """
+
+    name = "test-optimise-memref-stream"
+
+    passes: tuple[ModulePass, ...] = TEST_OPTIMISE_MEMREF_STREAM


### PR DESCRIPTION
Makes it a bit easier to see what is going on, and makes it easier for our paper experiments repos to keep up to date with xDSL developments.