### PR TITLE
transforms: (dce) region-level dce

### DIFF
--- a/tests/filecheck/transforms/dce.mlir
+++ b/tests/filecheck/transforms/dce.mlir
@@ -1,0 +1,50 @@
+// RUN: xdsl-opt --allow-unregistered-dialect %s -p dce | filecheck %s
+
+/// Simple op removal
+// CHECK:      "test.op"() ({
+// CHECK-NEXT:   "test.termop"() : () -> ()
+// CHECK-NEXT: }) : () -> ()
+"test.op"() ({
+  %0 = "test.pureop"() : () -> (i32)
+  %1 = "test.pureop"(%0) : (i32) -> (i32)
+  "test.termop"() : () -> ()
+}) : () -> ()
+
+/// Block removal
+// CHECK:      "test.op"() ({
+// CHECK-NEXT:   "test.termop"() [^0] : () -> ()
+// CHECK-NEXT: ^0:
+// CHECK-NEXT:   "test.termop"() : () -> ()
+// CHECK-NEXT: }) : () -> ()
+"test.op"() ({
+  "test.termop"()[^1] : () -> ()
+^0:
+  "test.op"() : () -> ()
+  "test.termop"()[^1] : () -> ()
+^1:
+  "test.termop"() : () -> ()
+}) : () -> ()
+
+/// Circular operation removal
+// CHECK:      "test.op"() ({
+// CHECK-NEXT:   "test.termop"() : () -> ()
+// CHECK-NEXT: }) : () -> ()
+"test.op"() ({
+  %0 = "test.pureop"(%1) : (i32) -> (i32)
+  %1 = "test.pureop"(%0) : (i32) -> (i32)
+  "test.termop"() : () -> ()
+}) : () -> ()
+
+/// Circular block removal
+// CHECK:      "test.op"() ({
+// CHECK-NEXT:   "test.termop"() : () -> ()
+// CHECK-NEXT: }) : () -> ()
+"test.op"() ({
+  "test.termop"() : () -> ()
+^0:
+  %0 = "test.op"(%1) : (i32) -> (i32)
+  "test.termop"()[^1] : () -> ()
+^1:
+  %1 = "test.op"(%0) : (i32) -> (i32)
+  "test.termop"()[^0] : () -> ()
+}) : () -> ()

--- a/tests/filecheck/transforms/dce.mlir
+++ b/tests/filecheck/transforms/dce.mlir
@@ -48,3 +48,18 @@
   %1 = "test.op"(%0) : (i32) -> (i32)
   "test.termop"()[^0] : () -> ()
 }) : () -> ()
+
+/// Recursive test
+// CHECK:      "test.op"() ({
+// CHECK-NEXT:   "test.op"() ({
+// CHECK-NEXT:     "test.termop"() : () -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT:   "test.termop"() : () -> ()
+// CHECK-NEXT: }) : () -> ()
+"test.op"() ({
+  "test.op"() ({
+    "test.pureop"() : () -> ()
+    "test.termop"() : () -> ()
+  }) : () -> ()
+  "test.termop"() : () -> ()
+}) : () -> ()

--- a/xdsl/ir/post_order.py
+++ b/xdsl/ir/post_order.py
@@ -1,0 +1,29 @@
+from collections import deque
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from xdsl.ir import Block, Operation
+from xdsl.traits import IsTerminator
+
+
+@dataclass(init=False)
+class PostOrderIterator(Iterator[Block]):
+    stack: deque[Block]
+    seen: set[Block]
+
+    def __init__(self, block: Block) -> None:
+        self.stack = deque((block,))
+        self.seen = {block}
+
+    def __iter__(self) -> Iterator[Block]:
+        return self
+
+    def __next__(self) -> Block:
+        if not self.stack:
+            raise StopIteration
+        block = self.stack.popleft()
+        term = block.last_op
+        if isinstance(term, Operation) and term.has_trait(IsTerminator()):
+            self.stack.extend(x for x in term.successors if x not in self.seen)
+            self.seen.update(term.successors)
+        return block

