### PR TITLE
bug: (libxsmm) fix the little matmul use case

### DIFF
--- a/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
+++ b/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
@@ -1,6 +1,6 @@
 // RUN: xdsl-opt -t x86-asm %s | filecheck %s
 
-// C: 4x2xf32 = A: 4x8xf32 * B: 8x2xf32
+// C: 4x4xf32 = A: 4x8xf32 * B: 8x4xf32
 x86_func.func @matmul() {
     // General registers loading; according to the x86 calling
     // conventions, rdi, rsi and rcx always contain the first

--- a/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
+++ b/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
@@ -18,6 +18,9 @@ x86_func.func @matmul() {
     %ymm6 = x86.get_avx_register : () -> !x86.avx2reg<ymm6>
     %ymm7 = x86.get_avx_register : () -> !x86.avx2reg<ymm7>
     %ymm8 = x86.get_avx_register : () -> !x86.avx2reg<ymm8>
+    %ymm9 = x86.get_avx_register : () -> !x86.avx2reg<ymm9>
+    %ymm10 = x86.get_avx_register : () -> !x86.avx2reg<ymm10>
+    %ymm11 = x86.get_avx_register : () -> !x86.avx2reg<ymm11>
     // Load rows of A
     %a_row_0 = x86.rm.vmovups %ymm0, %rdi, 0 : (!x86.avx2reg<ymm0>, !x86.reg<rdi>) -> (!x86.avx2reg<ymm0>)
     %a_row_1 = x86.rm.vmovups %ymm1, %rdi, 32 : (!x86.avx2reg<ymm1>, !x86.reg<rdi>) -> (!x86.avx2reg<ymm1>)
@@ -31,17 +34,31 @@ x86_func.func @matmul() {
     // Load column 0 of B
     %b_col_0 = x86.rm.vbroadcastss %ymm8, %rsi, 0 : (!x86.avx2reg<ymm8>, !x86.reg<rsi>) -> !x86.avx2reg<ymm8>
     // Reduction
-    %c0_tmp1 = x86.rrr.vfmadd231pd %b_col_0, %a_row_0, %c0_tmp0 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm0>, !x86.avx2reg<ymm4>) -> !x86.avx2reg<ymm4>
-    %c1_tmp1 = x86.rrr.vfmadd231pd %b_col_0, %a_row_1, %c1_tmp0 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm5>) -> !x86.avx2reg<ymm5>
-    %c2_tmp1 = x86.rrr.vfmadd231pd %b_col_0, %a_row_2, %c2_tmp0 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm2>, !x86.avx2reg<ymm6>) -> !x86.avx2reg<ymm6>
-    %c3_tmp1 = x86.rrr.vfmadd231pd %b_col_0, %a_row_3, %c3_tmp0 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm3>, !x86.avx2reg<ymm7>) -> !x86.avx2reg<ymm7>
+    %c0_tmp1 = x86.rrr.vfmadd231ps %c0_tmp0, %b_col_0, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
+    %c1_tmp1 = x86.rrr.vfmadd231ps %c1_tmp0, %b_col_0, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
+    %c2_tmp1 = x86.rrr.vfmadd231ps %c2_tmp0, %b_col_0, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
+    %c3_tmp1 = x86.rrr.vfmadd231ps %c3_tmp0, %b_col_0, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
     // Load column 1 of B
-    %b_col_1 = x86.rm.vbroadcastss %ymm8, %rsi, 4 : (!x86.avx2reg<ymm8>, !x86.reg<rsi>) -> !x86.avx2reg<ymm8>
+    %b_col_1 = x86.rm.vbroadcastss %ymm9, %rsi, 4 : (!x86.avx2reg<ymm9>, !x86.reg<rsi>) -> !x86.avx2reg<ymm9>
     // Reduction
-    %c0 = x86.rrr.vfmadd231pd %b_col_1, %a_row_0, %c0_tmp1 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm0>, !x86.avx2reg<ymm4>) -> !x86.avx2reg<ymm4>
-    %c1 = x86.rrr.vfmadd231pd %b_col_1, %a_row_1, %c1_tmp1 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm5>) -> !x86.avx2reg<ymm5>
-    %c2 = x86.rrr.vfmadd231pd %b_col_1, %a_row_2, %c2_tmp1 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm2>, !x86.avx2reg<ymm6>) -> !x86.avx2reg<ymm6>
-    %c3 = x86.rrr.vfmadd231pd %b_col_1, %a_row_3, %c3_tmp1 : (!x86.avx2reg<ymm8>, !x86.avx2reg<ymm3>, !x86.avx2reg<ymm7>) -> !x86.avx2reg<ymm7>
+    %c0_tmp2 = x86.rrr.vfmadd231ps %c0_tmp1, %b_col_1, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
+    %c1_tmp2 = x86.rrr.vfmadd231ps %c1_tmp1, %b_col_1, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
+    %c2_tmp2 = x86.rrr.vfmadd231ps %c2_tmp1, %b_col_1, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
+    %c3_tmp2 = x86.rrr.vfmadd231ps %c3_tmp1, %b_col_1, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
+    // Load column 2 of B
+    %b_col_2 = x86.rm.vbroadcastss %ymm10, %rsi, 8 : (!x86.avx2reg<ymm10>, !x86.reg<rsi>) -> !x86.avx2reg<ymm10>
+    // Reduction
+    %c0_tmp3 = x86.rrr.vfmadd231ps %c0_tmp2, %b_col_2, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
+    %c1_tmp3 = x86.rrr.vfmadd231ps %c1_tmp2, %b_col_2, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
+    %c2_tmp3 = x86.rrr.vfmadd231ps %c2_tmp2, %b_col_2, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
+    %c3_tmp3 = x86.rrr.vfmadd231ps %c3_tmp2, %b_col_2, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
+    // Load column 3 of B
+    %b_col_3 = x86.rm.vbroadcastss %ymm11, %rsi, 12 : (!x86.avx2reg<ymm11>, !x86.reg<rsi>) -> !x86.avx2reg<ymm11>
+    // Reduction
+    %c0 = x86.rrr.vfmadd231ps %c0_tmp3, %b_col_3, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
+    %c1 = x86.rrr.vfmadd231ps %c1_tmp3, %b_col_3, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
+    %c2 = x86.rrr.vfmadd231ps %c2_tmp3, %b_col_3, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
+    %c3 = x86.rrr.vfmadd231ps %c3_tmp3, %b_col_3, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
    // Store the results (rows of C)
     x86.mr.vmovups %rcx, %c0, 0 : (!x86.reg<rcx>,!x86.avx2reg<ymm4>) -> ()
     x86.mr.vmovups %rcx, %c1, 32 : (!x86.reg<rcx>,!x86.avx2reg<ymm5>) -> ()
