### PR TITLE
interactive: refactor to one use of get_all_passes/get_all_dialects

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -46,13 +46,13 @@ async def test_inputs():
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
         )
 
         assert isinstance(app.current_module, ParseError)
         assert (
             str(app.current_module)
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
         )
 
         # Test corect input
@@ -274,7 +274,9 @@ async def test_buttons():
         await pilot.pause()
         # assert after "Condense Button" is clicked that the state and condensed_pass list change accordingly
         assert app.condense_mode is True
-        assert app.available_pass_list == get_condensed_pass_list(expected_module)
+        assert app.available_pass_list == get_condensed_pass_list(
+            expected_module, app.all_passes
+        )
 
         # press "Uncondense" button
         await pilot.click("#uncondense_button")
@@ -321,7 +323,9 @@ async def test_rewrites():
         # assert after "Condense Button" is clicked that the state and get_condensed_pass list change accordingly
         assert app.condense_mode is True
         assert isinstance(app.current_module, ModuleOp)
-        condensed_list = get_condensed_pass_list(app.current_module) + (addi_pass,)
+        condensed_list = get_condensed_pass_list(app.current_module, app.all_passes) + (
+            addi_pass,
+        )
         assert app.available_pass_list == condensed_list
 
         # Select a rewrite

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -41,18 +41,18 @@ async def test_inputs():
         assert app.output_text_area.text == "No input"
         assert app.current_module is None
 
-        # Test inccorect input
+        # Test incorrect input
         app.input_text_area.insert("dkjfd")
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
         )
 
         assert isinstance(app.current_module, ParseError)
         assert (
             str(app.current_module)
-            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
         )
 
         # Test corect input

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -9,7 +9,7 @@ from xdsl.backend.riscv.lowering import (
     convert_func_to_riscv_func,
 )
 from xdsl.builder import ImplicitBuilder
-from xdsl.dialects import arith, func, riscv, riscv_func
+from xdsl.dialects import arith, func, get_all_dialects, riscv, riscv_func
 from xdsl.dialects.builtin import (
     IndexType,
     IntegerAttr,
@@ -21,7 +21,10 @@ from xdsl.interactive.add_arguments_screen import AddArguments
 from xdsl.interactive.app import InputApp
 from xdsl.interactive.passes import AvailablePass, get_condensed_pass_list
 from xdsl.ir import Block, Region
-from xdsl.transforms import individual_rewrite
+from xdsl.transforms import (
+    individual_rewrite,
+    get_all_passes,
+)
 from xdsl.transforms.experimental.dmp import stencil_global_to_local
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
@@ -30,7 +33,10 @@ from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
 @pytest.mark.asyncio
 async def test_inputs():
     """Test different inputs produce desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(
+        tuple(get_all_dialects().items()),
+        tuple((p_name, p()) for p_name, p in sorted(get_all_passes().items())),
+    ).run_test() as pilot:
         app = cast(InputApp, pilot.app)
 
         # clear preloaded code and unselect preselected pass
@@ -96,7 +102,10 @@ async def test_inputs():
 @pytest.mark.asyncio
 async def test_buttons():
     """Test pressing keys has the desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(
+        tuple(get_all_dialects().items()),
+        tuple((p_name, p()) for p_name, p in sorted(get_all_passes().items())),
+    ).run_test() as pilot:
         app = cast(InputApp, pilot.app)
 
         # clear preloaded code and unselect preselected pass
@@ -289,7 +298,10 @@ async def test_buttons():
 @pytest.mark.asyncio
 async def test_rewrites():
     """Test rewrite application has the desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(
+        tuple(get_all_dialects().items()),
+        tuple((p_name, p()) for p_name, p in sorted(get_all_passes().items())),
+    ).run_test() as pilot:
         app = cast(InputApp, pilot.app)
         # clear preloaded code and unselect preselected pass
         app.input_text_area.clear()
@@ -358,7 +370,10 @@ async def test_rewrites():
 @pytest.mark.asyncio
 async def test_passes():
     """Test pass application has the desired result."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(
+        tuple(get_all_dialects().items()),
+        tuple((p_name, p()) for p_name, p in sorted(get_all_passes().items())),
+    ).run_test() as pilot:
         app = cast(InputApp, pilot.app)
         # clear preloaded code and unselect preselected pass
         app.input_text_area.clear()
