### PR TITLE
misc: remove mentions of black formatter

### DIFF
--- a/.git-blame-ignored-commits
+++ b/.git-blame-ignored-commits
@@ -1,2 +1,4 @@
 #This commit just switched the whole codebase to black format
 c1d91c7c7e3dfa5f6c698c8591b2900d27203ab5
+#This commit switched to ruff format
+6d27775d1689c4f1c1289373055e5b26cbcc53bc

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,7 +1,7 @@
 # This workflow check the format all files in the repository
 # * It checks that all nonempty files have a newline at the end
 # * It checks that there are no whitespaces at the end of lines
-# * It checks that Python files are formatted with black
+# * It checks that Python files are formatted with ruff
 
 name: Code Formatting
 

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ TESTS_COVERAGE_FILE = ${COVERAGE_FILE}.tests
 .ONESHELL:
 
 # these targets don't produce files:
-.PHONY: ${VENV_DIR}/ venv clean clean-caches filecheck pytest pytest-nb tests-toy tests rerun-notebooks precommit-install precommit black pyright tests-marimo tests-marimo-mlir
-.PHONY: coverage coverage-tests coverage-filecheck-tests coverage-report-html coverage-report-md
+.PHONY: ${VENV_DIR}/ venv clean clean-caches filecheck pytest pytest-nb tests-toy tests
+.PHONY: rerun-notebooks precommit-install precommit pyright tests-marimo
+.PHONY: tests-marimo-mlir coverage coverage-tests coverage-filecheck-tests
+.PHONY: coverage-report-html coverage-report-md
 
 # set up the venv with all dependencies for development
 ${VENV_DIR}/: requirements.txt
@@ -45,7 +47,9 @@ pytest:
 
 # run pytest on notebooks
 pytest-nb:
-	pytest -W error --nbval -vv docs --ignore=docs/mlir_interoperation.ipynb --nbval-current-env
+	pytest -W error --nbval -vv docs \
+		--ignore=docs/mlir_interoperation.ipynb \
+		--nbval-current-env
 
 # run tests for Toy tutorial
 filecheck-toy:
@@ -89,7 +93,11 @@ tests: pytest tests-toy filecheck pytest-nb tests-marimo tests-marimo-mlir pyrig
 
 # re-generate the output from all jupyter notebooks in the docs directory
 rerun-notebooks:
-	jupyter nbconvert --ClearMetadataPreprocessor.enabled=True --inplace --to notebook --execute docs/*.ipynb docs/Toy/*.ipynb
+	jupyter nbconvert \
+		--ClearMetadataPreprocessor.enabled=True \
+		--inplace \
+		--to notebook \
+		--execute docs/*.ipynb docs/Toy/*.ipynb
 
 # set up all precommit hooks
 precommit-install:
@@ -104,12 +112,6 @@ pyright:
     # We make sure to generate the python typing stubs before running pyright
 	xdsl-stubgen
 	pyright $(shell git diff --staged --name-only  -- '*.py')
-
-# run black on all files currently staged
-black:
-	staged_files="$(shell git diff --staged --name-only)"
-	# run black on all of xdsl if no staged files exist
-	black $${staged_files:-xdsl}
 
 # run coverage over all tests and combine data files
 coverage: coverage-tests coverage-filecheck-tests

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ To automate the formatting, we use pre-commit hooks from the
 make precommit-install
 # to run the hooks:
 make precommit
-# Alternatively, run `ruff format`
+# alternatively, run ruff directly:
+ruff format
 ```
 
 Furthermore, all python code must run through [pyright](https://github.com/microsoft/pyright)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ make tests
 
 ### Formatting and Typechecking
 
-All python code used in xDSL uses [black](https://github.com/psf/black) to
+All python code used in xDSL uses [ruff](https://docs.astral.sh/ruff/formatter/) to
 format the code in a uniform manner.
 
 To automate the formatting, we use pre-commit hooks from the
@@ -127,8 +127,7 @@ To automate the formatting, we use pre-commit hooks from the
 make precommit-install
 # to run the hooks:
 make precommit
-# alternatively, running black on all staged files:
-make black  # or simply black $(git diff --staged --name-only)
+# Alternatively, run `ruff format`
 ```
 
 Furthermore, all python code must run through [pyright](https://github.com/microsoft/pyright)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ typeCheckingMode = "strict"
 
 [tool.ruff]
 target-version = "py310"
+extend-include = ["*.ipynb", "*.pyi"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "PT", "TID251"]


### PR DESCRIPTION
A bit of cleanup.

1. exclude ruff transition from git blame
2. remove `make black`
3. clean up comments
4. Makefile now also has 88 column width, because why not
5. Add jupyter notebooks and type stubs to ruff formatted file list