### PR TITLE
dialects: (linalg) enable generic printing in mlir conversion filecheck

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/linalg/ops.mlir
@@ -1,4 +1,5 @@
 // RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
+// RUN: xdsl-opt %s | xdsl-opt --print-op-generic | mlir-opt --allow-unregistered-dialect | filecheck %s
 
 %0, %1 = "test.op"() : () -> (f32, memref<1x256xf32>)
 


### PR DESCRIPTION
This PR adds generic printing to the mlir conversion filecheck

This will check whether the issues posed in #2959 are correctly resolved, by checking if mlir correctly parses the generic output of xdsl

There are still reminaing issues, solved in the following PRs:
(stacked on: ) #3838, #3839, #3840, #3841
