### PR TITLE
core: Add shorthand type for types that can be converted to IRDL

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1818,7 +1818,7 @@ _MemRefTypeElement = TypeVar(
     "_MemRefTypeElement", bound=Attribute, covariant=True, default=Attribute
 )
 _UnrankedMemRefTypeElems = TypeVar(
-    "_UnrankedMemRefTypeElems", bound=Attribute, covariant=True
+    "_UnrankedMemRefTypeElems", bound=Attribute, covariant=True, default=Attribute
 )
 _UnrankedMemRefTypeElemsInit = TypeVar("_UnrankedMemRefTypeElemsInit", bound=Attribute)
 

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Sequence
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects import llvm
 from xdsl.dialects.builtin import (
@@ -110,7 +112,7 @@ class DataType(ParametrizedAttribute, TypeAttribute):
 
 VectorWrappable = RequestType | StatusType | DataType
 VectorWrappableConstr = base(RequestType) | base(StatusType) | base(DataType)
-_VectorT = TypeVar("_VectorT", bound=VectorWrappable)
+_VectorT = TypeVar("_VectorT", bound=VectorWrappable, default=VectorWrappable)
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass
 from itertools import pairwise
 from math import prod
 from operator import add, lt, neg
-from typing import Annotated, Generic, TypeAlias, TypeVar, cast
+from typing import Annotated, Generic, TypeAlias, cast
+
+from typing_extensions import TypeVar
 
 from xdsl.dialects import builtin, memref
 from xdsl.dialects.builtin import (
@@ -73,7 +75,9 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.isattr import isattr
 
-_FieldTypeElement = TypeVar("_FieldTypeElement", bound=Attribute, covariant=True)
+_FieldTypeElement = TypeVar(
+    "_FieldTypeElement", bound=Attribute, covariant=True, default=Attribute
+)
 
 
 @irdl_attr_definition

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -251,11 +251,14 @@ def impl_cast(
     return annot
 
 
+AttributeInvNoDefaultT = TypeVar("AttributeInvNoDefaultT", bound=Attribute)
+
+
 def impl_attr(
-    input_type: type[AttributeInvT],
+    input_type: type[AttributeInvNoDefaultT],
 ) -> Callable[
-    [AttrImpl[_FT, AttributeInvT]],
-    AttrImpl[_FT, AttributeInvT],
+    [AttrImpl[_FT, AttributeInvNoDefaultT]],
+    AttrImpl[_FT, AttributeInvNoDefaultT],
 ]:
     """
     Marks the conversion from an attribute to a Python value. The

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -21,14 +21,13 @@ from typing import (
     Generic,
     NoReturn,
     Protocol,
-    TypeVar,
     cast,
     get_args,
     get_origin,
     overload,
 )
 
-from typing_extensions import Self, deprecated
+from typing_extensions import Self, TypeVar, deprecated
 
 from xdsl.traits import IsTerminator, NoTerminator, OpTrait, OpTraitInvT
 from xdsl.utils.exceptions import VerifyException
@@ -338,8 +337,10 @@ class SpacedOpaqueSyntaxAttribute(OpaqueSyntaxAttribute):
 
 DataElement = TypeVar("DataElement", covariant=True, bound=Hashable)
 
-AttributeCovT = TypeVar("AttributeCovT", bound=Attribute, covariant=True)
-AttributeInvT = TypeVar("AttributeInvT", bound=Attribute)
+AttributeCovT = TypeVar(
+    "AttributeCovT", bound=Attribute, covariant=True, default=Attribute
+)
+AttributeInvT = TypeVar("AttributeInvT", bound=Attribute, default=Attribute)
 
 
 @dataclass(frozen=True)

--- a/xdsl/irdl/attributes.py
+++ b/xdsl/irdl/attributes.py
@@ -11,9 +11,11 @@ from dataclasses import dataclass
 from inspect import isclass
 from types import FunctionType, GenericAlias, UnionType
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     Generic,
+    TypeAlias,
     TypeVar,
     Union,
     cast,
@@ -21,6 +23,10 @@ from typing import (
     get_origin,
     get_type_hints,
 )
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeForm
+
 
 from xdsl.ir import (
     Attribute,
@@ -256,8 +262,30 @@ def irdl_attr_definition(cls: TypeAttributeInvT) -> TypeAttributeInvT:
     )
 
 
+IRDLGenericAttrConstraint: TypeAlias = (
+    GenericAttrConstraint[AttributeInvT]
+    | Attribute
+    | type[AttributeInvT]
+    | "TypeForm[AttributeInvT]"
+    | ConstraintVar
+    | TypeVar
+)
+"""
+Attribute constraints represented using the IRDL python frontend. Attribute constraints
+can either be:
+- An instance of `AttrConstraint` representing a constraint on an attribute.
+- An instance of `Attribute` representing an equality constraint on an attribute.
+- A type representing a specific attribute class.
+- A TypeForm that can represent both unions and generic attributes.
+- A `ConstraintVar` representing a constraint variable.
+"""
+
+IRDLAttrConstraint = IRDLGenericAttrConstraint[Attribute]
+"""See `IRDLGenericAttrConstraint`."""
+
+
 def irdl_list_to_attr_constraint(
-    pyrdl_constraints: Sequence[Any],
+    pyrdl_constraints: Sequence[IRDLAttrConstraint],
     *,
     allow_type_var: bool = False,
     type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,
@@ -299,7 +327,7 @@ def irdl_list_to_attr_constraint(
 
 
 def irdl_to_attr_constraint(
-    irdl: Any,
+    irdl: IRDLAttrConstraint,
     *,
     allow_type_var: bool = False,
     type_var_mapping: dict[TypeVar, AttrConstraint] | None = None,

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -21,7 +21,6 @@ from typing import (
     overload,
 )
 
-import typing_extensions
 from typing_extensions import assert_never
 
 from xdsl.ir import (
@@ -46,6 +45,8 @@ from xdsl.utils.hints import (
 )
 
 from .attributes import (  # noqa: TID251
+    IRDLAttrConstraint,
+    IRDLGenericAttrConstraint,
     irdl_list_to_attr_constraint,
     irdl_to_attr_constraint,
 )
@@ -54,7 +55,6 @@ from .constraints import (  # noqa: TID251
     AttrConstraint,
     ConstraintContext,
     ConstraintVar,
-    GenericAttrConstraint,
     GenericRangeConstraint,
     RangeConstraint,
     RangeOf,
@@ -521,25 +521,17 @@ class _OpDefField(Generic[_ClsT]):
 
 
 class _RangeConstrainedOpDefField(Generic[_ClsT], _OpDefField[_ClsT]):
-    param: RangeConstraint | AttrConstraint | Attribute | type[Attribute] | TypeVar
+    param: RangeConstraint | IRDLAttrConstraint
 
-    def __init__(
-        self,
-        cls: type[_ClsT],
-        param: RangeConstraint | AttrConstraint | Attribute | type[Attribute] | TypeVar,
-    ):
+    def __init__(self, cls: type[_ClsT], param: RangeConstraint | IRDLAttrConstraint):
         super().__init__(cls)
         self.param = param
 
 
 class _ConstrainedOpDefField(Generic[_ClsT], _OpDefField[_ClsT]):
-    param: AttrConstraint | Attribute | type[Attribute] | TypeVar
+    param: IRDLAttrConstraint
 
-    def __init__(
-        self,
-        cls: type[_ClsT],
-        param: AttrConstraint | Attribute | type[Attribute] | TypeVar,
-    ):
+    def __init__(self, cls: type[_ClsT], param: IRDLAttrConstraint):
         super().__init__(cls)
         self.param = param
 
@@ -568,7 +560,7 @@ class _AttrOrPropFieldDef(
     def __init__(
         self,
         cls: type[AttrOrPropInvT],
-        param: AttrConstraint | Attribute | type[Attribute] | TypeVar,
+        param: IRDLAttrConstraint,
         ir_name: str | None = None,
         default_value: Attribute | None = None,
     ):
@@ -586,24 +578,12 @@ class _PropertyFieldDef(_AttrOrPropFieldDef[PropertyDef]):
 
 
 class _RegionFieldDef(_OpDefField[RegionDef]):
-    entry_args: (
-        GenericRangeConstraint[Attribute]
-        | AttrConstraint
-        | Attribute
-        | type[Attribute]
-        | TypeVar
-    )
+    entry_args: GenericRangeConstraint[Attribute] | IRDLAttrConstraint
 
     def __init__(
         self,
         cls: type[RegionDef],
-        entry_args: (
-            GenericRangeConstraint[Attribute]
-            | AttrConstraint
-            | Attribute
-            | type[Attribute]
-            | TypeVar
-        ),
+        entry_args: GenericRangeConstraint[Attribute] | IRDLAttrConstraint,
     ):
         super().__init__(cls)
         self.entry_args = entry_args
@@ -616,7 +596,7 @@ class _SuccessorFieldDef(_OpDefField[SuccessorDef]):
 
 
 def result_def(
-    constraint: (AttrConstraint | Attribute | type[Attribute] | TypeVar) = Attribute,
+    constraint: IRDLAttrConstraint = Attribute,
     *,
     default: None = None,
     resolver: None = None,
@@ -629,9 +609,7 @@ def result_def(
 
 
 def var_result_def(
-    constraint: (
-        RangeConstraint | AttrConstraint | Attribute | type[Attribute] | TypeVar
-    ) = Attribute,
+    constraint: RangeConstraint | IRDLAttrConstraint = Attribute,
     *,
     default: None = None,
     resolver: None = None,
@@ -644,9 +622,7 @@ def var_result_def(
 
 
 def opt_result_def(
-    constraint: (
-        RangeConstraint | AttrConstraint | Attribute | type[Attribute] | TypeVar
-    ) = Attribute,
+    constraint: RangeConstraint | IRDLAttrConstraint = Attribute,
     *,
     default: None = None,
     resolver: None = None,
@@ -659,7 +635,7 @@ def opt_result_def(
 
 
 def prop_def(
-    constraint: type[AttributeInvT] | TypeVar | GenericAttrConstraint[AttributeInvT],
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: Attribute | None = None,
     *,
     prop_name: str | None = None,
@@ -676,7 +652,7 @@ def prop_def(
 
 @overload
 def opt_prop_def(
-    constraint: type[AttributeInvT] | TypeVar | GenericAttrConstraint[AttributeInvT],
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: None = None,
     *,
     prop_name: str | None = None,
@@ -688,7 +664,7 @@ def opt_prop_def(
 
 @overload
 def opt_prop_def(
-    constraint: type[AttributeInvT] | TypeVar | GenericAttrConstraint[AttributeInvT],
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: Attribute,
     *,
     prop_name: str | None = None,
@@ -699,7 +675,7 @@ def opt_prop_def(
 
 
 def opt_prop_def(
-    constraint: type[AttributeInvT] | TypeVar | GenericAttrConstraint[AttributeInvT],
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: Attribute | None = None,
     *,
     prop_name: str | None = None,
@@ -715,7 +691,7 @@ def opt_prop_def(
 
 
 def attr_def(
-    constraint: (type[AttributeInvT] | TypeVar | GenericAttrConstraint[AttributeInvT]),
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: Attribute | None = None,
     *,
     attr_name: str | None = None,
@@ -734,7 +710,7 @@ def attr_def(
 
 @overload
 def opt_attr_def(
-    constraint: type[AttributeInvT] | TypeVar | GenericAttrConstraint[AttributeInvT],
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: None = None,
     *,
     attr_name: str | None = None,
@@ -746,7 +722,7 @@ def opt_attr_def(
 
 @overload
 def opt_attr_def(
-    constraint: type[AttributeInvT] | TypeVar | GenericAttrConstraint[AttributeInvT],
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: Attribute,
     *,
     attr_name: str | None = None,
@@ -757,7 +733,7 @@ def opt_attr_def(
 
 
 def opt_attr_def(
-    constraint: type[AttributeInvT] | TypeVar | AttrConstraint,
+    constraint: IRDLGenericAttrConstraint[AttributeInvT],
     default_value: Attribute | None = None,
     *,
     attr_name: str | None = None,
@@ -775,7 +751,7 @@ def opt_attr_def(
 
 
 def operand_def(
-    constraint: (AttrConstraint | Attribute | type[Attribute] | TypeVar) = Attribute,
+    constraint: IRDLAttrConstraint = Attribute,
     *,
     default: None = None,
     resolver: None = None,
@@ -788,14 +764,7 @@ def operand_def(
 
 
 def var_operand_def(
-    constraint: (
-        RangeConstraint
-        | AttrConstraint
-        | Attribute
-        | type[Attribute]
-        | TypeVar
-        | typing_extensions.TypeVar
-    ) = Attribute,
+    constraint: RangeConstraint | IRDLAttrConstraint = Attribute,
     *,
     default: None = None,
     resolver: None = None,
@@ -808,9 +777,7 @@ def var_operand_def(
 
 
 def opt_operand_def(
-    constraint: (
-        RangeConstraint | AttrConstraint | Attribute | type[Attribute] | TypeVar
-    ) = Attribute,
+    constraint: RangeConstraint | IRDLAttrConstraint = Attribute,
     *,
     default: None = None,
     resolver: None = None,
@@ -825,13 +792,9 @@ def opt_operand_def(
 def region_def(
     single_block: Literal["single_block"] | None = None,
     *,
-    entry_args: (
-        GenericRangeConstraint[Attribute]
-        | AttrConstraint
-        | Attribute
-        | type[Attribute]
-        | TypeVar
-    ) = RangeOf(AnyAttr()),
+    entry_args: GenericRangeConstraint[Attribute] | IRDLAttrConstraint = RangeOf(
+        AnyAttr()
+    ),
     default: None = None,
     resolver: None = None,
     init: Literal[False] = False,
@@ -846,13 +809,9 @@ def region_def(
 def var_region_def(
     single_block: Literal["single_block"] | None = None,
     *,
-    entry_args: (
-        GenericRangeConstraint[Attribute]
-        | AttrConstraint
-        | Attribute
-        | type[Attribute]
-        | TypeVar
-    ) = RangeOf(AnyAttr()),
+    entry_args: GenericRangeConstraint[Attribute] | IRDLAttrConstraint = RangeOf(
+        AnyAttr()
+    ),
     default: None = None,
     resolver: None = None,
     init: Literal[False] = False,
@@ -867,13 +826,9 @@ def var_region_def(
 def opt_region_def(
     single_block: Literal["single_block"] | None = None,
     *,
-    entry_args: (
-        GenericRangeConstraint[Attribute]
-        | AttrConstraint
-        | Attribute
-        | type[Attribute]
-        | TypeVar
-    ) = RangeOf(AnyAttr()),
+    entry_args: GenericRangeConstraint[Attribute] | IRDLAttrConstraint = RangeOf(
+        AnyAttr()
+    ),
     default: None = None,
     resolver: None = None,
     init: Literal[False] = False,
@@ -1118,13 +1073,7 @@ class OpDef:
 
                 # Get attribute constraints from a list of pyrdl constraints
                 def get_constraint(
-                    pyrdl_constr: (
-                        AttrConstraint
-                        | Attribute
-                        | type[Attribute]
-                        | TypeVar
-                        | ConstraintVar
-                    ),
+                    pyrdl_constr: IRDLAttrConstraint,
                 ) -> AttrConstraint:
                     return irdl_list_to_attr_constraint(
                         (pyrdl_constr,),
@@ -1134,17 +1083,11 @@ class OpDef:
 
                 # Get attribute constraints from a list of pyrdl constraints
                 def get_range_constraint(
-                    pyrdl_constr: (
-                        RangeConstraint
-                        | AttrConstraint
-                        | Attribute
-                        | type[Attribute]
-                        | TypeVar
-                        | ConstraintVar
-                    ),
+                    pyrdl_constr: RangeConstraint | IRDLAttrConstraint,
                 ) -> RangeConstraint:
                     if isinstance(pyrdl_constr, GenericRangeConstraint):
-                        return pyrdl_constr
+                        # Pyright does not know the type of the generic range constraint
+                        return cast(RangeConstraint, pyrdl_constr)
                     return RangeOf(get_constraint(pyrdl_constr))
 
                 field_names.add(field_name)

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -21,6 +21,7 @@ from typing import (
     overload,
 )
 
+import typing_extensions
 from typing_extensions import assert_never
 
 from xdsl.ir import (
@@ -788,7 +789,12 @@ def operand_def(
 
 def var_operand_def(
     constraint: (
-        RangeConstraint | AttrConstraint | Attribute | type[Attribute] | TypeVar
+        RangeConstraint
+        | AttrConstraint
+        | Attribute
+        | type[Attribute]
+        | TypeVar
+        | typing_extensions.TypeVar
     ) = Attribute,
     *,
     default: None = None,

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -93,7 +93,9 @@ def isa(arg: Any, hint: "TypeForm[_T]") -> TypeGuard[_T]:
     from xdsl.irdl import GenericData, irdl_to_attr_constraint
 
     if (origin is not None) and issubclass(origin, GenericData | ParametrizedAttribute):
-        constraint = irdl_to_attr_constraint(hint)
+        constraint = irdl_to_attr_constraint(
+            hint  # pyright: ignore[reportArgumentType]
+        )
         try:
             constraint.verify(arg, ConstraintContext())
             return True


### PR DESCRIPTION
Stacked PRs:
 * __->__#3836
 * #3835


--- --- ---

### core: Add shorthand type for types that can be converted to IRDL


There was a lot of inconsistencies in the typing of functions that are
using the type to constraint conversion. Having a shorthand makes this
more explicit.
