### PR TITLE
CI: include onnx interpreter for pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ typeCheckingMode = "strict"
     "xdsl/frontend/onnx/ir_builder.py",
     "xdsl/frontend/onnx/type.py",
     "xdsl/interpreters/experimental/wgpu.py",
-    "xdsl/interpreters/onnx.py",
 ]
 "ignore" = [
     "docs/marimo",

--- a/xdsl/interpreters/onnx.py
+++ b/xdsl/interpreters/onnx.py
@@ -144,7 +144,7 @@ class OnnxFunctions(InterpreterFunctions):
             raise NotImplementedError("Only dense constant values implemented")
         shape = op.value.get_shape()
         data = [el.value.data for el in op.value.data]
-        data_ptr = ptr.TypedPtr.new(
+        data_ptr = ptr.TypedPtr[Any].new(
             data,
             xtype=xtype_for_el_type(
                 op.value.get_element_type(), interpreter.index_bitwidth


### PR DESCRIPTION
ONNX used to not have type annotations but now does.