### PR TITLE
dialects: (builtin) add CompileTimeFixedBitwidthType

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -78,12 +78,15 @@ def test_IntegerType_formats():
     assert IntegerType(32).format == "<i"
     assert IntegerType(64).format == "<q"
 
+
 def test_IndexType_formats():
     assert IndexType().format == "<q"
+
 
 def test_IndexType_bitwidth():
     with pytest.raises(RuntimeError):
         IndexType().bitwidth
+
 
 def test_FloatType_packing():
     nums = (-128, -1, 0, 1, 127)

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -19,6 +19,7 @@ from xdsl.dialects.builtin import (
     Float80Type,
     Float128Type,
     FloatAttr,
+    IndexType,
     IntAttr,
     IntegerAttr,
     IntegerType,
@@ -77,6 +78,12 @@ def test_IntegerType_formats():
     assert IntegerType(32).format == "<i"
     assert IntegerType(64).format == "<q"
 
+def test_IndexType_formats():
+    assert IndexType().format == "<q"
+
+def test_IndexType_bitwidth():
+    with pytest.raises(RuntimeError):
+        IndexType().bitwidth
 
 def test_FloatType_packing():
     nums = (-128, -1, 0, 1, 127)

--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -83,11 +83,6 @@ def test_IndexType_formats():
     assert IndexType().format == "<q"
 
 
-def test_IndexType_bitwidth():
-    with pytest.raises(RuntimeError):
-        IndexType().bitwidth
-
-
 def test_FloatType_packing():
     nums = (-128, -1, 0, 1, 127)
     buffer = f32.pack(nums)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -556,7 +556,7 @@ class LocationAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class IndexType(ParametrizedAttribute):
+class IndexType(ParametrizedAttribute, StructPackableType[int]):
     name = "index"
 
     def print_value_without_type(self, value: int, printer: Printer):
@@ -565,6 +565,13 @@ class IndexType(ParametrizedAttribute):
         """
         printer.print_string(f"{value}")
 
+    @property
+    def format(self) -> str:
+        return "<q"
+
+    @property
+    def bitwidth(self) -> int:
+        raise RuntimeError("IndexType bitwidth not known at compile-time")
 
 IndexTypeConstr = BaseAttr(IndexType)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -590,10 +590,6 @@ class IndexType(ParametrizedAttribute, StructPackableType[int]):
         # index types are always packable as int64
         return "<q"
 
-    @property
-    def bitwidth(self) -> int:
-        raise RuntimeError("IndexType bitwidth not known at compile-time")
-
 
 IndexTypeConstr = BaseAttr(IndexType)
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -416,6 +416,14 @@ class PackableType(Generic[_PyT], CompileTimeFixedBitwidthType, ABC):
         """
         raise NotImplementedError()
 
+    @property
+    @abstractmethod
+    def packed_size(self) -> int:
+        """
+        Contiguous memory footprint of packed value in bytes.
+        """
+        raise NotImplementedError()
+
 
 class StructPackableType(Generic[_PyT], PackableType[_PyT], ABC):
     """
@@ -446,6 +454,10 @@ class StructPackableType(Generic[_PyT], PackableType[_PyT], ABC):
     def pack(self, values: Sequence[_PyT]) -> bytes:
         fmt = self.format[0] + str(len(values)) + self.format[1:]
         return struct.pack(fmt, *values)
+
+    @property
+    def packed_size(self) -> int:
+        return struct.calcsize(self.format)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -573,6 +573,7 @@ class IndexType(ParametrizedAttribute, StructPackableType[int]):
     def bitwidth(self) -> int:
         raise RuntimeError("IndexType bitwidth not known at compile-time")
 
+
 IndexTypeConstr = BaseAttr(IndexType)
 
 _IntegerAttrType = TypeVar(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -356,6 +356,14 @@ class CompileTimeFixedBitwidthType(TypeAttribute, ABC):
 
     name = "abstract.compile_time_fixed_bitwidth_type"
 
+    @property
+    @abstractmethod
+    def compile_time_size(self) -> int:
+        """
+        Contiguous memory footprint of the value during compilation.
+        """
+        raise NotImplementedError()
+
 
 class FixedBitwidthType(CompileTimeFixedBitwidthType, ABC):
     """
@@ -416,14 +424,6 @@ class PackableType(Generic[_PyT], CompileTimeFixedBitwidthType, ABC):
         """
         raise NotImplementedError()
 
-    @property
-    @abstractmethod
-    def packed_size(self) -> int:
-        """
-        Contiguous memory footprint of packed value in bytes.
-        """
-        raise NotImplementedError()
-
 
 class StructPackableType(Generic[_PyT], PackableType[_PyT], ABC):
     """
@@ -456,7 +456,7 @@ class StructPackableType(Generic[_PyT], PackableType[_PyT], ABC):
         return struct.pack(fmt, *values)
 
     @property
-    def packed_size(self) -> int:
+    def compile_time_size(self) -> int:
         return struct.calcsize(self.format)
 
 

--- a/xdsl/interpreters/utils/ptr.py
+++ b/xdsl/interpreters/utils/ptr.py
@@ -95,7 +95,7 @@ class TypedPtr(Generic[_T]):
 
     @property
     def size(self) -> int:
-        return self.xtype.packed_size
+        return self.xtype.compile_time_size
 
     def copy(self) -> Self:
         return type(self)(self.raw.copy(), xtype=self.xtype)
@@ -122,7 +122,7 @@ class TypedPtr(Generic[_T]):
 
     @staticmethod
     def zeros(count: int, *, xtype: PackableType[_T]) -> TypedPtr[_T]:
-        size = xtype.packed_size
+        size = xtype.compile_time_size
         return TypedPtr(RawPtr.zeros(size * count), xtype=xtype)
 
     @staticmethod
@@ -130,7 +130,7 @@ class TypedPtr(Generic[_T]):
         """
         Returns a new TypedPtr with the specified els packed into memory.
         """
-        el_size = xtype.packed_size
+        el_size = xtype.compile_time_size
         res = RawPtr.zeros(len(els) * el_size)
         for i, el in enumerate(els):
             xtype.pack_into(res.memory, i * el_size, el)

--- a/xdsl/interpreters/utils/ptr.py
+++ b/xdsl/interpreters/utils/ptr.py
@@ -95,7 +95,7 @@ class TypedPtr(Generic[_T]):
 
     @property
     def size(self) -> int:
-        return self.xtype.size
+        return self.xtype.packed_size
 
     def copy(self) -> Self:
         return type(self)(self.raw.copy(), xtype=self.xtype)
@@ -122,7 +122,7 @@ class TypedPtr(Generic[_T]):
 
     @staticmethod
     def zeros(count: int, *, xtype: PackableType[_T]) -> TypedPtr[_T]:
-        size = xtype.size
+        size = xtype.packed_size
         return TypedPtr(RawPtr.zeros(size * count), xtype=xtype)
 
     @staticmethod
@@ -130,7 +130,7 @@ class TypedPtr(Generic[_T]):
         """
         Returns a new TypedPtr with the specified els packed into memory.
         """
-        el_size = xtype.size
+        el_size = xtype.packed_size
         res = RawPtr.zeros(len(els) * el_size)
         for i, el in enumerate(els):
             xtype.pack_into(res.memory, i * el_size, el)


### PR DESCRIPTION
This PR adds the `CompileTimeFixedBitwidthType` to represent values that have a fixed bitwidth and are thus packable, but the bitwidth may not be known until compile time.

The new dependency graph now looks like the following: https://is.gd/q5N7Dx