### PR TITLE
transformations: Add memref-stream-tile-outer-loops

### DIFF
--- a/tests/filecheck/transforms/memref_stream_tile_outer_loops.mlir
+++ b/tests/filecheck/transforms/memref_stream_tile_outer_loops.mlir
@@ -1,0 +1,133 @@
+// RUN: xdsl-opt --split-input-file --verify-diagnostics -p memref-stream-tile-outer-loops{target-rank=4} %s | filecheck %s
+
+func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x1x18x18xf64> {"llvm.noalias"}, %Y : memref<1x1x8x8xf64> {"llvm.noalias"}) -> memref<1x1x8x8xf64> {
+    %cst = arith.constant -1.000000e+04 : f64
+    memref_stream.generic {
+        bounds = [1, 1, 8, 2, 3, 3, 4],
+        indexing_maps = [
+            affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), ((((d3 * 4) + d6) * 2) + d5))>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, ((d3 * 4) + d4))>
+        ],
+        iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "interleaved"]
+    } ins(%X : memref<1x1x18x18xf64>) outs(%Y : memref<1x1x8x8xf64>) inits(%cst : f64) {
+    ^0(%in : f64, %in_1 : f64, %in_2 : f64, %in_3 : f64, %out : f64, %out_1 : f64, %out_2 : f64, %out_3 : f64):
+        %res_0 = arith.maximumf %out, %in fastmath<fast> : f64
+        %res_1 = arith.maximumf %out_1, %in_1 fastmath<fast> : f64
+        %res_2 = arith.maximumf %out_2, %in_2 fastmath<fast> : f64
+        %res_3 = arith.maximumf %out_3, %in_3 fastmath<fast> : f64
+        memref_stream.yield %res_0, %res_1, %res_2, %res_3 : f64, f64, f64, f64
+    }
+    func.return %Y : memref<1x1x8x8xf64>
+}
+
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x1x18x18xf64> {"llvm.noalias"}, %Y : memref<1x1x8x8xf64> {"llvm.noalias"}) -> memref<1x1x8x8xf64> {
+// CHECK-NEXT:      %cst = arith.constant -1.000000e+04 : f64
+// CHECK-NEXT:      %c0 = arith.constant 0 : index
+// CHECK-NEXT:      %c1 = arith.constant 1 : index
+// CHECK-NEXT:      %ub = arith.constant 8 : index
+// CHECK-NEXT:      scf.for %i = %c0 to %ub step %c1 {
+// CHECK-NEXT:        %X_offset = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0)> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1)> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d2 * 2) + d4))> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((((d3 * 4) + d6) * 2) + d5))> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_subview = memref.subview %X[%X_offset, %X_offset_1, %X_offset_2, %X_offset_3] [1, 1, 3, 17] [1, 1, 1, 1] : memref<1x1x18x18xf64> to memref<1x1x3x17xf64, strided<[324, 324, 18, 1], offset: ?>>
+// CHECK-NEXT:        %Y_offset = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d0)> (%c0, %c0, %i, %c0, %c0)
+// CHECK-NEXT:        %Y_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d1)> (%c0, %c0, %i, %c0, %c0)
+// CHECK-NEXT:        %Y_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d2)> (%c0, %c0, %i, %c0, %c0)
+// CHECK-NEXT:        %Y_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (((d3 * 4) + d4))> (%c0, %c0, %i, %c0, %c0)
+// CHECK-NEXT:        %Y_subview = memref.subview %Y[%Y_offset, %Y_offset_1, %Y_offset_2, %Y_offset_3] [1, 1, 1, 8] [1, 1, 1, 1] : memref<1x1x8x8xf64> to memref<1x1x1x8xf64, strided<[64, 64, 8, 1], offset: ?>>
+// CHECK-NEXT:        memref_stream.generic {
+// CHECK-NEXT:          bounds = [1, 1, 1, 2, 3, 3, 4],
+// CHECK-NEXT:          indexing_maps = [
+// CHECK-NEXT:            affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), ((((d3 * 4) + d6) * 2) + d5))>,
+// CHECK-NEXT:            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, ((d3 * 4) + d4))>
+// CHECK-NEXT:          ],
+// CHECK-NEXT:          iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "interleaved"]
+// CHECK-NEXT:        } ins(%X_subview : memref<1x1x3x17xf64, strided<[324, 324, 18, 1], offset: ?>>) outs(%Y_subview : memref<1x1x1x8xf64, strided<[64, 64, 8, 1], offset: ?>>) inits(%cst : f64) {
+// CHECK-NEXT:        ^0(%in : f64, %in_1 : f64, %in_2 : f64, %in_3 : f64, %out : f64, %out_1 : f64, %out_2 : f64, %out_3 : f64):
+// CHECK-NEXT:          %res = arith.maximumf %out, %in fastmath<fast> : f64
+// CHECK-NEXT:          %res_1 = arith.maximumf %out_1, %in_1 fastmath<fast> : f64
+// CHECK-NEXT:          %res_2 = arith.maximumf %out_2, %in_2 fastmath<fast> : f64
+// CHECK-NEXT:          %res_3 = arith.maximumf %out_3, %in_3 fastmath<fast> : f64
+// CHECK-NEXT:          memref_stream.yield %res, %res_1, %res_2, %res_3 : f64, f64, f64, f64
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:      func.return %Y : memref<1x1x8x8xf64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+// -----
+
+func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x2x18x18xf64> {"llvm.noalias"}, %Y : memref<1x2x8x8xf64> {"llvm.noalias"}) -> memref<1x2x8x8xf64> {
+    %cst = arith.constant -1.000000e+04 : f64
+    memref_stream.generic {
+        bounds = [1, 2, 8, 2, 3, 3, 4],
+        indexing_maps = [
+            affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), ((((d3 * 4) + d6) * 2) + d5))>,
+            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, ((d3 * 4) + d4))>
+        ],
+        iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "interleaved"]
+    } ins(%X : memref<1x2x18x18xf64>) outs(%Y : memref<1x2x8x8xf64>) inits(%cst : f64) {
+    ^0(%in : f64, %in_1 : f64, %in_2 : f64, %in_3 : f64, %out : f64, %out_1 : f64, %out_2 : f64, %out_3 : f64):
+        %res_0 = arith.maximumf %out, %in fastmath<fast> : f64
+        %res_1 = arith.maximumf %out_1, %in_1 fastmath<fast> : f64
+        %res_2 = arith.maximumf %out_2, %in_2 fastmath<fast> : f64
+        %res_3 = arith.maximumf %out_3, %in_3 fastmath<fast> : f64
+        memref_stream.yield %res_0, %res_1, %res_2, %res_3 : f64, f64, f64, f64
+    }
+    func.return %Y : memref<1x2x8x8xf64>
+}
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x2x18x18xf64> {"llvm.noalias"}, %Y : memref<1x2x8x8xf64> {"llvm.noalias"}) -> memref<1x2x8x8xf64> {
+// CHECK-NEXT:      %cst = arith.constant -1.000000e+04 : f64
+// CHECK-NEXT:      %c0 = arith.constant 0 : index
+// CHECK-NEXT:      %c1 = arith.constant 1 : index
+// CHECK-NEXT:      %ub = arith.constant 2 : index
+// CHECK-NEXT:      scf.for %i = %c0 to %ub step %c1 {
+// CHECK-NEXT:        %X_offset = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0)> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1)> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d2 * 2) + d4))> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((((d3 * 4) + d6) * 2) + d5))> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_subview = memref.subview %X[%X_offset, %X_offset_1, %X_offset_2, %X_offset_3] [1, 1, 17, 17] [1, 1, 1, 1] : memref<1x2x18x18xf64> to memref<1x1x17x17xf64, strided<[648, 324, 18, 1], offset: ?>>
+// CHECK-NEXT:        %Y_offset = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d0)> (%c0, %i, %c0, %c0, %c0)
+// CHECK-NEXT:        %Y_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d1)> (%c0, %i, %c0, %c0, %c0)
+// CHECK-NEXT:        %Y_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d2)> (%c0, %i, %c0, %c0, %c0)
+// CHECK-NEXT:        %Y_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (((d3 * 4) + d4))> (%c0, %i, %c0, %c0, %c0)
+// CHECK-NEXT:        %Y_subview = memref.subview %Y[%Y_offset, %Y_offset_1, %Y_offset_2, %Y_offset_3] [1, 1, 8, 8] [1, 1, 1, 1] : memref<1x2x8x8xf64> to memref<1x1x8x8xf64, strided<[128, 64, 8, 1], offset: ?>>
+// CHECK-NEXT:        %c0_1 = arith.constant 0 : index
+// CHECK-NEXT:        %c1_1 = arith.constant 1 : index
+// CHECK-NEXT:        %ub_1 = arith.constant 8 : index
+// CHECK-NEXT:        scf.for %i_1 = %c0_1 to %ub_1 step %c1_1 {
+// CHECK-NEXT:          %X_subview_offset = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %X_subview_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %X_subview_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d2 * 2) + d4))> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %X_subview_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((((d3 * 4) + d6) * 2) + d5))> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %X_subview_subview = memref.subview %X_subview[%X_subview_offset, %X_subview_offset_1, %X_subview_offset_2, %X_subview_offset_3] [1, 1, 3, 17] [1, 1, 1, 1] : memref<1x1x17x17xf64, strided<[648, 324, 18, 1], offset: ?>> to memref<1x1x17x17xf64, strided<[648, 324, 18, 1], offset: ?>>
+// CHECK-NEXT:          %Y_subview_offset = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d0)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %Y_subview_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d1)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %Y_subview_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d2)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %Y_subview_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (((d3 * 4) + d4))> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %Y_subview_subview = memref.subview %Y_subview[%Y_subview_offset, %Y_subview_offset_1, %Y_subview_offset_2, %Y_subview_offset_3] [1, 1, 1, 8] [1, 1, 1, 1] : memref<1x1x8x8xf64, strided<[128, 64, 8, 1], offset: ?>> to memref<1x1x8x8xf64, strided<[128, 64, 8, 1], offset: ?>>
+// CHECK-NEXT:          memref_stream.generic {
+// CHECK-NEXT:            bounds = [1, 1, 1, 2, 3, 3, 4],
+// CHECK-NEXT:            indexing_maps = [
+// CHECK-NEXT:              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), ((((d3 * 4) + d6) * 2) + d5))>,
+// CHECK-NEXT:              affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, ((d3 * 4) + d4))>
+// CHECK-NEXT:            ],
+// CHECK-NEXT:            iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "interleaved"]
+// CHECK-NEXT:          } ins(%X_subview_subview : memref<1x1x17x17xf64, strided<[648, 324, 18, 1], offset: ?>>) outs(%Y_subview_subview : memref<1x1x8x8xf64, strided<[128, 64, 8, 1], offset: ?>>) inits(%cst : f64) {
+// CHECK-NEXT:          ^0(%in : f64, %in_1 : f64, %in_2 : f64, %in_3 : f64, %out : f64, %out_1 : f64, %out_2 : f64, %out_3 : f64):
+// CHECK-NEXT:            %res = arith.maximumf %out, %in fastmath<fast> : f64
+// CHECK-NEXT:            %res_1 = arith.maximumf %out_1, %in_1 fastmath<fast> : f64
+// CHECK-NEXT:            %res_2 = arith.maximumf %out_2, %in_2 fastmath<fast> : f64
+// CHECK-NEXT:            %res_3 = arith.maximumf %out_3, %in_3 fastmath<fast> : f64
+// CHECK-NEXT:            memref_stream.yield %res, %res_1, %res_2, %res_3 : f64, f64, f64, f64
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:      func.return %Y : memref<1x2x8x8xf64>
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -651,6 +651,51 @@ class Subview(IRDLOperation):
         )
 
     @staticmethod
