### PR TITLE
interpreter: (riscv) return raw ptr for dense array inputs

### DIFF
--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -374,9 +374,12 @@ def test_values():
     interpreter.register_implementations(riscv_functions)
     assert interpreter.value_for_attribute(IntegerAttr(1, i32), riscv.Registers.A0) == 1
 
-    assert interpreter.value_for_attribute(
-        DenseIntOrFPElementsAttr.create_dense_int(
-            TensorType(i32, [2, 3]), list(range(6))
-        ),
-        riscv.Registers.A0,
-    ) == TypedPtr.new_int32(list(range(6)))
+    assert (
+        interpreter.value_for_attribute(
+            DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(i32, [2, 3]), tuple(range(6))
+            ),
+            riscv.Registers.A0,
+        )
+        == TypedPtr.new_int32(tuple(range(6))).raw
+    )

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -613,6 +613,6 @@ class RiscvFunctions(InterpreterFunctions):
                         attr.get_element_type(), interpreter.index_bitwidth
                     ),
                 )
-                return data_ptr
+                return data_ptr.raw
             case _:
                 interpreter.raise_error(f"Unknown value type for int register: {attr}")


### PR DESCRIPTION
This isn't yet exercised anywhere apart from this unit test, but it's incorrect, we operate on RawPtr objects at the riscv level, not TypedPtr.