### PR TITLE
fix: various minor fixes for the csl variables

### DIFF
--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -416,7 +416,7 @@ class VariableOp(IRDLOperation):
             self.default.type != self.res.type.get_element_type()
         ):
             raise VerifyException(
-                "The type of the default value has to be the same as the type of the result, if the supplied is present"
+                "The type of the default value has to be the same as the type of the result, if the former is supplied"
             )
         return super().verify_()
 

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -401,7 +401,7 @@ class VariableOp(IRDLOperation):
 
     @staticmethod
     def from_type(child_type: TypeAttribute) -> VariableOp:
-        return VariableOp(result_types=[child_type])
+        return VariableOp(result_types=[VarType([child_type])])
 
     @staticmethod
     def from_value(value: ParamAttr) -> VariableOp:


### PR DESCRIPTION
* docstrings
* verifications
* `get_element_type` in `VariableOp`

These are fixes which should have been in #3183 