### PR TITLE
CI: add "tests" to extraPaths for Pyright to find conftest locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ reportMissingModuleSource = false
 enableTypeIgnoreComments = false
 enableExperimentalFeatures = true
 typeCheckingMode = "strict"
+extraPaths = ["tests"]
 "include" = ["docs", "xdsl", "tests", "bench"]
 "exclude" = [
     "tests/dialects/test_memref.py",


### PR DESCRIPTION
For some reason it started complaining on my computer.