### PR TITLE
transformations: (csl-stencil-bufferize) Inject accumulator in all csl-stencil linalg ops

### DIFF
--- a/tests/filecheck/transforms/csl_stencil_bufferize.mlir
+++ b/tests/filecheck/transforms/csl_stencil_bufferize.mlir
@@ -37,18 +37,18 @@ builtin.module {
 // CHECK-NEXT:     csl_stencil.apply(%a : memref<512xf32>, %1 : memref<510xf32>) outs (%b : memref<512xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64, "bounds" = #stencil.bounds<[0, 0], [1, 1]>, "operandSegmentSizes" = array<i32: 1, 1, 0, 0, 1>}> ({
 // CHECK-NEXT:     ^0(%2 : memref<4x255xf32>, %3 : index, %4 : memref<510xf32>):
 // CHECK-NEXT:       %5 = bufferization.to_tensor %4 restrict writable : memref<510xf32>
-// CHECK-NEXT:       %6 = csl_stencil.access %2[1, 0] : memref<4x255xf32>
-// CHECK-NEXT:       %7 = bufferization.to_tensor %6 restrict : memref<255xf32>
-// CHECK-NEXT:       %8 = csl_stencil.access %2[-1, 0] : memref<4x255xf32>
-// CHECK-NEXT:       %9 = bufferization.to_tensor %8 restrict : memref<255xf32>
-// CHECK-NEXT:       %10 = csl_stencil.access %2[0, 1] : memref<4x255xf32>
-// CHECK-NEXT:       %11 = bufferization.to_tensor %10 restrict : memref<255xf32>
-// CHECK-NEXT:       %12 = csl_stencil.access %2[0, -1] : memref<4x255xf32>
-// CHECK-NEXT:       %13 = bufferization.to_tensor %12 restrict : memref<255xf32>
-// CHECK-NEXT:       %14 = "tensor.extract_slice"(%5, %3) <{"static_offsets" = array<i64: -9223372036854775808>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 0, 0>}> : (tensor<510xf32>, index) -> tensor<255xf32>
-// CHECK-NEXT:       %15 = linalg.add ins(%13, %11 : tensor<255xf32>, tensor<255xf32>) outs(%14 : tensor<255xf32>) -> tensor<255xf32>
-// CHECK-NEXT:       %16 = linalg.add ins(%15, %9 : tensor<255xf32>, tensor<255xf32>) outs(%15 : tensor<255xf32>) -> tensor<255xf32>
-// CHECK-NEXT:       %17 = linalg.add ins(%16, %7 : tensor<255xf32>, tensor<255xf32>) outs(%16 : tensor<255xf32>) -> tensor<255xf32>
+// CHECK-NEXT:       %6 = "tensor.extract_slice"(%5, %3) <{"static_offsets" = array<i64: -9223372036854775808>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 0, 0>}> : (tensor<510xf32>, index) -> tensor<255xf32>
+// CHECK-NEXT:       %7 = csl_stencil.access %2[1, 0] : memref<4x255xf32>
+// CHECK-NEXT:       %8 = bufferization.to_tensor %7 restrict : memref<255xf32>
+// CHECK-NEXT:       %9 = csl_stencil.access %2[-1, 0] : memref<4x255xf32>
+// CHECK-NEXT:       %10 = bufferization.to_tensor %9 restrict : memref<255xf32>
+// CHECK-NEXT:       %11 = csl_stencil.access %2[0, 1] : memref<4x255xf32>
+// CHECK-NEXT:       %12 = bufferization.to_tensor %11 restrict : memref<255xf32>
+// CHECK-NEXT:       %13 = csl_stencil.access %2[0, -1] : memref<4x255xf32>
+// CHECK-NEXT:       %14 = bufferization.to_tensor %13 restrict : memref<255xf32>
+// CHECK-NEXT:       %15 = linalg.add ins(%14, %12 : tensor<255xf32>, tensor<255xf32>) outs(%6 : tensor<255xf32>) -> tensor<255xf32>
+// CHECK-NEXT:       %16 = linalg.add ins(%15, %10 : tensor<255xf32>, tensor<255xf32>) outs(%6 : tensor<255xf32>) -> tensor<255xf32>
+// CHECK-NEXT:       %17 = linalg.add ins(%16, %8 : tensor<255xf32>, tensor<255xf32>) outs(%6 : tensor<255xf32>) -> tensor<255xf32>
 // CHECK-NEXT:       %18 = "tensor.insert_slice"(%17, %5, %3) <{"static_offsets" = array<i64: -9223372036854775808>, "static_sizes" = array<i64: 255>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 1, 1, 0, 0>}> : (tensor<255xf32>, tensor<510xf32>, index) -> tensor<510xf32>
 // CHECK-NEXT:       %19 = bufferization.to_memref %18 : memref<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %19 : memref<510xf32>
@@ -61,8 +61,8 @@ builtin.module {
 // CHECK-NEXT:       %26 = "tensor.extract_slice"(%23) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %27 = "tensor.extract_slice"(%23) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %28 = linalg.add ins(%22, %27 : tensor<510xf32>, tensor<510xf32>) outs(%22 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %29 = linalg.add ins(%28, %26 : tensor<510xf32>, tensor<510xf32>) outs(%28 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %30 = linalg.mul ins(%29, %25 : tensor<510xf32>, tensor<510xf32>) outs(%29 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %29 = linalg.add ins(%28, %26 : tensor<510xf32>, tensor<510xf32>) outs(%22 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %30 = linalg.mul ins(%29, %25 : tensor<510xf32>, tensor<510xf32>) outs(%22 : tensor<510xf32>) -> tensor<510xf32>
 // CHECK-NEXT:       %31 = bufferization.to_memref %30 : memref<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %31 : memref<510xf32>
 // CHECK-NEXT:     }) to <[0, 0], [1, 1]>

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from xdsl.context import MLContext
 from xdsl.dialects import arith, bufferization, func, linalg, memref, stencil, tensor
 from xdsl.dialects.builtin import (
+    AnyTensorType,
     AnyTensorTypeConstr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
@@ -139,9 +140,6 @@ class ApplyOpBufferize(RewritePattern):
             else:
                 done_exchange_arg_mapping.append(arg)
 
-        assert isa(typ := op.receive_chunk.block.args[0].type, TensorType[Attribute])
-        chunk_type = TensorType(typ.get_element_type(), typ.get_shape()[1:])
-
         # inline blocks from old into new regions
         rewriter.inline_block(
             op.receive_chunk.block,
@@ -153,10 +151,6 @@ class ApplyOpBufferize(RewritePattern):
             op.done_exchange.block,
             InsertPoint.at_end(buf_apply_op.done_exchange.block),
             done_exchange_arg_mapping,
-        )
-
-        self._inject_iter_arg_into_linalg_outs(
-            buf_apply_op, rewriter, chunk_type, chunk_region_arg_mapping[2]
         )
 
         # insert new op
@@ -176,81 +170,6 @@ class ApplyOpBufferize(RewritePattern):
                     for arg in args
                 ]
             )
-        )
-
-    @staticmethod
-    def _inject_iter_arg_into_linalg_outs(
-        op: csl_stencil.ApplyOp,
-        rewriter: PatternRewriter,
-        chunk_type: TensorType[Attribute],
-        iter_arg: SSAValue,
-    ):
-        """
-        Finds a linalg op with `chunk_type` shape in `outs` and injects
-        an extracted slice of `iter_arg`. This is a work-around for the
-        way bufferization works, causing it to use `iter_arg` as an accumulator
-        and avoiding having an extra alloc + memref.copy.
-        """
-        linalg_op: linalg.NamedOpBase | None = None
-        for curr_op in op.receive_chunk.block.ops:
-            if (
-                isinstance(curr_op, linalg.NamedOpBase)
-                and len(curr_op.outputs) > 0
-                and curr_op.outputs.types[0] == chunk_type
-            ):
-                linalg_op = curr_op
-                break
-
-        if linalg_op is None:
-            return
-
-        rewriter.replace_op(
-            linalg_op,
-            [
-                extract_slice_op := tensor.ExtractSliceOp(
-                    operands=[iter_arg, [op.receive_chunk.block.args[1]], [], []],
-                    result_types=[chunk_type],
-                    properties={
-                        "static_offsets": DenseArrayBase.from_list(
-                            i64, (memref.Subview.DYNAMIC_INDEX,)
-                        ),
-                        "static_sizes": DenseArrayBase.from_list(
-                            i64, chunk_type.get_shape()
-                        ),
-                        "static_strides": DenseArrayBase.from_list(i64, (1,)),
-                    },
-                ),
-                type(linalg_op).build(
-                    operands=[linalg_op.inputs, extract_slice_op.results],
-                    result_types=linalg_op.result_types,
-                    properties=linalg_op.properties,
-                    attributes=linalg_op.attributes,
-                    regions=[linalg_op.detach_region(r) for r in linalg_op.regions],
-                ),
-            ],
-        )
-
-    @staticmethod
-    def _build_extract_slice(
-        op: csl_stencil.ApplyOp, to_tensor: bufferization.ToTensorOp, offset: SSAValue
-    ) -> tensor.ExtractSliceOp:
-        """
-        Helper function to create an early tensor.extract_slice in the apply.recv_chunk_cb region needed for bufferization.
-        """
-
-        # this is the unbufferized `tensor<(neighbours)x(ZDim)x(type)>` value
-        assert isa(typ := op.receive_chunk.block.args[0].type, TensorType[Attribute])
-
-        return tensor.ExtractSliceOp(
-            operands=[to_tensor.tensor, [offset], [], []],
-            result_types=[TensorType(typ.get_element_type(), typ.get_shape()[1:])],
-            properties={
-                "static_offsets": DenseArrayBase.from_list(
-                    i64, (memref.Subview.DYNAMIC_INDEX,)
-                ),
-                "static_sizes": DenseArrayBase.from_list(i64, typ.get_shape()[1:]),
-                "static_strides": DenseArrayBase.from_list(i64, (1,)),
-            },
         )
 
 
