### PR TITLE
dialects: add parametrised rz gate

### DIFF
--- a/tests/filecheck/dialects/qref/ops.mlir
+++ b/tests/filecheck/dialects/qref/ops.mlir
@@ -9,13 +9,13 @@ qref.h %q0
 
 // CHECK-NEXT: qref.h %q0
 
-qref.cz %q1, %q0
+qref.rz <pi/2> %q1
 
-// CHECK-NEXT: qref.cz %q1, %q0
+// CHECK-NEXT: qref.rz <pi/2> %q1
 
-qref.cnot %q1, %q0
+qref.cnot %q0, %q1
 
-// CHECK-NEXT: qref.cnot %q1, %q0
+// CHECK-NEXT: qref.cnot %q0, %q1
 
 %0 = qref.measure %q0
 
@@ -23,6 +23,6 @@ qref.cnot %q1, %q0
 
 // CHECK-GENERIC: %q0, %q1 = "qref.alloc"() : () -> (!qref.qubit, !qref.qubit)
 // CHECK-GENERIC-NEXT: "qref.h"(%q0) : (!qref.qubit) -> ()
-// CHECK-GENERIC-NEXT: "qref.cz"(%q1, %q0) : (!qref.qubit, !qref.qubit) -> ()
-// CHECK-GENERIC-NEXT: "qref.cnot"(%q1, %q0) : (!qref.qubit, !qref.qubit) -> ()
+// CHECK-GENERIC-NEXT: "qref.rz"(%q1) <{"angle" = !quantum.angle<pi/2>}> : (!qref.qubit) -> ()
+// CHECK-GENERIC-NEXT: "qref.cnot"(%q0, %q1) : (!qref.qubit, !qref.qubit) -> ()
 // CHECK-GENERIC-NEXT: %0 = "qref.measure"(%q0) : (!qref.qubit) -> i1

--- a/tests/filecheck/dialects/qref/ops.mlir
+++ b/tests/filecheck/dialects/qref/ops.mlir
@@ -9,9 +9,9 @@ qref.h %q0
 
 // CHECK-NEXT: qref.h %q0
 
-qref.rz <pi/2> %q1
+qref.rz <pi:2> %q1
 
-// CHECK-NEXT: qref.rz <pi/2> %q1
+// CHECK-NEXT: qref.rz <pi:2> %q1
 
 qref.cnot %q0, %q1
 
@@ -23,6 +23,6 @@ qref.cnot %q0, %q1
 
 // CHECK-GENERIC: %q0, %q1 = "qref.alloc"() : () -> (!qref.qubit, !qref.qubit)
 // CHECK-GENERIC-NEXT: "qref.h"(%q0) : (!qref.qubit) -> ()
-// CHECK-GENERIC-NEXT: "qref.rz"(%q1) <{"angle" = !quantum.angle<pi/2>}> : (!qref.qubit) -> ()
+// CHECK-GENERIC-NEXT: "qref.rz"(%q1) <{"angle" = !quantum.angle<pi:2>}> : (!qref.qubit) -> ()
 // CHECK-GENERIC-NEXT: "qref.cnot"(%q0, %q1) : (!qref.qubit, !qref.qubit) -> ()
 // CHECK-GENERIC-NEXT: %0 = "qref.measure"(%q0) : (!qref.qubit) -> i1

--- a/tests/filecheck/dialects/qssa/ops.mlir
+++ b/tests/filecheck/dialects/qssa/ops.mlir
@@ -9,20 +9,20 @@
 
 // CHECK-NEXT: %q2 = qssa.h %q0
 
-%q3, %q4 = qssa.cz %q1, %q2
+%q3 = qssa.rz <pi/2> %q1
 
-// CHECK-NEXT: %q3, %q4 = qssa.cz %q1, %q2
+// CHECK-NEXT: %q3 = qssa.rz <pi/2> %q1
 
-%q5, %q6 = qssa.cnot %q3, %q4
+%q4, %q5 = qssa.cnot %q2, %q3
 
-// CHECK-NEXT: %q5, %q6 = qssa.cnot %q3, %q4
+// CHECK-NEXT: %q4, %q5 = qssa.cnot %q2, %q3
 
-%0 = qssa.measure %q6
+%0 = qssa.measure %q4
 
