### PR TITLE
dialects (func): Add SymbolUserOpInterface implementation for `func.call` operation

### DIFF
--- a/tests/filecheck/dialects/func/func_invalid.mlir
+++ b/tests/filecheck/dialects/func/func_invalid.mlir
@@ -38,3 +38,60 @@ builtin.module {
 
 // CHECK:       Operation does not verify: Unexpected nested symbols in FlatSymbolRefAttr
 // CHECK-NEXT:  Underlying verification failure: expected empty array, but got ["invalid"]
+
+// -----
+
+func.func @bar() {
+    %1 = "test.op"() : () -> !test.type<"int">
+    %2 = func.call @foo(%1) : (!test.type<"int">) -> !test.type<"int">
+    func.return
+}
+
+// CHECK: '@foo' could not be found in symbol table
+
+// -----
+
+func.func @foo(%0 : !test.type<"int">) -> !test.type<"int">
+
+func.func @bar() {
+    %1 = func.call @foo() : () -> !test.type<"int">
+    func.return
+}
+
+// CHECK: incorrect number of operands for callee
+
+// -----
+
+func.func @foo(%0 : !test.type<"int">)
+
+func.func @bar() {
+    %1 = "test.op"() : () -> !test.type<"int">
+    %2 = func.call @foo(%1) : (!test.type<"int">) -> !test.type<"int">
+    func.return
+}
+
+// CHECK: incorrect number of results for callee
+
+// -----
+
+func.func @foo(%0 : !test.type<"int">) -> !test.type<"int">
+
+func.func @bar() {
+  %1 = "test.op"() : () -> !test.type<"foo">
+  %2 = func.call @foo(%1) : (!test.type<"foo">) -> !test.type<"int">
+  func.return
+}
+
+// CHECK: operand type mismatch: expected operand type !test.type<"int">, but provided !test.type<"foo"> for operand number 0
+
+// -----
+
+func.func @foo(%0 : !test.type<"int">) -> !test.type<"int">
+
+func.func @bar() {
+    %1 = "test.op"() : () -> !test.type<"int">
+    %2 = func.call @foo(%1) : (!test.type<"int">) -> !test.type<"foo">
+    func.return
+}
+
+// CHECK: result type mismatch: expected result type !test.type<"int">, but provided !test.type<"foo"> for result number 0

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -81,12 +81,12 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
         if len(found_callee.function_type.outputs) != len(op.result_types):
             raise VerifyException("incorrect number of results for callee")
 
-        for idx, (found_oprnd, oprnd) in enumerate(
+        for idx, (found_operand, operand) in enumerate(
             zip(found_callee.function_type.inputs, (arg.type for arg in op.arguments))
         ):
-            if found_oprnd != oprnd:
+            if found_operand != operand:
                 raise VerifyException(
-                    f"operand type mismatch: expected operand type {found_oprnd}, but provided {oprnd} for operand number {idx}"
+                    f"operand type mismatch: expected operand type {found_operand}, but provided {operand} for operand number {idx}"
                 )
 
         for idx, (found_res, res) in enumerate(

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -242,7 +242,7 @@ class IsolatedFromAbove(OpTrait):
 class SymbolUserOpInterface(OpTrait, abc.ABC):
     """
     Used to represent operations that reference Symbol operations. This provides the
-    ability To perform safe and efficient verification of symbol uses, as well as
+    ability to perform safe and efficient verification of symbol uses, as well as
     additional functionality.
 
     https://mlir.llvm.org/docs/Interfaces/#symbolinterfaces

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -239,6 +239,26 @@ class IsolatedFromAbove(OpTrait):
                         regions += child_op.regions
 
 
+class SymbolUserOpInterface(OpTrait, abc.ABC):
+    """
+    Used to represent operations that reference Symbol operations. This provides the
+    ability To perform safe and efficient verification of symbol uses, as well as
+    additional functionality.
+
+    https://mlir.llvm.org/docs/Interfaces/#symbolinterfaces
+    """
+
+    @abc.abstractmethod
+    def verify(self, op: Operation) -> None:
+        """
+        This method should be adapted to the requirements of specific symbol users per
+        operation.
+
+        It corresponds to the verifySymbolUses in upstream MLIR.
+        """
+        raise NotImplementedError()
+
+
 class SymbolTable(OpTrait):
     """
     SymbolTable operations are containers for Symbol operations. They offer lookup


### PR DESCRIPTION
This PR:

- Adds support for the `SymbolUserOpInterface` interface and implements it for `func.call`
- Adds tests (pytest and filecheck) of the above

Resolves #3497