### PR TITLE
core: use & for AllOf constraint

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -41,7 +41,6 @@ from xdsl.ir.affine import (
     AffineSymExpr,
 )
 from xdsl.irdl import (
-    AllOf,
     AnyAttr,
     AnyOf,
     AttrConstraint,
@@ -271,7 +270,7 @@ FlatSymbolRefAttrConstraint = MessageConstraint(
 FlatSymbolRefAttr = Annotated[SymbolRefAttr, FlatSymbolRefAttrConstraint]
 """SymbolRef constrained to have an empty `nested_references` property."""
 
-FlatSymbolRefAttrConstr = AllOf((base(SymbolRefAttr), FlatSymbolRefAttrConstraint))
+FlatSymbolRefAttrConstr = base(SymbolRefAttr) & FlatSymbolRefAttrConstraint
 
 
 @irdl_attr_definition
@@ -920,12 +919,9 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
     """The expected vector rank."""
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        constraint = AllOf(
-            (
-                VectorBaseTypeConstraint(self.expected_type),
-                VectorRankConstraint(self.expected_rank),
-            )
-        )
+        constraint = VectorBaseTypeConstraint(
+            self.expected_type
+        ) & VectorRankConstraint(self.expected_rank)
         constraint.verify(attr, constraint_context)
 
 

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -367,7 +367,7 @@ def irdl_to_attr_constraint(
             raise Exception(f"GenericData args must have length 1, got {args}")
         origin = cast(type[GenericData[Any]], origin)
         args = cast(tuple[Attribute], args)
-        return AllOf((BaseAttr(origin), origin.generic_constraint_coercion(args)))
+        return BaseAttr(origin) & origin.generic_constraint_coercion(args)
 
     # Generic ParametrizedAttributes case
     # We translate it to constraints over the attribute parameters.

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -367,7 +367,7 @@ def irdl_to_attr_constraint(
             raise Exception(f"GenericData args must have length 1, got {args}")
         origin = cast(type[GenericData[Any]], origin)
         args = cast(tuple[Attribute], args)
-        return BaseAttr(origin) & origin.generic_constraint_coercion(args)
+        return AllOf((BaseAttr(origin), origin.generic_constraint_coercion(args)))
 
     # Generic ParametrizedAttributes case
     # We translate it to constraints over the attribute parameters.

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -106,6 +106,11 @@ class GenericAttrConstraint(Generic[AttributeCovT], ABC):
     ) -> AnyOf[AttributeCovT | _AttributeCovT]:
         return AnyOf((self, value))
 
+    def __and__(
+        self, value: GenericAttrConstraint[AttributeCovT], /
+    ) -> AllOf[AttributeCovT]:
+        return AllOf((self, value))
+
 
 AttrConstraint: TypeAlias = GenericAttrConstraint[Attribute]
 
@@ -359,6 +364,11 @@ class AllOf(GenericAttrConstraint[AttributeCovT]):
             if base is not None:
                 return base
         return None
+
+    def __and__(
+        self, value: GenericAttrConstraint[AttributeCovT], /
+    ) -> AllOf[AttributeCovT]:
+        return AllOf((*self.attr_constrs, value))
 
 
 ParametrizedAttributeCovT = TypeVar(


### PR DESCRIPTION
Adds nice syntax for `AllOf`, similar to the one for `AnyOf`