### PR TITLE
CI: test 3.13 on the CI

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer


### PR DESCRIPTION
`uv venv` picks the newest Python available, and 3.13 seems to be failing for me locally. This is a problem with an easy workaround (pick an older Python), but I'd rather we just worked out of the box. I'll look into how to actually fix it in the next few days, help would be appreciated.