### PR TITLE
transformations: Materialise stores before bufferization

### DIFF
--- a/tests/filecheck/transforms/csl_stencil_bufferize.mlir
+++ b/tests/filecheck/transforms/csl_stencil_bufferize.mlir
@@ -34,7 +34,7 @@ builtin.module {
 // CHECK-NEXT:   func.func @bufferized_stencil(%a : memref<512xf32>, %b : memref<512xf32>) {
 // CHECK-NEXT:     %0 = tensor.empty() : tensor<510xf32>
 // CHECK-NEXT:     %1 = bufferization.to_memref %0 : memref<510xf32>
-// CHECK-NEXT:     csl_stencil.apply(%a : memref<512xf32>, %1 : memref<510xf32>, %b : memref<512xf32>) -> () <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64, "bounds" = #stencil.bounds<[0, 0], [1, 1]>, "operandSegmentSizes" = array<i32: 1, 1, 0, 1, 0>}> ({
+// CHECK-NEXT:     csl_stencil.apply(%a : memref<512xf32>, %1 : memref<510xf32>, %b : memref<512xf32>) outs (%b : memref<512xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64, "bounds" = #stencil.bounds<[0, 0], [1, 1]>, "operandSegmentSizes" = array<i32: 1, 1, 0, 1, 1>}> ({
 // CHECK-NEXT:     ^0(%2 : memref<4x255xf32>, %3 : index, %4 : memref<510xf32>):
 // CHECK-NEXT:       %5 = bufferization.to_tensor %4 restrict writable : memref<510xf32>
 // CHECK-NEXT:       %6 = csl_stencil.access %2[1, 0] : memref<4x255xf32>

--- a/tests/filecheck/transforms/csl_stencil_bufferize.mlir
+++ b/tests/filecheck/transforms/csl_stencil_bufferize.mlir
@@ -34,7 +34,7 @@ builtin.module {
 // CHECK-NEXT:   func.func @bufferized_stencil(%a : memref<512xf32>, %b : memref<512xf32>) {
 // CHECK-NEXT:     %0 = tensor.empty() : tensor<510xf32>
 // CHECK-NEXT:     %1 = bufferization.to_memref %0 : memref<510xf32>
-// CHECK-NEXT:     csl_stencil.apply(%a : memref<512xf32>, %1 : memref<510xf32>) outs (%b : memref<512xf32>) <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64, "bounds" = #stencil.bounds<[0, 0], [1, 1]>, "operandSegmentSizes" = array<i32: 1, 1, 0, 0, 1>}> ({
+// CHECK-NEXT:     csl_stencil.apply(%a : memref<512xf32>, %1 : memref<510xf32>, %b : memref<512xf32>) -> () <{"swaps" = [#csl_stencil.exchange<to [1, 0]>, #csl_stencil.exchange<to [-1, 0]>, #csl_stencil.exchange<to [0, 1]>, #csl_stencil.exchange<to [0, -1]>], "topo" = #dmp.topo<1022x510>, "num_chunks" = 2 : i64, "bounds" = #stencil.bounds<[0, 0], [1, 1]>, "operandSegmentSizes" = array<i32: 1, 1, 0, 1, 0>}> ({
 // CHECK-NEXT:     ^0(%2 : memref<4x255xf32>, %3 : index, %4 : memref<510xf32>):
 // CHECK-NEXT:       %5 = bufferization.to_tensor %4 restrict writable : memref<510xf32>
 // CHECK-NEXT:       %6 = csl_stencil.access %2[1, 0] : memref<4x255xf32>
@@ -53,18 +53,19 @@ builtin.module {
 // CHECK-NEXT:       %19 = bufferization.to_memref %18 : memref<510xf32>
 // CHECK-NEXT:       csl_stencil.yield %19 : memref<510xf32>
 // CHECK-NEXT:     }, {
-// CHECK-NEXT:     ^1(%20 : memref<512xf32>, %21 : memref<510xf32>):
-// CHECK-NEXT:       %22 = bufferization.to_tensor %21 restrict writable : memref<510xf32>
-// CHECK-NEXT:       %23 = bufferization.to_tensor %20 restrict : memref<512xf32>
-// CHECK-NEXT:       %24 = arith.constant dense<1.666600e-01> : memref<510xf32>
-// CHECK-NEXT:       %25 = bufferization.to_tensor %24 restrict : memref<510xf32>
-// CHECK-NEXT:       %26 = "tensor.extract_slice"(%23) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %27 = "tensor.extract_slice"(%23) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %28 = linalg.add ins(%22, %27 : tensor<510xf32>, tensor<510xf32>) outs(%22 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %29 = linalg.add ins(%28, %26 : tensor<510xf32>, tensor<510xf32>) outs(%28 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %30 = linalg.mul ins(%29, %25 : tensor<510xf32>, tensor<510xf32>) outs(%29 : tensor<510xf32>) -> tensor<510xf32>
-// CHECK-NEXT:       %31 = bufferization.to_memref %30 : memref<510xf32>
-// CHECK-NEXT:       csl_stencil.yield %31 : memref<510xf32>
+// CHECK-NEXT:     ^1(%20 : memref<512xf32>, %21 : memref<510xf32>, %22 : memref<512xf32>):
+// CHECK-NEXT:       %23 = bufferization.to_tensor %21 restrict writable : memref<510xf32>
+// CHECK-NEXT:       %24 = bufferization.to_tensor %20 restrict : memref<512xf32>
+// CHECK-NEXT:       %25 = arith.constant dense<1.666600e-01> : memref<510xf32>
+// CHECK-NEXT:       %26 = bufferization.to_tensor %25 restrict : memref<510xf32>
+// CHECK-NEXT:       %27 = "tensor.extract_slice"(%24) <{"static_offsets" = array<i64: 2>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %28 = "tensor.extract_slice"(%24) <{"static_offsets" = array<i64: 0>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %29 = linalg.add ins(%23, %28 : tensor<510xf32>, tensor<510xf32>) outs(%23 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %30 = linalg.add ins(%29, %27 : tensor<510xf32>, tensor<510xf32>) outs(%29 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %31 = bufferization.to_tensor %22 restrict writable : memref<512xf32>
+// CHECK-NEXT:       %32 = "tensor.extract_slice"(%31) <{"static_offsets" = array<i64: 1>, "static_sizes" = array<i64: 510>, "static_strides" = array<i64: 1>, "operandSegmentSizes" = array<i32: 1, 0, 0, 0>}> : (tensor<512xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       %33 = linalg.mul ins(%30, %26 : tensor<510xf32>, tensor<510xf32>) outs(%32 : tensor<510xf32>) -> tensor<510xf32>
+// CHECK-NEXT:       csl_stencil.yield
 // CHECK-NEXT:     }) to <[0, 0], [1, 1]>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -393,9 +393,9 @@ class ApplyOp(IRDLOperation):
                     f"Unexpected block argument type of done_exchange, got {arg.type} != {expected_type} at index {arg.index}"
                 )
 
-        if (len(self.res) == 0) == (len(self.dest) == 0):
+        if (len(self.res) != 0) and (len(self.dest) != 0):
             raise VerifyException(
-                "Expected stencil.apply to have either results or dest specified"
+                "Expected stencil.apply to have results or dest specified, but not both"
             )
 
     def get_rank(self) -> int:

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -393,9 +393,9 @@ class ApplyOp(IRDLOperation):
                     f"Unexpected block argument type of done_exchange, got {arg.type} != {expected_type} at index {arg.index}"
                 )
 
-        if (len(self.res) != 0) and (len(self.dest) != 0):
+        if (len(self.res) == 0) == (len(self.dest) == 0):
             raise VerifyException(
-                "Expected stencil.apply to have results or dest specified, but not both"
+                "Expected stencil.apply to have either results or dest specified"
             )
 
     def get_rank(self) -> int:

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -446,7 +446,7 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
                     attributes=linalg_op.attributes,
                 ),
             )
