### PR TITLE
misc: Stencil and csl lowering fixes

### DIFF
--- a/tests/filecheck/transforms/test-add-timers-to-top-level-funcs.mlir
+++ b/tests/filecheck/transforms/test-add-timers-to-top-level-funcs.mlir
@@ -47,8 +47,8 @@ builtin.module {
   // CHECK-NEXT:     "llvm.store"(%timediff, %timers) <{"ordering" = 0 : i64}> : (f64, !llvm.ptr) -> ()
   // CHECK-NEXT:     func.return
   // CHECK-NEXT:   }
-  // CHECK-NEXT:   func.func @timer_start() -> f64
-  // CHECK-NEXT:   func.func @timer_end(f64) -> f64
+  // CHECK-NEXT:   func.func private @timer_start() -> f64
+  // CHECK-NEXT:   func.func private @timer_end(f64) -> f64
   // CHECK-NEXT: }
 
   func.func @has_no_timers(%arg0 : i32, %arg1 : i32) -> i32 {

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -690,6 +690,16 @@ class AllocOp(IRDLOperation):
     traits = traits_def(AllocOpEffect())
 
 
+class CastOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.stencil import (
+            RemoveCastWithNoEffect,
+        )
+
+        return (RemoveCastWithNoEffect(),)
+
+
 @irdl_op_definition
 class CastOp(IRDLOperation):
     """
@@ -722,7 +732,7 @@ class CastOp(IRDLOperation):
         "$field attr-dict-with-keyword `:` type($field) `->` type($result)"
     )
 
-    traits = traits_def(NoMemoryEffect())
+    traits = traits_def(NoMemoryEffect(), CastOpHasCanonicalizationPatternsTrait())
 
     @staticmethod
     def get(

--- a/xdsl/transforms/canonicalization_patterns/stencil.py
+++ b/xdsl/transforms/canonicalization_patterns/stencil.py
@@ -109,3 +109,14 @@ class ApplyUnusedResults(RewritePattern):
 
         rewriter.replace_op(old_return, stencil.ReturnOp.get(return_args))
         rewriter.replace_matched_op(new, replace_results)
+
+
+class RemoveCastWithNoEffect(RewritePattern):
+    """
+    Remove `stencil.cast` where input and output types are equal.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: stencil.CastOp, rewriter: PatternRewriter) -> None:
+        if op.result.type == op.field.type:
+            rewriter.replace_matched_op([], new_results=[op.field])

--- a/xdsl/transforms/function_transformations.py
+++ b/xdsl/transforms/function_transformations.py
@@ -95,8 +95,8 @@ class TestAddBenchTimersToTopLevelFunctions(ModulePass):
         end_func_t = func.FunctionType.from_lists(
             [builtin.Float64Type()], [builtin.Float64Type()]
         )
-        start_func = func.FuncOp(TIMER_START, start_func_t, Region([]))
-        end_func = func.FuncOp(TIMER_END, end_func_t, Region([]))
+        start_func = func.FuncOp(TIMER_START, start_func_t, Region([]), "private")
+        end_func = func.FuncOp(TIMER_END, end_func_t, Region([]), "private")
 
         PatternRewriteWalker(
             AddBenchTimersPattern(start_func_t, end_func_t), apply_recursively=False


### PR DESCRIPTION
Various minor fixes:
* `stencil`: Add canonicalisation pattern for `stencil.cast` where input type == output type
* `csl-stencil-handle-async-flow`: When creating a function call graph, copy arith constants to the function in which they are used, undoing mlir-opt canonicalisation moving them around.
* `test-add-timers-to-top-level-funcs`: Generate timers as `private` functions