### PR TITLE
dialects: (stencil) add StencilType constraints

### DIFF
--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -126,7 +126,7 @@ class PrefetchOp(IRDLOperation):
     name = "csl_stencil.prefetch"
 
     input_stencil = operand_def(
-        base(stencil.StencilType[Attribute]) | AnyMemRefTypeConstr | AnyTensorTypeConstr
+        stencil.StencilTypeConstr | AnyMemRefTypeConstr | AnyTensorTypeConstr
     )
 
     swaps = prop_def(builtin.ArrayAttr[ExchangeDeclarationAttr])
@@ -202,12 +202,12 @@ class ApplyOp(IRDLOperation):
 
     name = "csl_stencil.apply"
 
-    field = operand_def(base(stencil.StencilType[Attribute]) | AnyMemRefTypeConstr)
+    field = operand_def(stencil.StencilTypeConstr | AnyMemRefTypeConstr)
 
     accumulator = operand_def(AnyTensorTypeConstr | AnyMemRefTypeConstr)
 
     args = var_operand_def(Attribute)
-    dest = var_operand_def(base(stencil.FieldType[Attribute]) | AnyMemRefTypeConstr)
+    dest = var_operand_def(stencil.FieldTypeConstr | AnyMemRefTypeConstr)
 
     receive_chunk = region_def()
     done_exchange = region_def()
@@ -220,7 +220,7 @@ class ApplyOp(IRDLOperation):
 
     bounds = opt_prop_def(stencil.StencilBoundsAttr)
 
