### PR TITLE
dialect: (csl) Adds variables to the dialect

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -180,6 +180,17 @@
     csl.return
   }
 
+  csl.func @variables() {
+    %one = arith.constant 1 : i32
+    %variable_with_default = "csl.variable"() <{default = 42 : i32}> : () -> !csl.var<i32>
+    %variable = "csl.variable"() : () -> !csl.var<i32>
+    %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+    %new_value = arith.addi %value, %one : i32
+    "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+    "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
+
+    csl.return
+  }
 
   "memref.global"() {"sym_name" = "uninit_array", "type" = memref<10xf32>, "sym_visibility" = "public", "initial_value"} : () -> ()
   "memref.global"() {"sym_name" = "global_array", "type" = memref<10xf32>, "sym_visibility" = "public", "initial_value" = dense<4.2> : tensor<1xf32>} : () -> ()
@@ -598,6 +609,15 @@ csl.func @builtins() {
 // CHECK-NEXT: }
 // CHECK-NEXT: {{ *}}
 // CHECK-NEXT: task control_task_no_bind() void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT: {{ *}}
+// CHECK-NEXT: fn variables() void {
+// CHECK-NEXT:   var variable_with_default : i32 = 42;
+// CHECK-NEXT:   var variable : i32;
+// CHECK-NEXT:   const value : i32 = variable_with_default;
+// CHECK-NEXT:   variable_with_default = (value + 1);
+// CHECK-NEXT:   variable = (value + 1);
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT: var uninit_array : [10]f32;

--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -184,10 +184,10 @@
     %one = arith.constant 1 : i32
     %variable_with_default = "csl.variable"() <{default = 42 : i32}> : () -> !csl.var<i32>
     %variable = "csl.variable"() : () -> !csl.var<i32>
-    %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+    %value = "csl.load_var"(%variable_with_default) : (!csl.var<i32>) -> i32
     %new_value = arith.addi %value, %one : i32
-    "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
-    "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
+    "csl.store_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+    "csl.store_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
 
     csl.return
   }

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -111,10 +111,10 @@ csl.func @initialize() {
     %one = "test.op"() : () -> i32
     %variable_with_default = "csl.variable"() <{default = 42 : i32}> : () -> !csl.var<i32>
     %variable = "csl.variable"() : () -> !csl.var<i32>
-    %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+    %value = "csl.load_var"(%variable_with_default) : (!csl.var<i32>) -> i32
     %new_value = arith.addi %value, %one : i32
-    "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
-    "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
+    "csl.store_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+    "csl.store_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
 
   csl.return
 }
