### PR TITLE
dialects (arm): add ARM dialect and initial mov op

### DIFF
--- a/tests/filecheck/dialects/arm/arm_assembly_emission.mlir
+++ b/tests/filecheck/dialects/arm/arm_assembly_emission.mlir
@@ -1,0 +1,7 @@
+// RUN: xdsl-opt -t arm-asm %s | filecheck %s
+
+%0 = arm.get_register : () -> !arm.reg<x0>
+%1 = arm.get_register : () -> !arm.reg<x1>
+
+%rr_mov = arm.rr.mov %0, %1 : (!arm.reg<x0>, !arm.reg<x1>) -> !arm.reg<x0>
+// CHECK: mov x0, x1

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -323,6 +323,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return X86
 
+    def get_arm():
+        from xdsl.dialects.arm import ARM
+
+        return ARM
+
     def get_transform():
         from xdsl.dialects.transform import Transform
 
@@ -392,6 +397,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "vector": get_vector,
         "wasm": get_wasm,
         "x86": get_x86,
+        "arm": get_arm,
         "transform": get_transform,
     }
 

--- a/xdsl/dialects/arm/__init__.py
+++ b/xdsl/dialects/arm/__init__.py
@@ -1,0 +1,11 @@
+from xdsl.ir import Dialect
+
+from .attributes import LabelAttr
+from .ops import GetRegisterOp, RR_MovOp
+from .register import GeneralRegisterType
+
+ARM = Dialect(
+    "arm",
+    [GetRegisterOp, RR_MovOp],
+    [GeneralRegisterType, LabelAttr],
+)

--- a/xdsl/dialects/arm/assembly.py
+++ b/xdsl/dialects/arm/assembly.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from xdsl.dialects.builtin import (
+    AnyIntegerAttr,
+    IndexType,
+    IntegerAttr,
+    IntegerType,
+    StringAttr,
+)
+from xdsl.ir import (
+    SSAValue,
+)
+from xdsl.parser import Parser
+from xdsl.printer import Printer
+from xdsl.utils.hints import isa
+
+from .attributes import LabelAttr
+from .register import GeneralRegisterType
+
+AssemblyInstructionArg: TypeAlias = (
+    AnyIntegerAttr | SSAValue | GeneralRegisterType | str | int | LabelAttr
+)
+
+
+def append_comment(line: str, comment: StringAttr | None) -> str:
+    if comment is None:
+        return line
+
+    padding = " " * max(0, 48 - len(line))
+
+    return f"{line}{padding} # {comment.data}"
+
+
+def assembly_arg_str(arg: AssemblyInstructionArg) -> str:
+    if isa(arg, AnyIntegerAttr):
+        return f"{arg.value.data}"
+    elif isinstance(arg, int):
+        return f"{arg}"
+    elif isinstance(arg, str):
+        return arg
+    elif isinstance(arg, GeneralRegisterType):
+        return arg.register_name
+    elif isinstance(arg, LabelAttr):
+        return arg.data
+    else:
+        if isinstance(arg.type, GeneralRegisterType):
+            reg = arg.type.register_name
+            return reg
+        else:
+            raise ValueError(f"Unexpected register type {arg.type}")
+
+
+def assembly_line(
+    name: str,
+    arg_str: str,
+    comment: StringAttr | None = None,
+    is_indented: bool = True,
+) -> str:
+    code = "    " if is_indented else ""
+    code += name
+    if arg_str:
+        code += f" {arg_str}"
+    code = append_comment(code, comment)
+    return code
+
+
+def parse_immediate_value(
+    parser: Parser, integer_type: IntegerType | IndexType
+) -> IntegerAttr[IntegerType | IndexType] | LabelAttr:
+    return parser.expect(
+        lambda: parse_optional_immediate_value(parser, integer_type),
+        "Expected immediate",
+    )
+
+
+def parse_optional_immediate_value(
+    parser: Parser, integer_type: IntegerType | IndexType
+) -> IntegerAttr[IntegerType | IndexType] | LabelAttr | None:
+    """
+    Parse an optional immediate value. If an integer is parsed, an integer attr with the specified type is created.
+    """
+    if (immediate := parser.parse_optional_integer()) is not None:
+        return IntegerAttr(immediate, integer_type)
+    if (immediate := parser.parse_optional_str_literal()) is not None:
+        return LabelAttr(immediate)
+
+
+def print_immediate_value(printer: Printer, immediate: AnyIntegerAttr | LabelAttr):
+    match immediate:
+        case IntegerAttr():
+            printer.print(immediate.value.data)
+        case LabelAttr():
+            printer.print_string_literal(immediate.data)
+
+
+def memory_access_str(
+    register: AssemblyInstructionArg, offset: AnyIntegerAttr | None
+) -> str:
+    register_str = assembly_arg_str(register)
+    if offset is not None:
+        offset_str = assembly_arg_str(offset)
+        if offset.value.data > 0:
+            mem_acc_str = f"[{register_str}+{offset_str}]"
+        else:
+            mem_acc_str = f"[{register_str}{offset_str}]"
+    else:
+        mem_acc_str = f"[{register_str}]"
+    return mem_acc_str
+
+
+def print_type_pair(printer: Printer, value: SSAValue) -> None:
+    printer.print_ssa_value(value)
+    printer.print_string(" : ")
+    printer.print_attribute(value.type)
+
+
+def parse_type_pair(parser: Parser) -> SSAValue:
+    unresolved = parser.parse_unresolved_operand()
+    parser.parse_punctuation(":")
+    type = parser.parse_type()
+    return parser.resolve_operand(unresolved, type)

