### PR TITLE
installation: specify find

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ xdsl-tblgen = "xdsl.tools.tblgen_to_py:main"
 platforms = ["Linux", "Mac OS-X", "Unix"]
 zip-safe = false
 
+[tool.setuptools.packages]
+find = {}
+
 [tool.setuptools.package-data]
 xdsl = ["**/*.irdl", "py.typed", "interactive/*.tcss", "_version.py"]
 


### PR DESCRIPTION
Reopens #3848, which fixes a regression introduced by #3815, and partially fixed with #3847.

While the issue is fixed on most installations with the other fix PR it breaks on some systems, and when a `site` folder is present after generating the docs website locally.

We tested this change with @georgebisbas today, on whose linux machine xDSL cannot currently be installed, and works after applying the changes in this PR.