### PR TITLE
interactive: use individual rewrite pass directly instead of helpers

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -20,10 +20,7 @@ from xdsl.interactive import _pasteboard
 from xdsl.interactive.add_arguments_screen import AddArguments
 from xdsl.interactive.app import InputApp
 from xdsl.interactive.passes import AvailablePass, get_condensed_pass_list
-from xdsl.interactive.rewrites import (
-    convert_indexed_individual_rewrites_to_available_pass,
-    get_all_possible_rewrites,
-)
+from xdsl.interactive.rewrites import get_all_possible_rewrites
 from xdsl.ir import Block, Region
 from xdsl.transforms import (
     get_all_passes,
@@ -295,9 +292,7 @@ async def test_buttons():
         )
         assert app.available_pass_list == get_condensed_pass_list(
             expected_module, app.all_passes
-        ) + convert_indexed_individual_rewrites_to_available_pass(
-            rewrites, expected_module
-        )
+        ) + tuple(rewrites)
 
         # press "Uncondense" button
         await pilot.click("#uncondense_button")

--- a/tests/interactive/test_rewrites.py
+++ b/tests/interactive/test_rewrites.py
@@ -5,20 +5,15 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.dialects.test import Test, TestOp
 from xdsl.interactive.passes import AvailablePass
-from xdsl.interactive.rewrites import (
-    IndexedIndividualRewrite,
-    IndividualRewrite,
-    convert_indexed_individual_rewrites_to_available_pass,
-    get_all_possible_rewrites,
-)
+from xdsl.interactive.rewrites import get_all_possible_rewrites
 from xdsl.parser import Parser
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.transforms import individual_rewrite
-from xdsl.utils.parse_pipeline import parse_pipeline
+from xdsl.transforms.individual_rewrite import ApplyIndividualRewritePass
+from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 class Rewrite(RewritePattern):
@@ -47,75 +42,31 @@ def test_get_all_possible_rewrite():
     module = parser.parse_module()
 
     expected_res = [
-        (
-            IndexedIndividualRewrite(
-                1, IndividualRewrite(operation="test.op", pattern="TestRewrite")
-            )
+        AvailablePass(
+            display_name='TestOp("test.op"() {"label" = "a"} : () -> ()):test.op:TestRewrite',
+            module_pass=ApplyIndividualRewritePass,
+            pass_spec=PipelinePassSpec(
+                "apply-individual-rewrite",
+                {
+                    "matched_operation_index": (1,),
+                    "operation_name": ("test.op",),
+                    "pattern_name": ("TestRewrite",),
+                },
+            ),
         ),
-        (
-            IndexedIndividualRewrite(
-                operation_index=2,
-                rewrite=IndividualRewrite(operation="test.op", pattern="TestRewrite"),
-            )
+        AvailablePass(
+            display_name='TestOp("test.op"() {"label" = "a"} : () -> ()):test.op:TestRewrite',
+            module_pass=ApplyIndividualRewritePass,
+            pass_spec=PipelinePassSpec(
+                "apply-individual-rewrite",
+                {
+                    "matched_operation_index": (2,),
+                    "operation_name": ("test.op",),
+                    "pattern_name": ("TestRewrite",),
+                },
+            ),
         ),
     ]
 
     res = get_all_possible_rewrites(module, {"test.op": {"TestRewrite": Rewrite()}})
-    assert res == expected_res
-
-
-def test_convert_indexed_individual_rewrites_to_available_pass():
-    # build module
-    prog = """
-    builtin.module {
-    "test.op"() {"label" = "a"} : () -> ()
-    "test.op"() {"label" = "a"} : () -> ()
-    "test.op"() {"label" = "b"} : () -> ()
-    }
-    """
-
-    ctx = MLContext()
-    ctx.load_dialect(Builtin)
-    ctx.load_dialect(Test)
-    parser = Parser(ctx, prog)
-    module = parser.parse_module()
-
-    rewrites = (
-        (
-            IndexedIndividualRewrite(
-                1, IndividualRewrite(operation="test.op", pattern="TestRewrite")
-            )
-        ),
-        (
-            IndexedIndividualRewrite(
-                operation_index=2,
-                rewrite=IndividualRewrite(operation="test.op", pattern="TestRewrite"),
-            )
-        ),
-    )
-
-    expected_res = tuple(
-        (
-            AvailablePass(
-                display_name='TestOp("test.op"() {"label" = "a"} : () -> ()):test.op:TestRewrite',
-                module_pass=individual_rewrite.ApplyIndividualRewritePass,
-                pass_spec=list(
-                    parse_pipeline(
-                        'apply-individual-rewrite{matched_operation_index=1 operation_name="test.op" pattern_name="TestRewrite"}'
-                    )
-                )[0],
-            ),
-            AvailablePass(
-                display_name='TestOp("test.op"() {"label" = "a"} : () -> ()):test.op:TestRewrite',
-                module_pass=individual_rewrite.ApplyIndividualRewritePass,
-                pass_spec=list(
-                    parse_pipeline(
-                        'apply-individual-rewrite{matched_operation_index=2 operation_name="test.op" pattern_name="TestRewrite"}'
-                    )
-                )[0],
-            ),
-        )
-    )
-
-    res = convert_indexed_individual_rewrites_to_available_pass(rewrites, module)
     assert res == expected_res

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -6,10 +6,7 @@ from xdsl.interactive.passes import (
     get_condensed_pass_list,
     get_new_registered_context,
 )
-from xdsl.interactive.rewrites import (
-    convert_indexed_individual_rewrites_to_available_pass,
-    get_all_possible_rewrites,
-)
+from xdsl.interactive.rewrites import get_all_possible_rewrites
 from xdsl.ir import Dialect
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass
@@ -34,19 +31,14 @@ def get_available_pass_list(
 
     current_module = apply_passes_to_module(current_module, ctx, pass_pipeline)
 
-    # get all rewrites
-    rewrites = get_all_possible_rewrites(
+    # get all individual rewrites
+    individual_rewrites = get_all_possible_rewrites(
         current_module,
         rewrite_by_names_dict,
-    )
-    # transform rewrites into passes
-    rewrites_as_pass_list = convert_indexed_individual_rewrites_to_available_pass(
-        rewrites, current_module
     )
     # merge rewrite passes with "other" pass list
     if condense_mode:
         pass_list = get_condensed_pass_list(current_module, all_passes)
-        return pass_list + rewrites_as_pass_list
     else:
         pass_list = tuple(AvailablePass(p.name, p, None) for _, p in all_passes)
-        return pass_list + rewrites_as_pass_list
+    return pass_list + tuple(individual_rewrites)

--- a/xdsl/interactive/rewrites.py
+++ b/xdsl/interactive/rewrites.py
@@ -1,68 +1,23 @@
 from collections.abc import Sequence
-from typing import NamedTuple
 
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.interactive.passes import AvailablePass
 from xdsl.pattern_rewriter import PatternRewriter, RewritePattern
 from xdsl.traits import HasCanonicalizationPatternsTrait
 from xdsl.transforms import individual_rewrite
-from xdsl.utils.parse_pipeline import PipelinePassSpec
-
-
-class IndividualRewrite(NamedTuple):
-    """
-    Type alias for a possible rewrite, described by an operation and pattern name.
-    """
-
-    operation: str
-    pattern: str
-
-
-class IndexedIndividualRewrite(NamedTuple):
-    """
-    Type alias for a specific rewrite pattern, additionally consisting of its operation index.
-    """
-
-    operation_index: int
-    rewrite: IndividualRewrite
-
-
-def convert_indexed_individual_rewrites_to_available_pass(
-    rewrites: Sequence[IndexedIndividualRewrite], current_module: ModuleOp
-) -> tuple[AvailablePass, ...]:
-    """
-    Function that takes a tuple of rewrites, converts each rewrite into an IndividualRewrite pass and returns the tuple of AvailablePass.
-    """
-    rewrites_as_pass_list: tuple[AvailablePass, ...] = ()
-    for op_idx, (op_name, pat_name) in rewrites:
-        rewrite_pass = individual_rewrite.ApplyIndividualRewritePass
-        rewrite_spec = PipelinePassSpec(
-            name=rewrite_pass.name,
-            args={
-                "matched_operation_index": (op_idx,),
-                "operation_name": (op_name,),
-                "pattern_name": (pat_name,),
-            },
-        )
-        op = list(current_module.walk())[op_idx]
-        rewrites_as_pass_list = (
-            *rewrites_as_pass_list,
-            (AvailablePass(f"{op}:{op_name}:{pat_name}", rewrite_pass, rewrite_spec)),
-        )
-    return rewrites_as_pass_list
 
 
 def get_all_possible_rewrites(
     module: ModuleOp,
     rewrite_by_name: dict[str, dict[str, RewritePattern]],
-) -> Sequence[IndexedIndividualRewrite]:
+) -> Sequence[AvailablePass]:
     """
     Function that takes a sequence of IndividualRewrite Patterns and a ModuleOp, and
     returns the possible rewrites.
     Issue filed: https://github.com/xdslproject/xdsl/issues/2162
     """
 
-    res: list[IndexedIndividualRewrite] = []
+    res: list[AvailablePass] = []
 
     for op_idx, matched_op in enumerate(module.walk()):
         pattern_by_name = rewrite_by_name.get(matched_op.name, {}).copy()
@@ -78,9 +33,14 @@ def get_all_possible_rewrites(
             rewriter = PatternRewriter(cloned_op)
             pattern.match_and_rewrite(cloned_op, rewriter)
             if rewriter.has_done_action:
+                p = individual_rewrite.ApplyIndividualRewritePass(
+                    op_idx, cloned_op.name, pattern_name
+                )
                 res.append(
-                    IndexedIndividualRewrite(
-                        op_idx, IndividualRewrite(cloned_op.name, pattern_name)
+                    AvailablePass(
+                        f"{cloned_op}:{cloned_op.name}:{pattern_name}",
+                        individual_rewrite.ApplyIndividualRewritePass,
+                        p.pipeline_pass_spec(),
                     )
                 )
 


### PR DESCRIPTION
It doesn't seem that this abstraction currently adds anything, both the available pass and pass itself are already immutable and can be reasoned about directly.