### PR TITLE
dialects: (memref_stream) make bounds in dialect index typed not IntAttr

### DIFF
--- a/tests/filecheck/dialects/memref_stream/ops.mlir
+++ b/tests/filecheck/dialects/memref_stream/ops.mlir
@@ -44,7 +44,7 @@ memref_stream.streaming_region {
 
 
 memref_stream.generic {
-    bounds = [#builtin.int<3>, #builtin.int<2>],
+    bounds = [3, 2],
     indexing_maps = [
         affine_map<(d0, d1) -> (d0)>,
         affine_map<(d0, d1) -> (d1)>,
@@ -56,18 +56,18 @@ memref_stream.generic {
     memref_stream.yield %arg3 : f32
 }
 
-// CHECK-NEXT:          memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs =  {"hello" = "world"} {
+// CHECK-NEXT:          memref_stream.generic {bounds = [3, 2], indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs =  {"hello" = "world"} {
 // CHECK-NEXT:          ^1(%arg3 : f32, %arg4 : f32):
 // CHECK-NEXT:            memref_stream.yield %arg3 : f32
 // CHECK-NEXT:          }
 
-// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%A, %B, %C) <{"bounds" = [#builtin.int<3>, #builtin.int<2>], "init_indices" = [], "indexing_maps" = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1, 0>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%A, %B, %C) <{"bounds" = [3 : index, 2 : index], "init_indices" = [], "indexing_maps" = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1, 0>}> ({
 // CHECK-GENERIC-NEXT:    ^1(%arg3 : f32, %arg4 : f32):
 // CHECK-GENERIC-NEXT:      "memref_stream.yield"(%arg3) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) {"hello" = "world"} : (memref<2xf32>, memref<3xf32>, memref<3x2xf64>) -> ()
 
 memref_stream.generic {
-    bounds = [#builtin.int<3>, #builtin.int<2>],
+    bounds = [3, 2],
     indexing_maps = [
         affine_map<(d0, d1) -> ()>,
         affine_map<(d0, d1) -> (d0, d1)>
@@ -78,12 +78,12 @@ memref_stream.generic {
     memref_stream.yield %d : f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%D : f64) outs(%C : memref<3x2xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [3, 2], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%D : f64) outs(%C : memref<3x2xf64>) {
 // CHECK-NEXT:    ^2(%d : f64, %c_1 : f64):
 // CHECK-NEXT:      memref_stream.yield %d : f64
 // CHECK-NEXT:    }
 
-// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%D, %C) <{"bounds" = [#builtin.int<3>, #builtin.int<2>], "init_indices" = [], "indexing_maps" = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 1, 1, 0>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%D, %C) <{"bounds" = [3 : index, 2 : index], "init_indices" = [], "indexing_maps" = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 1, 1, 0>}> ({
 // CHECK-GENERIC-NEXT:    ^2(%d : f64, %c_1 : f64):
 // CHECK-GENERIC-NEXT:      "memref_stream.yield"(%d) : (f64) -> ()
 // CHECK-GENERIC-NEXT:    }) : (f64, memref<3x2xf64>) -> ()
@@ -93,7 +93,7 @@ memref_stream.generic {
 // CHECK-GENERIC-NEXT:    %E, %F, %G, %H = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>, f64)
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d2)>,
         affine_map<(d0, d1, d2) -> (d2, d1)>,
@@ -107,14 +107,14 @@ memref_stream.generic {
     linalg.yield %acc_new : f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}} : memref<4x3xf64>) inits(%H : f64) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [4, 2, 3], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}} : memref<4x3xf64>) inits(%H : f64) {
 // CHECK-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
 // CHECK-NEXT:      %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f64
 // CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f64
 // CHECK-NEXT:      linalg.yield %{{.*}} : f64
 // CHECK-NEXT:    }
 
-// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %H) <{"bounds" = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], "init_indices" = [#builtin.int<0>], "indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %H) <{"bounds" = [4 : index, 2 : index, 3 : index], "init_indices" = [#builtin.int<0>], "indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
@@ -126,7 +126,7 @@ memref_stream.generic {
 // CHECK-GENERIC-NEXT:    %I = "test.op"() : () -> memref<4x3xf64>
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d2)>,
         affine_map<(d0, d1, d2) -> (d2, d1)>,
@@ -142,7 +142,7 @@ memref_stream.generic {
     linalg.yield %acc_new_0, %acc_new_1 : f64, f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}}, %{{.*}} : memref<4x3xf64>, memref<4x3xf64>) inits(%{{.*}} : f64, None) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [4, 2, 3], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}}, %{{.*}} : memref<4x3xf64>, memref<4x3xf64>) inits(%{{.*}} : f64, None) {
 // CHECK-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
 // CHECK-NEXT:      %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f64
 // CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f64
@@ -150,7 +150,7 @@ memref_stream.generic {
 // CHECK-NEXT:      linalg.yield %{{.*}}, %{{.*}} : f64, f64
 // CHECK-NEXT:    }
 
-// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"bounds" = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], "init_indices" = [#builtin.int<0>], "indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 2, 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"bounds" = [4 : index, 2 : index, 3 : index], "init_indices" = [#builtin.int<0>], "indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 2, 2, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<none>}> : (f64, f64) -> f64

--- a/tests/filecheck/dialects/memref_stream/verify.mlir
+++ b/tests/filecheck/dialects/memref_stream/verify.mlir
@@ -3,7 +3,7 @@
 %A, %B, %C = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d1)>,
         affine_map<(d0, d1, d2) -> (d1, d2)>,
@@ -24,7 +24,7 @@ memref_stream.generic {
 %A, %B, %C = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d1)>,
         affine_map<(d0, d1, d2) -> (d1, d2)>
@@ -44,7 +44,7 @@ memref_stream.generic {
 %A, %B, %C = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2, d3) -> (d0, d1)>,
         affine_map<(d0, d1, d2) -> (d1, d2)>,
@@ -65,7 +65,7 @@ memref_stream.generic {
 %A, %B, %C = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d1)>,
         affine_map<(d0, d1, d2) -> (d1, d2)>,
@@ -86,7 +86,7 @@ memref_stream.generic {
 %A, %B, %C, %D = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>, memref<4x3xf64>)
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d1)>,
         affine_map<(d0, d1, d2) -> (d1, d2)>,

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
@@ -240,13 +240,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     %Y : memref<8x8xf64>,
     %G : memref<8x8xf64>
   ) {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    %c4 = arith.constant 4 : index
-    %c8 = arith.constant 8 : index
-    %frep_count = arith.constant 6 : index
-
+    %zero_float = arith.constant 0.0 : f64
     memref_stream.streaming_region {
       patterns = [
         #memref_stream.stride_pattern<ub = [8, 2, 8, 4], index_map = (m, n, k, j) -> (m, k)>,
@@ -255,22 +249,14 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
       ]
     } ins(%X, %Y : memref<8x8xf64>, memref<8x8xf64>) outs(%G : memref<8x8xf64>) {
     ^0(%x_stream : !stream.readable<f64>, %y_stream : !stream.readable<f64>, %g_stream : !stream.writable<f64>):
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %c8 = arith.constant 8 : index
+      %frep_count = arith.constant 8 : index
       scf.for %i0 = %c0 to %c8 step %c1 {
         scf.for %i1 = %c0 to %c2 step %c1 {
-          %x00 = memref_stream.read from %x_stream : f64
-          %y00 = memref_stream.read from %y_stream : f64
-          %init0 = arith.mulf %x00, %y00 fastmath<fast> : f64
-          %x01 = memref_stream.read from %x_stream : f64
-          %y01 = memref_stream.read from %y_stream : f64
-          %init1 = arith.mulf %x01, %y01 fastmath<fast> : f64
-          %x02 = memref_stream.read from %x_stream : f64
-          %y02 = memref_stream.read from %y_stream : f64
-          %init2 = arith.mulf %x02, %y02 fastmath<fast> : f64
-          %x03 = memref_stream.read from %x_stream : f64
-          %y03 = memref_stream.read from %y_stream : f64
-          %init3 = arith.mulf %x03, %y03 fastmath<fast> : f64
-
-          %g00, %g01, %g02, %g03 = scf.for %inner_i = %c0 to %frep_count step %c1 iter_args(%acc0 = %init0, %acc1 = %init1, %acc2 = %init2, %acc3 = %init3) -> (f64, f64, f64, f64) {
+          %g00, %g01, %g02, %g03 = scf.for %inner_i = %c0 to %frep_count step %c1 iter_args(%acc0 = %zero_float, %acc1 = %zero_float, %acc2 = %zero_float, %acc3 = %zero_float) -> (f64, f64, f64, f64) {
             %x10 = memref_stream.read from %x_stream : f64
             %y10 = memref_stream.read from %y_stream : f64
             %prod10 = arith.mulf %x10, %y10 fastmath<fast> : f64
@@ -290,26 +276,10 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
             scf.yield %res0, %res1, %res2, %res3 : f64, f64, f64, f64
           }
 
-          %x20 = memref_stream.read from %x_stream : f64
-          %y20 = memref_stream.read from %y_stream : f64
-          %prod20 = arith.mulf %x20, %y20 fastmath<fast> : f64
-          %g10 = arith.addf %prod20, %g00 fastmath<fast> : f64
-          memref_stream.write %g10 to %g_stream : f64
-          %x21 = memref_stream.read from %x_stream : f64
-          %y21 = memref_stream.read from %y_stream : f64
-          %prod21 = arith.mulf %x21, %y21 fastmath<fast> : f64
-          %g11 = arith.addf %prod21, %g01 fastmath<fast> : f64
-          memref_stream.write %g11 to %g_stream : f64
-          %x22 = memref_stream.read from %x_stream : f64
-          %y22 = memref_stream.read from %y_stream : f64
-          %prod22 = arith.mulf %x22, %y22 fastmath<fast> : f64
-          %g12 = arith.addf %prod22, %g02 fastmath<fast> : f64
-          memref_stream.write %g12 to %g_stream : f64
-          %x23 = memref_stream.read from %x_stream : f64
-          %y23 = memref_stream.read from %y_stream : f64
-          %prod23 = arith.mulf %x23, %y23 fastmath<fast> : f64
-          %g13 = arith.addf %prod23, %g03 fastmath<fast> : f64
-          memref_stream.write %g13 to %g_stream : f64
+          memref_stream.write %g00 to %g_stream : f64
+          memref_stream.write %g01 to %g_stream : f64
+          memref_stream.write %g02 to %g_stream : f64
+          memref_stream.write %g03 to %g_stream : f64
         }
       }
     }
@@ -321,66 +291,67 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK-NEXT:  .globl matmul
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  matmul:
-// CHECK-NEXT:      mv t3, a0
-// CHECK-NEXT:      mv t0, a1
-// CHECK-NEXT:      mv t1, a2
-// CHECK-NEXT:      li t4, 3
-// CHECK-NEXT:      scfgwi t4, 64
-// CHECK-NEXT:      li t4, 7
-// CHECK-NEXT:      scfgwi t4, 96
-// CHECK-NEXT:      li t4, 1
-// CHECK-NEXT:      scfgwi t4, 128
-// CHECK-NEXT:      li t4, 7
-// CHECK-NEXT:      scfgwi t4, 160
+// CHECK-NEXT:      mv t0, a0
+// CHECK-NEXT:      mv t1, a1
+// CHECK-NEXT:      mv t2, a2
+// CHECK-NEXT:      fcvt.d.w ft3, zero
+// CHECK-NEXT:      li t3, 3
+// CHECK-NEXT:      scfgwi t3, 64
+// CHECK-NEXT:      li t3, 7
+// CHECK-NEXT:      scfgwi t3, 96
+// CHECK-NEXT:      li t3, 1
+// CHECK-NEXT:      scfgwi t3, 128
+// CHECK-NEXT:      li t3, 7
+// CHECK-NEXT:      scfgwi t3, 160
 // CHECK-NEXT:      scfgwi zero, 192
-// CHECK-NEXT:      li t4, 8
-// CHECK-NEXT:      scfgwi t4, 224
-// CHECK-NEXT:      li t4, -56
-// CHECK-NEXT:      scfgwi t4, 256
-// CHECK-NEXT:      li t4, 8
-// CHECK-NEXT:      scfgwi t4, 288
-// CHECK-NEXT:      li t4, 3
-// CHECK-NEXT:      scfgwi t4, 65
-// CHECK-NEXT:      li t4, 7
-// CHECK-NEXT:      scfgwi t4, 97
-// CHECK-NEXT:      li t4, 1
-// CHECK-NEXT:      scfgwi t4, 129
-// CHECK-NEXT:      li t4, 7
-// CHECK-NEXT:      scfgwi t4, 161
-// CHECK-NEXT:      li t4, 8
-// CHECK-NEXT:      scfgwi t4, 193
-// CHECK-NEXT:      li t4, 40
-// CHECK-NEXT:      scfgwi t4, 225
-// CHECK-NEXT:      li t4, -440
-// CHECK-NEXT:      scfgwi t4, 257
-// CHECK-NEXT:      li t4, -504
-// CHECK-NEXT:      scfgwi t4, 289
-// CHECK-NEXT:      li t4, 63
-// CHECK-NEXT:      scfgwi t4, 66
-// CHECK-NEXT:      li t4, 8
-// CHECK-NEXT:      scfgwi t4, 194
-// CHECK-NEXT:      scfgwi t3, 864
-// CHECK-NEXT:      scfgwi t0, 865
-// CHECK-NEXT:      scfgwi t1, 898
+// CHECK-NEXT:      li t3, 8
+// CHECK-NEXT:      scfgwi t3, 224
+// CHECK-NEXT:      li t3, -56
+// CHECK-NEXT:      scfgwi t3, 256
+// CHECK-NEXT:      li t3, 8
+// CHECK-NEXT:      scfgwi t3, 288
+// CHECK-NEXT:      li t3, 3
+// CHECK-NEXT:      scfgwi t3, 65
+// CHECK-NEXT:      li t3, 7
+// CHECK-NEXT:      scfgwi t3, 97
+// CHECK-NEXT:      li t3, 1
+// CHECK-NEXT:      scfgwi t3, 129
+// CHECK-NEXT:      li t3, 7
+// CHECK-NEXT:      scfgwi t3, 161
+// CHECK-NEXT:      li t3, 8
+// CHECK-NEXT:      scfgwi t3, 193
+// CHECK-NEXT:      li t3, 40
+// CHECK-NEXT:      scfgwi t3, 225
+// CHECK-NEXT:      li t3, -440
+// CHECK-NEXT:      scfgwi t3, 257
+// CHECK-NEXT:      li t3, -504
+// CHECK-NEXT:      scfgwi t3, 289
+// CHECK-NEXT:      li t3, 63
+// CHECK-NEXT:      scfgwi t3, 66
+// CHECK-NEXT:      li t3, 8
+// CHECK-NEXT:      scfgwi t3, 194
+// CHECK-NEXT:      scfgwi t0, 864
+// CHECK-NEXT:      scfgwi t1, 865
+// CHECK-NEXT:      scfgwi t2, 898
 // CHECK-NEXT:      csrrsi zero, 1984, 1
 // CHECK-NEXT:      li t1, 16
 // CHECK-NEXT:      mv t0, zero
 // CHECK-NEXT:      # Constant folded riscv_cf.bge
-// CHECK-NEXT:  scf_body_1_for:
-// CHECK-NEXT:      fmul.d ft6, ft0, ft1
-// CHECK-NEXT:      fmul.d ft5, ft0, ft1
-// CHECK-NEXT:      fmul.d ft4, ft0, ft1
-// CHECK-NEXT:      fmul.d ft3, ft0, ft1
-// CHECK-NEXT:      li t3, 5
+// CHECK-NEXT:  scf_body_{{\d+}}_for:
+// CHECK-NEXT:      fmv.d ft7, ft3
+// CHECK-NEXT:      fmv.d ft6, ft3
+// CHECK-NEXT:      fmv.d ft5, ft3
+// CHECK-NEXT:      fmv.d ft4, ft3
+// CHECK-NEXT:      li t3, 7
 // CHECK-NEXT:      frep.o t3, 4, 0, 0
+// CHECK-NEXT:      fmadd.d ft7, ft0, ft1, ft7
 // CHECK-NEXT:      fmadd.d ft6, ft0, ft1, ft6
 // CHECK-NEXT:      fmadd.d ft5, ft0, ft1, ft5
 // CHECK-NEXT:      fmadd.d ft4, ft0, ft1, ft4
-// CHECK-NEXT:      fmadd.d ft3, ft0, ft1, ft3
-// CHECK-NEXT:      fmadd.d ft2, ft0, ft1, ft6
-// CHECK-NEXT:      fmadd.d ft2, ft0, ft1, ft5
-// CHECK-NEXT:      fmadd.d ft2, ft0, ft1, ft4
-// CHECK-NEXT:      fmadd.d ft2, ft0, ft1, ft3
+// CHECK-NEXT:      fmv.d ft2, ft7
+// CHECK-NEXT:      fmv.d ft2, ft6
+// CHECK-NEXT:      fmv.d ft2, ft5
+// CHECK-NEXT:      fmv.d ft2, ft4
 // CHECK-NEXT:      addi t0, t0, 1
 // CHECK-NEXT:      blt t0, t1, scf_body_{{\d+}}_for
 // CHECK-NEXT:  scf_body_end_{{\d+}}_for:

--- a/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
+++ b/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
@@ -44,7 +44,7 @@ linalg.generic {
     linalg.yield %acc_new : f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<2>, #builtin.int<3>, #builtin.int<4>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%D, %E : memref<2x3xf64>, memref<3x4xf64>) outs(%F : memref<2x4xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [2, 3, 4], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d2)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%D, %E : memref<2x3xf64>, memref<3x4xf64>) outs(%F : memref<2x4xf64>) {
 // CHECK-NEXT:    ^1(%d : f64, %e : f64, %acc_old_1 : f64):
 // CHECK-NEXT:      %prod_1 = arith.mulf %d, %e : f64
 // CHECK-NEXT:      %acc_new_1 = arith.addf %acc_old_1, %prod_1 : f64
@@ -65,7 +65,7 @@ linalg.generic {
     linalg.yield %acc_new : f64
 }
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<3>, #builtin.int<2>], indexing_maps = [affine_map<(d0, d1) -> ((d0 + d1))>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%G, %H : memref<4xf64>, memref<2xf64>) outs(%I : memref<3xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [3, 2], indexing_maps = [affine_map<(d0, d1) -> ((d0 + d1))>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%G, %H : memref<4xf64>, memref<2xf64>) outs(%I : memref<3xf64>) {
 // CHECK-NEXT:    ^2(%g : f64, %h : f64, %acc_old_2 : f64):
 // CHECK-NEXT:      %prod_2 = arith.mulf %g, %h : f64
 // CHECK-NEXT:      %acc_new_2 = arith.addf %acc_old_2, %prod_2 : f64

--- a/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_loops.mlir
@@ -11,7 +11,7 @@
     ]
   } ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
     ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>, %2 : !stream.writable<f64>):
