### PR TITLE
backend: unify assembly printing helpers in AssemblyPrinter

### DIFF
--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -148,7 +148,7 @@ x86.directive ".align" "2"
 x86.label "label"
 // CHECK-NEXT: label:
 
-func.func @funcyasm() {
+x86_func.func @funcyasm() {
     %3 = x86.get_register : () -> !x86.reg<rax>
     %4 = x86.get_register : () -> !x86.reg<rdx>
     %rflags = x86.rr.cmp %3, %4 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.rflags<rflags>

--- a/xdsl/backend/assembly_printer.py
+++ b/xdsl/backend/assembly_printer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.utils.base_printer import BasePrinter
+
+
+class AssemblyPrinter(BasePrinter):
+    @staticmethod
+    def append_comment(line: str, comment: StringAttr | None) -> str:
+        if comment is None:
+            return line
+
+        padding = " " * max(0, 48 - len(line))
+
+        return f"{line}{padding} # {comment.data}"
+
+    @staticmethod
+    def assembly_line(
+        name: str,
+        arg_str: str,
+        comment: StringAttr | None = None,
+        is_indented: bool = True,
+    ) -> str:
+        code = "    " if is_indented else ""
+        code += name
+        if arg_str:
+            code += f" {arg_str}"
+        code = AssemblyPrinter.append_comment(code, comment)
+        return code
+
+    def print_module(self, module: ModuleOp) -> None:
+        for op in module.body.walk():
+            assert isinstance(op, AssemblyPrintable), f"{op}"
+            op.print_assembly(self)
+
+
+class AssemblyPrintable(ABC):
+    """
+    Base class for operations that can be a part of assembly printing.
+    """
+
+    @abstractmethod
+    def print_assembly(self, printer: AssemblyPrinter) -> None:
+        raise NotImplementedError()
+
+
+class OneLineAssemblyPrintable(AssemblyPrintable, ABC):
+    """
+    Base class for operations that can be printed in one line of assembly, or not
+    printed at all.
+    """
+
+    @abstractmethod
+    def assembly_line(self) -> str | None:
+        """
+        Returns the line that should be printed in assembly, or `None` to not be
+        printed.
+        """
+        raise NotImplementedError()
+
+    def print_assembly(self, printer: AssemblyPrinter) -> None:
+        line = self.assembly_line()
+        if line is not None:
+            printer.print_string(line + "\n")

--- a/xdsl/backend/assembly_printer.py
+++ b/xdsl/backend/assembly_printer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from xdsl.dialects.builtin import ModuleOp, StringAttr
+from xdsl.ir import Operation
 from xdsl.utils.base_printer import BasePrinter
 
 

--- a/xdsl/backend/assembly_printer.py
+++ b/xdsl/backend/assembly_printer.py
@@ -63,4 +63,5 @@ class OneLineAssemblyPrintable(AssemblyPrintable, ABC):
     def print_assembly(self, printer: AssemblyPrinter) -> None:
         line = self.assembly_line()
         if line is not None:
-            printer.print_string(line + "\n")
+            printer.print_string(line)
+            printer.print_string("\n")

--- a/xdsl/backend/assembly_printer.py
+++ b/xdsl/backend/assembly_printer.py
@@ -36,7 +36,7 @@ class AssemblyPrinter(BasePrinter):
             op.print_assembly(self)
 
 
-class AssemblyPrintable(ABC):
+class AssemblyPrintable(Operation, ABC):
     """
     Base class for operations that can be a part of assembly printing.
     """

--- a/xdsl/dialects/arm/__init__.py
+++ b/xdsl/dialects/arm/__init__.py
@@ -5,19 +5,17 @@ https://developer.arm.com/documentation/102374/0101/Overview
 
 from typing import IO
 
+from xdsl.backend.assembly_printer import AssemblyPrinter
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Dialect
 
-from .ops import ARMOperation, CmpRegOp, DSMovOp, DSSMulOp, GetRegisterOp, LabelOp
+from .ops import CmpRegOp, DSMovOp, DSSMulOp, GetRegisterOp, LabelOp
 from .register import IntRegisterType
 
 
 def print_assembly(module: ModuleOp, output: IO[str]) -> None:
-    for op in module.body.walk():
-        assert isinstance(op, ARMOperation), f"{op}"
-        asm = op.assembly_line()
-        if asm is not None:
-            print(asm, file=output)
+    printer = AssemblyPrinter(stream=output)
+    printer.print_module(module)
 
 
 ARM = Dialect(

--- a/xdsl/dialects/arm/assembly.py
+++ b/xdsl/dialects/arm/assembly.py
@@ -1,19 +1,9 @@
 from typing import TypeAlias
 
 from xdsl.dialects.arm.register import ARMRegisterType
-from xdsl.dialects.builtin import StringAttr
 from xdsl.ir import SSAValue
 
 AssemblyInstructionArg: TypeAlias = ARMRegisterType | SSAValue
-
-
-def append_comment(line: str, comment: StringAttr | None) -> str:
-    if comment is None:
-        return line
-
-    padding = " " * max(0, 48 - len(line))
-
-    return f"{line}{padding} # {comment.data}"
 
 
 def assembly_arg_str(arg: AssemblyInstructionArg) -> str:
@@ -26,17 +16,3 @@ def assembly_arg_str(arg: AssemblyInstructionArg) -> str:
             return reg
         else:
             raise ValueError(f"Unexpected argument type {type(arg)}")
-
-
-def assembly_line(
-    name: str,
-    arg_str: str,
-    comment: StringAttr | None = None,
-    is_indented: bool = True,
-) -> str:
-    code = "    " if is_indented else ""
-    code += name
-    if arg_str:
-        code += f" {arg_str}"
-    code = append_comment(code, comment)
-    return code

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from xdsl.backend.assembly_printer import AssemblyPrinter, OneLineAssemblyPrintable
 from xdsl.dialects.builtin import StringAttr
 from xdsl.ir import Operation, SSAValue
 from xdsl.irdl import (
@@ -11,23 +12,14 @@ from xdsl.irdl import (
     result_def,
 )
 
-from .assembly import (
-    AssemblyInstructionArg,
-    append_comment,
-    assembly_arg_str,
-    assembly_line,
-)
+from .assembly import AssemblyInstructionArg, assembly_arg_str
 from .register import IntRegisterType
 
 
-class ARMOperation(IRDLOperation, ABC):
+class ARMOperation(IRDLOperation, OneLineAssemblyPrintable, ABC):
     """
     Base class for operations that can be a part of ARM assembly printing.
     """
-
-    @abstractmethod
-    def assembly_line(self) -> str | None:
-        raise NotImplementedError()
 
 
 class ARMInstruction(ARMOperation, ABC):
@@ -65,7 +57,7 @@ class ARMInstruction(ARMOperation, ABC):
             for arg in self.assembly_line_args()
             if arg is not None
         )
-        return assembly_line(instruction_name, arg_str, self.comment)
+        return AssemblyPrinter.assembly_line(instruction_name, arg_str, self.comment)
 
 
 @irdl_op_definition
@@ -195,7 +187,7 @@ class LabelOp(ARMOperation):
         )
 
     def assembly_line(self) -> str | None:
-        return append_comment(f"{self.label.data}:", self.comment)
+        return AssemblyPrinter.append_comment(f"{self.label.data}:", self.comment)
 
 
 @irdl_op_definition

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -8,6 +8,7 @@ from typing import IO, Annotated, Generic, Literal, TypeAlias, TypeVar
 
 from typing_extensions import Self, assert_never
 
+from xdsl.backend.assembly_printer import AssemblyPrinter, OneLineAssemblyPrintable
 from xdsl.backend.register_allocatable import (
     HasRegisterConstraints,
     RegisterConstraints,
@@ -348,17 +349,15 @@ class LabelAttr(Data[str]):
             printer.print_string_literal(self.data)
 
 
-class RISCVAsmOperation(HasRegisterConstraints, IRDLOperation, ABC):
+class RISCVAsmOperation(
+    HasRegisterConstraints, IRDLOperation, OneLineAssemblyPrintable, ABC
+):
     """
     Base class for operations that can be a part of RISC-V assembly printing.
     """
 
     def get_register_constraints(self) -> RegisterConstraints:
         return RegisterConstraints(self.operands, self.results, ())
-
-    @abstractmethod
-    def assembly_line(self) -> str | None:
-        raise NotImplementedError()
 
 
 class RISCVCustomFormatOperation(IRDLOperation, ABC):
@@ -484,19 +483,10 @@ class RISCVInstruction(RISCVAsmOperation, ABC):
             for arg in self.assembly_line_args()
             if arg is not None
         )
-        return _assembly_line(instruction_name, arg_str, self.comment)
+        return AssemblyPrinter.assembly_line(instruction_name, arg_str, self.comment)
 
 
 # region Assembly printing
-
-
-def _append_comment(line: str, comment: StringAttr | None) -> str:
-    if comment is None:
-        return line
-
-    padding = " " * max(0, 48 - len(line))
-
-    return f"{line}{padding} # {comment.data}"
 
 
 def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
@@ -524,26 +514,9 @@ def _assembly_arg_str(arg: AssemblyInstructionArg) -> str:
     assert_never(arg)
 
 
-def _assembly_line(
-    name: str,
-    arg_str: str,
-    comment: StringAttr | None = None,
-    is_indented: bool = True,
-) -> str:
-    code = "    " if is_indented else ""
-    code += name
-    if arg_str:
-        code += f" {arg_str}"
-    code = _append_comment(code, comment)
-    return code
-
-
 def print_assembly(module: ModuleOp, output: IO[str]) -> None:
-    for op in module.body.walk():
-        assert isinstance(op, RISCVAsmOperation), f"{op}"
-        asm = op.assembly_line()
-        if asm is not None:
-            print(asm, file=output)
+    printer = AssemblyPrinter(stream=output)
+    printer.print_module(module)
 
 
 def riscv_code(module: ModuleOp) -> str:
@@ -2166,7 +2139,7 @@ class LwOp(RdRsImmIntegerOperation):
         value = _assembly_arg_str(self.rd)
         imm = _assembly_arg_str(self.immediate)
         offset = _assembly_arg_str(self.rs1)
-        return _assembly_line(
+        return AssemblyPrinter.assembly_line(
             instruction_name, f"{value}, {imm}({offset})", self.comment
         )
 
@@ -2233,7 +2206,7 @@ class SwOp(RsRsImmIntegerOperation):
         value = _assembly_arg_str(self.rs2)
         imm = _assembly_arg_str(self.immediate)
         offset = _assembly_arg_str(self.rs1)
-        return _assembly_line(
+        return AssemblyPrinter.assembly_line(
             instruction_name, f"{value}, {imm}({offset})", self.comment
         )
 
@@ -2630,7 +2603,7 @@ class LabelOp(RISCVCustomFormatOperation, RISCVAsmOperation):
         )
 
     def assembly_line(self) -> str | None:
-        return _append_comment(f"{self.label.data}:", self.comment)
+        return AssemblyPrinter.append_comment(f"{self.label.data}:", self.comment)
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -2690,7 +2663,9 @@ class DirectiveOp(RISCVCustomFormatOperation, RISCVAsmOperation):
         else:
             arg_str = ""
 
-        return _assembly_line(self.directive.data, arg_str, is_indented=False)
+        return AssemblyPrinter.assembly_line(
+            self.directive.data, arg_str, is_indented=False
+        )
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -2781,7 +2756,7 @@ class AssemblySectionOp(RISCVAsmOperation):
             printer.print_region(self.data)
 
     def assembly_line(self) -> str | None:
-        return _assembly_line(self.directive.data, "", is_indented=False)
+        return AssemblyPrinter.assembly_line(self.directive.data, "", is_indented=False)
 
 
 @irdl_op_definition
@@ -3621,7 +3596,7 @@ class FLwOp(RdRsImmFloatOperation):
         value = _assembly_arg_str(self.rd)
         imm = _assembly_arg_str(self.immediate)
         offset = _assembly_arg_str(self.rs1)
-        return _assembly_line(
+        return AssemblyPrinter.assembly_line(
             instruction_name, f"{value}, {imm}({offset})", self.comment
         )
 
@@ -3655,7 +3630,7 @@ class FSwOp(RsRsImmFloatOperation):
         value = _assembly_arg_str(self.rs2)
         imm = _assembly_arg_str(self.immediate)
         offset = _assembly_arg_str(self.rs1)
-        return _assembly_line(
+        return AssemblyPrinter.assembly_line(
             instruction_name, f"{value}, {imm}({offset})", self.comment
         )
 
@@ -3858,11 +3833,11 @@ class FLdOp(RdRsImmFloatOperation):
         imm = _assembly_arg_str(self.immediate)
         offset = _assembly_arg_str(self.rs1)
         if isinstance(self.immediate, LabelAttr):
-            return _assembly_line(
+            return AssemblyPrinter.assembly_line(
                 instruction_name, f"{value}, {imm}, {offset}", self.comment
             )
         else:
-            return _assembly_line(
+            return AssemblyPrinter.assembly_line(
                 instruction_name, f"{value}, {imm}({offset})", self.comment
             )
 
@@ -3896,7 +3871,7 @@ class FSdOp(RsRsImmFloatOperation):
         value = _assembly_arg_str(self.rs2)
         imm = _assembly_arg_str(self.immediate)
         offset = _assembly_arg_str(self.rs1)
-        return _assembly_line(
+        return AssemblyPrinter.assembly_line(
             instruction_name, f"{value}, {imm}({offset})", self.comment
         )
 

--- a/xdsl/dialects/x86/assembly.py
+++ b/xdsl/dialects/x86/assembly.py
@@ -2,15 +2,8 @@ from __future__ import annotations
 
 from typing import TypeAlias
 
-from xdsl.dialects.builtin import (
-    IndexType,
-    IntegerAttr,
-    IntegerType,
-    StringAttr,
-)
-from xdsl.ir import (
-    SSAValue,
-)
+from xdsl.dialects.builtin import IndexType, IntegerAttr, IntegerType
+from xdsl.ir import SSAValue
 from xdsl.parser import Parser
 from xdsl.printer import Printer
 from xdsl.utils.hints import isa
@@ -21,15 +14,6 @@ from .register import AVXRegisterType, GeneralRegisterType, RFLAGSRegisterType
 AssemblyInstructionArg: TypeAlias = (
     IntegerAttr | SSAValue | GeneralRegisterType | str | int | LabelAttr
 )
-
-
-def append_comment(line: str, comment: StringAttr | None) -> str:
-    if comment is None:
-        return line
-
-    padding = " " * max(0, 48 - len(line))
-
-    return f"{line}{padding} # {comment.data}"
 
 
 def assembly_arg_str(arg: AssemblyInstructionArg) -> str:
@@ -59,20 +43,6 @@ def assembly_arg_str(arg: AssemblyInstructionArg) -> str:
             return reg
         else:
             raise ValueError(f"Unexpected register type {arg.type}")
-
-
-def assembly_line(
-    name: str,
-    arg_str: str,
-    comment: StringAttr | None = None,
-    is_indented: bool = True,
-) -> str:
-    code = "    " if is_indented else ""
-    code += name
-    if arg_str:
-        code += f" {arg_str}"
-    code = append_comment(code, comment)
-    return code
 
 
 def parse_immediate_value(

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -7,6 +7,7 @@ from typing import IO, Generic, TypeVar
 
 from typing_extensions import Self
 
+from xdsl.backend.assembly_printer import AssemblyPrinter, OneLineAssemblyPrintable
 from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
@@ -14,7 +15,6 @@ from xdsl.dialects.builtin import (
     Signedness,
     StringAttr,
 )
-from xdsl.dialects.func import FuncOp
 from xdsl.ir import (
     Attribute,
     Dialect,
@@ -41,9 +41,7 @@ from xdsl.utils.exceptions import VerifyException
 
 from .assembly import (
     AssemblyInstructionArg,
-    append_comment,
     assembly_arg_str,
-    assembly_line,
     memory_access_str,
     parse_immediate_value,
     parse_optional_immediate_value,
@@ -64,7 +62,7 @@ R2InvT = TypeVar("R2InvT", bound=X86RegisterType)
 R3InvT = TypeVar("R3InvT", bound=X86RegisterType)
 
 
-class X86AsmOperation(IRDLOperation, ABC):
+class X86AsmOperation(IRDLOperation, OneLineAssemblyPrintable, ABC):
     """
     Base class for operations that can be a part of x86 assembly printing.
     """
@@ -184,7 +182,7 @@ class X86Instruction(X86AsmOperation):
             for arg in self.assembly_line_args()
             if arg is not None
         )
-        return assembly_line(instruction_name, arg_str, self.comment)
+        return AssemblyPrinter.assembly_line(instruction_name, arg_str, self.comment)
 
 
 class R_RR_Operation(
@@ -1616,7 +1614,7 @@ class LabelOp(X86AsmOperation, X86CustomFormatOperation):
         )
 
     def assembly_line(self) -> str | None:
-        return append_comment(f"{self.label.data}:", self.comment)
+        return AssemblyPrinter.append_comment(f"{self.label.data}:", self.comment)
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -1673,7 +1671,9 @@ class DirectiveOp(X86AsmOperation, X86CustomFormatOperation):
         else:
             arg_str = ""
 
-        return assembly_line(self.directive.data, arg_str, is_indented=False)
+        return AssemblyPrinter.assembly_line(
+            self.directive.data, arg_str, is_indented=False
+        )
 
     @classmethod
     def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
@@ -2582,14 +2582,8 @@ class GetAVXRegisterOp(GetAnyRegisterOperation[AVXRegisterType]):
 
 
 def print_assembly(module: ModuleOp, output: IO[str]) -> None:
-    for op in module.body.walk():
-        if isinstance(op, FuncOp):
-            print(f"{op.sym_name.data}:", file=output)
-            continue
-        assert isinstance(op, X86AsmOperation), f"{op}"
-        asm = op.assembly_line()
-        if asm is not None:
-            print(asm, file=output)
+    printer = AssemblyPrinter(stream=output)
+    printer.print_module(module)
 
 
 def x86_code(module: ModuleOp) -> str:


### PR DESCRIPTION
Now that we're adding more backend infrastructure, I think it would make sense to unify some of the helpers, and iterate on the logic. This PR introduces an AssemblyPrinter class that holds the helpers previously copy/pasted into each of the riscv, x86, and ARM dialects. 