### PR TITLE
(transform): csl-stencil to csl-wrapper pass

### DIFF
--- a/tests/dialects/test_csl_wrapper.py
+++ b/tests/dialects/test_csl_wrapper.py
@@ -43,7 +43,7 @@ def test_update_program_args():
             }
         )
 
-    m_op.update_program_block_args_from_layout()
+    m_op.update_program_block_args()
 
     assert len(m_op.program_module.block.args) == 6
     assert m_op.get_program_param("width") == m_op.program_module.block.args[0]
@@ -54,3 +54,40 @@ def test_update_program_args():
     assert m_op.get_program_param("seven_param") == m_op.program_module.block.args[5]
     assert m_op.program_module.block.args[4].type == IntegerType(16)
     assert m_op.program_module.block.args[5].type == IntegerType(32)
+
+
+def test_exported_symbols():
+    m_op = csl_wrapper.ModuleOp(
+        7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
+    )
+    assert len(m_op.program_module.block.args) == 4
+    with ImplicitBuilder(m_op.layout_module.block):
+        zero_const = arith.Constant(IntegerAttr(0, 16))
+        seven_const = arith.Constant(IntegerAttr(7, 32))
+        csl_wrapper.YieldOp.from_field_name_mapping(
+            {
+                "zero_param": zero_const,
+                "seven_param": seven_const,
+            }
+        )
+
+    m_op.update_program_block_args(
+        exported_symbols=[("a_export_arg", IntegerType(17)), (None, IntegerType(18))]
+    )
+
+    assert len(m_op.program_module.block.args) == 8
+    assert m_op.get_program_param("width") == m_op.program_module.block.args[0]
+    assert m_op.get_program_param("height") == m_op.program_module.block.args[1]
+    assert m_op.get_program_param("one") == m_op.program_module.block.args[2]
+    assert m_op.get_program_param("two") == m_op.program_module.block.args[3]
+    assert m_op.get_program_param("zero_param") == m_op.program_module.block.args[4]
+    assert m_op.get_program_param("seven_param") == m_op.program_module.block.args[5]
+    assert m_op.program_module.block.args[4].type == IntegerType(16)
+    assert m_op.program_module.block.args[5].type == IntegerType(32)
+
+    # test exported symbols
+    assert len(m_op.exported_symbols) == 2
+    assert m_op.exported_symbols[0] == m_op.program_module.block.args[6]
+    assert m_op.exported_symbols[1] == m_op.program_module.block.args[7]
+    assert m_op.program_module.block.args[6].type == IntegerType(17)
+    assert m_op.program_module.block.args[7].type == IntegerType(18)

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -689,6 +689,8 @@ def test_access_patterns():
     assert t1_acc.is_diagonal
 
     assert len(tuple(t1_acc.get_diagonals())) == 2
