### PR TITLE
testing: remove `assert_print_op` from rewriters tests

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1,8 +1,8 @@
 import re
 from collections.abc import Sequence
+from io import StringIO
 
 import pytest
-from conftest import assert_print_op
 
 from xdsl.builder import ImplicitBuilder
 from xdsl.context import Context
@@ -33,6 +33,7 @@ from xdsl.pattern_rewriter import (
     attr_type_rewrite_pattern,
     op_type_rewrite_pattern,
 )
+from xdsl.printer import Printer
 from xdsl.rewriter import BlockInsertPoint, InsertPoint
 
 
@@ -92,7 +93,11 @@ def rewrite_and_compare(
     walker.listener = listener
     did_rewrite = walker.rewrite_module(module)
 
-    assert_print_op(module, expected_prog, None)
+    file = StringIO()
+    printer = Printer(stream=file, print_generic_format=True)
+    printer.print(module)
+
+    assert file.getvalue().strip() == expected_prog.strip()
 
     assert num_op_inserted == op_inserted
     assert num_op_removed == op_removed

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
+from io import StringIO
 
 import pytest
-from conftest import assert_print_op
 
 from xdsl.context import Context
 from xdsl.dialects import test
@@ -9,6 +9,7 @@ from xdsl.dialects.arith import AddiOp, Arith, ConstantOp
 from xdsl.dialects.builtin import Builtin, Float32Type, Float64Type, ModuleOp, i32, i64
 from xdsl.ir import Block, Region
 from xdsl.parser import Parser
+from xdsl.printer import Printer
 from xdsl.rewriter import BlockInsertPoint, InsertPoint, Rewriter
 
 
@@ -26,7 +27,11 @@ def rewrite_and_compare(
     rewriter = Rewriter()
     transformation(module, rewriter)
 
-    assert_print_op(module, expected_prog, None)
+    file = StringIO()
+    printer = Printer(stream=file, print_generic_format=True)
+    printer.print(module)
+
+    assert file.getvalue().strip() == expected_prog.strip()
 
 
 def test_operation_deletion():


### PR DESCRIPTION
One more steps towards removing conftest, two to go.