### PR TITLE
core: rename MLIR-specific lexing constructs

### DIFF
--- a/bench/parser/bench_lexer.py
+++ b/bench/parser/bench_lexer.py
@@ -11,15 +11,15 @@ import timeit
 from collections.abc import Iterable
 
 from xdsl.utils.lexer import Input
-from xdsl.utils.mlir_lexer import Kind, Lexer
+from xdsl.utils.mlir_lexer import MLIRLexer, MLIRTokenKind
 
 
 def lex_file(file: Input):
     """
     Lex the given file
     """
-    lexer = Lexer(file)
-    while lexer.lex().kind is not Kind.EOF:
+    lexer = MLIRLexer(file)
+    while lexer.lex().kind is not MLIRTokenKind.EOF:
         pass
 
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -2,18 +2,18 @@ import pytest
 
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.lexer import Input
-from xdsl.utils.mlir_lexer import Kind, Lexer, Token
+from xdsl.utils.mlir_lexer import MLIRLexer, MLIRToken, MLIRTokenKind
 
 
-def get_token(input: str) -> Token:
+def get_token(input: str) -> MLIRToken:
     file = Input(input, "<unknown>")
-    lexer = Lexer(file)
+    lexer = MLIRLexer(file)
     token = lexer.lex()
     return token
 
 
 def assert_single_token(
-    input: str, expected_kind: Kind, expected_text: str | None = None
+    input: str, expected_kind: MLIRTokenKind, expected_text: str | None = None
 ):
     if expected_text is None:
         expected_text = input
@@ -26,7 +26,7 @@ def assert_single_token(
 
 def assert_token_fail(input: str):
     file = Input(input, "<unknown>")
-    lexer = Lexer(file)
+    lexer = MLIRLexer(file)
     with pytest.raises(ParseError):
         lexer.lex()
 
@@ -34,29 +34,29 @@ def assert_token_fail(input: str):
 @pytest.mark.parametrize(
     "text,kind",
     [
-        ("->", Kind.ARROW),
-        (":", Kind.COLON),
-        (",", Kind.COMMA),
-        ("...", Kind.ELLIPSIS),
-        ("=", Kind.EQUAL),
-        (">", Kind.GREATER),
-        ("{", Kind.L_BRACE),
-        ("(", Kind.L_PAREN),
-        ("[", Kind.L_SQUARE),
-        ("<", Kind.LESS),
-        ("-", Kind.MINUS),
-        ("+", Kind.PLUS),
-        ("?", Kind.QUESTION),
-        ("}", Kind.R_BRACE),
-        (")", Kind.R_PAREN),
-        ("]", Kind.R_SQUARE),
-        ("*", Kind.STAR),
-        ("|", Kind.VERTICAL_BAR),
-        ("{-#", Kind.FILE_METADATA_BEGIN),
-        ("#-}", Kind.FILE_METADATA_END),
+        ("->", MLIRTokenKind.ARROW),
+        (":", MLIRTokenKind.COLON),
+        (",", MLIRTokenKind.COMMA),
+        ("...", MLIRTokenKind.ELLIPSIS),
+        ("=", MLIRTokenKind.EQUAL),
+        (">", MLIRTokenKind.GREATER),
+        ("{", MLIRTokenKind.L_BRACE),
+        ("(", MLIRTokenKind.L_PAREN),
+        ("[", MLIRTokenKind.L_SQUARE),
+        ("<", MLIRTokenKind.LESS),
+        ("-", MLIRTokenKind.MINUS),
+        ("+", MLIRTokenKind.PLUS),
+        ("?", MLIRTokenKind.QUESTION),
+        ("}", MLIRTokenKind.R_BRACE),
+        (")", MLIRTokenKind.R_PAREN),
+        ("]", MLIRTokenKind.R_SQUARE),
+        ("*", MLIRTokenKind.STAR),
+        ("|", MLIRTokenKind.VERTICAL_BAR),
+        ("{-#", MLIRTokenKind.FILE_METADATA_BEGIN),
+        ("#-}", MLIRTokenKind.FILE_METADATA_END),
     ],
 )
-def test_punctuation(text: str, kind: Kind):
+def test_punctuation(text: str, kind: MLIRTokenKind):
     assert_single_token(text, kind)
 
 
@@ -69,7 +69,7 @@ def test_punctuation_fail(text: str):
     "text", ['""', '"@"', '"foo"', '"\\""', '"\\n"', '"\\\\"', '"\\t"']
 )
 def test_str_literal(text: str):
