### PR TITLE
dialects: Enable bufferized stencil.apply

### DIFF
--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -63,9 +63,15 @@ builtin.module {
 // CHECK-GENERIC-NEXT:   "func.func"() <{"sym_name" = "gauss_seidel_func", "function_type" = (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()}> ({
 // CHECK-GENERIC-NEXT:   ^0(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
 // CHECK-GENERIC-NEXT:     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
+<<<<<<< HEAD
 // CHECK-GENERIC-NEXT:     %pref = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<4x510xf32>
 // CHECK-GENERIC-NEXT:     %1 = "stencil.apply"(%0, %pref) ({
 // CHECK-GENERIC-NEXT:     ^1(%2 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3 : tensor<4x510xf32>):
+=======
+// CHECK-GENERIC-NEXT:     %pref = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
+// CHECK-GENERIC-NEXT:     %1 = "stencil.apply"(%0, %pref) <{"operandSegmentSizes" = array<i32: 2, 0>}> ({
+// CHECK-GENERIC-NEXT:     ^1(%2 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3 : memref<4xtensor<510xf32>>):
+>>>>>>> f34b76c92 (Allow expression of bufferized stencil computations.)
 // CHECK-GENERIC-NEXT:       %4 = "arith.constant"() <{"value" = 1.666600e-01 : f32}> : () -> f32
 // CHECK-GENERIC-NEXT:       %5 = "csl_stencil.access"(%3) <{"offset" = #stencil.index<[1, 0]>, "offset_mapping" = #stencil.index<[0, 1]>}> : (tensor<4x510xf32>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %6 = "csl_stencil.access"(%3) <{"offset" = #stencil.index<[-1, 0]>, "offset_mapping" = #stencil.index<[0, 1]>}> : (tensor<4x510xf32>) -> tensor<510xf32>

--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -63,15 +63,9 @@ builtin.module {
 // CHECK-GENERIC-NEXT:   "func.func"() <{"sym_name" = "gauss_seidel_func", "function_type" = (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> ()}> ({
 // CHECK-GENERIC-NEXT:   ^0(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>, %b : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>):
 // CHECK-GENERIC-NEXT:     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>) -> !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>
-<<<<<<< HEAD
 // CHECK-GENERIC-NEXT:     %pref = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> tensor<4x510xf32>
-// CHECK-GENERIC-NEXT:     %1 = "stencil.apply"(%0, %pref) ({
-// CHECK-GENERIC-NEXT:     ^1(%2 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3 : tensor<4x510xf32>):
-=======
-// CHECK-GENERIC-NEXT:     %pref = "csl_stencil.prefetch"(%0) <{"topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>]}> : (!stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>) -> memref<4xtensor<510xf32>>
 // CHECK-GENERIC-NEXT:     %1 = "stencil.apply"(%0, %pref) <{"operandSegmentSizes" = array<i32: 2, 0>}> ({
-// CHECK-GENERIC-NEXT:     ^1(%2 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3 : memref<4xtensor<510xf32>>):
->>>>>>> f34b76c92 (Allow expression of bufferized stencil computations.)
+// CHECK-GENERIC-NEXT:     ^1(%2 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %3 : tensor<4x510xf32>):
 // CHECK-GENERIC-NEXT:       %4 = "arith.constant"() <{"value" = 1.666600e-01 : f32}> : () -> f32
 // CHECK-GENERIC-NEXT:       %5 = "csl_stencil.access"(%3) <{"offset" = #stencil.index<[1, 0]>, "offset_mapping" = #stencil.index<[0, 1]>}> : (tensor<4x510xf32>) -> tensor<510xf32>
 // CHECK-GENERIC-NEXT:       %6 = "csl_stencil.access"(%3) <{"offset" = #stencil.index<[-1, 0]>, "offset_mapping" = #stencil.index<[0, 1]>}> : (tensor<4x510xf32>) -> tensor<510xf32>

--- a/tests/filecheck/dialects/stencil/invalid.mlir
+++ b/tests/filecheck/dialects/stencil/invalid.mlir
@@ -13,7 +13,7 @@ builtin.module {
 builtin.module {
   func.func @buffered_and_stored_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
-    %outt = "stencil.apply"(%int) ({
+    %outt = "stencil.apply"(%int) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%intb : !stencil.temp<[-1,68]xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<[-1,68]xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -31,7 +31,7 @@ builtin.module {
 builtin.module {
   func.func @buffer_types_mismatch_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[0,1024]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<[-1,68]xf64>
-    %outt = "stencil.apply"(%int) ({
+    %outt = "stencil.apply"(%int) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%intb : !stencil.temp<[-1,68]xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<[-1,68]xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -59,7 +59,7 @@ builtin.module {
 builtin.module {
   func.func @apply_no_return_1d(%in : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    "stencil.apply"(%int) ({
+    "stencil.apply"(%int) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%intb : !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"() : () -> ()
@@ -76,7 +76,7 @@ builtin.module {
   func.func @access_bad_temp_1d(%in : !stencil.field<[-4,68]xf64>, %bigin : !stencil.field<[-4,68]x[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
     %bigint = "stencil.load"(%bigin) : (!stencil.field<[-4,68]x[-4,68]xf64>) -> !stencil.temp<?x?xf64>
-    %outt = "stencil.apply"(%int, %bigint) ({
+    %outt = "stencil.apply"(%int, %bigint) <{"operandSegmentSizes" = array<i32: 2, 0>}> ({
     ^0(%intb : !stencil.temp<?xf64>, %bigintb : !stencil.temp<?x?xf64>):
       %v = "stencil.access"(%bigintb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?x?xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -93,7 +93,7 @@ builtin.module {
 builtin.module {
   func.func @access_bad_offset_1d(%in : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt = "stencil.apply"(%int) ({
+    %outt = "stencil.apply"(%int) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%intb : !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1, 1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -122,7 +122,7 @@ builtin.module {
 builtin.module {
   func.func @wrong_return_arity_1d(%in : !stencil.field<[-4,68]xf64>, %bigin : !stencil.field<[-4,68]x[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt1, %outt2 = "stencil.apply"(%int) ({
+    %outt1, %outt2 = "stencil.apply"(%int) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%intb : !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v) : (f64) -> ()
@@ -139,7 +139,7 @@ builtin.module {
 builtin.module {
   func.func @wrong_return_types_1d(%in : !stencil.field<[-4,68]xf64>, %bigin : !stencil.field<[-4,68]x[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt1, %outt2 = "stencil.apply"(%int) ({
+    %outt1, %outt2 = "stencil.apply"(%int) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%intb : !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v, %v) : (f64, f64) -> ()
@@ -157,7 +157,7 @@ builtin.module {
 builtin.module {
   func.func @different_apply_bounds(%in : !stencil.field<[-4,68]xf64>, %bigin : !stencil.field<[-4,68]x[-4,68]xf64>, %out : !stencil.field<[-4,68]xf64>) {
     %int = "stencil.load"(%in) : (!stencil.field<[-4,68]xf64>) -> !stencil.temp<?xf64>
-    %outt1, %outt2 = "stencil.apply"(%int) ({
+    %outt1, %outt2 = "stencil.apply"(%int) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%intb : !stencil.temp<?xf64>):
       %v = "stencil.access"(%intb) {"offset" = #stencil.index<[-1]>} : (!stencil.temp<?xf64>) -> f64
       "stencil.return"(%v, %v) : (f64, f64) -> ()

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -224,7 +224,7 @@ builtin.module {
 
 builtin.module {
   func.func @stencil_copy_bufferized(%0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
-    stencil.apply(%6 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+    stencil.apply(%6 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
       %7 = stencil.access %6[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
       %8 = stencil.store_result %7 : !stencil.result<f64>
       stencil.return %8 : !stencil.result<f64>
@@ -235,7 +235,7 @@ builtin.module {
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    func.func @stencil_copy_bufferized(%0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
-// CHECK-NEXT:      stencil.apply(%2 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+// CHECK-NEXT:      stencil.apply(%2 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) outs (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
 // CHECK-NEXT:        %3 = stencil.access %2[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:        %4 = stencil.store_result %3 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %4 : !stencil.result<f64>

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -228,7 +228,7 @@ builtin.module {
       %7 = stencil.access %6[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
       %8 = stencil.store_result %7 : !stencil.result<f64>
       stencil.return %8 : !stencil.result<f64>
-    } to [0, 0, 0] : [64, 64, 64]
+    } to <[0, 0, 0], [64, 64, 64]>
     func.return
   }
 }
@@ -239,7 +239,7 @@ builtin.module {
 // CHECK-NEXT:        %3 = stencil.access %2[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:        %4 = stencil.store_result %3 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %4 : !stencil.result<f64>
-// CHECK-NEXT:      }
+// CHECK-NEXT:      } to <[0, 0, 0], [64, 64, 64]>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -219,3 +219,16 @@ builtin.module {
 // CHECK-NEXT:      stencil.store %5 to %3 (<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
+
+// -----
+
+builtin.module {
+  func.func @stencil_copy_bufferized(%0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+    stencil.apply(%6 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+      %7 = stencil.access %6[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+      %8 = stencil.store_result %7 : !stencil.result<f64>
+      stencil.return %8 : !stencil.result<f64>
+    } to [0, 0, 0] : [64, 64, 64]
+    func.return
+  }
+}

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -232,3 +232,14 @@ builtin.module {
     func.return
   }
 }
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    func.func @stencil_copy_bufferized(%0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+// CHECK-NEXT:      stencil.apply(%2 = %0 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) -> (%1 : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+// CHECK-NEXT:        %3 = stencil.access %2[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:        %4 = stencil.store_result %3 : !stencil.result<f64>
+// CHECK-NEXT:        stencil.return %4 : !stencil.result<f64>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
+++ b/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
@@ -7,7 +7,7 @@ builtin.module {
     %0 = "stencil.external_load"(%a) : (memref<1024x512x512xf32>) -> !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>
     %1 = "stencil.load"(%0) : (!stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>) -> !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>
     %2 = "stencil.external_load"(%b) : (memref<1024x512x512xf32>) -> !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>
-    %3 = "stencil.apply"(%1) ({
+    %3 = "stencil.apply"(%1)  <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
     ^0(%4 : !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>):
       %5 = arith.constant 1.666600e-01 : f32
       %6 = "stencil.access"(%4) {"offset" = #stencil.index<[1, 0, 0]>} : (!stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>) -> f32
@@ -61,7 +61,7 @@ builtin.module {
 
   func.func @gauss_seidel_func(%a : !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>, %b : !stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>) {
     %0 = "stencil.load"(%a) : (!stencil.field<[-1,1023]x[-1,511]x[-1,511]xf32>) -> !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>
-    %1 = "stencil.apply"(%0) ({
+    %1 = "stencil.apply"(%0) <{"operandSegmentSizes" = array<i32: 1, 0>}>  ({
     ^0(%2 : !stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>):
       %3 = arith.constant 1.666600e-01 : f32
       %4 = "stencil.access"(%2) {"offset" = #stencil.index<[1, 0, 0]>} : (!stencil.temp<[-1,1023]x[-1,511]x[-1,511]xf32>) -> f32

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -481,6 +481,9 @@ class ApplyOp(IRDLOperation):
         printer.print(") ")
         printer.print_op_attributes(self.attributes, print_keyword=True)
         printer.print_region(self.region, print_entry_block_args=False)
+        if self.bounds is not None:
+            printer.print(" to ")
+            self.bounds.print_parameters(printer)
 
     @classmethod
     def parse(cls: type[ApplyOp], parser: Parser):

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -439,8 +439,11 @@ class ApplyOp(IRDLOperation):
     B = Annotated[Attribute, ConstraintVar("B")]
 
     args: VarOperand = var_operand_def(Attribute)
+    dest = var_operand_def(FieldType)
     region: Region = region_def()
     res: VarOpResult = var_result_def(TempType)
+
+    bounds = opt_prop_def(StencilBoundsAttr)
 
     traits = frozenset(
         [
@@ -450,6 +453,8 @@ class ApplyOp(IRDLOperation):
         ]
     )
 
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
     def print(self, printer: Printer):
         def print_assign_argument(args: tuple[BlockArgument, SSAValue, Attribute]):
             printer.print(args[0])
@@ -458,13 +463,21 @@ class ApplyOp(IRDLOperation):
             printer.print(" : ")
             printer.print(args[2])
 
+        def print_destination_operand(dest: SSAValue):
+            printer.print(dest)
+            printer.print(" : ")
+            printer.print(dest.type)
+
         printer.print("(")
         printer.print_list(
             zip(self.region.block.args, self.args, (a.type for a in self.args)),
             print_assign_argument,
         )
         printer.print(") -> (")
-        printer.print_list((r.type for r in self.res), printer.print_attribute)
+        if self.dest:
+            printer.print_list(self.dest, print_destination_operand)
+        else:
+            printer.print_list((r.type for r in self.res), printer.print_attribute)
         printer.print(") ")
         printer.print_op_attributes(self.attributes, print_keyword=True)
         printer.print_region(self.region, print_entry_block_args=False)
@@ -480,6 +493,12 @@ class ApplyOp(IRDLOperation):
             arg = arg.resolve(type)
             return arg, value
 
+        def parse_operand():
+            op = parser.parse_unresolved_operand()
+            parser.parse_punctuation(":")
+            type = parser.parse_attribute()
+            return parser.resolve_operand(op, type)
+
         assign_args = parser.parse_comma_separated_list(
             parser.Delimiter.PAREN, parse_assign_args
         )
@@ -488,18 +507,33 @@ class ApplyOp(IRDLOperation):
         args, operands = zip(*assign_args) if assign_args else ([], [])
 
         parser.parse_punctuation("->")
-        result_types = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, parser.parse_attribute
+        parser.parse_punctuation("(")
+        result_types = parser.parse_optional_undelimited_comma_separated_list(
+            parser.parse_optional_attribute, parser.parse_attribute
         )
+        if not result_types:
+            destinations = parser.parse_comma_separated_list(
+                parser.Delimiter.NONE, parse_operand
+            )
+        else:
+            destinations = []
+        parser.parse_punctuation(")")
         attrs = parser.parse_optional_attr_dict_with_keyword()
         if attrs is not None:
             attrs = attrs.data
+        else:
+            attrs = {}
         region = parser.parse_region(args)
+        if parser.parse_optional_keyword("to"):
+            bounds = StencilBoundsAttr.new(StencilBoundsAttr.parse_parameters(parser))
+        else:
+            bounds = None
         return cls(
-            operands=[operands],
-            result_types=[result_types],
+            operands=[operands, destinations or []],
+            result_types=[result_types or []],
             regions=[region],
             attributes=attrs,
+            properties={"bounds": bounds},
         )
 
     @staticmethod
@@ -514,7 +548,7 @@ class ApplyOp(IRDLOperation):
             body = Region(body)
 
         return ApplyOp.build(
-            operands=[list(args)],
+            operands=[list(args), []],
             regions=[body],
             result_types=[result_types],
         )
@@ -525,20 +559,45 @@ class ApplyOp(IRDLOperation):
                 raise VerifyException(
                     f"Expected argument type to match operand type, got {argument.type} != {operand.type} at index {argument.index}"
                 )
-        if len(self.res) < 1:
+        if len(self.res) > 0 and len(self.dest) > 0:
+            raise VerifyException(
+                "Expected stencil.apply to have all value-semantics result or buffer-semantic destination operands."
+            )
+        if len(self.res) > 0:
+            res_type = cast(TempType[Attribute], self.res[0].type)
+            for other in self.res[1:]:
+                other = cast(TempType[Attribute], other.type)
+                if res_type.bounds != other.bounds:
+                    raise VerifyException(
+                        "Expected all output types bounds to be equals."
+                    )
+        if len(self.dest) > 0:
+            if self.bounds is None:
+                raise VerifyException(
+                    "Expected stencil.apply to have bounds when having destination operands."
+                )
+
+        nres = max(len(self.res), len(self.dest))
+        if nres < 1:
             raise VerifyException(
                 f"Expected stencil.apply to have at least 1 result, got {len(self.res)}"
             )
-        res_type = cast(TempType[Attribute], self.res[0].type)
-        for other in self.res[1:]:
-            other = cast(TempType[Attribute], other.type)
-            if res_type.bounds != other.bounds:
-                raise VerifyException("Expected all output types bounds to be equals.")
 
     def get_rank(self) -> int:
-        res_type = self.res[0].type
-        assert isa(res_type, TempType[Attribute])
-        return res_type.get_num_dims()
+        if len(self.res) > 0:
+            res_type = self.res[0].type
+            assert isa(res_type, TempType[Attribute])
+            return res_type.get_num_dims()
+        else:
+            assert self.bounds is not None
+            return len(self.bounds.lb)
+
+    def get_num_results(self) -> int:
+        res = len(self.res)
+        if res > 0:
+            return res
+        else:
+            return len(self.dest)
 
     def get_accesses(self) -> Iterable[AccessPattern]:
         """
@@ -849,7 +908,7 @@ class AccessOp(IRDLOperation):
     name = "stencil.access"
     temp: Operand = operand_def(
         ParamAttrConstraint(
-            TempType,
+            StencilType,
             [
                 Attribute,
                 MessageConstraint(
@@ -933,8 +992,10 @@ class AccessOp(IRDLOperation):
             attrs["offset_mapping"] = IndexAttr.get(*offset_mapping)
         parser.parse_punctuation(":")
         res_type = parser.parse_attribute()
-        if not isa(res_type, TempType[Attribute]):
-            parser.raise_error("Expected return type to be a stencil.temp")
+        if not isa(res_type, StencilType[Attribute]):
+            parser.raise_error(
+                "Expected return type to be a stencil.temp or stencil.field"
+            )
         return cls.build(
             operands=[temp], result_types=[res_type.element_type], attributes=attrs
         )
@@ -979,7 +1040,7 @@ class AccessOp(IRDLOperation):
         apply.verify_()
 
         temp_type = self.temp.type
-        assert isa(temp_type, TempType[Attribute])
+        assert isa(temp_type, StencilType[Attribute])
         if temp_type.get_num_dims() != apply.get_rank():
             if self.offset_mapping is None:
                 raise VerifyException(
@@ -1315,7 +1376,14 @@ class ReturnOp(IRDLOperation):
             o.type.elem if isinstance(o.type, ResultType) else o.type for o in self.arg
         ]
         apply = cast(ApplyOp, self.parent_op())
-        res_types = [cast(TempType[Attribute], r.type).element_type for r in apply.res]
+        if len(apply.res) > 0:
+            res_types = [
+                cast(TempType[Attribute], r.type).element_type for r in apply.res
+            ]
+        else:
+            res_types = [
+                cast(FieldType[Attribute], o.type).element_type for o in apply.dest
+            ]
         if len(types) != len(res_types) * unroll_factor:
             raise VerifyException(
                 f"stencil.return expected {len(res_types) * unroll_factor} operands to match the parent "

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -769,7 +769,7 @@ class DynAccessOp(IRDLOperation):
 
     temp = operand_def(
         ParamAttrConstraint(
-            TempType,
+            StencilType,
             [
                 Attribute,
                 MessageConstraint(

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -473,10 +473,11 @@ class ApplyOp(IRDLOperation):
             zip(self.region.block.args, self.args, (a.type for a in self.args)),
             print_assign_argument,
         )
-        printer.print(") -> (")
         if self.dest:
+            printer.print(") outs (")
             printer.print_list(self.dest, print_destination_operand)
         else:
+            printer.print(") -> (")
             printer.print_list((r.type for r in self.res), printer.print_attribute)
         printer.print(") ")
         printer.print_op_attributes(self.attributes, print_keyword=True)
@@ -509,17 +510,19 @@ class ApplyOp(IRDLOperation):
         operands: list[SSAValue]
         args, operands = zip(*assign_args) if assign_args else ([], [])
 
-        parser.parse_punctuation("->")
-        parser.parse_punctuation("(")
-        result_types = parser.parse_optional_undelimited_comma_separated_list(
-            parser.parse_optional_attribute, parser.parse_attribute
-        )
-        if not result_types:
+        if parser.parse_optional_punctuation("->"):
+            parser.parse_punctuation("(")
+            result_types = parser.parse_optional_undelimited_comma_separated_list(
+                parser.parse_optional_attribute, parser.parse_attribute
+            )
+            destinations = []
+        else:
+            parser.parse_keyword("outs")
+            parser.parse_punctuation("(")
             destinations = parser.parse_comma_separated_list(
                 parser.Delimiter.NONE, parse_operand
             )
-        else:
-            destinations = []
+            result_types = []
         parser.parse_punctuation(")")
         attrs = parser.parse_optional_attr_dict_with_keyword()
         if attrs is not None:


### PR DESCRIPTION
I.e., make stencil.apply able to express computations on reference-semantic fields through destination operands, instead of only value-semantic through results.