### PR TITLE
misc (Makefile): Update coverage handling in Makefile

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,8 +10,6 @@ source =
     tests/
     docs/
 
-
-
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
@@ -23,3 +21,5 @@ exclude_lines =
     raise ValueError
     raise TypeError
     raise RuntimeError
+format = markdown
+ignore_errors = True

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,8 @@ LIT_OPTIONS ?= -v --order=smart
 # make tasks run all commands in a single shell
 .ONESHELL:
 
-# these targets don't produce files:
-.PHONY: ${VENV_DIR}/ venv clean clean-caches filecheck pytest pytest-nb tests-toy tests
-.PHONY: rerun-notebooks precommit-install precommit pyright tests-marimo
-.PHONY: coverage coverage-tests coverage-filecheck-tests coverage-report-html coverage-report coverage-clean
-.PHONY: pytest-toy-nb
-.PHONY: tests-marimo-onnx
-
 # set up the venv with all dependencies for development
+.PHONY: ${VENV_DIR}/
 ${VENV_DIR}/: requirements.txt
 	python3 -m venv ${VENV_DIR}
 	. ${VENV_DIR}/bin/activate
@@ -30,22 +24,27 @@ ${VENV_DIR}/: requirements.txt
 venv: ${VENV_DIR}/
 
 # remove all caches
+.PHONY: clean-caches
 clean-caches: coverage-clean
 	rm -rf .pytest_cache *.egg-info
 
 # remove all caches and the venv
+.PHONY: clean
 clean: clean-caches
 	rm -rf ${VENV_DIR}
 
 # run filecheck tests
+.PHONY: filecheck
 filecheck:
 	lit $(LIT_OPTIONS) tests/filecheck
 
 # run pytest tests
+.PHONY: pytest
 pytest:
 	pytest tests -W error -vv
 
 # run pytest on notebooks
+.PHONY: pytest-nb
 pytest-nb:
 	pytest -W error --nbval -vv docs \
 		--ignore=docs/mlir_interoperation.ipynb \
@@ -53,12 +52,15 @@ pytest-nb:
 		--nbval-current-env
 
 # run tests for Toy tutorial
+.PHONY: filecheck-toy
 filecheck-toy:
 	lit $(LIT_OPTIONS) docs/Toy/examples
 
+.PHONY: pytest-toy
 pytest-toy:
 	pytest docs/Toy/toy/tests
 
+.PHONY: pytest-toy-nb
 pytest-toy-nb:
 	@if python -c "import riscemu" > /dev/null 2>&1; then \
 		pytest -W error --nbval -vv docs/Toy --nbval-current-env; \
@@ -66,8 +68,10 @@ pytest-toy-nb:
 		echo "riscemu is not installed, skipping tests."; \
 	fi
 
+.PHONY: tests-toy
 tests-toy: filecheck-toy pytest-toy pytest-toy-nb
 
+.PHONY: tests-marimo
 tests-marimo:
 	@for file in docs/marimo/*.py; do \
 		echo "Running $$file"; \
@@ -79,6 +83,7 @@ tests-marimo:
 	done
 	@echo "All marimo tests passed successfully."
 
+.PHONY: tests-marimo-onnx
 tests-marimo-onnx:
 	@if python -c "import onnx" > /dev/null 2>&1; then \
 		echo "onnx is installed, running tests."; \
@@ -100,14 +105,17 @@ tests-marimo-onnx:
 	fi
 
 # run all tests
+.PHONY: tests-functional
 tests-functional: pytest tests-toy filecheck pytest-nb tests-marimo tests-marimo-onnx
 	@echo All functional tests done.
 
 # run all tests
+.PHONY: tests
 tests: tests-functional pyright
 	@echo All tests done.
 
 # re-generate the output from all jupyter notebooks in the docs directory
+.PHONY: rerun-notebooks
 rerun-notebooks:
 	jupyter nbconvert \
 		--ClearMetadataPreprocessor.enabled=True \
@@ -116,39 +124,48 @@ rerun-notebooks:
 		--execute docs/*.ipynb docs/Toy/*.ipynb
 
 # set up all precommit hooks
+.PHONY: precommit-install
 precommit-install:
 	pre-commit install
 
 # run all precommit hooks and apply them
+.PHONY: precommit
 precommit:
 	pre-commit run --all
 
 # run pyright on all files in the current git commit
 # make sure to generate the python typing stubs before running pyright
+.PHONY: pyright
 pyright:
 	xdsl-stubgen
 	pyright $(shell git diff --staged --name-only  -- '*.py')
 
 # run coverage over all tests and combine data files
+.PHONY: coverage
 coverage: coverage-tests coverage-filecheck-tests
 	coverage combine --append
 
 # run coverage over tests
 # use different coverage data file per coverage run, otherwise combine complains
+.PHONY: coverage-tests
 coverage-tests:
 	COVERAGE_FILE="${COVERAGE_FILE}.$@" pytest -W error --cov --cov-config=.coveragerc
 
 # run coverage over filecheck tests
+.PHONY: coverage-filecheck-tests
 coverage-filecheck-tests:
 	lit $(LIT_OPTIONS) tests/filecheck/ -DCOVERAGE
 
 # generate html coverage report
+.PHONY: coverage-report-html
 coverage-report-html:
 	coverage html
 
 # generate coverage report
+.PHONY: coverage-report
 coverage-report:
 	coverage report
 
+.PHONY: coverage-clean
 coverage-clean:
 	coverage erase


### PR DESCRIPTION
This PR:

- Moves coverage options from the `Makefile` to `.coveragerc` and adds the [`ignore_errors`](https://coverage.readthedocs.io/en/latest/config.html#report-ignore-errors) option
- Adds a `coverage-clean` target and lets the coverage module to erase the produced files from a coverage run
- Removes the `TESTS_COVERAGE_FILE` env variable as this is only used in a target to avoid name collision of coverage files; for all purposes using the common prefix as enforced by `COVERAGE_FILE` is enough to make things work uniformly across targets

I would have loved to [move](https://coverage.readthedocs.io/en/latest/config.html#sample-file) the `.coveragerc` configuration to `pyproject.toml`, but it seems that `pytest-cov` does not support it yet.