### PR TITLE
transforms: Fix constant pinning breaking for external functions

### DIFF
--- a/tests/filecheck/transforms/function-constant-pinning.mlir
+++ b/tests/filecheck/transforms/function-constant-pinning.mlir
@@ -212,3 +212,6 @@ func.func @specialize_multi_case() -> i32 {
 // CHECK-NEXT:     %v = arith.constant 1 : i64
 // CHECK-NEXT:     func.return %v : i32
 // CHECK-NEXT:   }
+
+func.func private @external_test(i32, i64, memref<?xf64>) -> f64
+// CHECK-NEXT: func.func private @external_test(i32, i64, memref<?xf64>) -> f64

--- a/xdsl/transforms/experimental/function_constant_pinning.py
+++ b/xdsl/transforms/experimental/function_constant_pinning.py
@@ -164,6 +164,8 @@ def func_contains_pinning_annotation(funcop: func.FuncOp) -> Operation | None:
 
     Only works on top-level operations, we can't handle nested things right now.
     """
+    if not funcop.body.blocks:
+        return None
     for op in funcop.body.block.ops:
         if PIN_CONSTANT_VALS in op.attributes:
             return op


### PR DESCRIPTION
Fixes `function-constant-pinning` pass to not break on functions without a body (external functions).