### PR TITLE
dialects: (riscv_snitch) lower arith.addf on vector<4xf16> to vfadd.h

### DIFF
--- a/tests/filecheck/backend/riscv/convert_arith_to_riscv_snitch.mlir
+++ b/tests/filecheck/backend/riscv/convert_arith_to_riscv_snitch.mlir
@@ -3,15 +3,21 @@
 // CHECK:   builtin.module
 // CHECK-NEXT:    %l, %r = "test.op"() : () -> (!riscv.freg, !riscv.freg)
 %l, %r = "test.op"() : () -> (!riscv.freg, !riscv.freg)
+%l16 = builtin.unrealized_conversion_cast %l : !riscv.freg to vector<4xf16>
+%r16 = builtin.unrealized_conversion_cast %r : !riscv.freg to vector<4xf16>
 %l32 = builtin.unrealized_conversion_cast %l : !riscv.freg to vector<2xf32>
 %r32 = builtin.unrealized_conversion_cast %r : !riscv.freg to vector<2xf32>
 %lhsvf64 = builtin.unrealized_conversion_cast %l : !riscv.freg to vector<1xf64>
 %rhsvf64 = builtin.unrealized_conversion_cast %r : !riscv.freg to vector<1xf64>
 
+// CHECK-NEXT:    %addf16 = riscv_snitch.vfadd.h %l, %r : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%addf16 = arith.addf %l16, %r16 : vector<4xf16>
 // CHECK-NEXT:    %addf32 = riscv_snitch.vfadd.s %l, %r : (!riscv.freg, !riscv.freg) -> !riscv.freg
 %addf32 = arith.addf %l32, %r32 : vector<2xf32>
 
 // tests with fastmath flags when set to "fast"
+// CHECK-NEXT:    %addf16_fm = riscv_snitch.vfadd.h %l, %r fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
+%addf16_fm = arith.addf %l16, %r16 fastmath<fast> : vector<4xf16>
 // CHECK-NEXT:    %addf32_fm = riscv_snitch.vfadd.s %l, %r fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.freg
 %addf32_fm = arith.addf %l32, %r32 fastmath<fast> : vector<2xf32>
 

--- a/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/assembly_emission.mlir
@@ -29,6 +29,8 @@ riscv_func.func @main() {
   %f4 = riscv_snitch.vfmac.s %f3, %f0, %f0 : (!riscv.freg<ft1>, !riscv.freg<ft0>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
   %f5 = riscv_snitch.vfsum.s %f4, %f0 : (!riscv.freg<ft1>, !riscv.freg<ft0>) -> !riscv.freg<ft1>
 
+  %f6 = riscv_snitch.vfadd.h %f4, %f0 : (!riscv.freg<ft1>, !riscv.freg<ft0>) -> !riscv.freg<ft3>
+
   riscv_func.return
 }
 
@@ -48,4 +50,5 @@ riscv_func.func @main() {
 // CHECK-NEXT:       vfcpka.s.s ft1, ft0, ft0
 // CHECK-NEXT:       vfmac.s ft1, ft0, ft0
 // CHECK-NEXT:       vfsum.s ft1, ft0
+// CHECK-NEXT:       vfadd.h ft3, ft1, ft0
 // CHECK-NEXT:       ret

--- a/tests/filecheck/dialects/riscv_snitch/ops.mlir
+++ b/tests/filecheck/dialects/riscv_snitch/ops.mlir
@@ -105,6 +105,9 @@ riscv_func.func @simd() {
   %4 = riscv_snitch.vfsum.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
   // CHECK-NEXT: %4 = riscv_snitch.vfsum.s %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
 
+  %5 = riscv_snitch.vfadd.h %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+  // CHECK-NEXT: %5 = riscv_snitch.vfadd.h %v, %v : (!riscv.freg, !riscv.freg) -> !riscv.freg
+
   riscv_func.return
 }
 
@@ -158,6 +161,7 @@ riscv_func.func @simd() {
 // CHECK-GENERIC-NEXT:       %2 = "riscv_snitch.vfcpka.s.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
 // CHECK-GENERIC-NEXT:       %3 = "riscv_snitch.vfmac.s"(%v, %v, %v) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg, !riscv.freg) -> !riscv.freg
 // CHECK-GENERIC-NEXT:       %4 = "riscv_snitch.vfsum.s"(%v, %v) : (!riscv.freg, !riscv.freg) -> !riscv.freg
+// CHECK-GENERIC-NEXT:       %5 = "riscv_snitch.vfadd.h"(%v, %v) {"fastmath" = #riscv.fastmath<none>} : (!riscv.freg, !riscv.freg) -> !riscv.freg
 // CHECK-GENERIC-NEXT:       "riscv_func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) {"sym_name" = "simd", "function_type" = () -> ()} : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -776,6 +776,27 @@ class VFAddSOp(riscv.RdRsRsFloatOperationWithFastMath):
     traits = frozenset((Pure(),))
 
 
+@irdl_op_definition
+class VFAddHOp(riscv.RdRsRsFloatOperationWithFastMath):
+    """
+    Performs vectorial addition of corresponding f16 values from
+    rs1 and rs2 and stores the results in the corresponding f16 lanes
+    into the vectorial 4xf16 rd operand, such as:
+
+    f[rd][0] = f[rs1][0] + f[rs2][0]
+    f[rd][1] = f[rs1][1] + f[rs2][1]
+    f[rd][2] = f[rs1][2] + f[rs2][2]
+    f[rd][3] = f[rs1][3] + f[rs2][3]
+    """
+
+    name = "riscv_snitch.vfadd.h"
+
+    def assembly_instruction_name(self) -> str:
+        return "vfadd.h"
+
+    traits = frozenset((Pure(),))
+
+
 RdRsFloatInvT = TypeVar("RdRsFloatInvT", bound=FloatRegisterType)
 
 
@@ -937,6 +958,7 @@ RISCV_Snitch = Dialect(
         VFCpkASSOp,
         VFMacSOp,
         VFSumSOp,
+        VFAddHOp,
     ],
     [],
 )


### PR DESCRIPTION
This PR adds support for the `vfadd.h` instruction in the riscv backend and fixes lowering of `arith.addf` on `vector<4xf16>` to it for Snitch. 