### PR TITLE
dialects: (builtin) move value range helper definitions to utils

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -73,6 +73,11 @@ from xdsl.traits import (
     OptionalSymbolOpInterface,
     SymbolTable,
 )
+from xdsl.utils.comparisons import (
+    signed_value_range,
+    signless_value_range,
+    unsigned_value_range,
+)
 from xdsl.utils.exceptions import DiagnosticException, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.isattr import isattr
@@ -303,16 +308,11 @@ class Signedness(Enum):
         """
         match self:
             case Signedness.SIGNLESS:
-                min_value = -((1 << bitwidth) >> 1)
-                max_value = 1 << bitwidth
+                return signless_value_range(bitwidth)
             case Signedness.SIGNED:
-                min_value = -((1 << bitwidth) >> 1)
-                max_value = 1 << (bitwidth - 1)
+                return signed_value_range(bitwidth)
             case Signedness.UNSIGNED:
-                min_value = 0
-                max_value = 1 << bitwidth
-
-        return min_value, max_value
+                return unsigned_value_range(bitwidth)
 
 
 @irdl_attr_definition

--- a/xdsl/utils/comparisons.py
+++ b/xdsl/utils/comparisons.py
@@ -56,16 +56,16 @@ def signed_upper_bound(bitwidth: int) -> int:
 
 def unsigned_value_range(bitwidth: int) -> tuple[int, int]:
     """
-    For a given bitwidth, returns the range `[min, max+1)`, where min and max are the
-    smallest and largest representable values.
+    For a given bitwidth, returns a tuple `(min, max)`, such that unsigned integers of
+    this bitwidth are in the range [`min`, `max`).
     """
     return 0, unsigned_upper_bound(bitwidth)
 
 
 def signed_value_range(bitwidth: int) -> tuple[int, int]:
     """
-    For a given bitwidth, returns the range `[min, max+1)`, where min and max are the
-    smallest and largest representable values.
+    For a given bitwidth, returns a tuple `(min, max)`, such that signed integers of
+    this bitwidth are in the range [`min`, `max`).
     """
     min_value = signed_lower_bound(bitwidth)
     max_value = signed_upper_bound(bitwidth)
@@ -75,8 +75,8 @@ def signed_value_range(bitwidth: int) -> tuple[int, int]:
 
 def signless_value_range(bitwidth: int) -> tuple[int, int]:
     """
-    For a given bitwidth, returns the range `[min, max+1)`, where min and max are the
-    smallest and largest representable values.
+    For a given bitwidth, returns a tuple `(min, max)`, such that signless integers of
+    this bitwidth are in the range [`min`, `max`).
 
     Signless integers are semantically just bit patterns, and don't represent an
     integer until being converted to signed or unsigned explicitly, so the representable

--- a/xdsl/utils/comparisons.py
+++ b/xdsl/utils/comparisons.py
@@ -32,31 +32,59 @@ involved. For example, a signless value of 5 is equal to a signless value of -3,
 their bit representations are the same.
 """
 
-from xdsl.dialects.builtin import Signedness
-
 
 def unsigned_upper_bound(bitwidth: int) -> int:
     """
     The maximum representable value + 1.
     """
-    _, ub = Signedness.UNSIGNED.value_range(bitwidth)
-    return ub
+    return 1 << bitwidth
 
 
 def signed_lower_bound(bitwidth: int) -> int:
     """
     The minimum representable value.
     """
-    lb, _ = Signedness.SIGNED.value_range(bitwidth)
-    return lb
+    return -((1 << bitwidth) >> 1)
 
 
 def signed_upper_bound(bitwidth: int) -> int:
     """
     The maximum representable value + 1.
     """
-    _, ub = Signedness.SIGNED.value_range(bitwidth)
-    return ub
+    return 1 << (bitwidth - 1)
+
+
+def unsigned_value_range(bitwidth: int) -> tuple[int, int]:
+    """
+    For a given bitwidth, returns (min, max+1), where min and max are the smallest and
+    largest representable values.
+    """
+    return 0, unsigned_upper_bound(bitwidth)
+
+
+def signed_value_range(bitwidth: int) -> tuple[int, int]:
+    """
+    For a given bitwidth, returns (min, max+1), where min and max are the smallest and
+    largest representable values.
+    """
+    min_value = signed_lower_bound(bitwidth)
+    max_value = signed_upper_bound(bitwidth)
+
+    return min_value, max_value
+
+
+def signless_value_range(bitwidth: int) -> tuple[int, int]:
+    """
+    For a given bitwidth, returns (min, max+1), where min and max are the smallest and
+    largest representable values.
+
+    Signless integers are bit patterns, so the representable range is the union of the
+    signed and unsigned representable ranges.
+    """
+    min_value = signed_lower_bound(bitwidth)
+    max_value = unsigned_upper_bound(bitwidth)
+
+    return min_value, max_value
 
 
 def to_unsigned(signless: int, bitwidth: int) -> int:

--- a/xdsl/utils/comparisons.py
+++ b/xdsl/utils/comparisons.py
@@ -2,18 +2,18 @@
 Signed numbers are stored as Two's complement, meaning that the highest bit is used as
 the sign. Here's a table of values for a three-bit two's complement integer type:
 
-|------|----------|--------|
-| bits | unsigned | signed |
-|------|----------|--------|
-|  000 |     0    |   +0   |
-|  001 |     1    |   +1   |
-|  010 |     2    |   +2   |
-|  011 |     3    |   +3   |
-|  100 |     4    |   -4   |
-|  101 |     5    |   -3   |
-|  110 |     6    |   -2   |
-|  111 |     7    |   -1   |
-|------|----------|--------|
+|------|----------|--------|----------|
+| bits | unsigned | signed | signless |
+|------|----------|--------|----------|
+|  000 |     0    |   +0   |    +0    |
+|  001 |     1    |   +1   |    +1    |
+|  010 |     2    |   +2   |    +2    |
+|  011 |     3    |   +3   |    +3    |
+|  100 |     4    |   -4   | +4 or -4 |
+|  101 |     5    |   -3   | +5 or -3 |
+|  110 |     6    |   -2   | +6 or -2 |
+|  111 |     7    |   -1   | +7 or -1 |
+|------|----------|--------|----------|
 
 https://en.wikipedia.org/wiki/Two%27s_complement
 
@@ -56,16 +56,16 @@ def signed_upper_bound(bitwidth: int) -> int:
 
 def unsigned_value_range(bitwidth: int) -> tuple[int, int]:
     """
