### PR TITLE
dialects: (arith) add muli canonicalization

### DIFF
--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -101,8 +101,8 @@ func.func @test_const_var_const() {
 // CHECK: "test.op"(%a, %a) {"identity multiplication check"} : (i32, i32) -> ()
 "test.op"(%one_times, %times_one) {"identity multiplication check"} : (i32, i32) -> ()
 
-// CHECK: %times_by_const = arith.muli %c2, %a : i32
-%times_by_const = arith.muli %a, %c2 : i32
+// CHECK: %times_by_const = arith.muli %a, %c2 : i32
+%times_by_const = arith.muli %c2, %a : i32
 "test.op"(%times_by_const) : (i32) -> ()
 
 // CHECK: %foldable_times = arith.constant 4 : i32

--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -90,3 +90,21 @@ func.func @test_const_var_const() {
 %z = arith.select %x, %y, %y : i64
 
 "test.op"(%z) : (i64) -> ()
+
+%c1 = arith.constant 1 : i32
+%c2 = arith.constant 2 : i32
+%a = "test.op"() : () -> (i32)
+
+%one_times = arith.muli %c1, %a : i32
+%times_one = arith.muli %a, %c1 : i32
+
+// CHECK: "test.op"(%a, %a) {"identity multiplication check"} : (i32, i32) -> ()
+"test.op"(%one_times, %times_one) {"identity multiplication check"} : (i32, i32) -> ()
+
+// CHECK: %times_by_const = arith.muli %c2, %a : i32
+%times_by_const = arith.muli %a, %c2 : i32
+"test.op"(%times_by_const) : (i32) -> ()
+
+// CHECK: %foldable_times = arith.constant 4 : i32
+%foldable_times = arith.muli %c2, %c2 : i32
+"test.op"(%foldable_times) : (i32) -> ()

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -397,7 +397,7 @@ class MuliHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns import arith
 
-        return (arith.MuliIdentityLeft(), arith.MuliConstantProp())
+        return (arith.MuliIdentityRight(), arith.MuliConstantProp())
 
 
 @irdl_op_definition

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -392,11 +392,19 @@ class AddUIExtendedOp(IRDLOperation):
         )
 
 
+class MuliHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns import arith
+
+        return (arith.MuliIdentityLeft(), arith.MuliConstantProp())
+
+
 @irdl_op_definition
 class MuliOp(SignlessIntegerBinaryOperationWithOverflow):
     name = "arith.muli"
 
-    traits = traits_def(Pure())
+    traits = traits_def(Pure(), MuliHasCanonicalizationPatterns())
 
 
 class MulExtendedBase(IRDLOperation):

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -166,23 +166,23 @@ class SelectSamePattern(RewritePattern):
             rewriter.replace_matched_op((), (op.lhs,))
 
 
-class MuliIdentityLeft(RewritePattern):
+class MuliIdentityRight(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.MuliOp, rewriter: PatternRewriter):
-        if (lhs := const_evaluate_operand(op.lhs)) is None:
+        if (rhs := const_evaluate_operand(op.rhs)) is None:
             return
-        if lhs != 1:
+        if rhs != 1:
             return
 
-        rewriter.replace_matched_op((), (op.rhs,))
+        rewriter.replace_matched_op((), (op.lhs,))
 
 
 class MuliConstantProp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: arith.MuliOp, rewriter: PatternRewriter):
-        if (rhs := const_evaluate_operand(op.rhs)) is None:
-            return
         if (lhs := const_evaluate_operand(op.lhs)) is None:
+            return
+        if (rhs := const_evaluate_operand(op.rhs)) is None:
             # Swap inputs if rhs is constant and lhs is not
             rewriter.replace_matched_op(arith.MuliOp(op.rhs, op.lhs))
             return


### PR DESCRIPTION
Adds two canonicalization patterns to `arith.muli`

The first checks if the left hand side is a constant 1, and removes the multiplication if so.
The second reverses the order of arguments if the right hand side is a constant and the left isn't, and folds the operation if both are constants.

This likely has some merge conflicts with the stuff @superlopuh is doing.

I also had to modify a test for the interactive mode, would appreciate a review on that part.