### PR TITLE
transformations: Persist func arg names as arg_attr

### DIFF
--- a/tests/filecheck/transforms/function-persist-arg-names.mlir
+++ b/tests/filecheck/transforms/function-persist-arg-names.mlir
@@ -1,0 +1,12 @@
+// RUN: xdsl-opt %s -p function-persist-arg-names | filecheck %s
+
+// CHECK: func.func @test(%one : i32 {"name" = "one"}, %two : f32 {"name" = "two"}, %three : f64 {"name" = "three"}) {
+func.func @test(%one: i32, %two: f32, %three: f64) -> () {
+    func.return
+}
+
+
+//CHECK: func.func @test2(%one : i32 {"name" = "preexisting_name"}, %two : f32 {"name" = "two", "some_other_arg_attr" = "some_other_val"}, %three : f64 {"name" = "three"}) {
+func.func @test2(%one : i32 {"name" = "preexisting_name"}, %two : f32 {"some_other_arg_attr" = "some_other_val"}, %three : f64) {
+  func.return
+}

--- a/tests/filecheck/transforms/function-persist-arg-names.mlir
+++ b/tests/filecheck/transforms/function-persist-arg-names.mlir
@@ -6,7 +6,18 @@ func.func @test(%one: i32, %two: f32, %three: f64) -> () {
 }
 
 
-//CHECK: func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %0 : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %three : f64 {"llvm.name" = "three"}) {
+// CHECK: func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %0 : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %three : f64 {"llvm.name" = "three"}) {
 func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %0 : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %three : f64) {
+  func.return
+}
+
+
+// CHECK: func.func @no_arg_names(%0 : i32, %1 : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %2 : f64) {
+func.func @no_arg_names(%0 : i32, %1 : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %2 : f64) {
+  func.return
+}
+
+// CHECK: func.func @no_arg_attrs_or_names(%0 : i32, %1 : f32, %2 : f64) {
+func.func @no_arg_attrs_or_names(%0 : i32, %1 : f32, %2 : f64) {
   func.return
 }

--- a/tests/filecheck/transforms/function-persist-arg-names.mlir
+++ b/tests/filecheck/transforms/function-persist-arg-names.mlir
@@ -1,12 +1,12 @@
 // RUN: xdsl-opt %s -p function-persist-arg-names | filecheck %s
 
-// CHECK: func.func @test(%one : i32 {"name" = "one"}, %two : f32 {"name" = "two"}, %three : f64 {"name" = "three"}) {
+// CHECK: func.func @test(%one : i32 {"llvm.name" = "one"}, %two : f32 {"llvm.name" = "two"}, %three : f64 {"llvm.name" = "three"}) {
 func.func @test(%one: i32, %two: f32, %three: f64) -> () {
     func.return
 }
 
 
-//CHECK: func.func @test2(%one : i32 {"name" = "preexisting_name"}, %two : f32 {"name" = "two", "some_other_arg_attr" = "some_other_val"}, %three : f64 {"name" = "three"}) {
-func.func @test2(%one : i32 {"name" = "preexisting_name"}, %two : f32 {"some_other_arg_attr" = "some_other_val"}, %three : f64) {
+//CHECK: func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %two : f32 {"llvm.name" = "two", "llvm.some_other_arg_attr" = "some_other_val"}, %three : f64 {"llvm.name" = "three"}) {
+func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %two : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %three : f64) {
   func.return
 }

--- a/tests/filecheck/transforms/function-persist-arg-names.mlir
+++ b/tests/filecheck/transforms/function-persist-arg-names.mlir
@@ -6,7 +6,7 @@ func.func @test(%one: i32, %two: f32, %three: f64) -> () {
 }
 
 
