### PR TITLE
CI: use .lint when required by ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,8 @@ typeCheckingMode = "strict"
 profile = "black"
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "UP", "PT", "TID251"]
-ignore = [
+lint.select = ["E", "F", "W", "I", "UP", "PT", "TID251"]
+lint.ignore = [
     "E741",  # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
     "PT006", # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
     "PT007", # https://beta.ruff.rs/docs/rules/pytest-parametrize-values-wrong-type/
@@ -107,7 +107,8 @@ ignore = [
 line-length = 300
 target-version = "py310"
 
-[tool.ruff.flake8-tidy-imports.banned-api]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
 "xdsl.parser.core".msg = "Use xdsl.parser instead."
 "xdsl.parser.attribute_parser".msg = "Use xdsl.parser instead."
 "xdsl.parser.affine_parser".msg = "Use xdsl.parser instead."
@@ -121,7 +122,7 @@ target-version = "py310"
 "xdsl.ir.affine.affine_set".msg = "Use xdsl.ir.affine instead"
 
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403"]
 "tests/filecheck/frontend/programs/invalid.py" = ["F811", "F841"]
 "tests/filecheck/frontend/dialects/invalid.py" = ["F811"]
@@ -130,7 +131,7 @@ target-version = "py310"
 "_version.py" = ["ALL"]
 "**/{docs/marimo}/*" = ["E501"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.black]

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
@@ -537,7 +537,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 // CHECK-NEXT:  scf_body_end_{{\d}}_for:
 // CHECK-NEXT:      ret
 
-  func.func public @relu(%X: memref<16x16xf64>, %Y: memref<16x16xf64>) {
+  func.func public @reluf64(%X: memref<16x16xf64>, %Y: memref<16x16xf64>) {
     %zero_float = arith.constant 0.0 : f64
 
     linalg.generic {
@@ -557,10 +557,10 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 
 
 // CHECK:       .text
-// CHECK-NEXT:  .globl relu
+// CHECK-NEXT:  .globl reluf64
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 3, "allocated_int": 6}
-// CHECK-NEXT:  relu:
+// CHECK-NEXT:  reluf64:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1
 // CHECK-NEXT:      fcvt.d.w ft3, zero
@@ -575,6 +575,58 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 // CHECK-NEXT:      li t0, 255
 // CHECK-NEXT:      frep.o t0, 1, 0, 0
 // CHECK-NEXT:      fmax.d ft1, ft0, ft3
+// CHECK-NEXT:      csrrci zero, 1984, 1                         # SSR disable
+// CHECK-NEXT:      ret
+
+
+  riscv.assembly_section ".text" {
+    riscv.directive ".globl" "reluf32"
+    riscv.directive ".p2align" "2"
+    riscv_func.func @reluf32(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>) {
+      %X_1 = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg
+      %Y_1 = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg
+      %zero = riscv.get_register : !riscv.reg<zero>
+      %zero_float = riscv.fcvt.d.w %zero : (!riscv.reg<zero>) -> !riscv.freg
+      %zero_vector = riscv_snitch.vfcpka.s.s %zero_float, %zero_float : (!riscv.freg, !riscv.freg) -> !riscv.freg
+      snitch_stream.streaming_region {
+        patterns = [
+          #snitch_stream.stride_pattern<ub = [128], strides = [8]>
+        ]
+      } ins(%X_1 : !riscv.reg) outs(%Y_1 : !riscv.reg) {
+      ^0(%x : !stream.readable<!riscv.freg<ft0>>, %0 : !stream.writable<!riscv.freg<ft1>>):
+        %c128 = riscv.li 128 : !riscv.reg
+        %c0 = riscv.li 0 : !riscv.reg
+        %c1 = riscv.li 1 : !riscv.reg
+        riscv_scf.for %i : !riscv.reg = %c0 to %c128 step %c1 {
+          %x_1 = riscv_snitch.read from %x : !riscv.freg<ft0>
+          %y = riscv_snitch.vfmax.s %x_1, %zero_vector : (!riscv.freg<ft0>, !riscv.freg) -> !riscv.freg<ft1>
+          riscv_snitch.write %y to %0 : !riscv.freg<ft1>
+        }
+      }
+      riscv_func.return
+    }
+  }
+
+// CHECK:       .text
+// CHECK-NEXT:  .globl reluf32
+// CHECK-NEXT:  .p2align 2
+// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": 3, "preallocated_int": 3, "allocated_float": 3, "allocated_int": 6}
+// CHECK-NEXT:  reluf32:
+// CHECK-NEXT:      mv t1, a0
+// CHECK-NEXT:      mv t0, a1
+// CHECK-NEXT:      fcvt.d.w ft3, zero
+// CHECK-NEXT:      vfcpka.s.s ft3, ft3, ft3
+// CHECK-NEXT:      li t2, 127
+// CHECK-NEXT:      scfgwi t2, 95                                # dm 31 dim 0 bound
+// CHECK-NEXT:      li t2, 8
+// CHECK-NEXT:      scfgwi t2, 223                               # dm 31 dim 0 stride
+// CHECK-NEXT:      scfgwi zero, 63                              # dm 31 repeat
+// CHECK-NEXT:      scfgwi t1, 768                               # dm 0 dim 0 source
+// CHECK-NEXT:      scfgwi t0, 897                               # dm 1 dim 0 destination
+// CHECK-NEXT:      csrrsi zero, 1984, 1                         # SSR enable
+// CHECK-NEXT:      li t0, 127
+// CHECK-NEXT:      frep.o t0, 1, 0, 0
+// CHECK-NEXT:      vfmax.s ft1, ft0, ft3
 // CHECK-NEXT:      csrrci zero, 1984, 1                         # SSR disable
 // CHECK-NEXT:      ret
 


### PR DESCRIPTION
As a consequence of updating ruff, it now raises warnings. This updates the config in accordance with ruff's suggestion.