### PR TITLE
core: always print unregistered ops

### DIFF
--- a/tests/filecheck/dialects/scf/unregistered.mlir
+++ b/tests/filecheck/dialects/scf/unregistered.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt %s --print-op-generic --allow-unregistered-dialect | xdsl-opt --split-input-file | filecheck %s
+
+  func.func @for_unregistered() {
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 42 : index
+    %s = arith.constant 3 : index
+    scf.for %iv = %lb to %ub step %s {
+      "unregistered_op"() : () -> ()
+      scf.yield
+    }
+    func.return
+  }

--- a/tests/filecheck/dialects/scf/unregistered.mlir
+++ b/tests/filecheck/dialects/scf/unregistered.mlir
@@ -1,12 +1,22 @@
 // RUN: xdsl-opt %s --print-op-generic --allow-unregistered-dialect | xdsl-opt --split-input-file | filecheck %s
 
-  func.func @for_unregistered() {
-    %lb = arith.constant 0 : index
-    %ub = arith.constant 42 : index
-    %s = arith.constant 3 : index
-    scf.for %iv = %lb to %ub step %s {
-      "unregistered_op"() : () -> ()
-      scf.yield
-    }
-    func.return
+// CHECK:      func.func @for_unregistered() {
+// CHECK-NEXT:   %lb = arith.constant 0 : index
+// CHECK-NEXT:   %ub = arith.constant 42 : index
+// CHECK-NEXT:   %s = arith.constant 3 : index
+// CHECK-NEXT:   scf.for %iv = %lb to %ub step %s {
+// CHECK-NEXT:     "unregistered_op"() : () -> ()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
+func.func @for_unregistered() {
+  %lb = arith.constant 0 : index
+  %ub = arith.constant 42 : index
+  %s = arith.constant 3 : index
+  scf.for %iv = %lb to %ub step %s {
+    "unregistered_op"() : () -> ()
+    scf.yield
   }
+  func.return
+}

--- a/tests/filecheck/dialects/scf/unregistered.mlir
+++ b/tests/filecheck/dialects/scf/unregistered.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --print-op-generic --allow-unregistered-dialect | xdsl-opt --split-input-file | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect | filecheck %s
 
 // CHECK:      func.func @for_unregistered() {
 // CHECK-NEXT:   %lb = arith.constant 0 : index

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -356,7 +356,9 @@ class Printer:
 
         with self.indented():
             for op in block.ops:
-                if not print_block_terminator and op.has_trait(IsTerminator):
+                if not print_block_terminator and op.has_trait(
+                    IsTerminator, value_if_unregistered=False
+                ):
                     continue
                 self._print_new_line()
                 self.print_op(op)


### PR DESCRIPTION
`scf.for` prints it's blocks without terminators if there are no `iter_args`. Unfortunately the check for whether an operation is a terminator returns true by default for unregistered operations (presumably so that they don't break verification), and so they don't get printed.

This change should make it so that these ops always get printed.