### PR TITLE
core: (assembly-format) omit default attributes/properties from attr-dict directive

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2965,6 +2965,68 @@ def test_default_property_with_extractor(program: str, generic: str):
     check_equivalence(program, generic, ctx)
 
 
+@pytest.mark.parametrize(
+    "program, generic",
+    [
+        (
+            "test.default_attr_dict",
+            '"test.default_attr_dict"() <{prop = false}> {attr = false} : () -> ()',
+        ),
+        (
+            "test.default_attr_dict {attr = true, prop = true}",
+            '"test.default_attr_dict"() <{prop = true}> {attr = true} : () -> ()',
+        ),
+    ],
+)
+def test_default_property_in_attr_dict(program: str, generic: str):
+    @irdl_op_definition
+    class DefaultAttrDictOp(IRDLOperation):
+        name = "test.default_attr_dict"
+
+        prop = prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+
+        attr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+
+        irdl_options = [ParsePropInAttrDict()]
+
+        assembly_format = "attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(DefaultAttrDictOp)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic",
+    [
+        (
+            "test.default_attr_dict",
+            '"test.default_attr_dict"() {attr = false} : () -> ()',
+        ),
+        (
+            "test.default_attr_dict {attr = true}",
+            '"test.default_attr_dict"() {attr = true} : () -> ()',
+        ),
+    ],
+)
+def test_default_attr_in_attr_dict(program: str, generic: str):
+    @irdl_op_definition
+    class DefaultAttrDictOp(IRDLOperation):
+        name = "test.default_attr_dict"
+
+        attr = attr_def(BoolAttr, default_value=BoolAttr.from_bool(False))
+
+        assembly_format = "attr-dict"
+
+    ctx = MLContext()
+    ctx.load_op(DefaultAttrDictOp)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic, ctx)
+
+
 ################################################################################
 #                                Extractors                                    #
 ################################################################################

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -441,7 +441,7 @@ class AttrDictDirective(FormatDirective):
             if any(name in op.attributes for name in op.properties):
                 raise ValueError(
                     "Cannot print attributes and properties with the same name "
-                    "in a signle dictionary"
+                    "in a single dictionary"
                 )
             op_def = op.get_irdl_definition()
             dictionary = op.attributes | op.properties

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -438,27 +438,41 @@ class AttrDictDirective(FormatDirective):
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if self.print_properties:
-            if (
-                not (set(op.attributes.keys()) | set(op.properties.keys()))
-                - self.reserved_attr_names
-            ):
-                return
             if any(name in op.attributes for name in op.properties):
                 raise ValueError(
                     "Cannot print attributes and properties with the same name "
                     "in a signle dictionary"
                 )
+            op_def = op.get_irdl_definition()
+            dictionary = op.attributes | op.properties
+            default_names = set(
+                name
+                for name, d in (op_def.properties | op_def.attributes).items()
+                if d.default_value is not None
+                and dictionary.get(name) == d.default_value
+            )
+            reserved_or_default = self.reserved_attr_names | default_names
+            if not (set(dictionary.keys())) - reserved_or_default:
+                return
             printer.print_op_attributes(
-                op.attributes | op.properties,
-                reserved_attr_names=self.reserved_attr_names,
+                dictionary,
+                reserved_attr_names=reserved_or_default,
                 print_keyword=self.with_keyword,
             )
         else:
-            if not set(op.attributes.keys()) - self.reserved_attr_names:
+            op_def = op.get_irdl_definition()
+            default_names = set(
+                name
+                for name, d in op_def.attributes.items()
+                if d.default_value is not None
+                and op.attributes.get(name) == d.default_value
+            )
+            reserved_or_default = self.reserved_attr_names | default_names
+            if not set(op.attributes.keys()) - reserved_or_default:
                 return
             printer.print_op_attributes(
                 op.attributes,
-                reserved_attr_names=self.reserved_attr_names,
+                reserved_attr_names=reserved_or_default,
                 print_keyword=self.with_keyword,
             )
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -445,14 +445,13 @@ class AttrDictDirective(FormatDirective):
                 )
             op_def = op.get_irdl_definition()
             dictionary = op.attributes | op.properties
-            default_names = set(
+            reserved_or_default = self.reserved_attr_names.union(
                 name
                 for name, d in (op_def.properties | op_def.attributes).items()
                 if d.default_value is not None
                 and dictionary.get(name) == d.default_value
             )
-            reserved_or_default = self.reserved_attr_names | default_names
-            if not (set(dictionary.keys())) - reserved_or_default:
+            if reserved_or_default.issuperset(dictionary.keys()):
                 return
             printer.print_op_attributes(
                 dictionary,
@@ -461,14 +460,13 @@ class AttrDictDirective(FormatDirective):
             )
         else:
             op_def = op.get_irdl_definition()
-            default_names = set(
+            reserved_or_default = self.reserved_attr_names.union(
                 name
                 for name, d in op_def.attributes.items()
                 if d.default_value is not None
                 and op.attributes.get(name) == d.default_value
             )
-            reserved_or_default = self.reserved_attr_names | default_names
-            if not set(op.attributes.keys()) - reserved_or_default:
+            if reserved_or_default.issuperset(op.attributes.keys()):
                 return
             printer.print_op_attributes(
                 op.attributes,


### PR DESCRIPTION
The `attr-dict` directive currently prints attributes/properties which are set to the default value, which is not the correct behaviour.