### PR TITLE
misc: reduce max-line-length ruff setting to 130 [NFC]

### DIFF
--- a/docs/Toy/Toy_Ch0.ipynb
+++ b/docs/Toy/Toy_Ch0.ipynb
@@ -79,8 +79,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Uncomment the following line to execute\n",
-    "# !python -m toy examples/interpret.toy --emit=scf --ir | xdsl-opt -p printf-to-llvm | mlir-opt --test-lower-to-llvm | mlir-cpu-runner --entry-point-result=void"
+    "# Uncomment the following lines to execute\n",
+    "# !python -m toy examples/interpret.toy --emit=scf --ir \\\n",
+    "# | xdsl-opt -p printf-to-llvm \\\n",
+    "# | mlir-opt --test-lower-to-llvm \\\n",
+    "# | mlir-cpu-runner --entry-point-result=void"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ignore = [
 # TODO: remove this setting and go to default line length of 88
 # Removing this line length results in a large number of errors for doc strings, ideally
 # these should be ignored separately.
-max-line-length = 230
+max-line-length = 200
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "xdsl.dialects.utils.fast_math".msg = "Use xdsl.dialects.utils instead"
@@ -128,8 +128,7 @@ max-line-length = 230
 [tool.ruff.lint.per-file-ignores]
 "versioneer.py" = ["ALL"]
 "tests/test_declarative_assembly_format.py" = ["F811"]
-"tests/filecheck/frontend/programs/invalid.py" = ["F811", "F841"]
-"tests/filecheck/frontend/dialects/invalid.py" = ["F811"]
+"**/filecheck/*" = ["F811", "F841", "E501"]
 "docs/xdsl-introduction.ipynb" = ["ALL"]
 "docs/tutorial.ipynb" = ["ALL"]
 "docs/Toy/Toy_Ch3.ipynb" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ignore = [
 # TODO: remove this setting and go to default line length of 88
 # Removing this line length results in a large number of errors for doc strings, ideally
 # these should be ignored separately.
-max-line-length = 300
+max-line-length = 230
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "xdsl.dialects.utils.fast_math".msg = "Use xdsl.dialects.utils instead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ignore = [
 # TODO: remove this setting and go to default line length of 88
 # Removing this line length results in a large number of errors for doc strings, ideally
 # these should be ignored separately.
-max-line-length = 150
+max-line-length = 130
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "xdsl.dialects.utils.fast_math".msg = "Use xdsl.dialects.utils instead"
@@ -141,6 +141,7 @@ max-line-length = 150
 "**/__marimo__/*" = ["ALL"]
 "_version.py" = ["ALL"]
 "__init__.py" = ["F403"]
+"tests/*" = ["E501"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ignore = [
 # TODO: remove this setting and go to default line length of 88
 # Removing this line length results in a large number of errors for doc strings, ideally
 # these should be ignored separately.
-max-line-length = 170
+max-line-length = 150
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "xdsl.dialects.utils.fast_math".msg = "Use xdsl.dialects.utils instead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ignore = [
 # TODO: remove this setting and go to default line length of 88
 # Removing this line length results in a large number of errors for doc strings, ideally
 # these should be ignored separately.
-max-line-length = 200
+max-line-length = 170
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "xdsl.dialects.utils.fast_math".msg = "Use xdsl.dialects.utils instead"

--- a/tests/dialects/test_transform.py
+++ b/tests/dialects/test_transform.py
@@ -78,7 +78,7 @@ def test_tileop_init():
             dynamic_sizes=[],
             static_sizes=static_sizes,
         ),
-        """%0, %1, %2 = "transform.structured.tile_using_for"(%3) <{static_sizes = array<i32: 8, 8>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op, !transform.any_op)""",  # noqa: E501
+        """%0, %1, %2 = "transform.structured.tile_using_for"(%3) <{static_sizes = array<i32: 8, 8>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op, !transform.any_op)""",
         None,
     )
 
@@ -115,7 +115,7 @@ def test_get_producer_of_operand():
     target = test.TestOp(result_types=[transform.AnyValueType()]).results[0]
     assert_print_op(
         transform.GetProducerOfOperandOp(operand_number=0, target=target),
-        """%0 = "transform.get_producer_of_operand"(%1) <{operand_number = 0 : i64}> : (!transform.any_value) -> !transform.any_op""",  # noqa: E501
+        """%0 = "transform.get_producer_of_operand"(%1) <{operand_number = 0 : i64}> : (!transform.any_value) -> !transform.any_op""",
         None,
     )
 
@@ -125,7 +125,7 @@ def test_get_result():
     result_number = 0
     assert_print_op(
         transform.GetResultOp(target=target, raw_position_list=[result_number]),
-        """%0 = "transform.get_result"(%1) <{raw_position_list = array<i64: 0>}> : (!transform.any_op) -> !transform.any_value""",  # noqa: E501
+        """%0 = "transform.get_result"(%1) <{raw_position_list = array<i64: 0>}> : (!transform.any_op) -> !transform.any_value""",
         None,
     )
 
@@ -210,7 +210,7 @@ def test_split_handle():
             fail_on_payload_too_small=True,
             overflow_result=1,
         ),
-        """ %0, %1 = "transform.split_handle"(%2) <{pass_through_empty_handle = true, fail_on_payload_too_small = true, overflow_result = 1 : i64}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op) """,  # noqa: E501
+        """ %0, %1 = "transform.split_handle"(%2) <{pass_through_empty_handle = true, fail_on_payload_too_small = true, overflow_result = 1 : i64}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op) """,
         None,
     )
 
@@ -232,7 +232,7 @@ def test_amount_of_loops():
             dynamic_sizes=[],
             static_sizes=static_sizes,
         ),
-        """%0, %1 = "transform.structured.tile_using_for"(%2) <{static_sizes = array<i32: 8, 0>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op)""",  # noqa: E501
+        """%0, %1 = "transform.structured.tile_using_for"(%2) <{static_sizes = array<i32: 8, 0>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op)""",
         None,
     )
 

--- a/tests/dialects/test_transform.py
+++ b/tests/dialects/test_transform.py
@@ -115,7 +115,7 @@ def test_get_producer_of_operand():
     target = test.TestOp(result_types=[transform.AnyValueType()]).results[0]
     assert_print_op(
         transform.GetProducerOfOperandOp(operand_number=0, target=target),
-        """%0 = "transform.get_producer_of_operand"(%1) <{operand_number = 0 : i64}> : (!transform.any_value) -> !transform.any_op""",
+        """%0 = "transform.get_producer_of_operand"(%1) <{operand_number = 0 : i64}> : (!transform.any_value) -> !transform.any_op""",  # noqa: E501
         None,
     )
 
@@ -125,7 +125,7 @@ def test_get_result():
     result_number = 0
     assert_print_op(
         transform.GetResultOp(target=target, raw_position_list=[result_number]),
-        """%0 = "transform.get_result"(%1) <{raw_position_list = array<i64: 0>}> : (!transform.any_op) -> !transform.any_value""",
+        """%0 = "transform.get_result"(%1) <{raw_position_list = array<i64: 0>}> : (!transform.any_op) -> !transform.any_value""",  # noqa: E501
         None,
     )
 

--- a/tests/dialects/test_transform.py
+++ b/tests/dialects/test_transform.py
@@ -210,7 +210,7 @@ def test_split_handle():
             fail_on_payload_too_small=True,
             overflow_result=1,
         ),
-        """ %0, %1 = "transform.split_handle"(%2) <{pass_through_empty_handle = true, fail_on_payload_too_small = true, overflow_result = 1 : i64}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op) """,
+        """ %0, %1 = "transform.split_handle"(%2) <{pass_through_empty_handle = true, fail_on_payload_too_small = true, overflow_result = 1 : i64}> : (!transform.any_op) -> (!transform.any_op, !transform.any_op) """,  # noqa: E501
         None,
     )
 

--- a/tests/dialects/test_transform.py
+++ b/tests/dialects/test_transform.py
@@ -78,7 +78,7 @@ def test_tileop_init():
             dynamic_sizes=[],
             static_sizes=static_sizes,
         ),
-        """%0, %1, %2 = "transform.structured.tile_using_for"(%3) <{static_sizes = array<i32: 8, 8>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op, !transform.any_op)""",
+        """%0, %1, %2 = "transform.structured.tile_using_for"(%3) <{static_sizes = array<i32: 8, 8>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op, !transform.any_op)""",  # noqa: E501
         None,
     )
 

--- a/tests/dialects/test_transform.py
+++ b/tests/dialects/test_transform.py
@@ -232,7 +232,7 @@ def test_amount_of_loops():
             dynamic_sizes=[],
             static_sizes=static_sizes,
         ),