@@ -51,27 +68,37 @@ x86_func.func @matmul() {
     x86_func.ret
 }
 
-// CHECK:      matmul:
-// CHECK-NEXT:     vmovups ymm0, [rdi]
-// CHECK-NEXT:     vmovups ymm1, [rdi+32]
-// CHECK-NEXT:     vmovups ymm2, [rdi+64]
-// CHECK-NEXT:     vmovups ymm3, [rdi+96]
-// CHECK-NEXT:     vmovups ymm4, [rcx]
-// CHECK-NEXT:     vmovups ymm5, [rcx+32]
-// CHECK-NEXT:     vmovups ymm6, [rcx+64]
-// CHECK-NEXT:     vmovups ymm7, [rcx+96]
-// CHECK-NEXT:     vbroadcastss ymm8, [rsi]
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm0, ymm4
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm1, ymm5
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm2, ymm6
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm3, ymm7
-// CHECK-NEXT:     vbroadcastss ymm8, [rsi+4]
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm0, ymm4
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm1, ymm5
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm2, ymm6
-// CHECK-NEXT:     vfmadd231pd ymm8, ymm3, ymm7
-// CHECK-NEXT:     vmovups [rcx], ymm4
-// CHECK-NEXT:     vmovups [rcx+32], ymm5
-// CHECK-NEXT:     vmovups [rcx+64], ymm6
-// CHECK-NEXT:     vmovups [rcx+96], ymm7
-// CHECK-NEXT:     ret
+// CHECK:       matmul:
+// CHECK-NEXT:      vmovups ymm0, [rdi]
+// CHECK-NEXT:      vmovups ymm1, [rdi+32]
+// CHECK-NEXT:      vmovups ymm2, [rdi+64]
+// CHECK-NEXT:      vmovups ymm3, [rdi+96]
+// CHECK-NEXT:      vmovups ymm4, [rcx]
+// CHECK-NEXT:      vmovups ymm5, [rcx+32]
+// CHECK-NEXT:      vmovups ymm6, [rcx+64]
+// CHECK-NEXT:      vmovups ymm7, [rcx+96]
+// CHECK-NEXT:      vbroadcastss ymm8, [rsi]
+// CHECK-NEXT:      vfmadd231ps ymm4, ymm8, ymm0
+// CHECK-NEXT:      vfmadd231ps ymm5, ymm8, ymm1
+// CHECK-NEXT:      vfmadd231ps ymm6, ymm8, ymm2
+// CHECK-NEXT:      vfmadd231ps ymm7, ymm8, ymm3
+// CHECK-NEXT:      vbroadcastss ymm9, [rsi+4]
+// CHECK-NEXT:      vfmadd231ps ymm4, ymm9, ymm0
+// CHECK-NEXT:      vfmadd231ps ymm5, ymm9, ymm1
+// CHECK-NEXT:      vfmadd231ps ymm6, ymm9, ymm2
+// CHECK-NEXT:      vfmadd231ps ymm7, ymm9, ymm3
+// CHECK-NEXT:      vbroadcastss ymm10, [rsi+8]
+// CHECK-NEXT:      vfmadd231ps ymm4, ymm10, ymm0
+// CHECK-NEXT:      vfmadd231ps ymm5, ymm10, ymm1
+// CHECK-NEXT:      vfmadd231ps ymm6, ymm10, ymm2
+// CHECK-NEXT:      vfmadd231ps ymm7, ymm10, ymm3
+// CHECK-NEXT:      vbroadcastss ymm11, [rsi+12]
+// CHECK-NEXT:      vfmadd231ps ymm4, ymm11, ymm0
+// CHECK-NEXT:      vfmadd231ps ymm5, ymm11, ymm1
+// CHECK-NEXT:      vfmadd231ps ymm6, ymm11, ymm2
+// CHECK-NEXT:      vfmadd231ps ymm7, ymm11, ymm3
+// CHECK-NEXT:      vmovups [rcx], ymm4
+// CHECK-NEXT:      vmovups [rcx+32], ymm5
+// CHECK-NEXT:      vmovups [rcx+64], ymm6
+// CHECK-NEXT:      vmovups [rcx+96], ymm7
+// CHECK-NEXT:      ret


### PR DESCRIPTION
The use case contained 4 bugs according to computing a matmul:
1- Bad order of vfmadd parameters (AT&T syntax instead of Intel syntax)
2- vfmadd231pd instead of vfmadd231ps (double precision instead of single precision)
3- Incosistency between B dimensions (4x2) and C dimensions (4x4)
4- (performance bug, avoidable dependency) Load all B columns in the same register
