### PR TITLE
interactive: mlir-gui version 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ xdsl-gui = "xdsl.interactive.app:main"
 xdsl-stubgen = "xdsl.utils.dialect_stub:make_all_stubs"
 xdsl-tblgen = "xdsl.tools.tblgen_to_py:main"
 
+mlir-gui = "xdsl.interactive.mlirapp:main"
+
 [tool.setuptools]
 platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false

--- a/uv.lock
+++ b/uv.lock
@@ -2457,7 +2457,7 @@ wheels = [
 
 [[package]]
 name = "xdsl"
-version = "0+dynamic"
+version = "0.25.0+86.gf73cc197.dirty"
 source = { editable = "." }
 dependencies = [
     { name = "immutabledict" },

--- a/uv.lock
+++ b/uv.lock
@@ -1203,11 +1203,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "1.19.1"
+version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fe/8133d3a21978e333a70f42561167551482b42044fc12cbbb7908aa64e5f5/narwhals-1.19.1.tar.gz", hash = "sha256:e597e7ed9da42ffb2c80b21e174817b27592a8570edea8c46c90a726e3b796af", size = 222808 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/56/2909562daa55568cebb8c9f410e3ab9e7da265a2fa7a7920854001099264/narwhals-1.19.0.tar.gz", hash = "sha256:a1a03bf922548ed1da5426acc954327a94c02c3a08558b65a0937dbd3b77fb48", size = 218994 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/0c/c01eb700963a978b741a93c0ed233d613643ece0ad54f5e2765a307f26f2/narwhals-1.19.1-py3-none-any.whl", hash = "sha256:72476dcc95f1d3f2c0c1f047cdd4879346b2871fe13d1223025466d8a3dcaea4", size = 260574 },
+    { url = "https://files.pythonhosted.org/packages/5a/67/5b9736f23b9ab599044b85bab0dbf994a3104ad2d0e332e821ebfe761c69/narwhals-1.19.0-py3-none-any.whl", hash = "sha256:517eca140103dbf61e4513fe462885a06bc21b565521a5ac0b79a7e31f152efe", size = 256396 },
 ]
 
 [[package]]
@@ -1669,15 +1669,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.13"
+version = "10.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/87/4998d1aac5afea5b081238a609d9814f4c33cd5c7123503276d1105fb6a9/pymdown_extensions-10.13.tar.gz", hash = "sha256:e0b351494dc0d8d14a1f52b39b1499a00ef1566b4ba23dc74f1eba75c736f5dd", size = 843302 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/0b/32f05854cfd432e9286bb41a870e0d1a926b72df5f5cdb6dec962b2e369e/pymdown_extensions-10.12.tar.gz", hash = "sha256:b0ee1e0b2bef1071a47891ab17003bfe5bf824a398e13f49f8ed653b699369a7", size = 840790 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/7f/46c7122186759350cf523c71d29712be534f769f073a1d980ce8f095072c/pymdown_extensions-10.13-py3-none-any.whl", hash = "sha256:80bc33d715eec68e683e04298946d47d78c7739e79d808203df278ee8ef89428", size = 264108 },
+    { url = "https://files.pythonhosted.org/packages/53/32/95a164ddf533bd676cbbe878e36e89b4ade3efde8dd61d0148c90cbbe57e/pymdown_extensions-10.12-py3-none-any.whl", hash = "sha256:49f81412242d3527b8b4967b990df395c89563043bc51a3d2d7d500e52123b77", size = 263448 },
 ]
 
 [[package]]
@@ -2149,14 +2149,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.43.0"
+version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/36/3a623a561dc8585a90973c8c0ed87511beebbe658c7e8f883fdab7ba55e1/starlette-0.43.0.tar.gz", hash = "sha256:d4887cfd776f8f925c1b140829da9f4c9b8d0973aa66a7cb2bcc48e9b3a69660", size = 2575219 }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/ae/0c98794b248370ce30f71018d0f39889f1d90c73a631e68e2f47e5efda2f/starlette-0.42.0.tar.gz", hash = "sha256:91f1fbd612f3e3d821a8a5f46bf381afe2a9722a7b8bbde1c07fb83384c2882a", size = 2575136 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/25/a94c01e7e3a72155bf2e1275f72bf2c1533d1c5adf7fc89d50c3ef16abd4/starlette-0.43.0-py3-none-any.whl", hash = "sha256:0e0a91f33c57b30820cbe0828f993df67f890f1e4ae48ed8080f24793446450c", size = 73291 },
+    { url = "https://files.pythonhosted.org/packages/c0/38/f790c69b2cbfe9cd4a8a89db1ef50d0a10e5121c07ff8b1d7c16d7807f41/starlette-0.42.0-py3-none-any.whl", hash = "sha256:02f877201a3d6d301714b5c72f15cac305ea5cc9e213c4b46a5af7eecad0d625", size = 73356 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1203,11 +1203,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "1.19.0"
+version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/56/2909562daa55568cebb8c9f410e3ab9e7da265a2fa7a7920854001099264/narwhals-1.19.0.tar.gz", hash = "sha256:a1a03bf922548ed1da5426acc954327a94c02c3a08558b65a0937dbd3b77fb48", size = 218994 }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fe/8133d3a21978e333a70f42561167551482b42044fc12cbbb7908aa64e5f5/narwhals-1.19.1.tar.gz", hash = "sha256:e597e7ed9da42ffb2c80b21e174817b27592a8570edea8c46c90a726e3b796af", size = 222808 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/67/5b9736f23b9ab599044b85bab0dbf994a3104ad2d0e332e821ebfe761c69/narwhals-1.19.0-py3-none-any.whl", hash = "sha256:517eca140103dbf61e4513fe462885a06bc21b565521a5ac0b79a7e31f152efe", size = 256396 },
+    { url = "https://files.pythonhosted.org/packages/80/0c/c01eb700963a978b741a93c0ed233d613643ece0ad54f5e2765a307f26f2/narwhals-1.19.1-py3-none-any.whl", hash = "sha256:72476dcc95f1d3f2c0c1f047cdd4879346b2871fe13d1223025466d8a3dcaea4", size = 260574 },
 ]
 
 [[package]]
