### PR TITLE
transforms: (memref_stream) add missing doc and library call in generic constructors

### DIFF
--- a/xdsl/transforms/canonicalization_patterns/memref_stream.py
+++ b/xdsl/transforms/canonicalization_patterns/memref_stream.py
@@ -72,6 +72,6 @@ class RemoveUnusedInitOperandPattern(RewritePattern):
                 op.bounds,
                 op.init_indices,
                 op.doc,
-                op.library_call
+                op.library_call,
             )
         )

--- a/xdsl/transforms/canonicalization_patterns/memref_stream.py
+++ b/xdsl/transforms/canonicalization_patterns/memref_stream.py
@@ -71,5 +71,7 @@ class RemoveUnusedInitOperandPattern(RewritePattern):
                 op.iterator_types,
                 op.bounds,
                 op.init_indices,
+                op.doc,
+                op.library_call
             )
         )

--- a/xdsl/transforms/memref_stream_fold_fill.py
+++ b/xdsl/transforms/memref_stream_fold_fill.py
@@ -43,7 +43,7 @@ def fold_fills_in_module(module_op: ModuleOp):
                         op.bounds,
                         init_indices,
                         op.doc,
-                        op.library_call
+                        op.library_call,
                     ),
                 )
                 for fill_op in set(value for value in fill_ops if value is not None):

--- a/xdsl/transforms/memref_stream_fold_fill.py
+++ b/xdsl/transforms/memref_stream_fold_fill.py
@@ -42,6 +42,8 @@ def fold_fills_in_module(module_op: ModuleOp):
                         op.iterator_types,
                         op.bounds,
                         init_indices,
+                        op.doc,
+                        op.library_call
                     ),
                 )
                 for fill_op in set(value for value in fill_ops if value is not None):

--- a/xdsl/transforms/memref_stream_interleave.py
+++ b/xdsl/transforms/memref_stream_interleave.py
@@ -145,7 +145,7 @@ class PipelineGenericPattern(RewritePattern):
                 ArrayAttr(new_bounds),
                 op.init_indices,
                 op.doc,
-                op.library_call
+                op.library_call,
             )
         )
 

--- a/xdsl/transforms/memref_stream_interleave.py
+++ b/xdsl/transforms/memref_stream_interleave.py
@@ -144,6 +144,8 @@ class PipelineGenericPattern(RewritePattern):
                 ),
                 ArrayAttr(new_bounds),
                 op.init_indices,
+                op.doc,
+                op.library_call
             )
         )
 

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -190,7 +190,7 @@ def materialize_loop(
         ArrayAttr(new_bounds),
         generic_op.init_indices,
         generic_op.doc,
-        generic_op.library_call
+        generic_op.library_call,
     )
 
     Rewriter.insert_op(new_generic_op, loc)

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -189,6 +189,8 @@ def materialize_loop(
         generic_op.iterator_types,
         ArrayAttr(new_bounds),
         generic_op.init_indices,
+        generic_op.doc,
+        generic_op.library_call
     )
 
     Rewriter.insert_op(new_generic_op, loc)

--- a/xdsl/transforms/memref_streamify.py
+++ b/xdsl/transforms/memref_streamify.py
@@ -116,6 +116,8 @@ class StreamifyGenericOpPattern(RewritePattern):
                 op.iterator_types,
                 op.bounds,
                 op.init_indices,
+                op.doc,
+                op.library_call
             ),
             InsertPoint.at_end(new_body),
         )

--- a/xdsl/transforms/memref_streamify.py
+++ b/xdsl/transforms/memref_streamify.py
@@ -117,7 +117,7 @@ class StreamifyGenericOpPattern(RewritePattern):
                 op.bounds,
                 op.init_indices,
                 op.doc,
-                op.library_call
+                op.library_call,
             ),
             InsertPoint.at_end(new_body),
         )


### PR DESCRIPTION
Without these, the attributes still get lost along the way. I forgot to add them to #2928 