### PR TITLE
backend: (riscv) preserve name hints when casting operands

### DIFF
--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -9,84 +9,84 @@
 %r, %c = "test.op"() : () -> (index, index)
 %m_f32, %m_f64, %m_i32, %m_scalar_i32 = "test.op"() : () -> (memref<3x2xf32>, memref<3x2xf64>, memref<3xi32>, memref<i32>)
 
-// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %v_f32 : f32 to !riscv.freg
-// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg
-// CHECK-NEXT:   %2 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
-// CHECK-NEXT:   %3 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
-// CHECK-NEXT:   %4 = riscv.li 2 : !riscv.reg
-// CHECK-NEXT:   %5 = riscv.mul %2, %4 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %6 = riscv.add %5, %3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %7 = riscv.li 4 : !riscv.reg
-// CHECK-NEXT:   %8 = riscv.mul %6, %7 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %9 = riscv.add %1, %8 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   riscv.fsw %9, %0, 0 {"comment" = "store float value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-NEXT:    %v_f32_1 = builtin.unrealized_conversion_cast %v_f32 : f32 to !riscv.freg
+// CHECK-NEXT:    %m_f32_1 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg
+// CHECK-NEXT:    %r_1 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:    %c_1 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:    %pointer_dim_stride = riscv.li 2 : !riscv.reg
+// CHECK-NEXT:    %pointer_dim_offset = riscv.mul %r_1, %pointer_dim_stride : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %pointer_offset = riscv.add %pointer_dim_offset, %c_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %bytes_per_element = riscv.li 4 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset = riscv.mul %pointer_offset, %bytes_per_element {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer = riscv.add %m_f32_1, %scaled_pointer_offset : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv.fsw %offset_pointer, %v_f32_1, 0 {"comment" = "store float value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
 memref.store %v_f32, %m_f32[%r, %c] {"nontemporal" = false} : memref<3x2xf32>
 
-// CHECK-NEXT:   %10 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg
-// CHECK-NEXT:   %11 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
-// CHECK-NEXT:   %12 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
-// CHECK-NEXT:   %13 = riscv.li 2 : !riscv.reg
-// CHECK-NEXT:   %14 = riscv.mul %11, %13 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %15 = riscv.add %14, %12 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %16 = riscv.li 4 : !riscv.reg
-// CHECK-NEXT:   %17 = riscv.mul %15, %16 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %18 = riscv.add %10, %17 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %x_f32 = riscv.flw %18, 0 {"comment" = "load float from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
-// CHECK-NEXT:   %x_f32_1 = builtin.unrealized_conversion_cast %x_f32 : !riscv.freg to f32
+// CHECK-NEXT:    %m_f32_2 = builtin.unrealized_conversion_cast %m_f32 : memref<3x2xf32> to !riscv.reg
+// CHECK-NEXT:    %r_2 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:    %c_2 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:    %pointer_dim_stride_1 = riscv.li 2 : !riscv.reg
+// CHECK-NEXT:    %pointer_dim_offset_1 = riscv.mul %r_2, %pointer_dim_stride_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %pointer_offset_1 = riscv.add %pointer_dim_offset_1, %c_2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %bytes_per_element_1 = riscv.li 4 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset_1 = riscv.mul %pointer_offset_1, %bytes_per_element_1 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer_1 = riscv.add %m_f32_2, %scaled_pointer_offset_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %x_f32 = riscv.flw %offset_pointer_1, 0 {"comment" = "load float from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
+// CHECK-NEXT:    %x_f32_1 = builtin.unrealized_conversion_cast %x_f32 : !riscv.freg to f32
 %x_f32 = memref.load %m_f32[%r, %c] {"nontemporal" = false} : memref<3x2xf32>
 
-// CHECK-NEXT:   %19 = builtin.unrealized_conversion_cast %v_i32 : i32 to !riscv.reg
-// CHECK-NEXT:   %20 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg
-// CHECK-NEXT:   %21 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
-// CHECK-NEXT:   %22 = riscv.li 4 : !riscv.reg
-// CHECK-NEXT:   %23 = riscv.mul %21, %22 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %24 = riscv.add %20, %23 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   riscv.sw %24, %19, 0 {"comment" = "store int value to memref of shape (3,)"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:    %v_i32_1 = builtin.unrealized_conversion_cast %v_i32 : i32 to !riscv.reg
+// CHECK-NEXT:    %m_i32_1 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg
+// CHECK-NEXT:    %c_3 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:    %bytes_per_element_2 = riscv.li 4 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset_2 = riscv.mul %c_3, %bytes_per_element_2 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer_2 = riscv.add %m_i32_1, %scaled_pointer_offset_2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv.sw %offset_pointer_2, %v_i32_1, 0 {"comment" = "store int value to memref of shape (3,)"} : (!riscv.reg, !riscv.reg) -> ()
 memref.store %v_i32, %m_i32[%c] {"nontemporal" = false} : memref<3xi32>
 
