### PR TITLE
dialects: (scf) Add parse/print to `scf.if`

### DIFF
--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -5,40 +5,41 @@ builtin.module {
 
 
   %0 = "test.op"() : () -> i1
-  "scf.if"(%0) ({
+  scf.if %0 {
     %1 = "test.op"() : () -> i32
     scf.yield
-  }, {
+  } else {
     %2 = "test.op"() : () -> i32
-    scf.yield
-  }) : (i1) -> ()
+  }
 
   // CHECK:      %{{.*}} = "test.op"() : () -> i1
-  // CHECK-NEXT: "scf.if"(%{{.*}}) ({
+  // CHECK-NEXT: scf.if %{{.*}} {
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   scf.yield
-  // CHECK-NEXT: }, {
+  // CHECK-NEXT: } else {
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
-  // CHECK-NEXT:   scf.yield
-  // CHECK-NEXT: }) : (i1) -> ()
+  // CHECK-NEXT: }
 
 
-  %3 = "scf.if"(%0) ({
+  %3 = scf.if %0 -> (i32) {
     %4 = "test.op"() : () -> i32
     scf.yield %4 : i32
-  }, {
+  } else {
     %5 = "test.op"() : () -> i32
     scf.yield %5 : i32
-  }) : (i1) -> i32
+  }
 
-
-  // CHECK:      %{{.*}} = "scf.if"(%{{.*}}) ({
+  // CHECK:      %{{.*}} = scf.if %{{.*}} -> (i32) {
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
   // CHECK-NEXT:   scf.yield %{{.*}} : i32
-  // CHECK-NEXT: }, {
+  // CHECK-NEXT: } else {
   // CHECK-NEXT:   %{{.*}} = "test.op"() : () -> i32
   // CHECK-NEXT:   scf.yield %{{.*}} : i32
-  // CHECK-NEXT: }) : (i1) -> i32
+  // CHECK-NEXT: }
+
+  scf.if %0 {}
+
+  // CHECK: scf.if %{{.*}} {
+  // CHECK-NEXT: }
 
   func.func @while() {
     %init = arith.constant 0 : i32

--- a/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
+++ b/tests/filecheck/dialects/stencil/oec-kernels/fvtp2d_qi.mlir
@@ -63,7 +63,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
     %22 = arith.addf %17, %21 : f64
     %23 = stencil.access %arg8 [0, 0, 0] : !stencil.temp<?x?x?xf64>
     %24 = arith.cmpf ogt, %23, %cst : f64
-    %25 = "scf.if"(%24) ({
+    %25 = scf.if %24 -> (f64) {
       %29 = stencil.access %arg10 [0, -1, 0] : !stencil.temp<?x?x?xf64>
       %30 = stencil.access %arg11 [0, -1, 0] : !stencil.temp<?x?x?xf64>
       %31 = arith.mulf %23, %30 : f64
@@ -71,7 +71,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
       %33 = arith.subf %cst_0, %23 : f64
       %34 = arith.mulf %33, %32 : f64
       scf.yield %34 : f64
-    }, {
+    } else {
       %29 = stencil.access %arg9 [0, 0, 0] : !stencil.temp<?x?x?xf64>
       %30 = stencil.access %arg11 [0, 0, 0] : !stencil.temp<?x?x?xf64>
       %31 = arith.mulf %23, %30 : f64
@@ -79,17 +79,17 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
       %33 = arith.addf %cst_0, %23 : f64
       %34 = arith.mulf %33, %32 : f64
       scf.yield %34 : f64
-    }) : (i1) -> (f64)
+    }
     %26 = arith.mulf %25, %22 : f64
-    %27 = "scf.if"(%24) ({
+    %27 = scf.if %24 -> (f64) {
       %29 = stencil.access %arg7 [0, -1, 0] : !stencil.temp<?x?x?xf64>
       %30 = arith.addf %29, %26 : f64
       scf.yield %30 : f64
-    }, {
+    } else {
       %29 = stencil.access %arg7 [0, 0, 0] : !stencil.temp<?x?x?xf64>
       %30 = arith.addf %29, %26 : f64
       scf.yield %30 : f64
-    }) : (i1) -> (f64)
+    }
     %28 = stencil.store_result %27 : !stencil.result<f64>
     stencil.return %28 : !stencil.result<f64>
   }
@@ -178,7 +178,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // CHECK-NEXT:        %23 = arith.addf %18, %22 : f64
 // CHECK-NEXT:        %24 = stencil.access %arg8[0, 0, 0] : !stencil.temp<?x?x?xf64>
 // CHECK-NEXT:        %25 = arith.cmpf ogt, %24, %cst : f64
-// CHECK-NEXT:        %26 = "scf.if"(%25) ({
+// CHECK-NEXT:        %26 = scf.if %25 -> (f64) {
 // CHECK-NEXT:          %27 = stencil.access %arg10[0, -1, 0] : !stencil.temp<?x?x?xf64>
 // CHECK-NEXT:          %28 = stencil.access %arg11[0, -1, 0] : !stencil.temp<?x?x?xf64>
 // CHECK-NEXT:          %29 = arith.mulf %24, %28 : f64
@@ -186,7 +186,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // CHECK-NEXT:          %31 = arith.subf %cst_1, %24 : f64
 // CHECK-NEXT:          %32 = arith.mulf %31, %30 : f64
 // CHECK-NEXT:          scf.yield %32 : f64
-// CHECK-NEXT:        }, {
+// CHECK-NEXT:        } else {
 // CHECK-NEXT:          %33 = stencil.access %arg9[0, 0, 0] : !stencil.temp<?x?x?xf64>
 // CHECK-NEXT:          %34 = stencil.access %arg11[0, 0, 0] : !stencil.temp<?x?x?xf64>
 // CHECK-NEXT:          %35 = arith.mulf %24, %34 : f64
@@ -194,17 +194,17 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // CHECK-NEXT:          %37 = arith.addf %cst_1, %24 : f64
 // CHECK-NEXT:          %38 = arith.mulf %37, %36 : f64
 // CHECK-NEXT:          scf.yield %38 : f64
-// CHECK-NEXT:        }) : (i1) -> f64
+// CHECK-NEXT:        }
 // CHECK-NEXT:        %39 = arith.mulf %26, %23 : f64
-// CHECK-NEXT:        %40 = "scf.if"(%25) ({
+// CHECK-NEXT:        %40 = scf.if %25 -> (f64) {
 // CHECK-NEXT:          %41 = stencil.access %arg7[0, -1, 0] : !stencil.temp<?x?x?xf64>
 // CHECK-NEXT:          %42 = arith.addf %41, %39 : f64
 // CHECK-NEXT:          scf.yield %42 : f64
-// CHECK-NEXT:        }, {
+// CHECK-NEXT:        } else {
 // CHECK-NEXT:          %43 = stencil.access %arg7[0, 0, 0] : !stencil.temp<?x?x?xf64>
 // CHECK-NEXT:          %44 = arith.addf %43, %39 : f64
 // CHECK-NEXT:          scf.yield %44 : f64
-// CHECK-NEXT:        }) : (i1) -> f64
+// CHECK-NEXT:        }
 // CHECK-NEXT:        %45 = stencil.store_result %40 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %45 : !stencil.result<f64>
 // CHECK-NEXT:      }
@@ -298,7 +298,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // SHAPE-NEXT:        %28 = arith.addf %23, %27 : f64
 // SHAPE-NEXT:        %29 = stencil.access %arg8[0, 0, 0] : !stencil.temp<[0,64]x[0,65]x[0,64]xf64>
 // SHAPE-NEXT:        %30 = arith.cmpf ogt, %29, %cst : f64
-// SHAPE-NEXT:        %31 = "scf.if"(%30) ({
+// SHAPE-NEXT:        %31 = scf.if %30 -> (f64) {
 // SHAPE-NEXT:          %32 = stencil.access %arg10[0, -1, 0] : !stencil.temp<[0,64]x[-1,65]x[0,64]xf64>
 // SHAPE-NEXT:          %33 = stencil.access %arg11[0, -1, 0] : !stencil.temp<[0,64]x[-1,65]x[0,64]xf64>
 // SHAPE-NEXT:          %34 = arith.mulf %29, %33 : f64
@@ -306,7 +306,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // SHAPE-NEXT:          %36 = arith.subf %cst_1, %29 : f64
 // SHAPE-NEXT:          %37 = arith.mulf %36, %35 : f64
 // SHAPE-NEXT:          scf.yield %37 : f64
-// SHAPE-NEXT:        }, {
+// SHAPE-NEXT:        } else {
 // SHAPE-NEXT:          %38 = stencil.access %arg9[0, 0, 0] : !stencil.temp<[0,64]x[-1,65]x[0,64]xf64>
 // SHAPE-NEXT:          %39 = stencil.access %arg11[0, 0, 0] : !stencil.temp<[0,64]x[-1,65]x[0,64]xf64>
 // SHAPE-NEXT:          %40 = arith.mulf %29, %39 : f64
@@ -314,17 +314,17 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // SHAPE-NEXT:          %42 = arith.addf %cst_1, %29 : f64
 // SHAPE-NEXT:          %43 = arith.mulf %42, %41 : f64
 // SHAPE-NEXT:          scf.yield %43 : f64
-// SHAPE-NEXT:        }) : (i1) -> f64
+// SHAPE-NEXT:        }
 // SHAPE-NEXT:        %44 = arith.mulf %31, %28 : f64
-// SHAPE-NEXT:        %45 = "scf.if"(%30) ({
+// SHAPE-NEXT:        %45 = scf.if %30 -> (f64) {
 // SHAPE-NEXT:          %46 = stencil.access %arg7[0, -1, 0] : !stencil.temp<[0,64]x[-3,67]x[0,64]xf64>
 // SHAPE-NEXT:          %47 = arith.addf %46, %44 : f64
 // SHAPE-NEXT:          scf.yield %47 : f64
-// SHAPE-NEXT:        }, {
+// SHAPE-NEXT:        } else {
 // SHAPE-NEXT:          %48 = stencil.access %arg7[0, 0, 0] : !stencil.temp<[0,64]x[-3,67]x[0,64]xf64>
 // SHAPE-NEXT:          %49 = arith.addf %48, %44 : f64
 // SHAPE-NEXT:          scf.yield %49 : f64
-// SHAPE-NEXT:        }) : (i1) -> f64
+// SHAPE-NEXT:        }
 // SHAPE-NEXT:        %50 = stencil.store_result %45 : !stencil.result<f64>
 // SHAPE-NEXT:        stencil.return %50 : !stencil.result<f64>
 // SHAPE-NEXT:      }
@@ -462,7 +462,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // MLIR-NEXT:        %84 = arith.addf %79, %83 : f64
 // MLIR-NEXT:        %85 = memref.load %9[%74, %75, %76] : memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
 // MLIR-NEXT:        %86 = arith.cmpf ogt, %85, %cst_5 : f64
-// MLIR-NEXT:        %87 = "scf.if"(%86) ({
+// MLIR-NEXT:        %87 = scf.if %86 -> (f64) {
 // MLIR-NEXT:          %88 = arith.constant -1 : index
 // MLIR-NEXT:          %89 = arith.addi %75, %88 : index
 // MLIR-NEXT:          %90 = memref.load %arg10[%74, %89, %76] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
@@ -474,7 +474,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // MLIR-NEXT:          %96 = arith.subf %cst_6, %85 : f64
 // MLIR-NEXT:          %97 = arith.mulf %96, %95 : f64
 // MLIR-NEXT:          scf.yield %97 : f64
-// MLIR-NEXT:        }, {
+// MLIR-NEXT:        } else {
 // MLIR-NEXT:          %98 = memref.load %arg9[%74, %75, %76] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
 // MLIR-NEXT:          %99 = memref.load %arg11[%74, %75, %76] : memref<64x66x64xf64, strided<[4224, 64, 1], offset: 64>>
 // MLIR-NEXT:          %100 = arith.mulf %85, %99 : f64
@@ -482,19 +482,19 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // MLIR-NEXT:          %102 = arith.addf %cst_6, %85 : f64
 // MLIR-NEXT:          %103 = arith.mulf %102, %101 : f64
 // MLIR-NEXT:          scf.yield %103 : f64
-// MLIR-NEXT:        }) : (i1) -> f64
+// MLIR-NEXT:        }
 // MLIR-NEXT:        %104 = arith.mulf %87, %84 : f64
-// MLIR-NEXT:        %105 = "scf.if"(%86) ({
+// MLIR-NEXT:        %105 = scf.if %86 -> (f64) {
 // MLIR-NEXT:          %106 = arith.constant -1 : index
 // MLIR-NEXT:          %107 = arith.addi %75, %106 : index
 // MLIR-NEXT:          %108 = memref.load %8[%74, %107, %76] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
 // MLIR-NEXT:          %109 = arith.addf %108, %104 : f64
 // MLIR-NEXT:          scf.yield %109 : f64
-// MLIR-NEXT:        }, {
+// MLIR-NEXT:        } else {
 // MLIR-NEXT:          %110 = memref.load %8[%74, %75, %76] : memref<64x70x64xf64, strided<[5184, 72, 1], offset: 21028>>
 // MLIR-NEXT:          %111 = arith.addf %110, %104 : f64
 // MLIR-NEXT:          scf.yield %111 : f64
-// MLIR-NEXT:        }) : (i1) -> f64
+// MLIR-NEXT:        }
 // MLIR-NEXT:        memref.store %105, %arg8_1[%74, %75, %76] : memref<64x65x64xf64, strided<[5184, 72, 1], offset: 21028>>
 // MLIR-NEXT:        scf.yield
 // MLIR-NEXT:      }) : (index, index, index, index, index, index, index, index, index) -> ()
@@ -610,7 +610,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // BUFF-NEXT:        %18 = arith.addf %13, %17 : f64
 // BUFF-NEXT:        %19 = stencil.access %arg8[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // BUFF-NEXT:        %20 = arith.cmpf ogt, %19, %cst : f64
-// BUFF-NEXT:        %21 = "scf.if"(%20) ({
+// BUFF-NEXT:        %21 = scf.if %20 -> (f64) {
 // BUFF-NEXT:          %22 = stencil.access %arg10[0, -1, 0] : !stencil.field<[0,64]x[-1,65]x[0,64]xf64>
 // BUFF-NEXT:          %23 = stencil.access %arg11[0, -1, 0] : !stencil.field<[0,64]x[-1,65]x[0,64]xf64>
 // BUFF-NEXT:          %24 = arith.mulf %19, %23 : f64
@@ -618,7 +618,7 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // BUFF-NEXT:          %26 = arith.subf %cst_1, %19 : f64
 // BUFF-NEXT:          %27 = arith.mulf %26, %25 : f64
 // BUFF-NEXT:          scf.yield %27 : f64
-// BUFF-NEXT:        }, {
+// BUFF-NEXT:        } else {
 // BUFF-NEXT:          %28 = stencil.access %arg9[0, 0, 0] : !stencil.field<[0,64]x[-1,65]x[0,64]xf64>
 // BUFF-NEXT:          %29 = stencil.access %arg11[0, 0, 0] : !stencil.field<[0,64]x[-1,65]x[0,64]xf64>
 // BUFF-NEXT:          %30 = arith.mulf %19, %29 : f64
@@ -626,17 +626,17 @@ func.func @fvtp2d_qi(%arg0: !stencil.field<?x?x?xf64>, %arg1: !stencil.field<?x?
 // BUFF-NEXT:          %32 = arith.addf %cst_1, %19 : f64
 // BUFF-NEXT:          %33 = arith.mulf %32, %31 : f64
 // BUFF-NEXT:          scf.yield %33 : f64
-// BUFF-NEXT:        }) : (i1) -> f64
+// BUFF-NEXT:        }
 // BUFF-NEXT:        %34 = arith.mulf %21, %18 : f64
-// BUFF-NEXT:        %35 = "scf.if"(%20) ({
+// BUFF-NEXT:        %35 = scf.if %20 -> (f64) {
 // BUFF-NEXT:          %36 = stencil.access %arg7[0, -1, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // BUFF-NEXT:          %37 = arith.addf %36, %34 : f64
 // BUFF-NEXT:          scf.yield %37 : f64
-// BUFF-NEXT:        }, {
+// BUFF-NEXT:        } else {
 // BUFF-NEXT:          %38 = stencil.access %arg7[0, 0, 0] : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
 // BUFF-NEXT:          %39 = arith.addf %38, %34 : f64
 // BUFF-NEXT:          scf.yield %39 : f64
-// BUFF-NEXT:        }) : (i1) -> f64
+// BUFF-NEXT:        }
 // BUFF-NEXT:        %40 = stencil.store_result %35 : !stencil.result<f64>
 // BUFF-NEXT:        stencil.return %40 : !stencil.result<f64>
 // BUFF-NEXT:      } to <[0, 0, 0], [64, 65, 64]>

--- a/tests/filecheck/frontend/dialects/scf.py
+++ b/tests/filecheck/frontend/dialects/scf.py
@@ -133,21 +133,18 @@ except CodeGenerationException as e:
 
 p = FrontendProgram()
 with CodeContext(p):
-    # CHECK:      %{{.*}} = "scf.if"(%{{.*}}) ({
+    # CHECK:      %{{.*}} = scf.if %{{.*}} -> (i32) {
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @x} : () -> i32
     # CHECK-NEXT:   scf.yield %{{.*}} : i32
-    # CHECK-NEXT: }, {
+    # CHECK-NEXT: } else {
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @y} : () -> i32
     # CHECK-NEXT:   scf.yield %{{.*}} : i32
