### PR TITLE
bug: (x86) always remove the register/memory prefix from the emitted assembly

### DIFF
--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -179,7 +179,7 @@ class X86Instruction(X86AsmOperation):
         By default, the name of the instruction is the same as the name of the operation.
         """
 
-        return Dialect.split_name(self.name)[1]
+        return Dialect.split_name(self.name)[1].split(".")[-1]
 
     def assembly_line(self) -> str | None:
         # default assembly code generator

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -17,7 +17,6 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import (
     Attribute,
-    Dialect,
     Operation,
     SSAValue,
 )

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -179,7 +179,7 @@ class X86Instruction(X86AsmOperation):
         By default, the name of the instruction is the same as the name of the operation.
         """
 
-        return Dialect.split_name(self.name)[1].split(".")[-1]
+        return self.name.split(".")[-1]
 
     def assembly_line(self) -> str | None:
         # default assembly code generator


### PR DESCRIPTION
The printer should not emit code like ```rr.add```, but our Python filecheck implementation only checks substrings (even when the dedicated knob is on). I fix the emitter to make it usable but a long-term solution is either to fix the Python filecheck reimplementation or to py-package LLVM filecheck.
