### PR TITLE
dialects: (llvm) changed the exact attribute to a UnitAttr

### DIFF
--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -3,7 +3,7 @@ from io import StringIO
 import pytest
 
 from xdsl.dialects import arith, builtin, llvm, test
-from xdsl.dialects.builtin import UnitAttr, i1, i32
+from xdsl.dialects.builtin import UnitAttr, i32
 from xdsl.ir import Attribute
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
@@ -56,16 +56,16 @@ def test_llvm_overflow_arithmetic_ops(
 @pytest.mark.parametrize(
     "op_type, attributes, exact",
     [
-        (llvm.UDivOp, {}, llvm.IntegerAttr(0, i1)),
-        (llvm.SDivOp, {}, llvm.IntegerAttr(0, i1)),
-        (llvm.LShrOp, {}, llvm.IntegerAttr(0, i1)),
-        (llvm.AShrOp, {}, llvm.IntegerAttr(0, i1)),
+        (llvm.UDivOp, {}, llvm.UnitAttr()),
+        (llvm.SDivOp, {}, llvm.UnitAttr()),
+        (llvm.LShrOp, {}, llvm.UnitAttr()),
+        (llvm.AShrOp, {}, llvm.UnitAttr()),
     ],
 )
 def test_llvm_exact_arithmetic_ops(
     op_type: type[llvm.ArithmeticBinOpExact],
     attributes: dict[str, Attribute],
-    exact: llvm.IntegerAttr[llvm.IntegerType],
+    exact: llvm.UnitAttr,
 ):
     op1, op2 = test.TestOp(result_types=[i32, i32]).results
     assert op_type(op1, op2, attributes, exact).is_structurally_equivalent(

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -10,7 +10,6 @@ from xdsl.dialects.builtin import (
     I64,
     AnyIntegerAttr,
     ArrayAttr,
-    BoolAttr,
     ContainerType,
     DenseArrayBase,
     IndexType,
@@ -483,7 +482,7 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
     lhs = operand_def(T)
     rhs = operand_def(T)
     res = result_def(T)
-    is_exact = prop_def(BoolAttr, prop_name="isExact", default_value=IntegerAttr(0, i1))
+    is_exact = opt_prop_def(UnitAttr, prop_name="isExact")
 
     traits = traits_def(NoMemoryEffect())
 
@@ -492,7 +491,7 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
         lhs: SSAValue,
         rhs: SSAValue,
         attributes: dict[str, Attribute] = {},
-        is_exact: BoolAttr = IntegerAttr(0, i1),
+        is_exact: UnitAttr | None = None,
     ):
         super().__init__(
             operands=[lhs, rhs],
@@ -506,11 +505,10 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
     @classmethod
     def parse_exact(cls, parser: Parser):
         if parser.parse_optional_keyword("exact") is not None:
-            return IntegerAttr(1, i1)
-        return IntegerAttr(0, i1)
+            return UnitAttr()
 
     def print_exact(self, printer: Printer) -> None:
-        if self.is_exact and self.is_exact.value.data:
+        if self.is_exact:
             printer.print(" exact ")
 
     @classmethod


### PR DESCRIPTION
This changes the representation of the exact attribute from a mandatory bool to an optional Unit.

This is to follow the syntax introduced by https://github.com/llvm/llvm-project/pull/115327