-// CHECK-NEXT: %0 = qssa.measure %q6
+// CHECK-NEXT: %0 = qssa.measure %q4
 
 // CHECK-GENERIC: %q0, %q1 = "qssa.alloc"() : () -> (!qssa.qubit, !qssa.qubit)
 // CHECK-GENERIC-NEXT: %q2 = "qssa.h"(%q0) : (!qssa.qubit) -> !qssa.qubit
-// CHECK-GENERIC-NEXT: %q3, %q4 = "qssa.cz"(%q1, %q2) : (!qssa.qubit, !qssa.qubit) -> (!qssa.qubit, !qssa.qubit)
-// CHECK-GENERIC-NEXT: %q5, %q6 = "qssa.cnot"(%q3, %q4) : (!qssa.qubit, !qssa.qubit) -> (!qssa.qubit, !qssa.qubit)
-// CHECK-GENERIC-NEXT: %0 = "qssa.measure"(%q6) : (!qssa.qubit) -> i1
+// CHECK-GENERIC-NEXT: %q3 = "qssa.rz"(%q1) <{"angle" = !quantum.angle<pi/2>}> : (!qssa.qubit) -> !qssa.qubit
+// CHECK-GENERIC-NEXT: %q4, %q5 = "qssa.cnot"(%q2, %q3) : (!qssa.qubit, !qssa.qubit) -> (!qssa.qubit, !qssa.qubit)
+// CHECK-GENERIC-NEXT: %0 = "qssa.measure"(%q4) : (!qssa.qubit) -> i1

--- a/tests/filecheck/dialects/qssa/ops.mlir
+++ b/tests/filecheck/dialects/qssa/ops.mlir
@@ -9,9 +9,9 @@
 
 // CHECK-NEXT: %q2 = qssa.h %q0
 
-%q3 = qssa.rz <pi/2> %q1
+%q3 = qssa.rz <pi:2> %q1
 
-// CHECK-NEXT: %q3 = qssa.rz <pi/2> %q1
+// CHECK-NEXT: %q3 = qssa.rz <pi:2> %q1
 
 %q4, %q5 = qssa.cnot %q2, %q3
 
@@ -23,6 +23,6 @@
 
 // CHECK-GENERIC: %q0, %q1 = "qssa.alloc"() : () -> (!qssa.qubit, !qssa.qubit)
 // CHECK-GENERIC-NEXT: %q2 = "qssa.h"(%q0) : (!qssa.qubit) -> !qssa.qubit
-// CHECK-GENERIC-NEXT: %q3 = "qssa.rz"(%q1) <{"angle" = !quantum.angle<pi/2>}> : (!qssa.qubit) -> !qssa.qubit
+// CHECK-GENERIC-NEXT: %q3 = "qssa.rz"(%q1) <{"angle" = !quantum.angle<pi:2>}> : (!qssa.qubit) -> !qssa.qubit
 // CHECK-GENERIC-NEXT: %q4, %q5 = "qssa.cnot"(%q2, %q3) : (!qssa.qubit, !qssa.qubit) -> (!qssa.qubit, !qssa.qubit)
 // CHECK-GENERIC-NEXT: %0 = "qssa.measure"(%q4) : (!qssa.qubit) -> i1

--- a/tests/filecheck/dialects/quantum/attrs.mlir
+++ b/tests/filecheck/dialects/quantum/attrs.mlir
@@ -1,0 +1,22 @@
+// RUN: XDSL_ROUNDTRIP
+
+"test.op"() {"angle" = !quantum.angle<0>} : () -> ()
+
+// CHECK: "test.op"() {"angle" = !quantum.angle<0>} : () -> ()
+
+"test.op"() {"angle" = !quantum.angle<pi>} : () -> ()
+
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi>} : () -> ()
+
+"test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()
+
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()
+
+"test.op"() {"angle" = !quantum.angle<3pi/2>} : () -> ()
+
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<3pi/2>} : () -> ()
+
+"test.op"() {"angle" = !quantum.angle<5pi/2>} : () -> ()
+
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()
+

--- a/tests/filecheck/dialects/quantum/attrs.mlir
+++ b/tests/filecheck/dialects/quantum/attrs.mlir
@@ -24,3 +24,7 @@
 
 // CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi:2>} : () -> ()
 
+"test.op"() {"angle" = !quantum.angle<-pi>} : () -> ()
+
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi>} : () -> ()
+

