### PR TITLE
core: fix bitwidth 0 value range

### DIFF
--- a/tests/utils/test_comparisons.py
+++ b/tests/utils/test_comparisons.py
@@ -1,9 +1,12 @@
 from xdsl.utils.comparisons import (
     signed_lower_bound,
     signed_upper_bound,
+    signed_value_range,
+    signless_value_range,
     to_signed,
     to_unsigned,
     unsigned_upper_bound,
+    unsigned_value_range,
 )
 
 BITWIDTH = 2
@@ -24,6 +27,15 @@ def test_bitwidth_2_values():
     Above calculations are correct for bitwidth 2.
     """
     assert list(SIGNED_RANGE) == [unsigned_to_signed(u) for u in UNSIGNED_RANGE]
+
+
+def test_bitwidth_0_values():
+    """
+    We support 0-width types, where the value is always 0.
+    """
+    assert unsigned_value_range(0) == (0, 1)
+    assert signed_value_range(0) == (0, 1)
+    assert signless_value_range(0) == (0, 1)
 
 
 def test_conversion():

--- a/xdsl/utils/comparisons.py
+++ b/xdsl/utils/comparisons.py
@@ -51,7 +51,7 @@ def signed_upper_bound(bitwidth: int) -> int:
     """
     The maximum representable value + 1.
     """
-    return 1 << (bitwidth - 1)
+    return 1 << max(bitwidth - 1, 0)
 
 
 def unsigned_value_range(bitwidth: int) -> tuple[int, int]:


### PR DESCRIPTION
I'm not 100% sure of my understanding of the contract of i0 and other width-0 integer types, but some logic I'm going to open a PR for soon depends on this not crashing and being explicitly stated.