### PR TITLE
core: remove unnecessary whitespace printing in assembly format

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -803,7 +803,7 @@ def test_operands(format: str, program: str, generic_program: str):
     [
         (
             "$args type($args) attr-dict",
-            '%0 = "test.op"() : () -> i32\n' "test.variadic_operand  ",
+            '%0 = "test.op"() : () -> i32\n' "test.variadic_operand",
             '%0 = "test.op"() : () -> i32\n' '"test.variadic_operand"() : () -> ()',
         ),
         (
@@ -851,7 +851,7 @@ def test_variadic_operand(format: str, program: str, generic_program: str):
     [
         (
             "$args type($args) attr-dict",
-            '%0 = "test.op"() : () -> i32\n' "test.optional_operand  ",
+            '%0 = "test.op"() : () -> i32\n' "test.optional_operand",
             '%0 = "test.op"() : () -> i32\n' '"test.optional_operand"() : () -> ()',
         ),
         (
@@ -942,7 +942,7 @@ def test_multiple_variadic_operands(
     "program, generic_program",
     [
         (
-            "test.optional_operands(: ) [: ]",
+            "test.optional_operands(:) [:]",
             '"test.optional_operands"() {operandSegmentSizes = array<i32:0,0>} : () -> ()',
         ),
         (
@@ -1083,7 +1083,7 @@ def test_results(format: str, program: str, generic_program: str):
     [
         (
             "`:` type($res) attr-dict",
-            "test.variadic_result : ",
+            "test.variadic_result :",
             '"test.variadic_result"() : () -> ()',
         ),
         (
@@ -1126,7 +1126,7 @@ def test_variadic_result(format: str, program: str, generic_program: str):
     [
         (
             "`:` type($res) attr-dict",
-            "test.optional_result : ",
+            "test.optional_result :",
             '"test.optional_result"() : () -> ()',
         ),
         (
@@ -1263,7 +1263,7 @@ def test_regions(format: str, program: str, generic_program: str):
     [
         (
             "attr-dict-with-keyword $region",
-            "test.variadic_region ",
+            "test.variadic_region",
             '"test.variadic_region"() : () -> ()',
         ),
         (
@@ -1306,7 +1306,7 @@ def test_variadic_region(format: str, program: str, generic_program: str):
     [
         (
             "attr-dict-with-keyword $region",
-            "test.optional_region ",
+            "test.optional_region",
             '"test.optional_region"() : () -> ()',
         ),
         (
@@ -1453,7 +1453,7 @@ def test_successors():
     "program, generic_program",
     [
         (
-            '"test.op"() ({\n  "test.op"() [^0] : () -> ()\n^0:\n  test.var_successor \n}) : () -> ()',
+            '"test.op"() ({\n  "test.op"() [^0] : () -> ()\n^0:\n  test.var_successor\n}) : () -> ()',
             textwrap.dedent(
                 """\
                 "test.op"() ({
@@ -1523,7 +1523,7 @@ def test_variadic_successor(program: str, generic_program: str):
     "program, generic_program",
     [
         (
-            '"test.op"() ({\n  "test.op"() [^0] : () -> ()\n^0:\n  test.opt_successor \n}) : () -> ()',
+            '"test.op"() ({\n  "test.op"() [^0] : () -> ()\n^0:\n  test.opt_successor\n}) : () -> ()',
             textwrap.dedent(
                 """\
                 "test.op"() ({

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -357,9 +357,12 @@ class VariadicTypeDirective(VariadicLikeFormatDirective):
         return self.inner.parse_many_types(parser, state)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        types = self.inner.get_types(op)
+        if not types:
+            return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        printer.print_list(self.inner.get_types(op), printer.print_attribute)
+        printer.print_list(types, printer.print_attribute)
         state.last_was_punctuation = False
         state.should_emit_space = True
 
@@ -535,13 +538,14 @@ class VariadicOperandVariable(VariadicVariable, VariadicOperandDirective):
         return ret
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        operand = getattr(op, self.name)
+        if not operand:
+            return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        operand = getattr(op, self.name)
-        if operand:
-            printer.print_list(operand, printer.print_ssa_value)
-            state.last_was_punctuation = False
-            state.should_emit_space = True
+        printer.print_list(operand, printer.print_ssa_value)
+        state.last_was_punctuation = False
+        state.should_emit_space = True
 
     def get_types(self, op: IRDLOperation) -> Sequence[Attribute]:
         return getattr(op, self.name).types
@@ -579,13 +583,14 @@ class OptionalOperandVariable(OptionalVariable, VariadicOperandDirective):
         return ret
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        operand = getattr(op, self.name)
+        if not operand:
+            return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        operand = getattr(op, self.name)
-        if operand:
-            printer.print_ssa_value(operand)
-            state.last_was_punctuation = False
-            state.should_emit_space = True
+        printer.print_ssa_value(operand)
+        state.last_was_punctuation = False
+        state.should_emit_space = True
 
     def get_types(self, op: IRDLOperation) -> Sequence[Attribute]:
         operand = getattr(op, self.name)
@@ -729,13 +734,14 @@ class VariadicRegionVariable(VariadicRegionDirective, VariadicVariable):
         return bool(regions)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        region = getattr(op, self.name)
+        if not region:
+            return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        region = getattr(op, self.name)
-        if region:
-            printer.print_list(region, printer.print_region, delimiter=" ")
-            state.last_was_punctuation = False
-            state.should_emit_space = True
+        printer.print_list(region, printer.print_region, delimiter=" ")
+        state.last_was_punctuation = False
+        state.should_emit_space = True
 
     def set_empty(self, state: ParsingState):
         state.regions[self.index] = ()
@@ -756,13 +762,14 @@ class OptionalRegionVariable(VariadicRegionDirective, OptionalVariable):
         return bool(region)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        region = getattr(op, self.name)
+        if not region:
+            return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        region = getattr(op, self.name)
-        if region:
-            printer.print_region(region)
-            state.last_was_punctuation = False
-            state.should_emit_space = True
+        printer.print_region(region)
+        state.last_was_punctuation = False
+        state.should_emit_space = True
 
     def set_empty(self, state: ParsingState):
         state.regions[self.index] = ()
@@ -816,13 +823,14 @@ class VariadicSuccessorVariable(VariadicSuccessorDirective, VariadicVariable):
         return bool(successors)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        successor = getattr(op, self.name)
+        if not successor:
+            return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        successor = getattr(op, self.name)
-        if successor:
-            printer.print_list(successor, printer.print_block_name, delimiter=" ")
-            state.last_was_punctuation = False
-            state.should_emit_space = True
+        printer.print_list(successor, printer.print_block_name, delimiter=" ")
+        state.last_was_punctuation = False
+        state.should_emit_space = True
 
     def set_empty(self, state: ParsingState):
         state.successors[self.index] = ()
@@ -843,13 +851,14 @@ class OptionalSuccessorVariable(VariadicSuccessorDirective, OptionalVariable):
         return bool(successor)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
+        successor = getattr(op, self.name)
+        if not successor:
+            return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        successor = getattr(op, self.name)
-        if successor:
-            printer.print_block_name(successor)
-            state.last_was_punctuation = False
-            state.should_emit_space = True
+        printer.print_block_name(successor)
+        state.last_was_punctuation = False
+        state.should_emit_space = True
 
     def set_empty(self, state: ParsingState):
         state.successors[self.index] = ()


### PR DESCRIPTION
Variadic arguments were printing whitespace even if they had nothing to print after the whitespace, resulting in extra unnecessary whitespace appearing. This change moves the whitespace printing after the check to see if there's anything to print.