### PR TITLE
core: fix attributes to func outputs

### DIFF
--- a/tests/filecheck/dialects/func/func_ops.mlir
+++ b/tests/filecheck/dialects/func/func_ops.mlir
@@ -81,4 +81,14 @@ builtin.module {
   // CHECK-NEXT:    %r1, %r2 = "test.op"() : () -> (f32, f32)
   // CHECK-NEXT:    func.return %r1, %r2 : f32, f32
   // CHECK-NEXT:  }
+
+  func.func @output_attribute_single() -> (f32 {dialect.a = 0 : i32}) {
+    %r1 = "test.op"() : () -> (f32)
+    return %r1: f32
+  }
+
+  // CHECK:       func.func @output_attribute_single() -> (f32 {"dialect.a" = 0 : i32}) {
+  // CHECK-NEXT:    %r1 = "test.op"() : () -> f32
+  // CHECK-NEXT:    func.return %r1 : f32
+  // CHECK-NEXT:  }
 }

--- a/xdsl/dialects/utils/format.py
+++ b/xdsl/dialects/utils/format.py
@@ -61,7 +61,7 @@ def print_func_op_like(
         printer.print(") ")
         if function_type.outputs:
             printer.print("-> ")
-            if len(function_type.outputs) > 1:
+            if len(function_type.outputs) > 1 or res_attrs is not None:
                 printer.print("(")
             if res_attrs is not None:
                 printer.print_list(
@@ -72,7 +72,7 @@ def print_func_op_like(
                 )
             else:
                 printer.print_list(function_type.outputs, printer.print_attribute)
-            if len(function_type.outputs) > 1:
+            if len(function_type.outputs) > 1 or res_attrs is not None:
                 printer.print(")")
             printer.print(" ")
     else:


### PR DESCRIPTION
There is a bug when we want to print a single output parameter with attributes - it still needs to be enclosed in braces.