### PR TITLE
misc: remove xdsl-opt file

### DIFF
--- a/docs/mlir_interoperation.ipynb
+++ b/docs/mlir_interoperation.ipynb
@@ -215,7 +215,7 @@
     }
    ],
    "source": [
-    "!./../xdsl/tools/xdsl-opt opt-out.mlir -f mlir -t mlir -o ret.mlir\n",
+    "!xdsl-opt opt-out.mlir -f mlir -t mlir -o ret.mlir\n",
     "!cat ret.mlir"
    ]
   }

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -8,7 +8,7 @@ config.name = "xDSL"
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {xdsl_src}"])
 config.suffixes = ['.test', '.mlir', '.py']
 
-xdsl_opt = "xdsl/tools/xdsl-opt"
+xdsl_opt = "xdsl/tools/xdsl_opt.py"
 xdsl_run = "xdsl/tools/xdsl_run.py"
 irdl_to_pyrdl = "xdsl/tools/irdl_to_pyrdl.py"
 

--- a/xdsl/tools/xdsl-opt
+++ b/xdsl/tools/xdsl-opt
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-from xdsl.xdsl_opt_main import xDSLOptMain
-
-if __name__ == "__main__":
-    xDSLOptMain().run()


### PR DESCRIPTION
I tested this locally by installing via a different path, seems like this is just unused at this point.