### PR TITLE
dialects: (riscv_snitch) Add f32 mul, add, pack from Snitch packed SIMD extension

### DIFF
--- a/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
@@ -22,6 +22,11 @@ riscv_func.func @main() {
   %4 = riscv_snitch.dmstat %3 : (!riscv.reg<a3>) -> !riscv.reg<a4>
   %5 = riscv_snitch.dmstati 22 : () -> !riscv.reg<a5>
 
+  %f0 = riscv.get_float_register : !riscv.freg<ft0>
+  %f1 = riscv_snitch.vfmul.s %f0, %f0 : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
+  %f2 = riscv_snitch.vfadd.s %f0, %f0 : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
+  %f3 = riscv_snitch.vfcpka.s.s %f0, %f0 : (!riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
+
   riscv_func.return
 }
 
@@ -36,4 +41,7 @@ riscv_func.func @main() {
 // CHECK-NEXT:       dmcpy a3, a0, a2
 // CHECK-NEXT:       dmstat a4, a3
 // CHECK-NEXT:       dmstati a5, 22
+// CHECK-NEXT:       vfmul.s ft1, ft0, ft0
+// CHECK-NEXT:       vfadd.s ft1, ft0, ft0
+// CHECK-NEXT:       vfcpka.s.s ft1, ft0, ft0
 // CHECK-NEXT:       ret

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -87,11 +87,11 @@ riscv_func.func @xdma() {
 }
 
 riscv_func.func @simd() {
-  // CHECK-LABEL: @simd
   %v = riscv.get_float_register : !riscv.freg
+  // CHECK: %v = riscv.get_float_register : !riscv.freg
   
   %0 = riscv_snitch.vfmul.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
-  // CHECK: %0 = riscv_snitch.vfmul.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  // CHECK-NEXT: %0 = riscv_snitch.vfmul.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
   %1 = riscv_snitch.vfadd.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
   // CHECK-NEXT: %1 = riscv_snitch.vfadd.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -86,6 +86,22 @@ riscv_func.func @xdma() {
   riscv_func.return
 }
 
+riscv_func.func @simd() {
+  // CHECK-LABEL: @simd
+  %v = riscv.get_float_register : !riscv.freg
+  
+  %0 = riscv_snitch.vfmul.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  // CHECK: %0 = riscv_snitch.vfmul.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+
+  %1 = riscv_snitch.vfadd.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  // CHECK-NEXT: %1 = riscv_snitch.vfadd.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+
+  %2 = riscv_snitch.vfcpka.s.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  // CHECK-NEXT: %2 = riscv_snitch.vfcpka.s.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+
+  riscv_func.return
+}
+
 
 // CHECK-GENERIC-NEXT: "builtin.module"() ({
 // CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
@@ -129,6 +145,13 @@ riscv_func.func @xdma() {
 // CHECK-GENERIC-NEXT:     %{{.*}} = "riscv_snitch.dmstati"() <{"status" = 0 : ui5}> : () -> !riscv.reg
 // CHECK-GENERIC-NEXT:     "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "xdma", "function_type" = () -> ()} : () -> ()
+// CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
+// CHECK-GENERIC-NEXT:       %v = "riscv.get_float_register"() : () -> !riscv.freg
+// CHECK-GENERIC-NEXT:       %0 = "riscv_snitch.vfmul.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:       %1 = "riscv_snitch.vfadd.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:       %2 = "riscv_snitch.vfcpka.s.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:       "riscv_func.return"() : () -> ()
+// CHECK-GENERIC-NEXT:     }) {"sym_name" = "simd", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()
 
 

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -16,8 +16,8 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.riscv import (
     AssemblyInstructionArg,
-    IntRegisterType,
     FloatRegisterType,
+    IntRegisterType,
     RdRsImmIntegerOperation,
     RdRsRsOperation,
     Registers,

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -20,7 +20,6 @@ from xdsl.dialects.riscv import (
     FloatRegisterType,
     RdRsImmIntegerOperation,
     RdRsRsOperation,
-    RdRsOperation,
     Registers,
     RISCVAsmOperation,
     RISCVInstruction,


### PR DESCRIPTION
This PR adds a small set of operations to `riscv_snitch` directly mapping on top of the Snitch custom packed SIMD ISA. Further ops are going to need operand constraints to be correctly register allocated.