### PR TITLE
dialects: (builtin) add AnyMemRefTypeConstr and AnyTensorTypeConstr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -789,6 +789,7 @@ class TensorType(
 
 
 AnyTensorType: TypeAlias = TensorType[Attribute]
+AnyTensorTypeConstr = BaseAttr[TensorType[Attribute]](TensorType)
 
 
 @irdl_attr_definition
@@ -1577,6 +1578,7 @@ class MemRefType(
 
 
 AnyMemRefType: TypeAlias = MemRefType[Attribute]
+AnyMemRefTypeConstr = BaseAttr[MemRefType[Attribute]](MemRefType)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -202,9 +202,7 @@ class ApplyOp(IRDLOperation):
 
     name = "csl_stencil.apply"
 
-    field = operand_def(
-        base(stencil.StencilType[Attribute]) | AnyMemRefTypeConstr
-    )
+    field = operand_def(base(stencil.StencilType[Attribute]) | AnyMemRefTypeConstr)
 
     accumulator = operand_def(AnyTensorTypeConstr | AnyMemRefTypeConstr)
 

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -6,6 +6,8 @@ from xdsl.dialects import builtin, memref, stencil
 from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     AnyMemRefType,
+    AnyMemRefTypeConstr,
+    AnyTensorTypeConstr,
     IndexType,
     MemRefType,
     TensorType,
@@ -124,16 +126,14 @@ class PrefetchOp(IRDLOperation):
     name = "csl_stencil.prefetch"
 
     input_stencil = operand_def(
-        base(stencil.StencilType[Attribute])
-        | base(memref.MemRefType[Attribute])
-        | base(TensorType[Attribute])
+        base(stencil.StencilType[Attribute]) | AnyMemRefTypeConstr | AnyTensorTypeConstr
     )
 
     swaps = prop_def(builtin.ArrayAttr[ExchangeDeclarationAttr])
 
     topo = prop_def(dmp.RankTopoAttr)
 
-    result = result_def(memref.MemRefType | TensorType)
+    result = result_def(AnyMemRefTypeConstr | AnyTensorTypeConstr)
 
     def __init__(
         self,
@@ -203,13 +203,13 @@ class ApplyOp(IRDLOperation):
     name = "csl_stencil.apply"
 
     field = operand_def(
-        base(stencil.StencilType[Attribute]) | base(memref.MemRefType[Attribute])
+        base(stencil.StencilType[Attribute]) | AnyMemRefTypeConstr
     )
 
-    accumulator = operand_def(TensorType[Attribute] | memref.MemRefType[Attribute])
+    accumulator = operand_def(AnyTensorTypeConstr | AnyMemRefTypeConstr)
 
     args = var_operand_def(Attribute)
-    dest = var_operand_def(stencil.FieldType | memref.MemRefType[Attribute])
+    dest = var_operand_def(base(stencil.FieldType[Attribute]) | AnyMemRefTypeConstr)
 
     receive_chunk = region_def()
     done_exchange = region_def()
@@ -334,8 +334,9 @@ class ApplyOp(IRDLOperation):
                 )
 
         # typecheck required (only) block arguments
-        assert isa(
-            self.accumulator.type, TensorType[Attribute] | memref.MemRefType[Attribute]
+        assert isattr(
+            self.accumulator.type,
+            AnyTensorTypeConstr | AnyMemRefTypeConstr,
         )
         chunk_region_req_types = [
             type(self.accumulator.type)(
@@ -377,7 +378,7 @@ class ApplyOp(IRDLOperation):
             res_type = self.dest[0].type
         else:
             res_type = self.res[0].type
-        if isa(res_type, stencil.StencilType[Attribute]):
+        if isattr(res_type, base(stencil.StencilType[Attribute])):
             return res_type.get_num_dims()
         elif self.bounds:
             return len(self.bounds.ub)
@@ -424,11 +425,11 @@ class AccessOp(IRDLOperation):
 
     name = "csl_stencil.access"
     op = operand_def(
-        base(AnyMemRefType) | base(stencil.StencilType) | base(TensorType[Attribute])
+        AnyMemRefTypeConstr | base(stencil.StencilType[Attribute]) | AnyTensorTypeConstr
     )
     offset = prop_def(stencil.IndexAttr)
     offset_mapping = opt_prop_def(stencil.IndexAttr)
-    result = result_def(TensorType | AnyMemRefType)
+    result = result_def(AnyTensorTypeConstr | AnyMemRefTypeConstr)
 
     traits = frozenset([HasAncestor(stencil.ApplyOp, ApplyOp), Pure()])
 
@@ -503,7 +504,7 @@ class AccessOp(IRDLOperation):
             props["offset_mapping"] = stencil.IndexAttr.get(*offset_mapping)
         parser.parse_punctuation(":")
         res_type = parser.parse_attribute()
-        if isa(res_type, stencil.StencilType[Attribute]):
+        if isattr(res_type, base(stencil.StencilType[Attribute])):
             return cls.build(
                 operands=[temp],
                 result_types=[res_type.get_element_type()],
@@ -536,7 +537,7 @@ class AccessOp(IRDLOperation):
                     raise VerifyException(
                         f"{type(self)} access to own data requires{self.op.type} but found {self.result.type}"
                     )
-            elif isa(self.op.type, stencil.StencilType[Attribute]):
+            elif isattr(self.op.type, base(stencil.StencilType[Attribute])):
                 if not self.result.type == self.op.type.get_element_type():
                     raise VerifyException(
                         f"{type(self)} access to own data requires{self.op.type.get_element_type()} but found {self.result.type}"
@@ -546,9 +547,7 @@ class AccessOp(IRDLOperation):
                     f"{type(self)} access to own data requires type stencil.StencilType or memref.MemRefType but found {self.op.type}"
                 )
         else:
-            if not isa(
-                self.op.type, TensorType[Attribute] | memref.MemRefType[Attribute]
-            ):
+            if not isattr(self.op.type, AnyTensorTypeConstr | AnyMemRefTypeConstr):
                 raise VerifyException(
                     f"{type(self)} access to neighbor data requires type memref.MemRefType or TensorType but found {self.op.type}"
                 )

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -9,6 +9,7 @@ from typing import Annotated, Generic, TypeAlias, TypeVar, cast
 
 from xdsl.dialects import builtin, memref
 from xdsl.dialects.builtin import (
+    AnyMemRefTypeConstr,
     ArrayAttr,
     IndexType,
     IntAttr,
@@ -911,7 +912,7 @@ class ExternalLoadOp(IRDLOperation):
 
     name = "stencil.external_load"
     field = operand_def(Attribute)
-    result = result_def(base(FieldType[Attribute]) | base(memref.MemRefType[Attribute]))
+    result = result_def(base(FieldType[Attribute]) | AnyMemRefTypeConstr)
 
     assembly_format = (
         "$field attr-dict-with-keyword `:` type($field) `->` type($result)"

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -5,7 +5,7 @@ from math import prod
 from xdsl.context import MLContext
 from xdsl.dialects import arith, stencil, tensor
 from xdsl.dialects.builtin import (
-    AnyMemRefType,
+    AnyMemRefTypeConstr,
     AnyTensorType,
     IndexType,
     IntegerAttr,
@@ -204,9 +204,9 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
             swap.size[2] == uniform_size for swap in op.swaps
         ), "all swaps need to be of uniform size"
 
-        assert isa(
+        assert isattr(
             op.input_stencil.type,
-            AnyMemRefType | stencil.StencilType[Attribute],
+            AnyMemRefTypeConstr | base(stencil.StencilType[Attribute]),
         )
         assert isa(
             t_type := op.input_stencil.type.get_element_type(), TensorType[Attribute]

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -5,8 +5,9 @@ from xdsl.builder import ImplicitBuilder
 from xdsl.context import MLContext
 from xdsl.dialects import arith, builtin, func, memref, stencil
 from xdsl.dialects.builtin import (
+    AnyMemRefTypeConstr,
+    AnyTensorTypeConstr,
     IntegerAttr,
-    MemRefType,
     ShapedType,
     TensorType,
 )
@@ -23,6 +24,7 @@ from xdsl.pattern_rewriter import (
 from xdsl.rewriter import InsertPoint
 from xdsl.transforms import csl_stencil_bufferize
 from xdsl.utils.hints import isa
+from xdsl.utils.isattr import isattr
 
 
 @dataclass(frozen=True)
@@ -96,9 +98,9 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
                 z_dim = max(z_dim, field_t.get_shape()[-1])
 
             num_chunks = max(num_chunks, apply_op.num_chunks.value.data)
-            if isa(
+            if isattr(
                 buf_t := apply_op.receive_chunk.block.args[0].type,
-                TensorType[Attribute] | MemRefType[Attribute],
+                AnyTensorTypeConstr | AnyMemRefTypeConstr,
             ):
                 chunk_size = max(chunk_size, buf_t.get_shape()[-1])
 


### PR DESCRIPTION
Another small step towards updating Pyright, 170 errors -> 142, by using constraints instead of types in a few places.