### PR TITLE
core: make all constr methods classmethods

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2364,8 +2364,9 @@ def test_nested_inference():
         p: ParameterDef[_T]
         q: ParameterDef[Attribute]
 
-        @staticmethod
+        @classmethod
         def constr(
+            cls,
             *,
             n: GenericAttrConstraint[Attribute] | None = None,
             p: GenericAttrConstraint[_ConstrT] | None = None,
@@ -2409,8 +2410,9 @@ def test_non_verifying_inference():
         name = "test.param_one"
         p: ParameterDef[_T]
 
-        @staticmethod
+        @classmethod
         def constr(
+            cls,
             *,
             p: GenericAttrConstraint[_ConstrT] | None = None,
         ) -> BaseAttr[ParamOne[Attribute]] | ParamAttrConstraint[ParamOne[_ConstrT]]:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -739,8 +739,9 @@ class IntegerAttr(
     def get_type(self) -> Attribute:
         return self.type
 
-    @staticmethod
+    @classmethod
     def constr(
+        cls,
         *,
         value: AttrConstraint | None = None,
         type: GenericAttrConstraint[_IntegerAttrTypeConstrT] = IntegerAttrTypeConstr,
@@ -1952,8 +1953,9 @@ class MemRefType(
             case _:
                 return self.layout.get_strides()
 
-    @staticmethod
+    @classmethod
     def constr(
+        cls,
         *,
         shape: GenericAttrConstraint[Attribute] | None = None,
         element_type: GenericAttrConstraint[_MemRefTypeElementConstrT] = AnyAttr(),


### PR DESCRIPTION
Makes every constr method (found with ripgrep `def\ constr`) a classmethod instead of a staticmethod. This is in preparation for adding a default `constr` method to `Attribute` in a future PR.

