### PR TITLE
dialects: (builtin) remove AnyIntegerAttrConstr

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -12,7 +12,6 @@ from xdsl.context import MLContext
 from xdsl.dialects import test
 from xdsl.dialects.builtin import (
     I32,
-    AnyIntegerAttrConstr,
     BoolAttr,
     Float64Type,
     FloatAttr,
@@ -2951,7 +2950,7 @@ def test_optional_property_with_extractor(program: str, generic: str):
         name = "test.opt_constant"
         T: ClassVar = VarConstraint("T", AnyAttr())
 
-        value = opt_prop_def(TypedAttributeConstraint(AnyIntegerAttrConstr, T))
+        value = opt_prop_def(TypedAttributeConstraint(IntegerAttr.constr(), T))
 
         res = opt_result_def(T)
 
@@ -2984,7 +2983,7 @@ def test_default_property_with_extractor(program: str, generic: str):
         T: ClassVar = VarConstraint("T", AnyAttr())
 
         value = prop_def(
-            TypedAttributeConstraint(AnyIntegerAttrConstr, T),
+            TypedAttributeConstraint(IntegerAttr.constr(), T),
             default_value=BoolAttr.from_bool(True),
         )
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -8,7 +8,6 @@ from xdsl.dialects.builtin import (
     AnyFloat,
     AnyFloatConstr,
     AnyIntegerAttr,
-    AnyIntegerAttrConstr,
     ContainerOf,
     DenseIntOrFPElementsAttr,
     Float16Type,
@@ -132,7 +131,7 @@ class ConstantOp(IRDLOperation):
     result = result_def(_T)
     value = prop_def(
         TypedAttributeConstraint(
-            AnyIntegerAttrConstr
+            IntegerAttr.constr()
             | BaseAttr[FloatAttr[AnyFloat]](FloatAttr)
             | BaseAttr(DenseIntOrFPElementsAttr),
             _T,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -783,7 +783,6 @@ class IntegerAttr(
 
 
 AnyIntegerAttr: TypeAlias = IntegerAttr[IntegerType | IndexType]
-AnyIntegerAttrConstr: BaseAttr[AnyIntegerAttr] = BaseAttr(IntegerAttr)
 BoolAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(1)]]
 
 

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -20,7 +20,6 @@ from xdsl.dialects.builtin import (
     AnyFloatAttr,
     AnyFloatAttrConstr,
     AnyIntegerAttr,
-    AnyIntegerAttrConstr,
     ArrayAttr,
     BoolAttr,
     ContainerType,
@@ -420,7 +419,7 @@ ColorIdAttr: TypeAlias = IntegerAttr[
 QueueIdAttr: TypeAlias = IntegerAttr[Annotated[IntegerType, IntegerType(3)]]
 
 ParamAttr: TypeAlias = AnyFloatAttr | AnyIntegerAttr
-ParamAttrConstr = AnyFloatAttrConstr | AnyIntegerAttrConstr
+ParamAttrConstr = AnyFloatAttrConstr | IntegerAttr.constr()
 
 
 @irdl_op_definition

--- a/xdsl/transforms/lower_csl_wrapper.py
+++ b/xdsl/transforms/lower_csl_wrapper.py
@@ -55,7 +55,7 @@ class ExtractCslModules(RewritePattern):
 
         params = list[SSAValue]()
         for param in op.params:
-            if isattr(param.value, builtin.AnyIntegerAttrConstr):
+            if isattr(param.value, builtin.IntegerAttr):
                 value = arith.ConstantOp(param.value)
             else:
                 value = None


### PR DESCRIPTION
`IntegerAttr` and `IntegerAttr.constr()` are sufficient