### PR TITLE
dialects: llvm.InLineAsmOp has_side_effects, is_align_stack are properties

### DIFF
--- a/tests/filecheck/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/dialects/llvm/inline_asm.mlir
@@ -2,7 +2,7 @@
 
 %0 = "test.op"() : () -> i32
 %1 = "test.op"() : () -> i32
-"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r"}> {has_side_effect} : (i32, i32) -> ()
+"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects}> : (i32, i32) -> ()
 
 %2 = "test.op"() : () -> vector<8xf32>
 %3 = "test.op"() : () -> vector<8xf32>
@@ -10,7 +10,7 @@
 
 // CHECK: %0 = "test.op"() : () -> i32
 // CHECK-NEXT: 1 = "test.op"() : () -> i32
-// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{"asm_string" = "csrw $0, $1", "constraints" = "i, r"}> {"has_side_effect"} : (i32, i32) -> ()
+// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{"asm_string" = "csrw $0, $1", "constraints" = "i, r", "has_side_effects"}> : (i32, i32) -> ()
 // CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{"asm_dialect" = 1 : i64, "asm_string" = "vaddps $0, $1, $2", "constraints" = "=x,x,x"}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/inline_asm.mlir
@@ -2,7 +2,7 @@
 
 %0 = "test.op"() : () -> i32
 %1 = "test.op"() : () -> i32
-"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r"}> {has_side_effect} : (i32, i32) -> ()
+"llvm.inline_asm"(%0, %1) <{asm_string = "csrw $0, $1", constraints = "i, r", has_side_effects}> : (i32, i32) -> ()
 
 %2 = "test.op"() : () -> vector<8xf32>
 %3 = "test.op"() : () -> vector<8xf32>
@@ -10,7 +10,7 @@
 
 // CHECK: %0 = "test.op"() : () -> i32
 // CHECK-NEXT: 1 = "test.op"() : () -> i32
-// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{"asm_string" = "csrw $0, $1", "constraints" = "i, r"}> {"has_side_effect"} : (i32, i32) -> ()
+// CHECK-NEXT: "llvm.inline_asm"(%0, %1) <{"asm_string" = "csrw $0, $1", "constraints" = "i, r", "has_side_effects"}> : (i32, i32) -> ()
 // CHECK-NEXT: %2 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %3 = "test.op"() : () -> vector<8xf32>
 // CHECK-NEXT: %4 = "llvm.inline_asm"(%2, %3) <{"asm_dialect" = 1 : i64, "asm_string" = "vaddps $0, $1, $2", "constraints" = "=x,x,x"}> : (vector<8xf32>, vector<8xf32>) -> vector<8xf32>

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -41,7 +41,6 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
-    opt_attr_def,
     opt_operand_def,
     opt_prop_def,
     opt_result_def,
@@ -740,8 +739,8 @@ class InlineAsmOp(IRDLOperation):
     asm_string = prop_def(StringAttr)
     constraints = prop_def(StringAttr)
 
-    has_side_effects = opt_attr_def(UnitAttr)
-    is_align_stack = opt_attr_def(UnitAttr)
+    has_side_effects = opt_prop_def(UnitAttr)
+    is_align_stack = opt_prop_def(UnitAttr)
 
     def __init__(
         self,
@@ -753,13 +752,10 @@ class InlineAsmOp(IRDLOperation):
         has_side_effects: bool = False,
         is_align_stack: bool = False,
     ):
-        props: dict[str, Attribute] = {
+        props: dict[str, Attribute | None] = {
             "asm_string": StringAttr(asm_string),
             "constraints": StringAttr(constraints),
             "asm_dialect": IntegerAttr.from_int_and_width(asm_dialect, 64),
-        }
-
-        attrs = {
             "has_side_effects": UnitAttr() if has_side_effects else None,
             "is_align_stack": UnitAttr() if is_align_stack else None,
         }
@@ -769,7 +765,6 @@ class InlineAsmOp(IRDLOperation):
 
         super().__init__(
             operands=[operands],
-            attributes=attrs,
             properties=props,
             result_types=[res_types],
         )


### PR DESCRIPTION
I apparently made a small yet significant error when I implemented this operation the first time, which sometimes gives weird errors in mixed pipelines.

`has_side_effects`, `is_align_stack` are optional properties defined as UnitAttributes.
I apparently gave a very difficult to find error because I tested them as attributes, and not as properties. and because `has_side_effects` is not exactly the same as `has_side_effect`

I'm not sure the implementation I'm using here for defining optional properties is correct. It seems there are multiple ways of doing this in xdsl?