-    assert_single_token(text, Kind.STRING_LIT)
+    assert_single_token(text, MLIRTokenKind.STRING_LIT)
 
 
 @pytest.mark.parametrize("text", ['"', '"\\"', '"\\a"', '"\n"', '"\v"', '"\f"'])
@@ -82,7 +82,7 @@ def test_str_literal_fail(text: str):
 )
 def test_bare_ident(text: str):
     """bare-id ::= (letter|[_]) (letter|digit|[_$.])*"""
-    assert_single_token(text, Kind.BARE_IDENT)
+    assert_single_token(text, MLIRTokenKind.BARE_IDENT)
 
 
 @pytest.mark.parametrize(
@@ -109,7 +109,7 @@ def test_bare_ident(text: str):
 )
 def test_at_ident(text: str):
     """at-ident ::= `@` (bare-id | string-literal)"""
-    assert_single_token(text, Kind.AT_IDENT)
+    assert_single_token(text, MLIRTokenKind.AT_IDENT)
 
 
 @pytest.mark.parametrize(
@@ -129,10 +129,10 @@ def test_prefixed_ident(text: str):
     """percent-ident  ::= `%` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)"""
     """caret-ident  ::= `^` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)"""
     """exclamation-ident  ::= `!` (digit+ | (letter|[$._-]) (letter|[$._-]|digit)*)"""
-    assert_single_token("#" + text, Kind.HASH_IDENT)
-    assert_single_token("%" + text, Kind.PERCENT_IDENT)
-    assert_single_token("^" + text, Kind.CARET_IDENT)
-    assert_single_token("!" + text, Kind.EXCLAMATION_IDENT)
+    assert_single_token("#" + text, MLIRTokenKind.HASH_IDENT)
+    assert_single_token("%" + text, MLIRTokenKind.PERCENT_IDENT)
+    assert_single_token("^" + text, MLIRTokenKind.CARET_IDENT)
+    assert_single_token("!" + text, MLIRTokenKind.EXCLAMATION_IDENT)
 
 
 @pytest.mark.parametrize("text", ["+", '""', "#", "%", "^", "!", "\n", ""])
@@ -155,46 +155,46 @@ def test_prefixed_ident_fail(text: str):
 )
 def test_prefixed_ident_split(text: str, expected: str):
     """Check that the prefixed identifier is split at the right character."""
-    assert_single_token("#" + text, Kind.HASH_IDENT, "#" + expected)
-    assert_single_token("%" + text, Kind.PERCENT_IDENT, "%" + expected)
-    assert_single_token("^" + text, Kind.CARET_IDENT, "^" + expected)
-    assert_single_token("!" + text, Kind.EXCLAMATION_IDENT, "!" + expected)
+    assert_single_token("#" + text, MLIRTokenKind.HASH_IDENT, "#" + expected)
+    assert_single_token("%" + text, MLIRTokenKind.PERCENT_IDENT, "%" + expected)
+    assert_single_token("^" + text, MLIRTokenKind.CARET_IDENT, "^" + expected)
+    assert_single_token("!" + text, MLIRTokenKind.EXCLAMATION_IDENT, "!" + expected)
 
 
 @pytest.mark.parametrize("text", ["0", "01", "123456789", "99", "0x1234", "0xabcdef"])
 def test_integer_literal(text: str):
-    assert_single_token(text, Kind.INTEGER_LIT)
+    assert_single_token(text, MLIRTokenKind.INTEGER_LIT)
 
 
 @pytest.mark.parametrize(
     "text,expected", [("0a", "0"), ("0xg", "0"), ("0xfg", "0xf"), ("0xf.", "0xf")]
 )
 def test_integer_literal_split(text: str, expected: str):
