### PR TITLE
Use classes in place of callables for resolvers

### DIFF
--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -56,14 +56,14 @@ class ConstraintContext:
 
 _AttributeCovT = TypeVar("_AttributeCovT", bound=Attribute, covariant=True)
 
-ResolveType = Attribute | Sequence[Attribute]
+ResolveType: TypeAlias = Attribute | Sequence[Attribute]
 
-T = TypeVar("T")
+_T = TypeVar("_T")
 
 
-class Resolver(Generic[T], abc.ABC):
+class Resolver(Generic[_T], abc.ABC):
     @abstractmethod
-    def resolve(self, a: T) -> ResolveType: ...
+    def resolve(self, a: _T) -> ResolveType: ...
 
 
 @dataclass(frozen=True)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -7,7 +7,7 @@ https://mlir.llvm.org/docs/DefiningDialects/Operations/#declarative-assembly-for
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -25,6 +25,7 @@ from xdsl.irdl import (
     IRDLOperationInvT,
     OpDef,
     OptionalDef,
+    Resolver,
     ResolveType,
     Successor,
     VariadicDef,
@@ -93,7 +94,7 @@ class FormatProgram:
     stmts: tuple[FormatDirective, ...]
     """The statements composing the program. They are executed in order."""
 
-    resolvers: dict[str, Callable[[ParsingState], ResolveType]]
+    resolvers: dict[str, Resolver[ParsingState]]
     """Resolvers for all type variables."""
 
     @staticmethod
@@ -170,7 +171,7 @@ class FormatProgram:
         )
 
     def resolve_constraint_variables(self, state: ParsingState):
-        state.variables = {v: r(state) for v, r in self.resolvers.items()}
+        state.variables = {v: r.resolve(state) for v, r in self.resolvers.items()}
 
     def resolve_operand_types(self, state: ParsingState, op_def: OpDef) -> None:
         """


### PR DESCRIPTION
This implements something halfway between what I originally had in #3456 and what @superlopuh suggested in https://github.com/xdslproject/xdsl/pull/3456#issuecomment-2479586661 . I think this a strict improvement over the original which uses callables and lambda functions and will merge it into that PR if people agree