### PR TITLE
backend: use negative indices to track infinite registers

### DIFF
--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -1,31 +1,75 @@
 import pytest
 
 from xdsl.backend.register_type import RegisterType
+from xdsl.dialects.builtin import IntAttr, StringAttr
 from xdsl.irdl import irdl_attr_definition
 
 
-@irdl_attr_definition
-class TestRegister(RegisterType):
-    name = "test.reg"
-
-    def verify(self) -> None: ...
-
-    @classmethod
-    def instruction_set_name(cls) -> str:
-        return "TEST"
-
-    @classmethod
-    def abi_index_by_name(cls) -> dict[str, int]:
-        return {"x0": 0}
-
-    @classmethod
-    def infinite_register_prefix(cls):
-        return "x"
-
-
 def test_register_clashes():
+    @irdl_attr_definition
+    class ClashRegister(RegisterType):
+        name = "test.reg_clash"
+
+        def verify(self) -> None: ...
+
+        @classmethod
+        def instruction_set_name(cls) -> str:
+            return "TEST"
+
+        @classmethod
+        def abi_index_by_name(cls) -> dict[str, int]:
+            return {"x0": 0}
+
+        @classmethod
+        def infinite_register_prefix(cls):
+            return "x"
+
     with pytest.raises(
         AssertionError,
         match="Invalid 'infinite' register name: x0 clashes with finite register set",
     ):
-        TestRegister.infinite_register(0)
+        ClashRegister.infinite_register(0)
+
+
+def test_register_from_string():
+    @irdl_attr_definition
+    class TestRegister(RegisterType):
+        name = "test.reg"
+
+        def verify(self) -> None: ...
+
+        @classmethod
+        def instruction_set_name(cls) -> str:
+            return "TEST"
+
+        @classmethod
+        def abi_index_by_name(cls) -> dict[str, int]:
+            return {"x0": 0, "x1": 1}
+
+        @classmethod
+        def infinite_register_prefix(cls):
+            return "y"
+
+    # Register with valid ABI name is fine
+    assert TestRegister("x0").spelling == StringAttr("x0")
+    assert TestRegister("x0").index == IntAttr(0)
+    assert TestRegister("x1").spelling == StringAttr("x1")
+    assert TestRegister("x1").index == IntAttr(1)
+
+    # Register with infinite ABI name is fine
+    assert TestRegister("y0").spelling == StringAttr("y0")
+    assert TestRegister("y0").index == IntAttr(-1)
+    assert TestRegister("y1").spelling == StringAttr("y1")
+    assert TestRegister("y1").index == IntAttr(-2)
+
+    # Infinite prefix but not a number
+    with pytest.raises(
+        ValueError, match="Invalid register spelling yy for class TestRegister"
+    ):
+        TestRegister("yy")
+
+    # Incorrect name
+    with pytest.raises(
+        ValueError, match="Invalid register spelling z0 for class TestRegister"
+    ):
+        TestRegister("z0")

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -6,7 +6,6 @@ from xdsl.dialects.builtin import (
     IntAttr,
     IntegerAttr,
     ModuleOp,
-    NoneAttr,
     Signedness,
     i32,
 )
@@ -35,7 +34,7 @@ def test_add_op():
     assert a2.type.index == IntAttr(12)
 
     # Registers that aren't predefined should not have an index.
-    assert isinstance(riscv.IntRegisterType("j_1").index, NoneAttr)
+    assert riscv.IntRegisterType("j_1").index == IntAttr(-2)
 
 
 def test_csr_op():