-        if len(additional_args) > 0:
+        if additional_args:
             rewriter.replace_op(yld, csl_stencil.YieldOp(*new_yield_args))
             for r in to_remove:
                 rewriter.erase_op(r)

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -415,9 +415,11 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
                 arg.type, len(op.done_exchange.block.args)
             )
             arg_to_tensor = to_tensor_op(arg, writable=True)
+
+            # set offset going from a buf with ghost cells to one without, assuming symmetric ghost cells on all sides
             symmetric_offsets = tuple(
-                (s - d) // 2
-                for s, d in zip(
+                (src - dst) // 2  # symmetric offset
+                for src, dst in zip(
                     arg_t.get_shape(), yld_arg.type.get_shape(), strict=True
                 )
             )

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -416,8 +416,8 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
             )
             arg_to_tensor = to_tensor_op(arg, writable=True)
 
-            # set offset going from a buf with ghost cells to one without, assuming symmetric ghost cells on all sides
-            symmetric_offsets = tuple(
+            # offset of core data, assuming symmetric ghost cells in each direction
+            offsets = tuple(
                 (src - dst) // 2  # symmetric offset
                 for src, dst in zip(
                     arg_t.get_shape(), yld_arg.type.get_shape(), strict=True
@@ -428,7 +428,7 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
                 operands=[arg_to_tensor, [], [], []],
                 result_types=[yld_arg.op.tensor.type],
                 properties={
-                    "static_offsets": DenseArrayBase.from_list(i64, symmetric_offsets),
+                    "static_offsets": DenseArrayBase.from_list(i64, offsets),
                     "static_sizes": DenseArrayBase.from_list(
                         i64, yld_arg.type.get_shape()
                     ),

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -436,9 +436,6 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
             rewriter.insert_op(
                 [arg_to_tensor, extract_slice_op], InsertPoint.before(linalg_op)
             )
-            # yld_arg.op.outputs[0] = extract_slice_op.result
-            # op.operands = [op.field, op.accumulator, op.args_rchunk, VarOperand([*op.args_dexchng, arg]), op.dest]
-            # op.args_dexchng = VarOperand([*op.args_dexchng, arg])
             rewriter.replace_op(
                 linalg_op,
                 type(linalg_op).build(
@@ -460,7 +457,7 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
                         op.accumulator,
                         [*op.args_rchunk],
                         [*op.args_dexchng, *additional_args],
-                        [*op.dest],
+                        [*new_dest],
                     ],
                     result_types=op.res.types or [[]],
                     regions=[op.detach_region(r) for r in op.regions],

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -457,7 +457,7 @@ class InjectApplyOutsIntoLinalgOuts(RewritePattern):
                         op.accumulator,
                         [*op.args_rchunk],
                         [*op.args_dexchng, *additional_args],
-                        [*new_dest],
+                        [*op.dest],
                     ],
                     result_types=op.res.types or [[]],
                     regions=[op.detach_region(r) for r in op.regions],


### PR DESCRIPTION
This technically performs some (all?) of the work of `csl-stencil-materialize-stores`, but before bufferization. Not sure if instead of this injection I should rewrite the pass?