### PR TITLE
dialects (arith) add fastmath option for float comparisons

### DIFF
--- a/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_arith_to_riscv.mlir
@@ -219,6 +219,55 @@ builtin.module {
     // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf14_2, 1 : (!riscv.reg) -> !riscv.reg
     %cmpf15 = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 15 : i32} : (f32, f32) -> i1
     // CHECK-NEXT: %{{.*}} = riscv.li 1 : !riscv.reg
+
+    // tests with fastmath flags when set to "fast"
+    %cmpf0_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 0 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.li 0 fastmath<fast> : !riscv.reg
+    %cmpf1_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 1 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %cmpf2_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 2 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %cmpf3_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 3 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %cmpf4_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 4 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %cmpf5_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 5 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    %cmpf6_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 6 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.or %cmpf6_fm_1, %cmpf6_fm : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %cmpf7_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 7 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.and %cmpf7_fm_1, %cmpf7_fm : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %cmpf8_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 8 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.or %cmpf8_fm_1, %cmpf8_fm : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf8_fm_2, 1 : (!riscv.reg) -> !riscv.reg
+    %cmpf9_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 9 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf9_fm, 1 : (!riscv.reg) -> !riscv.reg
+    %cmpf10_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 10 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf10_fm, 1 : (!riscv.reg) -> !riscv.reg
+    %cmpf11_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 11 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.fle.s %rhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf11_fm, 1 : (!riscv.reg) -> !riscv.reg
+    %cmpf12_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 12 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.flt.s %rhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf12_fm, 1 : (!riscv.reg) -> !riscv.reg
+    %cmpf13_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 13 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf13_fm, 1 : (!riscv.reg) -> !riscv.reg
+    %cmpf14_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 14 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %lhsf32_1, %lhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.feq.s %rhsf32_1, %rhsf32_1 fastmath<fast> : (!riscv.freg, !riscv.freg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.and %cmpf14_fm_1, %cmpf14_fm : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    // CHECK-NEXT: %{{.*}} = riscv.xori %cmpf14_fm_2, 1 : (!riscv.reg) -> !riscv.reg
+    %cmpf15_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 15 : i32, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
+    // CHECK-NEXT: %{{.*}} = riscv.li 1 fastmath<fast> : !riscv.reg
     %index_cast = "arith.index_cast"(%lhsindex) : (index) -> i32
     // CHECK-NEXT: }
 }

--- a/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
@@ -352,29 +352,33 @@ class LowerArithCmpf(RewritePattern):
         lhs, rhs = cast_operands_to_regs(rewriter)
         cast_matched_op_results(rewriter)
 
+        fastmath = None
+        if op.fastmath is not None:
+            fastmath = riscv.FastMathFlagsAttr(op.fastmath.data)
+
         match op.predicate.value.data:
             # false
             case 0:
-                rewriter.replace_matched_op([riscv.LiOp(0)])
+                rewriter.replace_matched_op([riscv.LiOp(0, fastmath=fastmath)])
             # oeq
             case 1:
-                rewriter.replace_matched_op([riscv.FeqSOP(lhs, rhs)])
+                rewriter.replace_matched_op([riscv.FeqSOP(lhs, rhs, fastmath=fastmath)])
             # ogt
             case 2:
-                rewriter.replace_matched_op([riscv.FltSOP(rhs, lhs)])
+                rewriter.replace_matched_op([riscv.FltSOP(rhs, lhs, fastmath=fastmath)])
             # oge
             case 3:
-                rewriter.replace_matched_op([riscv.FleSOP(rhs, lhs)])
+                rewriter.replace_matched_op([riscv.FleSOP(rhs, lhs, fastmath=fastmath)])
             # olt
             case 4:
-                rewriter.replace_matched_op([riscv.FltSOP(lhs, rhs)])
+                rewriter.replace_matched_op([riscv.FltSOP(lhs, rhs, fastmath=fastmath)])
             # ole
             case 5:
