### PR TITLE
rewriting: Move dce to rewriter

### DIFF
--- a/docs/Toy/Toy_Ch3.ipynb
+++ b/docs/Toy/Toy_Ch3.ipynb
@@ -175,9 +175,7 @@
     }
    ],
    "source": [
-    "from xdsl.transforms.dead_code_elimination import RemoveUnusedOperations\n",
-    "\n",
-    "PatternRewriteWalker(RemoveUnusedOperations()).rewrite_module(module)\n",
+    "PatternRewriteWalker(dead_code_elimination=True).rewrite_module(module)\n",
     "\n",
     "Printer().print_op(module)"
    ]
@@ -278,7 +276,7 @@
    ],
    "source": [
     "# Remove now unused original constants\n",
-    "PatternRewriteWalker(RemoveUnusedOperations()).rewrite_module(module)\n",
+    "PatternRewriteWalker(dead_code_elimination=True).rewrite_module(module)\n",
     "Printer().print_op(module)"
    ]
   },

--- a/tests/filecheck/dialects/stencil/canonicalize.mlir
+++ b/tests/filecheck/dialects/stencil/canonicalize.mlir
@@ -39,8 +39,7 @@ func.func @unused_res(%f1 : !stencil.field<[0,64]xf64>, %f2 : !stencil.field<[0,
 
 // CHECK:         func.func @unused_res(%f1 : !stencil.field<[0,64]xf64>, %f2 : !stencil.field<[0,64]xf64>, %of : !stencil.field<[0,64]xf64>) {
 // CHECK-NEXT:      %t1 = stencil.load %f1 : !stencil.field<[0,64]xf64> -> !stencil.temp<?xf64>
-// CHECK-NEXT:      %t2 = stencil.load %f2 : !stencil.field<[0,64]xf64> -> !stencil.temp<?xf64>
-// CHECK-NEXT:      %o1 = stencil.apply(%one = %t1 : !stencil.temp<?xf64>, %two = %t2 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
+// CHECK-NEXT:      %o1 = stencil.apply(%one = %t1 : !stencil.temp<?xf64>) -> (!stencil.temp<?xf64>) {
 // CHECK-NEXT:        %0 = stencil.access %one[0] : !stencil.temp<?xf64>
 // CHECK-NEXT:        stencil.return %0 : f64
 // CHECK-NEXT:      }

--- a/xdsl/transforms/canonicalize.py
+++ b/xdsl/transforms/canonicalize.py
@@ -9,7 +9,6 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
 )
 from xdsl.traits import HasCanonicalizationPatternsTrait
-from xdsl.transforms.dead_code_elimination import dce
 
 
 class CanonicalizationRewritePattern(RewritePattern):
@@ -34,5 +33,6 @@ class CanonicalizePass(ModulePass):
     name = "canonicalize"
 
     def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
-        PatternRewriteWalker(CanonicalizationRewritePattern()).rewrite_module(op)
-        dce(op)
+        PatternRewriteWalker(
+            CanonicalizationRewritePattern(), dead_code_elimination=True
+        ).rewrite_module(op)

--- a/xdsl/transforms/common_subexpression_elimination.py
+++ b/xdsl/transforms/common_subexpression_elimination.py
@@ -14,7 +14,7 @@ from xdsl.traits import (
     is_side_effect_free,
     only_has_effect,
 )
-from xdsl.transforms.dead_code_elimination import is_trivially_dead
+from xdsl.transforms.dead_code import is_trivially_dead
 
 
 @dataclass

--- a/xdsl/transforms/dead_code.py
+++ b/xdsl/transforms/dead_code.py
@@ -1,0 +1,43 @@
+from xdsl.ir import Operation, SSAValue
+from xdsl.traits import IsTerminator, MemoryEffectKind, SymbolOpInterface, get_effects
+
+
+def is_trivially_dead(op: Operation):
+    """
+    Returns if the operation has no observable effect.
+    """
+    return (
+        all(not result.uses for result in op.results)
+        and (not op.get_trait(IsTerminator))
+        and (not op.get_trait(SymbolOpInterface))
+        and result_only_effects(op)
+    )
+
+
+def result_only_effects(rootOp: Operation) -> bool:
+    """
+    Returns if we can ensure the operation would have no observable effect beyond its
+    returned values.
+
+    cf MLIR's WouldOpBeTriviallyDead:
+    https://mlir.llvm.org/doxygen/namespacemlir.html#a655db45ed8c23d04d5ed5ee0abe041ad
+
+    We have one key difference here:
+    - MLIR discard any allocation from an operation on its own result for this analysis
+    - xDSL discard any allocation effect of any nested operation on any value defined
+    by the root operation or its children.
+    """
+    effects = get_effects(rootOp)
+    # If the operation has unknown effect, we safely assume it has observable ones
+    return effects is not None and all(
+        # Read-only effect will not affect other operations
+        e.kind == MemoryEffectKind.READ
+        # Allocation of values defined by this operation or its children will not
+        # affect other operations
+        or (
+            e.kind == MemoryEffectKind.ALLOC
+            and isinstance(v := e.value, SSAValue)
+            and rootOp.is_ancestor(v.owner)
+        )
+        for e in effects
+    )

--- a/xdsl/transforms/dead_code_elimination.py
+++ b/xdsl/transforms/dead_code_elimination.py
@@ -1,65 +1,7 @@
 from xdsl.context import MLContext
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import Operation, SSAValue
 from xdsl.passes import ModulePass
-from xdsl.pattern_rewriter import PatternRewriter, PatternRewriteWalker, RewritePattern
-from xdsl.traits import (
-    IsTerminator,
-    MemoryEffectKind,
-    SymbolOpInterface,
-    get_effects,
-)
-
-
-def is_trivially_dead(op: Operation):
-    """
-    Returns if the operation has no observable effect.
-    """
-    return (
-        all(not result.uses for result in op.results)
-        and (not op.get_trait(IsTerminator))
-        and (not op.get_trait(SymbolOpInterface))
-        and result_only_effects(op)
-    )
-
-
-def result_only_effects(rootOp: Operation) -> bool:
-    """
-    Returns if we can ensure the operation would have no observable effect beyond its
-    returned values.
-
-    cf MLIR's WouldOpBeTriviallyDead:
-    https://mlir.llvm.org/doxygen/namespacemlir.html#a655db45ed8c23d04d5ed5ee0abe041ad
-
-    We have one key difference here:
-    - MLIR discard any allocation from an operation on its own result for this analysis
-    - xDSL discard any allocation effect of any nested operation on any value defined
-    by the root operation or its children.
-    """
-    effects = get_effects(rootOp)
-    # If the operation has unknown effect, we safely assume it has observable ones
-    return effects is not None and all(
-        # Read-only effect will not affect other operations
-        e.kind == MemoryEffectKind.READ
-        # Allocation of values defined by this operation or its children will not
-        # affect other operations
-        or (
-            e.kind == MemoryEffectKind.ALLOC
-            and isinstance(v := e.value, SSAValue)
-            and rootOp.is_ancestor(v.owner)
-        )
-        for e in effects
-    )
-
-
-class RemoveUnusedOperations(RewritePattern):
-    """
-    Removes operations annotated with the `Pure` trait, where results have no uses.
-    """
-
-    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter):
-        if is_trivially_dead(op) and op.parent is not None:
-            rewriter.erase_op(op)
+from xdsl.pattern_rewriter import PatternRewriteWalker
 
 
 def dce(op: ModuleOp):
