### PR TITLE
transformations: (csl) use constants instead of params

### DIFF
--- a/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
+++ b/tests/filecheck/dialects/csl/csl-wrapper-ops.mlir
@@ -3,7 +3,7 @@
 
 builtin.module {
     "csl_wrapper.module"() <{"width"=10 : i16, "height"=10: i16, "params" = [
-        #csl_wrapper.param<"z_dim" default=4: i16>, #csl_wrapper.param<"pattern" : i16>
+        #csl_wrapper.param<"z_dim" value=4: i16>, #csl_wrapper.param<"pattern" value=2: i16>
     ]}> ({
         ^0(%x: i16, %y: i16, %width: i16, %height: i16, %z_dim: i16, %pattern: i16):
             %0 = arith.constant 0 : i16
@@ -40,7 +40,7 @@ builtin.module {
 
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = [#csl_wrapper.param<"z_dim" default=4 : i16>, #csl_wrapper.param<"pattern" : i16>]}> ({
+// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = [#csl_wrapper.param<"z_dim" value=4 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>]}> ({
 // CHECK-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
 // CHECK-NEXT:     %0 = arith.constant 0 : i16
 // CHECK-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
@@ -71,7 +71,7 @@ builtin.module {
 
 
 // CHECK-GENERIC:      "builtin.module"() ({
-// CHECK-GENERIC-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = [#csl_wrapper.param<"z_dim" default=4 : i16>, #csl_wrapper.param<"pattern" : i16>]}> ({
+// CHECK-GENERIC-NEXT:   "csl_wrapper.module"() <{"width" = 10 : i16, "height" = 10 : i16, "params" = [#csl_wrapper.param<"z_dim" value=4 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>]}> ({
 // CHECK-GENERIC-NEXT:   ^0(%x : i16, %y : i16, %width : i16, %height : i16, %z_dim : i16, %pattern : i16):
 // CHECK-GENERIC-NEXT:     %0 = "arith.constant"() <{"value" = 0 : i16}> : () -> i16
 // CHECK-GENERIC-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color

--- a/tests/filecheck/transforms/csl-stencil-handle-async-flow.mlir
+++ b/tests/filecheck/transforms/csl-stencil-handle-async-flow.mlir
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt %s -p "csl-stencil-handle-async-flow" | filecheck %s
 
-  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
+  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
     %9 = arith.constant 0 : i16
     %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -67,7 +67,7 @@
   }) : () -> ()
 
 
-// CHECK:        "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
+// CHECK:        "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
 // CHECK-NEXT:   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
 // CHECK-NEXT:     %9 = arith.constant 0 : i16
 // CHECK-NEXT:     %10 = "csl.get_color"(%9) : (i16) -> !csl.color

--- a/tests/filecheck/transforms/csl-stencil-materialize-stores.mlir
+++ b/tests/filecheck/transforms/csl-stencil-materialize-stores.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt -p csl-stencil-materialize-stores %s | filecheck %s
 
 builtin.module {
-  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel", "width" = 1024 : i16}> ({
+  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=1 : i16>, #csl_wrapper.param<"chunk_size" value=510 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "gauss_seidel", "width" = 1024 : i16}> ({
   ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
     %0 = arith.constant 0 : i16
     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
@@ -65,7 +65,7 @@ builtin.module {
 }
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel", "width" = 1024 : i16}> ({
+// CHECK-NEXT:   "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=1 : i16>, #csl_wrapper.param<"chunk_size" value=510 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "gauss_seidel", "width" = 1024 : i16}> ({
 // CHECK-NEXT:   ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
 // CHECK-NEXT:     %0 = arith.constant 0 : i16
 // CHECK-NEXT:     %1 = "csl.get_color"(%0) : (i16) -> !csl.color

--- a/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/csl-stencil-to-csl-wrapper.mlir
@@ -33,7 +33,7 @@ func.func @gauss_seidel(%a : !stencil.field<[-1,1023]x[-1,511]xtensor<512xf32>>,
   func.return
 }
 
-// CHECK:      "csl_wrapper.module"() <{"width" = 1024 : i16, "height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel"}> ({
+// CHECK:      "csl_wrapper.module"() <{"width" = 1024 : i16, "height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "gauss_seidel"}> ({
 // CHECK-NEXT: ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
 // CHECK-NEXT:   %9 = arith.constant 0 : i16
 // CHECK-NEXT:   %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -129,7 +129,7 @@ func.func private @timer_start() -> f64
 func.func private @timer_end(f64) -> f64
 
 
-// CHECK:      "csl_wrapper.module"() <{"width" = 1024 : i16, "height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "bufferized"}> ({
+// CHECK:      "csl_wrapper.module"() <{"width" = 1024 : i16, "height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "bufferized"}> ({
 // CHECK-NEXT: ^2(%43 : i16, %44 : i16, %45 : i16, %46 : i16, %47 : i16, %48 : i16, %49 : i16, %50 : i16, %51 : i16):
 // CHECK-NEXT:   %52 = arith.constant 0 : i16
 // CHECK-NEXT:   %53 = "csl.get_color"(%52) : (i16) -> !csl.color

--- a/tests/filecheck/transforms/lower-csl-stencil.mlir
+++ b/tests/filecheck/transforms/lower-csl-stencil.mlir
@@ -3,7 +3,7 @@
 builtin.module {
 // CHECK-NEXT: builtin.module {
 
-  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
+  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
     %9 = arith.constant 0 : i16
     %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -62,7 +62,7 @@ builtin.module {
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
+// CHECK-NEXT:   "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
 // CHECK-NEXT:   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
 // CHECK-NEXT:     %9 = arith.constant 0 : i16
 // CHECK-NEXT:     %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -126,7 +126,7 @@ builtin.module {
 // CHECK-NEXT:   }) : () -> ()
 
 
-  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "loop", "width" = 1024 : i16}> ({
+  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=1 : i16>, #csl_wrapper.param<"chunk_size" value=510 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "loop", "width" = 1024 : i16}> ({
   ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
     %0 = arith.constant 0 : i16
     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
@@ -234,7 +234,7 @@ builtin.module {
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK-NEXT:  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "loop", "width" = 1024 : i16}> ({
+// CHECK-NEXT:  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=1 : i16>, #csl_wrapper.param<"chunk_size" value=510 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "loop", "width" = 1024 : i16}> ({
 // CHECK-NEXT:  ^2(%arg0_1 : i16, %arg1_1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
 // CHECK-NEXT:    %50 = arith.constant 0 : i16
 // CHECK-NEXT:    %51 = "csl.get_color"(%50) : (i16) -> !csl.color
@@ -349,7 +349,7 @@ builtin.module {
 // CHECK-NEXT:  }) : () -> ()
 
 
-  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "partial_access"}> ({
+  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "partial_access"}> ({
   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
     %9 = arith.constant 0 : i16
     %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -406,7 +406,7 @@ builtin.module {
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK-NEXT:  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "partial_access"}> ({
+// CHECK-NEXT:  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" value=512 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=2 : i16>, #csl_wrapper.param<"chunk_size" value=255 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "partial_access"}> ({
 // CHECK-NEXT:  ^4(%101 : i16, %102 : i16, %103 : i16, %104 : i16, %105 : i16, %106 : i16, %107 : i16, %108 : i16, %109 : i16):
 // CHECK-NEXT:    %110 = arith.constant 0 : i16
 // CHECK-NEXT:    %111 = "csl.get_color"(%110) : (i16) -> !csl.color
@@ -477,7 +477,7 @@ builtin.module {
 // CHECK-NEXT:    "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
 // CHECK-NEXT:  }) : () -> ()
 
-  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=511 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "chunk_reduce_only", "width" = 1024 : i16}> ({
+  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=511 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=1 : i16>, #csl_wrapper.param<"chunk_size" value=510 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "chunk_reduce_only", "width" = 1024 : i16}> ({
   ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
     %0 = arith.constant 1 : i16
     %1 = arith.constant 0 : i16
@@ -579,7 +579,7 @@ builtin.module {
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK-NEXT:  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=511 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "chunk_reduce_only", "width" = 1024 : i16}> ({
+// CHECK-NEXT:  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" value=511 : i16>, #csl_wrapper.param<"pattern" value=2 : i16>, #csl_wrapper.param<"num_chunks" value=1 : i16>, #csl_wrapper.param<"chunk_size" value=510 : i16>, #csl_wrapper.param<"padded_z_dim" value=510 : i16>], "program_name" = "chunk_reduce_only", "width" = 1024 : i16}> ({
 // CHECK-NEXT:  ^6(%arg0_4 : i16, %arg1_4 : i16, %arg2_2 : i16, %arg3_2 : i16, %arg4_2 : i16, %arg5_2 : i16, %arg6_2 : i16, %arg7_2 : i16, %arg8_2 : i16):
 // CHECK-NEXT:    %158 = arith.constant 1 : i16
 // CHECK-NEXT:    %159 = arith.constant 0 : i16

--- a/tests/filecheck/transforms/lower-csl-wrapper.mlir
+++ b/tests/filecheck/transforms/lower-csl-wrapper.mlir
@@ -5,11 +5,11 @@ builtin.module {
     "width" = 1022 : i16,
     "height" = 510 : i16,
     "params" = [
-      #csl_wrapper.param<"z_dim" default=512 : i16>,
-      #csl_wrapper.param<"pattern" default=2 : i16>,
-      #csl_wrapper.param<"num_chunks" default=2 : i16>,
-      #csl_wrapper.param<"chunk_size" default=255 : i16>,
-      #csl_wrapper.param<"padded_z_dim" default=510 : i16>
+      #csl_wrapper.param<"z_dim" value=512 : i16>,
+      #csl_wrapper.param<"pattern" value=2 : i16>,
+      #csl_wrapper.param<"num_chunks" value=2 : i16>,
+      #csl_wrapper.param<"chunk_size" value=255 : i16>,
+      #csl_wrapper.param<"padded_z_dim" value=510 : i16>
     ],
     "program_name" = "gauss_seidel_func"
   }> ({
@@ -75,56 +75,47 @@ builtin.module {
 
 // CHECK:      builtin.module {
 // CHECK-NEXT:   "csl.module"() <{"kind" = #csl<module_kind layout>}> ({
-// CHECK-NEXT:     %0 = arith.constant 2 : i16
-// CHECK-NEXT:     %pattern = "csl.param"(%0) <{"param_name" = "pattern"}> : (i16) -> i16
-// CHECK-NEXT:     %1 = arith.constant 1022 : i16
-// CHECK-NEXT:     %width = "csl.param"(%1) <{"param_name" = "width"}> : (i16) -> i16
-// CHECK-NEXT:     %2 = arith.constant 510 : i16
-// CHECK-NEXT:     %height = "csl.param"(%2) <{"param_name" = "height"}> : (i16) -> i16
+// CHECK-NEXT:     %pattern = arith.constant 2 : i16
+// CHECK-NEXT:     %width = arith.constant 1022 : i16
+// CHECK-NEXT:     %height = arith.constant 510 : i16
 // CHECK-NEXT:     %routesMod = "csl.const_struct"(%pattern, %width, %height) <{"ssa_fields" = ["pattern", "peWidth", "peHeight"]}> : (i16, i16, i16) -> !csl.comptime_struct
 // CHECK-NEXT:     %routesMod_1 = "csl.import_module"(%routesMod) <{"module" = "routes.csl"}> : (!csl.comptime_struct) -> !csl.imported_module
 // CHECK-NEXT:     %const0 = arith.constant 0 : i16
 // CHECK-NEXT:     %color0 = "csl.get_color"(%const0) : (i16) -> !csl.color
 // CHECK-NEXT:     %getParamsMod = "csl.const_struct"(%width, %height, %color0) <{"ssa_fields" = ["width", "height", "LAUNCH"]}> : (i16, i16, !csl.color) -> !csl.comptime_struct
 // CHECK-NEXT:     %getParamsMod_1 = "csl.import_module"(%getParamsMod) <{"module" = "<memcpy/get_params>"}> : (!csl.comptime_struct) -> !csl.imported_module
-// CHECK-NEXT:     %3 = arith.constant 0 : i16
-// CHECK-NEXT:     %4 = arith.constant 1 : i16
-// CHECK-NEXT:     %5 = arith.constant 512 : i16
-// CHECK-NEXT:     %zDim = "csl.param"(%5) <{"param_name" = "z_dim"}> : (i16) -> i16
-// CHECK-NEXT:     %6 = arith.constant 2 : i16
-// CHECK-NEXT:     %num_chunks = "csl.param"(%6) <{"param_name" = "num_chunks"}> : (i16) -> i16
-// CHECK-NEXT:     %7 = arith.constant 255 : i16
-// CHECK-NEXT:     %chunk_size = "csl.param"(%7) <{"param_name" = "chunk_size"}> : (i16) -> i16
-// CHECK-NEXT:     %8 = arith.constant 510 : i16
-// CHECK-NEXT:     %padded_z_dim = "csl.param"(%8) <{"param_name" = "padded_z_dim"}> : (i16) -> i16
+// CHECK-NEXT:     %0 = arith.constant 0 : i16
+// CHECK-NEXT:     %1 = arith.constant 1 : i16
+// CHECK-NEXT:     %z_dim = arith.constant 512 : i16
+// CHECK-NEXT:     %num_chunks = arith.constant 2 : i16
+// CHECK-NEXT:     %chunk_size = arith.constant 255 : i16
+// CHECK-NEXT:     %padded_z_dim = arith.constant 510 : i16
 // CHECK-NEXT:     csl.layout {
 // CHECK-NEXT:       "csl.set_rectangle"(%width, %height) : (i16, i16) -> ()
-// CHECK-NEXT:       scf.for %xDim = %3 to %width step %4 : i16 {
-// CHECK-NEXT:         scf.for %yDim = %3 to %height step %4 : i16 {
+// CHECK-NEXT:       scf.for %xDim = %0 to %width step %1 : i16 {
+// CHECK-NEXT:         scf.for %yDim = %0 to %height step %1 : i16 {
 // CHECK-NEXT:           %computeAllRoutesRes = "csl.member_call"(%routesMod_1, %xDim, %yDim, %width, %height, %pattern) <{"field" = "computeAllRoutes"}> : (!csl.imported_module, i16, i16, i16, i16, i16) -> !csl.comptime_struct
 // CHECK-NEXT:           %getParamsRes = "csl.member_call"(%getParamsMod_1, %xDim) <{"field" = "get_params"}> : (!csl.imported_module, i16) -> !csl.comptime_struct
-// CHECK-NEXT:           %9 = arith.constant 1 : i16
-// CHECK-NEXT:           %10 = arith.subi %pattern, %9 : i16
-// CHECK-NEXT:           %11 = arith.subi %width, %xDim : i16
-// CHECK-NEXT:           %12 = arith.subi %height, %yDim : i16
-// CHECK-NEXT:           %13 = arith.cmpi slt, %xDim, %10 : i16
-// CHECK-NEXT:           %14 = arith.cmpi slt, %yDim, %10 : i16
-// CHECK-NEXT:           %15 = arith.cmpi slt, %11, %pattern : i16
-// CHECK-NEXT:           %16 = arith.cmpi slt, %12, %pattern : i16
-// CHECK-NEXT:           %17 = arith.ori %13, %14 : i1
-// CHECK-NEXT:           %18 = arith.ori %17, %15 : i1
-// CHECK-NEXT:           %isBorderRegionPE = arith.ori %18, %16 : i1
-// CHECK-NEXT:           %19 = "csl.const_struct"(%width, %height, %getParamsRes, %computeAllRoutesRes, %isBorderRegionPE) <{"ssa_fields" = ["width", "height", "memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (i16, i16, !csl.comptime_struct, !csl.comptime_struct, i1) -> !csl.comptime_struct
-// CHECK-NEXT:           "csl.set_tile_code"(%xDim, %yDim, %19) <{"file" = "gauss_seidel_func.csl"}> : (i16, i16, !csl.comptime_struct) -> ()
+// CHECK-NEXT:           %2 = arith.constant 1 : i16
+// CHECK-NEXT:           %3 = arith.subi %pattern, %2 : i16
+// CHECK-NEXT:           %4 = arith.subi %width, %xDim : i16
+// CHECK-NEXT:           %5 = arith.subi %height, %yDim : i16
+// CHECK-NEXT:           %6 = arith.cmpi slt, %xDim, %3 : i16
+// CHECK-NEXT:           %7 = arith.cmpi slt, %yDim, %3 : i16
+// CHECK-NEXT:           %8 = arith.cmpi slt, %4, %pattern : i16
+// CHECK-NEXT:           %9 = arith.cmpi slt, %5, %pattern : i16
+// CHECK-NEXT:           %10 = arith.ori %6, %7 : i1
+// CHECK-NEXT:           %11 = arith.ori %10, %8 : i1
+// CHECK-NEXT:           %isBorderRegionPE = arith.ori %11, %9 : i1
+// CHECK-NEXT:           %12 = "csl.const_struct"(%width, %height, %getParamsRes, %computeAllRoutesRes, %isBorderRegionPE) <{"ssa_fields" = ["width", "height", "memcpy_params", "stencil_comms_params", "isBorderRegionPE"]}> : (i16, i16, !csl.comptime_struct, !csl.comptime_struct, i1) -> !csl.comptime_struct
+// CHECK-NEXT:           "csl.set_tile_code"(%xDim, %yDim, %12) <{"file" = "gauss_seidel_func.csl"}> : (i16, i16, !csl.comptime_struct) -> ()
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }) {"sym_name" = "gauss_seidel_func_layout"} : () -> ()
 // CHECK-NEXT:   "csl.module"() <{"kind" = #csl<module_kind program>}> ({
-// CHECK-NEXT:     %0 = arith.constant 2 : i16
-// CHECK-NEXT:     %pattern = "csl.param"(%0) <{"param_name" = "pattern"}> : (i16) -> i16
-// CHECK-NEXT:     %1 = arith.constant 255 : i16
-// CHECK-NEXT:     %chunk_size = "csl.param"(%1) <{"param_name" = "chunk_size"}> : (i16) -> i16
+// CHECK-NEXT:     %pattern = arith.constant 2 : i16
+// CHECK-NEXT:     %chunk_size = arith.constant 255 : i16
 // CHECK-NEXT:     %stencil_comms_params = "csl.param"() <{"param_name" = "stencil_comms_params"}> : () -> !csl.comptime_struct
 // CHECK-NEXT:     %stencilCommsMod = "csl.const_struct"(%pattern, %chunk_size) <{"ssa_fields" = ["pattern", "chunkSize"]}> : (i16, i16) -> !csl.comptime_struct
 // CHECK-NEXT:     %stencilCommsMod_1 = "csl.concat_structs"(%stencilCommsMod, %stencil_comms_params) : (!csl.comptime_struct, !csl.comptime_struct) -> !csl.comptime_struct
@@ -133,14 +124,11 @@ builtin.module {
 // CHECK-NEXT:     %memcpyMod = "csl.const_struct"() <{"ssa_fields" = []}> : () -> !csl.comptime_struct
 // CHECK-NEXT:     %memcpyMod_1 = "csl.concat_structs"(%memcpyMod, %memcpy_params) : (!csl.comptime_struct, !csl.comptime_struct) -> !csl.comptime_struct
 // CHECK-NEXT:     %memcpyMod_2 = "csl.import_module"(%memcpyMod_1) <{"module" = "<memcpy/memcpy>"}> : (!csl.comptime_struct) -> !csl.imported_module
-// CHECK-NEXT:     %width = "csl.param"() <{"param_name" = "width"}> : () -> i16
-// CHECK-NEXT:     %height = "csl.param"() <{"param_name" = "height"}> : () -> i16
-// CHECK-NEXT:     %2 = arith.constant 512 : i16
-// CHECK-NEXT:     %zDim = "csl.param"(%2) <{"param_name" = "z_dim"}> : (i16) -> i16
-// CHECK-NEXT:     %3 = arith.constant 2 : i16
-// CHECK-NEXT:     %num_chunks = "csl.param"(%3) <{"param_name" = "num_chunks"}> : (i16) -> i16
-// CHECK-NEXT:     %4 = arith.constant 510 : i16
-// CHECK-NEXT:     %padded_z_dim = "csl.param"(%4) <{"param_name" = "padded_z_dim"}> : (i16) -> i16
+// CHECK-NEXT:     %width = arith.constant 1022 : i16
+// CHECK-NEXT:     %height = arith.constant 510 : i16
+// CHECK-NEXT:     %z_dim = arith.constant 512 : i16
+// CHECK-NEXT:     %num_chunks = arith.constant 2 : i16
+// CHECK-NEXT:     %padded_z_dim = arith.constant 510 : i16
 // CHECK-NEXT:     %isBorderRegionPE = "csl.param"() <{"param_name" = "isBorderRegionPE"}> : () -> i1
 // CHECK-NEXT:     %inputArr = memref.alloc() : memref<512xf32>
 // CHECK-NEXT:     %outputArr = memref.alloc() : memref<512xf32>
@@ -153,29 +141,29 @@ builtin.module {
 // CHECK-NEXT:       %scratchBuffer = memref.alloc() {"alignment" = 64 : i64} : memref<510xf32>
 // CHECK-NEXT:       csl_stencil.apply(%inputArr : memref<512xf32>, %scratchBuffer : memref<510xf32>) outs (%outputArr : memref<512xf32>) <{"bounds" = #stencil.bounds<[0, 0], [1, 1]>, "num_chunks" = 2 : i64, "operandSegmentSizes" = array<i32: 1, 1, 0, 1>, "swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>}> ({
 // CHECK-NEXT:       ^0(%arg2 : memref<4x255xf32>, %arg3 : index, %arg4 : memref<510xf32>):
-// CHECK-NEXT:         %5 = csl_stencil.access %arg2[1, 0] : memref<4x255xf32>
-// CHECK-NEXT:         %6 = csl_stencil.access %arg2[-1, 0] : memref<4x255xf32>
-// CHECK-NEXT:         %7 = csl_stencil.access %arg2[0, 1] : memref<4x255xf32>
-// CHECK-NEXT:         %8 = csl_stencil.access %arg2[0, -1] : memref<4x255xf32>
-// CHECK-NEXT:         %9 = memref.subview %arg4[%arg3] [255] [1] : memref<510xf32> to memref<255xf32, strided<[1], offset: ?>>
-// CHECK-NEXT:         "csl.fadds"(%9, %8, %7) : (memref<255xf32, strided<[1], offset: ?>>, memref<255xf32>, memref<255xf32>) -> ()
-// CHECK-NEXT:         "csl.fadds"(%9, %9, %6) : (memref<255xf32, strided<[1], offset: ?>>, memref<255xf32, strided<[1], offset: ?>>, memref<255xf32>) -> ()
-// CHECK-NEXT:         "csl.fadds"(%9, %9, %5) : (memref<255xf32, strided<[1], offset: ?>>, memref<255xf32, strided<[1], offset: ?>>, memref<255xf32>) -> ()
+// CHECK-NEXT:         %0 = csl_stencil.access %arg2[1, 0] : memref<4x255xf32>
+// CHECK-NEXT:         %1 = csl_stencil.access %arg2[-1, 0] : memref<4x255xf32>
+// CHECK-NEXT:         %2 = csl_stencil.access %arg2[0, 1] : memref<4x255xf32>
+// CHECK-NEXT:         %3 = csl_stencil.access %arg2[0, -1] : memref<4x255xf32>
+// CHECK-NEXT:         %4 = memref.subview %arg4[%arg3] [255] [1] : memref<510xf32> to memref<255xf32, strided<[1], offset: ?>>
+// CHECK-NEXT:         "csl.fadds"(%4, %3, %2) : (memref<255xf32, strided<[1], offset: ?>>, memref<255xf32>, memref<255xf32>) -> ()
+// CHECK-NEXT:         "csl.fadds"(%4, %4, %1) : (memref<255xf32, strided<[1], offset: ?>>, memref<255xf32, strided<[1], offset: ?>>, memref<255xf32>) -> ()
+// CHECK-NEXT:         "csl.fadds"(%4, %4, %0) : (memref<255xf32, strided<[1], offset: ?>>, memref<255xf32, strided<[1], offset: ?>>, memref<255xf32>) -> ()
 // CHECK-NEXT:         csl_stencil.yield %arg4 : memref<510xf32>
 // CHECK-NEXT:       }, {
 // CHECK-NEXT:       ^1(%arg2_1 : memref<512xf32>, %arg3_1 : memref<510xf32>):
-// CHECK-NEXT:         %10 = memref.subview %arg2_1[2] [510] [1] : memref<512xf32> to memref<510xf32, strided<[1], offset: 2>>
-// CHECK-NEXT:         %11 = memref.subview %arg2_1[0] [510] [1] : memref<512xf32> to memref<510xf32, strided<[1]>>
-// CHECK-NEXT:         "csl.fadds"(%arg3_1, %arg3_1, %11) : (memref<510xf32>, memref<510xf32>, memref<510xf32, strided<[1]>>) -> ()
-// CHECK-NEXT:         "csl.fadds"(%arg3_1, %arg3_1, %10) : (memref<510xf32>, memref<510xf32>, memref<510xf32, strided<[1], offset: 2>>) -> ()
-// CHECK-NEXT:         %12 = arith.constant 1.666600e-01 : f32
-// CHECK-NEXT:         "csl.fmuls"(%arg3_1, %arg3_1, %12) : (memref<510xf32>, memref<510xf32>, f32) -> ()
+// CHECK-NEXT:         %5 = memref.subview %arg2_1[2] [510] [1] : memref<512xf32> to memref<510xf32, strided<[1], offset: 2>>
+// CHECK-NEXT:         %6 = memref.subview %arg2_1[0] [510] [1] : memref<512xf32> to memref<510xf32, strided<[1]>>
+// CHECK-NEXT:         "csl.fadds"(%arg3_1, %arg3_1, %6) : (memref<510xf32>, memref<510xf32>, memref<510xf32, strided<[1]>>) -> ()
+// CHECK-NEXT:         "csl.fadds"(%arg3_1, %arg3_1, %5) : (memref<510xf32>, memref<510xf32>, memref<510xf32, strided<[1], offset: 2>>) -> ()
+// CHECK-NEXT:         %7 = arith.constant 1.666600e-01 : f32
+// CHECK-NEXT:         "csl.fmuls"(%arg3_1, %arg3_1, %7) : (memref<510xf32>, memref<510xf32>, f32) -> ()
 // CHECK-NEXT:         csl_stencil.yield %arg3_1 : memref<510xf32>
 // CHECK-NEXT:       }) to <[0, 0], [1, 1]>
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
-// CHECK-NEXT:   %5 = "csl.member_access"(%memcpyMod_2) <{"field" = "LAUNCH"}> : (!csl.imported_module) -> !csl.color
-// CHECK-NEXT:   "csl.rpc"(%5) : (!csl.color) -> ()
+// CHECK-NEXT:   %0 = "csl.member_access"(%memcpyMod_2) <{"field" = "LAUNCH"}> : (!csl.imported_module) -> !csl.color
+// CHECK-NEXT:   "csl.rpc"(%0) : (!csl.color) -> ()
 // CHECK-NEXT:   }) {"sym_name" = "gauss_seidel_func_program"} : () -> ()
 // CHECK-NEXT: }
 // CHECK-EMPTY:

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -53,14 +53,14 @@ class ParamAttribute(ParametrizedAttribute):
     name = "csl_wrapper.param"
 
     key: ParameterDef[StringAttr]
-    value: ParameterDef[IntegerAttr[IntegerType] | NoneAttr]
+    value: ParameterDef[IntegerAttr[IntegerType]]
     type: ParameterDef[IntegerType]
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
             printer.print_string_literal(self.key.data)
             if not isinstance(self.value, NoneAttr):
-                printer.print(" default=")
+                printer.print(" value=")
                 printer.print_attribute(self.value)
             else:
                 printer.print(" : ")
@@ -70,7 +70,7 @@ class ParamAttribute(ParametrizedAttribute):
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
         with parser.in_angle_brackets():
             key = StringAttr(parser.parse_str_literal())
-            if parser.parse_optional_keyword("default"):
+            if parser.parse_optional_keyword("value"):
                 parser.parse_punctuation("=")
                 val = parser.parse_attribute()
                 assert isa(val, AnyIntegerAttr)
@@ -328,13 +328,10 @@ class ModuleOp(IRDLOperation):
             return self.width
         elif name == "height":
             return self.height
-        res = NoneAttr()
         for param in self.params.data:
             if name == param.key.data:
-                res = param.value
-        if isinstance(res, NoneAttr):
-            raise ValueError(f"Parameter name is unknown or has no value: {name}")
-        return res
+                return param.value
+        raise ValueError(f"Parameter name is unknown: {name}")
 
     @property
     def layout_yield_op(self) -> YieldOp:


### PR DESCRIPTION
`csl.param`s allow for flexibility we do not utilise whilst providing a possibility of accidentally overriding a value which was not intended to be overridden. In the `ModuleOp.get_param_value` function we even use the value of the param as if it will always be there.

After this PR: `csl_wrapper.ParamAttribute` can no longer omit its value (now referred to as "value" not "default")

In the layout module:
* All `param`s are now `arith.constant`s

In the program module:
* All params from the `csl_wrapper.ParamAttribute` are now `arith.constant`s
* Params from the layout module `yield` arguments are still `csl.param`s.