### PR TITLE
transformations: (csl-stencil-bufferize) AccessOp to read to_tensor's underlying memref

### DIFF
--- a/xdsl/transforms/csl_stencil_bufferize.py
+++ b/xdsl/transforms/csl_stencil_bufferize.py
@@ -289,10 +289,18 @@ class AccessOpBufferize(RewritePattern):
             rewriter.replace_matched_op(to_tensor_op(op.op))
             return
 
+        # accesses to buffers passed in additional args can read directly from memref underlying `to_tensor`
+        source = (
+            op.op.op.memref
+            if isinstance(op.op, OpResult)
+            and isinstance(op.op.op, bufferization.ToTensorOp)
+            else op.op
+        )
+
         rewriter.replace_matched_op(
             [
                 access := csl_stencil.AccessOp(
-                    op.op,
+                    source,
                     op.offset,
                     r_type,
                     op.offset_mapping,


### PR DESCRIPTION
`csl_stencil.AccessOp`s can read directly from memrefs underlying any `bufferization.to_tensor` passed into them.

Currently, in the presence of several buffers (ie, stencil fields translated to memrefs at this stage), all but the main buffer will have intermediate `bufferization.to_tensor` ops, which creates problems in lowering. The AccessOps can instead work directly off of the underlying memrefs.