### PR TITLE
dialects: (llvm) avoid double whitespace after `exact`

### DIFF
--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -509,7 +509,7 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
 
     def print_exact(self, printer: Printer) -> None:
         if self.is_exact:
-            printer.print(" exact ")
+            printer.print(" exact")
 
     @classmethod
     def parse(cls, parser: Parser):


### PR DESCRIPTION
The pretty printer of the `exact` keyword accidentally printed two whitespaces in a row, which led to non-canical code being emitted. This change ensures we only print a single whitespace after the `exact` keyword.