### PR TITLE
core: remove generic and generic check from TypedAttribute

### DIFF
--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -19,7 +19,6 @@ from xdsl.dialects.builtin import (
     IntegerType,
     NoneAttr,
     Signedness,
-    StringAttr,
 )
 from xdsl.ir import (
     Attribute,
@@ -252,22 +251,9 @@ def test_typed_attribute():
 
         @irdl_attr_definition
         class TypedAttr(  # pyright: ignore[reportUnusedClass]
-            TypedAttribute[Attribute]
+            TypedAttribute
         ):
             name = "test.typed"
-
-    with pytest.raises(
-        Exception,
-        match="A TypedAttribute `type` parameter must be of the same type as the type variable in the TypedAttribute base class.",
-    ):
-
-        @irdl_attr_definition
-        class TypedAttrBis(  # pyright: ignore[reportUnusedClass]
-            TypedAttribute[IntegerAttr[IndexType]]
-        ):
-            name = "test.typed"
-
-            type: ParameterDef[StringAttr]
 
 
 ################################################################################

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -449,7 +449,7 @@ AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
 @irdl_attr_definition
 class IntegerAttr(
     Generic[_IntegerAttrType],
-    TypedAttribute[_IntegerAttrType],
+    TypedAttribute,
 ):
     name = "integer"
     value: ParameterDef[IntAttr]
@@ -504,8 +504,8 @@ class IntegerAttr(
     @staticmethod
     def parse_with_type(
         parser: AttrParser,
-        type: AttributeInvT,
-    ) -> TypedAttribute[AttributeInvT]:
+        type: Attribute,
+    ) -> TypedAttribute:
         assert isinstance(type, IntegerType | IndexType)
         return IntegerAttr(parser.parse_integer(allow_boolean=(type == i1)), type)
 
@@ -634,7 +634,7 @@ _FloatAttrType = TypeVar("_FloatAttrType", bound=AnyFloat, covariant=True)
 
 
 @irdl_attr_definition
-class FloatAttr(Generic[_FloatAttrType], TypedAttribute[_FloatAttrType]):
+class FloatAttr(Generic[_FloatAttrType], TypedAttribute):
     name = "float"
 
     value: ParameterDef[FloatData]
@@ -671,8 +671,8 @@ class FloatAttr(Generic[_FloatAttrType], TypedAttribute[_FloatAttrType]):
     @staticmethod
     def parse_with_type(
         parser: AttrParser,
-        type: AttributeInvT,
-    ) -> TypedAttribute[AttributeInvT]:
+        type: Attribute,
+    ) -> TypedAttribute:
         assert isinstance(type, AnyFloat)
         return FloatAttr(parser.parse_float(), type)
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -606,7 +606,7 @@ class ParametrizedAttribute(Attribute):
         super()._verify()
 
 
-class TypedAttribute(ParametrizedAttribute, Generic[AttributeCovT], ABC):
+class TypedAttribute(ParametrizedAttribute, ABC):
     """
     An attribute with a type.
     """
@@ -617,8 +617,8 @@ class TypedAttribute(ParametrizedAttribute, Generic[AttributeCovT], ABC):
     @staticmethod
     def parse_with_type(
         parser: AttrParser,
-        type: AttributeInvT,
-    ) -> TypedAttribute[AttributeInvT]:
+        type: Attribute,
+    ) -> TypedAttribute:
         """
         Parse the attribute with the given type.
         """

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -24,7 +24,6 @@ from typing import (
 
 from xdsl.ir import (
     Attribute,
-    AttributeCovT,
     AttributeInvT,
     Data,
     ParametrizedAttribute,
@@ -34,7 +33,6 @@ from xdsl.utils.exceptions import PyRDLAttrDefinitionError, VerifyException
 from xdsl.utils.hints import (
     PropertyType,
     get_type_var_from_generic_class,
-    get_type_var_mapping,
 )
 from xdsl.utils.runtime_final import runtime_final
 
@@ -160,25 +158,6 @@ class ParamAttrDef:
         name = clsdict["name"]
 
         param_hints = irdl_param_attr_get_param_type_hints(pyrdl_def)
-        if issubclass(pyrdl_def, TypedAttribute):
-            pyrdl_def = cast(type[TypedAttribute[Attribute]], pyrdl_def)
-            try:
-                param_names = [name for name, _ in param_hints]
-                type_index = param_names.index("type")
-            except ValueError:
-                raise PyRDLAttrDefinitionError(
-                    f"TypedAttribute {pyrdl_def.__name__} should have a 'type' parameter."
-                )
-            typed_hint = param_hints[type_index][1]
-            if get_origin(typed_hint) is Annotated:
-                typed_hint = get_args(typed_hint)[0]
-            type_var = get_type_var_mapping(pyrdl_def)[1][AttributeCovT]
-
-            if typed_hint != type_var:
-                raise ValueError(
-                    "A TypedAttribute `type` parameter must be of the same type"
-                    " as the type variable in the TypedAttribute base class."
-                )
 
         parameters = list[tuple[str, AttrConstraint]]()
         for param_name, param_type in param_hints:
@@ -233,8 +212,14 @@ def irdl_param_attr_definition(cls: _PAttrTT) -> _PAttrTT:
     new_fields = get_accessors_from_param_attr_def(attr_def)
 
     if issubclass(cls, TypedAttribute):
-        parameter_names: tuple[str] = tuple(zip(*attr_def.parameters))[0]
-        type_index = parameter_names.index("type")
+        type_indexes = tuple(
+            i for i, (p, _) in enumerate(attr_def.parameters) if p == "type"
+        )
+        if not type_indexes:
+            raise PyRDLAttrDefinitionError(
+                f"TypedAttribute {cls.__name__} should have a 'type' parameter."
+            )
+        type_index = type_indexes[0]
 
         @classmethod
         def get_type_index(cls: Any) -> int:


### PR DESCRIPTION
As discussed in #3492, this check feels unnecessary and is unwanted for making `DenseIntOrFPElementsAttr` a `TypedAttribute`