### PR TITLE
dialects: (eqsat) add min_cost_index optional attribute to eclass

### DIFF
--- a/tests/filecheck/transforms/eqsat-add-costs.mlir
+++ b/tests/filecheck/transforms/eqsat-add-costs.mlir
@@ -1,14 +1,14 @@
 // RUN: xdsl-opt -p eqsat-add-costs --verify-diagnostics --split-input-file %s | filecheck %s
 
 // CHECK:         func.func @trivial_arithmetic(%a : index, %b : index) -> index {
-// CHECK-NEXT:      %a_eq = eqsat.eclass %a {"eqsat_cost" = #builtin.int<0>} : index
+// CHECK-NEXT:      %a_eq = eqsat.eclass %a {"min_cost_index" = #builtin.int<0>} : index
 // CHECK-NEXT:      %one = arith.constant {"eqsat_cost" = #builtin.int<1>} 1 : index
-// CHECK-NEXT:      %one_eq = eqsat.eclass %one {"eqsat_cost" = #builtin.int<1>} : index
+// CHECK-NEXT:      %one_eq = eqsat.eclass %one {"min_cost_index" = #builtin.int<0>} : index
 // CHECK-NEXT:      %two = arith.constant {"eqsat_cost" = #builtin.int<1>} 2 : index
-// CHECK-NEXT:      %two_eq = eqsat.eclass %two {"eqsat_cost" = #builtin.int<1>} : index
+// CHECK-NEXT:      %two_eq = eqsat.eclass %two {"min_cost_index" = #builtin.int<0>} : index
 // CHECK-NEXT:      %a_shift_one = arith.shli %a_eq, %one_eq {"eqsat_cost" = #builtin.int<2>} : index
 // CHECK-NEXT:      %a_times_two = arith.muli %a_eq, %two_eq {"eqsat_cost" = #builtin.int<2>} : index
-// CHECK-NEXT:      %res_eq = eqsat.eclass %a_shift_one, %a_times_two {"eqsat_cost" = #builtin.int<2>} : index
+// CHECK-NEXT:      %res_eq = eqsat.eclass %a_shift_one, %a_times_two {"min_cost_index" = #builtin.int<0>} : index
 // CHECK-NEXT:      func.return %res_eq : index
 // CHECK-NEXT:    }
 func.func @trivial_arithmetic(%a : index, %b : index) -> (index) {
@@ -35,14 +35,14 @@ func.func @no_eclass(%a : index, %b : index) -> (index) {
 }
 
 // CHECK-NEXT:    func.func @existing_cost(%a : index, %b : index) -> index {
-// CHECK-NEXT:      %a_eq = eqsat.eclass %a {"eqsat_cost" = #builtin.int<0>} : index
+// CHECK-NEXT:      %a_eq = eqsat.eclass %a {"min_cost_index" = #builtin.int<0>} : index
 // CHECK-NEXT:      %one = arith.constant {"eqsat_cost" = #builtin.int<1000>} 1 : index
-// CHECK-NEXT:      %one_eq = eqsat.eclass %one {"eqsat_cost" = #builtin.int<1000>} : index
+// CHECK-NEXT:      %one_eq = eqsat.eclass %one {"min_cost_index" = #builtin.int<0>} : index
 // CHECK-NEXT:      %two = arith.constant {"eqsat_cost" = #builtin.int<1>} 2 : index
-// CHECK-NEXT:      %two_eq = eqsat.eclass %two {"eqsat_cost" = #builtin.int<1>} : index
+// CHECK-NEXT:      %two_eq = eqsat.eclass %two {"min_cost_index" = #builtin.int<0>} : index
 // CHECK-NEXT:      %a_shift_one = arith.shli %a_eq, %one_eq {"eqsat_cost" = #builtin.int<1001>} : index
 // CHECK-NEXT:      %a_times_two = arith.muli %a_eq, %two_eq {"eqsat_cost" = #builtin.int<2>} : index
-// CHECK-NEXT:      %res_eq = eqsat.eclass %a_shift_one, %a_times_two {"eqsat_cost" = #builtin.int<2>} : index
+// CHECK-NEXT:      %res_eq = eqsat.eclass %a_shift_one, %a_times_two {"min_cost_index" = #builtin.int<1>} : index
 // CHECK-NEXT:      func.return %res_eq : index
 // CHECK-NEXT:    }
 func.func @existing_cost(%a : index, %b : index) -> (index) {

--- a/xdsl/dialects/eqsat.py
+++ b/xdsl/dialects/eqsat.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from xdsl.dialects.builtin import IntAttr
 from xdsl.ir import Attribute, Dialect, SSAValue
 from xdsl.irdl import (
     AnyAttr,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
+    opt_attr_def,
     result_def,
     var_operand_def,
 )
@@ -32,16 +34,26 @@ class EClassOp(IRDLOperation):
     name = "eqsat.eclass"
     arguments = var_operand_def(T)
     result = result_def(T)
+    min_cost_index = opt_attr_def(IntAttr)
 
     assembly_format = "$arguments attr-dict `:` type($result)"
 
-    def __init__(self, *arguments: SSAValue, res_type: Attribute | None = None):
+    def __init__(
+        self,
+        *arguments: SSAValue,
+        min_cost_index: IntAttr | None = None,
+        res_type: Attribute | None = None,
+    ):
         if not arguments:
             raise DiagnosticException("eclass op must have at least one operand")
         if res_type is None:
             res_type = arguments[0].type
 
-        super().__init__(operands=[arguments], result_types=[res_type])
+        super().__init__(
+            operands=[arguments],
+            result_types=[res_type],
+            attributes={"min_cost_index": min_cost_index},
+        )
 
     def verify_(self) -> None:
         # Check that none of the operands are produced by another eclass op.


### PR DESCRIPTION
Instead of storing the cost of the lowest-cost-operand-op, store its index. This will make extraction simpler by avoiding the work of looking again, and does not significantly impact adding costs.