+    assert t0_acc.max_distance() == 1
+    assert t1_acc.max_distance() == 1
 
 
 # TODO: Move to a notebook at some point with proper documentation

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -57,39 +57,36 @@ builtin.module {
 // CHECK-NEXT:     %22 = arith.ori %21, %19 : i1
 // CHECK-NEXT:     "csl_wrapper.yield"(%11, %10, %22) <{"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
 // CHECK-NEXT:   }, {
-// CHECK-NEXT:   ^1(%23 : i16, %24 : i16, %25 : i16, %26 : i16, %memcpy_params : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %isBorderRegionPE : i1):
-// CHECK-NEXT:     func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
-// CHECK-NEXT:       %27 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %28 = "csl_stencil.prefetch"(%27) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
-// CHECK-NEXT:       %29 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:       %30 = csl_stencil.apply(%27 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %29 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
-// CHECK-NEXT:       ^2(%31 : memref<4xtensor<255xf32>>, %32 : index, %33 : tensor<510xf32>):
-// CHECK-NEXT:         %34 = csl_stencil.access %31[1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %35 = csl_stencil.access %31[-1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %36 = csl_stencil.access %31[0, 1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %37 = csl_stencil.access %31[0, -1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %38 = arith.addf %35, %34 : tensor<255xf32>
-// CHECK-NEXT:         %39 = arith.addf %37, %36 : tensor<255xf32>
-// CHECK-NEXT:         %40 = arith.addf %39, %38 : tensor<255xf32>
-// CHECK-NEXT:         %41 = "tensor.insert_slice"(%40, %33, %32) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
-// CHECK-NEXT:         csl_stencil.yield %41 : tensor<510xf32>
-// CHECK-NEXT:       }, {
-// CHECK-NEXT:       ^3(%42 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %43 : tensor<510xf32>):
-// CHECK-NEXT:         %44 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:         %45 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:         %46 = arith.constant 1.666600e-01 : f32
-// CHECK-NEXT:         %47 = "tensor.extract_slice"(%44) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:         %48 = "tensor.extract_slice"(%45) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:         %49 = arith.addf %43, %48 : tensor<510xf32>
-// CHECK-NEXT:         %50 = arith.addf %49, %47 : tensor<510xf32>
-// CHECK-NEXT:         %51 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:         %52 = linalg.fill ins(%46 : f32) outs(%51 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:         %53 = arith.mulf %50, %52 : tensor<510xf32>
-// CHECK-NEXT:         csl_stencil.yield %53 : tensor<510xf32>
-// CHECK-NEXT:       })
-// CHECK-NEXT:       stencil.store %30 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
-// CHECK-NEXT:       func.return
-// CHECK-NEXT:     }
+// CHECK-NEXT:   ^1(%23 : i16, %24 : i16, %25 : i16, %26 : i16, %27 : !csl.comptime_struct, %28 : !csl.comptime_struct, %29 : i1, %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
+// CHECK-NEXT:     %30 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:     %31 = "csl_stencil.prefetch"(%30) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
+// CHECK-NEXT:     %32 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:     %33 = csl_stencil.apply(%30 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %32 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+// CHECK-NEXT:     ^2(%34 : memref<4xtensor<255xf32>>, %35 : index, %36 : tensor<510xf32>):
+// CHECK-NEXT:       %37 = csl_stencil.access %34[1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %38 = csl_stencil.access %34[-1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %39 = csl_stencil.access %34[0, 1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %40 = csl_stencil.access %34[0, -1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %41 = arith.addf %38, %37 : tensor<255xf32>
+// CHECK-NEXT:       %42 = arith.addf %40, %39 : tensor<255xf32>
+// CHECK-NEXT:       %43 = arith.addf %42, %41 : tensor<255xf32>
+// CHECK-NEXT:       %44 = "tensor.insert_slice"(%43, %36, %35) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield %44 : tensor<510xf32>
+// CHECK-NEXT:     }, {
+// CHECK-NEXT:     ^3(%45 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %46 : tensor<510xf32>):
+// CHECK-NEXT:       %47 = csl_stencil.access %45[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %48 = csl_stencil.access %45[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %49 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:       %50 = "tensor.extract_slice"(%47) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %51 = "tensor.extract_slice"(%48) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %52 = arith.addf %46, %51 : tensor<510xf32>
+// CHECK-NEXT:       %53 = arith.addf %52, %50 : tensor<510xf32>
+// CHECK-NEXT:       %54 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:       %55 = linalg.fill ins(%49 : f32) outs(%54 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %56 = arith.mulf %53, %55 : tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield %56 : tensor<510xf32>
+// CHECK-NEXT:     })
+// CHECK-NEXT:     stencil.store %33 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -36,7 +36,7 @@ builtin.module {
 }
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>]}> ({
+// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>], "program_name" = "gauss_seidel"}> ({
 // CHECK-NEXT:   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16):
 // CHECK-NEXT:     %6 = arith.constant 0 : i16
 // CHECK-NEXT:     %7 = "csl.get_color"(%6) : (i16) -> !csl.color

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -57,36 +57,39 @@ builtin.module {
 // CHECK-NEXT:     %22 = arith.ori %21, %19 : i1
 // CHECK-NEXT:     "csl_wrapper.yield"(%11, %10, %22) <{"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
 // CHECK-NEXT:   }, {
-// CHECK-NEXT:   ^1(%23 : i16, %24 : i16, %25 : i16, %26 : i16, %27 : !csl.comptime_struct, %28 : !csl.comptime_struct, %29 : i1, %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
-// CHECK-NEXT:     %30 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:     %31 = "csl_stencil.prefetch"(%30) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
-// CHECK-NEXT:     %32 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:     %33 = csl_stencil.apply(%30 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %32 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
-// CHECK-NEXT:     ^2(%34 : memref<4xtensor<255xf32>>, %35 : index, %36 : tensor<510xf32>):
-// CHECK-NEXT:       %37 = csl_stencil.access %34[1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %38 = csl_stencil.access %34[-1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %39 = csl_stencil.access %34[0, 1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %40 = csl_stencil.access %34[0, -1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %41 = arith.addf %38, %37 : tensor<255xf32>
-// CHECK-NEXT:       %42 = arith.addf %40, %39 : tensor<255xf32>
-// CHECK-NEXT:       %43 = arith.addf %42, %41 : tensor<255xf32>
-// CHECK-NEXT:       %44 = "tensor.insert_slice"(%43, %36, %35) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
-// CHECK-NEXT:       csl_stencil.yield %44 : tensor<510xf32>
-// CHECK-NEXT:     }, {
-// CHECK-NEXT:     ^3(%45 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %46 : tensor<510xf32>):
-// CHECK-NEXT:       %47 = csl_stencil.access %45[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %48 = csl_stencil.access %45[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %49 = arith.constant 1.666600e-01 : f32
-// CHECK-NEXT:       %50 = "tensor.extract_slice"(%47) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %51 = "tensor.extract_slice"(%48) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %52 = arith.addf %46, %51 : tensor<510xf32>
-// CHECK-NEXT:       %53 = arith.addf %52, %50 : tensor<510xf32>
-// CHECK-NEXT:       %54 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:       %55 = linalg.fill ins(%49 : f32) outs(%54 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %56 = arith.mulf %53, %55 : tensor<510xf32>
-// CHECK-NEXT:       csl_stencil.yield %56 : tensor<510xf32>
-// CHECK-NEXT:     })
-// CHECK-NEXT:     stencil.store %33 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:   ^1(%23 : i16, %24 : i16, %25 : i16, %26 : i16, %memcpy_params : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %isBorderRegionPE : i1, %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
+// CHECK-NEXT:     csl.func @gauss_seidel() {
+// CHECK-NEXT:       %27 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %28 = "csl_stencil.prefetch"(%27) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
+// CHECK-NEXT:       %29 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:       %30 = csl_stencil.apply(%27 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %29 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+// CHECK-NEXT:       ^2(%31 : memref<4xtensor<255xf32>>, %32 : index, %33 : tensor<510xf32>):
+// CHECK-NEXT:         %34 = csl_stencil.access %31[1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %35 = csl_stencil.access %31[-1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %36 = csl_stencil.access %31[0, 1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %37 = csl_stencil.access %31[0, -1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %38 = arith.addf %35, %34 : tensor<255xf32>
+// CHECK-NEXT:         %39 = arith.addf %37, %36 : tensor<255xf32>
+// CHECK-NEXT:         %40 = arith.addf %39, %38 : tensor<255xf32>
+// CHECK-NEXT:         %41 = "tensor.insert_slice"(%40, %33, %32) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:         csl_stencil.yield %41 : tensor<510xf32>
+// CHECK-NEXT:       }, {
+// CHECK-NEXT:       ^3(%42 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %43 : tensor<510xf32>):
+// CHECK-NEXT:         %44 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:         %45 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:         %46 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:         %47 = "tensor.extract_slice"(%44) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %48 = "tensor.extract_slice"(%45) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %49 = arith.addf %43, %48 : tensor<510xf32>
+// CHECK-NEXT:         %50 = arith.addf %49, %47 : tensor<510xf32>
+// CHECK-NEXT:         %51 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:         %52 = linalg.fill ins(%46 : f32) outs(%51 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %53 = arith.mulf %50, %52 : tensor<510xf32>
+// CHECK-NEXT:         csl_stencil.yield %53 : tensor<510xf32>
+// CHECK-NEXT:       })
+// CHECK-NEXT:       stencil.store %30 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:       csl.return
+// CHECK-NEXT:     }
 // CHECK-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -1,0 +1,95 @@
+// RUN: xdsl-opt %s -p "csl-stencil-to-csl-wrapper" | filecheck %s
+
+builtin.module {
+  func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
+    %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+    %1 = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
+    %2 = tensor.empty() : tensor<510xf32>
+    %3 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %2 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+    ^0(%4 : memref<4xtensor<255xf32>>, %5 : index, %6 : tensor<510xf32>):
+      %7 = csl_stencil.access %4[1, 0] : memref<4xtensor<255xf32>>
+      %8 = csl_stencil.access %4[-1, 0] : memref<4xtensor<255xf32>>
+      %9 = csl_stencil.access %4[0, 1] : memref<4xtensor<255xf32>>
+      %10 = csl_stencil.access %4[0, -1] : memref<4xtensor<255xf32>>
+      %11 = arith.addf %8, %7 : tensor<255xf32>
+      %12 = arith.addf %10, %9 : tensor<255xf32>
+      %13 = arith.addf %12, %11 : tensor<255xf32>
+      %14 = "tensor.insert_slice"(%13, %6, %5) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+      csl_stencil.yield %14 : tensor<510xf32>
+    }, {
+    ^1(%15 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %16 : tensor<510xf32>):
+      %17 = csl_stencil.access %15[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %18 = csl_stencil.access %15[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %19 = arith.constant 1.666600e-01 : f32
+      %20 = "tensor.extract_slice"(%17) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %21 = "tensor.extract_slice"(%18) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %22 = arith.addf %16, %21 : tensor<510xf32>
+      %23 = arith.addf %22, %20 : tensor<510xf32>
+      %24 = tensor.empty() : tensor<510xf32>
+      %25 = linalg.fill ins(%19 : f32) outs(%24 : tensor<510xf32>) -> tensor<510xf32>
+      %26 = arith.mulf %23, %25 : tensor<510xf32>
+      csl_stencil.yield %26 : tensor<510xf32>
+    })
+    stencil.store %3 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    func.return
+  }
+}
+
+// CHECK-NEXT: builtin.module {
+// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>]}> ({
+// CHECK-NEXT:   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16):
+// CHECK-NEXT:     %6 = arith.constant 0 : i16
+// CHECK-NEXT:     %7 = "csl.get_color"(%6) : (i16) -> !csl.color
+// CHECK-NEXT:     %8 = "csl_wrapper.import_module"(%2, %3, %7) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+// CHECK-NEXT:     %9 = "csl_wrapper.import_module"(%5, %2, %3) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+// CHECK-NEXT:     %10 = "csl.member_call"(%9, %0, %1, %2, %3, %5) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
+// CHECK-NEXT:     %11 = "csl.member_call"(%8, %0) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
+// CHECK-NEXT:     %12 = arith.constant 1 : i16
+// CHECK-NEXT:     %13 = arith.subi %12, %5 : i16
+// CHECK-NEXT:     %14 = arith.subi %2, %0 : i16
+// CHECK-NEXT:     %15 = arith.subi %3, %1 : i16
+// CHECK-NEXT:     %16 = arith.cmpi slt, %0, %13 : i16
+// CHECK-NEXT:     %17 = arith.cmpi slt, %1, %13 : i16
+// CHECK-NEXT:     %18 = arith.cmpi slt, %14, %5 : i16
+// CHECK-NEXT:     %19 = arith.cmpi slt, %15, %5 : i16
+// CHECK-NEXT:     %20 = arith.ori %16, %17 : i1
+// CHECK-NEXT:     %21 = arith.ori %20, %18 : i1
+// CHECK-NEXT:     %22 = arith.ori %21, %19 : i1
+// CHECK-NEXT:     "csl_wrapper.yield"(%11, %10, %22) <{"fields" = ["memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (!csl.comptime_struct, !csl.comptime_struct, i1) -> ()
+// CHECK-NEXT:   }, {
+// CHECK-NEXT:   ^1(%23 : i16, %24 : i16, %25 : i16, %26 : i16, %memcpy_params : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %isBorderRegionPE : i1):
+// CHECK-NEXT:     func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
+// CHECK-NEXT:       %27 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %28 = "csl_stencil.prefetch"(%27) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
+// CHECK-NEXT:       %29 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:       %30 = csl_stencil.apply(%27 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %29 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+// CHECK-NEXT:       ^2(%31 : memref<4xtensor<255xf32>>, %32 : index, %33 : tensor<510xf32>):
+// CHECK-NEXT:         %34 = csl_stencil.access %31[1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %35 = csl_stencil.access %31[-1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %36 = csl_stencil.access %31[0, 1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %37 = csl_stencil.access %31[0, -1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %38 = arith.addf %35, %34 : tensor<255xf32>
+// CHECK-NEXT:         %39 = arith.addf %37, %36 : tensor<255xf32>
+// CHECK-NEXT:         %40 = arith.addf %39, %38 : tensor<255xf32>
+// CHECK-NEXT:         %41 = "tensor.insert_slice"(%40, %33, %32) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:         csl_stencil.yield %41 : tensor<510xf32>
+// CHECK-NEXT:       }, {
+// CHECK-NEXT:       ^3(%42 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %43 : tensor<510xf32>):
+// CHECK-NEXT:         %44 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:         %45 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:         %46 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:         %47 = "tensor.extract_slice"(%44) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %48 = "tensor.extract_slice"(%45) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %49 = arith.addf %43, %48 : tensor<510xf32>
+// CHECK-NEXT:         %50 = arith.addf %49, %47 : tensor<510xf32>
+// CHECK-NEXT:         %51 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:         %52 = linalg.fill ins(%46 : f32) outs(%51 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %53 = arith.mulf %50, %52 : tensor<510xf32>
+// CHECK-NEXT:         csl_stencil.yield %53 : tensor<510xf32>
+// CHECK-NEXT:       })
+// CHECK-NEXT:       stencil.store %30 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:       func.return
+// CHECK-NEXT:     }
+// CHECK-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -331,7 +331,7 @@ class ApplyOp(IRDLOperation):
         Return the access patterns of each input.
 
          - An offset is a tuple describing a relative access
-         - An access pattern is a class wrappoing a sequence of offsets
+         - An access pattern is a class wrapping a sequence of offsets
          - This method returns an access pattern for each stencil
            field of the apply operation.
         """

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -28,6 +28,7 @@ from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,
     irdl_op_definition,
+    opt_prop_def,
     prop_def,
     region_def,
     result_def,
@@ -153,6 +154,7 @@ class ModuleOp(IRDLOperation):
 
     width = prop_def(IntegerAttr)
     height = prop_def(IntegerAttr)
+    program_name = opt_prop_def(StringAttr)
     params: ArrayAttr[ParamAttribute] = prop_def(ArrayAttr[ParamAttribute])
 
     layout_module = region_def("single_block")
@@ -317,6 +319,9 @@ class ModuleOp(IRDLOperation):
         return self.program_module.block.args[
             2 + len(self.params) + len(self.layout_yield_op.fields) :
         ]
+
+    def set_program_name(self, name: StringAttr):
+        self.program_name = name
 
 
 @irdl_op_definition

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -320,9 +320,6 @@ class ModuleOp(IRDLOperation):
             2 + len(self.params) + len(self.layout_yield_op.fields) :
         ]
 
-    def set_program_name(self, name: StringAttr):
-        self.program_name = name
-
 
 @irdl_op_definition
 class YieldOp(IRDLOperation):

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -524,7 +524,7 @@ class ApplyOp(IRDLOperation):
         Return the access patterns of each input.
 
          - An offset is a tuple describing a relative access
-         - An access pattern is a class wrappoing a sequence of offsets
+         - An access pattern is a class wrapping a sequence of offsets
          - This method returns an access pattern for each stencil
            field of the apply operation.
         """
@@ -1371,6 +1371,15 @@ class AccessPattern:
                 lefts[axis] = min(ax[axis], lefts[axis])
                 rights[axis] = max(ax[axis], rights[axis])
         return tuple(zip(lefts, rights))
+
+    def max_distance(self) -> int:
+        """
+        Returns the maximum absolute accessed distance across all axes.
+        """
+        res = 0
+        for ax in self.offsets:
+            res = max(res, max(abs(a) for a in ax))
+        return res
 
     def visual_pattern(self) -> str:
         """

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -91,6 +91,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return common_subexpression_elimination.CommonSubexpressionElimination
 
+    def get_csl_stencil_to_csl_wrapper():
+        from xdsl.transforms import csl_stencil_to_csl_wrapper
+
+        return csl_stencil_to_csl_wrapper.CslStencilToCslWrapperPass
+
     def get_dce():
         from xdsl.transforms import dead_code_elimination
 
@@ -378,6 +383,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "inline-snrt": get_convert_snrt_to_riscv,
         "convert-stencil-to-ll-mlir": get_convert_stencil_to_ll_mlir,
         "cse": get_cse,
+        "csl-stencil-to-csl-wrapper": get_csl_stencil_to_csl_wrapper,
         "dce": get_dce,
         "distribute-stencil": get_distribute_stencil,
         "dmp-to-mpi": get_lower_halo_to_mpi,

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -89,7 +89,7 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
 
         self.initialise_layout_module(module_op)
         module_op.update_program_block_args_from_layout()
-        module_op.set_program_name(op.sym_name)
+        module_op.program_name = op.sym_name
 
         # add func args to program_module block args
         for block_arg in op.body.block.args:

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -191,7 +191,10 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
 
 @dataclass(frozen=True)
 class CslStencilToCslWrapperPass(ModulePass):
-    """Wraps program in the csl_stencil dialect in a csl_wrapper"""
+    """
+    Wraps program in the csl_stencil dialect in a csl_wrapper by translating each
+    top-level function to one module wrapper.
+    """
 
     name = "csl-stencil-to-csl-wrapper"
 
@@ -200,7 +203,6 @@ class CslStencilToCslWrapperPass(ModulePass):
             GreedyRewritePatternApplier(
                 [
                     ConvertStencilFuncToModuleWrappedPattern(),
-                    # ConvertApplyOpPattern(num_chunks=self.num_chunks),
                 ]
             ),
             walk_reverse=False,

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -1,0 +1,209 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from xdsl.builder import ImplicitBuilder
+from xdsl.context import MLContext
+from xdsl.dialects import arith, builtin, func, stencil
+from xdsl.dialects.builtin import IntegerAttr, TensorType
+from xdsl.dialects.csl import csl, csl_stencil, csl_wrapper
+from xdsl.ir import Attribute
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.rewriter import InsertPoint
+from xdsl.utils.hints import isa
+
+
+@dataclass(frozen=True)
+class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
+    """
+    Wraps program in the csl_stencil dialect in a csl_wrapper module.
+    Scans the csl_stencil.apply ops for stencil-related params, passing them as properties to the wrapped module
+    (note, properties are in return passed as block args to the layout_module and program_module blocks).
+
+    The layout module wrapper can be used to initialise general program module params. This pass generates code
+    to initialise stencil-specific program params and yields them from the layout module.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: func.FuncOp, rewriter: PatternRewriter, /):
+        # find csl_stencil.apply ops, abort if there are none
+        apply_ops = self.get_csl_stencil_apply_ops(op)
+        if len(apply_ops) == 0:
+            return
+        neighbours: int = 1
+        width: int = 1
+        height: int = 1
+        z_dim_no_ghost_cells: int = 1
+        z_dim: int = 1
+        for apply_op in apply_ops:
+            # loop over accesses to get `neighbour` (from which we build `pattern`)
+            for ap in apply_op.get_accesses():
+                if ap.is_diagonal:
+                    raise ValueError("Diagonal accesses are currently not supported")
+                # if ap.dims != 2:
+                #     raise ValueError("Stencil accesses must be 2-dimensional at this stage")
+                if len(ap.offsets) > 0:
+                    neighbours = max(
+                        neighbours, max(abs(d) for offset in ap.offsets for d in offset)
+                    )
+
+            # find max x and y dimensions
+            if len(shape := apply_op.topo.shape.data) == 2:
+                assert isinstance(
+                    shape.data[0].data, int
+                ), "Cannot have a float data shape"
+                assert isinstance(
+                    shape.data[1].data, int
+                ), "Cannot have a float data shape"
+                width = max(width, shape.data[0].data)
+                height = max(height, shape.data[1].data)
+            else:
+                raise ValueError("Stencil accesses must be 2-dimensional at this stage")
+
+            # find max z dimension - we could get this from func args, store ops, or apply ops
+            for result in apply_op.results:
+                if isa(result.type, stencil.TempType[TensorType[Attribute]]):
+                    z_dim_no_ghost_cells = max(
+                        z_dim_no_ghost_cells,
+                        result.type.get_element_type().get_shape()[0],
+                    )
+            for arg in op.args:
+                if isa(field_t := arg.type, stencil.FieldType[TensorType[Attribute]]):
+                    z_dim = max(z_dim, field_t.get_element_type().get_shape()[0])
+
+        # initialise module op
+        module_op = csl_wrapper.ModuleOp(
+            width=IntegerAttr(width, 16),
+            height=IntegerAttr(height, 16),
+            params={
+                "z_dim": IntegerAttr(z_dim, 16),
+                "pattern": IntegerAttr(neighbours + 1, 16),
+            },
+        )
+
+        self.initialise_layout_module(module_op)
+        module_op.update_program_block_args_from_layout()
+
+        module_op.program_module.block.add_op(csl_wrapper.YieldOp([], []))
+        assert op.parent is not None
+
+        # insert module op and dump func.func in the program_module
+        rewriter.insert_op(module_op, InsertPoint.before(op))
+        op.parent.detach_op(op)
+        rewriter.insert_op(op, InsertPoint.at_start(module_op.program_module.block))
+
+    def get_csl_stencil_apply_ops(
+        self, op: func.FuncOp
+    ) -> Sequence[csl_stencil.ApplyOp]:
+        result: list[csl_stencil.ApplyOp] = []
+        for apply_op in op.body.walk():
+            if isinstance(apply_op, csl_stencil.ApplyOp):
+                result.append(apply_op)
+        return result
+
+    def initialise_layout_module(self, module_op: csl_wrapper.ModuleOp):
+        """Initialises the layout_module (wrapper block) by setting up (esp. stencil-related) program params"""
+
+        # extract layout module params as the function has linear complexity
+        param_width = module_op.get_layout_param("width")
+        param_height = module_op.get_layout_param("height")
+        param_x = module_op.get_layout_param("x")
+        param_y = module_op.get_layout_param("y")
+        param_pattern = module_op.get_layout_param("pattern")
+
+        # fill layout module wrapper block with ops
+        with ImplicitBuilder(module_op.layout_module.block):
+            # set up LAUNCH
+            zero = arith.Constant(IntegerAttr(0, 16))
+            launch = csl.GetColorOp(zero)
+
+            # import memcpy/get_params and routes
+            memcpy = csl_wrapper.ImportModuleOp(
+                "<memcpy/get_params>",
+                {
+                    "width": param_width,
+                    "height": param_height,
+                    "LAUNCH": launch.res,
+                },
+            )
+            routes = csl_wrapper.ImportModuleOp(
+                "routes.csl",
+                {
+                    "pattern": param_pattern,
+                    "peWidth": param_width,
+                    "peHeight": param_height,
+                },
+            )
+
+            # set up program param `stencil_comms_params`
+            all_routes = csl.MemberCallOp(
+                "computeAllRoutes",
+                csl.ComptimeStructType(),
+                routes,
+                params=[
+                    param_x,
+                    param_y,
+                    param_width,
+                    param_height,
+                    param_pattern,
+                ],
+            )
+            # set up program param `memcpy_params`
+            memcpy_params = csl.MemberCallOp(
+                "get_params",
+                csl.ComptimeStructType(),
+                memcpy,
+                params=[
+                    param_x,
+                ],
+            )
+
+            # set up program param `is_border_region_pe`
+            one = arith.Constant(IntegerAttr(1, 16))
+            pattern_minus_one = arith.Subi(one, param_pattern)
+            width_minus_x = arith.Subi(param_width, param_x)
+            height_minus_y = arith.Subi(param_height, param_y)
+            x_lt_pattern_minus_one = arith.Cmpi(param_x, pattern_minus_one, "slt")
+            y_lt_pattern_minus_one = arith.Cmpi(param_y, pattern_minus_one, "slt")
+            width_minus_one_lt_pattern = arith.Cmpi(width_minus_x, param_pattern, "slt")
+            height_minus_one_lt_pattern = arith.Cmpi(
+                height_minus_y, param_pattern, "slt"
+            )
+            or1_op = arith.OrI(x_lt_pattern_minus_one, y_lt_pattern_minus_one)
+            or2_op = arith.OrI(or1_op, width_minus_one_lt_pattern)
+            is_border_region_pe = arith.OrI(or2_op, height_minus_one_lt_pattern)
+
+            # yield things as named params to the program module
+            csl_wrapper.YieldOp.from_field_name_mapping(
+                field_name_mapping={
+                    "memcpy_params": memcpy_params.results[0],
+                    "stencil_comms_params": all_routes.results[0],
+                    "isBorderRegionPE": is_border_region_pe.result,
+                }
+            )
+
+
+@dataclass(frozen=True)
+class CslStencilToCslWrapperPass(ModulePass):
+    """Wraps program in the csl_stencil dialect in a csl_wrapper"""
+
+    name = "csl-stencil-to-csl-wrapper"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        module_pass = PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    ConvertStencilFuncToModuleWrappedPattern(),
+                    # ConvertApplyOpPattern(num_chunks=self.num_chunks),
+                ]
+            ),
+            walk_reverse=False,
+            apply_recursively=False,
+        )
+        module_pass.rewrite_module(op)

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -92,9 +92,7 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
 
         # add yield op args (implicit) and func args (explicit) to program_module block args
         module_op.update_program_block_args(
-            exported_symbols=[
-                (arg.name_hint, arg.type) for arg in module_op.program_module.block.args
-            ]
+            exported_symbols=[(arg.name_hint, arg.type) for arg in op.body.block.args]
         )
 
         # replace func.return

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -88,14 +88,14 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
         )
 
         self.initialise_layout_module(module_op)
