### PR TITLE
transformations: (arith-to-varith) Support more cases

### DIFF
--- a/tests/filecheck/transforms/convert-arith-to-varith.mlir
+++ b/tests/filecheck/transforms/convert-arith-to-varith.mlir
@@ -76,8 +76,8 @@ func.func @test_mulf() {
 func.func @test() {
     %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (f32, f32, f32, f32, f32, f32)
     %6 = arith.constant 1.234500e-01 : f32
-    %b = arith.addf %a, %3 : f32
     %a = arith.addf %5, %4 : f32
+    %b = arith.addf %a, %3 : f32
     %c = arith.addf %b, %2 : f32
     %d = arith.addf %c, %1 : f32
     %e = arith.addf %d, %0 : f32

--- a/tests/filecheck/transforms/convert-arith-to-varith.mlir
+++ b/tests/filecheck/transforms/convert-arith-to-varith.mlir
@@ -74,41 +74,41 @@ func.func @test_mulf() {
 }
 
 func.func @test() {
-    %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
-    %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
-    %a = arith.addf %5, %4 : tensor<8xf32>
-    %b = arith.addf %a, %3 : tensor<8xf32>
-    %c = arith.addf %b, %2 : tensor<8xf32>
-    %d = arith.addf %c, %1 : tensor<8xf32>
-    %e = arith.addf %d, %0 : tensor<8xf32>
-    %12 = arith.mulf %e, %6 : tensor<8xf32>
-    "test.op"(%12) : (tensor<8xf32>) -> ()
+    %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (f32, f32, f32, f32, f32, f32)
+    %6 = arith.constant 1.234500e-01 : f32
+    %b = arith.addf %a, %3 : f32
+    %a = arith.addf %5, %4 : f32
+    %c = arith.addf %b, %2 : f32
+    %d = arith.addf %c, %1 : f32
+    %e = arith.addf %d, %0 : f32
+    %12 = arith.mulf %e, %6 : f32
+    "test.op"(%12) : (f32) -> ()
     func.return
 
     // CHECK-LABEL: @test
-    // CHECK-NEXT:   %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
-    // CHECK-NEXT:   %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
-    // CHECK-NEXT:   %e = varith.add %5, %4, %3, %2, %1, %0 : tensor<8xf32>
-    // CHECK-NEXT:   %7 = arith.mulf %e, %6 : tensor<8xf32>
-    // CHECK-NEXT:   "test.op"(%7) : (tensor<8xf32>) -> ()
+    // CHECK-NEXT:   %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (f32, f32, f32, f32, f32, f32)
+    // CHECK-NEXT:   %6 = arith.constant 1.234500e-01 : 8xf32
+    // CHECK-NEXT:   %e = varith.add %5, %4, %3, %2, %1, %0 : f32
+    // CHECK-NEXT:   %7 = arith.mulf %e, %6 : f32
+    // CHECK-NEXT:   "test.op"(%7) : (f32) -> ()
 }
 
 func.func @test2() {
-    %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
-    %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
-    %a = arith.addf %5, %4 : tensor<8xf32>
-    %b = arith.addf %3, %a : tensor<8xf32>
-    %c = arith.addf %2, %b : tensor<8xf32>
-    %d = arith.addf %1, %c : tensor<8xf32>
-    %e = arith.addf %0, %d : tensor<8xf32>
-    %12 = arith.mulf %e, %6 : tensor<8xf32>
-    "test.op"(%12) : (tensor<8xf32>) -> ()
+    %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (f32, f32, f32, f32, f32, f32)
+    %6 = arith.constant 1.234500e-01 : f32
+    %a = arith.addf %5, %4 : f32
+    %b = arith.addf %3, %a : f32
+    %c = arith.addf %2, %b : f32
+    %d = arith.addf %1, %c : f32
+    %e = arith.addf %0, %d : f32
+    %12 = arith.mulf %e, %6 : f32
+    "test.op"(%12) : (f32) -> ()
     func.return
 
     // CHECK-LABEL: @test
-    // CHECK-NEXT:   %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
-    // CHECK-NEXT:   %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
-    // CHECK-NEXT:   %e = varith.add %1, %2, %3, %5, %4, %0 : tensor<8xf32>
-    // CHECK-NEXT:   %7 = arith.mulf %e, %6 : tensor<8xf32>
-    // CHECK-NEXT:   "test.op"(%7) : (tensor<8xf32>) -> ()
+    // CHECK-NEXT:   %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (f32, f32, f32, f32, f32, f32)
+    // CHECK-NEXT:   %6 = arith.constant 1.234500e-01 : f32
+    // CHECK-NEXT:   %e = varith.add %1, %2, %3, %5, %4, %0 : f32
+    // CHECK-NEXT:   %7 = arith.mulf %e, %6 : f32
+    // CHECK-NEXT:   "test.op"(%7) : (f32) -> ()
 }

--- a/tests/filecheck/transforms/convert-arith-to-varith.mlir
+++ b/tests/filecheck/transforms/convert-arith-to-varith.mlir
@@ -20,7 +20,7 @@ func.func @test_addi() {
     // CHECK-NEXT:   %a, %b, %c = "test.op"() : () -> (i32, i32, i32)
     // CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (i32, i32, i32)
     // CHECK-NEXT:   %x2 = arith.addi %0, %1 : i32
-    // CHECK-NEXT:   %r = varith.add %c, %a, %b, %2, %0, %1 : i32
+    // CHECK-NEXT:   %r = varith.add %a, %b, %c, %0, %1, %2 : i32
     // CHECK-NEXT:   "test.op"(%r, %x2) : (i32, i32) -> ()
 }
 
@@ -45,7 +45,7 @@ func.func @test_addf() {
     // CHECK-NEXT:   %a, %b, %c = "test.op"() : () -> (f32, f32, f32)
     // CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (f32, f32, f32)
     // CHECK-NEXT:   %x2 = arith.addf %0, %1 : f32
-    // CHECK-NEXT:   %r = varith.add %c, %a, %b, %2, %0, %1 : f32
+    // CHECK-NEXT:   %r = varith.add %a, %b, %c, %0, %1, %2 : f32
     // CHECK-NEXT:   "test.op"(%r, %x2) : (f32, f32) -> ()
 }
 
@@ -69,6 +69,46 @@ func.func @test_mulf() {
     // CHECK-NEXT:   %a, %b, %c = "test.op"() : () -> (f32, f32, f32)
     // CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (f32, f32, f32)
     // CHECK-NEXT:   %x2 = arith.mulf %0, %1 : f32
-    // CHECK-NEXT:   %r = varith.mul %c, %a, %b, %2, %0, %1 : f32
+    // CHECK-NEXT:   %r = varith.mul %a, %b, %c, %0, %1, %2 : f32
     // CHECK-NEXT:   "test.op"(%r, %x2) : (f32, f32) -> ()
+}
+
+func.func @test() {
+    %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
+    %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
+    %a = arith.addf %5, %4 : tensor<8xf32>
+    %b = arith.addf %a, %3 : tensor<8xf32>
+    %c = arith.addf %b, %2 : tensor<8xf32>
+    %d = arith.addf %c, %1 : tensor<8xf32>
+    %e = arith.addf %d, %0 : tensor<8xf32>
+    %12 = arith.mulf %e, %6 : tensor<8xf32>
+    "test.op"(%12) : (tensor<8xf32>) -> ()
+    func.return
+
+    // CHECK-LABEL: @test
+    // CHECK-NEXT:   %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
+    // CHECK-NEXT:   %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
+    // CHECK-NEXT:   %e = varith.add %5, %4, %3, %2, %1, %0 : tensor<8xf32>
+    // CHECK-NEXT:   %7 = arith.mulf %e, %6 : tensor<8xf32>
+    // CHECK-NEXT:   "test.op"(%7) : (tensor<8xf32>) -> ()
+}
+
+func.func @test2() {
+    %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
+    %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
+    %a = arith.addf %5, %4 : tensor<8xf32>
+    %b = arith.addf %3, %a : tensor<8xf32>
+    %c = arith.addf %2, %b : tensor<8xf32>
+    %d = arith.addf %1, %c : tensor<8xf32>
+    %e = arith.addf %0, %d : tensor<8xf32>
+    %12 = arith.mulf %e, %6 : tensor<8xf32>
+    "test.op"(%12) : (tensor<8xf32>) -> ()
+    func.return
+
+    // CHECK-LABEL: @test
+    // CHECK-NEXT:   %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
+    // CHECK-NEXT:   %6 = arith.constant dense<1.234500e-01> : tensor<8xf32>
+    // CHECK-NEXT:   %e = varith.add %1, %2, %3, %5, %4, %0 : tensor<8xf32>
+    // CHECK-NEXT:   %7 = arith.mulf %e, %6 : tensor<8xf32>
+    // CHECK-NEXT:   "test.op"(%7) : (tensor<8xf32>) -> ()
 }

--- a/tests/filecheck/transforms/convert-arith-to-varith.mlir
+++ b/tests/filecheck/transforms/convert-arith-to-varith.mlir
@@ -87,7 +87,7 @@ func.func @test() {
 
     // CHECK-LABEL: @test
     // CHECK-NEXT:   %0, %1, %2, %3, %4, %5 = "test.op"() : () -> (f32, f32, f32, f32, f32, f32)
-    // CHECK-NEXT:   %6 = arith.constant 1.234500e-01 : 8xf32
+    // CHECK-NEXT:   %6 = arith.constant 1.234500e-01 : f32
     // CHECK-NEXT:   %e = varith.add %5, %4, %3, %2, %1, %0 : f32
     // CHECK-NEXT:   %7 = arith.mulf %e, %6 : f32
     // CHECK-NEXT:   "test.op"(%7) : (f32) -> ()

--- a/xdsl/transforms/varith_transformations.py
+++ b/xdsl/transforms/varith_transformations.py
@@ -33,38 +33,29 @@ class ArithToVarithPattern(RewritePattern):
     Merges two arith operations into a varith operation.
     """
 
-    def match_and_rewrite(self, op: Operation, rewriter: PatternRewriter, /):
-        # check that the op is of a type that we can convert to varith
-        if type(op) not in ARITH_TO_VARITH_TYPE_MAP:
-            return
-
-        # this must be true, as all keys of ARITH_TO_VARITH_TYPE_MAP are binary ops
-        op = cast(
-            arith.SignlessIntegerBinaryOperation
-            | arith.FloatingPointLikeBinaryOperation,
-            op,
-        )
-
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self,
+        op: arith.Addi | arith.Addf | arith.Muli | arith.Mulf,
+        rewriter: PatternRewriter,
+        /,
+    ):
         dest_type = ARITH_TO_VARITH_TYPE_MAP[type(op)]
 
-        # check LHS and the RHS to see if they can be folded
-        # but abort after one is merged
-        for other in (op.rhs.owner, op.lhs.owner):
-            # if me and the other op are the same op
-            # (they must necessarily operate on the same data type)
-            if type(op) is type(other):
-                other_op = cast(
-                    arith.SignlessIntegerBinaryOperation
-                    | arith.FloatingPointLikeBinaryOperation,
-                    other,
-                )
-                # instantiate a varith op with three operands
-                rewriter.replace_matched_op(
-                    dest_type(op.rhs, other_op.lhs, other_op.rhs)
-                )
-                if len(other_op.result.uses) == 0:
-                    rewriter.erase_op(other_op)
-                return
+        if len(op.result.uses) != 1:
+            return
+        if type(use_op := list(op.result.uses)[0].operation) not in (
+            type(op),
+            dest_type,
+        ):
+            return
+
+        other_operands = [o for o in use_op.operands if o != op.result]
+        rewriter.replace_op(
+            use_op,
+            dest_type(op.lhs, op.rhs, *other_operands),
+        )
+        rewriter.erase_matched_op()
 
 
 class VarithToArithPattern(RewritePattern):
@@ -209,6 +200,7 @@ class ConvertArithToVarithPass(ModulePass):
                     MergeVarithOpsPattern(),
                 ]
             ),
+            walk_reverse=True,
         ).rewrite_op(op)
 
 

--- a/xdsl/transforms/varith_transformations.py
+++ b/xdsl/transforms/varith_transformations.py
@@ -24,9 +24,6 @@ ARITH_TO_VARITH_TYPE_MAP: dict[
     arith.Mulf: varith.VarithMulOp,
 }
 
-# map the arith operation to the right varith op:
-VARITH_TYPES = [varith.VarithAddOp, varith.VarithMulOp]
-
 
 class ArithToVarithPattern(RewritePattern):
     """


### PR DESCRIPTION
In some edge-cases a single arith op was not folded away. This should be fixed now.