-                rewriter.replace_matched_op([riscv.FleSOP(lhs, rhs)])
+                rewriter.replace_matched_op([riscv.FleSOP(lhs, rhs, fastmath=fastmath)])
             # one
             case 6:
-                flt1 = riscv.FltSOP(lhs, rhs)
-                flt2 = riscv.FltSOP(rhs, lhs)
+                flt1 = riscv.FltSOP(lhs, rhs, fastmath=fastmath)
+                flt2 = riscv.FltSOP(rhs, lhs, fastmath=fastmath)
                 rewriter.replace_matched_op(
                     [
                         flt1,
@@ -384,8 +388,8 @@ class LowerArithCmpf(RewritePattern):
                 )
             # ord
             case 7:
-                feq1 = riscv.FeqSOP(lhs, lhs)
-                feq2 = riscv.FeqSOP(rhs, rhs)
+                feq1 = riscv.FeqSOP(lhs, lhs, fastmath=fastmath)
+                feq2 = riscv.FeqSOP(rhs, rhs, fastmath=fastmath)
                 rewriter.replace_matched_op(
                     [
                         feq1,
@@ -395,39 +399,39 @@ class LowerArithCmpf(RewritePattern):
                 )
             # ueq
             case 8:
-                flt1 = riscv.FltSOP(lhs, rhs)
-                flt2 = riscv.FltSOP(rhs, lhs)
+                flt1 = riscv.FltSOP(lhs, rhs, fastmath=fastmath)
+                flt2 = riscv.FltSOP(rhs, lhs, fastmath=fastmath)
                 or_ = riscv.OrOp(flt2, flt1, rd=riscv.IntRegisterType.unallocated())
                 rewriter.replace_matched_op([flt1, flt2, or_, riscv.XoriOp(or_, 1)])
             # ugt
             case 9:
-                fle = riscv.FleSOP(lhs, rhs)
+                fle = riscv.FleSOP(lhs, rhs, fastmath=fastmath)
                 rewriter.replace_matched_op([fle, riscv.XoriOp(fle, 1)])
             # uge
             case 10:
-                fle = riscv.FltSOP(lhs, rhs)
+                fle = riscv.FltSOP(lhs, rhs, fastmath=fastmath)
                 rewriter.replace_matched_op([fle, riscv.XoriOp(fle, 1)])
             # ult
             case 11:
-                fle = riscv.FleSOP(rhs, lhs)
+                fle = riscv.FleSOP(rhs, lhs, fastmath=fastmath)
                 rewriter.replace_matched_op([fle, riscv.XoriOp(fle, 1)])
             # ule
             case 12:
-                flt = riscv.FltSOP(rhs, lhs)
+                flt = riscv.FltSOP(rhs, lhs, fastmath=fastmath)
                 rewriter.replace_matched_op([flt, riscv.XoriOp(flt, 1)])
             # une
             case 13:
-                feq = riscv.FeqSOP(lhs, rhs)
+                feq = riscv.FeqSOP(lhs, rhs, fastmath=fastmath)
                 rewriter.replace_matched_op([feq, riscv.XoriOp(feq, 1)])
             # uno
             case 14:
-                feq1 = riscv.FeqSOP(lhs, lhs)
-                feq2 = riscv.FeqSOP(rhs, rhs)
+                feq1 = riscv.FeqSOP(lhs, lhs, fastmath=fastmath)
+                feq2 = riscv.FeqSOP(rhs, rhs, fastmath=fastmath)
                 and_ = riscv.AndOp(feq2, feq1, rd=riscv.IntRegisterType.unallocated())
                 rewriter.replace_matched_op([feq1, feq2, and_, riscv.XoriOp(and_, 1)])
             # true
             case 15:
-                rewriter.replace_matched_op([riscv.LiOp(1)])
+                rewriter.replace_matched_op([riscv.LiOp(1, fastmath=fastmath)])
             case _:
                 raise NotImplementedError("Cmpf predicate not supported")
 


### PR DESCRIPTION
Add an optional fastmath attribute to `arith.cmpf` and include the attribute while lowering to riscv

Hopefully closes #2725.
