### PR TITLE
dialects: (riscv_snitch) add fastmath flags in vector ops

### DIFF
--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -147,8 +147,8 @@ riscv_func.func @simd() {
 // CHECK-GENERIC-NEXT:   }) {"sym_name" = "xdma", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT:   "riscv_func.func"() ({
 // CHECK-GENERIC-NEXT:       %v = "riscv.get_float_register"() : () -> !riscv.freg
-// CHECK-GENERIC-NEXT:       %0 = "riscv_snitch.vfmul.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
-// CHECK-GENERIC-NEXT:       %1 = "riscv_snitch.vfadd.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:       %0 = "riscv_snitch.vfmul.s"(%v, %v) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:       %1 = "riscv_snitch.vfadd.s"(%v, %v) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 // CHECK-GENERIC-NEXT:       %2 = "riscv_snitch.vfcpka.s.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
 // CHECK-GENERIC-NEXT:       "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) {"sym_name" = "simd", "function_type" = () -> ()} : () -> ()

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -734,9 +734,7 @@ class VFCpkASSOp(
 
 
 @irdl_op_definition
-class VFMulSOp(
-    RdRsRsOperation[FloatRegisterType, FloatRegisterType, FloatRegisterType]
-):
+class VFMulSOp(riscv.RdRsRsFloatOperationWithFastMath):
     """
     Performs vectorial multiplication of corresponding f32 values from
     rs1 and rs2 and stores the results in the corresponding f32 lanes
@@ -755,9 +753,7 @@ class VFMulSOp(
 
 
 @irdl_op_definition
-class VFAddSOp(
-    RdRsRsOperation[FloatRegisterType, FloatRegisterType, FloatRegisterType]
-):
+class VFAddSOp(riscv.RdRsRsFloatOperationWithFastMath):
     """
     Performs vectorial addition of corresponding f32 values from
     rs1 and rs2 and stores the results in the corresponding f32 lanes


### PR DESCRIPTION
It feels like fastmath is still appropriate on the vector ops, also it will make the lowering a little less tedious, by making the vector and scalar arithmetic ops a little more uniform.