### PR TITLE
core: add constr method to Attribute

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2364,8 +2364,9 @@ def test_nested_inference():
         p: ParameterDef[_T]
         q: ParameterDef[Attribute]
 
-        @staticmethod
+        @classmethod
         def constr(
+            cls,
             *,
             n: GenericAttrConstraint[Attribute] | None = None,
             p: GenericAttrConstraint[_ConstrT] | None = None,
@@ -2409,8 +2410,9 @@ def test_non_verifying_inference():
         name = "test.param_one"
         p: ParameterDef[_T]
 
-        @staticmethod
+        @classmethod
         def constr(
+            cls,
             *,
             p: GenericAttrConstraint[_ConstrT] | None = None,
         ) -> BaseAttr[ParamOne[Attribute]] | ParamAttrConstraint[ParamOne[_ConstrT]]:

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import textwrap
 from collections.abc import Callable
 from io import StringIO
-from typing import Annotated, ClassVar, Generic, TypeVar
+from typing import Annotated, ClassVar, Generic
 
 import pytest
+from typing_extensions import TypeVar
 
 from xdsl.context import MLContext
 from xdsl.dialects import test
@@ -2261,7 +2262,7 @@ def test_optional_successor(program: str, generic_program: str):
 # Inference                                                                   #
 ################################################################################
 
-_T = TypeVar("_T", bound=Attribute, covariant=True)
+_T = TypeVar("_T", bound=Attribute, covariant=True, default=Attribute)
 _ConstrT = TypeVar("_ConstrT", bound=Attribute, covariant=True)
 
 
@@ -2369,12 +2370,12 @@ def test_nested_inference():
             cls,
             *,
             n: GenericAttrConstraint[Attribute] | None = None,
-            p: GenericAttrConstraint[_ConstrT] | None = None,
+            p: GenericAttrConstraint[_T] | None = None,
             q: GenericAttrConstraint[Attribute] | None = None,
-        ) -> BaseAttr[ParamOne[Attribute]] | ParamAttrConstraint[ParamOne[_ConstrT]]:
+        ) -> BaseAttr[ParamOne[_T]] | ParamAttrConstraint[ParamOne[_T]]:
             if n is None and p is None and q is None:
-                return BaseAttr[ParamOne[Attribute]](ParamOne)
-            return ParamAttrConstraint[ParamOne[_ConstrT]](ParamOne, (n, p, q))
+                return BaseAttr[ParamOne[_T]](ParamOne)
+            return ParamAttrConstraint[ParamOne[_T]](ParamOne, (n, p, q))
 
     @irdl_op_definition
     class TwoOperandsNestedVarOp(IRDLOperation):
@@ -2414,11 +2415,11 @@ def test_non_verifying_inference():
         def constr(
             cls,
             *,
-            p: GenericAttrConstraint[_ConstrT] | None = None,
-        ) -> BaseAttr[ParamOne[Attribute]] | ParamAttrConstraint[ParamOne[_ConstrT]]:
+            p: GenericAttrConstraint[_T] | None = None,
+        ) -> BaseAttr[ParamOne[_T]] | ParamAttrConstraint[ParamOne[_T]]:
             if p is None:
-                return BaseAttr[ParamOne[Attribute]](ParamOne)
-            return ParamAttrConstraint[ParamOne[_ConstrT]](ParamOne, (p,))
+                return BaseAttr[ParamOne[_T]](ParamOne)
+            return ParamAttrConstraint[ParamOne[_T]](ParamOne, (p,))
 
     @irdl_op_definition
     class OneOperandOneResultNestedOp(IRDLOperation):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -739,8 +739,9 @@ class IntegerAttr(
     def get_type(self) -> Attribute:
         return self.type
 
-    @staticmethod
+    @classmethod
     def constr(
+        cls,
         *,
         value: AttrConstraint | None = None,
         type: GenericAttrConstraint[_IntegerAttrTypeConstrT] = IntegerAttrTypeConstr,
@@ -1952,8 +1953,9 @@ class MemRefType(
             case _:
                 return self.layout.get_strides()
 
-    @staticmethod
+    @classmethod
     def constr(
+        cls,
         *,
         shape: GenericAttrConstraint[Attribute] | None = None,
         element_type: GenericAttrConstraint[_MemRefTypeElementConstrT] = AnyAttr(),

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -13,13 +13,12 @@ from typing import (
     Any,
     Generic,
     TypeAlias,
-    TypeVar,
     cast,
     overload,
 )
 
 from immutabledict import immutabledict
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from xdsl.ir import (
     Attribute,
@@ -648,7 +647,10 @@ class IndexType(ParametrizedAttribute, StructPackableType[int]):
 IndexTypeConstr = BaseAttr(IndexType)
 
 _IntegerAttrType = TypeVar(
-    "_IntegerAttrType", bound=IntegerType | IndexType, covariant=True
+    "_IntegerAttrType",
+    bound=IntegerType | IndexType,
+    covariant=True,
+    default=IntegerType | IndexType,
 )
 _IntegerAttrTypeInvT = TypeVar("_IntegerAttrTypeInvT", bound=IntegerType | IndexType)
 _IntegerAttrTypeConstrT = TypeVar(
@@ -744,11 +746,11 @@ class IntegerAttr(
         cls,
         *,
         value: AttrConstraint | None = None,
-        type: GenericAttrConstraint[_IntegerAttrTypeConstrT] = IntegerAttrTypeConstr,
-    ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrTypeConstrT]]:
+        type: GenericAttrConstraint[_IntegerAttrType] = IntegerAttrTypeConstr,
+    ) -> GenericAttrConstraint[IntegerAttr[_IntegerAttrType]]:
         if value is None and type == AnyAttr():
-            return BaseAttr[IntegerAttr[_IntegerAttrTypeConstrT]](IntegerAttr)
-        return ParamAttrConstraint[IntegerAttr[_IntegerAttrTypeConstrT]](
+            return BaseAttr[IntegerAttr[_IntegerAttrType]](IntegerAttr)
+        return ParamAttrConstraint[IntegerAttr[_IntegerAttrType]](
             IntegerAttr,
             (
                 value,
@@ -1816,9 +1818,8 @@ f80 = Float80Type()
 f128 = Float128Type()
 
 
-_MemRefTypeElement = TypeVar("_MemRefTypeElement", bound=Attribute, covariant=True)
-_MemRefTypeElementConstrT = TypeVar(
-    "_MemRefTypeElementConstrT", bound=Attribute, covariant=True
+_MemRefTypeElement = TypeVar(
+    "_MemRefTypeElement", bound=Attribute, covariant=True, default=Attribute
 )
 _UnrankedMemrefTypeElems = TypeVar(
     "_UnrankedMemrefTypeElems", bound=Attribute, covariant=True
@@ -1958,18 +1959,18 @@ class MemRefType(
         cls,
         *,
         shape: GenericAttrConstraint[Attribute] | None = None,
-        element_type: GenericAttrConstraint[_MemRefTypeElementConstrT] = AnyAttr(),
+        element_type: GenericAttrConstraint[_MemRefTypeElement] = AnyAttr(),
         layout: GenericAttrConstraint[Attribute] | None = None,
         memory_space: GenericAttrConstraint[Attribute] | None = None,
-    ) -> GenericAttrConstraint[MemRefType[_MemRefTypeElementConstrT]]:
+    ) -> GenericAttrConstraint[MemRefType[_MemRefTypeElement]]:
         if (
             shape is None
             and element_type == AnyAttr()
             and layout is None
             and memory_space is None
         ):
-            return BaseAttr[MemRefType[_MemRefTypeElementConstrT]](MemRefType)
-        return ParamAttrConstraint[MemRefType[_MemRefTypeElementConstrT]](
+            return BaseAttr[MemRefType[_MemRefTypeElement]](MemRefType)
+        return ParamAttrConstraint[MemRefType[_MemRefTypeElement]](
             MemRefType, (shape, element_type, layout, memory_space)
         )
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -362,7 +362,7 @@ class StencilType(
         bounds: GenericAttrConstraint[Attribute] | None = None,
         element_type: GenericAttrConstraint[_FieldTypeElement] | None = None,
     ) -> (
-        BaseAttr[StencilType[Attribute]]
+        BaseAttr[StencilType[_FieldTypeElement]]
         | ParamAttrConstraint[StencilType[_FieldTypeElement]]
     ):
         if bounds is None and element_type is None:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -37,7 +37,7 @@ from xdsl.utils.str_enum import StrEnum
 
 # Used for cyclic dependencies in type hints
 if TYPE_CHECKING:
-    from xdsl.irdl import ParamAttrDef
+    from xdsl.irdl import GenericAttrConstraint, ParamAttrDef
     from xdsl.parser import AttrParser, Parser
     from xdsl.printer import Printer
 
@@ -298,6 +298,12 @@ class Attribute(ABC):
         printer = Printer(stream=res)
         printer.print_attribute(self)
         return res.getvalue()
+
+    @classmethod
+    def constr(cls) -> GenericAttrConstraint[Self]:
+        from xdsl.irdl import BaseAttr
+
+        return BaseAttr(cls)
 
 
 class TypeAttribute(Attribute):

--- a/xdsl/transforms/memref_to_dsd.py
+++ b/xdsl/transforms/memref_to_dsd.py
@@ -21,6 +21,7 @@ from xdsl.dialects.builtin import (
     StridedLayoutAttr,
     UnrealizedConversionCastOp,
 )
+from xdsl.dialects.csl.csl import ZerosOpAttr
 from xdsl.ir import Attribute, Operation, OpResult, SSAValue
 from xdsl.ir.affine import AffineConstantExpr, AffineDimExpr, AffineExpr, AffineMap
 from xdsl.passes import ModulePass
@@ -42,7 +43,7 @@ class LowerAllocOpPass(RewritePattern):
     def match_and_rewrite(self, op: memref.AllocOp, rewriter: PatternRewriter, /):
         assert isattr(
             memref_type := op.memref.type,
-            MemRefType.constr(element_type=csl.ZerosOpAttrConstr),
+            MemRefType[ZerosOpAttr].constr(element_type=csl.ZerosOpAttrConstr),
         )
         zeros_op = csl.ZerosOp(memref_type)
 


### PR DESCRIPTION
Stacked on top of #3826 
Adds a `constr` method to `Attribute` which allows the easy construction of `BaseAttr` constraints. The hope here is to move towards having a single interface for generating constraints, instead of interchangably constructing the constraints manually, using `constr` methods, and using `AnyXConstr` type aliases.