### PR TITLE
misc: hide base_parser, and avoid circular imports in parser files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ max-line-length = 300
 "xdsl.irdl.operations".msg = "Use xdsl.irdl instead"
 "xdsl.parser.affine_parser".msg = "Use xdsl.parser instead."
 "xdsl.parser.attribute_parser".msg = "Use xdsl.parser instead."
+"xdsl.parser.base_parser".msg = "Use xdsl.parser instead."
 "xdsl.parser.core".msg = "Use xdsl.parser instead."
 
 

--- a/xdsl/parser/affine_parser.py
+++ b/xdsl/parser/affine_parser.py
@@ -7,9 +7,10 @@ from xdsl.ir.affine import (
     AffineMap,
     AffineSet,
 )
-from xdsl.parser.base_parser import BaseParser, ParserState
 from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import MLIRToken, MLIRTokenKind
+
+from .base_parser import BaseParser, ParserState  # noqa: TID251
 
 
 class AffineParser(BaseParser):

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -62,7 +62,6 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import Attribute, Data, ParametrizedAttribute
 from xdsl.ir.affine import AffineMap, AffineSet
 from xdsl.irdl import BaseAttr, base
-from xdsl.parser.base_parser import BaseParser
 from xdsl.utils.bitwise_casts import (
     convert_u16_to_f16,
     convert_u32_to_f32,
@@ -72,6 +71,8 @@ from xdsl.utils.exceptions import ParseError, VerifyException
 from xdsl.utils.isattr import isattr
 from xdsl.utils.lexer import Position, Span
 from xdsl.utils.mlir_lexer import MLIRTokenKind, StringLiteral
+
+from .base_parser import BaseParser  # noqa: TID251
 
 
 @dataclass

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -17,10 +17,12 @@ from xdsl.ir import (
     SSAValue,
 )
 from xdsl.irdl import IRDLOperation
-from xdsl.parser import AttrParser, ParserState, Position
 from xdsl.utils.exceptions import MultipleSpansParseError
 from xdsl.utils.lexer import Input, Span
 from xdsl.utils.mlir_lexer import MLIRLexer, MLIRTokenKind
+
+from .attribute_parser import AttrParser, Position  # noqa: TID251
+from .base_parser import ParserState  # noqa: TID251
 
 
 @dataclass(eq=False)


### PR DESCRIPTION
Small bit of cleanup.

Note stacked PR.