### PR TITLE
API: add InferenceContext

### DIFF
--- a/tests/dialects/test_bufferization.py
+++ b/tests/dialects/test_bufferization.py
@@ -23,6 +23,7 @@ from xdsl.dialects.test import TestOp
 from xdsl.ir import Attribute
 from xdsl.irdl import (
     EqAttrConstraint,
+    InferenceContext,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
@@ -39,13 +40,13 @@ def test_tensor_from_memref_inference():
         EqAttrConstraint(MemRefType(f64, [10, 20, 30]))
     )
     assert constr2.can_infer(set())
-    assert constr2.infer({}) == TensorType(f64, [10, 20, 30])
+    assert constr2.infer(InferenceContext()) == TensorType(f64, [10, 20, 30])
 
     constr3 = TensorFromMemrefConstraint(
         EqAttrConstraint(UnrankedMemrefType.from_type(f64))
     )
     assert constr3.can_infer(set())
-    assert constr3.infer({}) == UnrankedTensorType(f64)
+    assert constr3.infer(InferenceContext()) == UnrankedTensorType(f64)
 
 
 @irdl_op_definition

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -10,6 +10,7 @@ from xdsl.irdl import (
     AttrConstraint,
     BaseAttr,
     EqAttrConstraint,
+    InferenceContext,
     ParamAttrConstraint,
     ParameterDef,
     VarConstraint,
@@ -77,7 +78,7 @@ def test_param_attr_constraint_inference():
     )
 
     assert constr.can_infer(set())
-    assert constr.infer({}) == WrapAttr((StringAttr("Hello"),))
+    assert constr.infer(InferenceContext()) == WrapAttr((StringAttr("Hello"),))
 
     var_constr = ParamAttrConstraint(
         WrapAttr,
@@ -92,7 +93,7 @@ def test_param_attr_constraint_inference():
     )
 
     assert var_constr.can_infer({"T"})
-    assert var_constr.infer({"T": StringAttr("Hello")}) == WrapAttr(
+    assert var_constr.infer(InferenceContext({"T": StringAttr("Hello")})) == WrapAttr(
         (StringAttr("Hello"),)
     )
 
@@ -127,7 +128,7 @@ def test_base_attr_constraint_inference():
     constr = BaseAttr(NoParamAttr)
 
     assert constr.can_infer(set())
-    assert constr.infer({}) == NoParamAttr()
+    assert constr.infer(InferenceContext()) == NoParamAttr()
 
     base_constr = BaseAttr(BaseNoParamAttr)
     assert not base_constr.can_infer(set())

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -20,8 +20,8 @@ from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
     AttrSizedOperandSegments,
     ConstraintContext,
-    ConstraintVariableType,
     GenericAttrConstraint,
+    InferenceContext,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
@@ -53,9 +53,9 @@ class TensorFromMemrefConstraint(
         return self.memref_constraint.can_infer(var_constraint_names)
 
     def infer(
-        self, variables: dict[str, ConstraintVariableType]
+        self, context: InferenceContext
     ) -> TensorType[Attribute] | UnrankedTensorType[Attribute]:
-        memref_type = self.memref_constraint.infer(variables)
+        memref_type = self.memref_constraint.infer(context)
         if isinstance(memref_type, MemRefType):
             return TensorType(memref_type.element_type, memref_type.shape)
         return UnrankedTensorType(memref_type.element_type)

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -22,6 +22,7 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     ConstraintVariableType,
+    InferenceContext,
     IRDLOperation,
     IRDLOperationInvT,
     OpDef,
@@ -186,7 +187,7 @@ class FormatProgram:
                 range_length = len(operand) if isinstance(operand, Sequence) else 1
                 operand_type = operand_def.constr.infer(
                     range_length,
-                    state.variables,
+                    InferenceContext(state.variables),
                 )
                 resolved_operand_type: Attribute | Sequence[Attribute]
                 if isinstance(operand_def, OptionalDef):
@@ -220,7 +221,7 @@ class FormatProgram:
                 range_length = 1
                 inferred_result_types = result_def.constr.infer(
                     range_length,
-                    state.variables,
+                    InferenceContext(state.variables),
                 )
                 resolved_result_type = inferred_result_types[0]
                 state.result_types[i] = resolved_result_type
@@ -885,7 +886,9 @@ class AttributeVariable(FormatDirective):
         ):
             attr = unique_base.new(unique_base.parse_parameters(parser))
         elif issubclass(unique_base, Data):
-            attr = unique_base.new(unique_base.parse_parameter(parser))  # pyright: ignore[reportUnknownVariableType]
+            attr = unique_base.new(  # pyright: ignore[reportUnknownVariableType]
+                unique_base.parse_parameter(parser)
+            )
         else:
             raise ValueError("Attributes must be Data or ParameterizedAttribute.")
         if self.is_property:

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -19,6 +19,7 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     AttrSizedSegments,
     ConstraintVariableType,
+    InferenceContext,
     OpDef,
     OptionalDef,
     OptOperandDef,
@@ -528,7 +529,7 @@ class FormatParser(BaseParser):
                             unique_base.get_type_index()
                         ]
                         if type_constraint.can_infer(set()):
-                            unique_type = type_constraint.infer({})
+                            unique_type = type_constraint.infer(InferenceContext())
                 if (
                     unique_base is not None
                     and unique_base in Builtin.attributes


### PR DESCRIPTION
A wrapper class to encapsulate the inference context. I have a feeling that we might want to split out the inference context into range and non-range variable assignments, this will hide the change from the signature of the `infer` method.