### PR TITLE
dialects: (arith) add SignlessIntegerBinaryOperation canonicalization

### DIFF
--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -154,3 +154,8 @@ func.func @test_const_var_const() {
 // CHECK: arith.subi %c2, %a : i32
 %10 = arith.subi %c2, %a : i32
 "test.op"(%10) : (i32) -> ()
+
+// CHECK: %{{.*}} = arith.constant false
+%11 = arith.constant true
+%12 = arith.addi %11, %11 : i1
+"test.op"(%12) : (i1) -> ()

--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -149,3 +149,8 @@ func.func @test_const_var_const() {
 %9 = arith.cmpi uge, %int, %int : i32
 
 "test.op"(%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %int) : (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32) -> ()
+
+// Subtraction is not commutative so should not have the constant swapped to the right
+// CHECK: arith.subi %c2, %a : i32
+%10 = arith.subi %c2, %a : i32
+"test.op"(%10) : (i32) -> ()

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -334,11 +334,11 @@ async def test_rewrites():
         await pilot.click("#condense_button")
 
         addi_pass = AvailablePass(
-            display_name="AddiOp(%res = arith.addi %n, %c0 : i32):arith.addi:AddiIdentityRight",
+            display_name="AddiOp(%res = arith.addi %n, %c0 : i32):arith.addi:SignlessIntegerBinaryOperationZeroOrUnitRight",
             module_pass=individual_rewrite.ApplyIndividualRewritePass,
             pass_spec=list(
                 parse_pipeline(
-                    'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddiIdentityRight"}'
+                    'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="SignlessIntegerBinaryOperationZeroOrUnitRight"}'
                 )
             )[0],
         )
@@ -359,7 +359,7 @@ async def test_rewrites():
                 individual_rewrite.ApplyIndividualRewritePass,
                 list(
                     parse_pipeline(
-                        'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddiIdentityRight"}'
+                        'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="SignlessIntegerBinaryOperationZeroOrUnitRight"}'
                     )
                 )[0],
             ),
@@ -568,7 +568,7 @@ async def test_apply_individual_rewrite():
                 n.data is not None
                 and n.data[1] is not None
                 and str(n.data[1])
-                == 'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddiConstantProp"}'
+                == 'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="SignlessIntegerBinaryOperationConstantProp"}'
             ):
                 node = n
 
@@ -598,7 +598,7 @@ async def test_apply_individual_rewrite():
                 n.data is not None
                 and n.data[1] is not None
                 and str(n.data[1])
-                == 'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="AddiIdentityRight"}'
+                == 'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="SignlessIntegerBinaryOperationZeroOrUnitRight"}'
             ):
                 node = n
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -198,6 +198,13 @@ class SignlessIntegerBinaryOperation(IRDLOperation, abc.ABC):
 
     @staticmethod
     def py_operation(lhs: int, rhs: int) -> int | None:
+        """
+        Performs a python function corresponding to this operation.
+
+        If `i := py_operation(lhs, rhs)` is an int, then this operation can be
+        canonicalized to a constant with value `i` when the inputs are constants
+        with values `lhs` and `rhs`.
+        """
         return None
 
     @staticmethod

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -167,13 +167,18 @@ class ConstantOp(IRDLOperation):
 
     @staticmethod
     def from_int_and_width(
-        value: int | IntAttr, value_type: int | IntegerType | IndexType
+        value: int | IntAttr,
+        value_type: int | IntegerType | IndexType,
+        *,
+        truncate_bits: bool = False,
     ) -> ConstantOp:
         if isinstance(value_type, int):
             value_type = IntegerType(value_type)
         return ConstantOp.create(
             result_types=[value_type],
-            properties={"value": IntegerAttr(value, value_type)},
+            properties={
+                "value": IntegerAttr(value, value_type, truncate_bits=truncate_bits)
+            },
         )
 
 

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -687,6 +687,12 @@ class Pure(NoMemoryEffect, AlwaysSpeculatable):
     """
 
 
+class Commutative(OpTrait):
+    """
+    A trait that signals that an operation is commutative.
+    """
+
+
 class HasInsnRepresentation(OpTrait, abc.ABC):
     """
     A trait providing information on how to encode an operation using a .insn assember directive.

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -44,7 +44,7 @@ class SignlessIntegerBinaryOperationConstantProp(RewritePattern):
         assert isinstance(op.result.type, IntegerType | IndexType)
 
         rewriter.replace_matched_op(
-            arith.ConstantOp.from_int_and_width(res, op.result.type)
+            arith.ConstantOp.from_int_and_width(res, op.result.type, truncate_bits=True)
         )
 
 

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -5,33 +5,46 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.transforms.canonicalization_patterns.utils import const_evaluate_operand
+from xdsl.traits import Commutative
+from xdsl.transforms.canonicalization_patterns.utils import (
+    const_evaluate_operand,
+    const_evaluate_operand_attribute,
+)
 from xdsl.utils.hints import isa
 
 
