### PR TITLE
CI: update ruff to 0.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.3
+    rev: v0.9.0
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]

--- a/docs/Toy/toy/frontend/toy_ast.py
+++ b/docs/Toy/toy/frontend/toy_ast.py
@@ -250,7 +250,7 @@ class PrototypeAST:
 
     def inner_dump(self, prefix: str, dumper: Dumper):
         dumper.append("", f"Proto '{self.name}' @{self.loc}")
-        dumper.append("Params: ", f'[{", ".join(arg.name for arg in self.args)}]')
+        dumper.append("Params: ", f"[{', '.join(arg.name for arg in self.args)}]")
 
 
 @dataclass

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -87,12 +87,12 @@ def build_affine_for(
     `body_builder_fn` is used to build the body of affine.for.
     """
 
-    assert (
-        len(lb_operands) == lb_map.num_dims
-    ), "lower bound operand count does not match the affine map"
-    assert (
-        len(ub_operands) == ub_map.num_dims
-    ), "upper bound operand count does not match the affine map"
+    assert len(lb_operands) == lb_map.num_dims, (
+        "lower bound operand count does not match the affine map"
+    )
+    assert len(ub_operands) == ub_map.num_dims, (
+        "upper bound operand count does not match the affine map"
+    )
     assert step > 0, "step has to be a positive integer constant"
 
     # Create a region and a block for the body.
@@ -440,9 +440,9 @@ class PrintOpLowering(RewritePattern):
 class ReturnOpLowering(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: toy.ReturnOp, rewriter: PatternRewriter):
-        assert (
-            op.input is None
-        ), "During this lowering, we expect that all function calls have been inlined."
+        assert op.input is None, (
+            "During this lowering, we expect that all function calls have been inlined."
+        )
 
         rewriter.replace_matched_op(func.ReturnOp())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "lit<19.0.0",
     "marimo==0.10.9",
     "pre-commit==4.0.1",
-    "ruff==0.8.6",
+    "ruff==0.9.0",
     "asv<0.7",
     "nbconvert>=7.7.2,<8.0.0",
     "textual-dev==1.7.0",

--- a/tests/dialects/stim/test_stim_printer_parser.py
+++ b/tests/dialects/stim/test_stim_printer_parser.py
@@ -87,7 +87,7 @@ def test_print_stim_qubit_coord_op():
 
 @pytest.mark.parametrize(
     "program",
-    [(""), ("\n"), ("#hi"), ("# hi \n" "#hi\n")],
+    [(""), ("\n"), ("#hi"), ("# hi \n#hi\n")],
 )
 def test_stim_roundtrip_empty_circuit(program: str):
     stim_parser = StimParser(program)
@@ -101,7 +101,7 @@ def test_stim_roundtrip_empty_circuit(program: str):
         ("QUBIT_COORDS() 0\n"),
         ("QUBIT_COORDS(0, 0) 0\n"),
         ("QUBIT_COORDS(0, 2) 1\n"),
-        ("QUBIT_COORDS(0, 0) 0\n" "QUBIT_COORDS(1, 2) 2\n"),
+        ("QUBIT_COORDS(0, 0) 0\nQUBIT_COORDS(1, 2) 2\n"),
     ],
 )
 def test_stim_roundtrip_qubit_coord_op(program: str):

--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -261,16 +261,16 @@ def test_inner_symbol_table_collection():
 
     sym_table1 = inner_sym_tables.get_inner_symbol_table(mod1)
     sym_table2 = inner_sym_tables.get_inner_symbol_table(mod2)
-    assert (
-        sym_table1 is not sym_table2
-    ), "Different InnerSymbolTableTrait objects must return different instances of inner symbol tables"
+    assert sym_table1 is not sym_table2, (
+        "Different InnerSymbolTableTrait objects must return different instances of inner symbol tables"
+    )
 
     unpopulated_inner_sym_tables = InnerSymbolTableCollection()
     sym_table3 = unpopulated_inner_sym_tables.get_inner_symbol_table(mod1)
     sym_table4 = unpopulated_inner_sym_tables.get_inner_symbol_table(mod2)
-    assert (
-        sym_table3 is not sym_table4
-    ), "InnerSymbolTableTrait still behave as expected when created on the fly"
+    assert sym_table3 is not sym_table4, (
+        "InnerSymbolTableTrait still behave as expected when created on the fly"
+    )
 
 
 def test_inner_ref_attr():
@@ -288,9 +288,9 @@ def test_inner_ref_attr():
     CircuitOp(attributes={"sym_name": StringAttr("circuit")}, regions=[[mod1, mod2]])
 
     ref = InnerRefAttr("mod2", "wire2")
-    assert (
-        ref.get_module().data == "mod2"
-    ), "Name of the referenced module should be returned correctly"
+    assert ref.get_module().data == "mod2", (
+        "Name of the referenced module should be returned correctly"
+    )
 
 
 def test_inner_sym_attr():
@@ -298,14 +298,14 @@ def test_inner_sym_attr():
     Test inner symbol attributes
     """
     invalid_sym_attr = InnerSymAttr()
-    assert (
-        invalid_sym_attr.get_sym_name() is None
-    ), "Invalid InnerSymAttr should return no name"
+    assert invalid_sym_attr.get_sym_name() is None, (
+        "Invalid InnerSymAttr should return no name"
+    )
 
     sym_attr = InnerSymAttr("sym")
-    assert sym_attr.get_sym_name() == StringAttr(
-        "sym"
-    ), "InnerSymAttr for “ground” type should return name"
+    assert sym_attr.get_sym_name() == StringAttr("sym"), (
+        "InnerSymAttr for “ground” type should return name"
+    )
 
     with pytest.raises(VerifyException, match=r"inner symbol cannot have empty name"):
         InnerSymAttr("")
@@ -318,22 +318,22 @@ def test_inner_sym_attr():
         ]
     )
 
-    assert aggregate_sym_attr.get_sym_name() == StringAttr(
-        "sym"
-    ), "InnerSymAttr for aggregate types should return name with field ID 0"
+    assert aggregate_sym_attr.get_sym_name() == StringAttr("sym"), (
+        "InnerSymAttr for aggregate types should return name with field ID 0"
+    )
 
     for inner, expected_field_id in zip(aggregate_sym_attr, [0, 1, 2]):
-        assert (
-            inner.field_id.data == expected_field_id
-        ), "InnerSymAttr should allow iterating its properties in order"
+        assert inner.field_id.data == expected_field_id, (
+            "InnerSymAttr should allow iterating its properties in order"
+        )
 
     aggregate_without_nested = aggregate_sym_attr.erase(2)
-    assert (
-        aggregate_without_nested.get_sym_if_exists(2) is None
-    ), "InnerSymAttr removal should work"
-    assert (
-        len(aggregate_without_nested) == 2
-    ), "InnerSymAttr removal should correctly change length"
+    assert aggregate_without_nested.get_sym_if_exists(2) is None, (
+        "InnerSymAttr removal should work"
+    )
+    assert len(aggregate_without_nested) == 2, (
+        "InnerSymAttr removal should correctly change length"
+    )
 
 
 def test_instance_builder():

