### PR TITLE
backend: (riscv) add allocate_same method to register allocator

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -1,0 +1,74 @@
+import re
+
+import pytest
+
+from xdsl.backend.riscv.register_allocation import RegisterAllocatorLivenessBlockNaive
+from xdsl.backend.riscv.register_queue import RegisterQueue
+from xdsl.dialects import riscv
+from xdsl.utils.exceptions import DiagnosticException
+from xdsl.utils.test_value import TestSSAValue
+
+
+def test_default_reserved_registers():
+    register_queue = RegisterQueue(
+        available_int_registers=[], available_float_registers=[]
+    )
+
+    unallocated = riscv.Registers.UNALLOCATED_INT
+
+    def j(index: int):
+        return riscv.IntRegisterType(f"j{index}")
+
+    assert register_queue.pop(riscv.IntRegisterType) == j(0)
+
+    register_allocator = RegisterAllocatorLivenessBlockNaive(register_queue)
+
+    assert not register_allocator.allocate_same(())
+
+    a = TestSSAValue(unallocated)
+    register_allocator.allocate_same((a,))
+
+    assert a.type == j(1)
+
+    register_allocator.allocate_same((a,))
+
+    assert a.type == j(1)
+
+    b0 = TestSSAValue(unallocated)
+    b1 = TestSSAValue(unallocated)
+
+    register_allocator.allocate_same((b0, b1))
+
+    assert b0.type == j(2)
+    assert b1.type == j(2)
+
+    c0 = TestSSAValue(j(2))
+    c1 = TestSSAValue(unallocated)
+
+    register_allocator.allocate_same((c0, c1))
+
+    assert c0.type == j(2)
+    assert c1.type == j(2)
+
+    d0 = TestSSAValue(j(2))
+    d1 = TestSSAValue(j(3))
+
+    with pytest.raises(
+        DiagnosticException,
+        match=re.escape(
+            "Cannot allocate registers to the same register ['!riscv.reg<j2>', '!riscv.reg<j3>']"
+        ),
+    ):
+        register_allocator.allocate_same((d0, d1))
+
+    e0 = TestSSAValue(j(2))
+    e1 = TestSSAValue(j(3))
+    e2 = TestSSAValue(unallocated)
+
+    with pytest.raises(
+        DiagnosticException,
+        match=re.escape(
+            "Cannot allocate registers to the same register ['!riscv.reg', '!riscv.reg<j2>', '!riscv.reg<j3>']"
+        ),
+    ):
+        register_allocator.allocate_same((e0, e1, e2))

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -121,6 +121,13 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
         return False
 
     def allocate_same(self, vals: Sequence[SSAValue]) -> bool:
+        """
+        Allocates the values passed in to the same register.
+        If some of the values are already allocated, they must be allocated to the same
+        register, and unallocated values are then allocated to this register.
+        If the values passed in are already allocated to differing registers, a
+        `DiagnosticException` is raised.
+        """
         reg_types = set(val.type for val in vals)
         assert all(isinstance(reg_type, RISCVRegisterType) for reg_type in reg_types)
         reg_types = cast(set[IntRegisterType | FloatRegisterType], reg_types)

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -142,6 +142,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 if reg_type_0.is_allocated:
                     if reg_type_1.is_allocated:
                         reg_names = [f"{reg_type}" for reg_type in reg_types]
+                        reg_names.sort()
                         raise DiagnosticException(
                             f"Cannot allocate registers to the same register {reg_names}"
                         )
@@ -153,6 +154,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 # More than one input is allocated, meaning we can't allocate them to be
                 # the same, error.
                 reg_names = [f"{reg_type}" for reg_type in reg_types]
+                reg_names.sort()
                 raise DiagnosticException(
                     f"Cannot allocate registers to the same register {reg_names}"
                 )

--- a/xdsl/backend/riscv/register_queue.py
+++ b/xdsl/backend/riscv/register_queue.py
@@ -1,4 +1,6 @@
 from collections import defaultdict
+from collections.abc import Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import overload
 
@@ -83,6 +85,16 @@ class RegisterQueue:
             reg not in self.reserved_registers
         ), f"Cannot pop a reserved register ({reg.register_name}), it must have been reserved while available."
         return reg
+
+    @contextmanager
+    def reserve_registers(self, regs: Sequence[IntRegisterType | FloatRegisterType]):
+        for reg in regs:
+            self.reserve_register(reg)
+
+        yield
+
+        for reg in regs:
+            self.unreserve_register(reg)
 
     def reserve_register(self, reg: IntRegisterType | FloatRegisterType) -> None:
         """


### PR DESCRIPTION
This is useful as a general factoring out of our loop allocation logic, but is also necessary for future operations that have constraints for results and operands that must be the same register.