### PR TITLE
core: new inference system for constraints

### DIFF
--- a/tests/dialects/test_bufferization.py
+++ b/tests/dialects/test_bufferization.py
@@ -45,7 +45,7 @@ def test_tensor_from_memref_inference():
         EqAttrConstraint(UnrankedMemrefType.from_type(f64))
     )
     assert constr3.can_infer(set())
-    assert constr3.infer(dict()) == UnrankedTensorType(f64)
+    assert constr3.infer({}) == UnrankedTensorType(f64)
 
 
 @irdl_op_definition

--- a/tests/dialects/test_bufferization.py
+++ b/tests/dialects/test_bufferization.py
@@ -39,7 +39,7 @@ def test_tensor_from_memref_inference():
         EqAttrConstraint(MemRefType(f64, [10, 20, 30]))
     )
     assert constr2.can_infer(set())
-    assert constr2.infer(dict()) == TensorType(f64, [10, 20, 30])
+    assert constr2.infer({}) == TensorType(f64, [10, 20, 30])
 
     constr3 = TensorFromMemrefConstraint(
         EqAttrConstraint(UnrankedMemrefType.from_type(f64))

--- a/tests/dialects/test_bufferization.py
+++ b/tests/dialects/test_bufferization.py
@@ -22,7 +22,6 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Attribute
 from xdsl.irdl import (
-    ConstraintContext,
     EqAttrConstraint,
     IRDLOperation,
     VarConstraint,
@@ -40,13 +39,13 @@ def test_tensor_from_memref_inference():
         EqAttrConstraint(MemRefType(f64, [10, 20, 30]))
     )
     assert constr2.can_infer(set())
-    assert constr2.infer(ConstraintContext()) == TensorType(f64, [10, 20, 30])
+    assert constr2.infer(dict()) == TensorType(f64, [10, 20, 30])
 
     constr3 = TensorFromMemrefConstraint(
         EqAttrConstraint(UnrankedMemrefType.from_type(f64))
     )
     assert constr3.can_infer(set())
-    assert constr3.infer(ConstraintContext()) == UnrankedTensorType(f64)
+    assert constr3.infer(dict()) == UnrankedTensorType(f64)
 
 
 @irdl_op_definition

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -163,7 +163,7 @@ def test_vector_rank_constraint_verify():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorRankConstraint(2)
 
-    constraint.verify(vector_type)
+    constraint.verify(vector_type, ConstraintContext())
 
 
 def test_vector_rank_constraint_rank_mismatch():
@@ -171,7 +171,7 @@ def test_vector_rank_constraint_rank_mismatch():
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, ConstraintContext())
     assert e.value.args[0] == "Expected vector rank to be 3, got 2."
 
 
@@ -180,7 +180,7 @@ def test_vector_rank_constraint_attr_mismatch():
     constraint = VectorRankConstraint(3)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type)
+        constraint.verify(memref_type, ConstraintContext())
     assert e.value.args[0] == "memref<1x2xi32> should be of type VectorType."
 
 
@@ -188,7 +188,7 @@ def test_vector_base_type_constraint_verify():
     vector_type = VectorType(i32, [1, 2])
     constraint = VectorBaseTypeConstraint(i32)
 
-    constraint.verify(vector_type)
+    constraint.verify(vector_type, ConstraintContext())
 
 
 def test_vector_base_type_constraint_type_mismatch():
@@ -196,7 +196,7 @@ def test_vector_base_type_constraint_type_mismatch():
     constraint = VectorBaseTypeConstraint(i64)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(vector_type)
+        constraint.verify(vector_type, ConstraintContext())
     assert e.value.args[0] == "Expected vector type to be i64, got i32."
 
 
@@ -205,7 +205,7 @@ def test_vector_base_type_constraint_attr_mismatch():
     constraint = VectorBaseTypeConstraint(i32)
 
     with pytest.raises(VerifyException) as e:
-        constraint.verify(memref_type)
+        constraint.verify(memref_type, ConstraintContext())
     assert e.value.args[0] == "memref<1x2xi32> should be of type VectorType."
 
 

--- a/tests/filecheck/dialects/onnx/onnx_invalid.mlir
+++ b/tests/filecheck/dialects/onnx/onnx_invalid.mlir
@@ -369,7 +369,7 @@ builtin.module {
   %t0 = "test.op"(): () ->  (f32)
 
   // CHECK: operand at position 0 does not verify:
-  // CHECK: Unexpected attribute f32
+  // CHECK: Expected tensor or memref type, got f32
   %res_max_pool_single_out =  "onnx.MaxPoolSingleOut"(%t0) {onnx_node_name = "/MaxPoolSingleOut"} : (f32) -> tensor<5x5x32x32xf32>
 }
 
@@ -379,7 +379,7 @@ builtin.module {
     %t0= "test.op"(): () ->  (tensor<5x5x32x32xf32>)
 
   // CHECK: result at position 0 does not verify:
-  // CHECK: Unexpected attribute tensor<5x5x32x32xi32>
+  // CHECK: attribute f32 expected from variable 'T', but got i32
   %res_max_pool_single_out = "onnx.MaxPoolSingleOut"(%t0) {"onnx_node_name" = "/MaxPoolSingleOut"} : (tensor<5x5x32x32xf32>) -> tensor<5x5x32x32xi32>
 
 }
