### PR TITLE
transformations: (scf) loop range folding

### DIFF
--- a/tests/filecheck/transforms/scf_for_loop_range_folding.mlir
+++ b/tests/filecheck/transforms/scf_for_loop_range_folding.mlir
@@ -1,24 +1,24 @@
 // RUN: xdsl-opt -p scf-for-loop-range-folding --split-input-file %s | filecheck %s
 
-// CHECK:       %new_lb = arith.addi %lb, %shift : index
-// CHECK-NEXT:  %new_ub = arith.addi %ub, %shift : index
-// CHECK-NEXT:  %new_lb_1 = arith.muli %new_lb, %mul_shift : index
-// CHECK-NEXT:  %new_ub_1 = arith.muli %new_ub, %mul_shift : index
-// CHECK-NEXT:  %new_step = arith.muli %step, %mul_shift : index
-// CHECK-NEXT:  scf.for %i = %new_lb_1 to %new_ub_1 step %new_step {
+// CHECK:       %shift_idx_lb = arith.addi %lb, %shift : index
+// CHECK-NEXT:  %shift_idx_ub = arith.addi %ub, %shift : index
+// CHECK-NEXT:  %mult_idx_lb = arith.muli %shift_idx_lb, %mul_shift : index
+// CHECK-NEXT:  %mult_idx_ub = arith.muli %shift_idx_ub, %mul_shift : index
+// CHECK-NEXT:  %mult_idx_step = arith.muli %step, %mul_shift : index
+// CHECK-NEXT:  scf.for %i = %mult_idx_lb to %mult_idx_ub step %mult_idx_step {
 // CHECK-NEXT:    "test.op"(%i) : (index) -> ()
 // CHECK-NEXT:  }
 
 %shift, %mul_shift, %lb, %ub, %step = "test.op"() : () -> (index, index, index, index, index)
 scf.for %i = %lb to %ub step %step {
-    %0 = arith.addi %shift, %i : index
-    %1 = arith.muli %0, %mul_shift : index
-    "test.op"(%1) : (index) -> ()
+    %shift_idx = arith.addi %shift, %i : index
+    %mult_idx = arith.muli %shift_idx, %mul_shift : index
+    "test.op"(%mult_idx) : (index) -> ()
 }
 
-// CHECK:       %new_lb_2 = arith.addi %lb, %shift : index
-// CHECK-NEXT:  %new_ub_2 = arith.addi %ub, %shift : index
-// CHECK-NEXT:  scf.for %i_1 = %new_lb_2 to %new_ub_2 step %step {
+// CHECK:       %shift_idx_lb_1 = arith.addi %lb, %shift : index
+// CHECK-NEXT:  %shift_idx_ub_1 = arith.addi %ub, %shift : index
+// CHECK-NEXT:  scf.for %i_1 = %shift_idx_lb_1 to %shift_idx_ub_1 step %step {
 // CHECK-NEXT:    %new_shift = arith.addi %mul_shift, %mul_shift : index
 // CHECK-NEXT:    %0 = arith.muli %i_1, %new_shift : index
 // CHECK-NEXT:    "test.op"(%0) : (index) -> ()
