### PR TITLE
misc: use preferred style for pytest parametrized tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ select = ["E", "F", "W", "I", "UP", "PT", "TID251"]
 ignore = [
     "E741",  # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
     "PT006", # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
-    "PT007", # https://beta.ruff.rs/docs/rules/pytest-parametrize-values-wrong-type/
     "PT011", # https://beta.ruff.rs/docs/rules/pytest-raises-too-broad/
     "PT012", # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
     "PT015", # https://beta.ruff.rs/docs/rules/pytest-assert-always-false/

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -105,11 +105,11 @@ def test_DenseArrayBase_verifier_failure():
 
 @pytest.mark.parametrize(
     "ref,expected",
-    (
+    [
         (SymbolRefAttr("test"), "test"),
         (SymbolRefAttr("test", ["2"]), "test.2"),
         (SymbolRefAttr("test", ["2", "3"]), "test.2.3"),
-    ),
+    ],
 )
 def test_SymbolRefAttr_string_value(ref: SymbolRefAttr, expected: str):
     assert ref.string_value() == expected
@@ -127,13 +127,13 @@ def test_array_len_and_iter_attr():
 
 @pytest.mark.parametrize(
     "attr, dims, num_scalable_dims",
-    (
+    [
         (i32, (1, 2), 0),
         (i32, (1, 2), 1),
         (i32, (1, 1, 3), 0),
         (i64, (1, 1, 3), 2),
         (i64, (), 0),
-    ),
+    ],
 )
 def test_vector_constructor(attr: Attribute, dims: list[int], num_scalable_dims: int):
     vec = VectorType(attr, dims, num_scalable_dims)
@@ -145,11 +145,11 @@ def test_vector_constructor(attr: Attribute, dims: list[int], num_scalable_dims:
 
 @pytest.mark.parametrize(
     "dims, num_scalable_dims",
-    (
+    [
         ([], 1),
         ([1, 2], 3),
         ([1], 2),
-    ),
+    ],
 )
 def test_vector_verifier_fail(dims: list[int], num_scalable_dims: int):
     with pytest.raises(VerifyException):

--- a/tests/dialects/test_printf.py
+++ b/tests/dialects/test_printf.py
@@ -7,13 +7,13 @@ from xdsl.transforms import printf_to_llvm
 
 @pytest.mark.parametrize(
     "given,expected",
-    (
+    [
         ("test", "test"),
         ("@hello  world", "hello_world"),
         ("something.with.dots", "something_with_dots"),
         ("this is 💩", "this_is"),
         ("123 is a number!", "123_is_a_number"),
-    ),
+    ],
 )
 def test_symbol_sanitizer(given: str, expected: str):
     assert printf_to_llvm.legalize_str_for_symbol_name(given) == expected

--- a/tests/dialects/test_riscv_snitch.py
+++ b/tests/dialects/test_riscv_snitch.py
@@ -18,7 +18,7 @@ ground_truth = {
 
 @pytest.mark.parametrize(
     "op",
-    (
+    [
         riscv_snitch.DMSourceOp,
         riscv_snitch.DMDestinationOp,
         riscv_snitch.DMCopyImmOp,
@@ -27,7 +27,7 @@ ground_truth = {
         riscv_snitch.DMStatOp,
         riscv_snitch.DMStrideOp,
         riscv_snitch.DMRepOp,
-    ),
+    ],
 )
 def test_insn_repr(op: RISCVInstruction):
     trait = op.get_trait(HasInsnRepresentation)

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -200,7 +200,7 @@ def test_stencil_apply_no_results():
 
 @pytest.mark.parametrize(
     "indices",
-    (
+    [
         ([1]),
         ([1, 2]),
         ([1, 2, 3]),
@@ -211,7 +211,7 @@ def test_stencil_apply_no_results():
                 IntAttr(3),
             ]
         ),
-    ),
+    ],
 )
 def test_create_index_attr_from_int_list(indices: list[int | IntAttr]):
     stencil_index_attr = IndexAttr.get(*indices)
@@ -236,7 +236,7 @@ def test_create_index_attr_from_list_edge_case2():
 
 @pytest.mark.parametrize(
     "indices",
-    (([1]), ([1, 2]), ([1, 2, 3])),
+    [([1]), ([1, 2]), ([1, 2, 3])],
 )
 def test_index_attr_neg(indices: list[int]):
     stencil_index_attr = IndexAttr.get(*indices)
@@ -248,7 +248,7 @@ def test_index_attr_neg(indices: list[int]):
 
 @pytest.mark.parametrize(
     "indices1, indices2",
-    (([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])),
+    [([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])],
 )
 def test_index_attr_add(indices1: list[int], indices2: list[int]):
     stencil_index_attr1 = IndexAttr.get(*indices1)
@@ -264,7 +264,7 @@ def test_index_attr_add(indices1: list[int], indices2: list[int]):
 
 @pytest.mark.parametrize(
     "indices1, indices2",
-    (([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])),
+    [([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])],
 )
 def test_index_attr_sub(indices1: list[int], indices2: list[int]):
     stencil_index_attr1 = IndexAttr.get(*indices1)
@@ -280,7 +280,7 @@ def test_index_attr_sub(indices1: list[int], indices2: list[int]):
 
 @pytest.mark.parametrize(
     "indices1, indices2",
-    (([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])),
+    [([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])],
 )
 def test_index_attr_min(indices1: list[int], indices2: list[int]):
     stencil_index_attr1 = IndexAttr.get(*indices1)
@@ -296,7 +296,7 @@ def test_index_attr_min(indices1: list[int], indices2: list[int]):
 
 @pytest.mark.parametrize(
     "indices1, indices2",
-    (([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])),
+    [([1], [4]), ([1, 2], [4, 5]), ([1, 2, 3], [5, 6, 7])],
 )
 def test_index_attr_max(indices1: list[int], indices2: list[int]):
     stencil_index_attr1 = IndexAttr.get(*indices1)
@@ -312,7 +312,7 @@ def test_index_attr_max(indices1: list[int], indices2: list[int]):
 
 @pytest.mark.parametrize(
     "indices",
-    (((1,)), ((1, 2)), ((1, 2, 3))),
+    [((1,)), ((1, 2)), ((1, 2, 3))],
 )
 def test_index_attr_iter(indices: tuple[int, ...]):
     stencil_index_attr = IndexAttr.get(*indices)
@@ -320,7 +320,7 @@ def test_index_attr_iter(indices: tuple[int, ...]):
     assert tuple(stencil_index_attr) == indices
 
 
-@pytest.mark.parametrize("indices", (([1]), ([1, 2]), ([1, 2, 3])))
+@pytest.mark.parametrize("indices", [([1]), ([1, 2]), ([1, 2, 3])])
 def test_index_attr_indices_length(indices: list[int]):
     stencil_index_attr = IndexAttr.get(*indices)
     stencil_index_attr_iter = iter(stencil_index_attr)
@@ -331,13 +331,13 @@ def test_index_attr_indices_length(indices: list[int]):
 
 @pytest.mark.parametrize(
     "attr, bounds",
-    (
+    [
         (i32, ((0, 64), (0, 64))),
         (
             i64,
             ((0, 32), (0, 32), (0, 32)),
         ),
-    ),
+    ],
 )
 def test_stencil_fieldtype_constructor_with_ArrayAttr(
     attr: IntegerType, bounds: tuple[tuple[int, int], ...]
@@ -354,11 +354,11 @@ def test_stencil_fieldtype_constructor_with_ArrayAttr(
 
 @pytest.mark.parametrize(
     "attr, bounds",
-    (
+    [
         (i32, ((0, 1), (0, 2))),
         (i32, ((0, 1), (0, 1), (0, 3))),
         (i64, ((0, 1), (0, 1), (0, 3))),
-    ),
+    ],
 )
 def test_stencil_fieldtype_constructor(
     attr: IntegerType, bounds: tuple[tuple[int, int], ...]
@@ -375,10 +375,10 @@ def test_stencil_fieldtype_constructor(
 
 @pytest.mark.parametrize(
     "attr, bounds",
-    (
+    [
         (i32, []),
         (i64, []),
-    ),
+    ],
 )
 def test_stencil_fieldtype_constructor_empty_list(
     attr: IntegerType, bounds: list[tuple[int, int]]
@@ -424,13 +424,13 @@ def test_stencil_load_bounds():
 
 @pytest.mark.parametrize(
     "attr, dims",
-    (
+    [
         (i32, ((0, 64), (0, 64))),
         (
             i64,
             ((0, 32), (0, 32), (0, 32)),
         ),
-    ),
+    ],
 )
 def test_stencil_temptype_constructor_with_ArrayAttr(
     attr: IntegerType, dims: tuple[tuple[int, int], ...]
@@ -446,11 +446,11 @@ def test_stencil_temptype_constructor_with_ArrayAttr(
 
 @pytest.mark.parametrize(
     "attr, dims",
-    (
+    [
         (i32, ((0, 1), (0, 2))),
         (i32, ((0, 1), (0, 1), (0, 3))),
         (i64, ((0, 1), (0, 1), (0, 3))),
-    ),
+    ],
 )
 def test_stencil_temptype_constructor(
     attr: IntegerType, dims: tuple[tuple[int, int], ...]
@@ -466,10 +466,10 @@ def test_stencil_temptype_constructor(
 
 @pytest.mark.parametrize(
     "attr, dims",
-    (
+    [
         (i32, []),
         (i64, []),
-    ),
+    ],
 )
 def test_stencil_temptype_constructor_empty_list(
     attr: IntegerType, dims: list[tuple[int, int]]
@@ -481,7 +481,7 @@ def test_stencil_temptype_constructor_empty_list(
 
 @pytest.mark.parametrize(
     "float_type",
-    ((bf16), (f16), (f32), (f64), (f80), (f128)),
+    [(bf16), (f16), (f32), (f64), (f80), (f128)],
 )
 def test_stencil_resulttype(float_type: AnyFloat):
     stencil_resulttype = ResultType(float_type)

--- a/tests/interpreters/test_cf_interpreter.py
+++ b/tests/interpreters/test_cf_interpreter.py
@@ -63,6 +63,6 @@ def sum_to_interp(n: int) -> int:
     return result
 
 
-@pytest.mark.parametrize("n", (0, 1, 2, 3, 4))
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 4])
 def test_sum_to(n: int):
     assert sum_to_fn(n) == sum_to_interp(n)

--- a/tests/interpreters/test_riscv_func_interpreter.py
+++ b/tests/interpreters/test_riscv_func_interpreter.py
@@ -30,6 +30,6 @@ def scf_interp(module_op: ModuleOp, func_name: str, n: int) -> int:
     return result
 
 
-@pytest.mark.parametrize("n,res", ((0, 0), (1, 1)))
+@pytest.mark.parametrize("n,res", [(0, 0), (1, 1)])
 def test_sum_to(n: int, res: int):
     assert res == scf_interp(my_module, "id", n)

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -95,7 +95,7 @@ def interp(module_op: ModuleOp, func_name: str, n: int) -> int:
     return result
 
 
-@pytest.mark.parametrize("n,res", ((0, 0), (1, 0), (2, 1), (3, 3), (4, 6), (5, 10)))
+@pytest.mark.parametrize("n,res", [(0, 0), (1, 0), (2, 1), (3, 3), (4, 6), (5, 10)])
 def test_sum_to(n: int, res: int):
     assert res == interp(sum_to_for_op, "sum_to", n)
     assert res == interp(sum_to_while_op, "sum_to", n)

--- a/tests/interpreters/test_scf_interpreter.py
+++ b/tests/interpreters/test_scf_interpreter.py
@@ -50,7 +50,7 @@ def scf_interp(module_op: ModuleOp, func_name: str, n: int) -> int:
     return result
 
 
-@pytest.mark.parametrize("n,res", ((0, 0), (1, 0), (2, 1), (3, 3), (4, 6), (5, 10)))
+@pytest.mark.parametrize("n,res", [(0, 0), (1, 0), (2, 1), (3, 3), (4, 6), (5, 10)])
 def test_sum_to(n: int, res: int):
     assert res == scf_interp(sum_to_for_op, "sum_to", n)
 

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2009,7 +2009,7 @@ def test_optional_group_variadic_result_anchor(
 
 @pytest.mark.parametrize(
     "format, error",
-    (
+    [
         ("()?", "An optional group must have a non-whitespace directive"),
         ("(`keyword`)?", "Every optional group must have an anchor."),
         (
@@ -2024,7 +2024,7 @@ def test_optional_group_variadic_result_anchor(
             "($mandatory_arg^)?",
             "First element of an optional group must be optionally parsable.",
         ),
-    ),
+    ],
 )
 def test_optional_group_checkers(format: str, error: str):
     with pytest.raises(

--- a/tests/riscv/test_abi_spec.py
+++ b/tests/riscv/test_abi_spec.py
@@ -5,12 +5,12 @@ from xdsl.backend.riscv import targets
 
 @pytest.mark.parametrize(
     "simple, expanded",
-    (
+    [
         ("RV32G", "IMAFDZicsr_Zifencei"),
         ("RV32D", "FDZicsr"),
         ("RV32F", "FZicsr"),
         ("RV32IMZam", "IMAZam"),
-    ),
+    ],
 )
 def test_march_expansion(simple: str, expanded: str):
     """

--- a/tests/test_dominance.py
+++ b/tests/test_dominance.py
@@ -36,7 +36,7 @@ blocks = op.regions[0].blocks
 
 @pytest.mark.parametrize(
     ("a", "b", "expected"),
-    (
+    [
         (1, 1, False),
         (1, 2, True),
         (1, 3, True),
@@ -58,7 +58,7 @@ blocks = op.regions[0].blocks
         (5, 5, False),
         (5, 6, False),
         (6, 6, False),
-    ),
+    ],
 )
 def test_region_strictly_dominates_block(a: int, b: int, expected: bool):
     """

--- a/tests/test_pass_from_spec.py
+++ b/tests/test_pass_from_spec.py
@@ -78,7 +78,7 @@ def test_pass_instantiation():
 
 @pytest.mark.parametrize(
     "spec, error_msg",
-    (
+    [
         (PipelinePassSpec("wrong", {"a": (1,)}), "Cannot create Pass simple"),
         (PipelinePassSpec("simple", {}), 'requires argument "a"'),
         (
@@ -91,7 +91,7 @@ def test_pass_instantiation():
             PipelinePassSpec("simple", {"a": ("test",), "literal": ("definitely",)}),
             "Incompatible types",
         ),
-    ),
+    ],
 )
 def test_pass_instantiation_error(spec: PipelinePassSpec, error_msg: str):
     """

--- a/tests/test_pass_lexer.py
+++ b/tests/test_pass_lexer.py
@@ -50,12 +50,12 @@ def test_pass_lex_errors():
 
 @pytest.mark.parametrize(
     "input_str, pass_name, pass_arg_names",
-    (
+    [
         ("pass-1,", "pass-1", set[str]()),
         ("pass-1{}", "pass-1", set[str]()),
         ("pass-1{arg1=true arg2}", "pass-1", {"arg1", "arg2"}),
         ("pass-1{arg2 arg1=false}", "pass-1", {"arg1", "arg2"}),
-    ),
+    ],
 )
 def test_pass_parser_argument_dict_edge_cases(
     input_str: str, pass_name: str, pass_arg_names: set[str]
@@ -71,12 +71,12 @@ def test_pass_parser_argument_dict_edge_cases(
 
 @pytest.mark.parametrize(
     "input_str",
-    (
+    [
         ("pass-1{"),
         ("pass-1{arg1,arg2}"),
         ("pass-1{arg1=arg2=arg3}"),
         ("pass-1{ }"),
-    ),
+    ],
 )
 def test_pass_parser_cases_fail(input_str: str):
     with pytest.raises(PassPipelineParseError):

--- a/tests/test_pass_to_arg_and_types_str.py
+++ b/tests/test_pass_to_arg_and_types_str.py
@@ -54,14 +54,14 @@ class SimplePass(ModulePass):
 
 @pytest.mark.parametrize(
     "str_arg, pass_arg",
-    (
+    [
         (
             """number=int|float single_number=int int_list=tuple[int, ...] non_init_thing=int str_thing=str nullable_str=str|None literal=no optional_bool=false""",
             CustomPass,
         ),
         ("", EmptyPass),
         ("""a=int|float b=int|None c=5""", SimplePass),
-    ),
+    ],
 )
 def test_pass_to_arg_and_type_str(str_arg: str, pass_arg: type[ModulePass]):
     assert get_pass_argument_names_and_types(pass_arg) == str_arg

--- a/tests/test_pass_to_spec.py
+++ b/tests/test_pass_to_spec.py
@@ -47,7 +47,7 @@ class SimplePass(ModulePass):
 
 @pytest.mark.parametrize(
     "test_pass, test_spec",
-    (
+    [
         (
             CustomPass(3, (1, 2), None, ("clown", "season")),
             PipelinePassSpec(
@@ -66,7 +66,7 @@ class SimplePass(ModulePass):
             SimplePass((3.14, 2.13), 2),
             PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
         ),
-    ),
+    ],
 )
 def test_pass_to_spec_include_default(
     test_pass: ModulePass,
@@ -77,7 +77,7 @@ def test_pass_to_spec_include_default(
 
 @pytest.mark.parametrize(
     "test_pass, test_spec",
-    (
+    [
         (
             CustomPass(3, (1, 2), None, ("clown", "season")),
             PipelinePassSpec(
@@ -94,7 +94,7 @@ def test_pass_to_spec_include_default(
             SimplePass((3.14, 2.13), 2),
             PipelinePassSpec("simple", {"a": (3.14, 2.13), "b": (2,)}),
         ),
-    ),
+    ],
 )
 def test_pass_to_spec_exclude_default(
     test_pass: ModulePass, test_spec: PipelinePassSpec

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -370,7 +370,7 @@ class PropSymbolOp(IRDLOperation):
         return super().__init__(properties={"sym_name": StringAttr(name)})
 
 
-@pytest.mark.parametrize("SymbolOp", (SymbolOp, PropSymbolOp))
+@pytest.mark.parametrize("SymbolOp", [SymbolOp, PropSymbolOp])
 def test_symbol_table(SymbolOp: type[PropSymbolOp | SymbolOp]):
     # Some helper classes
     @irdl_op_definition


### PR DESCRIPTION
I just ran `ruff check -fix --unsafe-fixes`