### PR TITLE
dialects: (ptr) Introducing ptr dialect

### DIFF
--- a/tests/filecheck/dialects/ptr/ops.mlir
+++ b/tests/filecheck/dialects/ptr/ops.mlir
@@ -1,0 +1,20 @@
+// RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s
+
+builtin.module {
+  %p, %idx, %v, %m = "test.op"() : () -> (!opaque_ptr.ptr, index, i32, memref<10xi32>)
+
+  // CHECK: %r0 = opaque_ptr.ptradd %p, %idx : (!opaque_ptr.ptr, index) -> !opaque_ptr.ptr
+  %r0 = opaque_ptr.ptradd %p, %idx : (!opaque_ptr.ptr, index) -> !opaque_ptr.ptr
+
+  // CHECK-NEXT: %r1 = "opaque_ptr.type_offset"() <{"elem_type" = i32}> : () -> index
+  %r1 = "opaque_ptr.type_offset"() <{"elem_type" = i32}> : () -> index
+
+  // CHECK-NEXT: opaque_ptr.store %v, %p : i32, !opaque_ptr.ptr
+  opaque_ptr.store %v, %p : i32, !opaque_ptr.ptr
+
+  // CHECK-NEXT: opaque_ptr.load %p : !opaque_ptr.ptr -> i32
+  %r3 = opaque_ptr.load %p : !opaque_ptr.ptr -> i32
+
+  // CHECK-NEXT: %pm = opaque_ptr.to_ptr %m : memref<10xi32> -> !opaque_ptr.ptr
+  %pm = opaque_ptr.to_ptr %m : memref<10xi32> -> !opaque_ptr.ptr
+}

--- a/tests/filecheck/dialects/ptr/ops.mlir
+++ b/tests/filecheck/dialects/ptr/ops.mlir
@@ -1,20 +1,18 @@
 // RUN: xdsl-opt %s --parsing-diagnostics --verify-diagnostics --split-input-file | filecheck %s
 
-builtin.module {
-  %p, %idx, %v, %m = "test.op"() : () -> (!opaque_ptr.ptr, index, i32, memref<10xi32>)
+%p, %idx, %v, %m = "test.op"() : () -> (!ptr_xdsl.ptr, index, i32, memref<10xi32>)
 
-  // CHECK: %r0 = opaque_ptr.ptradd %p, %idx : (!opaque_ptr.ptr, index) -> !opaque_ptr.ptr
-  %r0 = opaque_ptr.ptradd %p, %idx : (!opaque_ptr.ptr, index) -> !opaque_ptr.ptr
+// CHECK: %r0 = ptr_xdsl.ptradd %p, %idx : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+%r0 = ptr_xdsl.ptradd %p, %idx : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 
-  // CHECK-NEXT: %r1 = "opaque_ptr.type_offset"() <{"elem_type" = i32}> : () -> index
-  %r1 = "opaque_ptr.type_offset"() <{"elem_type" = i32}> : () -> index
+// CHECK-NEXT: %r1 = ptr_xdsl.type_offset i32 : index
+%r1 = ptr_xdsl.type_offset i32 : index
 
-  // CHECK-NEXT: opaque_ptr.store %v, %p : i32, !opaque_ptr.ptr
-  opaque_ptr.store %v, %p : i32, !opaque_ptr.ptr
+// CHECK-NEXT: ptr_xdsl.store %v, %p : i32, !ptr_xdsl.ptr
+ptr_xdsl.store %v, %p : i32, !ptr_xdsl.ptr
 
-  // CHECK-NEXT: opaque_ptr.load %p : !opaque_ptr.ptr -> i32
-  %r3 = opaque_ptr.load %p : !opaque_ptr.ptr -> i32
+// CHECK-NEXT: ptr_xdsl.load %p : !ptr_xdsl.ptr -> i32
+%r3 = ptr_xdsl.load %p : !ptr_xdsl.ptr -> i32
 
-  // CHECK-NEXT: %pm = opaque_ptr.to_ptr %m : memref<10xi32> -> !opaque_ptr.ptr
-  %pm = opaque_ptr.to_ptr %m : memref<10xi32> -> !opaque_ptr.ptr
-}
+// CHECK-NEXT: %pm = ptr_xdsl.to_ptr %m : memref<10xi32> -> !ptr_xdsl.ptr
+%pm = ptr_xdsl.to_ptr %m : memref<10xi32> -> !ptr_xdsl.ptr

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -188,7 +188,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return Printf
 
-    def get_opaque_ptr():
+    def get_ptr_xdsl():
         from xdsl.dialects.ptr import Ptr
 
         return Ptr
@@ -365,7 +365,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "onnx": get_onnx,
         "pdl": get_pdl,
         "printf": get_printf,
