### PR TITLE
backend: (riscv) make rd unallocated by default

### DIFF
--- a/tests/backend/riscv/test_preallocated.py
+++ b/tests/backend/riscv/test_preallocated.py
@@ -11,7 +11,7 @@ def test_gather_allocated():
         reg2 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(reg2).res
-        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
+        _ = riscv.AddOp(v1, v2).rd
 
     pa_regs = gather_allocated(riscv_func.FuncOp("foo", no_preallocated_body, ((), ())))
 
@@ -22,7 +22,7 @@ def test_gather_allocated():
         reg1 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        _ = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
+        _ = riscv.AddOp(v1, v2).rd
 
     pa_regs = gather_allocated(
         riscv_func.FuncOp("foo", one_preallocated_body, ((), ()))
@@ -35,7 +35,7 @@ def test_gather_allocated():
         reg1 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
+        sum1 = riscv.AddOp(v1, v2).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A7).rd
 
     pa_regs = gather_allocated(
@@ -49,7 +49,7 @@ def test_gather_allocated():
         reg1 = riscv.IntRegisterType()
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
-        sum1 = riscv.AddOp(v1, v2, rd=riscv.IntRegisterType()).rd
+        sum1 = riscv.AddOp(v1, v2).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A6).rd
 
     pa_regs = gather_allocated(

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -231,11 +231,11 @@ def test_float_register():
     a1 = TestSSAValue(riscv.Registers.A1)
     a2 = TestSSAValue(riscv.Registers.A2)
     with pytest.raises(VerifyException, match="Operation does not verify"):
-        riscv.FAddSOp(a1, a2, rd=riscv.FloatRegisterType()).verify()
+        riscv.FAddSOp(a1, a2).verify()
 
     f1 = TestSSAValue(riscv.Registers.FT0)
     f2 = TestSSAValue(riscv.Registers.FT1)
-    riscv.FAddSOp(f1, f2, rd=riscv.FloatRegisterType()).verify()
+    riscv.FAddSOp(f1, f2).verify()
 
 
 def test_riscv_parse_immediate_value():

--- a/tests/interpreters/test_riscv_emulator.py
+++ b/tests/interpreters/test_riscv_emulator.py
@@ -28,7 +28,7 @@ def test_simple():
         def body():
             six = riscv.LiOp(6).rd
             seven = riscv.LiOp(7).rd
-            forty_two = riscv.MulOp(six, seven, rd=riscv.IntRegisterType()).rd
+            forty_two = riscv.MulOp(six, seven).rd
             riscv_debug.PrintfOp("{}", (forty_two,))
             riscv.ReturnOp()
 

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -61,10 +61,7 @@ def test_riscv_interpreter():
     assert interpreter.run_op(riscv.LiOp("label1"), ()) == (
         TypedPtr.new_int32((59,)).raw,
     )
-    assert interpreter.run_op(
-        riscv.MVOp(TestSSAValue(register), rd=riscv.IntRegisterType()),
-        (42,),
-    ) == (42,)
+    assert interpreter.run_op(riscv.MVOp(TestSSAValue(register)), (42,)) == (42,)
 
     assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), 5), (0,)) == (1,)
     assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), 5), (10,)) == (0,)
@@ -75,20 +72,12 @@ def test_riscv_interpreter():
     assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), -10), (5,)) == (1,)
 
     assert interpreter.run_op(
-        riscv.AddOp(
-            TestSSAValue(register),
-            TestSSAValue(register),
-            rd=riscv.IntRegisterType(),
-        ),
+        riscv.AddOp(TestSSAValue(register), TestSSAValue(register)),
         (1, 2),
     ) == (3,)
 
     assert interpreter.run_op(
-        riscv.AddiOp(
-            TestSSAValue(register),
-            2,
-            rd=riscv.IntRegisterType(),
-        ),
+        riscv.AddiOp(TestSSAValue(register), 2),
         (1,),
     ) == (3,)
 
@@ -96,7 +85,6 @@ def test_riscv_interpreter():
         riscv.SubOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType(),
         ),
         (1, 2),
     ) == (-1,)
