### PR TITLE
(dialects): adding csl_wrapper dialect

### DIFF
--- a/tests/dialects/test_csl_wrapper.py
+++ b/tests/dialects/test_csl_wrapper.py
@@ -1,0 +1,54 @@
+from xdsl.builder import ImplicitBuilder
+from xdsl.dialects import arith
+from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.csl import csl_wrapper
+
+
+def test_get_layout_arg():
+    m_op = csl_wrapper.ModuleOp(
+        7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
+    )
+    assert m_op.get_layout_param("x") == m_op.layout_module.block.args[0]
+    assert m_op.get_layout_param("y") == m_op.layout_module.block.args[1]
+    assert m_op.get_layout_param("width") == m_op.layout_module.block.args[2]
+    assert m_op.get_layout_param("height") == m_op.layout_module.block.args[3]
+    assert m_op.get_layout_param("one") == m_op.layout_module.block.args[4]
+    assert m_op.get_layout_param("two") == m_op.layout_module.block.args[5]
+    assert len(m_op.layout_module.block.args) == 6
+
+
+def test_get_program_arg():
+    m_op = csl_wrapper.ModuleOp(
+        7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
+    )
+    assert m_op.get_program_param("width") == m_op.layout_module.block.args[0]
+    assert m_op.get_program_param("height") == m_op.layout_module.block.args[1]
+    assert m_op.get_program_param("one") == m_op.layout_module.block.args[2]
+    assert m_op.get_program_param("two") == m_op.layout_module.block.args[3]
+    assert len(m_op.program_module.block.args) == 4
+
+
+def test_update_program_args():
+    m_op = csl_wrapper.ModuleOp(
+        7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
+    )
+    assert len(m_op.program_module.block.args) == 4
+    with ImplicitBuilder(m_op.layout_module.block):
+        zero_const = arith.Constant(IntegerAttr(0, 16))
+        seven_const = arith.Constant(IntegerAttr(7, 32))
+        csl_wrapper.YieldOp.from_field_name_mapping(
+            {
+                "zero_param": zero_const,
+                "seven_param": seven_const,
+            }
+        )
+
+    m_op.update_program_block_args_from_layout()
+
+    assert len(m_op.program_module.block.args) == 6
+    assert m_op.get_program_param("width") == m_op.layout_module.block.args[0]
+    assert m_op.get_program_param("height") == m_op.layout_module.block.args[1]
+    assert m_op.get_program_param("one") == m_op.layout_module.block.args[2]
+    assert m_op.get_program_param("two") == m_op.layout_module.block.args[3]
+    assert m_op.get_program_param("zero_param") == m_op.layout_module.block.args[4]
+    assert m_op.get_program_param("seven_param") == m_op.layout_module.block.args[5]

--- a/tests/dialects/test_csl_wrapper.py
+++ b/tests/dialects/test_csl_wrapper.py
@@ -1,6 +1,6 @@
 from xdsl.builder import ImplicitBuilder
 from xdsl.dialects import arith
-from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.builtin import IntegerAttr, IntegerType
 from xdsl.dialects.csl import csl_wrapper
 
 
@@ -21,10 +21,10 @@ def test_get_program_arg():
     m_op = csl_wrapper.ModuleOp(
         7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
     )
-    assert m_op.get_program_param("width") == m_op.layout_module.block.args[0]
-    assert m_op.get_program_param("height") == m_op.layout_module.block.args[1]
-    assert m_op.get_program_param("one") == m_op.layout_module.block.args[2]
-    assert m_op.get_program_param("two") == m_op.layout_module.block.args[3]
+    assert m_op.get_program_param("width") == m_op.program_module.block.args[0]
+    assert m_op.get_program_param("height") == m_op.program_module.block.args[1]
+    assert m_op.get_program_param("one") == m_op.program_module.block.args[2]
+    assert m_op.get_program_param("two") == m_op.program_module.block.args[3]
     assert len(m_op.program_module.block.args) == 4
 
 
@@ -46,9 +46,11 @@ def test_update_program_args():
     m_op.update_program_block_args_from_layout()
 
     assert len(m_op.program_module.block.args) == 6