@@ -1669,15 +1669,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.12"
+version = "10.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/0b/32f05854cfd432e9286bb41a870e0d1a926b72df5f5cdb6dec962b2e369e/pymdown_extensions-10.12.tar.gz", hash = "sha256:b0ee1e0b2bef1071a47891ab17003bfe5bf824a398e13f49f8ed653b699369a7", size = 840790 }
+sdist = { url = "https://files.pythonhosted.org/packages/49/87/4998d1aac5afea5b081238a609d9814f4c33cd5c7123503276d1105fb6a9/pymdown_extensions-10.13.tar.gz", hash = "sha256:e0b351494dc0d8d14a1f52b39b1499a00ef1566b4ba23dc74f1eba75c736f5dd", size = 843302 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/32/95a164ddf533bd676cbbe878e36e89b4ade3efde8dd61d0148c90cbbe57e/pymdown_extensions-10.12-py3-none-any.whl", hash = "sha256:49f81412242d3527b8b4967b990df395c89563043bc51a3d2d7d500e52123b77", size = 263448 },
+    { url = "https://files.pythonhosted.org/packages/86/7f/46c7122186759350cf523c71d29712be534f769f073a1d980ce8f095072c/pymdown_extensions-10.13-py3-none-any.whl", hash = "sha256:80bc33d715eec68e683e04298946d47d78c7739e79d808203df278ee8ef89428", size = 264108 },
 ]
 
 [[package]]