@@ -105,7 +93,6 @@ def test_riscv_interpreter():
         riscv.SllOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType(),
         ),
         (3, 2),
     ) == (12,)
@@ -114,7 +101,6 @@ def test_riscv_interpreter():
         riscv.MulOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType(),
         ),
         (2, 3),
     ) == (6,)
@@ -123,7 +109,6 @@ def test_riscv_interpreter():
         riscv.DivOp(
             TestSSAValue(register),
             TestSSAValue(register),
-            rd=riscv.IntRegisterType(),
         ),
         (6, 3),
     ) == (2,)
@@ -168,7 +153,6 @@ def test_riscv_interpreter():
         riscv.FMulSOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (12.0,)
@@ -180,7 +164,6 @@ def test_riscv_interpreter():
             TestSSAValue(fregister),
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0, 5.0),
     ) == (17.0,)
@@ -189,7 +172,6 @@ def test_riscv_interpreter():
         riscv.FAddDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (7.0,)
@@ -198,7 +180,6 @@ def test_riscv_interpreter():
         riscv.FSubDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (-1.0,)
@@ -207,7 +188,6 @@ def test_riscv_interpreter():
         riscv.FMulDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (12.0,)
@@ -216,7 +196,6 @@ def test_riscv_interpreter():
         riscv.FDivDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (3.0, 4.0),
     ) == (0.75,)
@@ -225,7 +204,6 @@ def test_riscv_interpreter():
         riscv.FMinDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (1, 2),
     ) == (1,)
@@ -234,13 +212,12 @@ def test_riscv_interpreter():
         riscv.FMaxDOp(
             TestSSAValue(fregister),
             TestSSAValue(fregister),
-            rd=riscv.FloatRegisterType(),
         ),
         (1, 2),
     ) == (2,)
 
     assert interpreter.run_op(
-        riscv.FMVOp(TestSSAValue(register), rd=riscv.FloatRegisterType()),
+        riscv.FMVOp(TestSSAValue(register)),
         (42.0,),
     ) == (42.0,)
 
@@ -248,7 +225,7 @@ def test_riscv_interpreter():
     # the top line is the one that should pass, the other is the same as riscemu
     # assert interpreter.run_op(riscv.FMvWXOp(TestSSAValue(fregister)), (3,)) == (3.0,)
     assert interpreter.run_op(
-        riscv.FMvWXOp(TestSSAValue(fregister), rd=riscv.FloatRegisterType()),
+        riscv.FMvWXOp(TestSSAValue(fregister)),
         (convert_f32_to_u32(3.0),),
     ) == (3.0,)
 
@@ -287,7 +264,7 @@ def test_riscv_interpreter():
     ) == (5.0,)
 
     assert interpreter.run_op(
-        riscv.FCvtDWOp(TestSSAValue(register), rd=riscv.FloatRegisterType()),
+        riscv.FCvtDWOp(TestSSAValue(register)),
         (42,),
     ) == (42.0,)
 

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -36,7 +36,7 @@ def sum_to_for_op():
         @Builder.implicit_region((register, register))
         def for_loop_region(args: tuple[BlockArgument, ...]):
             (i, acc) = args
-            res = riscv.AddOp(i, acc, rd=riscv.IntRegisterType())
+            res = riscv.AddOp(i, acc)
             riscv_scf.YieldOp(res)
 
         result = riscv_scf.ForOp(lb, ub, step, (initial,), for_loop_region)
@@ -66,14 +66,14 @@ def sum_to_while_op():
         @Builder.implicit_region((register, register, register, register))
         def before_region(args: tuple[BlockArgument, ...]):
             (acc0, i0, ub0, step0) = args
-            cond = riscv.SltOp(i0, ub0, rd=riscv.IntRegisterType()).rd
+            cond = riscv.SltOp(i0, ub0).rd
             riscv_scf.ConditionOp(cond, acc0, i0, ub0, step0)
 
         @Builder.implicit_region((register, register, register, register))
         def after_region(args: tuple[BlockArgument, ...]):
             (acc1, i1, ub1, step1) = args
