### PR TITLE
[RFC] rewriting: Implement operation update methods

### DIFF
--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import wraps
 from types import UnionType
@@ -88,6 +88,55 @@ class PatternRewriter(PatternRewriterListener):
 
     has_done_action: bool = field(default=False, init=False)
     """Has the rewriter done any action during the current match."""
+
+    def update_op(
+        self,
+        op: Operation,
+        new_results: Sequence[SSAValue | None] | None = None,
+        safe_erase: bool = True,
+        *,
+        operands: Sequence[SSAValue] | None = None,
+        result_types: Sequence[Attribute] | None = None,
+        properties: Mapping[str, Attribute] | None = None,
+        attributes: Mapping[str, Attribute] | None = None,
+        successors: Sequence[Block] | None = None,
+        regions: Sequence[Region] | None = None,
+    ):
+        self.has_done_action = Rewriter.update_op(
+            op,
+            new_results,
+            safe_erase,
+            operands=operands,
+            result_types=result_types,
+            properties=properties,
+            attributes=attributes,
+            successors=successors,
+            regions=regions,
+        )
+
+    def update_matched_op(
+        self,
+        new_results: Sequence[SSAValue | None] | None = None,
+        safe_erase: bool = True,
+        *,
+        operands: Sequence[SSAValue] | None = None,
+        result_types: Sequence[Attribute] | None = None,
+        properties: Mapping[str, Attribute] | None = None,
+        attributes: Mapping[str, Attribute] | None = None,
+        successors: Sequence[Block] | None = None,
+        regions: Sequence[Region] | None = None,
+    ):
+        self.update_op(
+            self.current_operation,
+            new_results,
+            safe_erase,
+            operands=operands,
+            result_types=result_types,
+            properties=properties,
+            attributes=attributes,
+            successors=successors,
+            regions=regions,
+        )
 
     def insert_op(
         self, op: Operation | Sequence[Operation], insertion_point: InsertPoint

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -132,6 +132,13 @@ class Rewriter:
         successors: Sequence[Block] | None = None,
         regions: Sequence[Region] | None = None,
     ):
+        """
+        Recreate an operation with any passed field updated. All other fields
+        are take from the original operation.
+
+        If all passed fields are already equals to the existing ones, also just skip and
+        prevent endless pattern recursion.
+        """
         if (
             (operands is None or operands == op.operands)
             and (result_types is None or result_types == op.result_types)
@@ -144,9 +151,11 @@ class Rewriter:
         new_op = op.create(
             operands=op.operands if operands is None else operands,
             result_types=op.result_types if result_types is None else result_types,
-            properties=op.properties.copy() if properties is None else properties,
-            attributes=op.attributes.copy() if attributes is None else attributes,
-            successors=op.successors.copy() if successors is None else successors,
+            # No need to copy the properties, attributes, regions: we replace the
+            # original op so it won't use them anymore!
+            properties=op.properties if properties is None else properties,
+            attributes=op.attributes if attributes is None else attributes,
+            successors=op.successors if successors is None else successors,
             regions=(
                 tuple(op.detach_region(0) for _ in op.regions)
                 if regions is None

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
 from typing_extensions import deprecated
 
-from xdsl.ir import Block, Operation, Region, SSAValue
+from xdsl.ir import Attribute, Block, Operation, Region, SSAValue
 
 
 @dataclass(frozen=True)
@@ -118,6 +118,43 @@ class Rewriter:
                     res.name_hint = op.results[0].name_hint
 
         block.erase_op(op, safe_erase=safe_erase)
+
+    @staticmethod
+    def update_op(
+        op: Operation,
+        new_results: Sequence[SSAValue | None] | None = None,
+        safe_erase: bool = True,
+        *,
+        operands: Sequence[SSAValue] | None = None,
+        result_types: Sequence[Attribute] | None = None,
+        properties: Mapping[str, Attribute] | None = None,
+        attributes: Mapping[str, Attribute] | None = None,
+        successors: Sequence[Block] | None = None,
+        regions: Sequence[Region] | None = None,
+    ):
+        if (
+            (operands is None or operands == op.operands)
+            and (result_types is None or result_types == op.result_types)
+            and (properties is None or properties == op.properties)
+            and (attributes is None or attributes == op.attributes)
+            and (successors is None or successors == op.successors)
+            and (regions is None or regions == op.regions)
+        ):
+            return False
+        new_op = op.create(
+            operands=op.operands if operands is None else operands,
+            result_types=op.result_types if result_types is None else result_types,
+            properties=op.properties.copy() if properties is None else properties,
+            attributes=op.attributes.copy() if attributes is None else attributes,
+            successors=op.successors.copy() if successors is None else successors,
+            regions=(
+                tuple(op.detach_region(0) for _ in op.regions)
+                if regions is None
+                else regions
+            ),
+        )
+        Rewriter.replace_op(op, new_op, new_results, safe_erase)
+        return True
 
     @staticmethod
     def inline_block(


### PR DESCRIPTION
With @n-io (and potentially others?) we write a lot of patterns ultimately boiling down to "Just update this field on this op". Now, it's best practice to actually replace the op right, for patterns recursion and worklist management, if only that.

So it yields a lot of "Let me create this op of this type, from that op of this same type", re-expanding all fields to populate a constructor, and replace the old with the new. Also some error-prone (or just bad performance prone) stuff like region management, like region cloning or inlining, where they can just be carried over.

So I think it would make sense to have some API on the rewrite side to take care of this common pattern!