### PR TITLE
dialects: move FastMathFlag and FastMathAttrBase to xdsl.dialects.utils

### DIFF
--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -22,7 +22,7 @@ from xdsl.dialects.builtin import (
     UnrankedTensorType,
     VectorType,
 )
-from xdsl.dialects.llvm import FastMathAttrBase, FastMathFlag
+from xdsl.dialects.utils import FastMathAttrBase, FastMathFlag
 from xdsl.ir import Attribute, BitEnumAttribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AnyOf,

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -24,6 +24,7 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
+from xdsl.dialects.utils import FastMathAttrBase
 from xdsl.ir import (
     Attribute,
     BitEnumAttribute,
@@ -1479,22 +1480,6 @@ class ConstantOp(IRDLOperation):
         else:
             printer.print(self.value)
         printer.print(") : ", self.result.type)
-
-
-class FastMathFlag(StrEnum):
-    REASSOC = "reassoc"
-    NO_NANS = "nnan"
-    NO_INFS = "ninf"
-    NO_SIGNED_ZEROS = "nsz"
-    ALLOW_RECIP = "arcp"
-    ALLOW_CONTRACT = "contract"
-    APPROX_FUNC = "afn"
-
-
-@dataclass(frozen=True, init=False)
-class FastMathAttrBase(BitEnumAttribute[FastMathFlag]):
-    none_value = "none"
-    all_value = "fast"
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -24,7 +24,7 @@ from xdsl.dialects.builtin import (
     UnitAttr,
     i32,
 )
-from xdsl.dialects.llvm import FastMathAttrBase, FastMathFlag
+from xdsl.dialects.utils import FastMathAttrBase, FastMathFlag
 from xdsl.ir import (
     Attribute,
     Block,

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -394,7 +394,7 @@ def parse_dynamic_index_list_without_types(
     return values, indices
 
 
-# Fast Math Flags
+# region Fast Math Flags
 
 
 class FastMathFlag(StrEnum):
@@ -419,3 +419,6 @@ class FastMathAttrBase(BitEnumAttribute[FastMathFlag], ABC):
 
     none_value = "none"
     all_value = "fast"
+
+
+# endregion

--- a/xdsl/dialects/utils.py
+++ b/xdsl/dialects/utils.py
@@ -1,4 +1,6 @@
+from abc import ABC
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from typing import Generic
 
 from typing_extensions import Self
@@ -14,6 +16,7 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import (
     Attribute,
     AttributeInvT,
+    BitEnumAttribute,
     BlockArgument,
     Operation,
     Region,
@@ -22,6 +25,7 @@ from xdsl.ir import (
 from xdsl.irdl import IRDLOperation, var_operand_def
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
+from xdsl.utils.str_enum import StrEnum
 
 
 def print_call_op_like(
@@ -388,3 +392,30 @@ def parse_dynamic_index_list_without_types(
             values.append(value_or_index)
 
     return values, indices
+
+
+# Fast Math Flags
+
+
+class FastMathFlag(StrEnum):
+    """
+    Values specifying fast math behaviour of an arithmetic operation.
+    """
+
+    REASSOC = "reassoc"
+    NO_NANS = "nnan"
+    NO_INFS = "ninf"
+    NO_SIGNED_ZEROS = "nsz"
+    ALLOW_RECIP = "arcp"
+    ALLOW_CONTRACT = "contract"
+    APPROX_FUNC = "afn"
+
+
+@dataclass(frozen=True, init=False)
+class FastMathAttrBase(BitEnumAttribute[FastMathFlag], ABC):
+    """
+    Base class for attributes defining fast math behavior of arithmetic operations.
+    """
+
+    none_value = "none"
+    all_value = "fast"

--- a/xdsl/transforms/arith_add_fastmath.py
+++ b/xdsl/transforms/arith_add_fastmath.py
@@ -3,7 +3,8 @@
 from dataclasses import dataclass
 from typing import Literal
 
-from xdsl.dialects import arith, builtin, llvm
+from xdsl.dialects import arith, builtin
+from xdsl.dialects.utils import FastMathFlag
 from xdsl.passes import MLContext, ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -13,7 +14,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 
-_FASTMATH_NAMES_TO_ENUM = {str(member.value): member for member in llvm.FastMathFlag}
+_FASTMATH_NAMES_TO_ENUM = {str(member.value): member for member in FastMathFlag}
 
 
 def _get_flag_list(flags: tuple[str, ...]):

--- a/xdsl/transforms/canonicalization_patterns/riscv.py
+++ b/xdsl/transforms/canonicalization_patterns/riscv.py
@@ -1,7 +1,8 @@
 from typing import cast
 
-from xdsl.dialects import llvm, riscv, riscv_snitch
+from xdsl.dialects import riscv, riscv_snitch
 from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.utils import FastMathFlag
 from xdsl.ir import OpResult, SSAValue
 from xdsl.pattern_rewriter import (
     PatternRewriter,
@@ -336,10 +337,7 @@ class AdditionOfSameVariablesToMultiplyByTwo(RewritePattern):
 
 
 def _has_contract_flag(op: riscv.RdRsRsFloatOperationWithFastMath) -> bool:
-    return (
-        op.fastmath is not None
-        and llvm.FastMathFlag.ALLOW_CONTRACT in op.fastmath.flags
-    )
+    return op.fastmath is not None and FastMathFlag.ALLOW_CONTRACT in op.fastmath.flags
 
 
 class FuseMultiplyAddD(RewritePattern):


### PR DESCRIPTION
Removes the dependency of arith and riscv dialects on llvm, as well as some passes that operate on arith and riscv but not llvm.