### PR TITLE
tests: Do not run marimo mlir tests without MLIR installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,12 @@ tests-marimo:
 	@echo "All marimo tests passed successfully."
 
 tests-marimo-mlir:
+	@if command -v mlir-opt &> /dev/null; then
+		@echo "MLIR is installed, running tests."
+	else
+		@echo "MLIR is not installed, skipping tests."
+		exit 0
+	fi
 	@for file in docs/marimo/mlir/*.py; do \
 		echo "Running $$file"; \
 		python3 "$$file" || exit 1; \


### PR DESCRIPTION
title says it all.

closes #2826 