### PR TITLE
misc: remove unnecessary pyright ignore comments [NFC]

### DIFF
--- a/tests/backend/test_jax_executable.py
+++ b/tests/backend/test_jax_executable.py
@@ -170,7 +170,7 @@ def test_return_annotation_tuple_type():
         ),
     ):
 
-        @executable  # pyright: ignore[reportArgumentType, reportGeneralTypeIssues]
+        @executable  # pyright: ignore[reportArgumentType]
         def abs_wrong_tuple_type(a: jax.Array) -> tuple[int]: ...  # pyright: ignore[reportUnusedFunction]
 
 
@@ -190,7 +190,7 @@ def test_return_annotation_single():
         match="Return annotation is must be jnp.ndarray or a tuple of jnp.ndarray",
     ):
 
-        @executable  # pyright: ignore[reportArgumentType, reportGeneralTypeIssues]
+        @executable  # pyright: ignore[reportArgumentType]
         def abs_wrong_single_type(a: jax.Array) -> int: ...  # pyright: ignore[reportUnusedFunction]
 
 

--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -35,7 +35,4 @@ def test_insn_repr(op: RISCVInstruction):
     # Limitation of Pyright, see https://github.com/microsoft/pyright/issues/7105
     # We are currently stuck on an older version of Pyright, the update is
     # tracked in https://github.com/xdslproject/xdsl/issues/2791
-    assert (
-        trait.get_insn(op)  # pyright: ignore[reportGeneralTypeIssues]
-        == ground_truth[op.name[13:]]
-    )
+    assert trait.get_insn(op) == ground_truth[op.name[13:]]

--- a/tests/filecheck/frontend/dialects/affine.py
+++ b/tests/filecheck/frontend/dialects/affine.py
@@ -75,7 +75,7 @@ try:
         # CHECK: Expected integer constant for loop end, got 'float'.
         def test_not_supported_affine_loop_I():
             for _ in range(
-                12.0  # pyright: ignore[reportArgumentType, reportGeneralTypeIssues]
+                12.0  # pyright: ignore[reportArgumentType]
             ):
                 pass
             return
@@ -90,7 +90,7 @@ try:
         # CHECK: Expected integer constant for loop start, got 'str'.
         def test_not_supported_affine_loop_II():
             for _ in range(
-                "boom",  # pyright: ignore[reportArgumentType, reportGeneralTypeIssues]
+                "boom",  # pyright: ignore[reportArgumentType]
                 100,
             ):
                 pass
@@ -108,7 +108,7 @@ try:
             for _ in range(
                 0,
                 100,
-                1.0,  # pyright: ignore[reportArgumentType, reportGeneralTypeIssues]
+                1.0,  # pyright: ignore[reportArgumentType]
             ):
                 pass
             return

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -128,7 +128,7 @@ def test_format_and_parse_op():
     ):
 
         @irdl_op_definition
-        class FormatAndParseOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
+        class FormatAndParseOp(IRDLOperation):
             name = "test.format_and_parse"
 
             assembly_format = "attr-dict"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -426,7 +426,7 @@ def test_parse_block_name():
 
     ctx = MLContext()
     parser = Parser(ctx, block_str)
-    block = parser._parse_block()  # pyright: ignore[reportPrivateUsage]
+    block = parser._parse_block()
 
     assert block.args[0].name_hint == "name"
     assert block.args[1].name_hint is None

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -205,7 +205,7 @@ def test_traits_undefined():
 class WrongTraitsType(IRDLOperation):
     name = "test.no_traits"
 
-    traits = 1  # pyright: ignore[reportGeneralTypeIssues, reportAssignmentType]
+    traits = 1  # pyright: ignore[reportAssignmentType]
 
 
 def test_traits_wrong_type():

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -519,7 +519,7 @@ class IntegerAttr(
         *,
         # pyright needs updating, with the new one it works fine
         value: AttrConstraint | None = None,
-        type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,  # pyright: ignore[reportGeneralTypeIssues]
+        type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,
     ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrType]]:
         if value is None and type == AnyAttr():
             return BaseAttr[IntegerAttr[_IntegerAttrType]](IntegerAttr)
@@ -1605,7 +1605,7 @@ class MemRefType(
         *,
         shape: GenericAttrConstraint[Attribute] | None = None,
         # pyright needs updating, with the new one it works fine
-        element_type: GenericAttrConstraint[_MemRefTypeElement] = AnyAttr(),  # pyright: ignore[reportGeneralTypeIssues]
+        element_type: GenericAttrConstraint[_MemRefTypeElement] = AnyAttr(),
         layout: GenericAttrConstraint[Attribute] | None = None,
         memory_space: GenericAttrConstraint[Attribute] | None = None,
     ) -> GenericAttrConstraint[MemRefType[_MemRefTypeElement]]:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -517,7 +517,6 @@ class IntegerAttr(
     def constr(
         cls,
         *,
-        # pyright needs updating, with the new one it works fine
         value: AttrConstraint | None = None,
         type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,
     ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrType]]:
