### PR TITLE
backend: add `infinite_register` class method to RegisterType

### DIFF
--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -6,10 +6,6 @@ from xdsl.irdl import irdl_attr_definition
 
 @irdl_attr_definition
 class TestRegister(RegisterType):
-    """
-    A RISC-V register type.
-    """
-
     name = "test.reg"
 
     def verify(self) -> None: ...
@@ -23,10 +19,10 @@ class TestRegister(RegisterType):
         return {"x0": 0}
 
     @classmethod
-    def infinite_register_name(cls, index: int) -> str:
-        return f"x{index}"
+    def infinite_register_prefix(cls):
+        return "x"
 
 
-def test_register_type():
-    with pytest.raises(AssertionError):
+def test_register_clashes():
+    with pytest.raises(AssertionError, match="Invalid 'infinite' register name x"):
         TestRegister.infinite_register(0)

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -1,5 +1,3 @@
-from typing import override
-
 import pytest
 
 from xdsl.backend.register_type import RegisterType
@@ -25,7 +23,6 @@ class TestRegister(RegisterType):
         return {"x0": 0}
 
     @classmethod
-    @override
     def infinite_register_name(cls, index: int) -> str:
         return f"x{index}"
 

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -24,5 +24,8 @@ class TestRegister(RegisterType):
 
 
 def test_register_clashes():
-    with pytest.raises(AssertionError, match="Invalid 'infinite' register name x"):
+    with pytest.raises(
+        AssertionError,
+        match="Invalid 'infinite' register name: x0 clashes with finite register set",
+    ):
         TestRegister.infinite_register(0)

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -1,0 +1,35 @@
+from typing import override
+
+import pytest
+
+from xdsl.backend.register_type import RegisterType
+from xdsl.irdl import irdl_attr_definition
+
+
+@irdl_attr_definition
+class TestRegister(RegisterType):
+    """
+    A RISC-V register type.
+    """
+
+    name = "test.reg"
+
+    def verify(self) -> None: ...
+
+    @classmethod
+    def instruction_set_name(cls) -> str:
+        return "TEST"
+
+    @classmethod
+    def abi_index_by_name(cls) -> dict[str, int]:
+        return {"x0": 0}
+
+    @classmethod
+    @override
+    def infinite_register_name(cls, index: int) -> str:
+        return f"x{index}"
+
+
+def test_register_type():
+    with pytest.raises(AssertionError):
+        TestRegister.infinite_register(0)

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -96,9 +96,9 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
         """
         Provide the register at the given index in the "infinite" register set.
         """
