### PR TITLE
core: Fix extractor logic for optional and default-valued properties

### DIFF
--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -258,8 +258,9 @@ class FormatParser(BaseParser):
     class _AttrExtractor(VarExtractor[ParsingState]):
         """
         Extracts constraint variables from the attributes/properties of an operation.
-        The attribute/property is assumed to either be non-optional, or have a
-        default value given by the default_value field.
+        If the default_value field is None, then the attribute/property must always be
+        present (which is only the case for non-optional attributes/properties with no
+        default value).
         """
 
         name: str
@@ -272,8 +273,6 @@ class FormatParser(BaseParser):
                 attr = a.properties.get(self.name, self.default_value)
             else:
                 attr = a.attributes.get(self.name, self.default_value)
-            # This assertion should only fail if the property was not given
-            # and does not have a default value.
             assert attr is not None
             return self.inner.extract_var(attr)
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -256,6 +256,12 @@ class FormatParser(BaseParser):
 
     @dataclass(frozen=True)
     class _AttrExtractor(VarExtractor[ParsingState]):
+        """
+        Extracts constraint variables from the attributes/properties of an operation.
+        The attribute/property is assumed to either be non-optional, or have a
+        default value given by the default_value field.
+        """
+
         name: str
         is_prop: bool
         inner: VarExtractor[Attribute]
@@ -266,6 +272,8 @@ class FormatParser(BaseParser):
                 attr = a.properties.get(self.name, self.default_value)
             else:
                 attr = a.attributes.get(self.name, self.default_value)
+            # This assertion should only fail if the property was not given
+            # and does not have a default value.
             assert attr is not None
             return self.inner.extract_var(attr)
 


### PR DESCRIPTION
The extractor used in the assembly parser assumed that all properties/attributes were present. We should instead only propagate the extractors from the property constraint if the property is non-optional or there is a default value. The default_value also needs to be given to the extractor for when the property is not present.

Adds 2 tests to demonstrate this.