### PR TITLE
api: remove parameters field from Trait

### DIFF
--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -118,8 +118,8 @@ def test_has_trait_object():
     """
     assert TestOp.has_trait(LargerOperandTrait)
     assert not TestOp.has_trait(LargerResultTrait)
-    assert not TestOp.has_trait(BitwidthSumLessThanTrait, 0)
-    assert TestOp.has_trait(BitwidthSumLessThanTrait, 64)
+    assert not TestOp.has_trait(BitwidthSumLessThanTrait(0))
+    assert TestOp.has_trait(BitwidthSumLessThanTrait(64))
 
 
 def test_get_traits_of_type():
@@ -445,8 +445,8 @@ def test_lazy_parent():
     """Test the trait infrastructure for an operation that defines a trait "lazily"."""
     op = HasLazyParentOp.create()
     assert len(op.get_traits_of_type(HasParent)) != 0
-    assert op.get_traits_of_type(HasParent)[0].parameters == (TestOp,)
-    assert op.has_trait(HasParent, (TestOp,))
+    assert op.get_traits_of_type(HasParent)[0].op_types == (TestOp,)
+    assert op.has_trait(HasParent(TestOp))
     assert op.traits == frozenset([HasParent(TestOp)])
 
 
@@ -461,7 +461,7 @@ def test_has_ancestor():
     op = AncestorOp()
 
     assert op.get_traits_of_type(HasAncestor) == [HasAncestor(TestOp)]
-    assert op.has_trait(HasAncestor, (TestOp,))
+    assert op.has_trait(HasAncestor(TestOp))
 
     with pytest.raises(
         VerifyException, match="'test.ancestor' expects ancestor op 'test.test'"

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import KW_ONLY, dataclass, field
 from typing import Annotated, ClassVar, TypeAlias
 
 from xdsl.dialects import builtin
@@ -186,14 +186,15 @@ class InModuleKind(OpTrait):
     Ops with this trait are always allowed inside a csl_wrapper.module
     """
 
-    def __init__(self, kind: ModuleKind, *, direct_child: bool = True):
-        super().__init__((kind, direct_child))
+    kind: ModuleKind = field()
+    _: KW_ONLY
+    direct_child: bool = field(default=True)
 
     def verify(self, op: Operation) -> None:
         from xdsl.dialects.csl import csl_wrapper
 
-        kind: ModuleKind = self.parameters[0]
-        direct_child: bool = self.parameters[1]
+        kind: ModuleKind = self.kind
+        direct_child: bool = self.direct_child
 
         direct = "direct" if direct_child else "indirect"
         parent_module = op.parent_op()

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -472,7 +472,7 @@ class AccessOp(IRDLOperation):
 
         # As promised by HasAncestor(ApplyOp)
         trait = cast(
-            HasAncestor, AccessOp.get_trait(HasAncestor, (stencil.ApplyOp, ApplyOp))
+            HasAncestor, AccessOp.get_trait(HasAncestor(stencil.ApplyOp, ApplyOp))
         )
         apply = trait.get_ancestor(self)
         assert isinstance(apply, stencil.ApplyOp | ApplyOp)
@@ -510,7 +510,10 @@ class AccessOp(IRDLOperation):
         """
         Simple helper to get the parent apply and raise otherwise.
         """
-        trait = cast(HasAncestor, self.get_trait(HasAncestor, (stencil.ApplyOp,)))
+        trait = cast(
+            HasAncestor,
+            self.get_trait(HasAncestor(stencil.ApplyOp)),
+        )
         ancestor = trait.get_ancestor(self)
         if ancestor is None:
             raise ValueError(

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -802,7 +802,8 @@ class IndexOp(IRDLOperation):
         """
         Simple helper to get the parent apply and raise otherwise.
         """
-        trait = cast(HasAncestor, self.get_trait(HasAncestor, (ApplyOp,)))
+        trait = self.get_trait(HasAncestor(ApplyOp))
+        assert trait is not None
         ancestor = trait.get_ancestor(self)
         if ancestor is None:
             raise ValueError(
@@ -861,8 +862,9 @@ class AccessOp(IRDLOperation):
             print_keyword=True,
         )
 
-        # IRDL-enforced, not supposed to use custom syntax if not veriied
-        trait = cast(HasAncestor, AccessOp.get_trait(HasAncestor, (ApplyOp,)))
+        # IRDL-enforced, not supposed to use custom syntax if not verified
+        trait = AccessOp.get_trait(HasAncestor(ApplyOp))
+        assert trait is not None
         apply = cast(ApplyOp, trait.get_ancestor(self))
 
         mapping = self.offset_mapping
@@ -949,7 +951,8 @@ class AccessOp(IRDLOperation):
 
     def verify_(self) -> None:
         # As promised by HasAncestor(ApplyOp)
-        trait = cast(HasAncestor, AccessOp.get_trait(HasAncestor, (ApplyOp,)))
+        trait = AccessOp.get_trait(HasAncestor(ApplyOp))
+        assert trait is not None
         apply = trait.get_ancestor(self)
         assert isinstance(apply, ApplyOp)
 
@@ -1002,7 +1005,8 @@ class AccessOp(IRDLOperation):
         """
         Simple helper to get the parent apply and raise otherwise.
         """
-        trait = cast(HasAncestor, self.get_trait(HasAncestor, (ApplyOp,)))
+        trait = self.get_trait(HasAncestor(ApplyOp))
+        assert trait is not None
         ancestor = trait.get_ancestor(self)
         if ancestor is None:
             raise ValueError(

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -939,8 +939,8 @@ class Operation(IRNode):
     @classmethod
     def has_trait(
         cls,
-        trait: type[OpTrait],
-        parameters: Any = None,
+        trait: type[OpTrait] | OpTrait,
+        *,
         value_if_unregistered: bool = True,
     ) -> bool:
         """
@@ -953,18 +953,21 @@ class Operation(IRNode):
         if issubclass(cls, UnregisteredOp):
             return value_if_unregistered
 
-        return cls.get_trait(trait, parameters) is not None
+        return cls.get_trait(trait) is not None
 
     @classmethod
-    def get_trait(
-        cls, trait: type[OpTraitInvT], parameters: Any = None
-    ) -> OpTraitInvT | None:
+    def get_trait(cls, trait: type[OpTraitInvT] | OpTraitInvT) -> OpTraitInvT | None:
         """
         Return a trait with the given type and parameters, if it exists.
         """
-        for t in cls.traits:
-            if isinstance(t, trait) and t.parameters == parameters:
-                return t
+        if isinstance(trait, type):
+            for t in cls.traits:
+                if isinstance(t, trait):
+                    return t
+        else:
+            for t in cls.traits:
+                if t == trait:
+                    return cast(OpTraitInvT, t)
         return None
 
     @classmethod


### PR DESCRIPTION
These make the API more complicated than it needs to be, since all traits are frozen dataclasses we can let the dataclass annotation do the heavy lifting for comparison and hashability.