### PR TITLE
backend: default register type constructor returns unallocated register

### DIFF
--- a/tests/backend/riscv/test_preallocated.py
+++ b/tests/backend/riscv/test_preallocated.py
@@ -7,11 +7,11 @@ from xdsl.dialects.builtin import SymbolRefAttr
 def test_gather_allocated():
     @Builder.implicit_region
     def no_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType.unallocated()
-        reg2 = riscv.IntRegisterType.unallocated()
+        reg1 = riscv.IntRegisterType()
+        reg2 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(reg2).res
-        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
+        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
 
     pa_regs = gather_allocated(riscv_func.FuncOp("foo", no_preallocated_body, ((), ())))
 
@@ -19,10 +19,10 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def one_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType.unallocated()
+        reg1 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
+        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
 
     pa_regs = gather_allocated(
         riscv_func.FuncOp("foo", one_preallocated_body, ((), ()))
@@ -32,10 +32,10 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def repeated_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType.unallocated()
+        reg1 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
+        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A7).rd
 
     pa_regs = gather_allocated(
@@ -46,10 +46,10 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def multiple_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType.unallocated()
+        reg1 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType.unallocated()).rd
+        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A6).rd
 
     pa_regs = gather_allocated(
@@ -60,7 +60,7 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def func_call_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType.unallocated()
+        reg1 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.S0).res
         riscv_func.CallOp(SymbolRefAttr("hello"), (v1, v2), ())

--- a/tests/backend/riscv/test_utils.py
+++ b/tests/backend/riscv/test_utils.py
@@ -12,7 +12,7 @@ from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.utils.test_value import TestSSAValue
 
 INDEX_TYPE = builtin.IndexType()
-REGISTER_TYPE = riscv.IntRegisterType.unallocated()
+REGISTER_TYPE = riscv.IntRegisterType()
 
 
 def test_register_type_for_type():

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -231,11 +231,11 @@ def test_float_register():
     a1 = TestSSAValue(riscv.Registers.A1)
     a2 = TestSSAValue(riscv.Registers.A2)
     with pytest.raises(VerifyException, match="Operation does not verify"):
-        riscv.FAddSOp(a1, a2, rd=riscv.FloatRegisterType.unallocated()).verify()
+        riscv.FAddSOp(a1, a2, rd=riscv.FloatRegisterType()).verify()
 
     f1 = TestSSAValue(riscv.Registers.FT0)
     f2 = TestSSAValue(riscv.Registers.FT1)
-    riscv.FAddSOp(f1, f2, rd=riscv.FloatRegisterType.unallocated()).verify()
+    riscv.FAddSOp(f1, f2, rd=riscv.FloatRegisterType()).verify()
 
 
 def test_riscv_parse_immediate_value():

--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -7,23 +7,23 @@ from xdsl.dialects.builtin import IntegerAttr
 def test_unallocated_register():
     unallocated = x86.register.GeneralRegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.GeneralRegisterType.unallocated()
+    assert unallocated == x86.register.GeneralRegisterType()
 
     unallocated = x86.register.RFLAGSRegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.RFLAGSRegisterType.unallocated()
+    assert unallocated == x86.register.RFLAGSRegisterType()
 
     unallocated = x86.register.AVX2RegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.AVX2RegisterType.unallocated()
+    assert unallocated == x86.register.AVX2RegisterType()
 
     unallocated = x86.register.AVX512RegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.AVX512RegisterType.unallocated()
+    assert unallocated == x86.register.AVX512RegisterType()
 
     unallocated = x86.register.SSERegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.SSERegisterType.unallocated()
+    assert unallocated == x86.register.SSERegisterType()
 
 
 @pytest.mark.parametrize(

--- a/tests/interpreters/test_riscv_cf_interpreter.py
+++ b/tests/interpreters/test_riscv_cf_interpreter.py
@@ -5,7 +5,7 @@ from xdsl.interpreters.riscv_cf import RiscvCfFunctions
 from xdsl.ir import Block
 from xdsl.utils.test_value import TestSSAValue
 
-register = riscv.IntRegisterType.unallocated()
+register = riscv.IntRegisterType()
 module_op = ModuleOp([])
 
 

--- a/tests/interpreters/test_riscv_debug_interpreter.py
+++ b/tests/interpreters/test_riscv_debug_interpreter.py
@@ -10,8 +10,8 @@ from xdsl.utils.test_value import TestSSAValue
 
 def test_riscv_interpreter():
     module_op = ModuleOp([])
-    register = riscv.IntRegisterType.unallocated()
-    fregister = riscv.FloatRegisterType.unallocated()
+    register = riscv.IntRegisterType()
+    fregister = riscv.FloatRegisterType()
 
     riscv_functions = RiscvFunctions()
     riscv_debug_functions = RiscvDebugFunctions()

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -28,9 +28,7 @@ def test_simple():
         def body():
             six = riscv.LiOp(6).rd
             seven = riscv.LiOp(7).rd
-            forty_two = riscv.MulOp(
-                six, seven, rd=riscv.IntRegisterType.unallocated()
-            ).rd
+            forty_two = riscv.MulOp(six, seven, rd=riscv.IntRegisterType()).rd
             riscv_debug.PrintfOp("{}", (forty_two,))
             riscv.ReturnOp()
 

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -46,8 +46,8 @@ def test_riscv_interpreter():
             ),
         ]
     )
