### PR TITLE
api: add generic parameter to attribute constraint

### DIFF
--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -8,10 +8,12 @@ from xdsl.dialects.builtin import (
     IntAttr,
     IntegerAttr,
     IntegerType,
+    StringAttr,
 )
 from xdsl.ir import Attribute, ParametrizedAttribute
-from xdsl.irdl import ParameterDef, irdl_attr_definition
+from xdsl.irdl import BaseAttr, EqAttrConstraint, ParameterDef, irdl_attr_definition
 from xdsl.utils.hints import isa
+from xdsl.utils.isa import isattr
 
 
 class Class1:
@@ -395,3 +397,17 @@ def test_literal():
 
     assert not isa(1, Literal["1"])
     assert not isa("1", Literal[1])
+
+
+################################################################################
+# isattr
+################################################################################
+
+
+def test_isattr():
+    assert isattr(IntAttr(1), IntAttr)
+    assert not isattr(IntAttr(1), StringAttr)
+    assert isattr(IntAttr(1), BaseAttr(IntAttr))
+    assert not isattr(IntAttr(1), BaseAttr(StringAttr))
+    assert isattr(IntAttr(1), EqAttrConstraint(IntAttr(1)))
+    assert not isattr(IntAttr(1), EqAttrConstraint(IntAttr(2)))

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -46,6 +46,7 @@ from .constraints import (  # noqa: TID251
     ConstraintContext,
     ConstraintVar,
     EqAttrConstraint,
+    GenericAttrConstraint,
     ParamAttrConstraint,
     VarConstraint,
 )
@@ -311,8 +312,8 @@ def irdl_to_attr_constraint(
     allow_type_var: bool = False,
     type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
 ) -> AttrConstraint:
-    if isinstance(irdl, AttrConstraint):
-        return irdl
+    if isinstance(irdl, GenericAttrConstraint):
+        return cast(AttrConstraint, irdl)
 
     if isinstance(irdl, Attribute):
         return EqAttrConstraint(irdl)

--- a/xdsl/utils/isa.py
+++ b/xdsl/utils/isa.py
@@ -9,6 +9,10 @@ from xdsl.utils.hints import isa
 def isattr(
     arg: Any, hint: type[AttributeInvT] | GenericAttrConstraint[AttributeInvT]
 ) -> TypeGuard[AttributeInvT]:
+    """
+    A helper method to check whether a given attribute has a given type or conforms to a
+    given constraint.
+    """
     from xdsl.irdl import ConstraintContext
 
     if isinstance(hint, GenericAttrConstraint):

--- a/xdsl/utils/isa.py
+++ b/xdsl/utils/isa.py
@@ -1,0 +1,21 @@
+from typing import Any, TypeGuard
+
+from xdsl.ir import AttributeInvT
+from xdsl.irdl import GenericAttrConstraint
+from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.hints import isa
+
+
+def isattr(
+    arg: Any, hint: type[AttributeInvT] | GenericAttrConstraint[AttributeInvT]
+) -> TypeGuard[AttributeInvT]:
+    from xdsl.irdl import ConstraintContext
+
+    if isinstance(hint, GenericAttrConstraint):
+        try:
+            hint.verify(arg, ConstraintContext())
+            return True
+        except VerifyException:
+            return False
+
+    return isa(arg, hint)


### PR DESCRIPTION
PR 1/2 to make the Pylance errors in operation definitions go away.

The main idea is for the constraint type to carry the upper bound of the Attribute types that will pass verification. It is not guaranteed to be a strict upper bound.

Pyright errors: 489.