### PR TITLE
core: Fix bug in extractor when having nested variables

### DIFF
--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -303,7 +303,9 @@ class VarConstraint(GenericAttrConstraint[AttributeCovT]):
             constraint_context.set_variable(self.name, attr)
 
     def get_variable_extractors(self) -> dict[str, VarExtractor[AttributeCovT]]:
-        return {self.name: IdExtractor()}
+        return merge_extractor_dicts(
+            {self.name: IdExtractor()}, self.constraint.get_variable_extractors()
+        )
 
     def infer(self, context: InferenceContext) -> AttributeCovT:
         v = context.variables[self.name]


### PR DESCRIPTION
When having an attribute constraint variable `T` and a variable `U` that could infer the
variable `T` (for instance `U = Vector<T>`), the constraint `U` would not realize that it can infer `T`.