### PR TITLE
core: Fix multiline error printing

### DIFF
--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -61,3 +61,16 @@ builtin.module {
 }
 
 // CHECK: SSA value %1 is referenced with an index larger than its size
+
+// -----
+
+// A block defined twice
+
+builtin.module {
+    ^blockA:
+        "test.op"() : () -> ()
+    ^blockA:
+        "test.op"() : () -> ()
+}
+
+// CHECK: SSA value %1 is referenced with an index larger than its size

--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -73,11 +73,11 @@ builtin.module {
         "test.op"() : () -> ()
 }
 
-// CHECK:       /graph_region.mlir
+// CHECK:       /graph_region.mlir:72:4
 // CHECK-NEXT:      ^blockA:
 // CHECK-NEXT:      ^^^^^^^
 // CHECK-NEXT:      re-declaration of block 'blockA'
 // CHECK-NEXT:  originally declared here:
-// CHECK-NEXT:  tests/filecheck/parser-printer/graph_region.mlir:6:4
+// CHECK-NEXT:  /graph_region.mlir:6:4
 // CHECK-NEXT:      ^blockA:
 // CHECK-NEXT:      ^^^^^^^

--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -73,7 +73,7 @@ builtin.module {
         "test.op"() : () -> ()
 }
 
-// CHECK:       tests/filecheck/parser-printer/graph_region.mlir:72:4
+// CHECK:       /graph_region.mlir
 // CHECK-NEXT:      ^blockA:
 // CHECK-NEXT:      ^^^^^^^
 // CHECK-NEXT:      re-declaration of block 'blockA'

--- a/tests/filecheck/parser-printer/graph_region.mlir
+++ b/tests/filecheck/parser-printer/graph_region.mlir
@@ -73,4 +73,11 @@ builtin.module {
         "test.op"() : () -> ()
 }
 
-// CHECK: SSA value %1 is referenced with an index larger than its size
+// CHECK:       tests/filecheck/parser-printer/graph_region.mlir:72:4
+// CHECK-NEXT:      ^blockA:
+// CHECK-NEXT:      ^^^^^^^
+// CHECK-NEXT:      re-declaration of block 'blockA'
+// CHECK-NEXT:  originally declared here:
+// CHECK-NEXT:  tests/filecheck/parser-printer/graph_region.mlir:6:4
+// CHECK-NEXT:      ^blockA:
+// CHECK-NEXT:      ^^^^^^^

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -87,9 +87,10 @@ class MultipleSpansParseError(ParseError):
     ref_text: str | None
     refs: list[tuple[Span, str | None]]
 
-    def __repr__(self) -> str:
-        res = super().__repr__() + "\n"
-        res += self.ref_text or "With respect to:\n"
+    def __str__(self) -> str:
+        res = self.span.print_with_context(self.msg)
+        if self.ref_text is not None:
+            res += self.ref_text + "\n"
         for span, msg in self.refs:
             res += span.print_with_context(msg) + "\n"
         return res


### PR DESCRIPTION
Fix the MultipleSpanParseError to print multiple lines in the error output