--- a/tests/filecheck/dialects/quantum/attrs.mlir
+++ b/tests/filecheck/dialects/quantum/attrs.mlir
@@ -12,15 +12,15 @@
 
 // CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<0>} : () -> ()
 
-"test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()
+"test.op"() {"angle" = !quantum.angle<pi:2>} : () -> ()
 
-// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi:2>} : () -> ()
 
-"test.op"() {"angle" = !quantum.angle<3pi/2>} : () -> ()
+"test.op"() {"angle" = !quantum.angle<3pi:2>} : () -> ()
 
-// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<3pi/2>} : () -> ()
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<3pi:2>} : () -> ()
 
-"test.op"() {"angle" = !quantum.angle<5pi/2>} : () -> ()
+"test.op"() {"angle" = !quantum.angle<5pi:2>} : () -> ()
 
-// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi:2>} : () -> ()
 

--- a/tests/filecheck/dialects/quantum/attrs.mlir
+++ b/tests/filecheck/dialects/quantum/attrs.mlir
@@ -8,6 +8,10 @@
 
 // CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi>} : () -> ()
 
+"test.op"() {"angle" = !quantum.angle<2pi>} : () -> ()
+
+// CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<0>} : () -> ()
+
 "test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()
 
 // CHECK-NEXT: "test.op"() {"angle" = !quantum.angle<pi/2>} : () -> ()

--- a/tests/filecheck/transforms/convert_qref_to_qssa.mlir
+++ b/tests/filecheck/transforms/convert_qref_to_qssa.mlir
@@ -3,23 +3,23 @@
 
 %q0, %q1 = qref.alloc<2>
 qref.h %q0
-qref.cz %q1, %q0
-qref.cnot %q1, %q0
+qref.rz <pi/2> %q1
+qref.cnot %q0, %q1
 %0 = qref.measure %q0
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %q0, %q1 = qssa.alloc<2>
 // CHECK-NEXT:    %q0_1 = qssa.h %q0
-// CHECK-NEXT:    %q1_1, %q0_2 = qssa.cz %q1, %q0_1
-// CHECK-NEXT:    %q1_2, %q0_3 = qssa.cnot %q1_1, %q0_2
-// CHECK-NEXT:    %0 = qssa.measure %q0_3
+// CHECK-NEXT:    %q1_1 = qssa.rz <pi/2> %q1
+// CHECK-NEXT:    %q0_2, %q1_2 = qssa.cnot %q0_1, %q1_1
+// CHECK-NEXT:    %0 = qssa.measure %q0_2
 // CHECK-NEXT:  }
 
 // CHECK-ROUNDTRIP:       builtin.module {
 // CHECK-ROUNDTRIP-NEXT:    %q0, %q1 = qref.alloc<2>
 // CHECK-ROUNDTRIP-NEXT:    qref.h %q0
-// CHECK-ROUNDTRIP-NEXT:    qref.cz %q1, %q0
-// CHECK-ROUNDTRIP-NEXT:    qref.cnot %q1, %q0
+// CHECK-ROUNDTRIP-NEXT:    qref.rz <pi/2> %q1
+// CHECK-ROUNDTRIP-NEXT:    qref.cnot %q0, %q1
 // CHECK-ROUNDTRIP-NEXT:    %0 = qref.measure %q0
 // CHECK-ROUNDTRIP-NEXT:  }
 

--- a/tests/filecheck/transforms/convert_qref_to_qssa.mlir
+++ b/tests/filecheck/transforms/convert_qref_to_qssa.mlir
@@ -3,14 +3,14 @@
 
 %q0, %q1 = qref.alloc<2>
 qref.h %q0
-qref.rz <pi/2> %q1
+qref.rz <pi:2> %q1
 qref.cnot %q0, %q1
 %0 = qref.measure %q0
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %q0, %q1 = qssa.alloc<2>
 // CHECK-NEXT:    %q0_1 = qssa.h %q0
-// CHECK-NEXT:    %q1_1 = qssa.rz <pi/2> %q1
+// CHECK-NEXT:    %q1_1 = qssa.rz <pi:2> %q1
 // CHECK-NEXT:    %q0_2, %q1_2 = qssa.cnot %q0_1, %q1_1
 // CHECK-NEXT:    %0 = qssa.measure %q0_2
 // CHECK-NEXT:  }
