### PR TITLE
transformations: (memref-stream-interleave) always take bigger factor

### DIFF
--- a/xdsl/transforms/memref_stream_interleave.py
+++ b/xdsl/transforms/memref_stream_interleave.py
@@ -150,7 +150,7 @@ class MemrefStreamInterleavePass(ModulePass):
     The pass will select the largest factor of the corresponding bound smaller than
     `pipeline-depth * 2`.
     The search range is bound by `pipeline-depth * 2` as very large interleaving factors
-    would cause too much register pressure, potentially running out of registers.
+    can increase register pressure and potentially exhaust all available registers.
     In the future, it would be good to take the number of available registers into account
     when choosing a search range, as well as inspecting the generic body for
     read-after-write dependencies.


### PR DESCRIPTION
When I initially implemented this pass, I assumed that it was better to err on the side of caution, to take the smallest factor above 3. In practice, this isn't the best approach, as a factor of 4 is only good in the scenario with no function cache misses, and it's a safer bet to take bigger values if possible. We also learned from the Snitch backend paper experiments that the register pressure never goes close to the limit for the kernels we care about, so this should not be that risky.

My understanding is that this change is what @zero9178 implemented in Quidditch already.

I'm currently working on automatically pruning the space of possible values, and merging this PR would help keep the logic relatively simple, while sharing some helpers between this heurist-based pass, and the new compile-and-evaluate-based-pass.