### PR TITLE
transformations: (lift-arith-to-linalg) Add generic FMA

### DIFF
--- a/tests/filecheck/transforms/lift-arith-to-linalg.mlir
+++ b/tests/filecheck/transforms/lift-arith-to-linalg.mlir
@@ -1,15 +1,73 @@
+// RUN: xdsl-opt %s -p lift-arith-to-linalg{generate_fma=false} | filecheck %s --check-prefix=NO-FMA
+// RUN: xdsl-opt %s -p lift-arith-to-linalg{fma_require_scalar=true} | filecheck %s --check-prefix=FMA-SCALAR
+// RUN: xdsl-opt %s -p lift-arith-to-linalg{fma_require_erasable_mul=true} | filecheck %s --check-prefix=FMA-FOLD-MUL
 // RUN: xdsl-opt %s -p lift-arith-to-linalg | filecheck %s
 
 builtin.module {
     %t0, %t1, %t2, %t3 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
-    %0 = arith.addf %t0, %t1 : tensor<8xf32>
-    %1 = arith.subf %0, %t2 : tensor<8xf32>
-    %2 = arith.mulf %1, %t3 : tensor<8xf32>
+    %c = arith.constant dense<2.99792458e+08> : tensor<8xf32>
+    %0 = arith.mulf %t0, %t1 : tensor<8xf32>
+    %1 = arith.mulf %c, %t1 : tensor<8xf32>
+    %2 = arith.addf %0, %t2 : tensor<8xf32>
+    %3 = arith.addf %1, %t3 : tensor<8xf32>
+    %4 = arith.subf %1, %t3 : tensor<8xf32>
+
 }
+
+// NO-FMA-NEXT: builtin.module {
+// NO-FMA-NEXT:   %t0, %t1, %t2, %t3 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
+// NO-FMA-NEXT:   %c = arith.constant dense<2.997925e+08> : tensor<8xf32>
+// NO-FMA-NEXT:   %0 = linalg.mul ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%t0 : tensor<8xf32>) -> tensor<8xf32>
+// NO-FMA-NEXT:   %1 = linalg.mul ins(%c, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%c : tensor<8xf32>) -> tensor<8xf32>
+// NO-FMA-NEXT:   %2 = linalg.add ins(%0, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+// NO-FMA-NEXT:   %3 = linalg.add ins(%1, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%1 : tensor<8xf32>) -> tensor<8xf32>
+// NO-FMA-NEXT:   %4 = linalg.sub ins(%1, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%1 : tensor<8xf32>) -> tensor<8xf32>
+// NO-FMA-NEXT: }
+
+// FMA-SCALAR-NEXT: builtin.module {
+// FMA-SCALAR-NEXT:   %t0, %t1, %t2, %t3 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
+// FMA-SCALAR-NEXT:   %c = arith.constant dense<2.997925e+08> : tensor<8xf32>
+// FMA-SCALAR-NEXT:   %0 = linalg.mul ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%t0 : tensor<8xf32>) -> tensor<8xf32>
+// FMA-SCALAR-NEXT:   %1 = arith.mulf %c, %t1 : tensor<8xf32>
+// FMA-SCALAR-NEXT:   %2 = linalg.add ins(%0, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+// FMA-SCALAR-NEXT:   %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%c, %t1, %t3 : tensor<8xf32>, tensor<8xf32>, tensor<8xf32>) outs(%c : tensor<8xf32>) {
+// FMA-SCALAR-NEXT:   ^0(%4 : f32, %5 : f32, %6 : f32, %7 : f32):
+// FMA-SCALAR-NEXT:     %8 = arith.mulf %4, %5 : f32
+// FMA-SCALAR-NEXT:     %9 = arith.addf %8, %6 : f32
+// FMA-SCALAR-NEXT:     linalg.yield %9 : f32
+// FMA-SCALAR-NEXT:   } -> tensor<8xf32>
+// FMA-SCALAR-NEXT:   %10 = linalg.sub ins(%1, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%1 : tensor<8xf32>) -> tensor<8xf32>
+// FMA-SCALAR-NEXT: }
+
+// FMA-FOLD-MUL-NEXT: builtin.module {
+// FMA-FOLD-MUL-NEXT:   %t0, %t1, %t2, %t3 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
+// FMA-FOLD-MUL-NEXT:   %c = arith.constant dense<2.997925e+08> : tensor<8xf32>
+// FMA-FOLD-MUL-NEXT:   %0 = linalg.mul ins(%c, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%c : tensor<8xf32>) -> tensor<8xf32>
+// FMA-FOLD-MUL-NEXT:   %1 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%t0, %t1, %t2 : tensor<8xf32>, tensor<8xf32>, tensor<8xf32>) outs(%t0 : tensor<8xf32>) {
+// FMA-FOLD-MUL-NEXT:   ^0(%2 : f32, %3 : f32, %4 : f32, %5 : f32):
+// FMA-FOLD-MUL-NEXT:     %6 = arith.mulf %2, %3 : f32
+// FMA-FOLD-MUL-NEXT:     %7 = arith.addf %6, %4 : f32
+// FMA-FOLD-MUL-NEXT:     linalg.yield %7 : f32
+// FMA-FOLD-MUL-NEXT:   } -> tensor<8xf32>
+// FMA-FOLD-MUL-NEXT:   %8 = linalg.add ins(%0, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+// FMA-FOLD-MUL-NEXT:   %9 = linalg.sub ins(%0, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
+// FMA-FOLD-MUL-NEXT: }
 
 // CHECK-NEXT: builtin.module {
 // CHECK-NEXT:   %t0, %t1, %t2, %t3 = "test.op"() : () -> (tensor<8xf32>, tensor<8xf32>, tensor<8xf32>, tensor<8xf32>)