@@ -18,7 +18,7 @@ qref.cnot %q0, %q1
 // CHECK-ROUNDTRIP:       builtin.module {
 // CHECK-ROUNDTRIP-NEXT:    %q0, %q1 = qref.alloc<2>
 // CHECK-ROUNDTRIP-NEXT:    qref.h %q0
-// CHECK-ROUNDTRIP-NEXT:    qref.rz <pi/2> %q1
+// CHECK-ROUNDTRIP-NEXT:    qref.rz <pi:2> %q1
 // CHECK-ROUNDTRIP-NEXT:    qref.cnot %q0, %q1
 // CHECK-ROUNDTRIP-NEXT:    %0 = qref.measure %q0
 // CHECK-ROUNDTRIP-NEXT:  }

--- a/tests/filecheck/transforms/convert_qssa_to_qref.mlir
+++ b/tests/filecheck/transforms/convert_qssa_to_qref.mlir
@@ -3,14 +3,14 @@
 
 %q0, %q1 = qssa.alloc<2>
 %q2 = qssa.h %q0
-%q3 = qssa.rz <pi/2> %q1
+%q3 = qssa.rz <pi:2> %q1
 %q4, %q5 = qssa.cnot %q2, %q3
 %0 = qssa.measure %q4
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %q0, %q1 = qref.alloc<2>
 // CHECK-NEXT:    qref.h %q0
-// CHECK-NEXT:    qref.rz <pi/2> %q1
+// CHECK-NEXT:    qref.rz <pi:2> %q1
 // CHECK-NEXT:    qref.cnot %q0, %q1
 // CHECK-NEXT:    %0 = qref.measure %q0
 // CHECK-NEXT:  }
@@ -18,7 +18,7 @@
 // CHECK-ROUNDTRIP:       builtin.module {
 // CHECK-ROUNDTRIP-NEXT:    %q0, %q1 = qssa.alloc<2>
 // CHECK-ROUNDTRIP-NEXT:    %q0_1 = qssa.h %q0
-// CHECK-ROUNDTRIP-NEXT:    %q1_1 = qssa.rz <pi/2> %q1
+// CHECK-ROUNDTRIP-NEXT:    %q1_1 = qssa.rz <pi:2> %q1
 // CHECK-ROUNDTRIP-NEXT:    %q0_2, %q1_2 = qssa.cnot %q0_1, %q1_1
 // CHECK-ROUNDTRIP-NEXT:    %0 = qssa.measure %q0_2
 // CHECK-ROUNDTRIP-NEXT:  }

--- a/tests/filecheck/transforms/convert_qssa_to_qref.mlir
+++ b/tests/filecheck/transforms/convert_qssa_to_qref.mlir
@@ -3,23 +3,23 @@
 
 %q0, %q1 = qssa.alloc<2>
 %q2 = qssa.h %q0
-%q3, %q4 = qssa.cz %q1, %q2
-%q5, %q6 = qssa.cnot %q3, %q4
-%0 = qssa.measure %q6
+%q3 = qssa.rz <pi/2> %q1
+%q4, %q5 = qssa.cnot %q2, %q3
+%0 = qssa.measure %q4
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %q0, %q1 = qref.alloc<2>
 // CHECK-NEXT:    qref.h %q0
-// CHECK-NEXT:    qref.cz %q1, %q0
-// CHECK-NEXT:    qref.cnot %q1, %q0
+// CHECK-NEXT:    qref.rz <pi/2> %q1
+// CHECK-NEXT:    qref.cnot %q0, %q1
 // CHECK-NEXT:    %0 = qref.measure %q0
 // CHECK-NEXT:  }
 
 // CHECK-ROUNDTRIP:       builtin.module {
 // CHECK-ROUNDTRIP-NEXT:    %q0, %q1 = qssa.alloc<2>
 // CHECK-ROUNDTRIP-NEXT:    %q0_1 = qssa.h %q0
-// CHECK-ROUNDTRIP-NEXT:    %q1_1, %q0_2 = qssa.cz %q1, %q0_1
-// CHECK-ROUNDTRIP-NEXT:    %q1_2, %q0_3 = qssa.cnot %q1_1, %q0_2
-// CHECK-ROUNDTRIP-NEXT:    %0 = qssa.measure %q0_3
+// CHECK-ROUNDTRIP-NEXT:    %q1_1 = qssa.rz <pi/2> %q1
+// CHECK-ROUNDTRIP-NEXT:    %q0_2, %q1_2 = qssa.cnot %q0_1, %q1_1
+// CHECK-ROUNDTRIP-NEXT:    %0 = qssa.measure %q0_2
 // CHECK-ROUNDTRIP-NEXT:  }
 

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -171,6 +171,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return Printf
 
