### PR TITLE
dialects: (builtin) DenseIntOrFPElementsAttr: make data private and use getters instead

### DIFF
--- a/docs/Toy/Toy_Ch3.ipynb
+++ b/docs/Toy/Toy_Ch3.ipynb
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "e1ffdc6a",
    "metadata": {},
    "outputs": [
@@ -241,10 +241,9 @@
     "            return\n",
     "\n",
     "        assert isa(op.res.type, toy.TensorTypeF64)\n",
-    "        assert isa(reshape_input_op.value.data, ArrayAttr[AnyFloatAttr])\n",
     "\n",
     "        new_value = DenseIntOrFPElementsAttr.from_list(\n",
-    "            type=op.res.type, data=reshape_input_op.value.data.data\n",
+    "            type=op.res.type, data=reshape_input_op.value.get_values()\n",
     "        )\n",
     "        new_op = toy.ConstantOp(new_value)\n",
     "        rewriter.replace_matched_op(new_op)\n",
@@ -256,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "af69eccd",
    "metadata": {},
    "outputs": [
@@ -294,8 +293,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/docs/Toy/Toy_Ch3.ipynb
+++ b/docs/Toy/Toy_Ch3.ipynb
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "e1ffdc6a",
    "metadata": {},
    "outputs": [
@@ -219,7 +219,7 @@
     }
    ],
    "source": [
-    "from xdsl.dialects.builtin import AnyFloatAttr, ArrayAttr, DenseIntOrFPElementsAttr\n",
+    "from xdsl.dialects.builtin import DenseIntOrFPElementsAttr\n",
     "from xdsl.utils.hints import isa\n",
     "\n",
     "\n",

--- a/docs/Toy/Toy_Ch3.ipynb
+++ b/docs/Toy/Toy_Ch3.ipynb
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "e1ffdc6a",
    "metadata": {},
    "outputs": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "af69eccd",
    "metadata": {},
    "outputs": [

--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -116,7 +116,7 @@ class ConstantOp(IRDLOperation):
         return list(self.get_type().get_shape())
 
     def get_data(self) -> list[float]:
-        return [float(el.value.data) for el in self.value.data.data]
+        return list(self.value.get_values())
 
 
 class InferAddOpShapeTrait(ToyShapeInferenceTrait):

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -365,7 +365,7 @@ class ConstantOpLowering(RewritePattern):
 
         # Scalar constant values for elements of the tensor
         constants: list[arith.ConstantOp] = [
-            arith.ConstantOp(FloatAttr(i.value.data, f64)) for i in constant_value.data
+            arith.ConstantOp(FloatAttr(i, f64)) for i in constant_value.get_values()
         ]
 
         # n-d indices of elements

--- a/docs/Toy/toy/rewrites/optimise_toy.py
+++ b/docs/Toy/toy/rewrites/optimise_toy.py
@@ -1,10 +1,7 @@
 from typing import cast
 
 from xdsl.dialects.builtin import (
-    ArrayAttr,
     DenseIntOrFPElementsAttr,
-    Float64Type,
-    FloatAttr,
 )
 from xdsl.ir import OpResult
 from xdsl.pattern_rewriter import (
@@ -77,10 +74,9 @@ class FoldConstantReshapeOpPattern(RewritePattern):
             return
 
         assert isa(op.res.type, TensorTypeF64)
-        assert isa(reshape_input_op.value.data, ArrayAttr[FloatAttr[Float64Type]])
 
         new_value = DenseIntOrFPElementsAttr.create_dense_float(
-            type=op.res.type, data=reshape_input_op.value.data.data
+            type=op.res.type, data=reshape_input_op.value.get_values()
         )
         new_op = ConstantOp(new_value)
         rewriter.replace_matched_op(new_op)

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -50,8 +50,8 @@ def test_FloatType_bitwidths():
 def test_DenseIntOrFPElementsAttr_fp_type_conversion():
     check1 = DenseIntOrFPElementsAttr.tensor_from_list([4, 5], f32, [])
 
-    value1 = check1.data.data[0].value.data
-    value2 = check1.data.data[1].value.data
+    value1 = check1.get_attrs()[0].value.data
+    value2 = check1.get_attrs()[1].value.data
 
     # Ensure type conversion happened properly during attribute construction.
     assert isinstance(value1, float)
@@ -64,8 +64,8 @@ def test_DenseIntOrFPElementsAttr_fp_type_conversion():
 
     check2 = DenseIntOrFPElementsAttr.tensor_from_list([t1, t2], f32, [])
 
-    value3 = check2.data.data[0].value.data
-    value4 = check2.data.data[1].value.data
+    value3 = check2.get_attrs()[0].value.data
+    value4 = check2.get_attrs()[1].value.data
 
     # Ensure type conversion happened properly during attribute construction.
     assert isinstance(value3, float)
@@ -77,7 +77,6 @@ def test_DenseIntOrFPElementsAttr_fp_type_conversion():
 def test_DenseIntOrFPElementsAttr_from_list():
     attr = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
 
-    assert attr.data == ArrayAttr([FloatAttr(5.5, f32)])
     assert attr.type == AnyTensorType(f32, [])
 
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -449,8 +449,8 @@ class CslPrintContext:
                 return str(val.data)
             case StringAttr() as s:
                 return f'"{s.data}"'
-            case DenseIntOrFPElementsAttr(_data=_data, type=typ):
-                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(d) for d in _data)} }}"
+            case DenseIntOrFPElementsAttr(data=data, type=typ):
+                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(d) for d in data)} }}"
             case _:
                 return f"<!unknown value {attr}>"
 

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -248,7 +248,7 @@ class CslPrintContext:
             case UnitAttr():
                 return ""
             case DenseIntOrFPElementsAttr():
