### PR TITLE
transformations: `ptr` -> `riscv` conversion

### DIFF
--- a/tests/filecheck/backend/riscv/convert_ptr_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_ptr_to_riscv.mlir
@@ -22,5 +22,4 @@ ptr_xdsl.store %v, %p : i32, !ptr_xdsl.ptr
 %m2 = "test.op"() : () -> (memref<3x2xf128>)
 %p2 = ptr_xdsl.to_ptr %m2 : memref<3x2xf128> -> !ptr_xdsl.ptr
 %v1 = ptr_xdsl.load %p2 : !ptr_xdsl.ptr -> f128
-
 // CHECK: Unexpected floating point type f128

--- a/tests/filecheck/backend/riscv/convert_ptr_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_ptr_to_riscv.mlir
@@ -1,0 +1,19 @@
+// RUN: xdsl-opt %s -p convert-ptr-to-riscv --split-input-file | filecheck %s
+
+%m, %idx, %v = "test.op"() : () -> (memref<3x2xi32>, index, i32)
+
+%p = ptr_xdsl.to_ptr %m : memref<3x2xi32> -> !ptr_xdsl.ptr
+// CHECK: %p = builtin.unrealized_conversion_cast %m : memref<3x2xi32> to index
+
+%r0 = ptr_xdsl.ptradd %p, %idx : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %r0 = arith.addi %p, %idx : index
+
+ptr_xdsl.store %v, %p : i32, !ptr_xdsl.ptr
+// CHECK-NEXT:  %p_1 = builtin.unrealized_conversion_cast %p : index to !riscv.reg
+// CHECK-NEXT:  %v_1 = builtin.unrealized_conversion_cast %v : i32 to !riscv.reg
+// CHECK-NEXT:  riscv.sw %p_1, %v_1, 0 {"comment" = "store int value to pointer"} : (!riscv.reg, !riscv.reg) -> ()
+
+%r3 = ptr_xdsl.load %p : !ptr_xdsl.ptr -> i32
+// CHECK-NEXT:  %p_2 = builtin.unrealized_conversion_cast %p : index to !riscv.reg
+// CHECK-NEXT:  %r3 = riscv.lw %p_2, 0 {"comment" = "load word from pointer"} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %r3_1 = builtin.unrealized_conversion_cast %r3 : !riscv.reg to i32

--- a/tests/filecheck/backend/riscv/convert_ptr_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/convert_ptr_to_riscv.mlir
@@ -1,19 +1,26 @@
-// RUN: xdsl-opt %s -p convert-ptr-to-riscv --split-input-file | filecheck %s
+// RUN: xdsl-opt %s -p convert-ptr-to-riscv --split-input-file --verify-diagnostics | filecheck %s
 
 %m, %idx, %v = "test.op"() : () -> (memref<3x2xi32>, index, i32)
 
 %p = ptr_xdsl.to_ptr %m : memref<3x2xi32> -> !ptr_xdsl.ptr
-// CHECK: %p = builtin.unrealized_conversion_cast %m : memref<3x2xi32> to index
+// CHECK: %p = builtin.unrealized_conversion_cast %m : memref<3x2xi32> to !riscv.reg
 
 %r0 = ptr_xdsl.ptradd %p, %idx : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %r0 = arith.addi %p, %idx : index
+// CHECK-NEXT:  %idx_1 = builtin.unrealized_conversion_cast %idx : index to !riscv.reg
+// CHECK-NEXT:  %r0 = riscv.add %p, %idx_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
 
 ptr_xdsl.store %v, %p : i32, !ptr_xdsl.ptr
-// CHECK-NEXT:  %p_1 = builtin.unrealized_conversion_cast %p : index to !riscv.reg
 // CHECK-NEXT:  %v_1 = builtin.unrealized_conversion_cast %v : i32 to !riscv.reg
-// CHECK-NEXT:  riscv.sw %p_1, %v_1, 0 {"comment" = "store int value to pointer"} : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:  riscv.sw %p, %v_1, 0 {"comment" = "store int value to pointer"} : (!riscv.reg, !riscv.reg) -> ()
 
 %r3 = ptr_xdsl.load %p : !ptr_xdsl.ptr -> i32
-// CHECK-NEXT:  %p_2 = builtin.unrealized_conversion_cast %p : index to !riscv.reg
-// CHECK-NEXT:  %r3 = riscv.lw %p_2, 0 {"comment" = "load word from pointer"} : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:  %r3 = riscv.lw %p, 0 {"comment" = "load word from pointer"} : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:  %r3_1 = builtin.unrealized_conversion_cast %r3 : !riscv.reg to i32
+
+// -----
+
+%m2 = "test.op"() : () -> (memref<3x2xf128>)
+%p2 = ptr_xdsl.to_ptr %m2 : memref<3x2xf128> -> !ptr_xdsl.ptr
+%v1 = ptr_xdsl.load %p2 : !ptr_xdsl.ptr -> f128
+
+// CHECK: Unexpected floating point type f128

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -333,6 +333,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return convert_print_format_to_riscv_debug.ConvertPrintFormatToRiscvDebugPass
 
+    def get_convert_ptr_to_riscv():
+        from xdsl.transforms import convert_ptr_to_riscv
+
+        return convert_ptr_to_riscv.ConvertPtrToRiscvPass
+
     def get_convert_qref_to_qssa():
         from xdsl.transforms import convert_qref_to_qssa
 
