### PR TITLE
fix: add extension to filename when calling set_tile_code

### DIFF
--- a/tests/filecheck/transforms/lower-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/lower-csl-wrapper.mlir
@@ -115,7 +115,7 @@ builtin.module {
 // CHECK-NEXT:           %18 = arith.ori %17, %15 : i1
 // CHECK-NEXT:           %isBorderRegionPE = arith.ori %18, %16 : i1
 // CHECK-NEXT:           %19 = "csl.const_struct"(%width, %height, %getParamsRes, %computeAllRoutesRes, %isBorderRegionPE) <{"ssa_fields" = ["width", "height", "memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (i16, i16, !csl.comptime_struct, !csl.comptime_struct, i1) -> !csl.comptime_struct
-// CHECK-NEXT:           "csl.set_tile_code"(%xDim, %yDim, %19) <{"file" = "gauss_seidel_func"}> : (i16, i16, !csl.comptime_struct) -> ()
+// CHECK-NEXT:           "csl.set_tile_code"(%xDim, %yDim, %19) <{"file" = "gauss_seidel_func.csl"}> : (i16, i16, !csl.comptime_struct) -> ()
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }

--- a/xdsl/transforms/lower_csl_wrapper.py
+++ b/xdsl/transforms/lower_csl_wrapper.py
@@ -73,7 +73,9 @@ class ExtractCslModules(RewritePattern):
         )
         return (
             struct,
-            csl.SetTileCodeOp(fname=prog_name, x_coord=x, y_coord=y, params=struct),
+            csl.SetTileCodeOp(
+                fname=f"{prog_name}.csl", x_coord=x, y_coord=y, params=struct
+            ),
         )
 
     def lower_layout_module(


### PR DESCRIPTION
When directly invoking `cslc`, the `.csl` file extension is not required, but when compiling with the SDK it is.