@@ -1604,7 +1603,6 @@ class MemRefType(
         cls,
         *,
         shape: GenericAttrConstraint[Attribute] | None = None,
-        # pyright needs updating, with the new one it works fine
         element_type: GenericAttrConstraint[_MemRefTypeElement] = AnyAttr(),
         layout: GenericAttrConstraint[Attribute] | None = None,
         memory_space: GenericAttrConstraint[Attribute] | None = None,

--- a/xdsl/dialects/stream.py
+++ b/xdsl/dialects/stream.py
@@ -52,7 +52,6 @@ class StreamType(
     def constr(
         cls,
         *,
-        # pyright needs updating, with the new one it works fine
         element_type: GenericAttrConstraint[_StreamTypeElement] = AnyAttr(),
     ) -> GenericAttrConstraint[StreamType[_StreamTypeElement]]:
         if element_type == AnyAttr():

--- a/xdsl/dialects/stream.py
+++ b/xdsl/dialects/stream.py
@@ -53,7 +53,7 @@ class StreamType(
         cls,
         *,
         # pyright needs updating, with the new one it works fine
-        element_type: GenericAttrConstraint[_StreamTypeElement] = AnyAttr(),  # pyright: ignore[reportGeneralTypeIssues]
+        element_type: GenericAttrConstraint[_StreamTypeElement] = AnyAttr(),
     ) -> GenericAttrConstraint[StreamType[_StreamTypeElement]]:
         if element_type == AnyAttr():
             return BaseAttr[StreamType[_StreamTypeElement]](StreamType)

--- a/xdsl/frontend/dialects/builtin.py
+++ b/xdsl/frontend/dialects/builtin.py
@@ -39,8 +39,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import addi
 
         return addi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
+            self,  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
         )
 
     def __and__(
@@ -49,8 +49,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import andi
 
         return andi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
+            self,  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
         )
 
     def __lshift__(
@@ -59,8 +59,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import shli
 
         return shli(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
+            self,  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
         )
 
     def __mul__(
@@ -69,8 +69,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import muli
 
         return muli(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
+            self,  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
         )
 
     def __rshift__(
@@ -79,8 +79,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import shrsi
 
         return shrsi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
+            self,  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
         )
 
     def __sub__(
@@ -89,8 +89,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import subi
 
         return subi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportUnknownVariableType, reportArgumentType]
+            self,  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
         )
 
     def __eq__(  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -99,8 +99,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import cmpi
 
         return cmpi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
+            self,  # pyright: ignore[reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
             "eq",
         )
 
@@ -108,8 +108,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import cmpi
 
         return cmpi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
+            self,  # pyright: ignore[reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
             "sge",
         )
 
@@ -117,8 +117,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import cmpi
 
         return cmpi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
+            self,  # pyright: ignore[reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
             "sgt",
         )
 
@@ -126,8 +126,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import cmpi
 
         return cmpi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
+            self,  # pyright: ignore[reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
             "sle",
         )
 
@@ -135,8 +135,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import cmpi
 
         return cmpi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
+            self,  # pyright: ignore[reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
             "slt",
         )
 
@@ -146,8 +146,8 @@ class _Integer(Generic[_Width, _Signedness], _FrontendType):
         from xdsl.frontend.dialects.arith import cmpi
 
         return cmpi(
-            self,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
-            other,  # pyright: ignore[reportGeneralTypeIssues, reportArgumentType]
+            self,  # pyright: ignore[reportArgumentType]
+            other,  # pyright: ignore[reportArgumentType]
             "ne",
         )
 

--- a/xdsl/frontend/type_conversion.py
+++ b/xdsl/frontend/type_conversion.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from typing import (
     Any,
     TypeAlias,
-    _GenericAlias,  # pyright: ignore[reportPrivateUsage, reportGeneralTypeIssues, reportUnknownVariableType, reportAttributeAccessIssue]
+    _GenericAlias,  # pyright: ignore[reportUnknownVariableType, reportAttributeAccessIssue]
 )
 
 import xdsl.dialects.builtin as xdsl_builtin

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -240,9 +240,9 @@ def irdl_param_attr_definition(cls: _PAttrTT) -> _PAttrTT:
     return runtime_final(
         dataclass(frozen=True, init=False)(
             type.__new__(
-                type(cls),  # pyright: ignore[reportUnknownArgumentType]
+                type(cls),
                 cls.__name__,
-                (cls,),  # pyright: ignore[reportUnknownArgumentType]
+                (cls,),
                 {**cls.__dict__, **new_fields},
             )
         )

--- a/xdsl/tools/tblgen_to_py.py
+++ b/xdsl/tools/tblgen_to_py.py
@@ -455,7 +455,7 @@ class TblgenLoader:
                 "SizedRegion" in region.superclasses
                 and region.summary == "region with 1 blocks"
             )
-            match (variadic, single_block):  # pyright: ignore[reportMatchNotExhaustive]
+            match (variadic, single_block):
                 case (False, False):
                     fields[name] = "region_def()"
                 case (False, True):

--- a/xdsl/transforms/varith_transformations.py
+++ b/xdsl/transforms/varith_transformations.py
@@ -131,7 +131,7 @@ class MergeVarithOpsPattern(RewritePattern):
         # instantiate a new varith op of the same type as the old op:
         # we can ignore the type error as we know that all VarithOps are instantiated
         # with an *arg of their operands
-        rewriter.replace_matched_op(type(op)(*new_operands))  # pyright: ignore[reportUnknownArgumentType]
+        rewriter.replace_matched_op(type(op)(*new_operands))
 
         # check all ops that may be erased later:
         for old_op in possibly_erased_ops:


### PR DESCRIPTION
I added `reportUnnecessaryTypeIgnoreComment = true` to pyproject.toml to find these