### PR TITLE
core: custom format operations cannot be UnregisteredOp

### DIFF
--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -52,13 +52,13 @@ async def test_inputs():
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation dkjfd is not registered.\n"
         )
 
         assert isinstance(app.current_module, ParseError)
         assert (
             str(app.current_module)
-            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation builtin.unregistered does not have a custom format.\n"
+            == "<unknown>:1:5\ndkjfd\n     ^\n     Operation dkjfd is not registered.\n"
         )
 
         # Test corect input

--- a/tests/test_mlcontext.py
+++ b/tests/test_mlcontext.py
@@ -52,12 +52,14 @@ def test_get_op_unregistered():
     ctx.load_op(DummyOp)
 
     assert ctx.get_optional_op("test.dummy") == DummyOp
-    op = ctx.get_optional_op("test.dummy2")
+    op = ctx.get_optional_op("test.dummy2", is_generic=True)
     assert op is not None
     assert issubclass(op, UnregisteredOp)
 
     assert ctx.get_op("test.dummy") == DummyOp
     assert issubclass(ctx.get_op("test.dummy2"), UnregisteredOp)
+
+    assert ctx.get_optional_op("test.dummy3") is None
 
 
 def test_get_op_with_dialect_stack():
@@ -82,13 +84,13 @@ def test_get_op_unregistered_with_dialect_stack():
     ctx.load_op(DummyOp)
 
     assert ctx.get_optional_op("dummy", dialect_stack=("test",)) == DummyOp
-    op_type = ctx.get_optional_op("dummy2", dialect_stack=("test",))
+    op_type = ctx.get_optional_op("dummy2", dialect_stack=("test",), is_generic=True)
     assert op_type is not None
     assert issubclass(op_type, UnregisteredOp)
     assert op_type.create().op_name.data == "dummy2"
 
     assert ctx.get_op("dummy", dialect_stack=("test",)) == DummyOp
-    op_type = ctx.get_op("dummy2", dialect_stack=("test",))
+    op_type = ctx.get_op("dummy2", dialect_stack=("test",), is_generic=True)
     assert issubclass(op_type, UnregisteredOp)
     assert op_type.create().op_name.data == "dummy2"
 

--- a/xdsl/context.py
+++ b/xdsl/context.py
@@ -125,13 +125,14 @@ class MLContext:
                 return self._get_known_op(name)
 
     def get_optional_op(
-        self, name: str, *, dialect_stack: Sequence[str] = ()
+        self, name: str, *, is_generic: bool = False, dialect_stack: Sequence[str] = ()
     ) -> "type[Operation] | None":
         """
         Get an operation class from its name if it exists or is contained in one of the
         dialects in the dialect stack.
         If the operation is not registered, return None unless unregistered operations
-        are allowed in the context, in which case return an UnregisteredOp.
+        are allowed in the context or the name was found in custom syntax,
+        in which case return an UnregisteredOp.
         """
         # Check if the name is known.
         if op_type := self._get_known_op(name):
@@ -144,7 +145,7 @@ class MLContext:
                 return op_type
 
         # If the context allows unregistered operations then create an UnregisteredOp
-        if self.allow_unregistered:
+        if self.allow_unregistered and is_generic:
             from xdsl.dialects.builtin import UnregisteredOp
 
             op_type = UnregisteredOp.with_name(name)
@@ -152,7 +153,7 @@ class MLContext:
             return op_type
 
     def get_op(
-        self, name: str, *, dialect_stack: Sequence[str] = ()
+        self, name: str, *, dialect_stack: Sequence[str] = (), is_generic: bool = False
     ) -> "type[Operation]":
         """
         Get an operation class from its name if it exists or is contained in one of the
@@ -160,7 +161,9 @@ class MLContext:
         If the operation is not registered, raise an exception unless unregistered
         operations are allowed in the context, in which case return an UnregisteredOp.
         """
-        if op_type := self.get_optional_op(name, dialect_stack=dialect_stack):
+        if op_type := self.get_optional_op(
+            name, dialect_stack=dialect_stack, is_generic=is_generic
+        ):
             return op_type
         raise Exception(f"Operation {name} is not registered")
 

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -711,7 +711,7 @@ class Parser(AttrParser):
             op_name = self.expect(
                 self.parse_optional_str_literal, "operation name expected"
             )
-            op_type = self._get_op_by_name(op_name)
+            op_type = self._get_op_by_name(op_name, is_generic=True)
             dialect_name = op_type.dialect_name()
             self._parser_state.dialect_stack.append(dialect_name)
             op = self._parse_generic_operation(op_type)
@@ -736,17 +736,19 @@ class Parser(AttrParser):
 
         return op
 
-    def _get_op_by_name(self, name: str) -> type[Operation]:
+    def _get_op_by_name(
+        self, name: str, *, is_generic: bool = False
+    ) -> type[Operation]:
         """
         Get an operation type by its name.
         Raises an error if the operation is not registered, and if unregistered
-        dialects are not allowed.
+        dialects are not allowed or the name was encountered in custom syntax.
         """
         if op_type := self.ctx.get_optional_op(
-            name, dialect_stack=self._parser_state.dialect_stack
+            name, dialect_stack=self._parser_state.dialect_stack, is_generic=is_generic
         ):
             return op_type
-        self.raise_error(f"Operation {name} is not registered")
+        self.raise_error(f"Operation {name} is not registered.")
 
     def _parse_op_result(self) -> tuple[Span, int]:
         """


### PR DESCRIPTION
Fixes #3671 

I'm not sure if this is the cleanest way to achieve this, an alternative would be to temporarily set `allow_unregistered` off in the ctx when making a custom format operation.