-// CHECK-NEXT:   %25 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg
-// CHECK-NEXT:   %26 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
-// CHECK-NEXT:   %27 = riscv.li 4 : !riscv.reg
-// CHECK-NEXT:   %28 = riscv.mul %26, %27 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %29 = riscv.add %25, %28 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %x_i32 = riscv.lw %29, 0 {"comment" = "load word from memref of shape (3,)"} : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %x_i32_1 = builtin.unrealized_conversion_cast %x_i32 : !riscv.reg to i32
+// CHECK-NEXT:    %m_i32_2 = builtin.unrealized_conversion_cast %m_i32 : memref<3xi32> to !riscv.reg
+// CHECK-NEXT:    %c_4 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:    %bytes_per_element_3 = riscv.li 4 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset_3 = riscv.mul %c_4, %bytes_per_element_3 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer_3 = riscv.add %m_i32_2, %scaled_pointer_offset_3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %x_i32 = riscv.lw %offset_pointer_3, 0 {"comment" = "load word from memref of shape (3,)"} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %x_i32_1 = builtin.unrealized_conversion_cast %x_i32 : !riscv.reg to i32
 %x_i32 = memref.load %m_i32[%c] {"nontemporal" = false} : memref<3xi32>
 
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %v_f64 : f64 to !riscv.freg
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %r : index to !riscv.reg
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %c : index to !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.li 2 : !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.li 8 : !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   riscv.fsd %{{.*}}, %{{.*}}, 0 {"comment" = "store double value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
+// CHECK-NEXT:    %v_f64_1 = builtin.unrealized_conversion_cast %v_f64 : f64 to !riscv.freg
+// CHECK-NEXT:    %m_f64_1 = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg
+// CHECK-NEXT:    %r_3 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:    %c_5 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:    %pointer_dim_stride_2 = riscv.li 2 : !riscv.reg
+// CHECK-NEXT:    %pointer_dim_offset_2 = riscv.mul %r_3, %pointer_dim_stride_2 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %pointer_offset_2 = riscv.add %pointer_dim_offset_2, %c_5 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %bytes_per_element_4 = riscv.li 8 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset_4 = riscv.mul %pointer_offset_2, %bytes_per_element_4 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer_4 = riscv.add %m_f64_1, %scaled_pointer_offset_4 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv.fsd %offset_pointer_4, %v_f64_1, 0 {"comment" = "store double value to memref of shape (3, 2)"} : (!riscv.reg, !riscv.freg) -> ()
 memref.store %v_f64, %m_f64[%r, %c] {"nontemporal" = false} : memref<3x2xf64>
 
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg
-// CHECK-NEXT:   %scalar_x_i32 = riscv.lw %{{.*}}, 0 {"comment" = "load word from memref of shape ()"} : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %scalar_x_i32_1 = builtin.unrealized_conversion_cast %scalar_x_i32 : !riscv.reg to i32
+// CHECK-NEXT:    %m_scalar_i32_1 = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg
+// CHECK-NEXT:    %scalar_x_i32 = riscv.lw %m_scalar_i32_1, 0 {"comment" = "load word from memref of shape ()"} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %scalar_x_i32_1 = builtin.unrealized_conversion_cast %scalar_x_i32 : !riscv.reg to i32
 %scalar_x_i32 = memref.load %m_scalar_i32[] {"nontemporal" = false} : memref<i32>
 
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %scalar_x_i32_1 : i32 to !riscv.reg
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg
-// CHECK-NEXT:   riscv.sw %{{.*}}, %{{.*}}, 0 {"comment" = "store int value to memref of shape ()"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:    %scalar_x_i32_2 = builtin.unrealized_conversion_cast %scalar_x_i32_1 : i32 to !riscv.reg
+// CHECK-NEXT:    %m_scalar_i32_2 = builtin.unrealized_conversion_cast %m_scalar_i32 : memref<i32> to !riscv.reg
+// CHECK-NEXT:    riscv.sw %m_scalar_i32_2, %scalar_x_i32_2, 0 {"comment" = "store int value to memref of shape ()"} : (!riscv.reg, !riscv.reg) -> ()
 memref.store %scalar_x_i32, %m_scalar_i32[] {"nontemporal" = false} : memref<i32>
 
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %r : index to !riscv.reg
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %c : index to !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.li 2 : !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.li 8 : !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.mul %{{.*}}, %{{.*}} {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %{{.*}} = riscv.add %{{.*}}, %{{.*}} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:   %x_f64 = riscv.fld %{{.*}}, 0 {"comment" = "load double from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
-// CHECK-NEXT:   %x_f64_1 = builtin.unrealized_conversion_cast %x_f64 : !riscv.freg to f64
+// CHECK-NEXT:    %m_f64_2 = builtin.unrealized_conversion_cast %m_f64 : memref<3x2xf64> to !riscv.reg
+// CHECK-NEXT:    %r_4 = builtin.unrealized_conversion_cast %r : index to !riscv.reg
+// CHECK-NEXT:    %c_6 = builtin.unrealized_conversion_cast %c : index to !riscv.reg
+// CHECK-NEXT:    %pointer_dim_stride_3 = riscv.li 2 : !riscv.reg
+// CHECK-NEXT:    %pointer_dim_offset_3 = riscv.mul %r_4, %pointer_dim_stride_3 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %pointer_offset_3 = riscv.add %pointer_dim_offset_3, %c_6 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %bytes_per_element_5 = riscv.li 8 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset_5 = riscv.mul %pointer_offset_3, %bytes_per_element_5 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer_5 = riscv.add %m_f64_2, %scaled_pointer_offset_5 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %x_f64 = riscv.fld %offset_pointer_5, 0 {"comment" = "load double from memref of shape (3, 2)"} : (!riscv.reg) -> !riscv.freg
+// CHECK-NEXT:    %x_f64_1 = builtin.unrealized_conversion_cast %x_f64 : !riscv.freg to f64
 %x_f64 = memref.load %m_f64[%r, %c] {"nontemporal" = false} : memref<3x2xf64>
 
 // CHECK-NEXT:   riscv.assembly_section ".data" {
@@ -95,8 +95,8 @@ memref.store %scalar_x_i32, %m_scalar_i32[] {"nontemporal" = false} : memref<i32
 // CHECK-NEXT:   }
 "memref.global"() <{"sym_name" = "global", "sym_visibility" = "public", "type" = memref<2x3xf64>, "initial_value" = dense<[1, 2]> : tensor<2xi32>}> : () -> ()
 
-// CHECK-NEXT:   %{{.*}} riscv.li "global" : !riscv.reg
-// CHECK-NEXT:   %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to memref<2xi32>
+// CHECK-NEXT:    %global = riscv.li "global" : !riscv.reg
+// CHECK-NEXT:    %global_1 = builtin.unrealized_conversion_cast %global : !riscv.reg to memref<2xi32>
 %global = memref.get_global @global : memref<2xi32>
 
 // CHECK-NEXT: }
@@ -139,13 +139,13 @@ builtin.module {
 // CHECK-NEXT:    %v, %d0, %m = "test.op"() : () -> (i8, index, memref<1xi8>)
 %v, %d0, %m = "test.op"() : () -> (i8, index, memref<1xi8>)
 
-// CHECK-NEXT:    %0 = builtin.unrealized_conversion_cast %v : i8 to !riscv.reg
-// CHECK-NEXT:    %1 = builtin.unrealized_conversion_cast %m : memref<1xi8> to !riscv.reg
-// CHECK-NEXT:    %2 = builtin.unrealized_conversion_cast %d0 : index to !riscv.reg
-// CHECK-NEXT:    %3 = riscv.li 1 : !riscv.reg
-// CHECK-NEXT:    %4 = riscv.mul %2, %3 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:    %5 = riscv.add %1, %4 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:    riscv.sw %5, %0, 0 {"comment" = "store int value to memref of shape (1,)"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:    %v_1 = builtin.unrealized_conversion_cast %v : i8 to !riscv.reg
+// CHECK-NEXT:    %m_1 = builtin.unrealized_conversion_cast %m : memref<1xi8> to !riscv.reg
+// CHECK-NEXT:    %d0_1 = builtin.unrealized_conversion_cast %d0 : index to !riscv.reg
+// CHECK-NEXT:    %bytes_per_element = riscv.li 1 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset = riscv.mul %d0_1, %bytes_per_element {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer = riscv.add %m_1, %scaled_pointer_offset : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv.sw %offset_pointer, %v_1, 0 {"comment" = "store int value to memref of shape (1,)"} : (!riscv.reg, !riscv.reg) -> ()
 memref.store %v, %m[%d0] {"nontemporal" = false} : memref<1xi8>
 
 // CHECK-NEXT:  }
@@ -157,13 +157,13 @@ memref.store %v, %m[%d0] {"nontemporal" = false} : memref<1xi8>
 // CHECK-NEXT:    %v, %d0, %m = "test.op"() : () -> (i16, index, memref<1xi16>)
 %v, %d0, %m = "test.op"() : () -> (i16, index, memref<1xi16>)
 
-// CHECK-NEXT:    %0 = builtin.unrealized_conversion_cast %v : i16 to !riscv.reg
-// CHECK-NEXT:    %1 = builtin.unrealized_conversion_cast %m : memref<1xi16> to !riscv.reg
-// CHECK-NEXT:    %2 = builtin.unrealized_conversion_cast %d0 : index to !riscv.reg
-// CHECK-NEXT:    %3 = riscv.li 2 : !riscv.reg
-// CHECK-NEXT:    %4 = riscv.mul %2, %3 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:    %5 = riscv.add %1, %4 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:    riscv.sw %5, %0, 0 {"comment" = "store int value to memref of shape (1,)"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:    %v_1 = builtin.unrealized_conversion_cast %v : i16 to !riscv.reg
+// CHECK-NEXT:    %m_1 = builtin.unrealized_conversion_cast %m : memref<1xi16> to !riscv.reg
+// CHECK-NEXT:    %d0_1 = builtin.unrealized_conversion_cast %d0 : index to !riscv.reg
+// CHECK-NEXT:    %bytes_per_element = riscv.li 2 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset = riscv.mul %d0_1, %bytes_per_element {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer = riscv.add %m_1, %scaled_pointer_offset : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv.sw %offset_pointer, %v_1, 0 {"comment" = "store int value to memref of shape (1,)"} : (!riscv.reg, !riscv.reg) -> ()
 memref.store %v, %m[%d0] {"nontemporal" = false} : memref<1xi16>
 
 // CHECK-NEXT:  }
@@ -175,13 +175,13 @@ memref.store %v, %m[%d0] {"nontemporal" = false} : memref<1xi16>
 
 %v, %d0, %m = "test.op"() : () -> (i64, index, memref<1xi64>)
 
-// CHECK-NEXT:    %0 = builtin.unrealized_conversion_cast %v : i64 to !riscv.reg
-// CHECK-NEXT:    %1 = builtin.unrealized_conversion_cast %m : memref<1xi64> to !riscv.reg
-// CHECK-NEXT:    %2 = builtin.unrealized_conversion_cast %d0 : index to !riscv.reg
-// CHECK-NEXT:    %3 = riscv.li 8 : !riscv.reg
-// CHECK-NEXT:    %4 = riscv.mul %2, %3 {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:    %5 = riscv.add %1, %4 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:    riscv.sw %5, %0, 0 {"comment" = "store int value to memref of shape (1,)"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:    %v_1 = builtin.unrealized_conversion_cast %v : i64 to !riscv.reg
+// CHECK-NEXT:    %m_1 = builtin.unrealized_conversion_cast %m : memref<1xi64> to !riscv.reg
+// CHECK-NEXT:    %d0_1 = builtin.unrealized_conversion_cast %d0 : index to !riscv.reg
+// CHECK-NEXT:    %bytes_per_element = riscv.li 8 : !riscv.reg
+// CHECK-NEXT:    %scaled_pointer_offset = riscv.mul %d0_1, %bytes_per_element {"comment" = "multiply by element size"} : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    %offset_pointer = riscv.add %m_1, %scaled_pointer_offset : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:    riscv.sw %offset_pointer, %v_1, 0 {"comment" = "store int value to memref of shape (1,)"} : (!riscv.reg, !riscv.reg) -> ()
 memref.store %v, %m[%d0] {"nontemporal" = false} : memref<1xi64>
 
 // CHECK-NEXT:  }
@@ -191,17 +191,17 @@ memref.store %v, %m[%d0] {"nontemporal" = false} : memref<1xi64>
 %m = "test.op"() : () -> memref<2x3xf64, strided<[6, 1], offset: ?>>
 %i0, %i1 = "test.op"() : () -> (index, index)
 
-// CHECK: %0 = builtin.unrealized_conversion_cast %m : memref<2x3xf64, strided<[6, 1], offset: ?>> to !riscv.reg
-// CHECK-NEXT: %1 = builtin.unrealized_conversion_cast %i0 : index to !riscv.reg
-// CHECK-NEXT: %2 = builtin.unrealized_conversion_cast %i1 : index to !riscv.reg
-// CHECK-NEXT: %3 = riscv.li 6
-// CHECK-NEXT: %4 = riscv.mul %1, %3
-// CHECK-NEXT: %5 = riscv.add %4, %2
-// CHECK-NEXT: %6 = riscv.li 8
-// CHECK-NEXT: %7 = riscv.mul %5, %6
-// CHECK-NEXT: %8 = riscv.add %0, %7
-// CHECK-NEXT: %v = riscv.fld %8, 0
-// CHECK-NEXT: %v_1 = builtin.unrealized_conversion_cast %v : !riscv.freg to f64
+// CHECK:         %m_1 = builtin.unrealized_conversion_cast %m : memref<2x3xf64, strided<[6, 1], offset: ?>> to !riscv.reg
+// CHECK-NEXT:    %i0_1 = builtin.unrealized_conversion_cast %i0 : index to !riscv.reg
+// CHECK-NEXT:    %i1_1 = builtin.unrealized_conversion_cast %i1 : index to !riscv.reg
+// CHECK-NEXT:    %pointer_dim_stride = riscv.li 6
+// CHECK-NEXT:    %pointer_dim_offset = riscv.mul %i0_1, %pointer_dim_stride
+// CHECK-NEXT:    %pointer_offset = riscv.add %pointer_dim_offset, %i1_1
+// CHECK-NEXT:    %bytes_per_element = riscv.li 8
+// CHECK-NEXT:    %scaled_pointer_offset = riscv.mul %pointer_offset, %bytes_per_element
+// CHECK-NEXT:    %offset_pointer = riscv.add %m_1, %scaled_pointer_offset
+// CHECK-NEXT:    %v = riscv.fld %offset_pointer, 0
+// CHECK-NEXT:    %v_1 = builtin.unrealized_conversion_cast %v : !riscv.freg to f64
 %v = memref.load %m[%i0, %i1] : memref<2x3xf64, strided<[6, 1], offset: ?>>
 
 // -----
@@ -210,19 +210,19 @@ memref.store %v, %m[%d0] {"nontemporal" = false} : memref<1xi64>
 %v = "test.op"() : () -> f64
 %i0, %i1 = "test.op"() : () -> (index, index)
 
-memref.store %v, %m[%i0, %i1] : memref<2x3xf64, strided<[6, 1], offset: ?>>
+// CHECK:         %v_1 = builtin.unrealized_conversion_cast %v : f64 to !riscv.freg
+// CHECK-NEXT:    %m_1 = builtin.unrealized_conversion_cast %m : memref<2x3xf64, strided<[6, 1], offset: ?>> to !riscv.reg
+// CHECK-NEXT:    %i0_1 = builtin.unrealized_conversion_cast %i0 : index to !riscv.reg
+// CHECK-NEXT:    %i1_1 = builtin.unrealized_conversion_cast %i1 : index to !riscv.reg
+// CHECK-NEXT:    %pointer_dim_stride = riscv.li 6
+// CHECK-NEXT:    %pointer_dim_offset = riscv.mul %i0_1, %pointer_dim_stride
+// CHECK-NEXT:    %pointer_offset = riscv.add %pointer_dim_offset, %i1_1
+// CHECK-NEXT:    %bytes_per_element = riscv.li 8
+// CHECK-NEXT:    %scaled_pointer_offset = riscv.mul %pointer_offset, %bytes_per_element
+// CHECK-NEXT:    %offset_pointer = riscv.add %m_1, %scaled_pointer_offset
+// CHECK-NEXT:    riscv.fsd %offset_pointer, %v_1, 0
 
-// CHECK: %0 = builtin.unrealized_conversion_cast %v : f64 to !riscv.freg
-// CHECK-NEXT: %1 = builtin.unrealized_conversion_cast %m : memref<2x3xf64, strided<[6, 1], offset: ?>> to !riscv.reg
-// CHECK-NEXT: %2 = builtin.unrealized_conversion_cast %i0 : index to !riscv.reg
-// CHECK-NEXT: %3 = builtin.unrealized_conversion_cast %i1 : index to !riscv.reg
-// CHECK-NEXT: %4 = riscv.li 6
-// CHECK-NEXT: %5 = riscv.mul %2, %4
-// CHECK-NEXT: %6 = riscv.add %5, %3
-// CHECK-NEXT: %7 = riscv.li 8
-// CHECK-NEXT: %8 = riscv.mul %6, %7
-// CHECK-NEXT: %9 = riscv.add %1, %8
-// CHECK-NEXT: riscv.fsd %9, %0, 0
+memref.store %v, %m[%i0, %i1] : memref<2x3xf64, strided<[6, 1], offset: ?>>
 
 // -----
 

--- a/tests/filecheck/backend/riscv/print_format_to_riscv_debug.mlir
+++ b/tests/filecheck/backend/riscv/print_format_to_riscv_debug.mlir
@@ -8,9 +8,9 @@ printf.print_format "bitwidths {} {} {} {}", %i32 : i32, %i64 : i64, %f32 : f32,
 // CHECK:      builtin.module {
 // CHECK-NEXT:   %i32, %i64, %f32, %f64 = "test.op"() : () -> (i32, i64, f32, f64)
 // CHECK-NEXT:   riscv_debug.printf "Hello world!" : () -> ()
-// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %i32 : i32 to !riscv.reg
-// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %i64 : i64 to !riscv.reg
-// CHECK-NEXT:   %2 = builtin.unrealized_conversion_cast %f32 : f32 to !riscv.freg
-// CHECK-NEXT:   %3 = builtin.unrealized_conversion_cast %f64 : f64 to !riscv.freg
-// CHECK-NEXT:   riscv_debug.printf %0, %1, %2, %3 "bitwidths {} {} {} {}" : (!riscv.reg, !riscv.reg, !riscv.freg, !riscv.freg) -> ()
+// CHECK-NEXT:   %i32_1 = builtin.unrealized_conversion_cast %i32 : i32 to !riscv.reg
+// CHECK-NEXT:   %i64_1 = builtin.unrealized_conversion_cast %i64 : i64 to !riscv.reg
+// CHECK-NEXT:   %f32_1 = builtin.unrealized_conversion_cast %f32 : f32 to !riscv.freg
+// CHECK-NEXT:   %f64_1 = builtin.unrealized_conversion_cast %f64 : f64 to !riscv.freg
+// CHECK-NEXT:   riscv_debug.printf %i32_1, %i64_1, %f32_1, %f64_1 "bitwidths {} {} {} {}" : (!riscv.reg, !riscv.reg, !riscv.freg, !riscv.freg) -> ()
 // CHECK-NEXT: }

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -135,6 +135,8 @@ def get_strided_pointer(
                         ),
                     )
                 )
+                stride_op.rd.name_hint = "pointer_dim_stride"
+                offset_op.rd.name_hint = "pointer_dim_offset"
                 increment = offset_op.rd
 
         if head is None:
@@ -148,6 +150,7 @@ def get_strided_pointer(
                 head, increment, rd=riscv.IntRegisterType.unallocated()
             )
         )
+        add_op.rd.name_hint = "pointer_offset"
         head = add_op.rd
 
     if head is None:
@@ -167,6 +170,10 @@ def get_strided_pointer(
             ),
         ]
     )
+
+    bytes_per_element_op.rd.name_hint = "bytes_per_element"
+    offset_bytes.rd.name_hint = "scaled_pointer_offset"
+    ptr.rd.name_hint = "offset_pointer"
 
     return ops, ptr.rd
 

--- a/xdsl/backend/riscv/lowering/utils.py
+++ b/xdsl/backend/riscv/lowering/utils.py
@@ -161,9 +161,12 @@ def cast_ops_for_values(
                 (value,), (new_type.unallocated(),)
             )
             new_ops.append(cast_op)
-            value = cast_op.results[0]
+            new_value = cast_op.results[0]
+            new_value.name_hint = value.name_hint
+        else:
+            new_value = value
 
-        new_values.append(value)
+        new_values.append(new_value)
 
     return new_ops, new_values
 


### PR DESCRIPTION
I find this makes it much easier to read and debug the lowered code.