-class AddiIdentityRight(RewritePattern):
+class SignlessIntegerBinaryOperationZeroOrUnitRight(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: arith.AddiOp, rewriter: PatternRewriter) -> None:
-        if (rhs := const_evaluate_operand(op.rhs)) is None:
+    def match_and_rewrite(
+        self, op: arith.SignlessIntegerBinaryOperation, rewriter: PatternRewriter, /
+    ):
+        if (rhs := const_evaluate_operand_attribute(op.rhs)) is None:
             return
-        if rhs != 0:
-            return
-        rewriter.replace_matched_op((), (op.lhs,))
+        if op.is_right_zero(rhs):
+            rewriter.replace_matched_op((), (op.rhs,))
+        elif op.is_right_unit(rhs):
+            rewriter.replace_matched_op((), (op.lhs,))
 
 
-class AddiConstantProp(RewritePattern):
+class SignlessIntegerBinaryOperationConstantProp(RewritePattern):
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: arith.AddiOp, rewriter: PatternRewriter):
+    def match_and_rewrite(
+        self, op: arith.SignlessIntegerBinaryOperation, rewriter: PatternRewriter, /
+    ):
         if (lhs := const_evaluate_operand(op.lhs)) is None:
             return
         if (rhs := const_evaluate_operand(op.rhs)) is None:
             # Swap inputs if lhs is constant and rhs is not
-            rewriter.replace_matched_op(arith.AddiOp(op.rhs, op.lhs))
+            if op.has_trait(Commutative):
+                rewriter.replace_matched_op(op.__class__(op.rhs, op.lhs))
             return
 
+        if (res := op.py_operation(lhs, rhs)) is None:
+            return
         assert isinstance(op.result.type, IntegerType | IndexType)
+
         rewriter.replace_matched_op(
-            arith.ConstantOp.from_int_and_width(lhs + rhs, op.result.type)
+            arith.ConstantOp.from_int_and_width(res, op.result.type)
         )
 
 
@@ -174,33 +187,6 @@ class SelectSamePattern(RewritePattern):
     def match_and_rewrite(self, op: arith.SelectOp, rewriter: PatternRewriter):
         if op.lhs == op.rhs:
             rewriter.replace_matched_op((), (op.lhs,))
-
-
-class MuliIdentityRight(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: arith.MuliOp, rewriter: PatternRewriter):
-        if (rhs := const_evaluate_operand(op.rhs)) is None:
-            return
-        if rhs != 1:
-            return
-
-        rewriter.replace_matched_op((), (op.lhs,))
-
-
-class MuliConstantProp(RewritePattern):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: arith.MuliOp, rewriter: PatternRewriter):
-        if (lhs := const_evaluate_operand(op.lhs)) is None:
-            return
-        if (rhs := const_evaluate_operand(op.rhs)) is None:
-            # Swap inputs if rhs is constant and lhs is not
-            rewriter.replace_matched_op(arith.MuliOp(op.rhs, op.lhs))
-            return
-
-        assert isinstance(op.result.type, IntegerType | IndexType)
-        rewriter.replace_matched_op(
-            arith.ConstantOp.from_int_and_width(lhs * rhs, op.result.type)
-        )
 
 
 class ApplyCmpiPredicateToEqualOperands(RewritePattern):

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -15,7 +15,9 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
-from xdsl.transforms.canonicalization_patterns.utils import const_evaluate_operand
+from xdsl.transforms.canonicalization_patterns.utils import (
+    const_evaluate_operand,
+)
 
 
 class AssertTrue(RewritePattern):

--- a/xdsl/transforms/canonicalization_patterns/scf.py
+++ b/xdsl/transforms/canonicalization_patterns/scf.py
@@ -9,7 +9,9 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.rewriter import InsertPoint
 from xdsl.traits import ConstantLike
-from xdsl.transforms.canonicalization_patterns.utils import const_evaluate_operand
+from xdsl.transforms.canonicalization_patterns.utils import (
+    const_evaluate_operand,
+)
 
 
 class RehoistConstInLoops(RewritePattern):

--- a/xdsl/transforms/canonicalization_patterns/utils.py
+++ b/xdsl/transforms/canonicalization_patterns/utils.py
@@ -1,13 +1,21 @@
 from xdsl.dialects import arith
-from xdsl.dialects.builtin import IntegerAttr
+from xdsl.dialects.builtin import AnyIntegerAttr, IntegerAttr
 from xdsl.ir import SSAValue
 
 
-def const_evaluate_operand(operand: SSAValue) -> int | None:
+def const_evaluate_operand_attribute(operand: SSAValue) -> AnyIntegerAttr | None:
     """
     Try to constant evaluate an SSA value, returning None on failure.
     """
     if isinstance(op := operand.owner, arith.ConstantOp) and isinstance(
         val := op.value, IntegerAttr
     ):
-        return val.value.data
+        return val
+
+
+def const_evaluate_operand(operand: SSAValue) -> int | None:
+    """
+    Try to constant evaluate an SSA value, returning None on failure.
+    """
+    if (attr := const_evaluate_operand_attribute(operand)) is not None:
+        return attr.value.data


### PR DESCRIPTION
Got bored of implementing various arith canonicalizations that all looked the same, so I've done a bunch of them generically in one go.

I've missed out a fair few methods (shifting operations in particular stand out) where I wasn't sure if the python operation agreed with the mlir operation.