@@ -450,7 +465,10 @@ async def test_passes():
 @pytest.mark.asyncio
 async def test_argument_pass_screen():
     """Test that clicking on a pass that requires passes opens a screen to specify them."""
-    async with InputApp().run_test() as pilot:
+    async with InputApp(
+        tuple(get_all_dialects().items()),
+        tuple((p_name, p()) for p_name, p in sorted(get_all_passes().items())),
+    ).run_test() as pilot:
         app = cast(InputApp, pilot.app)
         # clear preloaded code and unselect preselected pass
         app.input_text_area.clear()

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -2,10 +2,13 @@ from xdsl.backend.riscv.lowering import (
     convert_arith_to_riscv,
     convert_func_to_riscv_func,
 )
+from xdsl.context import MLContext
+from xdsl.dialects import get_all_dialects
 from xdsl.interactive.get_all_available_passes import get_available_pass_list
 from xdsl.interactive.passes import AvailablePass
 from xdsl.interactive.rewrites import individual_rewrite
 from xdsl.transforms import (
+    get_all_passes,
     reconcile_unrealized_casts,
     test_lower_linalg_to_snitch,
 )
@@ -48,7 +51,17 @@ def test_get_all_available_passes():
         )
     )
 
+    ctx = MLContext()
+    for dialect_name, dialect_factory in get_all_dialects().items():
+        ctx.register_dialect(dialect_name, dialect_factory)
+
+    all_passes = tuple(
+        sorted((p_name, p()) for (p_name, p) in get_all_passes().items())
+    )
+
     res = get_available_pass_list(
+        ctx,
+        all_passes,
         input_text,
         pass_pipeline,
         condense_mode=True,

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -50,10 +50,11 @@ def test_get_all_available_passes():
         )
     )
 
-    all_passes = {p_name: p() for (p_name, p) in sorted(get_all_passes().items())}
+    all_dialects = tuple((d_name, d) for d_name, d in get_all_dialects().items())
+    all_passes = tuple((p_name, p()) for p_name, p in sorted(get_all_passes().items()))
 
     res = get_available_pass_list(
-        get_all_dialects(),
+        all_dialects,
         all_passes,
         input_text,
         pass_pipeline,

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -2,7 +2,6 @@ from xdsl.backend.riscv.lowering import (
     convert_arith_to_riscv,
     convert_func_to_riscv_func,
 )
-from xdsl.context import MLContext
 from xdsl.dialects import get_all_dialects
 from xdsl.interactive.get_all_available_passes import get_available_pass_list
 from xdsl.interactive.passes import AvailablePass
@@ -51,16 +50,10 @@ def test_get_all_available_passes():
         )
     )
 
