### PR TITLE
bug: wrong dataclass imported in stencil_tensorize_z_dimension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-xdsl = ["py.typed", "interactive/*.tcss", "_version.py"]
+xdsl = ["dialects/cmath.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel", "versioneer[toml]"]

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TypeGuard, cast
-
-from attr import dataclass
 
 from xdsl.context import MLContext
 from xdsl.dialects import builtin


### PR DESCRIPTION
This makes install without all the extras fail, as vanilla xdsl does not depend on attr