-            res = riscv.AddOp(i1, acc1, rd=riscv.IntRegisterType()).rd
-            i2 = riscv.AddOp(i1, step1, rd=riscv.IntRegisterType()).rd
+            res = riscv.AddOp(i1, acc1).rd
+            i2 = riscv.AddOp(i1, step1).rd
             riscv_scf.YieldOp(res, i2, ub1, step1)
 
         result, *_ = riscv_scf.WhileOp(

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -124,11 +124,7 @@ def get_strided_pointer(
                 ops.extend(
                     (
                         stride_op := riscv.LiOp(stride),
-                        offset_op := riscv.MulOp(
-                            increment,
-                            stride_op.rd,
-                            rd=riscv.IntRegisterType(),
-                        ),
+                        offset_op := riscv.MulOp(increment, stride_op.rd),
                     )
                 )
                 stride_op.rd.name_hint = "pointer_dim_stride"
@@ -141,7 +137,7 @@ def get_strided_pointer(
             continue
 
         # Otherwise sum up the products.
-        ops.append(add_op := riscv.AddOp(head, increment, rd=riscv.IntRegisterType()))
+        ops.append(add_op := riscv.AddOp(head, increment))
         add_op.rd.name_hint = "pointer_offset"
         head = add_op.rd
 
@@ -154,10 +150,9 @@ def get_strided_pointer(
             offset_bytes := riscv.MulOp(
                 head,
                 bytes_per_element_op.rd,
-                rd=riscv.IntRegisterType(),
                 comment="multiply by element size",
             ),
-            ptr := riscv.AddOp(src_ptr, offset_bytes, rd=riscv.IntRegisterType()),
+            ptr := riscv.AddOp(src_ptr, offset_bytes),
         ]
     )
 

--- a/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
+++ b/xdsl/backend/riscv/lowering/convert_snitch_stream_to_snitch.py
@@ -82,15 +82,13 @@ def insert_stride_pattern_ops(
         *interleaved_b_set_bound_ops,
         *s_ops,
         snitch.SsrSetDimensionStrideOp(s_ops[0], dm, ints[0]),
-        a_op := riscv.LiOp(0, rd=riscv.IntRegisterType()),
+        a_op := riscv.LiOp(0),
     ]
 
     for i in range(1, rank):
-        a_inc_op = riscv.MulOp(
-            new_b_ops[i - 1], s_ops[i - 1], rd=riscv.IntRegisterType()
-        )
-        new_a_op = riscv.AddOp(a_op, a_inc_op, rd=riscv.IntRegisterType())
-        stride_op = riscv.SubOp(s_ops[i], new_a_op, rd=riscv.IntRegisterType())
+        a_inc_op = riscv.MulOp(new_b_ops[i - 1], s_ops[i - 1])
+        new_a_op = riscv.AddOp(a_op, a_inc_op)
+        stride_op = riscv.SubOp(s_ops[i], new_a_op)
         set_stride_op = snitch.SsrSetDimensionStrideOp(stride_op.rd, dm, ints[i])
         new_ops.extend((a_inc_op, new_a_op, stride_op, set_stride_op))
         a_op = new_a_op

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -556,6 +556,34 @@ class RdRsRsOperation(
         return self.rd, self.rs1, self.rs2
 
 
+class RdRsRsIntegerOperation(
+    Generic[RS1InvT, RS2InvT], RdRsRsOperation[IntRegisterType, RS1InvT, RS2InvT], ABC
+):
+    def __init__(
+        self,
+        rs1: Operation | SSAValue,
+        rs2: Operation | SSAValue,
+        *,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
+        comment: str | StringAttr | None = None,
+    ):
+        super().__init__(rs1, rs2, rd=rd, comment=comment)
+
+
+class RdRsRsFloatOperation(
+    Generic[RS1InvT, RS2InvT], RdRsRsOperation[FloatRegisterType, RS1InvT, RS2InvT], ABC
+):
+    def __init__(
+        self,
+        rs1: Operation | SSAValue,
+        rs2: Operation | SSAValue,
+        *,
+        rd: FloatRegisterType = Registers.UNALLOCATED_FLOAT,
+        comment: str | StringAttr | None = None,
+    ):
+        super().__init__(rs1, rs2, rd=rd, comment=comment)
+
+
 class RdRsRsFloatOperationWithFastMath(
     RISCVCustomFormatOperation, RISCVInstruction, ABC
 ):
@@ -576,7 +604,7 @@ class RdRsRsFloatOperationWithFastMath(
         rs1: Operation | SSAValue,
         rs2: Operation | SSAValue,
         *,
-        rd: FloatRegisterType,
+        rd: FloatRegisterType = Registers.UNALLOCATED_FLOAT,
         fastmath: FastMathFlagsAttr | None = None,
         comment: str | StringAttr | None = None,
     ):
@@ -624,17 +652,13 @@ class RdImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         self,
         immediate: int | IntegerAttr | str | LabelAttr,
         *,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(immediate, i20)
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
-        if rd is None:
-            rd = IntRegisterType()
-        elif isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -680,15 +704,13 @@ class RdImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         self,
         immediate: int | SImm20Attr | str | LabelAttr,
         *,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(immediate, si20)
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
-        if isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -745,7 +767,7 @@ class RdRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
         rs1: Operation | SSAValue,
         immediate: int | SImm12Attr | str | LabelAttr,
         *,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -753,10 +775,6 @@ class RdRsImmIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC)
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
 
-        if rd is None:
-            rd = IntRegisterType()
-        elif isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -806,7 +824,7 @@ class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | UImm5Attr | str | LabelAttr,
         *,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -814,10 +832,6 @@ class RdRsImmShiftOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
 
-        if rd is None:
-            rd = IntRegisterType()
-        elif isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -870,16 +884,13 @@ class RdRsImmJumpOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | SImm12Attr | str | LabelAttr,
         *,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType | None = None,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
             immediate = IntegerAttr(immediate, si12)
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
-
-        if isinstance(rd, str):
-            rd = IntRegisterType(rd)
 
         if isinstance(comment, str):
             comment = StringAttr(comment)
@@ -941,6 +952,32 @@ class RdRsOperation(
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
         return self.rd, self.rs
+
+
+class RdRsIntegerOperation(
+    Generic[RSInvT], RdRsOperation[IntRegisterType, RSInvT], ABC
+):
+    def __init__(
+        self,
+        rs: Operation | SSAValue,
+        *,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
+        comment: str | StringAttr | None = None,
+    ):
+        super().__init__(rs, rd=rd, comment=comment)
+
+
+class RdRsFloatOperation(
+    Generic[RSInvT], RdRsOperation[FloatRegisterType, RSInvT], ABC
+):
+    def __init__(
+        self,
+        rs: Operation | SSAValue,
+        *,
+        rd: FloatRegisterType = Registers.UNALLOCATED_FLOAT,
+        comment: str | StringAttr | None = None,
+    ):
+        super().__init__(rs, rd=rd, comment=comment)
 
 
 class RsRsOffIntegerOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
@@ -1129,13 +1166,9 @@ class CsrReadWriteOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         csr: IntegerAttr,
         *,
         writeonly: bool = False,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
-        if rd is None:
-            rd = IntRegisterType()
-        elif isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1207,13 +1240,9 @@ class CsrBitwiseOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         csr: IntegerAttr,
         *,
         readonly: bool = False,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
-        if rd is None:
-            rd = IntRegisterType()
-        elif isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1283,13 +1312,9 @@ class CsrReadWriteImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC
         immediate: IntegerAttr,
         *,
         writeonly: bool = False,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
-        if rd is None:
-            rd = IntRegisterType()
-        elif isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1363,13 +1388,9 @@ class CsrBitwiseImmOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         csr: IntegerAttr,
         immediate: IntegerAttr,
         *,
-        rd: IntRegisterType | str | None = None,
+        rd: IntRegisterType = Registers.UNALLOCATED_INT,
         comment: str | StringAttr | None = None,
     ):
-        if rd is None:
-            rd = IntRegisterType()
-        elif isinstance(rd, str):
-            rd = IntRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -1602,7 +1623,7 @@ class MVHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class MVOp(RdRsOperation[IntRegisterType, IntRegisterType]):
+class MVOp(RdRsIntegerOperation[IntRegisterType]):
     """
     A pseudo instruction to copy contents of one int register to another.
 
@@ -1626,7 +1647,7 @@ class FMVHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class FMVOp(RdRsOperation[FloatRegisterType, FloatRegisterType]):
+class FMVOp(RdRsFloatOperation[FloatRegisterType]):
     """
     A pseudo instruction to copy contents of one float register to another.
 
@@ -1660,7 +1681,7 @@ class AddOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class AddOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class AddOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Adds the registers rs1 and rs2 and stores the result in rd.
     Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.
@@ -1681,7 +1702,7 @@ class AddOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class SltOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class SltOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Place the value 1 in register rd if register rs1 is less than register rs2 when both
     are treated as signed numbers, else 0 is written to rd.
@@ -1695,7 +1716,7 @@ class SltOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class SltuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class SltuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Place the value 1 in register rd if register rs1 is less than register rs2 when both
     are treated as unsigned numbers, else 0 is written to rd.
@@ -1717,7 +1738,7 @@ class BitwiseAndHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrai
 
 
 @irdl_op_definition
-class AndOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class AndOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs bitwise AND on registers rs1 and rs2 and place the result in rd.
 
@@ -1740,7 +1761,7 @@ class BitwiseOrHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait
 
 
 @irdl_op_definition
-class OrOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class OrOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs bitwise OR on registers rs1 and rs2 and place the result in rd.
 
@@ -1766,7 +1787,7 @@ class BitwiseXorHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrai
 
 
 @irdl_op_definition
-class XorOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class XorOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs bitwise XOR on registers rs1 and rs2 and place the result in rd.
 
@@ -1781,7 +1802,7 @@ class XorOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class SllOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class SllOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs logical left shift on the value in register rs1 by the shift amount
     held in the lower 5 bits of register rs2.
@@ -1795,7 +1816,7 @@ class SllOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class SrlOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class SrlOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Logical right shift on the value in register rs1 by the shift amount held
     in the lower 5 bits of register rs2.
@@ -1820,7 +1841,7 @@ class SubOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class SubOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class SubOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Subtracts the registers rs1 and rs2 and stores the result in rd.
     Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.
@@ -1836,7 +1857,7 @@ class SubOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class SraOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class SraOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs arithmetic right shift on the value in register rs1 by the shift amount held
     in the lower 5 bits of register rs2.
@@ -2355,7 +2376,7 @@ class MulOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class MulOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class MulOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs an XLEN-bit × XLEN-bit multiplication of signed rs1 by signed rs2
     and places the lower XLEN bits in the destination register.
@@ -2370,7 +2391,7 @@ class MulOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class MulhOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class MulhOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs an XLEN-bit × XLEN-bit multiplication of signed rs1 by signed rs2
     and places the upper XLEN bits in the destination register.
@@ -2383,7 +2404,7 @@ class MulhOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType])
 
 
 @irdl_op_definition