@@ -68,7 +10,9 @@ def dce(op: ModuleOp):
     Modifies input module in-place.
     """
     walker = PatternRewriteWalker(
-        RemoveUnusedOperations(), apply_recursively=True, walk_reverse=True
+        apply_recursively=True,
+        walk_reverse=True,
+        dead_code_elimination=True,
     )
     walker.rewrite_module(op)
 

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -39,7 +39,6 @@ from xdsl.pattern_rewriter import (
 from xdsl.rewriter import InsertPoint
 from xdsl.traits import MemoryEffectKind, get_effects
 from xdsl.transforms.canonicalization_patterns.stencil import ApplyUnusedResults
-from xdsl.transforms.dead_code_elimination import RemoveUnusedOperations
 from xdsl.utils.hints import isa
 
 _TypeElement = TypeVar("_TypeElement", bound=Attribute)
@@ -584,11 +583,11 @@ class StencilBufferize(ModulePass):
                     CombineStoreFold(),
                     LoadBufferFoldPattern(),
                     ApplyStoreFoldPattern(),
-                    RemoveUnusedOperations(),
                     ApplyUnusedResults(),
                     SwapBufferize(),
                 ]
             ),
             apply_recursively=True,
+            dead_code_elimination=True,
         )
         walker.rewrite_module(op)


### PR DESCRIPTION
In mlir, dead code elimination seems to be part of the rewriter itself. I am planning to write a full (region-level) dead code elimination pass but as a start I have moved the "trivial" dead code elimination to the rewriter. I think this change will make more sense with the full pass but I thought this was already enough for a PR.

This also makes canonicalization a little bit more aggressive as dead code elim and canonicalization patterns can be interleaved. This has changed one of the stencil tests so it would be good to get a confirmation that this is OK.

Looks like a lot of changes but it's mostly moving code around which git hasn't managed to keep track of.