### PR TITLE
testing: update path to wgpu interpreter for pyright exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ typeCheckingMode = "strict"
     "tests/test_frontend_python_code_check.py",
     "xdsl/frontend/onnx/ir_builder.py",
     "xdsl/frontend/onnx/type.py",
-    "xdsl/interpreters/experimental/wgpu.py",
+    "xdsl/interpreters/wgpu.py",
 ]
 "ignore" = [
     "docs/marimo",


### PR DESCRIPTION
I recently broke this, and didn't realise because I have wgpu installed. Uninstalling it and running make pyright triggered the errors. Changing the pyproject file fixed everything.