@@ -403,10 +403,10 @@ csl.func @builtins() {
 // CHECK-NEXT:       %one = "test.op"() : () -> i32
 // CHECK-NEXT:       %variable_with_default = "csl.variable"() <{"default" = 42 : i32}> : () -> !csl.var<i32>
 // CHECK-NEXT:       %variable = "csl.variable"() : () -> !csl.var<i32>
-// CHECK-NEXT:       %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+// CHECK-NEXT:       %value = "csl.load_var"(%variable_with_default) : (!csl.var<i32>) -> i32
 // CHECK-NEXT:       %new_value = arith.addi %value, %one : i32
-// CHECK-NEXT:       "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
-// CHECK-NEXT:       "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
+// CHECK-NEXT:       "csl.store_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+// CHECK-NEXT:       "csl.store_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     csl.func @builtins() {
@@ -647,10 +647,10 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:       %one = "test.op"() : () -> i32
 // CHECK-GENERIC-NEXT:       %variable_with_default = "csl.variable"() <{"default" = 42 : i32}> : () -> !csl.var<i32>
 // CHECK-GENERIC-NEXT:       %variable = "csl.variable"() : () -> !csl.var<i32>
-// CHECK-GENERIC-NEXT:       %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+// CHECK-GENERIC-NEXT:       %value = "csl.load_var"(%variable_with_default) : (!csl.var<i32>) -> i32
 // CHECK-GENERIC-NEXT:       %new_value = "arith.addi"(%value, %one) : (i32, i32) -> i32
-// CHECK-GENERIC-NEXT:       "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
-// CHECK-GENERIC-NEXT:       "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
+// CHECK-GENERIC-NEXT:       "csl.store_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+// CHECK-GENERIC-NEXT:       "csl.store_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
 // CHECK-GENERIC-NEXT:     "csl.func"() <{"sym_name" = "builtins", "function_type" = () -> ()}> ({

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -107,6 +107,15 @@ csl.func @initialize() {
     // this will fail as expected:
     // "csl.faddh"(%f32_ptr, %f16_val, %dsd_1d3)  : (!csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
 
+
+    %one = "test.op"() : () -> i32
+    %variable_with_default = "csl.variable"() <{default = 42 : i32}> : () -> !csl.var<i32>
+    %variable = "csl.variable"() : () -> !csl.var<i32>
+    %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+    %new_value = arith.addi %value, %one : i32
+    "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+    "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
+
   csl.return
 }
 
@@ -391,6 +400,13 @@ csl.func @builtins() {
 // CHECK-NEXT:       %f16_ptr, %f16_val, %f32_ptr = "test.op"() : () -> (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>)
 // CHECK-NEXT:       "csl.faddh"(%dsd_1d1, %dsd_1d2, %dsd_1d3) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-NEXT:       "csl.faddh"(%f16_ptr, %f16_val, %dsd_1d3) : (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
+// CHECK-NEXT:       %one = "test.op"() : () -> i32
+// CHECK-NEXT:       %variable_with_default = "csl.variable"() <{"default" = 42 : i32}> : () -> !csl.var<i32>
+// CHECK-NEXT:       %variable = "csl.variable"() : () -> !csl.var<i32>
+// CHECK-NEXT:       %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+// CHECK-NEXT:       %new_value = arith.addi %value, %one : i32
+// CHECK-NEXT:       "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+// CHECK-NEXT:       "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     csl.func @builtins() {
@@ -628,6 +644,13 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:       %f16_ptr, %f16_val, %f32_ptr = "test.op"() : () -> (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>)
 // CHECK-GENERIC-NEXT:       "csl.faddh"(%dsd_1d1, %dsd_1d2, %dsd_1d3) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-GENERIC-NEXT:       "csl.faddh"(%f16_ptr, %f16_val, %dsd_1d3) : (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
+// CHECK-GENERIC-NEXT:       %one = "test.op"() : () -> i32
+// CHECK-GENERIC-NEXT:       %variable_with_default = "csl.variable"() <{"default" = 42 : i32}> : () -> !csl.var<i32>
+// CHECK-GENERIC-NEXT:       %variable = "csl.variable"() : () -> !csl.var<i32>
+// CHECK-GENERIC-NEXT:       %value = "csl.get_var"(%variable_with_default) : (!csl.var<i32>) -> i32
+// CHECK-GENERIC-NEXT:       %new_value = "arith.addi"(%value, %one) : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:       "csl.update_var"(%variable_with_default, %new_value) : (!csl.var<i32>, i32) -> ()
+// CHECK-GENERIC-NEXT:       "csl.update_var"(%variable, %new_value) : (!csl.var<i32>, i32) -> ()
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
 // CHECK-GENERIC-NEXT:     "csl.func"() <{"sym_name" = "builtins", "function_type" = () -> ()}> ({

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -424,6 +424,8 @@ class CslPrintContext:
                 return "color"
             case csl.DsdType() as dsd:
                 return dsd.data
+            case csl.VarType() as v:
+                return self.mlir_type_to_csl_type(v.get_element_type())
             case _:
                 return f"<!unknown type {type_attr}>"
 
@@ -813,6 +815,22 @@ class CslPrintContext:
                     self.print(
                         f"@{op.name.removeprefix('csl.')}({', '.join(map(self._get_variable_name_for, ops))});"
                     )
+                case csl.VariableOp(default=default, res=res):
+                    var = self._var_use(res, "var")
+                    init_val = (
+                        f" = {self.attribute_value_to_str(default)}"
+                        if default is not None
+                        else ""
+                    )
+                    self.print(f"{var}{init_val};")
+                case csl.GetVarOp(var=var, res=res):
+                    var = self._var_use(var)
+                    const = self._var_use(res)
+                    self.print(f"{const} = {var};")
+                case csl.UpdateVarOp(var=var, new_value=new_value):
+                    var = self._var_use(var)
+                    other = self._var_use(new_value)
+                    self.print(f"{var} = {other};")
                 case anyop:
                     self.print(f"unknown op {anyop}", prefix="//")
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -823,11 +823,11 @@ class CslPrintContext:
                         else ""
                     )
                     self.print(f"{var}{init_val};")
-                case csl.GetVarOp(var=var, res=res):
+                case csl.LoadVarOp(var=var, res=res):
                     var = self._var_use(var)
                     const = self._var_use(res)
                     self.print(f"{const} = {var};")
-                case csl.UpdateVarOp(var=var, new_value=new_value):
+                case csl.StoreVarOp(var=var, new_value=new_value):
                     var = self._var_use(var)
                     other = self._var_use(new_value)
                     self.print(f"{var} = {other};")

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -362,11 +362,75 @@ class ColorType(ParametrizedAttribute, TypeAttribute):
     name = "csl.color"
 
 
+@irdl_attr_definition
+class VarType(ParametrizedAttribute, TypeAttribute, ContainerType[Attribute]):
+    name = "csl.var"
+
+    child_type: ParameterDef[TypeAttribute]
+
+    def get_element_type(self) -> TypeAttribute:
+        return self.child_type
+
+
 ColorIdAttr: TypeAlias = IntegerAttr[IntegerType]
 
 QueueIdAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(3)]]
 
 ParamAttr: TypeAlias = AnyFloatAttr | AnyIntegerAttr
