### PR TITLE
dialects: (llvm) Add a bunch of float methods

### DIFF
--- a/tests/filecheck/dialects/llvm/arithmetic.mlir
+++ b/tests/filecheck/dialects/llvm/arithmetic.mlir
@@ -1,6 +1,6 @@
 // RUN: XDSL_ROUNDTRIP
 
-%arg0, %arg1 = "test.op"() : () -> (i32, i32)
+%arg0, %arg1, %f1 = "test.op"() : () -> (i32, i32, f32)
 
 %add_both = llvm.add %arg0, %arg1 {"overflowFlags" = #llvm.overflow<nsw, nuw>} : i32
 // CHECK: %add_both = llvm.add %arg0, %arg1 {overflowFlags = #llvm.overflow<nsw,nuw>} : i32
@@ -121,3 +121,23 @@
 
 %icmp_uge = llvm.icmp "uge" %arg0, %arg1 : i32
 // CHECK: %icmp_uge = llvm.icmp "uge" %arg0, %arg1 : i32
+
+// float arith:
+
+%fmul = llvm.fmul %f1, %f1 : f32
+// CHECK: %fmul = llvm.fmul %f1, %f1 : f32
+
+%fmul_fast = llvm.fmul %f1, %f1 {fastmathFlags = #llvm.fastmath<fast>} : f32
+// CHECK: %fmul_fast = llvm.fmul %f1, %f1 {fastmathFlags = #llvm.fastmath<fast>} : f32
+
+%fdiv = llvm.fdiv %f1, %f1 : f32
+// CHECK: %fdiv = llvm.fdiv %f1, %f1 : f32
+
+%fadd = llvm.fadd %f1, %f1 : f32
+// CHECK: %fadd = llvm.fadd %f1, %f1 : f32
+
+%fsub = llvm.fsub %f1, %f1 : f32
+// CHECK: %fsub = llvm.fsub %f1, %f1 : f32
+
+%frem = llvm.frem %f1, %f1 : f32
+// CHECK: %frem = llvm.frem %f1, %f1 : f32

--- a/tests/filecheck/dialects/llvm/example.mlir
+++ b/tests/filecheck/dialects/llvm/example.mlir
@@ -90,4 +90,12 @@ builtin.module {
 
 // CHECK:      %val = "test.op"() : () -> i32
 // CHECK-NEXT: %fval = llvm.bitcast %val : i32 to f32
+
+  %fval2 = llvm.sitofp %val : i32 to f32
+
+// CHECK-NEXT: %fval2 = llvm.sitofp %val : i32 to f32
+
+  %fval3 = llvm.fpext %fval : f32 to f64
+
+// CHECK-NEXT: %fval3 = llvm.fpext %fval : f32 to f64
 }

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/arithmetic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/arithmetic.mlir
@@ -1,47 +1,68 @@
 // RUN: mlir-opt %s --mlir-print-op-generic | xdsl-opt | filecheck %s
 
 builtin.module {
-    %arg0, %arg1 = "test.op"() : () -> (i32, i32)
+    %arg0, %arg1, %f1 = "test.op"() : () -> (i32, i32, f32)
+    // CHECK: [[arg0:%\d+]], [[arg1:%\d+]], [[f1:%\d+]]
 
     %add = llvm.add %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.add %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.add [[arg0]], [[arg1]] : i32
 
     %add2 = llvm.add %arg0, %arg1 {"nsw"} : i32
-    // CHECK: %{{.*}} = llvm.add %{{.*}}, %{{.*}} {nsw} : i32
+    // CHECK: llvm.add [[arg0]], [[arg1]] {nsw} : i32
 
     %sub = llvm.sub %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.sub %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.sub [[arg0]], [[arg1]] : i32
 
     %mul = llvm.mul %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.mul %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.mul [[arg0]], [[arg1]] : i32
 
     %udiv = llvm.udiv %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.udiv %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.udiv [[arg0]], [[arg1]] : i32
 
     %sdiv = llvm.sdiv %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.sdiv %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.sdiv [[arg0]], [[arg1]] : i32
 
     %urem = llvm.urem %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.urem %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.urem [[arg0]], [[arg1]] : i32
 
     %srem = llvm.srem %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.srem %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.srem [[arg0]], [[arg1]] : i32
 
     %and = llvm.and %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.and %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.and [[arg0]], [[arg1]] : i32
 
     %or = llvm.or %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.or %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.or [[arg0]], [[arg1]] : i32
 
     %xor = llvm.xor %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.xor %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.xor [[arg0]], [[arg1]] : i32
 
     %shl = llvm.shl %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.shl %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.shl [[arg0]], [[arg1]] : i32
 
     %lshr = llvm.lshr %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.lshr %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.lshr [[arg0]], [[arg1]] : i32
 
     %ashr = llvm.ashr %arg0, %arg1 : i32
-    // CHECK: %{{.*}} = llvm.ashr %{{.*}}, %{{.*}} : i32
+    // CHECK: llvm.ashr [[arg0]], [[arg1]] : i32
+
+    // float arith:
+
+    %fmul = llvm.fmul %f1, %f1 : f32
+    // CHECK: llvm.fmul [[f1]], [[f1]] : f32
+
+    %fmul_fast = llvm.fmul %f1, %f1 {test = true, fastmathFlags = #llvm.fastmath<fast>} : f32
+    // CHECK: llvm.fmul [[f1]], [[f1]] {test = true, fastmathFlags = #llvm.fastmath<fast>} : f32
+
+    %fdiv = llvm.fdiv %f1, %f1 : f32
+    // CHECK: llvm.fdiv [[f1]], [[f1]] : f32
+
+    %fadd = llvm.fadd %f1, %f1 : f32
+    // CHECK: llvm.fadd [[f1]], [[f1]] : f32
+
+    %fsub = llvm.fsub %f1, %f1 : f32
+    // CHECK: llvm.fsub [[f1]], [[f1]] : f32
+
+    %frem = llvm.frem %f1, %f1 : f32
+    // CHECK: llvm.frem [[f1]], [[f1]] : f32
 }

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 from xdsl.dialects.builtin import (
     I64,
+    AnyFloatConstr,
     AnyIntegerAttr,
     ArrayAttr,
     ContainerType,
@@ -25,7 +26,7 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.dialects.utils import FastMathAttrBase
+from xdsl.dialects.utils import FastMathAttrBase, FastMathFlag
 from xdsl.ir import (
     Attribute,
     BitEnumAttribute,
@@ -41,6 +42,7 @@ from xdsl.irdl import (
     BaseAttr,
     IRDLOperation,
     ParameterDef,
+    ParsePropInAttrDict,
     VarConstraint,
     base,
     irdl_attr_definition,
@@ -57,7 +59,13 @@ from xdsl.irdl import (
 )
 from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
-from xdsl.traits import IsTerminator, NoMemoryEffect, SymbolOpInterface
+from xdsl.traits import (
+    IsTerminator,
+    NoMemoryEffect,
+    Pure,
+    SameOperandsAndResultType,
+    SymbolOpInterface,
+)
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.isattr import isattr
@@ -1710,10 +1718,7 @@ class ZeroOp(IRDLOperation):
     res = result_def(LLVMTypeConstr)
 
 
-@irdl_op_definition
-class BitcastOp(IRDLOperation):
-    name = "llvm.bitcast"
-
+class GenericCastOp(IRDLOperation, ABC):
     arg = operand_def(Attribute)
     """
     LLVM-compatible non-aggregate type
@@ -1735,56 +1740,136 @@ class BitcastOp(IRDLOperation):
         )
 
 
+class AbstractFloatArithOp(IRDLOperation, ABC):
+    T: ClassVar = VarConstraint("T", AnyFloatConstr)
+
+    lhs = operand_def(T)
+    rhs = operand_def(T)
+    res = result_def(T)
+
+    fastmathFlags = prop_def(FastMathAttr, default_value=FastMathAttr(None))
+
+    traits = traits_def(Pure())
+
+    assembly_format = "$lhs `,` $rhs attr-dict `:` type($lhs)"
+
+    irdl_options = [ParsePropInAttrDict(), SameOperandsAndResultType()]
+
+    def __init__(
+        self,
+        lhs: SSAValue | Operation,
+        rhs: SSAValue | Operation,
+        fast_math: FastMathAttr | FastMathFlag | None = None,
+        attrs: dict[str, Attribute] | None = None,
+    ):
+        if isinstance(fast_math, FastMathFlag | str | None):
+            fast_math = FastMathAttr(fast_math)
+
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[SSAValue.get(lhs).type],
+            properties={"fastmathFlags": fast_math},
+            attributes=attrs,
+        )
+
+
+@irdl_op_definition
+class FAddOp(AbstractFloatArithOp):
+    name = "llvm.fadd"
+
+
+@irdl_op_definition
+class FMulOp(AbstractFloatArithOp):
+    name = "llvm.fmul"
+
+
+@irdl_op_definition
+class FDivOp(AbstractFloatArithOp):
+    name = "llvm.fdiv"
+
+
+@irdl_op_definition
+class FSubOp(AbstractFloatArithOp):
+    name = "llvm.fsub"
+
+
+@irdl_op_definition
+class FRemOp(AbstractFloatArithOp):
+    name = "llvm.frem"
+
+
+@irdl_op_definition
+class BitcastOp(GenericCastOp):
+    name = "llvm.bitcast"
+
+
+@irdl_op_definition
+class SIToFPOp(GenericCastOp):
+    name = "llvm.sitofp"
+
+
+@irdl_op_definition
+class FPExtOp(GenericCastOp):
+    name = "llvm.fpext"
+
+
 LLVM = Dialect(
     "llvm",
     [
-        AddOp,
-        BitcastOp,
-        SubOp,
-        MulOp,
-        UDivOp,
-        SDivOp,
-        URemOp,
-        SRemOp,
-        AndOp,
-        OrOp,
-        XOrOp,
-        ShlOp,
-        LShrOp,
         AShrOp,
-        TruncOp,
-        ZExtOp,
-        SExtOp,
-        ICmpOp,
-        ExtractValueOp,
-        InsertValueOp,
-        InlineAsmOp,
-        UndefOp,
-        AllocaOp,
-        GEPOp,
-        IntToPtrOp,
-        NullOp,
-        LoadOp,
-        StoreOp,
-        GlobalOp,
+        AddOp,
         AddressOfOp,
-        FuncOp,
-        CallOp,
-        ReturnOp,
-        ConstantOp,
+        AllocaOp,
+        AndOp,
+        BitcastOp,
         CallIntrinsicOp,
+        CallOp,
+        ConstantOp,
+        ExtractValueOp,
+        FAddOp,
+        FDivOp,
+        FMulOp,
+        FPExtOp,
+        FRemOp,
+        FSubOp,
+        FuncOp,
+        GEPOp,
+        GlobalOp,
+        ICmpOp,
+        InlineAsmOp,
+        InsertValueOp,
+        IntToPtrOp,
+        LShrOp,
+        LoadOp,
+        MulOp,
+        NullOp,
+        OrOp,
+        ReturnOp,
+        SDivOp,
+        SExtOp,
+        SIToFPOp,
+        SRemOp,
+        ShlOp,
+        StoreOp,
+        SubOp,
+        TruncOp,
+        UDivOp,
+        URemOp,
+        UndefOp,
+        XOrOp,
+        ZExtOp,
         ZeroOp,
     ],
     [
-        LLVMStructType,
-        LLVMPointerType,
-        LLVMArrayType,
-        LLVMVoidType,
-        LLVMFunctionType,
-        LinkageAttr,
         CallingConventionAttr,
-        TailCallKindAttr,
         FastMathAttr,
+        LLVMArrayType,
+        LLVMFunctionType,
+        LLVMPointerType,
+        LLVMStructType,
+        LLVMVoidType,
+        LinkageAttr,
         OverflowAttr,
+        TailCallKindAttr,
     ],
 )


### PR DESCRIPTION
Adds the following llvm floating point operations:

- `llvm.fadd`
- `llvm.fsub`
- `llvm.fmul`
- `llvm.fdiv`
- `llvm.frem`
- `llvm.sitofp`
- `llvm.fpext`

Closes #3780 

I also took the liberty to sort the dialect lists alphabetically