### PR TITLE
core: add PassFailedException

### DIFF
--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -23,6 +23,10 @@ class VerifyException(DiagnosticException):
     pass
 
 
+class PassFailedException(DiagnosticException):
+    pass
+
+
 class PyRDLError(Exception):
     pass
 


### PR DESCRIPTION
Adds a `PassFailedException` as a subclass of `DiagnosticException`. Can be used to signify the failure of a pass in a way that can be caught by filecheck.