+
+
+@irdl_op_definition
+class VariableOp(IRDLOperation):
+    name = "csl.variable"
+
+    default = opt_prop_def(ParamAttr)
+    res = result_def(VarType)
+
+    def get_element_type(self):
+        assert isinstance(self.res, VarType)
+        return self.res.get_element_type()
+
+    @staticmethod
+    def from_type(child_type: TypeAttribute) -> VariableOp:
+        return VariableOp(result_types=[child_type])
+
+    @staticmethod
+    def from_value(value: ParamAttr) -> VariableOp:
+        return VariableOp(
+            properties={"default": value},
+            result_types=[VarType([value.type])],
+        )
+
+
+@irdl_op_definition
+class GetVarOp(IRDLOperation):
+    name = "csl.get_var"
+    var = operand_def(VarType)
+    res = result_def()
+
+    def __init__(self, var: VariableOp):
+        super().__init__(
+            operands=[var],
+            result_types=[var.get_element_type()],
+        )
+
+
+@irdl_op_definition
+class UpdateVarOp(IRDLOperation):
+    name = "csl.update_var"
+    var = operand_def(VarType)
+    new_value = operand_def()
+
+    def __init__(self, var: VariableOp, new_value: Operation | SSAValue):
+        super().__init__(operands=[var, new_value])
+
+    def verify_(self) -> None:
+        assert isinstance(self.var.type, VarType)
+        if self.var.type.get_element_type() != self.new_value.type:
+            raise VerifyException(
+                f"New value must match the element type of {self.var.type.name}"
+            )
+        return super().verify_()
 
 
 @irdl_op_definition
@@ -1880,6 +1944,9 @@ CSL = Dialect(
         Xp162fhOp,
         Xp162fsOp,
         ZerosOp,
+        VariableOp,
+        GetVarOp,
+        UpdateVarOp,
     ],
     [
         ColorType,
@@ -1893,5 +1960,6 @@ CSL = Dialect(
         PtrConstAttr,
         PtrKindAttr,
         TaskKindAttr,
+        VarType,
     ],
 )

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -403,8 +403,8 @@ class VariableOp(IRDLOperation):
 
 
 @irdl_op_definition
-class GetVarOp(IRDLOperation):
-    name = "csl.get_var"
+class LoadVarOp(IRDLOperation):
+    name = "csl.load_var"
     var = operand_def(VarType)
     res = result_def()
 
@@ -416,8 +416,8 @@ class GetVarOp(IRDLOperation):
 
 
 @irdl_op_definition
-class UpdateVarOp(IRDLOperation):
-    name = "csl.update_var"
+class StoreVarOp(IRDLOperation):
+    name = "csl.store_var"
     var = operand_def(VarType)
     new_value = operand_def()
 
@@ -1945,8 +1945,8 @@ CSL = Dialect(
         Xp162fsOp,
         ZerosOp,
         VariableOp,
-        GetVarOp,
-        UpdateVarOp,
+        LoadVarOp,
+        StoreVarOp,
     ],
     [
         ColorType,


### PR DESCRIPTION
Variables work very much like `memref.global`, but they are scalars.

Ops:
* `csl.variable`: declare variable with optional default value
* `csl.get_var`: get SSA value (constant) of the variable
* `csl.update_var` set variable from ssa value

Types:
* `csl.var<T>`: type of a variable