### PR TITLE
 dialects: (linalg) let PoolingOpsBase inherit from NamedOpBase 

### DIFF
--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -275,14 +275,16 @@ def test_linalg_pooling_nchw_max():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.PoolingNchwMaxOp(
-        DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-        DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
         (
             TestSSAValue(TensorType(f32, [1, 1, 4, 4])),
             TestSSAValue(TensorType(f32, [2, 2])),
         ),
         (TestSSAValue(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
+        {
+            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
+            "strides": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
+        },
     )
     a = ShapedArray(TypedPtr.new_float32(list(range(1, 17))), [1, 1, 4, 4])
     b = ShapedArray(
@@ -306,14 +308,16 @@ def test_linalg_pooling_nchw_max_strides_two():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.PoolingNchwMaxOp(
-        DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-        DenseIntOrFPElementsAttr.tensor_from_list([2], i64, [2]),
         (
             TestSSAValue(TensorType(f32, [1, 1, 4, 4])),
             TestSSAValue(TensorType(f32, [2, 2])),
         ),
         (TestSSAValue(TensorType(f32, [1, 1, 2, 2])),),
         (TensorType(f32, [1, 1, 2, 2]),),
+        {
+            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
+            "strides": DenseIntOrFPElementsAttr.tensor_from_list([2], i64, [2]),
+        },
     )
     a = ShapedArray(
         TypedPtr.new_float32([1, 1, 2, 4, 5, 6, 7, 8, 3, 2, 1, 0, 1, 2, 3, 4]),

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -949,44 +949,13 @@ class QuantizedMatmulOp(NamedOpBase):
         )
 
 
-class PoolingOpsBase(IRDLOperation, ABC):
+class PoolingOpsBase(NamedOpBase, ABC):
     """Base class for linalg pooling operations."""
 
-    inputs = var_operand_def()
-    outputs = var_operand_def(base(ShapedType))
-
-    res = var_result_def(AnyTensorType)
-
-    assembly_format = (
-        "attr-dict `ins` `(` $inputs `:` type($inputs) `)` ` ` "
-        "`outs` `(` $outputs `:` type($outputs) `)` `->` type($res)"
-    )
+    PRINT_ATTRS_IN_FRONT: ClassVar[bool] = True
 
     strides = attr_def(DenseIntOrFPElementsAttr)
     dilations = attr_def(DenseIntOrFPElementsAttr)
-
-    irdl_options = [AttrSizedOperandSegments(as_property=True), ParsePropInAttrDict()]
-
-    def __init__(
-        self,
-        dilations: Attribute,
-        strides: Attribute,
-        inputs: Sequence[SSAValue],
-        outputs: Sequence[SSAValue] = (),
-        res: Sequence[Attribute] | None = None,
-    ):
-        if res is None:
-            result_types = tuple(output.type for output in outputs)
-        else:
-            result_types = res
-        super().__init__(
-            attributes={
-                "dilations": dilations,
-                "strides": strides,
-            },
-            operands=(inputs, outputs),
-            result_types=result_types,
-        )
 
 
 @irdl_op_definition
@@ -998,6 +967,32 @@ class PoolingNchwMaxOp(PoolingOpsBase):
     """
 
     name = "linalg.pooling_nchw_max"
+
+    def __init__(
+        self,
+        inputs: Sequence[SSAValue],
+        outputs: Sequence[SSAValue] = (),
+        res: Sequence[Attribute] | None = None,
+        attributes: dict[str, Attribute] | None = None,
+    ):
+
+        arg_types = self.body_arg_types((*inputs, *outputs))
+
+        max_op = arith.MaximumfOp if isinstance(arg_types[-1], AnyFloat) else arith.MaxSIOp
+
+        @Builder.implicit_region(arg_types)
+        def hidden_region(args: tuple[BlockArgument, ...]) -> None:
+            result = max_op(args[0], args[1])
+            YieldOp(result)
+
+        super().__init__(
+            ins=inputs,
+            outs=outputs,
+            result_types=res,
+            attributes=attributes,
+            hidden_region=hidden_region,
+        )
+ 
 
 
 class ConvOpsBase(IRDLOperation, ABC):

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -975,10 +975,11 @@ class PoolingNchwMaxOp(PoolingOpsBase):
         res: Sequence[Attribute] | None = None,
         attributes: dict[str, Attribute] | None = None,
     ):
-
         arg_types = self.body_arg_types((*inputs, *outputs))
 
-        max_op = arith.MaximumfOp if isinstance(arg_types[-1], AnyFloat) else arith.MaxSIOp
+        max_op = (
+            arith.MaximumfOp if isinstance(arg_types[-1], AnyFloat) else arith.MaxSIOp
+        )
 
         @Builder.implicit_region(arg_types)
         def hidden_region(args: tuple[BlockArgument, ...]) -> None:
@@ -992,7 +993,6 @@ class PoolingNchwMaxOp(PoolingOpsBase):
             attributes=attributes,
             hidden_region=hidden_region,
         )
- 
 
 
 class ConvOpsBase(IRDLOperation, ABC):


### PR DESCRIPTION
To enable correct printing of the hidden regions in generic printing.

Resolves pooling in #2959 , will be tested in #3837 


The constructor of these ops had to change to comply with the NamedOpBase constructor ordering of arguments