### PR TITLE
interpreter: fix int64 format in ptr dtypes

### DIFF
--- a/tests/interpreters/test_ptr.py
+++ b/tests/interpreters/test_ptr.py
@@ -1,0 +1,12 @@
+from xdsl.interpreters import ptr
+
+
+def test_ptr():
+    assert ptr.float32.format == "<f"
+    assert ptr.float32.size == 4
+    assert ptr.float64.format == "<d"
+    assert ptr.float64.size == 8
+    assert ptr.int32.format == "<i"
+    assert ptr.int32.size == 4
+    assert ptr.int64.format == "<q"
+    assert ptr.int64.size == 8

--- a/xdsl/interpreters/ptr.py
+++ b/xdsl/interpreters/ptr.py
@@ -86,7 +86,7 @@ class XType(Generic[_TCov]):
 
 
 int32 = XType(int, "<i")
-int64 = XType(int, "<I")
+int64 = XType(int, "<q")
 float32 = XType(float, "<f")
 float64 = XType(float, "<d")
 


### PR DESCRIPTION
There is currently a bug, I used the wrong `struct` code for the encoding of int64.