### PR TITLE
CI: update ruff precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.0
+    rev: v0.6.3
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]


### PR DESCRIPTION
Brings the precommit version in line with the dependency version. I'm still not sure what the official way to do this is, it feels weird to keep the two in sync manually. IIUC the dependency is used in the VSCode extension, so is also useful...