### PR TITLE
(core) Support UnitAttr in assembly format

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -463,7 +463,7 @@ def test_optional_property(program: str, generic_program: str):
             '"test.optional_unit_attr_prop"() : () -> ()',
         ),
         (
-            "test.optional_unit_attr_prop unit_attr",
+            "test.optional_unit_attr_prop unit_attr ",  # todo this prints an extra whitespace
             '"test.optional_unit_attr_prop"() <{"unit_attr"}> : () -> ()',
         ),
     ],
@@ -494,7 +494,7 @@ def test_optional_unit_attr_property(program: str, generic_program: str):
             '"test.optional_unit_attr"() : () -> ()',
         ),
         (
-            "test.optional_unit_attr unit_attr",
+            "test.optional_unit_attr unit_attr ",  # todo this prints an extra whitespace
             '"test.optional_unit_attr"() <{"unit_attr"}> : () -> ()',
         ),
     ],

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -8,7 +8,7 @@ from typing import Annotated, Generic, TypeVar
 import pytest
 
 from xdsl.context import MLContext
-from xdsl.dialects.builtin import I32, IntegerAttr, ModuleOp
+from xdsl.dialects.builtin import I32, IntegerAttr, ModuleOp, UnitAttr
 from xdsl.dialects.test import Test, TestType
 from xdsl.ir import (
     Attribute,
@@ -449,6 +449,68 @@ def test_optional_property(program: str, generic_program: str):
 
     ctx = MLContext()
     ctx.load_op(OptionalPropertyOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            "test.optional_unit_attr_prop",
+            '"test.optional_unit_attr_prop"() : () -> ()',
+        ),
+        (
+            "test.optional_unit_attr_prop unit_attr",
+            '"test.optional_unit_attr_prop"() <{"unit_attr"}> : () -> ()',
+        ),
+    ],
+)
+def test_optional_unit_attr_property(program: str, generic_program: str):
+    """Test the parsing of optional UnitAttr operands"""
+
+    @irdl_op_definition
+    class OptionalUnitAttrPropertyOp(IRDLOperation):
+        name = "test.optional_unit_attr_prop"
+        unit_attr = opt_prop_def(UnitAttr)
+
+        assembly_format = "(`unit_attr` $unit_attr^)? attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(OptionalUnitAttrPropertyOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            "test.optional_unit_attr",
+            '"test.optional_unit_attr"() : () -> ()',
+        ),
+        (
+            "test.optional_unit_attr unit_attr",
+            '"test.optional_unit_attr"() <{"unit_attr"}> : () -> ()',
+        ),
+    ],
+)
+def test_optional_unit_attr_attribute(program: str, generic_program: str):
+    """Test the parsing of optional UnitAttr operands"""
+
+    @irdl_op_definition
+    class OptionalUnitAttrOp(IRDLOperation):
+        name = "test.optional_unit_attr"
+        unit_attr = opt_prop_def(UnitAttr)
+
+        assembly_format = "(`unit_attr` $unit_attr^)? attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(OptionalUnitAttrOp)
     ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -463,7 +463,7 @@ def test_optional_property(program: str, generic_program: str):
             '"test.optional_unit_attr_prop"() : () -> ()',
         ),
         (
-            "test.optional_unit_attr_prop unit_attr ",  # todo this prints an extra whitespace
+            "test.optional_unit_attr_prop unit_attr",
             '"test.optional_unit_attr_prop"() <{"unit_attr"}> : () -> ()',
         ),
     ],
@@ -494,7 +494,7 @@ def test_optional_unit_attr_property(program: str, generic_program: str):
             '"test.optional_unit_attr"() : () -> ()',
         ),
         (
-            "test.optional_unit_attr unit_attr ",  # todo this prints an extra whitespace
+            "test.optional_unit_attr unit_attr",
             '"test.optional_unit_attr"() <{"unit_attr"}> : () -> ()',
         ),
     ],

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -436,10 +436,6 @@ class UnitAttr(ParametrizedAttribute):
         """Parse the attribute parameters."""
         return []
 
