### PR TITLE
dialects: (Qref) fix bug in cnot initialiser

### DIFF
--- a/xdsl/dialects/qref.py
+++ b/xdsl/dialects/qref.py
@@ -141,7 +141,7 @@ class CNotGateOp(QRefBase):
     def __init__(self, in1: SSAValue, in2: SSAValue):
         super().__init__(
             operands=(in1, in2),
-            result_types=(qubit, qubit),
+            result_types=(),
         )
 
     def ssa_op(self) -> qssa.CNotGateOp:


### PR DESCRIPTION
The `qref.CNotGateOp` initialiser assigned the incorrect number of result qubits.