--- a/xdsl/dialects/arm/attributes.py
+++ b/xdsl/dialects/arm/attributes.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from xdsl.ir import Data
+from xdsl.irdl import irdl_attr_definition
+from xdsl.parser import AttrParser
+from xdsl.printer import Printer
+
+
+@irdl_attr_definition
+class LabelAttr(Data[str]):
+    name = "arm.label"
+
+    @classmethod
+    def parse_parameter(cls, parser: AttrParser) -> str:
+        with parser.in_angle_brackets():
+            return parser.parse_str_literal()
+
+    def print_parameter(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string_literal(self.data)

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence, Set
+from typing import IO, Generic, TypeVar
+
+from typing_extensions import Self
+
+from xdsl.dialects.builtin import (
+    ModuleOp,
+    StringAttr,
+)
+from xdsl.dialects.func import FuncOp
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    Operation,
+    SSAValue,
+)
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_op_definition,
+    operand_def,
+    opt_attr_def,
+    result_def,
+)
+from xdsl.parser import Parser, UnresolvedOperand
+from xdsl.printer import Printer
+
+from .assembly import AssemblyInstructionArg, assembly_arg_str, assembly_line
+from .register import GeneralRegisterType
+
+R1InvT = TypeVar("R1InvT", bound=GeneralRegisterType)
+R2InvT = TypeVar("R2InvT", bound=GeneralRegisterType)
+R3InvT = TypeVar("R3InvT", bound=GeneralRegisterType)
+
+
+class ARMOp(Operation, ABC):
+    """
+    Base class for operations that can be a part of ARM assembly printing.
+    """
+
+    @abstractmethod
+    def assembly_line(self) -> str | None:
+        raise NotImplementedError()
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        args = cls.parse_unresolved_operands(parser)
+        custom_attributes = cls.custom_parse_attributes(parser)
+        remaining_attributes = parser.parse_optional_attr_dict()
+        # TODO ensure distinct keys for attributes
+        attributes = custom_attributes | remaining_attributes
+        regions = parser.parse_region_list()
+        pos = parser.pos
+        operand_types, result_types = cls.parse_op_type(parser)
+        operands = parser.resolve_operands(args, operand_types, pos)
+        return cls.create(
+            operands=operands,
+            result_types=result_types,
+            attributes=attributes,
+            regions=regions,
+        )
+
+    @classmethod
+    def parse_unresolved_operands(cls, parser: Parser) -> list[UnresolvedOperand]:
+        """
+        Parse a list of comma separated unresolved operands.
+        Notice that this method will consume trailing comma.
+        """
+        if operand := parser.parse_optional_unresolved_operand():
+            operands = [operand]
+            while parser.parse_optional_punctuation(",") and (
+                operand := parser.parse_optional_unresolved_operand()
+            ):
+                operands.append(operand)
+            return operands
+        return []
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        """
+        Parse attributes with custom syntax. Subclasses may override this method.
+        """
+        return parser.parse_optional_attr_dict()
+
+    @classmethod
+    def parse_op_type(
+        cls, parser: Parser
+    ) -> tuple[Sequence[Attribute], Sequence[Attribute]]:
+        parser.parse_punctuation(":")
+        func_type = parser.parse_function_type()
+        return func_type.inputs.data, func_type.outputs.data
+
+    def print(self, printer: Printer) -> None:
+        if self.operands:
+            printer.print(" ")
+            printer.print_list(self.operands, printer.print_operand)
+        printed_attributes = self.custom_print_attributes(printer)
+        unprinted_attributes = {
+            name: attr
+            for name, attr in self.attributes.items()
+            if name not in printed_attributes
+        }
+        printer.print_op_attributes(unprinted_attributes)
+        printer.print_regions(self.regions)
+        self.print_op_type(printer)
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        """
+        Print attributes with custom syntax. Return the names of the attributes printed. Subclasses may override this method.
+        """
+        printer.print_op_attributes(self.attributes)
+        return self.attributes.keys()
+
+    def print_op_type(self, printer: Printer) -> None:
+        printer.print(" : ")
+        printer.print_operation_type(self)
+
+
+class ARMInstruction(ARMOp):
+    """
+    Base class for operations that can be a part of ARM assembly printing. Must
+    represent an instruction in the ARM instruction set.
+    The name of the operation will be used as the ARM assembly instruction name.
+    """
+
+    comment = opt_attr_def(StringAttr)
+    """
+    An optional comment that will be printed along with the instruction.
+    """
+
+    @abstractmethod
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        """
+        The arguments to the instruction, in the order they should be printed in the
+        assembly.
+        """
+        raise NotImplementedError()
+
+    def assembly_instruction_name(self) -> str:
+        """
+        By default, the name of the instruction is the same as the name of the operation.
+        """
+
+        return Dialect.split_name(self.name)[1]
+
+    def assembly_line(self) -> str | None:
+        # default assembly code generator
+        instruction_name = self.assembly_instruction_name()
+        arg_str = ", ".join(
+            assembly_arg_str(arg)
+            for arg in self.assembly_line_args()
+            if arg is not None
+        )
+        return assembly_line(instruction_name, arg_str, self.comment)
+
+
+class R_RR_Operation(Generic[R1InvT, R2InvT], IRDLOperation, ARMInstruction, ABC):
+    """
+    A base class for ARM operations that have two registers.
+    """
+
+    r1 = operand_def(R1InvT)
+    r2 = operand_def(R2InvT)
+
+    result = result_def(R1InvT)
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        r2: Operation | SSAValue,
+        *,
+        comment: str | StringAttr | None = None,
+        result: R1InvT,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1, r2],
+            attributes={
+                "comment": comment,
+            },
+            result_types=[result],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return self.r1, self.r2
+
+
+@irdl_op_definition
+class RR_MovOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
+    """
+    Copies the value of r1 into r2.
+    x[r1] = x[r2]
+    https://developer.arm.com/documentation/dui0473/m/arm-and-thumb-instructions/mov
+    """
+
+    name = "arm.rr.mov"
+
+
+class GetAnyRegisterOperation(Generic[R1InvT], IRDLOperation, ARMOp):
+    """
+    This instruction allows us to create an SSAValue for a given register name.
+    """
+
+    result = result_def(R1InvT)
+
+    def __init__(
+        self,
+        register_type: R1InvT,
+    ):
+        super().__init__(result_types=[register_type])
+
+    def assembly_line(self) -> str | None:
+        return None
+
+
+@irdl_op_definition
+class GetRegisterOp(GetAnyRegisterOperation[GeneralRegisterType]):
+    name = "arm.get_register"
+
+
+def print_assembly(module: ModuleOp, output: IO[str]) -> None:
+    for op in module.body.walk():
+        if isinstance(op, FuncOp):
+            print(f"{op.sym_name.data}:", file=output)
+            continue
+        assert isinstance(op, ARMOp), f"{op}"
+        asm = op.assembly_line()
+        if asm is not None:
+            print(asm, file=output)

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from xdsl.backend.register_type import RegisterType
+from xdsl.ir import Attribute
+from xdsl.irdl import (
+    irdl_attr_definition,
+)
+from xdsl.parser import AttrParser
+from xdsl.utils.exceptions import VerifyException
+
+
+class ARMRegisterType(RegisterType):
+    """
+    The abstract class for all ARM register types.
+    """
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
+        if parser.parse_optional_punctuation("<") is not None:
+            name = parser.parse_identifier()
+            parser.parse_punctuation(">")
+            if not name.startswith("x"):  # only including x regs for now
+                assert (
+                    name in cls.abi_index_by_name()
+                ), f"{name}"  # abi_index_by_name raises NotImplementedError (?)
+        else:
+            name = ""
+        return cls._parameters_from_spelling(name)
+
+    def verify(self) -> None:
+        name = self.spelling.data
+        if not self.is_allocated or name.startswith("x"):
+            return
+        if name not in type(self).abi_index_by_name():
+            raise VerifyException(f"{name} not in {self.instruction_set_name()}")
+
+
+ARM_INDEX_BY_NAME = {
+    "x0": 0,
+    "x1": 1,
+    "x2": 2,
+    "x3": 3,
+    "x4": 4,
+    "x5": 5,
+    "x6": 6,
+    "x7": 7,
+    "x8": 8,
+    "x9": 9,
+    "x10": 10,
+    "x11": 11,
+    "x12": 12,
+    "x13": 13,
+    "x14": 14,
+    "x15": 15,
+    "x16": 16,
+    "x17": 17,
+    "x18": 18,
+    "x19": 19,
+    "x20": 20,
+    "x21": 21,
+    "x22": 22,
+    "x23": 23,
+    "x24": 24,
+    "x25": 25,
+    "x26": 26,
+    "x27": 27,
+    "x28": 28,
+    "x29": 29,
+    "x30": 30,
+}
+
+
+@irdl_attr_definition
+class GeneralRegisterType(ARMRegisterType):
+    """
+    A scalar ARM register type representing general registers.
+    """
+
+    name = "arm.reg"
+
+    @classmethod
+    def unallocated(cls) -> GeneralRegisterType:
+        return UNALLOCATED_GENERAL
+
+    @classmethod
+    def instruction_set_name(cls) -> str:
+        return "arm"
+
+    @classmethod
+    def abi_index_by_name(cls) -> dict[str, int]:
+        return ARM_INDEX_BY_NAME
+
+
+UNALLOCATED_GENERAL = GeneralRegisterType("")
+X0 = GeneralRegisterType("x0")
+X1 = GeneralRegisterType("x1")
+X2 = GeneralRegisterType("x2")
+X3 = GeneralRegisterType("x3")
+X4 = GeneralRegisterType("x4")
+X5 = GeneralRegisterType("x5")
+X6 = GeneralRegisterType("x6")
+X7 = GeneralRegisterType("x7")
+X8 = GeneralRegisterType("x8")
+X9 = GeneralRegisterType("x9")
+X10 = GeneralRegisterType("x10")
+X11 = GeneralRegisterType("x11")
+X12 = GeneralRegisterType("x12")
+X13 = GeneralRegisterType("x13")
+X14 = GeneralRegisterType("x14")
+X15 = GeneralRegisterType("x15")
+X16 = GeneralRegisterType("x16")
+X17 = GeneralRegisterType("x17")
+X18 = GeneralRegisterType("x18")
+X19 = GeneralRegisterType("x19")
+X20 = GeneralRegisterType("x20")
+X21 = GeneralRegisterType("x21")
+X22 = GeneralRegisterType("x22")
+X23 = GeneralRegisterType("x23")
+X24 = GeneralRegisterType("x24")
+X25 = GeneralRegisterType("x25")
+X26 = GeneralRegisterType("x26")
+X27 = GeneralRegisterType("x27")
+X28 = GeneralRegisterType("x28")
+X29 = GeneralRegisterType("x29")
+X30 = GeneralRegisterType("x30")

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -212,6 +212,11 @@ class xDSLOptMain(CommandLineTool):
 
             print_assembly(prog, output)
 
+        def _output_arm_asm(prog: ModuleOp, output: IO[str]):
+            from xdsl.dialects.arm.ops import print_assembly
+
+            print_assembly(prog, output)
+
         def _output_wat(prog: ModuleOp, output: IO[str]):
             from xdsl.dialects.wasm import WasmModule
             from xdsl.dialects.wasm.wat import WatPrinter
@@ -244,6 +249,7 @@ class xDSLOptMain(CommandLineTool):
         self.available_targets["mlir"] = _output_mlir
         self.available_targets["riscv-asm"] = _output_riscv_asm
         self.available_targets["x86-asm"] = _output_x86_asm
+        self.available_targets["arm-asm"] = _output_arm_asm
         self.available_targets["riscemu"] = _emulate_riscv
         self.available_targets["wat"] = _output_wat
         self.available_targets["csl"] = _print_to_csl


### PR DESCRIPTION
Initialise a dialect for ARM instructions, similar to the existing x86 dialect. Add support for an initial mov operation which moves data from the source register to the destination.