### PR TITLE
dialects: (csl) handle negative-valued task ID representation

### DIFF
--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -167,19 +167,15 @@
   }
 
 
-  csl.task @data_task(%arg: f32) attributes {kind = #csl<task_kind data>, id = 0 : i5} {
+  csl.task @data_task(%arg: f32) attributes {kind = #csl<task_kind data>, id = 0 : ui5} {
     csl.return
   }
 
-  csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 1 : i5} {
+  csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 1 : ui5} {
     csl.return
   }
 
-  csl.task @control_task() attributes {kind = #csl<task_kind control>, id = 42 : i6} {
-    csl.return
-  }
-
-  csl.task @negative_id_repr_task() attributes {kind = #csl<task_kind control>, id = -22 : i6} {
+  csl.task @control_task() attributes {kind = #csl<task_kind control>, id = 42 : ui6} {
     csl.return
   }
 
@@ -427,8 +423,8 @@ csl.func @builtins() {
   %dsd_1d4 = "csl.set_dsd_length"(%dsd_1d3, %u16_value) : (!csl<dsd mem1d_dsd>, ui16) -> !csl<dsd mem1d_dsd>
   %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %i8_value) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 
-  %fabin_dsd = "csl.get_fab_dsd"(%i32_value) <{"fabric_color" = 2 : i5 , "queue_id" = 0 : i3}> : (si32) -> !csl<dsd fabin_dsd>
-  %fabout_dsd = "csl.get_fab_dsd"(%i32_value) <{"fabric_color" = 3 : i5 , "queue_id" = 1 : i3, "control"= true, "wavelet_index_offset" = false}>: (si32) -> !csl<dsd fabout_dsd>
+  %fabin_dsd = "csl.get_fab_dsd"(%i32_value) <{"fabric_color" = 2 : ui5 , "queue_id" = 0 : i3}> : (si32) -> !csl<dsd fabin_dsd>
+  %fabout_dsd = "csl.get_fab_dsd"(%i32_value) <{"fabric_color" = 3 : ui5 , "queue_id" = 1 : i3, "control"= true, "wavelet_index_offset" = false}>: (si32) -> !csl<dsd fabout_dsd>
 
   %zero_stride_dsd = "csl.get_mem_dsd"(%A, %i16_value, %i16_value, %i16_value) <{"strides" = [0 : si16, 0 : si16, 1 : si16]}> : (memref<24xf32>, si16, si16, si16) -> !csl<dsd mem4d_dsd>
 
@@ -473,9 +469,9 @@ csl.func @builtins() {
   "csl.xp162fh"(%dest_dsd, %src_dsd1)  : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
   "csl.xp162fs"(%dest_dsd, %src_dsd1)  : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 
-  csl.activate data, 0 : i32
-  csl.activate local, 1 : i32
-  csl.activate control, 42 : i32
+  csl.activate data, 0 : ui6
+  csl.activate local, 1 : ui6
+  csl.activate control, 42 : ui6
 
   csl.return
 }
@@ -656,13 +652,6 @@ csl.func @builtins() {
 // CHECK-NEXT:   @bind_control_task(control_task, @get_control_task_id(42));
 // CHECK-NEXT: }
 // CHECK-NEXT: {{ *}}
-// CHECK-NEXT: task negative_id_repr_task() void {
-// CHECK-NEXT:   return;
-// CHECK-NEXT: }
-// CHECK-NEXT: comptime {
-// CHECK-NEXT:   @bind_control_task(negative_id_repr_task, @get_control_task_id(42));
-// CHECK-NEXT: }
-// CHECK-NEXT: {{ *}}
 // CHECK-NEXT: task data_task_no_bind(arg0 : f32) void {
 // CHECK-NEXT:   return;
 // CHECK-NEXT: }
@@ -824,12 +813,12 @@ csl.func @builtins() {
 // CHECK-NEXT:   const fabin_dsd : fabin_dsd = @get_dsd(fabin_dsd, .{
 // CHECK-NEXT:     .extent = i32_value,
 // CHECK-NEXT:     .input_queue = @get_input_queue(0),
-// CHECK-NEXT:     .fabric_color = 2 : i5,
+// CHECK-NEXT:     .fabric_color = 2 : ui5,
 // CHECK-NEXT:   }});
 // CHECK-NEXT:   const fabout_dsd : fabout_dsd = @get_dsd(fabout_dsd, .{
 // CHECK-NEXT:     .extent = i32_value,
 // CHECK-NEXT:     .output_queue = @get_output_queue(1),
-// CHECK-NEXT:     .fabric_color = 3 : i5,
+// CHECK-NEXT:     .fabric_color = 3 : ui5,
 // CHECK-NEXT:     .wavelet_index_offset = false,
 // CHECK-NEXT:     .control = true,
 // CHECK-NEXT:   }});

--- a/tests/filecheck/backend/csl/print_csl.mlir
+++ b/tests/filecheck/backend/csl/print_csl.mlir
@@ -179,6 +179,10 @@
     csl.return
   }
 
+  csl.task @negative_id_repr_task() attributes {kind = #csl<task_kind control>, id = -22 : i6} {
+    csl.return
+  }
+
   csl.task @data_task_no_bind(%arg: f32) attributes {kind = #csl<task_kind data>} {
     csl.return
   }
@@ -650,6 +654,13 @@ csl.func @builtins() {
 // CHECK-NEXT: }
 // CHECK-NEXT: comptime {
 // CHECK-NEXT:   @bind_control_task(control_task, @get_control_task_id(42));
+// CHECK-NEXT: }
+// CHECK-NEXT: {{ *}}
+// CHECK-NEXT: task negative_id_repr_task() void {
+// CHECK-NEXT:   return;
+// CHECK-NEXT: }
+// CHECK-NEXT: comptime {
+// CHECK-NEXT:   @bind_control_task(negative_id_repr_task, @get_control_task_id(42));
 // CHECK-NEXT: }
 // CHECK-NEXT: {{ *}}
 // CHECK-NEXT: task data_task_no_bind(arg0 : f32) void {

--- a/tests/filecheck/dialects/csl/ops.mlir
+++ b/tests/filecheck/dialects/csl/ops.mlir
@@ -17,16 +17,16 @@ csl.func @func_with_args(%arg1: i32, %arg2: i16) -> i32 {
 %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
 %zeros2 = "csl.constants"(%zero, %c100) <{is_const}> : (i32, i32) -> memref<?xi32>
 
-csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 0 : i5} {
+csl.task @local_task() attributes {kind = #csl<task_kind local>, id = 0 : ui5} {
   csl.return
 }
-csl.task @data_task(%a: i32) attributes {kind = #csl<task_kind data>, id = 1 : i5} {
+csl.task @data_task(%a: i32) attributes {kind = #csl<task_kind data>, id = 1 : ui5} {
   csl.return
 }
-csl.task @control_task() attributes {kind = #csl<task_kind control>, id = 2 : i6} {
+csl.task @control_task() attributes {kind = #csl<task_kind control>, id = 2 : ui6} {
   csl.return
 }
-csl.task @control_task_args(%a: i32) attributes {kind = #csl<task_kind control>, id = 2 : i6} {
+csl.task @control_task_args(%a: i32) attributes {kind = #csl<task_kind control>, id = 2 : ui6} {
   csl.return
 }
 csl.task @runtime_bound_local_task() attributes {kind = #csl<task_kind local>} {
@@ -101,8 +101,8 @@ csl.func @initialize() {
     %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl<dsd mem1d_dsd>
     %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl<dsd mem1d_dsd>, tensor<510xf32>) -> !csl<dsd mem1d_dsd>
 
-    %fabin_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 2 : i5 , "queue_id" = 0 : i3}> : (i32) -> !csl<dsd fabin_dsd>
-    %fabout_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 3 : i5 , "queue_id" = 1 : i3, "control"= true, "wavelet_index_offset" = false}>: (i32) -> !csl<dsd fabout_dsd>
+    %fabin_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 2 : ui5 , "queue_id" = 0 : i3}> : (i32) -> !csl<dsd fabin_dsd>
+    %fabout_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 3 : ui5 , "queue_id" = 1 : i3, "control"= true, "wavelet_index_offset" = false}>: (i32) -> !csl<dsd fabout_dsd>
 
     %f16_ptr, %f16_val, %f32_ptr = "test.op"() : () -> (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>)
     "csl.faddh"(%dsd_1d1, %dsd_1d2, %dsd_1d3) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
@@ -305,7 +305,7 @@ csl.func @builtins() {
     "csl.xp162fs"(%dest_dsd, %i16_value) : (!csl<dsd mem1d_dsd>, si16) -> ()
     "csl.xp162fs"(%dest_dsd, %u16_value) : (!csl<dsd mem1d_dsd>, ui16) -> ()
 
-    csl.activate local, 0 : i32
+    csl.activate local, 0 : ui6
 
     csl.return
 }
@@ -348,16 +348,16 @@ csl.func @builtins() {
 // CHECK-NEXT:     %c100 = arith.constant 100 : i32
 // CHECK-NEXT:     %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
 // CHECK-NEXT:     %zeros2 = "csl.constants"(%zero, %c100) <{"is_const"}> : (i32, i32) -> memref<?xi32>
-// CHECK-NEXT:     csl.task @local_task()  attributes {"kind" = #csl<task_kind local>, "id" = 0 : i5}{
+// CHECK-NEXT:     csl.task @local_task()  attributes {"kind" = #csl<task_kind local>, "id" = 0 : ui5}{
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     csl.task @data_task(%a : i32)  attributes {"kind" = #csl<task_kind data>, "id" = 1 : i5}{
+// CHECK-NEXT:     csl.task @data_task(%a : i32)  attributes {"kind" = #csl<task_kind data>, "id" = 1 : ui5}{
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     csl.task @control_task()  attributes {"kind" = #csl<task_kind control>, "id" = 2 : i6}{
+// CHECK-NEXT:     csl.task @control_task()  attributes {"kind" = #csl<task_kind control>, "id" = 2 : ui6}{
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     csl.task @control_task_args(%a_1 : i32)  attributes {"kind" = #csl<task_kind control>, "id" = 2 : i6}{
+// CHECK-NEXT:     csl.task @control_task_args(%a_1 : i32)  attributes {"kind" = #csl<task_kind control>, "id" = 2 : ui6}{
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     csl.task @runtime_bound_local_task()  attributes {"kind" = #csl<task_kind local>}{
@@ -402,8 +402,8 @@ csl.func @builtins() {
 // CHECK-NEXT:       %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:       %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl<dsd mem1d_dsd>
 // CHECK-NEXT:       %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl<dsd mem1d_dsd>, tensor<510xf32>) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:       %fabin_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 2 : i5, "queue_id" = 0 : i3}> : (i32) -> !csl<dsd fabin_dsd>
-// CHECK-NEXT:       %fabout_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 3 : i5, "queue_id" = 1 : i3, "control" = true, "wavelet_index_offset" = false}> : (i32) -> !csl<dsd fabout_dsd>
+// CHECK-NEXT:       %fabin_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 2 : ui5, "queue_id" = 0 : i3}> : (i32) -> !csl<dsd fabin_dsd>
+// CHECK-NEXT:       %fabout_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 3 : ui5, "queue_id" = 1 : i3, "control" = true, "wavelet_index_offset" = false}> : (i32) -> !csl<dsd fabout_dsd>
 // CHECK-NEXT:       %f16_ptr, %f16_val, %f32_ptr = "test.op"() : () -> (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>)
 // CHECK-NEXT:       "csl.faddh"(%dsd_1d1, %dsd_1d2, %dsd_1d3) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-NEXT:       "csl.faddh"(%f16_ptr, %f16_val, %dsd_1d3) : (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
@@ -560,7 +560,7 @@ csl.func @builtins() {
 // CHECK-NEXT:       "csl.xp162fs"(%dest_dsd, %src_dsd1) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-NEXT:       "csl.xp162fs"(%dest_dsd, %i16_value) : (!csl<dsd mem1d_dsd>, si16) -> ()
 // CHECK-NEXT:       "csl.xp162fs"(%dest_dsd, %u16_value) : (!csl<dsd mem1d_dsd>, ui16) -> ()
-// CHECK-NEXT:       csl.activate local, 0 : i32
+// CHECK-NEXT:       csl.activate local, 0 : ui6
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>
@@ -593,17 +593,17 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:     %c100 = "arith.constant"() <{"value" = 100 : i32}> : () -> i32
 // CHECK-GENERIC-NEXT:     %zeros = "csl.constants"(%zero, %c100) : (i32, i32) -> memref<?xi32>
 // CHECK-GENERIC-NEXT:     %zeros2 = "csl.constants"(%zero, %c100) <{"is_const"}> : (i32, i32) -> memref<?xi32>
-// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "local_task", "function_type" = () -> (), "kind" = #csl<task_kind local>, "id" = 0 : i5}> ({
+// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "local_task", "function_type" = () -> (), "kind" = #csl<task_kind local>, "id" = 0 : ui5}> ({
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
-// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "data_task", "function_type" = (i32) -> (), "kind" = #csl<task_kind data>, "id" = 1 : i5}> ({
+// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "data_task", "function_type" = (i32) -> (), "kind" = #csl<task_kind data>, "id" = 1 : ui5}> ({
 // CHECK-GENERIC-NEXT:     ^1(%a : i32):
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
-// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "control_task", "function_type" = () -> (), "kind" = #csl<task_kind control>, "id" = 2 : i6}> ({
+// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "control_task", "function_type" = () -> (), "kind" = #csl<task_kind control>, "id" = 2 : ui6}> ({
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
-// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "control_task_args", "function_type" = (i32) -> (), "kind" = #csl<task_kind control>, "id" = 2 : i6}> ({
+// CHECK-GENERIC-NEXT:     "csl.task"() <{"sym_name" = "control_task_args", "function_type" = (i32) -> (), "kind" = #csl<task_kind control>, "id" = 2 : ui6}> ({
 // CHECK-GENERIC-NEXT:     ^2(%a_1 : i32):
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
@@ -649,8 +649,8 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:       %dsd_1d5 = "csl.set_dsd_stride"(%dsd_1d4, %int8) : (!csl<dsd mem1d_dsd>, si8) -> !csl<dsd mem1d_dsd>
 // CHECK-GENERIC-NEXT:       %tensor_dsd1 = "csl.get_mem_dsd"(%tens, %scalar) : (tensor<510xf32>, i32) -> !csl<dsd mem1d_dsd>
 // CHECK-GENERIC-NEXT:       %tensor_dsd2 = "csl.set_dsd_base_addr"(%dsd_1d, %tens) : (!csl<dsd mem1d_dsd>, tensor<510xf32>) -> !csl<dsd mem1d_dsd>
-// CHECK-GENERIC-NEXT:       %fabin_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 2 : i5, "queue_id" = 0 : i3}> : (i32) -> !csl<dsd fabin_dsd>
-// CHECK-GENERIC-NEXT:       %fabout_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 3 : i5, "queue_id" = 1 : i3, "control" = true, "wavelet_index_offset" = false}> : (i32) -> !csl<dsd fabout_dsd>
+// CHECK-GENERIC-NEXT:       %fabin_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 2 : ui5, "queue_id" = 0 : i3}> : (i32) -> !csl<dsd fabin_dsd>
+// CHECK-GENERIC-NEXT:       %fabout_dsd = "csl.get_fab_dsd"(%scalar) <{"fabric_color" = 3 : ui5, "queue_id" = 1 : i3, "control" = true, "wavelet_index_offset" = false}> : (i32) -> !csl<dsd fabout_dsd>
 // CHECK-GENERIC-NEXT:       %f16_ptr, %f16_val, %f32_ptr = "test.op"() : () -> (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl.ptr<f32, #csl<ptr_kind single>, #csl<ptr_const var>>)
 // CHECK-GENERIC-NEXT:       "csl.faddh"(%dsd_1d1, %dsd_1d2, %dsd_1d3) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-GENERIC-NEXT:       "csl.faddh"(%f16_ptr, %f16_val, %dsd_1d3) : (!csl.ptr<f16, #csl<ptr_kind single>, #csl<ptr_const var>>, f16, !csl<dsd mem1d_dsd>) -> ()
@@ -807,7 +807,7 @@ csl.func @builtins() {
 // CHECK-GENERIC-NEXT:       "csl.xp162fs"(%dest_dsd, %src_dsd1) : (!csl<dsd mem1d_dsd>, !csl<dsd mem1d_dsd>) -> ()
 // CHECK-GENERIC-NEXT:       "csl.xp162fs"(%dest_dsd, %i16_value) : (!csl<dsd mem1d_dsd>, si16) -> ()
 // CHECK-GENERIC-NEXT:       "csl.xp162fs"(%dest_dsd, %u16_value) : (!csl<dsd mem1d_dsd>, ui16) -> ()
-// CHECK-GENERIC-NEXT:       "csl.activate"() <{"kind" = #csl<task_kind local>, "id" = 0 : i32}> : () -> ()
+// CHECK-GENERIC-NEXT:       "csl.activate"() <{"kind" = #csl<task_kind local>, "id" = 0 : ui6}> : () -> ()
 // CHECK-GENERIC-NEXT:       "csl.return"() : () -> ()
 // CHECK-GENERIC-NEXT:     }) : () -> ()
 // CHECK-GENERIC-NEXT:     %global_ptr = "test.op"() : () -> !csl.ptr<i16, #csl<ptr_kind single>, #csl<ptr_const var>>

--- a/tests/filecheck/transforms/csl-stencil-handle-async-flow.mlir
+++ b/tests/filecheck/transforms/csl-stencil-handle-async-flow.mlir
@@ -108,10 +108,10 @@
 // CHECK-NEXT:       %40 = arith.constant 1 : index
 // CHECK-NEXT:       "csl.store_var"(%var0, %arg0) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
 // CHECK-NEXT:       "csl.store_var"(%var1, %arg1) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
-// CHECK-NEXT:       csl.activate local, 1 : i32
+// CHECK-NEXT:       csl.activate local, 1 : ui5
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : i5}{
+// CHECK-NEXT:     csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : ui5}{
 // CHECK-NEXT:       %41 = arith.constant 1000 : ui32
 // CHECK-NEXT:       %iteration_cond = "csl.load_var"(%iteration) : (!csl.var<ui32>) -> ui32
 // CHECK-NEXT:       %42 = arith.cmpi slt, %iteration_cond, %41 : ui32
@@ -159,7 +159,7 @@
 // CHECK-NEXT:       %var1_inc = "csl.load_var"(%var1) : (!csl.var<memref<512xf32>>) -> memref<512xf32>
 // CHECK-NEXT:       "csl.store_var"(%var0, %var1_inc) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
 // CHECK-NEXT:       "csl.store_var"(%var1, %var0_inc) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
-// CHECK-NEXT:       csl.activate local, 1 : i32
+// CHECK-NEXT:       csl.activate local, 1 : ui5
 // CHECK-NEXT:       csl.return
 // CHECK-NEXT:     }
 // CHECK-NEXT:     csl.func @for_post0() {

--- a/tests/filecheck/transforms/lower-csl-stencil.mlir
+++ b/tests/filecheck/transforms/lower-csl-stencil.mlir
@@ -168,10 +168,10 @@ builtin.module {
       %28 = arith.constant 1 : index
       "csl.store_var"(%24, %19) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
       "csl.store_var"(%25, %20) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
-      csl.activate local, 1 : i32
+      csl.activate local, 1 : ui6
       csl.return
     }
-    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : i5}{
+    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : ui5}{
       %29 = arith.constant 1000 : i16
       %30 = "csl.load_var"(%23) : (!csl.var<i16>) -> i16
       %31 = arith.cmpi slt, %30, %29 : i16
@@ -226,7 +226,7 @@ builtin.module {
       %37 = "csl.load_var"(%25) : (!csl.var<memref<512xf32>>) -> memref<512xf32>
       "csl.store_var"(%24, %37) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
       "csl.store_var"(%25, %36) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
-      csl.activate local, 1 : i32
+      csl.activate local, 1 : ui6
       csl.return
     }
     csl.func @for_post0() {
@@ -276,10 +276,10 @@ builtin.module {
 // CHECK-NEXT:      %79 = arith.constant 1 : index
 // CHECK-NEXT:      "csl.store_var"(%75, %70) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
 // CHECK-NEXT:      "csl.store_var"(%76, %71) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
-// CHECK-NEXT:      csl.activate local, 1 : i32
+// CHECK-NEXT:      csl.activate local, 1 : ui6
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }
-// CHECK-NEXT:    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : i5}{
+// CHECK-NEXT:    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : ui5}{
 // CHECK-NEXT:      %80 = arith.constant 1000 : i16
 // CHECK-NEXT:      %81 = "csl.load_var"(%74) : (!csl.var<i16>) -> i16
 // CHECK-NEXT:      %82 = arith.cmpi slt, %81, %80 : i16
@@ -342,7 +342,7 @@ builtin.module {
 // CHECK-NEXT:      %102 = "csl.load_var"(%76) : (!csl.var<memref<512xf32>>) -> memref<512xf32>
 // CHECK-NEXT:      "csl.store_var"(%75, %102) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
 // CHECK-NEXT:      "csl.store_var"(%76, %101) : (!csl.var<memref<512xf32>>, memref<512xf32>) -> ()
-// CHECK-NEXT:      csl.activate local, 1 : i32
+// CHECK-NEXT:      csl.activate local, 1 : ui6
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    csl.func @for_post0() {
@@ -521,10 +521,10 @@ builtin.module {
       %28 = arith.constant 1 : index
       "csl.store_var"(%24, %19) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
       "csl.store_var"(%25, %20) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
-      csl.activate local, 1 : i32
+      csl.activate local, 1 : ui6
       csl.return
     }
-    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : i5}{
+    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : ui5}{
       %29 = arith.constant 1000 : i16
       %30 = "csl.load_var"(%23) : (!csl.var<i16>) -> i16
       %31 = arith.cmpi slt, %30, %29 : i16
@@ -573,7 +573,7 @@ builtin.module {
       %37 = "csl.load_var"(%25) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
       "csl.store_var"(%24, %37) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
       "csl.store_var"(%25, %36) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
-      csl.activate local, 1 : i32
+      csl.activate local, 1 : ui6
       csl.return
     }
     csl.func @for_post0() {
@@ -623,10 +623,10 @@ builtin.module {
 // CHECK-NEXT:      %188 = arith.constant 1 : index
 // CHECK-NEXT:      "csl.store_var"(%184, %179) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
 // CHECK-NEXT:      "csl.store_var"(%185, %180) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
-// CHECK-NEXT:      csl.activate local, 1 : i32
+// CHECK-NEXT:      csl.activate local, 1 : ui6
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }
-// CHECK-NEXT:    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : i5}{
+// CHECK-NEXT:    csl.task @for_cond0()  attributes {"kind" = #csl<task_kind local>, "id" = 1 : ui5}{
 // CHECK-NEXT:      %189 = arith.constant 1000 : i16
 // CHECK-NEXT:      %190 = "csl.load_var"(%183) : (!csl.var<i16>) -> i16
 // CHECK-NEXT:      %191 = arith.cmpi slt, %190, %189 : i16
@@ -699,7 +699,7 @@ builtin.module {
 // CHECK-NEXT:      %218 = "csl.load_var"(%185) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
 // CHECK-NEXT:      "csl.store_var"(%184, %218) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
 // CHECK-NEXT:      "csl.store_var"(%185, %217) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
-// CHECK-NEXT:      csl.activate local, 1 : i32
+// CHECK-NEXT:      csl.activate local, 1 : ui6
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    csl.func @for_post0() {

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -31,6 +31,7 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Block, Operation, OpResult, Region, SSAValue
 from xdsl.irdl import Operand
 from xdsl.traits import is_side_effect_free
+from xdsl.utils.comparisons import to_unsigned
 from xdsl.utils.hints import isa
 
 _CSL_KW_SET = {
@@ -235,8 +236,9 @@ class CslPrintContext:
         if id is None:
             return
         with self.descend("comptime") as inner:
+            unsigned_id = to_unsigned(id.value.data, id.type.width.data)
             inner.print(
-                f"@bind_{kind.value}_task({name}, @get_{kind.value}_task_id({self._wrap_task_id(kind, id.value.data)}));"
+                f"@bind_{kind.value}_task({name}, @get_{kind.value}_task_id({self._wrap_task_id(kind, unsigned_id)}));"
             )
 
     def _memref_global_init(self, init: Attribute, type: str) -> str:


### PR DESCRIPTION
i6 and friends are signless, meaning that they are bitpatterns that don't have an inherent value. When printing CSL, we currently take the raw data of the IntegerAttr, but it seems like that's not valid for task identifiers, which are positive. This PR changes the printer to always print the unsigned version of the number, and adds a test case to the CSL filecheck.