### PR TITLE
core: (ContainerOf) improve python typing

### DIFF
--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping, Sequence
 from typing import ClassVar, Literal, TypeVar, cast, overload
 
 from xdsl.dialects.builtin import (
-    I1,
     AnyFloat,
     AnyFloatConstr,
     AnyIntegerAttr,
@@ -56,7 +55,7 @@ from xdsl.traits import (
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.str_enum import StrEnum
 
-boolLike = ContainerOf[I1](IntegerType(1))
+boolLike = ContainerOf(IntegerType(1))
 signlessIntegerLike = ContainerOf(AnyOf([IntegerType, IndexType]))
 floatingPointLike = ContainerOf(AnyOf([Float16Type, Float32Type, Float64Type]))
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import ClassVar, Literal, TypeVar, cast, overload
 
 from xdsl.dialects.builtin import (
+    I1,
     AnyFloat,
     AnyFloatConstr,
     AnyIntegerAttr,
@@ -55,7 +56,7 @@ from xdsl.traits import (
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.str_enum import StrEnum
 
-boolLike = ContainerOf(IntegerType(1))
+boolLike = ContainerOf[I1](IntegerType(1))
 signlessIntegerLike = ContainerOf(AnyOf([IntegerType, IndexType]))
 floatingPointLike = ContainerOf(AnyOf([Float16Type, Float32Type, Float64Type]))
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1094,13 +1094,21 @@ AnyUnrankedTensorTypeConstr = BaseAttr[AnyUnrankedTensorType](UnrankedTensorType
 
 
 @dataclass(frozen=True, init=False)
-class ContainerOf(AttrConstraint):
+class ContainerOf(
+    Generic[AttributeCovT],
+    GenericAttrConstraint[
+        AttributeCovT | VectorType[AttributeCovT] | TensorType[AttributeCovT]
+    ],
+):
     """A type constraint that can be nested once in a vector or a tensor."""
 
-    elem_constr: AttrConstraint
+    elem_constr: GenericAttrConstraint[AttributeCovT]
 
     def __init__(
-        self, elem_constr: Attribute | type[Attribute] | AttrConstraint
+        self,
+        elem_constr: Attribute
+        | type[AttributeCovT]
+        | GenericAttrConstraint[AttributeCovT],
     ) -> None:
         object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1106,7 +1106,7 @@ class ContainerOf(
 
     def __init__(
         self,
-        elem_constr: Attribute
+        elem_constr: AttributeCovT
         | type[AttributeCovT]
         | GenericAttrConstraint[AttributeCovT],
     ) -> None:

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -34,7 +34,7 @@ from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.traits import Pure
 
-integerOrFloatLike: ContainerOf = ContainerOf(
+integerOrFloatLike = ContainerOf(
     AnyOf(
         [
             IntegerType,


### PR DESCRIPTION
Improves the python typing bounds on the `ContainerOf` constraint.