### PR TITLE
CI: set pytest asyncio_default_fixture_loop_scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ python_files = ["tests/*test_*.py", "docs/*test_*.py"]
 python_classes = "Test_*"
 python_functions = "test_*"
 addopts = ["--durations=20", "--maxfail=5"]
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.versioneer]
 VCS = "git"


### PR DESCRIPTION
Removes the following error:

> PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
