### PR TITLE
tools: move verification and parsing command-line arguments from `xDSLOptMain` to `CommandLineTool`

### DIFF
--- a/xdsl/tools/command_line_tool.py
+++ b/xdsl/tools/command_line_tool.py
@@ -45,6 +45,22 @@ class CommandLineTool:
         arg_parser.add_argument("--disable-verify", default=False, action="store_true")
 
         arg_parser.add_argument(
+            "--verify-diagnostics",
+            default=False,
+            action="store_true",
+            help="Prints the content of a triggered "
+            "verifier exception and exits with code 0",
+        )
+
+        arg_parser.add_argument(
+            "--parsing-diagnostics",
+            default=False,
+            action="store_true",
+            help="Prints the content of a triggered "
+            "parsing exception and exits with code 0",
+        )
+
+        arg_parser.add_argument(
             "--allow-unregistered-dialect",
             default=False,
             action="store_true",
@@ -113,7 +129,7 @@ class CommandLineTool:
         except ParseError as e:
             s = e.span
             e.span = Span(s.start, s.end, s.input, start_offset)
-            if "parsing_diagnostics" in self.args and self.args.parsing_diagnostics:
+            if self.args.parsing_diagnostics:
                 print(e)
             else:
                 raise

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -129,22 +129,6 @@ class xDSLOptMain(CommandLineTool):
         )
 
         arg_parser.add_argument(
-            "--verify-diagnostics",
-            default=False,
-            action="store_true",
-            help="Prints the content of a triggered "
-            "verifier exception and exits with code 0",
-        )
-
-        arg_parser.add_argument(
-            "--parsing-diagnostics",
-            default=False,
-            action="store_true",
-            help="Prints the content of a triggered "
-            "parsing exception and exits with code 0",
-        )
-
-        arg_parser.add_argument(
             "--split-input-file",
             default=False,
             action="store_true",


### PR DESCRIPTION
This PR:

- moves verification and parsing command-line arguments from `xDSLOptMain` to `CommandLineTool`


as also discussed in #3866