-        """%0, %1 = "transform.structured.tile_using_for"(%2) <{static_sizes = array<i32: 8, 0>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op)""",
+        """%0, %1 = "transform.structured.tile_using_for"(%2) <{static_sizes = array<i32: 8, 0>}> : (!transform.any_value) -> (!transform.any_op, !transform.any_op)""",  # noqa: E501
         None,
     )
 

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -569,9 +569,7 @@ def test_informative_attribute():
 
     with pytest.raises(
         VerifyException,
-        match="Dear user, here's what this constraint means in your abstraction.\n"
-        "Underlying verification failure: #test.int<42> "
-        "should be of base attribute none",
+        match="Dear user, here's what this constraint means in your abstraction.\nUnderlying verification failure: #test.int<42> should be of base attribute none",
     ):
         InformativeAttr((IntData(42),))
 

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -569,7 +569,9 @@ def test_informative_attribute():
 
     with pytest.raises(
         VerifyException,
-        match="Dear user, here's what this constraint means in your abstraction.\nUnderlying verification failure: #test.int<42> should be of base attribute none",
+        match="Dear user, here's what this constraint means in your abstraction.\n"
+        "Underlying verification failure: #test.int<42> "
+        "should be of base attribute none",
     ):
         InformativeAttr((IntData(42),))
 

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1959,13 +1959,13 @@ def test_regions(format: str, program: str, generic_program: str):
         ),
         (
             "attr-dict-with-keyword $region",
-            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',  # noqa: E501
-            '"test.variadic_region"() ({ "test.op"() : () -> ()}, { "test.op"() : () -> ()}) : () -> ()',  # noqa: E501
+            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',
+            '"test.variadic_region"() ({ "test.op"() : () -> ()}, { "test.op"() : () -> ()}) : () -> ()',
         ),
         (
             "attr-dict-with-keyword $region",
-            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',  # noqa: E501
-            '"test.variadic_region"() ({ "test.op"() : () -> ()}, {"test.op"() : () -> ()}, {\n  "test.op"() : () -> ()\n}) : () -> ()',  # noqa: E501
+            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',
+            '"test.variadic_region"() ({ "test.op"() : () -> ()}, {"test.op"() : () -> ()}, {\n  "test.op"() : () -> ()\n}) : () -> ()',
         ),
     ],
 )

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -1959,13 +1959,13 @@ def test_regions(format: str, program: str, generic_program: str):
         ),
         (
             "attr-dict-with-keyword $region",
-            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',
-            '"test.variadic_region"() ({ "test.op"() : () -> ()}, { "test.op"() : () -> ()}) : () -> ()',
+            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',  # noqa: E501
+            '"test.variadic_region"() ({ "test.op"() : () -> ()}, { "test.op"() : () -> ()}) : () -> ()',  # noqa: E501
         ),
         (
             "attr-dict-with-keyword $region",
-            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',
-            '"test.variadic_region"() ({ "test.op"() : () -> ()}, {"test.op"() : () -> ()}, {\n  "test.op"() : () -> ()\n}) : () -> ()',
+            'test.variadic_region {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n} {\n  "test.op"() : () -> ()\n}',  # noqa: E501
+            '"test.variadic_region"() ({ "test.op"() : () -> ()}, {"test.op"() : () -> ()}, {\n  "test.op"() : () -> ()\n}) : () -> ()',  # noqa: E501
         ),
     ],
 )

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -852,7 +852,9 @@ class OptionlessMultipleVarOp(IRDLOperation):
 def test_no_multiple_var_option():
     with pytest.raises(
         PyRDLOpDefinitionError,
-        match="Operation test.multiple_var_op defines more than two variadic operands, but do not define any of SameVariadicOperandSize or AttrSizedOperandSegments PyRDL options.",
+        match="Operation test.multiple_var_op defines more than two variadic operands, "
+        "but do not define any of SameVariadicOperandSize or AttrSizedOperandSegments "
+        "PyRDL options.",
     ):
         irdl_op_definition(OptionlessMultipleVarOp)
 

