### PR TITLE
transformations: (lift-arith-to-linalg) Add support for partially bufferized programs

### DIFF
--- a/tests/filecheck/transforms/lift-arith-to-linalg.mlir
+++ b/tests/filecheck/transforms/lift-arith-to-linalg.mlir
@@ -1,15 +1,64 @@
 // RUN: xdsl-opt %s -p lift-arith-to-linalg | filecheck %s
 
 builtin.module {
+// CHECK: builtin.module {
+
+  func.func @a() {
     %t0, %t1, %t2, %t3 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
     %0 = arith.addf %t0, %t1 : tensor<8xf32>
     %1 = arith.subf %0, %t2 : tensor<8xf32>
     %2 = arith.mulf %1, %t3 : tensor<8xf32>
-}
+    func.return
+  }
 
-// CHECK-NEXT: builtin.module {
+// CHECK-NEXT: func.func @a() {
 // CHECK-NEXT:   %t0, %t1, %t2, %t3 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
 // CHECK-NEXT:   %0 = linalg.add ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%t0 : tensor<8xf32>) -> tensor<8xf32>
 // CHECK-NEXT:   %1 = linalg.sub ins(%0, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
 // CHECK-NEXT:   %2 = linalg.mul ins(%1, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%1 : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
+
+  func.func @choose_correct_tensor() {
+    %t0, %t1, %t2, %m0 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, memref<8xf32>)
+    %not_this = bufferization.to_tensor %m0 restrict : memref<8xf32>
+    %this = bufferization.to_tensor %m0 restrict writable : memref<8xf32>
+    %also_not_this = bufferization.to_tensor %m0 restrict : memref<8xf32>
+    %3 = arith.addf %t0, %t1 : tensor<8xf32>
+    %4 = arith.mulf %3, %t2 : tensor<8xf32>
+    func.return
+  }
+
+// CHECK-NEXT: func.func @choose_correct_tensor() {
+// CHECK-NEXT:   %t0, %t1, %t2, %m0 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, memref<8xf32>)
+// CHECK-NEXT:   %not_this = bufferization.to_tensor %m0 restrict : memref<8xf32>
+// CHECK-NEXT:   %this = bufferization.to_tensor %m0 restrict writable : memref<8xf32>
+// CHECK-NEXT:   %also_not_this = bufferization.to_tensor %m0 restrict : memref<8xf32>
+// CHECK-NEXT:   %0 = linalg.add ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%this : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   %1 = linalg.mul ins(%0, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
+  func.func @extract_slice() {
+    %t0, %t1, %t2, %m0 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, memref<16xf32>)
+    %tensor = bufferization.to_tensor %m0 restrict writable : memref<16xf32>
+    %slice = "tensor.extract_slice"(%tensor) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 8>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<16xf32>) -> tensor<8xf32>
+    %wrong_size_slice = "tensor.extract_slice"(%tensor) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 10>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<16xf32>) -> tensor<10xf32>
+    %3 = arith.addf %t0, %t1 : tensor<8xf32>
+    %4 = arith.mulf %3, %t2 : tensor<8xf32>
+    func.return
+  }
+
+// CHECK-NEXT: func.func @extract_slice() {
+// CHECK-NEXT:   %t0, %t1, %t2, %m0 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, memref<16xf32>)
+// CHECK-NEXT:   %tensor = bufferization.to_tensor %m0 restrict writable : memref<16xf32>
+// CHECK-NEXT:   %slice = "tensor.extract_slice"(%tensor) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 8>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<16xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   %wrong_size_slice = "tensor.extract_slice"(%tensor) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 10>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<16xf32>) -> tensor<10xf32>
+// CHECK-NEXT:   %0 = linalg.add ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%slice : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   %1 = linalg.mul ins(%0, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
+}
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/lift-arith-to-linalg.mlir
+++ b/tests/filecheck/transforms/lift-arith-to-linalg.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p lift-arith-to-linalg | filecheck %s
+// RUN: xdsl-opt %s -p "lift-arith-to-linalg{strategy=from_partially_bufferized}" | filecheck %s
 
 builtin.module {
 // CHECK: builtin.module {

--- a/tests/filecheck/transforms/lift-arith-to-linalg.mlir
+++ b/tests/filecheck/transforms/lift-arith-to-linalg.mlir
@@ -36,8 +36,8 @@ builtin.module {
 // CHECK-NEXT:   %0 = bufferization.to_tensor %m0 restrict : memref<8xf32>
 // CHECK-NEXT:   %1 = bufferization.to_tensor %m0 restrict writable : memref<8xf32>
 // CHECK-NEXT:   %2 = bufferization.to_tensor %m0 restrict : memref<8xf32>
-// CHECK-NEXT:   %0 = linalg.add ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%1 : tensor<8xf32>) -> tensor<8xf32>
-// CHECK-NEXT:   %1 = linalg.mul ins(%0, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   %3 = linalg.add ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%1 : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   %4 = linalg.mul ins(%3, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%3 : tensor<8xf32>) -> tensor<8xf32>
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 


### PR DESCRIPTION
This PR improves the selection of suitable `outs` arguments for the created linalg ops (see [here](https://github.com/llvm/llvm-project/issues/101709)).

Partially bufferized programs have `bufferization.to_tensor` ops. These can be flagged as `writable`, and the pass will look for one with a matching size. This may in fact be after an additional `tensor.extract_slice`.

This mechanism should only be triggered for the translation of the first op in a chained calculation, as subsequent ops will re-use the `outs` of their operands.