### PR TITLE
core: Fix 'parse_single_type' for operands/results directives

### DIFF
--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -665,9 +665,11 @@ class OperandsDirective(VariadicOperandDirective, OperandsOrResultDirective):
         return bool(operands)
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
-        if len(state.operand_types) > 1:
-            parser.raise_error("Expected multiple types but received one.")
-        state.operand_types[0] = parser.parse_type()
+        pos_start = parser.pos
+        if s := self._set_using_variadic_index(
+            state.operand_types, "operand types", (parser.parse_type(),)
+        ):
+            parser.raise_error(s, at_position=pos_start, end_position=parser.pos)
 
     def parse_many_types(self, parser: Parser, state: ParsingState) -> bool:
         pos_start = parser.pos
@@ -787,9 +789,11 @@ class ResultsDirective(OperandsOrResultDirective):
     """
 
     def parse_single_type(self, parser: Parser, state: ParsingState) -> None:
-        if len(state.result_types) > 1:
-            parser.raise_error("Expected multiple types but received one.")
-        state.result_types[0] = parser.parse_type()
+        pos_start = parser.pos
+        if s := self._set_using_variadic_index(
+            state.result_types, "result types", (parser.parse_type(),)
+        ):
+            parser.raise_error(s, at_position=pos_start, end_position=parser.pos)
 
     def parse_many_types(self, parser: Parser, state: ParsingState) -> bool:
         pos_start = parser.pos


### PR DESCRIPTION
Reworks the way 'parse_single_type' works for operands/results directives, reusing the infrastructure introduced for 'parse_many_types'. This now allows 'parse_single_type' to work when there are variadic operands, as demonstrated by the new tests. 

The new tests manually make a `FormatProgram`, as the format program parser will never generate such a program.

This currently makes no difference, as these functions are never called, but it will be important for the functional-type directive (#3517), as it allows a type like:
```mlir
(i32, i32) -> i32
```
to be parsed, even if the results of the operation is a variadic (the functional type directive calls 'parse_single_type' when the results are not wrapped in parentheses).