-    assert_single_token(text, Kind.INTEGER_LIT, expected)
+    assert_single_token(text, MLIRTokenKind.INTEGER_LIT, expected)
 
 
 @pytest.mark.parametrize(
     "text", ["0.", "1.", "0.2", "38.1243", "92.54e43", "92.5E43", "43.3e-54", "32.E+25"]
 )
 def test_float_literal(text: str):
-    assert_single_token(text, Kind.FLOAT_LIT)
+    assert_single_token(text, MLIRTokenKind.FLOAT_LIT)
 
 
 @pytest.mark.parametrize(
     "text,expected", [("3.9e", "3.9"), ("4.5e+", "4.5"), ("5.8e-", "5.8")]
 )
 def test_float_literal_split(text: str, expected: str):
-    assert_single_token(text, Kind.FLOAT_LIT, expected)
+    assert_single_token(text, MLIRTokenKind.FLOAT_LIT, expected)
 
 
 @pytest.mark.parametrize("text", ["0", " 0", "   0", "\n0", "\t0", "// Comment\n0"])
 def test_whitespace_skip(text: str):
-    assert_single_token(text, Kind.INTEGER_LIT, "0")
+    assert_single_token(text, MLIRTokenKind.INTEGER_LIT, "0")
 
 
 @pytest.mark.parametrize("text", ["", "   ", "\n\n", "// Comment\n"])
 def test_eof(text: str):
-    assert_single_token(text, Kind.EOF, "")
+    assert_single_token(text, MLIRTokenKind.EOF, "")
 
 
 @pytest.mark.parametrize(
@@ -209,7 +209,7 @@ def test_eof(text: str):
 )
 def test_token_get_int_value(text: str, expected: int):
     token = get_token(text)
-    assert token.kind == Kind.INTEGER_LIT
+    assert token.kind == MLIRTokenKind.INTEGER_LIT
     assert token.kind.get_int_value(token.span) == expected
 
 
@@ -228,7 +228,7 @@ def test_token_get_int_value(text: str, expected: int):
 )
 def test_token_get_float_value(text: str, expected: float):
     token = get_token(text)
-    assert token.kind == Kind.FLOAT_LIT
+    assert token.kind == MLIRTokenKind.FLOAT_LIT
     assert token.kind.get_float_value(token.span) == expected
 
 
@@ -246,5 +246,5 @@ def test_token_get_float_value(text: str, expected: float):
 )
 def test_token_get_string_literal_value(text: str, expected: float):
     token = get_token(text)
-    assert token.kind == Kind.STRING_LIT
+    assert token.kind == MLIRTokenKind.STRING_LIT
     assert token.kind.get_string_literal_value(token.span) == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,7 +30,7 @@ from xdsl.irdl import (
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import ParseError, VerifyException
-from xdsl.utils.mlir_lexer import Kind, PunctuationSpelling
+from xdsl.utils.mlir_lexer import MLIRTokenKind, PunctuationSpelling
 from xdsl.utils.str_enum import StrEnum
 
 # pyright: reportPrivateUsage=false
@@ -584,51 +584,54 @@ def test_parse_comma_separated_list_error_delimiters(
 
 
 @pytest.mark.parametrize(
-    "punctuation", list(Kind.get_punctuation_spelling_to_kind_dict().values())
+    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().values())
 )
-def test_is_punctuation_true(punctuation: Kind):
+def test_is_punctuation_true(punctuation: MLIRTokenKind):
     assert punctuation.is_punctuation()
 
 
-@pytest.mark.parametrize("punctuation", [Kind.BARE_IDENT, Kind.EOF, Kind.INTEGER_LIT])
-def test_is_punctuation_false(punctuation: Kind):
+@pytest.mark.parametrize(
+    "punctuation",
+    [MLIRTokenKind.BARE_IDENT, MLIRTokenKind.EOF, MLIRTokenKind.INTEGER_LIT],
+)
+def test_is_punctuation_false(punctuation: MLIRTokenKind):
     assert not punctuation.is_punctuation()
 
 
 @pytest.mark.parametrize(
-    "punctuation", list(Kind.get_punctuation_spelling_to_kind_dict().values())
+    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().values())
 )
-def test_is_spelling_of_punctuation_true(punctuation: Kind):
+def test_is_spelling_of_punctuation_true(punctuation: MLIRTokenKind):
     value = cast(PunctuationSpelling, punctuation.value)