-    register = riscv.IntRegisterType.unallocated()
-    fregister = riscv.FloatRegisterType.unallocated()
+    register = riscv.IntRegisterType()
+    fregister = riscv.FloatRegisterType()
 
     riscv_functions = RiscvFunctions(
         custom_instructions={"my_custom_instruction": my_custom_instruction},
@@ -62,7 +62,7 @@ def test_riscv_interpreter():
         TypedPtr.new_int32((59,)).raw,
     )
     assert interpreter.run_op(
-        riscv.MVOp(TestSSAValue(register), rd=riscv.IntRegisterType.unallocated()),
+        riscv.MVOp(TestSSAValue(register), rd=riscv.IntRegisterType()),
         (42,),
     ) == (42,)
 
@@ -78,7 +78,7 @@ def test_riscv_interpreter():
         riscv.AddOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType.unallocated(),
+            rd=riscv.IntRegisterType(),
         ),
         (1, 2),
     ) == (3,)
@@ -87,7 +87,7 @@ def test_riscv_interpreter():
         riscv.AddiOp(
             TestSSAValue(register),
             2,
-            rd=riscv.IntRegisterType.unallocated(),
+            rd=riscv.IntRegisterType(),
         ),
         (1,),
     ) == (3,)
@@ -96,7 +96,7 @@ def test_riscv_interpreter():
         riscv.SubOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType.unallocated(),
+            rd=riscv.IntRegisterType(),
         ),
         (1, 2),
     ) == (-1,)
@@ -105,7 +105,7 @@ def test_riscv_interpreter():
         riscv.SllOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType.unallocated(),
+            rd=riscv.IntRegisterType(),
         ),
         (3, 2),
     ) == (12,)
@@ -114,7 +114,7 @@ def test_riscv_interpreter():
         riscv.MulOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType.unallocated(),
+            rd=riscv.IntRegisterType(),
         ),
         (2, 3),
     ) == (6,)
@@ -123,7 +123,7 @@ def test_riscv_interpreter():
         riscv.DivOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType.unallocated(),
+            rd=riscv.IntRegisterType(),
         ),
         (6, 3),
     ) == (2,)
@@ -168,7 +168,7 @@ def test_riscv_interpreter():
         riscv.FMulSOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (12.0,)
@@ -180,7 +180,7 @@ def test_riscv_interpreter():
             TestSSAValue(fregister),
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0, 5.0),
     ) == (17.0,)
@@ -189,7 +189,7 @@ def test_riscv_interpreter():
         riscv.FAddDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (7.0,)
@@ -198,7 +198,7 @@ def test_riscv_interpreter():
         riscv.FSubDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (-1.0,)
@@ -207,7 +207,7 @@ def test_riscv_interpreter():
         riscv.FMulDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (12.0,)
@@ -216,7 +216,7 @@ def test_riscv_interpreter():
         riscv.FDivDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (0.75,)
@@ -225,7 +225,7 @@ def test_riscv_interpreter():
         riscv.FMinDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (1, 2),
     ) == (1,)
@@ -234,13 +234,13 @@ def test_riscv_interpreter():
         riscv.FMaxDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType.unallocated(),
+            rd=riscv.FloatRegisterType(),
         ),
         (1, 2),
     ) == (2,)
 
     assert interpreter.run_op(
-        riscv.FMVOp(TestSSAValue(register), rd=riscv.FloatRegisterType.unallocated()),
+        riscv.FMVOp(TestSSAValue(register), rd=riscv.FloatRegisterType()),
         (42.0,),
     ) == (42.0,)
 
@@ -248,9 +248,7 @@ def test_riscv_interpreter():
     # the top line is the one that should pass, the other is the same as riscemu
     # assert interpreter.run_op(riscv.FMvWXOp(TestSSAValue(fregister)), (3,)) == (3.0,)
     assert interpreter.run_op(
-        riscv.FMvWXOp(
-            TestSSAValue(fregister), rd=riscv.FloatRegisterType.unallocated()
-        ),
+        riscv.FMvWXOp(TestSSAValue(fregister), rd=riscv.FloatRegisterType()),
         (convert_f32_to_u32(3.0),),
     ) == (3.0,)
 
@@ -289,9 +287,7 @@ def test_riscv_interpreter():
     ) == (5.0,)
 
     assert interpreter.run_op(
-        riscv.FCvtDWOp(
-            TestSSAValue(register), rd=riscv.FloatRegisterType.unallocated()
-        ),
+        riscv.FCvtDWOp(TestSSAValue(register), rd=riscv.FloatRegisterType()),
         (42,),
     ) == (42.0,)
 
