### PR TITLE
core: refactor assembly format directives

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -696,7 +696,7 @@ def test_unknown_variable():
     """Test that variables should refer to an element in the operation."""
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="expected variable to refer to an operand, attribute, region, result, or successor",
+        match="expected variable to refer to an operand, attribute, region, or successor",
     ):
 
         @irdl_op_definition

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from xdsl.dialects.builtin import UnitAttr
 from xdsl.ir import (
@@ -237,19 +237,11 @@ class FormatProgram:
 
 
 @dataclass(frozen=True)
-class FormatDirective(ABC):
-    """A format directive for operation format."""
-
-    @abstractmethod
-    def parse(self, parser: Parser, state: ParsingState) -> None: ...
-
-    @abstractmethod
-    def print(
-        self, printer: Printer, state: PrintingState, op: IRDLOperation
-    ) -> None: ...
+class Directive(ABC):
+    """An assembly format directive"""
 
 
-class AnchorableDirective(FormatDirective, ABC):
+class AnchorableDirective(Directive, ABC):
     """
     Base class for Directive usable as anchors to optional groups.
     """
@@ -262,6 +254,18 @@ class AnchorableDirective(FormatDirective, ABC):
         ...
 
 
+class FormatDirective(Directive, ABC):
+    """A format directive for operation format."""
+
+    @abstractmethod
+    def parse(self, parser: Parser, state: ParsingState) -> None: ...
+
+    @abstractmethod
+    def print(
+        self, printer: Printer, state: PrintingState, op: IRDLOperation
+    ) -> None: ...
+
+
 class OptionallyParsableDirective(FormatDirective, ABC):
     """
     Base class for Directive that can be optionally parsed.
@@ -271,7 +275,7 @@ class OptionallyParsableDirective(FormatDirective, ABC):
     @abstractmethod
     def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
         """
-        Try parsing the directive and return if it was present.
+        Try parsing the directive and return True if it was present.
         """
         ...
 
@@ -279,18 +283,155 @@ class OptionallyParsableDirective(FormatDirective, ABC):
         self.parse_optional(parser, state)
 
 
-class VariadicLikeFormatDirective(AnchorableDirective, ABC):
+class VariadicLikeFormatDirective(
+    OptionallyParsableDirective, AnchorableDirective, ABC
+):
     """
-    Baseclass to help keep typechecking simple.
-    VariadicLike is mostly Variadic or Optional: Whatever directive that can accept
-    having nothing to parse.
+    A directive which parses/prints multiple objects separated by commas.
+    Such directives can not be followed by comma literals.
     """
 
-    pass
+    def set_empty(self, state: ParsingState):
+        """
+        Set the appropriate field of the parsing state to be empty.
+        Used when a variable appears in an optional group which is not parsed.
+        """
+        return
+
+
+class TypeableDirective(Directive, ABC):
+    """
+    Directives which can be used to set or get types.
+    """
+
+    @abstractmethod
+    def set_type(self, type: Attribute, state: ParsingState) -> None: ...
+
+    @abstractmethod
+    def get_type(self, op: IRDLOperation) -> Attribute: ...
+
+
+class VariadicTypeableDirective(AnchorableDirective, ABC):
+    """
+    Directives which can set or get multiple types.
+    """
+
+    @abstractmethod
+    def set_types(self, types: Sequence[Attribute], state: ParsingState) -> None: ...
+
+    @abstractmethod
+    def get_types(self, op: IRDLOperation) -> Sequence[Attribute]: ...
+
+
+class OptionalTypeableDirective(AnchorableDirective, ABC):
+    """
+    Directives which can optionally set or get a single type.
+    """
+
+    @abstractmethod
+    def set_type(self, type: Attribute | None, state: ParsingState) -> None: ...
+
+    @abstractmethod
+    def get_type(self, op: IRDLOperation) -> Attribute | None: ...
+
+
+AnyTypeableDirective: TypeAlias = (
+    TypeableDirective | VariadicTypeableDirective | OptionalTypeableDirective
+)
 
 
 @dataclass(frozen=True)
-class VariableDirective(FormatDirective, ABC):
+class TypeDirective(FormatDirective):
+    """
+    A directive which parses the type of a typeable directive, with format:
+      type-directive ::= type(typeable-directive)
+    """
+
+    inner: TypeableDirective
+
+    def parse(self, parser: Parser, state: ParsingState) -> None:
+        ty = parser.parse_type()
+        self.inner.set_type(ty, state)
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        printer.print_attribute(self.inner.get_type(op))
+        state.last_was_punctuation = False
+        state.should_emit_space = True
+
+
+class VariadicLikeTypeDirective(VariadicLikeFormatDirective):
+    """
+    Base class for type checking.
+    A variadic-like type directive can not be followed by a variadic-like type directive.
+    """
+
+
+@dataclass(frozen=True)
+class VariadicTypeDirective(VariadicLikeTypeDirective):
+    """
+    A directive which parses the type of a variadic typeable directive, with format:
+      type-directive ::= type(typeable-directive)
+    """
+
+    inner: VariadicTypeableDirective
+
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
+        types = parser.parse_optional_undelimited_comma_separated_list(
+            parser.parse_optional_type, parser.parse_type
+        )
+        if types is None:
+            types = ()
+        self.inner.set_types(types, state)
+        return bool(types)
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        printer.print_list(self.inner.get_types(op), printer.print_attribute)
+        state.last_was_punctuation = False
+        state.should_emit_space = True
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return self.inner.is_present(op)
+
+    def set_empty(self, state: ParsingState):
+        self.inner.set_types((), state)
+
+
+@dataclass(frozen=True)
+class OptionalTypeDirective(VariadicLikeTypeDirective):
+    """
+    A directive which parses the type of a optional typeable directive, with format:
+      type-directive ::= type(typeable-directive)
+    """
+
+    inner: OptionalTypeableDirective
+
+    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
+        type = parser.parse_optional_type()
+        self.inner.set_type(type, state)
+        return bool(type)
+
+    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        if state.should_emit_space or not state.last_was_punctuation:
+            printer.print(" ")
+        type = self.inner.get_type(op)
+        if type:
+            printer.print_attribute(type)
+            state.last_was_punctuation = False
+            state.should_emit_space = True
+
+    def is_present(self, op: IRDLOperation) -> bool:
+        return self.inner.is_present(op)
+
+    def set_empty(self, state: ParsingState):
+        self.inner.set_type(None, state)
+
+
+@dataclass(frozen=True)
+class VariableDirective(Directive, ABC):
     """
     A variable directive, with the following format:
       variable-directive ::= dollar-ident
@@ -303,47 +444,14 @@ class VariableDirective(FormatDirective, ABC):
     """Index of the variable(operand or result) definition."""
 
 
-class TypeDirective(VariableDirective, ABC):
-    """
-    Base class for Directive meant to parse types.
-    """
-
-    pass
-
-
-class RegionDirective(OptionallyParsableDirective, ABC):
-    """
-    Baseclass to help keep typechecking simple.
-    RegionDirective is for any RegionVariable, which are all OptionallyParsable.
-    """
-
-    pass
-
-
-class VariadicLikeVariable(VariadicLikeFormatDirective, VariableDirective, ABC):
-    pass
-
-
-class VariadicVariable(VariadicLikeVariable, ABC):
+class VariadicVariable(VariableDirective, AnchorableDirective, ABC):
     def is_present(self, op: IRDLOperation) -> bool:
         return len(getattr(op, self.name)) > 0
 
 
-class OptionalVariable(VariadicLikeVariable, ABC):
+class OptionalVariable(VariableDirective, AnchorableDirective, ABC):
     def is_present(self, op: IRDLOperation) -> bool:
         return getattr(op, self.name) is not None
-
-
-class VariadicLikeTypeDirective(VariadicLikeFormatDirective, VariableDirective, ABC):
-    pass
-
-
-class VariadicTypeDirective(VariadicLikeTypeDirective, VariadicVariable, ABC):
-    pass
-
-
-class OptionalTypeDirective(VariadicLikeTypeDirective, OptionalVariable, ABC):
-    pass
 
 
 @dataclass(frozen=True)
@@ -422,7 +530,7 @@ class AttrDictDirective(FormatDirective):
 
 
 @dataclass(frozen=True)
-class OperandVariable(VariableDirective):
+class OperandVariable(VariableDirective, FormatDirective, TypeableDirective):
     """
     An operand variable, with the following format:
       operand-directive ::= dollar-ident
@@ -433,6 +541,9 @@ class OperandVariable(VariableDirective):
         operand = parser.parse_unresolved_operand()
         state.operands[self.index] = operand
 
+    def set_type(self, type: Attribute, state: ParsingState) -> None:
+        state.operand_types[self.index] = type
+
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
@@ -440,10 +551,20 @@ class OperandVariable(VariableDirective):
         state.last_was_punctuation = False
         state.should_emit_space = True
 
+    def get_type(self, op: IRDLOperation) -> Attribute:
+        return getattr(op, self.name).type
+
+
+class VariadicOperandDirective(VariadicLikeFormatDirective, ABC):
+    """
+    Base class for typechecking.
+    A variadic operand directive cannot follow another variadic operand directive.
+    """
+
 
 @dataclass(frozen=True)
 class VariadicOperandVariable(
-    VariadicVariable, VariableDirective, OptionallyParsableDirective
+    VariadicVariable, VariadicOperandDirective, VariadicTypeableDirective
 ):
     """
     A variadic operand variable, with the following format:
@@ -460,6 +581,9 @@ class VariadicOperandVariable(
         state.operands[self.index] = operands
         return bool(operands)
 
+    def set_types(self, types: Sequence[Attribute], state: ParsingState) -> None:
+        state.operand_types[self.index] = types
+
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
@@ -469,8 +593,16 @@ class VariadicOperandVariable(
             state.last_was_punctuation = False
             state.should_emit_space = True
 
+    def get_types(self, op: IRDLOperation) -> Sequence[Attribute]:
+        return getattr(op, self.name).types
 
-class OptionalOperandVariable(OptionalVariable, OptionallyParsableDirective):
+    def set_empty(self, state: ParsingState):
+        state.operands[self.index] = ()
+
+
+class OptionalOperandVariable(
+    OptionalVariable, VariadicOperandDirective, OptionalTypeableDirective
+):
     """
     An optional operand variable, with the following format:
       operand-directive ::= ( percent-ident )?
@@ -484,6 +616,9 @@ class OptionalOperandVariable(OptionalVariable, OptionallyParsableDirective):
         state.operands[self.index] = operand
         return bool(operand)
 
+    def set_type(self, type: Attribute | None, state: ParsingState) -> None:
+        state.operand_types[self.index] = type or ()
+
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
@@ -493,80 +628,18 @@ class OptionalOperandVariable(OptionalVariable, OptionallyParsableDirective):
             state.last_was_punctuation = False
             state.should_emit_space = True
 
-
-@dataclass(frozen=True)
-class OperandTypeDirective(TypeDirective):
-    """
-    An operand variable type directive, with the following format:
-      operand-type-directive ::= type(dollar-ident)
-    The directive will request a space to be printed right after.
-    """
-
-    def parse(self, parser: Parser, state: ParsingState) -> None:
-        type = parser.parse_type()
-        state.operand_types[self.index] = type
-
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print(" ")
-        printer.print_attribute(getattr(op, self.name).type)
-        state.last_was_punctuation = False
-        state.should_emit_space = True
-
-
-@dataclass(frozen=True)
-class VariadicOperandTypeDirective(
-    TypeDirective, VariadicTypeDirective, OptionallyParsableDirective
-):
-    """
-    A variadic operand variable, with the following format:
-      operand-directive ::= ( percent-ident ( `,` percent-id )* )?
-    The directive will request a space to be printed after.
-    """
-
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        operand_types = parser.parse_optional_undelimited_comma_separated_list(
-            parser.parse_optional_type, parser.parse_type
-        )
-        if operand_types is None:
-            operand_types = ()
-        state.operand_types[self.index] = operand_types
-        return bool(operand_types)
-
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print(" ")
-        printer.print_list(getattr(op, self.name).types, printer.print_attribute)
-        state.last_was_punctuation = False
-        state.should_emit_space = True
-
-
-class OptionalOperandTypeDirective(OptionalTypeDirective, OptionallyParsableDirective):
-    """
-    An optional operand variable type directive, with the following format:
-      operand-type-directive ::= ( type(dollar-ident) )?
-    The directive will request a space to be printed after.
-    """
-
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        type = parser.parse_optional_type()
-        if type is None:
-            type = ()
-        state.operand_types[self.index] = type
-        return bool(type)
-
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print(" ")
+    def get_type(self, op: IRDLOperation) -> Attribute | None:
         operand = getattr(op, self.name)
         if operand:
-            printer.print_attribute(operand.type)
-            state.last_was_punctuation = False
-            state.should_emit_space = True
+            return operand.type
+        return None
+
+    def set_empty(self, state: ParsingState):
+        state.operands[self.index] = ()
 
 
 @dataclass(frozen=True)
-class ResultVariable(VariableDirective):
+class ResultVariable(VariableDirective, TypeableDirective):
     """
     An result variable, with the following format:
       result-directive ::= dollar-ident
@@ -574,23 +647,15 @@ class ResultVariable(VariableDirective):
     parsing is not handled by the custom operation parser.
     """
 
-    def parse(self, parser: Parser, state: ParsingState) -> None:
-        assert (
-            "Result variables cannot be used directly to parse/print in "
-            "declarative formats."
-        )
+    def set_type(self, type: Attribute, state: ParsingState) -> None:
+        state.result_types[self.index] = type
 
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        assert (
-            "Result variables cannot be used directly to parse/print in "
-            "declarative formats."
-        )
+    def get_type(self, op: IRDLOperation) -> Attribute:
+        return getattr(op, self.name).type
 
 
 @dataclass(frozen=True)
-class VariadicResultVariable(
-    ResultVariable, VariadicVariable, OptionallyParsableDirective
-):
+class VariadicResultVariable(VariadicVariable, VariadicTypeableDirective):
     """
     A variadic result variable, with the following format:
       result-directive ::= percent-ident (( `,` percent-id )* )?
@@ -598,21 +663,14 @@ class VariadicResultVariable(
     parsing is not handled by the custom operation parser.
     """
 
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        assert (
-            "Result variables cannot be used directly to parse/print in "
-            "declarative formats."
-        )
-        return False
+    def set_types(self, types: Sequence[Attribute], state: ParsingState) -> None:
+        state.result_types[self.index] = types
 
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        assert (
-            "Result variables cannot be used directly to parse/print in "
-            "declarative formats."
-        )
+    def get_types(self, op: IRDLOperation) -> Sequence[Attribute]:
+        return getattr(op, self.name).types
 
 
-class OptionalResultVariable(OptionalVariable, OptionallyParsableDirective):
+class OptionalResultVariable(OptionalVariable, OptionalTypeableDirective):
     """
     An optional result variable, with the following format:
       result-directive ::= ( percent-ident )?
@@ -620,91 +678,28 @@ class OptionalResultVariable(OptionalVariable, OptionallyParsableDirective):
     parsing is not handled by the custom operation parser.
     """
 
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        assert (
-            "Result variables cannot be used directly to parse/print in "
-            "declarative formats."
-        )
-        return False
+    def set_type(self, type: Attribute | None, state: ParsingState) -> None:
+        state.result_types[self.index] = type or ()
 
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        assert (
-            "Result variables cannot be used directly to parse/print in "
-            "declarative formats."
-        )
+    def get_type(self, op: IRDLOperation) -> Attribute | None:
+        res = getattr(op, self.name)
+        if res:
+            return res.type
+        return None
 
 
-@dataclass(frozen=True)
-class ResultTypeDirective(TypeDirective):
+class RegionDirective(OptionallyParsableDirective, ABC):
     """
-    A result variable type directive, with the following format:
-      result-type-directive ::= type(dollar-ident)
-    The directive will request a space to be printed right after.
+    Baseclass to help keep typechecking simple.
+    RegionDirective is for any RegionVariable, which are all OptionallyParsable.
     """
 
-    def parse(self, parser: Parser, state: ParsingState) -> None:
-        type = parser.parse_type()
-        state.result_types[self.index] = type
 
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print(" ")
-        printer.print_attribute(getattr(op, self.name).type)
-        state.last_was_punctuation = False
-        state.should_emit_space = True
-
-
-@dataclass(frozen=True)
-class VariadicResultTypeDirective(
-    TypeDirective, VariadicTypeDirective, OptionallyParsableDirective
-):
+class VariadicRegionDirective(RegionDirective, VariadicLikeFormatDirective, ABC):
     """
-    A variadic result variable type directive, with the following format:
-      variadic-result-type-directive ::= ( percent-ident ( `,` percent-id )* )?
-    The directive will request a space to be printed after.
+    Base class for typechecking.
+    A variadic region directive cannot follow another variadic region directive.
     """
-
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        result_types = parser.parse_optional_undelimited_comma_separated_list(
-            parser.parse_optional_type, parser.parse_type
-        )
-        if result_types is None:
-            result_types = ()
-        state.result_types[self.index] = result_types
-        return bool(result_types)
-
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print(" ")
-        printer.print_list(getattr(op, self.name).types, printer.print_attribute)
-        state.last_was_punctuation = False
-        state.should_emit_space = True
-
-
-class OptionalResultTypeDirective(
-    TypeDirective, OptionalTypeDirective, OptionallyParsableDirective
-):
-    """
-    An optional result variable type directive, with the following format:
-      result-type-directive ::= ( type(dollar-ident) )?
-    The directive will request a space to be printed after.
-    """
-
-    def parse_optional(self, parser: Parser, state: ParsingState) -> bool:
-        type = parser.parse_optional_type()
-        if type is None:
-            type = ()
-        state.result_types[self.index] = type
-        return bool(type)
-
-    def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if state.should_emit_space or not state.last_was_punctuation:
-            printer.print(" ")
-        result = getattr(op, self.name)
-        if result:
-            printer.print_attribute(result.type)
-            state.last_was_punctuation = False
-            state.should_emit_space = True
 
 
 @dataclass(frozen=True)
@@ -729,7 +724,7 @@ class RegionVariable(RegionDirective, VariableDirective):
 
 
 @dataclass(frozen=True)
-class VariadicRegionVariable(RegionDirective, VariadicVariable):
+class VariadicRegionVariable(VariadicRegionDirective, VariadicVariable):
     """
     A variadic region variable, with the following format:
       region-directive ::= dollar-ident
@@ -756,8 +751,11 @@ class VariadicRegionVariable(RegionDirective, VariadicVariable):
             state.last_was_punctuation = False
             state.should_emit_space = True
 
+    def set_empty(self, state: ParsingState):
+        state.regions[self.index] = ()
 
-class OptionalRegionVariable(RegionDirective, OptionalVariable):
+
+class OptionalRegionVariable(VariadicRegionDirective, OptionalVariable):
     """
     An optional region variable, with the following format:
       region-directive ::= dollar-ident
@@ -779,6 +777,16 @@ class OptionalRegionVariable(RegionDirective, OptionalVariable):
             printer.print_region(region)
             state.last_was_punctuation = False
             state.should_emit_space = True
+
+    def set_empty(self, state: ParsingState):
+        state.regions[self.index] = ()
+
+
+class VariadicSuccessorDirective(VariadicLikeFormatDirective, ABC):
+    """
+    Base class for type checking.
+    A variadic successor directive cannot follow another variadic successor directive.
+    """
 
 
 class SuccessorVariable(VariableDirective, OptionallyParsableDirective):
@@ -803,7 +811,7 @@ class SuccessorVariable(VariableDirective, OptionallyParsableDirective):
         state.should_emit_space = True
 
 
-class VariadicSuccessorVariable(VariadicVariable, OptionallyParsableDirective):
+class VariadicSuccessorVariable(VariadicSuccessorDirective, VariadicVariable):
     """
     A variadic successor variable, with the following format:
       successor-directive ::= dollar-ident
@@ -830,8 +838,11 @@ class VariadicSuccessorVariable(VariadicVariable, OptionallyParsableDirective):
             state.last_was_punctuation = False
             state.should_emit_space = True
 
+    def set_empty(self, state: ParsingState):
+        state.successors[self.index] = ()
 
-class OptionalSuccessorVariable(OptionalVariable, OptionallyParsableDirective):
+
+class OptionalSuccessorVariable(VariadicSuccessorDirective, OptionalVariable):
     """
     An optional successor variable, with the following format:
       successor-directive ::= dollar-ident
@@ -853,6 +864,9 @@ class OptionalSuccessorVariable(OptionalVariable, OptionallyParsableDirective):
             printer.print_block_name(successor)
             state.last_was_punctuation = False
             state.should_emit_space = True
+
+    def set_empty(self, state: ParsingState):
+        state.successors[self.index] = ()
 
 
 @dataclass(frozen=True)
@@ -1072,33 +1086,8 @@ class OptionalGroupDirective(FormatDirective):
         # type to empty
         else:
             for element in self.then_elements:
-                match element:
-                    case (
-                        OperandVariable(_, index)
-                        | VariadicOperandVariable(_, index)
-                        | OptionalOperandVariable(_, index)
-                    ):
-                        state.operands[index] = ()
-                    case (
-                        OperandTypeDirective(_, index)
-                        | VariadicOperandTypeDirective(_, index)
-                        | OptionalOperandTypeDirective(_, index)
-                    ):
-                        state.operand_types[index] = ()
-                    case (
-                        RegionVariable(_, index)
-                        | VariadicRegionVariable(_, index)
-                        | OptionalRegionVariable(_, index)
-                    ):
-                        state.regions[index] = ()
-                    case (
-                        ResultTypeDirective(_, index)
-                        | VariadicResultTypeDirective(_, index)
-                        | OptionalResultTypeDirective(_, index)
-                    ):
-                        state.result_types[index] = ()
-                    case _:
-                        pass
+                if isinstance(element, VariadicLikeFormatDirective):
+                    element.set_empty(state)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if self.anchor.is_present(op):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -446,7 +446,7 @@ class VariableDirective(Directive, ABC):
 
 class VariadicVariable(VariableDirective, AnchorableDirective, ABC):
     def is_present(self, op: IRDLOperation) -> bool:
-        return len(getattr(op, self.name)) > 0
+        return bool(getattr(op, self.name))
 
 
 class OptionalVariable(VariableDirective, AnchorableDirective, ABC):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -39,6 +39,7 @@ from xdsl.irdl import (
 )
 from xdsl.irdl.declarative_assembly_format import (
     AnchorableDirective,
+    AnyTypeableDirective,
     AttrDictDirective,
     AttributeVariable,
     DefaultValuedAttributeVariable,
@@ -46,35 +47,35 @@ from xdsl.irdl.declarative_assembly_format import (
     FormatProgram,
     KeywordDirective,
     OperandOrResult,
-    OperandTypeDirective,
     OperandVariable,
     OptionalAttributeVariable,
     OptionalGroupDirective,
     OptionallyParsableDirective,
-    OptionalOperandTypeDirective,
     OptionalOperandVariable,
     OptionalRegionVariable,
-    OptionalResultTypeDirective,
     OptionalResultVariable,
     OptionalSuccessorVariable,
+    OptionalTypeableDirective,
+    OptionalTypeDirective,
     OptionalUnitAttrVariable,
     ParsingState,
     PunctuationDirective,
     RegionDirective,
     RegionVariable,
-    ResultTypeDirective,
     ResultVariable,
     SuccessorVariable,
-    VariableDirective,
+    TypeDirective,
     VariadicLikeFormatDirective,
     VariadicLikeTypeDirective,
-    VariadicLikeVariable,
-    VariadicOperandTypeDirective,
+    VariadicOperandDirective,
     VariadicOperandVariable,
+    VariadicRegionDirective,
     VariadicRegionVariable,
-    VariadicResultTypeDirective,
     VariadicResultVariable,
+    VariadicSuccessorDirective,
     VariadicSuccessorVariable,
+    VariadicTypeableDirective,
+    VariadicTypeDirective,
     WhitespaceDirective,
 )
 from xdsl.parser import BaseParser, ParserState
@@ -147,8 +148,6 @@ class FormatParser(BaseParser):
     """The successor variables that are already parsed."""
     has_attr_dict: bool = field(default=False)
     """True if the attribute dictionary has already been parsed."""
-    context: ParsingContext = field(default=ParsingContext.TopLevel)
-    """Indicates if the parser is nested in a particular directive."""
     type_resolutions: dict[
         tuple[OperandOrResult, int],
         tuple[Callable[[Attribute], Attribute], OperandOrResult, int],
@@ -176,7 +175,7 @@ class FormatParser(BaseParser):
         """
         elements: list[FormatDirective] = []
         while self._current_token.kind != Token.Kind.EOF:
-            elements.append(self.parse_directive())
+            elements.append(self.parse_format_directive())
 
         self.add_reserved_attrs_to_directive(elements)
         extractors = self.extractors_by_name()
@@ -204,25 +203,19 @@ class FormatParser(BaseParser):
                     self.raise_error(
                         "A variadic type directive cannot be followed by another variadic type directive."
                     )
-                case VariadicLikeVariable(), VariadicLikeVariable():
-                    if not (
-                        isinstance(a, RegionDirective | VariadicLikeTypeDirective)
-                        or isinstance(b, RegionDirective | VariadicLikeTypeDirective)
-                    ):
-                        self.raise_error(
-                            "A variadic operand variable cannot be followed by another variadic operand variable."
-                        )
-                    elif isinstance(a, RegionDirective) and isinstance(
-                        b, RegionDirective
-                    ):
-                        self.raise_error(
-                            "A variadic region variable cannot be followed by another variadic region variable."
-                        )
-                case AttrDictDirective(), RegionDirective() if not (a.with_keyword):
+                case VariadicOperandDirective(), VariadicOperandDirective():
                     self.raise_error(
-                        "An `attr-dict' directive without keyword cannot be directly followed by a region variable as it is ambiguous."
+                        "A variadic operand variable cannot be followed by another variadic operand variable."
                     )
-                case AttrDictDirective(), RegionVariable() if not (a.with_keyword):
+                case VariadicRegionDirective(), VariadicRegionDirective():
+                    self.raise_error(
+                        "A variadic region variable cannot be followed by another variadic region variable."
+                    )
+                case VariadicSuccessorDirective(), VariadicSuccessorDirective():
+                    self.raise_error(
+                        "A variadic successor variable cannot be followed by another variadic successor variable."
+                    )
+                case AttrDictDirective(), RegionDirective() if not (a.with_keyword):
                     self.raise_error(
                         "An `attr-dict' directive without keyword cannot be directly followed by a region variable as it is ambiguous."
                     )
@@ -402,30 +395,22 @@ class FormatParser(BaseParser):
                     "directive to the custom assembly format."
                 )
 
-    def parse_optional_variable(
-        self,
-    ) -> VariableDirective | AttributeVariable | None:
-        """
-        Parse a variable, if present, with the following format:
-          variable ::= `$` bare-ident
-        The variable should refer to an operand, attribute, region, result,
-        or successor.
-        """
-        if self._current_token.text[0] != "$":
-            return None
-        self._consume_token()
-        variable_name = self.parse_identifier(" after '$'")
-
-        # Check if the variable is an operand
+    def _parse_optional_operand(
+        self, variable_name: str, top_level: bool
+    ) -> OptionalOperandVariable | VariadicOperandVariable | OperandVariable | None:
         for idx, (operand_name, operand_def) in enumerate(self.op_def.operands):
             if variable_name != operand_name:
                 continue
-            if self.context == ParsingContext.TopLevel:
+            if top_level:
                 if self.seen_operands[idx]:
                     self.raise_error(f"operand '{variable_name}' is already bound")
                 self.seen_operands[idx] = True
                 if isinstance(operand_def, VariadicDef | OptionalDef):
                     self.seen_attributes.add(AttrSizedOperandSegments.attribute_name)
+            else:
+                if self.seen_operand_types[idx]:
+                    self.raise_error(f"type of '{variable_name}' is already bound")
+                self.seen_operand_types[idx] = True
             match operand_def:
                 case OptOperandDef():
                     return OptionalOperandVariable(variable_name, idx)
@@ -434,15 +419,28 @@ class FormatParser(BaseParser):
                 case _:
                     return OperandVariable(variable_name, idx)
 
+    def parse_optional_typeable_variable(self) -> AnyTypeableDirective | None:
+        """
+        Parse a variable, if present, with the following format:
+          variable ::= `$` bare-ident
+        The variable should refer to an operand or result.
+        """
+        if self._current_token.text[0] != "$":
+            return None
+        self._consume_token()
+        variable_name = self.parse_identifier(" after '$'")
+
+        # Check if the variable is an operand
+        if (variable := self._parse_optional_operand(variable_name, False)) is not None:
+            return variable
+
         # Check if the variable is a result
         for idx, (result_name, result_def) in enumerate(self.op_def.results):
             if variable_name != result_name:
                 continue
-            if self.context == ParsingContext.TopLevel:
-                self.raise_error(
-                    "result variable cannot be in a toplevel directive. "
-                    f"Consider using 'type({variable_name})' instead."
-                )
+            if self.seen_result_types[idx]:
+                self.raise_error(f"type of '{variable_name}' is already bound")
+            self.seen_result_types[idx] = True
             match result_def:
                 case OptResultDef():
                     return OptionalResultVariable(variable_name, idx)
@@ -450,10 +448,25 @@ class FormatParser(BaseParser):
                     return VariadicResultVariable(variable_name, idx)
                 case _:
                     return ResultVariable(variable_name, idx)
-            if isinstance(result_def, VariadicDef):
-                return VariadicResultVariable(variable_name, idx)
-            else:
-                return ResultVariable(variable_name, idx)
+
+        self.raise_error("expected typeable variable to refer to an operand or result")
+
+    def parse_optional_variable(
+        self,
+    ) -> FormatDirective | None:
+        """
+        Parse a variable, if present, with the following format:
+          variable ::= `$` bare-ident
+        The variable should refer to an operand, attribute, region, or successor.
+        """
+        if self._current_token.text[0] != "$":
+            return None
+        self._consume_token()
+        variable_name = self.parse_identifier(" after '$'")
+
+        # Check if the variable is an operand
+        if (variable := self._parse_optional_operand(variable_name, True)) is not None:
+            return variable
 
         # Check if the variable is a region
         for idx, (region_name, region_def) in enumerate(self.op_def.regions):
@@ -491,17 +504,14 @@ class FormatParser(BaseParser):
             attr_name = variable_name
             attr_or_prop = attr_or_prop_by_name[attr_name]
             is_property = attr_or_prop == "property"
-            if self.context == ParsingContext.TopLevel:
-                if is_property:
-                    if attr_name in self.seen_properties:
-                        self.raise_error(f"property '{variable_name}' is already bound")
-                    self.seen_properties.add(attr_name)
-                else:
-                    if attr_name in self.seen_attributes:
-                        self.raise_error(
-                            f"attribute '{variable_name}' is already bound"
-                        )
-                    self.seen_attributes.add(attr_name)
+            if is_property:
+                if attr_name in self.seen_properties:
+                    self.raise_error(f"property '{variable_name}' is already bound")
+                self.seen_properties.add(attr_name)
+            else:
+                if attr_name in self.seen_attributes:
+                    self.raise_error(f"attribute '{variable_name}' is already bound")
+                self.seen_attributes.add(attr_name)
 
             attr_def = (
                 self.op_def.properties.get(attr_name)
@@ -559,63 +569,23 @@ class FormatParser(BaseParser):
 
         self.raise_error(
             "expected variable to refer to an operand, "
-            "attribute, region, result, or successor"
+            "attribute, region, or successor"
         )
 
     def parse_type_directive(self) -> FormatDirective:
         """
         Parse a type directive with the following format:
-          type-directive ::= `type` `(` variable `)`
+          type-directive ::= `type` `(` typeable-directive `)`
         `type` is expected to have already been parsed
         """
         self.parse_punctuation("(")
-
-        # Update the current context, since we are now in a type directive
-        previous_context = self.context
-        self.context = ParsingContext.TypeDirective
-
-        variable = self.parse_optional_variable()
-        match variable:
-            case None:
-                self.raise_error("'type' directive expects a variable argument")
-            case OptionalOperandVariable(name, index):
-                if self.seen_operand_types[index]:
-                    self.raise_error(f"types of '{name}' is already bound")
-                self.seen_operand_types[index] = True
-                res = OptionalOperandTypeDirective(name, index)
-            case VariadicOperandVariable(name, index):
-                if self.seen_operand_types[index]:
-                    self.raise_error(f"types of '{name}' is already bound")
-                self.seen_operand_types[index] = True
-                res = VariadicOperandTypeDirective(name, index)
-            case OperandVariable(name, index):
-                if self.seen_operand_types[index]:
-                    self.raise_error(f"type of '{name}' is already bound")
-                self.seen_operand_types[index] = True
-                res = OperandTypeDirective(name, index)
-            case OptionalResultVariable(name, index):
-                if self.seen_result_types[index]:
-                    self.raise_error(f"types of '{name}' is already bound")
-                self.seen_result_types[index] = True
-                res = OptionalResultTypeDirective(name, index)
-            case VariadicResultVariable(name, index):
-                if self.seen_result_types[index]:
-                    self.raise_error(f"types of '{name}' is already bound")
-                self.seen_result_types[index] = True
-                res = VariadicResultTypeDirective(name, index)
-            case ResultVariable(name, index):
-                if self.seen_result_types[index]:
-                    self.raise_error(f"type of '{name}' is already bound")
-                self.seen_result_types[index] = True
-                res = ResultTypeDirective(name, index)
-            case AttributeVariable():
-                self.raise_error("can only take the type of an operand or result")
-            case _:
-                raise ValueError(f"Unexpected variable type {type(variable)}")
-
+        inner = self.parse_typeable_directive()
         self.parse_punctuation(")")
-        self.context = previous_context
-        return res
+        if isinstance(inner, VariadicTypeableDirective):
+            return VariadicTypeDirective(inner)
+        if isinstance(inner, OptionalTypeableDirective):
+            return OptionalTypeDirective(inner)
+        return TypeDirective(inner)
 
     def parse_optional_group(self) -> FormatDirective:
         """
@@ -626,7 +596,7 @@ class FormatParser(BaseParser):
         anchor: FormatDirective | None = None
 
         while not self.parse_optional_punctuation(")"):
-            then_elements += (self.parse_directive(),)
+            then_elements += (self.parse_format_directive(),)
             if self.parse_optional_keyword("^"):
                 if anchor is not None:
                     self.raise_error("An optional group can only have one anchor.")
@@ -709,7 +679,16 @@ class FormatParser(BaseParser):
         self.parse_characters("`")
         return KeywordDirective(ident)
 
-    def parse_directive(self) -> FormatDirective:
+    def parse_typeable_directive(self) -> AnyTypeableDirective:
+        """
+        Parse a typeable directive, with the following format:
+          directive ::= variable
+        """
+        if variable := self.parse_optional_typeable_variable():
+            return variable
+        self.raise_error(f"unexpected token '{self._current_token.text}'")
+
+    def parse_format_directive(self) -> FormatDirective:
         """
         Parse a format directive, with the following format:
           directive ::= `attr-dict`


### PR DESCRIPTION
Refactors the assembly format directives to:
- Remove some unnecessary classes that made the system rigid
- Separate directives that go in a `type` clause from format directives
This will make it easier to add `operands`, `results`, and `functional-type` directives.