### PR TITLE
transformations: (csl) add `csl.rpc` op

### DIFF
--- a/tests/filecheck/transforms/csl_wrapper_to_csl.mlir
+++ b/tests/filecheck/transforms/csl_wrapper_to_csl.mlir
@@ -173,6 +173,8 @@ builtin.module {
 // CHECK-NEXT:       }) to <[0, 0], [1, 1]>
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
+// CHECK-NEXT:   %5 = "csl.member_access"(%memcpyMod_2) <{"field" = "LAUNCH"}> : (!csl.imported_module) -> !csl.color
+// CHECK-NEXT:   "csl.rpc"(%5) : (!csl.color) -> ()
 // CHECK-NEXT:   }) {"sym_name" = "gauss_seidel_func_program"} : () -> ()
 // CHECK-NEXT: }
 // CHECK-EMPTY:


### PR DESCRIPTION
When constructing the program module in `csl-wrapper-to-csl`:

* find the `memcpy/memcpy` module
* get the `LAUNCH` color from it 
* use it in the `csl.rpc` op.