@@ -309,7 +305,7 @@ def test_riscv_interpreter():
 
     assert interpreter.run_op(riscv.GetRegisterOp(riscv.Registers.ZERO), ()) == (0,)
 
-    get_non_zero = riscv.GetRegisterOp(riscv.IntRegisterType.unallocated())
+    get_non_zero = riscv.GetRegisterOp(riscv.IntRegisterType())
     with pytest.raises(
         InterpretationError,
         match="Cannot get value for unallocated register !riscv.reg",
@@ -336,7 +332,7 @@ def test_get_data():
 
 def test_cast():
     module_op = ModuleOp([])
-    fregister = riscv.FloatRegisterType.unallocated()
+    fregister = riscv.FloatRegisterType()
 
     riscv_functions = RiscvFunctions()
     interpreter = Interpreter(module_op)

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -10,7 +10,7 @@ from xdsl.interpreters.riscv_scf import RiscvScfFunctions
 from xdsl.ir import BlockArgument
 
 index = IndexType()
-register = riscv.IntRegisterType.unallocated()
+register = riscv.IntRegisterType()
 
 
 def sum_to_for_fn(n: int) -> int:
@@ -36,7 +36,7 @@ def sum_to_for_op():
         @Builder.implicit_region((register, register))
         def for_loop_region(args: tuple[BlockArgument, ...]):
             (i, acc) = args
-            res = riscv.AddOp(i, acc, rd=riscv.IntRegisterType.unallocated())
+            res = riscv.AddOp(i, acc, rd=riscv.IntRegisterType())
             riscv_scf.YieldOp(res)
 
         result = riscv_scf.ForOp(lb, ub, step, (initial,), for_loop_region)
@@ -66,14 +66,14 @@ def sum_to_while_op():
         @Builder.implicit_region((register, register, register, register))
         def before_region(args: tuple[BlockArgument, ...]):
             (acc0, i0, ub0, step0) = args
-            cond = riscv.SltOp(i0, ub0, rd=riscv.IntRegisterType.unallocated()).rd
+            cond = riscv.SltOp(i0, ub0, rd=riscv.IntRegisterType()).rd
             riscv_scf.ConditionOp(cond, acc0, i0, ub0, step0)
 
         @Builder.implicit_region((register, register, register, register))
         def after_region(args: tuple[BlockArgument, ...]):
             (acc1, i1, ub1, step1) = args
-            res = riscv.AddOp(i1, acc1, rd=riscv.IntRegisterType.unallocated()).rd
-            i2 = riscv.AddOp(i1, step1, rd=riscv.IntRegisterType.unallocated()).rd
+            res = riscv.AddOp(i1, acc1, rd=riscv.IntRegisterType()).rd
+            i2 = riscv.AddOp(i1, step1, rd=riscv.IntRegisterType()).rd
             riscv_scf.YieldOp(res, i2, ub1, step1)
 
         result, *_ = riscv_scf.WhileOp(

--- a/tests/interpreters/test_riscv_snitch_interpreter.py
+++ b/tests/interpreters/test_riscv_snitch_interpreter.py
@@ -58,7 +58,7 @@ def test_read_write():
 
 
 def test_frep_carried_vars():
-    float_register = riscv.IntRegisterType.unallocated()
+    float_register = riscv.IntRegisterType()
     acc_reg_type = riscv.Registers.FT[3]
 
     @ModuleOp

--- a/tests/interpreters/test_snitch_stream_interpreter.py
+++ b/tests/interpreters/test_snitch_stream_interpreter.py
@@ -57,7 +57,7 @@ def test_simplify_stride_pattern(
 
 
 def test_snitch_stream_interpreter():
-    register = riscv.IntRegisterType.unallocated()
+    register = riscv.IntRegisterType()
 
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(RiscvFunctions())

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
-from typing_extensions import Self
-
 from xdsl.dialects.builtin import (
     IntAttr,
     NoneAttr,
@@ -28,7 +26,7 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     index: ParameterDef[IntAttr | NoneAttr]
     spelling: ParameterDef[StringAttr]
 
-    def __init__(self, spelling: str):
+    def __init__(self, spelling: str = ""):
         super().__init__(self._parameters_from_spelling(spelling))
 
     @classmethod
@@ -41,11 +39,6 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
         index = cls.abi_index_by_name().get(spelling)
         index_attr = NoneAttr() if index is None else IntAttr(index)
         return index_attr, StringAttr(spelling)
-
-    @classmethod
-    @abstractmethod
-    def unallocated(cls) -> Self:
-        raise NotImplementedError()
 
     @property
     def register_name(self) -> str:

--- a/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
@@ -29,8 +29,8 @@ from xdsl.pattern_rewriter import (
 from xdsl.utils.bitwise_casts import convert_f32_to_u32
 from xdsl.utils.comparisons import signed_lower_bound, signed_upper_bound
 
-_INT_REGISTER_TYPE = riscv.IntRegisterType.unallocated()
-_FLOAT_REGISTER_TYPE = riscv.FloatRegisterType.unallocated()
+_INT_REGISTER_TYPE = riscv.IntRegisterType()
+_FLOAT_REGISTER_TYPE = riscv.FloatRegisterType()
 
 
 class LowerArithConstant(RewritePattern):
@@ -61,9 +61,7 @@ class LowerArithConstant(RewritePattern):
                             convert_f32_to_u32(op_val.value.data),
                             rd=_INT_REGISTER_TYPE,
                         ),
-                        fld := riscv.FMvWXOp(
-                            lui.rd, rd=riscv.FloatRegisterType.unallocated()
-                        ),
+                        fld := riscv.FMvWXOp(lui.rd, rd=riscv.FloatRegisterType()),
                         UnrealizedConversionCastOp.get(fld.results, (op_result_type,)),
                     ],
                 )
@@ -268,45 +266,43 @@ class LowerArithCmpi(RewritePattern):
         match op.predicate.value.data:
             # eq
             case 0:
-                xor_op = riscv.XorOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
+                xor_op = riscv.XorOp(lhs, rhs, rd=riscv.IntRegisterType())
                 seqz_op = riscv.SltiuOp(xor_op, 1)
                 rewriter.replace_matched_op([xor_op, seqz_op])
             # ne
             case 1:
                 zero = riscv.GetRegisterOp(riscv.Registers.ZERO)
-                xor_op = riscv.XorOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
-                snez_op = riscv.SltuOp(
-                    zero, xor_op, rd=riscv.IntRegisterType.unallocated()
-                )
+                xor_op = riscv.XorOp(lhs, rhs, rd=riscv.IntRegisterType())
+                snez_op = riscv.SltuOp(zero, xor_op, rd=riscv.IntRegisterType())
                 rewriter.replace_matched_op([zero, xor_op, snez_op])
             # slt
             case 2:
                 rewriter.replace_matched_op(
-                    [riscv.SltOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())]
+                    [riscv.SltOp(lhs, rhs, rd=riscv.IntRegisterType())]
                 )
             # sle
             case 3:
-                slt = riscv.SltOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
+                slt = riscv.SltOp(lhs, rhs, rd=riscv.IntRegisterType())
                 xori = riscv.XoriOp(slt, 1)
                 rewriter.replace_matched_op([slt, xori])
             # ult
             case 4:
                 rewriter.replace_matched_op(
-                    [riscv.SltuOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())]
+                    [riscv.SltuOp(lhs, rhs, rd=riscv.IntRegisterType())]
                 )
             # ule
             case 5:
