### PR TITLE
dialects: (transform) Add structured match operation

### DIFF
--- a/tests/dialects/test_transform.py
+++ b/tests/dialects/test_transform.py
@@ -226,6 +226,3 @@ def test_structured_match():
         """ %0 = "transform.structured.match"(%1) <{"ops" = [], "op_attrs" = {}}> : (!transform.any_op) -> !transform.any_op """,
         None,
     )
-
-
-test_structured_match()

--- a/tests/dialects/test_transform.py
+++ b/tests/dialects/test_transform.py
@@ -213,3 +213,19 @@ def test_split_handle():
         """ %0, %1 = "transform.split_handle"(%2) <{"pass_through_empty_handle" = true, "fail_on_payload_too_small" = true, "overflow_result" = 1 : i64}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op) """,
         None,
     )
+
+
+def test_structured_match():
+    handle = test.TestOp(result_types=[transform.AnyOpType()]).results[0]
+    assert_print_op(
+        transform.MatchOp(
+            target=handle,
+            ops=[],
+            op_attrs={},
+        ),
+        """ %0 = "transform.structured.match"(%1) <{"ops" = [], "op_attrs" = {}}> : (!transform.any_op) -> !transform.any_op """,
+        None,
+    )
+
+
+test_structured_match()

--- a/tests/filecheck/dialects/transform/transform_types.mlir
+++ b/tests/filecheck/dialects/transform/transform_types.mlir
@@ -40,6 +40,7 @@ builtin.module attributes  {"transform.with_named_sequence"} {
   %26 = "test.op"() : () -> !transform.any_param
   "transform.match.param.cmpi"(%25, %26) <{predicate = 1 : i32}> : (!transform.any_param, !transform.any_param) -> ()
   %27:2 = "transform.split_handle"(%24) <{fail_on_payload_too_small = true, pass_through_empty_handle = true}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %28 = "transform.structured.match"(%24) <{"op_attrs" = {"qmatmul_0"}}> : (!transform.any_op) -> !transform.any_op
 }
     
 
