### PR TITLE
core: introduce TypedAttributeConstraint

### DIFF
--- a/tests/filecheck/dialects/fsm/fsm_invalid.mlir
+++ b/tests/filecheck/dialects/fsm/fsm_invalid.mlir
@@ -141,9 +141,9 @@
     "fsm.transition"() ({
         "fsm.return"(%arg0) : (i1) -> ()
     }, {
-        
+
     }) {nextState = @A} : () -> ()
-    
+
 }) {sym_name = "A"} : () -> ()
 }) {function_type = (i1) -> (i1), initialState = "A", sym_name = "foo", res_names = ["names"],res_attrs = [{"name"="1","type"="2"}] } : () -> ()
 
@@ -160,7 +160,7 @@
     "fsm.output"() : () -> ()
 }, {
     "fsm.transition"() ({
-        ^bb1(%arg3: i1): 
+        ^bb1(%arg3: i1):
             "fsm.update"(%arg1, %arg2) {variable = "v1" , value = "v2"}: (i16,i16) -> ()
             "fsm.output"() : () -> ()
     }, {
@@ -179,16 +179,16 @@
 
 "fsm.state"() ({
     "fsm.output"() : () -> ()
-    
+
 }, {
     "fsm.transition"() ({
-        
+
     }, {
-        ^bb1(%arg3: i1): 
+        ^bb1(%arg3: i1):
             "fsm.update"(%arg1, %arg2) {variable = "v1" , value = "v2"}: (i16,i16) -> ()
             "fsm.update"(%arg1, %arg2) {variable = "v1" , value = "v2"}: (i16,i16) -> ()
     }) {nextState = @A} : () -> ()
-    
+
 }) {sym_name = "A"} : () -> ()
 }) {function_type = () -> (), initialState = "A", sym_name = "foo", res_names = ["names"],res_attrs = [{"name"="1","type"="2"}] } : () -> ()
 
@@ -203,10 +203,10 @@
 
 }, {
     "fsm.transition"() ({
-        
+
     }, {
     }) {nextState = @A} : () -> ()
-    
+
 }) {sym_name = "A"} : () -> ()
 
 }) {function_type = (i16) -> (i16) , initialState = "A", sym_name = "foo"} : () -> ()
@@ -257,7 +257,7 @@
       }, {
       }) {nextState = @A} : () -> ()
     }) {sym_name = "A"} : () -> ()
-    
+
   }) {function_type = (i16) -> (i1), initialState = "A", sym_name = "foo"} : () -> ()
   %arg1 = "arith.constant"() {value = 0 : i16} : () -> i16
   %arg2 = "arith.constant"() {value = 0 : i16} : () -> i16
@@ -328,12 +328,12 @@
         }) {nextState = @C} : () -> ()
     }) {sym_name = "C"} : () -> ()
     }) {function_type = (i16) -> (i16), initialState = "A", sym_name = "foo"} : () -> ()
- 
+
     "func.func"() ({
     %3 = "arith.constant"() {value = 16: i16} : () -> i16
-    
+
     %4 = "fsm.instance"() {machine = @foo, sym_name = "foo_inst"} : () -> !fsm.instancetype
-    %1 = "arith.constant"() {value = true} : () -> i16
+    %1 = "arith.constant"() {value = 0 : i16} : () -> i16
     %2 = "fsm.trigger"(%1, %4) : (i16, !fsm.instancetype) -> i1
     "func.return"() : () -> ()
   }) {function_type = () -> (), sym_name = "qux"} : () -> ()
@@ -371,10 +371,10 @@
         }) {nextState = @C} : () -> ()
     }) {sym_name = "C"} : () -> ()
     }) {function_type = (i16) -> (i16), initialState = "A", sym_name = "foo"} : () -> ()
