### PR TITLE
dialects (llvm): Add dense array constraint for the `position` attribute of `llvm.extractvalue` and `llvm.insertvalue` operations

### DIFF
--- a/tests/filecheck/dialects/llvm/invalid.mlir
+++ b/tests/filecheck/dialects/llvm/invalid.mlir
@@ -7,10 +7,29 @@ builtin.module {
 // CHECK: Varargs specifier `...` must be at the end of the argument definition
 
 // -----
-// CHECK: -----
 
 builtin.module {
     %cc = "test.op"() {"cconv" = #llvm.cconv<invalid>} : () -> ()
 }
 
 // CHECK: Unknown calling convention
+
+// -----
+
+func.func public @main() {
+  %0 = "test.op"() : () -> (!llvm.struct<(i32)>)
+  %1 = "llvm.extractvalue"(%0) {"position" = array<i32: 0>} : (!llvm.struct<(i32)>) -> i32
+  func.return
+}
+
+// CHECK: Expected attribute i64 but got i32
+
+// -----
+
+func.func public @main() {
+  %0, %1 = "test.op"() : () -> (!llvm.struct<(i32)>, i32)
+  %2 = "llvm.insertvalue"(%0, %1) {"position" = array<i32: 0>} : (!llvm.struct<(i32)>, i32) -> !llvm.struct<(i32)>
+  func.return
+}
+
+// CHECK: Expected attribute i64 but got i32

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1248,6 +1248,13 @@ class DenseArrayBase(ParametrizedAttribute):
         return len(self.data.data) // self.elt_type.size
 
 
+DenseI64ArrayConstraint = ParamAttrConstraint(DenseArrayBase, [i64, BytesAttr])
+"""Type constraint for DenseArrays containing integers of i64 integers."""
+
+DenseI64ArrayType: TypeAlias = Annotated[DenseArrayBase, DenseI64ArrayConstraint]
+"""Type alias constrained to dense array of i64 integers."""
+
+
 @irdl_attr_definition
 class FunctionType(ParametrizedAttribute, TypeAttribute):
     name = "fun"

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     ContainerType,
     DenseArrayBase,
+    DenseI64ArrayConstraint,
     IndexType,
     IntAttr,
     IntegerAttr,
@@ -1262,7 +1263,7 @@ class ExtractValueOp(IRDLOperation):
 
     name = "llvm.extractvalue"
 
-    position = prop_def(DenseArrayBase)
+    position = prop_def(DenseI64ArrayConstraint)
     container = operand_def(Attribute)
 
     res = result_def(Attribute)
@@ -1292,7 +1293,7 @@ class InsertValueOp(IRDLOperation):
 
     name = "llvm.insertvalue"
 
-    position = prop_def(DenseArrayBase)
+    position = prop_def(DenseI64ArrayConstraint)
     container = operand_def(Attribute)
     value = operand_def(Attribute)
 


### PR DESCRIPTION
This PR:

- Adds a dense array constraint for the `position` attribute of `llvm.extractvalue` and `llvm.insertvalue` operations, restricting to `i64` as in MLIR.
- Filecheck tests of the above

Resolves #3155
