### PR TITLE
 core: (HasParent) allow no parent for testing

### DIFF
--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -68,6 +68,20 @@ class HasMultipleParentOp(IRDLOperation):
     traits = frozenset([HasParent(ParentOp, Parent2Op)])
 
 
+def test_has_parent_no_parent():
+    """
+    A detached op with a HasParent trait should be verifyable when detached
+    """
+
+    single_parent = HasParentOp()
+
+    single_parent.verify()
+
+    multiple_parent = HasMultipleParentOp()
+
+    multiple_parent.verify()
+
+
 def test_has_parent_wrong_parent():
     """
     Test that an operation with an HasParentOp trait

--- a/tests/test_builtin_traits.py
+++ b/tests/test_builtin_traits.py
@@ -68,26 +68,6 @@ class HasMultipleParentOp(IRDLOperation):
     traits = frozenset([HasParent(ParentOp, Parent2Op)])
 
 
-def test_has_parent_no_parent():
-    """
-    Test that an operation with an HasParentOp trait
-    fails with no parents.
-    """
-    has_parent_op = HasParentOp()
-    with pytest.raises(
-        VerifyException, match="'test.has_parent' expects parent op 'test.parent'"
-    ):
-        has_parent_op.verify()
-
-    has_multiple_parent_op = HasMultipleParentOp()
-    message = (
-        "'test.has_multiple_parent' expects parent op to "
-        "be one of 'test.parent', 'test.parent2'"
-    )
-    with pytest.raises(VerifyException, match=message):
-        has_multiple_parent_op.verify()
-
-
 def test_has_parent_wrong_parent():
     """
     Test that an operation with an HasParentOp trait

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -50,6 +50,9 @@ class HasParent(OpTrait):
 
     def verify(self, op: Operation) -> None:
         parent = op.parent_op()
+        # Don't check parent when op is detached
+        if parent is None:
+            return
         if isinstance(parent, self.op_types):
             return
         if len(self.op_types) == 1:


### PR DESCRIPTION
Allows operations with the `HasParent` trait to verify when detached. This makes it easier to write unit tests for these operations, as there is no need to nest them within other operations. 