### PR TITLE
(bug): linalg named ops to include hidden regions in generic print

### DIFF
--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -19,11 +19,14 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 }
 
 
-%in_t1, %in_t2, %out_t1 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
-%in_m1, %in_m2, %out_m1 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
+%t1, %t2, %t3 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
+%m1, %m2, %m3 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
 
-%sum = linalg.add ins(%in_t1, %in_t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%out_t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
-linalg.add ins(%in_m1, %in_m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%out_m1 : memref<4x16xf32>) -> ()
+%sum = linalg.add ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+linalg.add ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>) -> ()
+
+%mul = linalg.mul ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+linalg.mul ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>)
 
 
 %2, %3 = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
@@ -44,10 +47,12 @@ linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs
 // CHECK-NEXT:    ^{{.*}}(%{{.*}}: f32, %{{.*}}: f32):
 // CHECK-NEXT:      linalg.yield %{{.*}} : f32
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %in_t1, %in_t2, %out_t1 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
-// CHECK-NEXT:    %in_m1, %in_m2, %out_m1 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
-// CHECK-NEXT:    %sum = linalg.add ins(%in_t1, %in_t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%out_t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
-// CHECK-NEXT:    linalg.add ins(%in_m1, %in_m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%out_m1 : memref<4x16xf32>)
+// CHECK-NEXT:    %t1, %t2, %t3 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
+// CHECK-NEXT:    %m1, %m2, %m3 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
+// CHECK-NEXT:    %sum = linalg.add ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-NEXT:    linalg.add ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>)
+// CHECK-NEXT:    %mul = linalg.mul ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-NEXT:    linalg.mul ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>)
 // CHECK-NEXT:    %2, %3 = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
 // CHECK-NEXT:    %4 = "test.op"() : () -> memref<64x4096xf32>
 // CHECK-NEXT:    linalg.matmul {"id"} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs(%4 : memref<64x4096xf32>)
@@ -67,15 +72,25 @@ linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-GENERIC-NEXT:  }) {"hello" = "world"} : (f32, memref<1x256xf32>) -> ()
 
-// CHECK-GENERIC-NEXT:    %in_t1, %in_t2, %out_t1 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
-// CHECK-GENERIC-NEXT:    %in_m1, %in_m2, %out_m1 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
-// CHECK-GENERIC-NEXT:    %sum = "linalg.add"(%in_t1, %in_t2, %out_t1) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    %t1, %t2, %t3 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
+// CHECK-GENERIC-NEXT:    %m1, %m2, %m3 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
+// CHECK-GENERIC-NEXT:    %sum = "linalg.add"(%t1, %t2, %t3) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^3(%2 : f32, %3 : f32, %4 : f32):
 // CHECK-GENERIC-NEXT:      %5 = "arith.addf"(%2, %3) : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%5) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
-// CHECK-GENERIC-NEXT:    "linalg.add"(%in_m1, %in_m2, %out_m1) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    "linalg.add"(%m1, %m2, %m3) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
 // CHECK-GENERIC-NEXT:    ^4(%6 : f32, %7 : f32, %8 : f32):
 // CHECK-GENERIC-NEXT:      %9 = "arith.addf"(%6, %7) : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%9) : (f32) -> ()
+// CHECK-GENERIC-NEXT:    }) : (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>) -> ()
+// CHECK-GENERIC-NEXT:    %mul = "linalg.mul"(%t1, %t2, %t3) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^5(%10 : f32, %11 : f32, %12 : f32):
+// CHECK-GENERIC-NEXT:      %13 = "arith.mulf"(%10, %11) : (f32, f32) -> f32
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%13) : (f32) -> ()
+// CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-GENERIC-NEXT:    "linalg.mul"(%m1, %m2, %m3) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^6(%14 : f32, %15 : f32, %16 : f32):
+// CHECK-GENERIC-NEXT:      %17 = "arith.mulf"(%14, %15) : (f32, f32) -> f32
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%17) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>) -> ()

--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -18,6 +18,14 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
     linalg.yield %arg3 : f32
 }
 
