### PR TITLE
core: allow result variadic inference

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -15,6 +15,7 @@ from xdsl.dialects.builtin import (
     BoolAttr,
     Float64Type,
     FloatAttr,
+    IndexType,
     IntegerAttr,
     MemRefType,
     ModuleOp,
@@ -1448,6 +1449,25 @@ def test_variadic_result(format: str, program: str, generic_program: str):
 
     check_roundtrip(program, ctx)
     check_equivalence(program, generic_program, ctx)
+
+
+def test_variadic_result_failure():
+    """Test that inferring a range of inferrable attributes of unknown length fails."""
+
+    with pytest.raises(
+        PyRDLOpDefinitionError,
+        match="type of result 'res' cannot be inferred",
+    ):
+
+        @irdl_op_definition
+        class VariadicResultsOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
+            name = "test.var_results_op"
+
+            res = var_result_def(IndexType())
+
+            irdl_options = [AttrSizedResultSegments()]
+
+            assembly_format = "attr-dict"
 
 
 @pytest.mark.parametrize(

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2374,23 +2374,19 @@ def test_variadic_length_inference():
 
         assembly_format = "$ins attr-dict `:` type($ins)"
 
-    with pytest.raises(
-        NotImplementedError,
-        match="Inference of length of variadic result 'outs' not implemented",
-    ):
-        ctx = MLContext()
-        ctx.load_op(RangeVarOp)
-        ctx.load_dialect(Test)
-        program = textwrap.dedent("""\
-        %in0, %in1 = "test.op"() : () -> (index, index)
-        %out0, %out1 = test.range_var %in0, %in1 : index, index
-        """)
+    ctx = MLContext()
+    ctx.load_op(RangeVarOp)
+    ctx.load_dialect(Test)
+    program = textwrap.dedent("""\
+    %in0, %in1 = "test.op"() : () -> (index, index)
+    %out0, %out1 = test.range_var %in0, %in1 : index, index
+    """)
 
-        parser = Parser(ctx, program)
-        test_op = parser.parse_optional_operation()
-        assert isinstance(test_op, test.Operation)
-        my_op = parser.parse_optional_operation()
-        assert isinstance(my_op, RangeVarOp)
+    parser = Parser(ctx, program)
+    test_op = parser.parse_optional_operation()
+    assert isinstance(test_op, test.Operation)
+    my_op = parser.parse_optional_operation()
+    assert isinstance(my_op, RangeVarOp)
 
 
 ################################################################################

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -677,7 +677,7 @@ class GenericRangeConstraint(Generic[AttributeCovT], ABC):
         """
         return {}
 
-    def can_infer(self, var_constraint_names: Set[str], length_known: bool) -> bool:
+    def can_infer(self, var_constraint_names: Set[str], *, length_known: bool) -> bool:
         """
         Check if there is enough information to infer the attribute given the
         constraint variables that are already set, and whether the length of the
@@ -687,7 +687,7 @@ class GenericRangeConstraint(Generic[AttributeCovT], ABC):
         return False
 
     def infer(
-        self, context: InferenceContext, length: int | None
+        self, context: InferenceContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
         """
         Infer the attribute given the the values for all variables, and possibly
@@ -741,11 +741,11 @@ class RangeVarConstraint(GenericRangeConstraint[AttributeCovT]):
     ) -> dict[str, VarExtractor[Sequence[AttributeCovT]]]:
         return {self.name: IdExtractor[Sequence[AttributeCovT]]()}
 
-    def can_infer(self, var_constraint_names: Set[str], length_known: bool) -> bool:
+    def can_infer(self, var_constraint_names: Set[str], *, length_known: bool) -> bool:
         return self.name in var_constraint_names
 
     def infer(
-        self, context: InferenceContext, length: int | None
+        self, context: InferenceContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
         v = context.variables[self.name]
         return cast(Sequence[AttributeCovT], v)
@@ -767,12 +767,13 @@ class RangeOf(GenericRangeConstraint[AttributeCovT]):
         for a in attrs:
             self.constr.verify(a, constraint_context)
 
-    def can_infer(self, var_constraint_names: Set[str], length_known: bool) -> bool:
+    def can_infer(self, var_constraint_names: Set[str], *, length_known: bool) -> bool:
         return length_known and self.constr.can_infer(var_constraint_names)
 
     def infer(
         self,
         context: InferenceContext,
+        *,
         length: int | None,
     ) -> Sequence[AttributeCovT]:
         assert length is not None
@@ -813,12 +814,12 @@ class SingleOf(GenericRangeConstraint[AttributeCovT]):
         }
 
     def can_infer(
-        self, var_constraint_names: Set[str], length_known: int | None
+        self, var_constraint_names: Set[str], *, length_known: int | None
     ) -> bool:
         return self.constr.can_infer(var_constraint_names)
 
     def infer(
-        self, context: InferenceContext, length: int | None
+        self, context: InferenceContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
         return (self.constr.infer(context),)
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -187,7 +187,7 @@ class FormatProgram:
                 range_length = len(operand) if isinstance(operand, Sequence) else 1
                 operand_type = operand_def.constr.infer(
                     InferenceContext(state.variables),
-                    range_length,
+                    length=range_length,
                 )
                 resolved_operand_type: Attribute | Sequence[Attribute]
                 if isinstance(operand_def, OptionalDef):
@@ -208,7 +208,7 @@ class FormatProgram:
         ):
             if result_type is None:
                 inferred_result_types = result_def.constr.infer(
-                    InferenceContext(state.variables), None
+                    InferenceContext(state.variables), length=None
                 )
                 resolved_result_type: Attribute | Sequence[Attribute]
                 if isinstance(result_def, OptionalDef):

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -330,7 +330,7 @@ class FormatParser(BaseParser):
                     "directive to the custom assembly format"
                 )
             if not seen_operand_type:
-                if not operand_def.constr.can_infer(var_constraint_names):
+                if not operand_def.constr.can_infer(var_constraint_names, True):
                     self.raise_error(
                         f"type of operand '{operand_name}' cannot be inferred, "
                         f"consider adding a 'type(${operand_name})' directive to the "
@@ -345,7 +345,7 @@ class FormatParser(BaseParser):
             self.seen_result_types, self.op_def.results, strict=True
         ):
             if not result_type:
-                if not result_def.constr.can_infer(var_constraint_names):
+                if not result_def.constr.can_infer(var_constraint_names, False):
                     self.raise_error(
                         f"type of result '{result_name}' cannot be inferred, "
                         f"consider adding a 'type(${result_name})' directive to the "

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -330,7 +330,9 @@ class FormatParser(BaseParser):
                     "directive to the custom assembly format"
                 )
             if not seen_operand_type:
-                if not operand_def.constr.can_infer(var_constraint_names, True):
+                if not operand_def.constr.can_infer(
+                    var_constraint_names, length_known=True
+                ):
                     self.raise_error(
                         f"type of operand '{operand_name}' cannot be inferred, "
                         f"consider adding a 'type(${operand_name})' directive to the "
@@ -345,7 +347,9 @@ class FormatParser(BaseParser):
             self.seen_result_types, self.op_def.results, strict=True
         ):
             if not result_type:
-                if not result_def.constr.can_infer(var_constraint_names, False):
+                if not result_def.constr.can_infer(
+                    var_constraint_names, length_known=False
+                ):
                     self.raise_error(
                         f"type of result '{result_name}' cannot be inferred, "
                         f"consider adding a 'type(${result_name})' directive to the "


### PR DESCRIPTION
Sort of a revert of #3416, but I believe this fixes the underlying problem.

Changes range constraint inference so that passing in a length is optional. The rationale for this is that the length of operands is always known, but the length of results is never known (as they can always be omitted). Similarly updates the `can_infer` function.

Probably needs a test of something. :shrug: 