### PR TITLE
core: Block predecessors

### DIFF
--- a/tests/irdl/test_operation_builder.py
+++ b/tests/irdl/test_operation_builder.py
@@ -677,7 +677,7 @@ def test_two_var_successor_builder():
     _ = Region([block0, block1, block2, block3, block4])
 
     op2.verify()
-    assert op2.successors == [block1, block2, block3, block4]
+    assert tuple(op2.successors) == (block1, block2, block3, block4)
     assert op2.attributes[
         AttrSizedSuccessorSegments.attribute_name
     ] == DenseArrayBase.from_list(i32, [2, 2])
@@ -699,7 +699,7 @@ def test_two_var_successor_builder2():
     _ = Region([block0, block1, block2, block3, block4])
 
     op2.verify()
-    assert op2.successors == [block1, block2, block3, block4]
+    assert tuple(op2.successors) == (block1, block2, block3, block4)
     assert op2.attributes[
         AttrSizedSuccessorSegments.attribute_name
     ] == DenseArrayBase.from_list(i32, [1, 3])

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,8 +1,6 @@
 from xdsl.context import MLContext
 from xdsl.dialects.builtin import Builtin, ModuleOp
-from xdsl.dialects.cf import Cf
-from xdsl.dialects.func import Func, FuncOp
-from xdsl.dialects.test import Test
+from xdsl.dialects.test import Test, TestOp
 from xdsl.ir import Use
 from xdsl.parser import Parser
 
@@ -33,15 +31,15 @@ def test_main():
 
 
 test_prog_blocks = """
-func.func @blocks() {
+"test.op"() ({
   "test.termop"() [^0, ^1] : () -> ()
 ^0:
-  cf.br ^2
+  "test.termop"()[^2] : () -> ()
 ^1:
-  cf.br ^2
+  "test.termop"()[^2] : () -> ()
 ^2:
-  func.return
-}
+  "test.termop"() : () -> ()
+}) : () -> ()
 """
 
 
@@ -49,16 +47,13 @@ def test_predecessor():
     ctx = MLContext()
     ctx.load_dialect(Builtin)
     ctx.load_dialect(Test)
-    ctx.load_dialect(Func)
-    ctx.load_dialect(Cf)
 
     parser = Parser(ctx, test_prog_blocks)
-    func = parser.parse_op()
+    op = parser.parse_op()
 
-    func.verify()
-    assert isinstance(func, FuncOp)
+    assert isinstance(op, TestOp)
 
-    block1, block2, block3, block4 = func.body.blocks
+    block1, block2, block3, block4 = op.regions[0].blocks
 
     assert block1.predecessors() == ()
     assert block2.predecessors() == (block1,)

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -1,5 +1,7 @@
 from xdsl.context import MLContext
 from xdsl.dialects.builtin import Builtin, ModuleOp
+from xdsl.dialects.cf import Cf
+from xdsl.dialects.func import Func, FuncOp
 from xdsl.dialects.test import Test
 from xdsl.ir import Use
 from xdsl.parser import Parser
@@ -28,3 +30,37 @@ def test_main():
     assert op2.results[0].uses == set()
 
     print("Done")
+
+
+test_prog_blocks = """
+func.func @blocks() {
+  "test.termop"() [^0, ^1] : () -> ()
+^0:
+  cf.br ^2
+^1:
+  cf.br ^2
+^2:
+  func.return
+}
+"""
+
+
+def test_predecessor():
+    ctx = MLContext()
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
+    ctx.load_dialect(Func)
+    ctx.load_dialect(Cf)
+
+    parser = Parser(ctx, test_prog_blocks)
+    func = parser.parse_op()
+
+    func.verify()
+    assert isinstance(func, FuncOp)
+
+    block1, block2, block3, block4 = func.body.blocks
+
+    assert block1.predecessors() == ()
+    assert block2.predecessors() == (block1,)
+    assert block3.predecessors() == (block1,)
+    assert set(block4.predecessors()) == set((block2, block3))

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -63,4 +63,4 @@ def test_predecessor():
     assert block1.predecessors() == ()
     assert block2.predecessors() == (block1,)
     assert block3.predecessors() == (block1,)
-    assert set(block4.predecessors()) == set((block2, block3))
+    assert set(block4.predecessors()) == {block2, block3}

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -91,7 +91,24 @@ class Use:
 
 
 @dataclass(eq=False)