-        "opaque_ptr": get_opaque_ptr,
+        "ptr_xdsl": get_ptr_xdsl,
         "quantum": get_quantum,
         "qref": get_qref,
         "qssa": get_qssa,

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -188,6 +188,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return Printf
 
+    def get_opaque_ptr():
+        from xdsl.dialects.ptr import Ptr
+
+        return Ptr
+
     def get_quantum():
         from xdsl.dialects.quantum import QUANTUM
 
@@ -360,6 +365,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "onnx": get_onnx,
         "pdl": get_pdl,
         "printf": get_printf,
+        "opaque_ptr": get_opaque_ptr,
         "quantum": get_quantum,
         "qref": get_qref,
         "qssa": get_qssa,

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -1,0 +1,83 @@
+from xdsl.dialects.builtin import IndexType, IntegerType, MemRefType, UnitAttr
+from xdsl.ir import Dialect, ParametrizedAttribute, TypeAttribute
+from xdsl.irdl import (
+    AnyOf,
+    Attribute,
+    IRDLOperation,
+    base,
+    irdl_attr_definition,
+    irdl_op_definition,
+    operand_def,
+    opt_prop_def,
+    prop_def,
+    result_def,
+)
+
+
+@irdl_attr_definition
+class PtrType(ParametrizedAttribute, TypeAttribute):
+    name = "opaque_ptr.ptr"
+
+
+@irdl_op_definition
+class PtrAddOp(IRDLOperation):
+    name = "opaque_ptr.ptradd"
+
+    addr = operand_def(PtrType)
+    offset = operand_def(AnyOf([IntegerType, IndexType]))
+    result = result_def(PtrType)
+
+    assembly_format = "$addr `,` $offset attr-dict `:` `(` type($addr) `,` type($offset) `)` `->` type($result)"
+
+
+# haven't managed to pass a type here yet. so did it with a hack.
+@irdl_op_definition
+class TypeOffsetOp(IRDLOperation):
+    name = "opaque_ptr.type_offset"
+
+    elem_type = prop_def(base(Attribute))
+    offset = result_def(AnyOf([IntegerType, IndexType]))
+
+
+@irdl_op_definition
+class StoreOp(IRDLOperation):
+    name = "opaque_ptr.store"
+
+    addr = operand_def(PtrType)
+    value = operand_def()
+
+    volatile = opt_prop_def(UnitAttr)
+    syncscope = opt_prop_def(UnitAttr)
+    ordering = opt_prop_def(UnitAttr)
+
+    assembly_format = "(`volatile` $volatile^)? $value `,` $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? attr-dict `:` type($value) `,` type($addr)"
+
+
+@irdl_op_definition
+class LoadOp(IRDLOperation):
+    name = "opaque_ptr.load"
+
+    addr = operand_def(PtrType)
+    res = result_def()
+
+    volatile = opt_prop_def(UnitAttr)
+    syncscope = opt_prop_def(UnitAttr)
+    ordering = opt_prop_def(UnitAttr)
+    invariant = opt_prop_def(UnitAttr)
+
+    assembly_format = "(`volatile` $volatile^)? $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? (`invariant` $invariant^)? attr-dict `:` type($addr) `->` type($res)"
+
+
+@irdl_op_definition
+class ToPtrOp(IRDLOperation):
+    name = "opaque_ptr.to_ptr"
+
+    source = operand_def(MemRefType)
+    res = result_def(PtrType)
+
+    assembly_format = "$source attr-dict `:` type($source) `->` type($res)"
+
+
+Ptr = Dialect(
+    "opaque_ptr", [PtrAddOp, TypeOffsetOp, StoreOp, LoadOp, ToPtrOp], [PtrType]
+)

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -3,15 +3,14 @@
 #  Main parts of the dialect has already been agreed upon but only the basic datatype is implemented upstream.
 #  When the upstream implementation is merged we should fix our implementation to be consistent with the mlir version.
 #  Current diviations:
-#  (1) Name of the dialect should be changed: opaque_ptr -> ptr. We currently chose another name to avoid conflicts when loading our dialect to mlir-opt.
+#  (1) Name of the dialect should be changed: ptr_xdsl -> ptr. We currently chose another name to avoid conflicts when loading our dialect to mlir-opt.
 #  (2) There is no ptr.to_ptr operation currently proposed, but there is a memref.to_ptr. We do this so that we can feed the results of convert-memref-to-ptr pass without any conflict.
 ########
 
 
