### PR TITLE
backend: (x86) consistently print the function type of x86_func

### DIFF
--- a/tests/filecheck/backend/x86/convert_func_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_func_to_x86.mlir
@@ -11,7 +11,7 @@ func.func @foo_int(%0: i32, %1: i32, %2: i32, %3: i32, %4: i32, %5: i32, %6: i32
   func.return %g: i32
 }
 // CHECK:       builtin.module {
-// CHECK-NEXT:    x86_func.func @foo_int() {
+// CHECK-NEXT:    x86_func.func @foo_int() -> () {
 // CHECK-NEXT:      %0 = x86.get_register : () -> !x86.reg<rdi>
 // CHECK-NEXT:      %1 = x86.get_register : () -> !x86.reg<rsi>
 // CHECK-NEXT:      %2 = x86.get_register : () -> !x86.reg<rdx>

--- a/tests/filecheck/dialects/x86_func/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86_func/x86_ops.mlir
@@ -2,15 +2,31 @@
 // RUN: XDSL_GENERIC_ROUNDTRIP
 // RUN: xdsl-opt -t x86-asm %s | filecheck %s --check-prefix=CHECK-ASM
 
-// CHECK:       x86_func.func @noarg_void() {
-// CHECK-NEXT:    x86_func.ret {comment = "this is a return instruction"}
+// CHECK:      builtin.module {
+// CHECK-NEXT: x86_func.func @noarg_void() -> () {
+// CHECK-NEXT:    x86_func.ret {comment = "return instruction for noarg_void"}
 // CHECK-NEXT:  }
 // CHECK-ASM: noarg_void:
-// CHECK-ASM: ret # this is a return instruction
+// CHECK-ASM: ret # return instruction for noarg_void
 x86_func.func @noarg_void() {
-    x86_func.ret {"comment" = "this is a return instruction"}
+    x86_func.ret {"comment" = "return instruction for noarg_void"}
 }
 
-// CHECK-GENERIC:       "x86_func.func"() ({
-// CHECK-GENERIC-NEXT:    "x86_func.ret"() {comment = "this is a return instruction"} : () -> ()
-// CHECK-GENERIC-NEXT:  }) {sym_name = "noarg_void", function_type = () -> ()} : () -> ()
+// CHECK-GENERIC:      "builtin.module"() ({
+// CHECK-GENERIC-NEXT: "x86_func.func"() ({
+// CHECK-GENERIC-NEXT:   "x86_func.ret"() {comment = "return instruction for noarg_void"} : () -> ()
+// CHECK-GENERIC-NEXT: }) {sym_name = "noarg_void", function_type = () -> ()} : () -> ()
+
+// CHECK:     x86_func.func @arg_i32(i32, i32) -> i32 {
+// CHECK-NEXT:   x86_func.ret {comment = "return instruction for arg_i32"}
+// CHECK-NEXT: }
+// CHECK-ASM: arg_i32:
+// CHECK-ASM: ret # return instruction for arg_i32
+x86_func.func @arg_i32(i32,i32) -> (i32) {
+    x86_func.ret {"comment" = "return instruction for arg_i32"}
+}
+
+// CHECK-GENERIC:      "x86_func.func"() ({
+// CHECK-GENERIC-NEXT:   "x86_func.ret"() {comment = "return instruction for arg_i32"} : () -> ()
+// CHECK-GENERIC-NEXT: }) {sym_name = "arg_i32", function_type = (i32, i32) -> i32} : () -> ()
+// CHECK-GENERIC-NEXT: }) : () -> ()

--- a/xdsl/dialects/x86_func.py
+++ b/xdsl/dialects/x86_func.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 from xdsl.dialects.builtin import FunctionType, StringAttr
 from xdsl.dialects.utils import (
     parse_func_op_like,
-    print_func_op_like,
 )
 from xdsl.dialects.x86.ops import X86AsmOperation, X86Instruction
 from xdsl.ir import Attribute, Dialect, Operation, Region
@@ -103,14 +102,13 @@ class FuncOp(X86AsmOperation):
             visibility = self.sym_visibility.data
             printer.print_string(f" {visibility}")
 
-        print_func_op_like(
-            printer,
-            self.sym_name,
-            self.function_type,
-            self.body,
-            self.attributes,
-            reserved_attr_names=("sym_name", "function_type", "sym_visibility"),
+        printer.print(f" @{self.sym_name.data}")
+        printer.print_function_type(
+            self.function_type.inputs.data, self.function_type.outputs.data
         )
+        if self.body.blocks:
+            printer.print(" ")
+            printer.print_region(self.body, False, False)
 
     def assembly_line(self) -> str | None:
         if self.body.blocks:


### PR DESCRIPTION
I assume that when in x86_func, arguments are passed using calling conventions (writing/reading registers and stack). Therefore, the arguments of the first basic block of the function should not be displayed, but rather the type of the function (which is just high-level information annotating the function).
