### PR TITLE
CI: don't run coverage by default in cmath conversion test

### DIFF
--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -1,4 +1,4 @@
-# RUN: coverage run %s | filecheck %s
+# RUN: python %s | filecheck %s
 
 from xdsl.dialects.cmath import Cmath
 from xdsl.dialects.irdl.pyrdl_to_irdl import dialect_to_irdl


### PR DESCRIPTION
This is the coverage bit in the lit config:
``` python
if "COVERAGE" in lit_config.params:
    config.substitutions.append(('xdsl-opt', f"coverage run {xdsl_opt}"))
    config.substitutions.append(('xdsl-run', f"coverage run {xdsl_run}"))
    config.substitutions.append(('irdl-to-pyrdl', f"coverage run {irdl_to_pyrdl}"))
    config.substitutions.append(('python', f"coverage run"))
```

We actually already perform this substitution when needed, so there's no need to provide it explicitly.

I found it confusing that I was generating coverage files without actually asking for coverage data.