### PR TITLE
interactive: when generating new MLContext, set allow_unregistered attribute to default (=false)

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -53,13 +53,13 @@ async def test_inputs():
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
         )
 
         assert isinstance(app.current_module, ParseError)
         assert (
             str(app.current_module)
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     unregistered operation dkjfd!\n"
         )
 
         # Test corect input

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -26,7 +26,7 @@ def get_new_registered_context(
     """
     Generates a new MLContext, registers it and returns it.
     """
-    ctx = MLContext(True)
+    ctx = MLContext()
     for dialect_name, dialect_factory in all_dialects:
         ctx.register_dialect(dialect_name, dialect_factory)
     return ctx


### PR DESCRIPTION
This PR sets the MLContext, `allow_unregistered` attribute to its default, which is false, instead of having it at true. 

This was causing a weird parsing error that did not allow the `mlir-opt` pass to run --> it was parsing `module {}` as UnregisteredOp. 

This fixes it. 