### PR TITLE
backend: (riscv) add tied operands/results to register allocation

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -24,8 +24,8 @@ from xdsl.utils.exceptions import VerifyException
 # We use the infamous post-increment load instruction
 # provided by several architectures (ARM, PULP, ...) that presents
 # the classical form of a 2-address instruction: the first operand
-# is incremented and in a brand new SSA value as the second result.
-# Both SSA values must be allocated on the same register, otherwise the
+# is incremented and returned in a brand new SSA value as the second result.
+# Both tied SSA values must be allocated on the same register, otherwise the
 # generated code is broken.
 @irdl_op_definition
 class PostIncrementLoad(RISCVInstruction):

--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -1,0 +1,82 @@
+from typing import Annotated, TypeAlias
+
+from xdsl.backend.riscv.register_allocation import RegisterAllocatorLivenessBlockNaive
+from xdsl.builder import Builder
+from xdsl.dialects import builtin, riscv_func, riscv
+from xdsl.dialects.riscv import (
+    AssemblyInstructionArg,
+    IntRegisterType,
+    RISCVInstruction,
+)
+from xdsl.ir import OpResult
+from xdsl.irdl import (
+    ConstraintVar,
+    Operand,
+    operand_def,
+    result_def,
+)
+from xdsl.irdl.operations import irdl_op_definition
+
+
+def test_allocate_2address():
+    # We use the infamous post-increment load instruction
+    # provided by several architectures (ARM, PULP, ...) that presents
+    # the classical form of a 2-address instruction: the first operand
+    # is returned as modified in a brand new SSA value as the second result.
+    # Both SSA values must be allocated on the same register, otherwise the
+    # generated code is broken.
+
+    @irdl_op_definition
+    class PostIncrementLoad(RISCVInstruction):
+        name = "postload"
+
+        SameIntRegisterType: TypeAlias = Annotated[IntRegisterType, ConstraintVar("T")]
+
+        rd: OpResult = result_def(IntRegisterType)  # loaded value
+        off: OpResult = result_def(
+            SameIntRegisterType
+        )  # new value of the incremented offset
+        rs1: Operand = operand_def(SameIntRegisterType)  # offset
+        rs2: Operand = operand_def(IntRegisterType)  # base adddress
+
+        def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+            return self.rd, self.rs1, self.rs2
+
+    # riscv_func.func @function() {
+    #     %0 = riscv.li 1 : !riscv.reg<t1>
+    #     %1 = riscv.li 2 : !riscv.reg<t2>
+    #        tied -------- tied                  tied ---------------------------------------------- tied
+    #         |             |                     |                                                   |
+    #     %2, %3 = postload %0, %1 : (!riscv.reg<t1>, !riscv.reg<t2>) -> (!riscv.reg<t0>, !riscv.reg<t1>)
+    #     %4 = builtin.unrealized_conversion_cast %2 : !riscv.reg<t0> to i32
+    #     %5 = builtin.unrealized_conversion_cast %3 : !riscv.reg<t1> to i32
+    #     riscv_func.return
+    # }
+    @Builder.implicit_region
+    def region():
+        base = riscv.LiOp(1)
+        offset = riscv.LiOp(2)
+        load = PostIncrementLoad(
+            operands=[base.rd, offset.rd],
+            result_types=[
+                IntRegisterType.unallocated(),
+                IntRegisterType.unallocated(),
+            ],
+        )
+        builtin.UnrealizedConversionCastOp.get((load.rd,), (builtin.i32,))
+        builtin.UnrealizedConversionCastOp.get((load.off,), (builtin.i32,))
+        riscv_func.ReturnOp()
+
+    func = riscv_func.FuncOp("function", region, ((), ()))
+    func.verify()
+
+    allocator = RegisterAllocatorLivenessBlockNaive()
+    allocator.allocate_func(func)
+
+    body = list(func.body.block.ops)
+    # load.rs1 == load.off
+    assert body[2].operands[0].type == body[2].results[1].type
+    # load.rs1 != load.rd
+    assert body[2].operands[0].type != body[2].results[0].type
+    # load.rs1 != load.rs2
+    assert body[2].operands[0].type != body[2].operands[1].type