-                sltu = riscv.SltuOp(lhs, rhs, rd=riscv.IntRegisterType.unallocated())
+                sltu = riscv.SltuOp(lhs, rhs, rd=riscv.IntRegisterType())
                 xori = riscv.XoriOp(sltu, 1)
                 rewriter.replace_matched_op([sltu, xori])
             # ugt
             case 6:
                 rewriter.replace_matched_op(
-                    [riscv.SltuOp(rhs, lhs, rd=riscv.IntRegisterType.unallocated())]
+                    [riscv.SltuOp(rhs, lhs, rd=riscv.IntRegisterType())]
                 )
             # uge
             case 7:
-                sltu = riscv.SltuOp(rhs, lhs, rd=riscv.IntRegisterType.unallocated())
+                sltu = riscv.SltuOp(rhs, lhs, rd=riscv.IntRegisterType())
                 xori = riscv.XoriOp(sltu, 1)
                 rewriter.replace_matched_op([sltu, xori])
             case _:
@@ -343,9 +339,7 @@ class LowerArithNegf(RewritePattern):
                 operand := UnrealizedConversionCastOp.get(
                     (op.operand,), (_FLOAT_REGISTER_TYPE,)
                 ),
-                negf := riscv.FSgnJNSOp(
-                    operand, operand, rd=riscv.FloatRegisterType.unallocated()
-                ),
+                negf := riscv.FSgnJNSOp(operand, operand, rd=riscv.FloatRegisterType()),
                 UnrealizedConversionCastOp.get((negf.rd,), (op.result.type,)),
             )
         )
@@ -387,7 +381,7 @@ class LowerArithCmpf(RewritePattern):
                     [
                         flt1,
                         flt2,
-                        riscv.OrOp(flt2, flt1, rd=riscv.IntRegisterType.unallocated()),
+                        riscv.OrOp(flt2, flt1, rd=riscv.IntRegisterType()),
                     ]
                 )
             # ord
@@ -398,14 +392,14 @@ class LowerArithCmpf(RewritePattern):
                     [
                         feq1,
                         feq2,
-                        riscv.AndOp(feq2, feq1, rd=riscv.IntRegisterType.unallocated()),
+                        riscv.AndOp(feq2, feq1, rd=riscv.IntRegisterType()),
                     ]
                 )
             # ueq
             case 8:
                 flt1 = riscv.FltSOp(lhs, rhs, fastmath=fastmath)
                 flt2 = riscv.FltSOp(rhs, lhs, fastmath=fastmath)