-// CHECK-NEXT:   %0 = linalg.add ins(%t0, %t1 : tensor<8xf32>, tensor<8xf32>) outs(%t0 : tensor<8xf32>) -> tensor<8xf32>
-// CHECK-NEXT:   %1 = linalg.sub ins(%0, %t2 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
-// CHECK-NEXT:   %2 = linalg.mul ins(%1, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%1 : tensor<8xf32>) -> tensor<8xf32>
+// CHECK-NEXT:   %c = arith.constant dense<2.997925e+08> : tensor<8xf32>
+// CHECK-NEXT:   %0 = arith.mulf %c, %t1 : tensor<8xf32>
+// CHECK-NEXT:   %1 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%t0, %t1, %t2 : tensor<8xf32>, tensor<8xf32>, tensor<8xf32>) outs(%t0 : tensor<8xf32>) {
+// CHECK-NEXT:   ^0(%2 : f32, %3 : f32, %4 : f32, %5 : f32):
+// CHECK-NEXT:     %6 = arith.mulf %2, %3 : f32
+// CHECK-NEXT:     %7 = arith.addf %6, %4 : f32
+// CHECK-NEXT:     linalg.yield %7 : f32
+// CHECK-NEXT:   } -> tensor<8xf32>
+// CHECK-NEXT:   %8 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%c, %t1, %t3 : tensor<8xf32>, tensor<8xf32>, tensor<8xf32>) outs(%c : tensor<8xf32>) {
+// CHECK-NEXT:   ^1(%9 : f32, %10 : f32, %11 : f32, %12 : f32):
+// CHECK-NEXT:     %13 = arith.mulf %9, %10 : f32
+// CHECK-NEXT:     %14 = arith.addf %13, %11 : f32
+// CHECK-NEXT:     linalg.yield %14 : f32
+// CHECK-NEXT:   } -> tensor<8xf32>
+// CHECK-NEXT:   %15 = linalg.sub ins(%0, %t3 : tensor<8xf32>, tensor<8xf32>) outs(%0 : tensor<8xf32>) -> tensor<8xf32>
 // CHECK-NEXT: }