@@ -26,22 +26,22 @@ scf.for %i = %lb to %ub step %step {
 
 // In this example muli can't be taken out of the loop. We need to loop invariant code motion transform to deal with it.
 scf.for %i = %lb to %ub step %step {
-    %0 = arith.addi %shift, %i : index
+    %shift_idx = arith.addi %shift, %i : index
     %new_shift = arith.addi %mul_shift, %mul_shift : index
-    %2 = arith.muli %0, %new_shift : index
+    %2 = arith.muli %shift_idx, %new_shift : index
     "test.op"(%2) : (index) -> ()
 }
 
-// CHECK:       %new_lb_3 = arith.addi %lb, %shift : index
-// CHECK-NEXT:  %new_ub_3 = arith.addi %ub, %shift : index
-// CHECK-NEXT:  %new_lb_4 = arith.muli %new_lb_3, %mul_shift : index
-// CHECK-NEXT:  %new_ub_4 = arith.muli %new_ub_3, %mul_shift : index
-// CHECK-NEXT:  %new_step_1 = arith.muli %step, %mul_shift : index
-// CHECK-NEXT:  scf.for %j = %new_lb_4 to %new_ub_4 step %new_step_1 {
-// CHECK-NEXT:    %new_ub_5 = arith.addi %ub2, %shift : index
-// CHECK-NEXT:    %new_ub_6 = arith.muli %new_ub_5, %mul_shift : index
-// CHECK-NEXT:    %new_step_2 = arith.muli %step2, %mul_shift : index
-// CHECK-NEXT:    scf.for %i_2 = %j to %new_ub_6 step %new_step_2 {
+// CHECK:       %new_lb_lb = arith.addi %lb, %shift : index
+// CHECK-NEXT:  %new_lb_ub = arith.addi %ub, %shift : index
+// CHECK-NEXT:  %new_lb_lb_1 = arith.muli %new_lb_lb, %mul_shift : index
+// CHECK-NEXT:  %new_lb_ub_1 = arith.muli %new_lb_ub, %mul_shift : index
+// CHECK-NEXT:  %new_lb_step = arith.muli %step, %mul_shift : index
+// CHECK-NEXT:  scf.for %j = %new_lb_lb_1 to %new_lb_ub_1 step %new_lb_step {
+// CHECK-NEXT:    %new_ub = arith.addi %ub2, %shift : index
+// CHECK-NEXT:    %new_ub_1 = arith.muli %new_ub, %mul_shift : index
+// CHECK-NEXT:    %new_step = arith.muli %step2, %mul_shift : index
+// CHECK-NEXT:    scf.for %i_2 = %j to %new_ub_1 step %new_step {
 // CHECK-NEXT:      "test.op"(%i_2) : (index) -> ()
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/scf_for_loop_range_folding.mlir
+++ b/tests/filecheck/transforms/scf_for_loop_range_folding.mlir
@@ -1,0 +1,95 @@
+// RUN: xdsl-opt -p scf-for-loop-range-folding --split-input-file %s | filecheck %s
+
+func.func @fold_one_loop(%arg0: memref<?xi32>, %arg1: index, %arg2: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  scf.for %i = %c0 to %arg1 step %c1 {
+    %0 = arith.addi %arg2, %i : index
+    %1 = arith.muli %0, %c4 : index
+    %2 = memref.load %arg0[%1] : memref<?xi32>
+    %3 = arith.muli %2, %2 : i32
+    memref.store %3, %arg0[%1] : memref<?xi32>
+  }
+  return
+}
+
+// CHECK:       %c0 = arith.constant 0 : index
+// CHECK-NEXT:  %c1 = arith.constant 1 : index
+// CHECK-NEXT:  %c4 = arith.constant 4 : index
+// CHECK-NEXT:  %0 = arith.addi %c0, %arg2 : index
+// CHECK-NEXT:  %1 = arith.addi %arg1, %arg2 : index
+// CHECK-NEXT:  %2 = arith.muli %0, %c4 : index
+// CHECK-NEXT:  %3 = arith.muli %1, %c4 : index
+// CHECK-NEXT:  %4 = arith.muli %c1, %c4 : index
+// CHECK-NEXT:  scf.for %i = %2 to %3 step %4 {
+// CHECK-NEXT:      %5 = memref.load %arg0[%i] : memref<?xi32>
+// CHECK-NEXT:      %6 = arith.muli %5, %5 : i32
+// CHECK-NEXT:      memref.store %6, %arg0[%i] : memref<?xi32>
+// CHECK-NEXT:  }
+
+// In this example muli can't be taken out of the loop
+func.func @fold_only_first_add(%arg0: memref<?xi32>, %arg1: index, %arg2: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  scf.for %i = %c0 to %arg1 step %c1 {
+    %0 = arith.addi %arg2, %i : index
+    %1 = arith.addi %arg2, %c4 : index
+    %2 = arith.muli %0, %1 : index
+    %3 = memref.load %arg0[%2] : memref<?xi32>
+    %4 = arith.muli %3, %3 : i32
+    memref.store %4, %arg0[%2] : memref<?xi32>
+  }
+  return
+}
+
+// CHECK:         %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    %0 = arith.addi %c0, %arg2 : index
+// CHECK-NEXT:    %1 = arith.addi %arg1, %arg2 : index
+// CHECK-NEXT:    scf.for %i = %0 to %1 step %c1 {
+// CHECK-NEXT:      %2 = arith.addi %arg2, %c4 : index
+// CHECK-NEXT:      %3 = arith.muli %i, %2 : index
+// CHECK-NEXT:      %4 = memref.load %arg0[%3] : memref<?xi32>
+// CHECK-NEXT:      %5 = arith.muli %4, %4 : i32
+// CHECK-NEXT:      memref.store %5, %arg0[%3] : memref<?xi32>
+// CHECK-NEXT:    }
+
+func.func @fold_two_loops(%arg0: memref<?xi32>, %arg1: index, %arg2: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c10 = arith.constant 10 : index
+  scf.for %j = %c0 to %c10 step %c1 {
+    scf.for %i = %j to %arg1 step %c1 {
+      %0 = arith.addi %arg2, %i : index
+      %1 = arith.muli %0, %c4 : index
+      %2 = memref.load %arg0[%1] : memref<?xi32>
+      %3 = arith.muli %2, %2 : i32
+      memref.store %3, %arg0[%1] : memref<?xi32>
+    }
+  }
+  return
+}
+
+// CHECK:         %c0 = arith.constant 0 : index
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    %c4 = arith.constant 4 : index
+// CHECK-NEXT:    %c10 = arith.constant 10 : index
+// CHECK-NEXT:    %0 = arith.addi %c0, %arg2 : index
+// CHECK-NEXT:    %1 = arith.addi %c10, %arg2 : index
+// CHECK-NEXT:    %2 = arith.muli %0, %c4 : index
+// CHECK-NEXT:    %3 = arith.muli %1, %c4 : index
+// CHECK-NEXT:    %4 = arith.muli %c1, %c4 : index
+// CHECK-NEXT:    scf.for %j = %2 to %3 step %4 {
+// CHECK-NEXT:      %5 = arith.addi %arg1, %arg2 : index
+// CHECK-NEXT:      %6 = arith.muli %5, %c4 : index
+// CHECK-NEXT:      %7 = arith.muli %c1, %c4 : index
+// CHECK-NEXT:      scf.for %i = %j to %6 step %7 {
+// CHECK-NEXT:        %8 = memref.load %arg0[%i] : memref<?xi32>
+// CHECK-NEXT:        %9 = arith.muli %8, %8 : i32
+// CHECK-NEXT:        memref.store %9, %arg0[%i] : memref<?xi32>
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }

--- a/tests/filecheck/transforms/scf_for_loop_range_folding.mlir
+++ b/tests/filecheck/transforms/scf_for_loop_range_folding.mlir
@@ -1,11 +1,11 @@
 // RUN: xdsl-opt -p scf-for-loop-range-folding --split-input-file %s | filecheck %s
 
-// CHECK:       %shift_idx_lb = arith.addi %lb, %shift : index
-// CHECK-NEXT:  %shift_idx_ub = arith.addi %ub, %shift : index
-// CHECK-NEXT:  %mult_idx_lb = arith.muli %shift_idx_lb, %mul_shift : index
-// CHECK-NEXT:  %mult_idx_ub = arith.muli %shift_idx_ub, %mul_shift : index
-// CHECK-NEXT:  %mult_idx_step = arith.muli %step, %mul_shift : index
-// CHECK-NEXT:  scf.for %i = %mult_idx_lb to %mult_idx_ub step %mult_idx_step {
+// CHECK:       %0 = arith.addi %lb, %shift : index
+// CHECK-NEXT:  %1 = arith.addi %ub, %shift : index
+// CHECK-NEXT:  %2 = arith.muli %0, %mul_shift : index
+// CHECK-NEXT:  %3 = arith.muli %1, %mul_shift : index
+// CHECK-NEXT:  %4 = arith.muli %step, %mul_shift : index
+// CHECK-NEXT:  scf.for %i = %2 to %3 step %4 {
 // CHECK-NEXT:    "test.op"(%i) : (index) -> ()
 // CHECK-NEXT:  }
 
@@ -16,32 +16,32 @@ scf.for %i = %lb to %ub step %step {
     "test.op"(%mult_idx) : (index) -> ()
 }
 
-// CHECK:       %shift_idx_lb_1 = arith.addi %lb, %shift : index
-// CHECK-NEXT:  %shift_idx_ub_1 = arith.addi %ub, %shift : index
-// CHECK-NEXT:  scf.for %i_1 = %shift_idx_lb_1 to %shift_idx_ub_1 step %step {
-// CHECK-NEXT:    %new_shift = arith.addi %mul_shift, %mul_shift : index
-// CHECK-NEXT:    %0 = arith.muli %i_1, %new_shift : index
-// CHECK-NEXT:    "test.op"(%0) : (index) -> ()
-// CHECK-NEXT:  }
+// CHECK:      %5 = arith.addi %lb, %shift : index
+// CHECK-NEXT  %6 = arith.addi %ub, %shift : index
+// CHECK-NEXT  scf.for %i_1 = %5 to %6 step %step {
+// CHECK-NEXT    %new_shift = arith.addi %mul_shift, %mul_shift : index
+// CHECK-NEXT    %mult_idx = arith.muli %i_1, %new_shift : index
+// CHECK-NEXT    "test.op"(%mult_idx) : (index) -> ()
+// CHECK-NEXT  }
 
 // In this example muli can't be taken out of the loop. We need to loop invariant code motion transform to deal with it.
 scf.for %i = %lb to %ub step %step {
     %shift_idx = arith.addi %shift, %i : index
     %new_shift = arith.addi %mul_shift, %mul_shift : index
-    %2 = arith.muli %shift_idx, %new_shift : index
-    "test.op"(%2) : (index) -> ()
+    %mult_idx = arith.muli %shift_idx, %new_shift : index
+    "test.op"(%mult_idx) : (index) -> ()
 }
 