-    res = var_result_def(stencil.StencilType)
+    res = var_result_def(stencil.StencilTypeConstr)
 
     traits = frozenset(
         [
@@ -376,7 +376,7 @@ class ApplyOp(IRDLOperation):
             res_type = self.dest[0].type
         else:
             res_type = self.res[0].type
-        if isattr(res_type, base(stencil.StencilType[Attribute])):
+        if isattr(res_type, stencil.StencilTypeConstr):
             return res_type.get_num_dims()
         elif self.bounds:
             return len(self.bounds.ub)
@@ -423,7 +423,7 @@ class AccessOp(IRDLOperation):
 
     name = "csl_stencil.access"
     op = operand_def(
-        AnyMemRefTypeConstr | base(stencil.StencilType[Attribute]) | AnyTensorTypeConstr
+        AnyMemRefTypeConstr | stencil.StencilTypeConstr | AnyTensorTypeConstr
     )
     offset = prop_def(stencil.IndexAttr)
     offset_mapping = opt_prop_def(stencil.IndexAttr)
@@ -502,7 +502,7 @@ class AccessOp(IRDLOperation):
             props["offset_mapping"] = stencil.IndexAttr.get(*offset_mapping)
         parser.parse_punctuation(":")
         res_type = parser.parse_attribute()
-        if isattr(res_type, base(stencil.StencilType[Attribute])):
+        if isattr(res_type, stencil.StencilTypeConstr):
             return cls.build(
                 operands=[temp],
                 result_types=[res_type.get_element_type()],
@@ -535,7 +535,7 @@ class AccessOp(IRDLOperation):
                     raise VerifyException(
                         f"{type(self)} access to own data requires{self.op.type} but found {self.result.type}"
                     )
-            elif isattr(self.op.type, base(stencil.StencilType[Attribute])):
+            elif isattr(self.op.type, stencil.StencilTypeConstr):
                 if not self.result.type == self.op.type.get_element_type():
                     raise VerifyException(
                         f"{type(self)} access to own data requires{self.op.type.get_element_type()} but found {self.result.type}"

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -686,7 +686,7 @@ class SwapOp(IRDLOperation):
 
     name = "dmp.swap"
 
-    input_stencil = operand_def(stencil.StencilType[Attribute])
+    input_stencil = operand_def(stencil.StencilTypeConstr)
     swapped_values = opt_result_def(stencil.TempType[Attribute])
 
     swaps = attr_def(builtin.ArrayAttr[ExchangeDeclarationAttr])

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -29,11 +29,11 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     AnyAttr,
-    AnyOf,
     AttrSizedOperandSegments,
     BaseAttr,
     ConstraintContext,
     ConstraintVar,
+    GenericAttrConstraint,
     IRDLOperation,
     MessageConstraint,
     ParamAttrConstraint,
@@ -359,6 +359,20 @@ class StencilType(
             nbounds = bounds
         return super().__init__([nbounds, element_type])
 
+    @classmethod
+    def constr(
+        cls,
+        *,
+        bounds: GenericAttrConstraint[Attribute] | None = None,
+        element_type: GenericAttrConstraint[_FieldTypeElement] | None = None,
+    ) -> (
+        BaseAttr[StencilType[Attribute]]
+        | ParamAttrConstraint[StencilType[_FieldTypeElement]]
+    ):
+        if bounds is None and element_type is None:
+            return BaseAttr(cls)
+        return ParamAttrConstraint(cls, (bounds, element_type))
+
 
 @irdl_attr_definition
 class FieldType(
@@ -392,9 +406,9 @@ class TempType(
     name = "stencil.temp"
 
 
-StencilTypeConstr = BaseAttr[StencilType[Attribute]](StencilType)
-FieldTypeConstr = BaseAttr[FieldType[Attribute]](FieldType)
-TempTypeConstr = BaseAttr[TempType[Attribute]](TempType)
+StencilTypeConstr = StencilType[Attribute].constr()
+FieldTypeConstr = FieldType[Attribute].constr()
+TempTypeConstr = TempType[Attribute].constr()
 
 AnyTempType: TypeAlias = TempType[Attribute]
 
@@ -702,27 +716,19 @@ class CastOp(IRDLOperation):
     name = "stencil.cast"
 
     field = operand_def(
-        ParamAttrConstraint(
-            FieldType,
-            [
-                Attribute,
-                MessageConstraint(
-                    VarConstraint("T", AnyAttr()),
-                    "Input and output fields must have the same element types",
-                ),
-            ],
+        FieldType[Attribute].constr(
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr()),
+                "Input and output fields must have the same element types",
+            )
         )
     )
     result = result_def(
-        ParamAttrConstraint(
-            FieldType,
-            [
-                Attribute,
-                MessageConstraint(
-                    VarConstraint("T", AnyAttr()),
-                    "Input and output fields must have the same element types",
-                ),
-            ],
+        FieldType[Attribute].constr(
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr()),
+                "Input and output fields must have the same element types",
+            )
         )
     )
 
@@ -857,17 +863,14 @@ class DynAccessOp(IRDLOperation):
     T = Annotated[Attribute, ConstraintVar("T")]
 
     temp = operand_def(
-        ParamAttrConstraint(
-            StencilType,
-            [
-                Attribute,
-                MessageConstraint(
-                    VarConstraint("T", AnyAttr()),
-                    "Expected result type to be the accessed temp's element type.",
-                ),
-            ],
+        StencilType[Attribute].constr(
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr()),
+                "Expected result type to be the accessed temp's element type.",
+            )
         )
     )
+
     offset = var_operand_def(builtin.IndexType())
     lb = attr_def(IndexAttr)
     ub = attr_def(IndexAttr)
@@ -1013,15 +1016,11 @@ class AccessOp(IRDLOperation):
 
     name = "stencil.access"
     temp = operand_def(
-        ParamAttrConstraint(
-            StencilType,
-            [
-                Attribute,
-                MessageConstraint(
-                    VarConstraint("T", AnyAttr()),
-                    "Expected return type to match the accessed temp's element type.",
-                ),
-            ],
+        StencilType[Attribute].constr(
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr()),
+                "Expected return type to match the accessed temp's element type.",
+            )
         )
     )
     offset = attr_def(IndexAttr)
@@ -1232,25 +1231,18 @@ class LoadOp(IRDLOperation):
     T = Annotated[Attribute, ConstraintVar("T")]
 
     field = operand_def(
-        ParamAttrConstraint(
-            FieldType,
-            [
-                StencilBoundsAttr,
-                MessageConstraint(
-                    VarConstraint("T", AnyAttr()), "Expected element types to match."
-                ),
-            ],
+        FieldType[Attribute].constr(
+            bounds=base(StencilBoundsAttr),
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr()), "Expected element types to match."
+            ),
         )
     )
     res = result_def(
-        ParamAttrConstraint(
-            TempType,
-            [
-                Attribute,
-                MessageConstraint(
-                    VarConstraint("T", AnyAttr()), "Expected element types to match."
-                ),
-            ],
+        TempType[Attribute].constr(
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr()), "Expected element types to match."
+            )
         )
     )
 
@@ -1315,33 +1307,27 @@ class BufferOp(IRDLOperation):
     T = Annotated[TempType[_FieldTypeElement], ConstraintVar("T")]
 
     temp = operand_def(
-        ParamAttrConstraint(
-            TempType,
-            [
-                MessageConstraint(
-                    VarConstraint("B", AnyAttr()),
-                    "Expected input and output to have the same bounds",
-                ),
-                MessageConstraint(
-                    VarConstraint("E", AnyAttr()),
-                    "Expected input and output to have the same element type",
-                ),
-            ],
+        TempType[Attribute].constr(
+            bounds=MessageConstraint(
+                VarConstraint("B", AnyAttr()),
+                "Expected input and output to have the same bounds",
+            ),
+            element_type=MessageConstraint(
+                VarConstraint("E", AnyAttr()),
+                "Expected input and output to have the same element type",
+            ),
         )
     )
     res = result_def(
-        ParamAttrConstraint(
-            StencilType,
-            [
-                MessageConstraint(
-                    VarConstraint("B", AnyAttr()),
-                    "Expected input and output to have the same bounds",
-                ),
-                MessageConstraint(
-                    VarConstraint("E", AnyAttr()),
-                    "Expected input and output to have the same element type",
-                ),
-            ],
+        StencilType[Attribute].constr(
+            bounds=MessageConstraint(
+                VarConstraint("B", AnyAttr()),
+                "Expected input and output to have the same bounds",
+            ),
+            element_type=MessageConstraint(
+                VarConstraint("E", AnyAttr()),
+                "Expected input and output to have the same element type",
+            ),
         )
     )
 
@@ -1420,40 +1406,24 @@ class StoreOp(IRDLOperation):
     name = "stencil.store"
 
     temp = operand_def(
-        ParamAttrConstraint(
-            TempType,
-            [
-                Attribute,
-                MessageConstraint(
-                    AnyOf(
-                        [
-                            VarConstraint("T", AnyAttr()),
-                            TensorIgnoreSizeConstraint("T", AnyAttr()),
-                        ]
-                    ),
-                    "Input and output fields must have the same element types",
-                ),
-            ],
+        TempType[Attribute].constr(
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr())
+                | TensorIgnoreSizeConstraint("T", AnyAttr()),
+                "Input and output fields must have the same element types",
+            ),
         )
     )
-    # field = operand_def(FieldType)
     field = operand_def(
-        ParamAttrConstraint(
-            FieldType,
-            [
-                MessageConstraint(
-                    StencilBoundsAttr, "Output type's size must be explicit"
-                ),
-                MessageConstraint(
-                    AnyOf(
-                        [
-                            VarConstraint("T", AnyAttr()),
-                            TensorIgnoreSizeConstraint("T", AnyAttr()),
-                        ]
-                    ),
-                    "Input and output fields must have the same element types",
-                ),
-            ],
+        FieldType[Attribute].constr(
+            bounds=MessageConstraint(
+                StencilBoundsAttr, "Output type's size must be explicit"
+            ),
+            element_type=MessageConstraint(
+                VarConstraint("T", AnyAttr())
+                | TensorIgnoreSizeConstraint("T", AnyAttr()),
+                "Input and output fields must have the same element types",
+            ),
         )
     )
     bounds = attr_def(StencilBoundsAttr)

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -31,6 +31,7 @@ from xdsl.irdl import (
     AnyAttr,
     AnyOf,
     AttrSizedOperandSegments,
+    BaseAttr,
     ConstraintContext,
     ConstraintVar,
     IRDLOperation,
@@ -70,6 +71,7 @@ from xdsl.traits import (
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
+from xdsl.utils.isattr import isattr
 
 _FieldTypeElement = TypeVar("_FieldTypeElement", bound=Attribute, covariant=True)
 
@@ -389,6 +391,10 @@ class TempType(
 
     name = "stencil.temp"
 
+
+StencilTypeConstr = BaseAttr[StencilType[Attribute]](StencilType)
+FieldTypeConstr = BaseAttr[FieldType[Attribute]](FieldType)
+TempTypeConstr = BaseAttr[TempType[Attribute]](TempType)
 
 AnyTempType: TypeAlias = TempType[Attribute]
 
@@ -1094,7 +1100,7 @@ class AccessOp(IRDLOperation):
             attrs["offset_mapping"] = IndexAttr.get(*offset_mapping)
         parser.parse_punctuation(":")
         res_type = parser.parse_attribute()
-        if not isa(res_type, StencilType[Attribute]):
+        if not isattr(res_type, StencilTypeConstr):
             parser.raise_error(
                 "Expected return type to be a stencil.temp or stencil.field"
             )
@@ -1142,7 +1148,7 @@ class AccessOp(IRDLOperation):
         apply.verify_()
 
         temp_type = self.temp.type
-        assert isa(temp_type, StencilType[Attribute])
+        assert isattr(temp_type, StencilTypeConstr)
         if temp_type.get_num_dims() != apply.get_rank():
             if self.offset_mapping is None:
                 raise VerifyException(

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -361,10 +361,13 @@ class ParamAttrConstraint(
         self,
         base_attr: type[ParametrizedAttributeCovT],
         param_constrs: Sequence[
-            (Attribute | type[Attribute] | GenericAttrConstraint[Attribute])
+            (Attribute | type[Attribute] | GenericAttrConstraint[Attribute] | None)
         ],
     ):
-        constrs = tuple(attr_constr_coercion(constr) for constr in param_constrs)
+        constrs = tuple(
+            attr_constr_coercion(constr) if constr is not None else AnyAttr()
+            for constr in param_constrs
+        )
         object.__setattr__(self, "base_attr", base_attr)
         object.__setattr__(self, "param_constrs", constrs)
 

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -206,7 +206,7 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
 
         assert isattr(
             op.input_stencil.type,
-            AnyMemRefTypeConstr | base(stencil.StencilType[Attribute]),
+            AnyMemRefTypeConstr | stencil.StencilTypeConstr,
         )
         assert isa(
             t_type := op.input_stencil.type.get_element_type(), TensorType[Attribute]

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -84,7 +84,7 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
                     apply_op.done_exchange.block.args[1].type.get_shape()[-1],
                 )
 
-            # retrieve z_dim from post_process arg[0]
+            # retrieve z_dim from done_exchange arg[0]
             if isattr(
                 field_t := apply_op.done_exchange.block.args[0].type,
                 stencil.StencilTypeConstr,

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -84,15 +84,16 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
                     apply_op.done_exchange.block.args[1].type.get_shape()[-1],
                 )
 
-            # retrieve z_dim from done_exchange arg[0]
-            if isa(
+            # retrieve z_dim from post_process arg[0]
+            if isattr(
                 field_t := apply_op.done_exchange.block.args[0].type,
-                stencil.StencilType[
-                    TensorType[Attribute] | memref.MemRefType[Attribute]
-                ],
+                stencil.StencilTypeConstr,
+            ) and isattr(
+                el_type := field_t.element_type,
+                AnyTensorTypeConstr | AnyMemRefTypeConstr,
             ):
                 # unbufferized csl_stencil
-                z_dim = max(z_dim, field_t.get_element_type().get_shape()[-1])
+                z_dim = max(z_dim, el_type.get_shape()[-1])
             elif isa(field_t, memref.MemRefType[Attribute]):
                 # bufferized csl_stencil
                 z_dim = max(z_dim, field_t.get_shape()[-1])

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -27,6 +27,7 @@ from xdsl.dialects.stencil import (
     ReturnOp,
     StencilBoundsAttr,
     StencilType,
+    StencilTypeConstr,
     StoreOp,
     StoreResultOp,
     TempType,
@@ -54,6 +55,7 @@ from xdsl.pattern_rewriter import (
 from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
+from xdsl.utils.isattr import isattr
 
 _TypeElement = TypeVar("_TypeElement", bound=Attribute)
 
@@ -458,7 +460,7 @@ class AccessOpToMemref(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: AccessOp, rewriter: PatternRewriter, /):
         temp = op.temp.type
-        assert isa(temp, StencilType[Attribute])
+        assert isattr(temp, StencilTypeConstr)
         assert isinstance(temp.bounds, StencilBoundsAttr)
 
         memref_offset = op.offset


### PR DESCRIPTION
This adds some constraint constants and a new `.constr` helper to construct parametrized constraints for stencil types. Pyright errors 143 -> 133