### PR TITLE
dialects: (stablehlo) Add support for returnOp

### DIFF
--- a/tests/filecheck/dialects/stablehlo/ops.mlir
+++ b/tests/filecheck/dialects/stablehlo/ops.mlir
@@ -30,3 +30,6 @@
 
 // CHECK: %and = "stablehlo.and"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
 %and = "stablehlo.and"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+
+// CHECK: "stablehlo.return"(%t0) : (tensor<i32>) -> ()
+"stablehlo.return"(%t0) : (tensor<i32>) -> ()

--- a/xdsl/dialects/stablehlo.py
+++ b/xdsl/dialects/stablehlo.py
@@ -18,7 +18,9 @@ from xdsl.irdl import (
     irdl_op_definition,
     operand_def,
     result_def,
+    var_operand_def,
 )
+from xdsl.traits import IsTerminator
 from xdsl.utils.exceptions import VerifyException
 
 # region Abstract Base Classes
@@ -160,6 +162,26 @@ class SubtractOp(ElementwiseBinaryOperation):
 
 
 @irdl_op_definition
+class ReturnOp(IRDLOperation):
+    """This op is un-documented.
+
+    StableHLO's return is used inside of the bodies of StableHLO ops.
+    It behaves like func.return but for StableHLO ops.
+    The func.return op is used inside of func.func op.
+
+    https://discord.com/channels/999073994483433573/1259494021269688360/1259992088565645312
+    """
+
+    name = "stablehlo.return"
+
+    input = var_operand_def(AnyTensorType)
+    traits = frozenset([IsTerminator()])
+
+    def __init__(self, input: list[SSAValue]):
+        super().__init__(operands=(input,))
+
+
+@irdl_op_definition
 class TransposeOp(IRDLOperation):
     """
     Permutes the dimensions of `operand` tensor using `permutation` and produces a
@@ -222,6 +244,7 @@ StableHLO = Dialect(
         AndOp,
         MultiplyOp,
         SubtractOp,
+        ReturnOp,
         TransposeOp,
     ],
     [],


### PR DESCRIPTION
Add support for `stablehlo.returnOp`.

Note: this operation is not listed in the standard, but it is used by examples in the standard. See for example:

```
// %index: -1
// %result_branch0: [0, 0]
// %result_branch1: [1, 1]
%result0, %result1 = "stablehlo.case"(%index) ({
  "stablehlo.return"(%result_branch0, %result_branch0) : (tensor<2xi64>, tensor<2xi64>) -> ()
}, {
  "stablehlo.return"(%result_branch1, %result_branch1) : (tensor<2xi64>, tensor<2xi64>) -> ()
}) : (tensor<i32>) -> (tensor<2xi64>, tensor<2xi64>)
// %result0: [1, 1]
// %result1: [1, 1]
```