### PR TITLE
fix: Add the missing call to `@set_rectangle`

### DIFF
--- a/tests/filecheck/transforms/csl_wrapper_to_csl.mlir
+++ b/tests/filecheck/transforms/csl_wrapper_to_csl.mlir
@@ -98,6 +98,7 @@ builtin.module {
 // CHECK-NEXT:     %8 = arith.constant 510 : i16
 // CHECK-NEXT:     %padded_z_dim = "csl.param"(%8) <{"param_name" = "padded_z_dim"}> : (i16) -> i16
 // CHECK-NEXT:     csl.layout {
+// CHECK-NEXT:       "csl.set_rectangle"(%width, %height) : (i16, i16) -> ()
 // CHECK-NEXT:       scf.for %xDim = %3 to %width step %4 : i16 {
 // CHECK-NEXT:         scf.for %yDim = %3 to %height step %4 : i16 {
 // CHECK-NEXT:           %computeAllRoutesRes = "csl.member_call"(%routesMod_1, %xDim, %yDim, %width, %height, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct

--- a/xdsl/transforms/csl_wrapper_to_csl.py
+++ b/xdsl/transforms/csl_wrapper_to_csl.py
@@ -124,6 +124,7 @@ class ExtractCslModules(RewritePattern):
 
             layout = csl.LayoutOp(Region())
             with ImplicitBuilder(layout.body.block):
+                csl.SetRectangleOp(operands=[param_width, param_height])
                 scf.For(
                     lb=const_0,
                     ub=param_width,


### PR DESCRIPTION
When generating the layout module in `csl_wrapper`, `@set_rectangle` needs to be called with the values of `width` and `height` (via `csl.set_rectangle`).