### PR TITLE
transformations: (cf) switch canonicalization

### DIFF
--- a/tests/filecheck/dialects/cf/canonicalize.mlir
+++ b/tests/filecheck/dialects/cf/canonicalize.mlir
@@ -204,18 +204,18 @@ func.func @branchCondProp(%arg0: i1) {
 // CHECK-NEXT:   "test.termop"() [^0, ^1] : () -> ()
 // CHECK-NEXT: ^0:
 // CHECK-NEXT:   cf.br ^1(%caseOperand0 : f32)
-// CHECK-NEXT: ^1(%bb2Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb2Arg) : (f32) -> ()
+// CHECK-NEXT: ^1(%arg : f32):
+// CHECK-NEXT:   "test.termop"(%arg) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_only_default(%flag : i32, %caseOperand0 : f32) {
   // add predecessors for all blocks to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2] : () -> ()
-  ^bb1:
+  "test.termop"() [^0, ^1] : () -> ()
+  ^0:
     cf.switch %flag : i32, [
-      default: ^bb2(%caseOperand0 : f32)
+      default: ^1(%caseOperand0 : f32)
     ]
-  ^bb2(%bb2Arg : f32):
-    "test.termop"(%bb2Arg) : (f32) -> ()
+  ^1(%arg : f32):
+    "test.termop"(%arg) : (f32) -> ()
 }
 
 
@@ -226,25 +226,25 @@ func.func @switch_only_default(%flag : i32, %caseOperand0 : f32) {
 // CHECK-NEXT:     default: ^1(%caseOperand0 : f32),
 // CHECK-NEXT:     10: ^2(%caseOperand1 : f32)
 // CHECK-NEXT:   ]
-// CHECK-NEXT: ^1(%bb2Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb2Arg) : (f32) -> ()
-// CHECK-NEXT: ^2(%bb3Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb3Arg) : (f32) -> ()
+// CHECK-NEXT: ^1(%arg : f32):
+// CHECK-NEXT:   "test.termop"(%arg) : (f32) -> ()
+// CHECK-NEXT: ^2(%arg2 : f32):
+// CHECK-NEXT:   "test.termop"(%arg2) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_case_matching_default(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32) {
   // add predecessors for all blocks to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2, ^bb3] : () -> ()
-  ^bb1:
+  "test.termop"() [^0, ^1, ^2] : () -> ()
+  ^0:
     cf.switch %flag : i32, [
-      default: ^bb2(%caseOperand0 : f32),
-      42: ^bb2(%caseOperand0 : f32),
-      10: ^bb3(%caseOperand1 : f32),
-      17: ^bb2(%caseOperand0 : f32)
+      default: ^1(%caseOperand0 : f32),
+      42: ^1(%caseOperand0 : f32),
+      10: ^2(%caseOperand1 : f32),
+      17: ^1(%caseOperand0 : f32)
     ]
-  ^bb2(%bb2Arg : f32):
-    "test.termop"(%bb2Arg) : (f32) -> ()
-  ^bb3(%bb3Arg : f32):
-    "test.termop"(%bb3Arg) : (f32) -> ()
+  ^1(%arg : f32):
+    "test.termop"(%arg) : (f32) -> ()
+  ^2(%arg2 : f32):
+    "test.termop"(%arg2) : (f32) -> ()
 }
 
 