--- a/xdsl/transforms/dead_code_elimination.py
+++ b/xdsl/transforms/dead_code_elimination.py
@@ -15,6 +15,9 @@ from xdsl.traits import (
 
 
 def would_be_trivially_dead(op: Operation):
+    """
+    Returns if the operation would be dead if all its results were dead.
+    """
     return (
         not op.get_trait(IsTerminator)
         and (not op.get_trait(SymbolOpInterface))

--- a/xdsl/transforms/dead_code_elimination.py
+++ b/xdsl/transforms/dead_code_elimination.py
@@ -1,6 +1,9 @@
+from dataclasses import dataclass, field
+
 from xdsl.context import MLContext
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.ir import Operation, SSAValue
+from xdsl.ir import Operation, Region, SSAValue
+from xdsl.ir.post_order import PostOrderIterator
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import PatternRewriter, PatternRewriteWalker, RewritePattern
 from xdsl.traits import (
@@ -11,16 +14,19 @@ from xdsl.traits import (
 )
 
 
+def would_be_trivially_dead(op: Operation):
+    return (
+        not op.get_trait(IsTerminator)
+        and (not op.get_trait(SymbolOpInterface))
+        and result_only_effects(op)
+    )
+
+
 def is_trivially_dead(op: Operation):
     """
     Returns if the operation has no observable effect.
     """
-    return (
-        all(not result.uses for result in op.results)
-        and (not op.get_trait(IsTerminator))
-        and (not op.get_trait(SymbolOpInterface))
-        and result_only_effects(op)
-    )
+    return all(not result.uses for result in op.results) and would_be_trivially_dead(op)
 
 
 def result_only_effects(rootOp: Operation) -> bool:
@@ -73,8 +79,80 @@ def dce(op: ModuleOp):
     walker.rewrite_module(op)
 
 
+@dataclass
+class LiveSet:
+    changed: bool = field(default=True)  # Force first iteration to happen
+    _live_ops: set[Operation] = field(default_factory=set)
+
+    def is_live(self, op: Operation) -> bool:
+        return op in self._live_ops
+
+    def set_live(self, op: Operation):
+        if not self.is_live(op):
+            self.changed = True
+            self._live_ops.add(op)
+
+    def propagate_op_liveness(self, op: Operation):
+        for region in op.regions:
+            self.propagate_region_liveness(region)
+
+        if self.is_live(op):
+            return
+
+        if not would_be_trivially_dead(op):
+            self.set_live(op)
+            return
+
+        if any(
+            self.is_live(use.operation) for result in op.results for use in result.uses
+        ):
+            self.set_live(op)
+
+    def propagate_region_liveness(self, region: Region):
+        first = region.first_block
+        if first is None:
+            return
+        for block in PostOrderIterator(first):
+            # Process operations in reverse order to speed convergence
+            for operation in reversed(block.ops):
+                self.propagate_op_liveness(operation)
+
+    def delete_dead(self, region: Region):
+        first = region.first_block
+        if first is None:
+            return
+
+        for block in reversed(region.blocks):
+            if not any(self.is_live(op) for op in block.ops) and block != first:
+                # If block is not the entry block and has no live ops then delete it
+                self.changed = True
+                region.erase_block(block, safe_erase=False)
+                continue
+
+            for operation in reversed(block.ops):
+                if not self.is_live(operation):
+                    self.changed = True
+                    block.erase_op(operation, safe_erase=False)
+                else:
+                    for r in operation.regions:
+                        self.delete_dead(r)
+
+
+def region_dce(region: Region) -> bool:
+    live_set = LiveSet()
+
+    while live_set.changed:
+        live_set.changed = False
+        live_set.propagate_region_liveness(region)
+
+    live_set.changed = False
+    live_set.delete_dead(region)
+    return live_set.changed
+
+
 class DeadCodeElimination(ModulePass):
     name = "dce"
 
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
-        dce(op)
+        for region in op.regions:
+            region_dce(region)

--- a/xdsl/transforms/dead_code_elimination.py
+++ b/xdsl/transforms/dead_code_elimination.py
@@ -148,7 +148,6 @@ def region_dce(region: Region) -> bool:
         live_set.changed = False
         live_set.propagate_region_liveness(region)
 
-    live_set.changed = False
     live_set.delete_dead(region)
     return live_set.changed
 


### PR DESCRIPTION
Introduces a region level algorithm for dead-code elimination, which is capable of deleting unused operations which occur in cycles and deleting blocks. It is modeled on the [mlir implementation](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Transforms/Utils/RegionUtils.cpp). While the mlir implementation separates this into two separate passes (removing dead blocks and then removing dead operations) they have a todo comment for merging them, and so I have implemented it here as a single pass.

I have not implemented removal of block argument removal, for the sake of keeping this PR smaller and my own sanity, as it seems to add a fair bit of complexity.