### PR TITLE
dialects: (arith, core) Constant op to accept tensor and memref

### DIFF
--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -193,4 +193,9 @@
 
   %index = arith.index_cast %lhsi32 : i32 to index
   // CHECK-NEXT: %index = arith.index_cast %lhsi32 : i32 to index
+
+  %t_const = arith.constant dense<1.234500e-01> : tensor<16xf32>
+  %m_const = arith.constant dense<1.678900e-01> : memref<64xf32>
+  // CHECK-NEXT: %t_const = arith.constant dense<1.234500e-01> : tensor<16xf32>
+  // CHECK-NEXT: %m_const = arith.constant dense<1.678900e-01> : memref<64xf32>
 }) : () -> ()

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -8,6 +8,7 @@ from xdsl.dialects.builtin import (
     AnyFloatConstr,
     AnyIntegerAttr,
     ContainerOf,
+    DenseIntOrFPElementsAttr,
     Float16Type,
     Float32Type,
     Float64Type,
@@ -110,7 +111,9 @@ class Constant(IRDLOperation):
 
     @overload
     def __init__(
-        self, value: AnyIntegerAttr | FloatAttr[AnyFloat], value_type: None = None
+        self,
+        value: AnyIntegerAttr | FloatAttr[AnyFloat] | DenseIntOrFPElementsAttr,
+        value_type: None = None,
     ) -> None: ...
 
     @overload
@@ -152,7 +155,12 @@ class Constant(IRDLOperation):
         p0 = parser.pos
         value = parser.parse_attribute()
 
-        if not isattr(value, base(AnyIntegerAttr) | base(FloatAttr[AnyFloat])):
+        if not isattr(
+            value,
+            base(AnyIntegerAttr)
+            | base(FloatAttr[AnyFloat])
+            | base(DenseIntOrFPElementsAttr),
+        ):
             parser.raise_error("Invalid constant value", p0, parser.pos)
 
         c = Constant(value)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1587,7 +1587,7 @@ class UnrankedMemrefType(
 
 AnyUnrankedMemrefType: TypeAlias = UnrankedMemrefType[Attribute]
 
-RankedVectorOrTensorOf: TypeAlias = (
+RankedStructure: TypeAlias = (
     VectorType[AttributeCovT] | TensorType[AttributeCovT] | MemRefType[AttributeCovT]
 )
 
@@ -1598,9 +1598,9 @@ class DenseIntOrFPElementsAttr(
 ):
     name = "dense"
     type: ParameterDef[
-        RankedVectorOrTensorOf[IntegerType]
-        | RankedVectorOrTensorOf[IndexType]
-        | RankedVectorOrTensorOf[AnyFloat]
+        RankedStructure[IntegerType]
+        | RankedStructure[IndexType]
+        | RankedStructure[AnyFloat]
     ]
     data: ParameterDef[ArrayAttr[AnyIntegerAttr] | ArrayAttr[AnyFloatAttr]]
 
@@ -1631,7 +1631,7 @@ class DenseIntOrFPElementsAttr(
 
     @staticmethod
     def create_dense_index(
-        type: RankedVectorOrTensorOf[IndexType],
+        type: RankedStructure[IndexType],
         data: Sequence[int] | Sequence[IntegerAttr[IndexType]],
     ) -> DenseIntOrFPElementsAttr:
         if len(data) and isinstance(data[0], int):
@@ -1645,7 +1645,7 @@ class DenseIntOrFPElementsAttr(
 
     @staticmethod
     def create_dense_int(
-        type: RankedVectorOrTensorOf[IntegerType],
+        type: RankedStructure[IntegerType],
         data: Sequence[int] | Sequence[IntegerAttr[IntegerType]],
     ) -> DenseIntOrFPElementsAttr:
         if len(data) and isinstance(data[0], int):
@@ -1660,7 +1660,7 @@ class DenseIntOrFPElementsAttr(
 
     @staticmethod
     def create_dense_float(
-        type: RankedVectorOrTensorOf[AnyFloat],
+        type: RankedStructure[AnyFloat],
         data: Sequence[int | float] | Sequence[AnyFloatAttr],
     ) -> DenseIntOrFPElementsAttr:
         if len(data) and isinstance(data[0], int | float):
@@ -1677,10 +1677,10 @@ class DenseIntOrFPElementsAttr(
     @staticmethod
     def from_list(
         type: (
-            RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType]
-            | RankedVectorOrTensorOf[AnyFloat]
-            | RankedVectorOrTensorOf[IntegerType]
-            | RankedVectorOrTensorOf[IndexType]
+            RankedStructure[AnyFloat | IntegerType | IndexType]
+            | RankedStructure[AnyFloat]
+            | RankedStructure[IntegerType]
+            | RankedStructure[IndexType]
         ),
         data: (
             Sequence[int]
@@ -1693,10 +1693,10 @@ class DenseIntOrFPElementsAttr(
     @staticmethod
     def from_list(
         type: (
-            RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType]
-            | RankedVectorOrTensorOf[AnyFloat]
-            | RankedVectorOrTensorOf[IntegerType]
-            | RankedVectorOrTensorOf[IndexType]
+            RankedStructure[AnyFloat | IntegerType | IndexType]
+            | RankedStructure[AnyFloat]
+            | RankedStructure[IntegerType]
+            | RankedStructure[IndexType]
         ),
         data: Sequence[int | float] | Sequence[AnyFloatAttr],
     ) -> DenseIntOrFPElementsAttr: ...
@@ -1704,23 +1704,23 @@ class DenseIntOrFPElementsAttr(
     @staticmethod
     def from_list(
         type: (
-            RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType]
-            | RankedVectorOrTensorOf[AnyFloat]
-            | RankedVectorOrTensorOf[IntegerType]
-            | RankedVectorOrTensorOf[IndexType]
+            RankedStructure[AnyFloat | IntegerType | IndexType]
+            | RankedStructure[AnyFloat]
+            | RankedStructure[IntegerType]
+            | RankedStructure[IndexType]
         ),
         data: Sequence[int | float] | Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr],
     ) -> DenseIntOrFPElementsAttr:
         if isinstance(type.element_type, AnyFloat):
-            new_type = cast(RankedVectorOrTensorOf[AnyFloat], type)
+            new_type = cast(RankedStructure[AnyFloat], type)
             new_data = cast(Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data)
             return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
         elif isinstance(type.element_type, IntegerType):
-            new_type = cast(RankedVectorOrTensorOf[IntegerType], type)
+            new_type = cast(RankedStructure[IntegerType], type)
             new_data = cast(Sequence[int] | Sequence[IntegerAttr[IntegerType]], data)
             return DenseIntOrFPElementsAttr.create_dense_int(new_type, new_data)
         else:
-            new_type = cast(RankedVectorOrTensorOf[IndexType], type)
+            new_type = cast(RankedStructure[IndexType], type)
             new_data = cast(Sequence[int] | Sequence[IntegerAttr[IndexType]], data)
             return DenseIntOrFPElementsAttr.create_dense_index(new_type, new_data)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -828,10 +828,6 @@ VectorOrTensorOf: TypeAlias = (
     | UnrankedTensorType[AttributeCovT]
 )
 
-RankedVectorOrTensorOf: TypeAlias = (
-    VectorType[AttributeCovT] | TensorType[AttributeCovT]
-)
-
 
 @dataclass(frozen=True)
 class VectorRankConstraint(AttrConstraint):
@@ -894,147 +890,6 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
             )
         )
         constraint.verify(attr, constraint_context)
-
-
-@irdl_attr_definition
-class DenseIntOrFPElementsAttr(
-    ParametrizedAttribute, ContainerType[IntegerType | IndexType | AnyFloat]
-):
-    name = "dense"
-    type: ParameterDef[
-        RankedVectorOrTensorOf[IntegerType]
-        | RankedVectorOrTensorOf[IndexType]
-        | RankedVectorOrTensorOf[AnyFloat]
-    ]
-    data: ParameterDef[ArrayAttr[AnyIntegerAttr] | ArrayAttr[AnyFloatAttr]]
-
-    # The type stores the shape data
-    def get_shape(self) -> tuple[int, ...] | None:
-        if isinstance(self.type, UnrankedTensorType):
-            return None
-        return self.type.get_shape()
-
-    def get_element_type(self) -> IntegerType | IndexType | AnyFloat:
-        return self.type.get_element_type()
-
-    @property
-    def shape_is_complete(self) -> bool:
-        shape = self.get_shape()
-        if shape is None or not len(shape):
-            return False
-
-        n = 1
-        for dim in shape:
-            if dim < 1:
-                # Dimensions need to be greater or equal to one
-                return False
-            n *= dim
-
-        # Product of dimensions needs to equal length
-        return n == len(self.data.data)
-
-    @staticmethod
-    def create_dense_index(
-        type: RankedVectorOrTensorOf[IndexType],
-        data: Sequence[int] | Sequence[IntegerAttr[IndexType]],
-    ) -> DenseIntOrFPElementsAttr:
-        if len(data) and isinstance(data[0], int):
-            attr_list = [
-                IntegerAttr.from_index_int_value(d) for d in cast(Sequence[int], data)
-            ]
-        else:
-            attr_list = cast(Sequence[IntegerAttr[IndexType]], data)
-
-        return DenseIntOrFPElementsAttr([type, ArrayAttr(attr_list)])
-
-    @staticmethod
-    def create_dense_int(
-        type: RankedVectorOrTensorOf[IntegerType],
-        data: Sequence[int] | Sequence[IntegerAttr[IntegerType]],
-    ) -> DenseIntOrFPElementsAttr:
-        if len(data) and isinstance(data[0], int):
-            attr_list = [
-                IntegerAttr[IntegerType](d, type.element_type)
-                for d in cast(Sequence[int], data)
-            ]
-        else:
-            attr_list = cast(Sequence[IntegerAttr[IntegerType]], data)
-
-        return DenseIntOrFPElementsAttr([type, ArrayAttr(attr_list)])
-
-    @staticmethod
-    def create_dense_float(
-        type: RankedVectorOrTensorOf[AnyFloat],
-        data: Sequence[int | float] | Sequence[AnyFloatAttr],
-    ) -> DenseIntOrFPElementsAttr:
-        if len(data) and isinstance(data[0], int | float):
-            attr_list = [
-                FloatAttr(float(d), type.element_type)
-                for d in cast(Sequence[int | float], data)
-            ]
-        else:
-            attr_list = cast(Sequence[AnyFloatAttr], data)
-
-        return DenseIntOrFPElementsAttr([type, ArrayAttr(attr_list)])
-
-    @overload
-    @staticmethod
-    def from_list(
-        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
-        data: (
-            Sequence[int]
-            | Sequence[IntegerAttr[IndexType]]
-            | Sequence[IntegerAttr[IntegerType]]
-        ),
-    ) -> DenseIntOrFPElementsAttr: ...
-
-    @overload
-    @staticmethod
-    def from_list(
-        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
-        data: Sequence[int | float] | Sequence[AnyFloatAttr],
-    ) -> DenseIntOrFPElementsAttr: ...
-
-    @staticmethod
-    def from_list(
-        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
-        data: Sequence[int | float] | Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr],
-    ) -> DenseIntOrFPElementsAttr:
-        if isinstance(type.element_type, AnyFloat):
-            new_type = cast(RankedVectorOrTensorOf[AnyFloat], type)
-            new_data = cast(Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data)
-            return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
-        elif isinstance(type.element_type, IntegerType):
-            new_type = cast(RankedVectorOrTensorOf[IntegerType], type)
-            new_data = cast(Sequence[int] | Sequence[IntegerAttr[IntegerType]], data)
-            return DenseIntOrFPElementsAttr.create_dense_int(new_type, new_data)
-        else:
-            new_type = cast(RankedVectorOrTensorOf[IndexType], type)
-            new_data = cast(Sequence[int] | Sequence[IntegerAttr[IndexType]], data)
-            return DenseIntOrFPElementsAttr.create_dense_index(new_type, new_data)
-
-    @staticmethod
-    def vector_from_list(
-        data: Sequence[int] | Sequence[float],
-        data_type: IntegerType | IndexType | AnyFloat,
-    ) -> DenseIntOrFPElementsAttr:
-        t = VectorType(data_type, [len(data)])
-        return DenseIntOrFPElementsAttr.from_list(t, data)
-
-    @staticmethod
-    def tensor_from_list(
-        data: (
-            Sequence[int]
-            | Sequence[float]
-            | Sequence[IntegerAttr[IndexType]]
-            | Sequence[IntegerAttr[IntegerType]]
-            | Sequence[AnyFloatAttr]
-        ),
-        data_type: IntegerType | IndexType | AnyFloat,
-        shape: Sequence[int],
-    ) -> DenseIntOrFPElementsAttr:
-        t = TensorType(data_type, shape)
-        return DenseIntOrFPElementsAttr.from_list(t, data)
 
 
 @irdl_attr_definition
@@ -1731,6 +1586,152 @@ class UnrankedMemrefType(
 
 
 AnyUnrankedMemrefType: TypeAlias = UnrankedMemrefType[Attribute]
+
+RankedVectorOrTensorOf: TypeAlias = (
+    VectorType[AttributeCovT] | TensorType[AttributeCovT] | MemRefType[AttributeCovT]
+)
+
+
+@irdl_attr_definition
+class DenseIntOrFPElementsAttr(
+    ParametrizedAttribute, ContainerType[IntegerType | IndexType | AnyFloat]
+):
+    name = "dense"
+    type: ParameterDef[
+        RankedVectorOrTensorOf[IntegerType]
+        | RankedVectorOrTensorOf[IndexType]
+        | RankedVectorOrTensorOf[AnyFloat]
+    ]
+    data: ParameterDef[ArrayAttr[AnyIntegerAttr] | ArrayAttr[AnyFloatAttr]]
+
+    # The type stores the shape data
+    def get_shape(self) -> tuple[int, ...] | None:
+        if isinstance(self.type, UnrankedTensorType):
+            return None
+        return self.type.get_shape()
+
+    def get_element_type(self) -> IntegerType | IndexType | AnyFloat:
+        return self.type.get_element_type()
+
+    @property
+    def shape_is_complete(self) -> bool:
+        shape = self.get_shape()
+        if shape is None or not len(shape):
+            return False
+
+        n = 1
+        for dim in shape:
+            if dim < 1:
+                # Dimensions need to be greater or equal to one
+                return False
+            n *= dim
+
+        # Product of dimensions needs to equal length
+        return n == len(self.data.data)
+
+    @staticmethod
+    def create_dense_index(
+        type: RankedVectorOrTensorOf[IndexType],
+        data: Sequence[int] | Sequence[IntegerAttr[IndexType]],
+    ) -> DenseIntOrFPElementsAttr:
+        if len(data) and isinstance(data[0], int):
+            attr_list = [
+                IntegerAttr.from_index_int_value(d) for d in cast(Sequence[int], data)
+            ]
+        else:
+            attr_list = cast(Sequence[IntegerAttr[IndexType]], data)
+
+        return DenseIntOrFPElementsAttr([type, ArrayAttr(attr_list)])
+
+    @staticmethod
+    def create_dense_int(
+        type: RankedVectorOrTensorOf[IntegerType],
+        data: Sequence[int] | Sequence[IntegerAttr[IntegerType]],
+    ) -> DenseIntOrFPElementsAttr:
+        if len(data) and isinstance(data[0], int):
+            attr_list = [
+                IntegerAttr[IntegerType](d, type.element_type)
+                for d in cast(Sequence[int], data)
+            ]
+        else:
+            attr_list = cast(Sequence[IntegerAttr[IntegerType]], data)
+
+        return DenseIntOrFPElementsAttr([type, ArrayAttr(attr_list)])
+
+    @staticmethod
+    def create_dense_float(
+        type: RankedVectorOrTensorOf[AnyFloat],
+        data: Sequence[int | float] | Sequence[AnyFloatAttr],
+    ) -> DenseIntOrFPElementsAttr:
+        if len(data) and isinstance(data[0], int | float):
+            attr_list = [
+                FloatAttr(float(d), type.element_type)
+                for d in cast(Sequence[int | float], data)
+            ]
+        else:
+            attr_list = cast(Sequence[AnyFloatAttr], data)
+
+        return DenseIntOrFPElementsAttr([type, ArrayAttr(attr_list)])
+
+    @overload
+    @staticmethod
+    def from_list(
+        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
+        data: (
+            Sequence[int]
+            | Sequence[IntegerAttr[IndexType]]
+            | Sequence[IntegerAttr[IntegerType]]
+        ),
+    ) -> DenseIntOrFPElementsAttr: ...
+
+    @overload
+    @staticmethod
+    def from_list(
+        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
+        data: Sequence[int | float] | Sequence[AnyFloatAttr],
+    ) -> DenseIntOrFPElementsAttr: ...
+
+    @staticmethod
+    def from_list(
+        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
+        data: Sequence[int | float] | Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr],
+    ) -> DenseIntOrFPElementsAttr:
+        if isinstance(type.element_type, AnyFloat):
+            new_type = cast(RankedVectorOrTensorOf[AnyFloat], type)
+            new_data = cast(Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data)
+            return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
+        elif isinstance(type.element_type, IntegerType):
+            new_type = cast(RankedVectorOrTensorOf[IntegerType], type)
+            new_data = cast(Sequence[int] | Sequence[IntegerAttr[IntegerType]], data)
+            return DenseIntOrFPElementsAttr.create_dense_int(new_type, new_data)
+        else:
+            new_type = cast(RankedVectorOrTensorOf[IndexType], type)
+            new_data = cast(Sequence[int] | Sequence[IntegerAttr[IndexType]], data)
+            return DenseIntOrFPElementsAttr.create_dense_index(new_type, new_data)
+
+    @staticmethod
+    def vector_from_list(
+        data: Sequence[int] | Sequence[float],
+        data_type: IntegerType | IndexType | AnyFloat,
+    ) -> DenseIntOrFPElementsAttr:
+        t = VectorType(data_type, [len(data)])
+        return DenseIntOrFPElementsAttr.from_list(t, data)
+
+    @staticmethod
+    def tensor_from_list(
+        data: (
+            Sequence[int]
+            | Sequence[float]
+            | Sequence[IntegerAttr[IndexType]]
+            | Sequence[IntegerAttr[IntegerType]]
+            | Sequence[AnyFloatAttr]
+        ),
+        data_type: IntegerType | IndexType | AnyFloat,
+        shape: Sequence[int],
+    ) -> DenseIntOrFPElementsAttr:
+        t = TensorType(data_type, shape)
+        return DenseIntOrFPElementsAttr.from_list(t, data)
+
 
 Builtin = Dialect(
     "builtin",

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1676,7 +1676,12 @@ class DenseIntOrFPElementsAttr(
     @overload
     @staticmethod
     def from_list(
-        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
+        type: (
+            RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType]
+            | RankedVectorOrTensorOf[AnyFloat]
+            | RankedVectorOrTensorOf[IntegerType]
+            | RankedVectorOrTensorOf[IndexType]
+        ),
         data: (
             Sequence[int]
             | Sequence[IntegerAttr[IndexType]]
@@ -1687,13 +1692,23 @@ class DenseIntOrFPElementsAttr(
     @overload
     @staticmethod
     def from_list(
-        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
+        type: (
+            RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType]
+            | RankedVectorOrTensorOf[AnyFloat]
+            | RankedVectorOrTensorOf[IntegerType]
+            | RankedVectorOrTensorOf[IndexType]
+        ),
         data: Sequence[int | float] | Sequence[AnyFloatAttr],
     ) -> DenseIntOrFPElementsAttr: ...
 
     @staticmethod
     def from_list(
-        type: RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType],
+        type: (
+            RankedVectorOrTensorOf[AnyFloat | IntegerType | IndexType]
+            | RankedVectorOrTensorOf[AnyFloat]
+            | RankedVectorOrTensorOf[IntegerType]
+            | RankedVectorOrTensorOf[IndexType]
+        ),
         data: Sequence[int | float] | Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr],
     ) -> DenseIntOrFPElementsAttr:
         if isinstance(type.element_type, AnyFloat):

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -45,7 +45,7 @@ from xdsl.dialects.builtin import (
     NoneAttr,
     NoneType,
     OpaqueAttr,
-    RankedVectorOrTensorOf,
+    RankedStructure,
     Signedness,
     StridedLayoutAttr,
     StringAttr,
@@ -694,9 +694,9 @@ class AttrParser(BaseParser):
         self,
         hex_string: str,
         type: (
-            RankedVectorOrTensorOf[IntegerType]
-            | RankedVectorOrTensorOf[IndexType]
-            | RankedVectorOrTensorOf[AnyFloat]
+            RankedStructure[IntegerType]
+            | RankedStructure[IndexType]
+            | RankedStructure[AnyFloat]
         ),
     ) -> tuple[list[int] | list[float], list[int]]:
         """
@@ -763,17 +763,17 @@ class AttrParser(BaseParser):
     def _parse_dense_literal_type(
         self,
     ) -> (
-        RankedVectorOrTensorOf[IntegerType]
-        | RankedVectorOrTensorOf[IndexType]
-        | RankedVectorOrTensorOf[AnyFloat]
+        RankedStructure[IntegerType]
+        | RankedStructure[IndexType]
+        | RankedStructure[AnyFloat]
     ):
         type = self.expect(self.parse_optional_type, "Dense attribute must be typed!")
         # Check that the type is correct.
         if not isattr(
             type,
-            base(RankedVectorOrTensorOf[IntegerType])
-            | base(RankedVectorOrTensorOf[IndexType])
-            | base(RankedVectorOrTensorOf[AnyFloat]),
+            base(RankedStructure[IntegerType])
+            | base(RankedStructure[IndexType])
+            | base(RankedStructure[AnyFloat]),
         ):
             self.raise_error(
                 "Expected memref, vector or tensor type of "

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -776,7 +776,8 @@ class AttrParser(BaseParser):
             | base(RankedVectorOrTensorOf[AnyFloat]),
         ):
             self.raise_error(
-                "Expected vector or tensor type of " "integer, index, or float type"
+                "Expected memref, vector or tensor type of "
+                "integer, index, or float type"
             )
 
         # Check for static shapes in type


### PR DESCRIPTION
Upstream mlir accepts the following arith.constant:
```
%t_const = arith.constant dense<1.234500e-01> : tensor<16xf32>
%m_const = arith.constant dense<1.678900e-01> : memref<64xf32>
```

As for tensors, xdsl currently accepts it in generic form and print it in both generic and non-generic form, but will fail to parse the non-generic form.

As for memrefs, xdsl will not accept it and requires an extensive change to the attribute parser to add support for memrefs in `RankedVectorOrTensorOf`. Some code had to be moved after the definition of `MemRefType` to support this change.