### PR TITLE
dependencies: add JAX as an optional dependency of xDSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In order to keep the set of dependencies ot a minimum, these extra dependencies 
 specified explicitly. To install these, use:
 
 ``` bash
-pip install xdsl[gui,riscv,wgpu,onnx]
+pip install xdsl[gui,jax,riscv,wgpu,onnx]
 ```
 
 To install the testing/development dependencies, use:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pyright==1.1.345",
 ]
 gui = ["textual==0.76.0", "pyclip==0.7"]
+jax = ["jax==0.4.31"]
 onnx = ["onnx==1.16.2"]
 riscv = ["riscemu==2.2.7"]
 wgpu = ["wgpu==0.16.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e .[gui,riscv,wgpu,onnx,dev]
+-e .[gui,jax,riscv,wgpu,onnx,dev]


### PR DESCRIPTION
There will be a number of projects using xDSL + JAX, might as well make this easy.