--- a/tests/test_pass_to_arg_and_types_str.py
+++ b/tests/test_pass_to_arg_and_types_str.py
@@ -56,7 +56,9 @@ class SimplePass(ModulePass):
     "str_arg, pass_arg",
     [
         (
-            """number=int|float single_number=int int_list=tuple[int, ...] non_init_thing=int str_thing=str nullable_str=str|None literal=no optional_bool=false""",
+            "number=int|float single_number=int int_list=tuple[int, ...] "
+            "non_init_thing=int str_thing=str nullable_str=str|None literal=no "
+            "optional_bool=false",
             CustomPass,
         ),
         ("", EmptyPass),

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -735,7 +735,7 @@ def test_dictionary_attr():
 
     prog = """
 "func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr}> {arg_attrs = {key_one = "value_one", key_two = "value_two", key_three = 72 : i64, unit_attr}} : () -> ()
-    """
+    """  # noqa: E501
 
     ctx = MLContext()
     ctx.load_dialect(Builtin)

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -752,7 +752,7 @@ def test_densearray_attr():
 
     prog = """
 "func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr}> {bool_attrs = array<i1: false, true>, int_attr = array<i32: 19, 23, 55>, float_attr = array<f32: 0.3400000035762787>} : () -> ()
-    """
+    """  # noqa: E501
 
     ctx = MLContext()
     ctx.load_dialect(Builtin)

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -890,11 +890,11 @@ def test_print_properties_as_attributes_safeguard():
 
     prog = """
 "func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private"}> {extra_attr, sym_name = "this should be overriden by the property"} : () -> ()
-    """
+    """  # noqa: E501
 
     retro_prog = """
 "func.func"() {extra_attr, sym_name = "test", function_type = i64, sym_visibility = "private"} : () -> ()
-    """
+    """  # noqa: E501
 
     ctx = MLContext()
     ctx.load_dialect(Builtin)

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -735,7 +735,7 @@ def test_dictionary_attr():
 
     prog = """
 "func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr}> {arg_attrs = {key_one = "value_one", key_two = "value_two", key_three = 72 : i64, unit_attr}} : () -> ()
-    """  # noqa: E501
+    """
 
     ctx = MLContext()
     ctx.load_dialect(Builtin)
@@ -752,7 +752,7 @@ def test_densearray_attr():
 
     prog = """
 "func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr}> {bool_attrs = array<i1: false, true>, int_attr = array<i32: 19, 23, 55>, float_attr = array<f32: 0.3400000035762787>} : () -> ()
-    """  # noqa: E501
+    """
 
     ctx = MLContext()
     ctx.load_dialect(Builtin)
@@ -890,11 +890,11 @@ def test_print_properties_as_attributes_safeguard():
 
     prog = """
 "func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private"}> {extra_attr, sym_name = "this should be overriden by the property"} : () -> ()
-    """  # noqa: E501
+    """
 
     retro_prog = """
 "func.func"() {extra_attr, sym_name = "test", function_type = i64, sym_visibility = "private"} : () -> ()
-    """  # noqa: E501
+    """
 
     ctx = MLContext()
     ctx.load_dialect(Builtin)

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -227,9 +227,10 @@ def test_allof_verify_multiple_failures():
 
     with pytest.raises(VerifyException) as e:
         constraint.verify(IntData(7), ConstraintContext())
-    assert (
-        e.value.args[0]
-        == f"The following constraints were not satisfied:\n{IntData(7)} should hold a value less than 5\n{IntData(7)} should hold a value greater than 8"
+    assert e.value.args[0] == (
+        f"The following constraints were not satisfied:\n{IntData(7)} "
+        f"should hold a value less than 5\n{IntData(7)} "
+        "should hold a value greater than 8"
     )
 
 

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -225,13 +225,12 @@ def test_allof_verify_multiple_failures():
     """
     constraint = AllOf((LessThan(5), GreaterThan(8)))
 
-    with pytest.raises(VerifyException) as e:
+    with pytest.raises(
+        VerifyException,
+        match=f"The following constraints were not satisfied:\n{IntData(7)} should "
+        f"hold a value less than 5\n{IntData(7)} should hold a value greater than 8",
+    ):
         constraint.verify(IntData(7), ConstraintContext())
-    assert e.value.args[0] == (
-        f"The following constraints were not satisfied:\n{IntData(7)} "
-        f"should hold a value less than 5\n{IntData(7)} "
-        "should hold a value greater than 8"
-    )
 
 
 def test_param_attr_verify():

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -823,9 +823,7 @@ class CslPrintContext:
                     )
                 case csl.SetDsdStrideOp(op=input_dsd, stride=stride, result=result):
                     self.print(
-                        f"{self._var_use(result)} = @set_dsd_stride("
-                        f"{self._get_variable_name_for(input_dsd)}, "
-                        f"{self._get_variable_name_for(stride)});"
+                        f"{self._var_use(result)} = @set_dsd_stride({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(stride)});"  # noqa: E501
                     )
                 case csl.BuiltinDsdOp(ops=ops):
                     self.print(

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -453,7 +453,7 @@ class CslPrintContext:
             case StringAttr() as s:
                 return f'"{s.data}"'
             case DenseIntOrFPElementsAttr(type=typ):
-                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(a) for a in attr.iter_attrs())} }}"
+                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(a) for a in attr.iter_attrs())} }}"  # noqa: E501
             case _:
                 return f"<!unknown value {attr}>"
 
@@ -819,11 +819,13 @@ class CslPrintContext:
                     )
                 case csl.SetDsdLengthOp(op=input_dsd, length=length, result=result):
                     self.print(
-                        f"{self._var_use(result)} = @set_dsd_length({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(length)});"
+                        f"{self._var_use(result)} = @set_dsd_length({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(length)});"  # noqa: E501
                     )
                 case csl.SetDsdStrideOp(op=input_dsd, stride=stride, result=result):
                     self.print(
-                        f"{self._var_use(result)} = @set_dsd_stride({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(stride)});"
+                        f"{self._var_use(result)} = @set_dsd_stride("
+                        f"{self._get_variable_name_for(input_dsd)}, "
+                        f"{self._get_variable_name_for(stride)});"
                     )
                 case csl.BuiltinDsdOp(ops=ops):
                     self.print(

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -815,7 +815,7 @@ class CslPrintContext:
                     op=input_dsd, offset=offset, elem_type=elem_type, result=result
                 ):
                     self.print(
-                        f"{self._var_use(result)} = @increment_dsd_offset({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(offset)}, {self.mlir_type_to_csl_type(elem_type)});"
+                        f"{self._var_use(result)} = @increment_dsd_offset({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(offset)}, {self.mlir_type_to_csl_type(elem_type)});"  # noqa: E501
                     )
                 case csl.SetDsdLengthOp(op=input_dsd, length=length, result=result):
                     self.print(

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -809,7 +809,7 @@ class CslPrintContext:
                     op=input_dsd, base_addr=base_addr, result=result
                 ):
                     self.print(
-                        f"{self._var_use(result)} = @set_dsd_base_addr({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(base_addr)});"
+                        f"{self._var_use(result)} = @set_dsd_base_addr({self._get_variable_name_for(input_dsd)}, {self._get_variable_name_for(base_addr)});"  # noqa: E501
                     )
                 case csl.IncrementDsdOffsetOp(
                     op=input_dsd, offset=offset, elem_type=elem_type, result=result

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -65,7 +65,10 @@ class ApplyOp(IRDLOperation):
     def verify_(self) -> None:
         if len(self.mapOperands) != self.map.data.num_dims + self.map.data.num_symbols:
             raise VerifyException(
-                f"{self.name} expects {self.map.data.num_dims + self.map.data.num_symbols} operands, but got {len(self.mapOperands)}. The number of map operands must match the sum of the dimensions and symbols of its map."
+                f"{self.name} expects "
+                f"{self.map.data.num_dims + self.map.data.num_symbols} operands, but "
+                f"got {len(self.mapOperands)}. The number of map operands must match "
+                "the sum of the dimensions and symbols of its map."
             )
         if len(self.map.data.results) != 1:
             raise VerifyException("affine.apply expects a unidimensional map.")
@@ -346,7 +349,10 @@ class MinOp(IRDLOperation):
     def verify_(self) -> None:
         if len(self.operands) != self.map.data.num_dims + self.map.data.num_symbols:
             raise VerifyException(
-                f"{self.name} expects {self.map.data.num_dims + self.map.data.num_symbols} operands, but got {len(self.operands)}. The number of map operands must match the sum of the dimensions and symbols of its map."
+                f"{self.name} expects "
+                f"{self.map.data.num_dims + self.map.data.num_symbols} "
+                "operands, but got {len(self.operands)}. The number of map operands "
+                "must match the sum of the dimensions and symbols of its map."
             )
 
 

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -1241,7 +1241,8 @@ class IndexCastOp(IRDLOperation):
         # exactly one of input or result must be of IndexType, no more, no less.
         if not isinstance(self.input.type, it) ^ isinstance(self.result.type, it):
             raise VerifyException(
-                f"'arith.index_cast' op operand type '{self.input.type}' and result type '{self.input.type}' are cast incompatible"
+                f"'arith.index_cast' op operand type '{self.input.type}' and result "
+                f"type '{self.input.type}' are cast incompatible"
             )
 
 

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -120,7 +120,7 @@ class AllocTensorOp(IRDLOperation):
 
     irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
-    assembly_format = "`(` $dynamic_sizes `)` ( `copy` `(` $copy^ `)`)? (`size_hint` `=` $size_hint^)? attr-dict `:` type($tensor)"
+    assembly_format = "`(` $dynamic_sizes `)` ( `copy` `(` $copy^ `)`)? (`size_hint` `=` $size_hint^)? attr-dict `:` type($tensor)"  # noqa E501
 
     def __init__(
         self,
@@ -216,7 +216,10 @@ class MaterializeInDestinationOp(IRDLOperation):
     restrict = opt_prop_def(UnitAttr)
     writable = opt_prop_def(UnitAttr)
 
-    assembly_format = "$source `in` (`restrict` $restrict^)? (`writable` $writable^)? $dest attr-dict `:` functional-type(operands, results)"
+    assembly_format = (
+        "$source `in` (`restrict` $restrict^)? (`writable` $writable^)? $dest "
+        "attr-dict `:` functional-type(operands, results)"
+    )
 
 
 Bufferization = Dialect(

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -216,10 +216,7 @@ class MaterializeInDestinationOp(IRDLOperation):
     restrict = opt_prop_def(UnitAttr)
     writable = opt_prop_def(UnitAttr)
 
-    assembly_format = (
-        "$source `in` (`restrict` $restrict^)? (`writable` $writable^)? $dest "
-        "attr-dict `:` functional-type(operands, results)"
-    )
+    assembly_format = "$source `in` (`restrict` $restrict^)? (`writable` $writable^)? $dest attr-dict `:` functional-type(operands, results)"  # noqa: E501
 
 
 Bufferization = Dialect(

--- a/xdsl/dialects/csl/csl_stencil.py
+++ b/xdsl/dialects/csl/csl_stencil.py
@@ -357,7 +357,8 @@ class ApplyOp(IRDLOperation):
         for operand, argument in zip(self.operands, op_args):
             if operand.type != argument.type:
                 raise VerifyException(
-                    f"Expected argument type of {type(self)} to match operand type, got {argument.type} != {operand.type} at index {argument.index}"
+                    f"Expected argument type of {type(self)} to match operand type, "
+                    f"got {argument.type} != {operand.type} at index {argument.index}"
                 )
 
         # typecheck required (only) block arguments
@@ -569,21 +570,26 @@ class AccessOp(IRDLOperation):
             if isa(self.op.type, memref.MemRefType[Attribute]):
                 if not self.result.type == self.op.type:
                     raise VerifyException(
-                        f"{type(self)} access to own data requires{self.op.type} but found {self.result.type}"
+                        f"{type(self)} access to own data requires{self.op.type} but "
+                        f"found {self.result.type}"
                     )
             elif isattr(self.op.type, stencil.StencilTypeConstr):
                 if not self.result.type == self.op.type.get_element_type():
                     raise VerifyException(
-                        f"{type(self)} access to own data requires{self.op.type.get_element_type()} but found {self.result.type}"
+                        f"{type(self)} access to own data requires "
+                        f"{self.op.type.get_element_type()} but found "
+                        f"{self.result.type}"
                     )
             else:
                 raise VerifyException(
-                    f"{type(self)} access to own data requires type stencil.StencilType or memref.MemRefType but found {self.op.type}"
+                    f"{type(self)} access to own data requires type "
+                    f"stencil.StencilType or memref.MemRefType but found {self.op.type}"
                 )
         else:
             if not isattr(self.op.type, AnyTensorTypeConstr | MemRefType.constr()):
                 raise VerifyException(
-                    f"{type(self)} access to neighbor data requires type memref.MemRefType or TensorType but found {self.op.type}"
+                    f"{type(self)} access to neighbor data requires type "
+                    f"memref.MemRefType or TensorType but found {self.op.type}"
                 )
 
         # As promised by HasAncestor(ApplyOp)

--- a/xdsl/dialects/experimental/air.py
+++ b/xdsl/dialects/experimental/air.py
@@ -284,7 +284,12 @@ class DmaMemcpyNdOp(IRDLOperation):
             result_types=[AsyncTokenAttr()],
         )
 
-    assembly_format = "(`async` $async_dependencies^)? `(` $dst `[` $dst_offsets `]``[` $dst_sizes `]``[` $dst_strides `]` `,` $src `[` $src_offsets `]``[` $src_sizes `]``[` $src_strides `]` `)`  attr-dict `:` `(` type($dst) `,` type($src) `)`"
+    assembly_format = (
+        "(`async` $async_dependencies^)? "
+        "`(` $dst `[` $dst_offsets `]``[` $dst_sizes `]``[` $dst_strides `]` `,` "
+        "$src `[` $src_offsets `]``[` $src_sizes `]``[` $src_strides `]` `)` "
+        "attr-dict `:` `(` type($dst) `,` type($src) `)`"
+    )
 
 
 @irdl_op_definition

--- a/xdsl/dialects/experimental/air.py
+++ b/xdsl/dialects/experimental/air.py
@@ -284,12 +284,7 @@ class DmaMemcpyNdOp(IRDLOperation):
             result_types=[AsyncTokenAttr()],
         )
 
-    assembly_format = (
-        "(`async` $async_dependencies^)? "
-        "`(` $dst `[` $dst_offsets `]``[` $dst_sizes `]``[` $dst_strides `]` `,` "
-        "$src `[` $src_offsets `]``[` $src_sizes `]``[` $src_strides `]` `)` "
-        "attr-dict `:` `(` type($dst) `,` type($src) `)`"
-    )
+    assembly_format = "(`async` $async_dependencies^)? `(` $dst `[` $dst_offsets `]``[` $dst_sizes `]``[` $dst_strides `]` `,` $src `[` $src_offsets `]``[` $src_sizes `]``[` $src_strides `]` `)`  attr-dict `:` `(` type($dst) `,` type($src) `)`"  # noqa: E501
 
 
 @irdl_op_definition

--- a/xdsl/dialects/experimental/air.py
+++ b/xdsl/dialects/experimental/air.py
@@ -138,7 +138,7 @@ class ChannelGetOp(IRDLOperation):
             ],
         )
 
-    assembly_format = "(`async` `[` $async_dependencies^ `]`)? $chan_name `[` $indices `]` `(` $dst `[` $dst_offsets `]``[` $dst_sizes `]``[` $dst_strides `]` `)` attr-dict `:` `(` type($dst) `)`"
+    assembly_format = "(`async` `[` $async_dependencies^ `]`)? $chan_name `[` $indices `]` `(` $dst `[` $dst_offsets `]``[` $dst_sizes `]``[` $dst_strides `]` `)` attr-dict `:` `(` type($dst) `)`"  # noqa: E501
 
 
 @irdl_op_definition
@@ -181,7 +181,7 @@ class ChannelPutOp(IRDLOperation):
             result_types=[AsyncTokenAttr()],
         )
 
-    assembly_format = "(`async` `[` $async_dependencies^ `]`)? $chan_name `[` $indices `]` `(` $src `[` $src_offsets `]``[` $src_sizes `]``[` $src_strides `]` `)` attr-dict `:` `(` type($src) `)`"
+    assembly_format = "(`async` `[` $async_dependencies^ `]`)? $chan_name `[` $indices `]` `(` $src `[` $src_offsets `]``[` $src_sizes `]``[` $src_strides `]` `)` attr-dict `:` `(` type($src) `)`"  # noqa: E501
 
 
 @irdl_op_definition

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -1027,7 +1027,7 @@ class CharExtremumOp(IRDLOperation):
     minimum or maximum number of characters. Example:
 
     %0 = hlfir.char_extremum min, %arg0, %arg1 : (!fir.ref<!fir.char<1,10>>, !fir.ref<!fir.char<1,20>>) -> !hlfir.expr<!fir.char<1,10>>
-    """
+    """  # noqa E501
 
     name = "hlfir.char_extremum"
     predicate = operand_def()

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -142,7 +142,7 @@ class DeclareOp(IRDLOperation):
       %3 = hfir.declare %arg0(%2) typeparams %1 {uniq_name = "c"} (fir.ref<!fir.array<?x?x!fir.char<1,?>>>, fir.shapeshift<2>, index) -> (fir.box<!fir.array<?x?x!fir.char<1,?>>>, fir.ref<!fir.array<?x?x!fir.char<1,?>>>)
       // ... uses %3#0 as "c"
     }
-    """
+    """  # noqa: E501
 
     name = "hlfir.declare"
     memref = operand_def()

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -86,7 +86,8 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
         ):
             if found_operand != operand:
                 raise VerifyException(
-                    f"operand type mismatch: expected operand type {found_operand}, but provided {operand} for operand number {idx}"
+                    f"operand type mismatch: expected operand type {found_operand}, "
+                    f"but provided {operand} for operand number {idx}"
                 )
 
         for idx, (found_res, res) in enumerate(
@@ -94,7 +95,8 @@ class CallOpSymbolUserOpInterface(SymbolUserOpInterface):
         ):
             if found_res != res:
                 raise VerifyException(
-                    f"result type mismatch: expected result type {found_res}, but provided {res} for result number {idx}"
+                    f"result type mismatch: expected result type {found_res}, but "
+                    f"provided {res} for result number {idx}"
                 )
 
         return

--- a/xdsl/dialects/memref_stream.py
+++ b/xdsl/dialects/memref_stream.py
@@ -471,18 +471,19 @@ class GenericOp(IRDLOperation):
     """
     inits = var_operand_def()
     """
-    Initial values for outputs. The outputs are at corresponding `init_indices`. The inits
-    may be set only for the imperfectly nested form.
+    Initial values for outputs. The outputs are at corresponding `init_indices`. The
+    inits may be set only for the imperfectly nested form.
     """
     indexing_maps = prop_def(ArrayAttr[AffineMapAttr])
     """
     Stride patterns that define the order of the input and output streams.
-    Like in linalg.generic, the indexing maps corresponding to inputs are followed by the
-    indexing maps for the outputs.
+    Like in linalg.generic, the indexing maps corresponding to inputs are followed by
+    the indexing maps for the outputs.
     """
     bounds = prop_def(ArrayAttr[IntegerAttr[IndexType]])
     """
-    The bounds of the iteration space, from the outermost loop inwards. All indexing maps must have the same number of dimensions as the length of `bounds`.
+    The bounds of the iteration space, from the outermost loop inwards.
+    All indexing maps must have the same number of dimensions as the length of `bounds`.
     """
 
     iterator_types = prop_def(ArrayAttr[IteratorTypeAttr])

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -1,12 +1,16 @@
-########
-#  This is a port of the 'ptr' dialect proposed in this thread https://discourse.llvm.org/t/rfc-ptr-dialect-modularizing-ptr-ops-in-the-llvm-dialect/75142/21
-#  Main parts of the dialect has already been agreed upon but only the basic datatype is implemented upstream.
-#  When the upstream implementation is merged we should fix our implementation to be consistent with the mlir version.
-#  Current diviations:
-#  (1) Name of the dialect should be changed: ptr_xdsl -> ptr. We currently chose another name to avoid conflicts when loading our dialect to mlir-opt.
-#  (2) There is no ptr.to_ptr operation currently proposed, but there is a memref.to_ptr. We do this so that we can feed the results of convert-memref-to-ptr pass without any conflict.
-########
-
+"""
+This is a port of the 'ptr' dialect proposed in this thread https://discourse.llvm.org/t/rfc-ptr-dialect-modularizing-ptr-ops-in-the-llvm-dialect/75142/21
+Main parts of the dialect has already been agreed upon but only the basic datatype is
+implemented upstream.
+When the upstream implementation is merged we should fix our implementation to be
+consistent with the mlir version.
+Current deviations:
+ 1. Name of the dialect should be changed: ptr_xdsl -> ptr. We currently chose another
+ name to avoid conflicts when loading our dialect to mlir-opt.
+ 2. There is no ptr.to_ptr operation currently proposed, but there is a memref.to_ptr.
+ We do this so that we can feed the results of convert-memref-to-ptr pass without any
+ conflict.
+"""
 
 from xdsl.dialects.builtin import AnyAttr, IntegerAttrTypeConstr, MemRefType, UnitAttr
 from xdsl.ir import Dialect, ParametrizedAttribute, TypeAttribute
@@ -74,7 +78,7 @@ class LoadOp(IRDLOperation):
     ordering = opt_prop_def(UnitAttr)
     invariant = opt_prop_def(UnitAttr)
 
-    assembly_format = "(`volatile` $volatile^)? $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? (`invariant` $invariant^)? attr-dict `:` type($addr) `->` type($res)"
+    assembly_format = "(`volatile` $volatile^)? $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? (`invariant` $invariant^)? attr-dict `:` type($addr) `->` type($res)"  # noqa: E501
 
 
 @irdl_op_definition

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -63,7 +63,7 @@ class StoreOp(IRDLOperation):
     syncscope = opt_prop_def(UnitAttr)
     ordering = opt_prop_def(UnitAttr)
 
-    assembly_format = "(`volatile` $volatile^)? $value `,` $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? attr-dict `:` type($value) `,` type($addr)"
+    assembly_format = "(`volatile` $volatile^)? $value `,` $addr (`atomic` (`syncscope` `(` $syncscope^ `)`)? $ordering^)? attr-dict `:` type($value) `,` type($addr)"  # noqa: E501
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3471,7 +3471,8 @@ class FCvtWuSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
 @irdl_op_definition
 class FMvXWOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
     """
-    Move the single-precision value in floating-point register rs1 represented in IEEE 754-2008 encoding to the lower 32 bits of integer register rd.
+    Move the single-precision value in floating-point register rs1 represented in IEEE
+    754-2008 encoding to the lower 32 bits of integer register rd.
 
     ```C
     x[rd] = sext(f[rs1][31:0])
@@ -3486,7 +3487,8 @@ class FMvXWOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
 @irdl_op_definition
 class FeqSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
     """
-    Performs a quiet equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+    Performs a quiet equal comparison between floating-point registers rs1 and rs2 and
+    record the Boolean result in integer register rd.
     Only signaling NaN inputs cause an Invalid Operation exception.
     The result is 0 if either operand is NaN.
 
@@ -3501,7 +3503,8 @@ class FeqSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
 @irdl_op_definition
 class FltSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
     """
-    Performs a quiet less comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+    Performs a quiet less comparison between floating-point registers rs1 and rs2 and
+    record the Boolean result in integer register rd.
     Only signaling NaN inputs cause an Invalid Operation exception.
     The result is 0 if either operand is NaN.
 
@@ -3516,7 +3519,8 @@ class FltSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
 @irdl_op_definition
 class FleSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
     """
-    Performs a quiet less or equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+    Performs a quiet less or equal comparison between floating-point registers rs1 and
+    rs2 and record the Boolean result in integer register rd.
     Only signaling NaN inputs cause an Invalid Operation exception.
     The result is 0 if either operand is NaN.
 
@@ -3812,7 +3816,8 @@ class FMaxDOp(RdRsRsFloatOperationWithFastMath):
 @irdl_op_definition
 class FCvtDWOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
     """
-    Converts a 32-bit signed integer, in integer register rs1 into a double-precision floating-point number in floating-point register rd.
+    Converts a 32-bit signed integer, in integer register rs1 into a double-precision
+    floating-point number in floating-point register rd.
 
     x[rd] = sext(s32_{f64}(f[rs1]))
 
@@ -3827,7 +3832,8 @@ class FCvtDWOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
 @irdl_op_definition
 class FCvtDWuOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
     """
-    Converts a 32-bit unsigned integer, in integer register rs1 into a double-precision floating-point number in floating-point register rd.
+    Converts a 32-bit unsigned integer, in integer register rs1 into a double-precision
+    floating-point number in floating-point register rd.
 
     f[rd] = f64_{u32}(x[rs1])
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -3531,7 +3531,8 @@ class FleSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
 @irdl_op_definition
 class FClassSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
     """
-    Examines the value in floating-point register rs1 and writes to integer register rd a 10-bit mask that indicates the class of the floating-point number.
+    Examines the value in floating-point register rs1 and writes to integer register rd
+    a 10-bit mask that indicates the class of the floating-point number.
     The format of the mask is described in [classify table]_.
     The corresponding bit in rd will be set if the property is true and clear otherwise.
     All other bits in rd are cleared. Note that exactly one bit in rd will be set.
@@ -3562,7 +3563,8 @@ class FCvtSWOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
 @irdl_op_definition
 class FCvtSWuOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
     """
-    Converts a 32-bit unsigned integer, in integer register rs1 into a floating-point number in floating-point register rd.
+    Converts a 32-bit unsigned integer, in integer register rs1 into a floating-point
+    number in floating-point register rd.
 
     ```C
     f[rd] = f32_{u32}(x[rs1])
@@ -3577,7 +3579,8 @@ class FCvtSWuOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
 @irdl_op_definition
 class FMvWXOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
     """
-    Move the single-precision value encoded in IEEE 754-2008 standard encoding from the lower 32 bits of integer register rs1 to the floating-point register rd.
+    Move the single-precision value encoded in IEEE 754-2008 standard encoding from the
+    lower 32 bits of integer register rs1 to the floating-point register rd.
 
     ```C
     f[rd] = x[rs1][31:0]

--- a/xdsl/dialects/snitch_runtime.py
+++ b/xdsl/dialects/snitch_runtime.py
@@ -100,7 +100,8 @@ class GlobalCoreBaseHartidOp(SnitchRuntimeGetInfo):
 @irdl_op_definition
 class GlobalCoreIdxOp(SnitchRuntimeGetInfo):
     """
-    Regardless of core type, return global core index, equal to the Hart ID of the current core - global base Hart ID of the cluster
+    Regardless of core type, return global core index, equal to the Hart ID of the
+    current core - global base Hart ID of the cluster
     """
 
     name = "snrt.global_core_idx"

--- a/xdsl/dialects/stablehlo.py
+++ b/xdsl/dialects/stablehlo.py
@@ -277,7 +277,8 @@ IntegerTensorType: TypeAlias = TensorType[IntegerType]
 @irdl_op_definition
 class AndOp(IRDLOperation):
     """
-    Performs element-wise AND of two tensors lhs and rhs and produces a result tensor. Depending on the element type, does the following:
+    Performs element-wise AND of two tensors lhs and rhs and produces a result tensor.
+    Depending on the element type, does the following:
 
     For booleans: logical AND.
     For integers: bitwise AND.

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -821,7 +821,13 @@ class CombineOp(IRDLOperation):
         CombineOpHasShapeInferencePatternsTrait(),
     )
 
-    assembly_format = "$dim `at` $index `lower` `=` `(` $lower `:` type($lower) `)` `upper` `=` `(` $upper `:` type($upper) `)` (`lowerext` `=` $lowerext^ `:` type($lowerext))? (`upperext` `=` $upperext^ `:` type($upperext))? attr-dict-with-keyword `:` type($results_)"
+    assembly_format = (
+        "$dim `at` $index `lower` `=` `(` $lower `:` type($lower) `)` "
+        "`upper` `=` `(` $upper `:` type($upper) `)` "
+        "(`lowerext` `=` $lowerext^ `:` type($lowerext))? "
+        "(`upperext` `=` $upperext^ `:` type($upperext))? "
+        "attr-dict-with-keyword `:` type($results_)"
+    )
 
     irdl_options = [
         AttrSizedOperandSegments(),

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -804,7 +804,7 @@ class CombineOp(IRDLOperation):
                └────────┼─────────┘     └────────┼─────────┘
                         │                        │
     ```
-    """
+    """  # noqa: E501
 
     name = "stencil.combine"
 

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -823,13 +823,7 @@ class CombineOp(IRDLOperation):
         CombineOpHasShapeInferencePatternsTrait(),
     )
 
-    assembly_format = (
-        "$dim `at` $index `lower` `=` `(` $lower `:` type($lower) `)` "
-        "`upper` `=` `(` $upper `:` type($upper) `)` "
-        "(`lowerext` `=` $lowerext^ `:` type($lowerext))? "
-        "(`upperext` `=` $upperext^ `:` type($upperext))? "
-        "attr-dict-with-keyword `:` type($results_)"
-    )
+    assembly_format = "$dim `at` $index `lower` `=` `(` $lower `:` type($lower) `)` `upper` `=` `(` $upper `:` type($upper) `)` (`lowerext` `=` $lowerext^ `:` type($lowerext))? (`upperext` `=` $upperext^ `:` type($upperext))? attr-dict-with-keyword `:` type($results_)"  # noqa: E501
 
     irdl_options = [
         AttrSizedOperandSegments(),

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -602,11 +602,13 @@ class ApplyOp(IRDLOperation):
         for operand, argument in zip(self.operands, self.region.block.args):
             if operand.type != argument.type:
                 raise VerifyException(
-                    f"Expected argument type to match operand type, got {argument.type} != {operand.type} at index {argument.index}"
+                    "Expected argument type to match operand type, got "
+                    f"{argument.type} != {operand.type} at index {argument.index}"
                 )
         if len(self.res) > 0 and len(self.dest) > 0:
             raise VerifyException(
-                "Expected stencil.apply to have all value-semantics result or buffer-semantic destination operands."
+                "Expected stencil.apply to have all value-semantics result or "
+                "buffer-semantic destination operands."
             )
         if len(self.res) > 0:
             res_type = cast(TempType[Attribute], self.res[0].type)

--- a/xdsl/dialects/stim/ops.py
+++ b/xdsl/dialects/stim/ops.py
@@ -50,15 +50,20 @@ class QubitAttr(StimPrintable, ParametrizedAttribute, TypeAttribute):
 @irdl_attr_definition
 class QubitMappingAttr(StimPrintable, ParametrizedAttribute):
     """
-    This attribute provides a way to indicate the required connectivity or layout of `physical` qubits.
+    This attribute provides a way to indicate the required connectivity or layout of
+    `physical` qubits.
 
     It consists of two parameters:
-        1. A co-ordinate array (currently it only anticipates a pair of qubits, but this is not fixed)
-        2. A value associated with a qubit referred to in a circuit.
+     1. A co-ordinate array (currently it only anticipates a pair of qubits, but this is
+     not fixed)
+     2. A value associated with a qubit referred to in a circuit.
 
-    The co-ordinates may be used as a physical address of a qubit, or the relative address with respect to some known physical address.
+    The co-ordinates may be used as a physical address of a qubit, or the relative
+    address with respect to some known physical address.
 
-    Operations that attach this as a property may represent the lattice-like structure of a physical quantum computer by having a property with an ArrayAttr[QubitCoordsAttr].
+    Operations that attach this as a property may represent the lattice-like structure
+    of a physical quantum computer by having a property with an
+    ArrayAttr[QubitCoordsAttr].
     """
 
     name = "stim.qubit_coord"

--- a/xdsl/dialects/stim/stim_parser.py
+++ b/xdsl/dialects/stim/stim_parser.py
@@ -228,7 +228,9 @@ class StimParser:
         """
         Parse targets with format:
             targets = SPACE INDENTS target targets?
-        TODO: the Stim documentation indicates that their parser requires at least one target per instruction - but their actual parser does not enforce this. Check incongruency.
+        TODO: the Stim documentation indicates that their parser requires at least one
+        target per instruction - but their actual parser does not enforce this.
+        Check incongruency.
         """
         # Check that there is a first target
         if (first := self.parse_optional_target()) is None:

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -549,7 +549,8 @@ class SequenceOp(IRDLOperation):
             self.failure_propagation_mode, FailurePropagationModeAttr
         ) and not isinstance(self.failure_propagation_mode, IntegerAttr):
             raise VerifyException(
-                f"Expected failure_propagation_mode to be of type FailurePropagationModeAttr, got {type(self.failure_propagation_mode)}"
+                "Expected failure_propagation_mode to be of type "
+                f"FailurePropagationModeAttr, got {type(self.failure_propagation_mode)}"
             )
 
 

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -133,28 +133,34 @@ class FMAOp(IRDLOperation):
 
         if self.res.type.element_type != self.lhs.type.element_type:
             raise VerifyException(
-                "Result vector type must match with all source vectors. Found different types for result vector and lhs vector."
+                "Result vector type must match with all source vectors. Found "
+                "different types for result vector and lhs vector."
             )
         elif self.res.type.element_type != self.rhs.type.element_type:
             raise VerifyException(
-                "Result vector type must match with all source vectors. Found different types for result vector and rhs vector."
+                "Result vector type must match with all source vectors. Found "
+                "different types for result vector and rhs vector."
             )
         elif self.res.type.element_type != self.acc.type.element_type:
             raise VerifyException(
-                "Result vector type must match with all source vectors. Found different types for result vector and acc vector."
+                "Result vector type must match with all source vectors. Found "
+                "different types for result vector and acc vector."
             )
 
         if res_shape != lhs_shape:
             raise VerifyException(
-                "Result vector shape must match with all source vector shapes. Found different shapes for result vector and lhs vector."
+                "Result vector shape must match with all source vector shapes. Found "
+                "different shapes for result vector and lhs vector."
             )
         elif res_shape != rhs_shape:
             raise VerifyException(
-                "Result vector shape must match with all source vector shapes. Found different shapes for result vector and rhs vector."
+                "Result vector shape must match with all source vector shapes. Found "
+                "different shapes for result vector and rhs vector."
             )
         elif res_shape != acc_shape:
             raise VerifyException(
-                "Result vector shape must match with all source vector shapes. Found different shapes for result vector and acc vector."
+                "Result vector shape must match with all source vector shapes. Found "
+                "different shapes for result vector and acc vector."
             )
 
     @staticmethod

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -1769,7 +1769,8 @@ class S_JmpOp(IRDLOperation, X86Instruction):
 @irdl_op_definition
 class RR_CmpOp(IRDLOperation, X86Instruction):
     """
-    Compares the first source operand with the second source operand and sets the status flags in the EFLAGS register according to the results.
+    Compares the first source operand with the second source operand and sets the status
+    flags in the EFLAGS register according to the results.
     https://www.felixcloutier.com/x86/cmp
     """
 
@@ -1806,7 +1807,8 @@ class RR_CmpOp(IRDLOperation, X86Instruction):
 @irdl_op_definition
 class RM_CmpOp(IRDLOperation, X86Instruction):
     """
-    Compares the first source operand with the second source operand and sets the status flags in the EFLAGS register according to the results.
+    Compares the first source operand with the second source operand and sets the status
+    flags in the EFLAGS register according to the results.
     https://www.felixcloutier.com/x86/cmp
     """
 
@@ -1865,7 +1867,8 @@ class RM_CmpOp(IRDLOperation, X86Instruction):
 @irdl_op_definition
 class RI_CmpOp(IRDLOperation, X86Instruction):
     """
-    Compares the first source operand with the second source operand and sets the status flags in the EFLAGS register according to the results.
+    Compares the first source operand with the second source operand and sets the status
+    flags in the EFLAGS register according to the results.
     https://www.felixcloutier.com/x86/cmp
     """
 
@@ -1917,7 +1920,8 @@ class RI_CmpOp(IRDLOperation, X86Instruction):
 @irdl_op_definition
 class MR_CmpOp(IRDLOperation, X86Instruction):
     """
-    Compares the first source operand with the second source operand and sets the status flags in the EFLAGS register according to the results.
+    Compares the first source operand with the second source operand and sets the status
+    flags in the EFLAGS register according to the results.
     https://www.felixcloutier.com/x86/cmp
     """
 
@@ -1976,7 +1980,8 @@ class MR_CmpOp(IRDLOperation, X86Instruction):
 @irdl_op_definition
 class MI_CmpOp(IRDLOperation, X86Instruction):
     """
-    Compares the first source operand with the second source operand and sets the status flags in the EFLAGS register according to the results.
+    Compares the first source operand with the second source operand and sets the status
+    flags in the EFLAGS register according to the results.
     https://www.felixcloutier.com/x86/cmp
     """
 
@@ -2501,7 +2506,8 @@ class RRR_Vfmadd231pdOp(
     RRROperation[AVXRegisterType, AVXRegisterType, AVXRegisterType]
 ):
     """
-    Multiply packed double-precision floating-point elements in r2 and r3, add the intermediate result to r1, and store the final result in r1.
+    Multiply packed double-precision floating-point elements in r2 and r3, add the
+    intermediate result to r1, and store the final result in r1.
     https://www.felixcloutier.com/x86/vfmadd132pd:vfmadd213pd:vfmadd231pd
     """
 
@@ -2511,7 +2517,8 @@ class RRR_Vfmadd231pdOp(
 @irdl_op_definition
 class RR_VmovapdOp(R_RR_Operation[AVXRegisterType, AVXRegisterType]):
     """
-    Move aligned packed double precision floating-point values from zmm1 to zmm2 using writemask k1
+    Move aligned packed double precision floating-point values from zmm1 to zmm2 using
+    writemask k1
     https://www.felixcloutier.com/x86/movapd
     """
 

--- a/xdsl/frontend/pyast/type_conversion.py
+++ b/xdsl/frontend/pyast/type_conversion.py
@@ -93,7 +93,8 @@ class TypeConverter:
                         self.file,
                         type_hint.lineno,
                         type_hint.col_offset,
-                        f"Expected 1 type argument for generic type '{type_name}', got {len(materialized_arguments)} type arguments instead.",
+                        f"Expected 1 type argument for generic type '{type_name}', got "
+                        f"{len(materialized_arguments)} type arguments instead.",
                     )
                 arguments_for_constructor.append(materialized_arguments[0])
                 continue

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -338,7 +338,8 @@ class InputApp(App[None]):
         child_pass_list: tuple[AvailablePass, ...],
     ) -> None:
         """
-        Helper function that adds a subtree to a node, i.e. adds a sub-tree containing the child_pass_list with expanded_pass as the root.
+        Helper function that adds a subtree to a node, i.e. adds a sub-tree containing
+        the child_pass_list with expanded_pass as the root.
         """
         # remove potential children nodes in case expand node has been clicked multiple times on the same node
         expanded_pass.remove_children()

--- a/xdsl/interactive/app.py
+++ b/xdsl/interactive/app.py
@@ -393,7 +393,8 @@ class InputApp(App[None]):
                     result,
                 )
 
-        # generates a string containing the concatenated_arg_val and types of the selected pass and initializes the AddArguments Screen to contain the string
+        # generates a string containing the concatenated_arg_val and types of the
+        # selected pass and initializes the AddArguments Screen to contain the string
         self.push_screen(
             AddArguments(selected_pass_value),
             on_exit,

--- a/xdsl/interpreter.py
+++ b/xdsl/interpreter.py
@@ -629,7 +629,8 @@ class Interpreter:
             actual_result_count := len(result.values)
         ):
             raise InterpretationError(
-                f"Number of operation results ({results_count}) doesn't match the number of implementation results ({actual_result_count})."
+                f"Number of operation results ({results_count}) doesn't match the "
+                f"number of implementation results ({actual_result_count})."
             )
         for listener in self.listeners:
             listener.did_interpret_op(op, result.values)

--- a/xdsl/ir/affine/affine_expr.py
+++ b/xdsl/ir/affine/affine_expr.py
@@ -43,7 +43,10 @@ class AffineExpr:
 
         Returns the composition of this AffineExpr with map.
 
-        Prerequisites: this and map are composable, i.e. that the number of AffineDimExpr of this is smaller than the number of results of map. If a result of a map does not have a corresponding AffineDimExpr, that result simply does not appear in the produced AffineExpr.
+        Prerequisites: this and map are composable, i.e. that the number of
+        AffineDimExpr of this is smaller than the number of results of map.
+        If a result of a map does not have a corresponding AffineDimExpr, that result
+        simply does not appear in the produced AffineExpr.
 
         Example:
         ```

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -148,7 +148,7 @@ class AffineMap:
         map2: (d0)[s0] -> (d0 + s0, d0 - s0)
         map1.compose(map2): (d0)[s0, s1, s2] -> (d0 + s1 + s2 + 1, d0 - s0 - s2 - 1)
         ```
-        """  #
+        """
         if self.num_dims != len(other.results):
             raise ValueError(
                 "Cannot compose AffineMaps with mismatching dimensions and results: "

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -135,9 +135,12 @@ class AffineMap:
         """
         Returns the `AffineMap` resulting from composing `self` with `other`.
 
-        The resulting `AffineMap` has as many dimensions as `other` and as many symbols as the concatenation of `self` and `other` (in which case the symbols of `self` come first).
+        The resulting `AffineMap` has as many dimensions as `other` and as many symbols
+        as the concatenation of `self` and `other` (in which case the symbols of `self`
+        come first).
 
-        Prerequisites: The maps are composable, i.e. that the number of dimensions of `self` matches the number of results of `other`.
+        Prerequisites: The maps are composable, i.e. that the number of dimensions of
+        `self` matches the number of results of `other`.
 
         Example:
         ```
@@ -145,7 +148,7 @@ class AffineMap:
         map2: (d0)[s0] -> (d0 + s0, d0 - s0)
         map1.compose(map2): (d0)[s0, s1, s2] -> (d0 + s1 + s2 + 1, d0 - s0 - s2 - 1)
         ```
-        """
+        """  #
         if self.num_dims != len(other.results):
             raise ValueError(
                 "Cannot compose AffineMaps with mismatching dimensions and results: "

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -114,7 +114,10 @@ class AffineMap:
         result_num_symbols: int,
     ) -> AffineMap:
         """
-        This method substitutes any uses of dimensions and symbols (e.g. dim#0 with dimReplacements[0]) in subexpressions and returns the modified expression mapping.  Because this can be used to eliminate dims and symbols, the client needs to specify the number of dims and symbols in the result.
+        This method substitutes any uses of dimensions and symbols (e.g. dim#0 with
+        dimReplacements[0]) in subexpressions and returns the modified expression
+        mapping.  Because this can be used to eliminate dims and symbols, the client
+        needs to specify the number of dims and symbols in the result.
 
         The returned map always has the same number of results.
         """

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -195,23 +195,28 @@ class FormatParser(BaseParser):
                     )
                 case VariadicTypeDirective(), VariadicTypeDirective():
                     self.raise_error(
-                        "A variadic type directive cannot be followed by another variadic type directive."
+                        "A variadic type directive cannot be followed by another "
+                        "variadic type directive."
                     )
                 case VariadicOperandDirective(), VariadicOperandDirective():
                     self.raise_error(
-                        "A variadic operand variable cannot be followed by another variadic operand variable."
+                        "A variadic operand variable cannot be followed by another "
+                        "variadic operand variable."
                     )
                 case VariadicRegionDirective(), VariadicRegionDirective():
                     self.raise_error(
-                        "A variadic region variable cannot be followed by another variadic region variable."
+                        "A variadic region variable cannot be followed by another "
+                        "variadic region variable."
                     )
                 case VariadicSuccessorDirective(), VariadicSuccessorDirective():
                     self.raise_error(
-                        "A variadic successor variable cannot be followed by another variadic successor variable."
+                        "A variadic successor variable cannot be followed by another "
+                        "variadic successor variable."
                     )
                 case AttrDictDirective(), RegionDirective() if not (a.with_keyword):
                     self.raise_error(
-                        "An `attr-dict' directive without keyword cannot be directly followed by a region variable as it is ambiguous."
+                        "An `attr-dict' directive without keyword cannot be directly "
+                        "followed by a region variable as it is ambiguous."
                     )
                 case _:
                     pass

--- a/xdsl/tools/xdsl_run.py
+++ b/xdsl/tools/xdsl_run.py
@@ -60,7 +60,8 @@ class xDSLRunMain(CommandLineTool):
             "--args",
             default="",
             type=str,
-            help="Arguments to pass to entry function. Comma-separated list of xDSL Attributes, that will be parsed and converted by the interpreter.",
+            help="Arguments to pass to entry function. Comma-separated list of xDSL "
+            "Attributes, that will be parsed and converted by the interpreter.",
         )
         return super().register_all_arguments(arg_parser)
 

