### PR TITLE
bug: Fix cse for FloatData

### DIFF
--- a/tests/filecheck/transforms/cse.mlir
+++ b/tests/filecheck/transforms/cse.mlir
@@ -19,7 +19,7 @@ func.func @simple_float_constant() -> (f32, f32) {
     func.return %0, %1 : f32, f32
 }
 
-// CHECK:         func.func @simple__float_constant() -> (f32, f32) {
+// CHECK:         func.func @simple_float_constant() -> (f32, f32) {
 // CHECK-NEXT:      %0 = arith.constant 1.000000e+00 : f32
 // CHECK-NEXT:      func.return %0, %0 : f32, f32
 // CHECK-NEXT:    }

--- a/tests/filecheck/transforms/cse.mlir
+++ b/tests/filecheck/transforms/cse.mlir
@@ -13,6 +13,17 @@ func.func @simple_constant() -> (i32, i32) {
 // CHECK-NEXT:      func.return %0, %0 : i32, i32
 // CHECK-NEXT:    }
 
+func.func @simple_float_constant() -> (f32, f32) {
+    %0 = arith.constant 1.0 : f32
+    %1 = arith.constant 1.0 : f32
+    func.return %0, %1 : f32, f32
+}
+
+// CHECK:         func.func @simple__float_constant() -> (f32, f32) {
+// CHECK-NEXT:      %0 = arith.constant 1.000000e+00 : f32
+// CHECK-NEXT:      func.return %0, %0 : f32, f32
+// CHECK-NEXT:    }
+
 // CHECK-LABEL: @basic
   func.func @basic() -> (index, index) {
     %2 = arith.constant 0 : index

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -636,6 +636,9 @@ class FloatData(Data[float]):
             math.isnan(self.data) and math.isnan(other.data) or self.data == other.data
         )
 
+    def __hash__(self):
+        return super().__hash__()
+
 
 _FloatAttrType = TypeVar("_FloatAttrType", bound=AnyFloat, covariant=True)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -637,7 +637,7 @@ class FloatData(Data[float]):
         )
 
     def __hash__(self):
-        return super().__hash__()
+        return hash(self.data)
 
 
 _FloatAttrType = TypeVar("_FloatAttrType", bound=AnyFloat, covariant=True)


### PR DESCRIPTION
FloatData recently received an `__eq__` method to handle `nan` inequalities. Because of this change, it also needs to provide a `__hash__` method.