--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -22,7 +22,7 @@ def test_allocate_2address():
     # We use the infamous post-increment load instruction
     # provided by several architectures (ARM, PULP, ...) that presents
     # the classical form of a 2-address instruction: the first operand
-    # is returned as modified in a brand new SSA value as the second result.
+    # is incremented and in a brand new SSA value as the second result.
     # Both SSA values must be allocated on the same register, otherwise the
     # generated code is broken.
 
@@ -72,6 +72,7 @@ def test_allocate_2address():
 
     allocator = RegisterAllocatorLivenessBlockNaive()
     allocator.allocate_func(func)
+    func.verify()
 
     body = list(func.body.block.ops)
     # load.rs1 == load.off

--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -1,5 +1,7 @@
 from typing import Annotated, TypeAlias
 
+import pytest
+
 from xdsl.backend.riscv.register_allocation import RegisterAllocatorLivenessBlockNaive
 from xdsl.builder import Builder
 from xdsl.dialects import builtin, riscv_func, riscv
@@ -16,32 +18,33 @@ from xdsl.irdl import (
     result_def,
 )
 from xdsl.irdl.operations import irdl_op_definition
+from xdsl.utils.exceptions import VerifyException
+
+
+# We use the infamous post-increment load instruction
+# provided by several architectures (ARM, PULP, ...) that presents
+# the classical form of a 2-address instruction: the first operand
+# is incremented and in a brand new SSA value as the second result.
+# Both SSA values must be allocated on the same register, otherwise the
+# generated code is broken.
+@irdl_op_definition
+class PostIncrementLoad(RISCVInstruction):
+    name = "postload"
+
+    SameIntRegisterType: TypeAlias = Annotated[IntRegisterType, ConstraintVar("T")]
+
+    rd: OpResult = result_def(IntRegisterType)  # loaded value
+    off: OpResult = result_def(
+        SameIntRegisterType
+    )  # new value of the incremented offset
+    rs1: Operand = operand_def(SameIntRegisterType)  # offset
+    rs2: Operand = operand_def(IntRegisterType)  # base adddress
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        return self.rd, self.rs1, self.rs2
 
 
 def test_allocate_2address():
-    # We use the infamous post-increment load instruction
-    # provided by several architectures (ARM, PULP, ...) that presents
-    # the classical form of a 2-address instruction: the first operand
-    # is incremented and in a brand new SSA value as the second result.
-    # Both SSA values must be allocated on the same register, otherwise the
-    # generated code is broken.
-
-    @irdl_op_definition
-    class PostIncrementLoad(RISCVInstruction):
-        name = "postload"
-
-        SameIntRegisterType: TypeAlias = Annotated[IntRegisterType, ConstraintVar("T")]
-
-        rd: OpResult = result_def(IntRegisterType)  # loaded value
-        off: OpResult = result_def(
-            SameIntRegisterType
-        )  # new value of the incremented offset
-        rs1: Operand = operand_def(SameIntRegisterType)  # offset
-        rs2: Operand = operand_def(IntRegisterType)  # base adddress
-
-        def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
-            return self.rd, self.rs1, self.rs2
-
     # riscv_func.func @function() {
     #     %0 = riscv.li 1 : !riscv.reg<t1>
     #     %1 = riscv.li 2 : !riscv.reg<t2>
@@ -77,6 +80,41 @@ def test_allocate_2address():
     body = list(func.body.block.ops)
     # load.rs1 == load.off
     assert body[2].operands[0].type == body[2].results[1].type
