### PR TITLE
dialects: (memref_stream) add interleaved iterator

### DIFF
--- a/tests/filecheck/dialects/memref_stream/ops.mlir
+++ b/tests/filecheck/dialects/memref_stream/ops.mlir
@@ -159,6 +159,137 @@ memref_stream.generic {
 // CHECK-GENERIC-NEXT:    }) : (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>, memref<4x3xf64>, f64) -> ()
 
 
+
+func.func @interleaved_no_init(%A0 : memref<3x5xf64>, %B0 : memref<5x8xf64>, %C0 : memref<3x8xf64>) -> memref<3x8xf64> {
+    memref_stream.generic {
+        bounds = [3, 2, 5, 4],
+        indexing_maps = [
+            affine_map<(d0, d1, d2, d3) -> (d0, d2)>,
+            affine_map<(d0, d1, d2, d3) -> (d2, d1 * 4 + d3)>,
+            affine_map<(d0, d1, d3) -> (d0, d1 * 4 + d3)>
+        ],
+        iterator_types = ["parallel", "parallel", "reduction", "interleaved"]
+    } ins(%A0, %B0 : memref<3x5xf64>, memref<5x8xf64>) outs(%C0 : memref<3x8xf64>) {
+    ^1(
+        %a0 : f64, %a1 : f64, %a2 : f64, %a3 : f64,
+        %b0 : f64, %b1 : f64, %b2 : f64, %b3 : f64,
+        %c0 : f64, %c1 : f64, %c2 : f64, %c3 : f64
+    ):
+        %prod0 = arith.mulf %a0, %b0 fastmath<fast> : f64
+        %prod1 = arith.mulf %a1, %b1 fastmath<fast> : f64
+        %prod2 = arith.mulf %a2, %b2 fastmath<fast> : f64
+        %prod3 = arith.mulf %a3, %b3 fastmath<fast> : f64
+
+        %res0 = arith.addf %prod0, %c0 fastmath<fast> : f64
+        %res1 = arith.addf %prod1, %c1 fastmath<fast> : f64
+        %res2 = arith.addf %prod2, %c2 fastmath<fast> : f64
+        %res3 = arith.addf %prod3, %c3 fastmath<fast> : f64
+
+        memref_stream.yield %res0, %res1, %res2, %res3 : f64, f64, f64, f64
+    }
+    func.return %C0 : memref<3x8xf64>
+}
+
+// CHECK-NEXT:    func.func @interleaved_no_init(%{{.*}} : memref<3x5xf64>, %{{.*}} : memref<5x8xf64>, %{{.*}} : memref<3x8xf64>) -> memref<3x8xf64> {
+// CHECK-NEXT:      memref_stream.generic {bounds = [3, 2, 5, 4], indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2)>, affine_map<(d0, d1, d2, d3) -> (d2, ((d1 * 4) + d3))>, affine_map<(d0, d1, d2) -> (d0, ((d1 * 4) + d2))>], iterator_types = ["parallel", "parallel", "reduction", "interleaved"]} ins(%{{.*}}, %{{.*}} : memref<3x5xf64>, memref<5x8xf64>) outs(%{{.*}} : memref<3x8xf64>) {
+// CHECK-NEXT:      ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        memref_stream.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f64, f64, f64, f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      func.return %{{.*}} : memref<3x8xf64>
+// CHECK-NEXT:    }
+
+// CHECK-GENERIC-NEXT:    "func.func"() <{"sym_name" = "interleaved_no_init", "function_type" = (memref<3x5xf64>, memref<5x8xf64>, memref<3x8xf64>) -> memref<3x8xf64>}> ({
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : memref<3x5xf64>, %{{.*}} : memref<5x8xf64>, %{{.*}} : memref<3x8xf64>):
+// CHECK-GENERIC-NEXT:      "memref_stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}) <{"bounds" = [3 : index, 2 : index, 5 : index, 4 : index], "init_indices" = [], "indexing_maps" = [affine_map<(d0, d1, d2, d3) -> (d0, d2)>, affine_map<(d0, d1, d2, d3) -> (d2, ((d1 * 4) + d3))>, affine_map<(d0, d1, d2) -> (d0, ((d1 * 4) + d2))>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<reduction>, #memref_stream.iterator_type<interleaved>], "operandSegmentSizes" = array<i32: 2, 1, 0>}> ({
+// CHECK-GENERIC-NEXT:      ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        "memref_stream.yield"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, f64, f64) -> ()
+// CHECK-GENERIC-NEXT:      }) : (memref<3x5xf64>, memref<5x8xf64>, memref<3x8xf64>) -> ()
+// CHECK-GENERIC-NEXT:      "func.return"(%{{.*}}) : (memref<3x8xf64>) -> ()
+// CHECK-GENERIC-NEXT:    }) : () -> ()
+
+
+func.func @interleaved_init(%A1 : memref<3x5xf64>, %B1 : memref<5x8xf64>, %C1 : memref<3x8xf64>) -> memref<3x8xf64> {
+    %zero_float = arith.constant 0.000000e+00 : f64
+    memref_stream.generic {
+        bounds = [3, 2, 5, 4],
+        indexing_maps = [
+            affine_map<(d0, d1, d2, d3) -> (d0, d2)>,
+            affine_map<(d0, d1, d2, d3) -> (d2, d1 * 4 + d3)>,
+            affine_map<(d0, d1, d3) -> (d0, d1 * 4 + d3)>
+        ],
+        iterator_types = ["parallel", "parallel", "reduction", "interleaved"]
+    } ins(%A1, %B1 : memref<3x5xf64>, memref<5x8xf64>) outs(%C1 : memref<3x8xf64>) inits(%zero_float : f64) {
+    ^1(
+        %a0 : f64, %a1 : f64, %a2 : f64, %a3 : f64,
+        %b0 : f64, %b1 : f64, %b2 : f64, %b3 : f64,
+        %c0 : f64, %c1 : f64, %c2 : f64, %c3 : f64
+    ):
+        %prod0 = arith.mulf %a0, %b0 fastmath<fast> : f64
+        %prod1 = arith.mulf %a1, %b1 fastmath<fast> : f64
+        %prod2 = arith.mulf %a2, %b2 fastmath<fast> : f64
+        %prod3 = arith.mulf %a3, %b3 fastmath<fast> : f64
+
+        %res0 = arith.addf %prod0, %c0 fastmath<fast> : f64
+        %res1 = arith.addf %prod1, %c1 fastmath<fast> : f64
+        %res2 = arith.addf %prod2, %c2 fastmath<fast> : f64
+        %res3 = arith.addf %prod3, %c3 fastmath<fast> : f64
+
+        memref_stream.yield %res0, %res1, %res2, %res3 : f64, f64, f64, f64
+    }
+    func.return %C1 : memref<3x8xf64>
+}
+
+// CHECK-NEXT:    func.func @interleaved_init(%{{.*}} : memref<3x5xf64>, %{{.*}} : memref<5x8xf64>, %{{.*}} : memref<3x8xf64>) -> memref<3x8xf64> {
+// CHECK-NEXT:      %{{.*}} = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:      memref_stream.generic {bounds = [3, 2, 5, 4], indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2)>, affine_map<(d0, d1, d2, d3) -> (d2, ((d1 * 4) + d3))>, affine_map<(d0, d1, d2) -> (d0, ((d1 * 4) + d2))>], iterator_types = ["parallel", "parallel", "reduction", "interleaved"]} ins(%{{.*}}, %{{.*}} : memref<3x5xf64>, memref<5x8xf64>) outs(%{{.*}} : memref<3x8xf64>) inits(%{{.*}} : f64) {
+// CHECK-NEXT:      ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.mulf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        %{{.*}} = arith.addf %{{.*}}, %{{.*}} fastmath<fast> : f64
+// CHECK-NEXT:        memref_stream.yield %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : f64, f64, f64, f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      func.return %{{.*}} : memref<3x8xf64>
+// CHECK-NEXT:    }
+
+// CHECK-GENERIC-NEXT:    "func.func"() <{"sym_name" = "interleaved_init", "function_type" = (memref<3x5xf64>, memref<5x8xf64>, memref<3x8xf64>) -> memref<3x8xf64>}> ({
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : memref<3x5xf64>, %{{.*}} : memref<5x8xf64>, %{{.*}} : memref<3x8xf64>):
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.constant"() <{"value" = 0.000000e+00 : f64}> : () -> f64
+// CHECK-GENERIC-NEXT:      "memref_stream.generic"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"bounds" = [3 : index, 2 : index, 5 : index, 4 : index], "init_indices" = [#builtin.int<0>], "indexing_maps" = [affine_map<(d0, d1, d2, d3) -> (d0, d2)>, affine_map<(d0, d1, d2, d3) -> (d2, ((d1 * 4) + d3))>, affine_map<(d0, d1, d2) -> (d0, ((d1 * 4) + d2))>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<reduction>, #memref_stream.iterator_type<interleaved>], "operandSegmentSizes" = array<i32: 2, 1, 1>}> ({
+// CHECK-GENERIC-NEXT:      ^{{.*}}(%{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64, %{{.*}} : f64):
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{"fastmath" = #arith.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-GENERIC-NEXT:        "memref_stream.yield"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, f64, f64) -> ()
+// CHECK-GENERIC-NEXT:      }) : (memref<3x5xf64>, memref<5x8xf64>, memref<3x8xf64>, f64) -> ()
+// CHECK-GENERIC-NEXT:      "func.return"(%{{.*}}) : (memref<3x8xf64>) -> ()
+// CHECK-GENERIC-NEXT:    }) : () -> ()
+
 memref_stream.fill %C with %D : memref<3x2xf64>
 
 // CHECK-NEXT: memref_stream.fill %C with %D : memref<3x2xf64>

--- a/tests/filecheck/dialects/memref_stream/verify.mlir
+++ b/tests/filecheck/dialects/memref_stream/verify.mlir
@@ -27,6 +27,27 @@ memref_stream.generic {
     bounds = [4, 2, 3],
     indexing_maps = [
         affine_map<(d0, d1, d2) -> (d0, d1)>,
+        affine_map<(d0, d1, d2) -> (d1, d2)>,
+        affine_map<(d0, d1, d2) -> (d0, d2)>
+    ],
+    iterator_types = ["parallel", "interleaved", "reduction"]
+} ins(%A, %B : memref<4x2xf64>, memref<2x3xf64>) outs(%C : memref<4x3xf64>) {
+^0(%a : f64, %b : f64, %acc_old : f64):
+    %prod = arith.mulf %a, %b : f64
+    %acc_new = arith.addf %acc_old, %prod : f64
+    memref_stream.yield %acc_new : f64
+}
+
+// CHECK: Operation does not verify: Unexpected order of iterator types: ['parallel', 'interleaved', 'reduction']
+
+// -----
+
+%A, %B, %C = "test.op"() : () -> (memref<4x2xf64>, memref<2x3xf64>, memref<4x3xf64>)
+
+memref_stream.generic {
+    bounds = [4, 2, 3],
+    indexing_maps = [
+        affine_map<(d0, d1, d2) -> (d0, d1)>,
         affine_map<(d0, d1, d2) -> (d1, d2)>
     ],
     iterator_types = ["parallel", "parallel", "reduction"]

--- a/tests/interpreters/test_memref_stream_interpreter.py
+++ b/tests/interpreters/test_memref_stream_interpreter.py
@@ -1,3 +1,5 @@
+import pytest
+
 from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import arith, memref_stream
 from xdsl.dialects.builtin import (
@@ -276,3 +278,88 @@ def test_memref_stream_generic_reduction_with_initial_value():
         TypedPtr.new_float32([6.5, 7.5, 21.5, 16.5, 17.5, 47.5, 26.5, 27.5, 73.5]),
         [3, 3],
     )
+
+
+def test_memref_stream_interleaved_reduction_with_initial_value():
+    interpreter = Interpreter(ModuleOp([]))
+    interpreter.register_implementations(MemrefStreamFunctions())
+    interpreter.register_implementations(ArithFunctions())
+
+    f32 = Float32Type()
+
+    op = memref_stream.GenericOp(
+        (
+            TestSSAValue(MemRefType(f32, [3, 5])),
+            TestSSAValue(MemRefType(f32, [5, 8])),
+        ),
+        (TestSSAValue(MemRefType(f32, [3, 8])),),
+        (TestSSAValue(f32),),
+        Region(
+            Block(
+                arg_types=(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32)
+            )
+        ),
+        ArrayAttr(
+            (
+                AffineMapAttr(AffineMap.from_callable(lambda n, m, k, j: (n, k))),
+                AffineMapAttr(
+                    AffineMap.from_callable(lambda n, m, k, j: (k, m * 4 + j))
+                ),
+                AffineMapAttr(AffineMap.from_callable(lambda n, m, j: (n, m * 4 + j))),
+            )
+        ),
+        ArrayAttr(
+            (
+                memref_stream.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.parallel(),
+                memref_stream.IteratorTypeAttr.reduction(),
+                memref_stream.IteratorTypeAttr.interleaved(),
+            )
+        ),
+        ArrayAttr((index(3), index(2), index(5), index(4))),
+        ArrayAttr((IntAttr(0),)),
+    )
+
+    with ImplicitBuilder(op.body) as (
+        lhs0,
+        lhs1,
+        lhs2,
+        lhs3,
+        rhs0,
+        rhs1,
+        rhs2,
+        rhs3,
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+    ):
+        sum0 = arith.Mulf(lhs0, rhs0).result
+        sum1 = arith.Mulf(lhs1, rhs1).result
+        sum2 = arith.Mulf(lhs2, rhs2).result
+        sum3 = arith.Mulf(lhs3, rhs3).result
+        new_acc0 = arith.Addf(sum0, acc0).result
+        new_acc1 = arith.Addf(sum1, acc1).result
+        new_acc2 = arith.Addf(sum2, acc2).result
+        new_acc3 = arith.Addf(sum3, acc3).result
+        memref_stream.YieldOp(new_acc0, new_acc1, new_acc2, new_acc3)
+
+    op.verify()
+
+    a = ShapedArray(TypedPtr.new_float32([float(i) for i in range(3 * 5)]), [3, 5])
+    b = ShapedArray(
+        TypedPtr.new_float32([float(i) / 100 for i in range(5 * 8)]), [5, 8]
+    )
+    c = ShapedArray(TypedPtr.new_float32([-1000.0] * (3 * 5)), [3, 5])
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Interpreter for interleaved operations not yet implemented",
+    ):
+        interpreter.run_op(op, (a, b, c, 0.5))
+    # assert c == ShapedArray(
+    #     TypedPtr.new_float32([ 2.9 ,  3.  ,  3.1 ,  3.2 ,  3.3 ,  3.4 ,  3.5 ,  3.6 ,  6.9 ,
+    #     7.25,  7.6 ,  7.95,  8.3 ,  8.65,  9.  ,  9.35, 10.9 , 11.5 ,
+    #    12.1 , 12.7 , 13.3 , 13.9 , 14.5 , 15.1 ]),
+    #     [3, 3],
+    # )

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -58,6 +58,7 @@ class IteratorType(StrEnum):
 
     PARALLEL = auto()
     REDUCTION = auto()
+    INTERLEAVED = auto()
 
 
 @irdl_attr_definition
@@ -71,6 +72,10 @@ class IteratorTypeAttr(EnumAttribute[IteratorType]):
     @classmethod
     def reduction(cls) -> IteratorTypeAttr:
         return IteratorTypeAttr(IteratorType.REDUCTION)
+
+    @classmethod
+    def interleaved(cls) -> IteratorTypeAttr:
+        return IteratorTypeAttr(IteratorType.INTERLEAVED)
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> IteratorType:
@@ -641,10 +646,21 @@ class GenericOp(IRDLOperation):
         # Parallel iterator types must preceed reduction iterators
         iterator_types = self.iterator_types.data
         num_parallel = iterator_types.count(IteratorTypeAttr.parallel())
+        num_reduction = iterator_types.count(IteratorTypeAttr.reduction())
+        num_interleaved = iterator_types.count(IteratorTypeAttr.interleaved())
+
         if IteratorTypeAttr.parallel() in iterator_types[num_parallel:]:
             raise VerifyException(
                 f"Unexpected order of iterator types: {[it.data.value for it in iterator_types]}"
             )
+        if (
+            IteratorTypeAttr.reduction()
+            in iterator_types[num_parallel + num_reduction :]
+        ):
+            raise VerifyException(
+                f"Unexpected order of iterator types: {[it.data.value for it in iterator_types]}"
+            )
+        assert num_parallel + num_reduction + num_interleaved == len(iterator_types)
 
         if len(self.inputs) + len(self.outputs) != len(self.indexing_maps):
             raise VerifyException(
@@ -673,13 +689,13 @@ class GenericOp(IRDLOperation):
                 "The number of dims in output indexing maps must all be the same"
             )
 
-        if min_dims not in (len(iterator_types), num_parallel):
+        if min_dims not in (len(iterator_types), num_parallel + num_interleaved):
             # To signify that the output is imperfectly nested, the output affine map has
             # as many dims as parallel iterators. Otherwise, it has as many dims as
             # the total number of iterators.
             raise VerifyException(
                 "The number of dims in output indexing maps must be "
-                f"{len(iterator_types)} or {num_parallel}"
+                f"{len(iterator_types)} or {num_parallel + num_interleaved}"
             )
 
         if len(self.init_indices) != len(self.inits):
@@ -696,7 +712,7 @@ class GenericOp(IRDLOperation):
             if not (0 <= index.data <= num_outputs):
                 raise VerifyException(f"Init index out of bounds: {index.data}")
             m = output_maps[index.data]
-            if m.data.num_dims != num_parallel:
+            if m.data.num_dims != (num_parallel + num_interleaved):
                 raise VerifyException(
                     "Incompatible affine map and initial value for output at index "
                     f"{index}"

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -57,8 +57,24 @@ class IteratorType(StrEnum):
     "Iterator type for memref_stream Attribute"
 
     PARALLEL = auto()
+    """
+    The corresponding iterators appear in the output.
+    """
     REDUCTION = auto()
+    """
+    The corresponding iterators do not appear in the output.
+    """
     INTERLEAVED = auto()
+    """
+    All inputs and outputs of the operation will be operated this many times in parallel.
+    This is helpful to circumvent the latency in the loop.
+    For example, if the ALU of the target has a pipeline of length 4, and the operation
+    accumulates its innermost dimension, there will be stalls waiting fof the pipeline to
+    clear in each iteration.
+    By interleaving the loop with a factor of 4, four dimensions can be processed in
+    parallel, removing the stalls.
+    The corresponding iterators may appear in the output.
+    """
 
 
 @irdl_attr_definition

--- a/xdsl/interpreters/memref_stream.py
+++ b/xdsl/interpreters/memref_stream.py
@@ -24,6 +24,11 @@ class MemrefStreamFunctions(InterpreterFunctions):
         args: tuple[Any, ...],
     ) -> PythonValues:
 
+        if memref_stream.IteratorTypeAttr.interleaved() in op.iterator_types:
+            raise NotImplementedError(
+                "Interpreter for interleaved operations not yet implemented"
+            )
+
         inputs_count = len(op.inputs)
         outputs_count = len(op.outputs)
 

--- a/xdsl/transforms/convert_memref_stream_to_loops.py
+++ b/xdsl/transforms/convert_memref_stream_to_loops.py
@@ -18,6 +18,7 @@ from xdsl.transforms.loop_nest_lowering_utils import (
     rewrite_generic_to_imperfect_loops,
     rewrite_generic_to_loops,
 )
+from xdsl.utils.exceptions import DiagnosticException
 
 
 def _insert_load(
@@ -65,6 +66,8 @@ class LowerGenericOpPattern(RewritePattern):
     def match_and_rewrite(
         self, op: memref_stream.GenericOp, rewriter: PatternRewriter
     ) -> None:
+        if memref_stream.IteratorTypeAttr.interleaved() in op.iterator_types:
+            raise DiagnosticException("Cannot yet lower interleaved iterators")
         ins_count = len(op.inputs)
         if any(not isinstance(init, UnitAttr) for init in op.inits):
             constant_vals: list[SSAValue | None] = [None] * len(op.outputs)

--- a/xdsl/transforms/memref_streamify.py
+++ b/xdsl/transforms/memref_streamify.py
@@ -63,16 +63,34 @@ class StreamifyGenericOpPattern(RewritePattern):
             stream.WritableStreamType(el_type) for el_type in output_el_types
         )
 
-        patterns = ArrayAttr(
-            tuple(
-                memref_stream.StridePattern(
-                    ArrayAttr(op.bounds.data[: indexing_map.data.num_dims]),
-                    indexing_map,
-                )
-                for index, _ in streamed_operand_indices
-                if (indexing_map := op.indexing_maps.data[index])
+        # input patterns are never unnested
+        input_patterns = tuple(
+            memref_stream.StridePattern(
+                op.bounds,
+                indexing_map,
             )
+            for index, _ in streamable_input_indices
+            if (indexing_map := op.indexing_maps.data[index])
         )
+        # output patterns never contain iteration dimensions
+        output_patterns = tuple(
+            memref_stream.StridePattern(
+                ArrayAttr(
+                    tuple(
+                        bound
+                        for iterator_type, bound in zip(
+                            op.iterator_types, op.bounds.data
+                        )
+                        if iterator_type.data != memref_stream.IteratorType.REDUCTION
+                    )
+                ),
+                indexing_map,
+            )
+            for output_index, _ in streamed_output_indices
+            if (indexing_map := op.indexing_maps.data[output_index + input_count])
+        )
+
+        patterns = ArrayAttr(input_patterns + output_patterns)
         rewriter.insert_op_before_matched_op(
             streaming_region_op := memref_stream.StreamingRegionOp(
                 tuple(op.inputs[index] for index, _ in streamed_input_indices),


### PR DESCRIPTION
The way this is modeled is with a region already interleaved. This should simplify the lowering to loops, as the region won't need to be modified, and we can 