### PR TITLE
core: Let inferrable constraints solve variables

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2450,7 +2450,7 @@ def test_non_verifying_inference():
 
 def test_variadic_length_inference():
     @irdl_op_definition
-    class RangeVarOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
+    class RangeVarOp(IRDLOperation):
         name = "test.range_var"
         T: ClassVar = RangeVarConstraint("T", RangeOf(AnyAttr()))
         ins = var_operand_def(T)
@@ -2475,7 +2475,7 @@ def test_variadic_length_inference():
 
 def test_range_var_inference():
     @irdl_op_definition
-    class RangeVarOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
+    class RangeVarOp(IRDLOperation):
         name = "test.range_var"
         T: ClassVar = RangeVarConstraint("T", RangeOf(EqAttrConstraint(IndexType())))
         ins = var_operand_def(T)


### PR DESCRIPTION
Allows an inferrable type to solve other variables, and further allows range variable constraints to be solved if the underlying constraint is inferrable. Includes a test with the motivating example.

Currently this is restricted to when the underlying constraint can be inferred using no variables, and so is likely only useful for the scenario in the test. Anything more involved would be a fair bit more complex.

I also have a branch somewhere with a draft implementation of "length variables", which would probably achieve a similar thing to this PR (and could potentially be extended to be more powerful). Would be good to hear people's thoughts on whether this would be preferable instead of this (slightly hacky) solution.