@@ -252,58 +252,58 @@ func.func @switch_case_matching_default(%flag : i32, %caseOperand0 : f32, %caseO
 // CHECK-NEXT:   "test.termop"() [^0, ^1, ^2, ^3] : () -> ()
 // CHECK-NEXT: ^0:
 // CHECK-NEXT:   cf.br ^1(%caseOperand0 : f32)
-// CHECK-NEXT: ^1(%bb2Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb2Arg) : (f32) -> ()
-// CHECK-NEXT: ^2(%bb3Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb3Arg) : (f32) -> ()
-// CHECK-NEXT: ^3(%bb4Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb4Arg) : (f32) -> ()
+// CHECK-NEXT: ^1(%arg : f32):
+// CHECK-NEXT:   "test.termop"(%arg) : (f32) -> ()
+// CHECK-NEXT: ^2(%arg2 : f32):
+// CHECK-NEXT:   "test.termop"(%arg2) : (f32) -> ()
+// CHECK-NEXT: ^3(%arg3 : f32):
+// CHECK-NEXT:   "test.termop"(%arg3) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_on_const_no_match(%caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32) {
   // add predecessors for all blocks to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2, ^bb3, ^bb4] : () -> ()
-  ^bb1:
+  "test.termop"() [^0, ^1, ^2, ^3] : () -> ()
+  ^0:
     %c0_i32 = arith.constant 0 : i32
     cf.switch %c0_i32 : i32, [
-      default: ^bb2(%caseOperand0 : f32),
-      -1: ^bb3(%caseOperand1 : f32),
-      1: ^bb4(%caseOperand2 : f32)
+      default: ^1(%caseOperand0 : f32),
+      -1: ^2(%caseOperand1 : f32),
+      1: ^3(%caseOperand2 : f32)
     ]
-  ^bb2(%bb2Arg : f32):
-    "test.termop"(%bb2Arg) : (f32) -> ()
-  ^bb3(%bb3Arg : f32):
-    "test.termop"(%bb3Arg) : (f32) -> ()
-  ^bb4(%bb4Arg : f32):
-    "test.termop"(%bb4Arg) : (f32) -> ()
+  ^1(%arg : f32):
+    "test.termop"(%arg) : (f32) -> ()
+  ^2(%arg2 : f32):
+    "test.termop"(%arg2) : (f32) -> ()
+  ^3(%arg3 : f32):
+    "test.termop"(%arg3) : (f32) -> ()
 }
 
 // CHECK:      func.func @switch_on_const_with_match(%caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32) {
 // CHECK-NEXT:   "test.termop"() [^0, ^1, ^2, ^3] : () -> ()
 // CHECK-NEXT: ^0:
 // CHECK-NEXT:   cf.br ^3(%caseOperand2 : f32)
-// CHECK-NEXT: ^1(%bb2Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb2Arg) : (f32) -> ()
-// CHECK-NEXT: ^2(%bb3Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb3Arg) : (f32) -> ()
-// CHECK-NEXT: ^3(%bb4Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb4Arg) : (f32) -> ()
+// CHECK-NEXT: ^1(%arg : f32):
+// CHECK-NEXT:   "test.termop"(%arg) : (f32) -> ()
+// CHECK-NEXT: ^2(%arg2 : f32):
+// CHECK-NEXT:   "test.termop"(%arg2) : (f32) -> ()
+// CHECK-NEXT: ^3(%arg3 : f32):
+// CHECK-NEXT:   "test.termop"(%arg3) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_on_const_with_match(%caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32) {
   // add predecessors for all blocks to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2, ^bb3, ^bb4] : () -> ()
-  ^bb1:
+  "test.termop"() [^0, ^1, ^2, ^3] : () -> ()
+  ^0:
     %c0_i32 = arith.constant 1 : i32
     cf.switch %c0_i32 : i32, [
-      default: ^bb2(%caseOperand0 : f32),
-      -1: ^bb3(%caseOperand1 : f32),
-      1: ^bb4(%caseOperand2 : f32)
+      default: ^1(%caseOperand0 : f32),
+      -1: ^2(%caseOperand1 : f32),
+      1: ^3(%caseOperand2 : f32)
     ]
-  ^bb2(%bb2Arg : f32):
-    "test.termop"(%bb2Arg) : (f32) -> ()
-  ^bb3(%bb3Arg : f32):
-    "test.termop"(%bb3Arg) : (f32) -> ()
-  ^bb4(%bb4Arg : f32):
-    "test.termop"(%bb4Arg) : (f32) -> ()
+  ^1(%arg : f32):
+    "test.termop"(%arg) : (f32) -> ()
+  ^2(%arg2 : f32):
+    "test.termop"(%arg2) : (f32) -> ()
+  ^3(%arg3 : f32):
+    "test.termop"(%arg3) : (f32) -> ()
 }
 
 // CHECK:      func.func @switch_passthrough(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32, %caseOperand3 : f32) {
