### PR TITLE
dialects (arm): add custom syntax

### DIFF
--- a/tests/filecheck/dialects/arm/test_ops.mlir
+++ b/tests/filecheck/dialects/arm/test_ops.mlir
@@ -1,5 +1,9 @@
 // RUN: XDSL_ROUNDTRIP
+// RUN: XDSL_GENERIC_ROUNDTRIP
 
 
-// CHECK: %x1 = "arm.get_register"() : () -> !arm.reg<x1>
-%x1 = "arm.get_register"() : () -> !arm.reg<x1>
+// CHECK: %x1 = arm.get_register : !arm.reg<x1>
+%x1 = arm.get_register : !arm.reg<x1>
+
+
+// CHECK-GENERIC: %x1 = "arm.get_register"() : () -> !arm.reg<x1>

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -36,3 +36,4 @@ class GetAnyRegisterOperation(Generic[R1InvT], IRDLOperation, ARMOp, ABC):
 @irdl_op_definition
 class GetRegisterOp(GetAnyRegisterOperation[IntRegisterType]):
     name = "arm.get_register"
+    assembly_format = "attr-dict `:` type($result)"


### PR DESCRIPTION
Add custom ARM assembly syntax and generic roundtrip test to filecheck.
Note: stacked PR