-class MulhsuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class MulhsuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs an XLEN-bit × XLEN-bit multiplication of signed rs1 by unsigned rs2
     and places the upper XLEN bits in the destination register.
@@ -2396,7 +2417,7 @@ class MulhsuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType
 
 
 @irdl_op_definition
-class MulhuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class MulhuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Performs an XLEN-bit × XLEN-bit multiplication of unsigned rs1 by unsigned rs2
     and places the upper XLEN bits in the destination register.
@@ -2410,7 +2431,7 @@ class MulhuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]
 
 ## Division Operations
 @irdl_op_definition
-class DivOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class DivOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Perform an XLEN bits by XLEN bits signed integer division of rs1 by rs2,
     rounding towards zero.
@@ -2423,7 +2444,7 @@ class DivOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class DivuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class DivuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Perform an XLEN bits by XLEN bits unsigned integer division of rs1 by rs2,
     rounding towards zero.
@@ -2436,7 +2457,7 @@ class DivuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType])
 
 
 @irdl_op_definition
-class RemOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class RemOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Perform an XLEN bits by XLEN bits signed integer reminder of rs1 by rs2.
     x[rd] = x[rs1] %s x[rs2]
@@ -2448,7 +2469,7 @@ class RemOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class RemuOp(RdRsRsOperation[IntRegisterType, IntRegisterType, IntRegisterType]):
+class RemuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     """
     Perform an XLEN bits by XLEN bits unsigned integer reminder of rs1 by rs2.
     x[rd] = x[rs1] %u x[rs2]
@@ -2504,7 +2525,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
         if rd is None:
-            rd = IntRegisterType()
+            rd = Registers.UNALLOCATED_INT
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -2959,13 +2980,9 @@ class RdRsRsRsFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         rs2: Operation | SSAValue,
         rs3: Operation | SSAValue,
         *,
-        rd: FloatRegisterType | str | None = None,
+        rd: FloatRegisterType = Registers.UNALLOCATED_FLOAT,
         comment: str | StringAttr | None = None,
     ):
-        if rd is None:
-            rd = FloatRegisterType()
-        elif isinstance(rd, str):
-            rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
 
@@ -3002,7 +3019,7 @@ class RdRsRsFloatFloatIntegerOperation(
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType()
+            rd = Registers.UNALLOCATED_INT
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -3045,7 +3062,7 @@ class RdRsRsFloatFloatIntegerOperationWithFastMath(
         comment: str | StringAttr | None = None,
     ):
         if rd is None:
-            rd = IntRegisterType()
+            rd = Registers.UNALLOCATED_INT
         elif isinstance(rd, str):
             rd = IntRegisterType(rd)
         if isinstance(comment, str):
@@ -3143,7 +3160,7 @@ class RdRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         rs1: Operation | SSAValue,
         immediate: int | Imm12Attr | str | LabelAttr,
         *,
-        rd: FloatRegisterType | str | None = None,
+        rd: FloatRegisterType = Registers.UNALLOCATED_FLOAT,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(immediate, int):
@@ -3151,10 +3168,6 @@ class RdRsImmFloatOperation(RISCVCustomFormatOperation, RISCVInstruction, ABC):
         elif isinstance(immediate, str):
             immediate = LabelAttr(immediate)
 
-        if rd is None:
-            rd = FloatRegisterType()
-        elif isinstance(rd, str):
-            rd = FloatRegisterType(rd)
         if isinstance(comment, str):
             comment = StringAttr(comment)
         super().__init__(
@@ -3304,7 +3317,7 @@ class FDivSOp(RdRsRsFloatOperationWithFastMath):
 
 
 @irdl_op_definition
-class FSqrtSOp(RdRsOperation[FloatRegisterType, FloatRegisterType]):
+class FSqrtSOp(RdRsFloatOperation[FloatRegisterType]):
     """
     Perform single-precision floating-point square root.
 
