### PR TITLE
backend: reserve registers not preserved across function calls in RISC-V

### DIFF
--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -4,7 +4,7 @@ from itertools import chain
 from ordered_set import OrderedSet
 
 from xdsl.backend.riscv.register_queue import RegisterQueue
-from xdsl.dialects import riscv_func, riscv_scf, riscv_snitch
+from xdsl.dialects import riscv, riscv_func, riscv_scf, riscv_snitch
 from xdsl.dialects.riscv import (
     FloatRegisterType,
     IntRegisterType,
@@ -25,6 +25,12 @@ def gather_allocated(func: riscv_func.FuncOp) -> set[RISCVRegisterType]:
     for op in func.walk():
         if not isinstance(op, RISCVAsmOperation):
             continue
+
+        if isinstance(op, riscv_func.CallOp):
+            allocated.update(riscv.Registers.A)
+            allocated.update(riscv.Registers.T)
+            allocated.update(riscv.Registers.FA)
+            allocated.update(riscv.Registers.FT)
 
         for param in chain(op.operands, op.results):
             if isinstance(param.type, RISCVRegisterType) and param.type.is_allocated:

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -27,6 +27,9 @@ def gather_allocated(func: riscv_func.FuncOp) -> set[RISCVRegisterType]:
             continue
 
         if isinstance(op, riscv_func.CallOp):
+            # These registers are not guaranteed to hold the same values when the callee
+            # returns, according to the RISC-V calling convention.
+            # https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf
             allocated.update(riscv.Registers.A)
             allocated.update(riscv.Registers.T)
             allocated.update(riscv.Registers.FA)


### PR DESCRIPTION
A little correctness improvement, we should only be allocating to s registers if there's a function call, of which there should be 0 for the foreseeable future, but it's nice not to silently miscompile.