### PR TITLE
misc: raise error if variadic results types aren't referenced in assembly format

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import textwrap
 from collections.abc import Callable
 from io import StringIO
@@ -8,7 +9,14 @@ from typing import ClassVar, Generic, TypeVar
 import pytest
 
 from xdsl.context import MLContext
-from xdsl.dialects.builtin import I32, BoolAttr, IntegerAttr, ModuleOp, UnitAttr
+from xdsl.dialects.builtin import (
+    I32,
+    BoolAttr,
+    IndexTypeConstr,
+    IntegerAttr,
+    ModuleOp,
+    UnitAttr,
+)
 from xdsl.dialects.test import Test, TestType
 from xdsl.ir import (
     Attribute,
@@ -2175,3 +2183,19 @@ def test_renamed_optional_prop(program: str, output: str, generic: str):
     printer.print_op(parsed)
 
     assert generic == stream.getvalue()
+
+
+def test_variadic_result_is_referenced():
+    with pytest.raises(
+        PyRDLOpDefinitionError,
+        match=re.escape(
+            "type and length of result 'variadic' cannot be inferred, consider adding a 'type($variadic)' directive to the custom assembly format"
+        ),
+    ):
+
+        @irdl_op_definition
+        class VariadicResult(IRDLOperation):  # pyright: ignore[reportUnusedClass]
+            name = "test.comma_safeguard"
+
+            variadic = var_result_def(IndexTypeConstr)
+            assembly_format = "attr-dict"

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import textwrap
 from collections.abc import Callable
 from io import StringIO
@@ -9,10 +8,10 @@ from typing import ClassVar, Generic, TypeVar
 import pytest
 
 from xdsl.context import MLContext
+from xdsl.dialects import test
 from xdsl.dialects.builtin import (
     I32,
     BoolAttr,
-    IndexTypeConstr,
     IntegerAttr,
     ModuleOp,
     UnitAttr,
@@ -37,6 +36,8 @@ from xdsl.irdl import (
     ParamAttrConstraint,
     ParameterDef,
     ParsePropInAttrDict,
+    RangeOf,
+    RangeVarConstraint,
     VarConstraint,
     VarOperand,
     VarOpResult,
@@ -1753,6 +1754,35 @@ def test_non_verifying_inference():
         check_roundtrip(program, ctx)
 
 
+def test_variadic_length_inference():
+    @irdl_op_definition
+    class RangeVarOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
+        name = "test.range_var"
+        T: ClassVar = RangeVarConstraint("T", RangeOf(AnyAttr()))
+        ins = var_operand_def(T)
+        outs = var_result_def(T)
+
+        assembly_format = "$ins attr-dict `:` type($ins)"
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Inference of length of variadic result 'outs' not implemented",
+    ):
+        ctx = MLContext()
+        ctx.load_op(RangeVarOp)
+        ctx.load_dialect(Test)
+        program = textwrap.dedent("""\
+        %in0, %in1 = "test.op"() : () -> (index, index)
+        %out0, %out1 = test.range_var %in0, %in1 : index, index
+        """)
+
+        parser = Parser(ctx, program)
+        test_op = parser.parse_optional_operation()
+        assert isinstance(test_op, test.Operation)
+        my_op = parser.parse_optional_operation()
+        assert isinstance(my_op, RangeVarOp)
+
+
 ################################################################################
 # Declarative Format Verification                                              #
 ################################################################################
@@ -2183,19 +2213,3 @@ def test_renamed_optional_prop(program: str, output: str, generic: str):
     printer.print_op(parsed)
 
     assert generic == stream.getvalue()
-
-
-def test_variadic_result_is_referenced():
-    with pytest.raises(
-        PyRDLOpDefinitionError,
-        match=re.escape(
-            "type and length of result 'variadic' cannot be inferred, consider adding a 'type($variadic)' directive to the custom assembly format"
-        ),
-    ):
-
-        @irdl_op_definition
-        class VariadicResult(IRDLOperation):  # pyright: ignore[reportUnusedClass]
-            name = "test.comma_safeguard"
-
-            variadic = var_result_def(IndexTypeConstr)
-            assembly_format = "attr-dict"

--- a/xdsl/dialects/experimental/air.py
+++ b/xdsl/dialects/experimental/air.py
@@ -154,7 +154,7 @@ class ChannelPutOp(IRDLOperation):
     src_sizes = var_operand_def(IndexType())
     src_strides = var_operand_def(IndexType())
 
-    async_token = opt_result_def(AsyncTokenAttr())
+    async_token = result_def(AsyncTokenAttr())
 
     irdl_options = [AttrSizedOperandSegments()]
 
@@ -242,7 +242,7 @@ class DmaMemcpyNdOp(IRDLOperation):
     src_sizes = var_operand_def(IndexType())
     src_strides = var_operand_def(IndexType())
 
-    async_token = opt_result_def(AsyncTokenAttr())
+    async_token = result_def(AsyncTokenAttr())
 
     irdl_options = [AttrSizedOperandSegments(as_property=True), ParsePropInAttrDict()]
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -234,7 +234,7 @@ class FormatProgram:
         Use the inferred type resolutions to fill missing result types from other parsed
         types.
         """
-        for i, (result_type, (_, result_def)) in enumerate(
+        for i, (result_type, (result_name, result_def)) in enumerate(
             zip(state.result_types, op_def.results, strict=True)
         ):
             if result_type is None:
@@ -244,7 +244,11 @@ class FormatProgram:
                 # of the results if multiple are variadic.
                 # In order to support variadic results, the types an length of all
                 # variadic results must be present in the custom syntax.
-                assert not isinstance(result_def, OptionalDef | VariadicDef)
+                if isinstance(result_def, OptionalDef | VariadicDef):
+                    raise NotImplementedError(
+                        f"Inference of length of variadic result '{result_name}' not "
+                        "implemented"
+                    )
                 range_length = 1
                 inferred_result_types = result_def.constr.infer(
                     range_length, state.constraint_context

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -291,11 +291,13 @@ class FormatParser(BaseParser):
             self.seen_result_types, self.op_def.results, strict=True
         ):
             if not result_type:
-                if not result_def.constr.can_infer(seen_variables):
+                can_infer_type = result_def.constr.can_infer(seen_variables)
+                can_infer_length = not isinstance(result_def, VariadicDef | OptionalDef)
+                if not (can_infer_type and can_infer_length):
                     self.raise_error(
-                        f"type of result '{result_name}' cannot be inferred, "
-                        f"consider adding a 'type(${result_name})' directive to the "
-                        "custom assembly format"
+                        f"type and length of result '{result_name}' cannot be "
+                        f"inferred, consider adding a 'type(${result_name})' directive "
+                        "to the custom assembly format"
                     )
 
     def verify_attr_dict(self):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -291,13 +291,11 @@ class FormatParser(BaseParser):
             self.seen_result_types, self.op_def.results, strict=True
         ):
             if not result_type:
-                can_infer_type = result_def.constr.can_infer(seen_variables)
-                can_infer_length = not isinstance(result_def, VariadicDef | OptionalDef)
-                if not (can_infer_type and can_infer_length):
+                if not result_def.constr.can_infer(seen_variables):
                     self.raise_error(
-                        f"type and length of result '{result_name}' cannot be "
-                        f"inferred, consider adding a 'type(${result_name})' directive "
-                        "to the custom assembly format"
+                        f"type of result '{result_name}' cannot be inferred, "
+                        f"consider adding a 'type(${result_name})' directive to the "
+                        "custom assembly format"
                     )
 
     def verify_attr_dict(self):


### PR DESCRIPTION
The number of results is not passed in when parsing operations. In the generic format, the type of the operation always specifies the types of the results, and `resultSegmentSizes` specifies the ranges of of the results if multiple are variadic. In order to support variadic results, the types an length of all variadic results must be present in the custom syntax.