-    # CHECK-NEXT: }) : (i1) -> i32
+    # CHECK-NEXT: }
     def test_if_expr(cond: i1, x: i32, y: i32) -> i32:
         return x if cond else y
 
-    # CHECK:      "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:   scf.yield
-    # CHECK-NEXT: }, {
-    # CHECK-NEXT:   scf.yield
-    # CHECK-NEXT: }) : (i1) -> ()
+    # CHECK:      scf.if %{{.*}} {
+    # CHECK-NEXT: }
     def test_if_I(cond: i1):
         if cond:
             pass
@@ -156,23 +153,16 @@ with CodeContext(p):
         return
 
     # CHECK:      %{{.*}} = "symref.fetch"() {"symbol" = @a} : () -> i1
-    # CHECK-NEXT: "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:   scf.yield
-    # CHECK-NEXT: }, {
+    # CHECK-NEXT: scf.if %{{.*}} {
+    # CHECK-NEXT: } else {
     # CHECK-NEXT:   %{{.*}} = "symref.fetch"() {"symbol" = @b} : () -> i1
-    # CHECK-NEXT:   "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:     scf.yield
-    # CHECK-NEXT:   }, {
+    # CHECK-NEXT:   scf.if %{{.*}} {
+    # CHECK-NEXT:   } else {
     # CHECK-NEXT:     %{{.*}} = "symref.fetch"() {"symbol" = @c} : () -> i1
