### PR TITLE
(transform): csl_stencil erase merged prefetch op

### DIFF
--- a/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
@@ -36,34 +36,33 @@ builtin.module {
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
 // CHECK-NEXT:     %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:     %1 = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
-// CHECK-NEXT:     %2 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:     %3 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %2 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
-// CHECK-NEXT:     ^0(%4 : memref<4xtensor<255xf32>>, %5 : index, %6 : tensor<510xf32>):
-// CHECK-NEXT:       %7 = csl_stencil.access %4[1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %8 = csl_stencil.access %4[-1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %9 = csl_stencil.access %4[0, 1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %10 = csl_stencil.access %4[0, -1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %11 = arith.addf %8, %7 : tensor<255xf32>
-// CHECK-NEXT:       %12 = arith.addf %10, %9 : tensor<255xf32>
-// CHECK-NEXT:       %13 = arith.addf %12, %11 : tensor<255xf32>
-// CHECK-NEXT:       %14 = "tensor.insert_slice"(%13, %6, %5) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
-// CHECK-NEXT:       csl_stencil.yield %14 : tensor<510xf32>
+// CHECK-NEXT:     %1 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:     %2 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+// CHECK-NEXT:     ^0(%3 : memref<4xtensor<255xf32>>, %4 : index, %5 : tensor<510xf32>):
+// CHECK-NEXT:       %6 = csl_stencil.access %3[1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %7 = csl_stencil.access %3[-1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %8 = csl_stencil.access %3[0, 1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %9 = csl_stencil.access %3[0, -1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:       %10 = arith.addf %7, %6 : tensor<255xf32>
+// CHECK-NEXT:       %11 = arith.addf %9, %8 : tensor<255xf32>
+// CHECK-NEXT:       %12 = arith.addf %11, %10 : tensor<255xf32>
+// CHECK-NEXT:       %13 = "tensor.insert_slice"(%12, %5, %4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield %13 : tensor<510xf32>
 // CHECK-NEXT:     }, {
-// CHECK-NEXT:     ^1(%15 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %16 : tensor<510xf32>):
-// CHECK-NEXT:       %17 = csl_stencil.access %15[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %18 = csl_stencil.access %15[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %19 = arith.constant 1.666600e-01 : f32
-// CHECK-NEXT:       %20 = "tensor.extract_slice"(%17) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %21 = "tensor.extract_slice"(%18) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %22 = arith.addf %16, %21 : tensor<510xf32>
-// CHECK-NEXT:       %23 = arith.addf %22, %20 : tensor<510xf32>
-// CHECK-NEXT:       %24 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:       %25 = linalg.fill ins(%19 : f32) outs(%24 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %26 = arith.mulf %23, %25 : tensor<510xf32>
-// CHECK-NEXT:       csl_stencil.yield %26 : tensor<510xf32>
+// CHECK-NEXT:     ^1(%14 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %15 : tensor<510xf32>):
+// CHECK-NEXT:       %16 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %17 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:       %18 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:       %19 = "tensor.extract_slice"(%16) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %20 = "tensor.extract_slice"(%17) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %21 = arith.addf %15, %20 : tensor<510xf32>
+// CHECK-NEXT:       %22 = arith.addf %21, %19 : tensor<510xf32>
+// CHECK-NEXT:       %23 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:       %24 = linalg.fill ins(%18 : f32) outs(%23 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %25 = arith.mulf %22, %24 : tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield %25 : tensor<510xf32>
 // CHECK-NEXT:     })
-// CHECK-NEXT:     stencil.store %3 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     stencil.store %2 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/xdsl/transforms/stencil_to_csl_stencil.py
+++ b/xdsl/transforms/stencil_to_csl_stencil.py
@@ -531,7 +531,8 @@ class ConvertApplyOpPattern(RewritePattern):
             )
         )
 
-        rewriter.erase_op(prefetch.op)
+        if len(prefetch.uses) == 0:
+            rewriter.erase_op(prefetch.op)
 
 
 @dataclass(frozen=True)

--- a/xdsl/transforms/stencil_to_csl_stencil.py
+++ b/xdsl/transforms/stencil_to_csl_stencil.py
@@ -531,6 +531,8 @@ class ConvertApplyOpPattern(RewritePattern):
             )
         )
 
+        rewriter.erase_op(prefetch.op)
+
 
 @dataclass(frozen=True)
 class StencilToCslStencilPass(ModulePass):


### PR DESCRIPTION
Bugfix: Erase merged prefetch op. The transform pass combines a `stencil.apply` and a `csl_stencil.prefetch` into a `csl_stencil.apply` op, and also needs to delete the now merged prefetch op.