### PR TITLE
core: (affine) override python floordiv symbol

### DIFF
--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -36,7 +36,7 @@ def test_quasiaffine_map():
     N = AffineExpr.symbol(0)
 
     # map1: (x)[N] -> (x floordiv 2)
-    map1 = AffineMap(1, 1, (x.floor_div(2),))
+    map1 = AffineMap(1, 1, (x // 2,))
     assert map1.eval([1], [10]) == (0,)
     assert map1.eval([2], [10]) == (1,)
     assert map1.eval([3], [10]) == (1,)
@@ -88,7 +88,7 @@ def test_composition():
         2,
         0,
         (
-            AffineExpr.dimension(0).floor_div(2),
+            AffineExpr.dimension(0) // 2,
             2 * AffineExpr.dimension(0) + 3 * AffineExpr.dimension(1),
         ),
     )

--- a/xdsl/ir/affine/affine_expr.py
+++ b/xdsl/ir/affine/affine_expr.py
@@ -208,7 +208,7 @@ class AffineExpr:
     def __rmul__(self, other: AffineExpr | int) -> AffineExpr:
         return self.__mul__(other)
 
-    def floor_div(self, other: AffineExpr | int) -> AffineExpr:
+    def __floordiv__(self, other: AffineExpr | int) -> AffineExpr:
         if isinstance(other, int):
             other = AffineExpr.constant(other)
 

--- a/xdsl/parser/affine_parser.py
+++ b/xdsl/parser/affine_parser.py
@@ -72,7 +72,7 @@ class AffineParser(BaseParser):
             case "ceildiv":
                 return lhs.ceil_div(rhs)
             case "floordiv":
-                return lhs.floor_div(rhs)
+                return lhs // rhs
             case "mod":
                 return lhs % rhs
             case _:


### PR DESCRIPTION
we can override the floordiv symbol, which makes for much nicer experience when using `AffineMap.from_callable`, among others.