-    assert Kind.is_spelling_of_punctuation(value)
+    assert MLIRTokenKind.is_spelling_of_punctuation(value)
 
 
 @pytest.mark.parametrize("punctuation", [">-", "o", "4", "$", "_", "@"])
 def test_is_spelling_of_punctuation_false(punctuation: str):
-    assert not Kind.is_spelling_of_punctuation(punctuation)
+    assert not MLIRTokenKind.is_spelling_of_punctuation(punctuation)
 
 
 @pytest.mark.parametrize(
-    "punctuation", list(Kind.get_punctuation_spelling_to_kind_dict().values())
+    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().values())
 )
-def test_get_punctuation_kind(punctuation: Kind):
+def test_get_punctuation_kind(punctuation: MLIRTokenKind):
     value = cast(PunctuationSpelling, punctuation.value)
     assert punctuation.get_punctuation_kind_from_spelling(value) == punctuation
 
 
 @pytest.mark.parametrize(
-    "punctuation", list(Kind.get_punctuation_spelling_to_kind_dict().keys())
+    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
 )
 def test_parse_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(MLContext(), punctuation)
 
     res = parser.parse_punctuation(punctuation)
     assert res == punctuation
-    assert parser._parse_token(Kind.EOF, "").kind == Kind.EOF
+    assert parser._parse_token(MLIRTokenKind.EOF, "").kind == MLIRTokenKind.EOF
 
 
 @pytest.mark.parametrize(
-    "punctuation", list(Kind.get_punctuation_spelling_to_kind_dict().keys())
+    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
 )
 def test_parse_punctuation_fail(punctuation: PunctuationSpelling):
     parser = Parser(MLContext(), "e +")
@@ -639,17 +642,17 @@ def test_parse_punctuation_fail(punctuation: PunctuationSpelling):
 
 
 @pytest.mark.parametrize(
-    "punctuation", list(Kind.get_punctuation_spelling_to_kind_dict().keys())
+    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
 )
 def test_parse_optional_punctuation(punctuation: PunctuationSpelling):
     parser = Parser(MLContext(), punctuation)
     res = parser.parse_optional_punctuation(punctuation)
     assert res == punctuation
-    assert parser._parse_token(Kind.EOF, "").kind == Kind.EOF
+    assert parser._parse_token(MLIRTokenKind.EOF, "").kind == MLIRTokenKind.EOF
 
 
 @pytest.mark.parametrize(
-    "punctuation", list(Kind.get_punctuation_spelling_to_kind_dict().keys())
+    "punctuation", list(MLIRTokenKind.get_punctuation_spelling_to_kind_dict().keys())
 )
 def test_parse_optional_punctuation_fail(punctuation: PunctuationSpelling):
     parser = Parser(MLContext(), "e +")

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -32,7 +32,7 @@ from typing_extensions import Self, deprecated
 
 from xdsl.traits import IsTerminator, NoTerminator, OpTrait, OpTraitInvT
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.mlir_lexer import Lexer
+from xdsl.utils.mlir_lexer import MLIRLexer
 from xdsl.utils.str_enum import StrEnum
 
 # Used for cyclic dependencies in type hints
