### PR TITLE
canonicalisation: (arith) Zero division result fix

### DIFF
--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -34,7 +34,7 @@ def _fold_const_operation(
         case arith.Divf:
             if rhs.value.data == 0.0:
                 # this mirrors what mlir does
-                val = float("inf")
+                val = float("inf") if lhs.value.data > 0 else float("-inf")
             else:
                 val = lhs.value.data / rhs.value.data
         case _:

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -34,7 +34,12 @@ def _fold_const_operation(
         case arith.Divf:
             if rhs.value.data == 0.0:
                 # this mirrors what mlir does
-                val = float("inf") if lhs.value.data > 0 else float("-inf")
+                if lhs.value.data == 0.0:
+                    val = float("nan")
+                elif lhs.value.data < 0:
+                    val = float("-inf")
+                else:
+                    val = float("inf")
             else:
                 val = lhs.value.data / rhs.value.data
         case _:


### PR DESCRIPTION
Dividing a negative number by zero should output negative inf, while dividing 0 by 0 should output nan. This is to match upstream mlir.