-                data = init.data.data
+                data = init.get_attrs()
                 assert (
                     len(data) == 1
                 ), f"Memref global initialiser has to have 1 value, got {len(data)}"
@@ -449,8 +449,8 @@ class CslPrintContext:
                 return str(val.data)
             case StringAttr() as s:
                 return f'"{s.data}"'
-            case DenseIntOrFPElementsAttr(data=ArrayAttr(data=data), type=typ):
-                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(d) for d in data)} }}"
+            case DenseIntOrFPElementsAttr(_data=_data, type=typ):
+                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(d) for d in _data)} }}"
             case _:
                 return f"<!unknown value {attr}>"
 

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -285,16 +285,16 @@ class ConvertMemrefGlobalOp(RewritePattern):
                     raise DiagnosticException(
                         f"Unsupported memref element type for riscv lowering: {element_type}"
                     )
-                ints = [d.value.data for d in initial_value.data]
+                ints = initial_value.get_values()
                 for i in ints:
                     assert isinstance(i, int)
                 ints = cast(list[int], ints)
                 ptr = TypedPtr.new_int32(ints).raw
             case Float32Type():
-                floats = [d.value.data for d in initial_value.data]
+                floats = initial_value.get_values()
                 ptr = TypedPtr.new_float32(floats).raw
             case Float64Type():
-                floats = [d.value.data for d in initial_value.data]
+                floats = initial_value.get_values()
                 ptr = TypedPtr.new_float64(floats).raw
             case _:
                 raise DiagnosticException(

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -246,11 +246,11 @@ class ParallelOp(IRDLOperation):
                 "Expected as many operands as results, lower bound args and upper bound args."
             )
 
