### PR TITLE
backend: (riscv) split out register queue interface from implementation

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -8,7 +8,7 @@ from xdsl.backend.riscv.register_allocation import (
     RegisterAllocatorLivenessBlockNaive,
     reg_types,
 )
-from xdsl.backend.riscv.register_queue import RegisterQueue
+from xdsl.backend.riscv.riscv_register_queue import RiscvRegisterQueue
 from xdsl.dialects import riscv
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
 from xdsl.utils.exceptions import DiagnosticException
@@ -16,7 +16,7 @@ from xdsl.utils.test_value import TestSSAValue
 
 
 def test_default_reserved_registers():
-    register_queue = RegisterQueue(
+    register_queue = RiscvRegisterQueue(
         available_int_registers=[], available_float_registers=[]
     )
 
@@ -108,7 +108,7 @@ def test_allocate_with_inout_constraints():
                 (self.rs0,), (self.rd0,), ((self.rs1, self.rd1),)
             )
 
-    register_queue = RegisterQueue(
+    register_queue = RiscvRegisterQueue(
         available_int_registers=[], available_float_registers=[]
     )
     register_allocator = RegisterAllocatorLivenessBlockNaive(register_queue)

--- a/tests/backend/riscv/test_register_queue.py
+++ b/tests/backend/riscv/test_register_queue.py
@@ -2,12 +2,12 @@ import re
 
 import pytest
 
-from xdsl.backend.riscv.register_queue import RegisterQueue
+from xdsl.backend.riscv.riscv_register_queue import RiscvRegisterQueue
 from xdsl.dialects import riscv
 
 
 def test_default_reserved_registers():
-    register_queue = RegisterQueue()
+    register_queue = RiscvRegisterQueue()
 
     for reg in (
         riscv.Registers.ZERO,
@@ -23,7 +23,7 @@ def test_default_reserved_registers():
 
 
 def test_push_j_register():
-    register_queue = RegisterQueue()
+    register_queue = RiscvRegisterQueue()
 
     register_queue.push(riscv.IntRegisterType("j0"))
     assert riscv.IntRegisterType("j0") == register_queue.available_int_registers[-1]
@@ -33,7 +33,7 @@ def test_push_j_register():
 
 
 def test_push_register():
-    register_queue = RegisterQueue()
+    register_queue = RiscvRegisterQueue()
 
     register_queue.push(riscv.Registers.A0)
     assert riscv.Registers.A0 == register_queue.available_int_registers[-1]
@@ -43,7 +43,7 @@ def test_push_register():
 
 
 def test_reserve_register():
-    register_queue = RegisterQueue()
+    register_queue = RiscvRegisterQueue()
 
     register_queue.reserve_register(riscv.IntRegisterType("j0"))
     assert register_queue.reserved_registers[riscv.IntRegisterType("j0")] == 1
@@ -72,7 +72,7 @@ def test_reserve_register():
 
 
 def test_limit():
-    register_queue = RegisterQueue()
+    register_queue = RiscvRegisterQueue()
     register_queue.limit_registers(1)
 
     assert not register_queue.pop(riscv.IntRegisterType).register_name.startswith("j")

--- a/xdsl/backend/register_queue.py
+++ b/xdsl/backend/register_queue.py
@@ -1,0 +1,66 @@
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from xdsl.backend.register_type import RegisterType
+
+_T = TypeVar("_T", bound=RegisterType)
+
+
+@dataclass
+class RegisterQueue(Generic[_T], ABC):
+    """
+    LIFO queue of registers available for allocation.
+    """
+
+    @abstractmethod
+    def push(self, reg: _T) -> None:
+        """
+        Return a register to be made available for allocation.
+        """
+        ...
+
+    @abstractmethod
+    def pop(self, reg_type: type[_T]) -> _T:
+        """
+        Get the next available register for allocation.
+        """
+        ...
+
+    @contextmanager
+    def reserve_registers(self, regs: Sequence[_T]):
+        for reg in regs:
+            self.reserve_register(reg)
+
+        yield
+
+        for reg in regs:
+            self.unreserve_register(reg)
+
+    @abstractmethod
+    def reserve_register(self, reg: _T) -> None:
+        """
+        Increase the reservation count for a register.
+        If the reservation count is greater than 0, a register cannot be pushed back onto
+        the queue.
+        It is invalid to reserve a register that is available, and popping it before
+        unreserving a register will result in an AssertionError.
+        """
+        ...
+
+    @abstractmethod
+    def unreserve_register(self, reg: _T) -> None:
+        """
+        Decrease the reservation count for a register. If the reservation count is 0, make
+        the register available for allocation.
+        """
+        ...
+
+    @abstractmethod
+    def exclude_register(self, reg: _T) -> None:
+        """
+        Removes regiesters from available set, if present.
+        """
+        ...

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from xdsl.backend.riscv.register_allocation import RegisterAllocatorLivenessBlockNaive
+from xdsl.backend.riscv.riscv_register_queue import RiscvRegisterQueue
 from xdsl.context import MLContext
 from xdsl.dialects import riscv_func
 from xdsl.dialects.builtin import ModuleOp
@@ -54,9 +55,12 @@ class RISCVRegisterAllocation(ModulePass):
 
         for inner_op in op.walk():
             if isinstance(inner_op, riscv_func.FuncOp):
-                allocator = allocator_strategies[self.allocation_strategy]()
+                riscv_register_queue = RiscvRegisterQueue()
                 if self.limit_registers is not None:
-                    allocator.available_registers.limit_registers(self.limit_registers)
+                    riscv_register_queue.limit_registers(self.limit_registers)
+                allocator = allocator_strategies[self.allocation_strategy](
+                    riscv_register_queue
+                )
                 allocator.exclude_preallocated = self.exclude_preallocated
                 allocator.exclude_snitch_reserved = self.exclude_snitch_reserved
                 allocator.allocate_func(


### PR DESCRIPTION
In preparation for ARM and x86 backends, this is the first PR towards interface-based, target-agnostic register allocation.