### PR TITLE
dialects: Add NoMemoryEffect trait in various LLVM and builtin ops

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -65,6 +65,7 @@ from xdsl.irdl import (
 )
 from xdsl.traits import (
     IsolatedFromAbove,
+    NoMemoryEffect,
     NoTerminator,
     OptionalSymbolOpInterface,
     SymbolTable,
@@ -1199,6 +1200,8 @@ class UnrealizedConversionCastOp(IRDLOperation):
 
     inputs: VarOperand = var_operand_def()
     outputs: VarOpResult = var_result_def()
+
+    traits = frozenset([NoMemoryEffect()])
 
     @staticmethod
     def get(inputs: Sequence[SSAValue | Operation], result_type: Sequence[Attribute]):

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -57,7 +57,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.traits import IsTerminator, SymbolOpInterface
+from xdsl.traits import IsTerminator, NoMemoryEffect, SymbolOpInterface
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
@@ -370,6 +370,8 @@ class ArithmeticBinOpBase(Generic[ArgT], IRDLOperation, ABC):
     rhs = operand_def(T)
     res = result_def(T)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def __init__(
         self,
         lhs: SSAValue,
@@ -587,6 +589,8 @@ class GEPOp(IRDLOperation):
     rawConstantIndices: DenseArrayBase = prop_def(DenseArrayBase)
     inbounds: UnitAttr | None = opt_prop_def(UnitAttr)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def __init__(
         self,
         ptr: SSAValue | Operation,
@@ -706,6 +710,8 @@ class IntToPtrOp(IRDLOperation):
 
     output: OpResult = result_def(LLVMPointerType)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def __init__(self, input: SSAValue | Operation, ptr_type: Attribute | None = None):
         if ptr_type is None:
             ptr_type = LLVMPointerType.opaque()
@@ -782,6 +788,8 @@ class PtrToIntOp(IRDLOperation):
 
     output: OpResult = result_def(IntegerType)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def __init__(self, arg: SSAValue | Operation, int_type: Attribute = i64):
         super().__init__(operands=[arg], result_types=[int_type])
 
@@ -855,6 +863,8 @@ class NullOp(IRDLOperation):
 
     nullptr: OpResult = result_def(LLVMPointerType)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def __init__(self, ptr_type: LLVMPointerType | None = None):
         if ptr_type is None:
             ptr_type = LLVMPointerType.opaque()
@@ -875,6 +885,8 @@ class ExtractValueOp(IRDLOperation):
     container: Operand = operand_def(Attribute)
 
     res: OpResult = result_def(Attribute)
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(
         self,
@@ -905,6 +917,8 @@ class InsertValueOp(IRDLOperation):
 
     res: OpResult = result_def(Attribute)
 
+    traits = frozenset([NoMemoryEffect()])
+
     def __init__(
         self,
         position: DenseArrayBase,
@@ -929,6 +943,8 @@ class UndefOp(IRDLOperation):
     name = "llvm.mlir.undef"
 
     res: OpResult = result_def(Attribute)
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(self, result_type: Attribute):
         super().__init__(result_types=[result_type])
@@ -1017,6 +1033,8 @@ class AddressOfOp(IRDLOperation):
 
     global_name: SymbolRefAttr = prop_def(SymbolRefAttr)
     result: OpResult = result_def(LLVMPointerType)
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(
         self,
@@ -1142,7 +1160,7 @@ class ReturnOp(IRDLOperation):
 
     arg: OptOperand = opt_operand_def(Attribute)
 
-    traits = frozenset((IsTerminator(),))
+    traits = frozenset((IsTerminator(), NoMemoryEffect()))
 
     def __init__(self, value: Attribute | None = None):
         super().__init__(attributes={"value": value})
@@ -1153,6 +1171,8 @@ class ConstantOp(IRDLOperation):
     name = "llvm.mlir.constant"
     result: OpResult = result_def(Attribute)
     value: Attribute = prop_def(Attribute)
+
+    traits = frozenset([NoMemoryEffect()])
 
     def __init__(self, value: Attribute, value_type: Attribute):
         super().__init__(properties={"value": value}, result_types=[value_type])
@@ -1268,6 +1288,8 @@ class ZeroOp(IRDLOperation):
     name = "llvm.mlir.zero"
 
     assembly_format = "attr-dict `:` type($res)"
+
+    traits = frozenset([NoMemoryEffect()])
 
     res = result_def(LLVMTypeConstr)
 


### PR DESCRIPTION
Some ops in builtin and llvm dialect have the NoMemoryEffect upstream,
but don't have this in xDSL yet, which means that they will always return False on `is_side_effect_free` even though they are completely side-effect-free.

I added all NoMemoryEffects to the current LLVM dialect and Builtin.