### PR TITLE
core: (rewriting) Fix recursive type conversion in block arguments for nested regions

### DIFF
--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -521,10 +521,7 @@ class TypeConversionPattern(RewritePattern):
         for region in op.regions:
             for block in region.blocks:
                 for arg in block.args:
-                    if self.recursive:
-                        converted = self._convert_type_rec(arg.type)
-                    else:
-                        converted = self.convert_type(arg.type)
+                    converted = self._convert_type_rec(arg.type)
                     if converted is not None and converted != arg.type:
                         rewriter.modify_block_argument_type(arg, converted)
         if changed:

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -521,7 +521,10 @@ class TypeConversionPattern(RewritePattern):
         for region in op.regions:
             for block in region.blocks:
                 for arg in block.args:
-                    converted = self.convert_type(arg.type)
+                    if self.recursive:
+                        converted = self._convert_type_rec(arg.type)
+                    else:
+                        converted = self.convert_type(arg.type)
                     if converted is not None and converted != arg.type:
                         rewriter.modify_block_argument_type(arg, converted)
         if changed:


### PR DESCRIPTION
closes #2857 

Solves the issue mentioned there and adds the reported testcase as a regression test.

Before, this was actually quite broken as not applying the recursive rewrite, but the normal rewrite, to the region would actually mean that the produced func_op did not even verify (the `function_type` attribute got rewritten properly, whereas the entry_block args would still have the old type). 

The reason why the old type was being printed is that the `print_func_op_like`-utility function defaults to printing the entry_block arguments in some cases.