-    # CHECK-NEXT:     "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:       scf.yield
-    # CHECK-NEXT:     }, {
-    # CHECK-NEXT:       scf.yield
-    # CHECK-NEXT:     }) : (i1) -> ()
-    # CHECK-NEXT:     scf.yield
-    # CHECK-NEXT:   }) : (i1) -> ()
-    # CHECK-NEXT:   scf.yield
-    # CHECK-NEXT: }) : (i1) -> ()
+    # CHECK-NEXT:     scf.if %{{.*}} {
+    # CHECK-NEXT:     }
+    # CHECK-NEXT:   }
+    # CHECK-NEXT: }
     def test_if_II(a: i1, b: i1, c: i1):
         if a:
             pass
@@ -183,11 +173,8 @@ with CodeContext(p):
         return
 
     # CHECK:      %{{.*}} = "symref.fetch"() {"symbol" = @cond} : () -> i1
-    # CHECK-NEXT: "scf.if"(%{{.*}}) ({
-    # CHECK-NEXT:   scf.yield
-    # CHECK-NEXT: }, {
-    # CHECK-NEXT:   scf.yield
-    # CHECK-NEXT: }) : (i1) -> ()
+    # CHECK-NEXT: scf.if %{{.*}} {
+    # CHECK-NEXT: }
     def test_if_III(cond: i1):
         if cond:
             pass

