### PR TITLE
interactive: remove unused spec variable from `get_pass_arguments` function 

### DIFF
--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -455,9 +455,7 @@ class InputApp(App[None]):
 
         # if selected_pass_value has arguments, call get_arguments_function to push screen for user input
         if fields(selected_pass_value) and selected_pass_spec is None:
-            self.get_pass_arguments(
-                selected_pass_value, root_to_child_pass_list
-            )
+            self.get_pass_arguments(selected_pass_value, root_to_child_pass_list)
         else:
             # if selected_pass_value contains no arguments add the selected pass to pass_pipeline
             if selected_pass_spec is None:

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -372,7 +372,6 @@ class InputApp(App[None]):
     def get_pass_arguments(
         self,
         selected_pass_value: type[ModulePass],
-        selected_pass_spec: PipelinePassSpec | None,
         root_to_child_pass_list: tuple[tuple[type[ModulePass], PipelinePassSpec], ...],
     ) -> None:
         """
@@ -457,7 +456,7 @@ class InputApp(App[None]):
         # if selected_pass_value has arguments, call get_arguments_function to push screen for user input
         if fields(selected_pass_value) and selected_pass_spec is None:
             self.get_pass_arguments(
-                selected_pass_value, selected_pass_spec, root_to_child_pass_list
+                selected_pass_value, root_to_child_pass_list
             )
         else:
             # if selected_pass_value contains no arguments add the selected pass to pass_pipeline


### PR DESCRIPTION
removes unnecessary variable passed to `get_pass_arguments` function to improve readability.