@@ -404,7 +404,7 @@ def _check_enum_constraints(
         raise TypeError("Only direct inheritance from EnumAttribute is allowed.")
 
     for v in enum_type:
-        if Lexer.bare_identifier_suffix_regex.fullmatch(v) is None:
+        if MLIRLexer.bare_identifier_suffix_regex.fullmatch(v) is None:
             raise ValueError(
                 "All StrEnum values of an EnumAttribute must be parsable as an identifer."
             )

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -80,11 +80,11 @@ from xdsl.irdl.declarative_assembly_format import (
 )
 from xdsl.parser import BaseParser, ParserState
 from xdsl.utils.lexer import Input
-from xdsl.utils.mlir_lexer import Kind, Lexer, Token
+from xdsl.utils.mlir_lexer import MLIRLexer, MLIRToken, MLIRTokenKind
 
 
 @dataclass
-class FormatLexer(Lexer):
+class FormatLexer(MLIRLexer):
     """
     A lexer for the declarative assembly format.
     The differences with the MLIR lexer are the following:
@@ -92,7 +92,7 @@ class FormatLexer(Lexer):
     * Bare identifiers may also may contain `-`.
     """
 
-    def lex(self) -> Token:
+    def lex(self) -> MLIRToken:
         """Lex a token from the input, and returns it."""
         # First, skip whitespaces
         self._consume_whitespace()
@@ -102,13 +102,13 @@ class FormatLexer(Lexer):
 
         # Handle end of file
         if current_char is None:
-            return self._form_token(Kind.EOF, start_pos)
+            return self._form_token(MLIRTokenKind.EOF, start_pos)
 
         # We parse '`', `\\` and '$' as a BARE_IDENT.
         # This is a hack to reuse the MLIR lexer.
         if current_char in ("`", "$", "\\", "^"):
             self._consume_chars()
-            return self._form_token(Kind.BARE_IDENT, start_pos)
+            return self._form_token(MLIRTokenKind.BARE_IDENT, start_pos)
         return super().lex()
 
     # Authorize `-` in bare identifier
@@ -168,7 +168,7 @@ class FormatParser(BaseParser):
         unambiguous and refer to all elements exactly once.
         """
         elements: list[FormatDirective] = []
-        while self._current_token.kind != Kind.EOF:
+        while self._current_token.kind != MLIRTokenKind.EOF:
             elements.append(self.parse_format_directive())
 
         self.add_reserved_attrs_to_directive(elements)
@@ -717,7 +717,7 @@ class FormatParser(BaseParser):
         if self._current_token.kind.is_punctuation():
             punctuation = self._consume_token().text
             self.parse_characters("`")
-            assert Kind.is_spelling_of_punctuation(punctuation)
+            assert MLIRTokenKind.is_spelling_of_punctuation(punctuation)
             return PunctuationDirective(punctuation)
 
         # Identifier case

--- a/xdsl/parser/affine_parser.py
+++ b/xdsl/parser/affine_parser.py
@@ -9,7 +9,7 @@ from xdsl.ir.affine import (
 )
 from xdsl.parser.base_parser import BaseParser, ParserState
 from xdsl.utils.exceptions import ParseError
-from xdsl.utils.mlir_lexer import Kind, Token
+from xdsl.utils.mlir_lexer import MLIRToken, MLIRTokenKind
 
 
 class AffineParser(BaseParser):
@@ -33,12 +33,12 @@ class AffineParser(BaseParser):
                   | `-` primary
         """
         # Handle parentheses
-        if self._parse_optional_token(Kind.L_PAREN):
+        if self._parse_optional_token(MLIRTokenKind.L_PAREN):
             expr = self._parse_affine_expr(dims, syms)
-            self._parse_token(Kind.R_PAREN, "Expected closing parenthesis")
+            self._parse_token(MLIRTokenKind.R_PAREN, "Expected closing parenthesis")
             return expr
         # Handle bare id
-        if bare_id := self._parse_optional_token(Kind.BARE_IDENT):
+        if bare_id := self._parse_optional_token(MLIRTokenKind.BARE_IDENT):
             if bare_id.text in dims:
                 return AffineExpr.dimension(dims.index(bare_id.text))
             elif bare_id.text in syms:
@@ -48,10 +48,10 @@ class AffineParser(BaseParser):
                     bare_id.span, f"Identifier not in space {bare_id.text}"
                 )
         # Handle integer literal
-        if int_lit := self._parse_optional_token(Kind.INTEGER_LIT):
+        if int_lit := self._parse_optional_token(MLIRTokenKind.INTEGER_LIT):
             return AffineExpr.constant(int_lit.kind.get_int_value(int_lit.span))
         # Handle negative primary
-        if self._parse_optional_token(Kind.MINUS):
+        if self._parse_optional_token(MLIRTokenKind.MINUS):
             return -self._parse_primary(dims, syms)
 
         raise ParseError(self._current_token.span, "Expected primary expression")