-class SSAValue(ABC):
+class IRWithUses(ABC):
+    """IRNode which stores a list of its uses."""
+
+    uses: set[Use] = field(init=False, default_factory=set, repr=False)
+    """All uses of the value."""
+
+    def add_use(self, use: Use):
+        """Add a new use of the value."""
+        self.uses.add(use)
+
+    def remove_use(self, use: Use):
+        """Remove a use of the value."""
+        assert use in self.uses, "use to be removed was not in use list"
+        self.uses.remove(use)
+
+
+@dataclass(eq=False)
+class SSAValue(IRWithUses, ABC):
     """
     A reference to an SSA variable.
     An SSA variable is either an operation result, or a basic block argument.
@@ -99,9 +116,6 @@ class SSAValue(ABC):
 
     type: Attribute
     """Each SSA variable is associated to a type."""
-
-    uses: set[Use] = field(init=False, default_factory=set, repr=False)
-    """All uses of the value."""
 
     _name: str | None = field(init=False, default=None)
 
@@ -152,15 +166,6 @@ class SSAValue(ABC):
                 raise ValueError(
                     "SSAValue.build: expected operation with a single result."
                 )
-
-    def add_use(self, use: Use):
-        """Add a new use of the value."""
-        self.uses.add(use)
-
-    def remove_use(self, use: Use):
-        """Remove a use of the value."""
-        assert use in self.uses, "use to be removed was not in use list"
-        self.uses.remove(use)
 
     def replace_by(self, value: SSAValue) -> None:
         """Replace the value by another value in all its uses."""
@@ -716,7 +721,7 @@ class Operation(IRNode):
     results: tuple[OpResult, ...] = field(default=())
     """The results created by the operation."""
 
-    successors: list[Block] = field(default_factory=list)
+    _successors: tuple[Block, ...] = field(default=())
     """
     The basic blocks that the operation may give control to.
     This list should be empty for non-terminator operations.
@@ -834,6 +839,19 @@ class Operation(IRNode):
         for idx, operand in enumerate(new):
             operand.add_use(Use(self, idx))
         self._operands = new
+
+    @property
+    def successors(self) -> OpSuccessors:
+        return OpSuccessors(self)
+
+    @successors.setter
+    def successors(self, new: Sequence[Block]):
+        new = tuple(new)
+        for idx, successor in enumerate(self._successors):
+            successor.remove_use(Use(self, idx))
+        for idx, successor in enumerate(new):
+            successor.add_use(Use(self, idx))
+        self._successors = new
 
     def __post_init__(self):
         assert self.name != ""
@@ -1330,7 +1348,7 @@ class BlockOps(Reversible[Operation], Iterable[Operation]):
 
 
 @dataclass(init=False)
-class Block(IRNode):
+class Block(IRNode, IRWithUses):
     """A sequence of operations"""
 
     _args: tuple[BlockArgument, ...]
@@ -1383,6 +1401,11 @@ class Block(IRNode):
     def prev_block(self) -> Block | None:
         """The previous block in the parent region"""
         return self._prev_block
+
+    def predecessors(self) -> tuple[Block, ...]:
+        return tuple(
+            p for use in self.uses if (p := use.operation.parent_block()) is not None
+        )
 
     def parent_op(self) -> Operation | None:
         return self.parent.parent if self.parent else None
@@ -1754,6 +1777,50 @@ class _RegionBlocksIterator(Iterator[Block]):
             raise StopIteration
         self.next_block = next_block.next_block
         return next_block
+
+
+@dataclass
+class OpSuccessors(Sequence[Block]):
+    """
+    A view of the successor list of an operation.
+    Any modification to the view is reflected on the operation.
+    """
+
+    _op: Operation
+    """The operation owning the successors."""
+
+    @overload
+    def __getitem__(self, idx: int) -> Block: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> Sequence[Block]: ...
+
+    def __getitem__(self, idx: int | slice) -> Block | Sequence[Block]:
+        return self._op._successors[idx]  # pyright: ignore[reportPrivateUsage]
+
+    def __setitem__(self, idx: int, successor: Block) -> None:
+        successors = self._op._successors  # pyright: ignore[reportPrivateUsage]
+        successors[idx].remove_use(Use(self._op, idx))
+        successor.add_use(Use(self._op, idx))
+        new_successors = (*successors[:idx], successor, *successors[idx + 1 :])
+        self._op._successors = new_successors  # pyright: ignore[reportPrivateUsage]
+
+    def __iter__(self) -> Iterator[Block]:
+        return iter(self._op._successors)  # pyright: ignore[reportPrivateUsage]
+
+    def __len__(self) -> int:
+        return len(self._op._successors)  # pyright: ignore[reportPrivateUsage]
+
+    def __eq__(self, other: object):
+        if not isinstance(other, OpSuccessors):
+            return False
+        return (
+            self._op._successors  # pyright: ignore[reportPrivateUsage]
+            == other._op._successors  # pyright: ignore[reportPrivateUsage]
+        )
+
+    def __hash__(self):
+        return hash(self._op._successors)  # pyright: ignore[reportPrivateUsage]
 
 
 @dataclass

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -814,7 +814,7 @@ class Printer:
 
         return
 
-    def print_successors(self, successors: list[Block]):
+    def print_successors(self, successors: Sequence[Block]):
         if len(successors) == 0:
             return
         self.print_string(" [")


### PR DESCRIPTION
Adds a list of uses to blocks, and adds a function to get the predecessors of a block.

I'm slightly unsure about the code re-use in this PR. It feels slightly wrong to use the `Use` class for both operand usage and successor usage, though the data is the same. I'm also unsure if I should have attempted to unify `OpOperands` and `OpSuccessors` under a single interface, as they are very similar.