### PR TITLE
(dialect): minor changes to csl and csl_wrapper

### DIFF
--- a/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
@@ -9,8 +9,8 @@ builtin.module {
             %0 = arith.constant 0 : i16
             %1 = "csl.get_color"(%0) : (i16) -> !csl.color
 
-            %routes = "csl_wrapper.import_module"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
-            %memcpy = "csl_wrapper.import_module"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+            %routes = "csl_wrapper.import"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+            %memcpy = "csl_wrapper.import"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
 
             %compute_all_routes = "csl.member_call"(%routes, %x, %y, %height, %width, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
             %memcpy_params = "csl.member_call"(%memcpy, %x) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
@@ -44,8 +44,8 @@ builtin.module {
 // CHECK-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
 // CHECK-NEXT:     %0 = arith.constant 0 : i16
 // CHECK-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
-// CHECK-NEXT:     %routes = "csl_wrapper.import_module"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
-// CHECK-NEXT:     %memcpy = "csl_wrapper.import_module"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+// CHECK-NEXT:     %routes = "csl_wrapper.import"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+// CHECK-NEXT:     %memcpy = "csl_wrapper.import"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
 // CHECK-NEXT:     %compute_all_routes = "csl.member_call"(%routes, %x, %y, %height, %width, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
 // CHECK-NEXT:     %memcpy_params = "csl.member_call"(%memcpy, %x) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
 // CHECK-NEXT:     %2 = arith.constant 1 : i16
@@ -75,8 +75,8 @@ builtin.module {
 // CHECK-GENERIC-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
 // CHECK-GENERIC-NEXT:     %0 = "arith.constant"() <{"value" = 0 : i16}> : () -> i16
 // CHECK-GENERIC-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
-// CHECK-GENERIC-NEXT:     %routes = "csl_wrapper.import_module"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
-// CHECK-GENERIC-NEXT:     %memcpy = "csl_wrapper.import_module"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+// CHECK-GENERIC-NEXT:     %routes = "csl_wrapper.import"(%pattern, %width, %height) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+// CHECK-GENERIC-NEXT:     %memcpy = "csl_wrapper.import"(%width, %height, %1) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
 // CHECK-GENERIC-NEXT:     %compute_all_routes = "csl.member_call"(%routes, %x, %y, %height, %width, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
 // CHECK-GENERIC-NEXT:     %memcpy_params = "csl.member_call"(%memcpy, %x) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
 // CHECK-GENERIC-NEXT:     %2 = "arith.constant"() <{"value" = 1 : i16}> : () -> i16

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -40,8 +40,8 @@ builtin.module {
 // CHECK-NEXT:   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16):
 // CHECK-NEXT:     %6 = arith.constant 0 : i16
 // CHECK-NEXT:     %7 = "csl.get_color"(%6) : (i16) -> !csl.color
-// CHECK-NEXT:     %8 = "csl_wrapper.import_module"(%2, %3, %7) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
-// CHECK-NEXT:     %9 = "csl_wrapper.import_module"(%5, %2, %3) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
+// CHECK-NEXT:     %8 = "csl_wrapper.import"(%2, %3, %7) <{"module" = "<memcpy/get_params>", "fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.imported_module
+// CHECK-NEXT:     %9 = "csl_wrapper.import"(%5, %2, %3) <{"module" = "routes.csl", "fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.imported_module
 // CHECK-NEXT:     %10 = "csl.member_call"(%9, %0, %1, %2, %3, %5) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
 // CHECK-NEXT:     %11 = "csl.member_call"(%8, %0) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
 // CHECK-NEXT:     %12 = arith.constant 1 : i16

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -92,13 +92,13 @@ class ParamAttribute(ParametrizedAttribute):
 
 
 @irdl_op_definition
-class ImportModuleOp(IRDLOperation):
+class ImportOp(IRDLOperation):
     """
     Lightweight wrapper around `csl.import_module` that allows specifying field names directly
     and removes the need for handling structs or setting up struct operands
     """
 
-    name = "csl_wrapper.import_module"
+    name = "csl_wrapper.import"
 
     ops = var_operand_def()
     module = prop_def(StringAttr)
@@ -391,7 +391,7 @@ class YieldOp(IRDLOperation):
 CSL_WRAPPER = Dialect(
     "csl_wrapper",
     [
-        ImportModuleOp,
+        ImportOp,
         ModuleOp,
         YieldOp,
     ],

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -143,7 +143,7 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
             launch = csl.GetColorOp(zero)
 
             # import memcpy/get_params and routes
-            memcpy = csl_wrapper.ImportModuleOp(
+            memcpy = csl_wrapper.ImportOp(
                 "<memcpy/get_params>",
                 {
                     "width": param_width,
@@ -151,7 +151,7 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
                     "LAUNCH": launch.res,
                 },
             )
-            routes = csl_wrapper.ImportModuleOp(
+            routes = csl_wrapper.ImportOp(
                 "routes.csl",
                 {
                     "pattern": param_pattern,


### PR DESCRIPTION
Minor changes to the `csl` and `csl_wrapper` dialects:

* csl: always allow ops with the `InModuleKind` trait to exist inside `csl_wrapper.ModuleOp`
* csl_wrapper: rename `import_module` to `import`