### PR TITLE
interactive: store passes in app instead of class+spec tuples

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -28,7 +28,7 @@ from xdsl.transforms import (
 )
 from xdsl.transforms.experimental.dmp import stencil_global_to_local
 from xdsl.utils.exceptions import ParseError
-from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
+from xdsl.utils.parse_pipeline import parse_pipeline
 
 
 @pytest.mark.asyncio
@@ -167,18 +167,12 @@ async def test_buttons():
         # Select two passes
         app.pass_pipeline = (
             *app.pass_pipeline,
-            (
-                convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass,
-                PipelinePassSpec(name="convert-func-to-riscv-func", args={}),
-            ),
+            convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass(),
         )
 
         app.pass_pipeline = (
             *app.pass_pipeline,
-            (
-                convert_arith_to_riscv.ConvertArithToRiscvPass,
-                PipelinePassSpec(name="convert-arith-to-riscv", args={}),
-            ),
+            convert_arith_to_riscv.ConvertArithToRiscvPass(),
         )
 
         # assert that pass selection affected Output Text Area
@@ -350,13 +344,8 @@ async def test_rewrites():
         # Select a rewrite
         app.pass_pipeline = (
             *app.pass_pipeline,
-            (
-                individual_rewrite.ApplyIndividualRewritePass,
-                list(
-                    parse_pipeline(
-                        'apply-individual-rewrite{matched_operation_index=3 operation_name="arith.addi" pattern_name="SignlessIntegerBinaryOperationZeroOrUnitRight"}'
-                    )
-                )[0],
+            individual_rewrite.ApplyIndividualRewritePass(
+                3, "arith.addi", "SignlessIntegerBinaryOperationZeroOrUnitRight"
             ),
         )
 
@@ -414,10 +403,7 @@ async def test_passes():
         # Select a pass
         app.pass_pipeline = (
             *app.pass_pipeline,
-            (
-                convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass,
-                PipelinePassSpec(name="convert-func-to-riscv-func", args={}),
-            ),
+            convert_func_to_riscv_func.ConvertFuncToRiscvFuncPass(),
         )
         # assert that the Output Text Area has changed accordingly
         await pilot.pause()

--- a/tests/interactive/test_get_all_available_passes.py
+++ b/tests/interactive/test_get_all_available_passes.py
@@ -68,12 +68,7 @@ def test_get_all_available_passes():
         tuple((p.name, p) for p in (ABPass, ACPass, BCPass, BDPass)),
         '"test.op"() {key="a"} : () -> ()',
         # Transforms the above op from "a" to "b" before testing passes
-        (
-            (
-                ABPass,
-                PipelinePassSpec(name="ab", args={}),
-            ),
-        ),
+        (ABPass(),),
         condense_mode=True,
         rewrite_by_names_dict={
             "test.op": {

--- a/xdsl/interactive/get_all_available_passes.py
+++ b/xdsl/interactive/get_all_available_passes.py
@@ -11,14 +11,13 @@ from xdsl.ir import Dialect
 from xdsl.parser import Parser
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import RewritePattern
-from xdsl.utils.parse_pipeline import PipelinePassSpec
 
 
 def get_available_pass_list(
     all_dialects: tuple[tuple[str, Callable[[], Dialect]], ...],
     all_passes: tuple[tuple[str, type[ModulePass]], ...],
     input_text: str,
-    pass_pipeline: tuple[tuple[type[ModulePass], PipelinePassSpec], ...],
+    pass_pipeline: tuple[ModulePass, ...],
     condense_mode: bool,
     rewrite_by_names_dict: dict[str, dict[str, RewritePattern]],
 ) -> tuple[AvailablePass, ...]:

--- a/xdsl/interactive/passes.py
+++ b/xdsl/interactive/passes.py
@@ -35,17 +35,13 @@ def get_new_registered_context(
 def apply_passes_to_module(
     module: builtin.ModuleOp,
     ctx: MLContext,
-    pass_pipeline: tuple[tuple[type[ModulePass], PipelinePassSpec], ...],
+    passes: tuple[ModulePass, ...],
 ) -> builtin.ModuleOp:
     """
-    Function that takes a ModuleOp, an MLContext and a pass_pipeline (consisting of a type[ModulePass] and PipelinePassSpec), applies the pass(es) to the ModuleOp and returns the new ModuleOp.
+    Function that takes a ModuleOp, an MLContext and a pass_pipeline, applies the
+    passes to the ModuleOp and returns the modified ModuleOp.
     """
-    pipeline = PipelinePass(
-        passes=tuple(
-            module_pass.from_pass_spec(pipeline_pass_spec)
-            for module_pass, pipeline_pass_spec in pass_pipeline
-        )
-    )
+    pipeline = PipelinePass(passes=passes)
     pipeline.apply(ctx, module)
     return module
 


### PR DESCRIPTION
This part of the code was written when passes were not yet immutable, so it was important to be able to reinitialize them each time. Now that they are immutable, we can store them directly and avoid the initialization work.

I didn't want to migrate everything in one go, but the tree is still in terms of class + spec pairs, once this PR is merged I can open the PR migrating that part of the codebase.