+    def get_quantum():
+        from xdsl.dialects.quantum import QUANTUM
+
+        return QUANTUM
+
     def get_qref():
         from xdsl.dialects.qref import QREF
 
@@ -315,6 +320,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "onnx": get_onnx,
         "pdl": get_pdl,
         "printf": get_printf,
+        "quantum": get_quantum,
         "qref": get_qref,
         "qssa": get_qssa,
         "riscv": get_riscv,

--- a/xdsl/dialects/qref.py
+++ b/xdsl/dialects/qref.py
@@ -166,10 +166,9 @@ class RZGateOp(QRefBase):
 
     assembly_format = "$angle $input attr-dict"
 
-    def __init__(self, input: SSAValue):
+    def __init__(self, angle: AngleAttr, input: SSAValue):
         super().__init__(
-            operands=(input,),
-            result_types=(),
+            operands=(input,), result_types=(), properties={"angle": angle}
         )
 
     def ssa_op(self) -> qssa.RZGateOp:

--- a/xdsl/dialects/qref.py
+++ b/xdsl/dialects/qref.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 
 from xdsl.dialects import qssa
 from xdsl.dialects.builtin import IntegerType
+from xdsl.dialects.quantum import AngleAttr
 from xdsl.ir import Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
@@ -11,6 +12,7 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
+    prop_def,
     result_def,
     var_result_def,
 )
@@ -155,26 +157,27 @@ class CNotGateOp(QRefBase):
 
 
 @irdl_op_definition
-class CZGateOp(QRefBase):
-    name = "qref.cz"
+class RZGateOp(QRefBase):
+    name = "qref.rz"
 
-    in1 = operand_def(qubit)
+    input = operand_def(qubit)
 
-    in2 = operand_def(qubit)
+    angle = prop_def(AngleAttr)
 
-    assembly_format = "$in1 `,` $in2 attr-dict"
+    assembly_format = "$angle $input attr-dict"
 
-    def __init__(self, in1: SSAValue, in2: SSAValue):
+    def __init__(self, input: SSAValue):
         super().__init__(
-            operands=(in1, in2),
+            operands=(input,),
             result_types=(),
         )
 
