### PR TITLE
api: add printing and parsing of dynamic lists as in MLIR

### DIFF
--- a/tests/test_dialect_utils.py
+++ b/tests/test_dialect_utils.py
@@ -1,0 +1,134 @@
+from io import StringIO
+
+import pytest
+
+from xdsl.context import MLContext
+from xdsl.dialects.builtin import DYNAMIC_INDEX, IndexType, IntegerType, i32
+from xdsl.dialects.utils import (
+    parse_dynamic_index_list_with_types,
+    parse_dynamic_index_list_without_types,
+    parse_dynamic_index_with_type,
+    parse_dynamic_index_without_type,
+    print_dynamic_index_list,
+)
+from xdsl.ir import SSAValue
+from xdsl.parser import Parser, UnresolvedOperand
+from xdsl.printer import Printer
+from xdsl.utils.test_value import TestSSAValue
+
+ctx = MLContext()
+index = IndexType()
+
+
+def test_print_dynamic_index_list():
+    # Test case 1: Only integers
+    stream = StringIO()
+    printer = Printer(stream)
+    print_dynamic_index_list(printer, [], [1, 2, 3])
+    assert stream.getvalue() == "[1, 2, 3]"
+
+    # Test case 2: Mix of integers and SSA values
+    stream = StringIO()
+    printer = Printer(stream)
+    values = [TestSSAValue(IndexType()), TestSSAValue(IndexType())]
+    print_dynamic_index_list(printer, values, [1, DYNAMIC_INDEX, 3, DYNAMIC_INDEX])
+    assert stream.getvalue() == "[1, %0, 3, %1]"
+
+    # Test case 3: With value types
+    stream = StringIO()
+    printer = Printer(stream)
+    values = [TestSSAValue(IndexType()), TestSSAValue(IntegerType(32))]
+    value_types = (IndexType(), IntegerType(32))
+    print_dynamic_index_list(
+        printer, values, [DYNAMIC_INDEX, 2, DYNAMIC_INDEX], value_types
+    )
+    assert stream.getvalue() == "[%0 : index, 2, %1 : i32]"
+
+    # Test case 4: Custom delimiter
+    stream = StringIO()
+    printer = Printer(stream)
+    print_dynamic_index_list(printer, [], [1, 2, 3], delimiter=Parser.Delimiter.PAREN)
+    assert stream.getvalue() == "(1, 2, 3)"
+
+    # Test case 5: Empty list
+    stream = StringIO()
+    printer = Printer(stream)
+    print_dynamic_index_list(printer, [], [])
+    assert stream.getvalue() == "[]"
+
+
+@pytest.mark.parametrize(
+    "delimiter,expected",
+    [
+        (Parser.Delimiter.SQUARE, "[1, 2, 3]"),
+        (Parser.Delimiter.PAREN, "(1, 2, 3)"),
+        (Parser.Delimiter.ANGLE, "<1, 2, 3>"),
+        (Parser.Delimiter.BRACES, "{1, 2, 3}"),
+    ],
+)
+def test_print_dynamic_index_list_delimiters(
+    delimiter: Parser.Delimiter, expected: str
+):
+    stream = StringIO()
+    printer = Printer(stream)
+    print_dynamic_index_list(printer, [], [1, 2, 3], delimiter=delimiter)
+    assert stream.getvalue() == expected
+
+
+def test_parse_dynamic_index_with_type():
+    parser = Parser(ctx, "%0 : i32")
+    result = parse_dynamic_index_with_type(parser)
+    assert isinstance(result, SSAValue)
+
+    parser = Parser(ctx, "42")
+    result = parse_dynamic_index_with_type(parser)
+    assert isinstance(result, int)
+    assert result == 42
+
+
+def test_parse_dynamic_index_without_type():
+    parser = Parser(ctx, "%0")
+    result = parse_dynamic_index_without_type(parser)
+    assert isinstance(result, UnresolvedOperand)
+
+    parser = Parser(ctx, "42")
+    result = parse_dynamic_index_without_type(parser)
+    assert isinstance(result, int)
+    assert result == 42
+
+
+def test_parse_dynamic_index_list_with_types():
+
+    parser = Parser(ctx, "[%0 : i32, 42, %1 : index]")
+    parser.ssa_values["0"] = (TestSSAValue(i32),)
+    parser.ssa_values["1"] = (TestSSAValue(index),)
+    values, indices = parse_dynamic_index_list_with_types(parser)
+    assert len(values) == 2
+    assert len(indices) == 1
+    assert isinstance(values[0], SSAValue)
+    assert isinstance(values[1], SSAValue)
+    assert indices[0] == 42
+
+
+def test_parse_dynamic_index_list_without_types():
+    parser = Parser(ctx, "[%0, 42, %1]")
+    values, indices = parse_dynamic_index_list_without_types(parser)
+    assert len(values) == 2
+    assert len(indices) == 1
+    assert isinstance(values[0], UnresolvedOperand)
+    assert isinstance(values[1], UnresolvedOperand)
+    assert indices[0] == 42
+
+
+def test_parse_dynamic_index_list_with_custom_delimiter():
+    parser = Parser(ctx, "(%0 : i32, 42, %1 : index)")
+    values, indices = parse_dynamic_index_list_with_types(
+        parser, delimiter=Parser.Delimiter.PAREN
+    )
+    parser.ssa_values["0"] = (TestSSAValue(i32),)
+    parser.ssa_values["1"] = (TestSSAValue(index),)
+    assert len(values) == 2
+    assert len(indices) == 1
+    assert isinstance(values[0], SSAValue)
+    assert isinstance(values[1], SSAValue)
+    assert indices[0] == 42

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -67,6 +67,11 @@ if TYPE_CHECKING:
     from xdsl.parser import AttrParser, Parser
     from xdsl.printer import Printer
 