@@ -3319,9 +3332,7 @@ class FSqrtSOp(RdRsOperation[FloatRegisterType, FloatRegisterType]):
 
 
 @irdl_op_definition
-class FSgnJSOp(
-    RdRsRsOperation[FloatRegisterType, FloatRegisterType, FloatRegisterType]
-):
+class FSgnJSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Produce a result that takes all bits except the sign bit from rs1.
     The result’s sign bit is rs2’s sign bit.
@@ -3337,9 +3348,7 @@ class FSgnJSOp(
 
 
 @irdl_op_definition
-class FSgnJNSOp(
-    RdRsRsOperation[FloatRegisterType, FloatRegisterType, FloatRegisterType]
-):
+class FSgnJNSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Produce a result that takes all bits except the sign bit from rs1.
     The result’s sign bit is opposite of rs2’s sign bit.
@@ -3355,9 +3364,7 @@ class FSgnJNSOp(
 
 
 @irdl_op_definition
-class FSgnJXSOp(
-    RdRsRsOperation[FloatRegisterType, FloatRegisterType, FloatRegisterType]
-):
+class FSgnJXSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Produce a result that takes all bits except the sign bit from rs1.
     The result’s sign bit is XOR of sign bit of rs1 and rs2.
@@ -3403,7 +3410,7 @@ class FMaxSOp(RdRsRsFloatOperationWithFastMath):
 
 
 @irdl_op_definition
-class FCvtWSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
+class FCvtWSOp(RdRsIntegerOperation[FloatRegisterType]):
     """
     Convert a floating-point number in floating-point register rs1 to a signed 32-bit in integer register rd.
 
@@ -3418,7 +3425,7 @@ class FCvtWSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
 
 
 @irdl_op_definition
-class FCvtWuSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
+class FCvtWuSOp(RdRsIntegerOperation[FloatRegisterType]):
     """
     Convert a floating-point number in floating-point register rs1 to a signed 32-bit in unsigned integer register rd.
 
@@ -3433,7 +3440,7 @@ class FCvtWuSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
 
 
 @irdl_op_definition
-class FMvXWOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
+class FMvXWOp(RdRsIntegerOperation[FloatRegisterType]):
     """
     Move the single-precision value in floating-point register rs1 represented in IEEE
     754-2008 encoding to the lower 32 bits of integer register rd.
@@ -3497,7 +3504,7 @@ class FleSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
 
 
 @irdl_op_definition
-class FClassSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
+class FClassSOp(RdRsIntegerOperation[FloatRegisterType]):
     """
     Examines the value in floating-point register rs1 and writes to integer register rd
     a 10-bit mask that indicates the class of the floating-point number.
@@ -3514,7 +3521,7 @@ class FClassSOp(RdRsOperation[IntRegisterType, FloatRegisterType]):
 
 
 @irdl_op_definition
-class FCvtSWOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
+class FCvtSWOp(RdRsFloatOperation[IntRegisterType]):
     """
     Converts a 32-bit signed integer, in integer register rs1 into a floating-point number in floating-point register rd.
 
@@ -3529,7 +3536,7 @@ class FCvtSWOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class FCvtSWuOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
+class FCvtSWuOp(RdRsFloatOperation[IntRegisterType]):
     """
     Converts a 32-bit unsigned integer, in integer register rs1 into a floating-point
     number in floating-point register rd.
@@ -3545,7 +3552,7 @@ class FCvtSWuOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class FMvWXOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
+class FMvWXOp(RdRsFloatOperation[IntRegisterType]):
     """
     Move the single-precision value encoded in IEEE 754-2008 standard encoding from the
     lower 32 bits of integer register rs1 to the floating-point register rd.
@@ -3778,7 +3785,7 @@ class FMaxDOp(RdRsRsFloatOperationWithFastMath):
 
 
 @irdl_op_definition
-class FCvtDWOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
+class FCvtDWOp(RdRsFloatOperation[IntRegisterType]):
     """
     Converts a 32-bit signed integer, in integer register rs1 into a double-precision
     floating-point number in floating-point register rd.
@@ -3794,7 +3801,7 @@ class FCvtDWOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
 
 
 @irdl_op_definition
-class FCvtDWuOp(RdRsOperation[FloatRegisterType, IntRegisterType]):
+class FCvtDWuOp(RdRsFloatOperation[IntRegisterType]):
     """
     Converts a 32-bit unsigned integer, in integer register rs1 into a double-precision
     floating-point number in floating-point register rd.
@@ -3883,7 +3890,7 @@ class FMvDHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
 
 
 @irdl_op_definition
-class FMvDOp(RdRsOperation[FloatRegisterType, FloatRegisterType]):
+class FMvDOp(RdRsFloatOperation[FloatRegisterType]):
     """
     A pseudo instruction to copy 64 bits of one float register to another.
 
@@ -3912,9 +3919,7 @@ class FMvDOp(RdRsOperation[FloatRegisterType, FloatRegisterType]):
 
 
 @irdl_op_definition
-class VFAddSOp(
-    RdRsRsOperation[FloatRegisterType, FloatRegisterType, FloatRegisterType]
-):
+class VFAddSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Perform a pointwise single-precision floating-point addition over vectors.
 
@@ -3928,9 +3933,7 @@ class VFAddSOp(
 
 
 @irdl_op_definition
-class VFMulSOp(
-    RdRsRsOperation[FloatRegisterType, FloatRegisterType, FloatRegisterType]
-):
+class VFMulSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     """
     Perform a pointwise single-precision floating-point multiplication over vectors.
 

--- a/xdsl/transforms/convert_ptr_to_riscv.py
+++ b/xdsl/transforms/convert_ptr_to_riscv.py
@@ -38,9 +38,7 @@ class ConvertPtrAddOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ptr.PtrAddOp, rewriter: PatternRewriter, /):
         oper1, oper2 = cast_operands_to_regs(rewriter)
-        rewriter.replace_matched_op(
-            riscv.AddOp(oper1, oper2, rd=riscv.IntRegisterType())
-        )
+        rewriter.replace_matched_op(riscv.AddOp(oper1, oper2))
 
 
 @dataclass

--- a/xdsl/transforms/convert_riscv_scf_for_to_frep.py
+++ b/xdsl/transforms/convert_riscv_scf_for_to_frep.py
@@ -61,7 +61,7 @@ class ScfForLowering(RewritePattern):
         rewriter.erase_block_argument(indvar)
         rewriter.replace_matched_op(
             (
-                iter_count := riscv.SubOp(op.ub, op.lb, rd=riscv.IntRegisterType()),
+                iter_count := riscv.SubOp(op.ub, op.lb),
                 iter_count_minus_one := riscv.AddiOp(iter_count, -1),
                 riscv_snitch.FrepOuterOp(
                     iter_count_minus_one,

--- a/xdsl/transforms/riscv_scf_loop_range_folding.py
+++ b/xdsl/transforms/riscv_scf_loop_range_folding.py
@@ -42,12 +42,8 @@ class HoistIndexTimesConstantOp(RewritePattern):
                     rewriter.insert_op_before_matched_op(
                         [
                             shift := riscv.LiOp(constant),
-                            new_lb := riscv.AddOp(
-                                op.lb, shift, rd=riscv.IntRegisterType()
-                            ),
-                            new_ub := riscv.AddOp(
-                                op.ub, shift, rd=riscv.IntRegisterType()
-                            ),
+                            new_lb := riscv.AddOp(op.lb, shift),
+                            new_ub := riscv.AddOp(op.ub, shift),
                         ]
                     )
                 case riscv.MulOp():
@@ -55,15 +51,9 @@ class HoistIndexTimesConstantOp(RewritePattern):
                     rewriter.insert_op_before_matched_op(
                         [
                             factor := riscv.LiOp(constant),
-                            new_lb := riscv.MulOp(
-                                op.lb, factor, rd=riscv.IntRegisterType()
-                            ),
-                            new_ub := riscv.MulOp(
-                                op.ub, factor, rd=riscv.IntRegisterType()
-                            ),
-                            new_step := riscv.MulOp(
-                                op.step, factor, rd=riscv.IntRegisterType()
-                            ),
+                            new_lb := riscv.MulOp(op.lb, factor),
+                            new_ub := riscv.MulOp(op.ub, factor),
+                            new_step := riscv.MulOp(op.step, factor),
                         ]
                     )
 


### PR DESCRIPTION
If I remember correctly, this was done as a kind of defensive API measure to make sure that users of the riscv operations knew to assign to the result register an appropriate value. I no longer think that the benefits of explicit result values outweigh the cost of verbose code everywhere. I'm currently refactoring register types, and I'd like to change the init and parsing situation, where it will no longer make sense for the default init with no parameters to create an unallocated register, so the API for those is about to change towards something less ergonomic, which will make the no default parameter situation worse.