-//CHECK: func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %two : f32 {"llvm.name" = "two", "llvm.some_other_arg_attr" = "some_other_val"}, %three : f64 {"llvm.name" = "three"}) {
-func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %two : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %three : f64) {
+//CHECK: func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %0 : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %three : f64 {"llvm.name" = "three"}) {
+func.func @test2(%one : i32 {"llvm.name" = "preexisting_name"}, %0 : f32 {"llvm.some_other_arg_attr" = "some_other_val"}, %three : f64) {
   func.return
 }

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -257,6 +257,7 @@ async def test_buttons():
         with ImplicitBuilder(expected_module.body):
             function = func.FuncOp("hello", ((index,), (index,)))
             with ImplicitBuilder(function.body) as (n,):
+                n.name_hint = "n"
                 two = arith.Constant(IntegerAttr(2, index)).result
                 res = arith.Muli(n, two)
                 func.Return(res)

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -365,6 +365,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return FunctionConstantPinningPass
 
+    def get_function_persist_arg_names():
+        from xdsl.transforms.function_transformations import FunctionPersistArgNames
+
+        return FunctionPersistArgNames
+
     def get_lower_scf_for_to_labels():
         from xdsl.backend.riscv import riscv_scf_to_asm
 
@@ -482,6 +487,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "dmp-to-mpi": get_lower_halo_to_mpi,
         "frontend-desymrefy": get_desymrefy,
         "function-constant-pinning": get_function_constant_pinning,
+        "function-persist-arg-names": get_function_persist_arg_names,
         "memref-to-gpu": get_gpu_allocs,
         "gpu-map-parallel-loops": get_gpu_map_parallel_loops,
         "hls-convert-stencil-to-ll-mlir": get_hls_convert_stencil_to_ll_mlir,

--- a/xdsl/transforms/function_transformations.py
+++ b/xdsl/transforms/function_transformations.py
@@ -13,6 +13,9 @@ from xdsl.pattern_rewriter import (
 class ArgNamesToArgAttrsPass(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: func.FuncOp, rewriter: PatternRewriter, /):
+        if not any(arg.name_hint for arg in op.args):
+            return
+
         arg_attrs = (
             op.arg_attrs.data
             if op.arg_attrs is not None

--- a/xdsl/transforms/function_transformations.py
+++ b/xdsl/transforms/function_transformations.py
@@ -1,0 +1,37 @@
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, func
+from xdsl.dialects.builtin import ArrayAttr, DictionaryAttr, StringAttr
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class ArgNamesToArgAttrsPass(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: func.FuncOp, rewriter: PatternRewriter, /):
+        arg_attrs = list(op.arg_attrs or (len(op.args) * [DictionaryAttr({})]))
+        new_arg_attrs: list[DictionaryAttr] = []
+        for arg, arg_attr in zip(op.args, arg_attrs):
+            if arg.name_hint:
+                d_attr = DictionaryAttr(
+                    {"name": StringAttr(arg.name_hint), **arg_attr.data}
+                )
+            else:
+                d_attr = arg_attr
+            new_arg_attrs.append(d_attr)
+
+        op.arg_attrs = ArrayAttr(new_arg_attrs)
+        rewriter.has_done_action = True
+
+
+class FunctionPersistArgNames(ModulePass):
+    name = "function-persist-arg-names"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            ArgNamesToArgAttrsPass(), apply_recursively=False
+        ).rewrite_module(op)

--- a/xdsl/transforms/function_transformations.py
+++ b/xdsl/transforms/function_transformations.py
@@ -18,7 +18,7 @@ class ArgNamesToArgAttrsPass(RewritePattern):
         for arg, arg_attr in zip(op.args, arg_attrs):
             if arg.name_hint:
                 d_attr = DictionaryAttr(
-                    {"name": StringAttr(arg.name_hint), **arg_attr.data}
+                    {"llvm.name": StringAttr(arg.name_hint), **arg_attr.data}
                 )
             else:
                 d_attr = arg_attr

--- a/xdsl/transforms/function_transformations.py
+++ b/xdsl/transforms/function_transformations.py
@@ -21,7 +21,7 @@ class ArgNamesToArgAttrsPass(RewritePattern):
                 if arg.name_hint
                 else arg_attr.data
             )
-            for arg, arg_attr in zip(op.args, arg_attrs)
+            for arg, arg_attr in zip(op.args, arg_attrs, strict=True)
         )
 
         if new_arg_attrs != op.arg_attrs:

--- a/xdsl/transforms/function_transformations.py
+++ b/xdsl/transforms/function_transformations.py
@@ -13,7 +13,11 @@ from xdsl.pattern_rewriter import (
 class ArgNamesToArgAttrsPass(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: func.FuncOp, rewriter: PatternRewriter, /):
-        arg_attrs = list(op.arg_attrs or (len(op.args) * [DictionaryAttr({})]))
+        arg_attrs = (
+            op.arg_attrs.data
+            if op.arg_attrs is not None
+            else ((DictionaryAttr({}),) * len(op.args))
+        )
 
         new_arg_attrs = ArrayAttr(
             DictionaryAttr(


### PR DESCRIPTION
Persisting function arg names to arg attributes as suggested [here](https://discourse.llvm.org/t/mlir-capi-how-to-set-function-argument-names-arg0/3892/2).

Note, upstream mlir will say `op arguments may only have dialect attributes`, requiring arg attribute names to be prefixed with a dialect.