- 
+
     "func.func"() ({
     %3 = "arith.constant"() {value = 16: i16} : () -> i16
-    
+
     %4 = "fsm.instance"() {machine = @foo, sym_name = "foo_inst"} : () -> !fsm.instancetype
     %1 = "arith.constant"() {value = true} : () -> i1
     %2 = "fsm.trigger"(%1, %4) : (i1, !fsm.instancetype) -> i16
@@ -391,8 +391,8 @@
     %0 = "fsm.variable"() {initValue = 0 : i16, name = "cnt"} : () -> i16
     "fsm.machine"() ({
     %4 = "test.op"() {machine = @foo, sym_name = "foo_inst"} : () -> !fsm.instancetype
-    %1 = "arith.constant"() {value = true} : () -> i16
-    %2 = "fsm.trigger"(%1, %4) : (i16, !fsm.instancetype) -> i1
+    %1 = "arith.constant"() {value = true} : () -> i1
+    %2 = "fsm.trigger"(%1, %4) : (i1, !fsm.instancetype) -> i1
     "func.return"() : () -> ()
   }) {function_type = () -> (), sym_name = "qux"} : () -> ()
 

--- a/tests/filecheck/runner/factorial.mlir
+++ b/tests/filecheck/runner/factorial.mlir
@@ -17,7 +17,7 @@ builtin.module {
     "func.return"(%ret) : (i64) -> ()
   }
   func.func @main() -> index {
-    %zero = "arith.constant"() {"value" = 0} : () -> index
+    %zero = "arith.constant"() {"value" = 0 : index} : () -> index
     %i = "arith.constant"() {"value" = 12} : () -> i64
     %fac = "func.call"(%i) {"callee" = @factorial} : (i64) -> i64
     printf.print_format "factorial({})={}", %i : i64, %fac : i64

--- a/tests/filecheck/runner/with-wgpu/global_id_inc.mlir
+++ b/tests/filecheck/runner/with-wgpu/global_id_inc.mlir
@@ -40,7 +40,7 @@ builtin.module attributes {gpu.container_module} {
     %hmemref = "memref.alloc"() {"alignment" = 0 : i64, "operandSegmentSizes" = array<i32: 0, 0>} : () -> memref<4x4xindex>
     "gpu.memcpy"(%hmemref, %memref) {"operandSegmentSizes" = array<i32: 0, 1, 1>} : (memref<4x4xindex>, memref<4x4xindex>) -> ()
     printf.print_format "Result : {}", %hmemref : memref<4x4xindex>
-    %zero  = "arith.constant"() {"value" = 0} : () -> (index)
+    %zero  = "arith.constant"() {"value" = 0 : index} : () -> (index)
     "func.return"(%zero) : (index) -> ()
   }
 }

--- a/tests/filecheck/transforms/function-constant-pinning.mlir
+++ b/tests/filecheck/transforms/function-constant-pinning.mlir
@@ -2,7 +2,7 @@
 
 
 func.func @basic() -> i32 {
-    %v = "test.op"() {pin_to_constants = [0]} : () -> i32
+    %v = "test.op"() {pin_to_constants = [0 : i32]} : () -> i32
     func.return %v : i32
 }
 
@@ -11,7 +11,7 @@ func.func @basic() -> i32 {
 // CHECK-NEXT:   func.func @basic() -> i32 {
 // CHECK-NEXT:     %v = "test.op"() : () -> i32
                    // compare the value to the constant we want to specialize for
-// CHECK-NEXT:     %0 = arith.constant 0 : i64
+// CHECK-NEXT:     %0 = arith.constant 0 : i32
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
 // CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
                      // if they are equal, branch to specialized function
@@ -25,7 +25,7 @@ func.func @basic() -> i32 {
                  // specialized function here
 // CHECK-NEXT:   func.func @basic_pinned() -> i32 {
                    // original op is replaced by constant instantiation
-// CHECK-NEXT:     %v = arith.constant 0 : i64
+// CHECK-NEXT:     %v = arith.constant 0 : i32
 // CHECK-NEXT:     func.return %v : i32
 // CHECK-NEXT:   }
 
@@ -79,7 +79,7 @@ func.func @control_flow() {
 
 
 func.func @function_args(%arg0: memref<100xf32>) -> i32 {
-    %v = "test.op"() {pin_to_constants = [0]} : () -> i32
+    %v = "test.op"() {pin_to_constants = [0 : i32]} : () -> i32
 
     "test.op"(%v, %arg0) : (i32, memref<100xf32>) -> ()
 
@@ -89,7 +89,7 @@ func.func @function_args(%arg0: memref<100xf32>) -> i32 {
 
 // CHECK-NEXT:   func.func @function_args(%arg0 : memref<100xf32>) -> i32 {
 // CHECK-NEXT:     %v = "test.op"() : () -> i32
-// CHECK-NEXT:     %0 = arith.constant 0 : i64
+// CHECK-NEXT:     %0 = arith.constant 0 : i32
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
 // CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
                      // make sure that we forward function args to the specialized function
@@ -103,7 +103,7 @@ func.func @function_args(%arg0: memref<100xf32>) -> i32 {
 // CHECK-NEXT:     func.return %2 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func @function_args_pinned(%arg0 : memref<100xf32>) -> i32 {
-// CHECK-NEXT:     %v = arith.constant 0 : i64
+// CHECK-NEXT:     %v = arith.constant 0 : i32
                    // here the function arg is used
 // CHECK-NEXT:     "test.op"(%v, %arg0) : (i32, memref<100xf32>) -> ()
 // CHECK-NEXT:     func.return %v : i32
@@ -155,7 +155,7 @@ func.func @control_flow_and_function_args(%arg: i32) -> i32 {
 
 
 func.func @specialize_multi_case() -> i32 {
-    %v = "test.op"() {pin_to_constants = [0, 1]} : () -> i32
+    %v = "test.op"() {pin_to_constants = [0 : i32, 1 : i32]} : () -> i32
     func.return %v : i32
 }
 
@@ -164,13 +164,13 @@ func.func @specialize_multi_case() -> i32 {
 
 // CHECK-NEXT:   func.func @specialize_multi_case() -> i32 {
 // CHECK-NEXT:     %v = "test.op"() : () -> i32
-// CHECK-NEXT:     %0 = arith.constant 0 : i64
+// CHECK-NEXT:     %0 = arith.constant 0 : i32
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
 // CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
 // CHECK-NEXT:       %3 = func.call @specialize_multi_case_pinned_1() : () -> i32
 // CHECK-NEXT:       scf.yield %3 : i32
 // CHECK-NEXT:     } else {
-// CHECK-NEXT:       %4 = arith.constant 1 : i64
+// CHECK-NEXT:       %4 = arith.constant 1 : i32
 // CHECK-NEXT:       %5 = arith.cmpi eq, %v, %4 : i32
 // CHECK-NEXT:       %6 = scf.if %5 -> (i32) {
 // CHECK-NEXT:         %7 = func.call @specialize_multi_case_pinned() : () -> i32
@@ -185,8 +185,8 @@ func.func @specialize_multi_case() -> i32 {
 // CHECK-NEXT:   func.func @specialize_multi_case_pinned_1() -> i32 {
                    // this function still carries the old specialization check within it, but MLIR can see that
                    // the branch is never taken, so it's completely removed.
-// CHECK-NEXT:     %v = arith.constant 0 : i64
-// CHECK-NEXT:     %0 = arith.constant 1 : i64
+// CHECK-NEXT:     %v = arith.constant 0 : i32
+// CHECK-NEXT:     %0 = arith.constant 1 : i32
 // CHECK-NEXT:     %1 = arith.cmpi eq, %v, %0 : i32
 // CHECK-NEXT:     %2 = scf.if %1 -> (i32) {
 // CHECK-NEXT:       %3 = func.call @specialize_multi_case_pinned() : () -> i32
@@ -197,7 +197,7 @@ func.func @specialize_multi_case() -> i32 {
 // CHECK-NEXT:     func.return %2 : i32
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func @specialize_multi_case_pinned() -> i32 {
-// CHECK-NEXT:     %v = arith.constant 1 : i64
+// CHECK-NEXT:     %v = arith.constant 1 : i32
 // CHECK-NEXT:     func.return %v : i32
 // CHECK-NEXT:   }
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -513,6 +513,9 @@ class IntegerAttr(
     def print_without_type(self, printer: Printer):
         return printer.print(self.value.data)
 
+    def get_type(self) -> Attribute:
+        return self.type
+
     @staticmethod
     def constr(
         *,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -29,7 +29,6 @@ from xdsl.dialects.builtin import (
     Float64Type,
     Float80Type,
     Float128Type,
-    FloatAttr,
     FloatData,
     FunctionType,
     IndexType,


### PR DESCRIPTION
Experiment in using Constraint variables to grab a type from an attribute, and an example of using this for `arith.constant`.

Unsure if this a good idea or cooking too hard.

Edit: I also couldn't really figure out how `TypedAttribute` worked, and was not sure if the functionality could be reused (I have use cases in mind where the associated type would not be a parameter)