### PR TITLE
dialects: (csl) add  `csl.activate`

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -431,6 +431,10 @@ csl.func @builtins() {
   "csl.xp162fh"(%dest_dsd, %src_dsd1)  : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
   "csl.xp162fs"(%dest_dsd, %src_dsd1)  : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 
+  csl.activate data, 0 : i32
+  csl.activate local, 1 : i32
+  csl.activate control, 42 : i32
+
   csl.return
 }
 
@@ -791,6 +795,9 @@ csl.func @builtins() {
 // CHECK-NEXT:   @xor16(dest_dsd, src_dsd1, src_dsd2);
 // CHECK-NEXT:   @xp162fh(dest_dsd, src_dsd1);
 // CHECK-NEXT:   @xp162fs(dest_dsd, src_dsd1);
+// CHECK-NEXT:   @activate(@get_data_task_id(0));
+// CHECK-NEXT:   @activate(@get_local_task_id(1));
+// CHECK-NEXT:   @activate(@get_control_task_id(42));
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
 // CHECK-NEXT: // -----

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -302,6 +302,8 @@ csl.func @builtins() {
     "csl.xp162fs"(%dest_dsd, %i16_value) : (!csl<dsd mem1d_dsd>, si16) -> ()
     "csl.xp162fs"(%dest_dsd, %u16_value) : (!csl<dsd mem1d_dsd>, ui16) -> ()
 
+    csl.activate local, 0 : i32
+
     csl.return
 }
 
@@ -553,6 +555,7 @@ csl.func @builtins() {
 // CHECK-NEXT:       "csl.xp162fs"(%dest_dsd, %src_dsd1) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-NEXT:       "csl.xp162fs"(%dest_dsd, %i16_value) : (!csl<dsd mem1d_dsd>, si16) -> ()
 // CHECK-NEXT:       "csl.xp162fs"(%dest_dsd, %u16_value) : (!csl<dsd mem1d_dsd>, ui16) -> ()
+// CHECK-NEXT:       csl.activate local, 0 : i32
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
@@ -797,6 +800,7 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:       "csl.xp162fs"(%dest_dsd, %src_dsd1) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-GENERIC-NEXT:       "csl.xp162fs"(%dest_dsd, %i16_value) : (!csl<dsd mem1d_dsd>, si16) -> ()
 // CHECK-GENERIC-NEXT:       "csl.xp162fs"(%dest_dsd, %u16_value) : (!csl<dsd mem1d_dsd>, ui16) -> ()
+// CHECK-GENERIC-NEXT:       "csl.activate"() <{"kind" = #csl<task_kind local>, "id" = 0 : i32}> : () -> ()
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
 // CHECK-GENERIC-NEXT:     %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -553,6 +553,9 @@ class CslPrintContext:
                     self._print_bind_task(name.data, kind.data, id)
                 case csl.FuncOp(sym_name=name, body=bdy, function_type=ftyp):
                     self._print_task_or_fn("fn", name, bdy, ftyp)
+                case csl.ActivateOp(id=id, kind=kind):
+                    id = self.attribute_value_to_str(id)
+                    self.print(f"@activate(@get_{kind.data.value}_task_id({id}));")
                 case csl.ReturnOp(ret_val=None):
                     self.print("return;")
                 case csl.ReturnOp(ret_val=val) if val is not None:

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -866,6 +866,37 @@ class TaskOp(_FuncBase):
 
 
 @irdl_op_definition
+class ActivateOp(IRDLOperation):
+    """
+    This operation corresponds directly to the builtin `@activate` combined with a call to the
+    corresponding `@get_<kind>_task_id` to convert the numeric ID to a task id, e.g.:
+
+    ```
+    csl.activate local, 0 : i32
+           |
+           V
+    @activate(@get_local_task_id(0));
+
+    ```
+    """
+
+    name = "csl.activate"
+
+    id = prop_def(ColorIdAttr)
+    kind = prop_def(TaskKindAttr)
+
+    assembly_format = "attr-dict $kind `,` $id"
+
+    def __init__(self, id: int | ColorIdAttr, kind: TaskKind | TaskKindAttr):
+        if isinstance(id, int):
+            id = IntegerAttr.from_int_and_width(id, 32)
+        if isinstance(kind, TaskKind):
+            kind = TaskKindAttr(kind)
+
+        super().__init__(properties={"id": id, "kind": kind})
+
+
+@irdl_op_definition
 class ReturnOp(IRDLOperation):
     """
     Return for CSL operations such as functions and tasks.
@@ -1976,6 +2007,7 @@ CSL = Dialect(
         Sub16Op,
         SymbolExportOp,
         TaskOp,
+        ActivateOp,
         Xor16Op,
         Xp162fhOp,
         Xp162fsOp,


### PR DESCRIPTION
This corresponds directly to the builtin `@activate` combined with a call to the corresponding `@get_<kind>_task_id` to convert the numeric ID to a task id.

