### PR TITLE
core: Disallow duplicate keys in attribute dictionaries

### DIFF
--- a/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
+++ b/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
@@ -7,4 +7,3 @@
 
 "test.op"() <{key1, key1}> : () -> ()
 // CHECK: Duplicate key 'key1' in properties dictionary 
-

--- a/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
+++ b/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
@@ -1,9 +1,9 @@
 // RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
 
-"test.op"() {key1, key1} : () -> ()
 // CHECK: Duplicate key 'key1' in dictionary attribute
+"test.op"() {key1, key1} : () -> ()
 
 // -----
 
-"test.op"() <{key1, key1}> : () -> ()
 // CHECK: Duplicate key 'key1' in properties dictionary 
+"test.op"() <{key1, key1}> : () -> ()

--- a/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
+++ b/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
@@ -1,6 +1,11 @@
 // RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
 
 // CHECK: Duplicate key 'key1' in dictionary attribute
+"test.op"() {a = {key1, key1}} : () -> ()
+
+// -----
+
+// CHECK: Duplicate key 'key1' in dictionary attribute
 "test.op"() {key1, key1} : () -> ()
 
 // -----

--- a/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
+++ b/tests/filecheck/parser-printer/duplicate_attribute_keys.mlir
@@ -1,0 +1,10 @@
+// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+
+"test.op"() {key1, key1} : () -> ()
+// CHECK: Duplicate key 'key1' in dictionary attribute
+
+// -----
+
+"test.op"() <{key1, key1}> : () -> ()
+// CHECK: Duplicate key 'key1' in properties dictionary 
+

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -195,12 +195,24 @@ class AttrParser(BaseParser):
 
         return name, self.parse_attribute()
 
+    def _find_duplicated_key(self, attrs: list[tuple[str, Attribute]]) -> str | None:
+        seen_keys: set[str] = set()
+        for key, _ in attrs:
+            if key in seen_keys:
+                return key
+            seen_keys.add(key)
+        return None
+
     def parse_optional_dictionary_attr_dict(self) -> dict[str, Attribute]:
         attrs = self.parse_optional_comma_separated_list(
             self.Delimiter.BRACES, self._parse_attribute_entry
         )
         if attrs is None:
             return dict()
+
+        if (key := self._find_duplicated_key(attrs)) is not None:
+            self.raise_error(f"Duplicate key '{key}' in dictionary attribute")
+
         return dict(attrs)
 
     def _parse_dialect_type_or_attribute_body(


### PR DESCRIPTION
This PR:

- Disallows duplicate keys in properties and attribute dictionaries
- Tests of the above

Bumped into this by accident and the tests are similar to https://github.com/llvm/llvm-project/blob/46b1543dc04970719caab0d4f9f65699fea6adbc/mlir/test/IR/invalid-builtin-attributes.mlir#L485

I don't venture often in the parser, so any feedback is welcome.