### PR TITLE
dialects: (builtin) make DenseIntOrFPElementsAttr generic on element type

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -84,12 +84,12 @@ class ConstantOp(IRDLOperation):
     """
 
     name = "toy.constant"
-    value = attr_def(DenseIntOrFPElementsAttr)
+    value = attr_def(DenseIntOrFPElementsAttr[Float64Type])
     res = result_def(TensorTypeF64)
 
     traits = traits_def(Pure())
 
-    def __init__(self, value: DenseIntOrFPElementsAttr):
+    def __init__(self, value: DenseIntOrFPElementsAttr[Float64Type]):
         super().__init__(result_types=[value.type], attributes={"value": value})
 
     @staticmethod

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -449,8 +449,8 @@ class CslPrintContext:
                 return str(val.data)
             case StringAttr() as s:
                 return f'"{s.data}"'
-            case DenseIntOrFPElementsAttr(data=ArrayAttr(data=data), type=typ):
-                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(d) for d in data)} }}"
+            case DenseIntOrFPElementsAttr(data=ArrayAttr(data=data)):
+                return f"{self.mlir_type_to_csl_type(attr.get_type())} {{ {', '.join(self.attribute_value_to_str(d) for d in data)} }}"
             case _:
                 return f"<!unknown value {attr}>"
 

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -9,7 +9,7 @@ from xdsl.dialects.builtin import (
     AnyIntegerAttr,
     ArrayAttr,
     ContainerType,
-    DenseIntOrFPElementsAttr,
+    DenseIntElementsAttr,
     IndexType,
     IntegerAttr,
     IntegerType,
@@ -224,9 +224,9 @@ class ParallelOp(IRDLOperation):
 
     reductions = prop_def(ArrayAttr[StringAttr])
     lowerBoundsMap = prop_def(AffineMapAttr)
-    lowerBoundsGroups = prop_def(DenseIntOrFPElementsAttr)
+    lowerBoundsGroups = prop_def(DenseIntElementsAttr)
     upperBoundsMap = prop_def(AffineMapAttr)
-    upperBoundsGroups = prop_def(DenseIntOrFPElementsAttr)
+    upperBoundsGroups = prop_def(DenseIntElementsAttr)
     steps = prop_def(ArrayAttr[IntegerAttr[IntegerType]])
 
     res = var_result_def()

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import ClassVar, Literal, TypeVar, cast, overload
 
 from xdsl.dialects.builtin import (
+    AnyDenseElement,
     AnyFloat,
     AnyFloatConstr,
     AnyIntegerAttr,
@@ -132,7 +133,9 @@ class Constant(IRDLOperation):
     @overload
     def __init__(
         self,
-        value: AnyIntegerAttr | FloatAttr[AnyFloat] | DenseIntOrFPElementsAttr,
+        value: AnyIntegerAttr
+        | FloatAttr[AnyFloat]
+        | DenseIntOrFPElementsAttr[AnyDenseElement],
         value_type: None = None,
     ) -> None: ...
 
@@ -179,7 +182,7 @@ class Constant(IRDLOperation):
             value,
             base(AnyIntegerAttr)
             | base(FloatAttr[AnyFloat])
-            | base(DenseIntOrFPElementsAttr),
+            | base(DenseIntOrFPElementsAttr[AnyDenseElement]),
         ):
             parser.raise_error("Invalid constant value", p0, parser.pos)
 

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -7,8 +7,7 @@ from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     DenseArrayBase,
-    DenseIntOrFPElementsAttr,
-    IndexType,
+    DenseIntElementsAttr,
     IndexTypeConstr,
     IntegerType,
     SignlessIntegerConstraint,
@@ -178,7 +177,7 @@ class Switch(IRDLOperation):
 
     name = "cf.switch"
 
-    case_values = opt_prop_def(DenseIntOrFPElementsAttr)
+    case_values = opt_prop_def(DenseIntElementsAttr)
 
     flag = operand_def(IndexTypeConstr | SignlessIntegerConstraint)
 
@@ -202,7 +201,7 @@ class Switch(IRDLOperation):
         flag: Operation | SSAValue,
         default_block: Successor,
         default_operands: Sequence[Operation | SSAValue],
-        case_values: DenseIntOrFPElementsAttr | None = None,
+        case_values: DenseIntElementsAttr | None = None,
         case_blocks: Sequence[Successor] = [],
         case_operands: Sequence[Sequence[Operation | SSAValue]] = [],
         attr_dict: dict[str, Attribute] | None = None,
@@ -355,15 +354,15 @@ class Switch(IRDLOperation):
         parser.parse_punctuation("[")
         parser.parse_keyword("default")
         (default_block, default_args) = cls._parse_case_body(parser)
-        case_values: DenseIntOrFPElementsAttr | None = None
+        case_values: DenseIntElementsAttr | None = None
         case_blocks: tuple[Block, ...] = ()
         case_operands: tuple[tuple[SSAValue, ...], ...] = ()
         if parser.parse_optional_punctuation(","):
             cases = parser.parse_comma_separated_list(
                 Parser.Delimiter.NONE, lambda: cls._parse_case(parser)
             )
-            assert isinstance(flag_type, IntegerType | IndexType)
-            case_values = DenseIntOrFPElementsAttr.vector_from_list(
+            assert isinstance(flag_type, IntegerType)
+            case_values = DenseIntElementsAttr.vector_from_list(
                 [x for (x, _, _) in cases], flag_type
             )
             case_blocks = tuple(x for (_, x, _) in cases)

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -16,7 +16,7 @@ from xdsl.dialects.builtin import (
     AnyTensorType,
     ArrayAttr,
     DenseArrayBase,
-    DenseIntOrFPElementsAttr,
+    DenseIntElementsAttr,
     IntegerType,
     MemRefType,
     ShapedType,
@@ -961,8 +961,8 @@ class PoolingOpsBase(IRDLOperation, ABC):
         "`outs` `(` $outputs `:` type($outputs) `)` `->` type($res)"
     )
 
-    strides = attr_def(DenseIntOrFPElementsAttr)
-    dilations = attr_def(DenseIntOrFPElementsAttr)
+    strides = attr_def(DenseIntElementsAttr)
+    dilations = attr_def(DenseIntElementsAttr)
 
     irdl_options = [AttrSizedOperandSegments(as_property=True), ParsePropInAttrDict()]
 
@@ -1012,8 +1012,8 @@ class ConvOpsBase(IRDLOperation, ABC):
         "`outs` `(` $outputs `:` type($outputs) `)` `->` type($res)"
     )
 
-    strides = attr_def(DenseIntOrFPElementsAttr)
-    dilations = attr_def(DenseIntOrFPElementsAttr)
+    strides = attr_def(DenseIntElementsAttr)
+    dilations = attr_def(DenseIntElementsAttr)
 
     irdl_options = [AttrSizedOperandSegments(as_property=True), ParsePropInAttrDict()]
 

--- a/xdsl/dialects/onnx.py
+++ b/xdsl/dialects/onnx.py
@@ -8,6 +8,7 @@ from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     Any,
+    AnyDenseElement,
     AnyFloat,
     AnyFloatConstr,
     AnyIntegerAttr,
@@ -44,6 +45,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.isattr import isattr
 
 
 def verify_unidirectional_broadcast_shape(
@@ -591,7 +593,7 @@ class Constant(IRDLOperation):
     name = "onnx.Constant"
     output = result_def(AnyTensorType)
 
-    value = opt_attr_def(DenseIntOrFPElementsAttr)
+    value = opt_attr_def(DenseIntOrFPElementsAttr[AnyDenseElement])
     value_float = opt_attr_def(FloatAttr[Float32Type])
     value_floats = opt_attr_def(ArrayAttr[FloatAttr[Float32Type]])
     value_int = opt_attr_def(IntegerAttr[IntegerType])
@@ -664,7 +666,7 @@ class Constant(IRDLOperation):
     @classmethod
     def parse(cls, parser: Parser) -> Self:
         v = parser.parse_attribute()
-        if not isinstance(v, DenseIntOrFPElementsAttr):
+        if not isattr(v, base(DenseIntOrFPElementsAttr[AnyDenseElement])):
             raise NotImplementedError()
         constant = cls(v, None, None, None, None, None, None, v.type)
         return constant

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 from xdsl.dialects.builtin import (
     BFloat16Type,
     ContainerOf,
-    DenseIntOrFPElementsAttr,
+    DenseIntElementsAttr,
     Float16Type,
     Float32Type,
     Float64Type,
@@ -93,7 +93,7 @@ class VarithSwitchOp(IRDLOperation):
     T: ClassVar = VarConstraint("T", AnyAttr())
 
     flag = operand_def(base(IntegerType) | base(IndexType))
-    case_values = prop_def(DenseIntOrFPElementsAttr)
+    case_values = prop_def(DenseIntElementsAttr)
 
     default_arg = operand_def(T)
     args = var_operand_def(T)
@@ -105,7 +105,7 @@ class VarithSwitchOp(IRDLOperation):
     def __init__(
         self,
         flag: SSAValue | Operation,
-        case_values: DenseIntOrFPElementsAttr,
+        case_values: DenseIntElementsAttr,
         default_arg: SSAValue | Operation,
         *args: SSAValue | Operation,
         attr_dict: dict[str, Attribute] | None = None,
@@ -128,7 +128,7 @@ class VarithSwitchOp(IRDLOperation):
         unresolved_flag = parser.parse_unresolved_operand()
         parser.parse_punctuation(":")
         flag_type = parser.parse_type()
-        assert isinstance(flag_type, IntegerType | IndexType)
+        assert isinstance(flag_type, IntegerType)
         flag = parser.resolve_operand(unresolved_flag, flag_type)
         parser.parse_punctuation("->")
         return_type = parser.parse_type()
@@ -151,7 +151,7 @@ class VarithSwitchOp(IRDLOperation):
         parser.parse_punctuation("]")
         attr_dict = parser.parse_optional_attr_dict()
 
-        case_values = DenseIntOrFPElementsAttr.vector_from_list(values, flag_type)
+        case_values = DenseIntElementsAttr.vector_from_list(values, flag_type)
 
         return cls(
             flag,

--- a/xdsl/interpreters/builtin.py
+++ b/xdsl/interpreters/builtin.py
@@ -2,6 +2,7 @@ from typing import Any, Literal, cast
 
 from xdsl.dialects import builtin
 from xdsl.dialects.builtin import (
+    AnyDenseElement,
     AnyFloatAttr,
     AnyIntegerAttr,
     Float32Type,
@@ -19,7 +20,9 @@ from xdsl.interpreter import (
 from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils import ptr
 from xdsl.ir import Attribute
+from xdsl.irdl import base
 from xdsl.utils.hints import isa
+from xdsl.utils.isattr import isattr
 
 
 def xtype_for_el_type(
@@ -85,7 +88,7 @@ class BuiltinFunctions(InterpreterFunctions):
         attr: Attribute,
         type_attr: builtin.MemRefType[Any],
     ) -> ShapedArray[Any]:
-        assert isinstance(attr, builtin.DenseIntOrFPElementsAttr)
+        assert isattr(attr, base(builtin.DenseIntOrFPElementsAttr[AnyDenseElement]))
         shape = attr.get_shape()
         data = [el.value.data for el in attr.data]
         data_ptr = ptr.TypedPtr[Any].new(

--- a/xdsl/interpreters/memref.py
+++ b/xdsl/interpreters/memref.py
@@ -14,6 +14,7 @@ from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.ir import Attribute
 from xdsl.traits import SymbolTable
+from xdsl.utils.isattr import isattr
 
 
 @register_impls
@@ -72,7 +73,9 @@ class MemrefFunctions(InterpreterFunctions):
         mem = SymbolTable.lookup_symbol(op, op.name_)
         assert isinstance(mem, memref.Global)
         initial_value = mem.initial_value
-        if not isinstance(initial_value, builtin.DenseIntOrFPElementsAttr):
+        if not isattr(
+            initial_value, builtin.DenseIntOrFPElementsAttr[builtin.AnyDenseElement]
+        ):
             raise NotImplementedError(
                 "Memrefs that are not dense int or float arrays are not implemented"
             )

--- a/xdsl/interpreters/ml_program.py
+++ b/xdsl/interpreters/ml_program.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from xdsl.dialects import ml_program
-from xdsl.dialects.builtin import DenseIntOrFPElementsAttr
+from xdsl.dialects.builtin import AnyDenseElement, DenseIntOrFPElementsAttr
 from xdsl.interpreter import (
     Interpreter,
     InterpreterFunctions,
@@ -12,6 +12,7 @@ from xdsl.interpreters.builtin import xtype_for_el_type
 from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.traits import SymbolTable
+from xdsl.utils.isattr import isattr
 
 
 @register_impls
@@ -26,7 +27,7 @@ class MLProgramFunctions(InterpreterFunctions):
         global_op = SymbolTable.lookup_symbol(op, op.global_attr)
         assert isinstance(global_op, ml_program.Global)
         global_value = global_op.value
-        assert isinstance(global_value, DenseIntOrFPElementsAttr)
+        assert isattr(global_value, DenseIntOrFPElementsAttr[AnyDenseElement])
         shape = global_value.get_shape()
         if shape is None:
             raise NotImplementedError()

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -5,7 +5,9 @@ from typing import Any, TypeAlias, TypeVar, cast
 
 from xdsl.dialects import builtin, riscv
 from xdsl.dialects.builtin import (
+    AnyDenseElement,
     AnyIntegerAttr,
+    DenseIntOrFPElementsAttr,
     IndexType,
     IntegerAttr,
     IntegerType,
@@ -23,9 +25,11 @@ from xdsl.interpreter import (
 from xdsl.interpreters.builtin import xtype_for_el_type
 from xdsl.interpreters.utils import ptr
 from xdsl.ir import Attribute, SSAValue
+from xdsl.irdl import base
 from xdsl.utils.bitwise_casts import convert_u32_to_f32
 from xdsl.utils.comparisons import to_signed, to_unsigned
 from xdsl.utils.exceptions import InterpretationError
+from xdsl.utils.isattr import isattr
 
 _T = TypeVar("_T")
 
@@ -606,6 +610,7 @@ class RiscvFunctions(InterpreterFunctions):
             case IntegerAttr():
                 return attr.value.data
             case builtin.DenseIntOrFPElementsAttr():
+                assert isattr(attr, base(DenseIntOrFPElementsAttr[AnyDenseElement]))
                 data = [el.value.data for el in attr.data]
                 data_ptr = ptr.TypedPtr[Any].new(
                     data,

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -29,7 +29,6 @@ from xdsl.dialects.builtin import (
     Float64Type,
     Float80Type,
     Float128Type,
-    FloatAttr,
     FloatData,
     FunctionType,
     IndexType,

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -13,6 +13,7 @@ from xdsl.dialects.arith import (
     Subf,
 )
 from xdsl.dialects.builtin import (
+    AnyDenseElement,
     AnyFloat,
     ArrayAttr,
     ContainerType,
@@ -46,7 +47,7 @@ from xdsl.ir import (
     OpResult,
     SSAValue,
 )
-from xdsl.irdl import Operand
+from xdsl.irdl import Operand, base
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -59,6 +60,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.rewriter import InsertPoint
 from xdsl.utils.hints import isa
+from xdsl.utils.isattr import isattr
 
 
 def get_required_result_type(op: Operation) -> TensorType[Attribute] | None:
@@ -423,7 +425,9 @@ class ConstOpUpdateShape(RewritePattern):
         if is_tensor(op.result.type):
             if typ := get_required_result_type(op):
                 if needs_update_shape(op.result.type, typ):
-                    assert isinstance(op.value, DenseIntOrFPElementsAttr)
+                    assert isattr(
+                        op.value, base(DenseIntOrFPElementsAttr[AnyDenseElement])
+                    )
                     rewriter.replace_matched_op(
                         Constant(DenseIntOrFPElementsAttr([typ, op.value.data]))
                     )


### PR DESCRIPTION
Started trying to make `DenseIntOrFPElementsAttr` a `TypedAttribute`.
`TypedAttribute`s force that the `type` parameter must appear as a type var generic. I am not sure why this is the case so it would be good to know what the original motivation for that was. To get this to go through I have disabled this check.

I then ended up adding a typevar for the elements to `DenseIntOrFPElementsAttr` which caused a lot of follow on changes and I am unsure if the result is nicer than what I started with. I think `DenseIntOrFPElementsAttr` can be made into a `TypedAttribute` without this type var.

I also imagine that extensive use of `isattr` is bad?