-    def ssa_op(self) -> qssa.CZGateOp:
-        return qssa.CZGateOp.create(
+    def ssa_op(self) -> qssa.RZGateOp:
+        return qssa.RZGateOp.create(
             operands=self.operands,
-            result_types=(qssa.qubit, qssa.qubit),
+            result_types=(qssa.qubit,),
             attributes=self.attributes,
+            properties=self.properties,
         )
 
     @property
@@ -214,7 +217,7 @@ QREF = Dialect(
     "qref",
     [
         CNotGateOp,
-        CZGateOp,
+        RZGateOp,
         HGateOp,
         MeasureOp,
         QRefAllocOp,

--- a/xdsl/dialects/qssa.py
+++ b/xdsl/dialects/qssa.py
@@ -174,10 +174,11 @@ class RZGateOp(QssaBase):
 
     assembly_format = "$angle $input attr-dict"
 
-    def __init__(self, input: SSAValue):
+    def __init__(self, angle: AngleAttr, input: SSAValue):
         super().__init__(
             operands=(input,),
             result_types=(qubit,),
+            properties={"angle": angle},
         )
 
     def ref_op(self) -> qref.RZGateOp:

--- a/xdsl/dialects/qssa.py
+++ b/xdsl/dialects/qssa.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 
 from xdsl.dialects import qref
 from xdsl.dialects.builtin import IntegerType
+from xdsl.dialects.quantum import AngleAttr
 from xdsl.ir import Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
@@ -11,6 +12,7 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
+    prop_def,
     result_def,
     var_result_def,
 )
@@ -161,30 +163,29 @@ class CNotGateOp(QssaBase):
 
 
 @irdl_op_definition
-class CZGateOp(QssaBase):
-    name = "qssa.cz"
+class RZGateOp(QssaBase):
+    name = "qssa.rz"
 
-    in1 = operand_def(qubit)
+    input = operand_def(qubit)
 
-    in2 = operand_def(qubit)
+    output = result_def(qubit)
 
-    out1 = result_def(qubit)
+    angle = prop_def(AngleAttr)
 
-    out2 = result_def(qubit)
+    assembly_format = "$angle $input attr-dict"
 
-    assembly_format = "$in1 `,` $in2 attr-dict"
-
-    def __init__(self, in1: SSAValue, in2: SSAValue):
+    def __init__(self, input: SSAValue):
         super().__init__(
-            operands=(in1, in2),
-            result_types=(qubit, qubit),
+            operands=(input,),
+            result_types=(qubit,),
         )
 
-    def ref_op(self) -> qref.CZGateOp:
-        return qref.CZGateOp.create(
+    def ref_op(self) -> qref.RZGateOp:
+        return qref.RZGateOp.create(
             operands=self.operands,
             result_types=(),
             attributes=self.attributes,
+            properties=self.properties,
         )
 
     @property
@@ -224,7 +225,7 @@ QSSA = Dialect(
     "qssa",
     [
         CNotGateOp,
-        CZGateOp,
+        RZGateOp,
         HGateOp,
         MeasureOp,
         QubitAllocOp,

--- a/xdsl/dialects/quantum.py
+++ b/xdsl/dialects/quantum.py
@@ -17,6 +17,10 @@ class AngleAttr(Data[Fraction], TypeAttribute):
     name = "quantum.angle"
 
     @classmethod
+    def from_fraction(cls, numerator: int, denominator: int = 1) -> AngleAttr:
+        return AngleAttr(Fraction(numerator, denominator) % 2)
+
+    @classmethod
     def parse_parameter(cls, parser: AttrParser) -> Fraction:
         with parser.in_angle_brackets():
             i = parser.parse_optional_integer()
@@ -42,11 +46,14 @@ class AngleAttr(Data[Fraction], TypeAttribute):
             if self.data.denominator != 1:
                 printer.print(":", self.data.denominator)
 
-    def __add__(self, other: AngleAttr):
-        AngleAttr.new([(self.data + other.data) % 2])
+    def __add__(self, other: AngleAttr) -> AngleAttr:
+        return AngleAttr.new((self.data + other.data) % 2)
 
-    def __sub__(self, other: AngleAttr):
-        AngleAttr.new([(self.data - other.data) % 2])
+    def __sub__(self, other: AngleAttr) -> AngleAttr:
+        return AngleAttr.new((self.data - other.data) % 2)
+
+    def __neg__(self) -> AngleAttr:
+        return AngleAttr.new(-self.data % 2)
 
 
 QUANTUM = Dialect(

--- a/xdsl/dialects/quantum.py
+++ b/xdsl/dialects/quantum.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from xdsl.ir import Data, TypeAttribute
-from xdsl.ir.core import Dialect
-from xdsl.irdl.attributes import irdl_attr_definition
-from xdsl.parser.attribute_parser import AttrParser
+
+from xdsl.ir import Data, Dialect, TypeAttribute
+from xdsl.irdl import irdl_attr_definition
+from xdsl.parser import AttrParser
 from xdsl.printer import Printer
 
 
@@ -13,6 +13,7 @@ class AngleAttr(Data[Fraction], TypeAttribute):
     """
     Attribute that wraps around a fraction, implicitly multiplying by pi and keeping the result in the range [0,2pi)
     """
+
     name = "quantum.angle"
 
     @classmethod
@@ -21,10 +22,12 @@ class AngleAttr(Data[Fraction], TypeAttribute):
             i = parser.parse_optional_integer()
             numerator = 1 if i is None else i
             if numerator == 0:
-                return Fraction(0,1)
-            parser.parse_characters('pi')
-            denominator = parser.parse_integer() if parser.parse_optional_characters('/') else 1
-            return Fraction(numerator,denominator) % 2
+                return Fraction(0, 1)
+            parser.parse_characters("pi")
+            denominator = (
+                parser.parse_integer() if parser.parse_optional_characters("/") else 1
+            )
+            return Fraction(numerator, denominator) % 2
 
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
@@ -35,12 +38,10 @@ class AngleAttr(Data[Fraction], TypeAttribute):
             if self.data.numerator != 1:
                 printer.print(self.data.numerator)
 
-            printer.print('pi')
+            printer.print("pi")
             if self.data.denominator != 1:
-                printer.print('/')
+                printer.print("/")
                 printer.print(self.data.denominator)
-
-
 
     def __add__(self, other: AngleAttr):
         AngleAttr.new([(self.data + other.data) % 2])

--- a/xdsl/dialects/quantum.py
+++ b/xdsl/dialects/quantum.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from fractions import Fraction
+from xdsl.ir import Data, TypeAttribute
+from xdsl.ir.core import Dialect
+from xdsl.irdl.attributes import irdl_attr_definition
+from xdsl.parser.attribute_parser import AttrParser
+from xdsl.printer import Printer
+
+
+@irdl_attr_definition
+class AngleAttr(Data[Fraction], TypeAttribute):
+    """
+    Attribute that wraps around a fraction, implicitly multiplying by pi and keeping the result in the range [0,2pi)
+    """
+    name = "quantum.angle"
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> Fraction:
+        with parser.in_angle_brackets():
+            i = parser.parse_optional_integer()
+            numerator = 1 if i is None else i
+            if numerator == 0:
+                return Fraction(0,1)
+            parser.parse_characters('pi')
+            denominator = parser.parse_integer() if parser.parse_optional_characters('/') else 1
+            return Fraction(numerator,denominator) % 2
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            if self.data == 0:
+                printer.print(0)
+                return
+
+            if self.data.numerator != 1:
+                printer.print(self.data.numerator)
+
+            printer.print('pi')
+            if self.data.denominator != 1:
+                printer.print('/')
+                printer.print(self.data.denominator)
+
+
+
+    def __add__(self, other: AngleAttr):
+        AngleAttr.new([(self.data + other.data) % 2])
+
+    def __sub__(self, other: AngleAttr):
+        AngleAttr.new([(self.data - other.data) % 2])
+
+
+QUANTUM = Dialect(
+    "quantum",
+    [],
+    [AngleAttr],
+)

--- a/xdsl/dialects/quantum.py
+++ b/xdsl/dialects/quantum.py
@@ -23,10 +23,16 @@ class AngleAttr(Data[Fraction], TypeAttribute):
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> Fraction:
         with parser.in_angle_brackets():
-            i = parser.parse_optional_integer()
-            numerator = 1 if i is None else i
+            negate = -1 if parser.parse_optional_punctuation("-") else 1
+
+            numerator = parser.parse_optional_integer()
+            if numerator is None:
+                numerator = 1
+            numerator = numerator * negate
+
             if numerator == 0:
                 return Fraction(0, 1)
+
             parser.parse_characters("pi")
             denominator = (
                 parser.parse_integer() if parser.parse_optional_punctuation(":") else 1

--- a/xdsl/dialects/quantum.py
+++ b/xdsl/dialects/quantum.py
@@ -40,8 +40,7 @@ class AngleAttr(Data[Fraction], TypeAttribute):
 
             printer.print("pi")
             if self.data.denominator != 1:
-                printer.print(":")
-                printer.print(self.data.denominator)
+                printer.print(":", self.data.denominator)
 
     def __add__(self, other: AngleAttr):
         AngleAttr.new([(self.data + other.data) % 2])

--- a/xdsl/dialects/quantum.py
+++ b/xdsl/dialects/quantum.py
@@ -25,7 +25,7 @@ class AngleAttr(Data[Fraction], TypeAttribute):
                 return Fraction(0, 1)
             parser.parse_characters("pi")
             denominator = (
-                parser.parse_integer() if parser.parse_optional_characters("/") else 1
+                parser.parse_integer() if parser.parse_optional_punctuation(":") else 1
             )
             return Fraction(numerator, denominator) % 2
 
@@ -40,7 +40,7 @@ class AngleAttr(Data[Fraction], TypeAttribute):
 
             printer.print("pi")
             if self.data.denominator != 1:
-                printer.print("/")
+                printer.print(":")
                 printer.print(self.data.denominator)
 
     def __add__(self, other: AngleAttr):


### PR DESCRIPTION
This pr does the following:
- Adds 'quantum' dialect which contains an angle attribute which is shared by both the 'qref' and 'qssa' dialects.
- angles are stored as rational multiples of 'pi' kept to the range [0,2pi)
- Adds rz gate which is parametrised by an angle (at the moment this is given via an attribute.
- Standardises the gate set to the one used in 'http://arxiv.org/abs/1710.07345'. I can revert the removal of the cz gate if this seems like a poor idea.

~Built on top of #2819 to allow '/' in the angle syntax~
Now using ':' instead to avoid the lexing change


