### PR TITLE
transformations: (apply-individual-rewrite) lazily find canonicalization patterns

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -291,7 +291,7 @@ async def test_buttons():
         assert app.condense_mode is True
         rewrites = get_all_possible_rewrites(
             expected_module,
-            individual_rewrite.REWRITE_BY_NAMES,
+            individual_rewrite.INDIVIDUAL_REWRITE_PATTERNS_BY_NAME,
         )
         assert app.available_pass_list == get_condensed_pass_list(
             expected_module, app.all_passes

--- a/tests/interactive/test_rewrites.py
+++ b/tests/interactive/test_rewrites.py
@@ -1,9 +1,9 @@
 from xdsl.context import MLContext
-from xdsl.dialects import get_all_dialects
 from xdsl.dialects.builtin import (
+    Builtin,
     StringAttr,
 )
-from xdsl.dialects.test import TestOp
+from xdsl.dialects.test import Test, TestOp
 from xdsl.interactive.passes import AvailablePass
 from xdsl.interactive.rewrites import (
     IndexedIndividualRewrite,
@@ -39,9 +39,10 @@ def test_get_all_possible_rewrite():
     }
     """
 
-    ctx = MLContext(True)
-    for dialect_name, dialect_factory in get_all_dialects().items():
-        ctx.register_dialect(dialect_name, dialect_factory)
+    ctx = MLContext()
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
+
     parser = Parser(ctx, prog)
     module = parser.parse_module()
 
@@ -73,9 +74,9 @@ def test_convert_indexed_individual_rewrites_to_available_pass():
     }
     """
 
-    ctx = MLContext(True)
-    for dialect_name, dialect_factory in get_all_dialects().items():
-        ctx.register_dialect(dialect_name, dialect_factory)
+    ctx = MLContext()
+    ctx.load_dialect(Builtin)
+    ctx.load_dialect(Test)
     parser = Parser(ctx, prog)
     module = parser.parse_module()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2390,7 +2390,7 @@ wheels = [
 
 [[package]]
 name = "xdsl"
-version = "0.25.0+37.g414bcb0e.dirty"
+version = "0.25.0+89.gb85bb1a8"
 source = { editable = "." }
 dependencies = [
     { name = "immutabledict" },

--- a/uv.lock
+++ b/uv.lock
@@ -2390,7 +2390,7 @@ wheels = [
 
 [[package]]
 name = "xdsl"
-version = "0.25.0+89.gb85bb1a8"
+version = "0.25.0+37.g414bcb0e.dirty"
 source = { editable = "." }
 dependencies = [
     { name = "immutabledict" },

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -266,7 +266,7 @@ class InputApp(App[None]):
                     self.input_text_area.text,
                     self.pass_pipeline,
                     self.condense_mode,
-                    individual_rewrite.REWRITE_BY_NAMES,
+                    individual_rewrite.INDIVIDUAL_REWRITE_PATTERNS_BY_NAME,
                 )
 
     def watch_available_pass_list(
@@ -509,7 +509,7 @@ class InputApp(App[None]):
             self.input_text_area.text,
             child_pass_pipeline,
             self.condense_mode,
-            individual_rewrite.REWRITE_BY_NAMES,
+            individual_rewrite.INDIVIDUAL_REWRITE_PATTERNS_BY_NAME,
         )
 
         self.expand_node(expanded_node, child_pass_list)

--- a/xdsl/transforms/individual_rewrite.py
+++ b/xdsl/transforms/individual_rewrite.py
@@ -44,29 +44,16 @@ class DivisionOfSameVariableToOne(RewritePattern):
             rewriter.replace_matched_op([], [mul_op.lhs])
 
 
-INDIVIDUAL_REWRITE_PATTERNS_BY_OP_CLASS: dict[
-    type[Operation], dict[str, RewritePattern]
-] = {
-    arith.AddiOp: {
+INDIVIDUAL_REWRITE_PATTERNS_BY_NAME: dict[str, dict[str, RewritePattern]] = {
+    arith.AddiOp.name: {
         AdditionOfSameVariablesToMultiplyByTwo.__name__: AdditionOfSameVariablesToMultiplyByTwo()
     },
-    arith.DivUIOp: {
+    arith.DivUIOp.name: {
         DivisionOfSameVariableToOne.__name__: DivisionOfSameVariableToOne()
     },
 }
 """
-Dictionary where the key is an Operation and the value is a tuple of rewrite pattern(s) associated with that operation. These are rewrite patterns defined in this class.
-"""
-
-REWRITE_BY_NAMES: dict[str, dict[str, RewritePattern]] = {
-    op.name: INDIVIDUAL_REWRITE_PATTERNS_BY_OP_CLASS.get(op, {})
-    for op in set(INDIVIDUAL_REWRITE_PATTERNS_BY_OP_CLASS)
-}
-"""
-Returns a dictionary representing all possible rewrites. Keys are operation names, and
-values are dictionaries. In the inner dictionary, the keys are names of patterns
-associated with each operation, and the values are the corresponding RewritePattern
-instances.
+Extra rewrite patterns available to ApplyIndividualRewritePass
 """
 
 
@@ -110,8 +97,8 @@ class ApplyIndividualRewritePass(ModulePass):
 
         # Check individual rewrites first
         if (
-            individual_rewrites := INDIVIDUAL_REWRITE_PATTERNS_BY_OP_CLASS.get(
-                type(matched_operation)
+            individual_rewrites := INDIVIDUAL_REWRITE_PATTERNS_BY_NAME.get(
+                self.operation_name
             )
         ) is not None and (p := individual_rewrites.get(self.pattern_name)) is not None:
             pattern = p

--- a/xdsl/transforms/individual_rewrite.py
+++ b/xdsl/transforms/individual_rewrite.py
@@ -57,7 +57,9 @@ Extra rewrite patterns available to ApplyIndividualRewritePass
 """
 
 
-def _get_pattern(op: Operation, pattern_name: str) -> RewritePattern | None:
+def _get_canonicalization_pattern(
+    op: Operation, pattern_name: str
+) -> RewritePattern | None:
     if (trait := op.get_trait(HasCanonicalizationPatternsTrait)) is None:
         return None
 
@@ -102,7 +104,9 @@ class ApplyIndividualRewritePass(ModulePass):
             )
         ) is not None and (p := individual_rewrites.get(self.pattern_name)) is not None:
             pattern = p
-        elif (p := _get_pattern(matched_operation, self.pattern_name)) is not None:
+        elif (
+            p := _get_canonicalization_pattern(matched_operation, self.pattern_name)
+        ) is not None:
             pattern = p
         else:
             raise ValueError(


### PR DESCRIPTION
It's time to make this part of the codebase a bit more extensible and robust, as we will be reusing it for some scheduling exploration. As a first step, this PR changes the rewrite infrastructure to get the available patterns on the operation lazily, instead of by scanning all ops of all dialects.