### PR TITLE
misc: use nullable getters in ConstraintContext

### DIFF
--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -1214,9 +1214,10 @@ class TensorIgnoreSizeConstraint(VarConstraint[Attribute]):
         )
 
     def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if self.name in constraint_context.variables:
+        ctx_attr = constraint_context.get_variable(self.name)
+        if ctx_attr is not None:
             if isa(attr, TensorType[Attribute]) and TensorIgnoreSizeConstraint.matches(
-                attr, constraint_context.get_variable(self.name)
+                attr, ctx_attr
             ):
                 return
         super().verify(attr, constraint_context)

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -49,8 +49,8 @@ class ConstraintContext:
         scoped_context = ScopedConstraintContext(inner_variables, inner_range_variables)
         yield scoped_context
         if scoped_context.commit_scope:
-            self._variables = inner_variables
-            self._range_variables = inner_range_variables
+            self._variables.local_scope |= inner_variables.local_scope
+            self._range_variables.local_scope |= inner_range_variables.local_scope
 
 
 @dataclass

--- a/xdsl/utils/scoped_dict.py
+++ b/xdsl/utils/scoped_dict.py
@@ -19,7 +19,7 @@ class ScopedDict(Generic[_Key, _Value]):
     ScopedDict instances may have a `name` property as a hint during debugging.
     """
 
-    _local_scope: dict[_Key, _Value]
+    local_scope: dict[_Key, _Value]
     parent: ScopedDict[_Key, _Value] | None
     name: str | None
 
@@ -30,7 +30,7 @@ class ScopedDict(Generic[_Key, _Value]):
         name: str | None = None,
         local_scope: dict[_Key, _Value] | None = None,
     ) -> None:
-        self._local_scope = {} if local_scope is None else local_scope
+        self.local_scope = {} if local_scope is None else local_scope
         self.parent = parent
         self.name = name
 
@@ -41,7 +41,7 @@ class ScopedDict(Generic[_Key, _Value]):
     def get(self, key: _Key, default: _Value) -> _Value: ...
 
     def get(self, key: _Key, default: _Value | None = None) -> _Value | None:
-        local = self._local_scope.get(key)
+        local = self.local_scope.get(key)
         if local is not None:
             return local
         if self.parent is None:
@@ -53,7 +53,7 @@ class ScopedDict(Generic[_Key, _Value]):
         Fetch key from environment. Attempts to first fetch from current scope,
         then from parent scopes. Raises KeyError error if not found.
         """
-        local = self._local_scope.get(key)
+        local = self.local_scope.get(key)
         if local is not None:
             return local
         if self.parent is None:
@@ -65,13 +65,11 @@ class ScopedDict(Generic[_Key, _Value]):
         Assign key to current scope. Raises InterpretationError if key already
         assigned to.
         """
-        if key in self._local_scope:
+        if key in self.local_scope:
             raise ValueError(
-                f"Cannot overwrite value {self._local_scope[key]} for key {key}"
+                f"Cannot overwrite value {self.local_scope[key]} for key {key}"
             )
-        self._local_scope[key] = value
+        self.local_scope[key] = value
 
     def __contains__(self, key: _Key) -> bool:
-        return (
-            key in self._local_scope or self.parent is not None and key in self.parent
-        )
+        return key in self.local_scope or self.parent is not None and key in self.parent

--- a/xdsl/utils/scoped_dict.py
+++ b/xdsl/utils/scoped_dict.py
@@ -19,7 +19,7 @@ class ScopedDict(Generic[_Key, _Value]):
     ScopedDict instances may have a `name` property as a hint during debugging.
     """
 
-    local_scope: dict[_Key, _Value]
+    _local_scope: dict[_Key, _Value]
     parent: ScopedDict[_Key, _Value] | None
     name: str | None
 
@@ -30,7 +30,7 @@ class ScopedDict(Generic[_Key, _Value]):
         name: str | None = None,
         local_scope: dict[_Key, _Value] | None = None,
     ) -> None:
-        self.local_scope = {} if local_scope is None else local_scope
+        self._local_scope = {} if local_scope is None else local_scope
         self.parent = parent
         self.name = name
 
@@ -41,7 +41,7 @@ class ScopedDict(Generic[_Key, _Value]):
     def get(self, key: _Key, default: _Value) -> _Value: ...
 
     def get(self, key: _Key, default: _Value | None = None) -> _Value | None:
-        local = self.local_scope.get(key)
+        local = self._local_scope.get(key)
         if local is not None:
             return local
         if self.parent is None:
@@ -53,7 +53,7 @@ class ScopedDict(Generic[_Key, _Value]):
         Fetch key from environment. Attempts to first fetch from current scope,
         then from parent scopes. Raises KeyError error if not found.
         """
-        local = self.local_scope.get(key)
+        local = self._local_scope.get(key)
         if local is not None:
             return local
         if self.parent is None:
@@ -65,11 +65,13 @@ class ScopedDict(Generic[_Key, _Value]):
         Assign key to current scope. Raises InterpretationError if key already
         assigned to.
         """
-        if key in self.local_scope:
+        if key in self._local_scope:
             raise ValueError(
-                f"Cannot overwrite value {self.local_scope[key]} for key {key}"
+                f"Cannot overwrite value {self._local_scope[key]} for key {key}"
             )
-        self.local_scope[key] = value
+        self._local_scope[key] = value
 
     def __contains__(self, key: _Key) -> bool:
-        return key in self.local_scope or self.parent is not None and key in self.parent
+        return (
+            key in self._local_scope or self.parent is not None and key in self.parent
+        )


### PR DESCRIPTION
Paring this PR down until it's clear that ScopedDicts are what we want to use for constraint contexts, reducing changes to just getters being nullable.