### PR TITLE
dialects: (tensor) add insertop and extractop

### DIFF
--- a/tests/filecheck/dialects/tensor/ops.mlir
+++ b/tests/filecheck/dialects/tensor/ops.mlir
@@ -6,8 +6,8 @@
 %dim2 = "tensor.dim"(%tensor, %index) {"hello" = "world"}: (tensor<?x?xf32>, index) -> index
 %cast1 = "tensor.cast"(%tensor) : (tensor<?x?xf32>) -> tensor<4x4xf32>
 %cast2 = "tensor.cast"(%tensor) {"hello" = "world"} : (tensor<?x?xf32>) -> tensor<4x4xf32>
-%extract1 = "tensor.extract"(%tensor, %index, %index1) : (tensor<?x?xf32>, index, index) -> f32
-%insert1 = "tensor.insert"(%extract1, %tensor, %index, %index1) : (f32, tensor<?x?xf32>, index, index) -> tensor<?x?xf32>
+%extract1 = tensor.extract %tensor[%index, %index1] : tensor<?x?xf32>
+%insert1 = tensor.insert %extract1 into %tensor[%index, %index1] : tensor<?x?xf32>
 
 
 // CHECK: builtin.module {

--- a/tests/filecheck/dialects/tensor/ops.mlir
+++ b/tests/filecheck/dialects/tensor/ops.mlir
@@ -1,24 +1,31 @@
 // RUN: XDSL_ROUNDTRIP
 // RUN: XDSL_GENERIC_ROUNDTRIP
 
-%index, %tensor = "test.op"() : () -> (index, tensor<?x?xf32>)
+%index, %index1, %tensor = "test.op"() : () -> (index, index, tensor<?x?xf32>)
 %dim1 = "tensor.dim"(%tensor, %index): (tensor<?x?xf32>, index) -> index
 %dim2 = "tensor.dim"(%tensor, %index) {"hello" = "world"}: (tensor<?x?xf32>, index) -> index
 %cast1 = "tensor.cast"(%tensor) : (tensor<?x?xf32>) -> tensor<4x4xf32>
 %cast2 = "tensor.cast"(%tensor) {"hello" = "world"} : (tensor<?x?xf32>) -> tensor<4x4xf32>
+%extract1 = "tensor.extract"(%tensor, %index, %index1) : (tensor<?x?xf32>, index, index) -> f32
+%insert1 = "tensor.insert"(%extract1, %tensor, %index, %index1) : (f32, tensor<?x?xf32>, index, index) -> tensor<?x?xf32>
+
 
 // CHECK: builtin.module {
-// CHECK-NEXT:   %index, %tensor = "test.op"() : () -> (index, tensor<?x?xf32>)
+// CHECK-NEXT:   %index, %index1, %tensor = "test.op"() : () -> (index, index, tensor<?x?xf32>)
 // CHECK-NEXT:   %dim1 = tensor.dim %tensor, %index : tensor<?x?xf32>
 // CHECK-NEXT:   %dim2 = tensor.dim {"hello" = "world"} %tensor, %index : tensor<?x?xf32>
 // CHECK-NEXT:   %cast1 = tensor.cast %tensor : tensor<?x?xf32> to tensor<4x4xf32>
 // CHECK-NEXT:   %cast2 = tensor.cast %tensor {"hello" = "world"} : tensor<?x?xf32> to tensor<4x4xf32>
+// CHECK-NEXT:   %extract1 = tensor.extract %tensor[%index, %index1] : tensor<?x?xf32>
+// CHECK-NEXT:   %insert1 = tensor.insert %extract1 into %tensor[%index, %index1] : tensor<?x?xf32>
 // CHECK-NEXT: }
 
 // CHECK-GENERIC: "builtin.module"() ({
-// CHECK-GENERIC-NEXT:   %index, %tensor = "test.op"() : () -> (index, tensor<?x?xf32>)
+// CHECK-GENERIC-NEXT:   %index, %index1, %tensor = "test.op"() : () -> (index, index, tensor<?x?xf32>)
 // CHECK-GENERIC-NEXT:   %dim1 = "tensor.dim"(%tensor, %index) : (tensor<?x?xf32>, index) -> index
 // CHECK-GENERIC-NEXT:   %dim2 = "tensor.dim"(%tensor, %index) {"hello" = "world"} : (tensor<?x?xf32>, index) -> index
 // CHECK-GENERIC-NEXT:   %cast1 = "tensor.cast"(%tensor) : (tensor<?x?xf32>) -> tensor<4x4xf32>
 // CHECK-GENERIC-NEXT:   %cast2 = "tensor.cast"(%tensor) {"hello" = "world"} : (tensor<?x?xf32>) -> tensor<4x4xf32>
