### PR TITLE
backend: (riscv) use separate indices for j and fj registers

### DIFF
--- a/tests/backend/riscv/test_register_queue.py
+++ b/tests/backend/riscv/test_register_queue.py
@@ -78,5 +78,7 @@ def test_limit():
     assert not register_queue.pop(riscv.IntRegisterType).register_name.startswith("j")
     assert register_queue.pop(riscv.IntRegisterType).register_name.startswith("j")
 
-    assert not register_queue.pop(riscv.FloatRegisterType).register_name.startswith("j")
-    assert register_queue.pop(riscv.FloatRegisterType).register_name.startswith("j")
+    assert not register_queue.pop(riscv.FloatRegisterType).register_name.startswith(
+        "fj"
+    )
+    assert register_queue.pop(riscv.FloatRegisterType).register_name.startswith("fj")

--- a/tests/filecheck/backend/riscv/register-allocation/frep.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/frep.mlir
@@ -41,9 +41,9 @@ riscv_func.func @main() {
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:    riscv_func.func @main() {
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.li 6 : !riscv.reg<j1>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.li 5 : !riscv.reg<s0>
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<j1>) -> !riscv.freg<j2>
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<j3>
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<j2>, !riscv.freg<j3>) -> !riscv.freg<j2>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<j1>) -> !riscv.freg<fj0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fcvt.s.w %{{\d+}} : (!riscv.reg<s0>) -> !riscv.freg<fj1>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.fadd.s %{{\d+}}, %{{\d+}} : (!riscv.freg<fj0>, !riscv.freg<fj1>) -> !riscv.freg<fj0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %{{\d+}} = riscv.add %{{\d+}}, %{{\d+}} : (!riscv.reg<j1>, !riscv.reg<s0>) -> !riscv.reg<j0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      riscv_snitch.frep_outer %{{\d+}} {
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      }

--- a/tests/filecheck/backend/riscv/register-allocation/generic.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/generic.mlir
@@ -54,9 +54,9 @@ riscv_func.func @main() {
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %zero = riscv.li 0 : !riscv.reg<zero>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %0 = riscv.li 6 : !riscv.reg<j1>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %1 = riscv.li 5 : !riscv.reg<s0>
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %2 = riscv.fcvt.s.w %0 : (!riscv.reg<j1>) -> !riscv.freg<j3>
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg<j4>
-//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %4 = riscv.fadd.s %2, %3 : (!riscv.freg<j3>, !riscv.freg<j4>) -> !riscv.freg<j3>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %2 = riscv.fcvt.s.w %0 : (!riscv.reg<j1>) -> !riscv.freg<fj0>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %3 = riscv.fcvt.s.w %1 : (!riscv.reg<s0>) -> !riscv.freg<fj1>
+//   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %4 = riscv.fadd.s %2, %3 : (!riscv.freg<fj0>, !riscv.freg<fj1>) -> !riscv.freg<fj0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      %5 = riscv.add %0, %1 : (!riscv.reg<j1>, !riscv.reg<s0>) -> !riscv.reg<j0>
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      riscv_scf.for %6 : !riscv.reg<j2> = %0 to %1 step %5 {
 //   CHECK-LIVENESS-BLOCK-NAIVE-J-NEXT:      }

--- a/xdsl/backend/riscv/riscv_register_queue.py
+++ b/xdsl/backend/riscv/riscv_register_queue.py
@@ -24,8 +24,11 @@ class RiscvRegisterQueue(RegisterQueue[IntRegisterType | FloatRegisterType]):
     DEFAULT_INT_REGISTERS = Registers.A[::-1] + Registers.T[::-1]
     DEFAULT_FLOAT_REGISTERS = Registers.FA[::-1] + Registers.FT[::-1]
 
-    _idx: int = 0
+    _j_idx: int = 0
     """Next `j` register index."""
+
+    _fj_idx: int = 0
+    """Next `fj` register index."""
 
     reserved_registers: defaultdict[IntRegisterType | FloatRegisterType, int] = field(
         default_factory=lambda: defaultdict[IntRegisterType | FloatRegisterType, int](
@@ -78,8 +81,13 @@ class RiscvRegisterQueue(RegisterQueue[IntRegisterType | FloatRegisterType]):
         if available_registers:
             reg = available_registers.pop()
         else:
-            reg = reg_type(f"j{self._idx}")
-            self._idx += 1
+            if issubclass(reg_type, IntRegisterType):
+                reg = reg_type(f"j{self._j_idx}")
+                self._j_idx += 1
+            else:
+                reg = reg_type(f"fj{self._fj_idx}")
+                self._fj_idx += 1
+
         assert reg not in self.reserved_registers, (
             f"Cannot pop a reserved register ({reg.register_name}), it must have been reserved while available."
         )

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -99,7 +99,7 @@ class RISCVRegisterType(RegisterType):
 
     def verify(self) -> None:
         name = self.spelling.data
-        if not self.is_allocated or name.startswith("j"):
+        if not self.is_allocated or name.startswith("j") or name.startswith("fj"):
             return
         if name not in type(self).abi_index_by_name():
             raise VerifyException(f"{name} not in {self.instruction_set_name()}")


### PR DESCRIPTION
We currently use the same indices which makes them difficult to distinguish and harder to spot.