@@ -60,7 +60,7 @@ class AffineParser(BaseParser):
         return self._BINOP_PRECEDENCE.get(self._current_token.text, -1)
 
     def _create_binop_expr(
-        self, lhs: AffineExpr, rhs: AffineExpr, binop: Token
+        self, lhs: AffineExpr, rhs: AffineExpr, binop: MLIRToken
     ) -> AffineExpr:
         match binop.text:
             case "+":
@@ -175,12 +175,14 @@ class AffineParser(BaseParser):
         """
 
         def parse_id() -> str:
-            return self._parse_token(Kind.BARE_IDENT, "Expected identifier").text
+            return self._parse_token(
+                MLIRTokenKind.BARE_IDENT, "Expected identifier"
+            ).text
 
         # Parse dimensions
         dims = self.parse_comma_separated_list(self.Delimiter.PAREN, parse_id)
         # Parse optional symbols
-        if self._current_token.kind != Kind.L_SQUARE:
+        if self._current_token.kind != MLIRTokenKind.L_SQUARE:
             syms = []
         else:
             syms = self.parse_comma_separated_list(self.Delimiter.SQUARE, parse_id)
@@ -195,7 +197,7 @@ class AffineParser(BaseParser):
         # Parse affine space
         dims, syms = self._parse_affine_space()
         # Parse : delimiter
-        self._parse_token(Kind.ARROW, "Expected `->`")
+        self._parse_token(MLIRTokenKind.ARROW, "Expected `->`")
         # Parse list of affine expressions
         exprs = self._parse_multi_affine_expr(dims, syms)
         # Create map and return.
@@ -209,7 +211,7 @@ class AffineParser(BaseParser):
         # Parse affine space
         dims, syms = self._parse_affine_space()
         # Parse : delimiter
-        self._parse_token(Kind.COLON, "Expected `:`")
+        self._parse_token(MLIRTokenKind.COLON, "Expected `:`")
         # Parse list of affine expressions
         constraints = self._parse_multi_affine_constaint(dims, syms)
         # Create map and return.

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -20,7 +20,7 @@ from xdsl.irdl import IRDLOperation
 from xdsl.parser import AttrParser, ParserState, Position
 from xdsl.utils.exceptions import MultipleSpansParseError
 from xdsl.utils.lexer import Input, Span
-from xdsl.utils.mlir_lexer import Kind, Lexer
+from xdsl.utils.mlir_lexer import MLIRLexer, MLIRTokenKind
 
 
 @dataclass(eq=False)
@@ -95,7 +95,7 @@ class Parser(AttrParser):
         input: str,
         name: str = "<unknown>",
     ) -> None:
-        super().__init__(ParserState(Lexer(Input(input, name))), ctx)
+        super().__init__(ParserState(MLIRLexer(Input(input, name))), ctx)
         self.ssa_values = dict()
         self.blocks = dict()
         self.forward_block_references = dict()
@@ -118,10 +118,10 @@ class Parser(AttrParser):
         else:
             parsed_ops: list[Operation] = []
 
-            while self._current_token.kind != Kind.EOF:
+            while self._current_token.kind != MLIRTokenKind.EOF:
                 if self._current_token.kind in (
-                    Kind.HASH_IDENT,
-                    Kind.EXCLAMATION_IDENT,
+                    MLIRTokenKind.HASH_IDENT,
+                    MLIRTokenKind.EXCLAMATION_IDENT,
                 ):
                     self._parse_alias_def()
                     continue
@@ -159,7 +159,7 @@ class Parser(AttrParser):
         """
         if (
             token := self._parse_optional_token_in(
-                [Kind.EXCLAMATION_IDENT, Kind.HASH_IDENT]
+                [MLIRTokenKind.EXCLAMATION_IDENT, MLIRTokenKind.HASH_IDENT]
             )
         ) is None:
             self.raise_error("expected attribute name")
@@ -191,13 +191,13 @@ class Parser(AttrParser):
             value-id-and-type-list ::= value-id-and-type (`,` ssa-id-and-type)*
             block-arg-list ::= `(` value-id-and-type-list? `)`
         """
-        if self._current_token.kind != Kind.L_PAREN:
+        if self._current_token.kind != MLIRTokenKind.L_PAREN:
             return None
 
         def parse_argument() -> None:
             """Parse a single block argument with its type."""
             arg_name = self._parse_token(
-                Kind.PERCENT_IDENT, "block argument expected"
+                MLIRTokenKind.PERCENT_IDENT, "block argument expected"
             ).span
             self.parse_punctuation(":")
             arg_type = self.parse_attribute()
@@ -226,7 +226,9 @@ class Parser(AttrParser):
           block-id       ::= caret-id
           block-arg-list ::= `(` ssa-id-and-type-list? `)`
         """
