### PR TITLE
dialects: (vector) add pure trait to vector.broadcast and vector.fma

### DIFF
--- a/tests/filecheck/dialects/vector/vector_pure_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_pure_ops.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt %s --verify-diagnostics -p cse | filecheck %s
+
+%m0, %i0 = "test.op"() : () -> (memref<4x4xindex>, index)
+%load = "vector.load"(%m0, %i0, %i0) : (memref<4x4xindex>, index, index) -> vector<2xindex>
+"vector.store"(%load, %m0, %i0, %i0) : (vector<2xindex>, memref<4x4xindex>, index, index) -> ()
+%broadcast = "vector.broadcast"(%i0) : (index) -> vector<1xindex>
+%fma = "vector.fma"(%load, %load, %load) : (vector<2xindex>, vector<2xindex>, vector<2xindex>) -> vector<2xindex>
+
+/// Check that unused results from vector.broadcast and vector.fma are eliminated
+// CHECK:       %m0, %i0 = "test.op"() : () -> (memref<4x4xindex>, index) 
+// CHECK-NEXT:  %load = "vector.load"(%m0, %i0, %i0) : (memref<4x4xindex>, index, index) -> vector<2xindex>
+// CHECK-NEXT:  "vector.store"(%load, %m0, %i0, %i0) : (vector<2xindex>, memref<4x4xindex>, index, index) -> ()

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -22,6 +22,7 @@ from xdsl.irdl import (
     result_def,
     var_operand_def,
 )
+from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import assert_isa, isa
 
@@ -89,6 +90,7 @@ class Broadcast(IRDLOperation):
     name = "vector.broadcast"
     source: Operand = operand_def(AnyAttr())
     vector: OpResult = result_def(VectorType)
+    traits = frozenset((Pure(),))
 
     def verify_(self):
         assert isa(self.vector.type, VectorType[Attribute])
@@ -113,6 +115,7 @@ class FMA(IRDLOperation):
     rhs: Operand = operand_def(VectorType)
     acc: Operand = operand_def(VectorType)
     res: OpResult = result_def(VectorType)
+    traits = frozenset((Pure(),))
 
     def verify_(self):
         assert isa(self.lhs.type, VectorType[Attribute])


### PR DESCRIPTION
Add `Pure` trait to `vector.broadcast` and `vector.fma`, fixes #3019

