### PR TITLE
misc: remove xdsl.irdl.error.error function

### DIFF
--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -34,10 +34,6 @@ for path in sorted(src.rglob("*.py")):
 
     ident = ".".join(parts)
 
-    if ident in ("irdl.error",):
-        # TODO: rename error function, treated as circular reference
-        continue
-
     nav[parts] = doc_path.as_posix()
 
     with mkdocs_gen_files.open(full_doc_path, "w") as fd:

--- a/xdsl/irdl/error.py
+++ b/xdsl/irdl/error.py
@@ -1,14 +1,5 @@
 from enum import Enum
 
-from xdsl.ir import Operation
-from xdsl.utils.diagnostic import Diagnostic
-
-
-def error(op: Operation, msg: str, e: Exception):
-    diag = Diagnostic()
-    diag.add_message(op, msg)
-    diag.raise_exception(msg, op, type(e), e)
-
 
 class IRDLAnnotations(Enum):
     ParamDefAnnot = 1

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -61,7 +61,7 @@ from .constraints import (  # noqa: TID251
     range_constr_coercion,
     single_range_constr_coercion,
 )
-from .error import IRDLAnnotations, error  # noqa: TID251
+from .error import IRDLAnnotations  # noqa: TID251
 
 if TYPE_CHECKING:
     from xdsl.parser import Parser
@@ -1598,10 +1598,10 @@ def irdl_op_verify_regions(
             entry_args_types = first_block.arg_types
             try:
                 region_def.entry_args.verify(entry_args_types, constraint_context)
-            except Exception as e:
-                error(
-                    op,
+            except VerifyException as e:
+                op.emit_error(
                     f"region #{i} entry arguments do not verify:\n{e}",
+                    type(e),
                     e,
                 )
 
@@ -1630,15 +1630,15 @@ def irdl_op_verify_arg_list(
         """Verify a single argument."""
         try:
             arg_def.constr.verify(tuple(a.type for a in arg), constraint_context)
-        except Exception as e:
+        except VerifyException as e:
             if len(arg) == 1:
                 pos = f"{arg_idx}"
             else:
                 pos = f"{arg_idx} to {arg_idx + len(arg) - 1}"
-            error(
-                op,
-                f"{get_construct_name(construct)} at position "
-                f"{pos} does not verify:\n{e}",
+            op.emit_error(
+                f"{get_construct_name(construct)} at position {pos} does not "
+                f"verify:\n{e}",
+                type(e),
                 e,
             )
 


### PR DESCRIPTION
The auto-generated docs website complained about this function with the same name as its module. We actually have a helper for it already on Operation, and can just remove it.