### PR TITLE
misc: cleanup leftover ConstraintVar

### DIFF
--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -32,7 +32,6 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     BaseAttr,
     ConstraintContext,
-    ConstraintVar,
     GenericAttrConstraint,
     IRDLOperation,
     MessageConstraint,
@@ -844,8 +843,6 @@ class DynAccessOp(IRDLOperation):
 
     name = "stencil.dyn_access"
 
-    T = Annotated[Attribute, ConstraintVar("T")]
-
     temp = operand_def(
         StencilType[Attribute].constr(
             element_type=MessageConstraint(
@@ -993,8 +990,6 @@ class AccessOp(IRDLOperation):
     Example:
       %0 = stencil.access %temp[-1, 0, 0] : !stencil.temp<?x?x?xf64>
     """
-
-    T = Annotated[Attribute, ConstraintVar("T")]
 
     name = "stencil.access"
     temp = operand_def(
@@ -1231,8 +1226,6 @@ class LoadOp(IRDLOperation):
 
     name = "stencil.load"
 
-    T = Annotated[Attribute, ConstraintVar("T")]
-
     field = operand_def(
         FieldType[Attribute].constr(
             bounds=base(StencilBoundsAttr),
@@ -1310,8 +1303,6 @@ class BufferOp(IRDLOperation):
     """
 
     name = "stencil.buffer"
-
-    T = Annotated[TempType[_FieldTypeElement], ConstraintVar("T")]
 
     temp = operand_def(
         TempType[Attribute].constr(

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence, Set
 from io import StringIO
-from typing import IO, Annotated, Generic, TypeVar
+from typing import IO, Generic, TypeVar
 
 from typing_extensions import Self
 
@@ -24,7 +24,6 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     AttrSizedOperandSegments,
-    ConstraintVar,
     IRDLOperation,
     Successor,
     attr_def,
@@ -374,7 +373,6 @@ class R_R_Operation(Generic[R1InvT], IRDLOperation, X86Instruction, ABC):
     A base class for x86 operations that have one register acting as both source and destination.
     """
 
-    T = Annotated[GeneralRegisterType, ConstraintVar("T")]
     source = operand_def(R1InvT)
     destination = result_def(R1InvT)
 


### PR DESCRIPTION
As far as I can tell, these annotated type vars were completely unused, and the tests we have seem to agree with me