-    def print_parameters(self, printer: Printer) -> None:
-        """Print the attribute parameters."""
-        pass
-
 
 @irdl_attr_definition
 class LocationAttr(ParametrizedAttribute):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -431,11 +431,6 @@ AnySignlessIntegerType: TypeAlias = Annotated[IntegerType, SignlessIntegerConstr
 class UnitAttr(ParametrizedAttribute):
     name = "unit"
 
-    @classmethod
-    def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
-        """Parse the attribute parameters."""
-        return []
-
 
 @irdl_attr_definition
 class LocationAttr(ParametrizedAttribute):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -431,6 +431,11 @@ AnySignlessIntegerType: TypeAlias = Annotated[IntegerType, SignlessIntegerConstr
 class UnitAttr(ParametrizedAttribute):
     name = "unit"
 
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
+        """Parse the attribute parameters."""
+        return []
+
 
 @irdl_attr_definition
 class LocationAttr(ParametrizedAttribute):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -436,6 +436,10 @@ class UnitAttr(ParametrizedAttribute):
         """Parse the attribute parameters."""
         return []
 
+    def print_parameters(self, printer: Printer) -> None:
+        """Print the attribute parameters."""
+        pass
+
 
 @irdl_attr_definition
 class LocationAttr(ParametrizedAttribute):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
+from xdsl.dialects.builtin import UnitAttr
 from xdsl.ir import (
     Attribute,
     Data,
@@ -772,15 +773,17 @@ class AttributeVariable(FormatDirective):
             state.attributes[self.name] = attr
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print(" ")
-        state.should_emit_space = True
-        state.last_was_punctuation = False
-
         if self.is_property:
             attr = op.properties[self.name]
         else:
             attr = op.attributes[self.name]
+        if isinstance(attr, UnitAttr):
+            return
+
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        state.should_emit_space = True
+        state.last_was_punctuation = False
 
         if self.unique_type is not None:
             return cast(TypedAttribute[Attribute], attr).print_without_type(printer)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -804,7 +804,12 @@ class OptionalAttributeVariable(AttributeVariable, OptionalVariable):
 
 class OptionalUnitAttrVariable(OptionalAttributeVariable):
     """
-    An optional UnitAttr variable
+    An optional UnitAttr variable that holds no value and derives its meaning from its existence. Holds a parse
+    and print method to reflect this.
+
+      operand-directive ::= (`unit_attr` unit_attr^)?
+
+    Also see: https://mlir.llvm.org/docs/DefiningDialects/Operations/#unit-attributes
     """
 
     def parse(self, parser: Parser, state: ParsingState) -> None:

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
+from xdsl.dialects.builtin import UnitAttr
 from xdsl.ir import (
     Attribute,
     Data,
@@ -799,6 +800,21 @@ class OptionalAttributeVariable(AttributeVariable, OptionalVariable):
       operand-directive ::= ( percent-ident )?
     The directive will request a space to be printed after.
     """
+
+
+class OptionalUnitAttrVariable(OptionalAttributeVariable):
+    """
+    An optional UnitAttr variable
+    """
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        if self.is_property:
+            state.properties[self.name] = UnitAttr()
+        else:
+            state.attributes[self.name] = UnitAttr()
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        return
 
 
 @dataclass(frozen=True)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -11,7 +11,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
-from xdsl.dialects.builtin import UnitAttr
 from xdsl.ir import (
     Attribute,
     Data,
@@ -773,17 +772,15 @@ class AttributeVariable(FormatDirective):
             state.attributes[self.name] = attr
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if self.is_property:
-            attr = op.properties[self.name]
-        else:
-            attr = op.attributes[self.name]
-        if isinstance(attr, UnitAttr):
-            return
-
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
         state.should_emit_space = True
         state.last_was_punctuation = False
+
+        if self.is_property:
+            attr = op.properties[self.name]
+        else:
+            attr = op.attributes[self.name]
 
         if self.unique_type is not None:
             return cast(TypedAttribute[Attribute], attr).print_without_type(printer)

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -12,6 +12,7 @@ from enum import Enum, auto
 from itertools import pairwise
 from typing import cast
 
+import xdsl.dialects.builtin
 from xdsl.dialects.builtin import Builtin
 from xdsl.ir import Attribute, TypedAttribute
 from xdsl.irdl import (
@@ -387,6 +388,7 @@ class FormatParser(BaseParser):
                             unique_type = type_constraint.infer(ConstraintContext())
                 if (
                     unique_base is not None
+                    and unique_base != xdsl.dialects.builtin.UnitAttr
                     and unique_base in Builtin.attributes
                     and unique_type is None
                 ):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -12,8 +12,7 @@ from enum import Enum, auto
 from itertools import pairwise
 from typing import cast
 
-import xdsl.dialects.builtin
-from xdsl.dialects.builtin import Builtin
+from xdsl.dialects.builtin import Builtin, UnitAttr
 from xdsl.ir import Attribute, TypedAttribute
 from xdsl.irdl import (
     AttrOrPropDef,
@@ -388,7 +387,7 @@ class FormatParser(BaseParser):
                             unique_type = type_constraint.infer(ConstraintContext())
                 if (
                     unique_base is not None
-                    and unique_base != xdsl.dialects.builtin.UnitAttr
+                    and unique_base != UnitAttr
                     and unique_base in Builtin.attributes
                     and unique_type is None
                 ):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -45,6 +45,7 @@ from xdsl.irdl.declarative_assembly_format import (
     OptionalOperandVariable,
     OptionalResultTypeDirective,
     OptionalResultVariable,
+    OptionalUnitAttrVariable,
     PunctuationDirective,
     ResultTypeDirective,
     ResultVariable,
@@ -352,8 +353,9 @@ class FormatParser(BaseParser):
         if variable_name in attr_or_prop_by_name:
             attr_name = variable_name
             attr_or_prop = attr_or_prop_by_name[attr_name]
+            is_property = attr_or_prop == "property"
             if self.context == ParsingContext.TopLevel:
-                if attr_or_prop == "property":
+                if is_property:
                     if attr_name in self.seen_properties:
                         self.raise_error(f"property '{variable_name}' is already bound")
                     self.seen_properties.add(attr_name)
@@ -366,11 +368,16 @@ class FormatParser(BaseParser):
 
             attr_def = (
                 self.op_def.properties.get(attr_name)
-                if attr_or_prop == "property"
+                if is_property
                 else self.op_def.attributes.get(attr_name)
             )
             if isinstance(attr_def, AttrOrPropDef):
                 unique_base = attr_def.constr.get_unique_base()
+                if unique_base == UnitAttr:
+                    return OptionalUnitAttrVariable(
+                        variable_name, is_property, None, None
+                    )
+
                 # Always qualify builtin attributes
                 # This is technically an approximation, but appears to be good enough
                 # for xDSL right now.
@@ -387,7 +394,6 @@ class FormatParser(BaseParser):
                             unique_type = type_constraint.infer(ConstraintContext())
                 if (
                     unique_base is not None
-                    and unique_base != UnitAttr
                     and unique_base in Builtin.attributes
                     and unique_type is None
                 ):
@@ -401,7 +407,6 @@ class FormatParser(BaseParser):
                     if isinstance(attr_def, OptionalDef)
                     else AttributeVariable
                 )
-                is_property = attr_or_prop == "property"
                 return variable_type(
                     variable_name, is_property, unique_base, unique_type
                 )


### PR DESCRIPTION
This PR enables support for UnitAttr in the assembly format parser.

The upstream MLIR assembly format syntax to represent a UnitAttr may be for instance ([source](https://mlir.llvm.org/docs/Dialects/BufferizationOps/#bufferizationto_memref-bufferizationtomemrefop)):
```
`bufferization.to_memref` $tensor (`read_only` $read_only^)? attr-dict `:` type($memref)
```

Specifically, if the keyword `read_only` is present, then the UnitAttr (of the same name) will be set. In xdsl, it would simply be set by assigning `= UnitAttr()`. The approach here is similar, if the optional keyword is present, then the value should be set.

This change consists of two parts:
* The first is to not change the `unique_base` variable in the assembly format parser in the way it's usually done for builtins. This causes `AttributeVariable.parse` to not execute the `parser.parse_attribute()` in the `unique_base is None` case (expecting to parse an actual value), but instead to use the custom parsing method of UnitAttr in the `issubclass(.. , ParametrizedAttribute)` case
* The second is to implement a `UnitAttr.parse_parameters` method returning an empty list, overriding the parse method of the superclass which attempts to parse an actual value.
