### PR TITLE
dialects (arm): Add CmpRegOp instruction

### DIFF
--- a/tests/filecheck/dialects/arm/test_ops.mlir
+++ b/tests/filecheck/dialects/arm/test_ops.mlir
@@ -21,7 +21,12 @@
 // CHECK-ASM: testlabel:                                       # this is a label
 arm.label "testlabel" {comment = "this is a label"}
 
+// CHECK-NEXT: arm.cmp %x2, %x1 {comment = "compare values in x2 and x1"}
+// CHECK-ASM: cmp x2, x1 # compare values in x2 and x1
+arm.cmp %x2, %x1 {comment = "compare values in x2 and x1"} : (!arm.reg<x2>, !arm.reg<x1>)
+
 // CHECK-GENERIC: %x1 = "arm.get_register"() : () -> !arm.reg<x1>
 // CHECK-GENERIC: %ds_mov = "arm.ds.mov"(%x1) {comment = "move contents of s to d"} : (!arm.reg<x1>) -> !arm.reg<x2>
 // CHECK-GENERIC: %dss_mul = "arm.dss.mul"(%x1, %x2) {comment = "multiply s1 by s2"} : (!arm.reg<x1>, !arm.reg<x2>) -> !arm.reg<x3>
 // CHECK-GENERIC: "arm.label"() <{label = "testlabel"}> {comment = "this is a label"} : () -> ()
+// CHECK-GENERIC: "arm.cmp"(%x2, %x1) {comment = "compare values in x2 and x1"} : (!arm.reg<x2>, !arm.reg<x1>) -> ()

--- a/xdsl/dialects/arm/__init__.py
+++ b/xdsl/dialects/arm/__init__.py
@@ -8,7 +8,7 @@ from typing import IO
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Dialect
 
-from .ops import ARMOperation, DSMovOp, DSSMulOp, GetRegisterOp, LabelOp
+from .ops import ARMOperation, CmpRegOp, DSMovOp, DSSMulOp, GetRegisterOp, LabelOp
 from .register import IntRegisterType
 
 
@@ -24,6 +24,7 @@ ARM = Dialect(
     "arm",
     [
         GetRegisterOp,
+        CmpRegOp,
         DSMovOp,
         DSSMulOp,
         LabelOp,

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -196,3 +196,38 @@ class LabelOp(ARMOperation):
 
     def assembly_line(self) -> str | None:
         return append_comment(f"{self.label.data}:", self.comment)
+
+
+@irdl_op_definition
+class CmpRegOp(ARMInstruction):
+    """
+    Compare (register) subtracts an optionally-shifted register value from a register value.
+    It updates the condition flags based on the result, and discards the result.
+    https://developer.arm.com/documentation/ddi0597/2024-12/Base-Instructions/CMP--register---Compare--register--?lang=en
+    """
+
+    name = "arm.cmp"
+    s1 = operand_def(IntRegisterType)
+    s2 = operand_def(IntRegisterType)
+
+    assembly_format = "$s1 `,` $s2 attr-dict `:` `(` type($s1) `,` type($s2) `)`"
+
+    def __init__(
+        self,
+        s1: Operation | SSAValue,
+        s2: Operation | SSAValue,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=(s1, s2),
+            attributes={
+                "comment": comment,
+            },
+        )
+
+    def assembly_line_args(self):
+        return (self.s1, self.s2)


### PR DESCRIPTION
Add ARM cmp (register) instruction, for comparing values in registers.
