### PR TITLE
misc: remove type annotations from VarConstraint ClassVars

### DIFF
--- a/docs/irdl.ipynb
+++ b/docs/irdl.ipynb
@@ -1066,7 +1066,7 @@
     "class BinaryOp(IRDLOperation):\n",
     "    name = \"binary_op\"\n",
     "\n",
-    "    T: ClassVar[VarConstraint[IntegerType]] = VarConstraint(\"T\", base(IntegerType))\n",
+    "    T: ClassVar = VarConstraint(\"T\", base(IntegerType))\n",
     "\n",
     "    lhs = operand_def(T)\n",
     "    rhs = operand_def(T)\n",

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1578,7 +1578,7 @@ def test_basic_inference(format: str):
 
     @irdl_op_definition
     class TwoOperandsOneResultWithVarOp(IRDLOperation):
-        T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+        T: ClassVar = VarConstraint("T", AnyAttr())
 
         name = "test.two_operands_one_result_with_var"
         res = result_def(T)
@@ -1678,7 +1678,7 @@ def test_nested_inference():
 
     @irdl_op_definition
     class TwoOperandsNestedVarOp(IRDLOperation):
-        T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+        T: ClassVar = VarConstraint("T", AnyAttr())
 
         name = "test.two_operands_one_result_with_var"
         res = result_def(T)
@@ -1722,7 +1722,7 @@ def test_non_verifying_inference():
 
     @irdl_op_definition
     class OneOperandOneResultNestedOp(IRDLOperation):
-        T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+        T: ClassVar = VarConstraint("T", AnyAttr())
 
         name = "test.one_operand_one_result_nested"
         res = result_def(T)

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -251,9 +251,7 @@ def test_constraint_var_fail_not_satisfy_constraint():
 class GenericConstraintVarOp(IRDLOperation):
     name = "test.constraint_var_op"
 
-    T: ClassVar[VarConstraint[IntegerType | IndexType]] = VarConstraint(
-        "T", base(IntegerType) | base(IndexType)
-    )
+    T: ClassVar = VarConstraint("T", base(IntegerType) | base(IndexType))
 
     operand = operand_def(T)
     result = result_def(T)

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -259,7 +259,7 @@ class ParallelOp(IRDLOperation):
 class Store(IRDLOperation):
     name = "affine.store"
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     value = operand_def(T)
     memref = operand_def(MemRefType[Attribute].constr(element_type=T))
@@ -292,7 +292,7 @@ class Store(IRDLOperation):
 class Load(IRDLOperation):
     name = "affine.load"
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     memref = operand_def(MemRefType[Attribute].constr(element_type=T))
     indices = var_operand_def(IndexType)

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -175,7 +175,7 @@ _T = TypeVar("_T", bound=Attribute)
 class SignlessIntegerBinaryOperation(IRDLOperation, abc.ABC):
     """A generic base class for arith's binary operations on signless integers."""
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", signlessIntegerLike)
+    T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -216,7 +216,7 @@ class SignlessIntegerBinaryOperation(IRDLOperation, abc.ABC):
 class FloatingPointLikeBinaryOperation(IRDLOperation, abc.ABC):
     """A generic base class for arith's binary operations on floats."""
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", floatingPointLike)
+    T: ClassVar = VarConstraint("T", floatingPointLike)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -290,7 +290,7 @@ class AddUIExtended(IRDLOperation):
 
     traits = frozenset([Pure()])
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", signlessIntegerLike)
+    T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -353,7 +353,7 @@ class Muli(SignlessIntegerBinaryOperation):
 class MulExtendedBase(IRDLOperation):
     """Base class for extended multiplication operations."""
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", signlessIntegerLike)
+    T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
     lhs = operand_def(T)
     rhs = operand_def(T)

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -56,7 +56,7 @@ class BinCombOperation(IRDLOperation, ABC):
     result, all of the same integer type.
     """
 
-    T: ClassVar[VarConstraint[IntegerType]] = VarConstraint("T", base(IntegerType))
+    T: ClassVar = VarConstraint("T", base(IntegerType))
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -103,7 +103,7 @@ class VariadicCombOperation(IRDLOperation, ABC):
     result, all of the same integer type.
     """
 
-    T: ClassVar[VarConstraint[IntegerType]] = VarConstraint("T", base(IntegerType))
+    T: ClassVar = VarConstraint("T", base(IntegerType))
 
     inputs = var_operand_def(T)
     result = result_def(T)
@@ -260,7 +260,7 @@ class ICmpOp(IRDLOperation, ABC):
 
     name = "comb.icmp"
 
-    T: ClassVar[VarConstraint[IntegerType]] = VarConstraint("T", base(IntegerType))
+    T: ClassVar = VarConstraint("T", base(IntegerType))
 
     predicate = attr_def(IntegerAttr[I64])
     lhs = operand_def(T)
@@ -562,7 +562,7 @@ class MuxOp(IRDLOperation):
 
     name = "comb.mux"
 
