### PR TITLE
dialects: (varith) add select

### DIFF
--- a/tests/filecheck/dialects/varith/varith_ops.mlir
+++ b/tests/filecheck/dialects/varith/varith_ops.mlir
@@ -29,3 +29,7 @@
 %x6 = "varith.mul"(%ta, %tb, %tc, %td) : (tensor<10xf32>, tensor<10xf32>, tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
 // CHECK:  %x6 = varith.mul %ta, %tb, %tc, %td : tensor<10xf32>
 // CHECK-GENERIC: %x6 = "varith.mul"(%ta, %tb, %tc, %td) : (tensor<10xf32>, tensor<10xf32>, tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
+
+%x7 = "varith.select"(%ia, %fa, %fb, %fc, %fd) : (i32, f32, f32, f32, f32) -> f32
+// CHECK: %x7 = varith.select(%ia : i32) %fa, %fb, %fc, %fd
+// CHECK-GENERIC: %x7 = "varith.select"(%ia, %fa, %fb, %fc, %fd) : (i32, f32, f32, f32, f32) -> f32


### PR DESCRIPTION
Adds a `varith.select function`

I'm not 100% the syntax is ideal.

I have also not included any sort of default case, but don't think this should be too troublesome? (Maybe it could be an optional argument?)