### PR TITLE
dialects (arith): add fastmath optional attribute to cmpf

### DIFF
--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -173,7 +173,7 @@
 
   %cmpf_fm = "arith.cmpf"(%lhsf32, %rhsf32) {"predicate" = 2 : i64, "fastmath" = #arith.fastmath<fast>} : (f32, f32) -> i1
 
-  // CHECK-NEXT: %cmpf_fm = arith.cmpf ogt, %lhsf32, %rhsf32 fastmath<fast> : f32
+  // CHECK-NEXT: %cmpf_fm = arith.cmpf ogt, %lhsf32, %rhsf32 {"fastmath" = #arith.fastmath<fast>} : f32
 
   %selecti = "arith.select"(%lhsi1, %lhsi32, %rhsi32) : (i1, i32, i32) -> i32
   %selectf = "arith.select"(%lhsi1, %lhsf32, %rhsf32) : (i1, f32, f32) -> f32

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/arith/arith_cmp.mlir
@@ -15,7 +15,7 @@
   %11 = "arith.select"(%10, %4, %5) : (i1, index, index) -> index
 }) : ()->()
 
-// CHECK:        "arith.cmpf"(%0, %1) <{"fastmath" = #arith.fastmath<none>, "predicate" = 2 : i64}> : (f64, f64) -> i1
+// CHECK:        "arith.cmpf"(%0, %1) <{"predicate" = 2 : i64, "fastmath" = #arith.fastmath<none>}> : (f64, f64) -> i1
 // CHECK:        "arith.select"(%6, %0, %1) : (i1, f64, f64) -> f64
 // CHECK:        "arith.cmpi"(%2, %3) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
 // CHECK:        "arith.select"(%8, %2, %3) : (i1, i32, i32) -> i32

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -829,8 +829,8 @@ class Cmpf(ComparisonOperation):
         printer.print(", ")
         printer.print_operand(self.rhs)
         if self.fastmath != FastMathFlagsAttr("none"):
-            printer.print_string(" fastmath")
-            self.fastmath.print_parameter(printer)
+            printer.print(" ")
+            printer.print_attr_dict({"fastmath": self.fastmath})
         printer.print(" : ")
         printer.print_attribute(self.lhs.type)
 


### PR DESCRIPTION
`arith`-only part of #3272, with a new dialect test added

