### PR TITLE
core: Improved treatment of whitespace in assembly format

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -756,7 +756,7 @@ builtin.module {
       %9 = arith.addf %8, %7 : f32
       stencil.return %9 : f32
     }
-    stencil.store %3 to %1 (<[0], [6]>) : !stencil.temp<?xf32> to !stencil.field<[-1,7]xf32>
+    stencil.store %3 to %1(<[0], [6]>) : !stencil.temp<?xf32> to !stencil.field<[-1,7]xf32>
     func.return
   }
 }

--- a/tests/filecheck/dialects/csl/csl-stencil-canonicalize.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-canonicalize.mlir
@@ -15,7 +15,7 @@ builtin.module {
       ^0(%8 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %9 : tensor<510xf32>):
         csl_stencil.yield %9 : tensor<510xf32>
       })
-    stencil.store %2 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %2 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 
     %10 = tensor.empty() : tensor<510xf32>
     %11 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %10 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "operandSegmentSizes" = array<i32: 1, 1, 0, 0>}> ({
@@ -27,7 +27,7 @@ builtin.module {
       ^0(%17 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %18 : tensor<510xf32>):
         csl_stencil.yield %18 : tensor<510xf32>
       })
-    stencil.store %11 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %11 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 
     %19 = tensor.empty() : tensor<510xf32>
     %20 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %19 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{"num_chunks" = 2, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "operandSegmentSizes" = array<i32: 1, 1, 0, 0>}> ({
@@ -39,7 +39,7 @@ builtin.module {
       ^0(%26 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %27 : tensor<510xf32>):
         csl_stencil.yield %27 : tensor<510xf32>
       })
-    stencil.store %20 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %20 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
     func.return
   }
 }
@@ -58,7 +58,7 @@ builtin.module {
 // CHECK-NEXT:     ^1(%8 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %9 : tensor<510xf32>):
 // CHECK-NEXT:       csl_stencil.yield %9 : tensor<510xf32>
 // CHECK-NEXT:     })
-// CHECK-NEXT:     stencil.store %2 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     stencil.store %2 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     %3 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{"num_chunks" = 2 : i64, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "operandSegmentSizes" = array<i32: 1, 1, 0, 0>}> ({
 // CHECK-NEXT:     ^0(%4 : tensor<4x255xf32>, %5 : index, %6 : tensor<510xf32>):
 // CHECK-NEXT:       %7 = csl_stencil.access %4[1, 0] : tensor<4x255xf32>
@@ -68,7 +68,7 @@ builtin.module {
 // CHECK-NEXT:     ^1(%9 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %10 : tensor<510xf32>):
 // CHECK-NEXT:       csl_stencil.yield %10 : tensor<510xf32>
 // CHECK-NEXT:     })
-// CHECK-NEXT:     stencil.store %3 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     stencil.store %3 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     %4 = csl_stencil.apply(%0 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %1 : tensor<510xf32>) -> (!stencil.temp<[0,1]x[0,1]xtensor<510xf32>>) <{"num_chunks" = 2 : i64, "topo" = #dmp.topo<1022x510>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "operandSegmentSizes" = array<i32: 1, 1, 0, 0>}> ({
 // CHECK-NEXT:     ^0(%5 : tensor<4x255xf32>, %6 : index, %7 : tensor<510xf32>):
 // CHECK-NEXT:       %8 = csl_stencil.access %5[1, 0] : tensor<4x255xf32>
@@ -78,7 +78,7 @@ builtin.module {
 // CHECK-NEXT:     ^1(%10 : !stencil.temp<[-1,2]x[-1,2]xtensor<512xf32>>, %11 : tensor<510xf32>):
 // CHECK-NEXT:       csl_stencil.yield %11 : tensor<510xf32>
 // CHECK-NEXT:     })
-// CHECK-NEXT:     stencil.store %4 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     stencil.store %4 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-stencil-ops.mlir
@@ -25,7 +25,7 @@ builtin.module {
       %20 = arith.mulf %17, %19 : tensor<510xf32>
       stencil.return %20 : tensor<510xf32>
     }
-    stencil.store %1 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %1 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
     func.return
   }
 }
@@ -54,7 +54,7 @@ builtin.module {
 // CHECK-NEXT:       %20 = arith.mulf %17, %19 : tensor<510xf32>
 // CHECK-NEXT:       stencil.return %20 : tensor<510xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     stencil.store %1 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     stencil.store %1 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -133,7 +133,7 @@ builtin.module {
         csl_stencil.yield %21 : tensor<510xf32>
       })
 