--- a/xdsl/transforms/canonicalization_patterns/scf.py
+++ b/xdsl/transforms/canonicalization_patterns/scf.py
@@ -17,7 +17,8 @@ from xdsl.transforms.canonicalization_patterns.utils import (
 class RehoistConstInLoops(RewritePattern):
     """
     Carry out const definitions from the loops.
-    In the future this will probably be done by the pattern rewriter itself, like it's done in the MLIR's applyPatternsAndFoldGreedily.
+    In the future this will probably be done by the pattern rewriter itself, like it's
+    done in the MLIR's applyPatternsAndFoldGreedily.
     """
 
     @op_type_rewrite_pattern

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -21,7 +21,10 @@ from xdsl.utils.exceptions import DiagnosticException
 def offset_calculations(
     memref_type: memref.MemRefType[Any], indices: Iterable[SSAValue]
 ) -> tuple[list[Operation], SSAValue]:
-    """Get operations calculating an offset which needs to be added to memref's base pointer to access an element referenced by indices."""
+    """
+    Get operations calculating an offset which needs to be added to memref's base
+    pointer to access an element referenced by indices.
+    """
 
     assert isinstance(memref_type.element_type, builtin.FixedBitwidthType)
 

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -483,7 +483,8 @@ class ConvertApplyOpPattern(RewritePattern):
             for idx, old in enumerate(done_exchange_used_block_args, start=2)
         )
 
