### PR TITLE
dialects: stencil: Allow loading and storing from a same field.

### DIFF
--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -529,27 +529,6 @@ def test_stencil_store():
     assert store.bounds is bounds
 
 
-def test_stencil_store_load_overlap():
-    temp_type = TempType([(0, 5), (0, 5)], f32)
-    temp_type_ssa_val = TestSSAValue(temp_type)
-
-    field_type = FieldType([(0, 2), (0, 2)], f32)
-    field_type_ssa_val = TestSSAValue(field_type)
-
-    lb = IndexAttr.get(1, 1)
-    ub = IndexAttr.get(64, 64)
-    bounds = StencilBoundsAttr.new((lb, ub))
-
-    load = LoadOp.get(field_type_ssa_val, lb, ub)
-    store = StoreOp.get(temp_type_ssa_val, field_type_ssa_val, bounds)
-
-    with pytest.raises(VerifyException, match="Cannot Load and Store the same field!"):
-        load.verify()
-
-    with pytest.raises(VerifyException, match="Cannot Load and Store the same field!"):
-        store.verify()
-
-
 def test_stencil_index():
     dim = IntAttr(10)
     offset = IndexAttr.get(1)

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1277,9 +1277,6 @@ class LoadOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        for use in self.field.uses:
-            if isa(use.operation, StoreOp):
-                raise VerifyException("Cannot Load and Store the same field!")
         field = self.field.type
         temp = self.res.type
         assert isa(field, FieldType[Attribute])
@@ -1466,13 +1463,6 @@ class StoreOp(IRDLOperation):
         bounds: StencilBoundsAttr,
     ):
         return StoreOp.build(operands=[temp, field], attributes={"bounds": bounds})
-
-    def verify_(self) -> None:
-        for use in self.field.uses:
-            if isa(use.operation, LoadOp):
-                raise VerifyException("Cannot Load and Store the same field!")
-            if isa(use.operation, LoadOp) and use.operation is not self:
-                raise VerifyException("Can only store once to a field!")
 
 
 @irdl_op_definition

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -231,7 +231,7 @@ class LoadOpToMemref(RewritePattern):
     def match_and_rewrite(self, op: LoadOp, rewriter: PatternRewriter, /):
         for use in op.field.uses:
             if isa(use.operation, StoreOp):
-                raise Exception(
+                raise VerifyException(
                     "Cannot lower directly if loading and storing the same field! Try running `stencil-bufferize` before."
                 )
         field = op.field.type
@@ -513,7 +513,7 @@ class StencilStoreToSubview(RewritePattern):
                 )
             if isa(use.operation, StoreOp) and use.operation is not op:
                 raise VerifyException(
-                    "Cannot lower directly if storing the same values multiple times! Try running `stencil-bufferize` before."
+                    "Cannot lower directly if storing to the same field multiple times! Try running `stencil-bufferize` before."
                 )
         field = op.field
         assert isa(field.type, FieldType[Attribute])

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -229,6 +229,11 @@ def assert_subset(field: FieldType[Attribute], temp: TempType[Attribute]):
 class LoadOpToMemref(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: LoadOp, rewriter: PatternRewriter, /):
+        for use in op.field.uses:
+            if isa(use.operation, StoreOp):
+                raise Exception(
+                    "Cannot lower directly if loading and storing the same field! Try running `stencil-bufferize` before."
+                )
         field = op.field.type
         assert isa(field, FieldType[Attribute])
         assert isa(field.bounds, StencilBoundsAttr)
@@ -501,6 +506,15 @@ class StencilStoreToSubview(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: StoreOp, rewriter: PatternRewriter, /):
+        for use in op.field.uses:
+            if isa(use.operation, LoadOp):
+                raise VerifyException(
+                    "Cannot lower directly if loading and storing the same field! Try running `stencil-bufferize` before."
+                )
+            if isa(use.operation, StoreOp) and use.operation is not op:
+                raise VerifyException(
+                    "Cannot lower directly if storing the same values multiple times! Try running `stencil-bufferize` before."
+                )
         field = op.field
         assert isa(field.type, FieldType[Attribute])
         assert isa(field.type.bounds, StencilBoundsAttr)


### PR DESCRIPTION
Now that `stencil-bufferize` can deal with those cases, lift this restriction at the stencil dialect level.
Keep the check in the specific old conversion patterns still assuming this property for least surprise. Point user to use `stencil-bufferize`, which if successful makes those operations disappear.