### PR TITLE
dialects: (memref_stream) add doc and library call support

### DIFF
--- a/tests/filecheck/dialects/memref_stream/ops.mlir
+++ b/tests/filecheck/dialects/memref_stream/ops.mlir
@@ -56,7 +56,9 @@ memref_stream.generic {
         affine_map<(d0, d1) -> (d1)>,
         affine_map<(d0, d1) -> (d0, d1)>
     ],
-    iterator_types = ["parallel", "parallel"]
+    iterator_types = ["parallel", "parallel"],
+    doc = "documentation string",
+    library_call = "library call"
 } ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs = {hello = "world"} {
 ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
     memref_stream.yield %arg3 : f32
@@ -70,12 +72,14 @@ memref_stream.generic {
 // CHECK-NEXT:      affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    iterator_types = ["parallel", "parallel"]
+// CHECK-NEXT:    doc = "documentation string",
+// CHECK-NEXT:    library_call = "library call"
 // CHECK-NEXT:  } ins(%A, %B : memref<2xf32>, memref<3xf32>) outs(%C : memref<3x2xf64>) attrs =  {"hello" = "world"} {
 // CHECK-NEXT:  ^1(%arg3 : f32, %arg4 : f32, %arg5 : f32):
 // CHECK-NEXT:    memref_stream.yield %arg3 : f32
 // CHECK-NEXT:  }
 
-// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%A, %B, %C) <{"bounds" = [3 : index, 2 : index], "init_indices" = [], "indexing_maps" = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "operandSegmentSizes" = array<i32: 2, 1, 0>}> ({
+// CHECK-GENERIC-NEXT:    "memref_stream.generic"(%A, %B, %C) <{"bounds" = [3 : index, 2 : index], "init_indices" = [], "indexing_maps" = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], "iterator_types" = [#memref_stream.iterator_type<parallel>, #memref_stream.iterator_type<parallel>], "doc" = "documentation string", "library_call" = "library call", "operandSegmentSizes" = array<i32: 2, 1, 0>}> ({
 // CHECK-GENERIC-NEXT:    ^1(%arg3 : f32, %arg4 : f32, %arg5 : f32):
 // CHECK-GENERIC-NEXT:      "memref_stream.yield"(%arg3) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) {"hello" = "world"} : (memref<2xf32>, memref<3xf32>, memref<3x2xf64>) -> ()

--- a/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
+++ b/tests/filecheck/transforms/convert_linalg_to_memref_stream.mlir
@@ -15,7 +15,9 @@ linalg.generic {
         affine_map<() -> ()>,
         affine_map<() -> ()>
     ],
-    iterator_types = []
+    iterator_types = [],
+    doc = "documentation string",
+    library_call = "library call"
 } ins(%A, %B : memref<f64>, memref<f64>) outs(%C : memref<f64>) {
 ^0(%a : f64, %b : f64, %acc_old : f64):
     %prod = arith.mulf %a, %b : f64
@@ -29,7 +31,9 @@ linalg.generic {
 // CHECK-NEXT:        affine_map<() -> ()>,
 // CHECK-NEXT:        affine_map<() -> ()>
 // CHECK-NEXT:      ],
-// CHECK-NEXT:      iterator_types = []
+// CHECK-NEXT:      iterator_types = [],
+// CHECK-NEXT:      doc = "documentation string",
+// CHECK-NEXT:      library_call = "library call"
 // CHECK-NEXT:    } ins(%A, %B : memref<f64>, memref<f64>) outs(%C : memref<f64>) {
 // CHECK-NEXT:    ^0(%a : f64, %b : f64, %acc_old : f64):
 // CHECK-NEXT:      %prod = arith.mulf %a, %b : f64

--- a/xdsl/transforms/convert_linalg_to_memref_stream.py
+++ b/xdsl/transforms/convert_linalg_to_memref_stream.py
@@ -49,6 +49,8 @@ class ConvertGenericOpPattern(RewritePattern):
                 iterator_types,
                 bounds,
                 ArrayAttr(()),
+                op.doc,
+                op.library_call,
             )
         )
 


### PR DESCRIPTION
We are using the `library_call` attribute to designate to which accelerator we want to dispatch a certain linalg generic to. Right now, this information gets lost when converting from linalg.generic to memref_stream.generic, which is somewhat annoying. This PR adds support for these generic attributes in the memref stream dialect.
