### PR TITLE
ir: Add forward slash ('/') to lexer

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -53,13 +53,14 @@ def assert_token_fail(input: str):
         ("|", Token.Kind.VERTICAL_BAR),
         ("{-#", Token.Kind.FILE_METADATA_BEGIN),
         ("#-}", Token.Kind.FILE_METADATA_END),
+        ("/", Token.Kind.FORWARD_SLASH),
     ],
 )
 def test_punctuation(text: str, kind: Token.Kind):
     assert_single_token(text, kind)
 
 
-@pytest.mark.parametrize("text", [".", "&", "/"])
+@pytest.mark.parametrize("text", [".", "&"])
 def test_punctuation_fail(text: str):
     assert_token_fail(text)
 

--- a/xdsl/utils/lexer.py
+++ b/xdsl/utils/lexer.py
@@ -249,6 +249,7 @@ class Token:
         VERTICAL_BAR = "|"
         FILE_METADATA_BEGIN = "{-#"
         FILE_METADATA_END = "#-}"
+        FORWARD_SLASH = "/"
 
         @staticmethod
         def get_punctuation_spelling_to_kind_dict() -> dict[str, Token.Kind]:
@@ -273,6 +274,7 @@ class Token:
                 "|": Token.Kind.VERTICAL_BAR,
                 "{-#": Token.Kind.FILE_METADATA_BEGIN,
                 "#-}": Token.Kind.FILE_METADATA_END,
+                "/": Token.Kind.FORWARD_SLASH,
             }
 
         def is_punctuation(self) -> bool:
@@ -317,6 +319,7 @@ class Token:
         "|",
         "{-#",
         "#-}",
+        "/",
     ]
 
     kind: Kind
@@ -460,6 +463,7 @@ class Lexer:
             "*": Token.Kind.STAR,
             "?": Token.Kind.QUESTION,
             "|": Token.Kind.VERTICAL_BAR,
+            "/": Token.Kind.FORWARD_SLASH,
         }
         if current_char in single_char_punctuation:
             return self._form_token(single_char_punctuation[current_char], start_pos)


### PR DESCRIPTION
Adds a forward slash token to the lexer. Mlir seems to accept this as a token so there seems little reason not to accept in in xdsl too (unless someone has a good reason not to). 

It's possible there are other missing tokens so if someone knows the appropriate place to look in mlir to see all the punctuation then I'd be happy to add more.