+    # load.rs1 != load.rd
+    assert body[2].operands[0].type != body[2].results[0].type
+    # load.rs1 != load.rs2
+    assert body[2].operands[0].type != body[2].operands[1].type
+
+
+def test_allocate_2address_preallocated():
+    @Builder.implicit_region
+    def region():
+        base = riscv.LiOp(1)
+        offset = riscv.LiOp(2)
+        load = PostIncrementLoad(
+            operands=[base.rd, offset.rd],
+            result_types=[
+                IntRegisterType.unallocated(),
+                riscv.Registers.A7,
+            ],
+        )
+        builtin.UnrealizedConversionCastOp.get((load.rd,), (builtin.i32,))
+        builtin.UnrealizedConversionCastOp.get((load.off,), (builtin.i32,))
+        riscv_func.ReturnOp()
+
+    func = riscv_func.FuncOp("function", region, ((), ()))
+    with pytest.raises(VerifyException):
+        func.verify()
+
+    allocator = RegisterAllocatorLivenessBlockNaive()
+    allocator.exclude_preallocated = True
+    allocator.allocate_func(func)
+    func.verify()
+
+    body = list(func.body.block.ops)
+    # load.rs1 == load.off
+    assert body[2].operands[0].type == riscv.Registers.A7
+    assert body[2].results[1].type == riscv.Registers.A7
     # load.rs1 != load.rd
     assert body[2].operands[0].type != body[2].results[0].type
     # load.rs1 != load.rs2

--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -47,12 +47,15 @@ class PostIncrementLoad(RISCVInstruction):
 def test_allocate_2address():
     # riscv_func.func @function() {
     #     %0 = riscv.li 1 : !riscv.reg<t1>
-    #     %1 = riscv.li 2 : !riscv.reg<t2>
+    #     %1 = riscv.li 2 : !riscv.reg<t0>
     #        tied -------- tied                  tied ---------------------------------------------- tied
     #         |             |                     |                                                   |
-    #     %2, %3 = postload %0, %1 : (!riscv.reg<t1>, !riscv.reg<t2>) -> (!riscv.reg<t0>, !riscv.reg<t1>)
-    #     %4 = builtin.unrealized_conversion_cast %2 : !riscv.reg<t0> to i32
-    #     %5 = builtin.unrealized_conversion_cast %3 : !riscv.reg<t1> to i32
+    #     %2, %3 = postload %0, %1 : (!riscv.reg<t1>, !riscv.reg<t0>) -> (!riscv.reg<t0>, !riscv.reg<t1>)
+    #
+    #                this add forces all results of the postload to be allocated first
+    #                 |
+    #     %4 = riscv.add %2, %3 : (!riscv.reg<t0>, !riscv.reg<t1>) -> !riscv.reg<t0>
+    #     %5 = builtin.unrealized_conversion_cast %4 : !riscv.reg<t0> to i32
     #     riscv_func.return
     # }
     @Builder.implicit_region

