### PR TITLE
core: remove indirection in operation cloning

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1104,14 +1104,14 @@ class Operation(IRNode):
             block_mapper = {}
         operands = [
             (value_mapper[operand] if operand in value_mapper else operand)
-            for operand in self.operands
+            for operand in self._operands
         ]
         result_types = self.result_types
         attributes = self.attributes.copy()
         properties = self.properties.copy()
         successors = [
             (block_mapper[successor] if successor in block_mapper else successor)
-            for successor in self.successors
+            for successor in self._successors
         ]
         regions = [Region() for _ in self.regions]
         cloned_op = self.create(


### PR DESCRIPTION
Toy example of using benchmarking to inform performance optimisation.

In this case, we remove indirection from the `clone_without_regions` method on `Operation` to avoid incurring the cost of creating extraneous `OpOperand` and `Successor` dataclasses, which are then only used to construct iterators on a private property of the original class.

Running `python3 benchmarks/microbenchmarks.py OpCreation.operation_clone timeit`
Before: Test OpCreation.operation_clone ran in: 2.44e-06 ± 3.27e-07s
After : Test OpCreation.operation_clone ran in: 2.15e-06 ± 2.75e-07s
(~10% performance uplift for this limited case of a moderately common feature)