### PR TITLE
transformations: (cf) cf.cond_br identical successors

### DIFF
--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -100,11 +100,16 @@ class ConditionalBranchHasCanonicalizationPatterns(HasCanonicalizationPatternsTr
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.cf import (
+            SimplifyCondBranchIdenticalSuccessors,
             SimplifyConstCondBranchPred,
             SimplifyPassThroughCondBranch,
         )
 
-        return (SimplifyConstCondBranchPred(), SimplifyPassThroughCondBranch())
+        return (
+            SimplifyConstCondBranchPred(),
+            SimplifyPassThroughCondBranch(),
+            SimplifyCondBranchIdenticalSuccessors(),
+        )
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -205,7 +205,7 @@ class SimplifyCondBranchIdenticalSuccessors(RewritePattern):
 
         merged_operands = tuple(
             self._merge_operand(op1, op2, rewriter, op)
-            for (op1, op2) in zip(op.then_arguments, op.else_arguments)
+            for (op1, op2) in zip(op.then_arguments, op.else_arguments, strict=True)
         )
 
         rewriter.replace_matched_op(cf.Branch(op.then_block, *merged_operands))


### PR DESCRIPTION
Adds simplification to `cf.cond_br` when both branches point to the same successor.

The mlir version only performs the reduction when either all the operands are the same, or the common destination branch only has one predecessor. I have no idea why this is and didn't include this condition.

Also updates some of the other tests which now reduce further