@@ -372,6 +291,104 @@ class ArithConstBufferize(RewritePattern):
 
 
 @dataclass(frozen=True)
+class LinalgAccumulatorInjection(RewritePattern):
+    """
+    Injects the `accumulator` block argument for linalg ops within the csl_stencil.apply regions
+    into the `outs` argument. This typically reduces the overhead of bufferization.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: linalg.NamedOpBase | linalg.Generic, rewriter: PatternRewriter, /
+    ):
+        # check if there is an output to inject the accumulator into
+        if len(op.outputs) != 1 or not isa(
+            target_t := op.outputs[0].type, AnyTensorType
+        ):
+            return
+
+        # find parent `csl_stencil.apply` and which of the regions `op` is in
+        p_region = op.parent_region()
+        apply = None
+        while (
+            p_region
+            and (apply := p_region.parent_op())
+            and not isinstance(apply, csl_stencil.ApplyOp)
+        ):
+            p_region = apply.parent_region()
+        if not isinstance(apply, csl_stencil.ApplyOp) or not p_region:
+            return
+
+        # retrieve the correct accumulator block arg
+        if p_region == apply.receive_chunk:
+            acc_block_arg = p_region.block.args[2]
+        elif p_region == apply.done_exchange:
+            acc_block_arg = p_region.block.args[1]
+        else:
+            raise ValueError("Invalid region")
+
+        # fetch the bufferization of the accumulator block arg
+        acc_uses = [
+            use.operation
+            for use in acc_block_arg.uses
+            if isinstance(use.operation, bufferization.ToTensorOp)
+        ]
+        if len(acc_uses) < 1:
+            return
+        acc_bufferization = acc_uses[0]
+
+        # in the `chunk_recieved` region, fetch or create a down-sized chunk of the accumulator
+        if (
+            acc_bufferization.tensor.type != target_t
+            and p_region == apply.receive_chunk
+        ):
+            # check if we can find an `extract_slice` to the desired size
+            extract_slice = None
+            for use in acc_bufferization.tensor.uses:
+                if (
+                    isinstance(use.operation, tensor.ExtractSliceOp)
+                    and use.operation.result.type == target_t
+                ):
+                    extract_slice = use.operation
+                    break
+
+            # create `extract_slice` op if none exists
+            if not extract_slice:
+                extract_slice = tensor.ExtractSliceOp(
+                    operands=[acc_bufferization, [p_region.block.args[1]], [], []],
+                    result_types=[target_t],
+                    properties={
+                        "static_offsets": DenseArrayBase.from_list(
+                            i64, (memref.Subview.DYNAMIC_INDEX,)
+                        ),
+                        "static_sizes": DenseArrayBase.from_list(
+                            i64, target_t.get_shape()
+                        ),
+                        "static_strides": DenseArrayBase.from_list(i64, (1,)),
+                    },
+                )
+                rewriter.insert_op(extract_slice, InsertPoint.after(acc_bufferization))
+
+            # use the `extract_slice` op fetched or created when rebuilding `op`
+            acc_bufferization = extract_slice
+
+        # check if `op` can be rebuild and needs to be rebuilt
+        if (
+            acc_bufferization.results[0].type == target_t
+            and acc_bufferization.results[0] != op.outputs[0]
+        ):
+            rewriter.replace_matched_op(
+                type(op).build(
+                    operands=[op.inputs, acc_bufferization],
+                    result_types=op.result_types,
+                    properties=op.properties,
+                    attributes=op.attributes,
+                    regions=[op.detach_region(r) for r in op.regions],
+                ),
+            )
+
+
+@dataclass(frozen=True)
 class CslStencilBufferize(ModulePass):
     """
     Bufferizes the csl_stencil dialect.
@@ -392,6 +409,7 @@ class CslStencilBufferize(ModulePass):
                     YieldOpBufferize(),
                     FuncOpBufferize(),
                     ArithConstBufferize(),
+                    LinalgAccumulatorInjection(),
                 ]
             )
         )


### PR DESCRIPTION
This is in preparation for `one-shot-bufferize` and significantly reduces the number of intermediate buffer allocations we need to keep.