-        spelling = cls.infinite_register_prefix()
-        res = cls(spelling + str(index))
+        spelling = cls.infinite_register_prefix() + str(index)
+        res = cls(spelling)
         assert isinstance(res.index, NoneAttr), (
-            f"Invalid 'infinite' register name {spelling}"
+            f"Invalid 'infinite' register name: {spelling} clashes with finite register set"
         )
         return res

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from typing import Self
 
 from xdsl.dialects.builtin import (
     IntAttr,
@@ -78,3 +79,24 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     @abstractmethod
     def abi_index_by_name(cls) -> dict[str, int]:
         raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def infinite_register_name(cls, index: int) -> str:
+        """
+        Provide the spelling for a register at the given index in the "infinite"
+        register set.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def infinite_register(cls, index: int) -> Self:
+        """
+        Provide the register at the given index in the "infinite" register set.
+        """
+        spelling = cls.infinite_register_name(index)
+        res = cls(spelling)
+        assert isinstance(res.index, NoneAttr), (
+            f"Invalid 'infinite' register name {spelling}"
+        )
+        return res

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -83,10 +83,11 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
 
     @classmethod
     @abstractmethod
-    def infinite_register_name(cls, index: int) -> str:
+    def infinite_register_prefix(cls) -> str:
         """
-        Provide the spelling for a register at the given index in the "infinite"
-        register set.
+        Provide the prefix for the spelling for a register at the given index in the
+        "infinite" register set.
+        For a prefix `x`, the spelling of the first infinite register will be `x0`.
         """
         raise NotImplementedError()
 
@@ -95,8 +96,8 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
         """
         Provide the register at the given index in the "infinite" register set.
         """
-        spelling = cls.infinite_register_name(index)
-        res = cls(spelling)
+        spelling = cls.infinite_register_prefix()
+        res = cls(spelling + str(index))
         assert isinstance(res.index, NoneAttr), (
             f"Invalid 'infinite' register name {spelling}"
         )

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Self
+
+from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     IntAttr,

--- a/xdsl/backend/riscv/riscv_register_queue.py
+++ b/xdsl/backend/riscv/riscv_register_queue.py
@@ -85,10 +85,10 @@ class RiscvRegisterQueue(RegisterQueue[IntRegisterType | FloatRegisterType]):
             reg = available_registers.pop()
         else:
             if issubclass(reg_type, IntRegisterType):
-                reg = reg_type(f"j_{self._j_idx}")
+                reg = reg_type.infinite_register(self._j_idx)
                 self._j_idx += 1
             else:
-                reg = reg_type(f"fj_{self._fj_idx}")
+                reg = reg_type.infinite_register(self._fj_idx)
                 self._fj_idx += 1
 
         reserved_registers = (

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -37,7 +37,7 @@ class IntRegisterType(ARMRegisterType):
 
     @classmethod
     def infinite_register_prefix(cls):
-        return "inf"
+        return "inf_"
 
 
 UNALLOCATED_INT = IntRegisterType("")

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -35,6 +35,10 @@ class IntRegisterType(ARMRegisterType):
     def abi_index_by_name(cls) -> dict[str, int]:
         return ARM_INDEX_BY_NAME
 
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"inf_{index}"
+
 
 UNALLOCATED_INT = IntRegisterType("")
 X0 = IntRegisterType("x0")

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -36,8 +36,8 @@ class IntRegisterType(ARMRegisterType):
         return ARM_INDEX_BY_NAME
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"inf_{index}"
+    def infinite_register_prefix(cls):
+        return "inf"
 
 
 UNALLOCATED_INT = IntRegisterType("")

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -156,6 +156,10 @@ class IntRegisterType(RISCVRegisterType):
     def a_register(cls, index: int) -> IntRegisterType:
         return Registers.A[index]
 
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"j_{index}"
+
 
 RV32F_INDEX_BY_NAME = {
     "ft0": 0,
@@ -212,6 +216,10 @@ class FloatRegisterType(RISCVRegisterType):
     @classmethod
     def a_register(cls, index: int) -> FloatRegisterType:
         return Registers.FA[index]
+
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"fj_{index}"
 
 
 RDInvT = TypeVar("RDInvT", bound=RISCVRegisterType)

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -157,8 +157,8 @@ class IntRegisterType(RISCVRegisterType):
         return Registers.A[index]
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"j_{index}"
+    def infinite_register_prefix(cls):
+        return "j_"
 
 
 RV32F_INDEX_BY_NAME = {
@@ -218,8 +218,8 @@ class FloatRegisterType(RISCVRegisterType):
         return Registers.FA[index]
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"fj_{index}"
+    def infinite_register_prefix(cls):
+        return "fj_"
 
 
 RDInvT = TypeVar("RDInvT", bound=RISCVRegisterType)

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -67,6 +67,10 @@ class GeneralRegisterType(X86RegisterType):
     def abi_index_by_name(cls) -> dict[str, int]:
         return X86_INDEX_BY_NAME
 
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"reg_{index}"
+
 
 UNALLOCATED_GENERAL = GeneralRegisterType("")
 RAX = GeneralRegisterType("rax")
@@ -117,6 +121,10 @@ class RFLAGSRegisterType(X86RegisterType):
     def abi_index_by_name(cls) -> dict[str, int]:
         return RFLAGS_INDEX_BY_NAME
 
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"rflags_{index}"
+
 
 UNALLOCATED_RFLAGS = RFLAGSRegisterType("")
 RFLAGS = RFLAGSRegisterType("rflags")
@@ -145,6 +153,10 @@ class SSERegisterType(X86VectorRegisterType):
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
         return SSE_INDEX_BY_NAME
+
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"sse_{index}"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
@@ -202,6 +214,10 @@ class AVX2RegisterType(X86VectorRegisterType):
     def abi_index_by_name(cls) -> dict[str, int]:
         return AVX2_INDEX_BY_NAME
 
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"avx2_{index}"
+
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
 AVX2_INDEX_BY_NAME = {
@@ -257,6 +273,10 @@ class AVX512RegisterType(X86VectorRegisterType):
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
         return X86AVX512_INDEX_BY_NAME
+
+    @classmethod
+    def infinite_register_name(cls, index: int):
+        return f"avx512_{index}"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -69,7 +69,7 @@ class GeneralRegisterType(X86RegisterType):
 
     @classmethod
     def infinite_register_prefix(cls):
-        return "inf_reg"
+        return "inf_reg_"
 
 
 UNALLOCATED_GENERAL = GeneralRegisterType("")
@@ -123,7 +123,7 @@ class RFLAGSRegisterType(X86RegisterType):
 
     @classmethod
     def infinite_register_prefix(cls):
-        return "inf_rflags"
+        return "inf_rflags_"
 
 
 UNALLOCATED_RFLAGS = RFLAGSRegisterType("")
@@ -156,7 +156,7 @@ class SSERegisterType(X86VectorRegisterType):
 
     @classmethod
     def infinite_register_prefix(cls):
-        return "inf_sse"
+        return "inf_sse_"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
@@ -216,7 +216,7 @@ class AVX2RegisterType(X86VectorRegisterType):
 
     @classmethod
     def infinite_register_prefix(cls):
-        return "inf_avx2"
+        return "inf_avx2_"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
@@ -276,7 +276,7 @@ class AVX512RegisterType(X86VectorRegisterType):
 
     @classmethod
     def infinite_register_prefix(cls):
-        return "inf_avx512"
+        return "inf_avx512_"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -68,8 +68,8 @@ class GeneralRegisterType(X86RegisterType):
         return X86_INDEX_BY_NAME
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"reg_{index}"
+    def infinite_register_prefix(cls):
+        return "inf_reg"
 
 
 UNALLOCATED_GENERAL = GeneralRegisterType("")
@@ -122,8 +122,8 @@ class RFLAGSRegisterType(X86RegisterType):
         return RFLAGS_INDEX_BY_NAME
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"rflags_{index}"
+    def infinite_register_prefix(cls):
+        return "inf_rflags"
 
 
 UNALLOCATED_RFLAGS = RFLAGSRegisterType("")
@@ -155,8 +155,8 @@ class SSERegisterType(X86VectorRegisterType):
         return SSE_INDEX_BY_NAME
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"sse_{index}"
+    def infinite_register_prefix(cls):
+        return "inf_sse"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
@@ -215,8 +215,8 @@ class AVX2RegisterType(X86VectorRegisterType):
         return AVX2_INDEX_BY_NAME
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"avx2_{index}"
+    def infinite_register_prefix(cls):
+        return "inf_avx2"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
@@ -275,8 +275,8 @@ class AVX512RegisterType(X86VectorRegisterType):
         return X86AVX512_INDEX_BY_NAME
 
     @classmethod
-    def infinite_register_name(cls, index: int):
-        return f"avx512_{index}"
+    def infinite_register_prefix(cls):
+        return "inf_avx512"
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers


### PR DESCRIPTION
It's nice to have a check to make sure that our fake infinite registers don't clash with the real ones.