### PR TITLE
core: Make print_string aware of indentation

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -885,3 +885,37 @@ def test_get_printed_name():
     printed = StringIO()
     picked_name = Printer(printed).print_ssa_value(val)
     assert f"%{picked_name}" == printed.getvalue()
+
+
+def test_indented():
+    output = StringIO()
+    printer = Printer(stream=output)
+    printer.print("\n{")
+    with printer.indented():
+        printer.print("\nhello\nhow are you?")
+        printer.print("\n(")
+        with printer.indented():
+            printer.print("\nfoo,")
+            printer.print("\nbar,")
+        printer.print("\n)")
+    printer.print("\n}")
+    printer.print("\n[")
+    with printer.indented(amount=3):
+        printer.print("\nbaz")
+    printer.print("\n]\n")
+
+    EXPECTED = """
+{
+  hello
+  how are you?
+  (
+    foo,
+    bar,
+  )
+}
+[
+      baz
+]
+"""
+
+    assert output.getvalue() == EXPECTED

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -897,6 +897,9 @@ def test_indented():
         with printer.indented():
             printer.print("\nfoo,")
             printer.print("\nbar,")
+            printer.print("\n")
+            printer.print_string_raw("test\nraw print!")
+            printer.print_string("\ndifferent indent level", indent=4)
         printer.print("\n)")
     printer.print("\n}")
     printer.print("\n[")
@@ -911,6 +914,9 @@ def test_indented():
   (
     foo,
     bar,
+    test
+raw print!
+        different indent level
   )
 }
 [

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -157,7 +157,7 @@ class Printer:
 
     def print_string(self, text: str, indent: int | None = None) -> None:
         """
-        Prints a string to the printer's output string.
+        Prints a string to the printer's output.
 
         This function takes into account indentation level when
         printing new lines.

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -142,7 +142,11 @@ class Printer:
             text = str(arg)
             self.print_string(text)
 
-    def print_string(self, text: str) -> None:
+    def print_string_raw(self, text: str) -> None:
+        """
+        Prints a string to the printer's output, without taking
+        indentation into account.
+        """
         lines = text.split("\n")
         if len(lines) != 1:
             self._current_line += len(lines) - 1
@@ -150,6 +154,47 @@ class Printer:
         else:
             self._current_column += len(lines[-1])
         print(text, end="", file=self.stream)
+
+    def print_string(self, text: str, indent: int | None = None) -> None:
+        """
+        Prints a string to the printer's output string.
+
+        This function takes into account indentation level when
+        printing new lines.
+
+        Indentation level for newlines within the printed string
+        can be overriden by specifying the `indent` argument.
+        """
+
+        lines = text.split("\n")
+
+        # Line and column information is not computed ahead of time
+        # as indent-aware newline printing may use it as part of
+        # callbacks.
+        indent = indent or self._indent
+        indent_len = indent * indentNumSpaces
+        print(lines[0], end="", file=self.stream)
+        self._current_column += len(lines[0])
+        for line in lines[1:]:
+            self._print_new_line(indent=indent)
+            print(line, end="", file=self.stream)
+            self._current_line += 1
+            self._current_column = len(line) + indent_len
+
+    @contextmanager
+    def indented(self, amount: int = 1):
+        """
+        Increases the indentation level by the provided amount
+        for the duration of the context.
+
+        Only affects new lines printed within the context.
+        """
+
+        self._indent += amount
+        try:
+            yield
+        finally:
+            self._indent -= amount
 
     def _add_message_on_next_line(self, message: str, begin_pos: int, end_pos: int):
         """Add a message that will be displayed on the next line."""
@@ -166,7 +211,7 @@ class Printer:
         Print a message.
         This is expected to be called at the beginning of a new line and to create a new
         line at the end.
-        [begin_pos, end_pos)
+        The span of the message to be underlined is represented as [begin_pos, end_pos).
         """
         indent = self._indent if indent is None else indent
         indent_size = indent * indentNumSpaces
@@ -216,12 +261,12 @@ class Printer:
         self, indent: int | None = None, print_message: bool = True
     ) -> None:
         indent = self._indent if indent is None else indent
-        self.print("\n")
+        self.print_string_raw("\n")
         if print_message:
             for callback in self._next_line_callback:
                 callback()
             self._next_line_callback = []
-        self.print(" " * indent * indentNumSpaces)
+        self.print_string_raw(" " * indent * indentNumSpaces)
 
     def _get_new_valid_name_id(self) -> str:
         self._next_valid_name_id[-1] += 1
@@ -295,13 +340,12 @@ class Printer:
                 self.print(")")
             self.print(":")
 
-        self._indent += 1
-        for op in block.ops:
-            if not print_block_terminator and op.has_trait(IsTerminator):
-                continue
-            self._print_new_line()
-            self.print_op(op)
-        self._indent -= 1
+        with self.indented():
+            for op in block.ops:
+                if not print_block_terminator and op.has_trait(IsTerminator):
+                    continue
+                self._print_new_line()
+                self.print_op(op)
 
     def print_block_argument(self, arg: BlockArgument, print_type: bool = True) -> None:
         """


### PR DESCRIPTION
This PR makes the `print_string` function in the printer aware of indentation, and will print newlines in strings accordingly.

For cases where this is not desired (such as printing a newline character in the indentation-aware newline logic), `print_string_raw` has been added to print the string ignoring indentation.

Additionally, a helper `indented` function for with statements has been added to control indentation within a scope. Feedback on this would be much appreciated, as a possible concern is that it may not be super intuitive (it indents newlines, not lines).