+
+%in_t1, %in_t2, %out_t1 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
+%in_m1, %in_m2, %out_m1 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
+
+%sum = linalg.add ins(%in_t1, %in_t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%out_t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
+linalg.add ins(%in_m1, %in_m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%out_m1 : memref<4x16xf32>) -> ()
+
+
 %2, %3 = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
 %4 = "test.op"() : () -> (memref<64x4096xf32>)
 linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs(%4 : memref<64x4096xf32>)
@@ -36,6 +44,10 @@ linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs
 // CHECK-NEXT:    ^{{.*}}(%{{.*}}: f32, %{{.*}}: f32):
 // CHECK-NEXT:      linalg.yield %{{.*}} : f32
 // CHECK-NEXT:    }
+// CHECK-NEXT:    %in_t1, %in_t2, %out_t1 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
+// CHECK-NEXT:    %in_m1, %in_m2, %out_m1 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
+// CHECK-NEXT:    %sum = linalg.add ins(%in_t1, %in_t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%out_t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-NEXT:    linalg.add ins(%in_m1, %in_m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%out_m1 : memref<4x16xf32>)
 // CHECK-NEXT:    %2, %3 = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
 // CHECK-NEXT:    %4 = "test.op"() : () -> memref<64x4096xf32>
 // CHECK-NEXT:    linalg.matmul {"id"} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs(%4 : memref<64x4096xf32>)
@@ -54,3 +66,16 @@ linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs
 // CHECK-GENERIC-NEXT:  ^{{.*}}(%{{.*}}: f32, %{{.*}}: f32):
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-GENERIC-NEXT:  }) {"hello" = "world"} : (f32, memref<1x256xf32>) -> ()
+
+// CHECK-GENERIC-NEXT:    %in_t1, %in_t2, %out_t1 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
+// CHECK-GENERIC-NEXT:    %in_m1, %in_m2, %out_m1 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
+// CHECK-GENERIC-NEXT:    %sum = "linalg.add"(%in_t1, %in_t2, %out_t1) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^3(%2 : f32, %3 : f32, %4 : f32):
+// CHECK-GENERIC-NEXT:      %5 = "arith.addf"(%2, %3) : (f32, f32) -> f32
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%5) : (f32) -> ()
+// CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-GENERIC-NEXT:    "linalg.add"(%in_m1, %in_m2, %out_m1) <{"operandSegmentSizes" = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^4(%6 : f32, %7 : f32, %8 : f32):
+// CHECK-GENERIC-NEXT:      %9 = "arith.addf"(%6, %7) : (f32, f32) -> f32
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%9) : (f32) -> ()
+// CHECK-GENERIC-NEXT:    }) : (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>) -> ()

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -494,16 +494,6 @@ class NamedOpBase(IRDLOperation):
         else:
             res_types = ()
 
-        # if parser.parse_optional_punctuation("->"):
-        #     is_bracketed = parser.parse_optional_punctuation("(")
-        #     res_types = parser.parse_optional_undelimited_comma_separated_list(
-        #         parser.parse_optional_attribute, parser.parse_attribute
-        #     )
-        #     if is_bracketed:
-        #         parser.parse_punctuation(")")
-        # else:
-        #     res_types = ()
-
         return cls(ins, outs, res_types, attrs)
 
     def print(self, printer: Printer):

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -446,7 +446,7 @@ class NamedOpBase(IRDLOperation):
     @classmethod
     def parse(
         cls, parser: Parser
-    ):  # -> tuple[Sequence[Operand], Sequence[Operand], Sequence[Attribute], dict[str, Attribute]]:
+    ):
         pos = parser.pos
         if parser.parse_optional_characters("ins"):
             parser.parse_punctuation("(")

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -559,7 +559,6 @@ class AddOp(NamedOpBase):
         else:
             result_types = res
 
-        assert len(inputs) == 2
         assert len(outputs) == 1
         assert isa(outputs[0].type, TensorType[Attribute] | MemRefType[Attribute])
         element_t = outputs[0].type.get_element_type()
@@ -606,7 +605,6 @@ class SubOp(NamedOpBase):
         else:
             result_types = res
 
-        assert len(inputs) == 2
         assert len(outputs) == 1
         assert isa(outputs[0].type, TensorType[Attribute] | MemRefType[Attribute])
         element_t = outputs[0].type.get_element_type()
@@ -705,7 +703,6 @@ class MulOp(NamedOpBase):
         else:
             result_types = res
 
-        assert len(inputs) == 2
         assert len(outputs) == 1
         assert isa(outputs[0].type, TensorType[Attribute] | MemRefType[Attribute])
         element_t = outputs[0].type.get_element_type()

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -444,9 +444,7 @@ class NamedOpBase(IRDLOperation):
         )
 
     @classmethod
-    def parse(
-        cls, parser: Parser
-    ):
+    def parse(cls, parser: Parser):
         pos = parser.pos
         if parser.parse_optional_characters("ins"):
             parser.parse_punctuation("(")


### PR DESCRIPTION
Linalg named ops have a hidden region that needs to be printed when calling `--[mlir-]print-op-generic`. This is a discrepancy between the upstream dialect and our partial implementation.

To reproduce, run:
```
xdsl-opt --print-op-generic tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir

[...]
%sum = "linalg.add"(%2, %2, %3) <{"operandSegmentSizes" = array<i32: 2, 1>}> : (tensor<2x3xf32>, tensor<2x3xf32>, tensor<2x3xf32>) -> tensor<2x3xf32>
```
vs.
```
mlir-opt --mlir-print-op-generic tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir

[...]
%2 = "linalg.add"(%1#0, %1#0, %1#1) <{operandSegmentSizes = array<i32: 2, 1>}> ({
^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
  %21 = "arith.addf"(%arg0, %arg1) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
  "linalg.yield"(%21) : (f32) -> ()
}) : (tensor<2x3xf32>, tensor<2x3xf32>, tensor<2x3xf32>) -> tensor<2x3xf32>
```

Done:
* Base class for shared `ins` and `outs` printing and parsing
* Added support for `AddOp`, `SubOp`, `MulOp`
* Added test for add/sub/mul in `tests/filecheck/dialects/linalg/linalg_ops.mlir`

Help wanted:
* [ ] FillOp
* [ ] TransposeOp
* [ ] MatmulOp
* [ ] PoolingNchwMaxOp
* [ ] Conv2DNchwFchwOp
* [ ] BroadcastOp
* [ ] Is there a non-manual way to verify MLIR compatibility (e.g. in `tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir`) ?