-        name_token = self._parse_token(Kind.CARET_IDENT, " in block definition")
+        name_token = self._parse_token(
+            MLIRTokenKind.CARET_IDENT, " in block definition"
+        )
 
         name = name_token.text[1:]
         if name not in self.blocks:
@@ -255,12 +257,12 @@ class Parser(AttrParser):
         Parse an operand with format `%<value-id>(#<int-literal>)?`, if present.
         The operand may be forward declared.
         """
-        name_token = self._parse_optional_token(Kind.PERCENT_IDENT)
+        name_token = self._parse_optional_token(MLIRTokenKind.PERCENT_IDENT)
         if name_token is None:
             return None
 
         index = 0
-        index_token = self._parse_optional_token(Kind.HASH_IDENT)
+        index_token = self._parse_optional_token(MLIRTokenKind.HASH_IDENT)
         if index_token is not None:
             if re.fullmatch(self._decimal_integer_regex, index_token.text[1:]) is None:
                 self.raise_error(
@@ -456,7 +458,7 @@ class Parser(AttrParser):
         """
 
         # The argument name
-        name_token = self._parse_optional_token(Kind.PERCENT_IDENT)
+        name_token = self._parse_optional_token(MLIRTokenKind.PERCENT_IDENT)
         if name_token is None:
             return None
 
@@ -528,7 +530,7 @@ class Parser(AttrParser):
             # Check that the entry block has no label.
             # Since a multi-block region block must have a terminator, there isn't a
             # possibility of having an empty entry block, and thus parsing the label directly.
-            if self._current_token.kind == Kind.CARET_IDENT:
+            if self._current_token.kind == MLIRTokenKind.CARET_IDENT:
                 self.raise_error("invalid block name in region with named arguments")
 
             # Set the block arguments in the context
@@ -542,8 +544,8 @@ class Parser(AttrParser):
 
         # If no arguments was provided, parse the entry block if present.
         elif self._current_token.kind not in (
-            Kind.CARET_IDENT,
-            Kind.R_BRACE,
+            MLIRTokenKind.CARET_IDENT,
+            MLIRTokenKind.R_BRACE,
         ):
             block = Block()
             self._parse_block_body(block)
@@ -604,7 +606,7 @@ class Parser(AttrParser):
         Parse a list of regions with format:
            regions-list ::= `(` region (`,` region)* `)`
         """
-        if self._current_token.kind == Kind.L_PAREN:
+        if self._current_token.kind == MLIRTokenKind.L_PAREN:
             return self.parse_comma_separated_list(
                 self.Delimiter.PAREN, self.parse_region, " in operation region list"
             )
@@ -668,9 +670,9 @@ class Parser(AttrParser):
             properties            ::= `<` dictionary-attribute `>`
         """
         if self._current_token.kind not in (
-            Kind.PERCENT_IDENT,
-            Kind.BARE_IDENT,
-            Kind.STRING_LIT,
+            MLIRTokenKind.PERCENT_IDENT,
+            MLIRTokenKind.BARE_IDENT,
+            MLIRTokenKind.STRING_LIT,
         ):
             return None
         return self.parse_operation()
@@ -695,7 +697,9 @@ class Parser(AttrParser):
         op_loc = self._current_token.span
         bound_results = self._parse_op_result_list()
 
-        if (op_name := self._parse_optional_token(Kind.BARE_IDENT)) is not None:
+        if (
+            op_name := self._parse_optional_token(MLIRTokenKind.BARE_IDENT)
+        ) is not None:
             # Custom operation format
             op_type = self._get_op_by_name(op_name.text)
             dialect_name = op_type.dialect_name()
