### PR TITLE
CI: move ruff line setting to only linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,11 @@ typeCheckingMode = "strict"
 ]
 
 [tool.ruff]
-lint.select = ["E", "F", "W", "I", "UP", "PT", "TID251"]
-lint.ignore = [
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "PT", "TID251"]
+ignore = [
     "E741",  # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
     "PT006", # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
     "PT007", # https://beta.ruff.rs/docs/rules/pytest-parametrize-values-wrong-type/
@@ -99,9 +102,9 @@ lint.ignore = [
     "PT012", # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
     "PT015", # https://beta.ruff.rs/docs/rules/pytest-assert-always-false/
 ]
-line-length = 300
-target-version = "py310"
 
+[tool.ruff.lint.pycodestyle]
+max-line-length = 300
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "xdsl.parser.core".msg = "Use xdsl.parser instead."
@@ -130,7 +133,7 @@ target-version = "py310"
 "docs/mlir_interoperation.ipynb" = ["E402"]
 "docs/irdl.ipynb" = ["ALL"]
 "docs/database_example.ipynb" = ["ALL"]
-"**/{docs/marimo}/*" = ["E501"]
+"**/{docs/marimo}/*" = ["E501", "I001"]
 "_version.py" = ["ALL"]
 "__init__.py" = ["F403"]
 


### PR DESCRIPTION
In preparation to migrating to use ruff to format the code.