### PR TITLE
core: Parse FloatAttr from hexadecimal bit representation

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
@@ -627,6 +628,12 @@ class FloatData(Data[float]):
 
     def print_parameter(self, printer: Printer) -> None:
         printer.print_string(f"{self.data}")
+
+    def __eq__(self, other: Any):
+        # avoid triggering `float('nan') != float('nan')` inequality
+        return isinstance(other, FloatData) and (
+            math.isnan(self.data) and math.isnan(other.data) or self.data == other.data
+        )
 
 
 _FloatAttrType = TypeVar("_FloatAttrType", bound=AnyFloat, covariant=True)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -1144,6 +1144,10 @@ class AttrParser(BaseParser):
         if bool is not None:
             return bool
 
+        hexadecimal_token: Token | None = None
+        if self._current_token.text[:2] in ["0x", "0X"]:
+            hexadecimal_token = self._current_token
+
         # Parse the value
         if (value := self.parse_optional_number()) is None:
             return None
@@ -1158,6 +1162,8 @@ class AttrParser(BaseParser):
         type = self._parse_attribute_type()
 
         if isinstance(type, AnyFloat):
+            if hexadecimal_token:
+                return FloatAttr(hexadecimal_token.get_float_value(), type)
             return FloatAttr(float(value), type)
 
         if isinstance(type, IntegerType | IndexType):


### PR DESCRIPTION
`FloatAttr`s can have their values specified by a hexadecimal literal. This should be interpreted as the bit representation of the float. However, it is currently interpreted as an int number and then converted to a float, leading to incorrect behaviour.

This PR is the second part of #3370 after #3377