### PR TITLE
tests: Increase timeout on lit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean: clean-caches
 
 # run filecheck tests
 filecheck:
-	lit -vv tests/filecheck --order=smart --timeout=10
+	lit -vv tests/filecheck --order=smart --timeout=20
 
 # run pytest tests
 pytest:


### PR DESCRIPTION
The test `/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir` keeps timing out on my system. Could we either increase the timeout (as in this pr) or fix the test.