### PR TITLE
core: default props should always be added

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2099,6 +2099,11 @@ class DefaultOp(IRDLOperation):
             "test.default attr 1 opt_attr 0",
             '"test.default"() <{"prop" = false}> {"attr" = true, "opt_attr" = false} : () -> ()',
         ),
+        (
+            '"test.default"() : () -> ()',
+            "test.default",
+            '"test.default"() <{"prop" = false}> {"attr" = false} : () -> ()',
+        ),
     ],
 )
 def test_default_properties(program: str, output: str, generic: str):

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -238,6 +238,7 @@ class GetNumResultsTraitForOpWithOneResult(GetNumResultsTrait):
         return 1
 
 
+@irdl_op_definition
 class OpWithInterface(IRDLOperation):
     name = "test.op_with_interface"
     traits = frozenset([GetNumResultsTraitForOpWithOneResult()])

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -161,24 +161,6 @@ class FormatProgram:
         else:
             properties = op_def.split_properties(state.attributes)
 
-        # Fill in default properties
-        for prop_name, prop_def in op_def.properties.items():
-            if (
-                prop_name not in properties
-                and not isinstance(prop_def, OptionalDef)
-                and prop_def.default_value is not None
-            ):
-                properties[prop_name] = prop_def.default_value
-
-        # Fill in default attributes
-        for attr_name, attr_def in op_def.attributes.items():
-            if (
-                attr_name not in state.attributes
-                and not isinstance(attr_def, OptionalDef)
-                and attr_def.default_value is not None
-            ):
-                state.attributes[attr_name] = attr_def.default_value
-
         return op_type.build(
             result_types=result_types,
             operands=operands,

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -130,6 +130,28 @@ class IRDLOperation(Operation):
             regions=regions,
         )
 
+    def __post_init__(self):
+        op_def = self.get_irdl_definition()
+        # Fill in default properties
+        for prop_name, prop_def in op_def.properties.items():
+            if (
+                prop_name not in self.properties
+                and not isinstance(prop_def, OptionalDef)
+                and prop_def.default_value is not None
+            ):
+                self.properties[prop_name] = prop_def.default_value
+
+        # Fill in default attributes
+        for attr_name, attr_def in op_def.attributes.items():
+            if (
+                attr_name not in self.attributes
+                and not isinstance(attr_def, OptionalDef)
+                and attr_def.default_value is not None
+            ):
+                self.attributes[attr_name] = attr_def.default_value
+
+        return super().__post_init__()
+
     @classmethod
     def build(
         cls: type[IRDLOperationInvT],


### PR DESCRIPTION
I messed up slightly on the default properties. It seems that the default should be inserted even when using the generic syntax. I've moved the default logic to `__post_init__` so that it triggers for all `Operation`s and added a test to clarify.