### PR TITLE
dialects: Update `tensor` side-effect traits

### DIFF
--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -31,7 +31,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.traits import Pure
+from xdsl.traits import NoMemoryEffect
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -52,6 +52,8 @@ class CastOp(IRDLOperation):
     dest = result_def(base(TensorType[Attribute]) | base(UnrankedTensorType[Attribute]))
 
     assembly_format = "$source attr-dict `:` type($source) `to` type($dest)"
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(self, source: SSAValue | Operation, dest: TensorType[Attribute]):
         super().__init__(operands=(source,), result_types=(dest,))
@@ -86,6 +88,8 @@ class DimOp(IRDLOperation):
     )
     index = operand_def(IndexType)
     result = result_def(IndexType)
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(
         self,
@@ -130,7 +134,7 @@ class EmptyOp(IRDLOperation):
 
     tensor = result_def(TensorType[Attribute])
 
-    traits = frozenset([Pure()])
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(self, dynamic_sizes: Sequence[SSAValue], tensor_type: Attribute):
         super().__init__(
@@ -180,6 +184,8 @@ class ReshapeOp(IRDLOperation):
     source = operand_def(TensorType[Attribute])
     shape = operand_def(TensorType[AnySignlessIntegerOrIndexType])
     result = result_def(TensorType[Attribute])
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(self, source: SSAValue, shape: SSAValue, result_type: Attribute):
         super().__init__(
@@ -279,6 +285,8 @@ class ExtractSliceOp(IRDLOperation):
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
+    traits = frozenset([NoMemoryEffect()])
+
     @staticmethod
     def from_static_parameters(
         source: SSAValue | Operation,
@@ -327,6 +335,8 @@ class InsertSliceOp(IRDLOperation):
     result: OpResult = result_def(TensorType)
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
+
+    traits = frozenset([NoMemoryEffect()])
 
     @staticmethod
     def get(

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -213,6 +213,9 @@ class ApplyStoreFoldPattern(RewritePattern):
     def is_dest_safe(apply: ApplyOp, store: StoreOp) -> bool:
         # Check that the destination is not used between the apply and store.
         dest = store.field
+        start = dest.owner
+        if isinstance(start, Block):
+            start = cast(Operation, start.first_op)
         effecting = [
             o
             for o in walk_from_to(apply, store)

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -213,11 +213,9 @@ class ApplyStoreFoldPattern(RewritePattern):
     def is_dest_safe(apply: ApplyOp, store: StoreOp) -> bool:
         # Check that the destination is not used between the apply and store.
         dest = store.field
-        if apply.next_op is None:
-            return True
         effecting = [
             o
-            for o in walk_from_to(apply.next_op, store)
+            for o in walk_from_to(apply, store)
             if might_effect(o, {MemoryEffectKind.READ, MemoryEffectKind.WRITE}, dest)
         ]
         return not effecting

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -213,9 +213,6 @@ class ApplyStoreFoldPattern(RewritePattern):
     def is_dest_safe(apply: ApplyOp, store: StoreOp) -> bool:
         # Check that the destination is not used between the apply and store.
         dest = store.field
-        start = dest.owner
-        if isinstance(start, Block):
-            start = cast(Operation, start.first_op)
         effecting = [
             o
             for o in walk_from_to(apply, store)

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -213,12 +213,11 @@ class ApplyStoreFoldPattern(RewritePattern):
     def is_dest_safe(apply: ApplyOp, store: StoreOp) -> bool:
         # Check that the destination is not used between the apply and store.
         dest = store.field
-        start = dest.owner
-        if isinstance(start, Block):
-            start = cast(Operation, start.first_op)
+        if apply.next_op is None:
+            return True
         effecting = [
             o
-            for o in walk_from_to(apply, store)
+            for o in walk_from_to(apply.next_op, store)
             if might_effect(o, {MemoryEffectKind.READ, MemoryEffectKind.WRITE}, dest)
         ]
         return not effecting


### PR DESCRIPTION
(@PapyChacal  edit)
Just implement the right side effect interfaces on the `tensor` dialect, and demonstrate usage in stencil bufferization.
- Checked against MLIR.
- Removed `Pure` from tensor.empty as the upstream is marked ConditionallySpeculatable. Again, we don't have those traits yet. 