@@ -314,16 +314,16 @@ func.func @switch_on_const_with_match(%caseOperand0 : f32, %caseOperand1 : f32, 
 // CHECK-NEXT:     43: ^5(%caseOperand1 : f32),
 // CHECK-NEXT:     44: ^3(%caseOperand2 : f32)
 // CHECK-NEXT:   ]
-// CHECK-NEXT: ^1(%bb2Arg : f32):
-// CHECK-NEXT:   cf.br ^4(%bb2Arg : f32)
-// CHECK-NEXT: ^2(%bb3Arg : f32):
-// CHECK-NEXT:   cf.br ^5(%bb3Arg : f32)
-// CHECK-NEXT: ^3(%bb4Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb4Arg) : (f32) -> ()
-// CHECK-NEXT: ^4(%bb5Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb5Arg) : (f32) -> ()
-// CHECK-NEXT: ^5(%bb6Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb6Arg) : (f32) -> ()
+// CHECK-NEXT: ^1(%arg : f32):
+// CHECK-NEXT:   cf.br ^4(%arg : f32)
+// CHECK-NEXT: ^2(%arg2 : f32):
+// CHECK-NEXT:   cf.br ^5(%arg2 : f32)
+// CHECK-NEXT: ^3(%arg3 : f32):
+// CHECK-NEXT:   "test.termop"(%arg3) : (f32) -> ()
+// CHECK-NEXT: ^4(%arg4 : f32):
+// CHECK-NEXT:   "test.termop"(%arg4) : (f32) -> ()
+// CHECK-NEXT: ^5(%arg5 : f32):
+// CHECK-NEXT:   "test.termop"(%arg5) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_passthrough(%flag : i32,
                          %caseOperand0 : f32,
@@ -331,23 +331,23 @@ func.func @switch_passthrough(%flag : i32,
                          %caseOperand2 : f32,
                          %caseOperand3 : f32) {
   // add predecessors for all blocks to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6] : () -> ()
-  ^bb1:
+  "test.termop"() [^0, ^1, ^2, ^3, ^4, ^5] : () -> ()
+  ^0:
     cf.switch %flag : i32, [
-      default: ^bb2(%caseOperand0 : f32),
-      43: ^bb3(%caseOperand1 : f32),
-      44: ^bb4(%caseOperand2 : f32)
+      default: ^1(%caseOperand0 : f32),
+      43: ^2(%caseOperand1 : f32),
+      44: ^3(%caseOperand2 : f32)
     ]
-  ^bb2(%bb2Arg : f32):
-    cf.br ^bb5(%bb2Arg : f32)
-  ^bb3(%bb3Arg : f32):
-    cf.br ^bb6(%bb3Arg : f32)
-  ^bb4(%bb4Arg : f32):
-    "test.termop"(%bb4Arg) : (f32) -> ()
-  ^bb5(%bb5Arg : f32):
-    "test.termop"(%bb5Arg) : (f32) -> ()
-  ^bb6(%bb6Arg : f32):
-    "test.termop"(%bb6Arg) : (f32) -> ()
+  ^1(%arg : f32):
+    cf.br ^4(%arg : f32)
+  ^2(%arg2 : f32):
+    cf.br ^5(%arg2 : f32)
+  ^3(%arg3 : f32):
+    "test.termop"(%arg3) : (f32) -> ()
+  ^4(%arg4 : f32):
+    "test.termop"(%arg4) : (f32) -> ()
+  ^5(%arg5 : f32):
+    "test.termop"(%arg5) : (f32) -> ()
 }
 
 // CHECK:      func.func @switch_from_switch_with_same_value_with_match(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32) {
@@ -362,33 +362,33 @@ func.func @switch_passthrough(%flag : i32,
 // CHECK-NEXT: ^4:
 // CHECK-NEXT:   "test.op"() : () -> ()
 // CHECK-NEXT:   cf.br ^3(%caseOperand1 : f32)
-// CHECK-NEXT: ^2(%bb4Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb4Arg) : (f32) -> ()
-// CHECK-NEXT: ^3(%bb5Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb5Arg) : (f32) -> ()
+// CHECK-NEXT: ^2(%arg3 : f32):
+// CHECK-NEXT:   "test.termop"(%arg3) : (f32) -> ()
+// CHECK-NEXT: ^3(%arg4 : f32):
+// CHECK-NEXT:   "test.termop"(%arg4) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_from_switch_with_same_value_with_match(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32) {
-  // add predecessors for all blocks except ^bb3 to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2, ^bb4, ^bb5] : () -> ()
-  ^bb1:
+  // add predecessors for all blocks except ^2 to avoid other canonicalizations.
+  "test.termop"() [^0, ^1, ^3, ^4] : () -> ()
+  ^0:
     cf.switch %flag : i32, [
-      default: ^bb2,
-      42: ^bb3
+      default: ^1,
+      42: ^2
     ]
 
-  ^bb2:
+  ^1:
     "test.termop"() : () -> ()
-  ^bb3:
+  ^2:
     // prevent this block from being simplified away
     "test.op"() : () -> ()
     cf.switch %flag : i32, [
-      default: ^bb4(%caseOperand0 : f32),
-      42: ^bb5(%caseOperand1 : f32)
+      default: ^3(%caseOperand0 : f32),
+      42: ^4(%caseOperand1 : f32)
     ]
-  ^bb4(%bb4Arg : f32):
-    "test.termop"(%bb4Arg) : (f32) -> ()
-  ^bb5(%bb5Arg : f32):
-    "test.termop"(%bb5Arg) : (f32) -> ()
+  ^3(%arg3 : f32):
+    "test.termop"(%arg3) : (f32) -> ()
+  ^4(%arg4 : f32):
+    "test.termop"(%arg4) : (f32) -> ()
 }
 
 // CHECK:      func.func @switch_from_switch_with_same_value_no_match(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32) {
@@ -403,36 +403,36 @@ func.func @switch_from_switch_with_same_value_with_match(%flag : i32, %caseOpera
 // CHECK-NEXT: ^5:
 // CHECK-NEXT:   "test.op"() : () -> ()
 // CHECK-NEXT:   cf.br ^2(%caseOperand0 : f32)
-// CHECK-NEXT: ^2(%bb4Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb4Arg) : (f32) -> ()
-// CHECK-NEXT: ^3(%bb5Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb5Arg) : (f32) -> ()
-// CHECK-NEXT: ^4(%bb6Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb6Arg) : (f32) -> ()
+// CHECK-NEXT: ^2(%arg3 : f32):
+// CHECK-NEXT:   "test.termop"(%arg3) : (f32) -> ()
+// CHECK-NEXT: ^3(%arg4 : f32):
+// CHECK-NEXT:   "test.termop"(%arg4) : (f32) -> ()
+// CHECK-NEXT: ^4(%arg5 : f32):
+// CHECK-NEXT:   "test.termop"(%arg5) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_from_switch_with_same_value_no_match(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32) {
-  // add predecessors for all blocks except ^bb3 to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2, ^bb4, ^bb5, ^bb6] : () -> ()
-  ^bb1:
+  // add predecessors for all blocks except ^2 to avoid other canonicalizations.
+  "test.termop"() [^0, ^1, ^3, ^4, ^5] : () -> ()
+  ^0:
     cf.switch %flag : i32, [
-      default: ^bb2,
-      42: ^bb3
+      default: ^1,
+      42: ^2
     ]
-  ^bb2:
+  ^1:
     "test.termop"() : () -> ()
-  ^bb3:
+  ^2:
     "test.op"() : () -> ()
     cf.switch %flag : i32, [
-      default: ^bb4(%caseOperand0 : f32),
-      0: ^bb5(%caseOperand1 : f32),
-      43: ^bb6(%caseOperand2 : f32)
+      default: ^3(%caseOperand0 : f32),
+      0: ^4(%caseOperand1 : f32),
+      43: ^5(%caseOperand2 : f32)
     ]
-  ^bb4(%bb4Arg : f32):
-    "test.termop"(%bb4Arg) : (f32) -> ()
-  ^bb5(%bb5Arg : f32):
-    "test.termop"(%bb5Arg) : (f32) -> ()
-  ^bb6(%bb6Arg : f32):
-    "test.termop"(%bb6Arg) : (f32) -> ()
+  ^3(%arg3 : f32):
+    "test.termop"(%arg3) : (f32) -> ()
+  ^4(%arg4 : f32):
+    "test.termop"(%arg4) : (f32) -> ()
+  ^5(%arg5 : f32):
+    "test.termop"(%arg5) : (f32) -> ()
 }
 
 // CHECK:      func.func @switch_from_switch_default_with_same_value(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32) {
@@ -450,34 +450,34 @@ func.func @switch_from_switch_with_same_value_no_match(%flag : i32, %caseOperand
 // CHECK-NEXT:     default: ^2(%caseOperand0 : f32),
 // CHECK-NEXT:     43: ^4(%caseOperand2 : f32)
 // CHECK-NEXT:   ]
-// CHECK-NEXT: ^2(%bb4Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb4Arg) : (f32) -> ()
-// CHECK-NEXT: ^3(%bb5Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb5Arg) : (f32) -> ()
-// CHECK-NEXT: ^4(%bb6Arg : f32):
-// CHECK-NEXT:   "test.termop"(%bb6Arg) : (f32) -> ()
+// CHECK-NEXT: ^2(%arg3 : f32):
+// CHECK-NEXT:   "test.termop"(%arg3) : (f32) -> ()
+// CHECK-NEXT: ^3(%arg4 : f32):
+// CHECK-NEXT:   "test.termop"(%arg4) : (f32) -> ()
+// CHECK-NEXT: ^4(%arg5 : f32):
+// CHECK-NEXT:   "test.termop"(%arg5) : (f32) -> ()
 // CHECK-NEXT: }
 func.func @switch_from_switch_default_with_same_value(%flag : i32, %caseOperand0 : f32, %caseOperand1 : f32, %caseOperand2 : f32) {
-  // add predecessors for all blocks except ^bb3 to avoid other canonicalizations.
-  "test.termop"() [^bb1, ^bb2, ^bb4, ^bb5, ^bb6] : () -> ()
-  ^bb1:
+  // add predecessors for all blocks except ^2 to avoid other canonicalizations.
+  "test.termop"() [^0, ^1, ^3, ^4, ^5] : () -> ()
+  ^0:
     cf.switch %flag : i32, [
-      default: ^bb3,
-      42: ^bb2
+      default: ^2,
+      42: ^1
     ]
-  ^bb2:
+  ^1:
     "test.termop"() : () -> ()
-  ^bb3:
+  ^2:
     "test.op"() : () -> ()
     cf.switch %flag : i32, [
-      default: ^bb4(%caseOperand0 : f32),
-      42: ^bb5(%caseOperand1 : f32),
-      43: ^bb6(%caseOperand2 : f32)
+      default: ^3(%caseOperand0 : f32),
+      42: ^4(%caseOperand1 : f32),
+      43: ^5(%caseOperand2 : f32)
     ]
-  ^bb4(%bb4Arg : f32):
-    "test.termop"(%bb4Arg) : (f32) -> ()
-  ^bb5(%bb5Arg : f32):
-    "test.termop"(%bb5Arg) : (f32) -> ()
-  ^bb6(%bb6Arg : f32):
-    "test.termop"(%bb6Arg) : (f32) -> ()
+  ^3(%arg3 : f32):
+    "test.termop"(%arg3) : (f32) -> ()
+  ^4(%arg4 : f32):
+    "test.termop"(%arg4) : (f32) -> ()
+  ^5(%arg5 : f32):
+    "test.termop"(%arg5) : (f32) -> ()
 }

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -151,6 +151,26 @@ class ConditionalBranch(IRDLOperation):
     """
 
 
+class SwitchHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.cf import (
+            DropSwitchCasesThatMatchDefault,
+            SimplifyConstSwitchValue,
+            SimplifyPassThroughSwitch,
+            SimplifySwitchFromSwitchOnSameCondition,
+            SimplifySwitchWithOnlyDefault,
+        )
+
+        return (
+            SimplifySwitchWithOnlyDefault(),
+            SimplifyConstSwitchValue(),
+            SimplifyPassThroughSwitch(),
+            DropSwitchCasesThatMatchDefault(),
+            SimplifySwitchFromSwitchOnSameCondition(),
+        )
+
+
 @irdl_op_definition
 class Switch(IRDLOperation):
     """Switch operation"""
@@ -174,7 +194,7 @@ class Switch(IRDLOperation):
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
-    traits = frozenset([IsTerminator(), Pure()])
+    traits = frozenset([IsTerminator(), Pure(), SwitchHasCanonicalizationPatterns()])
 
     def __init__(
         self,

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -1,8 +1,14 @@
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from typing import cast
 
 from xdsl.dialects import arith, cf
-from xdsl.dialects.builtin import BoolAttr, IntegerAttr
-from xdsl.ir import Block, BlockArgument, SSAValue
+from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
+    BoolAttr,
+    DenseIntOrFPElementsAttr,
+    IntegerAttr,
+)
+from xdsl.ir import Block, BlockArgument, Operation, SSAValue
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
@@ -257,3 +263,276 @@ class CondBranchTruthPropagation(RewritePattern):
                     const_false.result,
                     lambda use: use.operation.parent_block() is op.else_block,
                 )
+
+
+class SimplifySwitchWithOnlyDefault(RewritePattern):
+    """
+    switch %flag : i32, [
+      default:  ^bb1
+    ]
+     -> br ^bb1
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: cf.Switch, rewriter: PatternRewriter):
+        if len(op.case_blocks) == 0:
+            rewriter.replace_matched_op(
+                cf.Branch(op.default_block, *op.default_operands)
+            )
+
+
+def drop_case_helper(
+    rewriter: PatternRewriter,
+    op: cf.Switch,
+    predicate: Callable[[AnyIntegerAttr, Block, Sequence[Operation | SSAValue]], bool],
+):
+    case_values = op.case_values
+    if case_values is None:
+        return
+    requires_change = False
+
+    new_case_values: list[int] = []
+    new_case_blocks: list[Block] = []
+    new_case_operands: list[Sequence[Operation | SSAValue]] = []
+
+    for switch_case, block, operands in zip(
+        case_values.data.data, op.case_blocks, op.case_operand
+    ):
+        int_switch_case = cast(AnyIntegerAttr, switch_case)
+        if predicate(int_switch_case, block, operands):
+            requires_change = True
+            continue
+        new_case_values.append(cast(AnyIntegerAttr, switch_case).value.data)
+        new_case_blocks.append(block)
+        new_case_operands.append(operands)
+
+    if requires_change:
+        rewriter.replace_matched_op(
+            cf.Switch(
+                op.flag,
+                op.default_block,
+                op.default_operands,
+                DenseIntOrFPElementsAttr.vector_from_list(
+                    new_case_values, case_values.get_element_type()
+                ),
+                new_case_blocks,
+                new_case_operands,
+            )
+        )
+
+
+class DropSwitchCasesThatMatchDefault(RewritePattern):
+    """
+    switch %flag : i32, [
+      default: ^bb1,
+      42: ^bb1,
+      43: ^bb2
+    ]
+    ->
+    switch %flag : i32, [
+      default: ^bb1,
+      43: ^bb2
+    ]
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: cf.Switch, rewriter: PatternRewriter):
+        def predicate(
+            switch_case: AnyIntegerAttr,
+            block: Block,
+            operands: Sequence[Operation | SSAValue],
+        ) -> bool:
+            return block == op.default_block and operands == op.default_operands
+
+        drop_case_helper(rewriter, op, predicate)
+
+
+def foldSwitch(switch: cf.Switch, rewriter: PatternRewriter, flag: int):
+    """
+    Helper for folding a switch with a constant value.
+    switch %c_42 : i32, [
+      default: ^bb1 ,
+      42: ^bb2,
+      43: ^bb3
+    ]
+    -> br ^bb2
+    """
+    case_values = switch.case_values
+    if case_values is not None:
+        for i, c in enumerate(case_values.data.data):
+            if flag == c.value.data:
+                rewriter.replace_matched_op(
+                    cf.Branch(switch.case_blocks[i], *switch.case_operand[i])
+                )
+                return
+
+    rewriter.replace_matched_op(
+        cf.Branch(switch.default_block, *switch.default_operands)
+    )
+
+
+class SimplifyConstSwitchValue(RewritePattern):
+    """
+    switch %c_42 : i32, [
+      default: ^bb1,
+      42: ^bb2,
+      43: ^bb3
+    ]
+    -> br ^bb2
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: cf.Switch, rewriter: PatternRewriter):
+        if (flag := const_evaluate_operand(op.flag)) is not None:
+            foldSwitch(op, rewriter, flag)
+
+
+class SimplifyPassThroughSwitch(RewritePattern):
+    """
+    switch %c_42 : i32, [
+      default: ^bb1,
+      42: ^bb2,
+    ]
+    ^bb2:
+      br ^bb3
+    ->
+    switch %c_42 : i32, [
+      default: ^bb1,
+      42: ^bb3,
+    ]
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: cf.Switch, rewriter: PatternRewriter):
+        requires_change = False
+
+        new_case_blocks: list[Block] = []
+        new_case_operands: list[Sequence[Operation | SSAValue]] = []
+
+        for block, operands in zip(op.case_blocks, op.case_operand):
+            collapsed = collapse_branch(block, operands)
+            requires_change |= collapsed is not None
+            (new_block, new_operands) = collapsed or (block, operands)
+            new_case_blocks.append(new_block)
+            new_case_operands.append(new_operands)
+
+        collapsed = collapse_branch(op.default_block, op.default_operands)
+
+        requires_change |= collapsed is not None
+
+        (default_block, default_operands) = collapsed or (
+            op.default_block,
+            op.default_operands,
+        )
+
+        if requires_change:
+            rewriter.replace_matched_op(
+                cf.Switch(
+                    op.flag,
+                    default_block,
+                    default_operands,
+                    op.case_values,
+                    new_case_blocks,
+                    new_case_operands,
+                )
+            )
+
+
+class SimplifySwitchFromSwitchOnSameCondition(RewritePattern):
+    """
+    switch %flag : i32, [
+      default: ^bb1,
+      42: ^bb2,
+    ]
+    ^bb2:
+      switch %flag : i32, [
+        default: ^bb3,
+        42: ^bb4
+      ]
+    ->
+    switch %flag : i32, [
+      default: ^bb1,
+      42: ^bb2,
+    ]
+    ^bb2:
+      br ^bb4
+
+     and
+
+    switch %flag : i32, [
+      default: ^bb1,
+      42: ^bb2,
+    ]
+    ^bb2:
+      switch %flag : i32, [
+        default: ^bb3,
+        43: ^bb4
+      ]
+    ->
+    switch %flag : i32, [
+      default: ^bb1,
+      42: ^bb2,
+    ]
+    ^bb2:
+      br ^bb3
+
+    and
+
+    switch %flag : i32, [
+      default: ^bb1,
+      42: ^bb2
+    ]
+    ^bb1:
+      switch %flag : i32, [
+        default: ^bb3,
+        42: ^bb4,
+        43: ^bb5
+      ]
+    ->
+    switch %flag : i32, [
+      default: ^bb1,
+      42: ^bb2,
+    ]
+    ^bb1:
+      switch %flag : i32, [
+        default: ^bb3,
+        43: ^bb5
+      ]
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: cf.Switch, rewriter: PatternRewriter):
+        block = op.parent_block()
+        if block is None:
+            return
+        preds = block.uses
+        if len(preds) != 1:
+            return
+        pred = next(iter(preds))
+        switch = pred.operation
+        if not isinstance(switch, cf.Switch):
+            return
+
+        if switch.flag != op.flag:
+            return
+
+        case_values = switch.case_values
+        if case_values is None:
+            return
+
+        if pred.index != 0:
+            foldSwitch(
+                op,
+                rewriter,
+                cast(int, case_values.data.data[pred.index - 1].value.data),
+            )
+        else:
+
+            def predicate(
+                switch_case: AnyIntegerAttr,
+                block: Block,
+                operands: Sequence[Operation | SSAValue],
+            ) -> bool:
+                return switch_case in case_values.data.data
+
+            drop_case_helper(rewriter, op, predicate)

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -357,17 +357,16 @@ def fold_switch(switch: cf.Switch, rewriter: PatternRewriter, flag: int):
     ]
     -> br ^bb2
     """
-    case_values = switch.case_values
-    if case_values is not None:
-        for i, c in enumerate(case_values.data.data):
-            if flag == c.value.data:
-                rewriter.replace_matched_op(
-                    cf.Branch(switch.case_blocks[i], *switch.case_operand[i])
-                )
-                return
+    case_values = () if switch.case_values is None else switch.case_values.data.data
+
+    new_block, new_operands = next(
+        ((block, operand) 
+        for (c, block, operand) in zip(case_values, switch.case_blocks, switch.case_operands, strict=True)
+        if flag == c.value.data),
+        (switch.default_block, switch.default_operands)
 
     rewriter.replace_matched_op(
-        cf.Branch(switch.default_block, *switch.default_operands)
+        cf.Branch(new_block, *new_operands)
     )
 
 

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -275,7 +275,7 @@ class SimplifySwitchWithOnlyDefault(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: cf.Switch, rewriter: PatternRewriter):
-        if len(op.case_blocks) == 0:
+        if not op.case_blocks:
             rewriter.replace_matched_op(
                 cf.Branch(op.default_block, *op.default_operands)
             )
@@ -296,7 +296,10 @@ def drop_case_helper(
     new_case_operands: list[Sequence[Operation | SSAValue]] = []
 
     for switch_case, block, operands in zip(
-        case_values.data.data, op.case_blocks, op.case_operand
+        case_values.data.data,
+        op.case_blocks,
+        op.case_operand,
+        strict=True,
     ):
         int_switch_case = cast(AnyIntegerAttr, switch_case)
         if predicate(int_switch_case, block, operands):
@@ -411,7 +414,7 @@ class SimplifyPassThroughSwitch(RewritePattern):
         new_case_blocks: list[Block] = []
         new_case_operands: list[Sequence[Operation | SSAValue]] = []
 
-        for block, operands in zip(op.case_blocks, op.case_operand):
+        for block, operands in zip(op.case_blocks, op.case_operand, strict=True):
             collapsed = collapse_branch(block, operands)
             requires_change |= collapsed is not None
             (new_block, new_operands) = collapsed or (block, operands)

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -347,7 +347,7 @@ class DropSwitchCasesThatMatchDefault(RewritePattern):
         drop_case_helper(rewriter, op, predicate)
 
 
-def foldSwitch(switch: cf.Switch, rewriter: PatternRewriter, flag: int):
+def fold_switch(switch: cf.Switch, rewriter: PatternRewriter, flag: int):
     """
     Helper for folding a switch with a constant value.
     switch %c_42 : i32, [
@@ -384,7 +384,7 @@ class SimplifyConstSwitchValue(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: cf.Switch, rewriter: PatternRewriter):
         if (flag := const_evaluate_operand(op.flag)) is not None:
-            foldSwitch(op, rewriter, flag)
+            fold_switch(op, rewriter, flag)
 
 
 class SimplifyPassThroughSwitch(RewritePattern):
@@ -521,7 +521,7 @@ class SimplifySwitchFromSwitchOnSameCondition(RewritePattern):
             return
 
         if pred.index != 0:
-            foldSwitch(
+            fold_switch(
                 op,
                 rewriter,
                 cast(int, case_values.data.data[pred.index - 1].value.data),

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -360,14 +360,17 @@ def fold_switch(switch: cf.Switch, rewriter: PatternRewriter, flag: int):
     case_values = () if switch.case_values is None else switch.case_values.data.data
 
     new_block, new_operands = next(
-        ((block, operand) 
-        for (c, block, operand) in zip(case_values, switch.case_blocks, switch.case_operands, strict=True)
-        if flag == c.value.data),
-        (switch.default_block, switch.default_operands)
-
-    rewriter.replace_matched_op(
-        cf.Branch(new_block, *new_operands)
+        (
+            (block, operand)
+            for (c, block, operand) in zip(
+                case_values, switch.case_blocks, switch.case_operand, strict=True
+            )
+            if flag == c.value.data
+        ),
+        (switch.default_block, switch.default_operands),
     )
+
+    rewriter.replace_matched_op(cf.Branch(new_block, *new_operands))
 
 
 class SimplifyConstSwitchValue(RewritePattern):


### PR DESCRIPTION
Adds all the switch canonicalization patterns present in mlir. I'm happy to anonymise some of the block names in the filecheck tests if this is deemed worth doing.