### PR TITLE
dialects: (scf) fix `scf.if` printing bug

### DIFF
--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -261,7 +261,7 @@ class If(IRDLOperation):
                 print_block_terminators=print_block_terminators,
             )
 
-        if bool(self.attributes.keys):
+        if bool(self.attributes.keys()):
             printer.print_attr_dict(self.attributes)
 
 


### PR DESCRIPTION
Didn't catch this on the original PR as the bug is crazy and filecheck isn't checking whole lines. Apparently functions in python cast to true.

Should we enforce matching on whole lines in the `scf_ops.mlir` filecheck test?

