### PR TITLE
core: Add FixedbitWidthType Interface

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -39,12 +39,12 @@ from xdsl.utils.exceptions import VerifyException
 
 
 def test_FloatType_bitwidths():
-    assert BFloat16Type().get_bitwidth == 16
-    assert Float16Type().get_bitwidth == 16
-    assert Float32Type().get_bitwidth == 32
-    assert Float64Type().get_bitwidth == 64
-    assert Float80Type().get_bitwidth == 80
-    assert Float128Type().get_bitwidth == 128
+    assert BFloat16Type().bitwidth == 16
+    assert Float16Type().bitwidth == 16
+    assert Float32Type().bitwidth == 32
+    assert Float64Type().bitwidth == 64
+    assert Float80Type().bitwidth == 80
+    assert Float128Type().bitwidth == 128
 
 
 def test_DenseIntOrFPElementsAttr_fp_type_conversion():

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -11,7 +11,7 @@ from xdsl.context import MLContext
 from xdsl.dialects import memref, riscv, riscv_func
 from xdsl.dialects.builtin import (
     AnyFloat,
-    BitWidthType,
+    FixedBitwidthType,
     DenseIntOrFPElementsAttr,
     Float32Type,
     Float64Type,
@@ -44,7 +44,7 @@ class ConvertMemrefAllocOp(RewritePattern):
     def match_and_rewrite(self, op: memref.Alloc, rewriter: PatternRewriter) -> None:
         assert isinstance(op_memref_type := op.memref.type, memref.MemRefType)
         op_memref_type = cast(memref.MemRefType[Any], op_memref_type)
-        assert isinstance(op_memref_type.element_type, BitWidthType)
+        assert isinstance(op_memref_type.element_type, FixedBitwidthType)
         width_in_bytes = op_memref_type.element_type.get_element_width
         size = prod(op_memref_type.get_shape()) * width_in_bytes
         rewriter.replace_matched_op(
@@ -90,7 +90,7 @@ def get_strided_pointer(
     a new pointer to the element being accessed by the 'indices'.
     """
 
-    assert isinstance(memref_type.element_type, BitWidthType)
+    assert isinstance(memref_type.element_type, FixedBitwidthType)
     bytes_per_element = memref_type.element_type.get_element_width
 
     match memref_type.layout:
@@ -368,7 +368,7 @@ class ConvertMemrefSubviewOp(RewritePattern):
 
         offset = result_layout_attr.get_offset()
 
-        assert isinstance(result_type.element_type, BitWidthType)
+        assert isinstance(result_type.element_type, FixedBitwidthType)
         factor = result_type.element_type.get_element_width
 
         if offset == 0:

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -11,6 +11,7 @@ from xdsl.context import MLContext
 from xdsl.dialects import memref, riscv, riscv_func
 from xdsl.dialects.builtin import (
     AnyFloat,
+    BitWidthType,
     DenseIntOrFPElementsAttr,
     Float32Type,
     Float64Type,
@@ -37,42 +38,14 @@ from xdsl.traits import SymbolTable
 from xdsl.utils.exceptions import DiagnosticException
 
 
-def bitwidth_of_type(type_attribute: Attribute) -> int:
-    """
-    Returns the width of an element type in bits, or raises DiagnosticException for unknown inputs.
-    """
-    if isinstance(type_attribute, AnyFloat):
-        return type_attribute.get_bitwidth
-    elif isinstance(type_attribute, IntegerType):
-        return type_attribute.width.data
-    else:
-        raise NotImplementedError(
-            f"Unsupported memref element type for riscv lowering: {type_attribute}"
-        )
-
-
-def element_size_for_type(type_attribute: Attribute) -> int:
-    """
-    Returns the width of an element type in bytes, or raises DiagnosticException for
-    unknown inputs, or sizes not divisible by 8.
-    """
-    bitwidth = bitwidth_of_type(type_attribute)
-    if bitwidth % 8:
-        raise DiagnosticException(
-            f"Cannot determine size for element type {type_attribute}"
-            f" with bitwidth {bitwidth}"
-        )
-    bytes_per_element = bitwidth // 8
-    return bytes_per_element
-
-
 class ConvertMemrefAllocOp(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.Alloc, rewriter: PatternRewriter) -> None:
         assert isinstance(op_memref_type := op.memref.type, memref.MemRefType)
         op_memref_type = cast(memref.MemRefType[Any], op_memref_type)
-        width_in_bytes = bitwidth_of_type(op_memref_type.element_type) // 8
+        assert isinstance(op_memref_type.element_type, BitWidthType)
+        width_in_bytes = op_memref_type.element_type.get_element_width
         size = prod(op_memref_type.get_shape()) * width_in_bytes
         rewriter.replace_matched_op(
             (
@@ -117,7 +90,8 @@ def get_strided_pointer(
     a new pointer to the element being accessed by the 'indices'.
     """
 
-    bytes_per_element = element_size_for_type(memref_type.element_type)
+    assert isinstance(memref_type.element_type, BitWidthType)
+    bytes_per_element = memref_type.element_type.get_element_width
 
     match memref_type.layout:
         case NoneAttr():
@@ -394,7 +368,8 @@ class ConvertMemrefSubviewOp(RewritePattern):
 
         offset = result_layout_attr.get_offset()
 
-        factor = element_size_for_type(result_type.element_type)
+        assert isinstance(result_type.element_type, BitWidthType)
+        factor = result_type.element_type.get_element_width
 
         if offset == 0:
             rewriter.replace_matched_op(

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -11,8 +11,8 @@ from xdsl.context import MLContext
 from xdsl.dialects import memref, riscv, riscv_func
 from xdsl.dialects.builtin import (
     AnyFloat,
-    FixedBitwidthType,
     DenseIntOrFPElementsAttr,
+    FixedBitwidthType,
     Float32Type,
     Float64Type,
     IntegerType,
@@ -45,7 +45,7 @@ class ConvertMemrefAllocOp(RewritePattern):
         assert isinstance(op_memref_type := op.memref.type, memref.MemRefType)
         op_memref_type = cast(memref.MemRefType[Any], op_memref_type)
         assert isinstance(op_memref_type.element_type, FixedBitwidthType)
-        width_in_bytes = op_memref_type.element_type.get_element_width
+        width_in_bytes = op_memref_type.element_type.size
         size = prod(op_memref_type.get_shape()) * width_in_bytes
         rewriter.replace_matched_op(
             (
@@ -91,7 +91,7 @@ def get_strided_pointer(
     """
 
     assert isinstance(memref_type.element_type, FixedBitwidthType)
-    bytes_per_element = memref_type.element_type.get_element_width
+    bytes_per_element = memref_type.element_type.size
 
     match memref_type.layout:
         case NoneAttr():
@@ -369,7 +369,7 @@ class ConvertMemrefSubviewOp(RewritePattern):
         offset = result_layout_attr.get_offset()
 
         assert isinstance(result_type.element_type, FixedBitwidthType)
-        factor = result_type.element_type.get_element_width
+        factor = result_type.element_type.size
 
         if offset == 0:
             rewriter.replace_matched_op(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -353,7 +353,7 @@ class SignednessAttr(Data[Signedness]):
                 raise ValueError(f"Invalid signedness {data}")
 
 
-class BitWidthType(TypeAttribute, ABC):
+class FixedBitwidthType(TypeAttribute, ABC):
     """
     A type attribute with a defined bitwidth
     """
@@ -385,7 +385,7 @@ class BitWidthType(TypeAttribute, ABC):
 
 
 @irdl_attr_definition
-class IntegerType(ParametrizedAttribute, BitWidthType):
+class IntegerType(ParametrizedAttribute, FixedBitwidthType):
     name = "integer_type"
     width: ParameterDef[IntAttr]
     signedness: ParameterDef[SignednessAttr]
@@ -534,7 +534,7 @@ class _FloatType(ABC):
 
 
 @irdl_attr_definition
-class BFloat16Type(ParametrizedAttribute, BitWidthType, _FloatType):
+class BFloat16Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "bf16"
 
     @property
@@ -543,7 +543,7 @@ class BFloat16Type(ParametrizedAttribute, BitWidthType, _FloatType):
 
 
 @irdl_attr_definition
-class Float16Type(ParametrizedAttribute, BitWidthType, _FloatType):
+class Float16Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f16"
 
     @property
@@ -552,7 +552,7 @@ class Float16Type(ParametrizedAttribute, BitWidthType, _FloatType):
 
 
 @irdl_attr_definition
-class Float32Type(ParametrizedAttribute, BitWidthType, _FloatType):
+class Float32Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f32"
 
     @property
@@ -561,7 +561,7 @@ class Float32Type(ParametrizedAttribute, BitWidthType, _FloatType):
 
 
 @irdl_attr_definition
-class Float64Type(ParametrizedAttribute, BitWidthType, _FloatType):
+class Float64Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f64"
 
     @property
@@ -570,7 +570,7 @@ class Float64Type(ParametrizedAttribute, BitWidthType, _FloatType):
 
 
 @irdl_attr_definition
-class Float80Type(ParametrizedAttribute, BitWidthType, _FloatType):
+class Float80Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f80"
 
     @property
@@ -579,7 +579,7 @@ class Float80Type(ParametrizedAttribute, BitWidthType, _FloatType):
 
 
 @irdl_attr_definition
-class Float128Type(ParametrizedAttribute, BitWidthType, _FloatType):
+class Float128Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f128"
 
     @property

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from math import ceil, prod
+from math import prod
 from typing import (
     TYPE_CHECKING,
     Annotated,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -372,7 +372,7 @@ class BitWidthType(TypeAttribute, ABC):
     def get_element_width(self) -> int:
         """
         Returns the width of an element type in bytes, or raises DiagnosticException for
-        unknown inputs, or sizes not divisible by 8.
+        sizes not divisible by 8.
         """
         bitwidth = self.get_bitwidth
         if bitwidth % 8:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -373,7 +373,7 @@ class FixedBitwidthType(TypeAttribute, ABC):
         """
         Contiguous memory footprint in bytes, defaults to `ceil(bitwidth / 8)`
         """
-        return ceil(self.bitwidth / 8)
+        return self.bitwidth >> 3 + bool(self.bitwidth % 8)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -353,8 +353,39 @@ class SignednessAttr(Data[Signedness]):
                 raise ValueError(f"Invalid signedness {data}")
 
 
+class BitWidthType(TypeAttribute, ABC):
+    """
+    A type attribute with a defined bitwidth
+    """
+
+    name = "abstract.bitwidth_type"
+
+    @property
+    @abstractmethod
+    def get_bitwidth(self) -> int:
+        """
+        Returns the width of an element type in bits.
+        """
+        raise NotImplementedError()
+
+    @property
+    def get_element_width(self) -> int:
+        """
+        Returns the width of an element type in bytes, or raises DiagnosticException for
+        unknown inputs, or sizes not divisible by 8.
+        """
+        bitwidth = self.get_bitwidth
+        if bitwidth % 8:
+            raise DiagnosticException(
+                f"Cannot determine size for element type {self}"
+                f" with bitwidth {bitwidth}"
+            )
+        bytes_per_element = bitwidth // 8
+        return bytes_per_element
+
+
 @irdl_attr_definition
-class IntegerType(ParametrizedAttribute, TypeAttribute):
+class IntegerType(ParametrizedAttribute, BitWidthType):
     name = "integer_type"
     width: ParameterDef[IntAttr]
     signedness: ParameterDef[SignednessAttr]
@@ -372,6 +403,10 @@ class IntegerType(ParametrizedAttribute, TypeAttribute):
 
     def value_range(self) -> tuple[int, int]:
         return self.signedness.data.value_range(self.width.data)
+
+    @property
+    def get_bitwidth(self) -> int:
+        return self.width.data
 
 
 i64 = IntegerType(64)
@@ -499,7 +534,7 @@ class _FloatType(ABC):
 
 
 @irdl_attr_definition
-class BFloat16Type(ParametrizedAttribute, TypeAttribute, _FloatType):
+class BFloat16Type(ParametrizedAttribute, BitWidthType, _FloatType):
     name = "bf16"
 
     @property
@@ -508,7 +543,7 @@ class BFloat16Type(ParametrizedAttribute, TypeAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float16Type(ParametrizedAttribute, TypeAttribute, _FloatType):
+class Float16Type(ParametrizedAttribute, BitWidthType, _FloatType):
     name = "f16"
 
     @property
@@ -517,7 +552,7 @@ class Float16Type(ParametrizedAttribute, TypeAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float32Type(ParametrizedAttribute, TypeAttribute, _FloatType):
+class Float32Type(ParametrizedAttribute, BitWidthType, _FloatType):
     name = "f32"
 
     @property
@@ -526,7 +561,7 @@ class Float32Type(ParametrizedAttribute, TypeAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float64Type(ParametrizedAttribute, TypeAttribute, _FloatType):
+class Float64Type(ParametrizedAttribute, BitWidthType, _FloatType):
     name = "f64"
 
     @property
@@ -535,7 +570,7 @@ class Float64Type(ParametrizedAttribute, TypeAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float80Type(ParametrizedAttribute, TypeAttribute, _FloatType):
+class Float80Type(ParametrizedAttribute, BitWidthType, _FloatType):
     name = "f80"
 
     @property
@@ -544,7 +579,7 @@ class Float80Type(ParametrizedAttribute, TypeAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float128Type(ParametrizedAttribute, TypeAttribute, _FloatType):
+class Float128Type(ParametrizedAttribute, BitWidthType, _FloatType):
     name = "f128"
 
     @property

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from math import prod
+from math import ceil, prod
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -362,26 +362,18 @@ class FixedBitwidthType(TypeAttribute, ABC):
 
     @property
     @abstractmethod
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         """
-        Returns the width of an element type in bits.
+        Contiguous memory footprint in bits
         """
         raise NotImplementedError()
 
     @property
-    def get_element_width(self) -> int:
+    def size(self) -> int:
         """
-        Returns the width of an element type in bytes, or raises DiagnosticException for
-        sizes not divisible by 8.
+        Contiguous memory footprint in bytes, defaults to `ceil(bitwidth / 8)`
         """
-        bitwidth = self.get_bitwidth
-        if bitwidth % 8:
-            raise DiagnosticException(
-                f"Cannot determine size for element type {self}"
-                f" with bitwidth {bitwidth}"
-            )
-        bytes_per_element = bitwidth // 8
-        return bytes_per_element
+        return ceil(self.bitwidth / 8)
 
 
 @irdl_attr_definition
@@ -405,7 +397,7 @@ class IntegerType(ParametrizedAttribute, FixedBitwidthType):
         return self.signedness.data.value_range(self.width.data)
 
     @property
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         return self.width.data
 
 
@@ -529,7 +521,7 @@ BoolAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(1)]]
 class _FloatType(ABC):
     @property
     @abstractmethod
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         raise NotImplementedError()
 
 
@@ -538,7 +530,7 @@ class BFloat16Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "bf16"
 
     @property
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         return 16
 
 
@@ -547,7 +539,7 @@ class Float16Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f16"
 
     @property
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         return 16
 
 
@@ -556,7 +548,7 @@ class Float32Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f32"
 
     @property
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         return 32
 
 
@@ -565,7 +557,7 @@ class Float64Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f64"
 
     @property
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         return 64
 
 
@@ -574,7 +566,7 @@ class Float80Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f80"
 
     @property
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         return 80
 
 
@@ -583,7 +575,7 @@ class Float128Type(ParametrizedAttribute, FixedBitwidthType, _FloatType):
     name = "f128"
 
     @property
-    def get_bitwidth(self) -> int:
+    def bitwidth(self) -> int:
         return 128
 
 

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -204,7 +204,7 @@ def strides_map_from_memref_type(memref_type: MemRefType[AttributeCovT]) -> Affi
         )
 
     assert isinstance(memref_type.element_type, FixedBitwidthType)
-    factor = memref_type.element_type.get_element_width
+    factor = memref_type.element_type.size
 
     return AffineMap(
         len(strides),

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -19,7 +19,7 @@ from xdsl.dialects import (
 )
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    BitWidthType,
+    FixedBitwidthType,
     IntAttr,
     MemRefType,
     ModuleOp,
@@ -203,7 +203,7 @@ def strides_map_from_memref_type(memref_type: MemRefType[AttributeCovT]) -> Affi
             f"Unsupported empty shape in memref of type {memref_type}"
         )
 
-    assert isinstance(memref_type.element_type, BitWidthType)
+    assert isinstance(memref_type.element_type, FixedBitwidthType)
     factor = memref_type.element_type.get_element_width
 
     return AffineMap(

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -2,7 +2,6 @@ import operator
 from functools import reduce
 from typing import cast
 
-from xdsl.backend.riscv.lowering.convert_memref_to_riscv import element_size_for_type
 from xdsl.backend.riscv.lowering.utils import (
     cast_operands_to_regs,
     move_to_unallocated_regs,
@@ -20,6 +19,7 @@ from xdsl.dialects import (
 )
 from xdsl.dialects.builtin import (
     ArrayAttr,
+    BitWidthType,
     IntAttr,
     MemRefType,
     ModuleOp,
@@ -203,7 +203,8 @@ def strides_map_from_memref_type(memref_type: MemRefType[AttributeCovT]) -> Affi
             f"Unsupported empty shape in memref of type {memref_type}"
         )
 
-    factor = element_size_for_type(memref_type.element_type)
+    assert isinstance(memref_type.element_type, BitWidthType)
+    factor = memref_type.element_type.get_element_width
 
     return AffineMap(
         len(strides),


### PR DESCRIPTION
These functions to determine the bit/byte width of an element are useful in many places. I think I have them implemented in a couple of different places myself, so I think this abstraction is quite useful in this regard. The functions were now defined in a pass, I simply moved them over.