-    assert m_op.get_program_param("width") == m_op.layout_module.block.args[0]
-    assert m_op.get_program_param("height") == m_op.layout_module.block.args[1]
-    assert m_op.get_program_param("one") == m_op.layout_module.block.args[2]
-    assert m_op.get_program_param("two") == m_op.layout_module.block.args[3]
-    assert m_op.get_program_param("zero_param") == m_op.layout_module.block.args[4]
-    assert m_op.get_program_param("seven_param") == m_op.layout_module.block.args[5]
+    assert m_op.get_program_param("width") == m_op.program_module.block.args[0]
+    assert m_op.get_program_param("height") == m_op.program_module.block.args[1]
+    assert m_op.get_program_param("one") == m_op.program_module.block.args[2]
+    assert m_op.get_program_param("two") == m_op.program_module.block.args[3]
+    assert m_op.get_program_param("zero_param") == m_op.program_module.block.args[4]
+    assert m_op.get_program_param("seven_param") == m_op.program_module.block.args[5]
+    assert m_op.program_module.block.args[4].type == IntegerType(16)
+    assert m_op.program_module.block.args[5].type == IntegerType(32)

--- a/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
@@ -3,7 +3,7 @@
 
 builtin.module {
     "csl_wrapper.module"() <{"width"=10 : i16, "height"=10: i16, "params" = [
-        #csl_wrapper.param<"z_dim" default=4: i16>, #csl_wrapper.param<"pattern" : i16>
+        #csl_wrapper.param<"z_dim" default=4: i16>, #csl_wrapper.param<"pattern" : i16>,
     ]}> ({
         ^0(%x: i16, %y: i16, %width: i16, %height: i16, %z_dim: i16, %pattern: i16):
             %0 = arith.constant 0 : i16

--- a/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
@@ -3,7 +3,7 @@
 
 builtin.module {
     "csl_wrapper.module"() <{"width"=10 : i16, "height"=10: i16, "params" = [
-        #csl_wrapper.param<"z_dim" default=4: i16>, #csl_wrapper.param<"pattern" : i16>,
+        #csl_wrapper.param<"z_dim" default=4: i16>, #csl_wrapper.param<"pattern" : i16>
     ]}> ({
         ^0(%x: i16, %y: i16, %width: i16, %height: i16, %z_dim: i16, %pattern: i16):
             %0 = arith.constant 0 : i16

--- a/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
@@ -1,0 +1,99 @@
+// RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
+
+builtin.module {
+    csl_wrapper.module() <{"width"=10 : i16, "height"=10: i16, "z_dim"=10: i16, "pattern"=5: i16}> ({
+        ^0(%x: i16, %y: i16, %width: i16, %height: i16, %z_dim: i16, %pattern: i16):
+            %0 = arith.constant 0 : i16
+            %1 = "csl.get_color"(%0) : (i16) -> !csl.color
+
+            %routes = "csl_wrapper.import_module"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+            %memcpy = "csl_wrapper.import_module"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+
+            %compute_all_routes = "csl.member_call"(%routes, %x, %y, %height, %width, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
+            %memcpy_params = "csl.member_call"(%memcpy, %x) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
+
+            %2 = arith.constant 1 : i16
+            %3 = arith.minsi %pattern, %2 : i16
+            %4 = arith.minsi %width, %x : i16
+            %5 = arith.minsi %height, %y : i16
+            %6 = arith.cmpi slt, %x, %3 : i16
+            %7 = arith.cmpi slt, %y, %3 : i16
+            %8 = arith.cmpi slt, %4, %pattern : i16
+            %9 = arith.cmpi slt, %5, %pattern : i16
+            %10 = arith.ori %6, %7 : i1
+            %11 = arith.ori %10, %8 : i1
+            %is_border_region_pe = arith.ori %11, %9 : i1
+
+            csl_wrapper.yield {"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]} %memcpy_params, %compute_all_routes, %is_border_region_pe : !csl.comptime_struct, !csl.comptime_struct, i1
+    }, {
+        ^0(%width: i16, %height: i16, %z_dim: i16, %pattern: i16, %memcpy_params: !csl.comptime_struct, %stencil_comms_params: !csl.comptime_struct, %is_border_region_pe: i1):
+
+            func.func @gauss_seidel () {
+                func.return
+            }
+            csl_wrapper.yield
+    })
+}
+
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   csl_wrapper.module() <{"width" = 10 : i16, "height" = 10 : i16, "z_dim" = 10 : i16, "pattern" = 5 : i16}> ({
+// CHECK-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
+// CHECK-NEXT:     %0 = arith.constant 0 : i16
+// CHECK-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
+// CHECK-NEXT:     %routes = "csl_wrapper.import_module"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+// CHECK-NEXT:     %memcpy = "csl_wrapper.import_module"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+// CHECK-NEXT:     %compute_all_routes = "csl.member_call"(%routes, %x, %y, %height, %width, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
+// CHECK-NEXT:     %memcpy_params = "csl.member_call"(%memcpy, %x) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
+// CHECK-NEXT:     %2 = arith.constant 1 : i16
+// CHECK-NEXT:     %3 = arith.minsi %pattern, %2 : i16
+// CHECK-NEXT:     %4 = arith.minsi %width, %x : i16
+// CHECK-NEXT:     %5 = arith.minsi %height, %y : i16
+// CHECK-NEXT:     %6 = arith.cmpi slt, %x, %3 : i16
+// CHECK-NEXT:     %7 = arith.cmpi slt, %y, %3 : i16
+// CHECK-NEXT:     %8 = arith.cmpi slt, %4, %pattern : i16
+// CHECK-NEXT:     %9 = arith.cmpi slt, %5, %pattern : i16
+// CHECK-NEXT:     %10 = arith.ori %6, %7 : i1
+// CHECK-NEXT:     %11 = arith.ori %10, %8 : i1
+// CHECK-NEXT:     %is_border_region_pe = arith.ori %11, %9 : i1
+// CHECK-NEXT:     csl_wrapper.yield  {"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]} %memcpy_params, %compute_all_routes, %is_border_region_pe : !csl.comptime_struct, !csl.comptime_struct, i1
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:   ^1(%width_1 : i16, %height_1 : i16, %z_dim_1 : i16, %pattern_1 : i16, %memcpy_params_1 : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %is_border_region_pe_1 : i1):
+// CHECK-NEXT:     func.func @gauss_seidel() {
+// CHECK-NEXT:       func.return
+// CHECK-NEXT:     }
+// CHECK-NEXT:     csl_wrapper.yield
+// CHECK-NEXT:   })
+// CHECK-NEXT: }
+
+
+// CHECK-GENERIC:      "builtin.module"() ({
+// CHECK-GENERIC-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = {"z_dim" = 10 : i16, "pattern" = 5 : i16}}> ({
+// CHECK-GENERIC-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
+// CHECK-GENERIC-NEXT:     %0 = "arith.constant"() <{"value" = 0 : i16}> : () -> i16
+// CHECK-GENERIC-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
+// CHECK-GENERIC-NEXT:     %routes = "csl_wrapper.import_module"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+// CHECK-GENERIC-NEXT:     %memcpy = "csl_wrapper.import_module"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+// CHECK-GENERIC-NEXT:     %compute_all_routes = "csl.member_call"(%routes, %x, %y, %height, %width, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
+// CHECK-GENERIC-NEXT:     %memcpy_params = "csl.member_call"(%memcpy, %x) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
+// CHECK-GENERIC-NEXT:     %2 = "arith.constant"() <{"value" = 1 : i16}> : () -> i16
+// CHECK-GENERIC-NEXT:     %3 = "arith.minsi"(%pattern, %2) : (i16, i16) -> i16
+// CHECK-GENERIC-NEXT:     %4 = "arith.minsi"(%width, %x) : (i16, i16) -> i16
+// CHECK-GENERIC-NEXT:     %5 = "arith.minsi"(%height, %y) : (i16, i16) -> i16
+// CHECK-GENERIC-NEXT:     %6 = "arith.cmpi"(%x, %3) <{"predicate" = 2 : i64}> : (i16, i16) -> i1
+// CHECK-GENERIC-NEXT:     %7 = "arith.cmpi"(%y, %3) <{"predicate" = 2 : i64}> : (i16, i16) -> i1
+// CHECK-GENERIC-NEXT:     %8 = "arith.cmpi"(%4, %pattern) <{"predicate" = 2 : i64}> : (i16, i16) -> i1
+// CHECK-GENERIC-NEXT:     %9 = "arith.cmpi"(%5, %pattern) <{"predicate" = 2 : i64}> : (i16, i16) -> i1
+// CHECK-GENERIC-NEXT:     %10 = "arith.ori"(%6, %7) : (i1, i1) -> i1
+// CHECK-GENERIC-NEXT:     %11 = "arith.ori"(%10, %8) : (i1, i1) -> i1
+// CHECK-GENERIC-NEXT:     %is_border_region_pe = "arith.ori"(%11, %9) : (i1, i1) -> i1
+// CHECK-GENERIC-NEXT:     "csl_wrapper.yield"(%memcpy_params, %compute_all_routes, %is_border_region_pe) {"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]} : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
+// CHECK-GENERIC-NEXT:   }, {
+// CHECK-GENERIC-NEXT:   ^1(%width_1 : i16, %height_1 : i16, %z_dim_1 : i16, %pattern_1 : i16, %memcpy_params_1 : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %is_border_region_pe_1 : i1):
+// CHECK-GENERIC-NEXT:     "func.func"() <{"sym_name" = "gauss_seidel", "function_type" = () -> ()}> ({
+// CHECK-GENERIC-NEXT:       "func.return"() : () -> ()
+// CHECK-GENERIC-NEXT:     }) : () -> ()
+// CHECK-GENERIC-NEXT:     "csl_wrapper.yield"() : () -> ()
+// CHECK-GENERIC-NEXT:   }) : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
@@ -2,7 +2,9 @@
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
 builtin.module {
-    csl_wrapper.module() <{"width"=10 : i16, "height"=10: i16, "z_dim"=10: i16, "pattern"=5: i16}> ({
+    "csl_wrapper.module"() <{"width"=10 : i16, "height"=10: i16, "params" = [
+        #csl_wrapper.param<"z_dim" default=4: i16>, #csl_wrapper.param<"pattern" : i16>
+    ]}> ({
         ^0(%x: i16, %y: i16, %width: i16, %height: i16, %z_dim: i16, %pattern: i16):
             %0 = arith.constant 0 : i16
             %1 = "csl.get_color"(%0) : (i16) -> !csl.color
@@ -33,12 +35,12 @@ builtin.module {
                 func.return
             }
             csl_wrapper.yield
-    })
+    }) : () -> ()
 }
 
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   csl_wrapper.module() <{"width" = 10 : i16, "height" = 10 : i16, "z_dim" = 10 : i16, "pattern" = 5 : i16}> ({
+// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = [#csl_wrapper.param<"z_dim" default=4 : i16>, #csl_wrapper.param<"pattern" : i16>]}> ({
 // CHECK-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
 // CHECK-NEXT:     %0 = arith.constant 0 : i16
 // CHECK-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
@@ -64,12 +66,12 @@ builtin.module {
 // CHECK-NEXT:       func.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     csl_wrapper.yield
-// CHECK-NEXT:   })
+// CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }
 
 
 // CHECK-GENERIC:      "builtin.module"() ({
-// CHECK-GENERIC-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = {"z_dim" = 10 : i16, "pattern" = 5 : i16}}> ({
+// CHECK-GENERIC-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = [#csl_wrapper.param<"z_dim" default=4 : i16>, #csl_wrapper.param<"pattern" : i16>]}> ({
 // CHECK-GENERIC-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
 // CHECK-GENERIC-NEXT:     %0 = "arith.constant"() <{"value" = 0 : i16}> : () -> i16
 // CHECK-GENERIC-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color

--- a/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
@@ -27,14 +27,14 @@ builtin.module {
             %11 = arith.ori %10, %8 : i1
             %is_border_region_pe = arith.ori %11, %9 : i1
 
-            csl_wrapper.yield {"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]} %memcpy_params, %compute_all_routes, %is_border_region_pe : !csl.comptime_struct, !csl.comptime_struct, i1
+            "csl_wrapper.yield"(%memcpy_params, %compute_all_routes, %is_border_region_pe) <{"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
     }, {
         ^0(%width: i16, %height: i16, %z_dim: i16, %pattern: i16, %memcpy_params: !csl.comptime_struct, %stencil_comms_params: !csl.comptime_struct, %is_border_region_pe: i1):
 
             func.func @gauss_seidel () {
                 func.return
             }
-            csl_wrapper.yield
+            "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
     }) : () -> ()
 }
 
@@ -59,13 +59,13 @@ builtin.module {
 // CHECK-NEXT:     %10 = arith.ori %6, %7 : i1
 // CHECK-NEXT:     %11 = arith.ori %10, %8 : i1
 // CHECK-NEXT:     %is_border_region_pe = arith.ori %11, %9 : i1
-// CHECK-NEXT:     csl_wrapper.yield  {"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]} %memcpy_params, %compute_all_routes, %is_border_region_pe : !csl.comptime_struct, !csl.comptime_struct, i1
+// CHECK-NEXT:     "csl_wrapper.yield"(%memcpy_params, %compute_all_routes, %is_border_region_pe) <{"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
 // CHECK-NEXT:   }, {
 // CHECK-NEXT:   ^1(%width_1 : i16, %height_1 : i16, %z_dim_1 : i16, %pattern_1 : i16, %memcpy_params_1 : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %is_border_region_pe_1 : i1):
 // CHECK-NEXT:     func.func @gauss_seidel() {
 // CHECK-NEXT:       func.return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     csl_wrapper.yield
+// CHECK-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }
 
@@ -90,12 +90,12 @@ builtin.module {
 // CHECK-GENERIC-NEXT:     %10 = "arith.ori"(%6, %7) : (i1, i1) -> i1
 // CHECK-GENERIC-NEXT:     %11 = "arith.ori"(%10, %8) : (i1, i1) -> i1
 // CHECK-GENERIC-NEXT:     %is_border_region_pe = "arith.ori"(%11, %9) : (i1, i1) -> i1
-// CHECK-GENERIC-NEXT:     "csl_wrapper.yield"(%memcpy_params, %compute_all_routes, %is_border_region_pe) {"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]} : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
+// CHECK-GENERIC-NEXT:     "csl_wrapper.yield"(%memcpy_params, %compute_all_routes, %is_border_region_pe) <{"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
 // CHECK-GENERIC-NEXT:   }, {
 // CHECK-GENERIC-NEXT:   ^1(%width_1 : i16, %height_1 : i16, %z_dim_1 : i16, %pattern_1 : i16, %memcpy_params_1 : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %is_border_region_pe_1 : i1):
 // CHECK-GENERIC-NEXT:     "func.func"() <{"sym_name" = "gauss_seidel", "function_type" = () -> ()}> ({
 // CHECK-GENERIC-NEXT:       "func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
-// CHECK-GENERIC-NEXT:     "csl_wrapper.yield"() : () -> ()
+// CHECK-GENERIC-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
 // CHECK-GENERIC-NEXT:   }) : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -66,6 +66,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return CSL_STENCIL
 
+    def get_csl_wrapper():
+        from xdsl.dialects.csl.csl_wrapper import CSL_WRAPPER
+
+        return CSL_WRAPPER
+
     def get_dmp():
         from xdsl.dialects.experimental.dmp import DMP
 
@@ -289,6 +294,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "comb": get_comb,
         "csl": get_csl,
         "csl_stencil": get_csl_stencil,
+        "csl_wrapper": get_csl_wrapper,
         "dmp": get_dmp,
         "fir": get_fir,
         "fsm": get_fsm,

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -58,7 +58,7 @@ class ParamAttribute(ParametrizedAttribute):
     name = "csl_wrapper.param"
 
     key: ParameterDef[StringAttr]
-    value: ParameterDef[IntegerAttr | NoneAttr]
+    value: ParameterDef[IntegerAttr[IntegerType] | NoneAttr]
     type: ParameterDef[IntegerType]
 
     def print_parameters(self, printer: Printer) -> None:

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -1,0 +1,245 @@
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    DictionaryAttr,
+    IntegerAttr,
+    IntegerType,
+    StringAttr,
+)
+from xdsl.dialects.csl import csl
+from xdsl.dialects.utils import AbstractYieldOperation
+from xdsl.ir import Attribute, Block, Dialect, Region
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_op_definition,
+    opt_attr_def,
+    opt_prop_def,
+    prop_def,
+    region_def,
+    result_def,
+    traits_def,
+    var_operand_def,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.traits import HasParent, IsTerminator, Pure
+from xdsl.utils.hints import isa
+
+
+@irdl_op_definition
+class ImportModule(IRDLOperation):
+    """
+    Lightweight wrapper around `csl.import_module` that allows specifying field names directly
+    and removes the need for handling structs or setting up struct operands
+    """
+
+    name = "csl_wrapper.import_module"
+
+    ops = var_operand_def()
+    module = prop_def(StringAttr)
+    fields = prop_def(ArrayAttr[StringAttr])
+    result = result_def(csl.ImportedModuleType())
+
+    def verify_(self) -> None:
+        if len(self.fields) != len(self.ops):
+            raise ValueError("Number of fields does not match number of operands")
+
+
+@irdl_op_definition
+class ModuleOp(IRDLOperation):
+    """
+    Wrapper class that manages initialisation of layout and program module.
+
+    Specified properties will be lowered to module params (`csl.param`). As such, all properties
+    are passed as BlockArgs to the `layout_module` and `program_module` region. The order in which
+    properties are specified is important and must match the order of the block args.
+
+    Additionally, any value yielded by the `layout_module` is passed as a block arg (lowered to `csl.param`)
+    to the program module. Order is important here as well. The layout module's `yield` op should be lowered to
+    `@set_tile_code`, while the program module's `yield` op should be discarded.
+
+    The layout module has two additional block args `x` and `y` as part of the `@set_tile_code` loop nest.
+    Operations using these args need to be lowered to the correct place in the loop nest.
+    """
+
+    name = "csl_wrapper.module"
+
+    width = prop_def(IntegerAttr)
+    height = prop_def(IntegerAttr)
+    params = opt_prop_def(DictionaryAttr)
+
+    layout_module = region_def("single_block")
+    program_module = region_def("single_block")
+
+    @staticmethod
+    def from_properties(properties: dict[str, Attribute]):
+        layout_module = Region(Block())
+        x = layout_module.block.insert_arg(IntegerType(16), 0)
+        y = layout_module.block.insert_arg(IntegerType(16), 1)
+        x.name_hint = "x"
+        y.name_hint = "y"
+
+        for name, value in properties.items():
+            arg = layout_module.block.insert_arg(value, len(layout_module.block.args))
+            arg.name_hint = name
+
+        return ModuleOp(properties=properties, regions=[layout_module, Region(Block())])
+
+    def create_program_block_args_from_layout(self):
+        """Initialise `program_module` BlockArguments from properties and `layout_module` yield op"""
+        assert (
+            len(self.program_module.block.args) == 0
+        ), "program_module block args are not empty"
+        for name, value in self.properties.items():
+            arg = self.program_module.block.insert_arg(
+                value, len(self.program_module.block.args)
+            )
+            arg.name_hint = name
+
+        yield_op = self.layout_module.block.last_op
+        if not isinstance(yield_op, YieldOp):
+            raise ValueError("layout module must be terminated by csl_wrapper.yield")
+
+        if yield_op.fields is None:
+            raise ValueError("layout module yield must specify fields property")
+        yield_op.verify_()
+        for name, op in zip(yield_op.fields, yield_op.arguments):
+            arg = self.program_module.block.insert_arg(
+                op.type, len(self.program_module.block.args)
+            )
+            arg.name_hint = name.data
+
+    def verify_(self):
+        if "x" in self.properties or "y" in self.properties:
+            raise ValueError("'x' and 'y' not allowed as property names")
+
+        all_params: dict[str, Attribute] = {"width": self.width, "height": self.height}
+        if self.params is not None:
+            all_params.update(self.params.data)
+
+        expected_layout_args: dict[str, IntegerType] = {
+            "x": IntegerType(16),
+            "y": IntegerType(16),
+        }
+        expected_program_args: dict[str, Attribute] = {}
+        for name, attr in all_params.items():
+            if not isa(attr, IntegerAttr[IntegerType]):
+                raise ValueError(f"property {name} must be IntegerAttr[IntegerType]")
+            expected_layout_args[name] = attr.type
+            expected_program_args[name] = attr.type
+
+        for got, (name, exp) in zip(
+            [a.type for a in self.layout_module.block.args],
+            expected_layout_args.items(),
+            strict=True,
+        ):
+            if exp != got:
+                raise ValueError(
+                    f"Layout module block arg types do not match for arg {name} expected: {exp} but got: {got}. Block arg types must correspond to prop types (in order)"
+                )
+
+        yield_op = self.layout_module.block.last_op
+        if not isinstance(yield_op, YieldOp):
+            raise ValueError("layout module must be terminated by csl_wrapper.yield")
+
+        if yield_op.fields is None:
+            raise ValueError("layout module yield must specify fields property")
+        yield_op.verify_()
+        for name, op in zip(yield_op.fields, yield_op.arguments):
+            expected_program_args[name.data] = op.type
+
+        for got, (name, exp) in zip(
+            [a.type for a in self.program_module.block.args],
+            expected_program_args.items(),
+            strict=True,
+        ):
+            if exp != got:
+                raise ValueError(
+                    f"Program module block arg types do not match for arg {name} expected: {exp} but got: {got}. Block arg types must correspond to prop types and layout yield result types (in order)"
+                )
+
+        program_yield_op = self.program_module.block.last_op
+        if (
+            not isinstance(program_yield_op, YieldOp)
+            or program_yield_op.fields is not None
+        ):
+            raise ValueError("program module yield may not specify fields property")
+
+    @classmethod
+    def parse(cls, parser: Parser):
+        args = parser.parse_op_args_list()
+        operands = parser.resolve_operands(args, [], parser.pos)
+
+        props = parser.parse_optional_properties_dict()
+        props_l = list(props.items())
+        assert len(props_l) >= 2
+        name, width = props_l.pop(0)
+        assert name == "width"
+        name, height = props_l.pop(0)
+        assert name == "height"
+        params = dict[str, Attribute]()
+        for name, value in props_l:
+            params[name] = value
+
+        parser.parse_punctuation("(")
+        layout_module = parser.parse_region()
+        parser.parse_punctuation(",")
+        program_module = parser.parse_region()
+        parser.parse_punctuation(")")
+
+        return cls(
+            operands=operands,
+            result_types=[],
+            regions=[layout_module, program_module],
+            properties={
+                "width": width,
+                "height": height,
+                "params": DictionaryAttr(data=params),
+            },
+            attributes={},
+        )
+
+    def print(self, printer: Printer):
+        printer.print("() ")
+
+        params: dict[str, Attribute] = {"width": self.width, "height": self.height}
+        if self.params is not None:
+            params.update(self.params.data)
+
+        printer.print("<")
+        printer.print_attr_dict(params)
+        printer.print("> (")
+        printer.print_region(self.layout_module, print_entry_block_args=True)
+        printer.print(", ")
+        printer.print_region(self.program_module, print_entry_block_args=True)
+        printer.print(")")
+
+
+@irdl_op_definition
+class YieldOp(AbstractYieldOperation[Attribute]):
+    """
+    Layout module `yield` ops should be lowered to `@set_tile_code` and must specify `fields`.
+    Program module `yield` ops have no particular meaning and may not specify `fields`.
+    """
+
+    name = "csl_wrapper.yield"
+
+    fields = opt_attr_def(ArrayAttr[StringAttr])
+
+    traits = traits_def(
+        lambda: frozenset([IsTerminator(), HasParent(ModuleOp), Pure()])
+    )
+
+    def verify_(self) -> None:
+        if self.fields is not None and len(self.fields) != len(self.operands):
+            raise ValueError("Number of fields must match the number of operands")
+
+
+CSL_WRAPPER = Dialect(
+    "csl_wrapper",
+    [
+        ImportModule,
+        ModuleOp,
+        YieldOp,
+    ],
+    [],
+)

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -279,9 +279,8 @@ class YieldOp(AbstractYieldOperation[Attribute]):
     def __init__(self, *operands: SSAValue | Operation):
         super().__init__(*operands)
 
-    def from_field_name_mapping(
-        self, field_name_mapping: dict[str, Operand | SSAValue]
-    ):
+    @staticmethod
+    def from_field_name_mapping(field_name_mapping: dict[str, Operand | SSAValue]):
         operands: list[Operand | SSAValue] = []
         attributes: list[StringAttr] = []
         for attr, op in field_name_mapping.items():
@@ -289,6 +288,7 @@ class YieldOp(AbstractYieldOperation[Attribute]):
             operands.append(op)
         result = YieldOp(*operands)
         result.attributes.update({"fields": ArrayAttr[StringAttr](attributes)})
+        return result
 
     def verify_(self) -> None:
         if self.fields is not None and len(self.fields) != len(self.operands):

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -15,7 +15,6 @@ from xdsl.dialects.builtin import (
     StringAttr,
 )
 from xdsl.dialects.csl import ParameterDef, csl
-from xdsl.dialects.utils import AbstractYieldOperation
 from xdsl.ir import (
     Attribute,
     Block,

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -31,7 +31,6 @@ from xdsl.irdl import (
     Operand,
     irdl_attr_definition,
     irdl_op_definition,
-    opt_attr_def,
     prop_def,
     region_def,
     result_def,
@@ -319,7 +318,7 @@ class YieldOp(IRDLOperation):
         args: Sequence[str] | ArrayAttr[StringAttr],
     ):
         if not isinstance(args, ArrayAttr):
-            args = ArrayAttr((StringAttr(arg) for arg in args))
+            args = ArrayAttr(StringAttr(arg) for arg in args)
         super().__init__(
             operands=[operands],
             properties={

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -16,6 +16,7 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.csl import ParameterDef, csl
 from xdsl.ir import (
     Attribute,
+    Block,
     BlockArgument,
     Dialect,
     Operation,
@@ -181,7 +182,24 @@ class ModuleOp(IRDLOperation):
                 "height": height,
                 "params": params_attr,
             },
-            regions=[Region(), Region()],
+            regions=[
+                Region(
+                    Block(
+                        arg_types=itertools.chain(
+                            [i16] * 4,
+                            (param.type for param in params),
+                        )
+                    )
+                ),
+                Region(
+                    Block(
+                        arg_types=itertools.chain(
+                            [i16] * 2,
+                            (param.type for param in params),
+                        )
+                    )
+                ),
+            ],
         )
 
     def update_program_block_args_from_layout(self):

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -125,7 +125,7 @@ class ImportModuleOp(IRDLOperation):
 
     def verify_(self) -> None:
         if len(self.fields) != len(self.ops):
-            raise ValueError("Number of fields does not match number of operands")
+            raise VerifyException("Number of fields does not match number of operands")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -7,7 +7,15 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.csl import csl
 from xdsl.dialects.utils import AbstractYieldOperation
-from xdsl.ir import Attribute, Block, Dialect, Operation, Region, SSAValue
+from xdsl.ir import (
+    Attribute,
+    Block,
+    BlockArgument,
+    Dialect,
+    Operation,
+    Region,
+    SSAValue,
+)
 from xdsl.irdl import (
     IRDLOperation,
     Operand,
@@ -233,7 +241,7 @@ class ModuleOp(IRDLOperation):
         printer.print_region(self.program_module, print_entry_block_args=True)
         printer.print(")")
 
-    def get_layout_arg(self, name: str):
+    def get_layout_arg(self, name: str) -> BlockArgument:
         """Retrieve layout block arg for name that is x, y, or one of the properties"""
         available_arg_names = ["x", "y", "width", "height"] + list(
             self.params.data.keys()
@@ -244,7 +252,7 @@ class ModuleOp(IRDLOperation):
         idx = available_arg_names.index(name)
         return self.layout_module.block.args[idx]
 
-    def get_program_arg(self, name: str):
+    def get_program_arg(self, name: str) -> BlockArgument:
         """Retrieve program block arg for name that is one of the properties or a param set up by layout yield"""
         layout_yield = self.layout_module.block.last_op
         assert isinstance(layout_yield, YieldOp)

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -234,6 +234,7 @@ class ModuleOp(IRDLOperation):
         printer.print(")")
 
     def get_layout_arg(self, name: str):
+        """Retrieve layout block arg for name that is x, y, or one of the properties"""
         available_arg_names = ["x", "y", "width", "height"] + list(
             self.params.data.keys()
         )
@@ -244,6 +245,7 @@ class ModuleOp(IRDLOperation):
         return self.layout_module.block.args[idx]
 
     def get_program_arg(self, name: str):
+        """Retrieve program block arg for name that is one of the properties or a param set up by layout yield"""
         layout_yield = self.layout_module.block.last_op
         assert isinstance(layout_yield, YieldOp)
         yield_args = (
@@ -265,7 +267,7 @@ class ModuleOp(IRDLOperation):
 class YieldOp(AbstractYieldOperation[Attribute]):
     """
     Layout module `yield` ops should be lowered to `@set_tile_code` and must specify `fields`.
-    Program module `yield` ops have no particular meaning and may not specify `fields`.
+    Program module `yield` ops have no particular meaning and specify `fields` here is permitted but undefined.
     """
 
     name = "csl_wrapper.yield"

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -46,8 +46,6 @@ i16 = builtin.IntegerType(16)
 @irdl_attr_definition
 class ParamAttribute(ParametrizedAttribute):
     """
-    TODO: better name here
-
     Represents a module parameter that needs to have a type, and may have a value.
     """
 
@@ -282,7 +280,7 @@ class ModuleOp(IRDLOperation):
         # not found = value error
         raise ValueError(f"{name} does not refer to a block arg of this layout_module")
 
-    def get_program_param_arg(self, name: str) -> BlockArgument:
+    def get_program_param(self, name: str) -> BlockArgument:
         """Retrieve program block arg for name that is one of the properties or a param set up by layout yield"""
         # check static params
         if name in ("width", "height"):

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -284,15 +284,15 @@ class ModuleOp(IRDLOperation):
         """Retrieve program block arg for name that is one of the properties or a param set up by layout yield"""
         # check static params
         if name in ("width", "height"):
-            return self.layout_module.block.args[("width", "height").index(name)]
+            return self.program_module.block.args[("width", "height").index(name)]
         # check module params
         for i, param in enumerate(self.params):
             if param.key.data == name:
-                return self.layout_module.block.args[2 + i]
+                return self.program_module.block.args[2 + i]
         # check yielded params:
         for i, (key, _) in enumerate(self.layout_yield_op.items()):
             if key == name:
-                return self.layout_module.block.args[2 + len(self.params) + i]
+                return self.program_module.block.args[2 + len(self.params) + i]
         # not found = value error
         raise ValueError(f"{name} does not refer to a block arg of this program_module")
 


### PR DESCRIPTION
The `csl_wrapper` dialect is helps initialise CSL modules and manage params.

* Properties of the `csl_wrapper.module` are passed as BlockArgs to both layout_module and program_module
* The layout module takes `%x` and `%y` BlockArgs, as well as all properties. The layout module offers various simplifications:
  * The terminating `csl_wrapper.yield` op is lowered to `@set_tile_code`. Any values yielded are passed as BlockArgs to the program module
  * Any operation using `%x` or `%y` will automatically be placed at the correct level of nesting for the generated `@set_tile_code` loop
  * Structs do not need to be handled manually at this stage and should be constructed automatically when lowering. At this level, we can simply provide a list of field names and args to yield.
  * The `csl_wrapper.import_module` op and `yield` can both take field names directly, without the need to handle structs at this level (the former exists solely for this purpose)
* The program module's BlockArgs are all `csl_wrapper.module` properties as well as every field yielded by layout's `yield` op.
* The semantics of properties-as-BlockArgs should hopefully keep program parameters nicely organised - i.e.., that we don't end up with separate, diverging copies of anything. This should make it really straightforward to manage program-wide properties before further lowering.