-    T: ClassVar[VarConstraint[TypeAttribute]] = VarConstraint("T", base(TypeAttribute))
+    T: ClassVar = VarConstraint("T", base(TypeAttribute))
 
     cond = operand_def(IntegerType(1))
     true_value = operand_def(T)

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -614,7 +614,7 @@ class ZerosOp(IRDLOperation):
 
     name = "csl.zeros"
 
-    T: ClassVar[VarConstraint[ZerosOpAttr]] = VarConstraint("T", ZerosOpAttrConstr)
+    T: ClassVar = VarConstraint("T", ZerosOpAttrConstr)
 
     size = opt_operand_def(T)
 
@@ -649,7 +649,7 @@ class ConstantsOp(IRDLOperation):
 
     name = "csl.constants"
 
-    T: ClassVar[VarConstraint[IntegerType | Float32Type | Float16Type]] = VarConstraint(
+    T: ClassVar = VarConstraint(
         "T", BaseAttr(IntegerType) | BaseAttr(Float32Type) | BaseAttr(Float16Type)
     )
 
@@ -1965,7 +1965,7 @@ class ParamOp(IRDLOperation):
     command line by passing params to the compiler.
     """
 
-    T: ClassVar[VarConstraint[ParamOpAttr]] = VarConstraint("T", ParamOpAttrConstr)
+    T: ClassVar = VarConstraint("T", ParamOpAttrConstr)
 
     name = "csl.param"
 

--- a/xdsl/dialects/eqsat.py
+++ b/xdsl/dialects/eqsat.py
@@ -27,7 +27,7 @@ from xdsl.utils.exceptions import DiagnosticException
 
 @irdl_op_definition
 class EClassOp(IRDLOperation):
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     name = "eqsat.eclass"
     arguments = var_operand_def(T)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -356,7 +356,7 @@ class LinkageAttr(ParametrizedAttribute):
 class ArithmeticBinOperation(IRDLOperation, ABC):
     """Class for arithmetic binary operations."""
 
-    T: ClassVar[VarConstraint[IntegerType]] = VarConstraint("T", BaseAttr(IntegerType))
+    T: ClassVar = VarConstraint("T", BaseAttr(IntegerType))
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -412,7 +412,7 @@ class OverflowAttr(OverflowAttrBase):
 class ArithmeticBinOpOverflow(IRDLOperation, ABC):
     """Class for arithmetic binary operations that use overflow flags."""
 
-    T: ClassVar[VarConstraint[IntegerType]] = VarConstraint("T", BaseAttr(IntegerType))
+    T: ClassVar = VarConstraint("T", BaseAttr(IntegerType))
 
     lhs = operand_def(T)
     rhs = operand_def(T)

--- a/xdsl/dialects/ltl.py
+++ b/xdsl/dialects/ltl.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from xdsl.dialects.builtin import IntegerType
-from xdsl.ir import Attribute, Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
+from xdsl.ir import Dialect, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     AnyOf,
     IRDLOperation,
@@ -51,9 +51,7 @@ class AndOp(IRDLOperation):
 
     name = "ltl.and"
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint(
-        "T", AnyOf([Sequence, Property, IntegerType(1)])
-    )
+    T: ClassVar = VarConstraint("T", AnyOf([Sequence, Property, IntegerType(1)]))
 
     input = var_operand_def(T)
 

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -72,7 +72,7 @@ from xdsl.utils.hints import isa
 class Load(IRDLOperation):
     name = "memref.load"
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     nontemporal = opt_prop_def(BoolAttr)
 
@@ -109,7 +109,7 @@ class Load(IRDLOperation):
 
 @irdl_op_definition
 class Store(IRDLOperation):
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     name = "memref.store"
 
@@ -360,9 +360,7 @@ class Alloca(IRDLOperation):
 class AtomicRMWOp(IRDLOperation):
     name = "memref.atomic_rmw"
 
-    T: ClassVar[VarConstraint[AnyFloat | AnySignlessIntegerType]] = VarConstraint(
-        "T", AnyFloatConstr | SignlessIntegerConstraint
-    )
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | SignlessIntegerConstraint)
 
     value = operand_def(T)
     memref = operand_def(

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -849,7 +849,7 @@ class YieldOp(AbstractYieldOperation[Attribute]):
 class FillOp(IRDLOperation):
     name = "memref_stream.fill"
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     memref = operand_def(memref.MemRefType[Attribute].constr(element_type=T))
     value = operand_def(T)

--- a/xdsl/dialects/mod_arith.py
+++ b/xdsl/dialects/mod_arith.py
@@ -26,7 +26,7 @@ class BinaryOp(IRDLOperation, ABC):
     Simple binary operation
     """
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", signlessIntegerLike)
+    T: ClassVar = VarConstraint("T", signlessIntegerLike)
 
     lhs = operand_def(T)
     rhs = operand_def(T)

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -809,8 +809,8 @@ class RdRsRsAccumulatingFloatOperationWithFastMath(RISCVInstruction, ABC):
     be annotated with fastmath flags.
     """
 
-    SAME_FLOAT_REGISTER_TYPE: ClassVar[VarConstraint[FloatRegisterType]] = (
-        VarConstraint("SAME_FLOAT_REGISTER_TYPE", base(FloatRegisterType))
+    SAME_FLOAT_REGISTER_TYPE: ClassVar = VarConstraint(
+        "SAME_FLOAT_REGISTER_TYPE", base(FloatRegisterType)
     )
 
     rd_out = result_def(SAME_FLOAT_REGISTER_TYPE)
@@ -873,8 +873,8 @@ class RdRsAccumulatingFloatOperation(RISCVInstruction, ABC):
     that also acts as a source register, and a source floating-point register.
     """
 
-    SAME_FLOAT_REGISTER_TYPE: ClassVar[VarConstraint[FloatRegisterType]] = (
-        VarConstraint("SAME_FLOAT_REGISTER_TYPE", base(FloatRegisterType))
+    SAME_FLOAT_REGISTER_TYPE: ClassVar = VarConstraint(
+        "SAME_FLOAT_REGISTER_TYPE", base(FloatRegisterType)
     )
 
     rd_out = result_def(SAME_FLOAT_REGISTER_TYPE)

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -6,7 +6,6 @@ from typing import ClassVar
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
-    AnySignlessIntegerOrIndexType,
     DenseArrayBase,
     IndexType,
     IntegerType,
@@ -286,9 +285,7 @@ class ForOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 class For(IRDLOperation):
     name = "scf.for"
 
-    T: ClassVar[VarConstraint[AnySignlessIntegerOrIndexType]] = VarConstraint(
-        "T", base(IndexType) | SignlessIntegerConstraint
-    )
+    T: ClassVar = VarConstraint("T", base(IndexType) | SignlessIntegerConstraint)
 
     lb = operand_def(T)
     ub = operand_def(T)

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -15,7 +15,7 @@ from xdsl.dialects.builtin import (
     i1,
 )
 from xdsl.dialects.hw import InnerSymAttr
-from xdsl.ir import Attribute, Data, Dialect, Operation, SSAValue
+from xdsl.ir import Data, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyAttr,
     AttrSizedOperandSegments,
@@ -94,7 +94,7 @@ class CompRegOp(IRDLOperation):
 
     name = "seq.compreg"
 
-    DATA_TYPE: ClassVar[VarConstraint[Attribute]] = VarConstraint("DataType", AnyAttr())
+    DATA_TYPE: ClassVar = VarConstraint("DataType", AnyAttr())
 
     inner_sym = opt_attr_def(InnerSymAttr)
     input = operand_def(DATA_TYPE)

--- a/xdsl/dialects/stablehlo.py
+++ b/xdsl/dialects/stablehlo.py
@@ -59,7 +59,7 @@ from xdsl.utils.exceptions import VerifyException
 
 class ElementwiseBinaryOperation(IRDLOperation, abc.ABC):
     # TODO: Remove this constraint for complex types.
-    T: ClassVar[VarConstraint[AnyTensorType]] = VarConstraint("T", base(AnyTensorType))
+    T: ClassVar = VarConstraint("T", base(AnyTensorType))
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -223,7 +223,7 @@ class AbsOp(IRDLOperation):
     name = "stablehlo.abs"
 
     # TODO: Remove this constraint for complex types.
-    T: ClassVar[VarConstraint[AnyTensorType]] = VarConstraint("T", base(AnyTensorType))
+    T: ClassVar = VarConstraint("T", base(AnyTensorType))
 
     operand = operand_def(T)
     result = result_def(T)
@@ -286,9 +286,7 @@ class AndOp(IRDLOperation):
 
     name = "stablehlo.and"
 
-    T: ClassVar[VarConstraint[IntegerTensorType]] = VarConstraint(
-        "T", base(IntegerTensorType)
-    )
+    T: ClassVar = VarConstraint("T", base(IntegerTensorType))
 
     lhs = operand_def(T)
     rhs = operand_def(T)

--- a/xdsl/dialects/stream.py
+++ b/xdsl/dialects/stream.py
@@ -79,7 +79,7 @@ class ReadOperation(IRDLOperation, abc.ABC):
     Abstract base class for operations that read from a stream.
     """
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     stream = operand_def(ReadableStreamType[Attribute].constr(element_type=T))
     res = result_def(T)
@@ -112,7 +112,7 @@ class WriteOperation(IRDLOperation, abc.ABC):
     Abstract base class for operations that write to a stream.
     """
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", AnyAttr())
+    T: ClassVar = VarConstraint("T", AnyAttr())
 
     value = operand_def(T)
     stream = operand_def(WritableStreamType[Attribute].constr(element_type=T))

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -11,7 +11,7 @@ from xdsl.dialects.builtin import (
     IndexType,
     IntegerType,
 )
-from xdsl.ir import Attribute, Dialect, Operation, SSAValue
+from xdsl.ir import Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyOf,
     IRDLOperation,
@@ -43,7 +43,7 @@ class VarithOp(IRDLOperation):
     Variadic arithmetic operation
     """
 
-    T: ClassVar[VarConstraint[Attribute]] = VarConstraint("T", integerOrFloatLike)
+    T: ClassVar = VarConstraint("T", integerOrFloatLike)
 
     args = var_operand_def(T)
     res = result_def(T)


### PR DESCRIPTION
It turns out that Pyright can infer them, makes relevant code much cleaner IMO