-from xdsl.dialects.builtin import IndexType, IntegerType, MemRefType, UnitAttr
+from xdsl.dialects.builtin import IntegerAttrTypeConstr, MemRefType, UnitAttr
 from xdsl.ir import Dialect, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (
-    AnyOf,
     Attribute,
     IRDLOperation,
     base,
@@ -26,15 +25,15 @@ from xdsl.irdl import (
 
 @irdl_attr_definition
 class PtrType(ParametrizedAttribute, TypeAttribute):
-    name = "opaque_ptr.ptr"
+    name = "ptr_xdsl.ptr"
 
 
 @irdl_op_definition
 class PtrAddOp(IRDLOperation):
-    name = "opaque_ptr.ptradd"
+    name = "ptr_xdsl.ptradd"
 
     addr = operand_def(PtrType)
-    offset = operand_def(AnyOf([IntegerType, IndexType]))
+    offset = operand_def(IntegerAttrTypeConstr)
     result = result_def(PtrType)
 
     assembly_format = "$addr `,` $offset attr-dict `:` `(` type($addr) `,` type($offset) `)` `->` type($result)"
@@ -43,15 +42,17 @@ class PtrAddOp(IRDLOperation):
 # haven't managed to pass a type here yet. so did it with a hack.
 @irdl_op_definition
 class TypeOffsetOp(IRDLOperation):
-    name = "opaque_ptr.type_offset"
+    name = "ptr_xdsl.type_offset"
 
     elem_type = prop_def(base(Attribute))
-    offset = result_def(AnyOf([IntegerType, IndexType]))
+    offset = result_def(IntegerAttrTypeConstr)
+
+    assembly_format = "$elem_type attr-dict `:` type($offset)"
 
 
 @irdl_op_definition
 class StoreOp(IRDLOperation):
-    name = "opaque_ptr.store"
+    name = "ptr_xdsl.store"
 
     addr = operand_def(PtrType)
     value = operand_def()
@@ -65,7 +66,7 @@ class StoreOp(IRDLOperation):
 
 @irdl_op_definition
 class LoadOp(IRDLOperation):
-    name = "opaque_ptr.load"
+    name = "ptr_xdsl.load"
 
     addr = operand_def(PtrType)
     res = result_def()
@@ -80,7 +81,7 @@ class LoadOp(IRDLOperation):
 
 @irdl_op_definition
 class ToPtrOp(IRDLOperation):
-    name = "opaque_ptr.to_ptr"
+    name = "ptr_xdsl.to_ptr"
 
     source = operand_def(MemRefType)
     res = result_def(PtrType)
@@ -89,5 +90,15 @@ class ToPtrOp(IRDLOperation):
 
 
 Ptr = Dialect(
-    "opaque_ptr", [PtrAddOp, TypeOffsetOp, StoreOp, LoadOp, ToPtrOp], [PtrType]
+    "ptr_xdsl",
+    [
+        PtrAddOp,
+        TypeOffsetOp,
+        StoreOp,
+        LoadOp,
+        ToPtrOp,
+    ],
+    [
+        PtrType,
+    ],
 )

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -1,3 +1,13 @@
+########
+#  This is a port of the 'ptr' dialect proposed in this thread https://discourse.llvm.org/t/rfc-ptr-dialect-modularizing-ptr-ops-in-the-llvm-dialect/75142/21
+#  Main parts of the dialect has already been agreed upon but only the basic datatype is implemented upstream.
+#  When the upstream implementation is merged we should fix our implementation to be consistent with the mlir version.
+#  Current diviations:
+#  (1) Name of the dialect should be changed: opaque_ptr -> ptr. We currently chose another name to avoid conflicts when loading our dialect to mlir-opt.
+#  (2) There is no ptr.to_ptr operation currently proposed, but there is a memref.to_ptr. We do this so that we can feed the results of convert-memref-to-ptr pass without any conflict.
+########
+
+
 from xdsl.dialects.builtin import IndexType, IntegerType, MemRefType, UnitAttr
 from xdsl.ir import Dialect, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -8,12 +8,10 @@
 ########
 
 
-from xdsl.dialects.builtin import IntegerAttrTypeConstr, MemRefType, UnitAttr
+from xdsl.dialects.builtin import AnyAttr, IntegerAttrTypeConstr, MemRefType, UnitAttr
 from xdsl.ir import Dialect, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import (
-    Attribute,
     IRDLOperation,
-    base,
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
@@ -44,7 +42,7 @@ class PtrAddOp(IRDLOperation):
 class TypeOffsetOp(IRDLOperation):
     name = "ptr_xdsl.type_offset"
 
-    elem_type = prop_def(base(Attribute))
+    elem_type = prop_def(AnyAttr())
     offset = result_def(IntegerAttrTypeConstr)
 
     assembly_format = "$elem_type attr-dict `:` type($offset)"


### PR DESCRIPTION
Porting the ptr dialect proposed [here](https://discourse.llvm.org/t/rfc-ptr-dialect-modularizing-ptr-ops-in-the-llvm-dialect/75142/21). Going to transfer the riscv compilation pipeline to it.