### PR TITLE
misc: shorten PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,16 +8,20 @@ assignees: ''
 ---
 
 ### Description
-A clear and concise description of the issue or bug. 
+
+A clear and concise description of the issue or bug.
 
 ### Expected vs Actual Behavior
+
 Include what you expected to happen and what actually happened (e.g., when compared with upstream MLIR).
 
 ### Steps to Reproduce and a Minimal Working Example (MWE)
+
 1. Describe the steps to reproduce the issue (commands, etc.).
 2. If applicable, describe the environment (e.g., operating system, Python version, etc.).
-3. Please make your reproducible example as small as possible.  
+3. Please make your reproducible example as small as possible.
 It should be self-contained and easy to run.
 
 ### Additional Information
+
 Any extra information that might help debug the issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,8 @@
-*Short paragraph summarizing the changes*
+---
+title: ""
 
 ---
 
-Thank you for submitting a PR to xDSL!
+Please add a short description of your changes, and the motivation behind them.
 
-Make sure to follow the steps in the checklist below *before* you submit this PR!
-
-## Checklist before you submit this PR:
-
- - [ ] If your PR is not ready for review, open it as a draft instead.
- - [ ] Make sure your PR title follows the [guidelines](https://github.com/xdslproject/xdsl/wiki#commit-and-pr-message-formatting)
- - [ ] Add some tags to categorize the PR, if able.
- - [ ] Request review from people you *know* have to sign off on these changes, you can leave it blank for now if you are not sure or don't have the rights to request reviews.
- - [ ] Tag people you wish to get feedback from (using @\<username>), they will then sort out the reviewers.
- - [ ] Assign this PR to yourself, if able.
- - [ ] Delete this checklist and the line above it, only after you've completed all previous tasks.
+Make sure your PR title follows the [guidelines](https://github.com/xdslproject/xdsl/wiki#commit-and-pr-message-formatting)


### PR DESCRIPTION
I have a feeling that our template is too long, and that people just see a wall of text and zone out, when there are actually only two things to pay attention to: 1. read the guidelines if you haven't, 2. add a motivation. We can easily do the labels, reviewers and assignees as maintainers.