--- a/tests/dialects/test_mpi_lowering.py
+++ b/tests/dialects/test_mpi_lowering.py
@@ -30,9 +30,9 @@ def check_emitted_function_signature(
     for arg, arg_type in zip(call.arguments, types):
         # check that the argument type is correct (if constraint present)
         if arg_type is not None:
-            assert isinstance(
-                arg.type, arg_type
-            ), f"Expected argument to be of type {arg_type} (got {arg.type} instead)"
+            assert isinstance(arg.type, arg_type), (
+                f"Expected argument to be of type {arg_type} (got {arg.type} instead)"
+            )
 
 
 @irdl_op_definition

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -769,15 +769,13 @@ def test_operands_duplicated_type():
     [
         (
             "$lhs $rhs type($lhs) type($rhs) attr-dict",
-            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
-            "test.two_operands %0 %1 i32 i64",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\ntest.two_operands %0 %1 i32 i64',
             '%0, %1 = "test.op"() : () -> (i32, i64)\n'
             '"test.two_operands"(%0, %1) : (i32, i64) -> ()',
         ),
         (
             "$rhs $lhs type($rhs) type($lhs) attr-dict",
-            '%0, %1 = "test.op"() : () -> (i32, i64)\n'
-            "test.two_operands %1 %0 i64 i32",
+            '%0, %1 = "test.op"() : () -> (i32, i64)\ntest.two_operands %1 %0 i64 i32',
             '%0, %1 = "test.op"() : () -> (i32, i64)\n'
             '"test.two_operands"(%0, %1) : (i32, i64) -> ()',
         ),
@@ -814,14 +812,13 @@ def test_operands(format: str, program: str, generic_program: str):
     [
         (
             "$args type($args) attr-dict",
-            '%0 = "test.op"() : () -> i32\n' "test.variadic_operand",
-            '%0 = "test.op"() : () -> i32\n' '"test.variadic_operand"() : () -> ()',
+            '%0 = "test.op"() : () -> i32\ntest.variadic_operand',
+            '%0 = "test.op"() : () -> i32\n"test.variadic_operand"() : () -> ()',
         ),
         (
             "$args type($args) attr-dict",
-            '%0 = "test.op"() : () -> i32\n' "test.variadic_operand %0 i32",
-            '%0 = "test.op"() : () -> i32\n'
-            '"test.variadic_operand"(%0) : (i32) -> ()',
+            '%0 = "test.op"() : () -> i32\ntest.variadic_operand %0 i32',
+            '%0 = "test.op"() : () -> i32\n"test.variadic_operand"(%0) : (i32) -> ()',
         ),
         (
             "$args type($args) attr-dict",
@@ -862,14 +859,13 @@ def test_variadic_operand(format: str, program: str, generic_program: str):
     [
         (
             "$args type($args) attr-dict",
-            '%0 = "test.op"() : () -> i32\n' "test.optional_operand",
-            '%0 = "test.op"() : () -> i32\n' '"test.optional_operand"() : () -> ()',
+            '%0 = "test.op"() : () -> i32\ntest.optional_operand',
+            '%0 = "test.op"() : () -> i32\n"test.optional_operand"() : () -> ()',
         ),
         (
             "$args type($args) attr-dict",
-            '%0 = "test.op"() : () -> i32\n' "test.optional_operand %0 i32",
-            '%0 = "test.op"() : () -> i32\n'
-            '"test.optional_operand"(%0) : (i32) -> ()',
+            '%0 = "test.op"() : () -> i32\ntest.optional_operand %0 i32',
+            '%0 = "test.op"() : () -> i32\n"test.optional_operand"(%0) : (i32) -> ()',
         ),
     ],
 )
@@ -895,15 +891,13 @@ def test_optional_operand(format: str, program: str, generic_program: str):
     "program, generic_program, as_property",
     [
         (
-            '%0 = "test.op"() : () -> i32\n'
-            "test.variadic_operands(%0 : i32) [%0 : i32]",
+            '%0 = "test.op"() : () -> i32\ntest.variadic_operands(%0 : i32) [%0 : i32]',
             '%0 = "test.op"() : () -> i32\n'
             '"test.variadic_operands"(%0, %0) {operandSegmentSizes = array<i32:1,1>} : (i32,i32) -> ()',
             False,
         ),
         (
-            '%0 = "test.op"() : () -> i32\n'
-            "test.variadic_operands(%0 : i32) [%0 : i32]",
+            '%0 = "test.op"() : () -> i32\ntest.variadic_operands(%0 : i32) [%0 : i32]',
             '%0 = "test.op"() : () -> i32\n'
             '"test.variadic_operands"(%0, %0) <{operandSegmentSizes = array<i32:1,1>}> : (i32,i32) -> ()',
             True,
@@ -957,8 +951,7 @@ def test_multiple_variadic_operands(
             '"test.optional_operands"() {operandSegmentSizes = array<i32:0,0>} : () -> ()',
         ),
         (
-            '%0 = "test.op"() : () -> i32\n'
-            "test.optional_operands(%0 : i32) [%0 : i32]",
+            '%0 = "test.op"() : () -> i32\ntest.optional_operands(%0 : i32) [%0 : i32]',
             '%0 = "test.op"() : () -> i32\n'
             '"test.optional_operands"(%0, %0) {operandSegmentSizes = array<i32:1,1>} : (i32,i32) -> ()',
         ),
@@ -2559,8 +2552,8 @@ def test_chained_variadic_operands_safeguard(
     "program, generic_program",
     [
         (
-            '%0 = "test.op"() : () -> i32\n' "test.optional_group(%0 : i32)",
-            '%0 = "test.op"() : () -> i32\n' '"test.optional_group"(%0) : (i32) -> ()',
+            '%0 = "test.op"() : () -> i32\ntest.optional_group(%0 : i32)',
+            '%0 = "test.op"() : () -> i32\n"test.optional_group"(%0) : (i32) -> ()',
         ),
         (
             "test.optional_group",
@@ -2598,8 +2591,8 @@ def test_optional_group_optional_operand_anchor(
             '"test.optional_group"(%0, %1) : (i32, i64) -> ()',
         ),
         (
-            '%0 = "test.op"() : () -> i32\n' "test.optional_group %0 : i32",
-            '%0 = "test.op"() : () -> i32\n' '"test.optional_group"(%0) : (i32) -> ()',
+            '%0 = "test.op"() : () -> i32\ntest.optional_group %0 : i32',
+            '%0 = "test.op"() : () -> i32\n"test.optional_group"(%0) : (i32) -> ()',
         ),
         (
             "test.optional_group",
@@ -2737,17 +2730,17 @@ def test_optional_group_checkers(format: str, error: str):
     "program, generic_program",
     [
         (
-            '%0 = "test.op"() : () -> !test.type<"index">\n' "test.mixed %0()",
+            '%0 = "test.op"() : () -> !test.type<"index">\ntest.mixed %0()',
             '%0 = "test.op"() : () -> !test.type<"index">\n'
             '"test.mixed"(%0) : (!test.type<"index">) -> ()',
         ),
         (
-            '%0 = "test.op"() : () -> !test.type<"index">\n' "test.mixed %0(%0)",
+            '%0 = "test.op"() : () -> !test.type<"index">\ntest.mixed %0(%0)',
             '%0 = "test.op"() : () -> !test.type<"index">\n'
             '"test.mixed"(%0, %0) : (!test.type<"index">, !test.type<"index">) -> ()',
         ),
         (
-            '%0 = "test.op"() : () -> !test.type<"index">\n' "test.mixed %0(%0, %0)",
+            '%0 = "test.op"() : () -> !test.type<"index">\ntest.mixed %0(%0, %0)',
             '%0 = "test.op"() : () -> !test.type<"index">\n'
             '"test.mixed"(%0, %0, %0) : (!test.type<"index">, !test.type<"index">, !test.type<"index">) -> ()',
         ),

--- a/tests/test_frontend_op_inserter.py
+++ b/tests/test_frontend_op_inserter.py
@@ -43,7 +43,7 @@ def test_raises_exception_on_op_with_no_blocks_II():
     with pytest.raises(FrontendProgramException) as err:
         inserter.set_insertion_point_from_region(empty_region)
     assert err.value.msg == (
-        "Trying to set the insertion point from the region without" " blocks."
+        "Trying to set the insertion point from the region without blocks."
     )
 
 

--- a/tests/test_op_builder.py
+++ b/tests/test_op_builder.py
@@ -305,5 +305,5 @@ def test_build_implicit_region_fail():
 
         _ = region
     assert e.value.args[0] == (
-        "Cannot insert operation explicitly when an implicit" " builder exists."
+        "Cannot insert operation explicitly when an implicit builder exists."
     )

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -104,7 +104,7 @@ class BitwidthSumLessThanTrait(OpTrait):
 
         if sum_bitwidth >= self.max_sum:
             raise VerifyException(
-                "Operation has a bitwidth sum " f"greater or equal to {self.max_sum}."
+                f"Operation has a bitwidth sum greater or equal to {self.max_sum}."
             )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2047,27 +2047,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.8.6"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/00/089db7890ea3be5709e3ece6e46408d6f1e876026ec3fd081ee585fef209/ruff-0.8.6.tar.gz", hash = "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5", size = 3473116 }
+sdist = { url = "https://files.pythonhosted.org/packages/75/48/385f276f41e89623a5ea8e4eb9c619a44fdfc2a64849916b3584eca6cb9f/ruff-0.9.0.tar.gz", hash = "sha256:143f68fa5560ecf10fc49878b73cee3eab98b777fcf43b0e62d43d42f5ef9d8b", size = 3489167 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/28/aa07903694637c2fa394a9f4fe93cf861ad8b09f1282fa650ef07ff9fe97/ruff-0.8.6-py3-none-linux_armv6l.whl", hash = "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3", size = 10628735 },
-    { url = "https://files.pythonhosted.org/packages/2b/43/827bb1448f1fcb0fb42e9c6edf8fb067ca8244923bf0ddf12b7bf949065c/ruff-0.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1", size = 10386758 },
-    { url = "https://files.pythonhosted.org/packages/df/93/fc852a81c3cd315b14676db3b8327d2bb2d7508649ad60bfdb966d60738d/ruff-0.8.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807", size = 10007808 },
-    { url = "https://files.pythonhosted.org/packages/94/e9/e0ed4af1794335fb280c4fac180f2bf40f6a3b859cae93a5a3ada27325ae/ruff-0.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25", size = 10861031 },
-    { url = "https://files.pythonhosted.org/packages/82/68/da0db02f5ecb2ce912c2bef2aa9fcb8915c31e9bc363969cfaaddbc4c1c2/ruff-0.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d", size = 10388246 },
-    { url = "https://files.pythonhosted.org/packages/ac/1d/b85383db181639019b50eb277c2ee48f9f5168f4f7c287376f2b6e2a6dc2/ruff-0.8.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75", size = 11424693 },
-    { url = "https://files.pythonhosted.org/packages/ac/b7/30bc78a37648d31bfc7ba7105b108cb9091cd925f249aa533038ebc5a96f/ruff-0.8.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315", size = 12141921 },
-    { url = "https://files.pythonhosted.org/packages/60/b3/ee0a14cf6a1fbd6965b601c88d5625d250b97caf0534181e151504498f86/ruff-0.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188", size = 11692419 },
-    { url = "https://files.pythonhosted.org/packages/ef/d6/c597062b2931ba3e3861e80bd2b147ca12b3370afc3889af46f29209037f/ruff-0.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf", size = 12981648 },
-    { url = "https://files.pythonhosted.org/packages/68/84/21f578c2a4144917985f1f4011171aeff94ab18dfa5303ac632da2f9af36/ruff-0.8.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117", size = 11251801 },
-    { url = "https://files.pythonhosted.org/packages/6c/aa/1ac02537c8edeb13e0955b5db86b5c050a1dcba54f6d49ab567decaa59c1/ruff-0.8.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe", size = 10849857 },
-    { url = "https://files.pythonhosted.org/packages/eb/00/020cb222252d833956cb3b07e0e40c9d4b984fbb2dc3923075c8f944497d/ruff-0.8.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d", size = 10470852 },
-    { url = "https://files.pythonhosted.org/packages/00/56/e6d6578202a0141cd52299fe5acb38b2d873565f4670c7a5373b637cf58d/ruff-0.8.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a", size = 10972997 },
-    { url = "https://files.pythonhosted.org/packages/be/31/dd0db1f4796bda30dea7592f106f3a67a8f00bcd3a50df889fbac58e2786/ruff-0.8.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76", size = 11317760 },
-    { url = "https://files.pythonhosted.org/packages/d4/70/cfcb693dc294e034c6fed837fa2ec98b27cc97a26db5d049345364f504bf/ruff-0.8.6-py3-none-win32.whl", hash = "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764", size = 8799729 },
-    { url = "https://files.pythonhosted.org/packages/60/22/ae6bcaa0edc83af42751bd193138bfb7598b2990939d3e40494d6c00698c/ruff-0.8.6-py3-none-win_amd64.whl", hash = "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905", size = 9673857 },
-    { url = "https://files.pythonhosted.org/packages/91/f8/3765e053acd07baa055c96b2065c7fab91f911b3c076dfea71006666f5b0/ruff-0.8.6-py3-none-win_arm64.whl", hash = "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162", size = 9149556 },
+    { url = "https://files.pythonhosted.org/packages/e9/01/e0885e5519212efc7ab9d868bc39cb9781931c4c6f9b17becafa81193ec4/ruff-0.9.0-py3-none-linux_armv6l.whl", hash = "sha256:949b3513f931741e006cf267bf89611edff04e1f012013424022add3ce78f319", size = 10647069 },
+    { url = "https://files.pythonhosted.org/packages/dd/69/510a9a5781dcf84c2ad513c2003936fefc802f39c745d5f2355d77fa45fd/ruff-0.9.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:99fbcb8c7fe94ae1e462ab2a1ef17cb20b25fb6438b9f198b1bcf5207a0a7916", size = 10401936 },
+    { url = "https://files.pythonhosted.org/packages/07/9f/37fb86bfdf28c4cbfe94cbcc01fb9ab0cb8128548f243f34d5298b212562/ruff-0.9.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b022afd8eb0fcfce1e0adec84322abf4d6ce3cd285b3b99c4f17aae7decf749", size = 10010347 },
+    { url = "https://files.pythonhosted.org/packages/30/0d/b95121f53c7f7bfb7ba427a35d25f983ed3b476620c5cd69f45caa5b294e/ruff-0.9.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:336567ce92c9ca8ec62780d07b5fa11fbc881dc7bb40958f93a7d621e7ab4589", size = 10882152 },
+    { url = "https://files.pythonhosted.org/packages/d4/0b/a955cb6b19eb900c4c594707ab72132ce2d5cd8b5565137fb8fed21b8f08/ruff-0.9.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d338336c44bda602dc8e8766836ac0441e5b0dfeac3af1bd311a97ebaf087a75", size = 10405502 },
+    { url = "https://files.pythonhosted.org/packages/1e/fa/9a6c70af74f20edd2519b89eb3322f4bfa399315cf306383443700f2d6b6/ruff-0.9.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d9b3ececf523d733e90b540e7afcc0494189e8999847f8855747acd5a9a8c45f", size = 11465069 },
+    { url = "https://files.pythonhosted.org/packages/ee/8b/7effac8915470da496be009fe861060baff2692f92801976b2c01cdc8c54/ruff-0.9.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a11c0872a31232e473e2e0e2107f3d294dbadd2f83fb281c3eb1c22a24866924", size = 12176850 },
+    { url = "https://files.pythonhosted.org/packages/bd/ed/626179786889eca47b1e821c1582622ac0c1c8f01d60ac974f8b96867a57/ruff-0.9.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b5fd06220c17a9cc0dc7fc6552f2ac4db74e8e8bff9c401d160ac59d00566f54", size = 11700963 },
+    { url = "https://files.pythonhosted.org/packages/75/79/094c34ddec47fd3c61a0bc5e83ca164344c592949cff91f05961fd40922e/ruff-0.9.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0457e775c74bf3976243f910805242b7dcd389e1d440deccbd1194ca17a5728c", size = 13096560 },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ec85dca0dcb329835197401734501bfa1d39e72343df64628c67b72bcbf5/ruff-0.9.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05415599bbcb318f730ea1b46a39e4fbf71f6a63fdbfa1dda92efb55f19d7ecf", size = 11278658 },
+    { url = "https://files.pythonhosted.org/packages/6c/17/1b3ea5f06578ea1daa08ac35f9de099d1827eea6e116a8cabbf11235c925/ruff-0.9.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fbf9864b009e43cfc1c8bed1a6a4c529156913105780af4141ca4342148517f5", size = 10879847 },
+    { url = "https://files.pythonhosted.org/packages/a6/e5/00bc97d6f419da03c0d898e95cca77311494e7274dc7cc17d94976e32e52/ruff-0.9.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:37b3da222b12e2bb2ce628e02586ab4846b1ed7f31f42a5a0683b213453b2d49", size = 10494220 },
+    { url = "https://files.pythonhosted.org/packages/cc/70/d0a23d94f3e40b7ffac0e5506f33bb504672569173781a6c7cab0db6a4ba/ruff-0.9.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:733c0fcf2eb0c90055100b4ed1af9c9d87305b901a8feb6a0451fa53ed88199d", size = 11004182 },
+    { url = "https://files.pythonhosted.org/packages/20/8e/367cf8e401890f823d0e4eb33635d0113719d5660b6522b7295376dd95fd/ruff-0.9.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8221a454bfe5ccdf8017512fd6bb60e6ec30f9ea252b8a80e5b73619f6c3cefd", size = 11345761 },
+    { url = "https://files.pythonhosted.org/packages/fe/08/4b54e02da73060ebc29368ab15868613f7d2496bde3b01d284d5423646bc/ruff-0.9.0-py3-none-win32.whl", hash = "sha256:d345f2178afd192c7991ddee59155c58145e12ad81310b509bd2e25c5b0247b3", size = 8807005 },
+    { url = "https://files.pythonhosted.org/packages/a1/a7/0b422971e897c51bf805f998d75bcfe5d4d858f5002203832875fc91b733/ruff-0.9.0-py3-none-win_amd64.whl", hash = "sha256:0cbc0905d94d21305872f7f8224e30f4bbcd532bc21b2225b2446d8fc7220d19", size = 9689974 },
+    { url = "https://files.pythonhosted.org/packages/73/0e/c00f66731e514be3299801b1d9d54efae0abfe8f00a5c14155f2ab9e2920/ruff-0.9.0-py3-none-win_arm64.whl", hash = "sha256:7b1148771c6ca88f820d761350a053a5794bc58e0867739ea93eb5e41ad978cd", size = 9147729 },
 ]
 
 [[package]]
@@ -2542,7 +2542,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==0.25.1" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "riscemu", marker = "extra == 'riscv'", specifier = "==2.2.7" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.8.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9" },
     { name = "textual", marker = "extra == 'gui'", specifier = "==1.0.0" },
     { name = "textual-dev", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "toml", marker = "extra == 'dev'", specifier = "<0.11" },

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -252,9 +252,9 @@ class CslPrintContext:
                 return ""
             case DenseIntOrFPElementsAttr():
                 data = init.get_attrs()
-                assert (
-                    len(data) == 1
-                ), f"Memref global initialiser has to have 1 value, got {len(data)}"
+                assert len(data) == 1, (
+                    f"Memref global initialiser has to have 1 value, got {len(data)}"
+                )
                 return f" = @constants({type}, {self.attribute_value_to_str(data[0])})"
             case other:
                 return f"<unknown memref.global init type {other}>"
@@ -344,9 +344,9 @@ class CslPrintContext:
         """
         type = val.type
         assert isa(type, MemRefType[Attribute])
-        assert isinstance(
-            val, OpResult
-        ), "The value provided to _memref_type_to_string must be an op result"
+        assert isinstance(val, OpResult), (
+            "The value provided to _memref_type_to_string must be an op result"
+        )
         dims: list[str] = []
         idx = 0
         for dim in type.get_shape():
@@ -716,7 +716,7 @@ class CslPrintContext:
                     if init is None:
                         init = ""
                     else:
-                        init = f" = { self._get_variable_name_for(init)}"
+                        init = f" = {self._get_variable_name_for(init)}"
                     ty = self.mlir_type_to_csl_type(res.type)
                     self.variables[res] = name.data
                     self.print(f"param {name.data} : {ty}{init};")

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -220,9 +220,9 @@ class ConvertMemrefStoreOp(RewritePattern):
 class ConvertMemrefLoadOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: memref.LoadOp, rewriter: PatternRewriter):
-        assert isinstance(
-            op_memref_type := op.memref.type, memref.MemRefType
-        ), f"{op.memref.type}"
+        assert isinstance(op_memref_type := op.memref.type, memref.MemRefType), (
+            f"{op.memref.type}"
+        )
         memref_type = cast(memref.MemRefType[Any], op_memref_type)
 
         mem, *indices = cast_operands_to_regs(rewriter)

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -249,9 +249,9 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
             self.allocate(live_in)
 
         yield_op = loop.body.block.last_op
-        assert (
-            yield_op is not None
-        ), "last op of riscv_scf.ForOp is guaranteed to be riscv_scf.Yield"
+        assert yield_op is not None, (
+            "last op of riscv_scf.ForOp is guaranteed to be riscv_scf.Yield"
+        )
         block_args = loop.body.block.args
 
         # The loop-carried variables are trickier

--- a/xdsl/backend/riscv/register_queue.py
+++ b/xdsl/backend/riscv/register_queue.py
@@ -81,9 +81,9 @@ class RegisterQueue:
         else:
             reg = reg_type(f"j{self._idx}")
             self._idx += 1
-        assert (
-            reg not in self.reserved_registers
-        ), f"Cannot pop a reserved register ({reg.register_name}), it must have been reserved while available."
+        assert reg not in self.reserved_registers, (
+            f"Cannot pop a reserved register ({reg.register_name}), it must have been reserved while available."
+        )
         return reg
 
     @contextmanager

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -61,7 +61,7 @@ class Builder(BuilderListener):
 
         if implicit_builder is not None and implicit_builder is not self:
             raise ValueError(
-                "Cannot insert operation explicitly when an implicit " "builder exists."
+                "Cannot insert operation explicitly when an implicit builder exists."
             )
 
         block = self.insertion_point.block

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -328,9 +328,9 @@ class SetupOp(IRDLOperation):
             val = parser.parse_operand(f'expected value for field "{name}"')
             parser.parse_punctuation(":")
             typ = parser.parse_type()
-            assert (
-                val.type == typ
-            ), f"ssa value type mismatch! Expected {typ}, got {val.type}"
+            assert val.type == typ, (
+                f"ssa value type mismatch! Expected {typ}, got {val.type}"
+            )
             return name, val
 
         args: Sequence[tuple[str, SSAValue]] = parser.parse_comma_separated_list(

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -790,9 +790,9 @@ class FuncOp(_FuncBase):
         if res_attrs:
             raise NotImplementedError("res_attrs not implemented in csl FuncOp")
 
-        assert (
-            len(return_types) <= 1
-        ), f"{cls.name} can't have more than one result type!"
+        assert len(return_types) <= 1, (
+            f"{cls.name} can't have more than one result type!"
+        )
 
         func = cls(
             name=name,
@@ -848,9 +848,9 @@ class TaskOp(_FuncBase):
                 id, IntegerType(task_kind.get_color_bits(), Signedness.UNSIGNED)
             )
         if id is not None:
-            assert (
-                id.type.width.data == task_kind.get_color_bits()
-            ), f"{task_kind.data.value} task id has to have {task_kind.get_color_bits()} bits, got {id.type.width.data}"
+            assert id.type.width.data == task_kind.get_color_bits(), (
+                f"{task_kind.data.value} task id has to have {task_kind.get_color_bits()} bits, got {id.type.width.data}"
+            )
 
         properties |= {
             "kind": task_kind,
@@ -911,9 +911,9 @@ class TaskOp(_FuncBase):
                 parser.pos,
             )
 
-        assert (
-            len(return_types) <= 1
-        ), f"{cls.name} can't have more than one result type!"
+        assert len(return_types) <= 1, (
+            f"{cls.name} can't have more than one result type!"
+        )
 
         task = cls(
             name=name,

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -228,7 +228,9 @@ class ModuleOp(IRDLOperation):
             len(self.program_module.block.args)
             == len(self.layout_module.block.args) - 2
             # minus two as layout_module has additional x and y args
-        ), "program_module block args should only contain args from properties when calling this function"
+        ), (
+            "program_module block args should only contain args from properties when calling this function"
+        )
 
         if yield_args is None:
             yield_args = self.layout_yield_op.items()

--- a/xdsl/dialects/experimental/dmp.py
+++ b/xdsl/dialects/experimental/dmp.py
@@ -471,16 +471,16 @@ class GridSlice2dAttr(DomainDecompositionStrategy):
         )
 
     def _verify(self):
-        assert (
-            len(self.topology.as_tuple()) >= 2
-        ), "GridSlice2d requires at least two dimensions"
+        assert len(self.topology.as_tuple()) >= 2, (
+            "GridSlice2d requires at least two dimensions"
+        )
 
     def calc_resize(self, shape: tuple[int, ...]) -> tuple[int, ...]:
         assert len(shape) >= 2, "GridSlice2d requires at least two dimensions"
         for size, node_count in zip(shape, self.topology.as_tuple()):
-            assert (
-                size % node_count == 0
-            ), "GridSlice2d requires domain be neatly divisible by shape"
+            assert size % node_count == 0, (
+                "GridSlice2d requires domain be neatly divisible by shape"
+            )
         return (
             *(
                 size // node_count
@@ -519,16 +519,16 @@ class GridSlice3dAttr(DomainDecompositionStrategy):
         )
 
     def _verify(self):
-        assert (
-            len(self.topology.as_tuple()) >= 3
-        ), "GridSlice3d requires at least three dimensions"
+        assert len(self.topology.as_tuple()) >= 3, (
+            "GridSlice3d requires at least three dimensions"
+        )
 
     def calc_resize(self, shape: tuple[int, ...]) -> tuple[int, ...]:
         assert len(shape) >= 3, "GridSlice3d requires at least two dimensions"
         for size, node_count in zip(shape, self.topology.as_tuple()):
-            assert (
-                size % node_count == 0
-            ), "GridSlice3d requires domain be neatly divisible by shape"
+            assert size % node_count == 0, (
+                "GridSlice3d requires domain be neatly divisible by shape"
+            )
         return (
             *(
                 size // node_count

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -255,9 +255,9 @@ class FuncOp(IRDLOperation):
         block argument types or return statement arguments.
         """
         # Refuse to work with external function definitions, as they don't have block args
-        assert (
-            not self.is_declaration
-        ), "update_function_type does not work with function declarations!"
+        assert not self.is_declaration, (
+            "update_function_type does not work with function declarations!"
+        )
         return_op = self.get_return_op()
         return_type = self.function_type.outputs.data
 
@@ -288,9 +288,9 @@ class FuncOp(IRDLOperation):
         """
         A helper to quickly get access to the block arguments of the function
         """
-        assert (
-            not self.is_declaration
-        ), "Function declarations don't have BlockArguments!"
+        assert not self.is_declaration, (
+            "Function declarations don't have BlockArguments!"
+        )
 
         block = self.body.blocks.first
         assert block is not None

--- a/xdsl/dialects/onnx.py
+++ b/xdsl/dialects/onnx.py
@@ -1019,9 +1019,9 @@ class SqueezeOp(IRDLOperation):
         )
 
     def verify_(self) -> None:
-        assert isinstance(
-            input_tensor_type := self.input_tensor.type, TensorType
-        ), "onnx elementwise operation operands and result must be of type TensorType"
+        assert isinstance(input_tensor_type := self.input_tensor.type, TensorType), (
+            "onnx elementwise operation operands and result must be of type TensorType"
+        )
 
         input_tensor_shape = input_tensor_type.get_shape()
 

--- a/xdsl/dialects/riscv_scf.py
+++ b/xdsl/dialects/riscv_scf.py
@@ -83,7 +83,7 @@ class ForRofOperation(IRDLOperation, ABC):
     def verify_(self):
         if (len(self.iter_args) + 1) != len(self.body.block.args):
             raise VerifyException(
-                f"Wrong number of block arguments, expected {len(self.iter_args)+1}, got "
+                f"Wrong number of block arguments, expected {len(self.iter_args) + 1}, got "
                 f"{len(self.body.block.args)}. The body must have the induction "
                 f"variable and loop-carried variables as arguments."
             )

--- a/xdsl/dialects/scf.py
+++ b/xdsl/dialects/scf.py
@@ -632,8 +632,8 @@ class IndexSwitchOp(IRDLOperation):
 
         if yield_op.operand_types != self.result_types:
             raise VerifyException(
-                f'region {name} returns values of types ({", ".join(str(x) for x in yield_op.operand_types)})'
-                f' but expected ({", ".join(str(x) for x in self.result_types)})'
+                f"region {name} returns values of types ({', '.join(str(x) for x in yield_op.operand_types)})"
+                f" but expected ({', '.join(str(x) for x in self.result_types)})"
             )
 
     def verify_(self) -> None:

--- a/xdsl/dialects/snitch.py
+++ b/xdsl/dialects/snitch.py
@@ -142,7 +142,7 @@ class SsrSetDimensionConfigOperation(IRDLOperation, ABC):
     def verify_(self) -> None:
         if self.dimension.data >= SnitchResources.dimensions:
             raise VerifyException(
-                f"dimension attribute out of range [0..{SnitchResources.dimensions-1}], "
+                f"dimension attribute out of range [0..{SnitchResources.dimensions - 1}], "
                 f"Snitch supports up to {SnitchResources.dimensions} dimensions per streamer"
             )
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -104,7 +104,7 @@ class IndexAttr(ParametrizedAttribute, Iterable[int]):
         printer.print(">")
 
     def print_nested_parameters(self, printer: Printer) -> None:
-        printer.print(f'[{", ".join(str(e) for e in self)}]')
+        printer.print(f"[{', '.join(str(e) for e in self)}]")
 
     def verify(self) -> None:
         l = len(self)

--- a/xdsl/frontend/code_generation.py
+++ b/xdsl/frontend/code_generation.py
@@ -190,7 +190,7 @@ class CodeGenerationVisitor(ast.NodeVisitor):
                 self.file,
                 node.lineno,
                 node.col_offset,
-                "Expected a single comparator, but found " f"{len(node.comparators)}.",
+                f"Expected a single comparator, but found {len(node.comparators)}.",
             )
         comp = node.comparators[0]
         op_name: str = node.ops[0].__class__.__name__

--- a/xdsl/frontend/python_code_check.py
+++ b/xdsl/frontend/python_code_check.py
@@ -187,8 +187,7 @@ class CheckStructure:
                 self.file,
                 stmt.lineno,
                 stmt.col_offset,
-                "Frontend program must consist of functions or constant "
-                "expressions.",
+                "Frontend program must consist of functions or constant expressions.",
             )
 
         # Check structure of all functions and if necessary populate the map
@@ -459,8 +458,7 @@ class ConstantInliner(ast.NodeTransformer):
                 self.file,
                 node.lineno,
                 node.col_offset,
-                f"Constant '{self.name}' is already defined and cannot be "
-                "assigned to.",
+                f"Constant '{self.name}' is already defined and cannot be assigned to.",
             )
         node.value = self.visit(node.value)
         return node

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -737,7 +737,7 @@ def main():
         "-p",
         "--passes",
         required=False,
-        help="Delimited list of passes." f" Available passes are: {available_passes}",
+        help=f"Delimited list of passes. Available passes are: {available_passes}",
         type=str,
         default="",
     )

--- a/xdsl/interpreters/eqsat_pdl.py
+++ b/xdsl/interpreters/eqsat_pdl.py
@@ -14,9 +14,9 @@ class EqsatPDLMatcher(PDLMatcher):
     ):
         owner = xdsl_val.owner
         assert isinstance(owner, eqsat.EClassOp)
-        assert (
-            len(owner.operands) == 1
-        ), "newly converted eqsat always has 1 element in eclass"
+        assert len(owner.operands) == 1, (
+            "newly converted eqsat always has 1 element in eclass"
+        )
         arg = owner.operands[0]
         res = super().match_operand(ssa_val, pdl_op, arg)
         return res

--- a/xdsl/interpreters/pdl.py
+++ b/xdsl/interpreters/pdl.py
@@ -133,9 +133,9 @@ class PDLMatcher:
             assert isinstance(pdl_op.value_type, OpResult)
             assert isinstance(pdl_op.value_type.op, pdl.TypeOp)
 
-            assert isa(
-                xdsl_attr, IntegerAttr[IntegerType]
-            ), "Only handle integer types for now"
+            assert isa(xdsl_attr, IntegerAttr[IntegerType]), (
+                "Only handle integer types for now"
+            )
 
             if not self.match_type(
                 pdl_op.value_type, pdl_op.value_type.op, xdsl_attr.type
@@ -233,9 +233,9 @@ class PDLRewritePattern(RewritePattern):
     def match_and_rewrite(self, xdsl_op: Operation, rewriter: PatternRewriter) -> None:
         pdl_op_val = self.pdl_rewrite_op.root
         assert pdl_op_val is not None, "TODO: handle None root op in pdl.RewriteOp"
-        assert (
-            self.pdl_rewrite_op.body is not None
-        ), "TODO: handle None body op in pdl.RewriteOp"
+        assert self.pdl_rewrite_op.body is not None, (
+            "TODO: handle None body op in pdl.RewriteOp"
+        )
 
         assert isinstance(pdl_op_val, OpResult)
         pdl_op = pdl_op_val.op

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -344,7 +344,7 @@ def irdl_to_attr_constraint(
             if irdl in type_var_mapping:
                 return type_var_mapping[irdl]
         if irdl.__bound__ is None:
-            raise Exception("Type variables used in IRDL are expected to" " be bound.")
+            raise Exception("Type variables used in IRDL are expected to be bound.")
         # We do not allow nested type variables.
         return irdl_to_attr_constraint(irdl.__bound__)
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -142,15 +142,15 @@ class FormatProgram:
         for uo, ot in zip(unresolved_operands, operand_types, strict=True):
             assert uo is not None
             if isinstance(uo, UnresolvedOperand):
-                assert isinstance(
-                    ot, Attribute
-                ), "Something went wrong with the declarative assembly format parser."
+                assert isinstance(ot, Attribute), (
+                    "Something went wrong with the declarative assembly format parser."
+                )
                 "Single operand has no type or variadic/optional type"
                 operands.append(parser.resolve_operand(uo, ot))
             else:
-                assert isinstance(
-                    ot, Sequence
-                ), f"Something went wrong with the declarative assembly format parser. {type(ot)} {ot}"
+                assert isinstance(ot, Sequence), (
+                    f"Something went wrong with the declarative assembly format parser. {type(ot)} {ot}"
+                )
                 "Variadic or optional operand has no type or a single type "
                 operands.append(parser.resolve_operands(uo, ot, parser.pos))
 

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -606,8 +606,7 @@ class FormatParser(BaseParser):
                 )
 
         self.raise_error(
-            "expected variable to refer to an operand, "
-            "attribute, region, or successor"
+            "expected variable to refer to an operand, attribute, region, or successor"
         )
 
     def parse_type_directive(self) -> FormatDirective:

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1505,8 +1505,7 @@ def get_variadic_sizes(
     if len(variadic_defs) == 1:
         if len(args) - len(defs) + 1 < 0:
             raise VerifyException(
-                f"Expected at least {len(defs) - 1} "
-                f"{def_type_name}s, got {len(defs)}"
+                f"Expected at least {len(defs) - 1} {def_type_name}s, got {len(defs)}"
             )
         return [len(args) - len(defs) + 1]
 
@@ -2097,9 +2096,9 @@ def get_accessors_from_op_def(
 def irdl_op_definition(cls: type[IRDLOperationInvT]) -> type[IRDLOperationInvT]:
     """Decorator used on classes to define a new operation definition."""
 
-    assert issubclass(
-        cls, IRDLOperation
-    ), f"class {cls.__name__} should be a subclass of IRDLOperation"
+    assert issubclass(cls, IRDLOperation), (
+        f"class {cls.__name__} should be a subclass of IRDLOperation"
+    )
 
     op_def = OpDef.from_pyrdl(cls)
     new_attrs = get_accessors_from_op_def(op_def, getattr(cls, "verify_", None))

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -458,13 +458,12 @@ class AttrParser(BaseParser):
         """
         if self._current_token.kind != MLIRTokenKind.BARE_IDENT:
             self.raise_error(
-                "Expected 'x' in shape delimiter, got "
-                f"{self._current_token.kind.name}"
+                f"Expected 'x' in shape delimiter, got {self._current_token.kind.name}"
             )
 
         if self._current_token.text[0] != "x":
             self.raise_error(
-                "Expected 'x' in shape delimiter, got " f"{self._current_token.text}"
+                f"Expected 'x' in shape delimiter, got {self._current_token.text}"
             )
 
         # Move the lexer to the position after 'x'.

--- a/xdsl/parser/base_parser.py
+++ b/xdsl/parser/base_parser.py
@@ -255,7 +255,7 @@ class BaseParser(GenericParser[MLIRTokenKind]):
         # This check is only necessary to catch errors made by users that
         # are not using pyright.
         assert MLIRTokenKind.is_spelling_of_punctuation(punctuation), (
-            "'parse_optional_punctuation' must be " "called with a valid punctuation"
+            "'parse_optional_punctuation' must be called with a valid punctuation"
         )
         kind = MLIRTokenKind.get_punctuation_kind_from_spelling(punctuation)
         if self._parse_optional_token(kind) is not None:
@@ -271,9 +271,9 @@ class BaseParser(GenericParser[MLIRTokenKind]):
         """
         # This check is only necessary to catch errors made by users that
         # are not using pyright.
-        assert MLIRTokenKind.is_spelling_of_punctuation(
-            punctuation
-        ), "'parse_punctuation' must be called with a valid punctuation"
+        assert MLIRTokenKind.is_spelling_of_punctuation(punctuation), (
+            "'parse_punctuation' must be called with a valid punctuation"
+        )
         kind = MLIRTokenKind.get_punctuation_kind_from_spelling(punctuation)
         self._parse_token(kind, f"Expected '{punctuation}'" + context_msg)
         return punctuation

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -161,19 +161,19 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
             rewriter.erase_matched_op(False)
             return
 
-        assert all(
-            len(swap.size) == 3 for swap in op.swaps
-        ), "currently only 3-dimensional stencils are supported"
+        assert all(len(swap.size) == 3 for swap in op.swaps), (
+            "currently only 3-dimensional stencils are supported"
+        )
 
-        assert all(
-            swap.size[:2] == (1, 1) for swap in op.swaps
-        ), "invoke dmp to decompose from (x,y,z) to (1,1,z)"
+        assert all(swap.size[:2] == (1, 1) for swap in op.swaps), (
+            "invoke dmp to decompose from (x,y,z) to (1,1,z)"
+        )
 
         # check that size is uniform
         uniform_size = op.swaps.data[0].size[2]
-        assert all(
-            swap.size[2] == uniform_size for swap in op.swaps
-        ), "all swaps need to be of uniform size"
+        assert all(swap.size[2] == uniform_size for swap in op.swaps), (
+            "all swaps need to be of uniform size"
+        )
 
         assert isattr(
             op.input_stencil.type,
@@ -182,9 +182,9 @@ class ConvertSwapToPrefetchPattern(RewritePattern):
         assert isa(
             t_type := op.input_stencil.type.get_element_type(), TensorType[Attribute]
         )
-        assert (
-            op.strategy.comm_layout() is not None
-        ), f"topology on {type(op)} is not given"
+        assert op.strategy.comm_layout() is not None, (
+            f"topology on {type(op)} is not given"
+        )
 
         # when translating swaps, remove third dimension
         prefetch_op = csl_stencil.PrefetchOp(

--- a/xdsl/transforms/csl_stencil_handle_async_flow.py
+++ b/xdsl/transforms/csl_stencil_handle_async_flow.py
@@ -120,9 +120,9 @@ class ConvertForLoopToCallGraphPass(RewritePattern):
         # limitation: can yield iter_args in any order, but they cannot be modified in the loop body
         terminator = op.body.block.last_op
         assert isinstance(terminator, scf.YieldOp)
-        assert all(
-            arg in op.body.block.args for arg in terminator.arguments
-        ), "Can only yield unmodified iter_args (in any order)"
+        assert all(arg in op.body.block.args for arg in terminator.arguments), (
+            "Can only yield unmodified iter_args (in any order)"
+        )
 
         # limitation: currently only loops built from arith.constant are supported
         assert isinstance(op.lb, OpResult)

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -167,9 +167,9 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
         # replace func.return by unblock_cmd_stream and csl.return
         func_return = main_func.body.block.last_op
         assert isinstance(func_return, func.ReturnOp)
-        assert (
-            len(func_return.arguments) == 0
-        ), "Non-empty returns currently not supported"
+        assert len(func_return.arguments) == 0, (
+            "Non-empty returns currently not supported"
+        )
         memcpy = module_op.get_program_import("<memcpy/memcpy>")
         unblock_call = csl.MemberCallOp(
             struct=memcpy, fname="unblock_cmd_stream", params=[], result_type=None

--- a/xdsl/transforms/eqsat_extract.py
+++ b/xdsl/transforms/eqsat_extract.py
@@ -26,9 +26,9 @@ def eqsat_extract(block: Block):
                         if isinstance(operand, OpResult)
                     )
                 if isinstance(min_cost_operand, OpResult):
-                    assert (
-                        eqsat.EQSAT_COST_LABEL in min_cost_operand.op.attributes
-                    ), min_cost_operand.op
+                    assert eqsat.EQSAT_COST_LABEL in min_cost_operand.op.attributes, (
+                        min_cost_operand.op
+                    )
                     del min_cost_operand.op.attributes[eqsat.EQSAT_COST_LABEL]
                 Rewriter.replace_op(op, (), new_results=(min_cost_operand,))
             continue

--- a/xdsl/transforms/experimental/function_constant_pinning.py
+++ b/xdsl/transforms/experimental/function_constant_pinning.py
@@ -147,9 +147,9 @@ def generate_func_with_pinned_val(
             for bad_ops in ops_between_op_and_func_start(func_op, op):
                 rewriter.erase_op(bad_ops)
             # then check that we really just have one result (sanity check)
-            assert (
-                len(op.results) == 1
-            ), "Constant pinning only work on single return operations"
+            assert len(op.results) == 1, (
+                "Constant pinning only work on single return operations"
+            )
             # replace op by constant
             rewriter.replace_op(op, arith.ConstantOp(pin, op.results[0].type))
             # don't look at more operations inside the function

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -54,9 +54,9 @@ def get_dir_and_distance(
     if isinstance(offset, stencil.IndexAttr):
         offset = tuple(offset)
     assert len(offset) == 2, "Expecting 2-dimensional access"
-    assert (offset[0] == 0) != (
-        offset[1] == 0
-    ), "Expecting neighbour access in a star-shape pattern"
+    assert (offset[0] == 0) != (offset[1] == 0), (
+        "Expecting neighbour access in a star-shape pattern"
+    )
     if offset[0] < 0:
         d = csl.Direction.EAST
     elif offset[0] > 0:
@@ -147,9 +147,9 @@ class LowerApplyOp(RewritePattern):
             ):
                 break
             parent_func = op.parent_op()
-        assert (
-            parent_func
-        ), "Expected csl_stencil.apply to be inside a func.func or csl.func"
+        assert parent_func, (
+            "Expected csl_stencil.apply to be inside a func.func or csl.func"
+        )
 
         # set up csl funcs
         chunk_fn = csl.FuncOp(

--- a/xdsl/transforms/memref_to_dsd.py
+++ b/xdsl/transforms/memref_to_dsd.py
@@ -131,18 +131,18 @@ class LowerSubviewOpPass(RewritePattern):
             sizes = op.static_sizes.get_values()
             counter_sizes = collections.Counter(sizes)
             counter_sizes.pop(1, None)
-            assert (
-                len(counter_sizes) == 1
-            ), "1d access into nd memref must specify one size > 1"
+            assert len(counter_sizes) == 1, (
+                "1d access into nd memref must specify one size > 1"
+            )
             size, size_count = counter_sizes.most_common()[0]
             size = cast(int, size)
 
-            assert (
-                size_count == 1
-            ), "1d access into nd memref can only specify one size > 1, which can occur only once"
-            assert all(
-                stride == 1 for stride in op.static_strides.get_values()
-            ), "All strides must equal 1"
+            assert size_count == 1, (
+                "1d access into nd memref can only specify one size > 1, which can occur only once"
+            )
+            assert all(stride == 1 for stride in op.static_strides.get_values()), (
+                "All strides must equal 1"
+            )
 
             amap: list[AffineExpr] = [
                 AffineConstantExpr(

--- a/xdsl/utils/deprecation.py
+++ b/xdsl/utils/deprecation.py
@@ -16,7 +16,7 @@ def deprecated(reason: str):
     def decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:
         def new_func(*args: _P.args, **kwargs: _P.kwargs) -> _T:
             warnings.warn(
-                f'Call to deprecated method {str(func).split(" ")[1]}: {reason}'
+                f"Call to deprecated method {str(func).split(' ')[1]}: {reason}"
             )
             return func(*args, **kwargs)
 
@@ -27,4 +27,4 @@ def deprecated(reason: str):
 
 def deprecated_constructor(func: Callable[_P, _T]) -> Callable[_P, _T]:
     # TOFIX: improve printing
-    return deprecated(f'{"use the constructor (`ClassName(...)`) instead."}')(func)
+    return deprecated(f"{'use the constructor (`ClassName(...)`) instead.'}")(func)

--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -419,9 +419,9 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
 
         The first character is expected to have already been parsed.
         """
-        assert (
-            self.pos != 0
-        ), "First prefixed identifier character must have been parsed"
+        assert self.pos != 0, (
+            "First prefixed identifier character must have been parsed"
+        )
         first_char = self.input.at(self.pos - 1)
         if first_char == "#":
             kind = MLIRTokenKind.HASH_IDENT
@@ -430,9 +430,9 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
         elif first_char == "^":
             kind = MLIRTokenKind.CARET_IDENT
         else:
-            assert (
-                first_char == "%"
-            ), "First prefixed identifier character must have been parsed correctly"
+            assert first_char == "%", (
+                "First prefixed identifier character must have been parsed correctly"
+            )
             kind = MLIRTokenKind.PERCENT_IDENT
 
         match = self._consume_regex(self._suffix_id)

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -123,7 +123,7 @@ def _pass_arg_element_type_str(arg: PassArgElementType) -> str:
 
 def _pass_arg_list_type_str(name: str, arg: PassArgListType) -> str:
     if arg:
-        return f'{name}={",".join(_pass_arg_element_type_str(val) for val in arg)}'
+        return f"{name}={','.join(_pass_arg_element_type_str(val) for val in arg)}"
     else:
         return name
 

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -107,7 +107,7 @@ class xDSLOptMain(CommandLineTool):
             "-p",
             "--passes",
             required=False,
-            help="Delimited list of passes." f" Available passes are: {pass_names}",
+            help=f"Delimited list of passes. Available passes are: {pass_names}",
             type=str,
             default="",
         )


### PR DESCRIPTION
Ruff now has better support for strings, and formats within f strings, I thought I'd open a PR myself to do this and to update the precommit version.

https://astral.sh/blog/ruff-v0.9.0