### PR TITLE
transformations: Canonicalizations for arith on float constants

### DIFF
--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -15,3 +15,22 @@
 // CHECK-NEXT:   %addf = arith.addf %lhsf32, %rhsf32 : f32
 // CHECK-NEXT:   %addf_vector = arith.addf %lhsvec, %rhsvec : vector<4xf32>
 // CHECK-NEXT:   "test.op"(%addf, %addf_vector) : (f32, vector<4xf32>) -> ()
+
+func.func @test_const_const() {
+    %a = arith.constant 2.9979 : f32
+    %b = arith.constant 3.1415 : f32
+    %1 = arith.addf %a, %b  : f32
+    %2 = arith.subf %a, %b  : f32
+    %3 = arith.mulf %a, %b  : f32
+    %4 = arith.divf %a, %b  : f32
+    "test.op"(%1, %2, %3, %4) : (f32, f32, f32, f32) -> ()
+
+    return
+
+    // CHECK-LABEL: @test_const_const
+    // CHECK-NEXT:   %0 = arith.constant 6.139400e+00 : f32
+    // CHECK-NEXT:   %1 = arith.constant -1.436000e-01 : f32
+    // CHECK-NEXT:   %2 = arith.constant 9.417903e+00 : f32
+    // CHECK-NEXT:   %3 = arith.constant 9.542894e-01 : f32
+    // CHECK-NEXT:   "test.op"(%0, %1, %2, %3) : (f32, f32, f32, f32) -> ()
+}

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -250,6 +250,16 @@ class SignlessIntegerBinaryOperationWithOverflow(
         )
 
 
+class FloatingPointLikeBinaryOpHasCanonicalizationPatternsTrait(
+    HasCanonicalizationPatternsTrait
+):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.arith import FoldConstConstOp
+
+        return (FoldConstConstOp(),)
+
+
 class FloatingPointLikeBinaryOperation(IRDLOperation, abc.ABC):
     """A generic base class for arith's binary operations on floats."""
 
@@ -902,28 +912,36 @@ class Select(IRDLOperation):
 class Addf(FloatingPointLikeBinaryOperation):
     name = "arith.addf"
 
-    traits = frozenset([Pure()])
+    traits = frozenset(
+        [Pure(), FloatingPointLikeBinaryOpHasCanonicalizationPatternsTrait()]
+    )
 
 
 @irdl_op_definition
 class Subf(FloatingPointLikeBinaryOperation):
     name = "arith.subf"
 
-    traits = frozenset([Pure()])
+    traits = frozenset(
+        [Pure(), FloatingPointLikeBinaryOpHasCanonicalizationPatternsTrait()]
+    )
 
 
 @irdl_op_definition
 class Mulf(FloatingPointLikeBinaryOperation):
     name = "arith.mulf"
 
-    traits = frozenset([Pure()])
+    traits = frozenset(
+        [Pure(), FloatingPointLikeBinaryOpHasCanonicalizationPatternsTrait()]
+    )
 
 
 @irdl_op_definition
 class Divf(FloatingPointLikeBinaryOperation):
     name = "arith.divf"
 
-    traits = frozenset([Pure()])
+    traits = frozenset(
+        [Pure(), FloatingPointLikeBinaryOpHasCanonicalizationPatternsTrait()]
+    )
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -38,11 +38,11 @@ class FoldConstConstOp(RewritePattern):
                 case arith.Mulf:
                     val = l.value.data * r.value.data
                 case arith.Divf:
-                    if rhs.value.data == 0.0:
+                    if r.value.data == 0.0:
                         # this mirrors what mlir does
                         val = float("inf")
                     else:
-                        val = lhs.value.data / rhs.value.data
+                        val = l.value.data / r.value.data
                 case _:
                     return
             rewriter.replace_matched_op(arith.Constant(builtin.FloatAttr(val, l.type)))

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -1,10 +1,11 @@
-from xdsl.dialects import arith
+from xdsl.dialects import arith, builtin
 from xdsl.dialects.builtin import IntegerAttr
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
     op_type_rewrite_pattern,
 )
+from xdsl.utils.hints import isa
 
 
 class AddImmediateZero(RewritePattern):
@@ -16,3 +17,28 @@ class AddImmediateZero(RewritePattern):
             and value.value.data == 0
         ):
             rewriter.replace_matched_op([], [op.rhs])
+
+
+class FoldConstConstOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: arith.FloatingPointLikeBinaryOperation, rewriter: PatternRewriter, /
+    ):
+        if (
+            isinstance(op.lhs.owner, arith.Constant)
+            and isinstance(op.rhs.owner, arith.Constant)
+            and isa(l := op.lhs.owner.value, builtin.AnyFloatAttr)
+            and isa(r := op.rhs.owner.value, builtin.AnyFloatAttr)
+        ):
+            match type(op):
+                case arith.Addf:
+                    val = l.value.data + r.value.data
+                case arith.Subf:
+                    val = l.value.data - r.value.data
+                case arith.Mulf:
+                    val = l.value.data * r.value.data
+                case arith.Divf:
+                    val = l.value.data / r.value.data
+                case _:
+                    return
+            rewriter.replace_matched_op(arith.Constant(builtin.FloatAttr(val, l.type)))

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -38,7 +38,11 @@ class FoldConstConstOp(RewritePattern):
                 case arith.Mulf:
                     val = l.value.data * r.value.data
                 case arith.Divf:
-                    val = l.value.data / r.value.data
+                    if rhs.value.data == 0.0:
+                        # this mirrors what mlir does
+                        val = float("inf")
+                    else:
+                        val = lhs.value.data / rhs.value.data
                 case _:
                     return
             rewriter.replace_matched_op(arith.Constant(builtin.FloatAttr(val, l.type)))


### PR DESCRIPTION
This adds the first of two canonicalisation patterns `FloatingPointLikeBinaryOperation`s on `arith.constants`.

* Ops with two constant operands are folded by canonicalisation, regardless of math flags
* ~~Chained ops of the form `(const1 * var) * const2` are rewritten as `(const1 * const2) * var` iff the `fastmath<reassoc>` or `fastmath<fast>` flags are set, and if the ops are multiplications or additions. Note, this is not currently implemented in upstream mlir.~~

See [here](https://godbolt.org/z/1KKf6vbfv) to check how it works in upstream mlir.

Note, these canonicalisations currently do not support container types.