+// CHECK-GENERIC-NEXT:   %extract1 = "tensor.extract"(%tensor, %index, %index1) : (tensor<?x?xf32>, index, index) -> f32
+// CHECK-GENERIC-NEXT:   %insert1 = "tensor.insert"(%extract1, %tensor, %index, %index1) : (f32, tensor<?x?xf32>, index, index) -> tensor<?x?xf32>
 // CHECK-GENERIC-NEXT: }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/tensor/ops.mlir
@@ -15,6 +15,8 @@
 %cast2 = "tensor.cast"(%t1) {"hello" = "world"} : (tensor<2x3xf32>) -> tensor<?x?xf32>
 %big_tensor = tensor.empty() : tensor<2x3x2x3xf32>
 %collapsed = tensor.collapse_shape %big_tensor [[0, 1], [2, 3]] : tensor<2x3x2x3xf32> into tensor<6x6xf32>
+%extracted = tensor.extract %t2[%i1] : tensor<2xf32>
+%tensor_with_ins = tensor.insert %extracted into %t2[%i1] : tensor<2xf32>
 
 
 // CHECK:       module {
@@ -33,4 +35,6 @@
 // CHECK-NEXT:  %{{.*}} = tensor.cast %{{.*}} {hello = "world"} : tensor<2x3xf32> to tensor<?x?xf32>
 // CHECK-NEXT:  %6 = tensor.empty() : tensor<2x3x2x3xf32>
 // CHECK-NEXT:  %collapsed = tensor.collapse_shape %6 [[0, 1], [2, 3]] : tensor<2x3x2x3xf32> into tensor<6x6xf32>
+// CHECK-NEXT:  %extracted = tensor.extract %1[%2] : tensor<2xf32>
+// CHECK-NEXT:  %{{.*}} = tensor.insert %extracted into %1[%2] : tensor<2xf32>
 // CHECK-NEXT: }

--- a/xdsl/dialects/tensor.py
+++ b/xdsl/dialects/tensor.py
@@ -444,17 +444,17 @@ class ExtractOp(IRDLOperation):
     tensor = operand_def(TensorType)
     indices = var_operand_def(IndexType)
     result = result_def(Attribute)
+    # assembly_format = "$tensor `[` $indices `]` attr-dict `:` type($tensor)"
 
-    @classmethod
-    def get(
-        cls,
+    def __init__(
+        self,
         tensor: SSAValue,
         indices: Sequence[SSAValue] | SSAValue,
         result_type: Attribute,
     ):
         if isinstance(indices, SSAValue):
             indices = [indices]
-        return cls(operands=[tensor, indices], result_types=[result_type])
+        return super().__init__(operands=[tensor, indices], result_types=[result_type])
 
     def print(self, printer: Printer):
         printer.print_string(" ")
@@ -474,7 +474,7 @@ class ExtractOp(IRDLOperation):
         parser.parse_punctuation(":")
         source_tensor_type = parser.parse_type()
         tensor_type = cast(TensorType[Attribute], source_tensor_type)
-        return cls.get(tensor, indices, tensor_type.get_element_type())
+        return cls(tensor, indices, tensor_type.get_element_type())
 
 
 @irdl_op_definition
@@ -485,17 +485,17 @@ class InsertOp(IRDLOperation):
     dest = operand_def(TensorType)
     indices = var_operand_def(IndexType)
     result = result_def(TensorType)
+    # assembly_format = "$scalar `into` $dest `[` $indices `]` attr-dict `:` type($dest)"
 
-    @classmethod
-    def get(
-        cls,
+    def __init__(
+        self,
         scalar: SSAValue,
         dest: SSAValue,
         indices: Sequence[SSAValue] | SSAValue,
     ):
         if isinstance(indices, SSAValue):
             indices = [indices]
-        return cls(operands=[scalar, dest, indices], result_types=[dest.type])
+        super().__init__(operands=(scalar, dest, indices), result_types=(dest.type,))
 
     def print(self, printer: Printer):
         printer.print_string(" ")
@@ -518,7 +518,7 @@ class InsertOp(IRDLOperation):
         )
         parser.parse_punctuation(":")
         parser.parse_type()
-        return cls.get(scalar, dest, indices)
+        return cls(scalar, dest, indices)
 
 
 Tensor = Dialect(


### PR DESCRIPTION
This PR adds the following operations to the tensor dialect:
- tensor.InsertOp [docs](https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorinsert-tensorinsertop)
- tensor.ExtractOp [docs](https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorextract-tensorextractop)

that I currently use for a tree ensemble compiler implemented using xdsl ([link](https://github.com/francescodaghero/treeco/tree/main)).

I have tried to mirror the operations available in MLIR, customizing both the print/parse functions, but I am not 100% sure I did it correctly, as this is my first PR.