@@ -565,7 +565,7 @@ builtin.module {
 
 builtin.module {
   %t0 = "test.op"() : () -> (tensor<3x4xf32>)
-  
+
   // CHECK: Operation does not verify: tensor input shape (3, 4) is not equal to tensor output shape (7, 3)
   %res_sigmoid =  "onnx.Sigmoid"(%t0) {onnx_node_name = "/Sigmoid"} : (tensor<3x4xf32>) -> tensor<7x3xf32>
 }

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -381,11 +381,7 @@ def test_union_constraint_fail():
 
 
 class PositiveIntConstr(AttrConstraint):
-    def verify(
-        self,
-        attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
-    ) -> None:
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(
                 f"Expected {IntData.name} attribute, but got {attr.name}."
@@ -602,7 +598,7 @@ def test_informative_constraint():
         match="User-enlightening message.\nUnderlying verification failure: Expected attribute #none but got #builtin.int<1>",
     ):
         constr.verify(IntAttr(1), ConstraintContext())
-    assert constr.get_resolved_variables() == set()
+    assert constr.can_infer(set())
     assert constr.get_unique_base() == NoneAttr
 
 

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -62,7 +62,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import ParseError, PyRDLOpDefinitionError
+from xdsl.utils.exceptions import ParseError, PyRDLOpDefinitionError, VerifyException
 
 ################################################################################
 # Utils for this test file                                                     #
@@ -1748,10 +1748,12 @@ def test_non_verifying_inference():
     %1 = test.one_operand_one_result_nested %0 : i32"""
     )
     with pytest.raises(
-        ParseError,
-        match="Verification error while inferring operation type: ",
+        VerifyException,
+        match="i32 should be of base attribute test.param_one",
     ):
-        check_roundtrip(program, ctx)
+        parser = Parser(ctx, program)
+        while (op := parser.parse_optional_operation()) is not None:
+            op.verify()
 
 
 def test_variadic_length_inference():

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -13,6 +13,7 @@ from xdsl.dialects.builtin import (
     I32,
     BoolAttr,
     IntegerAttr,
+    MemRefType,
     ModuleOp,
     UnitAttr,
 )
@@ -2215,3 +2216,103 @@ def test_renamed_optional_prop(program: str, output: str, generic: str):
     printer.print_op(parsed)
 
     assert generic == stream.getvalue()
+
+
+################################################################################
+#                                Extractors                                    #
+################################################################################
+
+
+@irdl_op_definition
+class AllOfExtractorOp(IRDLOperation):
+    name = "test.all_of_extractor"
+
+    T: ClassVar = VarConstraint("T", AnyAttr())
+    lhs = operand_def(T & MemRefType.constr(element_type=T))
+    rhs = operand_def(T)
+
+    assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs)"
+
+
+def test_all_of_extraction_fails():
+    ctx = MLContext()
+    ctx.load_op(AllOfExtractorOp)
+    ctx.load_dialect(Test)
+    parser = Parser(
+        ctx,
+        '%0 = "test.op"() : () -> memref<10xindex>\ntest.all_of_extractor %0, %0 : memref<10xindex>',
+    )
+    parser.parse_operation()
+    with pytest.raises(
+        ValueError,
+        match="Value of variable T could not be uniquely extracted.\n"
+        "Possible values are: {index, memref<10xindex>}",
+    ):
+        parser.parse_operation()
+
+
+@irdl_attr_definition
+class DoubleParamAttr(ParametrizedAttribute, TypeAttribute):
+    """An attribute with two unbounded attribute parameters."""
+
+    name = "test.param"
+
+    param1: ParameterDef[Attribute]
+    param2: ParameterDef[Attribute]
+
+
+@irdl_op_definition
+class ParamExtractorOp(IRDLOperation):
+    name = "test.param_extractor"
+
+    T: ClassVar = VarConstraint("T", AnyAttr())
+    lhs = operand_def(ParamAttrConstraint(DoubleParamAttr, (T, T)))
+    rhs = operand_def(T)
+
+    assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs)"
+
+
+def test_param_extraction_fails():
+    ctx = MLContext()
+    ctx.load_attr(DoubleParamAttr)
+    ctx.load_op(ParamExtractorOp)
+    ctx.load_dialect(Test)
+    parser = Parser(
+        ctx,
+        '%0 = "test.op"() : () -> !test.param<i32,i64>\ntest.param_extractor %0, %0 : !test.param<i32,i64>',
+    )
+    parser.parse_operation()
+    with pytest.raises(
+        ValueError,
+        match="Value of variable T could not be uniquely extracted.\n"
+        "Possible values are: {i32, i64}",
+    ):
+        parser.parse_operation()
+
+
+@irdl_op_definition
+class MultipleOperandExtractorOp(IRDLOperation):
+    name = "test.multiple_operand_extractor"
+
+    T: ClassVar = VarConstraint("T", AnyAttr())
+    lhs = operand_def(T)
+    rhs = operand_def(T)
+
+    assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs)"
+
+
+def test_multiple_operand_extraction_fails():
+    ctx = MLContext()
+    ctx.load_op(MultipleOperandExtractorOp)
+    ctx.load_dialect(Test)
+    parser = Parser(
+        ctx,
+        '%0, %1 = "test.op"() : () -> (index, i32)\ntest.multiple_operand_extractor %0, %1 : index, i32',
+    )
+    parser.parse_operation()
+    with pytest.raises(
+        ValueError,
+        match="Value of variable T could not be uniquely extracted.\n"
+        "Possible values are: {i32, index}",
+    ):
+        parser.parse_operation()

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -135,7 +135,7 @@ class LessThan(AttrConstraint):
     def verify(
         self,
         attr: Attribute,
-        constraint_context: ConstraintContext | None = None,
+        constraint_context: ConstraintContext,
     ) -> None:
         if not isinstance(attr, IntData):
             raise VerifyException(f"{attr} should be of base attribute {IntData.name}")

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Sequence, Set
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
@@ -22,6 +22,7 @@ from xdsl.irdl import (
     ConstraintContext,
     GenericAttrConstraint,
     IRDLOperation,
+    ResolveType,
     VarConstraint,
     irdl_op_definition,
     operand_def,
@@ -48,18 +49,16 @@ class TensorFromMemrefConstraint(
         MemRefType[Attribute] | UnrankedMemrefType[Attribute]
     ]
 
-    def can_infer(self, constraint_names: set[str]) -> bool:
-        return self.memref_constraint.can_infer(constraint_names)
+    def can_infer(self, variables: Set[str]) -> bool:
+        return self.memref_constraint.can_infer(variables)
 
-    def infer(self, constraint_context: ConstraintContext) -> Attribute:
-        memref_type = self.memref_constraint.infer(constraint_context)
-        if isa(memref_type, MemRefType[Attribute]):
+    def infer(
+        self, variables: dict[str, ResolveType]
+    ) -> TensorType[Attribute] | UnrankedTensorType[Attribute]:
+        memref_type = self.memref_constraint.infer(variables)
+        if isinstance(memref_type, MemRefType):
             return TensorType(memref_type.element_type, memref_type.shape)
-        assert isa(memref_type, UnrankedMemrefType[Attribute])
         return UnrankedTensorType(memref_type.element_type)
-
-    def get_resolved_variables(self) -> set[str]:
-        return self.memref_constraint.get_resolved_variables()
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         if isa(attr, TensorType[Attribute]):
@@ -67,8 +66,8 @@ class TensorFromMemrefConstraint(
             return self.memref_constraint.verify(memref_type, constraint_context)
         if isa(attr, UnrankedTensorType[Attribute]):
             memref_type = UnrankedMemrefType.from_type(attr.element_type)
-            return self.memref_constraint.verify(memref_type, constraint_context)
-        raise VerifyException(f"Expected tensor or unranked tensor type, got {attr}")
+
+        raise VerifyException(f"Expected TensorType or UnrankedTensorType, got {attr}")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -63,11 +63,13 @@ class TensorFromMemrefConstraint(
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         if isa(attr, TensorType[Attribute]):
             memref_type = MemRefType(attr.element_type, attr.shape)
-            return self.memref_constraint.verify(memref_type, constraint_context)
-        if isa(attr, UnrankedTensorType[Attribute]):
+        elif isa(attr, UnrankedTensorType[Attribute]):
             memref_type = UnrankedMemrefType.from_type(attr.element_type)
-
-        raise VerifyException(f"Expected TensorType or UnrankedTensorType, got {attr}")
+        else:
+            raise VerifyException(
+                f"Expected tensor or unranked tensor type, got {attr}"
+            )
+        return self.memref_constraint.verify(memref_type, constraint_context)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -20,9 +20,9 @@ from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     ConstraintContext,
+    ConstraintVariableType,
     GenericAttrConstraint,
     IRDLOperation,
-    ResolveType,
     VarConstraint,
     irdl_op_definition,
     operand_def,
@@ -53,7 +53,7 @@ class TensorFromMemrefConstraint(
         return self.memref_constraint.can_infer(variables)
 
     def infer(
-        self, variables: dict[str, ResolveType]
+        self, variables: dict[str, ConstraintVariableType]
     ) -> TensorType[Attribute] | UnrankedTensorType[Attribute]:
         memref_type = self.memref_constraint.infer(variables)
         if isinstance(memref_type, MemRefType):

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -49,8 +49,8 @@ class TensorFromMemrefConstraint(
         MemRefType[Attribute] | UnrankedMemrefType[Attribute]
     ]
 
-    def can_infer(self, variables: Set[str]) -> bool:
-        return self.memref_constraint.can_infer(variables)
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return self.memref_constraint.can_infer(var_constraint_names)
 
     def infer(
         self, variables: dict[str, ConstraintVariableType]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -22,6 +22,7 @@ from typing_extensions import Self, deprecated
 from xdsl.ir import (
     Attribute,
     AttributeCovT,
+    AttributeInvT,
     Block,
     BlockOps,
     Data,
@@ -52,6 +53,8 @@ from xdsl.irdl import (
     MessageConstraint,
     ParamAttrConstraint,
     ParameterDef,
+    Resolver,
+    ResolveType,
     attr_constr_coercion,
     base,
     irdl_attr_definition,
@@ -83,7 +86,7 @@ A constant value denoting a dynamic index in a shape.
 """
 
 
-class ShapedType(ABC):
+class ShapedType(Attribute, ABC):
     @abstractmethod
     def get_num_dims(self) -> int: ...
 
@@ -99,14 +102,6 @@ class ShapedType(ABC):
         from itertools import accumulate
 
         return tuple(accumulate(reversed(shape), operator.mul, initial=factor))[-2::-1]
-
-
-class AnyShapedType(AttrConstraint):
-    def verify(
-        self, attr: Attribute, constraint_context: ConstraintContext | None = None
-    ) -> None:
-        if not isinstance(attr, ShapedType):
-            raise Exception(f"expected type ShapedType but got {attr}")
 
 
 _ContainerElementTypeT = TypeVar(
@@ -1635,6 +1630,49 @@ class MemRefType(
 
 AnyMemRefType: TypeAlias = MemRefType[Attribute]
 AnyMemRefTypeConstr = BaseAttr[MemRefType[Attribute]](MemRefType)
+
+
+@dataclass(frozen=True, init=False)
+class TensorOrMemrefOf(
+    GenericAttrConstraint[TensorType[AttributeCovT] | MemRefType[AttributeCovT]]
+):
+    """A type constraint that can be nested once in a memref or a tensor."""
+
+    elem_constr: GenericAttrConstraint[AttributeCovT]
+
+    def __init__(
+        self,
+        elem_constr: AttributeCovT
+        | type[AttributeCovT]
+        | GenericAttrConstraint[AttributeCovT],
+    ) -> None:
+        object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
+
+    @dataclass(frozen=True)
+    class _Resolver(Resolver[TensorType[AttributeInvT] | MemRefType[AttributeInvT]]):
+        resolver: Resolver[AttributeInvT]
+
+        def resolve(
+            self, a: TensorType[AttributeInvT] | MemRefType[AttributeInvT]
+        ) -> ResolveType:
+            return self.resolver.resolve(a.element_type)
+
+    def get_resolvers(
+        self,
+    ) -> dict[
+        str,
+        Resolver[TensorType[AttributeCovT] | MemRefType[AttributeCovT]],
+    ]:
+        return {
+            v: self._Resolver(r) for v, r in self.elem_constr.get_resolvers().items()
+        }
+
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+        if isinstance(attr, VectorType) or isinstance(attr, TensorType):
+            attr = cast(VectorType[Attribute] | TensorType[Attribute], attr)
+            self.elem_constr.verify(attr.element_type, constraint_context)
+        else:
+            raise VerifyException(f"Expected tensor or memref type, got {attr}")
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -13,7 +13,6 @@ from xdsl.dialects.builtin import (
     AffineMapAttr,
     AnyFloat,
     AnyMemRefType,
-    AnyShapedType,
     AnyTensorType,
     ArrayAttr,
     DenseArrayBase,
@@ -100,7 +99,7 @@ class Generic(IRDLOperation):
     name = "linalg.generic"
 
     inputs = var_operand_def()
-    outputs = var_operand_def(AnyShapedType())
+    outputs = var_operand_def(base(ShapedType))
 
     res = var_result_def(AnyTensorType)
 
@@ -396,7 +395,7 @@ class NamedOpBase(IRDLOperation, ABC):
     """
 
     inputs = var_operand_def()
-    outputs = var_operand_def(AnyShapedType())
+    outputs = var_operand_def(base(ShapedType))
 
     res = var_result_def(AnyTensorType)
 
@@ -951,7 +950,7 @@ class PoolingOpsBase(IRDLOperation, ABC):
     """Base class for linalg pooling operations."""
 
     inputs = var_operand_def()
-    outputs = var_operand_def(AnyShapedType())
+    outputs = var_operand_def(base(ShapedType))
 
     res = var_result_def(AnyTensorType)
 
@@ -1002,7 +1001,7 @@ class ConvOpsBase(IRDLOperation, ABC):
     """Base class for linalg convolution operations."""
 
     inputs = var_operand_def()
-    outputs = var_operand_def(AnyShapedType())
+    outputs = var_operand_def(base(ShapedType))
 
     res = var_result_def(AnyTensorType)
 

--- a/xdsl/dialects/onnx.py
+++ b/xdsl/dialects/onnx.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import math
 from abc import ABC
-from typing import Annotated, cast
+from typing import Annotated, ClassVar, cast
 
 from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     Any,
     AnyFloat,
+    AnyFloatConstr,
     AnyIntegerAttr,
     AnyTensorType,
     ArrayAttr,
@@ -22,6 +23,7 @@ from xdsl.dialects.builtin import (
     SSAValue,
     StringAttr,
     SymbolRefAttr,
+    TensorOrMemrefOf,
     TensorType,
 )
 from xdsl.ir import (
@@ -31,6 +33,7 @@ from xdsl.ir import (
 from xdsl.irdl import (
     ConstraintVar,
     IRDLOperation,
+    VarConstraint,
     attr_def,
     base,
     irdl_op_definition,
@@ -703,9 +706,9 @@ class MaxPoolSingleOut(IRDLOperation):
 
     name = "onnx.MaxPoolSingleOut"
 
-    T = Annotated[AnyFloat | IntegerType, ConstraintVar("T")]
-    data = operand_def(base(TensorType[T]) | base(MemRefType[T]))
-    output = result_def(base(TensorType[T]) | base(MemRefType[T]))
+    T: ClassVar = VarConstraint("T", AnyFloatConstr | base(IntegerType))
+    data = operand_def(TensorOrMemrefOf(T))
+    output = result_def(TensorOrMemrefOf(T))
 
     auto_pad = attr_def(StringAttr)
     ceil_mode = attr_def(AnyIntegerAttr)

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1213,10 +1213,7 @@ class TensorIgnoreSizeConstraint(VarConstraint[Attribute]):
             and attr.get_element_type() == other.get_element_type()
         )
 
-    def verify(
-        self, attr: Attribute, constraint_context: ConstraintContext | None = None
-    ) -> None:
-        constraint_context = constraint_context or ConstraintContext()
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
         if self.name in constraint_context.variables:
             if isa(attr, TensorType[Attribute]) and TensorIgnoreSizeConstraint.matches(
                 attr, constraint_context.get_variable(self.name)

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -572,7 +572,7 @@ class MessageConstraint(GenericAttrConstraint[AttributeCovT]):
 
 @dataclass(frozen=True)
 class GenericRangeConstraint(Generic[AttributeCovT], ABC):
-    """Constrain an range of attributes to certain values."""
+    """Constrain a range of attributes to certain values."""
 
     @abstractmethod
     def verify(

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -146,7 +146,7 @@ class GenericAttrConstraint(Generic[AttributeCovT], ABC):
         which provide a method to obtain the value of each constraint variable from
         the value of the attribute which is verified by this constraint.
         """
-        return dict()
+        return {}
 
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
         """

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -97,7 +97,7 @@ class MergeExtractor(VarExtractor[_T]):
             )
 
     def flatten(self) -> Iterator[VarExtractor[_T]]:
-        return self.extractors.__iter__()
+        return iter(self.extractors)
 
 
 def merge_extractors(variable: str, *extractors: VarExtractor[_T]) -> VarExtractor[_T]:

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -594,7 +594,7 @@ class GenericRangeConstraint(Generic[AttributeCovT], ABC):
         which provide a method to obtain the value of each constraint variable from
         the value of the attribute range which is verified by this constraint.
         """
-        return dict()
+        return {}
 
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
         """

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -148,7 +148,7 @@ class GenericAttrConstraint(Generic[AttributeCovT], ABC):
         """
         return dict()
 
-    def can_infer(self, variables: Set[str]) -> bool:
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
         """
         Check if there is enough information to infer the attribute given the
         constraint variables that are already set.
@@ -232,8 +232,8 @@ class VarConstraint(GenericAttrConstraint[AttributeCovT]):
         v = variables[self.name]
         return cast(AttributeCovT, v)
 
-    def can_infer(self, variables: Set[str]) -> bool:
-        return self.name in variables
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return self.name in var_constraint_names
 
     def get_unique_base(self) -> type[Attribute] | None:
         return self.constraint.get_unique_base()
@@ -269,7 +269,7 @@ class EqAttrConstraint(Generic[AttributeCovT], GenericAttrConstraint[AttributeCo
         if attr != self.attr:
             raise VerifyException(f"Expected attribute {self.attr} but got {attr}")
 
-    def can_infer(self, variables: Set[str]) -> bool:
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
         return True
 
     def infer(self, variables: dict[str, ConstraintVariableType]) -> AttributeCovT:
@@ -422,8 +422,10 @@ class AllOf(GenericAttrConstraint[AttributeCovT]):
             *(constr.get_variable_extractors() for constr in self.attr_constrs)
         )
 
-    def can_infer(self, variables: Set[str]) -> bool:
-        return any(constr.can_infer(variables) for constr in self.attr_constrs)
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return any(
+            constr.can_infer(var_constraint_names) for constr in self.attr_constrs
+        )
 
     def infer(self, variables: dict[str, ConstraintVariableType]) -> AttributeCovT:
         for constr in self.attr_constrs:
@@ -561,8 +563,8 @@ class MessageConstraint(GenericAttrConstraint[AttributeCovT]):
     def get_unique_base(self) -> type[Attribute] | None:
         return self.constr.get_unique_base()
 
-    def can_infer(self, variables: Set[str]) -> bool:
-        return self.constr.can_infer(variables)
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return self.constr.can_infer(var_constraint_names)
 
     def infer(self, variables: dict[str, ConstraintVariableType]) -> AttributeCovT:
         return self.constr.infer(variables)
@@ -594,7 +596,7 @@ class GenericRangeConstraint(Generic[AttributeCovT], ABC):
         """
         return dict()
 
-    def can_infer(self, variables: Set[str]) -> bool:
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
         """
         Check if there is enough information to infer the attribute given the
         constraint variables that are already set.
@@ -655,8 +657,8 @@ class RangeVarConstraint(GenericRangeConstraint[AttributeCovT]):
     ) -> dict[str, VarExtractor[Sequence[AttributeCovT]]]:
         return {self.name: IdExtractor[Sequence[AttributeCovT]]()}
 
-    def can_infer(self, variables: Set[str]) -> bool:
-        return self.name in variables
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return self.name in var_constraint_names
 
     def infer(
         self,
@@ -683,8 +685,8 @@ class RangeOf(GenericRangeConstraint[AttributeCovT]):
         for a in attrs:
             self.constr.verify(a, constraint_context)
 
-    def can_infer(self, variables: Set[str]) -> bool:
-        return self.constr.can_infer(variables)
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return self.constr.can_infer(var_constraint_names)
 
     def infer(
         self,
@@ -727,8 +729,8 @@ class SingleOf(GenericRangeConstraint[AttributeCovT]):
             for v, r in self.constr.get_variable_extractors().items()
         }
 
-    def can_infer(self, variables: Set[str]) -> bool:
-        return self.constr.can_infer(variables)
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return self.constr.can_infer(var_constraint_names)
 
     def infer(
         self,

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -21,13 +21,13 @@ from xdsl.ir import (
     TypedAttribute,
 )
 from xdsl.irdl import (
+    ConstraintVariableType,
     IRDLOperation,
     IRDLOperationInvT,
     OpDef,
     OptionalDef,
-    Resolver,
-    ResolveType,
     Successor,
+    VarExtractor,
     VariadicDef,
     VarIRConstruct,
 )
@@ -53,7 +53,7 @@ class ParsingState:
     successors: list[Successor | None | Sequence[Successor]]
     attributes: dict[str, Attribute]
     properties: dict[str, Attribute]
-    variables: dict[str, ResolveType]
+    variables: dict[str, ConstraintVariableType]
 
     def __init__(self, op_def: OpDef):
         self.operands = [None] * len(op_def.operands)
@@ -94,8 +94,8 @@ class FormatProgram:
     stmts: tuple[FormatDirective, ...]
     """The statements composing the program. They are executed in order."""
 
-    resolvers: dict[str, Resolver[ParsingState]]
-    """Resolvers for all type variables."""
+    extractors: dict[str, VarExtractor[ParsingState]]
+    """Extractors for all type variables from the parsing state."""
 
     @staticmethod
     def from_str(input: str, op_def: OpDef) -> FormatProgram:
@@ -171,7 +171,7 @@ class FormatProgram:
         )
 
     def resolve_constraint_variables(self, state: ParsingState):
-        state.variables = {v: r.resolve(state) for v, r in self.resolvers.items()}
+        state.variables = {v: r.extract_var(state) for v, r in self.extractors.items()}
 
     def resolve_operand_types(self, state: ParsingState, op_def: OpDef) -> None:
         """

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -21,18 +21,18 @@ from xdsl.ir import (
     TypedAttribute,
 )
 from xdsl.irdl import (
-    ConstraintContext,
     IRDLOperation,
     IRDLOperationInvT,
     OpDef,
     OptionalDef,
+    Resolver,
+    ResolveType,
     Successor,
     VariadicDef,
     VarIRConstruct,
 )
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.lexer import PunctuationSpelling
 
 OperandOrResult = Literal[VarIRConstruct.OPERAND, VarIRConstruct.RESULT]
@@ -53,7 +53,7 @@ class ParsingState:
     successors: list[Successor | None | Sequence[Successor]]
     attributes: dict[str, Attribute]
     properties: dict[str, Attribute]
-    constraint_context: ConstraintContext
+    variables: dict[str, ResolveType]
 
     def __init__(self, op_def: OpDef):
         self.operands = [None] * len(op_def.operands)
@@ -63,7 +63,7 @@ class ParsingState:
         self.successors = [None] * len(op_def.successors)
         self.attributes = {}
         self.properties = {}
-        self.constraint_context = ConstraintContext()
+        self.variables = {}
 
 
 @dataclass
@@ -94,6 +94,9 @@ class FormatProgram:
     stmts: tuple[FormatDirective, ...]
     """The statements composing the program. They are executed in order."""
 
+    resolvers: dict[str, Resolver[ParsingState]]
+    """Resolvers for all type variables."""
+
     @staticmethod
     def from_str(input: str, op_def: OpDef) -> FormatProgram:
         """
@@ -120,7 +123,7 @@ class FormatProgram:
             stmt.parse(parser, state)
 
         # Get constraint variables from the parsed operand and result types
-        self.assign_constraint_variables(parser, state, op_def)
+        self.resolve_constraint_variables(state)
 
         # Infer operand types that should be inferred
         unresolved_operands = state.operands
@@ -167,35 +170,8 @@ class FormatProgram:
             successors=state.successors,
         )
 
-    def assign_constraint_variables(
-        self, parser: Parser, state: ParsingState, op_def: OpDef
-    ):
-        """
-        Assign constraint variables with values got from the
-        parsed operand and result types.
-        """
-        if any(type is None for type in (*state.operand_types, *state.result_types)):
-            try:
-                for (_, operand_def), operand_type in zip(
-                    op_def.operands, state.operand_types, strict=True
-                ):
-                    if operand_type is None:
-                        continue
-                    if isinstance(operand_type, Attribute):
-                        operand_type = (operand_type,)
-                    operand_def.constr.verify(operand_type, state.constraint_context)
-                for (_, result_def), result_type in zip(
-                    op_def.results, state.result_types, strict=True
-                ):
-                    if result_type is None:
-                        continue
-                    if isinstance(result_type, Attribute):
-                        result_type = (result_type,)
-                    result_def.constr.verify(result_type, state.constraint_context)
-            except VerifyException as e:
-                parser.raise_error(
-                    "Verification error while inferring operation type: " + str(e)
-                )
+    def resolve_constraint_variables(self, state: ParsingState):
+        state.variables = {v: r.resolve(state) for v, r in self.resolvers.items()}
 
     def resolve_operand_types(self, state: ParsingState, op_def: OpDef) -> None:
         """
@@ -209,7 +185,8 @@ class FormatProgram:
                 operand = state.operands[i]
                 range_length = len(operand) if isinstance(operand, Sequence) else 1
                 operand_type = operand_def.constr.infer(
-                    range_length, state.constraint_context
+                    range_length,
+                    state.variables,
                 )
                 resolved_operand_type: Attribute | Sequence[Attribute]
                 if isinstance(operand_def, OptionalDef):
@@ -242,7 +219,8 @@ class FormatProgram:
                     )
                 range_length = 1
                 inferred_result_types = result_def.constr.infer(
-                    range_length, state.constraint_context
+                    range_length,
+                    state.variables,
                 )
                 resolved_result_type = inferred_result_types[0]
                 state.result_types[i] = resolved_result_type

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -179,15 +179,15 @@ class FormatParser(BaseParser):
             elements.append(self.parse_directive())
 
         self.add_reserved_attrs_to_directive(elements)
-        resolvers = self.resolve_types()
+        extractors = self.extractors_by_name()
         self.verify_directives(elements)
         self.verify_attr_dict()
         self.verify_properties()
-        self.verify_operands(resolvers.keys())
-        self.verify_results(resolvers.keys())
+        self.verify_operands(extractors.keys())
+        self.verify_results(extractors.keys())
         self.verify_regions()
         self.verify_successors()
-        return FormatProgram(tuple(elements), resolvers)
+        return FormatProgram(tuple(elements), extractors)
 
     def verify_directives(self, elements: list[FormatDirective]):
         """
@@ -260,7 +260,7 @@ class FormatParser(BaseParser):
                 types = (types,)
             return self.inner.extract_var(types)
 
-    def resolve_types(self) -> dict[str, VarExtractor[ParsingState]]:
+    def extractors_by_name(self) -> dict[str, VarExtractor[ParsingState]]:
         """
         Find out which constraint variables can be inferred from the parsed attributes.
         """

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -283,7 +283,7 @@ class FormatParser(BaseParser):
                 )
         return merge_extractor_dicts(*extractor_dicts)
 
-    def verify_operands(self, variables: Set[str]):
+    def verify_operands(self, var_constraint_names: Set[str]):
         """
         Check that all operands and operand types are refered at least once, or inferred
         from another construct.
@@ -305,14 +305,14 @@ class FormatParser(BaseParser):
                     "directive to the custom assembly format"
                 )
             if not seen_operand_type:
-                if not operand_def.constr.can_infer(variables):
+                if not operand_def.constr.can_infer(var_constraint_names):
                     self.raise_error(
                         f"type of operand '{operand_name}' cannot be inferred, "
                         f"consider adding a 'type(${operand_name})' directive to the "
                         "custom assembly format"
                     )
 
-    def verify_results(self, variables: Set[str]):
+    def verify_results(self, var_constraint_names: Set[str]):
         """Check that all result types are refered at least once, or inferred
         from another construct."""
 
@@ -320,7 +320,7 @@ class FormatParser(BaseParser):
             self.seen_result_types, self.op_def.results, strict=True
         ):
             if not result_type:
-                if not result_def.constr.can_infer(variables):
+                if not result_def.constr.can_infer(var_constraint_names):
                     self.raise_error(
                         f"type of result '{result_name}' cannot be inferred, "
                         f"consider adding a 'type(${result_name})' directive to the "

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -35,6 +35,7 @@ from xdsl.irdl import (
     VarResultDef,
     VarSingleBlockRegionDef,
     VarSuccessorDef,
+    merge_extractor_dicts,
 )
 from xdsl.irdl.declarative_assembly_format import (
     AnchorableDirective,
@@ -263,10 +264,10 @@ class FormatParser(BaseParser):
         """
         Find out which constraint variables can be inferred from the parsed attributes.
         """
-        resolvers = dict[str, VarExtractor[ParsingState]]()
+        extractor_dicts: list[dict[str, VarExtractor[ParsingState]]] = []
         for i, (_, operand_def) in enumerate(self.op_def.operands):
             if self.seen_operand_types[i]:
-                resolvers.update(
+                extractor_dicts.append(
                     {
                         v: self._OperandResultExtractor(i, True, r)
                         for v, r in operand_def.constr.get_variable_extractors().items()
@@ -274,13 +275,13 @@ class FormatParser(BaseParser):
                 )
         for i, (_, result_def) in enumerate(self.op_def.results):
             if self.seen_result_types[i]:
-                resolvers.update(
+                extractor_dicts.append(
                     {
                         v: self._OperandResultExtractor(i, False, r)
                         for v, r in result_def.constr.get_variable_extractors().items()
                     }
                 )
-        return resolvers
+        return merge_extractor_dicts(*extractor_dicts)
 
     def verify_operands(self, variables: Set[str]):
         """

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -6,7 +6,7 @@ https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-for
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence, Set
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from itertools import pairwise
@@ -18,7 +18,6 @@ from xdsl.irdl import (
     AttrOrPropDef,
     AttrSizedOperandSegments,
     AttrSizedSegments,
-    ConstraintContext,
     OpDef,
     OptionalDef,
     OptOperandDef,
@@ -28,6 +27,8 @@ from xdsl.irdl import (
     OptSuccessorDef,
     ParamAttrConstraint,
     ParsePropInAttrDict,
+    Resolver,
+    ResolveType,
     VariadicDef,
     VarOperandDef,
     VarRegionDef,
@@ -56,6 +57,7 @@ from xdsl.irdl.declarative_assembly_format import (
     OptionalResultVariable,
     OptionalSuccessorVariable,
     OptionalUnitAttrVariable,
+    ParsingState,
     PunctuationDirective,
     RegionDirective,
     RegionVariable,
@@ -176,15 +178,15 @@ class FormatParser(BaseParser):
             elements.append(self.parse_directive())
 
         self.add_reserved_attrs_to_directive(elements)
-        seen_variables = self.resolve_types()
+        resolvers = self.resolve_types()
         self.verify_directives(elements)
         self.verify_attr_dict()
         self.verify_properties()
-        self.verify_operands(seen_variables)
-        self.verify_results(seen_variables)
+        self.verify_operands(resolvers.keys())
+        self.verify_results(resolvers.keys())
         self.verify_regions()
         self.verify_successors()
-        return FormatProgram(tuple(elements))
+        return FormatProgram(tuple(elements), resolvers)
 
     def verify_directives(self, elements: list[FormatDirective]):
         """
@@ -241,20 +243,46 @@ class FormatParser(BaseParser):
                 )
                 return
 
-    def resolve_types(self) -> set[str]:
+    @dataclass(frozen=True)
+    class _OperandResultResolver(Resolver[ParsingState]):
+        idx: int
+        is_operand: bool
+        resolver: Resolver[Sequence[Attribute]]
+
+        def resolve(self, a: ParsingState) -> ResolveType:
+            if self.is_operand:
+                types = a.operand_types[self.idx]
+            else:
+                types = a.result_types[self.idx]
+            assert types is not None
+            if isinstance(types, Attribute):
+                types = (types,)
+            return self.resolver.resolve(types)
+
+    def resolve_types(self) -> dict[str, Resolver[ParsingState]]:
         """
         Find out which constraint variables can be inferred from the parsed attributes.
         """
-        seen_variables = set[str]()
+        resolvers = dict[str, Resolver[ParsingState]]()
         for i, (_, operand_def) in enumerate(self.op_def.operands):
             if self.seen_operand_types[i]:
-                seen_variables |= operand_def.constr.get_resolved_variables()
+                resolvers.update(
+                    {
+                        v: self._OperandResultResolver(i, True, r)
+                        for v, r in operand_def.constr.get_resolvers().items()
+                    }
+                )
         for i, (_, result_def) in enumerate(self.op_def.results):
             if self.seen_result_types[i]:
-                seen_variables |= result_def.constr.get_resolved_variables()
-        return seen_variables
+                resolvers.update(
+                    {
+                        v: self._OperandResultResolver(i, False, r)
+                        for v, r in result_def.constr.get_resolvers().items()
+                    }
+                )
+        return resolvers
 
-    def verify_operands(self, seen_variables: set[str]):
+    def verify_operands(self, variables: Set[str]):
         """
         Check that all operands and operand types are refered at least once, or inferred
         from another construct.
@@ -276,14 +304,14 @@ class FormatParser(BaseParser):
                     "directive to the custom assembly format"
                 )
             if not seen_operand_type:
-                if not operand_def.constr.can_infer(seen_variables):
+                if not operand_def.constr.can_infer(variables):
                     self.raise_error(
                         f"type of operand '{operand_name}' cannot be inferred, "
                         f"consider adding a 'type(${operand_name})' directive to the "
                         "custom assembly format"
                     )
 
-    def verify_results(self, seen_variables: set[str]):
+    def verify_results(self, variables: Set[str]):
         """Check that all result types are refered at least once, or inferred
         from another construct."""
 
@@ -291,7 +319,7 @@ class FormatParser(BaseParser):
             self.seen_result_types, self.op_def.results, strict=True
         ):
             if not result_type:
-                if not result_def.constr.can_infer(seen_variables):
+                if not result_def.constr.can_infer(variables):
                     self.raise_error(
                         f"type of result '{result_name}' cannot be inferred, "
                         f"consider adding a 'type(${result_name})' directive to the "
@@ -499,7 +527,7 @@ class FormatParser(BaseParser):
                             unique_base.get_type_index()
                         ]
                         if type_constraint.can_infer(set()):
-                            unique_type = type_constraint.infer(ConstraintContext())
+                            unique_type = type_constraint.infer(dict())
                 if (
                     unique_base is not None
                     and unique_base in Builtin.attributes

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -528,7 +528,7 @@ class FormatParser(BaseParser):
                             unique_base.get_type_index()
                         ]
                         if type_constraint.can_infer(set()):
-                            unique_type = type_constraint.infer(dict())
+                            unique_type = type_constraint.infer({})
                 if (
                     unique_base is not None
                     and unique_base in Builtin.attributes


### PR DESCRIPTION
I've gone through a few different refactors this week and have eventually settled on this slightly smaller refactor for the constraint system. The key addition is that each constraint now returns a dictionary of "resolvers" (name can maybe be improved) which resolve a variable from the given attribute. This allows inference to be decoupled entirely from verification, and inference should no longer be quite as fragile/maybe slightly quicker.

In this version, the resolvers are not used for verification, as I had originally planned, and instead the previous verification framework is left as is. I believe this change can enable the following changes in the future:
- Allow constraints on properties to resolve variables in a clean way (see #3318)
- Allow the introduction of "length/int constraints" for managing the length of variadics (see #3416)
- Potentially facilitate extensions to assembly format (i.e. directly supplying a variable)
- Resolvers could be used to automate construction of initialiser methods for operation. 

PS. as of time of writing it appears this saves 4 lines of code

