### PR TITLE
misc (Makefile): Fix custom `venv` treatment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COVERAGE_FILE ?= .coverage
 
 # allow overriding the name of the venv directory
 VENV_DIR ?= venv
-export UV_PROJECT_ENVIRONMENT=${VENV_DIR}
+UV_PROJECT_ENVIRONMENT=${VENV_DIR}
 
 # allow overriding which extras are installed
 VENV_EXTRAS ?= --extra gui --extra dev --extra jax --extra riscv
@@ -29,6 +29,7 @@ ${VENV_DIR}/: uv-installed
 	uv sync ${VENV_EXTRAS}
 
 # make sure `make venv` also works correctly
+.PHONY: venv
 venv: ${VENV_DIR}/
 
 # remove all caches


### PR DESCRIPTION
This PR:

- Removes `export` from `UV_PROJECT_ENVIRONMENT`, according to [here](https://stackoverflow.com/questions/2838715/makefile-variable-initialization-and-export?noredirect=1&lq=1), its function is rather peculiar
- Adds a missed phony target


My issue is that doing:
1) `VENV_DIR=.vevn make venv`
2) `source .venv/bin/activate`
3) `make tests`

issues the following warning:

> warning: `VIRTUAL_ENV=.venv` does not match the project environment path `venv` and will be ignored

and leads to failed tests (cannot find `riscemu`), as `uv run` according to its documentation will create a venv:

> When used in a project, the project environment will be created and updated before invoking the command.