### PR TITLE
misc: refactor xdsl-gui

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -31,7 +31,7 @@ from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
 @pytest.mark.asyncio
 async def test_inputs():
     """Test different inputs produce desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(args=[]).run_test() as pilot:
         app = cast(InputApp, pilot.app)
 
         # clear preloaded code and unselect preselected pass
@@ -47,13 +47,13 @@ async def test_inputs():
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
         )
 
         assert isinstance(app.current_module, ParseError)
         assert (
             str(app.current_module)
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
         )
 
         # Test corect input
@@ -97,7 +97,7 @@ async def test_inputs():
 @pytest.mark.asyncio
 async def test_buttons():
     """Test pressing keys has the desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(args=[]).run_test() as pilot:
         app = cast(InputApp, pilot.app)
 
         # clear preloaded code and unselect preselected pass
@@ -265,7 +265,9 @@ async def test_buttons():
         await pilot.pause()
         # assert after "Condense Button" is clicked that the state and condensed_pass list change accordingly
         assert app.condense_mode is True
-        assert app.available_pass_list == get_condensed_pass_list(expected_module)
+        assert app.available_pass_list == get_condensed_pass_list(
+            expected_module, app.all_passes
+        )
 
         # press "Uncondense" button
         await pilot.click("#uncondense_button")
@@ -278,7 +280,7 @@ async def test_buttons():
 @pytest.mark.asyncio
 async def test_rewrites():
     """Test rewrite application has the desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(args=[]).run_test() as pilot:
         app = cast(InputApp, pilot.app)
         # clear preloaded code and unselect preselected pass
         app.input_text_area.clear()
@@ -312,7 +314,9 @@ async def test_rewrites():
         # assert after "Condense Button" is clicked that the state and get_condensed_pass list change accordingly
         assert app.condense_mode is True
         assert isinstance(app.current_module, ModuleOp)
-        condensed_list = get_condensed_pass_list(app.current_module) + (addi_pass,)
+        condensed_list = get_condensed_pass_list(app.current_module, app.all_passes) + (
+            addi_pass,
+        )
         assert app.available_pass_list == condensed_list
 
         # Select a rewrite
@@ -345,7 +349,7 @@ async def test_rewrites():
 @pytest.mark.asyncio
 async def test_passes():
     """Test pass application has the desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(args=[]).run_test() as pilot:
         app = cast(InputApp, pilot.app)
         # clear preloaded code and unselect preselected pass
         app.input_text_area.clear()
