### PR TITLE
(transform, minor): stencil-to-csl-stencil retain interesting compute structure property

### DIFF
--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -3,34 +3,33 @@
 builtin.module {
   func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) {
     %0 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-    %1 = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
-    %2 = tensor.empty() : tensor<510xf32>
-    %3 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %2 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
-    ^0(%4 : memref<4xtensor<255xf32>>, %5 : index, %6 : tensor<510xf32>):
-      %7 = csl_stencil.access %4[1, 0] : memref<4xtensor<255xf32>>
-      %8 = csl_stencil.access %4[-1, 0] : memref<4xtensor<255xf32>>
-      %9 = csl_stencil.access %4[0, 1] : memref<4xtensor<255xf32>>
-      %10 = csl_stencil.access %4[0, -1] : memref<4xtensor<255xf32>>
-      %11 = arith.addf %8, %7 : tensor<255xf32>
-      %12 = arith.addf %10, %9 : tensor<255xf32>
-      %13 = arith.addf %12, %11 : tensor<255xf32>
-      %14 = "tensor.insert_slice"(%13, %6, %5) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
-      csl_stencil.yield %14 : tensor<510xf32>
+    %1 = tensor.empty() : tensor<510xf32>
+    %2 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+    ^0(%3 : memref<4xtensor<255xf32>>, %4 : index, %5 : tensor<510xf32>):
+      %6 = csl_stencil.access %3[1, 0] : memref<4xtensor<255xf32>>
+      %7 = csl_stencil.access %3[-1, 0] : memref<4xtensor<255xf32>>
+      %8 = csl_stencil.access %3[0, 1] : memref<4xtensor<255xf32>>
+      %9 = csl_stencil.access %3[0, -1] : memref<4xtensor<255xf32>>
+      %10 = arith.addf %9, %8 : tensor<255xf32>
+      %11 = arith.addf %10, %7 : tensor<255xf32>
+      %12 = arith.addf %11, %6 : tensor<255xf32>
+      %13 = "tensor.insert_slice"(%12, %5, %4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+      csl_stencil.yield %13 : tensor<510xf32>
     }, {
-    ^1(%15 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %16 : tensor<510xf32>):
-      %17 = csl_stencil.access %15[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %18 = csl_stencil.access %15[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-      %19 = arith.constant 1.666600e-01 : f32
-      %20 = "tensor.extract_slice"(%17) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-      %21 = "tensor.extract_slice"(%18) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-      %22 = arith.addf %16, %21 : tensor<510xf32>
-      %23 = arith.addf %22, %20 : tensor<510xf32>
-      %24 = tensor.empty() : tensor<510xf32>
-      %25 = linalg.fill ins(%19 : f32) outs(%24 : tensor<510xf32>) -> tensor<510xf32>
-      %26 = arith.mulf %23, %25 : tensor<510xf32>
-      csl_stencil.yield %26 : tensor<510xf32>
+    ^1(%14 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %15 : tensor<510xf32>):
+      %16 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %17 = csl_stencil.access %14[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+      %18 = arith.constant 1.666600e-01 : f32
+      %19 = "tensor.extract_slice"(%16) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %20 = "tensor.extract_slice"(%17) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+      %21 = arith.addf %15, %20 : tensor<510xf32>
+      %22 = arith.addf %21, %19 : tensor<510xf32>
+      %23 = tensor.empty() : tensor<510xf32>
+      %24 = linalg.fill ins(%18 : f32) outs(%23 : tensor<510xf32>) -> tensor<510xf32>
+      %25 = arith.mulf %22, %24 : tensor<510xf32>
+      csl_stencil.yield %25 : tensor<510xf32>
     })
-    stencil.store %3 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %2 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
     func.return
   }
 }
@@ -60,34 +59,33 @@ builtin.module {
 // CHECK-NEXT:   ^1(%23 : i16, %24 : i16, %25 : i16, %26 : i16, %memcpy_params : !csl.comptime_struct, %stencil_comms_params : !csl.comptime_struct, %isBorderRegionPE : i1, %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
 // CHECK-NEXT:     csl.func @gauss_seidel() {
 // CHECK-NEXT:       %27 = stencil.load %a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>> -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:       %28 = "csl_stencil.prefetch"(%27) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
-// CHECK-NEXT:       %29 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:       %30 = csl_stencil.apply(%27 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %29 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
-// CHECK-NEXT:       ^2(%31 : memref<4xtensor<255xf32>>, %32 : index, %33 : tensor<510xf32>):
-// CHECK-NEXT:         %34 = csl_stencil.access %31[1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %35 = csl_stencil.access %31[-1, 0] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %36 = csl_stencil.access %31[0, 1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %37 = csl_stencil.access %31[0, -1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:         %38 = arith.addf %35, %34 : tensor<255xf32>
-// CHECK-NEXT:         %39 = arith.addf %37, %36 : tensor<255xf32>
-// CHECK-NEXT:         %40 = arith.addf %39, %38 : tensor<255xf32>
-// CHECK-NEXT:         %41 = "tensor.insert_slice"(%40, %33, %32) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
-// CHECK-NEXT:         csl_stencil.yield %41 : tensor<510xf32>
+// CHECK-NEXT:       %28 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:       %29 = csl_stencil.apply(%27 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %28 : tensor<510xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64}> -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) ({
+// CHECK-NEXT:       ^2(%30 : memref<4xtensor<255xf32>>, %31 : index, %32 : tensor<510xf32>):
+// CHECK-NEXT:         %33 = csl_stencil.access %30[1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %34 = csl_stencil.access %30[-1, 0] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %35 = csl_stencil.access %30[0, 1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %36 = csl_stencil.access %30[0, -1] : memref<4xtensor<255xf32>>
+// CHECK-NEXT:         %37 = arith.addf %36, %35 : tensor<255xf32>
+// CHECK-NEXT:         %38 = arith.addf %37, %34 : tensor<255xf32>
+// CHECK-NEXT:         %39 = arith.addf %38, %33 : tensor<255xf32>
+// CHECK-NEXT:         %40 = "tensor.insert_slice"(%39, %32, %31) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:         csl_stencil.yield %40 : tensor<510xf32>
 // CHECK-NEXT:       }, {
-// CHECK-NEXT:       ^3(%42 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %43 : tensor<510xf32>):
-// CHECK-NEXT:         %44 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:         %45 = csl_stencil.access %42[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-// CHECK-NEXT:         %46 = arith.constant 1.666600e-01 : f32
-// CHECK-NEXT:         %47 = "tensor.extract_slice"(%44) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:         %48 = "tensor.extract_slice"(%45) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:         %49 = arith.addf %43, %48 : tensor<510xf32>
-// CHECK-NEXT:         %50 = arith.addf %49, %47 : tensor<510xf32>
-// CHECK-NEXT:         %51 = tensor.empty() : tensor<510xf32>
-// CHECK-NEXT:         %52 = linalg.fill ins(%46 : f32) outs(%51 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:         %53 = arith.mulf %50, %52 : tensor<510xf32>
-// CHECK-NEXT:         csl_stencil.yield %53 : tensor<510xf32>
+// CHECK-NEXT:       ^3(%41 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %42 : tensor<510xf32>):
+// CHECK-NEXT:         %43 = csl_stencil.access %41[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:         %44 = csl_stencil.access %41[0, 0] : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+// CHECK-NEXT:         %45 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:         %46 = "tensor.extract_slice"(%43) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %47 = "tensor.extract_slice"(%44) <{"static_offsets" = array<i64: -1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %48 = arith.addf %42, %47 : tensor<510xf32>
+// CHECK-NEXT:         %49 = arith.addf %48, %46 : tensor<510xf32>
+// CHECK-NEXT:         %50 = tensor.empty() : tensor<510xf32>
+// CHECK-NEXT:         %51 = linalg.fill ins(%45 : f32) outs(%50 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:         %52 = arith.mulf %49, %51 : tensor<510xf32>
+// CHECK-NEXT:         csl_stencil.yield %52 : tensor<510xf32>
 // CHECK-NEXT:       })
-// CHECK-NEXT:       stencil.store %30 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:       stencil.store %29 to %b ([0, 0] : [1, 1]) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()

--- a/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
@@ -43,9 +43,9 @@ builtin.module {
 // CHECK-NEXT:       %7 = csl_stencil.access %3[-1, 0] : memref<4xtensor<255xf32>>
 // CHECK-NEXT:       %8 = csl_stencil.access %3[0, 1] : memref<4xtensor<255xf32>>
 // CHECK-NEXT:       %9 = csl_stencil.access %3[0, -1] : memref<4xtensor<255xf32>>
-// CHECK-NEXT:       %10 = arith.addf %7, %6 : tensor<255xf32>
-// CHECK-NEXT:       %11 = arith.addf %9, %8 : tensor<255xf32>
-// CHECK-NEXT:       %12 = arith.addf %11, %10 : tensor<255xf32>
+// CHECK-NEXT:       %10 = arith.addf %9, %8 : tensor<255xf32>
+// CHECK-NEXT:       %11 = arith.addf %10, %7 : tensor<255xf32>
+// CHECK-NEXT:       %12 = arith.addf %11, %6 : tensor<255xf32>
 // CHECK-NEXT:       %13 = "tensor.insert_slice"(%12, %5, %4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %13 : tensor<510xf32>
 // CHECK-NEXT:     }, {

--- a/xdsl/transforms/stencil_to_csl_stencil.py
+++ b/xdsl/transforms/stencil_to_csl_stencil.py
@@ -108,14 +108,8 @@ class RestructureSymmetricReductionPattern(RewritePattern):
             return
         elif self.move_back(a) and self.move_back(b):
             return
-        elif self.move_fwd(a) and self.move_fwd(c):
+        elif self.move_fwd(c) and self.move_back(b):
             rewrite(a_op, c_op, b_op)
-        elif self.move_fwd(b) and self.move_fwd(c):
-            rewrite(b_op, c_op, a_op)
-        elif self.move_back(a) and not self.move_back(c):
-            rewrite(c_op, b_op, a_op)
-        elif self.move_back(b) and not self.move_back(c):
-            rewrite(c_op, a_op, b_op)
 
     def move_fwd(self, accs: set[Operand]) -> bool:
         return self.buf in accs and len(accs) == 1
@@ -394,7 +388,8 @@ class ConvertApplyOpPattern(RewritePattern):
 
         # run pass (on this apply's region only) to consume data from `prefetch` accesses first
         nested_rewriter = PatternRewriteWalker(
-            RestructureSymmetricReductionPattern(op.region.block.args[prefetch_idx])
+            RestructureSymmetricReductionPattern(op.region.block.args[prefetch_idx]),
+            walk_reverse=True,
         )
         nested_rewriter.rewrite_op(op)
 


### PR DESCRIPTION
Minor fix to retain the imbalanced tree compute structure.

Before the transform, the compute structure was of the form:
`(((a + b) + c) + d)`

After the transform, the compute structure was of the form:
`(a + b) + (c + d)`

As the imbalanced tree structure (first) is preferable for reference semantics and easier to translate, this pass should retain this property.