### PR TITLE
parser: parse bytes directly into a BytesAttr for DenseIntOrFPElementsAttrs

### DIFF
--- a/tests/filecheck/parser-printer/invalid_dense_attr.mlir
+++ b/tests/filecheck/parser-printer/invalid_dense_attr.mlir
@@ -1,20 +1,8 @@
 // RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
 
-"func.func"() ({}) {function_type = () -> (), value1 = dense<"0x0BAD"> : tensor<2xf16>, sym_name = "unsupported_float"} : () -> ()
-
-// CHECK: Hex strings for dense literals are only supported for int, f32 and f64 types
-
-// -----
-
 "func.func"() ({}) {function_type = () -> (), value1 = dense<"0x0INVALID"> : tensor<2xf32>, sym_name = "invalid_hex"} : () -> ()
 
 // CHECK: Hex string in denseAttr is invalid
-
-// -----
-
-"func.func"() ({}) {function_type = () -> (), value1 = dense<"0xFF"> : tensor<1xi9>, sym_name = "invalid_integer_type"} : () -> ()
-
-// CHECK: Hex strings for dense literals only support integer types that are a multiple of 8 bits
 
 // -----
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -779,9 +779,18 @@ class AttrParser(BaseParser):
             data_values = []
         elif isinstance(dense_contents, str):
             # Hex-encoded string case: convert straight to bytes (without the 0x prefix)
-            return DenseIntOrFPElementsAttr(
-                [type, BytesAttr(bytes.fromhex(dense_contents[2:]))]
-            )
+            try:
+                bytes_attr = BytesAttr(bytes.fromhex(dense_contents[2:]))
+            except ValueError:
+                self.raise_error("Hex string in denseAttr is invalid")
+            attr = DenseIntOrFPElementsAttr([type, bytes_attr])
+            if type_num_values != len(attr):
+                self.raise_error(
+                    f"Shape mismatch in dense literal. Expected {type_num_values} "
+                    f"elements from the type, but got {len(attr)} elements."
+                )
+            return attr
+
         else:
             # Tensor literal case
             dense_values, shape = dense_contents

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -780,10 +780,16 @@ class AttrParser(BaseParser):
         elif isinstance(dense_contents, str):
             # Hex-encoded string case: convert straight to bytes (without the 0x prefix)
             try:
-                bytes_attr = BytesAttr(bytes.fromhex(dense_contents[2:]))
+                bytes_values = bytes.fromhex(dense_contents[2:])
             except ValueError:
                 self.raise_error("Hex string in denseAttr is invalid")
-            attr = DenseIntOrFPElementsAttr([type, bytes_attr])
+
+            # Handle splat values given in hex
+            if len(bytes_values) == type.element_type.compile_time_size:
+                bytes_values *= type_num_values
+
+            # Create attribute
+            attr = DenseIntOrFPElementsAttr([type, BytesAttr(bytes_values)])
             if type_num_values != len(attr):
                 self.raise_error(
                     f"Shape mismatch in dense literal. Expected {type_num_values} "


### PR DESCRIPTION
Because DenseIntOrFPElementsAttrs are backed by `bytes`, there is no need to convert the hex representation to a list of values when creating the attribute. We can directly convert the hex representation to a BytesAttr when constructing the attribute.

This is a lot faster, and gets rid of a lot of code somewhat duplicating the `StructPackable` things we made.