### PR TITLE
dialects (riscv_func): Use assembly format for `riscv_func.call` operation

### DIFF
--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -80,7 +80,9 @@ class CallOp(riscv.RISCVInstruction):
     callee = attr_def(SymbolRefAttr)
     ress = var_result_def(riscv.RISCVRegisterType)
 
-    assembly_format = "$callee `(` $args`)` attr-dict `:` functional-type($args, $ress)"
+    assembly_format = (
+        "$callee `(` $args `)` attr-dict `:` functional-type($args, $ress)"
+    )
 
     def __init__(
         self,

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import cast
 
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
@@ -13,9 +12,7 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
 )
 from xdsl.dialects.utils import (
-    parse_call_op_like,
     parse_func_op_like,
-    print_call_op_like,
     print_func_op_like,
 )
 from xdsl.ir import Attribute, Dialect, Operation, Region, SSAValue
@@ -83,6 +80,8 @@ class CallOp(riscv.RISCVInstruction):
     callee = attr_def(SymbolRefAttr)
     ress = var_result_def(riscv.RISCVRegisterType)
 
+    assembly_format = "$callee `(` $args`)` attr-dict `:` functional-type($args, $ress)"
+
     def __init__(
         self,
         callee: SymbolRefAttr,
@@ -109,27 +108,6 @@ class CallOp(riscv.RISCVInstruction):
             raise VerifyException(
                 f"Function op has too many results ({len(self.results)}), expected fewer than 3"
             )
-
-    def print(self, printer: Printer):
-        print_call_op_like(
-            printer,
-            self,
-            self.callee,
-            self.args,
-            self.attributes,
-            reserved_attr_names=("callee",),
-        )
-
-    @classmethod
-    def parse(cls, parser: Parser) -> CallOp:
-        callee, arguments, results, extra_attributes = parse_call_op_like(
-            parser, reserved_attr_names=("callee",)
-        )
-        ress = cast(tuple[riscv.RISCVRegisterType, ...], results)
-        call = CallOp(callee, arguments, ress)
-        if extra_attributes is not None:
-            call.attributes |= extra_attributes.data
-        return call
 
     def assembly_instruction_name(self) -> str:
         return "jal"

--- a/xdsl/dialects/utils/format.py
+++ b/xdsl/dialects/utils/format.py
@@ -7,7 +7,6 @@ from xdsl.dialects.builtin import (
     DictionaryAttr,
     FunctionType,
     StringAttr,
-    SymbolRefAttr,
 )
 from xdsl.ir import (
     Attribute,
@@ -20,49 +19,6 @@ from xdsl.ir import (
 from xdsl.irdl import IRDLOperation, var_operand_def
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
-
-
-def print_call_op_like(
-    printer: Printer,
-    op: Operation,
-    callee: SymbolRefAttr,
-    args: Sequence[SSAValue],
-    attributes: dict[str, Attribute],
-    *,
-    reserved_attr_names: Sequence[str],
-):
-    printer.print_string(" ")
-    printer.print_attribute(callee)
-    printer.print_string("(")
-    printer.print_list(args, printer.print_ssa_value)
-    printer.print_string(")")
-    printer.print_op_attributes(attributes, reserved_attr_names=reserved_attr_names)
-    printer.print_string(" : ")
-    printer.print_operation_type(op)
-
-
-def parse_call_op_like(
-    parser: Parser, *, reserved_attr_names: Sequence[str]
-) -> tuple[
-    SymbolRefAttr, Sequence[SSAValue], Sequence[Attribute], DictionaryAttr | None
-]:
-    callee = parser.parse_symbol_name()
-    unresolved_arguments = parser.parse_op_args_list()
-    extra_attributes = parser.parse_optional_attr_dict_with_reserved_attr_names(
-        reserved_attr_names
-    )
-    parser.parse_characters(":")
-    pos = parser.pos
-    function_type = parser.parse_function_type()
-    arguments = parser.resolve_operands(
-        unresolved_arguments, function_type.inputs.data, pos
-    )
-    return (
-        SymbolRefAttr(callee),
-        arguments,
-        function_type.outputs.data,
-        extra_attributes,
-    )
 
 
 class AbstractYieldOperation(Generic[AttributeInvT], IRDLOperation):


### PR DESCRIPTION
This PR:

- uses the declarative assembly format for `riscv_func.call` made possible by `functional-type` #3517 
- removes unused utility methods for generic printing/parsing of the above since there are no users for them as a result of the above

Also discussed in #3618 

