### PR TITLE
core: simplify TypedAttribute

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -22,6 +22,7 @@ from typing_extensions import Self, deprecated
 from xdsl.ir import (
     Attribute,
     AttributeCovT,
+    AttributeInvT,
     Block,
     BlockOps,
     Data,
@@ -506,17 +507,13 @@ class IntegerAttr(
                 f"range [{min_value}, {max_value})"
             )
 
-    @classmethod
+    @staticmethod
     def parse_with_type(
-        cls: type[IntegerAttr[_IntegerAttrType]],
         parser: AttrParser,
-        type: Attribute,
-    ) -> IntegerAttr[_IntegerAttrType]:
-        assert isinstance(type, IntegerType) or isinstance(type, IndexType)
-        return cast(
-            IntegerAttr[_IntegerAttrType],
-            IntegerAttr(parser.parse_integer(allow_boolean=(type == i1)), type),
-        )
+        type: AttributeInvT,
+    ) -> TypedAttribute[AttributeInvT]:
+        assert isinstance(type, IntegerType | IndexType)
+        return IntegerAttr(parser.parse_integer(allow_boolean=(type == i1)), type)
 
     def print_without_type(self, printer: Printer):
         return printer.print(self.value.data)

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -614,12 +614,11 @@ class TypedAttribute(ParametrizedAttribute, Generic[AttributeCovT], ABC):
     @staticmethod
     def get_type_index() -> int: ...
 
-    @classmethod
+    @staticmethod
     def parse_with_type(
-        cls: type[TypedAttribute[AttributeCovT]],
         parser: AttrParser,
-        type: Attribute,
-    ) -> TypedAttribute[AttributeCovT]:
+        type: AttributeInvT,
+    ) -> TypedAttribute[AttributeInvT]:
         """
         Parse the attribute with the given type.
         """

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -900,7 +900,7 @@ class AttributeVariable(FormatDirective):
             attr = parser.parse_attribute()
         elif self.unique_type is not None:
             assert issubclass(unique_base, TypedAttribute)
-            attr = unique_base.parse_with_type(parser, self.unique_type)  # pyright: ignore[reportUnknownVariableType]
+            attr = unique_base.parse_with_type(parser, self.unique_type)
         elif issubclass(
             unique_base,
             ParametrizedAttribute,


### PR DESCRIPTION
Changes `parse_with_type` from a classmethod to a staticmethod allowing a stricter type constraint to be put on the input type and allowing the removal of a cast and pyright suppression