-                or_ = riscv.OrOp(flt2, flt1, rd=riscv.IntRegisterType.unallocated())
+                or_ = riscv.OrOp(flt2, flt1, rd=riscv.IntRegisterType())
                 rewriter.replace_matched_op([flt1, flt2, or_, riscv.XoriOp(or_, 1)])
             # ugt
             case 9:
@@ -431,7 +425,7 @@ class LowerArithCmpf(RewritePattern):
             case 14:
                 feq1 = riscv.FeqSOp(lhs, lhs, fastmath=fastmath)
                 feq2 = riscv.FeqSOp(rhs, rhs, fastmath=fastmath)
-                and_ = riscv.AndOp(feq2, feq1, rd=riscv.IntRegisterType.unallocated())
+                and_ = riscv.AndOp(feq2, feq1, rd=riscv.IntRegisterType())
                 rewriter.replace_matched_op([feq1, feq2, and_, riscv.XoriOp(and_, 1)])
             # true
             case 15:
@@ -456,9 +450,7 @@ class LowerArithSIToFPOp(RewritePattern):
                 cast_input := UnrealizedConversionCastOp.get(
                     (op.input,), (_INT_REGISTER_TYPE,)
                 ),
-                new_op := cls(
-                    cast_input.results[0], rd=riscv.FloatRegisterType.unallocated()
-                ),
+                new_op := cls(cast_input.results[0], rd=riscv.FloatRegisterType()),
                 UnrealizedConversionCastOp.get((new_op.rd,), (op.result.type,)),
             )
         )
@@ -473,7 +465,7 @@ class LowerArithFPToSIOp(RewritePattern):
                     (op.input,), (_FLOAT_REGISTER_TYPE,)
                 ),
                 new_op := riscv.FCvtWSOp(
-                    cast_input.results[0], rd=riscv.IntRegisterType.unallocated()
+                    cast_input.results[0], rd=riscv.IntRegisterType()
                 ),
                 UnrealizedConversionCastOp.get((new_op.rd,), (op.result.type,)),
             )

--- a/xdsl/backend/riscv/lowering/convert_arith_to_riscv_snitch.py
+++ b/xdsl/backend/riscv/lowering/convert_arith_to_riscv_snitch.py
@@ -21,7 +21,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
 )
 
-_FLOAT_REGISTER_TYPE = riscv.FloatRegisterType.unallocated()
+_FLOAT_REGISTER_TYPE = riscv.FloatRegisterType()
 
 
 @dataclass

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -127,7 +127,7 @@ def get_strided_pointer(
                         offset_op := riscv.MulOp(
                             increment,
                             stride_op.rd,
-                            rd=riscv.IntRegisterType.unallocated(),
+                            rd=riscv.IntRegisterType(),
                         ),
                     )
                 )
@@ -141,11 +141,7 @@ def get_strided_pointer(
             continue
 
         # Otherwise sum up the products.
-        ops.append(
-            add_op := riscv.AddOp(
-                head, increment, rd=riscv.IntRegisterType.unallocated()
-            )
-        )
+        ops.append(add_op := riscv.AddOp(head, increment, rd=riscv.IntRegisterType()))
         add_op.rd.name_hint = "pointer_offset"
         head = add_op.rd
 
@@ -158,12 +154,10 @@ def get_strided_pointer(
             offset_bytes := riscv.MulOp(
                 head,
                 bytes_per_element_op.rd,
-                rd=riscv.IntRegisterType.unallocated(),
+                rd=riscv.IntRegisterType(),
                 comment="multiply by element size",
             ),
-            ptr := riscv.AddOp(
-                src_ptr, offset_bytes, rd=riscv.IntRegisterType.unallocated()
-            ),
+            ptr := riscv.AddOp(src_ptr, offset_bytes, rd=riscv.IntRegisterType()),
         ]
     )
 
@@ -377,9 +371,7 @@ class ConvertMemRefSubviewOp(RewritePattern):
             )
             return
 
-        src = UnrealizedConversionCastOp.get(
-            (source,), (riscv.IntRegisterType.unallocated(),)
-        )
+        src = UnrealizedConversionCastOp.get((source,), (riscv.IntRegisterType(),))
         src_rd = src.results[0]
 
         if offset is None:
@@ -393,7 +385,7 @@ class ConvertMemRefSubviewOp(RewritePattern):
                     index_ops.append(
                         cast_index_op := UnrealizedConversionCastOp.get(
                             (op.offsets[dynamic_offset_index],),
-                            (riscv.IntRegisterType.unallocated(),),
+                            (riscv.IntRegisterType(),),
                         )
                     )
                     index_val = cast_index_op.results[0]

