### PR TITLE
CI: remove version override in uv

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/workflows/ci-lockfile.yml
+++ b/.github/workflows/ci-lockfile.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
@@ -35,4 +35,4 @@ jobs:
       run: |
         # Install all default extras.
         # Fail if the lockfile dependencies are out of date with pyproject.toml.
-        XDSL_VERSION_OVERRIDE="0+dynamic" uv sync --extra gui --extra dev --extra jax --extra riscv --locked
+        uv sync --extra gui --extra dev --extra jax --extra riscv --locked

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/workflows/ci-pyright-fails.yml
+++ b/.github/workflows/ci-pyright-fails.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -15,7 +15,7 @@ jobs:
           path: xdsl
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v5
 
     - name: Set up Python
       run: uv python install 3.11

--- a/.github/workflows/remake-lockfile.yml
+++ b/.github/workflows/remake-lockfile.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v5
 
       - run: |
           rm uv.lock

--- a/.github/workflows/update-lockfile-bot.yml
+++ b/.github/workflows/update-lockfile-bot.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -28,7 +28,7 @@ jobs:
       - name: Install the package locally and update lockfile
         run: |
           # Install all default extras.
-          XDSL_VERSION_OVERRIDE="0+dynamic" make venv
+          make venv
 
       - uses: EndBug/add-and-commit@v9
         with:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ uv-installed:
 # set up the venv with all dependencies for development
 .PHONY: ${VENV_DIR}/
 ${VENV_DIR}/: uv-installed
-	XDSL_VERSION_OVERRIDE="0+dynamic" uv sync ${VENV_EXTRAS}
+	uv sync ${VENV_EXTRAS}
 	@if [ ! -z "$(XDSL_MLIR_OPT_PATH)" ]; then \
 		ln -sf $(XDSL_MLIR_OPT_PATH) ${VENV_DIR}/bin/mlir-opt; \
 	fi

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Mapping
 from typing import cast
 
@@ -6,10 +5,7 @@ from setuptools import Command, find_packages, setup
 
 import versioneer
 
-if "XDSL_VERSION_OVERRIDE" in os.environ:
-    version = os.environ["XDSL_VERSION_OVERRIDE"]
-else:
-    version = versioneer.get_version()
+version = versioneer.get_version()
 
 
 setup(

--- a/uv.lock
+++ b/uv.lock
@@ -2459,7 +2459,6 @@ wheels = [
 
 [[package]]
 name = "xdsl"
-version = "0+dynamic"
 source = { editable = "." }
 dependencies = [
     { name = "immutabledict" },

--- a/xdsl/__init__.py
+++ b/xdsl/__init__.py
@@ -9,14 +9,9 @@ class LazyVersion:
 
     def __str__(self):
         if self._version is None:
-            import os
+            from . import _version
 
-            if "XDSL_VERSION_OVERRIDE" in os.environ:
-                self._version = os.environ["XDSL_VERSION_OVERRIDE"]
-            else:
-                from . import _version
-
-                self._version = _version.get_versions()["version"]
+            self._version = _version.get_versions()["version"]
         return self._version
 
 


### PR DESCRIPTION
UV now supports dynamic versions, by ommitting them from the lockfile! No more need for our workaround.

https://github.com/astral-sh/uv/pull/10622

After this PR is merged, all xDSL contributors must update to uv version 0.5.20 or higher.