### PR TITLE
core: Assembly format shouldn't require `$*SegmentSizes`

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -862,29 +862,41 @@ def test_optional_operand(format: str, program: str, generic_program: str):
 
 
 @pytest.mark.parametrize(
-    "program, generic_program",
+    "program, generic_program, as_property",
     [
         (
             '%0 = "test.op"() : () -> i32\n'
             "test.variadic_operands(%0 : i32) [%0 : i32]",
             '%0 = "test.op"() : () -> i32\n'
             '"test.variadic_operands"(%0, %0) {operandSegmentSizes = array<i32:1,1>} : (i32,i32) -> ()',
+            False,
+        ),
+        (
+            '%0 = "test.op"() : () -> i32\n'
+            "test.variadic_operands(%0 : i32) [%0 : i32]",
+            '%0 = "test.op"() : () -> i32\n'
+            '"test.variadic_operands"(%0, %0) <{operandSegmentSizes = array<i32:1,1>}> : (i32,i32) -> ()',
+            True,
         ),
         (
             '%0, %1 = "test.op"() : () -> (i32, i64)\n'
             "test.variadic_operands(%0, %1 : i32, i64) [%1, %0 : i64, i32]",
             '%0, %1 = "test.op"() : () -> (i32, i64)\n'
             '"test.variadic_operands"(%0, %1, %1, %0) {operandSegmentSizes = array<i32:2,2>} : (i32, i64, i64, i32) -> ()',
+            False,
         ),
         (
             '%0, %1, %2 = "test.op"() : () -> (i32, i64, i128)\n'
             "test.variadic_operands(%0, %1, %2 : i32, i64, i128) [%2, %1, %0 : i128, i64, i32]",
             '%0, %1, %2 = "test.op"() : () -> (i32, i64, i128)\n'
             '"test.variadic_operands"(%0, %1, %2, %2, %1, %0) {operandSegmentSizes = array<i32:3,3>} : (i32, i64, i128, i128, i64, i32) -> ()',
+            False,
         ),
     ],
 )
-def test_multiple_variadic_operands(program: str, generic_program: str):
+def test_multiple_variadic_operands(
+    program: str, generic_program: str, as_property: bool
+):
     """Test the parsing of variadic operands"""
 
     @irdl_op_definition
@@ -893,7 +905,7 @@ def test_multiple_variadic_operands(program: str, generic_program: str):
         args1 = var_operand_def()
         args2 = var_operand_def()
 
-        irdl_options = [AttrSizedOperandSegments()]
+        irdl_options = [AttrSizedOperandSegments(as_property=as_property)]
 
         assembly_format = (
             "`(` $args1 `:` type($args1) `)` `[` $args2 `:` type($args2) `]` attr-dict"

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -17,6 +17,7 @@ from xdsl.ir import Attribute, TypedAttribute
 from xdsl.irdl import (
     AttrOrPropDef,
     AttrSizedOperandSegments,
+    AttrSizedSegments,
     ConstraintContext,
     OpDef,
     OptionalDef,
@@ -308,7 +309,13 @@ class FormatParser(BaseParser):
                     "parsed from the attribute dictionary."
                 )
             return
+
         missing_properties = set(self.op_def.properties.keys()) - self.seen_properties
+
+        for option in self.op_def.options:
+            if isinstance(option, AttrSizedSegments) and option.as_property:
+                missing_properties.remove(option.attribute_name)
+
         if missing_properties:
             self.raise_error(
                 f"{', '.join(missing_properties)} properties are missing from "


### PR DESCRIPTION
Removes `*SegmentSizes` from the required properties seen if the appropriate option is set of the operation