### PR TITLE
transformations: handle strided layout attr in memref_stream lowering

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -491,10 +491,10 @@ def test_memref_copy():
 
 
 def test_get_strides():
-    strided = StridedLayoutAttr((12, 4, 1), 5)
+    strided = StridedLayoutAttr((24, 4, 1), 5)
     affine = AffineMapAttr(AffineMap.identity(3))
 
-    assert tuple(strided.get_strides()) == (12, 4, 1)
+    assert tuple(strided.get_strides()) == (24, 4, 1)
     with pytest.raises(
         DiagnosticException, match="Cannot yet extract strides from affine map"
     ):
@@ -504,4 +504,4 @@ def test_get_strides():
     assert tuple(t_none.get_strides()) == (12, 4, 1)
 
     t_id = MemRefType(i32, (2, 3, 4), strided)
-    assert tuple(t_id.get_strides()) == (12, 4, 1)
+    assert tuple(t_id.get_strides()) == (24, 4, 1)

--- a/tests/filecheck/transforms/convert_memref_stream_to_snitch_stream.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_snitch_stream.mlir
@@ -197,4 +197,29 @@ memref_stream.streaming_region {
 // CHECK-NEXT:      memref_stream.yield %res : f64
 // CHECK-NEXT:    }
 
+
+%A_strided = "test.op"() : () -> memref<3x2xf64, strided<[4, 1]>>
+// CHECK-NEXT:    %A_strided = "test.op"() : () -> memref<3x2xf64, strided<[4, 1]>>
+
+
+memref_stream.streaming_region {
+    patterns = [
+        #memref_stream.stride_pattern<ub = [3, 2], index_map = (d0, d1) -> (d0, d1)>
+    ]
+} ins(%A_strided : memref<3x2xf64, strided<[4, 1]>>) {
+^bb0(%a_strided: !stream.readable<f64>):
+    "test.op"(%a_strided) : (!stream.readable<f64>) -> ()
+}
+
+// CHECK-NEXT:    %A_strided_1 = builtin.unrealized_conversion_cast %A_strided : memref<3x2xf64, strided<[4, 1]>> to !riscv.reg
+// CHECK-NEXT:    snitch_stream.streaming_region {
+// CHECK-NEXT:      patterns = [
+// CHECK-NEXT:        #snitch_stream.stride_pattern<ub = [3, 2], strides = [32, 8]>
+// CHECK-NEXT:      ]
+// CHECK-NEXT:    } ins(%A_strided_1 : !riscv.reg) {
+// CHECK-NEXT:    ^{{.*}}(%a_strided : !stream.readable<!riscv.freg>):
+// CHECK-NEXT:      %a_strided_1 = builtin.unrealized_conversion_cast %a_strided : !stream.readable<!riscv.freg> to !stream.readable<f64>
+// CHECK-NEXT:      "test.op"(%a_strided_1) : (!stream.readable<f64>) -> ()
+// CHECK-NEXT:    }
+
 // CHECK-NEXT:  }

--- a/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
+++ b/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
@@ -1,21 +1,46 @@
-from xdsl.ir.affine import AffineExpr, AffineMap
+from collections.abc import Sequence
+
+import pytest
+
+from xdsl.dialects.builtin import Float64Type, MemRefType, f64
+from xdsl.ir.affine import AffineMap
 from xdsl.transforms.convert_memref_stream_to_snitch_stream import (
-    offset_map_from_shape,
     strides_for_affine_map,
+    strides_map_from_memref_type,
 )
+from xdsl.utils.exceptions import DiagnosticException
 
 
-def test_offset_map_from_shape():
-    assert offset_map_from_shape([], 5) == AffineMap(0, 0, (AffineExpr.constant(5),))
-    assert offset_map_from_shape([2, 3], 5) == AffineMap.from_callable(
-        lambda i, j: (i * 15 + j * 5,)
+def mem_type(shape: Sequence[int]) -> MemRefType[Float64Type]:
+    return MemRefType(f64, shape)
+
+
+def test_strides_map_from_memref_type():
+    with pytest.raises(
+        DiagnosticException,
+        match="Unsupported empty shape in memref of type memref<f64>",
+    ):
+        strides_map_from_memref_type(mem_type([]))
+
+    assert strides_map_from_memref_type(mem_type([2, 3])) == AffineMap.from_callable(
+        lambda i, j: (i * 24 + j * 8,)
     )
 
 
 def test_strides_for_affine_map():
-    assert strides_for_affine_map(AffineMap.identity(1), [2], 8) == [8]
-    assert strides_for_affine_map(AffineMap.identity(2), [2, 3], 8) == [24, 8]
-    assert strides_for_affine_map(AffineMap.identity(2), [3, 2], 8) == [16, 8]
-    assert strides_for_affine_map(AffineMap.identity(3), [4, 3, 2], 8) == [48, 16, 8]
-    assert strides_for_affine_map(AffineMap.transpose_map(), [3, 2], 8) == [8, 16]
-    assert strides_for_affine_map(AffineMap.transpose_map(), [2, 3], 8) == [8, 24]
+    assert strides_for_affine_map(AffineMap.identity(1), mem_type([2])) == [8]
+    assert strides_for_affine_map(AffineMap.identity(2), mem_type([2, 3])) == [24, 8]
+    assert strides_for_affine_map(AffineMap.identity(2), mem_type([3, 2])) == [16, 8]
+    assert strides_for_affine_map(AffineMap.identity(3), mem_type([4, 3, 2])) == [
+        48,
+        16,
+        8,
+    ]
+    assert strides_for_affine_map(AffineMap.transpose_map(), mem_type([3, 2])) == [
+        8,
+        16,
+    ]
+    assert strides_for_affine_map(AffineMap.transpose_map(), mem_type([2, 3])) == [
+        8,
+        24,
+    ]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -61,7 +61,7 @@ from xdsl.traits import (
     OptionalSymbolOpInterface,
     SymbolTable,
 )
-from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.exceptions import DiagnosticException, VerifyException
 
 if TYPE_CHECKING:
     from xdsl.parser import AttrParser, Parser
@@ -1137,7 +1137,9 @@ class MemrefLayoutAttr(Attribute, ABC):
 
     name = "abstract.memref_layout_att"
 
-    pass
+    @abstractmethod
+    def get_strides(self) -> Iterable[int | None]:
+        raise NotImplementedError()
 
 
 @irdl_attr_definition
@@ -1213,6 +1215,9 @@ class AffineMapAttr(MemrefLayoutAttr, Data[AffineMap]):
     @staticmethod
     def constant_map(value: int) -> AffineMapAttr:
         return AffineMapAttr(AffineMap.constant_map(value))
+
+    def get_strides(self) -> Iterable[int | None]:
+        raise DiagnosticException("Cannot yet extract strides from affine map")
 
 
 @irdl_attr_definition
@@ -1557,6 +1562,18 @@ class MemRefType(
         if self.layout != NoneAttr() or self.memory_space != NoneAttr():
             printer.print(", ", self.layout, ", ", self.memory_space)
         printer.print(">")
+
+    def get_strides(self) -> Iterable[int | None]:
+        """
+        Yields the strides of the memref for each dimension.
+        The stride of a dimension is the number of elements that are skipped when
+        incrementing the corresponding index by one.
+        """
+        match self.layout:
+            case NoneAttr():
+                return ShapedType.strides_for_shape(self.get_shape())
+            case _:
+                return self.layout.get_strides()
 
 
 @irdl_attr_definition

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -1,8 +1,8 @@
 import operator
-from collections.abc import Sequence
 from functools import reduce
 from typing import cast
 
+from xdsl.backend.riscv.lowering.convert_memref_to_riscv import element_size_for_type
 from xdsl.backend.riscv.lowering.utils import (
     cast_operands_to_regs,
     move_to_unallocated_regs,
@@ -21,11 +21,11 @@ from xdsl.dialects import (
 from xdsl.dialects.builtin import (
     ArrayAttr,
     IntAttr,
+    MemRefType,
     ModuleOp,
-    ShapedType,
     UnrealizedConversionCastOp,
 )
-from xdsl.ir import Attribute, Operation
+from xdsl.ir import Attribute, AttributeCovT, Operation
 from xdsl.ir.affine import AffineExpr, AffineMap
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -36,6 +36,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
+from xdsl.utils.exceptions import DiagnosticException
 
 
 class ReadOpLowering(RewritePattern):
@@ -119,19 +120,17 @@ class StreamOpLowering(RewritePattern):
         if not all(el_type == builtin.f64 for el_type in el_types):
             # Only support f64 streams for now
             return
-        bytes_per_element = 8
-        shapes = tuple(operand_type.get_shape() for operand_type in operand_types)
         stride_patterns = tuple(
             snitch_stream.StridePattern(
                 ArrayAttr(ub.value for ub in pattern.ub),
                 ArrayAttr(
                     IntAttr(stride)
                     for stride in strides_for_affine_map(
-                        pattern.index_map.data, shape, bytes_per_element
+                        pattern.index_map.data, memref_type
                     )
                 ),
             ).simplified()
-            for pattern, shape in zip(op.patterns, shapes, strict=True)
+            for pattern, memref_type in zip(op.patterns, operand_types, strict=True)
         )
         if len(set(stride_patterns)) == 1:
             stride_patterns = (stride_patterns[0],)
@@ -166,7 +165,7 @@ class StreamOpLowering(RewritePattern):
             rewriter.modify_block_argument_type(arg, stream_type)
 
 
-def offset_map_from_shape(shape: Sequence[int], factor: int) -> AffineMap:
+def strides_map_from_memref_type(memref_type: MemRefType[AttributeCovT]) -> AffineMap:
     """
     Given a list of lengths for each dimension of a memref, and the number of bytes per
     element, returns the map from indices to an offset in bytes in memory. The resulting
@@ -182,35 +181,48 @@ def offset_map_from_shape(shape: Sequence[int], factor: int) -> AffineMap:
             el = my_list[k]
             print(el) # -> 1, 2, 3, 4, 5, 6
 
-    map = offset_map_from_strides([3, 1])
+    map = strides_map_from_memref_type(MemRefType(f64, [3, 1]))
 
     for i in range(2):
         for j in range(3):
-            k = map.eval(i, j)
+            k = map.eval(i, j) // 8 # factor of 8 since 8 bytes in f64
             el = my_list[k]
             print(el) # -> 1, 2, 3, 4, 5, 6
     ```
     """
-    if not shape:
-        # Return empty map to avoid reducing over an empty sequence
-        return AffineMap(0, 0, (AffineExpr.constant(factor),))
+    maybe_strides = tuple(memref_type.get_strides())
+    for stride in maybe_strides:
+        if stride is None:
+            raise DiagnosticException(
+                f"Cannot get strides from dynamic layout {memref_type}"
+            )
 
-    strides = ShapedType.strides_for_shape(shape, factor)
+    strides = cast(tuple[int, ...], maybe_strides)
+
+    if not strides:
+        raise DiagnosticException(
+            f"Unsupported empty shape in memref of type {memref_type}"
+        )
+
+    factor = element_size_for_type(memref_type.element_type)
 
     return AffineMap(
-        len(shape),
+        len(strides),
         0,
         (
             reduce(
                 operator.add,
-                (AffineExpr.dimension(i) * stride for i, stride in enumerate(strides)),
+                (
+                    AffineExpr.dimension(i) * stride * factor
+                    for i, stride in enumerate(strides)
+                ),
             ),
         ),
     )
 
 
 def strides_for_affine_map(
-    affine_map: AffineMap, shape: Sequence[int], factor: int
+    affine_map: AffineMap, memref_type: MemRefType[AttributeCovT]
 ) -> list[int]:
     """
     Given an iteration space represented as an affine map (for indexing) and a shape (for
@@ -220,7 +232,7 @@ def strides_for_affine_map(
     """
     if affine_map.num_symbols:
         raise ValueError("Cannot create strides for affine map with symbols")
-    offset_map = offset_map_from_shape(shape, factor)
+    offset_map = strides_map_from_memref_type(memref_type)
     composed = offset_map.compose(affine_map)
 
     zeros = [0] * composed.num_dims

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -167,9 +167,8 @@ class StreamOpLowering(RewritePattern):
 
 def strides_map_from_memref_type(memref_type: MemRefType[AttributeCovT]) -> AffineMap:
     """
-    Given a list of lengths for each dimension of a memref, and the number of bytes per
-    element, returns the map from indices to an offset in bytes in memory. The resulting
-    map has one result expression.
+    Given a memref returns the map from indices to an offset in bytes in memory. The
+    resulting map has one result expression.
 
     e.g.:
     ```


### PR DESCRIPTION
We currently treat all memrefs as raw pointers in our memref_stream.streaming_region lowering, but that's not correct, we want to take the strided layout into account when possible. This PR adds some helpers to compute the appropriate stride map, and uses them to construct the correct snitch stride pattern.