### PR TITLE
documentation: (marimo) move pipeline_html helper to utils

### DIFF
--- a/docs/marimo/onnx/onnx_demo.py
+++ b/docs/marimo/onnx/onnx_demo.py
@@ -175,8 +175,9 @@ def _(
     mo,
     xmo,
 ):
-    bufferized_module, linalg_html = xmo.pipeline_html(
+    bufferized_ctx, bufferized_module, linalg_html = xmo.pipeline_html(
         ctx,
+        init_module,
         (
             (
                 mo.md(
@@ -213,8 +214,7 @@ def _(
                     ]
                 )
             )
-        ),
-        init_module
+        )
     )
 
     linalg_html

--- a/xdsl/utils/marimo.py
+++ b/xdsl/utils/marimo.py
@@ -33,8 +33,8 @@ def _spec_str(p: ModulePass) -> str:
 
 
 def pipeline_html(
-    ctx: MLContext, passes: Sequence[tuple[mo.Html, ModulePass]], module: ModuleOp
-) -> tuple[ModuleOp, mo.Html]:
+    ctx: MLContext, module: ModuleOp, passes: Sequence[tuple[mo.Html, ModulePass]]
+) -> tuple[MLContext, ModuleOp, mo.Html]:
     """
     Returns a tuple of the resulting module after applying the passes, and the
     Marimo-optimised representation of the modules throughout compilation.
@@ -64,4 +64,4 @@ def pipeline_html(
                 )
             )
         )
-    return (res, mo.carousel(d))
+    return (ctx, res, mo.carousel(d))

--- a/xdsl/utils/marimo.py
+++ b/xdsl/utils/marimo.py
@@ -1,6 +1,11 @@
+from collections import Counter
+from collections.abc import Sequence
+
 import marimo as mo
 
+from xdsl.context import MLContext
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.passes import ModulePass, PipelinePass
 
 
 def asm_html(asm: str) -> mo.Html:
@@ -15,3 +20,48 @@ def module_html(module: ModuleOp) -> mo.Html:
     Returns a Marimo-optimised representation of the module passed in.
     """
     return mo.ui.code_editor(str(module), language="javascript", disabled=True)
+
+
+def _spec_str(p: ModulePass) -> str:
+    """
+    A string representation of the pass passed in, to display to the user.
+    """
+    if isinstance(p, PipelinePass):
+        return ",".join(str(c.pipeline_pass_spec()) for c in p.passes)
+    else:
+        return str(p.pipeline_pass_spec())
+
+
+def pipeline_html(
+    ctx: MLContext, passes: Sequence[tuple[mo.Html, ModulePass]], module: ModuleOp
+) -> tuple[ModuleOp, mo.Html]:
+    """
+    Returns a tuple of the resulting module after applying the passes, and the
+    Marimo-optimised representation of the modules throughout compilation.
+
+    The input is the input MLContext, a sequence of tuples of optional
+    """
+    res = module.clone()
+    ctx = ctx.clone()
+    d: list[mo.Html] = []
+    total_key_count = Counter(_spec_str(p) for _, p in passes)
+    d_key_count = Counter[str]()
+    for text, p in passes:
+        p.apply(ctx, res)
+        spec = _spec_str(p)
+        d_key_count[spec] += 1
+        if total_key_count[spec] != 1:
+            header = f"{spec} ({d_key_count[spec]})"
+        else:
+            header = spec
+        html_res = module_html(res)
+        d.append(
+            mo.vstack(
+                (
+                    header,
+                    text,
+                    html_res,
+                )
+            )
+        )
+    return (res, mo.carousel(d))


### PR DESCRIPTION
Creates a unified way of presenting the intermediate stages of compilation in the marimo notebooks, together with optional descriptions of what's happening. I'm not super happy with the way it's presented right now, but we can iterate on it once it's in, and all the notebooks will benefit from it at the same time. I'm relatively sure that this API is all we need, but we can change it later also.