-    ctx = MLContext()
-    for dialect_name, dialect_factory in get_all_dialects().items():
-        ctx.register_dialect(dialect_name, dialect_factory)
-
-    all_passes = tuple(
-        sorted((p_name, p()) for (p_name, p) in get_all_passes().items())
-    )
+    all_passes = {p_name: p() for (p_name, p) in sorted(get_all_passes().items())}
 
     res = get_available_pass_list(
-        ctx,
+        get_all_dialects(),
         all_passes,
         input_text,
         pass_pipeline,

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -31,6 +31,8 @@ from textual.widgets import (
 )
 from textual.widgets.tree import TreeNode
 
+from xdsl.context import MLContext
+from xdsl.dialects import get_all_dialects
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.interactive.add_arguments_screen import AddArguments
 from xdsl.interactive.get_all_available_passes import get_available_pass_list
@@ -41,10 +43,8 @@ from xdsl.interactive.pass_metrics import (
     get_diff_operation_count,
 )
 from xdsl.interactive.passes import (
-    ALL_PASSES,
     AvailablePass,
     apply_passes_to_module,
-    get_new_registered_context,
 )
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass, PipelinePass, get_pass_argument_names_and_types
@@ -90,6 +90,11 @@ class InputApp(App[None]):
           func.return %res : i32
         }
         """
+
+    ctx: MLContext
+
+    all_passes: tuple[tuple[str, type[ModulePass]], ...]
+    """Contains the list of xDSL passes."""
 
     current_module = reactive[ModuleOp | Exception | None](None)
     """
@@ -145,6 +150,15 @@ class InputApp(App[None]):
         input_text: str | None = None,
         pass_pipeline: tuple[tuple[type[ModulePass], PipelinePassSpec], ...] = (),
     ):
+        self.ctx = MLContext()
+
+        for dialect_name, dialect_factory in get_all_dialects().items():
+            self.ctx.register_dialect(dialect_name, dialect_factory)
+
+        self.all_passes = tuple(
+            sorted((p_name, p()) for (p_name, p) in get_all_passes().items())
+        )
+
         if file_path is None:
             self.current_file_path = ""
         else:
@@ -217,7 +231,7 @@ class InputApp(App[None]):
         self.query_one("#output_container").border_title = "Output xDSL IR"
 
         # initialize Tree to contain the pass options
