### PR TITLE
[RFC] core: Better support for splat in DenseIntOrFPElementsAttr

### DIFF
--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -142,11 +142,10 @@ class CslPrintContext:
             case UnitAttr():
                 return ""
             case DenseIntOrFPElementsAttr():
-                data = init.data.data
                 assert (
-                    len(data) == 1
-                ), f"Memref global initialiser has to have 1 value, got {len(data)}"
-                return f" = @constants({type}, {self.attribute_value_to_str(data[0])})"
+                    data := init.get_single_element()
+                ), "Memref global initialiser has to have a single value"
+                return f" = @constants({type}, {self.attribute_value_to_str(data)})"
             case other:
                 return f"<unknown memref.global init type {other}>"
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -757,7 +757,7 @@ class AttrParser(BaseParser):
         if len(data_values) == 1:
             # Splat attribute case, same value everywhere,
             # Emit values repeatedly and emit empty shape
-            return [data_values[0]] * math.prod(type.get_shape()), []
+            return [data_values[0]], []
         return data_values, [num_chunks]
 
     def _parse_dense_literal_type(
@@ -842,7 +842,7 @@ class AttrParser(BaseParser):
                 value.to_type(self, type.element_type) for value in dense_values
             ]
             # Elements from _parse_tensor_literal need to be converted to values.
-            if shape:
+            if shape and len(data_values) > 1:
                 # Check that the shape matches the data when given a shaped data.
                 # For splat attributes any shape is fine
                 if type_shape != shape:
@@ -852,7 +852,6 @@ class AttrParser(BaseParser):
                     )
             else:
                 assert len(data_values) == 1, "Fatal error in parser"
-                data_values *= type_num_values
 
         return DenseIntOrFPElementsAttr.from_list(type, data_values)
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -627,7 +627,7 @@ class Printer:
             assert shape is not None, "If shape is complete, then it cannot be None"
             if len(data) == 0:
                 pass
-            elif data.count(data[0]) == len(data):
+            elif attribute.is_splat or data.count(data[0]) == len(data):
                 print_one_elem(data[0])
             else:
                 print_dense_list(data, shape)

--- a/xdsl/transforms/linalg_to_csl.py
+++ b/xdsl/transforms/linalg_to_csl.py
@@ -75,9 +75,9 @@ class ConvertBinaryLinalgOp(RewritePattern):
             isinstance(op, OpResult)
             and isinstance(op.op, arith.Constant)
             and isa(val := op.op.value, DenseIntOrFPElementsAttr)
-            and val.data.data.count(val.data.data[0]) == len(val.data.data)
+            and (single_element := val.get_single_element())
         ):
-            return val.data.data[0]
+            return single_element
 
 
 class ConvertLinalgAddPass(ConvertBinaryLinalgOp):


### PR DESCRIPTION
When DenseIntOrFPElementsAttr consists of a single data element, it is currently replicated across the entire shape, which is inefficient for large shapes, and handled as a special case in upstream MLIR (the [docs](https://mlir.llvm.org/docs/Dialects/Builtin/#denseintorfpelementsattr) refer to this as a splat value).

This PR removes the replication from the parser and makes it lazy (when `data` is accessed). This is done by making the `data` field protected ( -> `_data`) and hiding it behind a property of the same name.

Ideally, we'd fix the places in the code that rely on this redundancy and remove the `@property data` again.