### PR TITLE
transformations: (stencil-tensorize-z-dimension) Minor pipeline fixes

### DIFF
--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -114,11 +114,10 @@ class ConvertAccessOpFromPrefetchPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: stencil.AccessOp, rewriter: PatternRewriter, /):
         assert len(op.offset) == 2
-        if op.temp != op.get_apply().region.block.args[self.arg_index]:
-            return
-
-        # translate access to own data, which operates on stencil.TempType
-        if tuple(op.offset) == (0, 0):
+        # translate access to own data or non-prefetch data, which operates on stencil.TempType
+        if op.temp != op.get_apply().region.block.args[self.arg_index] or tuple(
+            op.offset
+        ) == (0, 0):
             assert isattr(op.res.type, base(AnyTensorType))
             rewriter.replace_matched_op(
                 csl_stencil.AccessOp(


### PR DESCRIPTION
Applies various minor fixes evolving around tensorization:

* Relaxes the constraint on the `stencil.LoadOp` in the same way it was previously done on `stencil.StoreOp`.
* Simplifies rebuilding apply op, using operand types as block arg types (bug fix)
* Convert all `stencil.access` to `csl_stencil.access` without bailing out (bug fix)