--- a/xdsl/transforms/lift_arith_to_linalg.py
+++ b/xdsl/transforms/lift_arith_to_linalg.py
@@ -1,9 +1,16 @@
 from dataclasses import dataclass
 
+from xdsl.builder import Builder
 from xdsl.context import MLContext
 from xdsl.dialects import arith, linalg
-from xdsl.dialects.builtin import ModuleOp, TensorType
-from xdsl.ir import Attribute
+from xdsl.dialects.builtin import (
+    AffineMapAttr,
+    DenseIntOrFPElementsAttr,
+    ModuleOp,
+    TensorType,
+)
+from xdsl.ir import Attribute, BlockArgument, OpResult, SSAValue
+from xdsl.ir.affine import AffineMap
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -13,6 +20,72 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.utils.hints import isa
+
+
+def get_generic_fma(
+    mul_op1: SSAValue, mul_op2: SSAValue, add_op: SSAValue, out: SSAValue
+) -> linalg.Generic:
+    inputs = (mul_op1, mul_op2, add_op)
+    outputs = (out,)
+
+    arg_types = linalg.NamedOpBase.body_arg_types((*inputs, *outputs))
+
+    @Builder.implicit_region(arg_types)
+    def body(args: tuple[BlockArgument, ...]) -> None:
+        m = arith.Mulf(args[0], args[1])
+        a = arith.Addf(m, args[2])
+        linalg.YieldOp(a)
+
+    return linalg.Generic(
+        inputs,
+        outputs,
+        body,
+        4 * [AffineMapAttr(AffineMap.from_callable(lambda i,: (i,)))],
+        [linalg.IteratorTypeAttr.parallel()],
+        [out.type],
+    )
+
+
+@dataclass
+class LiftFMAPass(RewritePattern):
+    fma_require_scalar: bool
+    fma_require_erasable_mul: bool
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, mul: arith.Mulf, rewriter: PatternRewriter, /):
+        if self.fma_require_erasable_mul and len(mul.result.uses) != 1:
+            return
+
+        for add in [
+            use.operation
+            for use in mul.result.uses
+            if isinstance(use.operation, arith.Addf)
+        ]:
+            add_operand = add.lhs if mul.result == add.rhs else add.rhs
+
+            if (
+                self.fma_require_scalar
+                and not self.is_scalar_constant(mul.lhs)
+                and not self.is_scalar_constant(mul.rhs)
+            ):
+                return
+
+            fma = get_generic_fma(mul.lhs, mul.rhs, add_operand, mul.lhs)
+
+            rewriter.replace_op(add, fma)
+            if len(mul.result.uses) == 0:
+                rewriter.erase_matched_op()
+
+    @staticmethod
+    def is_scalar_constant(op: SSAValue) -> bool:
+        return (
+            isinstance(op, OpResult)
+            and isinstance(op.op, arith.Constant)
+            and (
+                not isinstance(v := op.op.value, DenseIntOrFPElementsAttr)
+                or v.data.data.count(v.data.data[0]) == len(v.data.data)
+            )
+        )
 
 
 class LiftAddfPass(RewritePattern):
@@ -50,10 +123,26 @@ class LiftArithToLinalg(ModulePass):
 
     name = "lift-arith-to-linalg"
 
+    generate_fma: bool = True
+    """Set to generate fused multiply-add as `linalg.generic`"""
+
+    fma_require_scalar: bool = False
+    """Set to require one of the mul factors to be a scalar constant"""
+
+    fma_require_erasable_mul: bool = False
+    """Set to only fuse ops if the multiply has no other use and can be erased"""
+
     def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        fma_pass = (
+            [LiftFMAPass(self.fma_require_scalar, self.fma_require_erasable_mul)]
+            if self.generate_fma
+            else []
+        )
+
         module_pass = PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
+                    *fma_pass,
                     LiftAddfPass(),
                     LiftSubfPass(),
                     LiftMulfPass(),


### PR DESCRIPTION
Adds the option to lift arith to generic fused multiply-add ops, with various flags to control behaviour.