@@ -437,7 +441,7 @@ async def test_passes():
 @pytest.mark.asyncio
 async def test_argument_pass_screen():
     """Test that clicking on a pass that requires passes opens a screen to specify them."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(args=[]).run_test() as pilot:
         app = cast(InputApp, pilot.app)
         # clear preloaded code and unselect preselected pass
         app.input_text_area.clear()

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -2,10 +2,13 @@ from xdsl.backend.riscv.lowering import (
     convert_arith_to_riscv,
     convert_func_to_riscv_func,
 )
+from xdsl.context import MLContext
+from xdsl.dialects import get_all_dialects
 from xdsl.interactive.get_all_available_passes import get_available_pass_list
 from xdsl.interactive.passes import AvailablePass
 from xdsl.interactive.rewrites import individual_rewrite
 from xdsl.transforms import (
+    get_all_passes,
     reconcile_unrealized_casts,
     test_lower_linalg_to_snitch,
 )
@@ -48,7 +51,17 @@ def test_get_all_available_passes():
         )
     )
 
+    ctx = MLContext()
+    for dialect_name, dialect_factory in get_all_dialects().items():
+        ctx.register_dialect(dialect_name, dialect_factory)
+
+    all_passes = tuple(
+        sorted((p_name, p()) for (p_name, p) in get_all_passes().items())
+    )
+
     res = get_available_pass_list(
+        ctx,
+        all_passes,
         input_text,
         pass_pipeline,
         condense_mode=True,

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -1,9 +1,8 @@
+from xdsl.context import MLContext
 from xdsl.interactive.passes import (
-    ALL_PASSES,
     AvailablePass,
     apply_passes_to_module,
     get_condensed_pass_list,
-    get_new_registered_context,
 )
 from xdsl.interactive.rewrites import (
     convert_indexed_individual_rewrites_to_available_pass,
@@ -16,6 +15,8 @@ from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 def get_available_pass_list(
+    ctx: MLContext,
+    all_passes: tuple[tuple[str, type[ModulePass]], ...],
     input_text: str,
     pass_pipeline: tuple[tuple[type[ModulePass], PipelinePassSpec], ...],
     condense_mode: bool,
@@ -24,7 +25,6 @@ def get_available_pass_list(
     """
     This function returns the available pass list file based on an input text string, pass_pipeline and condense_mode.
     """
-    ctx = get_new_registered_context()
     parser = Parser(ctx, input_text)
     current_module = parser.parse_module()
 
@@ -41,8 +41,8 @@ def get_available_pass_list(
     )
     # merge rewrite passes with "other" pass list
     if condense_mode:
-        pass_list = get_condensed_pass_list(current_module)
+        pass_list = get_condensed_pass_list(current_module, all_passes)
         return pass_list + rewrites_as_pass_list
     else:
-        pass_list = tuple(AvailablePass(p.name, p, None) for _, p in ALL_PASSES)
+        pass_list = tuple(AvailablePass(p.name, p, None) for _, p in all_passes)
         return pass_list + rewrites_as_pass_list

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -3,12 +3,8 @@ from typing import NamedTuple
 from xdsl.context import MLContext
 from xdsl.dialects import builtin, get_all_dialects
 from xdsl.passes import ModulePass, PipelinePass
-from xdsl.transforms import get_all_passes
 from xdsl.transforms.mlir_opt import MLIROptPass
 from xdsl.utils.parse_pipeline import PipelinePassSpec
-
-ALL_PASSES = tuple(sorted((p_name, p()) for (p_name, p) in get_all_passes().items()))
-"""Contains the list of xDSL passes."""
 
 
 class AvailablePass(NamedTuple):
@@ -20,16 +16,6 @@ class AvailablePass(NamedTuple):
     display_name: str
     module_pass: type[ModulePass]
     pass_spec: PipelinePassSpec | None
-
-
-def get_new_registered_context() -> MLContext:
-    """
-    Generates a new MLContext, registers it and returns it.
-    """
-    ctx = MLContext(True)
-    for dialect_name, dialect_factory in get_all_dialects().items():
-        ctx.register_dialect(dialect_name, dialect_factory)
-    return ctx
 
 
 def apply_passes_to_module(
@@ -50,14 +36,16 @@ def apply_passes_to_module(
     return module
 
 
-def iter_condensed_passes(input: builtin.ModuleOp):
+def iter_condensed_passes(
+    input: builtin.ModuleOp, all_passes: tuple[tuple[str, type[ModulePass]], ...]
+):
     ctx = MLContext(True)
 
     for dialect_name, dialect_factory in get_all_dialects().items():
         ctx.register_dialect(dialect_name, dialect_factory)
 
     selections: list[AvailablePass] = []
-    for _, value in ALL_PASSES:
+    for _, value in all_passes:
         if value is MLIROptPass:
             # Always keep MLIROptPass as an option in condensed list
             selections.append(AvailablePass(value.name, value, None))
@@ -73,9 +61,11 @@ def iter_condensed_passes(input: builtin.ModuleOp):
             pass
 
 
-def get_condensed_pass_list(input: builtin.ModuleOp) -> tuple[AvailablePass, ...]:
+def get_condensed_pass_list(
+    input: builtin.ModuleOp, all_passes: tuple[tuple[str, type[ModulePass]], ...]
+) -> tuple[AvailablePass, ...]:
     """
     Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
     change the ModuleOp.
     """
-    return tuple(ap for ap, _ in iter_condensed_passes(input))
+    return tuple(ap for ap, _ in iter_condensed_passes(input, all_passes))


### PR DESCRIPTION
Creates a new class `CommandLineToolWithPasses` which contains the shared functionality of `xdsl-opt` and `xdsl-gui` and inherits from `CommandLineTool`.

Makes `xdsl-gui` inherit from this new class, allowing the available dialects and passes to be overriden in the same way as for xdsl-opt.

As part of this change the ctx becomes static instead of being remade of each input change. I am unsure if this will cause problems so would be good if anyone is aware of any dodgy cases.