### PR TITLE
transformations: (mlir-opt) separate mlir-opt pass errors

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/mlir_opt_fail.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p mlir-opt{arguments='--hello','--mlir-print-op-generic'} --print-op-generic --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt %s -p mlir-opt{arguments='--hello','--mlir-print-op-generic'} --print-op-generic --verify-diagnostics | filecheck %s --check-prefix=CHECK-PARSING
 // RUN: xdsl-opt %s -p mlir-opt[this-probably-will-never-be-an-MLIR-pass-name] --print-op-generic --verify-diagnostics | filecheck %s
 // RUN: xdsl-opt %s -p mlir-opt{executable='"false"'} --print-op-generic --verify-diagnostics | filecheck %s
 
@@ -10,4 +10,5 @@
 }) : () -> ()
 
 
-// CHECK:         Error executing mlir-opt pass
+// CHECK-PARSING:         Error parsing mlir-opt pass output
+// CHECK:                 Error executing mlir-opt pass


### PR DESCRIPTION
We currently have two statements that can raise an error when calling out to `mlir-opt`, one for errors the executable raises, the other for parsing in xDSL, these should be reported separately.