### PR TITLE
core: relax typing on ParamAttrConstraint and MemRefType.constr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -53,6 +53,8 @@ from xdsl.irdl import (
     GenericData,
     InferenceContext,
     IntConstraint,
+    IRDLAttrConstraint,
+    IRDLGenericAttrConstraint,
     IRDLOperation,
     MessageConstraint,
     ParamAttrConstraint,
@@ -1951,10 +1953,10 @@ class MemRefType(
     def constr(
         cls,
         *,
-        shape: GenericAttrConstraint[Attribute] | None = None,
-        element_type: GenericAttrConstraint[_MemRefTypeElement] = AnyAttr(),
-        layout: GenericAttrConstraint[Attribute] | None = None,
-        memory_space: GenericAttrConstraint[Attribute] | None = None,
+        shape: IRDLAttrConstraint | None = None,
+        element_type: IRDLGenericAttrConstraint[_MemRefTypeElement] = AnyAttr(),
+        layout: IRDLAttrConstraint | None = None,
+        memory_space: IRDLAttrConstraint | None = None,
     ) -> GenericAttrConstraint[MemRefType[_MemRefTypeElement]]:
         if (
             shape is None

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator, Sequence, Set
 from dataclasses import KW_ONLY, dataclass, field
 from inspect import isclass
-from typing import Generic, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Generic, TypeAlias, TypeVar, cast
 
 from typing_extensions import assert_never
 
@@ -18,6 +18,9 @@ from xdsl.ir import (
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.runtime_final import is_runtime_final
+
+if TYPE_CHECKING:
+    from xdsl.irdl import IRDLAttrConstraint
 
 
 @dataclass
@@ -563,10 +566,12 @@ class ParamAttrConstraint(
     def __init__(
         self,
         base_attr: type[ParametrizedAttributeCovT],
-        param_constrs: Sequence[(Attribute | type[Attribute] | AttrConstraint | None)],
+        param_constrs: Sequence[IRDLAttrConstraint | None],
     ):
+        from xdsl.irdl import irdl_to_attr_constraint
+
         constrs = tuple(
-            attr_constr_coercion(constr) if constr is not None else AnyAttr()
+            irdl_to_attr_constraint(constr) if constr is not None else AnyAttr()
             for constr in param_constrs
         )
         object.__setattr__(self, "base_attr", base_attr)


### PR DESCRIPTION
Attempts to relax constraints on MemRefType.constr in order to make the api less verbose. 

I know @superlopuh was against this idea in general, but thought I would put it forward anyway.

As an example use-case: in `BitcastOp` we could replace `AnyFloatConstr` by `AnyFloat` (I realise this is a very small gain).