### PR TITLE
dialects: (linalg) fix `linalg.matmul` to correctly store integer arg types

### DIFF
--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -159,12 +159,12 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:     %{{.*}} = "test.op"() : () -> tensor<64x4096xi32>
 
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.quantized_matmul"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 4, 1>}> ({
-// CHECK-GENERIC-NEXT:       ^11(%41 : i8, %42 : i8, %43 : i32, %44 : i32, %45 : i32):
-// CHECK-GENERIC-NEXT:         %46 = "arith.extsi"(%41) : (i8) -> i32
-// CHECK-GENERIC-NEXT:         %47 = "arith.subi"(%46, %43) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-// CHECK-GENERIC-NEXT:         %48 = "arith.extsi"(%42) : (i8) -> i32
-// CHECK-GENERIC-NEXT:         %49 = "arith.subi"(%48, %44) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-// CHECK-GENERIC-NEXT:         %50 = "arith.muli"(%47, %49) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-// CHECK-GENERIC-NEXT:         %51 = "arith.addi"(%45, %50) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-//  CHECK-GENERIC-NEXT:        "linalg.yield"(%51) : (i32) -> ()
+// CHECK-GENERIC-NEXT:       ^11(%{{.*}}  : i8, %{{.*}}  : i8, %{{.*}}  : i32, %{{.*}}  : i32, %{{.*}}  : i32):
+// CHECK-GENERIC-NEXT:         %{{.*}} = "arith.extsi"(%{{.*}}) : (i8) -> i32
+// CHECK-GENERIC-NEXT:         %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:         %{{.*}} = "arith.extsi"(%{{.*}}) : (i8) -> i32
+// CHECK-GENERIC-NEXT:         %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+//  CHECK-GENERIC-NEXT:        "linalg.yield"(%{{.*}}) : (i32) -> ()
 // CHECK-GENERIC-NEXT:       }) {linalg.memoized_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>]} : (tensor<64x9216xi8>, tensor<9216x4096xi8>, i32, i32, tensor<64x4096xi32>) -> tensor<64x4096xi32>

--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -32,6 +32,10 @@ linalg.mul ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<
 %4 = "test.op"() : () -> (memref<64x4096xf32>)
 linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs(%4 : memref<64x4096xf32>)
 
+%i2, %i3 = "test.op"() : () -> (memref<64x9216xi32>, memref<9216x4096xi32>)
+%i4 = "test.op"() : () -> (memref<64x4096xi32>)
+linalg.matmul {id} ins(%i2, %i3 : memref<64x9216xi32>, memref<9216x4096xi32>) outs(%i4 : memref<64x4096xi32>)
+
 %fill = linalg.fill ins(%0 : f32) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
 linalg.fill ins(%0 : f32) outs(%m3 : memref<4x16xf32>)
 
@@ -66,6 +70,9 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-NEXT:    %{{.*}} %{{.*}} = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
 // CHECK-NEXT:    %{{.*}} = "test.op"() : () -> memref<64x4096xf32>
 // CHECK-NEXT:    linalg.matmul {id} ins(%{{.*}} %{{.*}} : memref<64x9216xf32>, memref<9216x4096xf32>) outs(%{{.*}} : memref<64x4096xf32>)
+// CHECK-NEXT:    %{{.*}} %{{.*}} = "test.op"() : () -> (memref<64x9216xi32>, memref<9216x4096xi32>)
+// CHECK-NEXT:    %{{.*}} = "test.op"() : () -> memref<64x4096xi32>
+// CHECK-NEXT:    linalg.matmul {id} ins(%{{.*}} %{{.*}} : memref<64x9216xi32>, memref<9216x4096xi32>) outs(%{{.*}} : memref<64x4096xi32>)
 // CHECK-NEXT:    %{{.*}} = linalg.fill ins(%{{.*}} : f32) outs(%{{.*}} : tensor<4x16xf32>) -> tensor<4x16xf32>
 // CHECK-NEXT:    linalg.fill ins(%{{.*}} : f32) outs(%{{.*}} : memref<4x16xf32>)
 // CHECK-NEXT:    %5, %6 = "test.op"() : () -> (tensor<64x9216xi8>, tensor<9216x4096xi8>)