--- a/tests/filecheck/mlir-conversion/with-mlir/control_flow_hoist_collab.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/control_flow_hoist_collab.mlir
@@ -7,17 +7,17 @@ func.func @nested_loop_invariant(%n : index) {
     %100 = arith.constant 100 : index
     scf.for %i = %0 to %100 step %1 {
         %cond = "test.op"() : () -> (i1)
-        %thing = "scf.if"(%cond)  ({
+        %thing = scf.if %cond -> (index) {
             // This is loop invariant
             // Also is nested in conditional
             // Contradictory local intuitions :S
             // MLIR really want to keep operations nested if they only occur on one
             // branch, which locally makes sense!
-            %n100 = arith.muli %n, %100 : index 
+            %n100 = arith.muli %n, %100 : index
             scf.yield %n100 :index
-        }, {
+        } else {
             scf.yield %n : index
-        }) : (i1) -> index
+        }
         "test.op"(%thing) : (index) -> ()
         scf.yield
     }
@@ -32,12 +32,12 @@ func.func @nested_loop_invariant(%n : index) {
 // WITHOUT-NEXT:      %2 = arith.constant 100 : index
 // WITHOUT-NEXT:      scf.for %arg1 = %0 to %2 step %1 {
 // WITHOUT-NEXT:        %3 = "test.op"() : () -> i1
-// WITHOUT-NEXT:        %4 = "scf.if"(%3) ({
+// WITHOUT-NEXT:        %4 = scf.if %3 -> (index) {
 // WITHOUT-NEXT:          %5 = arith.muli %arg0, %2 : index
 // WITHOUT-NEXT:          scf.yield %5 : index
-// WITHOUT-NEXT:        }, {
+// WITHOUT-NEXT:        } else {
 // WITHOUT-NEXT:          scf.yield %arg0 : index
-// WITHOUT-NEXT:        }) : (i1) -> index
+// WITHOUT-NEXT:        }
 // WITHOUT-NEXT:        "test.op"(%4) : (index) -> ()
 // WITHOUT-NEXT:      }
 // WITHOUT-NEXT:      func.return
@@ -54,11 +54,11 @@ func.func @nested_loop_invariant(%n : index) {
 // WITH-NEXT:      %3 = arith.muli %arg0, %2 : index
 // WITH-NEXT:      scf.for %arg1 = %0 to %2 step %1 {
 // WITH-NEXT:        %4 = "test.op"() : () -> i1
-// WITH-NEXT:        %5 = "scf.if"(%4) ({
+// WITH-NEXT:        %5 = scf.if %4 -> (index) {
 // WITH-NEXT:          scf.yield %3 : index
-// WITH-NEXT:        }, {
+// WITH-NEXT:        } else {
 // WITH-NEXT:          scf.yield %arg0 : index
-// WITH-NEXT:        }) : (i1) -> index
+// WITH-NEXT:        }
 // WITH-NEXT:        "test.op"(%5) : (index) -> ()
 // WITH-NEXT:      }
 // WITH-NEXT:      func.return

--- a/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
+++ b/tests/filecheck/transforms/convert-stencil-to-ll-mlir.mlir
@@ -622,13 +622,13 @@ func.func @store_result_lowering(%arg0 : f64) {
 func.func @if_lowering(%arg0_1 : f64, %b0 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>, %b1 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>)  attributes {"stencil.program"}{
     %101, %102 = stencil.apply(%arg1_1 = %arg0_1 : f64) -> (!stencil.temp<[0,7]x[0,7]x[0,7]xf64>, !stencil.temp<[0,7]x[0,7]x[0,7]xf64>) {
       %true = "test.op"() : () -> i1
-      %103, %104 = "scf.if"(%true) ({
+      %103, %104 = scf.if %true -> (!stencil.result<f64>, f64) {
         %105 = stencil.store_result %arg1_1 : !stencil.result<f64>
         scf.yield %105, %arg1_1 : !stencil.result<f64>, f64
-      }, {
+      } else {
         %106 = stencil.store_result  : !stencil.result<f64>
         scf.yield %106, %arg1_1 : !stencil.result<f64>, f64
-      }) : (i1) -> (!stencil.result<f64>, f64)
+      }
       %107 = stencil.store_result %104 : !stencil.result<f64>
       stencil.return %103, %107 : !stencil.result<f64>, !stencil.result<f64>
     }
@@ -652,13 +652,13 @@ func.func @if_lowering(%arg0_1 : f64, %b0 : !stencil.field<[0,7]x[0,7]x[0,7]xf64
 // CHECK-NEXT:      "scf.parallel"(%0, %1, %2, %6, %7, %8, %3, %4, %5) <{"operandSegmentSizes" = array<i32: 3, 3, 3, 0>}> ({
 // CHECK-NEXT:      ^0(%9 : index, %10 : index, %11 : index):
 // CHECK-NEXT:        %true = "test.op"() : () -> i1
-// CHECK-NEXT:        %12, %13 = "scf.if"(%true) ({
+// CHECK-NEXT:        %12, %13 = scf.if %true -> (f64, f64) {
 // CHECK-NEXT:          memref.store %arg0, %b0_storeview[%9, %10, %11] : memref<7x7x7xf64, strided<[49, 7, 1]>>
 // CHECK-NEXT:          scf.yield %arg0, %arg0 : f64, f64
-// CHECK-NEXT:        }, {
+// CHECK-NEXT:        } else {
 // CHECK-NEXT:          %14 = builtin.unrealized_conversion_cast to f64
 // CHECK-NEXT:          scf.yield %14, %arg0 : f64, f64
-// CHECK-NEXT:        }) : (i1) -> (f64, f64)
+// CHECK-NEXT:        }
 // CHECK-NEXT:        memref.store %13, %b1_storeview[%9, %10, %11] : memref<7x7x7xf64, strided<[49, 7, 1]>>
 // CHECK-NEXT:        scf.yield
 // CHECK-NEXT:      }) : (index, index, index, index, index, index, index, index, index) -> ()

--- a/tests/filecheck/transforms/distribute-stencil.mlir
+++ b/tests/filecheck/transforms/distribute-stencil.mlir
@@ -181,13 +181,13 @@ func.func @store_result_lowering(%arg0 : f64) {
 func.func @if_lowering(%arg0_1 : f64, %b0 : !stencil.field<[0,8]x[0,8]x[0,8]xf64>, %b1 : !stencil.field<[0,8]x[0,8]x[0,8]xf64>)  attributes {"stencil.program"}{
     %101, %102 = stencil.apply(%arg1_1 = %arg0_1 : f64) -> (!stencil.temp<[0,8]x[0,8]x[0,8]xf64>, !stencil.temp<[0,8]x[0,8]x[0,8]xf64>) {
       %true = "test.op"() : () -> i1
-      %103, %104 = "scf.if"(%true) ({
+      %103, %104 = scf.if %true -> (!stencil.result<f64>, f64) {
         %105 = stencil.store_result %arg1_1 : !stencil.result<f64>
         scf.yield %105, %arg1_1 : !stencil.result<f64>, f64
-      }, {
+      } else {
         %106 = stencil.store_result  : !stencil.result<f64>
         scf.yield %106, %arg1_1 : !stencil.result<f64>, f64
-      }) : (i1) -> (!stencil.result<f64>, f64)
+      }
       %107 = stencil.store_result %104 : !stencil.result<f64>
       stencil.return %103, %107 : !stencil.result<f64>, !stencil.result<f64>
     }
@@ -199,13 +199,13 @@ func.func @if_lowering(%arg0_1 : f64, %b0 : !stencil.field<[0,8]x[0,8]x[0,8]xf64
 // SHAPE:         func.func @if_lowering(%arg0 : f64, %b0 : !stencil.field<[0,8]x[0,8]x[0,8]xf64>, %b1 : !stencil.field<[0,8]x[0,8]x[0,8]xf64>)  attributes {"stencil.program"}{
 // SHAPE-NEXT:      %0, %1 = stencil.apply(%arg1 = %arg0 : f64) -> (!stencil.temp<[0,8]x[0,8]x[0,8]xf64>, !stencil.temp<[0,8]x[0,8]x[0,8]xf64>) {
 // SHAPE-NEXT:        %true = "test.op"() : () -> i1
-// SHAPE-NEXT:        %2, %3 = "scf.if"(%true) ({
+// SHAPE-NEXT:        %2, %3 = scf.if %true -> (!stencil.result<f64>, f64) {
 // SHAPE-NEXT:          %4 = stencil.store_result %arg1 : !stencil.result<f64>
 // SHAPE-NEXT:          scf.yield %4, %arg1 : !stencil.result<f64>, f64
-// SHAPE-NEXT:        }, {
+// SHAPE-NEXT:        } else {
 // SHAPE-NEXT:          %5 = stencil.store_result  : !stencil.result<f64>
 // SHAPE-NEXT:          scf.yield %5, %arg1 : !stencil.result<f64>, f64
-// SHAPE-NEXT:        }) : (i1) -> (!stencil.result<f64>, f64)
+// SHAPE-NEXT:        }
 // SHAPE-NEXT:        %6 = stencil.store_result %3 : !stencil.result<f64>
 // SHAPE-NEXT:        stencil.return %2, %6 : !stencil.result<f64>, !stencil.result<f64>
 // SHAPE-NEXT:      }

--- a/tests/filecheck/transforms/function-constant-pinning.mlir
+++ b/tests/filecheck/transforms/function-constant-pinning.mlir
@@ -13,13 +13,13 @@ func.func @basic() -> i32 {
                    // compare the value to the constant we want to specialize for
 // CHECK-NEXT:     %0 = arith.constant 0 : i64
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
-// CHECK-NEXT:     %2 = "scf.if"(%1) ({
+// CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
                      // if they are equal, branch to specialized function
 // CHECK-NEXT:       %3 = func.call @basic_pinned() : () -> i32
 // CHECK-NEXT:       scf.yield %3 : i32
-// CHECK-NEXT:     }, {
+// CHECK-NEXT:     } else {
 // CHECK-NEXT:       scf.yield %v : i32
-// CHECK-NEXT:     }) : (i1) -> i32
+// CHECK-NEXT:     }
 // CHECK-NEXT:     func.return %2 : i32
 // CHECK-NEXT:   }
                  // specialized function here
@@ -35,12 +35,11 @@ func.func @control_flow() {
 
     %cond = "test.op"() {"pin_to_constants"= [true]} : () -> i1
 
-    "scf.if"(%cond) ({
+    scf.if %cond {
         "test.op"() {"inside_if"} : () -> ()
-        scf.yield
-    }, {
-        scf.yield
-    }) : (i1) -> ()
+    } else {
+      scf.yield
+    }
 
     "test.op"() {"after_op"} : () -> ()
 
@@ -52,21 +51,17 @@ func.func @control_flow() {
 // CHECK-NEXT:      %cond = "test.op"() : () -> i1
 // CHECK-NEXT:      %0 = arith.constant true
 // CHECK-NEXT:      %1 = arith.cmpi eq, %cond, %0 : i1
-// CHECK-NEXT:      "scf.if"(%1) ({
+// CHECK-NEXT:      scf.if %1 {
 // CHECK-NEXT:        func.call @control_flow_pinned() : () -> ()
-// CHECK-NEXT:        scf.yield
-// CHECK-NEXT:      }, {
+// CHECK-NEXT:      } else {
                       // inline the rest of the function inside the else statement of the specialization block
                       // (there is no early return in MLIR)
-// CHECK-NEXT:        "scf.if"(%cond) ({
+// CHECK-NEXT:        scf.if %cond {
 // CHECK-NEXT:          "test.op"() {"inside_if"} : () -> ()
-// CHECK-NEXT:          scf.yield
-// CHECK-NEXT:        }, {
-// CHECK-NEXT:          scf.yield
-// CHECK-NEXT:        }) : (i1) -> ()
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:        }
 // CHECK-NEXT:        "test.op"() {"after_op"} : () -> ()
-// CHECK-NEXT:        scf.yield
-// CHECK-NEXT:      }) : (i1) -> ()
+// CHECK-NEXT:      }
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
                   // specialized function does not contain operations that happen before the specialized function
@@ -74,12 +69,10 @@ func.func @control_flow() {
 // CHECK-NEXT:    func.func @control_flow_pinned() {
 // CHECK-NEXT:      %cond = arith.constant true
                     // this scf.if can be constant folded by MLIR later on (not done as part of this pass)
-// CHECK-NEXT:      "scf.if"(%cond) ({
+// CHECK-NEXT:      scf.if %cond {
 // CHECK-NEXT:        "test.op"() {"inside_if"} : () -> ()
-// CHECK-NEXT:        scf.yield
-// CHECK-NEXT:      }, {
-// CHECK-NEXT:        scf.yield
-// CHECK-NEXT:      }) : (i1) -> ()
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:      }
 // CHECK-NEXT:      "test.op"() {"after_op"} : () -> ()
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
@@ -98,15 +91,15 @@ func.func @function_args(%arg0: memref<100xf32>) -> i32 {
 // CHECK-NEXT:     %v = "test.op"() : () -> i32
 // CHECK-NEXT:     %0 = arith.constant 0 : i64
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
-// CHECK-NEXT:     %2 = "scf.if"(%1) ({
+// CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
                      // make sure that we forward function args to the specialized function
                      // and weave return values through the generated if/else
 // CHECK-NEXT:       %3 = func.call @function_args_pinned(%arg0) : (memref<100xf32>) -> i32
 // CHECK-NEXT:       scf.yield %3 : i32
-// CHECK-NEXT:     }, {
+// CHECK-NEXT:     } else {
 // CHECK-NEXT:       "test.op"(%v, %arg0) : (i32, memref<100xf32>) -> ()
 // CHECK-NEXT:       scf.yield %v : i32
-// CHECK-NEXT:     }) : (i1) -> i32
+// CHECK-NEXT:     }
 // CHECK-NEXT:     func.return %2 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func @function_args_pinned(%arg0 : memref<100xf32>) -> i32 {
@@ -122,12 +115,11 @@ func.func @function_args(%arg0: memref<100xf32>) -> i32 {
 func.func @control_flow_and_function_args(%arg: i32) -> i32 {
     %cond = "test.op"() {"pin_to_constants"= [true]} : () -> i1
 
-    "scf.if"(%cond) ({
+    scf.if %cond {
         "test.op"() {"inside_if"} : () -> ()
+    } else {
         scf.yield
-    }, {
-        scf.yield
-    }) : (i1) -> ()
+    }
 
     %rval = "test.op"(%arg) {"after_op"} : (i32) -> i32
 
@@ -138,29 +130,25 @@ func.func @control_flow_and_function_args(%arg: i32) -> i32 {
 // CHECK-NEXT:     %cond = "test.op"() : () -> i1
 // CHECK-NEXT:     %0 = arith.constant true
 // CHECK-NEXT:     %1 = arith.cmpi eq, %cond, %0 : i1
-// CHECK-NEXT:     %2 = "scf.if"(%1) ({
+// CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
 // CHECK-NEXT:       %3 = func.call @control_flow_and_function_args_pinned(%arg) : (i32) -> i32
 // CHECK-NEXT:       scf.yield %3 : i32
-// CHECK-NEXT:     }, {
-// CHECK-NEXT:       "scf.if"(%cond) ({
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:       scf.if %cond {
 // CHECK-NEXT:         "test.op"() {"inside_if"} : () -> ()
-// CHECK-NEXT:         scf.yield
-// CHECK-NEXT:       }, {
-// CHECK-NEXT:         scf.yield
-// CHECK-NEXT:       }) : (i1) -> ()
+// CHECK-NEXT:       } else {
+// CHECK-NEXT:       }
 // CHECK-NEXT:       %rval = "test.op"(%arg) {"after_op"} : (i32) -> i32
 // CHECK-NEXT:       scf.yield %rval : i32
-// CHECK-NEXT:     }) : (i1) -> i32
+// CHECK-NEXT:     }
 // CHECK-NEXT:     func.return %2 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func @control_flow_and_function_args_pinned(%arg : i32) -> i32 {
 // CHECK-NEXT:     %cond = arith.constant true
-// CHECK-NEXT:     "scf.if"(%cond) ({
+// CHECK-NEXT:     scf.if %cond {
 // CHECK-NEXT:       "test.op"() {"inside_if"} : () -> ()
-// CHECK-NEXT:       scf.yield
-// CHECK-NEXT:     }, {
-// CHECK-NEXT:       scf.yield
-// CHECK-NEXT:     }) : (i1) -> ()
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:     }
 // CHECK-NEXT:     %rval = "test.op"(%arg) {"after_op"} : (i32) -> i32
 // CHECK-NEXT:     func.return %rval : i32
 // CHECK-NEXT:   }
@@ -178,20 +166,20 @@ func.func @specialize_multi_case() -> i32 {
 // CHECK-NEXT:     %v = "test.op"() : () -> i32
 // CHECK-NEXT:     %0 = arith.constant 0 : i64
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
-// CHECK-NEXT:     %2 = "scf.if"(%1) ({
+// CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
 // CHECK-NEXT:       %3 = func.call @specialize_multi_case_pinned_1() : () -> i32
 // CHECK-NEXT:       scf.yield %3 : i32
-// CHECK-NEXT:     }, {
+// CHECK-NEXT:     } else {
 // CHECK-NEXT:       %4 = arith.constant 1 : i64
 // CHECK-NEXT:       %5 = arith.cmpi eq, %v, %4 : i32
-// CHECK-NEXT:       %6 = "scf.if"(%5) ({
+// CHECK-NEXT:       %6 = scf.if %5 -> (i32) {
 // CHECK-NEXT:         %7 = func.call @specialize_multi_case_pinned() : () -> i32
 // CHECK-NEXT:         scf.yield %7 : i32
-// CHECK-NEXT:       }, {
+// CHECK-NEXT:       } else {
 // CHECK-NEXT:         scf.yield %v : i32
-// CHECK-NEXT:       }) : (i1) -> i32
+// CHECK-NEXT:       }
 // CHECK-NEXT:       scf.yield %6 : i32
-// CHECK-NEXT:     }) : (i1) -> i32
+// CHECK-NEXT:     }
 // CHECK-NEXT:     func.return %2 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func @specialize_multi_case_pinned_1() -> i32 {
@@ -200,12 +188,12 @@ func.func @specialize_multi_case() -> i32 {
 // CHECK-NEXT:     %v = arith.constant 0 : i64
 // CHECK-NEXT:     %0 = arith.constant 1 : i64
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
-// CHECK-NEXT:     %2 = "scf.if"(%1) ({
+// CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
 // CHECK-NEXT:       %3 = func.call @specialize_multi_case_pinned() : () -> i32
 // CHECK-NEXT:       scf.yield %3 : i32
-// CHECK-NEXT:     }, {
+// CHECK-NEXT:     } else {
 // CHECK-NEXT:       scf.yield %v : i32
-// CHECK-NEXT:     }) : (i1) -> i32
+// CHECK-NEXT:     }
 // CHECK-NEXT:     func.return %2 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func @specialize_multi_case_pinned() -> i32 {

--- a/tests/filecheck/transforms/stencil-bufferize.mlir
+++ b/tests/filecheck/transforms/stencil-bufferize.mlir
@@ -344,13 +344,13 @@ func.func @stencil_init_index_offset(%0 : !stencil.field<[0,64]x[0,64]x[0,64]xin
 func.func @if_lowering(%arg0 : f64, %b0 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>, %b1 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>)  attributes {"stencil.program"}{
   %0, %1 = stencil.apply(%arg1 = %arg0 : f64) -> (!stencil.temp<[0,7]x[0,7]x[0,7]xf64>, !stencil.temp<[0,7]x[0,7]x[0,7]xf64>) {
     %true = "test.pureop"() : () -> i1
-    %2, %3 = "scf.if"(%true) ({
+    %2, %3 = scf.if %true -> (!stencil.result<f64>, f64) {
       %4 = stencil.store_result %arg1 : !stencil.result<f64>
       scf.yield %4, %arg1 : !stencil.result<f64>, f64
-    }, {
+    } else {
       %5 = stencil.store_result  : !stencil.result<f64>
       scf.yield %5, %arg1 : !stencil.result<f64>, f64
-    }) : (i1) -> (!stencil.result<f64>, f64)
+    }
     %6 = stencil.store_result %3 : !stencil.result<f64>
     stencil.return %2, %6 : !stencil.result<f64>, !stencil.result<f64>
   }
@@ -362,13 +362,13 @@ func.func @if_lowering(%arg0 : f64, %b0 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>,
 // CHECK:         func.func @if_lowering(%arg0 : f64, %b0 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>, %b1 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>)  attributes {"stencil.program"}{
 // CHECK-NEXT:      stencil.apply(%arg1 = %arg0 : f64) outs (%b0 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>, %b1 : !stencil.field<[0,7]x[0,7]x[0,7]xf64>) {
 // CHECK-NEXT:        %true = "test.pureop"() : () -> i1
-// CHECK-NEXT:        %0, %1 = "scf.if"(%true) ({
+// CHECK-NEXT:        %0, %1 = scf.if %true -> (!stencil.result<f64>, f64) {
 // CHECK-NEXT:          %2 = stencil.store_result %arg1 : !stencil.result<f64>
 // CHECK-NEXT:          scf.yield %2, %arg1 : !stencil.result<f64>, f64
-// CHECK-NEXT:        }, {
+// CHECK-NEXT:        } else {
 // CHECK-NEXT:          %3 = stencil.store_result  : !stencil.result<f64>
 // CHECK-NEXT:          scf.yield %3, %arg1 : !stencil.result<f64>, f64
-// CHECK-NEXT:        }) : (i1) -> (!stencil.result<f64>, f64)
+// CHECK-NEXT:        }
 // CHECK-NEXT:        %4 = stencil.store_result %1 : !stencil.result<f64>
 // CHECK-NEXT:        stencil.return %0, %4 : !stencil.result<f64>, !stencil.result<f64>
 // CHECK-NEXT:      } to <[0, 0, 0], [7, 7, 7]>


### PR DESCRIPTION
Adds custom parsing to some scf ops and fixes the relevant tests.

I noticed during this that `scf.reduce` is now quite different to upstream mlir, but didn't attempt to change this.