### PR TITLE
CI: set maxIndividualTestTime in lit cfg

### DIFF
--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -19,3 +19,18 @@ if "COVERAGE" in lit_config.params:
     config.substitutions.append(('xdsl-run', f"coverage run {xdsl_run}"))
     config.substitutions.append(('irdl-to-pyrdl', f"coverage run {irdl_to_pyrdl}"))
     config.substitutions.append(('python', f"coverage run"))
+
+
+# checking if maxIndividualTestTime is available on the platform and sets
+# it to 20sec if so, declares lit-max-individual-test-time feature for
+# further checking by tests.
+supported, errormsg = lit_config.maxIndividualTestTimeIsSupported
+if supported:
+    config.available_features.add("lit-max-individual-test-time")
+    lit_config.maxIndividualTestTime = 20
+else:
+    lit_config.warning(
+        "Setting a timeout per test not supported. "
+        + errormsg
+        + " Some tests will be skipped."
+    )


### PR DESCRIPTION
I copied the approach in https://github.com/llvm/llvm-project/blob/69227a11fe1d00b2fc6f93b2a985abbe888d0876/bolt/test/lit.cfg.py#L55