### PR TITLE
transformations: add call to `unblock_cmd_stream`

### DIFF
--- a/tests/filecheck/transforms/lower-csl-stencil.mlir
+++ b/tests/filecheck/transforms/lower-csl-stencil.mlir
@@ -133,6 +133,7 @@ builtin.module {
 // CHECK-NEXT:       "csl.fadds"(%arg4, %arg4, %58) : (memref<510xf32>, memref<510xf32>, memref<510xf32, strided<[1], offset: 2>>) -> ()
 // CHECK-NEXT:       %60 = arith.constant 1.666600e-01 : f32
 // CHECK-NEXT:       "csl.fmuls"(%arg4, %arg4, %60) : (memref<510xf32>, memref<510xf32>, f32) -> ()
+// CHECK-NEXT:       "csl.member_call"(%33) <{"field" = "unblock_cmd_stream"}> : (!csl.imported_module) -> ()
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -64,13 +64,6 @@ def _get_module_wrapper(op: Operation) -> csl_wrapper.ModuleOp | None:
     return None
 
 
-def _get_memcpy_mod(op: Block):
-    for o in op.walk():
-        if isinstance(o, csl_wrapper.ImportOp) and o.module.data == "<memcpy/memcpy>":
-            return o
-    raise RuntimeError("Could not find memcpy module")
-
-
 @dataclass(frozen=True)
 class LowerAccessOp(RewritePattern):
     """
@@ -169,7 +162,7 @@ class LowerApplyOp(RewritePattern):
         )
 
         # add a call to `unblock_cmd_stream` at the end of the prost_process fn
-        memcpy = _get_memcpy_mod(module_wrapper_op.program_module.block)
+        memcpy = module_wrapper_op.get_program_import("<memcpy/memcpy>")
         unblock_cmd_stream_call = csl.MemberCallOp(
             struct=memcpy, fname="unblock_cmd_stream", params=[], result_type=None
         )


### PR DESCRIPTION
This is needed at the end of the post-processing function to signal
program end.