--- a/tests/backend/riscv/test_register_allocation_constraints.py
+++ b/tests/backend/riscv/test_register_allocation_constraints.py
@@ -42,7 +42,7 @@ class TestOp4(Generic[RD1InvT, RD2InvT, RS1InvT, RS2InvT], RISCVInstruction, ABC
 SameIntRegisterType: TypeAlias = Annotated[IntRegisterType, ConstraintVar("T")]
 
 
-def test_constrained_single():
+def test_tie_constrained_single():
     @irdl_op_definition
     class ConstrainedOp(
         TestOp4[SameIntRegisterType, IntRegisterType, IntRegisterType, IntRegisterType]
@@ -82,7 +82,7 @@ def test_constrained_single():
     assert constr.operand_is_constrained_to(3) is None
 
 
-def test_constrained_all_unallocated():
+def test_tie_constrained_all_unallocated():
     @irdl_op_definition
     class ConstrainedOp(
         TestOp4[
@@ -127,7 +127,7 @@ def test_constrained_all_unallocated():
     assert constr.operand_is_constrained_to(1) == Registers.A1
 
 
-def test_constrained_all_allocated():
+def test_tie_constrained():
     @irdl_op_definition
     class ConstrainedOp(
         TestOp4[
@@ -172,5 +172,6 @@ def test_constrained_all_allocated():
     op.rs2.type = Registers.A2
     with pytest.raises(VerifyException):
         op.verify()
+    constr.operand_satisfy_constraint(0, Registers.A1)
     with pytest.raises(ValueError):
         constr.operand_satisfy_constraint(0, Registers.A2)

--- a/tests/backend/riscv/test_register_allocation_constraints.py
+++ b/tests/backend/riscv/test_register_allocation_constraints.py
@@ -1,0 +1,176 @@
+from abc import ABC
+from typing import Annotated, Generic, TypeAlias, TypeVar
+
+import pytest
+
+from xdsl.backend.riscv.register_allocation_constraints import OpTieConstraints
+from xdsl.dialects.riscv import (
+    AssemblyInstructionArg,
+    IntRegisterType,
+    Registers,
+    RISCVInstruction,
+    RISCVRegisterType,
+)
+from xdsl.ir import OpResult
+from xdsl.irdl import (
+    ConstraintVar,
+    Operand,
+    irdl_op_definition,
+    operand_def,
+    result_def,
+)
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.test_value import TestSSAValue
+
+RD1InvT = TypeVar("RD1InvT", bound=RISCVRegisterType)
+RD2InvT = TypeVar("RD2InvT", bound=RISCVRegisterType)
+RS1InvT = TypeVar("RS1InvT", bound=RISCVRegisterType)
+RS2InvT = TypeVar("RS2InvT", bound=RISCVRegisterType)
+
+
+class TestOp4(Generic[RD1InvT, RD2InvT, RS1InvT, RS2InvT], RISCVInstruction, ABC):
+
+    rd1: OpResult = result_def(RD1InvT)
+    rd2: OpResult = result_def(RD2InvT)
+    rs1: Operand = operand_def(RS1InvT)
+    rs2: Operand = operand_def(RS2InvT)
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        return self.rd1, self.rd2, self.rs1, self.rs2
+
+
+SameIntRegisterType: TypeAlias = Annotated[IntRegisterType, ConstraintVar("T")]
+
+
+def test_constrained_single():
+    @irdl_op_definition
+    class ConstrainedOp(
+        TestOp4[SameIntRegisterType, IntRegisterType, IntRegisterType, IntRegisterType]
+    ):
+        name = "constrained_op"
+
+    op = ConstrainedOp(
+        result_types=[
+            IntRegisterType.unallocated(),  # rd1
+            IntRegisterType.unallocated(),  # rd2
+        ],
+        operands=[
+            TestSSAValue(IntRegisterType.unallocated()),  # rs1
+            TestSSAValue(IntRegisterType.unallocated()),  # rs2
+        ],
+    )
+    op.verify()
+
+    constr = OpTieConstraints.from_op(op)
+    assert constr.result_has_constraints(0)
+    assert not constr.result_has_constraints(1)
+    assert not constr.operand_has_constraints(0)
+    assert not constr.operand_has_constraints(1)
+
+    assert constr.result_is_constrained_to(0) is None
+    assert constr.result_is_constrained_to(1) is None
+    assert constr.operand_is_constrained_to(2) is None
+    assert constr.operand_is_constrained_to(3) is None
+
+    # Allocate rd1
+    op.rd1.type = Registers.A1
+    constr.result_satisfy_constraint(0, Registers.A1)
+
+    assert constr.result_is_constrained_to(0) == Registers.A1
+    assert constr.result_is_constrained_to(1) is None
+    assert constr.operand_is_constrained_to(2) is None
+    assert constr.operand_is_constrained_to(3) is None
+
+
+def test_constrained_all_unallocated():
+    @irdl_op_definition
+    class ConstrainedOp(
+        TestOp4[
+            SameIntRegisterType,
+            SameIntRegisterType,
+            SameIntRegisterType,
+            SameIntRegisterType,
+        ]
+    ):
+        name = "constrained_op"
+
+    op = ConstrainedOp(
+        result_types=[
+            IntRegisterType.unallocated(),  # rd1
+            IntRegisterType.unallocated(),  # rd2
+        ],
+        operands=[
+            TestSSAValue(IntRegisterType.unallocated()),  # rs1
+            TestSSAValue(IntRegisterType.unallocated()),  # rs2
+        ],
+    )
+    op.verify()
+
+    constr = OpTieConstraints.from_op(op)
+    assert constr.result_has_constraints(0)
+    assert constr.result_has_constraints(1)
+    assert constr.operand_has_constraints(0)
+    assert constr.operand_has_constraints(1)
+
+    assert constr.result_is_constrained_to(0) is None
+    assert constr.result_is_constrained_to(1) is None
+    assert constr.operand_is_constrained_to(0) is None
+    assert constr.operand_is_constrained_to(1) is None
+
+    # Allocate rs2
+    op.rs2.type = Registers.A1
+    constr.operand_satisfy_constraint(1, Registers.A1)
+
+    assert constr.result_is_constrained_to(0) == Registers.A1
+    assert constr.result_is_constrained_to(1) == Registers.A1
+    assert constr.operand_is_constrained_to(0) == Registers.A1
+    assert constr.operand_is_constrained_to(1) == Registers.A1
+
+
+def test_constrained_all_allocated():
+    @irdl_op_definition
+    class ConstrainedOp(
+        TestOp4[
+            SameIntRegisterType,
+            SameIntRegisterType,
+            SameIntRegisterType,
+            SameIntRegisterType,
+        ]
+    ):
+        name = "constrained_op"
+
+    op = ConstrainedOp(
+        result_types=[
+            IntRegisterType.unallocated(),  # rd1
+            IntRegisterType.unallocated(),  # rd2
+        ],
+        operands=[
+            TestSSAValue(Registers.A1),  # rs1
+            TestSSAValue(IntRegisterType.unallocated()),  # rs2
+        ],
+    )
+    with pytest.raises(VerifyException):
+        op.verify()
+
+    constr = OpTieConstraints.from_op(op)
+    assert constr.result_has_constraints(0)
+    assert constr.result_has_constraints(1)
+    assert constr.operand_has_constraints(0)
+    assert constr.operand_has_constraints(1)
+
+    assert constr.result_is_constrained_to(0) == Registers.A1
+    assert constr.result_is_constrained_to(1) == Registers.A1
+    assert constr.operand_is_constrained_to(0) == Registers.A1
+    assert constr.operand_is_constrained_to(1) == Registers.A1
+
+    op.rd1.type = Registers.A1
+    op.rd2.type = Registers.A1
+    op.rs1.type = Registers.A1
+    op.rs2.type = Registers.A1
+    op.verify()
+
+    op.rs2.type = Registers.A2
+    with pytest.raises(VerifyException):
+        op.verify()
+    with pytest.raises(ValueError):
+        constr.operand_satisfy_constraint(0, Registers.A2)

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -194,7 +194,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 self.allocate(operand)
 
         for result in allocated_results_to_ties:
-            # Free the registers that were allocated to atied results
+            # Free the registers that were allocated to tied results
             # FIXME this could be done earlier, e.g. as soon as all the
             # tied operands/results have been allocated. Not sure this
             # would improve register usage though.

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -195,6 +195,9 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
 
         for result in allocated_results_to_ties:
             # Free the registers that were allocated to atied results
+            # FIXME this could be done earlier, e.g. as soon as all the
+            # tied operands/results have been allocated. Not sure this
+            # would improve register usage though.
             self._free(result)
 
     def allocate_for_loop(self, loop: riscv_scf.ForOp) -> None:

--- a/xdsl/backend/riscv/register_allocation_constraints.py
+++ b/xdsl/backend/riscv/register_allocation_constraints.py
@@ -20,7 +20,7 @@ from xdsl.irdl import (
 
 class RegisterAllocationConstraints(abc.ABC):
     """
-    Base class for register allocation strategies.
+    Base class for register allocation constraints.
     """
 
     @abc.abstractmethod

--- a/xdsl/backend/riscv/register_allocation_constraints.py
+++ b/xdsl/backend/riscv/register_allocation_constraints.py
@@ -49,26 +49,65 @@ class RegisterAllocationConstraints(abc.ABC):
 
 
 @dataclass(frozen=True)
-class OpOperand:
+class OpOperandIdx:
     idx: int
 
 
 @dataclass(frozen=True)
-class OpResult:
+class OpResultIdx:
     idx: int
 
 
 @dataclass
 class Tie:
-    elements: frozenset[OpResult | OpOperand]
+    elements: frozenset[OpResultIdx | OpOperandIdx]
     register: RegisterType | None
 
 
 class OpTieConstraints(RegisterAllocationConstraints):
 
-    ConstraintsDict: TypeAlias = dict[OpOperand | OpResult, Tie]
+    ConstraintsDict: TypeAlias = dict[OpOperandIdx | OpResultIdx, Tie]
 
     _constraints: ConstraintsDict
+
+    @staticmethod
+    def _gather_constraint_vars(
+        vars: dict[str, list[OpOperandIdx | OpResultIdx]],
+        defs: Sequence[tuple[str, OperandDef | ResultDef]],
+    ) -> None:
+        for idx, (_, reg_def) in enumerate(defs):
+            constr = reg_def.constr
+            if isinstance(constr, RangeOf | SingleOf) and isinstance(
+                constr.constr, VarConstraint
+            ):
+                # We use the VarConstraint name as a dict key just like
+                # ConstraintContext
+                var_name: str = constr.constr.name
+                if isinstance(reg_def, OperandDef):
+                    tag = OpOperandIdx(idx)
+                else:
+                    assert isinstance(reg_def, ResultDef)
+                    tag = OpResultIdx(idx)
+                vars.setdefault(var_name, []).append(tag)
+
+    @staticmethod
+    def _gather_preallocated(constr: OpTieConstraints, op: IRDLOperation):
+        for idx, arg in enumerate(op.operands):
+            if not (
+                isinstance(arg.type, RegisterType)
+                and arg.type.is_allocated
+                and constr.operand_has_constraints(idx)
+            ):
+                continue
+            constr.operand_satisfy_constraint(idx, arg.type)
+        for idx, res in enumerate(op.results):
+            if not (
+                isinstance(res.type, RegisterType)
+                and res.type.is_allocated
+                and constr.result_has_constraints(idx)
+            ):
+                continue
+            constr.result_satisfy_constraint(idx, res.type)
 
     @staticmethod
     def from_op(op: IRDLOperation) -> OpTieConstraints:
@@ -81,49 +120,20 @@ class OpTieConstraints(RegisterAllocationConstraints):
             Sequence[tuple[str, OperandDef]],
             get_construct_defs(op_def, VarIRConstruct.OPERAND),
         )
-        var_constraints: dict[str, list[OpOperand | OpResult]] = {}
-        for idx, (_, reg_def) in enumerate(arg_defs):
-            constr = reg_def.constr
-            if isinstance(constr, RangeOf | SingleOf) and isinstance(
-                constr.constr, VarConstraint
-            ):
-                # We use the VarConstraint name as a dict key just like
-                # ConstraintContext
-                var_name: str = constr.constr.name
-                var_constraints.setdefault(var_name, []).append(OpOperand(idx))
-        for idx, (_, reg_def) in enumerate(result_defs):
-            constr = reg_def.constr
-            if isinstance(constr, RangeOf | SingleOf) and isinstance(
-                constr.constr, VarConstraint
-            ):
-                # We use the VarConstraint name as a dict key just like
-                # ConstraintContext
-                var_name: str = constr.constr.name
-                var_constraints.setdefault(var_name, []).append(OpResult(idx))
+        # Gather all ConstraintVars associated to operands/results
+        constraint_vars: dict[str, list[OpOperandIdx | OpResultIdx]] = {}
+        OpTieConstraints._gather_constraint_vars(constraint_vars, result_defs)
+        OpTieConstraints._gather_constraint_vars(constraint_vars, arg_defs)
         tie_constraints = [
             Tie(elements=frozenset(value), register=None)
-            for value in var_constraints.values()
+            for value in constraint_vars.values()
         ]
+        # Init the constraints dict
         ret = OpTieConstraints(
             {idx: tie for tie in tie_constraints for idx in tie.elements}
         )
         # Take into account any pre-allocated result/operand
-        for idx, arg in enumerate(op.operands):
-            if not (
-                isinstance(arg.type, RegisterType)
-                and arg.type.is_allocated
-                and ret.operand_has_constraints(idx)
-            ):
-                continue
-            ret.operand_satisfy_constraint(idx, arg.type)
-        for idx, res in enumerate(op.results):
-            if not (
-                isinstance(res.type, RegisterType)
-                and res.type.is_allocated
-                and ret.result_has_constraints(idx)
-            ):
-                continue
-            ret.result_satisfy_constraint(idx, res.type)
+        OpTieConstraints._gather_preallocated(ret, op)
         return ret
 
     def __init__(self, constr: ConstraintsDict | None = None) -> None:
@@ -133,16 +143,18 @@ class OpTieConstraints(RegisterAllocationConstraints):
             self._constraints = {}
         super().__init__()
 
-    def _has_constraints(self, element: OpOperand | OpResult) -> bool:
+    def _has_constraints(self, element: OpOperandIdx | OpResultIdx) -> bool:
         return element in self._constraints
 
-    def _is_constrained_to(self, element: OpOperand | OpResult) -> RegisterType | None:
+    def _is_constrained_to(
+        self, element: OpOperandIdx | OpResultIdx
+    ) -> RegisterType | None:
         if element not in self._constraints:
             return None
         return self._constraints[element].register
 
     def _satisfy_constraint(
-        self, element: OpOperand | OpResult, reg: RegisterType
+        self, element: OpOperandIdx | OpResultIdx, reg: RegisterType
     ) -> None:
         if element not in self._constraints:
             raise KeyError()
@@ -152,19 +164,19 @@ class OpTieConstraints(RegisterAllocationConstraints):
         self._constraints[element].register = reg
 
     def operand_has_constraints(self, idx: int) -> bool:
-        return self._has_constraints(OpOperand(idx))
+        return self._has_constraints(OpOperandIdx(idx))
 
     def operand_is_constrained_to(self, idx: int) -> RegisterType | None:
-        return self._is_constrained_to(OpOperand(idx))
+        return self._is_constrained_to(OpOperandIdx(idx))
 
     def operand_satisfy_constraint(self, idx: int, reg: RegisterType) -> None:
-        self._satisfy_constraint(OpOperand(idx), reg)
+        self._satisfy_constraint(OpOperandIdx(idx), reg)
 
     def result_has_constraints(self, idx: int) -> bool:
-        return self._has_constraints(OpResult(idx))
+        return self._has_constraints(OpResultIdx(idx))
 
     def result_is_constrained_to(self, idx: int) -> RegisterType | None:
-        return self._is_constrained_to(OpResult(idx))
+        return self._is_constrained_to(OpResultIdx(idx))
 
     def result_satisfy_constraint(self, idx: int, reg: RegisterType) -> None:
-        self._satisfy_constraint(OpResult(idx), reg)
+        self._satisfy_constraint(OpResultIdx(idx), reg)

--- a/xdsl/backend/riscv/register_allocation_constraints.py
+++ b/xdsl/backend/riscv/register_allocation_constraints.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import abc
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TypeAlias, cast
+
+from xdsl.backend.register_type import RegisterType
+from xdsl.irdl import (
+    IRDLOperation,
+    OperandDef,
+    RangeOf,
+    ResultDef,
+    SingleOf,
+    VarConstraint,
+    VarIRConstruct,
+    get_construct_defs,
+)
+
+
+class RegisterAllocationConstraints(abc.ABC):
+    """
+    Base class for register allocation strategies.
+    """
+
+    @abc.abstractmethod
+    def operand_has_constraints(self, idx: int) -> bool:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def operand_is_constrained_to(self, idx: int) -> RegisterType | None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def operand_satisfy_constraint(self, idx: int, reg: RegisterType) -> None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def result_has_constraints(self, idx: int) -> bool:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def result_is_constrained_to(self, idx: int) -> RegisterType | None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def result_satisfy_constraint(self, idx: int, reg: RegisterType) -> None:
+        raise NotImplementedError()
+
+
+@dataclass(frozen=True)
+class OpOperand:
+    idx: int
+
+
+@dataclass(frozen=True)
+class OpResult:
+    idx: int
+
+
+@dataclass
+class Tie:
+    elements: frozenset[OpResult | OpOperand]
+    register: RegisterType | None
+
+
+class OpTieConstraints(RegisterAllocationConstraints):
+
+    ConstraintsDict: TypeAlias = dict[OpOperand | OpResult, Tie]
+
+    _constraints: ConstraintsDict
+
+    @staticmethod
+    def from_op(op: IRDLOperation) -> OpTieConstraints:
+        op_def = op.get_irdl_definition()
+        result_defs = cast(
+            Sequence[tuple[str, ResultDef]],
+            get_construct_defs(op_def, VarIRConstruct.RESULT),
+        )
+        arg_defs = cast(
+            Sequence[tuple[str, OperandDef]],
+            get_construct_defs(op_def, VarIRConstruct.OPERAND),
+        )
+        var_constraints: dict[str, list[OpOperand | OpResult]] = {}
+        for idx, (_, reg_def) in enumerate(arg_defs):
+            constr = reg_def.constr
+            if isinstance(constr, RangeOf | SingleOf) and isinstance(
+                constr.constr, VarConstraint
+            ):
+                # We use the VarConstraint name as a dict key just like
+                # ConstraintContext
+                var_name: str = constr.constr.name
+                var_constraints.setdefault(var_name, []).append(OpOperand(idx))
+        for idx, (_, reg_def) in enumerate(result_defs):
+            constr = reg_def.constr
+            if isinstance(constr, RangeOf | SingleOf) and isinstance(
+                constr.constr, VarConstraint
+            ):
+                # We use the VarConstraint name as a dict key just like
+                # ConstraintContext
+                var_name: str = constr.constr.name
+                var_constraints.setdefault(var_name, []).append(OpResult(idx))
+        tie_constraints = [
+            Tie(elements=frozenset(value), register=None)
+            for value in var_constraints.values()
+        ]
+        ret = OpTieConstraints(
+            {idx: tie for tie in tie_constraints for idx in tie.elements}
+        )
+        # Take into account any pre-allocated result/operand
+        for idx, arg in enumerate(op.operands):
+            if not (
+                isinstance(arg.type, RegisterType)
+                and arg.type.is_allocated
+                and ret.operand_has_constraints(idx)
+            ):
+                continue
+            ret.operand_satisfy_constraint(idx, arg.type)
+        for idx, res in enumerate(op.results):
+            if not (
+                isinstance(res.type, RegisterType)
+                and res.type.is_allocated
+                and ret.result_has_constraints(idx)
+            ):
+                continue
+            ret.result_satisfy_constraint(idx, res.type)
+        return ret
+
+    def __init__(self, constr: ConstraintsDict | None = None) -> None:
+        if constr is not None:
+            self._constraints = constr
+        else:
+            self._constraints = {}
+        super().__init__()
+
+    def _has_constraints(self, element: OpOperand | OpResult) -> bool:
+        return element in self._constraints
+
+    def _is_constrained_to(self, element: OpOperand | OpResult) -> RegisterType | None:
+        if element not in self._constraints:
+            return None
+        return self._constraints[element].register
+
+    def _satisfy_constraint(
+        self, element: OpOperand | OpResult, reg: RegisterType
+    ) -> None:
+        if element not in self._constraints:
+            raise KeyError()
+        current_reg = self._constraints[element].register
+        if current_reg is not None and current_reg != reg:
+            raise ValueError()
+        self._constraints[element].register = reg
+
+    def operand_has_constraints(self, idx: int) -> bool:
+        return self._has_constraints(OpOperand(idx))
+
+    def operand_is_constrained_to(self, idx: int) -> RegisterType | None:
+        return self._is_constrained_to(OpOperand(idx))
+
+    def operand_satisfy_constraint(self, idx: int, reg: RegisterType) -> None:
+        self._satisfy_constraint(OpOperand(idx), reg)
+
+    def result_has_constraints(self, idx: int) -> bool:
+        return self._has_constraints(OpResult(idx))
+
+    def result_is_constrained_to(self, idx: int) -> RegisterType | None:
+        return self._is_constrained_to(OpResult(idx))
+
+    def result_satisfy_constraint(self, idx: int, reg: RegisterType) -> None:
+        self._satisfy_constraint(OpResult(idx), reg)


### PR DESCRIPTION
This PR adds the concept of *tied operands* found in LLVM to be able to model 2-address instructions, a.k.a. when an operand register is both read and written in-place by an instruction. Both the operand and the result must be represented in their own SSA values, but the regalloc must allocate both on the same register to be able to generate correct code.

**Keeping as draft for feedback**, things that I would like to change:

* I don't like the APIs, it could be nice to have our own `TiedConstraint` instead of a generic `ConstraintVar("T")`
* ~~The code that collects all operands/results definitions that share the same `ConstraintVar` is a mess, to be cleaned up.~~