-// CHECK:       %new_lb_lb = arith.addi %lb, %shift : index
-// CHECK-NEXT:  %new_lb_ub = arith.addi %ub, %shift : index
-// CHECK-NEXT:  %new_lb_lb_1 = arith.muli %new_lb_lb, %mul_shift : index
-// CHECK-NEXT:  %new_lb_ub_1 = arith.muli %new_lb_ub, %mul_shift : index
-// CHECK-NEXT:  %new_lb_step = arith.muli %step, %mul_shift : index
-// CHECK-NEXT:  scf.for %j = %new_lb_lb_1 to %new_lb_ub_1 step %new_lb_step {
-// CHECK-NEXT:    %new_ub = arith.addi %ub2, %shift : index
-// CHECK-NEXT:    %new_ub_1 = arith.muli %new_ub, %mul_shift : index
-// CHECK-NEXT:    %new_step = arith.muli %step2, %mul_shift : index
-// CHECK-NEXT:    scf.for %i_2 = %j to %new_ub_1 step %new_step {
+// CHECK:       %7 = arith.addi %lb, %shift : index
+// CHECK-NEXT:  %8 = arith.addi %ub, %shift : index
+// CHECK-NEXT:  %9 = arith.muli %7, %mul_shift : index
+// CHECK-NEXT:  %10 = arith.muli %8, %mul_shift : index
+// CHECK-NEXT:  %11 = arith.muli %step, %mul_shift : index
+// CHECK-NEXT:  scf.for %j = %9 to %10 step %11 {
+// CHECK-NEXT:    %12 = arith.addi %ub2, %shift : index
+// CHECK-NEXT:    %13 = arith.muli %12, %mul_shift : index
+// CHECK-NEXT:    %14 = arith.muli %step2, %mul_shift : index
+// CHECK-NEXT:    scf.for %i_2 = %j to %13 step %14 {
 // CHECK-NEXT:      "test.op"(%i_2) : (index) -> ()
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -49,8 +49,8 @@ scf.for %i = %lb to %ub step %step {
 %ub2, %step2 = "test.op"() : () -> (index, index)
 scf.for %j = %lb to %ub step %step {
     scf.for %i = %j to %ub2 step %step2 {
-        %0 = arith.addi %shift, %i : index
-        %1 = arith.muli %0, %mul_shift : index
-        "test.op"(%1) : (index) -> ()
+        %shift_idx = arith.addi %shift, %i : index
+        %mult_idx = arith.muli %shift_idx, %mul_shift : index
+        "test.op"(%mult_idx) : (index) -> ()
     }
 }

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -271,6 +271,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return scf_for_loop_flatten.ScfForLoopFlattenPass
 
+    def get_scf_for_loop_range_folding():
+        from xdsl.transforms import scf_for_loop_range_folding
+
+        return scf_for_loop_range_folding.ScfForLoopRangeFoldingPass
+
     def get_riscv_scf_loop_range_folding():
         from xdsl.transforms import riscv_scf_loop_range_folding
 
@@ -539,6 +544,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "replace-incompatible-fpga": get_replace_incompatible_fpga,
         "riscv-allocate-registers": get_riscv_register_allocation,
         "scf-for-loop-flatten": get_scf_for_loop_flatten,
+        "scf-for-loop-range-folding": get_scf_for_loop_range_folding,
         "riscv-scf-loop-range-folding": get_riscv_scf_loop_range_folding,
         "scf-parallel-loop-tiling": get_scf_parallel_loop_tiling,
         "snitch-allocate-registers": get_snitch_register_allocation,

--- a/xdsl/transforms/scf_for_loop_range_folding.py
+++ b/xdsl/transforms/scf_for_loop_range_folding.py
@@ -62,8 +62,11 @@ class ScfForLoopRangeFolding(RewritePattern):
                             new_step := arith.Muli(op.step, folding_const),
                         ]
                     )
+                    new_step.result.name_hint = "new_step"
                     op.operands[2] = new_step.result
 
+            new_lb.result.name_hint = "new_lb"
+            new_ub.result.name_hint = "new_ub"
             op.operands[0] = new_lb.result
             op.operands[1] = new_ub.result
 

