### PR TITLE
transformations: (csl-stencil-bufferize) Reselect linalg outs

### DIFF
--- a/tests/filecheck/transforms/csl_stencil_bufferize.mlir
+++ b/tests/filecheck/transforms/csl_stencil_bufferize.mlir
@@ -20,9 +20,9 @@ builtin.module {
       %15 = arith.constant dense<1.666600e-01> : tensor<510xf32>
       %16 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
       %17 = "tensor.extract_slice"(%14) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-      %18 = linalg.add ins(%13, %17 : tensor<510xf32>, tensor<510xf32>) outs(%13 : tensor<510xf32>) -> tensor<510xf32>
-      %19 = linalg.add ins(%18, %16 : tensor<510xf32>, tensor<510xf32>) outs(%18 : tensor<510xf32>) -> tensor<510xf32>
-      %20 = linalg.mul ins(%19, %15 : tensor<510xf32>, tensor<510xf32>) outs(%19 : tensor<510xf32>) -> tensor<510xf32>
+      %18 = linalg.add ins(%13, %17 : tensor<510xf32>, tensor<510xf32>) outs(%17 : tensor<510xf32>) -> tensor<510xf32>
+      %19 = linalg.add ins(%18, %16 : tensor<510xf32>, tensor<510xf32>) outs(%16 : tensor<510xf32>) -> tensor<510xf32>
+      %20 = linalg.mul ins(%19, %15 : tensor<510xf32>, tensor<510xf32>) outs(%15 : tensor<510xf32>) -> tensor<510xf32>
       csl_stencil.yield %20 : tensor<510xf32>
     }) to <[0, 0], [1, 1]>
     func.return

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -395,7 +395,7 @@ class ReselectLinalgOutsFromInputs(RewritePattern):
         if (
             op.outputs[0] not in op.inputs
             or self.is_writable(op.outputs[0])
-            and len(op.outputs) == 1
+            or len(op.outputs) != 1
         ):
             return
 


### PR DESCRIPTION
This PR sets destination buffers for linalg ops, if the destination buffer is one of its inputs.

Known caveats:
* Setting the outs for all ops to one buffer known to be writable causes read-after-write conflicts, which the bufferization does not analyse for
* The default behaviour (of mlir-opt's `linalg-fuse-elementwise-ops` pass) is to set `outs` to `input[0]`, which in some cases causes a significant overhead of `memref.alloc`s

Iff the `outs` of a linalg op is its own `input[n]`, this PR re-selects `n` in one of two ways:
* prefer an input with the `writable` flag and no later use, or if none is found
* prefer a linalg op input with no later use (i.e. chaining)