### PR TITLE
misc: don't set pass spec arguments from instance when they are the default value

### DIFF
--- a/tests/test_pass_to_spec.py
+++ b/tests/test_pass_to_spec.py
@@ -46,7 +46,7 @@ class SimplePass(ModulePass):
 
 
 @pytest.mark.parametrize(
-    "test_pass, test_spec_with_default, test_spec_no_default",
+    "test_pass, test_spec",
     (
         (
             CustomPass(3, (1, 2), None, ("clown", "season")),
@@ -60,6 +60,26 @@ class SimplePass(ModulePass):
                     "optional_bool": (False,),
                 },
             ),
+        ),
+        (EmptyPass(), PipelinePassSpec("empty", {})),
+        (
+            SimplePass((3.14, 2.13), 2),
+            PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
+        ),
+    ),
+)
+def test_pass_to_spec_include_default(
+    test_pass: ModulePass,
+    test_spec: PipelinePassSpec,
+):
+    assert test_pass.pipeline_pass_spec(include_default=True) == test_spec
+
+
+@pytest.mark.parametrize(
+    "test_pass, test_spec",
+    (
+        (
+            CustomPass(3, (1, 2), None, ("clown", "season")),
             PipelinePassSpec(
                 "custom-pass",
                 {
@@ -69,19 +89,15 @@ class SimplePass(ModulePass):
                 },
             ),
         ),
-        (EmptyPass(), PipelinePassSpec("empty", {}), PipelinePassSpec("empty", {})),
+        (EmptyPass(), PipelinePassSpec("empty", {})),
         (
             SimplePass((3.14, 2.13), 2),
-            PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
             PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
         ),
     ),
 )
-def test_pass_to_spec_equality(
-    test_pass: ModulePass,
-    test_spec_with_default: PipelinePassSpec,
-    test_spec_no_default: PipelinePassSpec,
+def test_pass_to_spec_exclude_default(
+    test_pass: ModulePass, test_spec: PipelinePassSpec
 ):
-    assert test_pass.pipeline_pass_spec(include_default=True) == test_spec_with_default
-    assert test_pass.pipeline_pass_spec(include_default=False) == test_spec_no_default
-    assert test_pass.pipeline_pass_spec() == test_spec_no_default
+    assert test_pass.pipeline_pass_spec(include_default=False) == test_spec
+    assert test_pass.pipeline_pass_spec() == test_spec

--- a/tests/test_pass_to_spec.py
+++ b/tests/test_pass_to_spec.py
@@ -46,7 +46,7 @@ class SimplePass(ModulePass):
 
 
 @pytest.mark.parametrize(
-    "test_pass, test_spec",
+    "test_pass, test_spec_with_default, test_spec_no_default",
     (
         (
             CustomPass(3, (1, 2), None, ("clown", "season")),
@@ -60,13 +60,28 @@ class SimplePass(ModulePass):
                     "optional_bool": (False,),
                 },
             ),
+            PipelinePassSpec(
+                "custom-pass",
+                {
+                    "number": (3,),
+                    "int_list": (1, 2),
+                    "list_str": ("clown", "season"),
+                },
+            ),
         ),
-        (EmptyPass(), PipelinePassSpec("empty", {})),
+        (EmptyPass(), PipelinePassSpec("empty", {}), PipelinePassSpec("empty", {})),
         (
             SimplePass((3.14, 2.13), 2),
+            PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
             PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
         ),
     ),
 )
-def test_pass_to_spec_equality(test_pass: ModulePass, test_spec: PipelinePassSpec):
-    assert test_pass.pipeline_pass_spec() == test_spec
+def test_pass_to_spec_equality(
+    test_pass: ModulePass,
+    test_spec_with_default: PipelinePassSpec,
+    test_spec_no_default: PipelinePassSpec,
+):
+    assert test_pass.pipeline_pass_spec(include_default=True) == test_spec_with_default
+    assert test_pass.pipeline_pass_spec(include_default=False) == test_spec_no_default
+    assert test_pass.pipeline_pass_spec() == test_spec_no_default

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -116,32 +116,39 @@ class ModulePass(ABC):
             field.name for field in dataclasses.fields(cls) if not _is_optional(field)
         }
 
-    def pipeline_pass_spec(self) -> PipelinePassSpec:
+    def pipeline_pass_spec(self, *, include_default: bool = False) -> PipelinePassSpec:
         """
         This function takes a ModulePass and returns a PipelinePassSpec.
+
+        If `include_default` is `True`, then add arguments that are optional are not
+        included in the spec.
         """
         # get all dataclass fields
-        fields: tuple[Field[Any], ...] = dataclasses.fields(self)
-        arg_dict: dict[str, PassArgListType] = {}
+        fields = dataclasses.fields(self)
+        args: dict[str, PassArgListType] = {}
 
         # iterate over all fields of the dataclass
         for op_field in fields:
+            name = op_field.name
             # ignore the name field and everything that's not used by __init__
-            if op_field.name == "name" or not op_field.init:
+            if name == "name" or not op_field.init:
                 continue
 
+            val = getattr(self, name)
+
             if _is_optional(op_field):
-                arg_dict[op_field.name] = _get_default(op_field)
+                if val == _get_default(op_field) and not include_default:
+                    continue
 
-            val = getattr(self, op_field.name)
             if val is None:
-                arg_dict.update({op_field.name: ()})
+                arg_list = ()
             elif isinstance(val, PassArgElementType):
-                arg_dict.update({op_field.name: (getattr(self, op_field.name),)})
+                arg_list = (val,)
             else:
-                arg_dict.update({op_field.name: getattr(self, op_field.name)})
+                arg_list = val
 
-        return PipelinePassSpec(self.name, arg_dict)
+            args[name] = arg_list
+        return PipelinePassSpec(self.name, args)
 
 
 # Git Issue: https://github.com/xdslproject/xdsl/issues/1845

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -120,8 +120,8 @@ class ModulePass(ABC):
         """
         This function takes a ModulePass and returns a PipelinePassSpec.
 
-        If `include_default` is `True`, then add arguments that are optional are not
-        included in the spec.
+        If `include_default` is `True`, then optional arguments are not included in the
+        spec.
         """
         # get all dataclass fields
         fields = dataclasses.fields(self)


### PR DESCRIPTION
This is useful in a few places, it makes the `xdsl-gui` pass pipeline a little cleaner, as well as the marimo notebook showing the different stages of the pipeline in the slides.