### PR TITLE
dialects: (bufferization) Simplify tensor/memref constraint

### DIFF
--- a/tests/dialects/test_bufferization.py
+++ b/tests/dialects/test_bufferization.py
@@ -1,6 +1,139 @@
-from xdsl.dialects.bufferization import AllocTensorOp, ToTensorOp
-from xdsl.dialects.builtin import MemRefType, TensorType, UnitAttr, f64
+from typing import ClassVar
+
+import pytest
+
+from xdsl.dialects.bufferization import (
+    AllocTensorOp,
+    TensorFromMemrefConstraint,
+    ToTensorOp,
+)
+from xdsl.dialects.builtin import (
+    AnyMemRefTypeConstr,
+    AnyUnrankedMemrefTypeConstr,
+    IndexType,
+    IntegerType,
+    MemRefType,
+    TensorType,
+    UnitAttr,
+    UnrankedMemrefType,
+    UnrankedTensorType,
+    f64,
+)
 from xdsl.dialects.test import TestOp
+from xdsl.ir import Attribute
+from xdsl.irdl import (
+    ConstraintContext,
+    EqAttrConstraint,
+    IRDLOperation,
+    VarConstraint,
+    irdl_op_definition,
+    operand_def,
+)
+from xdsl.utils.exceptions import VerifyException
+
+
+def test_tensor_from_memref_inference():
+    constr = TensorFromMemrefConstraint(AnyMemRefTypeConstr)
+    assert not constr.can_infer(set())
+
+    constr2 = TensorFromMemrefConstraint(
+        EqAttrConstraint(MemRefType(f64, [10, 20, 30]))
+    )
+    assert constr2.can_infer(set())
+    assert constr2.infer(ConstraintContext()) == TensorType(f64, [10, 20, 30])
+
+    constr3 = TensorFromMemrefConstraint(
+        EqAttrConstraint(UnrankedMemrefType.from_type(f64))
+    )
+    assert constr3.can_infer(set())
+    assert constr3.infer(ConstraintContext()) == UnrankedTensorType(f64)
+
+
+@irdl_op_definition
+class TensorFromMemref(IRDLOperation):
+    name = "test.tensor_from_memref"
+    T: ClassVar = VarConstraint("T", AnyMemRefTypeConstr | AnyUnrankedMemrefTypeConstr)
+
+    in_tensor = operand_def(
+        TensorFromMemrefConstraint(
+            MemRefType.constr(element_type=EqAttrConstraint(IndexType()))
+        )
+    )
+
+    in_var_memref = operand_def(T)
+
+    in_var_tensor = operand_def(TensorFromMemrefConstraint(T))
+
+
+def test_tensor_from_memref_constraint():
+    [v_memref, v_tensor] = TestOp(
+        result_types=[
+            MemRefType(IndexType(), [10, 20, 30]),
+            TensorType(IndexType(), [10, 20, 30]),
+        ]
+    ).res
+    op1 = TensorFromMemref(operands=(v_tensor, v_memref, v_tensor))
+    op1.verify()
+
+    [v_unranked_memref, v_unranked_tensor] = TestOp(
+        result_types=[
+            UnrankedMemrefType.from_type(IndexType()),
+            UnrankedTensorType(IndexType()),
+        ]
+    ).res
+    op2 = TensorFromMemref(operands=(v_tensor, v_unranked_memref, v_unranked_tensor))
+    op2.verify()
+
+
+@pytest.mark.parametrize(
+    "type1, type2, type3, error",
+    [
+        (
+            IndexType(),
+            MemRefType(IndexType(), [10, 20, 30]),
+            TensorType(IndexType(), [10, 20, 30]),
+            "Expected tensor or unranked tensor type, got index",
+        ),
+        (
+            TensorType(IntegerType(32), [10, 10, 10]),
+            MemRefType(IndexType(), [10, 20, 30]),
+            TensorType(IndexType(), [10, 20, 30]),
+            "Expected attribute index but got i32",
+        ),
+        (
+            UnrankedTensorType(IndexType()),
+            MemRefType(IndexType(), [10, 20, 30]),
+            TensorType(IndexType(), [10, 20, 30]),
+            "memref<\\*xindex> should be of base attribute memref",
+        ),
+        (
+            TensorType(IndexType(), [10, 10, 10]),
+            MemRefType(IndexType(), [10, 20, 30]),
+            TensorType(IndexType(), [10, 20, 20]),
+            "attribute memref<10x20x30xindex> expected from variable 'T', but got memref<10x20x20xindex>",
+        ),
+        (
+            TensorType(IndexType(), [10, 10, 10]),
+            MemRefType(IntegerType(32), [10, 20, 30]),
+            TensorType(IndexType(), [10, 20, 30]),
+            "attribute memref<10x20x30xi32> expected from variable 'T', but got memref<10x20x30xindex>",
+        ),
+    ],
+)
+def test_tensor_from_memref_constraint_failure(
+    type1: Attribute, type2: Attribute, type3: Attribute, error: str
+):
+    [v1, v2, v3] = TestOp(
+        result_types=[
+            type1,
+            type2,
+            type3,
+        ]
+    ).res
+
+    op1 = TensorFromMemref(operands=(v1, v2, v3))
+    with pytest.raises(VerifyException, match=error):
+        op1.verify()
 
 
 def test_to_tensor():

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -68,7 +68,7 @@ class TensorFromMemrefConstraint(
         if isa(attr, UnrankedTensorType[Attribute]):
             memref_type = UnrankedMemrefType.from_type(attr.element_type)
             return self.memref_constraint.verify(memref_type, constraint_context)
-        raise VerifyException(f"Expected TensorType or UnrankedTensorType, got {attr}")
+        raise VerifyException(f"Expected tensor or unranked tensor type, got {attr}")
 
 
 @irdl_op_definition

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -68,7 +68,7 @@ class TensorFromMemrefConstraint(
         if isa(attr, UnrankedTensorType[Attribute]):
             memref_type = UnrankedMemrefType.from_type(attr.element_type)
             return self.memref_constraint.verify(memref_type, constraint_context)
-        raise VerifyException(f"Expceted TensorType or UnrankedTensorType, got {attr}")
+        raise VerifyException(f"Expected TensorType or UnrankedTensorType, got {attr}")
 
 
 @irdl_op_definition


### PR DESCRIPTION
Removes the `TensorMemrefInferenceConstraint` in favour of a simpler `TensorFromMemrefConstraint`. 