### PR TITLE
core: Implement getAffine for MemrefLayout attributes

### DIFF
--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -33,7 +33,7 @@ from xdsl.dialects.memref import (
 )
 from xdsl.ir import Attribute, BlockArgument, OpResult
 from xdsl.ir.affine import AffineMap
-from xdsl.utils.exceptions import DiagnosticException, VerifyException
+from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.test_value import TestSSAValue
 
@@ -495,13 +495,12 @@ def test_get_strides():
     affine = AffineMapAttr(AffineMap.identity(3))
 
     assert tuple(strided.get_strides()) == (24, 4, 1)
-    with pytest.raises(
-        DiagnosticException, match="Cannot yet extract strides from affine map"
-    ):
-        affine.get_strides()
+    assert affine.get_strides() is None
 
     t_none = MemRefType(i32, (2, 3, 4))
-    assert tuple(t_none.get_strides()) == (12, 4, 1)
+    assert (strides := t_none.get_strides())
+    assert tuple(strides) == (12, 4, 1)
 
     t_id = MemRefType(i32, (2, 3, 4), strided)
-    assert tuple(t_id.get_strides()) == (24, 4, 1)
+    assert (strides := t_id.get_strides())
+    assert tuple(strides) == (24, 4, 1)

--- a/tests/filecheck/parser-printer/affine_map.mlir
+++ b/tests/filecheck/parser-printer/affine_map.mlir
@@ -28,7 +28,7 @@ builtin.module {
   // CHECK: "f9"() {"map" = affine_map<(d0, d1, d2)[s0, s1, s2] -> ((d0 + s0), (d1 + s1), (d2 + s2))>} : () -> ()
   "f9"() {map = affine_map<(d0, d1, d2)[s0, s1, s2] -> (d0 + s0, d1 + s1, d2 + s2)>} : () -> ()
 
-  // CHECK: "f10"() {"map" = affine_map<(d0, d1) -> (((((d1 + (d0 * -1)) + (((d0 + (d1 * -1)) + 1) * 2)) + d1) + -1), (((((d1 + d1) + 1) + d1) + d1) + 1))>} : () -> ()
+  // CHECK: "f10"() {"map" = affine_map<(d0, d1) -> (((((d1 + (d0 * -1)) + (((d0 * 2) + (d1 * -2)) + 2)) + d1) + -1), (((((d1 + d1) + 1) + d1) + d1) + 1))>} : () -> ()
   "f10"() { map = affine_map<(i, j) -> ((j - i) + 2*(i - j + 1) + j - 1 + 0, j + j + 1 + j + j + 1)> } : () -> ()
 
   // CHECK: "f11"() {"map" = affine_map<(d0, d1) -> ((d0 + 2), d1)>} : () -> ()
@@ -37,7 +37,7 @@ builtin.module {
   // CHECK: "f12"() {"map" = affine_map<(d0, d1) -> ((d0 + 1), ((d1 * 4) + 2))>} : () -> ()
   "f12"() { map = affine_map<(i, j) -> (1*i+3*2-2*2-1, 4*j + 2)>} : () -> ()
 
-  // CHECK: "f13"() {"map" = affine_map<(d0, d1)[s0, s1] -> ((d0 * -5), (d1 * -3), -2, ((d0 + d1) * -1), (s0 * -1))>} : () -> ()
+  // CHECK: "f13"() {"map" = affine_map<(d0, d1)[s0, s1] -> ((d0 * -5), (d1 * -3), -2, ((d0 * -1) + (d1 * -1)), (s0 * -1))>} : () -> ()
   "f13"() { map = affine_map<(i, j)[s0, s1] -> (-5*i, -3*j, -2, -1*(i+j), -1*s0)>} : () -> ()
 
   // CHECK: "f14"() {"map" = affine_map<(d0, d1, d2) -> ((d0 * 0), d1, ((d0 * 128) floordiv 64), ((d1 * 0) floordiv 64))>} : () -> ()

--- a/tests/filecheck/transforms/memref_stream_tile_outer_loops.mlir
+++ b/tests/filecheck/transforms/memref_stream_tile_outer_loops.mlir
@@ -31,7 +31,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x1x18x18xf64> {"llvm.n
 // CHECK-NEXT:        %X_offset = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0)> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
 // CHECK-NEXT:        %X_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1)> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
 // CHECK-NEXT:        %X_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d2 * 2) + d4))> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
-// CHECK-NEXT:        %X_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((((d3 * 4) + d6) * 2) + d5))> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ((((d3 * 8) + (d6 * 2)) + d5))> (%c0, %c0, %i, %c0, %c0, %c0, %c0)
 // CHECK-NEXT:        %X_subview = memref.subview %X[%X_offset, %X_offset_1, %X_offset_2, %X_offset_3] [1, 1, 3, 17] [1, 1, 1, 1] : memref<1x1x18x18xf64> to memref<1x1x3x17xf64, strided<[324, 324, 18, 1], offset: ?>>
 // CHECK-NEXT:        %Y_offset = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d0)> (%c0, %c0, %i, %c0, %c0)
 // CHECK-NEXT:        %Y_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d1)> (%c0, %c0, %i, %c0, %c0)
@@ -41,7 +41,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x1x18x18xf64> {"llvm.n
 // CHECK-NEXT:        memref_stream.generic {
 // CHECK-NEXT:          bounds = [1, 1, 1, 2, 3, 3, 4],
 // CHECK-NEXT:          indexing_maps = [
-// CHECK-NEXT:            affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), ((((d3 * 4) + d6) * 2) + d5))>,
+// CHECK-NEXT:            affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), (((d3 * 8) + (d6 * 2)) + d5))>
 // CHECK-NEXT:            affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, ((d3 * 4) + d4))>
 // CHECK-NEXT:          ],
 // CHECK-NEXT:          iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "interleaved"]
@@ -90,7 +90,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x2x18x18xf64> {"llvm.n
 // CHECK-NEXT:        %X_offset = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0)> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
 // CHECK-NEXT:        %X_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1)> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
 // CHECK-NEXT:        %X_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d2 * 2) + d4))> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
-// CHECK-NEXT:        %X_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((((d3 * 4) + d6) * 2) + d5))> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
+// CHECK-NEXT:        %X_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ((((d3 * 8) + (d6 * 2)) + d5))> (%c0, %i, %c0, %c0, %c0, %c0, %c0)
 // CHECK-NEXT:        %X_subview = memref.subview %X[%X_offset, %X_offset_1, %X_offset_2, %X_offset_3] [1, 1, 17, 17] [1, 1, 1, 1] : memref<1x2x18x18xf64> to memref<1x1x17x17xf64, strided<[648, 324, 18, 1], offset: ?>>
 // CHECK-NEXT:        %Y_offset = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d0)> (%c0, %i, %c0, %c0, %c0)
 // CHECK-NEXT:        %Y_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d1)> (%c0, %i, %c0, %c0, %c0)
@@ -104,7 +104,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x2x18x18xf64> {"llvm.n
 // CHECK-NEXT:          %X_subview_offset = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
 // CHECK-NEXT:          %X_subview_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
 // CHECK-NEXT:          %X_subview_offset_2 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((d2 * 2) + d4))> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
-// CHECK-NEXT:          %X_subview_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (((((d3 * 4) + d6) * 2) + d5))> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
+// CHECK-NEXT:          %X_subview_offset_3 = affine.apply affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ((((d3 * 8) + (d6 * 2)) + d5))> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1, %c0_1, %c0_1)
 // CHECK-NEXT:          %X_subview_subview = memref.subview %X_subview[%X_subview_offset, %X_subview_offset_1, %X_subview_offset_2, %X_subview_offset_3] [1, 1, 3, 17] [1, 1, 1, 1] : memref<1x1x17x17xf64, strided<[648, 324, 18, 1], offset: ?>> to memref<1x1x17x17xf64, strided<[648, 324, 18, 1], offset: ?>>
 // CHECK-NEXT:          %Y_subview_offset = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d0)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1)
 // CHECK-NEXT:          %Y_subview_offset_1 = affine.apply affine_map<(d0, d1, d2, d3, d4) -> (d1)> (%c0_1, %c0_1, %i_1, %c0_1, %c0_1)
@@ -114,7 +114,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(%X : memref<1x2x18x18xf64> {"llvm.n
 // CHECK-NEXT:          memref_stream.generic {
 // CHECK-NEXT:            bounds = [1, 1, 1, 2, 3, 3, 4],
 // CHECK-NEXT:            indexing_maps = [
-// CHECK-NEXT:              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), ((((d3 * 4) + d6) * 2) + d5))>,
+// CHECK-NEXT:              affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, ((d2 * 2) + d4), (((d3 * 8) + (d6 * 2)) + d5))>,
 // CHECK-NEXT:              affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, ((d3 * 4) + d4))>
 // CHECK-NEXT:            ],
 // CHECK-NEXT:            iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "interleaved"]

--- a/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
+++ b/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
@@ -6,7 +6,6 @@ from xdsl.dialects.builtin import Float64Type, MemRefType, f64
 from xdsl.ir.affine import AffineMap
 from xdsl.transforms.convert_memref_stream_to_snitch_stream import (
     strides_for_affine_map,
-    strides_map_from_memref_type,
 )
 from xdsl.utils.exceptions import DiagnosticException
 
@@ -20,9 +19,9 @@ def test_strides_map_from_memref_type():
         DiagnosticException,
         match="Unsupported empty shape in memref of type memref<f64>",
     ):
-        strides_map_from_memref_type(mem_type([]))
+        mem_type([]).get_affine_map()
 
-    assert strides_map_from_memref_type(mem_type([2, 3])) == AffineMap.from_callable(
+    assert mem_type([2, 3]).get_affine_map() == AffineMap.from_callable(
         lambda i, j: (i * 24 + j * 8,)
     )
 

--- a/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
+++ b/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
@@ -19,9 +19,9 @@ def test_strides_map_from_memref_type():
         DiagnosticException,
         match="Unsupported empty shape in memref of type memref<f64>",
     ):
-        mem_type([]).get_affine_map_bytes()
+        mem_type([]).get_affine_map_in_bytes()
 
-    assert mem_type([2, 3]).get_affine_map_bytes() == AffineMap.from_callable(
+    assert mem_type([2, 3]).get_affine_map_in_bytes() == AffineMap.from_callable(
         lambda i, j: (i * 24 + j * 8,)
     )
 

--- a/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
+++ b/tests/transforms/test_convert_memref_stream_to_snitch_stream.py
@@ -19,9 +19,9 @@ def test_strides_map_from_memref_type():
         DiagnosticException,
         match="Unsupported empty shape in memref of type memref<f64>",
     ):
-        mem_type([]).get_affine_map()
+        mem_type([]).get_affine_map_bytes()
 
-    assert mem_type([2, 3]).get_affine_map() == AffineMap.from_callable(
+    assert mem_type([2, 3]).get_affine_map_bytes() == AffineMap.from_callable(
         lambda i, j: (i * 24 + j * 8,)
     )
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1679,7 +1679,7 @@ class MemRefType(
 
         return map
 
-    def get_affine_map_bytes(self) -> AffineMap:
+    def get_affine_map_in_bytes(self) -> AffineMap:
         """
         Return the affine mapping from the iteration space of this
         memref's layout to the byte offset in linear memory.

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1197,8 +1197,8 @@ class MemrefLayoutAttr(Attribute, ABC):
         in linear memory for every dimension in the iteration space of
         this memref layout attribute.
 
-        Note: The dimension of the iteration space may differ from the data
-        it represents. For instance, this can occur in a tiled layout.
+        Note: The dimension of the iteration space may differ from the dimension
+        of the data it represents. For instance, this can occur in a tiled layout.
 
         This is only applicable to hyper-rectangular layouts.
         If this is not applicable for a given layout, returns None

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1281,6 +1281,7 @@ class StridedLayoutAttr(MemrefLayoutAttr, ParametrizedAttribute):
             result += AffineConstantExpr(self.offset.data)
         else:  # NoneAttr
             result += AffineSymExpr(nb_symbols)
+            nb_symbols += 1
 
         for dim, stride in enumerate(self.strides.data):
             if isinstance(stride, IntAttr):

--- a/xdsl/ir/affine/affine_expr.py
+++ b/xdsl/ir/affine/affine_expr.py
@@ -180,6 +180,13 @@ class AffineExpr:
         if isinstance(self, AffineBinaryOpExpr) and self.kind == AffineBinaryOpKind.Mul:
             if fold := self.rhs._try_fold_constant(other, AffineBinaryOpKind.Mul):
                 return self.lhs * fold
+        # Fold (expr + expr) * constant.
+        if (
+            isinstance(self, AffineBinaryOpExpr)
+            and self.kind == AffineBinaryOpKind.Add
+            and isinstance(other, AffineConstantExpr)
+        ):
+            return self.lhs * other + self.rhs * other
         return None
 
     def __mul__(self, other: AffineExpr | int) -> AffineExpr:

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -132,9 +132,9 @@ class AffineMap:
         """
         Returns the `AffineMap` resulting from composing `self` with `other`.
 
-        The resulting `AffineMap` has as many `AffineDimExpr` as `other` and as many `AffineSymbolExpr` as the concatenation of `self` and `other` (in which case the symbols of `self` come first).
+        The resulting `AffineMap` has as many dimensions as `other` and as many symbols as the concatenation of `self` and `other` (in which case the symbols of `self` come first).
 
-        Prerequisites: The maps are composable, i.e. that the number of `AffineDimExpr` of `self` matches the number of results of `map`.
+        Prerequisites: The maps are composable, i.e. that the number of dimensions of `self` matches the number of results of `other`.
 
         Example:
         ```

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -191,6 +191,7 @@ class StreamOpLowering(RewritePattern):
             cast_op.operands = (arg,)
             rewriter.modify_block_argument_type(arg, stream_type)
 
+
 def strides_for_affine_map(
     affine_map: AffineMap, memref_type: MemRefType[AttributeCovT]
 ) -> list[int]:

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -207,7 +207,7 @@ def strides_for_affine_map(
     if not all(static_shapes):
         raise ValueError("Cannot create strides for a memref with dynamic shapes")
 
-    offset_map = memref_type.get_affine_map_bytes()
+    offset_map = memref_type.get_affine_map_in_bytes()
     composed = offset_map.compose(affine_map)
 
     zeros = [0] * composed.num_dims

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -1,5 +1,3 @@
-import operator
-from functools import reduce
 from typing import Any, cast
 
 from xdsl.backend.riscv.lowering.utils import (
@@ -18,7 +16,6 @@ from xdsl.dialects import (
 )
 from xdsl.dialects.builtin import (
     ArrayAttr,
-    FixedBitwidthType,
     Float16Type,
     Float32Type,
     Float64Type,
@@ -39,6 +36,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
+from xdsl.utils.exceptions import DiagnosticException
 
 
 def snitch_stream_element_type_is_valid(attr: Attribute) -> bool:

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -72,7 +72,9 @@ def insert_subview(
         raise DiagnosticException("Cannot create subview from non-memref type")
     source_type = cast(MemRefType[Attribute], source_type)
     layout_attr = source_type.layout
-    strides = tuple(source_type.get_strides())
+    strides = source_type.get_strides()
+    assert strides is not None
+    strides = tuple(strides)
     match layout_attr:
         case NoneAttr():
             layout_attr = StridedLayoutAttr(strides, None)

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -72,8 +72,7 @@ def insert_subview(
         raise DiagnosticException("Cannot create subview from non-memref type")
     source_type = cast(MemRefType[Attribute], source_type)
     layout_attr = source_type.layout
-    strides = source_type.get_strides()
-    assert strides is not None
+    assert (strides := source_type.get_strides())
     strides = tuple(strides)
     match layout_attr:
         case NoneAttr():


### PR DESCRIPTION
This PR defines `get_affine_map` in the `MemrefLayoutAttr`, and implements this for the available layout attributes.
This is also defined for the memref type. `memreftype.get_affine_map` still returns the element offset, while `memreftype.get_affine_map_in_bytes` returns the byte offset (accounting for element type width).

Additionally, it replaces all code that (partially) implemented this functionality in their respective transforms (mostly `convert-memref-stream-to-snitch-stream`), by using the new interface in the builtin dialect.