### PR TITLE
transformations: `stencil-bufferize` side-effect analysis fix

### DIFF
--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1353,6 +1353,11 @@ class BufferOp(IRDLOperation):
         super().__init__(operands=[temp], result_types=[temp.type])
 
     def verify_(self) -> None:
+        # When used as a bufferization op, it should be flexible.
+        # This is probably something you don't want to see, but should be valid - it just
+        # means bufferization was incomplete.
+        if isinstance(self.res.type, FieldType):
+            return
         if not isinstance(self.temp.owner, ApplyOp | CombineOp):
             raise VerifyException(
                 f"Expected stencil.buffer to buffer a stencil.apply or stencil.combine's output, got "

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -122,13 +122,15 @@ def walk_from(a: Operation) -> Generator[Operation, Any, None]:
         a = a.next_op
 
 
-def walk_from_to(a: Operation, b: Operation):
+def walk_from_to(a: Operation, b: Operation, *, inclusive: bool = False):
     """
     Walk through all operations recursively inside a or its block, until b is met, if
     ever.
     """
     for o in walk_from(a):
         if o == b:
+            if inclusive:
+                yield o
             return
         yield o
 
@@ -179,7 +181,7 @@ class LoadBufferFoldPattern(RewritePattern):
 
         effecting = [
             o
-            for o in walk_from_to(load, last_user)
+            for o in walk_from_to(load, last_user, inclusive=True)
             if might_effect(o, {MemoryEffectKind.WRITE}, underlying)
         ]
         if effecting:


### PR DESCRIPTION
Just forgot to check side-effects *including* the last user when fold `stencil.buffer`