### PR TITLE
backend: (csl) Add comparison operators to CSL

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -56,6 +56,45 @@
     csl.return
   }
 
+  csl.func @comparisons() -> i1 {
+    %int1 = arith.constant 0 : i32
+    %int2 = arith.constant 1 : i32
+
+    %float1 = arith.constant 0.0 : f32
+    %float2 = arith.constant 1.1 : f32
+
+    %intEq  = arith.cmpi eq,  %int1, %int2 : i32
+    %intNe  = arith.cmpi ne,  %int1, %int2 : i32
+    %intSlt = arith.cmpi slt, %int1, %int2 : i32
+    %intSle = arith.cmpi sle, %int1, %int2 : i32
+    %intSgt = arith.cmpi sgt, %int1, %int2 : i32
+    %intSge = arith.cmpi sge, %int1, %int2 : i32
+    %intUlt = arith.cmpi ult, %int1, %int2 : i32
+    %intUle = arith.cmpi ule, %int1, %int2 : i32
+    %intUgt = arith.cmpi ugt, %int1, %int2 : i32
+    %intUge = arith.cmpi uge, %int1, %int2 : i32
+
+    %floatFalse = arith.cmpf false, %float1, %float2 : f32
+    %floatOeq   = arith.cmpf oeq,   %float1, %float2 : f32
+    %floatOgt   = arith.cmpf ogt,   %float1, %float2 : f32
+    %floatOge   = arith.cmpf oge,   %float1, %float2 : f32
+    %floatOlt   = arith.cmpf olt,   %float1, %float2 : f32
+    %floatOle   = arith.cmpf ole,   %float1, %float2 : f32
+    %floatOne   = arith.cmpf one,   %float1, %float2 : f32
+    %floatUeq   = arith.cmpf ueq,   %float1, %float2 : f32
+    %floatUgt   = arith.cmpf ugt,   %float1, %float2 : f32
+    %floatUge   = arith.cmpf uge,   %float1, %float2 : f32
+    %floatUlt   = arith.cmpf ult,   %float1, %float2 : f32
+    %floatUle   = arith.cmpf ule,   %float1, %float2 : f32
+    %floatUne   = arith.cmpf une,   %float1, %float2 : f32
+    %floatTrue  = arith.cmpf true,  %float1, %float2 : f32
+
+    %or_ = arith.ori %intSle, %floatUgt : i1
+    %and_ = arith.andi %or_, %floatOge : i1
+
+    csl.return %and_ : i1
+  }
+
   csl.func @constants() {
     %inline_const = arith.constant 100 : i32
 
@@ -407,6 +446,31 @@ csl.func @builtins() {
 // CHECK-NEXT:   const castI32again : i32 = @as(i32, @as(i16, 0.0));
 // CHECK-NEXT:   const castU32 : u32 = @as(u32, 0);
 // CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT: {{ *}}
+// CHECK-NEXT: fn comparisons() bool {
+// CHECK-NEXT:   const intEq : bool = 0  ==  1;
+// CHECK-NEXT:   const intNe : bool = 0  !=  1;
+// CHECK-NEXT:   const intSlt : bool = 0  <  1;
+// CHECK-NEXT:   const intSgt : bool = 0  >  1;
+// CHECK-NEXT:   const intSge : bool = 0  >=  1;
+// CHECK-NEXT:   const intUlt : bool = 0  <  1;
+// CHECK-NEXT:   const intUle : bool = 0  <=  1;
+// CHECK-NEXT:   const intUgt : bool = 0  >  1;
+// CHECK-NEXT:   const intUge : bool = 0  >=  1;
+// CHECK-NEXT:   const floatFalse : bool = false;
+// CHECK-NEXT:   const floatOeq : bool = 0.0  ==  1.1;
+// CHECK-NEXT:   const floatOgt : bool = 0.0  >  1.1;
+// CHECK-NEXT:   const floatOlt : bool = 0.0  <  1.1;
+// CHECK-NEXT:   const floatOle : bool = 0.0  <=  1.1;
+// CHECK-NEXT:   const floatOne : bool = 0.0  !=  1.1;
+// CHECK-NEXT:   const floatUeq : bool = 0.0  ==  1.1;
+// CHECK-NEXT:   const floatUge : bool = 0.0  >=  1.1;
+// CHECK-NEXT:   const floatUlt : bool = 0.0  <  1.1;
+// CHECK-NEXT:   const floatUle : bool = 0.0  <=  1.1;
+// CHECK-NEXT:   const floatUne : bool = 0.0  !=  1.1;
+// CHECK-NEXT:   const floatTrue : bool = true;
+// CHECK-NEXT:   return (((0  <=  1) or (0.0  >  1.1)) and (0.0  >=  1.1));
 // CHECK-NEXT: }
 // CHECK-NEXT: {{ *}}
 // CHECK-NEXT: fn constants() void {

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -53,6 +53,8 @@ class CslPrintContext:
     Maps operation name => operand for binary operands
     """
 
+    _cmp_ops: dict[str, dict[str, str | None]] = field(default_factory=dict)
+
     def register_binops(self):
         self._binops.update(
             {
@@ -68,8 +70,63 @@ class CslPrintContext:
                 arith.RemSI.name: "%",
                 arith.RemUI.name: "%",
                 arith.ShLI.name: "<<",
+                arith.AndI.name: "and",
+                arith.OrI.name: "or",
             }
         )
+        self._cmp_ops.update(
+            {
+                arith.Cmpi.name: {
+                    "eq": "==",
+                    "ne": "!=",
+                    "slt": "<",
+                    "sle": "<=",
+                    "sgt": ">",
+                    "sge": ">=",
+                    "ult": "<",
+                    "ule": "<=",
+                    "ugt": ">",
+                    "uge": ">=",
+                },
+                arith.Cmpf.name: {
+                    "false": None,
+                    "oeq": "==",
+                    "ogt": ">",
+                    "oge": ">=",
+                    "olt": "<",
+                    "ole": "<=",
+                    "one": "!=",
+                    "ord": None,
+                    "ueq": "==",
+                    "ugt": ">",
+                    "uge": ">=",
+                    "ult": "<",
+                    "ule": "<=",
+                    "une": "!=",
+                    "uno": None,
+                    "true": None,
+                },
+            }
+        )
+
+    def _cmp_value_expr(self, op: arith.Cmpi | arith.Cmpf):
+        pred = op.predicate.value.data
+        str_pred = {
+            arith.Cmpi.name: arith.CMPI_COMPARISON_OPERATIONS,
+            arith.Cmpf.name: arith.CMPF_COMPARISON_OPERATIONS,
+        }[op.name][pred]
+        lhs_name = self._get_variable_name_for(op.lhs)
+        rhs_name = self._get_variable_name_for(op.rhs)
+
+        if sym := self._cmp_ops[op.name][str_pred]:
+            return f"{lhs_name}  {sym}  {rhs_name}"
+        match str_pred:
+            case "true" | "false":
+                return str_pred
+            case "ord" | "uno":
+                raise RuntimeError(f"{str_pred}: comparison not supported")
+            case unknown:
+                raise RuntimeError(f"Unknown predicate {unknown}")
 
     def _binop_value_expr(self, op: Operation):
         assert len(op.operands) == 2, "binops must have exactly two operands"
@@ -502,6 +559,10 @@ class CslPrintContext:
                     type_out = self.mlir_type_to_csl_type(res.type)
                     value_str = f"@as({type_out}, {name_in})"
                     self._print_or_promote_to_inline_expr(res, value_str)
+                case arith.Cmpi(result=res) | arith.Cmpf(result=res):
+                    self._print_or_promote_to_inline_expr(
+                        res, self._cmp_value_expr(op), brackets=True
+                    )
                 case csl.ConcatStructOp(this_struct=a, another_struct=b, result=res):
                     a_var = self._get_variable_name_for(a)
                     b_var = self._get_variable_name_for(b)
@@ -725,6 +786,7 @@ class CslPrintContext:
             output=self.output,
             variables=self.variables.copy(),
             _symbols_to_export=self._symbols_to_export,
+            _cmp_ops=self._cmp_ops,
             _binops=self._binops,
             _counter=self._counter,
             _prefix=self._prefix + self._INDENT,


### PR DESCRIPTION
Adds integer and floating point comparisons as well as `and` and `or`.

Signed and unsigned integers are compared the same way.

Ordered and unordered floats are compared the same way.

`true` and `false` float comparisons are printed as `true` and `false` literals.

`ord` and `uno` comparisons result in an error.

`arith.andi` and `arith.ori` produce `and` and `or` operators when operating on `i1` (bools) and `&` and `|` otherwise