### PR TITLE
core: (constraints) add IntAttrConstraint

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3163,25 +3163,26 @@ def test_multiple_operand_extraction_fails():
 ################################################################################
 
 
+@irdl_op_definition
+class IntAttrExtractOp(IRDLOperation):
+    name = "test.int_attr_extract"
+
+    _I: ClassVar = IntVarConstraint("I", AnyInt())
+
+    prop = prop_def(
+        IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
+    )
+
+    outs = var_result_def(RangeOf(eq(IndexType()), length=_I))
+
+    assembly_format = "$prop attr-dict"
+
+
 @pytest.mark.parametrize(
     "program",
     ["%0 = test.int_attr_extract 1", "%0, %1 = test.int_attr_extract 2"],
 )
 def test_int_attr_extraction(program: str):
-    @irdl_op_definition
-    class IntAttrExtractOp(IRDLOperation):
-        name = "test.int_attr_extract"
-
-        _I: ClassVar = IntVarConstraint("I", AnyInt())
-
-        prop = prop_def(
-            IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
-        )
-
-        outs = var_result_def(RangeOf(eq(IndexType()), length=_I))
-
-        assembly_format = "$prop attr-dict"
-
     ctx = MLContext()
     ctx.load_op(IntAttrExtractOp)
 
@@ -3202,25 +3203,30 @@ def test_int_attr_extraction(program: str):
     ],
 )
 def test_int_attr_extraction_errors(program: str, error: str):
-    @irdl_op_definition
-    class IntAttrExtractOp(IRDLOperation):
-        name = "test.int_attr_extract"
-
-        _I: ClassVar = IntVarConstraint("I", AnyInt())
-
-        prop = prop_def(
-            IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
-        )
-
-        outs = var_result_def(RangeOf(eq(IndexType()), length=_I))
-
-        assembly_format = "$prop attr-dict"
-
     ctx = MLContext()
     ctx.load_op(IntAttrExtractOp)
     parser = Parser(ctx, program)
     with pytest.raises(ParseError, match=error):
         parser.parse_optional_operation()
+
+
+@irdl_op_definition
+class IntAttrVerifyOp(IRDLOperation):
+    name = "test.int_attr_verify"
+
+    _I: ClassVar = IntVarConstraint("I", AnyInt())
+
+    prop = prop_def(
+        IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
+    )
+
+    prop2 = opt_prop_def(
+        IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
+    )
+
+    ins = var_operand_def(RangeOf(eq(IndexType()), length=_I))
+
+    assembly_format = "$prop (`and` $prop2^)? `,` $ins attr-dict"
 
 
 @pytest.mark.parametrize(
@@ -3233,26 +3239,8 @@ def test_int_attr_extraction_errors(program: str, error: str):
     ],
 )
 def test_int_attr_verify(program: str):
-    @irdl_op_definition
-    class IntAttrExtractOp(IRDLOperation):
-        name = "test.int_attr_verify"
-
-        _I: ClassVar = IntVarConstraint("I", AnyInt())
-
-        prop = prop_def(
-            IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
-        )
-
-        prop2 = opt_prop_def(
-            IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
-        )
-
-        ins = var_operand_def(RangeOf(eq(IndexType()), length=_I))
-
-        assembly_format = "$prop (`and` $prop2^)? `,` $ins attr-dict"
-
     ctx = MLContext()
-    ctx.load_op(IntAttrExtractOp)
+    ctx.load_op(IntAttrVerifyOp)
 
     check_roundtrip(program, ctx)
 
@@ -3283,26 +3271,8 @@ def test_int_attr_verify(program: str):
     ],
 )
 def test_int_attr_verify_errors(program: str, error_type: type[Exception], error: str):
-    @irdl_op_definition
-    class IntAttrExtractOp(IRDLOperation):
-        name = "test.int_attr_verify"
-
-        _I: ClassVar = IntVarConstraint("I", AnyInt())
-
-        prop = prop_def(
-            IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
-        )
-
-        prop2 = opt_prop_def(
-            IntegerAttr.constr(value=IntAttrConstraint(_I), type=eq(IndexType()))
-        )
-
-        ins = var_operand_def(RangeOf(eq(IndexType()), length=_I))
-
-        assembly_format = "$prop (`and` $prop2^)? `,` $ins attr-dict"
-
     ctx = MLContext()
-    ctx.load_op(IntAttrExtractOp)
+    ctx.load_op(IntAttrVerifyOp)
 
     parser = Parser(ctx, program)
     with pytest.raises(error_type, match=error):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import struct
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence, Set
 from dataclasses import dataclass
 from enum import Enum
 from math import prod
@@ -52,6 +52,8 @@ from xdsl.irdl import (
     ConstraintVariableType,
     GenericAttrConstraint,
     GenericData,
+    InferenceContext,
+    IntConstraint,
     IRDLOperation,
     MessageConstraint,
     ParamAttrConstraint,
@@ -294,6 +296,42 @@ class IntAttr(Data[int]):
     def print_parameter(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
             printer.print_string(f"{self.data}")
+
+
+@dataclass(frozen=True)
+class IntAttrConstraint(GenericAttrConstraint[IntAttr]):
+    """
+    Constrains the value of an IntAttr.
+    """
+
+    int_constraint: IntConstraint
+
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+        if not isinstance(attr, IntAttr):
+            raise VerifyException(f"attribute {attr} expected to be an IntAttr")
+        self.int_constraint.verify(attr.data, constraint_context)
+
+    @dataclass(frozen=True)
+    class _Extractor(VarExtractor[IntAttr]):
+        inner: VarExtractor[int]
+
+        def extract_var(self, a: IntAttr) -> ConstraintVariableType:
+            return self.inner.extract_var(a.data)
+
+    def get_variable_extractors(self) -> dict[str, VarExtractor[IntAttr]]:
+        return {
+            k: self._Extractor(v)
+            for k, v in self.int_constraint.get_length_extractors().items()
+        }
+
+    def can_infer(self, var_constraint_names: Set[str]) -> bool:
+        return self.int_constraint.can_infer(var_constraint_names)
+
+    def infer(self, context: InferenceContext) -> IntAttr:
+        return IntAttr(self.int_constraint.infer(context))
+
+    def get_unique_base(self) -> type[Attribute] | None:
+        return IntAttr
 
 
 class Signedness(Enum):


### PR DESCRIPTION
Adds a constraint that applies an integer constraint to the value of an integer attribute.

See: https://github.com/xdslproject/inconspiquous/blob/70f923cfe577b7eb48ece03d6f9a597c296cb698/inconspiquous/dialects/gate.py#L237
and https://github.com/xdslproject/inconspiquous/blob/70f923cfe577b7eb48ece03d6f9a597c296cb698/inconspiquous/dialects/qssa.py#L78

for an example of using this. 

I'm unsure if this is the best place for this to live, or if it should be upstreamed at all.