@@ -126,13 +133,23 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) {id, linalg.memoized_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>]} : (memref<64x9216xf32>, memref<9216x4096xf32>, memref<64x4096xf32>) -> ()
 
+// CHECK-GENERIC-NEXT:    %{{.*}} %{{.*}} = "test.op"() : () -> (memref<64x9216xi32>, memref<9216x4096xi32>)
+// CHECK-GENERIC-NEXT:    %{{.*}} = "test.op"() : () -> memref<64x4096xi32>
+
+// CHECK-GENERIC-NEXT:    "linalg.matmul"(%{{.*}} %{{.*}} %{{.*}} <{operandSegmentSizes = array<i32: 2, 1>}> ({
+// CHECK-GENERIC-NEXT:    ^8(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}} : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}} : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (i32) -> ()
+// CHECK-GENERIC-NEXT:    }) {id, linalg.memoized_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>]} : (memref<64x9216xi32>, memref<9216x4096xi32>, memref<64x4096xi32>) -> ()
+
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.fill"(%{{.*}}, %{{.*}} <{operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^8(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^9(%{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (f32, tensor<4x16xf32>) -> tensor<4x16xf32>
 
 // CHECK-GENERIC-NEXT:    "linalg.fill"(%{{.*}}, %{{.*}} <{operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^9(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^10(%{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (f32, memref<4x16xf32>) -> ()
 
@@ -142,12 +159,12 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:     %{{.*}} = "test.op"() : () -> tensor<64x4096xi32>
 
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.quantized_matmul"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 4, 1>}> ({
-// CHECK-GENERIC-NEXT:       ^10(%36 : i8, %37 : i8, %38 : i32, %39 : i32, %40 : i32):
-// CHECK-GENERIC-NEXT:         %41 = "arith.extsi"(%36) : (i8) -> i32
-// CHECK-GENERIC-NEXT:         %42 = "arith.subi"(%41, %38) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-// CHECK-GENERIC-NEXT:         %43 = "arith.extsi"(%37) : (i8) -> i32
-// CHECK-GENERIC-NEXT:         %44 = "arith.subi"(%43, %39) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-// CHECK-GENERIC-NEXT:         %45 = "arith.muli"(%42, %44) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-// CHECK-GENERIC-NEXT:         %46 = "arith.addi"(%40, %45) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-//  CHECK-GENERIC-NEXT:        "linalg.yield"(%46) : (i32) -> ()
+// CHECK-GENERIC-NEXT:       ^11(%41 : i8, %42 : i8, %43 : i32, %44 : i32, %45 : i32):
+// CHECK-GENERIC-NEXT:         %46 = "arith.extsi"(%41) : (i8) -> i32
+// CHECK-GENERIC-NEXT:         %47 = "arith.subi"(%46, %43) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:         %48 = "arith.extsi"(%42) : (i8) -> i32
+// CHECK-GENERIC-NEXT:         %49 = "arith.subi"(%48, %44) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:         %50 = "arith.muli"(%47, %49) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+// CHECK-GENERIC-NEXT:         %51 = "arith.addi"(%45, %50) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+//  CHECK-GENERIC-NEXT:        "linalg.yield"(%51) : (i32) -> ()
 // CHECK-GENERIC-NEXT:       }) {linalg.memoized_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>]} : (tensor<64x9216xi8>, tensor<9216x4096xi8>, i32, i32, tensor<64x4096xi32>) -> tensor<64x4096xi32>

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -864,7 +864,7 @@ class MatmulOp(NamedOpBase):
         add, mul = (
             (arith.AddfOp, arith.MulfOp)
             if isinstance(arg_types[-1], AnyFloat)
-            else (arith.AddiOp, arith.MulfOp)
+            else (arith.AddiOp, arith.MuliOp)
         )
 
         @Builder.implicit_region(arg_types)


### PR DESCRIPTION
@superlopuh @compor