### PR TITLE
dialects: (tosa) turn attributes into properties

### DIFF
--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -5,8 +5,8 @@
 %2 = tosa.rescale %0 {double_round = false, input_zp = 127 : i32, multiplier = array<i32: 1073741824>, output_zp = -1 : i32, per_channel = false, scale32 = true, shift = array<i32: 30>} : (tensor<12x34xi32>) -> tensor<12x34xi32>
 
 
-// CHECK: module {
+// CHECK: builtin.module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> tensor<12x34xi32>
-// CHECK-NEXT:   %1 = tosa.clamp %0 {"max_fp" = 1.000000e+00 : f32, "max_int" = 1 : i64, "min_fp" = 0.000000e+00 : f32, "min_int" = 0 : i64} : (tensor<12x34xi32>) -> tensor<12x34xi32>
-// CHECK-NEXT:   %2 = tosa.rescale %0 {"double_round" = false, "input_zp" = 127 : i32, "multiplier" = array<i32: 1073741824>, "output_zp" = -1 : i32, "per_channel" = false, "scale32" = true, "shift" = array<i32: 30>} : (tensor<12x34xi32>) -> tensor<12x34xi32>
+// CHECK-NEXT:   %1 = tosa.clamp %0 {"min_int" = 0 : i64, "max_int" = 1 : i64, "min_fp" = 0.000000e+00 : f32, "max_fp" = 1.000000e+00 : f32} : (tensor<12x34xi32>) -> tensor<12x34xi32>
+// CHECK-NEXT:   %2 = tosa.rescale %0 {"input_zp" = 127 : i32, "output_zp" = -1 : i32, "multiplier" = array<i32: 1073741824>, "shift" = array<i32: 30>, "scale32" = true, "double_round" = false, "per_channel" = false} : (tensor<12x34xi32>) -> tensor<12x34xi32>
 // CHECK-NEXT: }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tosa/ops.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s | xdsl-opt | mlir-opt | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | mlir-opt --mlir-print-op-generic | xdsl-opt | mlir-opt | filecheck %s
 
 %0 = "test.op"() : () -> tensor<12x34xi32>
 %1 = tosa.clamp %0 {min_fp = 0.0 : f32, max_fp = 1.0: f32, min_int = 0 : i64, max_int = 1 : i64} : (tensor<12x34xi32>) -> tensor<12x34xi32>

--- a/xdsl/dialects/tosa.py
+++ b/xdsl/dialects/tosa.py
@@ -11,9 +11,10 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Dialect
 from xdsl.irdl import (
     IRDLOperation,
-    attr_def,
+    ParsePropInAttrDict,
     irdl_op_definition,
     operand_def,
+    prop_def,
     result_def,
 )
 
@@ -26,14 +27,16 @@ class ClampOp(IRDLOperation):
 
     name = "tosa.clamp"
 
-    min_int = attr_def(IntegerAttr[I64])
-    max_int = attr_def(IntegerAttr[I64])
+    min_int = prop_def(IntegerAttr[I64])
+    max_int = prop_def(IntegerAttr[I64])
 
-    min_fp = attr_def(FloatAttr[AnyFloat])
-    max_fp = attr_def(FloatAttr[AnyFloat])
+    min_fp = prop_def(FloatAttr[AnyFloat])
+    max_fp = prop_def(FloatAttr[AnyFloat])
 
     input = operand_def(TensorType)
     output = result_def(TensorType)
+
+    irdl_options = [ParsePropInAttrDict()]
 
     assembly_format = "$input attr-dict `:` `(` type($input) `)` `->` type($output)"
 
@@ -46,16 +49,18 @@ class RescaleOp(IRDLOperation):
 
     name = "tosa.rescale"
 
-    input_zp = attr_def(IntegerAttr[I32])
-    output_zp = attr_def(IntegerAttr[I32])
-    multiplier = attr_def(DenseArrayBase)
-    shift = attr_def(DenseArrayBase)
-    scale32 = attr_def(BoolAttr)
-    double_round = attr_def(BoolAttr)
-    per_channel = attr_def(BoolAttr)
+    input_zp = prop_def(IntegerAttr[I32])
+    output_zp = prop_def(IntegerAttr[I32])
+    multiplier = prop_def(DenseArrayBase)
+    shift = prop_def(DenseArrayBase)
+    scale32 = prop_def(BoolAttr)
+    double_round = prop_def(BoolAttr)
+    per_channel = prop_def(BoolAttr)
 
     input = operand_def(TensorType)
     output = result_def(TensorType)
+
+    irdl_options = [ParsePropInAttrDict()]
 
     assembly_format = "$input attr-dict `:` `(` type($input) `)` `->` type($output)"
 


### PR DESCRIPTION
The attributes are actually properties in tosa.
I got fooled by the `ParsePropInAttrDict` ☹️ 
