### PR TITLE
documentation: update MLIR interoperation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ MLIR version is commit `d401987fe349a87c53fe25829215b080b70c0c1a`.
 ### Subprojects With Extra Dependencies
 
 xDSL has a number of subprojects, some of which require extra dependencies.
-In order to keep the set of dependencies ot a minimum, these extra dependencies have to be
+In order to keep the set of dependencies to a minimum, these extra dependencies have to be
 specified explicitly. To install these, use:
 
 ``` bash
@@ -78,7 +78,7 @@ for users interested in that use case.
 - [A Database example](https://xdsl.dev/xdsl/lab/index.html?path=database_example.ipynb)
 - [A simple introduction](https://xdsl.dev/xdsl/lab/index.html?path=tutorial.ipynb)
 - [A DSL for defining new IRs](https://xdsl.dev/xdsl/lab/index.html?path=irdl.ipynb)
-- [Connecting xDSL with MLIR](docs/mlir_interoperation.md)
+- [Connecting xDSL with MLIR](docs/guides/mlir_interoperation.md)
 
 We provide a Makefile containing a lot of common tasks, which might provide
 an overview of common actions.


### PR DESCRIPTION
# PR Summary
Small PR - Commit bba4671d32019aee7918d51db79e8ca94e657704 moved `mlir_interoperation.md`. This PR adjusts sources to changes. It also fixes a typo along the way.