-        for n, module_pass in ALL_PASSES:
+        for n, module_pass in self.all_passes:
             self.passes_tree.root.add(
                 label=n,
                 data=(module_pass, None),
@@ -243,11 +257,13 @@ class InputApp(App[None]):
         """
         match self.current_module:
             case None:
-                return tuple(AvailablePass(p.name, p, None) for _, p in ALL_PASSES)
+                return tuple(AvailablePass(p.name, p, None) for _, p in self.all_passes)
             case Exception():
                 return ()
             case ModuleOp():
                 return get_available_pass_list(
+                    self.ctx,
+                    self.all_passes,
                     self.input_text_area.text,
                     self.pass_pipeline,
                     self.condense_mode,
@@ -489,6 +505,8 @@ class InputApp(App[None]):
         )
 
         child_pass_list = get_available_pass_list(
+            self.ctx,
+            self.all_passes,
             self.input_text_area.text,
             child_pass_pipeline,
             self.condense_mode,
@@ -518,12 +536,11 @@ class InputApp(App[None]):
             self.update_input_operation_count_tuple(ModuleOp([], None))
             return
         try:
-            ctx = get_new_registered_context()
-            parser = Parser(ctx, input_text)
+            parser = Parser(self.ctx, input_text)
             module = parser.parse_module()
             self.update_input_operation_count_tuple(module)
             self.current_module = apply_passes_to_module(
-                module, ctx, self.pass_pipeline
+                module, self.ctx, self.pass_pipeline
             )
         except Exception as e:
             self.current_module = e

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -148,16 +148,14 @@ class InputApp(App[None]):
 
     def __init__(
         self,
+        all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...],
+        all_passes: tuple[tuple[str, type[ModulePass]], ...],
         file_path: str | None = None,
         input_text: str | None = None,
         pass_pipeline: tuple[tuple[type[ModulePass], PipelinePassSpec], ...] = (),
-        all_dialects: dict[str, Callable[[], Dialect]] = get_all_dialects(),
-        all_passes: dict[str, Callable[[], type[ModulePass]]] = get_all_passes(),
     ):
-        self.all_dialects = tuple((d_name, d) for d_name, d in all_dialects.items())
-        self.all_passes = tuple(
-            (p_name, p()) for (p_name, p) in sorted(all_passes.items())
-        )
+        self.all_dialects = all_dialects
+        self.all_passes = all_passes
 
         if file_path is None:
             self.current_file_path = ""
@@ -760,7 +758,13 @@ def main():
     pass_list = get_all_passes()
     pipeline = tuple(PipelinePass.build_pipeline_tuples(pass_list, pass_spec_pipeline))
 
-    return InputApp(file_path, file_contents, pipeline).run()
+    return InputApp(
+        tuple(get_all_dialects().items()),
+        tuple((p_name, p()) for p_name, p in sorted(get_all_passes().items())),
+        file_path,
+        file_contents,
+        pipeline,
+    ).run()
 
 
 if __name__ == "__main__":

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -138,7 +138,8 @@ class InputApp(App[None]):
     """DataTable displaying the operation names and counts of the input text area."""
     diff_operation_count_datatable: DataTable[str | int]
     """
-    DataTable displaying the diff of operation names and counts of the input and     text areas.
+    DataTable displaying the diff of operation names and counts of the input and output
+    text areas.
     """
 
     pre_loaded_input_text: str

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -1,9 +1,8 @@
+from xdsl.context import MLContext
 from xdsl.interactive.passes import (
-    ALL_PASSES,
     AvailablePass,
     apply_passes_to_module,
     get_condensed_pass_list,
-    get_new_registered_context,
 )
 from xdsl.interactive.rewrites import (
     convert_indexed_individual_rewrites_to_available_pass,
@@ -16,6 +15,8 @@ from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 def get_available_pass_list(
+    ctx: MLContext,
+    all_passes: tuple[tuple[str, type[ModulePass]], ...],
     input_text: str,
     pass_pipeline: tuple[tuple[type[ModulePass], PipelinePassSpec], ...],
     condense_mode: bool,
@@ -24,7 +25,6 @@ def get_available_pass_list(
     """
     This function returns the available pass list file based on an input text string, pass_pipeline and condense_mode.
     """
-    ctx = get_new_registered_context()
     parser = Parser(ctx, input_text)
     current_module = parser.parse_module()
 
@@ -41,8 +41,8 @@ def get_available_pass_list(
     )
     # merge rewrite passes with "other" pass list
     if condense_mode:
-        pass_list = get_condensed_pass_list(current_module)
+        pass_list = get_condensed_pass_list(current_module, all_passes)
         return pass_list + rewrites_as_pass_list
     else:
-        pass_list = tuple(AvailablePass(p.name, p, None) for _, p in ALL_PASSES)
+        pass_list = tuple(AvailablePass(p.name, p, None) for _, p in all_passes)
         return pass_list + rewrites_as_pass_list

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -18,8 +18,8 @@ from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 def get_available_pass_list(
-    all_dialects: dict[str, Callable[[], Dialect]],
-    all_passes: dict[str, type[ModulePass]],
+    all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...],
+    all_passes: tuple[tuple[str, type[ModulePass]], ...],
     input_text: str,
     pass_pipeline: tuple[tuple[type[ModulePass], PipelinePassSpec], ...],
     condense_mode: bool,
@@ -48,5 +48,5 @@ def get_available_pass_list(
         pass_list = get_condensed_pass_list(current_module, all_passes)
         return pass_list + rewrites_as_pass_list
     else:
-        pass_list = tuple(AvailablePass(p.name, p, None) for _, p in all_passes.items())
+        pass_list = tuple(AvailablePass(p.name, p, None) for _, p in all_passes)
         return pass_list + rewrites_as_pass_list

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -21,13 +21,13 @@ class AvailablePass(NamedTuple):
 
 
 def get_new_registered_context(
-    all_dialects: dict[str, Callable[[], Dialect]],
+    all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...],
 ) -> MLContext:
     """
     Generates a new MLContext, registers it and returns it.
     """
     ctx = MLContext(True)
-    for dialect_name, dialect_factory in all_dialects.items():
+    for dialect_name, dialect_factory in all_dialects:
         ctx.register_dialect(dialect_name, dialect_factory)
     return ctx
 
@@ -52,7 +52,7 @@ def apply_passes_to_module(
 
 def iter_condensed_passes(
     input: builtin.ModuleOp,
-    all_passes: dict[str, type[ModulePass]],
+    all_passes: tuple[tuple[str, type[ModulePass]], ...],
 ):
     ctx = MLContext(True)
 
@@ -60,7 +60,7 @@ def iter_condensed_passes(
         ctx.register_dialect(dialect_name, dialect_factory)
 
     selections: list[AvailablePass] = []
-    for _, value in all_passes.items():
+    for _, value in all_passes:
         if value is MLIROptPass:
             # Always keep MLIROptPass as an option in condensed list
             selections.append(AvailablePass(value.name, value, None))
@@ -78,7 +78,7 @@ def iter_condensed_passes(
 
 def get_condensed_pass_list(
     input: builtin.ModuleOp,
-    all_passes: dict[str, type[ModulePass]],
+    all_passes: tuple[tuple[str, type[ModulePass]], ...],
 ) -> tuple[AvailablePass, ...]:
     """
     Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -3,12 +3,8 @@ from typing import NamedTuple
 from xdsl.context import MLContext
 from xdsl.dialects import builtin, get_all_dialects
 from xdsl.passes import ModulePass, PipelinePass
-from xdsl.transforms import get_all_passes
 from xdsl.transforms.mlir_opt import MLIROptPass
 from xdsl.utils.parse_pipeline import PipelinePassSpec
-
-ALL_PASSES = tuple(sorted((p_name, p()) for (p_name, p) in get_all_passes().items()))
-"""Contains the list of xDSL passes."""
 
 
 class AvailablePass(NamedTuple):
@@ -20,16 +16,6 @@ class AvailablePass(NamedTuple):
     display_name: str
     module_pass: type[ModulePass]
     pass_spec: PipelinePassSpec | None
-
-
-def get_new_registered_context() -> MLContext:
-    """
-    Generates a new MLContext, registers it and returns it.
-    """
-    ctx = MLContext(True)
-    for dialect_name, dialect_factory in get_all_dialects().items():
-        ctx.register_dialect(dialect_name, dialect_factory)
-    return ctx
 
 
 def apply_passes_to_module(
@@ -50,14 +36,16 @@ def apply_passes_to_module(
     return module
 
 
-def iter_condensed_passes(input: builtin.ModuleOp):
+def iter_condensed_passes(
+    input: builtin.ModuleOp, all_passes: tuple[tuple[str, type[ModulePass]], ...]
+):
     ctx = MLContext(True)
 
     for dialect_name, dialect_factory in get_all_dialects().items():
         ctx.register_dialect(dialect_name, dialect_factory)
 
     selections: list[AvailablePass] = []
-    for _, value in ALL_PASSES:
+    for _, value in all_passes:
         if value is MLIROptPass:
             # Always keep MLIROptPass as an option in condensed list
             selections.append(AvailablePass(value.name, value, None))
@@ -73,9 +61,11 @@ def iter_condensed_passes(input: builtin.ModuleOp):
             pass
 
 
-def get_condensed_pass_list(input: builtin.ModuleOp) -> tuple[AvailablePass, ...]:
+def get_condensed_pass_list(
+    input: builtin.ModuleOp, all_passes: tuple[tuple[str, type[ModulePass]], ...]
+) -> tuple[AvailablePass, ...]:
     """
     Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
     change the ModuleOp.
     """
-    return tuple(ap for ap, _ in iter_condensed_passes(input))
+    return tuple(ap for ap, _ in iter_condensed_passes(input, all_passes))


### PR DESCRIPTION
Changes the interactive app object to store a pass list and context, which are set for now in the initialization function. This will allow further refactors which allow these to be overridden more easily by downstream projects.