-        if sum(g.value.data for g in self.lowerBoundsGroups.data) != len(
+        if sum(self.lowerBoundsGroups.get_values()) != len(
             self.lowerBoundsMap.data.results
         ):
             raise VerifyException("Expected a lower bound group for each lower bound")
-        if sum(g.value.data for g in self.upperBoundsGroups.data) != len(
+        if sum(self.upperBoundsGroups.get_values()) != len(
             self.upperBoundsMap.data.results
         ):
             raise VerifyException("Expected an upper bound group for each upper bound")

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1888,7 +1888,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
         """
         return self._data.data
 
-    def is_scalar(self) -> bool:
+    def is_splat(self) -> bool:
         """
         Return whethere or not this dense attribute is defined entirely
         by a single value (splat).

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1730,7 +1730,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
         | RankedStructure[IndexType]
         | RankedStructure[AnyFloat]
     ]
-    _data: ParameterDef[ArrayAttr[AnyIntegerAttr] | ArrayAttr[AnyFloatAttr]]
+    data: ParameterDef[ArrayAttr[AnyIntegerAttr] | ArrayAttr[AnyFloatAttr]]
 
     # The type stores the shape data
     def get_shape(self) -> tuple[int, ...] | None:
@@ -1755,7 +1755,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
             n *= dim
 
         # Product of dimensions needs to equal length
-        return n == len(self._data.data)
+        return n == len(self.data.data)
 
     @staticmethod
     def create_dense_index(
@@ -1879,21 +1879,21 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
         """
         Return all the values of the elements in this DenseIntOrFPElementsAttr
         """
-        return tuple(el.value.data for el in self._data.data)
+        return tuple(el.value.data for el in self.data.data)
 
     def get_attrs(self) -> Sequence[AnyIntegerAttr] | Sequence[AnyFloatAttr]:
         """
         Return all elements of the dense attribute in their relevant
         attribute representation (IntegerAttr / FloatAttr)
         """
-        return self._data.data
+        return self.data.data
 
     def is_splat(self) -> bool:
         """
         Return whethere or not this dense attribute is defined entirely
         by a single value (splat).
         """
-        return self._data.data.count(self._data.data[0]) == len(self._data.data)
+        return self.data.data.count(self.data.data[0]) == len(self.data.data)
 
     @staticmethod
     def parse_with_type(parser: AttrParser, type: Attribute) -> TypedAttribute:
@@ -1937,7 +1937,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
 
     def print_without_type(self, printer: Printer):
         printer.print_string("dense<")
-        data = self._data.data
+        data = self.data.data
         shape = self.get_shape() if self.shape_is_complete else (len(data),)
         assert shape is not None, "If shape is complete, then it cannot be None"
         if len(data) == 0:

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -304,9 +304,11 @@ class SwitchOp(IRDLOperation):
             cases = [("default", self.default_block, self.default_operands)]
             if self.case_values:
                 cases = cases + [
-                    (str(c.value.data), block, operands)
+                    (str(c), block, operands)
                     for (c, block, operands) in zip(
-                        self.case_values.data.data, self.case_blocks, self.case_operand
+                        self.case_values.get_values(),
+                        self.case_blocks,
+                        self.case_operand,
                     )
                 ]
 

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -178,9 +178,9 @@ class VarithSwitchOp(IRDLOperation):
         with printer.indented():
             printer.print_string("\n")
             cases = [("default", self.default_arg)] + [
-                (str(c.value.data), arg)
+                (str(c), arg)
                 for (c, arg) in zip(
-                    self.case_values.data.data,
+                    self.case_values.get_values(),
                     self.args,
                     strict=True,
                 )

--- a/xdsl/interpreters/builtin.py
+++ b/xdsl/interpreters/builtin.py
@@ -87,7 +87,7 @@ class BuiltinFunctions(InterpreterFunctions):
     ) -> ShapedArray[Any]:
         assert isinstance(attr, builtin.DenseIntOrFPElementsAttr)
         shape = attr.get_shape()
-        data = [el.value.data for el in attr.data]
+        data = attr.get_values()
         data_ptr = ptr.TypedPtr[Any].new(
             data,
             xtype=xtype_for_el_type(

--- a/xdsl/interpreters/linalg.py
+++ b/xdsl/interpreters/linalg.py
@@ -188,7 +188,7 @@ class LinalgFunctions(InterpreterFunctions):
         strides_type = op.strides.type
         assert isinstance(strides_type, TensorType)
         (strides_shape,) = strides_type.get_shape()
-        strides = tuple(value.value.data for value in op.strides.data)
+        strides = op.strides.get_values()
         if strides_shape != 2:
             raise NotImplementedError("Only 2d max pooling supported")
 
@@ -233,7 +233,7 @@ class LinalgFunctions(InterpreterFunctions):
             raise NotImplementedError()
         m_height, m_width = input.shape[2:]
         ky, kx = kernel_filter.shape[2], kernel_filter.shape[3]
-        strides = tuple(value.value.data for value in op.strides.data)
+        strides = op.strides.get_values()
         # convert input into a numpy like array
         input_data = [
             [input.data[r * m_width + c] for c in range(m_width)]

--- a/xdsl/interpreters/memref.py
+++ b/xdsl/interpreters/memref.py
@@ -76,7 +76,7 @@ class MemrefFunctions(InterpreterFunctions):
             raise NotImplementedError(
                 "Memrefs that are not dense int or float arrays are not implemented"
             )
-        data = [el.value.data for el in initial_value.data]
+        data = initial_value.get_values()
         shape = initial_value.get_shape()
         assert shape is not None
         xtype = xtype_for_el_type(

--- a/xdsl/interpreters/ml_program.py
+++ b/xdsl/interpreters/ml_program.py
@@ -33,8 +33,6 @@ class MLProgramFunctions(InterpreterFunctions):
         xtype = xtype_for_el_type(
             global_value.get_element_type(), interpreter.index_bitwidth
         )
-        data = TypedPtr[Any].new(
-            [el.value.data for el in global_value.data], xtype=xtype
-        )
+        data = TypedPtr[Any].new(global_value.get_values(), xtype=xtype)
         shaped_array = ShapedArray(data, list(shape))
         return (shaped_array,)

--- a/xdsl/interpreters/onnx.py
+++ b/xdsl/interpreters/onnx.py
@@ -138,7 +138,7 @@ class OnnxFunctions(InterpreterFunctions):
         if op.value is None:
             raise NotImplementedError("Only dense constant values implemented")
         shape = op.value.get_shape()
-        data = [el.value.data for el in op.value.data]
+        data = op.value.get_values()
         data_ptr = ptr.TypedPtr[Any].new(
             data,
             xtype=xtype_for_el_type(

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -606,7 +606,7 @@ class RiscvFunctions(InterpreterFunctions):
             case IntegerAttr():
                 return attr.value.data
             case builtin.DenseIntOrFPElementsAttr():
-                data = [el.value.data for el in attr.data]
+                data = attr.get_values()
                 data_ptr = ptr.TypedPtr[Any].new(
                     data,
                     xtype=xtype_for_el_type(

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -296,7 +296,7 @@ def drop_case_helper(
     new_case_operands: list[Sequence[Operation | SSAValue]] = []
 
     for switch_case, block, operands in zip(
-        case_values.data.data,
+        case_values.get_attrs(),
         op.case_blocks,
         op.case_operand,
         strict=True,
@@ -360,7 +360,7 @@ def fold_switch(switch: cf.SwitchOp, rewriter: PatternRewriter, flag: int):
     ]
     -> br ^bb2
     """
-    case_values = () if switch.case_values is None else switch.case_values.data.data
+    case_values = () if switch.case_values is None else switch.case_values.get_attrs()
 
     new_block, new_operands = next(
         (
@@ -529,7 +529,7 @@ class SimplifySwitchFromSwitchOnSameCondition(RewritePattern):
             fold_switch(
                 op,
                 rewriter,
-                cast(int, case_values.data.data[pred.index - 1].value.data),
+                cast(int, case_values.get_values()[pred.index - 1]),
             )
         else:
 
@@ -538,6 +538,6 @@ class SimplifySwitchFromSwitchOnSameCondition(RewritePattern):
                 block: Block,
                 operands: Sequence[Operation | SSAValue],
             ) -> bool:
-                return switch_case in case_values.data.data
+                return switch_case in case_values.get_attrs()
 
             drop_case_helper(rewriter, op, predicate)

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -578,10 +578,11 @@ class PromoteCoefficients(RewritePattern):
         if (
             not isinstance(cnst := coeff.owner, arith.ConstantOp)
             or not isinstance(dense := cnst.value, DenseIntOrFPElementsAttr)
-            or dense.data.data.count(val := dense.data.data[0]) != len(dense.data.data)
+            or not dense.is_scalar()
         ):
             return
 
+        val = dense.get_attrs()[0]
         assert isattr(val, AnyFloatAttr)
         apply.add_coeff(op.offset, val)
         rewriter.replace_op(mulf, [], new_results=[op.result])

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -578,7 +578,7 @@ class PromoteCoefficients(RewritePattern):
         if (
             not isinstance(cnst := coeff.owner, arith.ConstantOp)
             or not isinstance(dense := cnst.value, DenseIntOrFPElementsAttr)
-            or not dense.is_scalar()
+            or not dense.is_splat()
         ):
             return
 

--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -1,16 +1,21 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import cast
 
 from xdsl.context import MLContext
 from xdsl.dialects import arith, bufferization, func, linalg, memref, stencil, tensor
 from xdsl.dialects.builtin import (
+    AnyFloat,
     AnyMemRefType,
     AnyTensorType,
     AnyTensorTypeConstr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
     FunctionType,
+    IndexType,
+    IntegerType,
     ModuleOp,
+    RankedStructure,
     TensorType,
     i64,
 )
@@ -370,9 +375,11 @@ class ArithConstBufferize(RewritePattern):
             return
         assert isinstance(op.value, DenseIntOrFPElementsAttr)
         assert isa(op.value.type, TensorType[Attribute])
-        typ = DenseIntOrFPElementsAttr(
-            [tensor_to_memref_type(op.value.type), op.value.data]
+        memref_type = cast(
+            RankedStructure[AnyFloat | IntegerType | IndexType],
+            tensor_to_memref_type(op.value.type),
         )
+        typ = DenseIntOrFPElementsAttr.from_list(memref_type, op.value.get_values())
         rewriter.replace_matched_op(
             [
                 c := arith.ConstantOp(typ),

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -17,8 +17,11 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     ContainerType,
     DenseIntOrFPElementsAttr,
+    IndexType,
     IntAttr,
+    IntegerType,
     ModuleOp,
+    RankedStructure,
     ShapedType,
     TensorType,
 )
@@ -425,7 +428,15 @@ class ConstOpUpdateShape(RewritePattern):
                 if needs_update_shape(op.result.type, typ):
                     assert isinstance(op.value, DenseIntOrFPElementsAttr)
                     rewriter.replace_matched_op(
-                        ConstantOp(DenseIntOrFPElementsAttr([typ, op.value.data]))
+                        ConstantOp(
+                            DenseIntOrFPElementsAttr.from_list(
+                                cast(
+                                    RankedStructure[AnyFloat | IntegerType | IndexType],
+                                    typ,
+                                ),
+                                op.value.get_values(),
+                            )
+                        )
                     )
 
 

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -17,11 +17,8 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     ContainerType,
     DenseIntOrFPElementsAttr,
-    IndexType,
     IntAttr,
-    IntegerType,
     ModuleOp,
-    RankedStructure,
     ShapedType,
     TensorType,
 )
@@ -428,15 +425,7 @@ class ConstOpUpdateShape(RewritePattern):
                 if needs_update_shape(op.result.type, typ):
                     assert isinstance(op.value, DenseIntOrFPElementsAttr)
                     rewriter.replace_matched_op(
-                        ConstantOp(
-                            DenseIntOrFPElementsAttr.from_list(
-                                cast(
-                                    RankedStructure[AnyFloat | IntegerType | IndexType],
-                                    typ,
-                                ),
-                                op.value.get_values(),
-                            )
-                        )
+                        ConstantOp(DenseIntOrFPElementsAttr([typ, op.value.data]))
                     )
 
 

--- a/xdsl/transforms/linalg_to_csl.py
+++ b/xdsl/transforms/linalg_to_csl.py
@@ -45,9 +45,9 @@ def get_scalar_const(op: SSAValue) -> AnyFloatAttr | AnyIntegerAttr | None:
         isinstance(op, OpResult)
         and isinstance(op.op, arith.ConstantOp)
         and isa(val := op.op.value, DenseIntOrFPElementsAttr)
-        and val.data.data.count(val.data.data[0]) == len(val.data.data)
+        and val.is_scalar()
     ):
-        return val.data.data[0]
+        return val.get_attrs()[0]
 
 
 class ConvertBinaryLinalgOp(RewritePattern):

--- a/xdsl/transforms/linalg_to_csl.py
+++ b/xdsl/transforms/linalg_to_csl.py
@@ -45,7 +45,7 @@ def get_scalar_const(op: SSAValue) -> AnyFloatAttr | AnyIntegerAttr | None:
         isinstance(op, OpResult)
         and isinstance(op.op, arith.ConstantOp)
         and isa(val := op.op.value, DenseIntOrFPElementsAttr)
-        and val.is_scalar()
+        and val.is_splat()
     ):
         return val.get_attrs()[0]
 

--- a/xdsl/transforms/linalg_transformations.py
+++ b/xdsl/transforms/linalg_transformations.py
@@ -93,7 +93,7 @@ class FuseMultiplyAddPass(RewritePattern):
             and isinstance(op.op, arith.ConstantOp)
             and (
                 not isinstance(v := op.op.value, DenseIntOrFPElementsAttr)
-                or v.is_scalar()
+                or v.is_splat()
             )
         )
 

--- a/xdsl/transforms/linalg_transformations.py
+++ b/xdsl/transforms/linalg_transformations.py
@@ -93,7 +93,7 @@ class FuseMultiplyAddPass(RewritePattern):
             and isinstance(op.op, arith.ConstantOp)
             and (
                 not isinstance(v := op.op.value, DenseIntOrFPElementsAttr)
-                or v.data.data.count(v.data.data[0]) == len(v.data.data)
+                or v.is_scalar()
             )
         )
 


### PR DESCRIPTION
To prepare for the change of internal data representation, this PR makes the actual data of the attribute a private attribute. Everthing is accessed with the getters `get_attrs` (IntegerAttr, ...) and `get_values` (int, float).

The check whether the dense is set by a scalar is pretty common, so i included an additional helper function for that as well