### PR TITLE
dialects: (builtin) apply normalization on ints, not IntAttrs

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -106,17 +106,17 @@ def test_IntegerType_normalized():
     si8 = IntegerType(8, Signedness.SIGNED)
     ui8 = IntegerType(8, Signedness.UNSIGNED)
 
-    assert i8.normalized_value(IntAttr(-1)) == IntAttr(-1)
-    assert i8.normalized_value(IntAttr(1)) == IntAttr(1)
-    assert i8.normalized_value(IntAttr(255)) == IntAttr(-1)
+    assert i8.normalized_value(-1) == -1
+    assert i8.normalized_value(1) == 1
+    assert i8.normalized_value(255) == -1
 
-    assert si8.normalized_value(IntAttr(-1)) == IntAttr(-1)
-    assert si8.normalized_value(IntAttr(1)) == IntAttr(1)
-    assert si8.normalized_value(IntAttr(255)) is None
+    assert si8.normalized_value(-1) == -1
+    assert si8.normalized_value(1) == 1
+    assert si8.normalized_value(255) is None
 
-    assert ui8.normalized_value(IntAttr(-1)) is None
-    assert ui8.normalized_value(IntAttr(1)) == IntAttr(1)
-    assert ui8.normalized_value(IntAttr(255)) == IntAttr(255)
+    assert ui8.normalized_value(-1) is None
+    assert ui8.normalized_value(1) == 1
+    assert ui8.normalized_value(255) == 255
 
 
 def test_IntegerAttr_normalize():


### PR DESCRIPTION
the current flow of creating dense attrs is the following:
`parse -> int -> IntAttr -> normalize -> IntAttr -> int -> bytes`

this PR changes the normalization to work on ints to get the following:
`parse -> int -> normalize -> int -> bytes`

which simplifies things somewhat and should improve performance significantly for larger arrays