-        # add translation from old to new arg index for non-optional args - note, access to accumulator must be handled separately below
+        # add translation from old to new arg index for non-optional args - note, access
+        # to accumulator must be handled separately below
         chunk_region_oprnd_table[op.region.block.args[prefetch_idx]] = (
             receive_chunk.block.args[0]
         )

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -191,7 +191,8 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
         self, args: Sequence[BlockArgument], attrs: ArrayAttr[DictionaryAttr] | None
     ) -> tuple[Sequence[Operation], Sequence[SSAValue]]:
         """
-        Args of the top-level function act as the interface to the program and need to be translated to writable buffers.
+        Args of the top-level function act as the interface to the program and need to
+        be translated to writable buffers.
         """
         arg_ops: list[Operation] = []
         arg_op_mapping: list[SSAValue] = []

--- a/xdsl/transforms/eqsat_add_costs.py
+++ b/xdsl/transforms/eqsat_add_costs.py
@@ -33,7 +33,8 @@ def add_eqsat_costs(block: Block):
 
         if len(op.results) != 1:
             raise DiagnosticException(
-                f"Cannot compute cost of one result of operation with multiple results: {op}"
+                "Cannot compute cost of one result of operation with multiple "
+                "results: {op}"
             )
 
         costs = tuple(get_eqsat_cost(value) for value in op.operands)