+DYNAMIC_INDEX = -1
+"""
+A constant value denoting a dynamic index in a shape.
+"""
+
 
 class ShapedType(ABC):
     @abstractmethod

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -271,6 +271,8 @@ def print_dynamic_index_list(
     values: Sequence[SSAValue],
     integers: Iterable[int],
     value_types: Sequence[Attribute] = (),
+    *,
+    dynamic_index: int = DYNAMIC_INDEX,
     delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
 ):
     """
@@ -281,6 +283,8 @@ def print_dynamic_index_list(
     indicating their types. This allows idiomatic printing of mixed value and
     integer attributes in a list. E.g.
     `[%arg0 : index, 7, 42, %arg42 : i32]`.
+    The `dynamic_index` parameter specifies the sentinel value to use to print an ssa
+    value instead of a constant.
     """
     if delimiter.value is not None:
         printer.print_string(delimiter.value[0])
@@ -288,7 +292,7 @@ def print_dynamic_index_list(
     for integer_index, integer in enumerate(integers):
         if integer_index:
             printer.print_string(", ")
-        if integer == DYNAMIC_INDEX:
+        if integer == dynamic_index:
             printer.print_ssa_value(values[value_index])
             if value_types:
                 printer.print_string_raw(" : ")
@@ -328,11 +332,15 @@ def parse_dynamic_index_without_type(parser: Parser) -> int | UnresolvedOperand:
 
 def parse_dynamic_index_list_with_types(
     parser: Parser,
+    *,
+    dynamic_index: int = DYNAMIC_INDEX,
     delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
 ) -> tuple[Sequence[SSAValue], Sequence[int]]:
     """
     Parses an in index list, composed of a mix of indices and ssa values without a type:
     e.g. `[1, 2, 3, %val, 5]`.
+    The `dynamic_index` parameter specifies the sentinel value to use to print an ssa
+    value instead of a constant.
     """
     mixed_values = parser.parse_comma_separated_list(
         delimiter, lambda: parse_dynamic_index_with_type(parser)
@@ -345,6 +353,7 @@ def parse_dynamic_index_list_with_types(
         if isinstance(value_or_index, int):
             indices.append(value_or_index)
         else:
+            indices.append(dynamic_index)
             values.append(value_or_index)
 
     return values, indices
@@ -352,11 +361,15 @@ def parse_dynamic_index_list_with_types(
 
 def parse_dynamic_index_list_without_types(
     parser: Parser,
+    *,
+    dynamic_index: int = DYNAMIC_INDEX,
     delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
 ) -> tuple[Sequence[UnresolvedOperand], Sequence[int]]:
     """
     Parses an in index list, composed of a mix of indices and ssa values with a types:
     e.g. `[1, 2, 3, %val : i32, 5]`.
+    The `dynamic_index` parameter specifies the sentinel value to use to print an ssa
+    value instead of a constant.
     """
     mixed_values = parser.parse_comma_separated_list(
         delimiter, lambda: parse_dynamic_index_without_type(parser)
@@ -369,6 +382,7 @@ def parse_dynamic_index_list_without_types(
         if isinstance(value_or_index, int):
             indices.append(value_or_index)
         else:
+            indices.append(dynamic_index)
             values.append(value_or_index)
 
     return values, indices

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -1,16 +1,24 @@
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Generic
 
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
+    DYNAMIC_INDEX,
     ArrayAttr,
     DictionaryAttr,
     FunctionType,
     StringAttr,
     SymbolRefAttr,
 )
-from xdsl.ir import Attribute, AttributeInvT, BlockArgument, Operation, Region, SSAValue
+from xdsl.ir import (
+    Attribute,
+    AttributeInvT,
+    BlockArgument,
+    Operation,
+    Region,
+    SSAValue,
+)
 from xdsl.irdl import IRDLOperation, var_operand_def
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
@@ -256,3 +264,111 @@ def parse_assignment(
     parser.parse_characters("=")
     val = parser.parse_unresolved_operand()
     return arg, val
+
+
+def print_dynamic_index_list(
+    printer: Printer,
+    values: Sequence[SSAValue],
+    integers: Iterable[int],
+    value_types: Sequence[Attribute] = (),
+    delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
+):
+    """
+    Prints a list with either
+      1) the static integer value in `integers` is `ShapedType.DYNAMIC` or
+      2) the next value otherwise.
+    If `value_types` is non-empty, it is expected to contain as many elements as `values`
+    indicating their types. This allows idiomatic printing of mixed value and
+    integer attributes in a list. E.g.
+    `[%arg0 : index, 7, 42, %arg42 : i32]`.
+    """
+    if delimiter.value is not None:
+        printer.print_string(delimiter.value[0])
+    value_index = 0
+    for integer_index, integer in enumerate(integers):
+        if integer_index:
+            printer.print_string(", ")
+        if integer == DYNAMIC_INDEX:
+            printer.print_ssa_value(values[value_index])
+            if value_types:
+                printer.print_string_raw(" : ")
+                printer.print_attribute(value_types[value_index])
+            value_index += 1
+        else:
+            printer.print_string(f"{integer}")
+    if delimiter.value is not None:
+        printer.print_string(delimiter.value[1])
+
+
+def parse_dynamic_index_with_type(parser: Parser) -> int | SSAValue:
+    """
+    Parses an element in an index list, either an index or an ssa value with a type:
+    e.g. `42` or `%val : i32`.
+    """
+    value = parser.parse_optional_unresolved_operand()
+    if value is None:
+        return parser.parse_integer(allow_boolean=False, allow_negative=False)
+    else:
+        parser.parse_punctuation(":")
+        value_type = parser.parse_attribute()
+        return parser.resolve_operand(value, value_type)
+
+
+def parse_dynamic_index_without_type(parser: Parser) -> int | UnresolvedOperand:
+    """
+    Parses an element in an index list, either an index or an ssa value without a type:
+    e.g. `42` or `%val`.
+    """
+    value = parser.parse_optional_unresolved_operand()
+    if value is None:
+        return parser.parse_integer(allow_boolean=False, allow_negative=False)
+    else:
+        return value
+
+
+def parse_dynamic_index_list_with_types(
+    parser: Parser,
+    delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
+) -> tuple[Sequence[SSAValue], Sequence[int]]:
+    """
+    Parses an in index list, composed of a mix of indices and ssa values without a type:
+    e.g. `[1, 2, 3, %val, 5]`.
+    """
+    mixed_values = parser.parse_comma_separated_list(
+        delimiter, lambda: parse_dynamic_index_with_type(parser)
+    )
+
+    values: list[SSAValue] = []
+    indices: list[int] = []
+
+    for value_or_index in mixed_values:
+        if isinstance(value_or_index, int):
+            indices.append(value_or_index)
+        else:
+            values.append(value_or_index)
+
+    return values, indices
+
+
+def parse_dynamic_index_list_without_types(
+    parser: Parser,
+    delimiter: Parser.Delimiter = Parser.Delimiter.SQUARE,
+) -> tuple[Sequence[UnresolvedOperand], Sequence[int]]:
+    """
+    Parses an in index list, composed of a mix of indices and ssa values with a types:
+    e.g. `[1, 2, 3, %val : i32, 5]`.
+    """
+    mixed_values = parser.parse_comma_separated_list(
+        delimiter, lambda: parse_dynamic_index_without_type(parser)
+    )
+
+    values: list[UnresolvedOperand] = []
+    indices: list[int] = []
+
+    for value_or_index in mixed_values:
+        if isinstance(value_or_index, int):
+            indices.append(value_or_index)
+        else:
+            values.append(value_or_index)
+
+    return values, indices


### PR DESCRIPTION
This is used in a few places, notably in memref.subview custom syntax, which is the next PR