### PR TITLE
misc (Makefile): Group `lit` options and allow them to be overriden during `make` invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ COVERAGE_FILE ?= .coverage
 # use different coverage data file per coverage run, otherwise combine complains
 TESTS_COVERAGE_FILE = ${COVERAGE_FILE}.tests
 
+# default lit options
+LIT_OPTIONS ?= -v --order=smart
+
 # make tasks run all commands in a single shell
 .ONESHELL:
 
@@ -39,7 +42,7 @@ clean: clean-caches
 
 # run filecheck tests
 filecheck:
-	lit -vv tests/filecheck --order=smart --timeout=20
+	lit $(LIT_OPTIONS) tests/filecheck
 
 # run pytest tests
 pytest:
@@ -54,7 +57,7 @@ pytest-nb:
 
 # run tests for Toy tutorial
 filecheck-toy:
-	lit -v docs/Toy/examples --order=smart
+	lit $(LIT_OPTIONS) docs/Toy/examples
 
 pytest-toy:
 	pytest docs/Toy/toy/tests
@@ -141,7 +144,7 @@ coverage-tests:
 
 # run coverage over filecheck tests
 coverage-filecheck-tests:
-	lit -v tests/filecheck/ -DCOVERAGE
+	lit $(LIT_OPTIONS) tests/filecheck/ -DCOVERAGE
 
 # generate html coverage report
 coverage-report-html:


### PR DESCRIPTION
This PR:

- Groups `lit` options as a Makefile variable that can be overridden during `make` invocation,
  e.g., `make filecheck LIT_OPTIONS="-v --order=smart --timeout=30`
- The default timeout value is 20secs and it is currently provided in `lit.cfg` since #3590
- the `-vv` option is deprecated, `-v` does what we want.

Based on the discussion [here](https://github.com/xdslproject/xdsl/pull/3590#issuecomment-2527765677).