### PR TITLE
dialects: (builtin) add support for f16 packing and unpacking

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -33,6 +33,7 @@ from xdsl.dialects.builtin import (
     VectorBaseTypeConstraint,
     VectorRankConstraint,
     VectorType,
+    f16,
     f32,
     f64,
     i1,
@@ -58,8 +59,7 @@ def test_FloatType_bitwidths():
 def test_FloatType_formats():
     with pytest.raises(NotImplementedError):
         BFloat16Type().format
-    with pytest.raises(NotImplementedError):
-        Float16Type().format
+    assert Float16Type().format == "<e"
     assert Float32Type().format == "<f"
     assert Float64Type().format == "<d"
     with pytest.raises(NotImplementedError):
@@ -171,6 +171,12 @@ def test_IntegerType_packing():
     buffer_i64 = i64.pack(nums_i64)
     unpacked_i64 = i64.unpack(buffer_i64, len(nums_i64))
     assert nums_i64 == unpacked_i64
+
+    # f16
+    nums_f16 = (-3.140625, -1.0, 0.0, 1.0, 3.140625)
+    buffer_f16 = f16.pack(nums_f16)
+    unpacked_f16 = f16.unpack(buffer_f16, len(nums_f16))
+    assert nums_f16 == unpacked_f16
 
     # f32
     nums_f32 = (-3.140000104904175, -1.0, 0.0, 1.0, 3.140000104904175)

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -699,7 +699,7 @@ class Float16Type(ParametrizedAttribute, _FloatType):
 
     @property
     def format(self) -> str:
-        raise NotImplementedError()
+        return "<e"
 
 
 @irdl_attr_definition


### PR DESCRIPTION
The "<e" comes with the following warning:

> The IEEE 754 binary16 “half precision” type was introduced in the 2008 revision of the [IEEE 754 standard](https://en.wikipedia.org/wiki/IEEE_754-2008_revision). It has a sign bit, a 5-bit exponent and 11-bit precision (with 10 bits explicitly stored), and can represent numbers between approximately 6.1e-05 and 6.5e+04 at full precision. This type is not widely supported by C compilers: on a typical machine, an unsigned short can be used for storage, but not for math operations. See the Wikipedia page on the [half-precision floating-point format](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) for more information.

As we only use it for storage, this should be fine though imo