### PR TITLE
installation: fix packages discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,9 @@ xdsl-tblgen = "xdsl.tools.tblgen_to_py:main"
 [tool.setuptools]
 platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
-packages = ["xdsl"]
+
+[tool.setuptools.packages]
+find = {}
 
 [tool.setuptools.package-data]
 xdsl = ["**/*.irdl", "py.typed", "interactive/*.tcss", "_version.py"]


### PR DESCRIPTION
Fixes regression in #3815, turns out that it expects all the packages in the folder, not just the root.