### PR TITLE
core (traits): Fix implicit terminator when last op is unregistered

### DIFF
--- a/tests/filecheck/dialects/scf/unregistered.mlir
+++ b/tests/filecheck/dialects/scf/unregistered.mlir
@@ -1,22 +1,24 @@
-// RUN: xdsl-opt %s --print-op-generic --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt %s --split-input-file --print-op-generic --allow-unregistered-dialect | xdsl-opt --allow-unregistered-dialect | filecheck %s
 
-// CHECK:      func.func @for_unregistered() {
-// CHECK-NEXT:   %lb = arith.constant 0 : index
-// CHECK-NEXT:   %ub = arith.constant 42 : index
-// CHECK-NEXT:   %s = arith.constant 3 : index
-// CHECK-NEXT:   scf.for %iv = %lb to %ub step %s {
-// CHECK-NEXT:     "unregistered_op"() : () -> ()
+// CHECK:        %0 = arith.constant 0 : index
+// CHECK-NEXT:   scf.for %iv = %0 to %0 step %0 {
+// CHECK-NEXT:       "unregistered_op"() : () -> ()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   func.return
-// CHECK-NEXT: }
 
-func.func @for_unregistered() {
-  %lb = arith.constant 0 : index
-  %ub = arith.constant 42 : index
-  %s = arith.constant 3 : index
-  scf.for %iv = %lb to %ub step %s {
+%0 = arith.constant 0 : index
+scf.for %iv = %0 to %0 step %0 {
     "unregistered_op"() : () -> ()
     scf.yield
-  }
-  func.return
+}
+
+// -----
+
+// CHECK:        %0 = arith.constant 0 : index
+// CHECK-NEXT:   scf.for %iv = %0 to %0 step %0 {
+// CHECK-NEXT:       "unregistered_op"() : () -> ()
+// CHECK-NEXT:   }
+
+%0 = arith.constant 0 : index
+scf.for %iv = %0 to %0 step %0 {
+    "unregistered_op"() : () -> ()
 }

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -175,9 +175,12 @@ def ensure_terminator(op: Operation, trait: SingleBlockImplicitTerminator) -> No
         if len(region.blocks) > 1:
             raise VerifyException(f"'{op.name}' does not contain single-block regions")
 
+        from xdsl.dialects.builtin import UnregisteredOp
+
         for block in region.blocks:
             if (
                 (last_op := block.last_op) is not None
+                and not isinstance(last_op, UnregisteredOp)
                 and last_op.has_trait(IsTerminator)
                 and not isinstance(last_op, trait.op_type)
             ):
@@ -195,7 +198,7 @@ def ensure_terminator(op: Operation, trait: SingleBlockImplicitTerminator) -> No
 
         for block in region.blocks:
             if (last_op := block.last_op) is None or not last_op.has_trait(
-                IsTerminator
+                IsTerminator, value_if_unregistered=False
             ):
                 with ImplicitBuilder(block):
                     trait.op_type.create()


### PR DESCRIPTION
This PR:

- Fixes the implicit addition of a terminator when the last operation is an (allowed) unregisted operation
- Adds a filecheck test for the above

Fixes #3325 