### PR TITLE
core: (irdl) ParamAttrConstraint can infer recursively

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -60,11 +60,13 @@ def test_attr_constraint_get_unique_base(
 
 
 def test_param_attr_constraint_inference():
-    @irdl_attr_definition
-    class WrapAttr(ParametrizedAttribute):
+    class BaseWrapAttr(ParametrizedAttribute):
         name = "wrap"
 
         inner: ParameterDef[Attribute]
+
+    @irdl_attr_definition
+    class WrapAttr(BaseWrapAttr): ...
 
     constr = ParamAttrConstraint(
         WrapAttr,
@@ -94,3 +96,13 @@ def test_param_attr_constraint_inference():
     assert var_constr.infer(ConstraintContext({"T": StringAttr("Hello")})) == WrapAttr(
         (StringAttr("Hello"),)
     )
+
+    base_constr = ParamAttrConstraint(
+        BaseWrapAttr,
+        (
+            eq(
+                StringAttr("Hello"),
+            ),
+        ),
+    )
+    assert not base_constr.can_infer(set())

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -2,16 +2,19 @@ from abc import ABC
 
 import pytest
 
+from xdsl.dialects.builtin import StringAttr
 from xdsl.ir import Attribute, ParametrizedAttribute
 from xdsl.irdl import (
     AllOf,
     AnyAttr,
     AttrConstraint,
     BaseAttr,
+    ConstraintContext,
     EqAttrConstraint,
     ParamAttrConstraint,
     ParameterDef,
     VarConstraint,
+    eq,
     irdl_attr_definition,
 )
 
@@ -54,3 +57,40 @@ def test_attr_constraint_get_unique_base(
     constraint: AttrConstraint, expected: type[Attribute] | None
 ):
     assert constraint.get_unique_base() == expected
+
+
+def test_param_attr_constraint_inference():
+    @irdl_attr_definition
+    class WrapAttr(ParametrizedAttribute):
+        name = "wrap"
+
+        inner: ParameterDef[Attribute]
+
+    constr = ParamAttrConstraint(
+        WrapAttr,
+        (
+            eq(
+                StringAttr("Hello"),
+            ),
+        ),
+    )
+
+    assert constr.can_infer(set())
+    assert constr.infer(ConstraintContext()) == WrapAttr((StringAttr("Hello"),))
+
+    var_constr = ParamAttrConstraint(
+        WrapAttr,
+        (
+            VarConstraint(
+                "T",
+                eq(
+                    StringAttr("Hello"),
+                ),
+            ),
+        ),
+    )
+
+    assert var_constr.can_infer({"T"})
+    assert var_constr.infer(ConstraintContext({"T": StringAttr("Hello")})) == WrapAttr(
+        (StringAttr("Hello"),)
+    )

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -422,6 +422,16 @@ class ParamAttrConstraint(
         for idx, param_constr in enumerate(self.param_constrs):
             param_constr.verify(attr.parameters[idx], constraint_context)
 
+    def can_infer(self, constraint_names: set[str]) -> bool:
+        return all(constr.can_infer(constraint_names) for constr in self.param_constrs)
+
+    def infer(self, constraint_context: ConstraintContext) -> Attribute:
+        params = tuple(
+            constr.infer(constraint_context) for constr in self.param_constrs
+        )
+        attr = self.base_attr.new(params)
+        return attr
+
     def get_resolved_variables(self) -> set[str]:
         if not self.param_constrs:
             return set()

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -423,7 +423,9 @@ class ParamAttrConstraint(
             param_constr.verify(attr.parameters[idx], constraint_context)
 
     def can_infer(self, constraint_names: set[str]) -> bool:
-        return all(constr.can_infer(constraint_names) for constr in self.param_constrs)
+        return is_runtime_final(self.base_attr) and all(
+            constr.can_infer(constraint_names) for constr in self.param_constrs
+        )
 
     def infer(self, constraint_context: ConstraintContext) -> Attribute:
         params = tuple(


### PR DESCRIPTION
This seems to work, is there any reason not to do this?

Note: conflicts with #3456