### PR TITLE
bug: (x86) memory-to-register mv operation should not take two operands

### DIFF
--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -255,15 +255,14 @@ def test_mr_vops(
 )
 def test_rm_vops(
     OpClass: type[
-        x86.ops.R_RM_Operation[
-            x86.register.X86VectorRegisterType, x86.register.GeneralRegisterType
+        x86.ops.R_M_Operation[
+            x86.register.GeneralRegisterType, x86.register.X86VectorRegisterType
         ]
     ],
     dest: x86.register.X86VectorRegisterType,
     src: x86.register.GeneralRegisterType,
 ):
     input = x86.ops.GetRegisterOp(src)
-    output = x86.ops.GetAVXRegisterOp(dest)
-    op = OpClass(r1=output, r2=input, result=dest, offset=IntegerAttr(0, 64))
-    assert op.r1.type == dest
-    assert op.r2.type == src
+    op = OpClass(r1=input, result=dest, offset=IntegerAttr(0, 64))
+    assert op.r1.type == src
+    assert op.result.type == dest

--- a/tests/filecheck/backend/x86/convert_func_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_func_to_x86.mlir
@@ -19,22 +19,20 @@ func.func @foo_int(%0: i32, %1: i32, %2: i32, %3: i32, %4: i32, %5: i32, %6: i32
 // CHECK-NEXT:      %10 = builtin.unrealized_conversion_cast %3 : !x86.reg<rcx> to i32
 // CHECK-NEXT:      %11 = builtin.unrealized_conversion_cast %4 : !x86.reg<r8> to i32
 // CHECK-NEXT:      %12 = builtin.unrealized_conversion_cast %5 : !x86.reg<r9> to i32
-// CHECK-NEXT:      %13 = x86.get_register : () -> !x86.reg
-// CHECK-NEXT:      %14 = x86.rm.mov %13, %6, 8 {comment = "Load the 7th argument of the function"} : (!x86.reg, !x86.reg<rsp>) -> !x86.reg
-// CHECK-NEXT:      %15 = builtin.unrealized_conversion_cast %14 : !x86.reg to i32
-// CHECK-NEXT:      %16 = x86.get_register : () -> !x86.reg
-// CHECK-NEXT:      %17 = x86.rm.mov %16, %6, 16 {comment = "Load the 8th argument of the function"} : (!x86.reg, !x86.reg<rsp>) -> !x86.reg
-// CHECK-NEXT:      %18 = builtin.unrealized_conversion_cast %17 : !x86.reg to i32
+// CHECK-NEXT:      %13 = x86.rm.mov %6, 8 {comment = "Load the 7th argument of the function"} : (!x86.reg<rsp>) -> !x86.reg
+// CHECK-NEXT:      %14 = builtin.unrealized_conversion_cast %13 : !x86.reg to i32
+// CHECK-NEXT:      %15 = x86.rm.mov %6, 16 {comment = "Load the 8th argument of the function"} : (!x86.reg<rsp>) -> !x86.reg
+// CHECK-NEXT:      %16 = builtin.unrealized_conversion_cast %15 : !x86.reg to i32
 // CHECK-NEXT:      %a = "test.op"(%7, %8) : (i32, i32) -> i32
 // CHECK-NEXT:      %b = "test.op"(%a, %9) : (i32, i32) -> i32
 // CHECK-NEXT:      %c = "test.op"(%b, %10) : (i32, i32) -> i32
 // CHECK-NEXT:      %d = "test.op"(%c, %11) : (i32, i32) -> i32
 // CHECK-NEXT:      %e = "test.op"(%d, %12) : (i32, i32) -> i32
-// CHECK-NEXT:      %f = "test.op"(%e, %15) : (i32, i32) -> i32
-// CHECK-NEXT:      %g = "test.op"(%f, %18) : (i32, i32) -> i32
-// CHECK-NEXT:      %19 = builtin.unrealized_conversion_cast %g : i32 to !x86.reg
-// CHECK-NEXT:      %20 = x86.get_register : () -> !x86.reg<rax>
-// CHECK-NEXT:      %21 = x86.rr.mov %19, %20 : (!x86.reg, !x86.reg<rax>) -> !x86.reg<rax>
+// CHECK-NEXT:      %f = "test.op"(%e, %14) : (i32, i32) -> i32
+// CHECK-NEXT:      %g = "test.op"(%f, %16) : (i32, i32) -> i32
+// CHECK-NEXT:      %17 = builtin.unrealized_conversion_cast %g : i32 to !x86.reg
+// CHECK-NEXT:      %18 = x86.get_register : () -> !x86.reg<rax>
+// CHECK-NEXT:      %19 = x86.rr.mov %17, %18 : (!x86.reg, !x86.reg<rax>) -> !x86.reg<rax>
 // CHECK-NEXT:      x86_func.ret
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -55,7 +55,7 @@
 // CHECK-NEXT: or rax, [rdx+8]
 %rm_xor = x86.rm.xor %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK-NEXT: xor rax, [rdx+8]
-%rm_mov = x86.rm.mov %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%rm_mov = x86.rm.mov %1, 8 : (!x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK-NEXT: mov rax, [rdx+8]
 %rm_cmp = x86.rm.cmp %0, %1, 8 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.rflags<rflags>
 // CHECK-NEXT: cmp rax, [rdx+8]
@@ -338,9 +338,9 @@ x86.mr.vmovapd %0, %xmm1, 0 : (!x86.reg<rax>, !x86.ssereg<xmm1>) -> ()
 // CHECK-NEXT: vmovapd [rax], xmm1
 x86.mr.vmovapd %0, %xmm1, 8 : (!x86.reg<rax>, !x86.ssereg<xmm1>) -> ()
 // CHECK-NEXT: vmovapd [rax+8], xmm1
-%rm_vbroadcastsd_sse0 = x86.rm.vbroadcastsd %xmm0, %1, 0 : (!x86.ssereg<xmm0>, !x86.reg<rdx>) -> !x86.ssereg<xmm0>
+%rm_vbroadcastsd_sse0 = x86.rm.vbroadcastsd %1, 0 : (!x86.reg<rdx>) -> !x86.ssereg<xmm0>
 // CHECK-NEXT: vbroadcastsd xmm0, [rdx]
-%rm_vbroadcastsd_sse = x86.rm.vbroadcastsd %xmm0, %1, 8 : (!x86.ssereg<xmm0>, !x86.reg<rdx>) -> !x86.ssereg<xmm0>
+%rm_vbroadcastsd_sse = x86.rm.vbroadcastsd %1, 8 : (!x86.reg<rdx>) -> !x86.ssereg<xmm0>
 // CHECK-NEXT: vbroadcastsd xmm0, [rdx+8]
 
 %ymm0 = x86.get_avx_register : () -> !x86.avx2reg<ymm0>
@@ -353,9 +353,9 @@ x86.mr.vmovapd %0, %xmm1, 8 : (!x86.reg<rax>, !x86.ssereg<xmm1>) -> ()
 // CHECK-NEXT: vmovapd ymm0, ymm1
 x86.mr.vmovapd %0, %ymm1, 8 : (!x86.reg<rax>, !x86.avx2reg<ymm1>) -> ()
 // CHECK-NEXT: vmovapd [rax+8], ymm1
-%rm_vbroadcastsd_avx20 = x86.rm.vbroadcastsd %ymm0, %1, 0 : (!x86.avx2reg<ymm0>, !x86.reg<rdx>) -> !x86.avx2reg<ymm0>
+%rm_vbroadcastsd_avx20 = x86.rm.vbroadcastsd %1, 0 : (!x86.reg<rdx>) -> !x86.avx2reg<ymm0>
 // CHECK-NEXT: vbroadcastsd ymm0, [rdx]
-%rm_vbroadcastsd_avx2 = x86.rm.vbroadcastsd %ymm0, %1, 8 : (!x86.avx2reg<ymm0>, !x86.reg<rdx>) -> !x86.avx2reg<ymm0>
+%rm_vbroadcastsd_avx2 = x86.rm.vbroadcastsd %1, 8 : (!x86.reg<rdx>) -> !x86.avx2reg<ymm0>
 // CHECK-NEXT: vbroadcastsd ymm0, [rdx+8]
 
 %zmm0 = x86.get_avx_register : () -> !x86.avx512reg<zmm0>
@@ -370,23 +370,23 @@ x86.mr.vmovapd %0, %zmm1, 0 : (!x86.reg<rax>, !x86.avx512reg<zmm1>) -> ()
 // CHECK-NEXT: vmovapd [rax], zmm1
 x86.mr.vmovapd %0, %zmm1, 8 : (!x86.reg<rax>, !x86.avx512reg<zmm1>) -> ()
 // CHECK-NEXT: vmovapd [rax+8], zmm1
-%rm_vbroadcastsd_avx5120 = x86.rm.vbroadcastsd %zmm0, %1, 0 : (!x86.avx512reg<zmm0>, !x86.reg<rdx>) -> !x86.avx512reg<zmm0>
+%rm_vbroadcastsd_avx5120 = x86.rm.vbroadcastsd %1, 0 : (!x86.reg<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK-NEXT: vbroadcastsd zmm0, [rdx]
-%rm_vbroadcastsd_avx512 = x86.rm.vbroadcastsd %zmm0, %1, 8 : (!x86.avx512reg<zmm0>, !x86.reg<rdx>) -> !x86.avx512reg<zmm0>
+%rm_vbroadcastsd_avx512 = x86.rm.vbroadcastsd %1, 8 : (!x86.reg<rdx>) -> !x86.avx512reg<zmm0>
 // CHECK-NEXT: vbroadcastsd zmm0, [rdx+8]
 
-%rm_vmovups_avx512 = x86.rm.vmovups %zmm0, %1 : (!x86.avx512reg<zmm0>, !x86.reg<rdx>) -> (!x86.avx512reg<zmm0>)
+%rm_vmovups_avx512 = x86.rm.vmovups %1 : (!x86.reg<rdx>) -> (!x86.avx512reg<zmm0>)
 // CHECK: vmovups zmm0, [rdx]
-%rm_vmovups_avx2 = x86.rm.vmovups %ymm0, %1 : (!x86.avx2reg<ymm0>, !x86.reg<rdx>) -> (!x86.avx2reg<ymm0>)
+%rm_vmovups_avx2 = x86.rm.vmovups %1 : (!x86.reg<rdx>) -> (!x86.avx2reg<ymm0>)
 // CHECK-NEXT: vmovups ymm0, [rdx]
-%rm_vmovups_sse = x86.rm.vmovups %xmm0, %1 : (!x86.ssereg<xmm0>, !x86.reg<rdx>) -> (!x86.ssereg<xmm0>)
+%rm_vmovups_sse = x86.rm.vmovups %1 : (!x86.reg<rdx>) -> (!x86.ssereg<xmm0>)
 // CHECK-NEXT: vmovups xmm0, [rdx]
 
-%rm_vbroadcastss_avx512 = x86.rm.vbroadcastss %zmm0, %1 : (!x86.avx512reg<zmm0>, !x86.reg<rdx>) -> (!x86.avx512reg<zmm0>)
+%rm_vbroadcastss_avx512 = x86.rm.vbroadcastss %1 : (!x86.reg<rdx>) -> (!x86.avx512reg<zmm0>)
 // CHECK: vbroadcastss zmm0, [rdx]
-%rm_vbroadcastss_avx2 = x86.rm.vbroadcastss %ymm0, %1 : (!x86.avx2reg<ymm0>, !x86.reg<rdx>) -> (!x86.avx2reg<ymm0>)
+%rm_vbroadcastss_avx2 = x86.rm.vbroadcastss %1 : (!x86.reg<rdx>) -> (!x86.avx2reg<ymm0>)
 // CHECK-NEXT: vbroadcastss ymm0, [rdx]
-%rm_vbroadcastss_sse = x86.rm.vbroadcastss %xmm0, %1 : (!x86.ssereg<xmm0>, !x86.reg<rdx>) -> (!x86.ssereg<xmm0>)
+%rm_vbroadcastss_sse = x86.rm.vbroadcastss %1 : (!x86.reg<rdx>) -> (!x86.ssereg<xmm0>)
 // CHECK-NEXT: vbroadcastss xmm0, [rdx]
 
 x86.mr.vmovups %0, %zmm1, 0 : (!x86.reg<rax>, !x86.avx512reg<zmm1>) -> ()

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -56,8 +56,8 @@
 // CHECK-NEXT: %{{.*}} = x86.rm.or %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
 %rm_xor = x86.rm.xor %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
 // CHECK-NEXT: %{{.*}} = x86.rm.xor %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
-%rm_mov = x86.rm.mov %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
-// CHECK-NEXT: %{{.*}} = x86.rm.mov %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.reg
+%rm_mov = x86.rm.mov %1, 8 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rm.mov %{{.*}}, 8 : (!x86.reg) -> !x86.reg
 %rm_cmp = x86.rm.cmp %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.rflags<rflags>
 // CHECK-NEXT: %{{.*}} = x86.rm.cmp %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.reg) -> !x86.rflags
 %rm_lea = x86.rm.lea %0, %1, 8 : (!x86.reg, !x86.reg) -> !x86.reg
@@ -355,8 +355,8 @@ func.func @funcyasm() {
 // CHECK-NEXT: x86.rr.vmovapd %{{.*}}, %{{.*}} : (!x86.ssereg, !x86.ssereg) -> !x86.ssereg
 x86.mr.vmovapd %0, %xmm1, 8 : (!x86.reg, !x86.ssereg) -> ()
 // CHECK-NEXT: x86.mr.vmovapd %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.ssereg) -> ()
-%rm_vbroadcastsd_sse = x86.rm.vbroadcastsd %xmm1, %0, 8 : (!x86.ssereg, !x86.reg) -> !x86.ssereg
-// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, %{{.*}}, 8 : (!x86.ssereg, !x86.reg) -> !x86.ssereg
+%rm_vbroadcastsd_sse = x86.rm.vbroadcastsd %0, 8 : (!x86.reg) -> !x86.ssereg
+// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, 8 : (!x86.reg) -> !x86.ssereg
 
 %ymm0, %ymm1, %ymm2 = "test.op"() : () -> (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg)
 
@@ -366,8 +366,8 @@ x86.mr.vmovapd %0, %xmm1, 8 : (!x86.reg, !x86.ssereg) -> ()
 // CHECK-NEXT: x86.rr.vmovapd %{{.*}}, %{{.*}} : (!x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
 x86.mr.vmovapd %0, %ymm1, 8 : (!x86.reg, !x86.avx2reg) -> ()
 // CHECK-NEXT: x86.mr.vmovapd %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.avx2reg) -> ()
-%rm_vbroadcastsd_avx2 = x86.rm.vbroadcastsd %ymm1, %0, 8 : (!x86.avx2reg, !x86.reg) -> !x86.avx2reg
-// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, %{{.*}}, 8 : (!x86.avx2reg, !x86.reg) -> !x86.avx2reg
+%rm_vbroadcastsd_avx2 = x86.rm.vbroadcastsd %0, 8 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, 8 : (!x86.reg) -> !x86.avx2reg
 
 %zmm0, %zmm1, %zmm2 = "test.op"() : () -> (!x86.avx512reg, !x86.avx512reg, !x86.avx512reg)
 
@@ -377,22 +377,22 @@ x86.mr.vmovapd %0, %ymm1, 8 : (!x86.reg, !x86.avx2reg) -> ()
 // CHECK-NEXT: x86.rr.vmovapd %{{.*}}, %{{.*}} : (!x86.avx512reg, !x86.avx512reg) -> !x86.avx512reg
 x86.mr.vmovapd %0, %zmm1, 8 : (!x86.reg, !x86.avx512reg) -> ()
 // CHECK-NEXT: x86.mr.vmovapd %{{.*}}, %{{.*}}, 8 : (!x86.reg, !x86.avx512reg) -> ()
-%rm_vbroadcastsd_avx512 = x86.rm.vbroadcastsd %zmm1, %0, 8 : (!x86.avx512reg, !x86.reg) -> !x86.avx512reg
-// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, %{{.*}}, 8 : (!x86.avx512reg, !x86.reg) -> !x86.avx512reg
+%rm_vbroadcastsd_avx512 = x86.rm.vbroadcastsd %0, 8 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastsd %{{.*}}, 8 : (!x86.reg) -> !x86.avx512reg
 
-%rm_vmovups_avx512 = x86.rm.vmovups %zmm0, %1, 8 : (!x86.avx512reg, !x86.reg) -> (!x86.avx512reg)
-// CHECK: %{{.*}} = x86.rm.vmovups %{{.*}}, %{{.*}}, 8 : (!x86.avx512reg, !x86.reg) -> !x86.avx512reg
-%rm_vmovups_avx2 = x86.rm.vmovups %ymm0, %1, 8 : (!x86.avx2reg, !x86.reg) -> (!x86.avx2reg)
-// CHECK-NEXT: %{{.*}} = x86.rm.vmovups %{{.*}}, %{{.*}}, 8 : (!x86.avx2reg, !x86.reg) -> !x86.avx2reg
-%rm_vmovups_sse = x86.rm.vmovups %xmm0, %1, 8 : (!x86.ssereg, !x86.reg) -> (!x86.ssereg)
-// CHECK-NEXT: %{{.*}} = x86.rm.vmovups %{{.*}}, %{{.*}}, 8 : (!x86.ssereg, !x86.reg) -> !x86.ssereg
+%rm_vmovups_avx512 = x86.rm.vmovups %1, 8 : (!x86.reg) -> (!x86.avx512reg)
+// CHECK: %{{.*}} = x86.rm.vmovups %{{.*}}, 8 : (!x86.reg) -> !x86.avx512reg
+%rm_vmovups_avx2 = x86.rm.vmovups %1, 8 : (!x86.reg) -> (!x86.avx2reg)
+// CHECK-NEXT: %{{.*}} = x86.rm.vmovups %{{.*}}, 8 : (!x86.reg) -> !x86.avx2reg
+%rm_vmovups_sse = x86.rm.vmovups %1, 8 : (!x86.reg) -> (!x86.ssereg)
+// CHECK-NEXT: %{{.*}} = x86.rm.vmovups %{{.*}}, 8 : (!x86.reg) -> !x86.ssereg
 
-%rm_vbroadcastss_avx512 = x86.rm.vbroadcastss %zmm0, %1, 8 : (!x86.avx512reg, !x86.reg) -> (!x86.avx512reg)
-// CHECK: %{{.*}} = x86.rm.vbroadcastss %{{.*}}, %{{.*}}, 8 : (!x86.avx512reg, !x86.reg) -> !x86.avx512reg
-%rm_vbroadcastss_avx2 = x86.rm.vbroadcastss %ymm0, %1, 8 : (!x86.avx2reg, !x86.reg) -> (!x86.avx2reg)
-// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastss %{{.*}}, %{{.*}}, 8 : (!x86.avx2reg, !x86.reg) -> !x86.avx2reg
-%rm_vbroadcastss_sse = x86.rm.vbroadcastss %xmm0, %1, 8 : (!x86.ssereg, !x86.reg) -> (!x86.ssereg)
-// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastss %{{.*}}, %{{.*}}, 8 : (!x86.ssereg, !x86.reg) -> !x86.ssereg
+%rm_vbroadcastss_avx512 = x86.rm.vbroadcastss %1, 8 : (!x86.reg) -> (!x86.avx512reg)
+// CHECK: %{{.*}} = x86.rm.vbroadcastss %{{.*}}, 8 : (!x86.reg) -> !x86.avx512reg
+%rm_vbroadcastss_avx2 = x86.rm.vbroadcastss %1, 8 : (!x86.reg) -> (!x86.avx2reg)
+// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastss %{{.*}}, 8 : (!x86.reg) -> !x86.avx2reg
+%rm_vbroadcastss_sse = x86.rm.vbroadcastss %1, 8 : (!x86.reg) -> (!x86.ssereg)
+// CHECK-NEXT: %{{.*}} = x86.rm.vbroadcastss %{{.*}}, 8 : (!x86.reg) -> !x86.ssereg
 
 x86.mr.vmovups %0, %zmm1, 0 : (!x86.reg, !x86.avx512reg) -> ()
 // CHECK: x86.mr.vmovups %{{.*}}, %{{.*}} : (!x86.reg, !x86.avx512reg) -> ()

--- a/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
+++ b/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
@@ -1,59 +1,40 @@
 // RUN: xdsl-opt -t x86-asm %s | filecheck %s
 
 // C: 4x4xf32 = A: 4x8xf32 * B: 8x4xf32
-x86_func.func @matmul() {
-    // General registers loading; according to the x86 calling
-    // conventions, rdi, rsi and rcx always contain the first
-    // three parameters of a function
-    %rdi = x86.get_register : () -> !x86.reg<rdi>
-    %rsi = x86.get_register : () -> !x86.reg<rsi>
-    %rcx = x86.get_register : () -> !x86.reg<rcx>
-    // Vector registers loading
-    %ymm0 = x86.get_avx_register : () -> !x86.avx2reg<ymm0>
-    %ymm1 = x86.get_avx_register : () -> !x86.avx2reg<ymm1>
-    %ymm2 = x86.get_avx_register : () -> !x86.avx2reg<ymm2>
-    %ymm3 = x86.get_avx_register : () -> !x86.avx2reg<ymm3>
-    %ymm4 = x86.get_avx_register : () -> !x86.avx2reg<ymm4>
-    %ymm5 = x86.get_avx_register : () -> !x86.avx2reg<ymm5>
-    %ymm6 = x86.get_avx_register : () -> !x86.avx2reg<ymm6>
-    %ymm7 = x86.get_avx_register : () -> !x86.avx2reg<ymm7>
-    %ymm8 = x86.get_avx_register : () -> !x86.avx2reg<ymm8>
-    %ymm9 = x86.get_avx_register : () -> !x86.avx2reg<ymm9>
-    %ymm10 = x86.get_avx_register : () -> !x86.avx2reg<ymm10>
-    %ymm11 = x86.get_avx_register : () -> !x86.avx2reg<ymm11>
+x86_func.func @matmul(%rdi: !x86.reg<rdi>, %rsi: !x86.reg<rsi>, %rcx: !x86.reg<rcx>) {
     // Load rows of A
-    %a_row_0 = x86.rm.vmovups %ymm0, %rdi, 0 : (!x86.avx2reg<ymm0>, !x86.reg<rdi>) -> (!x86.avx2reg<ymm0>)
-    %a_row_1 = x86.rm.vmovups %ymm1, %rdi, 32 : (!x86.avx2reg<ymm1>, !x86.reg<rdi>) -> (!x86.avx2reg<ymm1>)
-    %a_row_2 = x86.rm.vmovups %ymm2, %rdi, 64 : (!x86.avx2reg<ymm2>, !x86.reg<rdi>) -> (!x86.avx2reg<ymm2>)
-    %a_row_3 = x86.rm.vmovups %ymm3, %rdi, 96 : (!x86.avx2reg<ymm3>, !x86.reg<rdi>) -> (!x86.avx2reg<ymm3>)
+    %a_row_0 = x86.rm.vmovups %rdi, 0 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm0>)
+    %a_row_1 = x86.rm.vmovups %rdi, 32 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm1>)
+    %a_row_2 = x86.rm.vmovups %rdi, 64 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm2>)
+    %a_row_3 = x86.rm.vmovups %rdi, 96 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm3>)
     // Initialize the accumulators (rows of C)
-    %c0_tmp0 = x86.rm.vmovups %ymm4, %rcx, 0 : (!x86.avx2reg<ymm4>, !x86.reg<rcx>) -> !x86.avx2reg<ymm4>
-    %c1_tmp0 = x86.rm.vmovups %ymm5, %rcx, 32 : (!x86.avx2reg<ymm5>, !x86.reg<rcx>) -> !x86.avx2reg<ymm5>
-    %c2_tmp0 = x86.rm.vmovups %ymm6, %rcx, 64 : (!x86.avx2reg<ymm6>, !x86.reg<rcx>) -> !x86.avx2reg<ymm6>
-    %c3_tmp0 = x86.rm.vmovups %ymm7, %rcx, 96 : (!x86.avx2reg<ymm7>, !x86.reg<rcx>) -> !x86.avx2reg<ymm7>
+    %c0_tmp0 = x86.rm.vmovups %rcx, 0 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm4>
+    %c1_tmp0 = x86.rm.vmovups %rcx, 32 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm5>
+    %c2_tmp0 = x86.rm.vmovups %rcx, 64 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm6>
+    %c3_tmp0 = x86.rm.vmovups %rcx, 96 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm7>
     // Load column 0 of B
-    %b_col_0 = x86.rm.vbroadcastss %ymm8, %rsi, 0 : (!x86.avx2reg<ymm8>, !x86.reg<rsi>) -> !x86.avx2reg<ymm8>
+    %b_col_0 = x86.rm.vbroadcastss %rsi, 0 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm8>
     // Reduction
     %c0_tmp1 = x86.rrr.vfmadd231ps %c0_tmp0, %b_col_0, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
     %c1_tmp1 = x86.rrr.vfmadd231ps %c1_tmp0, %b_col_0, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
     %c2_tmp1 = x86.rrr.vfmadd231ps %c2_tmp0, %b_col_0, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
     %c3_tmp1 = x86.rrr.vfmadd231ps %c3_tmp0, %b_col_0, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
     // Load column 1 of B
-    %b_col_1 = x86.rm.vbroadcastss %ymm9, %rsi, 4 : (!x86.avx2reg<ymm9>, !x86.reg<rsi>) -> !x86.avx2reg<ymm9>
+    %b_col_1 = x86.rm.vbroadcastss %rsi, 4 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm9>
     // Reduction
     %c0_tmp2 = x86.rrr.vfmadd231ps %c0_tmp1, %b_col_1, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
     %c1_tmp2 = x86.rrr.vfmadd231ps %c1_tmp1, %b_col_1, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
     %c2_tmp2 = x86.rrr.vfmadd231ps %c2_tmp1, %b_col_1, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
     %c3_tmp2 = x86.rrr.vfmadd231ps %c3_tmp1, %b_col_1, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
     // Load column 2 of B
-    %b_col_2 = x86.rm.vbroadcastss %ymm10, %rsi, 8 : (!x86.avx2reg<ymm10>, !x86.reg<rsi>) -> !x86.avx2reg<ymm10>
+    %b_col_2 = x86.rm.vbroadcastss %rsi, 8 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm10>
     // Reduction
     %c0_tmp3 = x86.rrr.vfmadd231ps %c0_tmp2, %b_col_2, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
     %c1_tmp3 = x86.rrr.vfmadd231ps %c1_tmp2, %b_col_2, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
     %c2_tmp3 = x86.rrr.vfmadd231ps %c2_tmp2, %b_col_2, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
     %c3_tmp3 = x86.rrr.vfmadd231ps %c3_tmp2, %b_col_2, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
     // Load column 3 of B
-    %b_col_3 = x86.rm.vbroadcastss %ymm11, %rsi, 12 : (!x86.avx2reg<ymm11>, !x86.reg<rsi>) -> !x86.avx2reg<ymm11>
+    %b_col_3 = x86.rm.vbroadcastss %rsi, 12 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm11>
     // Reduction
     %c0 = x86.rrr.vfmadd231ps %c0_tmp3, %b_col_3, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
     %c1 = x86.rrr.vfmadd231ps %c1_tmp3, %b_col_3, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>

--- a/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
+++ b/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
@@ -87,10 +87,8 @@ class LowerFuncOp(RewritePattern):
         for i in range(num_inputs - MAX_REG_PASSING_INPUTS):
             arg = first_block.args[MAX_REG_PASSING_INPUTS + 1]
             assert sp != arg
-            get_reg_op = x86.ops.GetRegisterOp(x86.register.GeneralRegisterType(""))
             mov_op = x86.RM_MovOp(
-                r1=get_reg_op.result,
-                r2=sp,
+                r1=sp,
                 offset=STACK_SLOT_SIZE_BYTES * (i + 1),
                 result=x86.register.GeneralRegisterType(""),
                 comment=f"Load the {i + MAX_REG_PASSING_INPUTS + 1}th argument of the function",
@@ -98,7 +96,7 @@ class LowerFuncOp(RewritePattern):
             cast_op = builtin.UnrealizedConversionCastOp.get(
                 (mov_op.result,), (arg.type,)
             )
-            rewriter.insert_op([get_reg_op, mov_op, cast_op], insertion_point)
+            rewriter.insert_op([mov_op, cast_op], insertion_point)
             arg.replace_by(cast_op.results[0])
             first_block.erase_arg(arg)
 

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -743,9 +743,9 @@ class RM_XorOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
 @irdl_op_definition
 class RM_MovOp(R_M_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
-    Copies the value from the memory location pointed to by source register into destination register.
+    Copies the value from the memory location pointed to by source register r1 into destination register r2.
     ```C
-    x[output] = [x[operand]]
+    x[r2] = [x[r1]]
     ```
     https://www.felixcloutier.com/x86/mov
     """

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -743,7 +743,7 @@ class RM_XorOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
 @irdl_op_definition
 class RM_MovOp(R_M_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
-    Copies the value from the memory location pointed to by operand register into output register.
+    Copies the value from the memory location pointed to by source register into destination register.
     ```C
     x[output] = [x[operand]]
     ```


### PR DESCRIPTION
Addresses [this issue](https://github.com/xdslproject/xdsl/issues/3937)