--- a/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
+++ b/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
@@ -82,17 +82,15 @@ def insert_stride_pattern_ops(
         *interleaved_b_set_bound_ops,
         *s_ops,
         snitch.SsrSetDimensionStrideOp(s_ops[0], dm, ints[0]),
-        a_op := riscv.LiOp(0, rd=riscv.IntRegisterType.unallocated()),
+        a_op := riscv.LiOp(0, rd=riscv.IntRegisterType()),
     ]
 
     for i in range(1, rank):
         a_inc_op = riscv.MulOp(
-            new_b_ops[i - 1], s_ops[i - 1], rd=riscv.IntRegisterType.unallocated()
+            new_b_ops[i - 1], s_ops[i - 1], rd=riscv.IntRegisterType()
         )
-        new_a_op = riscv.AddOp(a_op, a_inc_op, rd=riscv.IntRegisterType.unallocated())
-        stride_op = riscv.SubOp(
-            s_ops[i], new_a_op, rd=riscv.IntRegisterType.unallocated()
-        )
+        new_a_op = riscv.AddOp(a_op, a_inc_op, rd=riscv.IntRegisterType())
+        stride_op = riscv.SubOp(s_ops[i], new_a_op, rd=riscv.IntRegisterType())
         set_stride_op = snitch.SsrSetDimensionStrideOp(stride_op.rd, dm, ints[i])
         new_ops.extend((a_inc_op, new_a_op, stride_op, set_stride_op))
         a_op = new_a_op

