### PR TITLE
backend: (riscv) fix register allocation stats

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -4,7 +4,10 @@ import pytest
 from typing_extensions import Self
 
 from xdsl.backend.register_allocatable import RegisterConstraints
-from xdsl.backend.riscv.register_allocation import RegisterAllocatorLivenessBlockNaive
+from xdsl.backend.riscv.register_allocation import (
+    RegisterAllocatorLivenessBlockNaive,
+    count_reg_types,
+)
 from xdsl.backend.riscv.register_queue import RegisterQueue
 from xdsl.dialects import riscv
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
@@ -128,3 +131,12 @@ def test_allocate_with_inout_constraints():
     assert op1.rs1.type == riscv.IntRegisterType("a0")
     assert op1.rd0.type == riscv.IntRegisterType("j2")
     assert op1.rd1.type == riscv.IntRegisterType("a0")
+
+
+def test_count_reg_types():
+    a0 = riscv.Registers.A0
+    a1 = riscv.Registers.A1
+
+    fa0 = riscv.Registers.FA0
+
+    assert count_reg_types([a0, a0, a1, fa0, fa0]) == (2, 1)

--- a/tests/filecheck/backend/riscv/register-allocation/preallocated.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/preallocated.mlir
@@ -11,7 +11,7 @@ riscv_func.func @main() {
 }
 
 // LIVE-BNAIVE:       builtin.module {
-// LIVE-BNAIVE-NEXT:    riscv.comment {"comment" = "Regalloc stats: {\"preallocated_float\": 1, \"preallocated_int\": 1, \"allocated_float\": 5, \"allocated_int\": 7}"} : () -> ()
+// LIVE-BNAIVE-NEXT:    riscv.comment {"comment" = "Regalloc stats: {\"preallocated_float\": 1, \"preallocated_int\": 1, \"allocated_float\": 2, \"allocated_int\": 2}"} : () -> ()
 // LIVE-BNAIVE-NEXT:    riscv_func.func @main() {
 // LIVE-BNAIVE-NEXT:      %0 = riscv.li 6 : !riscv.reg<t1>
 // LIVE-BNAIVE-NEXT:      %1 = riscv.li 5 : !riscv.reg<t0>

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
@@ -24,7 +24,7 @@ func.func public @ssum(
 // CHECK:       .text
 // CHECK-NEXT:  .globl ssum
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 6, "allocated_int": 21}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 3, "allocated_int": 8}
 // CHECK-NEXT:  ssum:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -81,7 +81,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK:       .text
 // CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 57, "allocated_int": 109}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 8, "allocated_int": 14}
 // CHECK-NEXT:  conv_2d_nchw_fchw_d1_s1_3x3:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -205,7 +205,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK:       .text
 // CHECK-NEXT:  .globl ddot
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 15, "allocated_int": 25}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 3, "allocated_int": 8}
 // CHECK-NEXT:  ddot:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -252,7 +252,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK:       .text
 // CHECK-NEXT:  .globl dsum
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 6, "allocated_int": 21}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 3, "allocated_int": 8}
 // CHECK-NEXT:  dsum:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -296,7 +296,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK:       .text
 // CHECK-NEXT:  .globl fill
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 4, "preallocated_int": 2, "allocated_float": 5, "allocated_int": 15}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 4, "preallocated_int": 2, "allocated_float": 3, "allocated_int": 4}
 // CHECK-NEXT:  fill:
 // CHECK-NEXT:      fmv.d ft3, fa0
 // CHECK-NEXT:      mv t0, a0
@@ -353,7 +353,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl matmul
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 57, "allocated_int": 67}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 8, "allocated_int": 8}
 // CHECK-NEXT:  matmul:
 // CHECK-NEXT:      mv t0, a0
 // CHECK-NEXT:      mv t1, a1
@@ -463,7 +463,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 49, "allocated_int": 92}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 7, "allocated_int": 12}
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1
@@ -559,7 +559,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 // CHECK:       .text
 // CHECK-NEXT:  .globl relu
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 6, "allocated_int": 22}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 3, "allocated_int": 6}
 // CHECK-NEXT:  relu:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1
@@ -618,7 +618,7 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 49, "allocated_int": 94}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 7, "allocated_int": 12}
 // CHECK-NEXT:  pooling_nchw_sum_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1

--- a/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
@@ -15,7 +15,7 @@ func.func @main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1(%
 // CHECK:       .text
 // CHECK-NEXT:  .globl main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1
 // CHECK-NEXT:  .p2align 2
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 75, "allocated_int": 44}
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 4, "allocated_float": 7, "allocated_int": 8}
 // CHECK-NEXT:  main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -63,7 +63,7 @@ func.func @main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1(%
 // CHECK-OPT:       .text
 // CHECK-OPT-NEXT:  .globl main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1
 // CHECK-OPT-NEXT:  .p2align 2
-// CHECK-OPT-NEXT:  # Regalloc stats: {"preallocated_float": 0, "preallocated_int": 4, "allocated_float": 8, "allocated_int": 63}
+// CHECK-OPT-NEXT:  # Regalloc stats: {"preallocated_float": 0, "preallocated_int": 4, "allocated_float": 3, "allocated_int": 14}
 // CHECK-OPT-NEXT:  main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1:
 // CHECK-OPT-NEXT:      mv t4, a0
 // CHECK-OPT-NEXT:      mv t3, a1

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -70,12 +70,16 @@ def count_reg_types(regs: Iterable[Attribute]) -> tuple[int, int]:
     """
     Returns a tuple containing the count of IntRegister and FloatRegister in the iterable.
     """
-    num_complex = sum(
-        isinstance(reg, IntRegisterType) + 1j * isinstance(reg, FloatRegisterType)
-        for reg in regs
-    )
+    int_regs: set[str] = set()
+    float_regs: set[str] = set()
 
-    return int(num_complex.real), int(num_complex.imag)
+    for reg in regs:
+        if isinstance(reg, IntRegisterType):
+            int_regs.add(reg.spelling.data)
+        elif isinstance(reg, FloatRegisterType):
+            float_regs.add(reg.spelling.data)
+
+    return len(int_regs), len(float_regs)
 
 
 class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):


### PR DESCRIPTION
We were overcounting the registers, since there was no uniquing going on.