-      memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
+      memref_stream.generic {bounds = [8, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
       ^1(%in : f64, %in_0 : f64, %out : f64):
         %3 = arith.addf %in, %in_0 : f64
         memref_stream.yield %3 : f64
@@ -48,7 +48,7 @@
     ]
   } ins(%arg0_1 : memref<16x16xf64>) outs(%arg1_1 : memref<16x16xf64>) {
     ^2(%4 : !stream.readable<f64>, %5 : !stream.writable<f64>):
-      memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : !stream.readable<f64>) outs(%5 : !stream.writable<f64>) {
+      memref_stream.generic {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : !stream.readable<f64>) outs(%5 : !stream.writable<f64>) {
       ^3(%in_1 : f64, %out_1 : f64):
         %6 = arith.maximumf %in_1, %cst : f64
         memref_stream.yield %6 : f64
@@ -85,7 +85,7 @@ func.func public @fill(%arg0 : memref<16x16xf64>) -> memref<16x16xf64> {
   } outs(%arg0 : memref<16x16xf64>) {
   ^3(%7 : !stream.writable<f64>):
     memref_stream.generic {
-        bounds = [#builtin.int<16>, #builtin.int<16>],
+        bounds = [16, 16],
         indexing_maps = [
             affine_map<(d0, d1) -> ()>,
             affine_map<(d0, d1) -> (d0, d1)>
@@ -125,7 +125,7 @@ func.func @main(%A : memref<4x2xf64>, %B : memref<2x3xf64>, %C : memref<4x3xf64>
     } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) {
     ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>):
       memref_stream.generic {
-        bounds = [#builtin.int<4>, #builtin.int<3>, #builtin.int<2>],
+        bounds = [4, 3, 2],
         indexing_maps = [
           affine_map<(d0, d1, d2) -> (d0, d2)>,
           affine_map<(d0, d1, d2) -> (d2, d1)>,
@@ -174,7 +174,7 @@ func.func @elide_affine(%A : memref<6xf64>, %B : memref<f64>) -> memref<f64> {
     } ins(%A : memref<6xf64>) {
     ^0(%0 : !stream.readable<f64>):
       memref_stream.generic {
-        bounds = [#builtin.int<2>, #builtin.int<3>],
+        bounds = [2, 3],
         indexing_maps = [
           affine_map<(d0, d1) -> (d0 * 3 + d1)>,
           affine_map<(d0, d1) -> ()>
@@ -215,7 +215,7 @@ func.func @nested_imperfect(%A : memref<2x3x4xf64>, %B : memref<f64>) -> memref<
     } ins(%A : memref<2x3x4xf64>) {
     ^0(%0 : !stream.readable<f64>):
       memref_stream.generic {
-        bounds = [#builtin.int<2>, #builtin.int<3>, #builtin.int<4>],
+        bounds = [2, 3, 4],
         indexing_maps = [
           affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
           affine_map<() -> ()>
@@ -265,7 +265,7 @@ func.func @main_inits(%A : memref<4x2xf64>, %B : memref<2x3xf64>, %C : memref<4x
     } ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) {
     ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>):
       memref_stream.generic {
-        bounds = [#builtin.int<4>, #builtin.int<3>, #builtin.int<2>],
+        bounds = [4, 3, 2],
         indexing_maps = [
           affine_map<(d0, d1, d2) -> (d0, d2)>,
           affine_map<(d0, d1, d2) -> (d2, d1)>,

--- a/tests/filecheck/transforms/memref_stream_fold_fill.mlir
+++ b/tests/filecheck/transforms/memref_stream_fold_fill.mlir
@@ -16,7 +16,7 @@ memref_stream.fill %m1 with %s2 : memref<5xf64>
 // The third operand is not filled, and should not have a corresponding init
 
 memref_stream.generic {
-    bounds = [#builtin.int<5>, #builtin.int<3>],
+    bounds = [5, 3],
     indexing_maps = [
         affine_map<(d0, d1) -> (d0, d1)>,  // m3
         affine_map<(d0) -> (d0)>,          // m0
@@ -31,7 +31,7 @@ memref_stream.generic {
     %sum2 = arith.addf %out2, %in : f64
     memref_stream.yield %sum0, %sum1, %sum2 : f64, f64, f64
 }
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<5>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%m3 : memref<5x3xf64>) outs(%m0, %m1, %m2 : memref<5xf64>, memref<5xf64>, memref<5xf64>) inits(%s1 : f64, %s2 : f64, None) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [5, 3], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%m3 : memref<5x3xf64>) outs(%m0, %m1, %m2 : memref<5xf64>, memref<5xf64>, memref<5xf64>) inits(%s1 : f64, %s2 : f64, None) {
 // CHECK-NEXT:    ^0(%in : f64, %out0 : f64, %out1 : f64, %out2 : f64):
 // CHECK-NEXT:      %sum0 = arith.addf %out0, %in : f64
 // CHECK-NEXT:      %sum1 = arith.addf %out1, %in : f64
@@ -45,7 +45,7 @@ memref_stream.generic {
 memref_stream.fill %m0 with %s1 : memref<5xf64>
 memref_stream.fill %m1 with %s2 : memref<5xf64>
 memref_stream.generic {
-    bounds = [#builtin.int<5>, #builtin.int<3>],
+    bounds = [5, 3],
     indexing_maps = [
         affine_map<(d0, d1) -> (d0, d1)>,  // m3
         affine_map<(d0, d1) -> (d0)>,      // m0
@@ -62,7 +62,7 @@ memref_stream.generic {
 }
 // CHECK-NEXT:    memref_stream.fill %m0 with %s1 : memref<5xf64>
 // CHECK-NEXT:    memref_stream.fill %m1 with %s2 : memref<5xf64>
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<5>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%m3 : memref<5x3xf64>) outs(%m0, %m1, %m2 : memref<5xf64>, memref<5xf64>, memref<5xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [5, 3], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%m3 : memref<5x3xf64>) outs(%m0, %m1, %m2 : memref<5xf64>, memref<5xf64>, memref<5xf64>) {
 // CHECK-NEXT:    ^1(%in_1 : f64, %out0_1 : f64, %out1_1 : f64, %out2_1 : f64):
 // CHECK-NEXT:      %sum0_1 = arith.addf %out0_1, %in_1 : f64
 // CHECK-NEXT:      %sum1_1 = arith.addf %out1_1, %in_1 : f64

--- a/tests/filecheck/transforms/memref_stream_generalize_fill.mlir
+++ b/tests/filecheck/transforms/memref_stream_generalize_fill.mlir
@@ -7,7 +7,7 @@
 
 memref_stream.fill %Z with %zero : memref<8x8xf64>
 
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<8>], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%zero : f64) outs(%Z : memref<8x8xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [8, 8], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%zero : f64) outs(%Z : memref<8x8xf64>) {
 // CHECK-NEXT:    ^{{.*}}(%{{.*}}: f64, %{{.*}}: f64):
 // CHECK-NEXT:        memref_stream.yield %{{.*}} : f64
 // CHECK-NEXT:    }

--- a/tests/filecheck/transforms/memref_stream_infer_fill.mlir
+++ b/tests/filecheck/transforms/memref_stream_infer_fill.mlir
@@ -6,7 +6,7 @@
 // CHECK-NEXT:   %Z, %zero = "test.op"() : () -> (memref<8x8xf64>, f64)
 
 memref_stream.generic {
-    bounds = [#builtin.int<8>, #builtin.int<8>],
+    bounds = [8, 8],
     indexing_maps = [
         affine_map<(d0, d1) -> ()>,
         affine_map<(d0, d1) -> (d0, d1)>

--- a/tests/filecheck/transforms/memref_stream_unnest_out_parameters.mlir
+++ b/tests/filecheck/transforms/memref_stream_unnest_out_parameters.mlir
@@ -4,7 +4,7 @@
 %A, %B, %C = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
 
 memref_stream.generic {
-    bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>],
+    bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d2)>,
         affine_map<(d0, d1, d2) -> (d2, d1)>,
@@ -20,7 +20,7 @@ memref_stream.generic {
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %{{.*}}, %{{.*}}, %{{.*}} = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<4>, #builtin.int<2>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}} : memref<4x3xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [4, 2, 3], indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%{{.*}}, %{{.*}} : memref<4x2xf64>, memref<2x3xf64>) outs(%{{.*}} : memref<4x3xf64>) {
 // CHECK-NEXT:    ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
 // CHECK-NEXT:      %{{.*}} = arith.mulf %{{.*}}, %{{.*}} : f64
 // CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}} : f64
@@ -30,7 +30,7 @@ memref_stream.generic {
 %X, %Y, %Z  = "test.op"() : () -> (memref<1x1x8x8xf64>, memref<1x1x3x3xf64>, memref<1x1x6x6xf64>)
 
 memref_stream.generic {
-    bounds = [#builtin.int<1>, #builtin.int<1>, #builtin.int<6>, #builtin.int<6>, #builtin.int<1>, #builtin.int<3>, #builtin.int<3>],
+    bounds = [1, 1, 6, 6, 1, 3, 3],
     indexing_maps = [
     affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>,
     affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>,
@@ -45,7 +45,7 @@ memref_stream.generic {
 }
 
 // CHECK-NEXT:    %X, %Y, %Z = "test.op"() : () -> (memref<1x1x8x8xf64>, memref<1x1x3x3xf64>, memref<1x1x6x6xf64>)
-// CHECK-NEXT:    memref_stream.generic {bounds = [#builtin.int<1>, #builtin.int<1>, #builtin.int<6>, #builtin.int<6>, #builtin.int<1>, #builtin.int<3>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, (d2 + d5), (d3 + d6))>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%X, %Y : memref<1x1x8x8xf64>, memref<1x1x3x3xf64>) outs(%Z : memref<1x1x6x6xf64>) {
+// CHECK-NEXT:    memref_stream.generic {bounds = [1, 1, 6, 6, 1, 3, 3], indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, (d2 + d5), (d3 + d6))>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%X, %Y : memref<1x1x8x8xf64>, memref<1x1x3x3xf64>) outs(%Z : memref<1x1x6x6xf64>) {
 // CHECK-NEXT:    ^1(%x : f64, %y : f64, %acc : f64):
 // CHECK-NEXT:      %prod_1 = arith.mulf %x, %y fastmath<fast> : f64
 // CHECK-NEXT:      %res = arith.addf %prod_1, %acc fastmath<fast> : f64

--- a/tests/filecheck/transforms/memref_streamify.mlir
+++ b/tests/filecheck/transforms/memref_streamify.mlir
@@ -8,7 +8,7 @@
 
 func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2 : memref<8x16xf64>) -> memref<8x16xf64> {
     memref_stream.generic {
-        bounds = [#builtin.int<8>, #builtin.int<16>],
+        bounds = [8, 16],
         indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
         iterator_types = ["parallel", "parallel"]
     } ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
@@ -22,7 +22,7 @@ func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2
 // CHECK-NEXT:    func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2 : memref<8x16xf64>) -> memref<8x16xf64> {
 // CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [8, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%arg0, %arg1 : memref<8x16xf64>, memref<8x16xf64>) outs(%arg2 : memref<8x16xf64>) {
 // CHECK-NEXT:      ^0(%0 : !stream.readable<f64>, %1 : !stream.readable<f64>, %2 : !stream.writable<f64>):
-// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<8>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
+// CHECK-NEXT:        memref_stream.generic {bounds = [8, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0, %1 : !stream.readable<f64>, !stream.readable<f64>) outs(%2 : !stream.writable<f64>) {
 // CHECK-NEXT:        ^1(%in : f64, %in_1 : f64, %out : f64):
 // CHECK-NEXT:          %3 = arith.addf %in, %in_1 : f64
 // CHECK-NEXT:          memref_stream.yield %3 : f64
@@ -34,7 +34,7 @@ func.func public @dsum(%arg0 : memref<8x16xf64>, %arg1 : memref<8x16xf64>, %arg2
 func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> memref<16x16xf64> {
     %cst = arith.constant 0.000000e+00 : f64
     memref_stream.generic {
-        bounds = [#builtin.int<16>, #builtin.int<16>],
+        bounds = [16, 16],
         indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
         iterator_types = ["parallel", "parallel"]
     } ins(%arg0 : memref<16x16xf64>) outs(%arg1 : memref<16x16xf64>) {
@@ -49,7 +49,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
 // CHECK-NEXT:      %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>, #memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>]} ins(%arg0 : memref<16x16xf64>) outs(%arg1 : memref<16x16xf64>) {
 // CHECK-NEXT:      ^0(%0 : !stream.readable<f64>, %1 : !stream.writable<f64>):
-// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : !stream.readable<f64>) outs(%1 : !stream.writable<f64>) {
+// CHECK-NEXT:        memref_stream.generic {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : !stream.readable<f64>) outs(%1 : !stream.writable<f64>) {
 // CHECK-NEXT:        ^1(%in : f64, %out : f64):
 // CHECK-NEXT:          %2 = arith.maximumf %in, %cst : f64
 // CHECK-NEXT:          memref_stream.yield %2 : f64
@@ -63,7 +63,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
     %Y : memref<16x16xf64>
   ) {
     memref_stream.generic {
-        bounds = [#builtin.int<16>, #builtin.int<16>],
+        bounds = [16, 16],
         indexing_maps = [
             affine_map<(d0, d1) -> ()>,
             affine_map<(d0, d1) -> (d0, d1)>
@@ -80,7 +80,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
 // CHECK-NEXT:    func.func @fill(%{{.*}} : f64, %{{.*}} : memref<16x16xf64>) {
 // CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [16, 16], index_map = (d0, d1) -> (d0, d1)>]} outs(%{{.*}} : memref<16x16xf64>) {
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : !stream.writable<f64>):
-// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<16>, #builtin.int<16>], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%{{.*}} : f64) outs(%{{.*}} : !stream.writable<f64>) {
+// CHECK-NEXT:        memref_stream.generic {bounds = [16, 16], indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%{{.*}} : f64) outs(%{{.*}} : !stream.writable<f64>) {
 // CHECK-NEXT:        ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64):
 // CHECK-NEXT:          memref_stream.yield %{{.*}} : f64
 // CHECK-NEXT:        }
@@ -95,7 +95,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
     ) {
     %zero_float = arith.constant 0.000000e+00 : f64
     memref_stream.generic {
-      bounds = [#builtin.int<1>, #builtin.int<1>, #builtin.int<6>, #builtin.int<6>, #builtin.int<1>, #builtin.int<3>, #builtin.int<3>],
+      bounds = [1, 1, 6, 6, 1, 3, 3],
       indexing_maps = [
         affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, d2 + d5, d3 + d6)>,
         affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>,
@@ -116,7 +116,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
 // CHECK-NEXT:        %zero_float = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:        memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [1, 1, 6, 6, 1, 3, 3], index_map = (d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, (d2 + d5), (d3 + d6))>, #memref_stream.stride_pattern<ub = [1, 1, 6, 6, 1, 3, 3], index_map = (d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>, #memref_stream.stride_pattern<ub = [1, 1, 6, 6], index_map = (d0, d1, d2, d3) -> (d0, d1, d2, d3)>]} ins(%X, %Y : memref<1x1x8x8xf64>, memref<1x1x3x3xf64>) outs(%Z : memref<1x1x6x6xf64>) {
 // CHECK-NEXT:        ^0(%{{.*}} : !stream.readable<f64>, %{{.*}} : !stream.readable<f64>, %{{.*}} : !stream.writable<f64>):
-// CHECK-NEXT:          memref_stream.generic {bounds = [#builtin.int<1>, #builtin.int<1>, #builtin.int<6>, #builtin.int<6>, #builtin.int<1>, #builtin.int<3>, #builtin.int<3>], indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, (d2 + d5), (d3 + d6))>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%{{.*}}, %{{.*}} : !stream.readable<f64>, !stream.readable<f64>) outs(%{{.*}} : !stream.writable<f64>) inits(%zero_float : f64) {
+// CHECK-NEXT:          memref_stream.generic {bounds = [1, 1, 6, 6, 1, 3, 3], indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, (d2 + d5), (d3 + d6))>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%{{.*}}, %{{.*}} : !stream.readable<f64>, !stream.readable<f64>) outs(%{{.*}} : !stream.writable<f64>) inits(%zero_float : f64) {
 // CHECK-NEXT:          ^{{\d+}}(%x : f64, %y : f64, %acc : f64):
 // CHECK-NEXT:            %prod = arith.mulf %x, %y fastmath<fast> : f64
 // CHECK-NEXT:            %res = arith.addf %prod, %acc fastmath<fast> : f64
@@ -132,7 +132,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
         %Z : memref<2xf64>
     ) {
     memref_stream.generic {
-      bounds = [#builtin.int<2>],
+      bounds = [2],
       indexing_maps = [
         affine_map<(d0) -> (d0)>,
         affine_map<(d0) -> (d0)>,
@@ -150,7 +150,7 @@ func.func public @relu(%arg0 : memref<16x16xf64>, %arg1 : memref<16x16xf64>) -> 
 // CHECK-NEXT:    func.func public @used_only(%{{.*}} : memref<2xf64>, %{{.*}} : memref<2xf64>, %{{.*}} : memref<2xf64>) {
 // CHECK-NEXT:      memref_stream.streaming_region {patterns = [#memref_stream.stride_pattern<ub = [2], index_map = (d0) -> (d0)>, #memref_stream.stride_pattern<ub = [2], index_map = (d0) -> (d0)>]} ins(%{{.*}} : memref<2xf64>) outs(%{{.*}} : memref<2xf64>) {
 // CHECK-NEXT:      ^{{.*}}(%{{.*}} : !stream.readable<f64>, %{{.*}} : !stream.writable<f64>):
-// CHECK-NEXT:        memref_stream.generic {bounds = [#builtin.int<2>], indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%{{.*}}, %{{.*}} : !stream.readable<f64>, memref<2xf64>) outs(%{{.*}} : !stream.writable<f64>) {
+// CHECK-NEXT:        memref_stream.generic {bounds = [2], indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%{{.*}}, %{{.*}} : !stream.readable<f64>, memref<2xf64>) outs(%{{.*}} : !stream.writable<f64>) {
 // CHECK-NEXT:        ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
 // CHECK-NEXT:          memref_stream.yield %{{.*}} : f64
 // CHECK-NEXT:        }

--- a/tests/interpreters/test_memref_stream_interpreter.py
+++ b/tests/interpreters/test_memref_stream_interpreter.py
@@ -4,7 +4,9 @@ from xdsl.dialects.builtin import (
     AffineMapAttr,
     ArrayAttr,
     Float32Type,
+    IndexType,
     IntAttr,
+    IntegerAttr,
     MemRefType,
     ModuleOp,
     i32,
@@ -17,6 +19,12 @@ from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.ir import Block, Region
 from xdsl.ir.affine import AffineExpr, AffineMap
 from xdsl.utils.test_value import TestSSAValue
+
+indextype = IndexType()
+
+
+def index(value: int) -> IntegerAttr[IndexType]:
+    return IntegerAttr(value, indextype)
 
 
 def test_memref_stream_generic():
@@ -54,7 +62,7 @@ def test_memref_stream_generic():
                 memref_stream.IteratorTypeAttr.parallel(),
             )
         ),
-        ArrayAttr((IntAttr(2), IntAttr(3))),
+        ArrayAttr((index(2), index(3))),
         ArrayAttr(()),
     )
 
@@ -108,7 +116,7 @@ def test_memref_stream_generic_scalar():
                 memref_stream.IteratorTypeAttr.parallel(),
             )
         ),
-        ArrayAttr((IntAttr(2), IntAttr(3))),
+        ArrayAttr((index(2), index(3))),
         ArrayAttr(()),
     )
 
@@ -148,7 +156,7 @@ def test_memref_stream_generic_reduction():
             )
         ),
         ArrayAttr((memref_stream.IteratorTypeAttr.reduction(),)),
-        ArrayAttr((IntAttr(3),)),
+        ArrayAttr((index(3),)),
         ArrayAttr(()),
     )
 
@@ -197,7 +205,7 @@ def test_memref_stream_generic_imperfect_nesting():
                 memref_stream.IteratorTypeAttr.reduction(),
             )
         ),
-        ArrayAttr((IntAttr(3), IntAttr(3), IntAttr(2))),
+        ArrayAttr((index(3), index(3), index(2))),
         ArrayAttr(()),
     )
 
@@ -248,7 +256,7 @@ def test_memref_stream_generic_reduction_with_initial_value():
                 memref_stream.IteratorTypeAttr.reduction(),
             )
         ),
-        ArrayAttr((IntAttr(3), IntAttr(3), IntAttr(2))),
+        ArrayAttr((index(3), index(3), index(2))),
         ArrayAttr((IntAttr(0),)),
     )
 

--- a/xdsl/transforms/convert_linalg_to_memref_stream.py
+++ b/xdsl/transforms/convert_linalg_to_memref_stream.py
@@ -1,6 +1,6 @@
 from xdsl.context import MLContext
 from xdsl.dialects import linalg, memref_stream
-from xdsl.dialects.builtin import ArrayAttr, IntAttr, ModuleOp
+from xdsl.dialects.builtin import ArrayAttr, IndexType, IntAttr, IntegerAttr, ModuleOp
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -34,7 +34,8 @@ class ConvertGenericOpPattern(RewritePattern):
         # the nested loop bounds from the shapes of the inputs, so we need to cache that
         # derived information here, as we may not be able to recover it later.
         ubs = op.get_static_loop_ranges()
-        bounds = ArrayAttr(IntAttr(ub) for ub in ubs)
+        index = IndexType()
+        bounds = ArrayAttr(IntegerAttr(IntAttr(ub), index) for ub in ubs)
 
         iterator_types = ArrayAttr(iterator_type_attr(t) for t in op.iterator_types)
 

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -123,7 +123,7 @@ class StreamOpLowering(RewritePattern):
         shapes = tuple(operand_type.get_shape() for operand_type in operand_types)
         stride_patterns = tuple(
             snitch_stream.StridePattern(
-                pattern.ub,
+                ArrayAttr(ub.value for ub in pattern.ub),
                 ArrayAttr(
                     IntAttr(stride)
                     for stride in strides_for_affine_map(

--- a/xdsl/transforms/memref_stream_generalize_fill.py
+++ b/xdsl/transforms/memref_stream_generalize_fill.py
@@ -7,7 +7,8 @@ from xdsl.dialects import memref, memref_stream
 from xdsl.dialects.builtin import (
     AffineMapAttr,
     ArrayAttr,
-    IntAttr,
+    IndexType,
+    IntegerAttr,
     MemRefType,
     ModuleOp,
 )
@@ -39,7 +40,8 @@ class GeneralizeFillPattern(RewritePattern):
         memref_type = cast(MemRefType[Attribute], memref_type)
 
         shape = memref_type.get_shape()
-        ubs = ArrayAttr(IntAttr(ub) for ub in shape)
+        index = IndexType()
+        ubs = ArrayAttr(IntegerAttr(ub, index) for ub in shape)
 
         rewriter.replace_matched_op(
             memref_stream.GenericOp(

--- a/xdsl/transforms/memref_stream_infer_fill.py
+++ b/xdsl/transforms/memref_stream_infer_fill.py
@@ -44,7 +44,7 @@ class InferFillPattern(RewritePattern):
         output_type = cast(memref.MemRefType[Attribute], output.type)
 
         type_shape = output_type.get_shape()
-        bounds = tuple(attr.data for attr in op.bounds)
+        bounds = tuple(attr.value.data for attr in op.bounds)
 
         if type_shape != bounds:
             return


### PR DESCRIPTION
I really should not have been lazy and done this from the start. It makes sense from a semantic point of view, since these are converted to loop bounds, which are index-valued already.

Note stacked PR