### PR TITLE
testing: fix mlir-opt check for MacOS make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,11 @@ tests-marimo:
 	@echo "All marimo tests passed successfully."
 
 tests-marimo-mlir:
-	@if command -v mlir-opt &> /dev/null; then
-		@echo "MLIR is installed, running tests."
-	else
-		@echo "MLIR is not installed, skipping tests."
-		exit 0
+	@if command -v mlir-opt &> /dev/null; then \
+		echo "MLIR is installed, running tests."; \
+	else \
+		echo "MLIR is not installed, skipping tests."; \
+		exit 0; \
 	fi
 	@for file in docs/marimo/mlir/*.py; do \
 		echo "Running $$file"; \


### PR DESCRIPTION
For some reason, running the version in `main` complains about a syntax error, the updated version works, and will hopefully be more portable.