-    For a given bitwidth, returns (min, max+1), where min and max are the smallest and
-    largest representable values.
+    For a given bitwidth, returns the range `[min, max+1)`, where min and max are the
+    smallest and largest representable values.
     """
     return 0, unsigned_upper_bound(bitwidth)
 
 
 def signed_value_range(bitwidth: int) -> tuple[int, int]:
     """
-    For a given bitwidth, returns (min, max+1), where min and max are the smallest and
-    largest representable values.
+    For a given bitwidth, returns the range `[min, max+1)`, where min and max are the
+    smallest and largest representable values.
     """
     min_value = signed_lower_bound(bitwidth)
     max_value = signed_upper_bound(bitwidth)
@@ -75,11 +75,12 @@ def signed_value_range(bitwidth: int) -> tuple[int, int]:
 
 def signless_value_range(bitwidth: int) -> tuple[int, int]:
     """
-    For a given bitwidth, returns (min, max+1), where min and max are the smallest and
-    largest representable values.
+    For a given bitwidth, returns the range `[min, max+1)`, where min and max are the
+    smallest and largest representable values.
 
-    Signless integers are bit patterns, so the representable range is the union of the
-    signed and unsigned representable ranges.
+    Signless integers are semantically just bit patterns, and don't represent an
+    integer until being converted to signed or unsigned explicitly, so the representable
+    range is the union of the signed and unsigned representable ranges.
     """
     min_value = signed_lower_bound(bitwidth)
     max_value = unsigned_upper_bound(bitwidth)
@@ -89,7 +90,8 @@ def signless_value_range(bitwidth: int) -> tuple[int, int]:
 
 def to_unsigned(signless: int, bitwidth: int) -> int:
     """
-    Transforms values in range [MIN_SIGNED, MAX_UNSIGNED] to range [0, MAX_UNSIGNED].
+    Transforms values in range `[MIN_SIGNED, MAX_UNSIGNED)` to range `[0,
+    MAX_UNSIGNED)`.
     """
     # Normalise to unsigned range by adding the unsigned range and taking the remainder
     modulus = unsigned_upper_bound(bitwidth)
@@ -98,7 +100,8 @@ def to_unsigned(signless: int, bitwidth: int) -> int:
 
 def to_signed(signless: int, bitwidth: int) -> int:
     """
-    Transforms values in range [MIN_SIGNED, MAX_UNSIGNED] to range [MIN_SIGNED, MAX_SIGNED].
+    Transforms values in range `[MIN_SIGNED, MAX_UNSIGNED)` to range `[MIN_SIGNED,
+    MAX_SIGNED)`.
     """
     # Normalise to unsigned range by adding the unsigned range and taking the remainder
     modulus = unsigned_upper_bound(bitwidth)


### PR DESCRIPTION
This flips the dependency of the two files, I'd like to add some more helpers to the utils one for use in `builtin.py`.