### PR TITLE
dialects: (builtin) fix formatting of module printing with attributes

### DIFF
--- a/tests/filecheck/dialects/builtin/module.mlir
+++ b/tests/filecheck/dialects/builtin/module.mlir
@@ -1,22 +1,28 @@
 // RUN: XDSL_ROUNDTRIP
-// RUN: xdsl-opt %s --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt %s --allow-unregistered-dialect | filecheck --strict-whitespace %s
 
-builtin.module {
-  // CHECK: builtin.module {
-    builtin.module {}
-    // CHECK: builtin.module {
-    // CHECK-NEXT: }
-    builtin.module attributes {a = "foo", b = "bar", unit} {}
-    // CHECK-NEXT: builtin.module attributes {a = "foo", b = "bar", unit} {
-    // CHECK-NEXT: }
-    builtin.module @moduleName {}
-    // CHECK-NEXT: builtin.module @moduleName {
-    // CHECK-NEXT: }
-    builtin.module @otherModule attributes {dialect.attr} {}
-    // CHECK-NEXT: builtin.module @otherModule attributes  {dialect.attr} {
-    // CHECK-NEXT: }
-    module {}
-    // CHECK-NEXT: builtin.module {
-    // CHECK-NEXT: }
-}
-// CHECK: }
+// CHECK:builtin.module {
+         builtin.module {
+
+// CHECK-NEXT:  builtin.module {
+// CHECK-NEXT:  }
+                builtin.module {}
+
+// CHECK-NEXT:  builtin.module attributes {a = "foo", b = "bar", unit} {
+// CHECK-NEXT:  }
+                builtin.module attributes {a = "foo", b = "bar", unit} {}
+
+// CHECK-NEXT:  builtin.module @moduleName {
+// CHECK-NEXT:  }
+                builtin.module @moduleName {}
+
+// CHECK-NEXT:  builtin.module @otherModule attributes {dialect.attr} {
+// CHECK-NEXT:  }
+                builtin.module @otherModule attributes {dialect.attr} {}
+
+// CHECK-NEXT:  builtin.module {
+// CHECK-NEXT:  }
+                module {}
+
+// CHECK:}
+         }

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1735,9 +1735,8 @@ class ModuleOp(IRDLOperation):
         if self.sym_name is not None:
             printer.print(f" @{self.sym_name.data}")
 
-        if len(self.attributes) != 0:
-            printer.print(" attributes ")
-            printer.print_op_attributes(self.attributes)
+        if self.attributes:
+            printer.print_op_attributes(self.attributes, print_keyword=True)
 
         if not self.body.block.ops:
             # Do not print the entry block if the region has an empty block


### PR DESCRIPTION
Instead of printing two spaces, print one.