### PR TITLE
interactive: move pass parsing logic to AddArgumentsScreen

### DIFF
--- a/tests/interactive/test_add_arguments_screen.py
+++ b/tests/interactive/test_add_arguments_screen.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+from textual.app import App
+
+from xdsl.interactive.add_arguments_screen import AddArguments
+from xdsl.passes import ModulePass
+
+
+@dataclass(frozen=True)
+class TestPass(ModulePass):
+    """Test pass with required arguments for testing AddArguments screen"""
+
+    name = "testpass"
+
+    required_arg: int
+    optional_arg: str | None = None
+
+    def apply(self, ctx: Any, op: Any) -> None:
+        pass
+
+
+class LaunchScreenApp(App[None]):
+    """A minimal app that can launch the AddArguments screen for testing."""
+
+    ...
+
+
+@pytest.mark.asyncio
+async def test_enter_button_enabled_state():
+    """Test that enter button is enabled/disabled based on argument validity"""
+    async with LaunchScreenApp().run_test() as pilot:
+        app = cast(LaunchScreenApp, pilot.app)
+
+        screen = AddArguments(TestPass)
+
+        app.push_screen(screen)
+        await pilot.pause()
+
+        # Initially disabled with empty args
+        assert screen.argument_text_area.text == "required_arg=int optional_arg=none"
+        assert screen.selected_pass_value is None
+        assert screen.enter_button.disabled
+
+        # Invalid args - missing required field
+        screen.argument_text_area.load_text('optional_arg="test"')
+        await pilot.pause()
+        assert screen.enter_button.disabled
+
+        # Invalid args - wrong type
+        screen.argument_text_area.load_text('required_arg="not_a_number"')
+        await pilot.pause()
+        assert screen.enter_button.disabled
+
+        # Valid args - only required
+        screen.argument_text_area.load_text("required_arg=42")
+        await pilot.pause()
+        assert not screen.enter_button.disabled
+
+        # Valid args - with optional
+        screen.argument_text_area.load_text('required_arg=42 optional_arg="hello"')
+        await pilot.pause()
+        assert screen.selected_pass_value == TestPass(42, "hello")
+
+        assert not screen.enter_button.disabled
+
+        # Invalid args - syntax error
+        screen.argument_text_area.load_text("required_arg=42,")
+        await pilot.pause()
+        assert screen.enter_button.disabled

--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -7,7 +7,7 @@ from textual.widgets import Button, TextArea
 
 from xdsl.passes import ModulePass, get_pass_argument_names_and_types
 from xdsl.utils.exceptions import PassPipelineParseError
-from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
+from xdsl.utils.parse_pipeline import parse_pipeline
 
 
 class AddArguments(Screen[ModulePass | None]):
@@ -46,6 +46,8 @@ class AddArguments(Screen[ModulePass | None]):
         ).border_title = "Provide arguments to apply to selected pass."
         # Initialize parsed pass
         self.update_selected_pass_value()
+        # Initialize enter button
+        self.watch_selected_pass_value()
 
     @on(TextArea.Changed, "#argument_text_area")
     def update_selected_pass_value(self) -> None:
@@ -76,7 +78,7 @@ class AddArguments(Screen[ModulePass | None]):
         except ValueError:
             self.selected_pass_value = None
 
-    def watch_selected_pass_value(self, new_value: PipelinePassSpec | None):
+    def watch_selected_pass_value(self):
         self.enter_button.disabled = self.selected_pass_value is None
 
     @on(Button.Pressed, "#quit_screen_button")

--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -1,22 +1,33 @@
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, ScrollableContainer
+from textual.reactive import Reactive
 from textual.screen import Screen
 from textual.widgets import Button, TextArea
 
+from xdsl.passes import ModulePass, get_pass_argument_names_and_types
+from xdsl.utils.exceptions import PassPipelineParseError
+from xdsl.utils.parse_pipeline import PipelinePassSpec, parse_pipeline
 
-class AddArguments(Screen[str | None]):
+
+class AddArguments(Screen[ModulePass | None]):
     """
     Screen called when selected pass has arguments requiring user input.
     """
 
     CSS_PATH = "add_arguments_screen.tcss"
 
+    selected_pass_type: type[ModulePass]
+    selected_pass_value = Reactive[ModulePass | None](None)
     argument_text_area: TextArea
 
-    def __init__(self, parameter_one: TextArea):
-        self.argument_text_area = parameter_one
-        self.input_text_area = TextArea(id="input")
+    def __init__(self, selected_pass_type: type[ModulePass]):
+        self.selected_pass_type = selected_pass_type
+        self.argument_text_area = TextArea(
+            get_pass_argument_names_and_types(selected_pass_type),
+            id="argument_text_area",
+        )
+        self.enter_button = Button("Enter", id="enter_button")
 
         super().__init__()
 
@@ -25,7 +36,7 @@ class AddArguments(Screen[str | None]):
             yield self.argument_text_area
             with Horizontal(id="cancel_enter_buttons"):
                 yield Button("Clear Text", id="clear_input_screen_button")
-                yield Button("Enter", id="enter_button")
+                yield self.enter_button
                 yield Button("Cancel", id="quit_screen_button")
 
     def on_mount(self) -> None:
@@ -33,6 +44,40 @@ class AddArguments(Screen[str | None]):
         self.query_one(
             "#argument_text_area"
         ).border_title = "Provide arguments to apply to selected pass."
+        # Initialize parsed pass
+        self.update_selected_pass_value()
+
+    @on(TextArea.Changed, "#argument_text_area")
+    def update_selected_pass_value(self) -> None:
+        concatenated_arg_val = self.argument_text_area.text
+
+        try:
+            parsed_spec = list(
+                parse_pipeline(
+                    f"{self.selected_pass_type.name}{{{concatenated_arg_val}}}"
+                )
+            )[0]
+        except PassPipelineParseError:
+            self.selected_pass_value = None
+            return
+
+        missing_fields = self.selected_pass_type.required_fields().difference(
+            parsed_spec.args.keys()
+        )
+
+        if missing_fields:
+            self.selected_pass_value = None
+            return
+
+        try:
+            self.selected_pass_value = self.selected_pass_type.from_pass_spec(
+                parsed_spec
+            )
+        except ValueError:
+            self.selected_pass_value = None
+
+    def watch_selected_pass_value(self, new_value: PipelinePassSpec | None):
+        self.enter_button.disabled = self.selected_pass_value is None
 
     @on(Button.Pressed, "#quit_screen_button")
     def exit_screen(self, event: Button.Pressed) -> None:
@@ -44,4 +89,5 @@ class AddArguments(Screen[str | None]):
 
     @on(Button.Pressed, "#enter_button")
     def enter_arguments(self, event: Button.Pressed) -> None:
-        self.dismiss(self.argument_text_area.text)
+        assert self.selected_pass_value is not None
+        self.dismiss(self.selected_pass_value)


### PR DESCRIPTION
The main app should be as small as possible, with each screen/view encapsulating logic. Now the AddArguments screen has a contract, the user passes the type to add arguments to, and the screen returns a valid pass or None, depending on what the user did.

Now the screen validates the pass before letting the user enter, and has better error handling during validation, fixing a couple of crashing behaviours.