### PR TITLE
interactive: do not auto_expand passes_list

### DIFF
--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -179,6 +179,7 @@ class InputApp(App[None]):
         self.output_text_area = OutputTextArea(id="output")
         self.selected_passes_list_view = ListView(id="selected_passes_list_view")
         self.passes_tree = Tree(label=".", id="passes_tree")
+        self.passes_tree.auto_expand = False
         self.input_operation_count_datatable = DataTable(
             id="input_operation_count_datatable"
         )


### PR DESCRIPTION
I was really struggling to debug this, but from what I can understand the `child_pass_pipeline` was ending up with duplicate passes because `self.pass_pipeline` shouldn't have been added. 
I'm not 100% this is the correct fix as I didn't manage to work out what everything did and why.