### PR TITLE
dialects: (tensor) Incorrect default 'dynamic index' on insert_slice op

### DIFF
--- a/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
@@ -46,7 +46,7 @@ builtin.module {
 // CHECK-NEXT:       %10 = arith.addf %9, %8 : tensor<255xf32>
 // CHECK-NEXT:       %11 = arith.addf %10, %7 : tensor<255xf32>
 // CHECK-NEXT:       %12 = arith.addf %11, %6 : tensor<255xf32>
-// CHECK-NEXT:       %13 = "tensor.insert_slice"(%12, %5, %4) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
+// CHECK-NEXT:       %13 = "tensor.insert_slice"(%12, %5, %4) <{"static_offsets" = array<i64: -9223372036854775808>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %13 : tensor<510xf32>
 // CHECK-NEXT:     }, {
 // CHECK-NEXT:     ^1(%14 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %15 : tensor<510xf32>):


### PR DESCRIPTION
If the `tensor.insert_slice` op is set up with dynamic index, the default value should be `DYNAMIC_INDEX`.

This is required by mlir upstream. The default values in the static get method are currently set incorrectly.