-        module_op.update_program_block_args_from_layout()
         module_op.program_name = op.sym_name
 
-        # add func args to program_module block args
-        for block_arg in op.body.block.args:
-            module_op.program_module.block.insert_arg(
-                block_arg.type, len(module_op.program_module.block.args)
-            )
+        # add yield op args (implicit) and func args (explicit) to program_module block args
+        module_op.update_program_block_args(
+            exported_symbols=[
+                (arg.name_hint, arg.type) for arg in module_op.program_module.block.args
+            ]
+        )
 
         # replace func.return
         func_return = op.body.block.last_op

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -224,7 +224,6 @@ class CslStencilToCslWrapperPass(ModulePass):
                     ConvertStencilFuncToModuleWrappedPattern(),
                 ]
             ),
-            walk_reverse=False,
             apply_recursively=False,
         )
         module_pass.rewrite_module(op)

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -88,9 +88,7 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
 
         self.initialise_layout_module(module_op)
         module_op.update_program_block_args_from_layout()
-
-        # module_op.program_module.block.add_op(csl_wrapper.YieldOp([], []))
-        assert op.parent is not None
+        module_op.set_program_name(op.sym_name)
 
         # move func.body into program_module, with combined args
         for block_arg in reversed(module_op.program_module.block.args):


### PR DESCRIPTION
Pass to lower `csl_stencil` to `csl_wrapper`.

* Creates one `csl_wrapper.module` for each module-level function
* Extracts stencil-related params to initialise `csl_wrapper.modue` and both of its `layout_module` and `program_module` regions
* Initialises `layout_module` with everything required for running stencil programs and yields it to `program_module`, specifically: memcpy params, routes config, and `isBorderRegionPE` bool

Not in this PR:
* ~~Handling host-device transferable symbols and setting up exports~~
* ~~Setting up and exporting program entry point~~

~~As such, the translated func is currently simply placed inside the `program_module`.~~

Update:
* Host-device transferable symbols are now added to the `program_module` block args
* The function op is resolved
* The function `sym_name` is stored as a property on the module
* ~~The function body is moved into the program module body~~
* We set up a main entry point `csl.func` named after the translated `func.func`, transfer the ops into the new csl main func, and add the function to the program module body