### PR TITLE
transformations: New varith-fuse-repeated-operands pass

### DIFF
--- a/tests/filecheck/transforms/varith-fuse-repeated-operands.mlir
+++ b/tests/filecheck/transforms/varith-fuse-repeated-operands.mlir
@@ -1,0 +1,43 @@
+// RUN: xdsl-opt --split-input-file -p varith-fuse-repeated-operands %s | filecheck %s
+
+func.func @test_addi() {
+    %a, %b, %c = "test.op"() : () -> (i32, i32, i32)
+    %1, %2, %3 = "test.op"() : () -> (i32, i32, i32)
+
+    %r = varith.add %a, %b, %a, %a, %b, %c : i32
+
+    "test.op"(%r) : (i32) -> ()
+
+    return
+
+    // CHECK-LABEL: @test_addi
+    // CHECK-NEXT:   %a, %b, %c = "test.op"() : () -> (i32, i32, i32)
+    // CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (i32, i32, i32)
+    // CHECK-NEXT:   %3 = arith.constant 3 : i32
+    // CHECK-NEXT:   %4 = arith.constant 2 : i32
+    // CHECK-NEXT:   %5 = arith.muli %3, %a : i32
+    // CHECK-NEXT:   %6 = arith.muli %4, %b : i32
+    // CHECK-NEXT:   %r = varith.add %5, %6, %c : i32
+    // CHECK-NEXT:   "test.op"(%r) : (i32) -> ()
+}
+
+func.func @test_addf() {
+    %a, %b, %c = "test.op"() : () -> (f32, f32, f32)
+    %1, %2, %3 = "test.op"() : () -> (f32, f32, f32)
+
+    %r = varith.add %a, %b, %a, %a, %b, %c : f32
+
+    "test.op"(%r) : (f32) -> ()
+
+    return
+
+    // CHECK-LABEL: @test_addf
+    // CHECK-NEXT:   %a, %b, %c = "test.op"() : () -> (f32, f32, f32)
+    // CHECK-NEXT:   %0, %1, %2 = "test.op"() : () -> (f32, f32, f32)
+    // CHECK-NEXT:   %3 = arith.constant 3.000000e+00 : f32
+    // CHECK-NEXT:   %4 = arith.constant 2.000000e+00 : f32
+    // CHECK-NEXT:   %5 = arith.mulf %3, %a : f32
+    // CHECK-NEXT:   %6 = arith.mulf %4, %b : f32
+    // CHECK-NEXT:   %r = varith.add %5, %6, %c : f32
+    // CHECK-NEXT:   "test.op"(%r) : (f32) -> ()
+}

--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -440,6 +440,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return stencil_shape_minimize.StencilShapeMinimize
 
+    def get_varith_fuse_repeated_operands():
+        from xdsl.transforms import varith_transformations
+
+        return varith_transformations.VarithFuseRepeatedOperandsPass
+
     return {
         "arith-add-fastmath": get_arith_add_fastmath,
         "loop-hoist-memref": get_loop_hoist_memref,
@@ -525,6 +530,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "stencil-shape-minimize": get_stencil_shape_minimize,
         "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
         "eqsat-create-eclasses": get_eqsat_create_eclasses,
+        "varith-fuse-repeated-operands": get_varith_fuse_repeated_operands,
     }
 
 


### PR DESCRIPTION
This PR rewrites 
```
varith.add %n, %n, %n, %x
```
as
```
%three arith.constant 3
%three_n = arith.mulx %n, %three       // mulf or muli
%varith.add %three_n, %x
```

This is useful in particular when operating on tensors, in order to avoid repeatedly adding a large tensor to itself (we have such a case).

The number of repetitions minimally required to trigger fusion behaviour can be controlled via a flag (default=2).