### PR TITLE
dialects: (accfg) Update ACCFG dialect to match version in snax-mlir

### DIFF
--- a/tests/filecheck/dialects/accfg/accfg_ops.mlir
+++ b/tests/filecheck/dialects/accfg/accfg_ops.mlir
@@ -4,20 +4,23 @@
 "accfg.accelerator"() <{
     name               = @acc1,
     fields             = {A=0x3c0, B=0x3c1},
-    launch_addr        = 0x3cf,
+    launch_fields      = {launch=0x3cf},
     barrier            = 0x7c3
 }> : () -> ()
 
 func.func @test() {
     %one, %two = "test.op"() : () -> (i32, i32)
-
+    %zero = arith.constant 0 : i32
     %state = "accfg.setup"(%one, %two) <{
         param_names = ["A", "B"],
         accelerator = "acc1",
         operandSegmentSizes = array<i32: 2, 0>
-    }> : (i32, i32) -> !accfg.state<"acc1">
+    }> {"test_attr" = 100 : i64} : (i32, i32) -> !accfg.state<"acc1">
 
-    %token = "accfg.launch"(%state) <{accelerator = "acc1"}>: (!accfg.state<"acc1">) -> !accfg.token<"acc1">
+    %token = "accfg.launch"(%zero, %state) <{
+        param_names = ["launch"],
+        accelerator = "acc1"
+    }>: (i32, !accfg.state<"acc1">) -> !accfg.token<"acc1">
 
     %state2 = "accfg.setup"(%one, %two, %state) <{
         param_names = ["A", "B"],
@@ -27,31 +30,41 @@ func.func @test() {
 
     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
 
+    "test.op"() {"accfg.effects" = #accfg.effects<none>} : () -> ()
+
+    "test.op"() {"accfg.effects" = #accfg.effects<full>} : () -> ()
+
     func.return
 }
 
 
 // CHECK-NEXT: builtin.module {
-// CHECK-NEXT:   "accfg.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier" = 1987 : i64}> : () -> ()
+// CHECK-NEXT:   "accfg.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_fields" = {"launch" = 975 : i64}, "barrier" = 1987 : i64}> : () -> ()
 // CHECK-NEXT:   func.func @test() {
 // CHECK-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
-// CHECK-NEXT:     %state = "accfg.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !accfg.state<"acc1">
-// CHECK-NEXT:     %token = "accfg.launch"(%state) <{"accelerator" = "acc1"}> : (!accfg.state<"acc1">) -> !accfg.token<"acc1">
-// CHECK-NEXT:     %state2 = "accfg.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !accfg.state<"acc1">) -> !accfg.state<"acc1">
+// CHECK-NEXT:     %zero = arith.constant 0 : i32
+// CHECK-NEXT:     %state = accfg.setup "acc1" to ("A" = %one : i32, "B" = %two : i32) attrs {"test_attr" = 100 : i64} : !accfg.state<"acc1">
+// CHECK-NEXT:     %token = "accfg.launch"(%zero, %state) <{"param_names" = ["launch"], "accelerator" = "acc1"}> : (i32, !accfg.state<"acc1">) -> !accfg.token<"acc1">
+// CHECK-NEXT:     %state2 = accfg.setup "acc1" from %state to ("A" = %one : i32, "B" = %two : i32) : !accfg.state<"acc1">
 // CHECK-NEXT:     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
+// CHECK-NEXT:    "test.op"() {"accfg.effects" = #accfg.effects<none>} : () -> ()
+// CHECK-NEXT:    "test.op"() {"accfg.effects" = #accfg.effects<full>} : () -> ()
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
 
 // CHECK-GENERIC-NEXT: "builtin.module"() ({
-// CHECK-GENERIC-NEXT:   "accfg.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_addr" = 975 : i64, "barrier" = 1987 : i64}> : () -> ()
+// CHECK-GENERIC-NEXT:   "accfg.accelerator"() <{"name" = @acc1, "fields" = {"A" = 960 : i64, "B" = 961 : i64}, "launch_fields" = {"launch" = 975 : i64}, "barrier" = 1987 : i64}> : () -> ()
 // CHECK-GENERIC-NEXT:   "func.func"() <{"sym_name" = "test", "function_type" = () -> ()}> ({
 // CHECK-GENERIC-NEXT:     %one, %two = "test.op"() : () -> (i32, i32)
-// CHECK-GENERIC-NEXT:     %state = "accfg.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}> : (i32, i32) -> !accfg.state<"acc1">
-// CHECK-GENERIC-NEXT:     %token = "accfg.launch"(%state) <{"accelerator" = "acc1"}> : (!accfg.state<"acc1">) -> !accfg.token<"acc1">
+// CHECK-GENERIC-NEXT:     %zero = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+// CHECK-GENERIC-NEXT:     %state = "accfg.setup"(%one, %two) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 0>}>  {"test_attr" = 100 : i64}  : (i32, i32) -> !accfg.state<"acc1">
+// CHECK-GENERIC-NEXT:     %token = "accfg.launch"(%zero, %state) <{"param_names" = ["launch"], "accelerator" = "acc1"}> : (i32, !accfg.state<"acc1">) -> !accfg.token<"acc1">
 // CHECK-GENERIC-NEXT:     %state2 = "accfg.setup"(%one, %two, %state) <{"param_names" = ["A", "B"], "accelerator" = "acc1", "operandSegmentSizes" = array<i32: 2, 1>}> : (i32, i32, !accfg.state<"acc1">) -> !accfg.state<"acc1">
 // CHECK-GENERIC-NEXT:     "accfg.await"(%token) : (!accfg.token<"acc1">) -> ()
+// CHECK-GENERIC-NEXT:    "test.op"() {"accfg.effects" = #accfg.effects<none>} : () -> ()
+// CHECK-GENERIC-NEXT:    "test.op"() {"accfg.effects" = #accfg.effects<full>} : () -> ()
 // CHECK-GENERIC-NEXT:     "func.return"() : () -> ()
 // CHECK-GENERIC-NEXT:   }) : () -> ()
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from enum import Enum
+from typing import cast
 
 from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
     ArrayAttr,
     DictionaryAttr,
     IntegerAttr,
@@ -376,7 +378,9 @@ class AcceleratorOp(IRDLOperation):
 
     launch_fields = prop_def(DictionaryAttr)
 
-    barrier = prop_def(IntegerAttr[IntegerType])  # TODO: this will be reworked in a later version
+    barrier = prop_def(
+        IntegerAttr[IntegerType]
+    )  # TODO: this will be reworked in a later version
 
     def __init__(
         self,
@@ -418,18 +422,16 @@ class AcceleratorOp(IRDLOperation):
     def field_names(self) -> tuple[str, ...]:
         return tuple(self.fields.data.keys())
 
-    def field_items(self) -> Iterable[tuple[str, IntegerAttr]]:
+    def field_items(self) -> Iterable[tuple[str, AnyIntegerAttr]]:
         for name, val in self.fields.data.items():
-            assert isinstance(val, IntegerAttr)
-            yield name, val
+            yield name, cast(AnyIntegerAttr, val)
 
     def launch_field_names(self) -> tuple[str, ...]:
         return tuple(self.launch_fields.data.keys())
 
-    def launch_field_items(self) -> Iterable[tuple[str, IntegerAttr]]:
+    def launch_field_items(self) -> Iterable[tuple[str, AnyIntegerAttr]]:
         for name, val in self.launch_fields.data.items():
-            assert isinstance(val, IntegerAttr)
-            yield name, val
+            yield name, cast(AnyIntegerAttr, val)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -31,6 +31,7 @@ from xdsl.irdl import (
     opt_operand_def,
     prop_def,
     result_def,
+    traits_def,
     var_operand_def,
 )
 from xdsl.parser import AttrParser, Parser
@@ -366,7 +367,7 @@ class AcceleratorOp(IRDLOperation):
 
     name = "accfg.accelerator"
 
-    traits = frozenset([AcceleratorSymbolOpTrait()])
+    traits = traits_def(AcceleratorSymbolOpTrait())
 
     name_prop = prop_def(SymbolRefAttr, prop_name="name")
 

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
+from enum import Enum
 
 from xdsl.dialects.builtin import (
-    AnyIntegerAttr,
     ArrayAttr,
     DictionaryAttr,
     IntegerAttr,
@@ -13,6 +13,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import (
     Attribute,
+    Data,
     Dialect,
     Operation,
     ParametrizedAttribute,
@@ -30,18 +31,49 @@ from xdsl.irdl import (
     opt_operand_def,
     prop_def,
     result_def,
-    traits_def,
     var_operand_def,
 )
+from xdsl.parser import AttrParser, Parser
+from xdsl.printer import Printer
 from xdsl.traits import SymbolOpInterface
+
+
+class EffectsEnum(Enum):
+    """
+    Specify to explicitly say:
+    * NONE: There are no accfg side-effects to this operation
+    * FULL: There are accfg side-effects to this operation
+    """
+
+    NONE = "none"
+    FULL = "full"
+
+
+class EffectsAttr(Data[EffectsEnum]):
+    """
+    An Attribute specifying if the marked operation has any effects on accelerator states.
+    """
+
+    name = "accfg.effects"
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> EffectsEnum:
+        with parser.in_angle_brackets():
+            for field in EffectsEnum:
+                if parser.parse_optional_keyword(field.value):
+                    return field
+            valid_vals = ", ".join(field.value for field in EffectsEnum)
+            parser.raise_error(f"Unknown keyword, expected one of: {valid_vals}")
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print(self.data.value)
 
 
 @irdl_attr_definition
 class TokenType(ParametrizedAttribute, TypeAttribute):
     """
-    Async token type for managing synchronization between asynchronously
-    launched accelerators. You can use them to create def-use chains
-    between accfg.launch and accfg.await ops.
+    Async token type for launched accelerator requests.
     """
 
     name = "accfg.token"
@@ -51,15 +83,13 @@ class TokenType(ParametrizedAttribute, TypeAttribute):
     def __init__(self, accelerator: str | StringAttr):
         if not isinstance(accelerator, StringAttr):
             accelerator = StringAttr(accelerator)
-        return super().__init__([accelerator])
+        super().__init__([accelerator])
 
 
 @irdl_attr_definition
 class StateType(ParametrizedAttribute, TypeAttribute):
     """
-    State type to manage accelerator configuration state.
-    States are chained through the def-use chain to allow
-    deduplication of setup calls.
+    Used to trace an accelerators CSR state through def-use chain
     """
 
     name = "accfg.state"
@@ -72,116 +102,57 @@ class StateType(ParametrizedAttribute, TypeAttribute):
         return super().__init__([accelerator])
 
 
-class AcceleratorSymbolOpTrait(SymbolOpInterface):
-    """
-    Symbol op trait to define multiple accelerator names.
-    """
-
-    def get_sym_attr_name(self, op: Operation) -> StringAttr | None:
-        assert isinstance(op, AcceleratorOp)
-        return StringAttr(op.name_prop.string_value())
-
-
-@irdl_op_definition
-class AcceleratorOp(IRDLOperation):
-    """
-    Declares an accelerator that can be configured, launched, etc.
-    `fields` is a dictionary mapping accelerator configuration names to
-    registers addresses.
-    """
-
-    name = "accfg.accelerator"
-
-    traits = traits_def(AcceleratorSymbolOpTrait())
-
-    name_prop = prop_def(SymbolRefAttr, prop_name="name")
-
-    fields = prop_def(DictionaryAttr)
-
-    launch_addr = prop_def(AnyIntegerAttr)
-
-    # TODO: the barrier field will likely be changed in the future
-
-    # The exact translation of accfg.await is not final,
-    # and as such the information required for this on the accfg.accelerator
-    # op will probably change again in the future.
-    # We're looking into ways of generalizing this aspect currently,
-    # but this is a thing that actually works for snitch now.
-
-    barrier = prop_def(AnyIntegerAttr)
-
-    def __init__(
-        self,
-        name: str | StringAttr | SymbolRefAttr,
-        fields: dict[str, int] | DictionaryAttr,
-        launch: int | AnyIntegerAttr,
-        barrier: int | AnyIntegerAttr,
-    ):
-        if not isinstance(fields, DictionaryAttr):
-            fields = DictionaryAttr(
-                {name: IntegerAttr(val, i32) for name, val in fields.items()}
-            )
-
-        super().__init__(
-            properties={
-                "name": (
-                    SymbolRefAttr(name) if not isinstance(name, SymbolRefAttr) else name
-                ),
-                "fields": fields,
-                "launch_addr": (
-                    IntegerAttr(launch, i32)
-                    if not isinstance(launch, IntegerAttr)
-                    else launch
-                ),
-                "barrier": (
-                    IntegerAttr(barrier, i32)
-                    if not isinstance(barrier, IntegerAttr)
-                    else barrier
-                ),
-            }
-        )
-
-    def verify_(self) -> None:
-        for _, val in self.fields.data.items():
-            if not isinstance(val, IntegerAttr):
-                raise VerifyException("fields must only contain IntegerAttr!")
-
-    def field_names(self) -> tuple[str, ...]:
-        return tuple(self.fields.data.keys())
-
-    def field_items(self) -> Iterable[tuple[str, AnyIntegerAttr]]:
-        for name, val in self.fields.data.items():
-            assert isinstance(val, IntegerAttr)
-            yield name, val
-
-
 @irdl_op_definition
 class LaunchOp(IRDLOperation):
     """
-    Launch an accelerator.
-    We assume that all values in configuration registers are consumed
-    by the accelerator at this point. This means that
-    the configuration registers to the accelerator can be reconfigured
-    safely after a launch op without interfering with the Accelerator.
+    Launch an accelerator. This acts as a barrier for CSR values,
+    meaning CSRs can be safely modified after a launch op without
+    interfering with the Accelerator.
     """
 
     name = "accfg.launch"
 
+    values = var_operand_def(Attribute)  # TODO: make more precise?
+    """
+    The actual values used to set up registers linked to launch
+    """
+
     state = operand_def(StateType)
+
+    param_names = prop_def(ArrayAttr[StringAttr])
+    """
+    Maps the SSA values in `values` to accelerator launch parameters
+    """
 
     accelerator = prop_def(StringAttr)
 
     token = result_def()
 
-    def __init__(self, state: SSAValue | Operation):
+    def __init__(
+        self,
+        vals: list[SSAValue | Operation],
+        param_names: Iterable[str] | Iterable[StringAttr],
+        state: SSAValue | Operation,
+    ):
         state_val: SSAValue = SSAValue.get(state)
+
         if not isinstance(state_val.type, StateType):
             raise ValueError("`state` SSA Value must be of type `accfg.state`!")
+
+        param_names_tuple: tuple[StringAttr, ...] = tuple(
+            StringAttr(name) if isinstance(name, str) else name for name in param_names
+        )
         super().__init__(
-            operands=[state],
-            properties={"accelerator": state_val.type.accelerator},
+            operands=[vals, state],
+            properties={
+                "param_names": ArrayAttr(param_names_tuple),
+                "accelerator": state_val.type.accelerator,
+            },
             result_types=[TokenType(state_val.type.accelerator)],
         )
+
+    def iter_params(self) -> Iterable[tuple[str, SSAValue]]:
+        return zip((p.data for p in self.param_names), self.values)
 
     def verify_(self) -> None:
         # that the state and my accelerator match
@@ -202,14 +173,19 @@ class LaunchOp(IRDLOperation):
             next(iter(self.token.uses)).operation, AwaitOp
         ):
             raise VerifyException("Launch token must be used by exactly one await op")
+
+        # that len(values) == len(param_names)
+        if len(self.values) != len(self.param_names):
+            raise ValueError(
+                "Must have received same number of values as parameter names"
+            )
         # TODO: allow use in control flow
 
 
 @irdl_op_definition
 class AwaitOp(IRDLOperation):
     """
-    Wait until the launched operation finishes.
-    Awaits the token emitted by an accfg.launch operation.
+    Blocks until the launched operation finishes.
     """
 
     name = "accfg.await"
@@ -261,7 +237,7 @@ class SetupOp(IRDLOperation):
 
     def __init__(
         self,
-        vals: Sequence[SSAValue | Operation],
+        vals: Iterable[SSAValue | Operation],
         param_names: Iterable[str] | Iterable[StringAttr],
         accelerator: str | StringAttr,
         in_state: SSAValue | Operation | None = None,
@@ -283,7 +259,7 @@ class SetupOp(IRDLOperation):
         )
 
     def iter_params(self) -> Iterable[tuple[str, SSAValue]]:
-        return zip((p.data for p in self.param_names), self.values, strict=True)
+        return zip((p.data for p in self.param_names), self.values)
 
     def verify_(self) -> None:
         # that accelerator on input matches output
@@ -303,16 +279,180 @@ class SetupOp(IRDLOperation):
                 "Must have received same number of values as parameter names"
             )
 
+    def print(self, printer: Printer):
+        printer.print(" ")
+        printer.print_string_literal(self.accelerator.data)
+
+        if self.in_state:
+            printer.print_string(" from ")
+            printer.print_ssa_value(self.in_state)
+
+        printer.print_string(" to (")
+
+        for i, (name, val) in enumerate(zip(self.param_names, self.values)):
+            printer.print_string_literal(name.data)
+            printer.print_string(" = ")
+            printer.print_ssa_value(val)
+            printer.print_string(" : ")
+            printer.print_attribute(val.type)
+            # for all but the last value print separator
+            if i != len(self.values) - 1:
+                printer.print_string(", ")
+        printer.print_string(") ")
+
+        if self.attributes:
+            printer.print("attrs ")
+            printer.print_attr_dict(self.attributes)
+            printer.print(" ")
+
+        printer.print_string(": ")
+        printer.print_attribute(self.out_state.type)
+
+    @classmethod
+    def parse(cls: type[SetupOp], parser: Parser) -> SetupOp:
+        accelerator = parser.parse_str_literal("accelerator name")
+
+        in_state: SSAValue | None = None
+        if parser.parse_optional_keyword("from"):
+            in_state = parser.parse_operand()
+
+        parser.parse_keyword("to")
+
+        def parse_itm() -> tuple[str, SSAValue]:
+            name = parser.parse_str_literal("accelerator field name")
+            parser.parse_punctuation("=")
+            val = parser.parse_operand(f'expected value for field "{name}"')
+            parser.parse_punctuation(":")
+            typ = parser.parse_type()
+            assert (
+                val.type == typ
+            ), f"ssa value type mismatch! Expected {typ}, got {val.type}"
+            return name, val
+
+        args: list[tuple[str, SSAValue]] = parser.parse_comma_separated_list(
+            Parser.Delimiter.PAREN, parse_itm
+        )
+
+        attributes = {}
+        if parser.parse_optional_keyword("attrs"):
+            attributes = parser.parse_optional_attr_dict()
+
+        parser.parse_punctuation(":")
+        res_typ = parser.parse_type()
+        setup_op = cls(
+            [val for _, val in args],
+            [name for name, _ in args],
+            accelerator,
+            in_state,
+        )
+        setup_op.out_state.type = res_typ
+        setup_op.attributes.update(attributes)
+        return setup_op
+
+
+class AcceleratorSymbolOpTrait(SymbolOpInterface):
+    def get_sym_attr_name(self, op: Operation) -> StringAttr | None:
+        assert isinstance(op, AcceleratorOp)
+        return StringAttr(op.name_prop.string_value())
+
+
+@irdl_op_definition
+class AcceleratorOp(IRDLOperation):
+    """
+    Declares an accelerator that can be configured, launched, etc.
+    `fields` is a dictionary mapping accelerator configuration names to
+    CSR addresses.
+    """
+
+    name = "accfg.accelerator"
+
+    traits = frozenset([AcceleratorSymbolOpTrait()])
+
+    name_prop = prop_def(SymbolRefAttr, prop_name="name")
+
+    fields = prop_def(DictionaryAttr)
+
+    launch_fields = prop_def(DictionaryAttr)
+
+    barrier = prop_def(IntegerAttr)  # TODO: this will be reworked in a later version
+
+    def __init__(
+        self,
+        name: str | StringAttr | SymbolRefAttr,
+        fields: dict[str, int] | DictionaryAttr,
+        launch_fields: dict[str, int] | DictionaryAttr,
+        barrier: int | IntegerAttr,
+    ):
+        if not isinstance(fields, DictionaryAttr):
+            fields = DictionaryAttr(
+                {name: IntegerAttr(val, i32) for name, val in fields.items()}
+            )
+
+        if not isinstance(launch_fields, DictionaryAttr):
+            launch_fields = DictionaryAttr(
+                {name: IntegerAttr(val, i32) for name, val in launch_fields.items()}
+            )
+
+        super().__init__(
+            properties={
+                "name": (
+                    SymbolRefAttr(name) if not isinstance(name, SymbolRefAttr) else name
+                ),
+                "fields": fields,
+                "launch_fields": launch_fields,
+                "barrier": (
+                    IntegerAttr(barrier, i32)
+                    if not isinstance(barrier, IntegerAttr)
+                    else barrier
+                ),
+            }
+        )
+
+    def verify_(self) -> None:
+        for _, val in self.fields.data.items():
+            if not isinstance(val, IntegerAttr):
+                raise VerifyException("fields must only contain IntegerAttr!")
+
+    def field_names(self) -> tuple[str, ...]:
+        return tuple(self.fields.data.keys())
+
+    def field_items(self) -> Iterable[tuple[str, IntegerAttr]]:
+        for name, val in self.fields.data.items():
+            assert isinstance(val, IntegerAttr)
+            yield name, val
+
+    def launch_field_names(self) -> tuple[str, ...]:
+        return tuple(self.launch_fields.data.keys())
+
+    def launch_field_items(self) -> Iterable[tuple[str, IntegerAttr]]:
+        for name, val in self.launch_fields.data.items():
+            assert isinstance(val, IntegerAttr)
+            yield name, val
+
+
+@irdl_op_definition
+class ResetOp(IRDLOperation):
+    name = "accfg.reset"
+
+    in_state = operand_def(StateType)
+
+    assembly_format = "$in_state attr-dict `:` type($in_state)"
+
+    def __init__(self, in_state: Operation | SSAValue):
+        super().__init__(operands=[in_state])
+
 
 ACCFG = Dialect(
     "accfg",
     [
         AcceleratorOp,
-        SetupOp,
-        LaunchOp,
         AwaitOp,
+        LaunchOp,
+        ResetOp,
+        SetupOp,
     ],
     [
+        EffectsAttr,
         StateType,
         TokenType,
     ],

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from enum import Enum
 
 from xdsl.dialects.builtin import (
     ArrayAttr,
     DictionaryAttr,
     IntegerAttr,
+    IntegerType,
     StringAttr,
     SymbolRefAttr,
     i32,
@@ -131,7 +132,7 @@ class LaunchOp(IRDLOperation):
 
     def __init__(
         self,
-        vals: list[SSAValue | Operation],
+        vals: Sequence[SSAValue | Operation],
         param_names: Iterable[str] | Iterable[StringAttr],
         state: SSAValue | Operation,
     ):
@@ -238,8 +239,8 @@ class SetupOp(IRDLOperation):
 
     def __init__(
         self,
-        vals: Iterable[SSAValue | Operation],
-        param_names: Iterable[str] | Iterable[StringAttr],
+        vals: Sequence[SSAValue | Operation],
+        param_names: Sequence[str] | Sequence[StringAttr],
         accelerator: str | StringAttr,
         in_state: SSAValue | Operation | None = None,
     ):
@@ -330,7 +331,7 @@ class SetupOp(IRDLOperation):
             ), f"ssa value type mismatch! Expected {typ}, got {val.type}"
             return name, val
 
-        args: list[tuple[str, SSAValue]] = parser.parse_comma_separated_list(
+        args: Sequence[tuple[str, SSAValue]] = parser.parse_comma_separated_list(
             Parser.Delimiter.PAREN, parse_itm
         )
 
@@ -375,14 +376,14 @@ class AcceleratorOp(IRDLOperation):
 
     launch_fields = prop_def(DictionaryAttr)
 
-    barrier = prop_def(IntegerAttr)  # TODO: this will be reworked in a later version
+    barrier = prop_def(IntegerAttr[IntegerType])  # TODO: this will be reworked in a later version
 
     def __init__(
         self,
         name: str | StringAttr | SymbolRefAttr,
         fields: dict[str, int] | DictionaryAttr,
         launch_fields: dict[str, int] | DictionaryAttr,
-        barrier: int | IntegerAttr,
+        barrier: int | IntegerAttr[IntegerType],
     ):
         if not isinstance(fields, DictionaryAttr):
             fields = DictionaryAttr(


### PR DESCRIPTION
The `accfg` dialect in snax-mlir has diverged slightly from what it is in upstream xDSL. This PR aims to change that so that we can start upstreaming passes from snax-mlir as well.

Some of things that were reconverged:
* Introduction of `launch_fields` instead of a single `launch_addr`
* Introduction of accfg-effect to model side-effects.
* Introduction of custom syntax on the setup op for improved legibility