-    stencil.store %2 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %2 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
     func.return
   }
 }
@@ -167,7 +167,7 @@ builtin.module {
 // CHECK-NEXT:       %21 = arith.mulf %17, %20 : tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %21 : tensor<510xf32>
 // CHECK-NEXT:     })
-// CHECK-NEXT:     stencil.store %2 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     stencil.store %2 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/stencil/canonicalize.mlir
+++ b/tests/filecheck/dialects/stencil/canonicalize.mlir
@@ -18,8 +18,8 @@ func.func @dup_operand(%f : !stencil.field<[0,64]xf64>, %of1 : !stencil.field<[0
 // CHECK-NEXT:        %0 = stencil.access %one[0] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %0, %0 : f64, f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %o1 to %of1 (<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>
-// CHECK-NEXT:      stencil.store %o2 to %of2 (<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>
+// CHECK-NEXT:      stencil.store %o1 to %of1(<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>
+// CHECK-NEXT:      stencil.store %o2 to %of2(<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -44,6 +44,6 @@ func.func @unused_res(%f1 : !stencil.field<[0,64]xf64>, %f2 : !stencil.field<[0,
 // CHECK-NEXT:        %0 = stencil.access %one[0] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %0 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %o1 to %of (<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>
+// CHECK-NEXT:      stencil.store %o1 to %of(<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[0,64]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }

--- a/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
+++ b/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
@@ -227,8 +227,8 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // CHECK-NEXT:        %29 = stencil.store_result %28 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %29 : !stencil.result<f64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %17 to %6 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:      stencil.store %19 to %5 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %17 to %6(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %19 to %5(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -348,8 +348,8 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // SHAPE-NEXT:        %35 = stencil.store_result %34 : !stencil.result<f64>
 // SHAPE-NEXT:        stencil.return %35 : !stencil.result<f64>
 // SHAPE-NEXT:      }
-// SHAPE-NEXT:      stencil.store %22 to %6 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,65]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// SHAPE-NEXT:      stencil.store %25 to %5 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// SHAPE-NEXT:      stencil.store %22 to %6(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,65]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// SHAPE-NEXT:      stencil.store %25 to %5(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // SHAPE-NEXT:      func.return
 // SHAPE-NEXT:    }
 

--- a/tests/filecheck/dialects/stencil/stencil_ops.mlir
+++ b/tests/filecheck/dialects/stencil/stencil_ops.mlir
@@ -10,7 +10,7 @@ builtin.module {
       %8 = stencil.store_result %7 : !stencil.result<f64>
       stencil.return %8 : !stencil.result<f64>
     }
-    stencil.store %5 to %3 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    stencil.store %5 to %3(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     func.return
   }
 }
@@ -25,7 +25,7 @@ builtin.module {
 // CHECK-NEXT:        %8 = stencil.store_result %7 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %8 : !stencil.result<f64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %5 to %3 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %5 to %3(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -44,7 +44,7 @@ builtin.module {
         %v = stencil.access %ti_[0, 0, 0] : !stencil.temp<?x?x?xf32>
         stencil.return %v : f32
       }
-      stencil.store %tip1 to %fip1 (<[0, 0, 0], [50, 80, 40]>) : !stencil.temp<?x?x?xf32> to !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+      stencil.store %tip1 to %fip1(<[0, 0, 0], [50, 80, 40]>) : !stencil.temp<?x?x?xf32> to !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
       scf.yield %fip1, %fi : !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
     }
     func.return
@@ -63,7 +63,7 @@ builtin.module {
 // CHECK-NEXT:          %v = stencil.access %ti_[0, 0, 0] : !stencil.temp<?x?x?xf32>
 // CHECK-NEXT:          stencil.return %v : f32
 // CHECK-NEXT:        }
-// CHECK-NEXT:        stencil.store %tip1 to %fip1 (<[0, 0, 0], [50, 80, 40]>) : !stencil.temp<?x?x?xf32> to !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
+// CHECK-NEXT:        stencil.store %tip1 to %fip1(<[0, 0, 0], [50, 80, 40]>) : !stencil.temp<?x?x?xf32> to !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:        scf.yield %fip1, %fi : !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>, !stencil.field<[-4,54]x[-4,84]x[-4,44]xf32>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      func.return
@@ -90,7 +90,7 @@ builtin.module {
       %17 = arith.mulf %16, %13 : f64
       stencil.return %17 : f64
     }
-    stencil.store %5 to %3 (<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
+    stencil.store %5 to %3(<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
     func.return
   }
 }
@@ -114,7 +114,7 @@ builtin.module {
 // CHECK-NEXT:        %17 = arith.mulf %16, %13 : f64
 // CHECK-NEXT:        stencil.return %17 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %5 to %3 (<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %5 to %3(<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -133,7 +133,7 @@ builtin.module {
       stencil.return %9 : f64
     }
     %10 = stencil.combine 0 at 11 lower = (%6 : !stencil.temp<?xf64>) upper = (%7 : !stencil.temp<?xf64>) : !stencil.temp<?xf64>
-    stencil.store %10 to %1 (<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    stencil.store %10 to %1(<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
     func.return
   }
 }
@@ -151,7 +151,7 @@ builtin.module {
 // CHECK-NEXT:        stencil.return %7 : f64
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %6 = stencil.combine 0 at 11 lower = (%4 : !stencil.temp<?xf64>) upper = (%5 : !stencil.temp<?xf64>) : !stencil.temp<?xf64>
-// CHECK-NEXT:      stencil.store %6 to %1 (<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %6 to %1(<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -167,7 +167,7 @@ builtin.module {
       %8 = stencil.access %6[0, _] : !stencil.temp<[-1,65]xf64>
       stencil.return %8 : f64
     }
-    stencil.store %5 to %3 (<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
+    stencil.store %5 to %3(<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
     func.return
   }
 }
@@ -182,7 +182,7 @@ builtin.module {
 // CHECK-NEXT:        %8 = stencil.access %6[0, _] : !stencil.temp<[-1,65]xf64>
 // CHECK-NEXT:        stencil.return %8 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %5 to %3 (<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %5 to %3(<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -200,7 +200,7 @@ builtin.module {
       %7 = stencil.dyn_access %6[%i, %j] in <[-1, -1]> : <[1, 1]> : !stencil.temp<[-1,65]x[-1,65]xf64>
       stencil.return %7 : f64
     }
-    stencil.store %5 to %3 (<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
+    stencil.store %5 to %3(<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
     func.return
   }
 }
@@ -216,7 +216,7 @@ builtin.module {
 // CHECK-NEXT:        %7 = stencil.dyn_access %6[%i, %j] in <[-1, -1]> : <[1, 1]> : !stencil.temp<[-1,65]x[-1,65]xf64>
 // CHECK-NEXT:        stencil.return %7 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %5 to %3 (<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %5 to %3(<[0, 0], [64, 64]>) : !stencil.temp<[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/stencil/ops.mlir
@@ -48,7 +48,7 @@ func.func @dyn_access(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<
     %43 = stencil.store_result %42 : !stencil.result<f64>
     stencil.return %8, %13, %18, %23, %28, %33, %38, %43 unroll <[1, 8, 1]> : !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>
   }
-  stencil.store %3 to %1 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+  stencil.store %3 to %1(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
   func.return
 }
 
@@ -100,7 +100,7 @@ func.func @dyn_access(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<
 // CHECK-NEXT:        %43 = stencil.store_result %42 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %8, %13, %18, %23, %28, %33, %38, %43 unroll <[1, 8, 1]> : !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %3 to %1 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      stencil.store %3 to %1(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -29,7 +29,7 @@ builtin.module {
       %25 = arith.mulf %22, %24 : tensor<510xf32>
       csl_stencil.yield %25 : tensor<510xf32>
     })
-    stencil.store %2 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %2 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
     func.return
   }
 }
