### PR TITLE
core: Implement speculability trait and helper.

### DIFF
--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -534,7 +534,7 @@ def test_speculability(
         name = "test.speculatability"
         region = region_def()
 
-        traits = frozenset([*trait])
+        traits = frozenset(trait)
 
     op = SupeculatabilityTestOp(regions=[Region(Block(nested_ops))])
     optrait = op.get_trait(ConditionallySpeculatable)


### PR DESCRIPTION
It is way simpler than side effects, as an op is either speculatable or is not!

Similarly to what was decided on side effects, I only changed that MLIR has an extra return value signifying "recursively speculatable", where here it is handled by an implementation of the trait, rather than in user code.
This prevents some amount of ninja-coding in said user code, but also a lot of ninja headaches.

