### PR TITLE
dialects: (func) clean up is_declaration [NFC]

### DIFF
--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -302,7 +302,7 @@ class FuncOp(IRDLOperation):
         A helper to identify functions that are external declarations (have an empty
         function body)
         """
-        return len(self.body.blocks) == 0
+        return not self.body.blocks
 
 
 @irdl_op_definition


### PR DESCRIPTION
Avoids O(n) len computation.