--- a/xdsl/transforms/eqsat_add_costs.py
+++ b/xdsl/transforms/eqsat_add_costs.py
@@ -34,7 +34,7 @@ def add_eqsat_costs(block: Block):
         if len(op.results) != 1:
             raise DiagnosticException(
                 "Cannot compute cost of one result of operation with multiple "
-                "results: {op}"
+                f"results: {op}"
             )
 
         costs = tuple(get_eqsat_cost(value) for value in op.operands)

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -513,11 +513,13 @@ class StencilStoreToSubview(RewritePattern):
         for use in op.field.uses:
             if isa(use.operation, LoadOp):
                 raise VerifyException(
-                    "Cannot lower directly if loading and storing the same field! Try running `stencil-bufferize` before."
+                    "Cannot lower directly if loading and storing the same field! "
+                    "Try running `stencil-bufferize` before."
                 )
             if isa(use.operation, StoreOp) and use.operation is not op:
                 raise VerifyException(
-                    "Cannot lower directly if storing to the same field multiple times! Try running `stencil-bufferize` before."
+                    "Cannot lower directly if storing to the same field multiple "
+                    "times! Try running `stencil-bufferize` before."
                 )
         field = op.field
         assert isa(field.type, FieldType[Attribute])

--- a/xdsl/transforms/experimental/function_constant_pinning.py
+++ b/xdsl/transforms/experimental/function_constant_pinning.py
@@ -117,8 +117,8 @@ def generate_func_with_pinned_val(
     rewriter: PatternRewriter,
 ):
     """
-    Specializes a function to pin a value to a compile time constant. Assumes the function is top-level
-    inside the module.
+    Specializes a function to pin a value to a compile time constant. Assumes the
+    function is top-level inside the module.
 
     This will do the following things:
     - clone the function

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -1070,8 +1070,9 @@ class PackData(RewritePattern):
                     assert isinstance(insertvalue.container, OpResult)
                     container_op = insertvalue.container.op
                     if isinstance(container_op, UndefOp):
-                        # We mark the UndefOp to update its type in the next pass and also update the type returned by the insertvalue
-                        # operation that uses it
+                        # We mark the UndefOp to update its type in the next pass and
+                        # also update the type returned by the insertvalue operation
+                        # that uses it
 
                         container_op.attributes["replace"] = IntAttr(0)
 

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -1054,7 +1054,8 @@ class PackData(RewritePattern):
         if op.attributes["inout"].data == OUT or (
             op.attributes["inout"].data == IN and ndims == 3
         ):
-            # TODO: this should be generalised by packaging the original type instead of f64. We would need intrinsics to deal with the different types
+            # TODO: this should be generalised by packaging the original type instead of
+            # f64. We would need intrinsics to deal with the different types
             packed_type = LLVMPointerType.typed(
                 LLVMStructType.from_type_list(
                     [LLVMArrayType.from_size_and_type(8, f64)]

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -531,7 +531,10 @@ class ApplyOpToHLS(RewritePattern):
 
         # We replace the temp arguments by HLS streams. Only for the 3D temps
         for k in range(len(apply_clones_lst)):
-            # Insert the HLS stream operands and their corresponding block arguments for reading from the shift buffer and writing # to external memory # We replace by streams only the 3D temps. The rest should be left as is operand_stream = dict()
+            # Insert the HLS stream operands and their corresponding block arguments for
+            # reading from the shift buffer and writing to external memory.
+            # We replace by streams only the 3D temps.
+            # The rest should be left as is operand_stream = dict()
             current_stream = 0
 
             new_operands_lst: list[OpResult] = []

--- a/xdsl/transforms/individual_rewrite.py
+++ b/xdsl/transforms/individual_rewrite.py
@@ -116,5 +116,6 @@ class ApplyIndividualRewritePass(ModulePass):
         pattern.match_and_rewrite(matched_operation, rewriter)
         if not rewriter.has_done_action:
             raise ValueError(
-                f"Invalid rewrite ({self.pattern_name}) for operation ({matched_operation}) at location {self.matched_operation_index}."
+                f"Invalid rewrite ({self.pattern_name}) for operation "
+                f"({matched_operation}) at location {self.matched_operation_index}."
             )

--- a/xdsl/transforms/memref_stream_tile_outer_loops.py
+++ b/xdsl/transforms/memref_stream_tile_outer_loops.py
@@ -35,10 +35,10 @@ def insert_subview(
     location: InsertPoint,
 ):
     """