@@ -87,7 +87,7 @@ builtin.module {
 // CHECK-NEXT:         %60 = arith.mulf %57, %59 : tensor<510xf32>
 // CHECK-NEXT:         csl_stencil.yield %60 : tensor<510xf32>
 // CHECK-NEXT:       })
-// CHECK-NEXT:       stencil.store %37 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:       stencil.store %37 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()

--- a/tests/filecheck/transforms/distribute-stencil.mlir
+++ b/tests/filecheck/transforms/distribute-stencil.mlir
@@ -19,8 +19,8 @@ builtin.module {
       %46 = arith.addf %45, %44 : f64
       stencil.return %46, %45 : f64, f64
     }
-    stencil.store %34 to %28 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-    stencil.store %35 to %29 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    stencil.store %34 to %28(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    stencil.store %35 to %29(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     func.return
   }
 
@@ -41,8 +41,8 @@ builtin.module {
 // CHECK-NEXT:        %16 = arith.addf %15, %14 : f64
 // CHECK-NEXT:        stencil.return %16, %15 : f64, f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %4 to %1 (<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,32]x[0,32]x[0,32]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
-// CHECK-NEXT:      stencil.store %5 to %2 (<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,32]x[0,32]x[0,32]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %4 to %1(<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,32]x[0,32]x[0,32]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %5 to %2(<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,32]x[0,32]x[0,32]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -73,7 +73,7 @@ builtin.module {
       %xyz = arith.addi %xy, %z : index
       stencil.return %xyz : index
     }
-    stencil.store %92 to %91 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
+    stencil.store %92 to %91(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
     func.return
   }
 
@@ -86,7 +86,7 @@ builtin.module {
 // CHECK-NEXT:        %xyz = arith.addi %xy, %z : index
 // CHECK-NEXT:        stencil.return %xyz : index
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %1 to %0 (<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
+// CHECK-NEXT:      stencil.store %1 to %0(<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -99,7 +99,7 @@ builtin.module {
       %xyz_1 = arith.addi %xy_1, %z_1 : index
       stencil.return %xyz_1 : index
     }
-    stencil.store %94 to %93 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
+    stencil.store %94 to %93(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
     func.return
   }
 
@@ -112,7 +112,7 @@ builtin.module {
 // CHECK-NEXT:        %xyz = arith.addi %xy, %z : index
 // CHECK-NEXT:        stencil.return %xyz : index
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %1 to %0 (<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
+// CHECK-NEXT:      stencil.store %1 to %0(<[0, 0, 0], [32, 32, 32]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xindex> to !stencil.field<[0,64]x[0,64]x[0,64]xindex>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -151,8 +151,8 @@ func.func @if_lowering(%arg0_1 : f64, %b0 : !stencil.field<[0,8]x[0,8]x[0,8]xf64
       %107 = stencil.store_result %104 : !stencil.result<f64>
       stencil.return %103, %107 : !stencil.result<f64>, !stencil.result<f64>
     }
-    stencil.store %101 to %b0 (<[0, 0, 0], [8, 8, 8]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
-    stencil.store %102 to %b1 (<[0, 0, 0], [8, 8, 8]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
+    stencil.store %101 to %b0(<[0, 0, 0], [8, 8, 8]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
+    stencil.store %102 to %b1(<[0, 0, 0], [8, 8, 8]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
     func.return
   }
 
@@ -169,11 +169,11 @@ func.func @if_lowering(%arg0_1 : f64, %b0 : !stencil.field<[0,8]x[0,8]x[0,8]xf64
 // CHECK-NEXT:        %6 = stencil.store_result %3 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %2, %6 : !stencil.result<f64>, !stencil.result<f64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %0 to %b0 (<[0, 0, 0], [4, 4, 4]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
-// CHECK-NEXT:      stencil.store %1 to %b1 (<[0, 0, 0], [4, 4, 4]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
+// CHECK-NEXT:      stencil.store %0 to %b0(<[0, 0, 0], [4, 4, 4]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
+// CHECK-NEXT:      stencil.store %1 to %b1(<[0, 0, 0], [4, 4, 4]>) : !stencil.temp<[0,8]x[0,8]x[0,8]xf64> to !stencil.field<[0,8]x[0,8]x[0,8]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
-  
+
 
 }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -10,7 +10,7 @@ builtin.module {
       %o = arith.addf %l, %r : f64
       stencil.return %o : f64
     }
-    stencil.store %tout to %out (<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    stencil.store %tout to %out(<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
     func.return
   }
 }
@@ -24,7 +24,7 @@ builtin.module {
 // CHECK-NEXT:        %o = arith.addf %l, %r : f64
 // CHECK-NEXT:        stencil.return %o : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %tout to %out (<[0], [64]>) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %tout to %out(<[0], [64]>) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -49,7 +49,7 @@ builtin.module {
       %16 = arith.addf %15, %14 : f64
       stencil.return %16 : f64
     }
-    stencil.store %5 to %3 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    stencil.store %5 to %3(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     func.return
   }
 }
@@ -73,7 +73,7 @@ builtin.module {
 // CHECK-NEXT:        %16 = arith.addf %15, %14 : f64
 // CHECK-NEXT:        stencil.return %16 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %5 to %3 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %5 to %3(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -98,7 +98,7 @@ builtin.module {
       %16 = arith.addf %15, %14 : f64
       stencil.return %16 : f64
     }
-    stencil.store %5 to %3 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    stencil.store %5 to %3(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     func.return
   }
 }
@@ -118,7 +118,7 @@ builtin.module {
       %6 = arith.addf %4, %5 : f64
       stencil.return %6 : f64
     }
-    stencil.store %3 to %2 (<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
+    stencil.store %3 to %2(<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
     func.return
   }
 }
@@ -130,7 +130,7 @@ builtin.module {
 // CHECK-NEXT:        %6 = arith.addf %4, %5 : f64
 // CHECK-NEXT:        stencil.return %6 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %3 to %2 (<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
+// CHECK-NEXT:      stencil.store %3 to %2(<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -148,7 +148,7 @@ builtin.module {
       %9 = stencil.access %8[0] : !stencil.temp<?xf64>
       stencil.return %9 : f64
     }
-    stencil.store %7 to %1 (<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    stencil.store %7 to %1(<[0], [64]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
     func.return
   }
 }
@@ -164,7 +164,7 @@ builtin.module {
 // CHECK-NEXT:        %7 = stencil.access %6[0] : !stencil.temp<[0,64]xf64>
 // CHECK-NEXT:        stencil.return %7 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %5 to %1 (<[0], [64]>) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %5 to %1(<[0], [64]>) : !stencil.temp<[0,64]xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -180,7 +180,7 @@ func.func @dyn_access(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<
       %5 = stencil.store_result %4 : !stencil.result<f64>
       stencil.return %5 : !stencil.result<f64>
     }
-    stencil.store %3 to %1 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+    stencil.store %3 to %1(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
     func.return
   }
 
@@ -194,7 +194,7 @@ func.func @dyn_access(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<
 // CHECK-NEXT:        %5 = stencil.store_result %4 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %5 : !stencil.result<f64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %3 to %1 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      stencil.store %3 to %1(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -215,7 +215,7 @@ func.func @combine(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<?x?
       stencil.return %8 : !stencil.result<f64>
     }
     %9 = stencil.combine 0 at 32 lower = (%3 : !stencil.temp<?x?x?xf64>) upper = (%6 : !stencil.temp<?x?x?xf64>) : !stencil.temp<?x?x?xf64>
-    stencil.store %9 to %1 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+    stencil.store %9 to %1(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
     func.return
   }
 
@@ -234,7 +234,7 @@ func.func @combine(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<?x?
 // CHECK-NEXT:        stencil.return %6 : !stencil.result<f64>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %5 = stencil.combine 0 at 32 lower = (%3 : !stencil.temp<[0,32]x[0,64]x[0,60]xf64>) upper = (%4 : !stencil.temp<[32,64]x[0,64]x[0,60]xf64>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64>
-// CHECK-NEXT:      stencil.store %5 to %1 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      stencil.store %5 to %1(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -278,9 +278,9 @@ func.func @buffer(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<?x?x
       %23 = stencil.store_result %22 : !stencil.result<f64>
       stencil.return %23 : !stencil.result<f64>
     }
-    stencil.store %15 to %0 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
-    stencil.store %18 to %1 (<[0, 0, 0], [16, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
-    stencil.store %21 to %2 (<[48, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+    stencil.store %15 to %0(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+    stencil.store %18 to %1(<[0, 0, 0], [16, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+    stencil.store %21 to %2(<[48, 0, 0], [64, 64, 60]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
     func.return
   }
 
@@ -322,8 +322,8 @@ func.func @buffer(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<?x?x
 // CHECK-NEXT:        %16 = stencil.store_result %15 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %16 : !stencil.result<f64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %12 to %0 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
-// CHECK-NEXT:      stencil.store %13 to %1 (<[0, 0, 0], [16, 64, 60]>) : !stencil.temp<[0,16]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
-// CHECK-NEXT:      stencil.store %14 to %2 (<[48, 0, 0], [64, 64, 60]>) : !stencil.temp<[48,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      stencil.store %12 to %0(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      stencil.store %13 to %1(<[0, 0, 0], [16, 64, 60]>) : !stencil.temp<[0,16]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      stencil.store %14 to %2(<[48, 0, 0], [64, 64, 60]>) : !stencil.temp<[48,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }

--- a/tests/filecheck/transforms/stencil-storage-materialization.mlir
+++ b/tests/filecheck/transforms/stencil-storage-materialization.mlir
@@ -9,7 +9,7 @@ builtin.module{
       %v = stencil.access %inb[-1] : !stencil.temp<?xf64>
       stencil.return %v : f64
     }
-    stencil.store %outt to %out (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    stencil.store %outt to %out(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
     func.return
   }
 
@@ -19,7 +19,7 @@ builtin.module{
 // CHECK-NEXT:        %v = stencil.access %inb[-1] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %v : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %outt to %out (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %outt to %out(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -35,7 +35,7 @@ builtin.module{
       %v = stencil.access %midb[-1] : !stencil.temp<?xf64>
       stencil.return %v : f64
     }
-    stencil.store %outt to %out (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    stencil.store %outt to %out(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
     func.return
   }
 
@@ -50,7 +50,7 @@ builtin.module{
 // CHECK-NEXT:        %v = stencil.access %midb[-1] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %v : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %outt to %out (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %outt to %out(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -62,12 +62,12 @@ builtin.module{
       %v = stencil.access %inb[-1] : !stencil.temp<?xf64>
       stencil.return %v : f64
     }
-    stencil.store %midt to %midout (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    stencil.store %midt to %midout(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
     %outt = stencil.apply(%midb = %midt : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
       %v = stencil.access %midb[-1] : !stencil.temp<?xf64>
       stencil.return %v : f64
     }
-    stencil.store %outt to %out (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+    stencil.store %outt to %out(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
     func.return
   }
 
@@ -77,12 +77,12 @@ builtin.module{
 // CHECK-NEXT:        %v = stencil.access %inb[-1] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %v : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %midt to %midout (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %midt to %midout(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      %outt = stencil.apply(%midb = %midt : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
 // CHECK-NEXT:        %v = stencil.access %midb[-1] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %v : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %outt to %out (<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %outt to %out(<[0], [68]>) : !stencil.temp<?xf64> to !stencil.field<[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -103,7 +103,7 @@ builtin.module{
       %11 = arith.addf %9, %10 : f64
       stencil.return %11 : f64
     }
-    stencil.store %7 to %1 (<[1, 2], [65, 66]>) : !stencil.temp<[1,65]x[2,66]xf64> to !stencil.field<[-3,67]x[-3,67]xf64>
+    stencil.store %7 to %1(<[1, 2], [65, 66]>) : !stencil.temp<[1,65]x[2,66]xf64> to !stencil.field<[-3,67]x[-3,67]xf64>
     func.return
   }
 
@@ -125,7 +125,7 @@ builtin.module{
 // CHECK-NEXT:        %10 = arith.addf %8, %9 : f64
 // CHECK-NEXT:        stencil.return %10 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %6 to %1 (<[1, 2], [65, 66]>) : !stencil.temp<[1,65]x[2,66]xf64> to !stencil.field<[-3,67]x[-3,67]xf64>
+// CHECK-NEXT:      stencil.store %6 to %1(<[1, 2], [65, 66]>) : !stencil.temp<[1,65]x[2,66]xf64> to !stencil.field<[-3,67]x[-3,67]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 

--- a/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
+++ b/tests/filecheck/transforms/stencil-tensorize-z-dimension.mlir
@@ -55,7 +55,7 @@ builtin.module {
 // CHECK-NEXT:          %24 = arith.mulf %23, %5 : tensor<510xf32>
 // CHECK-NEXT:          stencil.return %24 : tensor<510xf32>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        stencil.store %3 to %2 (<[0, 0], [1022, 510]>) : !stencil.temp<[0,1022]x[0,510]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:        stencil.store %3 to %2(<[0, 0], [1022, 510]>) : !stencil.temp<[0,1022]x[0,510]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:        func.return
 // CHECK-NEXT:      }
 
@@ -107,7 +107,7 @@ builtin.module {
 // CHECK-NEXT:         %22 = arith.mulf %21, %3 : tensor<510xf32>
 // CHECK-NEXT:         stencil.return %22 : tensor<510xf32>
 // CHECK-NEXT:       }
-// CHECK-NEXT:       stencil.store %1 to %b (<[0, 0], [1022, 510]>) : !stencil.temp<[0,1022]x[0,510]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:       stencil.store %1 to %b(<[0, 0], [1022, 510]>) : !stencil.temp<[0,1022]x[0,510]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:       func.return
 // CHECK-NEXT:     }
 

--- a/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
+++ b/tests/filecheck/transforms/stencil-to-csl-stencil.mlir
@@ -28,7 +28,7 @@ builtin.module {
       %23 = arith.mulf %20, %22 : tensor<510xf32>
       stencil.return %23 : tensor<510xf32>
     }
-    stencil.store %1 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+    stencil.store %1 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
     func.return
   }
 }
@@ -62,7 +62,7 @@ builtin.module {
 // CHECK-NEXT:       %25 = arith.mulf %22, %24 : tensor<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %25 : tensor<510xf32>
 // CHECK-NEXT:     })
-// CHECK-NEXT:     stencil.store %2 to %b (<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
+// CHECK-NEXT:     stencil.store %2 to %b(<[0, 0], [1, 1]>) : !stencil.temp<[0,1]x[0,1]xtensor<510xf32>> to !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/transforms/stencil-unroll.mlir
+++ b/tests/filecheck/transforms/stencil-unroll.mlir
@@ -7,7 +7,7 @@
       %6 = arith.addf %4, %5 : f64
       stencil.return %6 : f64
     }
-    stencil.store %3 to %2 (<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
+    stencil.store %3 to %2(<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
     func.return
   }
 
@@ -32,7 +32,7 @@
 // CHECK-NEXT:        %20 = arith.addf %4, %19 : f64
 // CHECK-NEXT:        stencil.return %6, %8, %10, %12, %14, %16, %18, %20 unroll <[1, 8, 1]> : f64, f64, f64, f64, f64, f64, f64, f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %3 to %2 (<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
+// CHECK-NEXT:      stencil.store %3 to %2(<[1, 2, 3], [65, 66, 63]>) : !stencil.temp<[1,65]x[2,66]x[3,63]xf64> to !stencil.field<[-3,67]x[-3,67]x[-3,67]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -44,7 +44,7 @@
       %12 = stencil.access %11[-1] : !stencil.temp<[-1,68]xf64>
       stencil.return %12 : f64
     }
-    stencil.store %10 to %outc (<[0], [68]>) : !stencil.temp<[0,68]xf64> to !stencil.field<[0,1024]xf64>
+    stencil.store %10 to %outc(<[0], [68]>) : !stencil.temp<[0,68]xf64> to !stencil.field<[0,1024]xf64>
     func.return
   }
 
@@ -56,7 +56,7 @@
 // CHECK-NEXT:        %5 = stencil.access %4[-1] : !stencil.temp<[-1,68]xf64>
 // CHECK-NEXT:        stencil.return %5 : f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %3 to %outc (<[0], [68]>) : !stencil.temp<[0,68]xf64> to !stencil.field<[0,1024]xf64>
+// CHECK-NEXT:      stencil.store %3 to %outc(<[0], [68]>) : !stencil.temp<[0,68]xf64> to !stencil.field<[0,1024]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -79,7 +79,7 @@
       %32 = arith.addf %31, %30 : f64
       stencil.return %32, %31 : f64, f64
     }
-    stencil.store %20 to %17 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+    stencil.store %20 to %17(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
     func.return
   }
 
@@ -179,7 +179,7 @@
 // CHECK-NEXT:        %89 = arith.addf %88, %87 : f64
 // CHECK-NEXT:        stencil.return %19, %18, %29, %28, %39, %38, %49, %48, %59, %58, %69, %68, %79, %78, %89, %88 unroll <[1, 8, 1]> : f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %7 to %4 (<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:      stencil.store %7 to %4(<[0, 0, 0], [64, 64, 64]>) : !stencil.temp<[0,64]x[0,64]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
 
@@ -195,7 +195,7 @@ func.func @dyn_access(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<
       %41 = stencil.store_result %40 : !stencil.result<f64>
       stencil.return %41 : !stencil.result<f64>
     }
-    stencil.store %36 to %34 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+    stencil.store %36 to %34(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
     func.return
   }
 
@@ -246,6 +246,6 @@ func.func @dyn_access(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<
 // CHECK-NEXT:        %43 = stencil.store_result %42 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %8, %13, %18, %23, %28, %33, %38, %43 unroll <[1, 8, 1]> : !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>, !stencil.result<f64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      stencil.store %3 to %1 (<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
+// CHECK-NEXT:      stencil.store %3 to %1(<[0, 0, 0], [64, 64, 60]>) : !stencil.temp<[0,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -459,6 +459,37 @@ def test_optional_property(program: str, generic_program: str):
     "program, generic_program",
     [
         (
+            "test.optional_property()",
+            '"test.optional_property"() : () -> ()',
+        ),
+        (
+            "test.optional_property( prop i32 )",
+            '"test.optional_property"() <{"prop" = i32}> : () -> ()',
+        ),
+    ],
+)
+def test_optional_property_with_whitespace(program: str, generic_program: str):
+    """Test the parsing of optional operands"""
+
+    @irdl_op_definition
+    class OptionalPropertyOp(IRDLOperation):
+        name = "test.optional_property"
+        prop = opt_prop_def(Attribute)
+
+        assembly_format = "`(` (` ` `prop` $prop^ ` `)? `)` attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(OptionalPropertyOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
             "test.optional_unit_attr_prop",
             '"test.optional_unit_attr_prop"() : () -> ()',
         ),
@@ -603,6 +634,7 @@ def test_typed_attribute_variable(program: str, generic_program: str):
             "test.punctuation keyword, keyword",
         ),
         ("`keyword` ` ` `,` `keyword` attr-dict", "test.punctuation keyword , keyword"),
+        ("`keyword` `,` `` `keyword` attr-dict", "test.punctuation keyword,keyword"),
         (
             "`keyword` `\\n` `,` `keyword` attr-dict",
             "test.punctuation keyword\n, keyword",

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1512,7 +1512,7 @@ def test_optional_group_variadic_result_anchor(
 @pytest.mark.parametrize(
     "format, error",
     (
-        ("()?", "An optional group cannot be empty"),
+        ("()?", "An optional group must have a non-whitespace directive"),
         ("(`keyword`)?", "Every optional group must have an anchor."),
         (
             "($args^ type($rets)^)?",

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -822,13 +822,13 @@ class OptionalUnitAttrVariable(OptionalAttributeVariable):
 class WhitespaceDirective(FormatDirective):
     """
     A whitespace directive, with the following format:
-      whitespace-directive ::= `\n` | ` `
+      whitespace-directive ::= `\n` | ` ` | ``
     This directive is only applied during printing, and has no effect during
     parsing.
     The directive will not request any space to be printed after.
     """
 
-    whitespace: Literal[" ", "\n"]
+    whitespace: Literal[" ", "\n", ""]
     """The whitespace that should be printed."""
 
     def parse(self, parser: Parser, state: ParsingState) -> None:

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -836,7 +836,7 @@ class WhitespaceDirective(FormatDirective):
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         printer.print(self.whitespace)
-        state.last_was_punctuation = len(self.whitespace) == 0
+        state.last_was_punctuation = self.whitespace == ""
         state.should_emit_space = False
 
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -908,6 +908,7 @@ class KeywordDirective(OptionallyParsableDirective):
 @dataclass(frozen=True)
 class OptionalGroupDirective(FormatDirective):
     anchor: AnchorableDirective
+    then_whitespace: tuple[WhitespaceDirective, ...]
     then_first: OptionallyParsableDirective
     then_elements: tuple[FormatDirective, ...]
 
@@ -944,5 +945,9 @@ class OptionalGroupDirective(FormatDirective):
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if self.anchor.is_present(op):
-            for element in (self.then_first, *self.then_elements):
+            for element in (
+                *self.then_whitespace,
+                self.then_first,
+                *self.then_elements,
+            ):
                 element.print(printer, state, op)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -836,7 +836,7 @@ class WhitespaceDirective(FormatDirective):
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         printer.print(self.whitespace)
-        state.last_was_punctuation = False
+        state.last_was_punctuation = len(self.whitespace) == 0
         state.should_emit_space = False
 
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -523,9 +523,9 @@ class FormatParser(BaseParser):
             whitespace = self.lexer.input.content[
                 start_token.span.end : end_token.span.start
             ]
-            if whitespace != " ":
+            if whitespace != " " and whitespace != "":
                 self.raise_error(
-                    "unexpected whitespace in directive, only ` ` whitespace is allowed"
+                    "unexpected whitespace in directive, only ` ` or `` whitespace is allowed"
                 )
             return WhitespaceDirective(" ")
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -508,8 +508,8 @@ class FormatParser(BaseParser):
         Parse a keyword or a punctuation directive, with the following format:
           keyword-or-punctuation-directive ::= `\\`` (bare-ident | punctuation) `\\``
         """
-        self.parse_characters("`")
         start_token = self._current_token
+        self.parse_characters("`")
 
         # New line case
         if self.parse_optional_keyword("\\"):
@@ -518,8 +518,8 @@ class FormatParser(BaseParser):
             return WhitespaceDirective("\n")
 
         # Space case
+        end_token = self._current_token
         if self.parse_optional_characters("`"):
-            end_token = self._current_token
             whitespace = self.lexer.input.content[
                 start_token.span.end : end_token.span.start
             ]
@@ -527,7 +527,7 @@ class FormatParser(BaseParser):
                 self.raise_error(
                     "unexpected whitespace in directive, only ` ` or `` whitespace is allowed"
                 )
-            return WhitespaceDirective(" ")
+            return WhitespaceDirective(whitespace)
 
         # Punctuation case
         if self._current_token.kind.is_punctuation():


### PR DESCRIPTION
This makes the following changes:
- Makes assembly format recognise the empty whitespace directive ``` `` ```
- Fixes a bug in the assembly format parsing so that this is actually parsed correctly
- Allows whitespace at the start of an optional group
- Modifies existing stencil tests now that they print correctly (i.e. without a space in `stencil.store`
- Adds tests for new functionality

These changes bring the assembly format closer to the assembly format of mlir