@@ -84,4 +85,5 @@ builtin.module attributes  {"transform.with_named_sequence"} {
 //CHECK-NEXT:  %22 = "test.op"() : () -> !transform.any_param
 //CHECK-NEXT:  "transform.match.param.cmpi"(%21, %22) <{"predicate" = 1 : i32}> : (!transform.any_param, !transform.any_param) -> ()
 //CHECK-NEXT:  %23, %24 = "transform.split_handle"(%20) <{"fail_on_payload_too_small" = true, "pass_through_empty_handle" = true}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+//CHECK-NEXT:  %25 = "transform.structured.match"(%20) <{"op_attrs" = {"qmatmul_0"}}> : (!transform.any_op) -> !transform.any_op
 //CHECK-NEXT:}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/transform/transform_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/transform/transform_types.mlir
@@ -40,6 +40,7 @@ builtin.module attributes  {"transform.with_named_sequence"} {
   %26 = "test.op"() : () -> !transform.any_param
   "transform.match.param.cmpi"(%25, %26) <{predicate = 1 : i32}> : (!transform.any_param, !transform.any_param) -> ()
   %27:2 = "transform.split_handle"(%24) <{fail_on_payload_too_small = true, pass_through_empty_handle = true}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+  %28 = "transform.structured.match"(%24) <{"op_attrs" = {"qmatmul_0"}}> : (!transform.any_op) -> !transform.any_op
 }
     
 
@@ -55,15 +56,15 @@ builtin.module attributes  {"transform.with_named_sequence"} {
 //CHECK-NEXT:   %4 = "test.op"() : () -> !transform.param<i64>
 //CHECK-NEXT:   %5 = "test.op"() : () -> !transform.type
 //CHECK-NEXT:   transform.named_sequence @__transform_main(%arg0: !transform.any_op, %arg1: !transform.op<"linalg.quantized_matmul">, %arg2: !transform.op<"linalg.elemwise_binary">) {
-//CHECK-NEXT:     %18 = transform.cast %arg1 : !transform.op<"linalg.quantized_matmul"> to !transform.any_op
+//CHECK-NEXT:     %19 = transform.cast %arg1 : !transform.op<"linalg.quantized_matmul"> to !transform.any_op
 //CHECK-NEXT:     %tiled_op, %forall_op = transform.structured.tile_using_forall %arg1 tile_sizes [4, 32] : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op)
 //CHECK-NEXT:     %tiled_linalg_op, %loops:2 = transform.structured.tile_using_for %arg1[8, 8] : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 //CHECK-NEXT:     transform.yield 
 //CHECK-NEXT:   }
 //CHECK-NEXT:   transform.sequence  failures(propagate) {
 //CHECK-NEXT:   ^bb0(%arg0: !transform.any_op):
-//CHECK-NEXT:     %18 = select "linalg.quantized_matmul" in %arg0 : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">
-//CHECK-NEXT:     %tiled_linalg_op, %loops:2 = transform.structured.tile_using_for %18[8, 8] : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+//CHECK-NEXT:     %19 = select "linalg.quantized_matmul" in %arg0 : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">
+//CHECK-NEXT:     %tiled_linalg_op, %loops:2 = transform.structured.tile_using_for %19[8, 8] : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 //CHECK-NEXT:   }
 //CHECK-NEXT:   %6 = "test.op"() : () -> !transform.any_op
 //CHECK-NEXT:   %7 = transform.get_producer_of_operand %6[0] : (!transform.any_op) -> !transform.any_op
@@ -81,4 +82,5 @@ builtin.module attributes  {"transform.with_named_sequence"} {
 //CHECK-NEXT:   %16 = "test.op"() : () -> !transform.any_param
 //CHECK-NEXT:   transform.match.param.cmpi ne %15, %16 : !transform.any_param
 //CHECK-NEXT:   %17:2 = transform.split_handle %14 : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+//CHECK-NEXT:   %18 = transform.structured.match attributes {qmatmul_0} in %14 : (!transform.any_op) -> !transform.any_op
 //CHECK-NEXT: }

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -767,6 +767,10 @@ class CastOp(IRDLOperation):
 
 @irdl_op_definition
 class MatchOp(IRDLOperation):
+    """
+    https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredmatch-transformmatchop
+    """
+
     name = "transform.structured.match"
 
     ops = opt_prop_def(ArrayAttr[StringAttr])

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Annotated, TypeAlias
 
 from xdsl.dialects.builtin import (
@@ -765,6 +765,47 @@ class CastOp(IRDLOperation):
         super().__init__(operands=[input], result_types=[AnyOpType()])
 
 
+@irdl_op_definition
+class MatchOp(IRDLOperation):
+    name = "transform.structured.match"
+
+    ops = opt_prop_def(ArrayAttr[StringAttr])
+    # interface = opt_prop_def(EnumAttribute[StrEnum])
+    op_attrs = opt_prop_def(DictionaryAttr)
+    filter_result_types = opt_prop_def(TypeAttribute)
+    filter_operand_types = opt_prop_def(TypeAttribute)
+
+    target = operand_def(TransformOpHandleType)
+    result = result_def(TransformOpHandleType)
+
+    def __init__(
+        self,
+        target: SSAValue,
+        ops: Sequence[str] | ArrayAttr[StringAttr] | None = None,
+        # interface: StrEnum | EnumAttribute[StrEnum] | None = None,
+        op_attrs: dict[str, Attribute] | DictionaryAttr | None = None,
+        filter_result_types: TypeAttribute | None = None,
+        filter_operand_types: TypeAttribute | None = None,
+    ):
+        if isinstance(ops, Sequence):
+            ops = ArrayAttr([StringAttr(op) for op in ops])
+        # if isinstance(interface, StrEnum):
+        #     interface = EnumAttribute(interface)
+        if isinstance(op_attrs, Mapping):
+            op_attrs = DictionaryAttr(op_attrs)
+        super().__init__(
+            properties={
+                "ops": ops,
+                # "interface": interface,
+                "op_attrs": op_attrs,
+                "filter_result_types": filter_result_types,
+                "filter_operand_types": filter_operand_types,
+            },
+            operands=[target],
+            result_types=[AnyOpType()],
+        )
+
+
 Transform = Dialect(
     "transform",
     [
@@ -788,6 +829,7 @@ Transform = Dialect(
         SelectOp,
         NamedSequenceOp,
         CastOp,
+        MatchOp,
     ],
     [
         # Types


### PR DESCRIPTION
This PR adds the important operation of the structured match in the transform dialect.
The PR is opened as a draft as I have not been able to find out how to implement the interface-attribute. which should be of kind enum (https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredmatch-transformmatchop)
@superlopuh @jorendumoulin 