-    A helper method to insert a subview from the input `memref_val` to one with new upper
-    bounds, given that it will be accessed with the specified affine map.
-    `dim_offsets` are the operands to use to determine the new offset, and `upper_bounds`
-    the new shape.
+    A helper method to insert a subview from the input `memref_val` to one with new
+    upper bounds, given that it will be accessed with the specified affine map.
+    `dim_offsets` are the operands to use to determine the new offset, and
+    `upper_bounds` the new shape.
     Any new operations should be inserted at `location`.
     """
     name_hint_prefix = (

--- a/xdsl/transforms/memref_streamify.py
+++ b/xdsl/transforms/memref_streamify.py
@@ -135,8 +135,8 @@ class StreamifyGenericOpPattern(RewritePattern):
 @dataclass(frozen=True)
 class MemRefStreamifyPass(ModulePass):
     """
-    Converts a memref generic on memrefs to a memref generic on streams, by moving it into
-    a streaming region.
+    Converts a memref generic on memrefs to a memref generic on streams, by moving it
+    into a streaming region.
     """
 
     name = "memref-streamify"

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -431,7 +431,7 @@ class CombineStoreFold(RewritePattern):
     stencil.store %1 to %dest1 (<[16], [32]>) : !stencil.temp<[16,32]xf64> to !stencil.field<[-2,34]xf64>
     stencil.store %2 to %dest2 (<[0], [16]>) : !stencil.temp<[0,16]xf64> to !stencil.field<[-2,34]xf64>
     ```
-    """
+    """  # noqa: E501
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: CombineOp, rewriter: PatternRewriter):

--- a/xdsl/transforms/stencil_bufferize.py
+++ b/xdsl/transforms/stencil_bufferize.py
@@ -389,7 +389,7 @@ class BufferAlloc(RewritePattern):
     %forward = stencil.load %alloc : !stencil.field<[0,32]>xf64 -> !stencil.temp<[0,32]>
     // [...]
     ```
-    """
+    """  # noqa: E501
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: BufferOp, rewriter: PatternRewriter):

--- a/xdsl/utils/dialect_stub.py
+++ b/xdsl/utils/dialect_stub.py
@@ -71,8 +71,8 @@ class DialectStubGenerator:
 
     def _generate_constraint_type(self, constraint: AttrConstraint) -> str:
         """