--- a/xdsl/backend/riscv/lowering/utils.py
+++ b/xdsl/backend/riscv/lowering/utils.py
@@ -33,7 +33,7 @@ def cast_to_regs(values: Iterable[SSAValue]) -> tuple[list[Operation], list[SSAV
         if not isinstance(value.type, riscv.RISCVRegisterType):
             register_type = register_type_for_type(value.type)
             cast_op = builtin.UnrealizedConversionCastOp.get(
-                (value,), (register_type.unallocated(),)
+                (value,), (register_type(),)
             )
             new_ops.append(cast_op)
             value = cast_op.results[0]
@@ -133,9 +133,7 @@ def move_to_unallocated_regs(
 
     for value, value_type in zip(values, value_types, strict=True):
         register_type = register_type_for_type(value.type)
-        move_op, new_value = move_ops_for_value(
-            value, value_type, register_type.unallocated()
-        )
+        move_op, new_value = move_ops_for_value(value, value_type, register_type())
         new_ops.append(move_op)
         new_values.append(new_value)
 
@@ -157,9 +155,7 @@ def cast_ops_for_values(
     for value in values:
         if not isinstance(value.type, riscv.IntRegisterType | riscv.FloatRegisterType):
             new_type = register_type_for_type(value.type)
-            cast_op = builtin.UnrealizedConversionCastOp.get(
-                (value,), (new_type.unallocated(),)
-            )
+            cast_op = builtin.UnrealizedConversionCastOp.get((value,), (new_type(),))
             new_ops.append(cast_op)
             new_value = cast_op.results[0]
             new_value.name_hint = value.name_hint
@@ -216,9 +212,7 @@ def cast_block_args_from_a_regs(block: Block, rewriter: PatternRewriter):
 
     for arg in block.args:
         register_type = register_type_for_type(arg.type)
-        move_op, new_value = move_ops_for_value(
-            arg, arg.type, register_type.unallocated()
-        )
+        move_op, new_value = move_ops_for_value(arg, arg.type, register_type())
         cast_op = builtin.UnrealizedConversionCastOp.get((new_value,), (arg.type,))
         new_ops.append(move_op)
         new_ops.append(cast_op)
@@ -246,6 +240,6 @@ def cast_block_args_to_regs(block: Block, rewriter: PatternRewriter):
             InsertPoint.at_start(block),
         )
 
-        arg.type = register_type_for_type(arg.type).unallocated()
+        arg.type = register_type_for_type(arg.type)()
         arg.replace_by(new_val.results[0])
         new_val.operands[new_val.results[0].index] = arg

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -28,10 +28,6 @@ class IntRegisterType(ARMRegisterType):
     name = "arm.reg"
 
     @classmethod
-    def unallocated(cls) -> IntRegisterType:
-        return UNALLOCATED_INT
-
-    @classmethod
     def instruction_set_name(cls) -> str:
         return "arm"
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -145,10 +145,6 @@ class IntRegisterType(RISCVRegisterType):
     name = "riscv.reg"
 
     @classmethod
-    def unallocated(cls) -> IntRegisterType:
-        return Registers.UNALLOCATED_INT
-
-    @classmethod
     def instruction_set_name(cls) -> str:
         return "RV32I"
 
@@ -204,10 +200,6 @@ class FloatRegisterType(RISCVRegisterType):
     """
 
     name = "riscv.freg"
-
-    @classmethod
-    def unallocated(cls) -> FloatRegisterType:
-        return Registers.UNALLOCATED_FLOAT
 
     @classmethod
     def instruction_set_name(cls) -> str:
@@ -632,7 +624,7 @@ class RdImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -754,7 +746,7 @@ class RdRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -815,7 +807,7 @@ class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -1133,7 +1125,7 @@ class CsrReadWriteOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -1211,7 +1203,7 @@ class CsrBitwiseOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -1287,7 +1279,7 @@ class CsrReadWriteImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -1367,7 +1359,7 @@ class CsrBitwiseImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -2504,7 +2496,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -2963,7 +2955,7 @@ class RdRsRsRsFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = FloatRegisterType.unallocated()
+            rd = FloatRegisterType()
         elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):
@@ -3002,7 +2994,7 @@ class RdRsRsFloatFloatIntegerOperation(
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -3045,7 +3037,7 @@ class RdRsRsFloatFloatIntegerOperationWithFastMath(
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType.unallocated()
+            rd = IntRegisterType()
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -3152,7 +3144,7 @@ class RdRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
             immediate = LabelAttr(immediate)
 
         if rd is None:
-            rd = FloatRegisterType.unallocated()
+            rd = FloatRegisterType()
         elif isinstance(rd, str):
             rd = FloatRegisterType(rd)
         if isinstance(comment, str):

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -56,7 +56,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.IntRegisterType.unallocated() if has_result else None],
+            result_types=[riscv.IntRegisterType() if has_result else None],
         )
 
     def verify_(self):

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -601,7 +601,7 @@ class DMCopyOp(RISCVCustomFormatOperation, RISCVInstruction):
         self,
         size: SSAValue | Operation,
         config: SSAValue | Operation,
-        result_type: IntRegisterType = IntRegisterType.unallocated(),
+        result_type: IntRegisterType = IntRegisterType(),
     ):
         super().__init__(operands=[size, config], result_types=[result_type])
 
@@ -623,7 +623,7 @@ class DMStatOp(RISCVCustomFormatOperation, RISCVInstruction):
     def __init__(
         self,
         status: SSAValue | Operation,
-        result_type: IntRegisterType = IntRegisterType.unallocated(),
+        result_type: IntRegisterType = IntRegisterType(),
     ):
         super().__init__(operands=[status], result_types=[result_type])
 
@@ -647,7 +647,7 @@ class DMCopyImmOp(RISCVInstruction):
         self,
         size: SSAValue | Operation,
         config: int | UImm5Attr,
-        result_type: IntRegisterType = IntRegisterType.unallocated(),
+        result_type: IntRegisterType = IntRegisterType(),
     ):
         if isinstance(config, int):
             config = IntegerAttr(config, IntegerType(5, signedness=Signedness.UNSIGNED))
@@ -700,7 +700,7 @@ class DMStatImmOp(RISCVInstruction):
     def __init__(
         self,
         status: int | UImm5Attr,
-        result_type: IntRegisterType = IntRegisterType.unallocated(),
+        result_type: IntRegisterType = IntRegisterType(),
     ):
         if isinstance(status, int):
             status = IntegerAttr(status, IntegerType(5, signedness=Signedness.UNSIGNED))

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -60,10 +60,6 @@ class GeneralRegisterType(X86RegisterType):
     name = "x86.reg"
 
     @classmethod
-    def unallocated(cls) -> GeneralRegisterType:
-        return UNALLOCATED_GENERAL
-
-    @classmethod
     def instruction_set_name(cls) -> str:
         return "x86"
 
@@ -114,10 +110,6 @@ class RFLAGSRegisterType(X86RegisterType):
     name = "x86.rflags"
 
     @classmethod
-    def unallocated(cls) -> RFLAGSRegisterType:
-        return UNALLOCATED_RFLAGS
-
-    @classmethod
     def instruction_set_name(cls) -> str:
         return "x86"
 
@@ -145,10 +137,6 @@ class SSERegisterType(X86VectorRegisterType):
     """
 
     name = "x86.ssereg"
-
-    @classmethod
-    def unallocated(cls) -> SSERegisterType:
-        return UNALLOCATED_SSE
 
     @classmethod
     def instruction_set_name(cls) -> str:
@@ -207,10 +195,6 @@ class AVX2RegisterType(X86VectorRegisterType):
     name = "x86.avx2reg"
 
     @classmethod
-    def unallocated(cls) -> AVX2RegisterType:
-        return UNALLOCATED_AVX2
-
-    @classmethod
     def instruction_set_name(cls) -> str:
         return "AVX2"
 
@@ -265,10 +249,6 @@ class AVX512RegisterType(X86VectorRegisterType):
     """
 
     name = "x86.avx512reg"
-
-    @classmethod
-    def unallocated(cls) -> AVX512RegisterType:
-        return UNALLOCATED_AVX512
 
     @classmethod
     def instruction_set_name(cls) -> str:

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -162,7 +162,7 @@ class StreamOpLowering(RewritePattern):
         new_operands = cast_operands_to_regs(rewriter)
         new_inputs = new_operands[: len(op.inputs)]
         new_outputs = new_operands[len(op.inputs) :]
-        freg = riscv.FloatRegisterType.unallocated()
+        freg = riscv.FloatRegisterType()
 
         rewriter.replace_matched_op(
             new_op := snitch_stream.StreamingRegionOp(

--- a/xdsl/transforms/convert_ptr_to_riscv.py
+++ b/xdsl/transforms/convert_ptr_to_riscv.py
@@ -30,7 +30,7 @@ from xdsl.utils.exceptions import DiagnosticException
 class PtrTypeConversion(TypeConversionPattern):
     @attr_type_rewrite_pattern
     def convert_type(self, typ: ptr.PtrType) -> riscv.IntRegisterType:
-        return riscv.IntRegisterType.unallocated()
+        return riscv.IntRegisterType()
 
 
 @dataclass
@@ -39,7 +39,7 @@ class ConvertPtrAddOp(RewritePattern):
     def match_and_rewrite(self, op: ptr.PtrAddOp, rewriter: PatternRewriter, /):
         oper1, oper2 = cast_operands_to_regs(rewriter)
         rewriter.replace_matched_op(
-            riscv.AddOp(oper1, oper2, rd=riscv.IntRegisterType.unallocated())
+            riscv.AddOp(oper1, oper2, rd=riscv.IntRegisterType())
         )
 
 
@@ -114,9 +114,7 @@ class ConvertMemRefToPtrOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ptr.ToPtrOp, rewriter: PatternRewriter, /):
         rewriter.replace_matched_op(
-            UnrealizedConversionCastOp.get(
-                [op.source], [riscv.IntRegisterType.unallocated()]
-            )
+            UnrealizedConversionCastOp.get([op.source], [riscv.IntRegisterType()])
         )
 
 

--- a/xdsl/transforms/convert_riscv_scf_for_to_frep.py
+++ b/xdsl/transforms/convert_riscv_scf_for_to_frep.py
@@ -61,9 +61,7 @@ class ScfForLowering(RewritePattern):
         rewriter.erase_block_argument(indvar)
         rewriter.replace_matched_op(
             (
-                iter_count := riscv.SubOp(
-                    op.ub, op.lb, rd=riscv.IntRegisterType.unallocated()
-                ),
+                iter_count := riscv.SubOp(op.ub, op.lb, rd=riscv.IntRegisterType()),
                 iter_count_minus_one := riscv.AddiOp(iter_count, -1),
                 riscv_snitch.FrepOuterOp(
                     iter_count_minus_one,

--- a/xdsl/transforms/inline_snrt.py
+++ b/xdsl/transforms/inline_snrt.py
@@ -109,7 +109,7 @@ class LowerDMAStart1D(RewritePattern):
             return snrt_dma_start_1d_wideptr((size_t)dst, (size_t)src, size);
         }
         """
-        reg_t = riscv.IntRegisterType.unallocated()
+        reg_t = riscv.IntRegisterType()
         rewriter.replace_matched_op(
             [
                 zero := riscv.GetRegisterOp(riscv.Registers.ZERO),
@@ -197,7 +197,7 @@ class LowerDMAStart1DWidePtr(RewritePattern):
 
         P.S. We only implement taking the top branch for now.
         """
-        reg_t = riscv.IntRegisterType.unallocated()
+        reg_t = riscv.IntRegisterType()
         rewriter.replace_matched_op(
             [
                 # "Take an ui64 and split it in two 32 bit-wide RISC-V registers"
@@ -231,7 +231,7 @@ class LowerDMAStart1DWidePtr(RewritePattern):
 
 
 class LowerDMAStart2DBase(RewritePattern, ABC):
-    any_reg = riscv.IntRegisterType.unallocated()
+    any_reg = riscv.IntRegisterType()
 
     def generate_dma_instructions(
         self,

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -43,10 +43,10 @@ class HoistIndexTimesConstantOp(RewritePattern):
                         [
                             shift := riscv.LiOp(constant),
                             new_lb := riscv.AddOp(
-                                op.lb, shift, rd=riscv.IntRegisterType.unallocated()
+                                op.lb, shift, rd=riscv.IntRegisterType()
                             ),
                             new_ub := riscv.AddOp(
-                                op.ub, shift, rd=riscv.IntRegisterType.unallocated()
+                                op.ub, shift, rd=riscv.IntRegisterType()
                             ),
                         ]
                     )
@@ -56,13 +56,13 @@ class HoistIndexTimesConstantOp(RewritePattern):
                         [
                             factor := riscv.LiOp(constant),
                             new_lb := riscv.MulOp(
-                                op.lb, factor, rd=riscv.IntRegisterType.unallocated()
+                                op.lb, factor, rd=riscv.IntRegisterType()
                             ),
                             new_ub := riscv.MulOp(
-                                op.ub, factor, rd=riscv.IntRegisterType.unallocated()
+                                op.ub, factor, rd=riscv.IntRegisterType()
                             ),
                             new_step := riscv.MulOp(
-                                op.step, factor, rd=riscv.IntRegisterType.unallocated()
+                                op.step, factor, rd=riscv.IntRegisterType()
                             ),
                         ]
                     )


### PR DESCRIPTION
The .unallocated was a kind of premature optimisation, I'm not sure that it makes sense any more, and it makes the code more difficult to read IMO.