@@ -469,6 +474,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "convert-scf-to-riscv-scf": get_convert_scf_to_riscv_scf,
         "convert-snitch-stream-to-snitch": get_convert_snitch_stream_to_snitch,
         "convert-stencil-to-csl-stencil": get_convert_stencil_to_csl_stencil,
+        "convert-ptr-to-riscv": get_convert_ptr_to_riscv,
         "inline-snrt": get_convert_snrt_to_riscv,
         "convert-stencil-to-ll-mlir": get_convert_stencil_to_ll_mlir,
         "cse": get_cse,

--- a/xdsl/transforms/convert_ptr_to_riscv.py
+++ b/xdsl/transforms/convert_ptr_to_riscv.py
@@ -110,7 +110,7 @@ class ConvertLoadOp(RewritePattern):
                 assert False, f"Unexpected register type {result_register_type}"
 
         rewriter.replace_matched_op(
-            [lw := lw_op, UnrealizedConversionCastOp.get(lw.results, (op.res.type,))]
+            (lw := lw_op, UnrealizedConversionCastOp.get(lw.results, (op.res.type,)))
         )
 
 

--- a/xdsl/transforms/convert_ptr_to_riscv.py
+++ b/xdsl/transforms/convert_ptr_to_riscv.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass
+from typing import cast
+
+from xdsl.backend.riscv.lowering.utils import (
+    cast_operands_to_regs,
+    register_type_for_type,
+)
+from xdsl.context import MLContext
+from xdsl.dialects import arith, ptr, riscv
+from xdsl.dialects.builtin import (
+    AnyFloat,
+    Float32Type,
+    Float64Type,
+    IndexType,
+    ModuleOp,
+    UnrealizedConversionCastOp,
+)
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    TypeConversionPattern,
+    attr_type_rewrite_pattern,
+    op_type_rewrite_pattern,
+)
+
+
+class PtrTypeConversion(TypeConversionPattern):
+    @attr_type_rewrite_pattern
+    def convert_type(self, typ: ptr.PtrType) -> IndexType:
+        return IndexType()
+
+
+@dataclass
+class ConvertPtrAddOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.PtrAddOp, rewriter: PatternRewriter, /):
+        rewriter.replace_matched_op(arith.Addi(op.operands[0], op.operands[1]))
+
+
+@dataclass
+class ConvertStoreOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.StoreOp, rewriter: PatternRewriter, /):
+        addr, value = cast_operands_to_regs(rewriter)
+
+        match value.type:
+            case riscv.IntRegisterType():
+                new_op = riscv.SwOp(
+                    addr, value, 0, comment="store int value to pointer"
+                )
+            case riscv.FloatRegisterType():
+                float_type = cast(AnyFloat, op.value.type)
+                match float_type:
+                    case Float32Type():
+                        new_op = riscv.FSwOp(
+                            addr,
+                            value,
+                            0,
+                            comment="store float value to pointer",
+                        )
+                    case Float64Type():
+                        new_op = riscv.FSdOp(
+                            addr,
+                            value,
+                            0,
+                            comment="store double value to pointer",
+                        )
+                    case _:
+                        assert False, f"Unexpected floating point type {float_type}"
+
+            case _:
+                assert False, f"Unexpected register type {op.value.type}"
+
+        rewriter.replace_matched_op(new_op)
+
+
+@dataclass
+class ConvertLoadOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.LoadOp, rewriter: PatternRewriter, /):
+        casted = cast_operands_to_regs(rewriter)
+        addr = casted[0]
+
+        result_register_type = register_type_for_type(op.res.type)
+
+        match result_register_type:
+            case riscv.IntRegisterType:
+                lw_op = riscv.LwOp(addr, 0, comment="load word from pointer")
+            case riscv.FloatRegisterType:
+                float_type = cast(AnyFloat, op.res.type)
+                match float_type:
+                    case Float32Type():
+                        lw_op = riscv.FLwOp(addr, 0, comment="load float from pointer")
+                    case Float64Type():
+                        lw_op = riscv.FLdOp(addr, 0, comment="load double from pointer")
+                    case _:
+                        assert False, f"Unexpected floating point type {float_type}"
+
+            case _:
+                assert False, f"Unexpected register type {result_register_type}"
+
+        rewriter.replace_matched_op(
+            [lw := lw_op, UnrealizedConversionCastOp.get(lw.results, (op.res.type,))]
+        )
+
+
+@dataclass
+class ConvertMemrefToPtrOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.ToPtrOp, rewriter: PatternRewriter, /):
+        rewriter.replace_matched_op(
+            UnrealizedConversionCastOp.get([op.source], [IndexType()])
+        )
+
+
+class ConvertPtrToRiscvPass(ModulePass):
+    name = "convert-ptr-to-riscv"
+
+    def apply(self, ctx: MLContext, op: ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    PtrTypeConversion(),
+                    ConvertPtrAddOp(),
+                    ConvertStoreOp(),
+                    ConvertLoadOp(),
+                    ConvertMemrefToPtrOp(),
+                ]
+            ),
+        ).rewrite_module(op)


### PR DESCRIPTION
Part 3 of introducing `ptr` dialect to snitch compilation. Pass to lower `ptr` to `riscv`.