### PR TITLE
bug: ship cmath.irdl file in pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-xdsl = ["dialects/cmath.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
+xdsl = ["**.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel", "versioneer[toml]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-xdsl = ["py.typed", "interactive/*.tcss", "_version.py"]
+xdsl = ["dialects/cmath.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel", "versioneer[toml]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-xdsl = ["dialects/*.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
+xdsl = ["**/*.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel", "versioneer[toml]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-xdsl = ["**.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
+xdsl = ["dialects/*.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel", "versioneer[toml]"]


### PR DESCRIPTION
For some reason I couldn't test this locally, when I install into a different folder with a relative path, the old cmath.py file is also included for some spooky reason...