@@ -756,13 +760,13 @@ class Parser(AttrParser):
         value tuple (by default 1).
         """
         value_token = self._parse_token(
-            Kind.PERCENT_IDENT, "Expected result SSA value!"
+            MLIRTokenKind.PERCENT_IDENT, "Expected result SSA value!"
         )
-        if self._parse_optional_token(Kind.COLON) is None:
+        if self._parse_optional_token(MLIRTokenKind.COLON) is None:
             return (value_token.span, 1)
 
         size_token = self._parse_token(
-            Kind.INTEGER_LIT, "Expected SSA value tuple size"
+            MLIRTokenKind.INTEGER_LIT, "Expected SSA value tuple size"
         )
         size = size_token.kind.get_int_value(size_token.span)
         return (value_token.span, size)
@@ -774,7 +778,7 @@ class Parser(AttrParser):
         Each result is a tuple of the span of the SSA value name (including the `%`),
         and the size of the value tuple (by default 1).
         """
-        if self._current_token.kind == Kind.PERCENT_IDENT:
+        if self._current_token.kind == MLIRTokenKind.PERCENT_IDENT:
             res = self.parse_comma_separated_list(
                 self.Delimiter.NONE, self._parse_op_result, " in operation result list"
             )
@@ -890,7 +894,7 @@ class Parser(AttrParser):
         Parse a successor with format:
             successor      ::= caret-id
         """
-        block_token = self._parse_optional_token(Kind.CARET_IDENT)
+        block_token = self._parse_optional_token(MLIRTokenKind.CARET_IDENT)
         if block_token is None:
             return None
         name = block_token.text[1:]
@@ -912,7 +916,7 @@ class Parser(AttrParser):
             successor-list ::= `[` successor (`,` successor)* `]`
             successor      ::= caret-id
         """
-        if self._current_token.kind != Kind.L_SQUARE:
+        if self._current_token.kind != MLIRTokenKind.L_SQUARE:
             return None
         return self.parse_successors()
 

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -74,7 +74,7 @@ from xdsl.utils.bitwise_casts import (
     convert_f64_to_u64,
 )
 from xdsl.utils.diagnostic import Diagnostic
-from xdsl.utils.mlir_lexer import Lexer
+from xdsl.utils.mlir_lexer import MLIRLexer
 
 indentNumSpaces = 2
 
@@ -447,7 +447,7 @@ class Printer:
         Prints the provided string as an identifier if it is one,
         and as a string literal otherwise.
         """
-        if Lexer.bare_identifier_regex.fullmatch(string) is None:
+        if MLIRLexer.bare_identifier_regex.fullmatch(string) is None:
             self.print_string_literal(string)
             return
         self.print_string(string)

--- a/xdsl/utils/lexer.py
+++ b/xdsl/utils/lexer.py
@@ -149,7 +149,7 @@ TokenKindT = TypeVar("TokenKindT", bound=Enum)
 
 
 @dataclass
-class GenericToken(Generic[TokenKindT]):
+class Token(Generic[TokenKindT]):
     kind: TokenKindT
 
     span: Span
@@ -161,7 +161,7 @@ class GenericToken(Generic[TokenKindT]):
 
 
 @dataclass
-class AbstractLexer(Generic[TokenKindT], ABC):
+class Lexer(Generic[TokenKindT], ABC):
     input: Input
     """Input that is currently being lexed."""
 
@@ -171,16 +171,14 @@ class AbstractLexer(Generic[TokenKindT], ABC):
     The position can be out of bounds, in which case the lexer is in EOF state.
     """
 
-    def _form_token(
-        self, kind: TokenKindT, start_pos: Position
-    ) -> GenericToken[TokenKindT]:
+    def _form_token(self, kind: TokenKindT, start_pos: Position) -> Token[TokenKindT]:
         """
         Return a token with the given kind, and the start position.
         """
-        return GenericToken(kind, Span(start_pos, self.pos, self.input))
+        return Token(kind, Span(start_pos, self.pos, self.input))
 
     @abstractmethod
-    def lex(self) -> GenericToken[TokenKindT]:
+    def lex(self) -> Token[TokenKindT]:
         """
         Lex a token from the input, and returns it.
         """


### PR DESCRIPTION
A cleanup PR renaming some things, I did it in two steps to make the diff smaller on the previous PR.

Note stacked PR.