### PR TITLE
transformations: Enable dmp.swap stencil bufferization.

### DIFF
--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -600,11 +600,20 @@ class SwapOpHasShapeInferencePatterns(HasShapeInferencePatternsTrait):
 
 
 class SwapOpMemoryEffect(MemoryEffect):
+    """
+    Side effect implementation of dmp.swap.
+    """
+
     @classmethod
     def get_effects(cls, op: Operation) -> set[EffectInstance]:
         op = cast(SwapOp, op)
+        # If it's operating in value-semantic mode, it has no side effects.
         if op.swapped_values:
             return set()
+        # If it's operating in reference-semantic mode, it reads and writes to its field.
+        # TODO: consider the empty swaps case at some point.
+        # Right now, it relies on it before inferring them, so not very safe.
+        # But it could be an elegant way to generically simplify those.
         return {
             EffectInstance(MemoryEffectKind.WRITE, op.input_stencil),
             EffectInstance(MemoryEffectKind.READ, op.input_stencil),

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -4,6 +4,7 @@ from typing import Any, TypeVar, cast
 
 from xdsl.context import MLContext
 from xdsl.dialects import builtin
+from xdsl.dialects.experimental.dmp import SwapOp
 from xdsl.dialects.stencil import (
     AllocOp,
     ApplyOp,
@@ -166,17 +167,19 @@ class LoadBufferFoldPattern(RewritePattern):
 
         underlying = load.field
 
-        # TODO: propery analysis of effects in between
-        # For illustration, only fold a single use of the handle
-        # (Requires more boilerplate to analyse the whole live range otherwise)
+        # TODO: further analysis
+        # For now, only handle usages in the same block
         uses = op.res.uses.copy()
-        if len(uses) > 1:
+        block = op.parent
+        if not block or any(use.operation.parent is not block for use in uses):
             return
-        user = uses.pop().operation
+        last_user = max(
+            uses, key=lambda u: block.get_operation_index(u.operation)
+        ).operation
 
         effecting = [
             o
-            for o in walk_from_to(load, user)
+            for o in walk_from_to(load, last_user)
             if might_effect(o, {MemoryEffectKind.WRITE}, underlying)
         ]
         if effecting:
@@ -498,6 +501,37 @@ class CombineStoreFold(RewritePattern):
             return
 
 
+class SwapBufferize(RewritePattern):
+    """
+    Bufferize a dmp.swap operation.
+
+    NB: This should most likely consider a shared pass following canonicalize and
+    shape-inference.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: SwapOp, rewriter: PatternRewriter):
+        temp = op.input_stencil
+
+        if not isa(temp_t := temp.type, TempType[Attribute]):
+            return
+
+        load = temp.owner
+        if not isinstance(load, LoadOp):
+            return
+
+        buffer = BufferOp.create(
+            operands=[temp], result_types=[field_from_temp(temp_t)]
+        )
+        new_swap = SwapOp.get(buffer.res, op.strategy)
+        new_swap.swaps = op.swaps
+        load = LoadOp(operands=[buffer.res], result_types=[temp_t])
+
+        rewriter.replace_matched_op(
+            new_ops=[buffer, new_swap, load],
+        )
+
+
 @dataclass(frozen=True)
 class StencilBufferize(ModulePass):
     """
@@ -520,7 +554,9 @@ class StencilBufferize(ModulePass):
                     ApplyStoreFoldPattern(),
                     RemoveUnusedOperations(),
                     ApplyUnusedResults(),
+                    SwapBufferize(),
                 ]
-            )
+            ),
+            apply_recursively=True,
         )
         walker.rewrite_module(op)


### PR DESCRIPTION
- Implement side effect interface of dmp.swap
- Slightly extend the side-effect analysis of stencil bufferization.
- Add a `dmp.swap` bufferization pattern in `stencil-bufferize`. To just work for now as dmp is only used in stencil so far - decoupling this as shape inference and all is left to future work!