--- a/tests/filecheck/dialects/riscv_cf/riscv_invalid_register.mlir
+++ b/tests/filecheck/dialects/riscv_cf/riscv_invalid_register.mlir
@@ -1,0 +1,67 @@
+// RUN: xdsl-opt --split-input-file --parsing-diagnostics --verify-diagnostics %s | filecheck %s --strict-whitespace --match-full-lines
+
+// Valid register names as sanity check
+
+"test.op"() : () -> (!riscv.reg<a0>)
+"test.op"() : () -> (!riscv.reg<j_0>)
+"test.op"() : () -> (!riscv.freg<ft0>)
+"test.op"() : () -> (!riscv.freg<fj_0>)
+
+//      CHECK:  %0 = "test.op"() : () -> !riscv.reg<a0>
+// CHECK-NEXT:  %1 = "test.op"() : () -> !riscv.reg<j_0>
+// CHECK-NEXT:  %2 = "test.op"() : () -> !riscv.freg<ft0>
+// CHECK-NEXT:  %3 = "test.op"() : () -> !riscv.freg<fj_0>
+
+// -----
+
+// Invalid integer register name
+"test.op"() : () -> (!riscv.reg<ft0>)
+
+//      CHECK:"test.op"() : () -> (!riscv.reg<ft0>)
+// CHECK-NEXT:                                ^^^
+// CHECK-NEXT:                                Invalid register spelling ft0 for class IntRegisterType
+
+// -----
+
+// Invalid float register name
+"test.op"() : () -> (!riscv.freg<a0>)
+
+//      CHECK:"test.op"() : () -> (!riscv.freg<a0>)
+// CHECK-NEXT:                                 ^^
+// CHECK-NEXT:                                 Invalid register spelling a0 for class FloatRegisterType
+
+// -----
+
+// Non-existent integer register name
+"test.op"() : () -> (!riscv.reg<x99>)
+
+//      CHECK:"test.op"() : () -> (!riscv.reg<x99>)
+// CHECK-NEXT:                                ^^^
+// CHECK-NEXT:                                Invalid register spelling x99 for class IntRegisterType
+
+// -----
+
+// Non-existent float register name
+"test.op"() : () -> (!riscv.freg<ft99>)
+
+//      CHECK:"test.op"() : () -> (!riscv.freg<ft99>)
+// CHECK-NEXT:                                 ^^^^
+// CHECK-NEXT:                                 Invalid register spelling ft99 for class FloatRegisterType
+
+// -----
+
+// Integer register with non-integer suffix
+"test.op"() : () -> (!riscv.reg<j_j>)
+
+//      CHECK:"test.op"() : () -> (!riscv.reg<j_j>)
+// CHECK-NEXT:                                ^^^
+// CHECK-NEXT:                                Invalid register spelling j_j for class IntRegisterType
+
+// -----
+
+// Float register with non-integer suffix
+"test.op"() : () -> (!riscv.freg<fj_bla>)
+
+//      CHECK:"test.op"() : () -> (!riscv.freg<fj_bla>)
+// CHECK-NEXT:                                 ^^^^^
+// CHECK-NEXT:                                 Invalid register spelling fj_bla for class FloatRegisterType

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -29,17 +29,37 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     spelling: ParameterDef[StringAttr]
 
     def __init__(self, spelling: str = ""):
-        super().__init__(self._parameters_from_spelling(spelling))
+        params = self._parameters_from_spelling(spelling)
+        if params is None:
+            raise ValueError(
+                f"Invalid register spelling {spelling} for class {type(self).__name__}"
+            )
+        super().__init__(params)
 
     @classmethod
     def _parameters_from_spelling(
         cls, spelling: str
-    ) -> tuple[IntAttr | NoneAttr, StringAttr]:
+    ) -> tuple[IntAttr | NoneAttr, StringAttr] | None:
         """
         Returns the parameter list required to construct a register instance from the given spelling.
         """
+        if not spelling:
+            return NoneAttr(), StringAttr(spelling)
         index = cls.abi_index_by_name().get(spelling)
-        index_attr = NoneAttr() if index is None else IntAttr(index)
+        if index is None:
+            # Try to decode as infinite register
+            prefix = cls.infinite_register_prefix()
+            if spelling.startswith(prefix):
+                suffix = spelling[len(prefix) :]
+                # infinite registers go from -1 to -inf
+                try:
+                    index = ~int(suffix)
+                except ValueError:
+                    return None
+            else:
+                return None
+
+        index_attr = IntAttr(index)
         return index_attr, StringAttr(spelling)
 
     @property
@@ -57,11 +77,21 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     @classmethod
     def parse_parameters(cls, parser: AttrParser) -> Sequence[Attribute]:
         if parser.parse_optional_punctuation("<"):
+            start_pos = parser.pos
             name = parser.parse_identifier()
+            end_pos = parser.pos
             parser.parse_punctuation(">")
+            params = cls._parameters_from_spelling(name)
+            if params is None:
+                parser.raise_error(
+                    f"Invalid register spelling {name} for class {cls.__name__}",
+                    at_position=start_pos,
+                    end_position=end_pos,
+                )
         else:
-            name = ""
-        return cls._parameters_from_spelling(name)
+            params = (StringAttr(""), NoneAttr())
+
+        return params
 
     def print_parameters(self, printer: Printer) -> None:
         if self.spelling.data:
@@ -98,7 +128,8 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
         """
         spelling = cls.infinite_register_prefix() + str(index)
         res = cls(spelling)
-        assert isinstance(res.index, NoneAttr), (
+        assert isinstance(res.index, IntAttr)
+        assert res.index.data < 0, (
             f"Invalid 'infinite' register name: {spelling} clashes with finite register set"
         )
         return res


### PR DESCRIPTION
The overall goal is to be able to track registers when allocating by their indices, instead of an instance. On some platforms, 32-bit registers and 64-bit registers overlap, so the type of the register class does not uniquely identify the space of non-aliasing registers. Even in RISC-V, we already have this problem, as the `x` register names alias with the `a`, `t`, `s`, etc register names.

This PR is a first step in that direction, which lets us uniquely specify an index for the "infinite" register set for each class. Subsequent PRs will actually leverage this index.