### PR TITLE
dialects (arm): add mul instruction with 2 source registers

### DIFF
--- a/tests/filecheck/dialects/arm/test_ops.mlir
+++ b/tests/filecheck/dialects/arm/test_ops.mlir
@@ -6,9 +6,17 @@
 // CHECK: %x1 = arm.get_register : !arm.reg<x1>
 %x1 = arm.get_register : !arm.reg<x1>
 
+// CHECK: %x2 = arm.get_register : !arm.reg<x2>
+%x2 = arm.get_register : !arm.reg<x2>
+
 // CHECK: %ds_mov = arm.ds.mov %x1 {"comment" = "move contents of s to d"} : (!arm.reg<x1>) -> !arm.reg<x2>
 // CHECK-ASM: mov x2, x1 # move contents of s to d
 %ds_mov = arm.ds.mov %x1 {"comment" = "move contents of s to d"} : (!arm.reg<x1>) -> !arm.reg<x2>
 
+// CHECK: %dss_mul = arm.dss.mul %x1, %x2 {"comment" = "multiply s1 by s2"} : (!arm.reg<x1>, !arm.reg<x2>) -> !arm.reg<x3>
+// CHECK-ASM: mul x3, x1, x2 # multiply s1 by s2
+%dss_mul = arm.dss.mul %x1, %x2 {"comment" = "multiply s1 by s2"} : (!arm.reg<x1>, !arm.reg<x2>) -> !arm.reg<x3>
+
 // CHECK-GENERIC: %x1 = "arm.get_register"() : () -> !arm.reg<x1>
 // CHECK-GENERIC: %ds_mov = "arm.ds.mov"(%x1) {"comment" = "move contents of s to d"} : (!arm.reg<x1>) -> !arm.reg<x2>
+// CHECK-GENERIC: %dss_mul = "arm.dss.mul"(%x1, %x2) {"comment" = "multiply s1 by s2"} : (!arm.reg<x1>, !arm.reg<x2>) -> !arm.reg<x3>

--- a/xdsl/dialects/arm/__init__.py
+++ b/xdsl/dialects/arm/__init__.py
@@ -8,7 +8,7 @@ from typing import IO
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Dialect
 
-from .ops import ARMOperation, DSMovOp, GetRegisterOp
+from .ops import ARMOperation, DSMovOp, DSSMulOp, GetRegisterOp
 from .register import IntRegisterType
 
 
@@ -25,6 +25,7 @@ ARM = Dialect(
     [
         GetRegisterOp,
         DSMovOp,
+        DSSMulOp,
     ],
     [
         IntRegisterType,

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -114,3 +114,43 @@ class GetRegisterOp(ARMOperation):
 
     def assembly_line(self):
         return None
+
+
+@irdl_op_definition
+class DSSMulOp(ARMInstruction):
+    """
+    Multiplies the values in s1 and s2 and stores the result in d.
+
+    https://developer.arm.com/documentation/ddi0597/2024-06/Base-Instructions/MUL--MULS--Multiply-?lang=en
+    """
+
+    name = "arm.dss.mul"
+
+    d = result_def(IntRegisterType)
+    s1 = operand_def(IntRegisterType)
+    s2 = operand_def(IntRegisterType)
+    assembly_format = (
+        "$s1 `,` $s2 attr-dict `:` `(` type($s1) `,` type($s2) `)` `->` type($d)"
+    )
+
+    def __init__(
+        self,
+        d: IntRegisterType,
+        s1: Operation | SSAValue,
+        s2: Operation | SSAValue,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=(s1, s2),
+            attributes={
+                "comment": comment,
+            },
+            result_types=(d,),
+        )
+
+    def assembly_line_args(self):
+        return (self.d, self.s1, self.s2)

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -135,10 +135,10 @@ class DSSMulOp(ARMInstruction):
 
     def __init__(
         self,
-        d: IntRegisterType,
         s1: Operation | SSAValue,
         s2: Operation | SSAValue,
         *,
+        d: IntRegisterType,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(comment, str):


### PR DESCRIPTION
Add mul instruction (https://developer.arm.com/documentation/ddi0597/2024-06/Base-Instructions/MUL--MULS--Multiply-?lang=en).

The mul instruction supports either 2 or 3 operands (in the case of 2, the destination is also treated as the 2nd source). This PR only handles the case where 3 operands are provided, 2 source registers and 1 destination.
