### PR TITLE
dialects: (scf) make iteration variable type explicit

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -168,7 +168,7 @@ csl.func @initialize() {
   %b = memref.get_global @b : memref<4xf32>
   %y = memref.get_global @y : memref<4xf32>
 
-  scf.for %idx = %lb to %ub step %step {
+  scf.for %idx = %lb to %ub step %step : i16 {
     %idx_f32 = arith.sitofp %idx : i16 to f32
     %idx_index = "arith.index_cast"(%idx) : (i16) -> index
     memref.store %idx_f32, %A[%idx_index] : memref<24xf32>
@@ -176,7 +176,7 @@ csl.func @initialize() {
 
   %ub_6 = arith.constant 6 : i16
 
-  scf.for %j = %lb to %ub_6 step %step {
+  scf.for %j = %lb to %ub_6 step %step : i16 {
     %val = arith.constant 1.0 : f32
     %j_idx = "arith.index_cast"(%j) : (i16) -> index
     memref.store %val, %x[%j_idx] : memref<6xf32>
@@ -184,7 +184,7 @@ csl.func @initialize() {
 
   %ub_4 = arith.constant 6 : i16
 
-  scf.for %i = %lb to %ub_4 step %step {
+  scf.for %i = %lb to %ub_4 step %step : i16 {
     %c2 = arith.constant 2.0 : f32
     %c0 = arith.constant 0.0 : f32
     %i_idx = "arith.index_cast"(%i) : (i16) -> index

--- a/tests/filecheck/dialects/scf/scf_ops.mlir
+++ b/tests/filecheck/dialects/scf/scf_ops.mlir
@@ -138,11 +138,10 @@ builtin.module {
     %ub = arith.constant 42 : index
     %s = arith.constant 3 : index
     %prod = arith.constant 1 : index
-    %res_1 = "scf.for"(%lb, %ub, %s, %prod) ({
-    ^2(%iv : index, %prod_iter : index):
+    %res_1 = scf.for %iv = %lb to %ub step %s iter_args(%prod_iter = %prod) -> (index) {
       %prod_new = arith.muli %prod_iter, %iv : index
       scf.yield %prod_new : index
-    }) : (index, index, index, index) -> index
+    }
     func.return
   }
 
@@ -158,5 +157,27 @@ builtin.module {
   // CHECK-NEXT:   func.return
   // CHECK-NEXT: }
 
+  func.func @for_i32() {
+    %lb = arith.constant 0 : i32
+    %ub = arith.constant 42 : i32
+    %s = arith.constant 3 : i32
+    %prod = arith.constant 1 : i32
+    %res_1 = scf.for %iv = %lb to %ub step %s iter_args(%prod_iter = %prod) -> (i32) : i32 {
+      %prod_new = arith.muli %prod_iter, %iv : i32
+      scf.yield %prod_new : i32
+    }
+    func.return
+  }
 
+  // CHECK-NEXT: func.func @for_i32() {
+  // CHECK-NEXT:   %{{.*}} = arith.constant 0 : i32
+  // CHECK-NEXT:   %{{.*}} = arith.constant 42 : i32
+  // CHECK-NEXT:   %{{.*}} = arith.constant 3 : i32
+  // CHECK-NEXT:   %{{.*}} = arith.constant 1 : i32
+  // CHECK-NEXT:   %{{.*}} = scf.for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%{{.*}} = %{{.*}}) -> (i32) : i32 {
+  // CHECK-NEXT:     %{{.*}} = arith.muli %{{.*}}, %{{.*}} : i32
+  // CHECK-NEXT:     scf.yield %{{.*}} : i32
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   func.return
+  // CHECK-NEXT: }
 }

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up.mlir
@@ -187,7 +187,7 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
         %c0 = arith.constant 0 : i32
         %c1 = arith.constant 1 : i32
         %c128 = arith.constant 128 : i32
-        %g = scf.for %i = %c0 to %c128 step %c1 iter_args(%acc = %zero_float) -> (f64) {
+        %g = scf.for %i = %c0 to %c128 step %c1 iter_args(%acc = %zero_float) -> (f64) : i32 {
           %x = memref_stream.read from %x_stream : f64
           %y = memref_stream.read from %y_stream : f64
           %prod = arith.mulf %x, %y fastmath<fast> : f64

--- a/tests/filecheck/transforms/convert_memref_stream_to_snitch_stream.mlir
+++ b/tests/filecheck/transforms/convert_memref_stream_to_snitch_stream.mlir
@@ -185,7 +185,7 @@ memref_stream.streaming_region {
     %c0 = arith.constant 0 : i32
     %c1 = arith.constant 1 : i32
     %c256 = arith.constant 256 : i32
-    scf.for %i = %c0 to %c256 step %c1 {
+    scf.for %i = %c0 to %c256 step %c1 : i32 {
         memref_stream.write %G to %h_stream : f64
     }
 }

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -425,9 +425,12 @@ class For(IRDLOperation):
         )
 
         # Set induction variable type
-        indvar = unresolved_indvar.resolve(lb.type)
-        if parser.parse_optional_characters(":"):
-            indvar.type = parser.parse_type()
+        indvar_type = (
+            parser.parse_type()
+            if parser.parse_optional_characters(":")
+            else IndexType()
+        )
+        indvar = unresolved_indvar.resolve(indvar_type)
 
         # Set block argument types
         iter_args = [


### PR DESCRIPTION
In mlir, if the iteration variable of `scf.for` does not have an explicit type, then it is assumed to be `index`. This change matches this behaviour in xDSL.