-        Return a type hint for the member constrained by a constraint, by it an attribute
-        parameter, or an operation attribute/property.
+        Return a type hint for the member constrained by a constraint, by it an
+        attribute parameter, or an operation attribute/property.
         """
         import xdsl.dialects.builtin
         import xdsl.ir
@@ -94,7 +94,7 @@ class DialectStubGenerator:
                 )
             case AllOf(constraints):
                 self._import(typing, "Annotated")
-                return f"Annotated[{', '.join(self._generate_constraint_type(c) for c in reversed(constraints))}]"
+                return f"Annotated[{', '.join(self._generate_constraint_type(c) for c in reversed(constraints))}]"  # noqa: E501
             case ArrayOfConstraint(constraint):
                 self._import(xdsl.dialects.builtin, ArrayAttr)
                 return f"ArrayAttr[{self._generate_constraint_type(constraint)}]"
@@ -144,7 +144,8 @@ class DialectStubGenerator:
         """
         Generate type stub for an irdl operation.
         """
-        # Keep track of whether the operation has any body, to generate a pass if it does not.
+        # Keep track of whether the operation has any body, to generate a pass if it
+        # does not.
         had_body = False
 
         # They all are IRDLOperations.
@@ -184,14 +185,14 @@ class DialectStubGenerator:
             had_body = True
             match o:
                 case OptAttributeDef():
-                    yield f"    {name} : {self._generate_constraint_type(o.constr)} | None"
+                    yield f"    {name} : {self._generate_constraint_type(o.constr)} | None"  # noqa: E501
                 case AttributeDef():
                     yield f"    {name} : {self._generate_constraint_type(o.constr)}"
         for name, o in op_def.properties.items():
             had_body = True
             match o:
                 case OptPropertyDef():
-                    yield f"    {name} : {self._generate_constraint_type(o.constr)} | None"
+                    yield f"    {name} : {self._generate_constraint_type(o.constr)} | None"  # noqa: E501
                 case PropertyDef():
                     yield f"    {name} : {self._generate_constraint_type(o.constr)}"
 

--- a/xdsl/utils/disjoint_set.py
+++ b/xdsl/utils/disjoint_set.py
@@ -156,7 +156,8 @@ class DisjointSet(Generic[_T]):
         """
         Merge the sets containing the two given values if they are different.
 
-        Returns `True` if the sets were merged, `False` if they were already the same set.
+        Returns `True` if the sets were merged, `False` if they were already the same
+        set.
 
         Raises:
             KeyError: If either value is not in the disjoint set

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -50,7 +50,8 @@ class InvalidIRException(Exception):
 
 class ShrinkException(Exception):
     """
-    Exception for test case reduction when used in conjunction with the [Shrink Ray](https://github.com/DRMacIver/shrinkray) reducer.
+    Exception for test case reduction when used in conjunction with the [Shrink Ray](https://github.com/DRMacIver/shrinkray)
+    reducer.
 
     To find a reduced version of a test case, raise this exception on the line of code you want to hit,
     and pass the `--shrink` argument to `xdsl-opt`, by changing its invocation from:

--- a/xdsl/utils/hashable_module.py
+++ b/xdsl/utils/hashable_module.py
@@ -22,8 +22,8 @@ class HashableModule(Hashable):
     def __hash__(self) -> int:
         """
         The hash of the module is a hash of the ordered combination of operation names.
-        As most transformations on IR modify at least one operation, this should be enough
-        to minimise collisions.
+        As most transformations on IR modify at least one operation, this should be
+        enough to minimise collisions.
         """
         hasher = Hasher()
         for op in self.module.walk():

--- a/xdsl/utils/lexer.py
+++ b/xdsl/utils/lexer.py
@@ -69,7 +69,8 @@ class Input:
 @dataclass(frozen=True)
 class Span:
     """
-    Parts of the input are always passed around as spans, so we know where they originated.
+    Parts of the input are always passed around as spans, so we know where they
+    originated.
     """
 
     start: Position

--- a/xdsl/utils/marimo.py
+++ b/xdsl/utils/marimo.py
@@ -36,8 +36,8 @@ def pipeline_html(
     ctx: MLContext, module: ModuleOp, passes: Sequence[tuple[mo.Html, ModulePass]]
 ) -> tuple[MLContext, ModuleOp, mo.Html]:
     """
-    Returns a tuple of the resulting context and module after applying the passes, and the
-    Marimo-optimised representation of the modules throughout compilation.
+    Returns a tuple of the resulting context and module after applying the passes, and
+    the Marimo-optimised representation of the modules throughout compilation.
 
     The input is the input MLContext, a sequence of tuples of
     (pass description, module pass).

--- a/xdsl/utils/parse_pipeline.py
+++ b/xdsl/utils/parse_pipeline.py
@@ -43,7 +43,8 @@ _lexer_rules: list[tuple[re.Pattern[str], Token.Kind]] = [
     (re.compile(r","), Token.Kind.COMMA),
 ]
 """
-This is a list of lexer rules that should be tried in this specific order to get the next token.
+This is a list of lexer rules that should be tried in this specific order to get the
+next token.
 """
 
 
@@ -148,8 +149,8 @@ class PipelinePassSpec:
 
     def __str__(self) -> str:
         """
-        This function returns a string containing the PipelineSpec name, its arguments and
-        respective values for use on the commandline.
+        This function returns a string containing the PipelineSpec name, its arguments
+        and respective values for use on the commandline.
         """
         query = f"{self.name}"
         arguments_pipeline = " ".join(
@@ -310,7 +311,8 @@ def _parse_arg_value_element(lexer: PipelineLexer) -> PassArgElementType:
     """
     Parse a singular value element
     """
-    # valid value elements are quoted strings, numbers, true|false, and "ident" type strings
+    # valid value elements are quoted strings, numbers, true|false, and "ident" type
+    # strings
     match lexer.lex():
         case Token(kind=Token.Kind.STRING_LIT, span=span):
             # string literals are converted to unescaped strings
@@ -335,5 +337,6 @@ def _parse_arg_value_element(lexer: PipelineLexer) -> PassArgElementType:
             # every other token type is invalid as a value
             raise PassPipelineParseError(
                 token,
-                "Unknown argument value, wrap argument in quotes to pass arbitrary string values",
+                "Unknown argument value, wrap argument in quotes to pass arbitrary "
+                "string values",
             )

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -139,8 +139,8 @@ class xDSLOptMain(CommandLineTool):
             "--split-input-file",
             default=False,
             action="store_true",
-            help="Split the input file into pieces and process each chunk independently by "
-            " using `// -----`",
+            help="Split the input file into pieces and process each chunk "
+            "independently by using `// -----`",
         )
 
         arg_parser.add_argument(


### PR DESCRIPTION
I don't know if we'll ever get to 88, but it feels like it would be good to get the line lengths a little more under control. In this PR, I update the line length, ignore all test files, ignore the line length limit on all assembly format strings, reflow some doc strings, and split up some inline strings in the code.

After this change, there are 840 errors when I set the line length to 88, and 313 if I set it to 100. I think without some sort of AI "fix everything" button it's a waste of time to go shorter, but our current setting of 300 definitely seems to big.

This PR contains about 60 whitespace changes.