+    def get(
+        source: SSAValue,
+        offsets: Sequence[SSAValue | int],
+        sizes: Sequence[SSAValue | int],
+        strides: Sequence[SSAValue | int],
+        result_type: Attribute,
+    ) -> Subview:
+        dyn_offsets: list[SSAValue] = []
+        dyn_sizes: list[SSAValue] = []
+        dyn_strides: list[SSAValue] = []
+        static_offsets: list[int] = []
+        static_sizes: list[int] = []
+        static_strides: list[int] = []
+
+        for offset in offsets:
+            if isinstance(offset, int):
+                static_offsets.append(offset)
+            else:
+                static_offsets.append(Subview.DYNAMIC_INDEX)
+                dyn_offsets.append(offset)
+        for size in sizes:
+            if isinstance(size, int):
+                static_sizes.append(size)
+            else:
+                static_sizes.append(Subview.DYNAMIC_INDEX)
+                dyn_sizes.append(size)
+        for stride in strides:
+            if isinstance(stride, int):
+                static_strides.append(stride)
+            else:
+                static_strides.append(Subview.DYNAMIC_INDEX)
+                dyn_strides.append(stride)
+
+        return Subview(
+            source,
+            dyn_offsets,
+            dyn_sizes,
+            dyn_strides,
+            static_offsets,
+            static_sizes,
+            static_strides,
+            result_type,
+        )
+
+    @staticmethod
     def from_static_parameters(
         source: SSAValue | Operation,
         source_type: MemRefType[Attribute],

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -176,6 +176,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return memref_stream_interleave.MemrefStreamInterleavePass
 
+    def get_memref_stream_tile_outer_loops():
+        from xdsl.transforms import memref_stream_tile_outer_loops
+
+        return memref_stream_tile_outer_loops.MemrefStreamTileOuterLoopsPass
+
     def get_mlir_opt():
         from xdsl.transforms import mlir_opt
 
@@ -394,6 +399,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "memref-stream-generalize-fill": get_memref_stream_generalize_fill,
         "memref-stream-infer-fill": get_memref_stream_infer_fill,
         "memref-stream-interleave": get_memref_stream_interleave,
+        "memref-stream-tile-outer-loops": get_memref_stream_tile_outer_loops,
         "mlir-opt": get_mlir_opt,
         "printf-to-llvm": get_printf_to_llvm,
         "printf-to-putchar": get_printf_to_putchar,

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -1,0 +1,208 @@
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import cast
+
+from xdsl.context import MLContext
+from xdsl.dialects import affine, arith, memref, memref_stream, scf
+from xdsl.dialects.builtin import (
+    AffineMapAttr,
+    ArrayAttr,
+    IndexType,
+    IntegerAttr,
+    MemRefType,
+    ModuleOp,
+    NoneAttr,
+    StridedLayoutAttr,
+)
+from xdsl.ir import Attribute, Block, Operation, Region, SSAValue
+from xdsl.ir.affine import AffineMap
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint, Rewriter
+from xdsl.utils.exceptions import DiagnosticException
+
+
+def insert_subview(
+    val: SSAValue,
+    m: AffineMapAttr,
+    apply_operands: Sequence[SSAValue],
+    upper_bounds: Sequence[int],
+    location: InsertPoint,
+):
+
+    name_hint_prefix = val.name_hint + "_" if val.name_hint is not None else ""
+    apply_ops = tuple(
+        affine.ApplyOp(
+            apply_operands,
+            AffineMapAttr(AffineMap(m.data.num_dims, m.data.num_symbols, (res,))),
+        )
+        for res in m.data.results
+    )
+    offset_vals = tuple(apply_op.result for apply_op in apply_ops)
+    for offset_val in offset_vals:
+        offset_val.name_hint = name_hint_prefix + "offset"
+    Rewriter.insert_op(apply_ops, location)
+
+    # New subview shape
+    max_values = tuple(ub - 1 for ub in upper_bounds)
+    sizes = tuple(
+        apply_op.map.data.eval(max_values, ())[0] + 1 for apply_op in apply_ops
+    )
+
+    source_type = val.type
+    if not isinstance(source_type, memref.MemRefType):
+        raise DiagnosticException("Cannot create subview from non-memref type")
+    source_type = cast(MemRefType[Attribute], source_type)
+    layout_attr = source_type.layout
+    strides = tuple(source_type.get_strides())
+    if isinstance(layout_attr, NoneAttr):
+        layout_attr = StridedLayoutAttr(strides, None)
+        dest_type = MemRefType(source_type.element_type, sizes, layout_attr)
+    else:
+        dest_type = source_type
+
+    # While not technically incorrect, the new size should be smaller than the source,
+    # instead of just reusing the source shape.
+    # We could compute the new shape and make it dynamic but it's not strictly
+    # speaking necessar for the rest of the pipeline.
+    subview_op = memref.Subview.get(
+        val,
+        offset_vals,
+        sizes,
+        (1,) * len(strides),
+        dest_type,
+    )
+    subview_op.result.name_hint = name_hint_prefix + "subview"
+    Rewriter.insert_op(subview_op, location)
+    return subview_op.result
+
+
+def materialize_loop(
+    rewriter: PatternRewriter, generic_op: memref_stream.GenericOp, index: int
+) -> Sequence[Operation]:
+    """
+    Replaces a given generic op with a for loop containing an op with the ub at the
+    specified index set to 1.
+    """
+    if (
+        generic_op.iterator_types.data[index].data
+        != memref_stream.IteratorType.PARALLEL
+    ):
+        raise DiagnosticException("Cannot ")
+
+    ops: list[Operation] = [
+        zero_op := arith.Constant(IntegerAttr.from_index_int_value(0)),
+        one_op := arith.Constant(IntegerAttr.from_index_int_value(1)),
+        ub_op := arith.Constant(generic_op.bounds.data[index]),
+    ]
+    zero_val = zero_op.result
+    zero_val.name_hint = "c0"
+    one_op.result.name_hint = "c1"
+    ub_op.result.name_hint = "ub"
+
+    for_block = Block((yield_op := scf.Yield(),), arg_types=(IndexType(),))
+
+    loc = InsertPoint.before(yield_op)
+
+    ops.append(scf.For(zero_op, ub_op, one_op, (), Region(for_block)))
+
+    index_val = for_block.args[0]
+    index_val.name_hint = "i"
+
+    input_apply_operands: list[SSAValue] = [zero_val] * len(generic_op.iterator_types)
+    input_apply_operands[index] = index_val
+    output_apply_operands: list[SSAValue] = [zero_val] * (
+        len(generic_op.iterator_types)
+        - sum(
+            it.data == memref_stream.IteratorType.REDUCTION
+            for it in generic_op.iterator_types
+        )
+    )
+    output_apply_operands[index] = index_val
+
+    input_upper_bounds = list(ub.value.data for ub in generic_op.bounds)
+    input_upper_bounds[index] = 1
+    output_upper_bounds = list(
+        ub.value.data
+        for (it, ub) in zip(generic_op.iterator_types, generic_op.bounds)
+        if it.data != memref_stream.IteratorType.REDUCTION
+    )
+    output_upper_bounds[index] = 1
+
+    num_inputs = len(generic_op.inputs)
+
+    new_inputs = tuple(
+        insert_subview(input_val, m, input_apply_operands, input_upper_bounds, loc)
+        for input_val, m in zip(
+            generic_op.inputs, generic_op.indexing_maps.data[:num_inputs], strict=True
+        )
+    )
+    new_outputs = tuple(
+        insert_subview(output_val, m, output_apply_operands, output_upper_bounds, loc)
+        for output_val, m in zip(
+            generic_op.outputs, generic_op.indexing_maps.data[num_inputs:], strict=True
+        )
+    )
+
+    new_bounds = list(generic_op.bounds)
+    new_bounds[index] = IntegerAttr.from_index_int_value(1)
+
+    new_generic_op = memref_stream.GenericOp(
+        new_inputs,
+        new_outputs,
+        generic_op.inits,
+        Rewriter.move_region_contents_to_new_regions(generic_op.body),
+        generic_op.indexing_maps,
+        generic_op.iterator_types,
+        ArrayAttr(new_bounds),
+        generic_op.init_indices,
+    )
+
+    Rewriter.insert_op(new_generic_op, loc)
+
+    rewriter.replace_matched_op(ops)
+
+    return ops
+
+
+@dataclass(frozen=True)
+class TileGenericPattern(RewritePattern):
+
+    target_rank: int = field()
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: memref_stream.GenericOp, rewriter: PatternRewriter
+    ) -> None:
+        ubs = tuple(bound.value.data for bound in op.bounds)
+        effective_rank = sum(ub > 1 for ub in ubs)
+        if effective_rank <= self.target_rank:
+            return
+        index = 0
+        for index, ub in enumerate(ubs):
+            if ub > 1:
+                break
+        materialize_loop(rewriter, op, index)
+
+
+@dataclass(frozen=True)
+class MemrefStreamTileOuterLoopsPass(ModulePass):
+    """
+    Materializes loops around memref_stream.generic operations that have greater than
+    specified number of non-1 upper bounds.
+    """
+
+    name = "memref-stream-tile-outer-loops"
+
+    target_rank: int = field()
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        PatternRewriteWalker(
+            TileGenericPattern(self.target_rank),
+            apply_recursively=False,
+        ).rewrite_module(op)

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -217,5 +217,4 @@ class MemrefStreamTileOuterLoopsPass(ModulePass):
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
         PatternRewriteWalker(
             TileGenericPattern(self.target_rank),
-            apply_recursively=False,
         ).rewrite_module(op)


### PR DESCRIPTION
We sometimes have too high a rank when lowering to snitch_stream, this avoids that at the memref_stream level, before streamification.