@@ -2149,14 +2149,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.42.0"
+version = "0.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/ae/0c98794b248370ce30f71018d0f39889f1d90c73a631e68e2f47e5efda2f/starlette-0.42.0.tar.gz", hash = "sha256:91f1fbd612f3e3d821a8a5f46bf381afe2a9722a7b8bbde1c07fb83384c2882a", size = 2575136 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/36/3a623a561dc8585a90973c8c0ed87511beebbe658c7e8f883fdab7ba55e1/starlette-0.43.0.tar.gz", hash = "sha256:d4887cfd776f8f925c1b140829da9f4c9b8d0973aa66a7cb2bcc48e9b3a69660", size = 2575219 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/38/f790c69b2cbfe9cd4a8a89db1ef50d0a10e5121c07ff8b1d7c16d7807f41/starlette-0.42.0-py3-none-any.whl", hash = "sha256:02f877201a3d6d301714b5c72f15cac305ea5cc9e213c4b46a5af7eecad0d625", size = 73356 },
+    { url = "https://files.pythonhosted.org/packages/96/25/a94c01e7e3a72155bf2e1275f72bf2c1533d1c5adf7fc89d50c3ef16abd4/starlette-0.43.0-py3-none-any.whl", hash = "sha256:0e0a91f33c57b30820cbe0828f993df67f890f1e4ae48ed8080f24793446450c", size = 73291 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2457,7 +2457,7 @@ wheels = [
 
 [[package]]
 name = "xdsl"
-version = "0.25.0+86.gf73cc197.dirty"
+version = "0+dynamic"
 source = { editable = "." }
 dependencies = [
     { name = "immutabledict" },

--- a/xdsl/interactive/mlir_helper.py
+++ b/xdsl/interactive/mlir_helper.py
@@ -1,3 +1,4 @@
+import subprocess
 from collections.abc import Callable
 
 from xdsl.context import MLContext
@@ -7,7 +8,6 @@ from xdsl.passes import ModulePass
 from xdsl.transforms.mlir_opt import MLIROptPass
 from xdsl.utils.parse_pipeline import PipelinePassSpec
 
-import subprocess
 
 def iterate_and_extract_options() -> list[str]:
     """
@@ -21,14 +21,13 @@ def iterate_and_extract_options() -> list[str]:
     # Step 1: Call `mlir-opt --help` and capture the output
     try:
         result = subprocess.run(
-            ["mlir-opt", "--help"],
-            capture_output=True,
-            text=True,
-            check=True
+            ["mlir-opt", "--help"], capture_output=True, text=True, check=True
         )
         help_output = result.stdout
     except FileNotFoundError:
-        print("Error: 'mlir-opt' not found. Make sure it is installed and added to your PATH.")
+        print(
+            "Error: 'mlir-opt' not found. Make sure it is installed and added to your PATH."
+        )
         return []
     except subprocess.CalledProcessError as e:
         print(f"Error while running 'mlir-opt --help': {e}")
@@ -37,15 +36,17 @@ def iterate_and_extract_options() -> list[str]:
     # Step 2: Parse the options from the output
     for line in help_output.splitlines():
         line = line.strip()
-        if '--' in line:
-            start_index = line.find('--')
-            option = line[start_index:].split()[0]  # Extract the word directly after `--`
+        if "--" in line:
+            start_index = line.find("--")
+            option = line[start_index:].split()[
+                0
+            ]  # Extract the word directly after `--`
             options.append(option)
 
     return options
 
-def get_mlir_pass_list(
-) -> tuple[str, ...]:
+
+def get_mlir_pass_list() -> tuple[str, ...]:
     """
     Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
     change the ModuleOp.
@@ -66,14 +67,12 @@ def get_new_registered_context(
     return ctx
 
 
-def generate_mlir_pass_spec(args : tuple[str, ...]) -> PipelinePassSpec | None:
+def generate_mlir_pass_spec(args: tuple[str, ...]) -> PipelinePassSpec | None:
     return MLIROptPass("mlir-opt", arguments=args)
 
 
 def apply_mlir_pass_with_args_to_module(
-    module: builtin.ModuleOp,
-    ctx: MLContext,
-    module_pass: ModulePass
+    module: builtin.ModuleOp, ctx: MLContext, module_pass: ModulePass
 ) -> builtin.ModuleOp:
     """
     Function that takes a ModuleOp, an MLContext and a pass_pipeline (consisting of a type[ModulePass] and PipelinePassSpec), applies the pass(es) to the ModuleOp and returns the new ModuleOp.

--- a/xdsl/interactive/mlir_helper.py
+++ b/xdsl/interactive/mlir_helper.py
@@ -60,7 +60,7 @@ def get_new_registered_context(
     """
     Generates a new MLContext, registers it and returns it.
     """
-    ctx = MLContext()
+    ctx = MLContext(True)
     for dialect_name, dialect_factory in all_dialects:
         ctx.register_dialect(dialect_name, dialect_factory)
     return ctx

--- a/xdsl/interactive/mlir_helper.py
+++ b/xdsl/interactive/mlir_helper.py
@@ -6,7 +6,6 @@ from xdsl.dialects import builtin
 from xdsl.ir import Dialect
 from xdsl.passes import ModulePass
 from xdsl.transforms.mlir_opt import MLIROptPass
-from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 def iterate_and_extract_options() -> list[str]:
@@ -16,6 +15,7 @@ def iterate_and_extract_options() -> list[str]:
     Returns:
         list: A list of strings containing the extracted options.
     """
+    options: list[str]
     options = []
 
     # Step 1: Call `mlir-opt --help` and capture the output
@@ -67,7 +67,7 @@ def get_new_registered_context(
     return ctx
 
 
-def generate_mlir_pass_spec(args: tuple[str, ...]) -> PipelinePassSpec | None:
+def generate_mlir_pass(args: tuple[str, ...]) -> MLIROptPass:
     return MLIROptPass("mlir-opt", arguments=args)
 
 

--- a/xdsl/interactive/mlir_helper.py
+++ b/xdsl/interactive/mlir_helper.py
@@ -1,0 +1,87 @@
+from collections.abc import Callable
+from typing import NamedTuple
+
+from xdsl.context import MLContext
+from xdsl.dialects import builtin, get_all_dialects
+from xdsl.ir import Dialect
+from xdsl.passes import ModulePass, PipelinePass
+from xdsl.transforms.mlir_opt import MLIROptPass
+from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
+from xdsl.parser import Parser
+from xdsl.dialects import get_all_dialects
+
+
+import os
+import subprocess
+
+def iterate_and_extract_options() -> list[str]:
+    """
+    Fetch MLIR passes by calling `mlir-opt --help` and extract options starting with `--`.
+
+    Returns:
+        list: A list of strings containing the extracted options.
+    """
+    options = []
+
+    # Step 1: Call `mlir-opt --help` and capture the output
+    try:
+        result = subprocess.run(
+            ["mlir-opt", "--help"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        help_output = result.stdout
+    except FileNotFoundError:
+        print("Error: 'mlir-opt' not found. Make sure it is installed and added to your PATH.")
+        return []
+    except subprocess.CalledProcessError as e:
+        print(f"Error while running 'mlir-opt --help': {e}")
+        return []
+
+    # Step 2: Parse the options from the output
+    for line in help_output.splitlines():
+        line = line.strip()
+        if '--' in line:
+            start_index = line.find('--')
+            option = line[start_index:].split()[0]  # Extract the word directly after `--`
+            options.append(option)
+
+    return options
+
+def get_mlir_pass_list(
+) -> tuple[str, ...]:
+    """
+    Function that returns the condensed pass list for a given ModuleOp, i.e. the passes that
+    change the ModuleOp.
+    """
+
+    return tuple(pass_name for pass_name in iterate_and_extract_options())
+
+
+def get_new_registered_context(
+    all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...],
+) -> MLContext:
+    """
+    Generates a new MLContext, registers it and returns it.
+    """
+    ctx = MLContext()
+    for dialect_name, dialect_factory in all_dialects:
+        ctx.register_dialect(dialect_name, dialect_factory)
+    return ctx
+
+
+def generate_mlir_pass_spec(args : tuple[str, ...]) -> PipelinePassSpec | None:
+    return MLIROptPass("mlir-opt", arguments=args)
+
+
+def apply_mlir_pass_with_args_to_module(
+    module: builtin.ModuleOp,
+    ctx: MLContext,
+    module_pass: ModulePass
+) -> builtin.ModuleOp:
+    """
+    Function that takes a ModuleOp, an MLContext and a pass_pipeline (consisting of a type[ModulePass] and PipelinePassSpec), applies the pass(es) to the ModuleOp and returns the new ModuleOp.
+    """
+    module_pass.apply(ctx, module)
+    return module

--- a/xdsl/interactive/mlir_helper.py
+++ b/xdsl/interactive/mlir_helper.py
@@ -43,7 +43,7 @@ def iterate_and_extract_options() -> list[str]:
             ]  # Extract the word directly after `--`
             options.append(option)
 
-    return options
+    return sorted(options)
 
 
 def get_mlir_pass_list() -> tuple[str, ...]:

--- a/xdsl/interactive/mlir_helper.py
+++ b/xdsl/interactive/mlir_helper.py
@@ -1,17 +1,12 @@
 from collections.abc import Callable
-from typing import NamedTuple
 
 from xdsl.context import MLContext
-from xdsl.dialects import builtin, get_all_dialects
+from xdsl.dialects import builtin
 from xdsl.ir import Dialect
-from xdsl.passes import ModulePass, PipelinePass
+from xdsl.passes import ModulePass
 from xdsl.transforms.mlir_opt import MLIROptPass
-from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
-from xdsl.parser import Parser
-from xdsl.dialects import get_all_dialects
+from xdsl.utils.parse_pipeline import PipelinePassSpec
 
-
-import os
 import subprocess
 
 def iterate_and_extract_options() -> list[str]:

--- a/xdsl/interactive/mlirapp.py
+++ b/xdsl/interactive/mlirapp.py
@@ -378,15 +378,13 @@ class MLIRApp(App[None]):
         Function returning a string containing the textual description of the pass
         pipeline generated thus far.
         """
-        if self.current_file_path == "":
-            query = "-p "
-        else:
-            query = self.current_file_path + " -p "
+        query = self.current_file_path 
 
         if self.pass_pipeline:
             query += " ".join(val for 
                val in self.pass_pipeline
             )
+        
         return f"mlir-opt {query}"
 
     def action_toggle_dark(self) -> None:

--- a/xdsl/interactive/mlirapp.py
+++ b/xdsl/interactive/mlirapp.py
@@ -35,7 +35,7 @@ from xdsl.interactive.add_arguments_screen import AddArguments
 from xdsl.interactive.load_file_screen import LoadFile
 from xdsl.interactive.mlir_helper import (
     apply_mlir_pass_with_args_to_module,
-    generate_mlir_pass_spec,
+    generate_mlir_pass,
     get_mlir_pass_list,
     get_new_registered_context,
 )
@@ -182,7 +182,7 @@ class MLIRApp(App[None]):
         for pass_name in self.all_passes:
             self.passes_tree.root.add(
                 label=pass_name,
-                data=(pass_name, None),
+                data=pass_name,
             )
 
         # initialize GUI with either specified input text or default example
@@ -202,7 +202,7 @@ class MLIRApp(App[None]):
         for pass_name in child_pass_list:
             expanded_pass.add(
                 label=pass_name,
-                data=(pass_name, None),
+                data=pass_name,
             )
 
     def update_root_of_passes_tree(self) -> None:
@@ -218,7 +218,7 @@ class MLIRApp(App[None]):
             value = self.pass_pipeline[-1]
             self.passes_tree.reset(
                 label=str(value),
-                data=(value, None),
+                data=value,
             )
         # expand the node
         self.expand_node(self.passes_tree.root, sorted(self.all_passes))
@@ -255,12 +255,12 @@ class MLIRApp(App[None]):
             ctx = get_new_registered_context(self.all_dialects)
             parser = Parser(ctx, input_text)
             module = parser.parse_module()
-            current_spec = generate_mlir_pass_spec(self.pass_pipeline)
-            if current_spec is None:
+            current_mlir_opt_pass = generate_mlir_pass(self.pass_pipeline)
+            if current_mlir_opt_pass is None:
                 self.current_module = module  # $
             else:
                 self.current_module = apply_mlir_pass_with_args_to_module(
-                    module, ctx, current_spec
+                    module, ctx, current_mlir_opt_pass
                 )
                 self.current_module = module
         except Exception as e:
@@ -353,7 +353,7 @@ class MLIRApp(App[None]):
             return
 
         # get instance
-        selected_pass_value, selected_pass_spec = selected_pass.data
+        selected_pass_value = selected_pass.data
 
         if "=" in selected_pass_value:
             # Add pass with arguments to pass pipeline
@@ -475,7 +475,7 @@ def main():
 
     return MLIRApp(
         tuple(get_all_dialects().items()),
-        sorted(get_mlir_pass_list()),
+        get_mlir_pass_list(),
         file_path,
         file_contents,
         pipeline,

--- a/xdsl/interactive/mlirapp.py
+++ b/xdsl/interactive/mlirapp.py
@@ -182,7 +182,7 @@ class MLIRApp(App[None]):
         for pass_name in self.all_passes:
             self.passes_tree.root.add(
                 label=pass_name,
-                data=pass_name,
+                data=(pass_name, None),
             )
 
         # initialize GUI with either specified input text or default example
@@ -202,7 +202,7 @@ class MLIRApp(App[None]):
         for pass_name in child_pass_list:
             expanded_pass.add(
                 label=pass_name,
-                data=pass_name,
+                data=(pass_name, None),
             )
 
     def update_root_of_passes_tree(self) -> None:
@@ -218,7 +218,7 @@ class MLIRApp(App[None]):
             value = self.pass_pipeline[-1]
             self.passes_tree.reset(
                 label=str(value),
-                data=value,
+                data=(value, None),
             )
         # expand the node
         self.expand_node(self.passes_tree.root, self.all_passes)
@@ -353,7 +353,7 @@ class MLIRApp(App[None]):
             return
 
         # get instance
-        selected_pass_value = selected_pass.data
+        selected_pass_value, selected_pass_spec = selected_pass.data
 
         if "=" in selected_pass_value:
             # Add pass with arguments to pass pipeline

--- a/xdsl/interactive/mlirapp.py
+++ b/xdsl/interactive/mlirapp.py
@@ -1,0 +1,468 @@
+"""
+An interactive command-line tool to explore compilation pipeline construction.
+
+Execute `mlir-gui` in your terminal to run it.
+
+Run `textual run xdsl.interactive.mlirapp:MLIRApp --dev` to run in development mode. Please
+be sure to install `textual-dev` to run this command.
+"""
+
+import argparse
+import os
+from collections.abc import Callable
+from dataclasses import fields
+from io import StringIO
+from typing import Any, ClassVar
+
+from textual import events, on
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, ScrollableContainer, Vertical
+from textual.reactive import reactive
+from textual.screen import Screen
+from textual.widgets import (
+    Button,
+    DataTable,
+    Footer,
+    Label,
+    ListItem,
+    ListView,
+    TextArea,
+    Tree,
+    SelectionList
+)
+from textual.widgets.tree import TreeNode
+
+from xdsl.interactive.add_arguments_screen import AddArguments
+from xdsl.interactive.load_file_screen import LoadFile
+from xdsl.interactive.mlir_helper import (
+    get_mlir_pass_list,
+    get_new_registered_context,
+    apply_mlir_pass_with_args_to_module,
+    generate_mlir_pass_spec
+)
+from xdsl.dialects import get_all_dialects
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.printer import Printer
+from xdsl.ir import Dialect
+from xdsl.parser import Parser
+from xdsl.passes import ModulePass, PipelinePass, get_pass_argument_names_and_types
+from xdsl.printer import Printer
+from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
+
+from ._pasteboard import pyclip_copy
+
+class OutputTextArea(TextArea):
+    """Used to prevent users from being able to alter the Output TextArea."""
+
+    async def _on_key(self, event: events.Key) -> None:
+        event.prevent_default()
+
+class MLIRApp(App[None]):   
+    """
+    Interactive application for constructing compiler pipelines.
+    """
+
+    CSS_PATH = "app.tcss"
+
+    BINDINGS = [
+        ("d", "toggle_dark", "Toggle dark mode"),
+        ("q", "quit_app", "Quit"),
+    ]
+
+    SCREENS: ClassVar[dict[str, type[Screen[Any]] | Callable[[], Screen[Any]]]] = {
+        "load_file": LoadFile,
+        "add_arguments_screen": AddArguments,
+    }
+    """
+    A dictionary that maps names on to Screen objects.
+    """
+
+    INITIAL_IR_TEXT = """builtin.module {
+    func.func @hello(%n : i32) -> i32 {
+        %b = arith.addi %n, %n : i32
+        %c = arith.muli %b, %b : i32
+        func.return %b : i32
+    }
+}
+    """
+
+    all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...]
+    """A dictionary of (uninstantiated) dialects."""
+    all_passes: tuple[str, ...]
+    """A dictionary of MLIR passes."""
+    pass_pipeline = reactive(tuple[str, ...])
+    """Reactive variable that saves the list of selected passes."""
+
+    current_module = reactive[ModuleOp | Exception | None](None)
+    """
+    Reactive variable used to save the current state of the modified Input TextArea
+    (i.e. is the Output TextArea).
+    """
+
+
+    input_text_area: TextArea
+    """Input TextArea."""
+    output_text_area: OutputTextArea
+    """Output TextArea."""
+    selected_passes_list_view: ListView
+    """"ListView displaying the selected passes."""
+    passes_tree: Tree[str]
+    """Tree displaying the passes available to apply."""
+    
+    pre_loaded_input_text: str
+    current_file_path: str
+
+    def __init__(
+        self,
+        # all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...],
+        # all_passes: tuple[str, ...],
+        file_path: str | None = None,
+        input_text: str | None = None,
+    ):
+        self.all_dialects = tuple(get_all_dialects().items())
+        self.all_passes = sorted(get_mlir_pass_list())
+                
+        if file_path is None:
+            self.current_file_path = ""
+        else:
+            self.current_file_path = file_path
+
+        if input_text is None:
+            self.pre_loaded_input_text = MLIRApp.INITIAL_IR_TEXT
+        else:
+            self.pre_loaded_input_text = input_text
+        super().__init__()
+
+    def compose(self) -> ComposeResult:
+        """
+        Creates the required widgets, events, etc.
+        """
+        self.input_text_area = TextArea(id="input")
+        self.output_text_area = OutputTextArea(id="output")
+        self.selected_passes_list_view = ListView(id="selected_passes_list_view")
+        self.passes_tree = Tree(label="mlir-opt", id="passes_tree")
+        self.passes_tree.expand = False
+
+        with Horizontal(id="top_container"):
+            with Vertical(id="veritcal_tree_selected_passes_list_view"):
+                yield self.selected_passes_list_view
+                yield self.passes_tree
+            with ScrollableContainer(id="buttons"):
+                yield Button("Copy Query", id="copy_query_button")
+                yield Button("Clear Passes", id="clear_passes_button")
+                yield Button("Remove Last Pass", id="remove_last_pass_button")
+        with Horizontal(id="bottom_container"):
+            with Horizontal(id="input_horizontal_container"):
+                with Vertical(id="input_container"):
+                    yield self.input_text_area
+                    with Horizontal(id="input_horizontal"):
+                        yield Button("Clear Input", id="clear_input_button")
+                        yield Button("Load File", id="load_file_button")
+
+            with Horizontal(id="output_horizontal_container"):
+                with Vertical(id="output_container"):
+                    yield self.output_text_area
+                    yield Button("Copy Output", id="copy_output_button")
+        yield Footer()
+
+
+    def on_mount(self) -> None:
+        """Configure widgets in this application before it is first shown."""
+        # Registers the theme for the Input/Output TextAreas
+        self.input_text_area.theme = "vscode_dark"
+        self.output_text_area.theme = "vscode_dark"
+
+        # add titles for various widgets
+        self.query_one("#input_container").border_title = "Input MLIR IR"
+        self.query_one("#output_container").border_title = "Output MLIR IR"
+        
+        # initialize Tree to contain the pass options
+        for pass_name in self.all_passes:
+            self.passes_tree.root.add(
+                label=pass_name,
+                data=(pass_name, None),
+            )
+
+        # initialize GUI with either specified input text or default example
+        self.input_text_area.load_text(self.pre_loaded_input_text)
+    
+    def expand_node(
+        self,
+        expanded_pass: TreeNode[tuple[str, ...]],
+        child_pass_list: tuple[str, ...],
+    ) -> None:
+        """
+        Helper function that adds a subtree to a node, i.e. adds a sub-tree containing the child_pass_list with expanded_pass as the root.
+        """
+        # remove potential children nodes in case expand node has been clicked multiple times on the same node
+        expanded_pass.remove_children()
+
+        for pass_name in child_pass_list:
+            expanded_pass.add(
+                label=pass_name,
+                data=(pass_name, None),
+            )
+
+    def update_root_of_passes_tree(self) -> None:
+        """
+        Helper function that updates the passes_tree by first resetting the root (to be
+        either the "." root if the pass_pipeline is empty or to the last selected pass) and
+        updates the subtree of the root.
+        """
+        # reset rootnode  of tree
+        if self.pass_pipeline == ():
+            self.passes_tree.reset(".")
+        else:
+            value = self.pass_pipeline[-1]
+            self.passes_tree.reset(
+                label=str(value),
+                data=(value, None),
+            )
+        # expand the node
+        self.expand_node(self.passes_tree.root, sorted(self.all_passes))
+
+
+    def update_selected_passes_list_view(self) -> None:
+        """
+        Helper function that updates the selected passes ListView to display the passes in pass_pipeline.
+        """
+        self.selected_passes_list_view.clear()
+        if len(self.pass_pipeline) >= 1:
+            self.selected_passes_list_view.append(ListItem(Label("mlir-opt"), name="."))
+
+        if not self.pass_pipeline:
+            return
+
+        # last element is the node of the tree
+        pass_pipeline = self.pass_pipeline[:-1]
+        for pass_value in pass_pipeline:
+            self.selected_passes_list_view.append(
+                ListItem(Label(str(pass_value)), name = pass_value)
+            )
+
+
+    @on(TextArea.Changed, "#input")
+    def update_current_module(self) -> None:
+        """
+        Function to parse the input and to apply the list of selected passes to it.
+        """
+        input_text = self.input_text_area.text
+        if (input_text) == "":
+            self.current_module = None
+            self.current_get_condensed_list = ()
+            return
+        try:
+            ctx = get_new_registered_context(self.all_dialects)
+            parser = Parser(ctx, input_text)
+            module = parser.parse_module()
+            current_spec = generate_mlir_pass_spec(self.pass_pipeline)
+            if current_spec is None:
+                self.current_module = module #$
+            else: 
+                self.current_module = apply_mlir_pass_with_args_to_module(
+                    module, ctx, current_spec
+                )
+                self.current_module = module 
+        except Exception as e:
+            self.current_module = e
+
+    def watch_current_module(self):
+        """
+        Function called when the reactive variable current_module changes - updates the
+        Output TextArea.
+        """
+        match self.current_module:
+            case None:
+                output_text = "No input"
+            case Exception() as e:
+                output_stream = StringIO()
+                Printer(output_stream).print(e)
+                output_text = output_stream.getvalue()
+            case ModuleOp():
+                output_stream = StringIO()
+                Printer(output_stream).print(self.current_module)
+                output_text = output_stream.getvalue()
+
+        self.output_text_area.load_text(output_text)
+
+
+    def watch_pass_pipeline(self) -> None:
+        """
+        Function called when the reactive variable pass_pipeline changes - updates the
+        label to display the respective generated query in the Label.
+        """
+        self.update_selected_passes_list_view()
+        self.update_root_of_passes_tree()
+        self.update_current_module()
+
+    def get_pass_arguments(
+        self,
+        selected_pass_value: type[ModulePass],
+    ) -> None:
+        """
+        This function facilitates user input of pass concatenated_arg_val by navigating
+        to the AddArguments screen, and subsequently parses the returned string upon
+        screen dismissal and appends the pass to the pass_pipeline variable.
+        """
+
+        def add_pass_with_arguments_to_pass_pipeline(
+            concatenated_arg_val: str | None,
+        ) -> None:
+            """
+            Called when AddArguments Screen is dismissed. This function attempts to parse
+            the returned string, and if successful, adds it to the pass_pipeline variable.
+            In case of parsing failure, the AddArguments Screen is pushed, revealing the
+            Parse Error.
+            """
+            try:
+                # if screen was dismissed and user 1) cleared the screen 2) made no changes
+                if concatenated_arg_val is None:
+                    return
+                
+                self.pass_pipeline = (
+                    *self.pass_pipeline,
+                    concatenated_arg_val
+                )
+                return
+
+            except PassPipelineParseError as e:
+                error = f"PassPipelineParseError: {e}"
+
+            screen = AddArguments(TextArea(error, id="argument_text_area"))
+            self.push_screen(screen, add_pass_with_arguments_to_pass_pipeline)
+
+        # generates a string containing the concatenated_arg_val and types of the selected pass and initializes the AddArguments Screen to contain the string
+        self.push_screen(
+            AddArguments(
+                TextArea(
+                    selected_pass_value,
+                    id="argument_text_area",
+                )
+            ),
+            add_pass_with_arguments_to_pass_pipeline,
+        )
+
+    @on(Tree.NodeSelected, "#passes_tree")
+    def update_pass_pipeline(
+        self, event: Tree.NodeSelected[tuple[str, ...]]
+    ) -> None:
+        """
+        When a new selection is made, the reactive variable storing the list of selected
+        passes is updated.
+        """
+        selected_pass = event.node
+        if selected_pass.data is None:
+            return
+
+        # block ability to select root (i.e. add root pass to the pipeline)
+        if selected_pass.is_root:
+            return
+
+        # get instance
+        selected_pass_value, selected_pass_spec = selected_pass.data
+
+        if "=" in selected_pass_value:
+            # Add pass with arguments to pass pipeline
+            self.get_pass_arguments(
+                selected_pass_value
+            )
+
+        else: # Add pass without arguments to pass pipeline
+            self.pass_pipeline = (
+                *self.pass_pipeline,
+                selected_pass_value
+            )
+
+    def get_query_string(self) -> str:
+        """
+        Function returning a string containing the textual description of the pass
+        pipeline generated thus far.
+        """
+        if self.current_file_path == "":
+            query = "-p "
+        else:
+            query = self.current_file_path + " -p "
+
+        if self.pass_pipeline:
+            query += " ".join(val for 
+               val in self.pass_pipeline
+            )
+        return f"mlir-opt {query}"
+
+    def action_toggle_dark(self) -> None:
+        """An action to toggle dark mode."""
+        self.theme = (
+            "textual-dark" if self.theme == "textual-light" else "textual-light"
+        )
+
+    def action_quit_app(self) -> None:
+        """An action to quit the app."""
+        self.exit()
+
+    @on(Button.Pressed, "#clear_input_button")
+    def clear_input(self, event: Button.Pressed) -> None:
+        """Input TextArea is cleared when "Clear Input" button is pressed."""
+        self.input_text_area.clear()
+
+    @on(Button.Pressed, "#copy_output_button")
+    def copy_output(self, event: Button.Pressed) -> None:
+        """Output TextArea is copied when "Copy Output" button is pressed."""
+        pyclip_copy(self.output_text_area.text)
+
+    @on(Button.Pressed, "#copy_query_button")
+    def copy_query(self, event: Button.Pressed) -> None:
+        """Selected passes/query Label is copied when "Copy Query" button is pressed."""
+        pyclip_copy(self.get_query_string())
+
+    @on(Button.Pressed, "#clear_passes_button")
+    def clear_passes(self, event: Button.Pressed) -> None:
+        """Selected passes cleared when "Clear Passes" button is pressed."""
+        self.pass_pipeline = tuple[str, ...]()
+
+    @on(Button.Pressed, "#remove_last_pass_button")
+    def remove_last_pass(self, event: Button.Pressed) -> None:
+        """Last selected pass removed when "Remove Last Pass" button is pressed."""
+        self.pass_pipeline = self.pass_pipeline[:-1]
+
+    @on(Button.Pressed, "#load_file_button")
+    def load_file(self, event: Button.Pressed) -> None:
+        """
+        Pushes screen displaying DirectoryTree widget when "Load File" button is pressed.
+        """
+
+        def check_load_file(file_path: str | None) -> None:
+            """
+            Called when LoadFile is dismissed. Loads selected file into
+            input_text_area.
+            """
+            if file_path is None:
+                return
+
+            # Clear Input TextArea and Pass Pipeline
+            self.pass_pipeline = ()
+            self.input_text_area.clear()
+
+            try:
+                if os.path.exists(file_path):
+                    # Open the file and read its contents
+                    with open(file_path) as file:
+                        file_contents = file.read()
+                        self.input_text_area.load_text(file_contents)
+                    self.current_file_path = file_path
+                else:
+                    self.input_text_area.load_text(
+                        f"The file '{file_path}' does not exist."
+                    )
+            except Exception as e:
+                self.input_text_area.load_text(str(e))
+
+        self.push_screen("load_file", check_load_file)
+
+
+def main():
+    return MLIRApp(
+        None, None).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/xdsl/interactive/mlirapp.py
+++ b/xdsl/interactive/mlirapp.py
@@ -221,7 +221,7 @@ class MLIRApp(App[None]):
                 data=value,
             )
         # expand the node
-        self.expand_node(self.passes_tree.root, sorted(self.all_passes))
+        self.expand_node(self.passes_tree.root, self.all_passes)
 
     def update_selected_passes_list_view(self) -> None:
         """
@@ -450,7 +450,7 @@ def main():
         "input_file", type=str, nargs="?", help="path to input file"
     )
 
-    available_passes = ",".join([name for name in sorted(get_mlir_pass_list())])
+    available_passes = ",".join([name for name in get_mlir_pass_list()])
     arg_parser.add_argument(
         "-p",
         "--passes",
@@ -470,7 +470,7 @@ def main():
         file_contents = None
 
     pass_spec_pipeline = list(parse_pipeline(args.passes))
-    pass_list = sorted(get_mlir_pass_list())
+    pass_list = get_mlir_pass_list()
     pipeline = tuple(PipelinePass.build_pipeline_tuples(pass_list, pass_spec_pipeline))
 
     return MLIRApp(


### PR DESCRIPTION
This is a first attempt at creating an mlir-gui. I would like to upstream it (still figuring out whether to do that in this repo or in the mlir repo). Open to feedback/advice from anyone interested :)

It is very similar to xdsl-gui, with some changes: 
- only executes `mlir-opt --passes` , no xdsl-passes
- displays the list of available mlir-opt passes via parsing the output of `mlir-opt --help' (rather ugly way to get the mlir passes, if I upstream it, will make it more fancy)
- condense button not there anymore
- requires mlir-opt to be on your PATH
- call `mlir-gui` in terminal to get it :)

<img width="1116" alt="Screenshot 2024-12-22 at 16 34 11" src="https://github.com/user-attachments/assets/39e544c8-886d-4e39-9790-bd96bc30caa8" />

Some open questions: 
- should it be connected to xdsl-gui with a button (users can flip between xdsl-gui app and mlir-gui app)? 
- does it belong in the xdsl repo?

Note: It is not perfect and has some errors if you search hard enough (especially with pass selection)! Still needs work, this is just version 1 :)