--- a/xdsl/transforms/scf_for_loop_range_folding.py
+++ b/xdsl/transforms/scf_for_loop_range_folding.py
@@ -46,6 +46,9 @@ class ScfForLoopRangeFolding(RewritePattern):
                     return
                 folding_const = user.operands[0]
 
+            new_name_hint = (
+                user.result.name_hint if user.result.name_hint is not None else "new"
+            )
             match user:
                 case arith.Addi():
                     rewriter.insert_op_before_matched_op(
@@ -62,11 +65,11 @@ class ScfForLoopRangeFolding(RewritePattern):
                             new_step := arith.Muli(op.step, folding_const),
                         ]
                     )
-                    new_step.result.name_hint = "new_step"
                     op.operands[2] = new_step.result
+                    new_step.result.name_hint = new_name_hint + "_step"
 
-            new_lb.result.name_hint = "new_lb"
-            new_ub.result.name_hint = "new_ub"
+            new_lb.result.name_hint = new_name_hint + "_lb"
+            new_ub.result.name_hint = new_name_hint + "_ub"
             op.operands[0] = new_lb.result
             op.operands[1] = new_ub.result
 

--- a/xdsl/transforms/scf_for_loop_range_folding.py
+++ b/xdsl/transforms/scf_for_loop_range_folding.py
@@ -46,9 +46,6 @@ class ScfForLoopRangeFolding(RewritePattern):
                     return
                 folding_const = user.operands[0]
 
-            new_name_hint = (
-                user.result.name_hint if user.result.name_hint is not None else "new"
-            )
             match user:
                 case arith.Addi():
                     rewriter.insert_op_before_matched_op(
@@ -66,10 +63,7 @@ class ScfForLoopRangeFolding(RewritePattern):
                         ]
                     )
                     op.operands[2] = new_step.result
-                    new_step.result.name_hint = new_name_hint + "_step"
 
-            new_lb.result.name_hint = new_name_hint + "_lb"
-            new_ub.result.name_hint = new_name_hint + "_ub"
             op.operands[0] = new_lb.result
             op.operands[1] = new_ub.result
 

--- a/xdsl/transforms/scf_for_loop_range_folding.py
+++ b/xdsl/transforms/scf_for_loop_range_folding.py
@@ -1,0 +1,84 @@
+from xdsl.context import MLContext
+from xdsl.dialects import arith, builtin, scf
+from xdsl.ir import BlockArgument, OpResult, SSAValue
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+def is_foldable(val: SSAValue, for_op: scf.For):
+    if isinstance(val, BlockArgument):
+        return True
+
+    if not isinstance(val, OpResult):
+        return False
+
+    return not for_op.is_ancestor(val.op)
+
+
+class ScfForLoopRangeFolding(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: scf.For, rewriter: PatternRewriter) -> None:
+        index = op.body.block.args[0]
+
+        # Fold until a fixed point is reached
+        while True:
+            if len(index.uses) != 1:
+                # If the induction variable is used more than once, we can't fold its
+                # arith ops into the loop range
+                return
+
+            user = next(iter(index.uses)).operation
+
+            if not isinstance(user, arith.Addi | arith.Muli):
+                return
+
+            if user.operands[0] is index:
+                if not is_foldable(user.operands[1], op):
+                    return
+                folding_const = user.operands[1]
+            else:
+                if not is_foldable(user.operands[0], op):
+                    return
+                folding_const = user.operands[0]
+
+            match user:
+                case arith.Addi():
+                    rewriter.insert_op_before_matched_op(
+                        [
+                            new_lb := arith.Addi(op.lb, folding_const),
+                            new_ub := arith.Addi(op.ub, folding_const),
+                        ]
+                    )
+                case arith.Muli():
+                    rewriter.insert_op_before_matched_op(
+                        [
+                            new_lb := arith.Muli(op.lb, folding_const),
+                            new_ub := arith.Muli(op.ub, folding_const),
+                            new_step := arith.Muli(op.step, folding_const),
+                        ]
+                    )
+                    op.operands[2] = new_step.result
+
+            op.operands[0] = new_lb.result
+            op.operands[1] = new_ub.result
+
+            rewriter.replace_op(user, [], [index])
+
+
+class ScfForLoopRangeFoldingPass(ModulePass):
+    """
+    xdsl implementation of the pass with the same name
+    """
+
+    name = "scf-for-loop-range-folding"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            ScfForLoopRangeFolding(),
+            apply_recursively=True,
+        ).rewrite_module(op)


### PR DESCRIPTION
Porting mlir pass of the same name. The logic is almost the same. We need this to keep snitch compilation fully inside xdsl.