### PR TITLE
backend: (riscv) use named unallocated registers instead of empty init

### DIFF
--- a/tests/backend/riscv/test_preallocated.py
+++ b/tests/backend/riscv/test_preallocated.py
@@ -7,10 +7,8 @@ from xdsl.dialects.builtin import SymbolRefAttr
 def test_gather_allocated():
     @Builder.implicit_region
     def no_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType()
-        reg2 = riscv.IntRegisterType()
-        v1 = riscv.GetRegisterOp(reg1).res
-        v2 = riscv.GetRegisterOp(reg2).res
+        v1 = riscv.GetRegisterOp(riscv.Registers.UNALLOCATED_INT).res
+        v2 = riscv.GetRegisterOp(riscv.Registers.UNALLOCATED_INT).res
         _ = riscv.AddOp(v1, v2).rd
 
     pa_regs = gather_allocated(riscv_func.FuncOp("foo", no_preallocated_body, ((), ())))
@@ -19,7 +17,7 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def one_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType()
+        reg1 = riscv.Registers.UNALLOCATED_INT
         v1 = riscv.GetRegisterOp(reg1).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
         _ = riscv.AddOp(v1, v2).rd
@@ -32,8 +30,7 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def repeated_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType()
-        v1 = riscv.GetRegisterOp(reg1).res
+        v1 = riscv.GetRegisterOp(riscv.Registers.UNALLOCATED_INT).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
         sum1 = riscv.AddOp(v1, v2).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A7).rd
@@ -46,8 +43,7 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def multiple_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType()
-        v1 = riscv.GetRegisterOp(reg1).res
+        v1 = riscv.GetRegisterOp(riscv.Registers.UNALLOCATED_INT).res
         v2 = riscv.GetRegisterOp(riscv.Registers.A7).res
         sum1 = riscv.AddOp(v1, v2).rd
         _ = riscv.AddiOp(sum1, 1, rd=riscv.Registers.A6).rd
@@ -60,8 +56,7 @@ def test_gather_allocated():
 
     @Builder.implicit_region
     def func_call_preallocated_body() -> None:
-        reg1 = riscv.IntRegisterType()
-        v1 = riscv.GetRegisterOp(reg1).res
+        v1 = riscv.GetRegisterOp(riscv.Registers.UNALLOCATED_INT).res
         v2 = riscv.GetRegisterOp(riscv.Registers.S0).res
         riscv_func.CallOp(SymbolRefAttr("hello"), (v1, v2), ())
 

--- a/tests/backend/riscv/test_utils.py
+++ b/tests/backend/riscv/test_utils.py
@@ -12,7 +12,7 @@ from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.utils.test_value import TestSSAValue
 
 INDEX_TYPE = builtin.IndexType()
-REGISTER_TYPE = riscv.IntRegisterType()
+REGISTER_TYPE = riscv.Registers.UNALLOCATED_INT
 
 
 def test_register_type_for_type():

--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -7,23 +7,23 @@ from xdsl.dialects.builtin import IntegerAttr
 def test_unallocated_register():
     unallocated = x86.register.GeneralRegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.GeneralRegisterType()
+    assert unallocated == x86.register.UNALLOCATED_GENERAL
 
     unallocated = x86.register.RFLAGSRegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.RFLAGSRegisterType()
+    assert unallocated == x86.register.UNALLOCATED_RFLAGS
 
     unallocated = x86.register.AVX2RegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.AVX2RegisterType()
+    assert unallocated == x86.register.UNALLOCATED_AVX2
 
     unallocated = x86.register.AVX512RegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.AVX512RegisterType()
+    assert unallocated == x86.register.UNALLOCATED_AVX512
 
     unallocated = x86.register.SSERegisterType("")
     assert not unallocated.is_allocated
-    assert unallocated == x86.register.SSERegisterType()
+    assert unallocated == x86.register.UNALLOCATED_SSE
 
 
 @pytest.mark.parametrize(

--- a/tests/interpreters/test_riscv_cf_interpreter.py
+++ b/tests/interpreters/test_riscv_cf_interpreter.py
@@ -5,7 +5,7 @@ from xdsl.interpreters.riscv_cf import RiscvCfFunctions
 from xdsl.ir import Block
 from xdsl.utils.test_value import TestSSAValue
 
-register = riscv.IntRegisterType()
+register = riscv.Registers.UNALLOCATED_INT
 module_op = ModuleOp([])
 
 

--- a/tests/interpreters/test_riscv_debug_interpreter.py
+++ b/tests/interpreters/test_riscv_debug_interpreter.py
@@ -10,8 +10,6 @@ from xdsl.utils.test_value import TestSSAValue
 
 def test_riscv_interpreter():
     module_op = ModuleOp([])
-    register = riscv.IntRegisterType()
-    fregister = riscv.FloatRegisterType()
 
     riscv_functions = RiscvFunctions()
     riscv_debug_functions = RiscvDebugFunctions()
@@ -25,10 +23,10 @@ def test_riscv_interpreter():
             riscv_debug.PrintfOp(
                 "{} {} {} {}",
                 (
-                    TestSSAValue(register),
-                    TestSSAValue(register),
-                    TestSSAValue(fregister),
-                    TestSSAValue(fregister),
+                    TestSSAValue(riscv.Registers.UNALLOCATED_INT),
+                    TestSSAValue(riscv.Registers.UNALLOCATED_INT),
+                    TestSSAValue(riscv.Registers.UNALLOCATED_FLOAT),
+                    TestSSAValue(riscv.Registers.UNALLOCATED_FLOAT),
                 ),
             ),
             (1, -1, 2.0, -2.0),

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -46,8 +46,8 @@ def test_riscv_interpreter():
             ),
         ]
     )
-    register = riscv.IntRegisterType()
-    fregister = riscv.FloatRegisterType()
+    register = riscv.Registers.UNALLOCATED_INT
+    fregister = riscv.Registers.UNALLOCATED_FLOAT
 
     riscv_functions = RiscvFunctions(
         custom_instructions={"my_custom_instruction": my_custom_instruction},
@@ -282,7 +282,7 @@ def test_riscv_interpreter():
 
     assert interpreter.run_op(riscv.GetRegisterOp(riscv.Registers.ZERO), ()) == (0,)
 
-    get_non_zero = riscv.GetRegisterOp(riscv.IntRegisterType())
+    get_non_zero = riscv.GetRegisterOp(riscv.Registers.UNALLOCATED_INT)
     with pytest.raises(
         InterpretationError,
         match="Cannot get value for unallocated register !riscv.reg",
@@ -309,13 +309,12 @@ def test_get_data():
 
 def test_cast():
     module_op = ModuleOp([])
-    fregister = riscv.FloatRegisterType()
 
     riscv_functions = RiscvFunctions()
     interpreter = Interpreter(module_op)
     interpreter.register_implementations(riscv_functions)
 
-    assert interpreter.cast_value(fregister, f64, 42.0) == 42.0
+    assert interpreter.cast_value(riscv.Registers.UNALLOCATED_FLOAT, f64, 42.0) == 42.0
 
 
 def test_register_contents():

--- a/tests/interpreters/test_riscv_scf_interpreter.py
+++ b/tests/interpreters/test_riscv_scf_interpreter.py
@@ -10,7 +10,7 @@ from xdsl.interpreters.riscv_scf import RiscvScfFunctions
 from xdsl.ir import BlockArgument
 
 index = IndexType()
-register = riscv.IntRegisterType()
+register = riscv.Registers.UNALLOCATED_INT
 
 
 def sum_to_for_fn(n: int) -> int:

--- a/tests/interpreters/test_riscv_snitch_interpreter.py
+++ b/tests/interpreters/test_riscv_snitch_interpreter.py
@@ -58,7 +58,7 @@ def test_read_write():
 
 
 def test_frep_carried_vars():
-    float_register = riscv.IntRegisterType()
+    float_register = riscv.Registers.UNALLOCATED_FLOAT
     acc_reg_type = riscv.Registers.FT[3]
 
     @ModuleOp

--- a/tests/interpreters/test_snitch_stream_interpreter.py
+++ b/tests/interpreters/test_snitch_stream_interpreter.py
@@ -57,7 +57,7 @@ def test_simplify_stride_pattern(
 
 
 def test_snitch_stream_interpreter():
-    register = riscv.IntRegisterType()
+    register = riscv.Registers.UNALLOCATED_INT
 
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(RiscvFunctions())

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -28,7 +28,7 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
     index: ParameterDef[IntAttr | NoneAttr]
     spelling: ParameterDef[StringAttr]
 
-    def __init__(self, spelling: str = ""):
+    def __init__(self, spelling: str):
         super().__init__(self._parameters_from_spelling(spelling))
 
     @classmethod

--- a/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_arith_to_riscv.py
@@ -29,8 +29,8 @@ from xdsl.pattern_rewriter import (
 from xdsl.utils.bitwise_casts import convert_f32_to_u32
 from xdsl.utils.comparisons import signed_lower_bound, signed_upper_bound
 
-_INT_REGISTER_TYPE = riscv.IntRegisterType()
-_FLOAT_REGISTER_TYPE = riscv.FloatRegisterType()
+_INT_REGISTER_TYPE = riscv.Registers.UNALLOCATED_INT
+_FLOAT_REGISTER_TYPE = riscv.Registers.UNALLOCATED_FLOAT
 
 
 class LowerArithConstant(RewritePattern):

--- a/xdsl/backend/riscv/lowering/convert_arith_to_riscv_snitch.py
+++ b/xdsl/backend/riscv/lowering/convert_arith_to_riscv_snitch.py
@@ -21,8 +21,6 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
 )
 
-_FLOAT_REGISTER_TYPE = riscv.FloatRegisterType()
-
 
 @dataclass
 class LowerBinaryFloatVectorOp(RewritePattern):
@@ -44,8 +42,12 @@ class LowerBinaryFloatVectorOp(RewritePattern):
         operand_type = cast(VectorType[Any], operand_type)
         scalar_type = operand_type.element_type
 
-        lhs = UnrealizedConversionCastOp.get((op.lhs,), (_FLOAT_REGISTER_TYPE,))
-        rhs = UnrealizedConversionCastOp.get((op.rhs,), (_FLOAT_REGISTER_TYPE,))
+        lhs = UnrealizedConversionCastOp.get(
+            (op.lhs,), (riscv.Registers.UNALLOCATED_FLOAT,)
+        )
+        rhs = UnrealizedConversionCastOp.get(
+            (op.rhs,), (riscv.Registers.UNALLOCATED_FLOAT,)
+        )
 
         match scalar_type:
             case Float64Type():
@@ -67,7 +69,7 @@ class LowerBinaryFloatVectorOp(RewritePattern):
         if op.fastmath is not None:
             rv_flags = riscv.FastMathFlagsAttr(op.fastmath.data)
 
-        new_op = cls(lhs, rhs, rd=_FLOAT_REGISTER_TYPE, fastmath=rv_flags)
+        new_op = cls(lhs, rhs, rd=riscv.Registers.UNALLOCATED_FLOAT, fastmath=rv_flags)
         cast_op = UnrealizedConversionCastOp.get((new_op.rd,), (op.result.type,))
 
         rewriter.replace_matched_op((lhs, rhs, new_op, cast_op))

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -176,11 +176,11 @@ class ConvertMemRefStoreOp(RewritePattern):
 
         rewriter.insert_op_before_matched_op(ops)
         match value.type:
-            case riscv.Registers.UNALLOCATED_INT:
+            case riscv.IntRegisterType():
                 new_op = riscv.SwOp(
                     ptr, value, 0, comment=f"store int value to memref of shape {shape}"
                 )
-            case riscv.Registers.UNALLOCATED_FLOAT:
+            case riscv.FloatRegisterType():
                 float_type = cast(AnyFloat, memref_type.element_type)
                 match float_type:
                     case Float32Type():

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -176,11 +176,11 @@ class ConvertMemRefStoreOp(RewritePattern):
 
         rewriter.insert_op_before_matched_op(ops)
         match value.type:
-            case riscv.IntRegisterType():
+            case riscv.Registers.UNALLOCATED_INT:
                 new_op = riscv.SwOp(
                     ptr, value, 0, comment=f"store int value to memref of shape {shape}"
                 )
-            case riscv.FloatRegisterType():
+            case riscv.Registers.UNALLOCATED_FLOAT:
                 float_type = cast(AnyFloat, memref_type.element_type)
                 match float_type:
                     case Float32Type():
@@ -366,7 +366,9 @@ class ConvertMemRefSubviewOp(RewritePattern):
             )
             return
 
-        src = UnrealizedConversionCastOp.get((source,), (riscv.IntRegisterType(),))
+        src = UnrealizedConversionCastOp.get(
+            (source,), (riscv.Registers.UNALLOCATED_INT,)
+        )
         src_rd = src.results[0]
 
         if offset is None:
@@ -380,7 +382,7 @@ class ConvertMemRefSubviewOp(RewritePattern):
                     index_ops.append(
                         cast_index_op := UnrealizedConversionCastOp.get(
                             (op.offsets[dynamic_offset_index],),
-                            (riscv.IntRegisterType(),),
+                            (riscv.Registers.UNALLOCATED_INT,),
                         )
                     )
                     index_val = cast_index_op.results[0]

--- a/xdsl/backend/riscv/lowering/utils.py
+++ b/xdsl/backend/riscv/lowering/utils.py
@@ -33,7 +33,7 @@ def cast_to_regs(values: Iterable[SSAValue]) -> tuple[list[Operation], list[SSAV
         if not isinstance(value.type, riscv.RISCVRegisterType):
             register_type = register_type_for_type(value.type)
             cast_op = builtin.UnrealizedConversionCastOp.get(
-                (value,), (register_type(),)
+                (value,), (register_type(""),)
             )
             new_ops.append(cast_op)
             value = cast_op.results[0]
@@ -133,7 +133,7 @@ def move_to_unallocated_regs(
 
     for value, value_type in zip(values, value_types, strict=True):
         register_type = register_type_for_type(value.type)
-        move_op, new_value = move_ops_for_value(value, value_type, register_type())
+        move_op, new_value = move_ops_for_value(value, value_type, register_type(""))
         new_ops.append(move_op)
         new_values.append(new_value)
 
@@ -155,7 +155,7 @@ def cast_ops_for_values(
     for value in values:
         if not isinstance(value.type, riscv.IntRegisterType | riscv.FloatRegisterType):
             new_type = register_type_for_type(value.type)
-            cast_op = builtin.UnrealizedConversionCastOp.get((value,), (new_type(),))
+            cast_op = builtin.UnrealizedConversionCastOp.get((value,), (new_type(""),))
             new_ops.append(cast_op)
             new_value = cast_op.results[0]
             new_value.name_hint = value.name_hint
@@ -212,7 +212,7 @@ def cast_block_args_from_a_regs(block: Block, rewriter: PatternRewriter):
 
     for arg in block.args:
         register_type = register_type_for_type(arg.type)
-        move_op, new_value = move_ops_for_value(arg, arg.type, register_type())
+        move_op, new_value = move_ops_for_value(arg, arg.type, register_type(""))
         cast_op = builtin.UnrealizedConversionCastOp.get((new_value,), (arg.type,))
         new_ops.append(move_op)
         new_ops.append(cast_op)
@@ -240,6 +240,6 @@ def cast_block_args_to_regs(block: Block, rewriter: PatternRewriter):
             InsertPoint.at_start(block),
         )
 
-        arg.type = register_type_for_type(arg.type)()
+        arg.type = register_type_for_type(arg.type)("")
         arg.replace_by(new_val.results[0])
         new_val.operands[new_val.results[0].index] = arg

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -56,7 +56,7 @@ class SyscallOp(IRDLOperation):
         super().__init__(
             operands=[operands],
             attributes={"syscall_num": num},
-            result_types=[riscv.IntRegisterType() if has_result else None],
+            result_types=[riscv.Registers.UNALLOCATED_INT if has_result else None],
         )
 
     def verify_(self):

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -601,7 +601,7 @@ class DMCopyOp(RISCVCustomFormatOperation, RISCVInstruction):
         self,
         size: SSAValue | Operation,
         config: SSAValue | Operation,
-        result_type: IntRegisterType = IntRegisterType(),
+        result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         super().__init__(operands=[size, config], result_types=[result_type])
 
@@ -623,7 +623,7 @@ class DMStatOp(RISCVCustomFormatOperation, RISCVInstruction):
     def __init__(
         self,
         status: SSAValue | Operation,
-        result_type: IntRegisterType = IntRegisterType(),
+        result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         super().__init__(operands=[status], result_types=[result_type])
 
@@ -647,7 +647,7 @@ class DMCopyImmOp(RISCVInstruction):
         self,
         size: SSAValue | Operation,
         config: int | UImm5Attr,
-        result_type: IntRegisterType = IntRegisterType(),
+        result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         if isinstance(config, int):
             config = IntegerAttr(config, IntegerType(5, signedness=Signedness.UNSIGNED))
@@ -700,7 +700,7 @@ class DMStatImmOp(RISCVInstruction):
     def __init__(
         self,
         status: int | UImm5Attr,
-        result_type: IntRegisterType = IntRegisterType(),
+        result_type: IntRegisterType = riscv.Registers.UNALLOCATED_INT,
     ):
         if isinstance(status, int):
             status = IntegerAttr(status, IntegerType(5, signedness=Signedness.UNSIGNED))

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -162,7 +162,7 @@ class StreamOpLowering(RewritePattern):
         new_operands = cast_operands_to_regs(rewriter)
         new_inputs = new_operands[: len(op.inputs)]
         new_outputs = new_operands[len(op.inputs) :]
-        freg = riscv.FloatRegisterType()
+        freg = riscv.Registers.UNALLOCATED_FLOAT
 
         rewriter.replace_matched_op(
             new_op := snitch_stream.StreamingRegionOp(

--- a/xdsl/transforms/convert_ptr_to_riscv.py
+++ b/xdsl/transforms/convert_ptr_to_riscv.py
@@ -48,11 +48,11 @@ class ConvertStoreOp(RewritePattern):
         addr, value = cast_operands_to_regs(rewriter)
 
         match value.type:
-            case riscv.Registers.UNALLOCATED_INT:
+            case riscv.IntRegisterType():
                 new_op = riscv.SwOp(
                     addr, value, 0, comment="store int value to pointer"
                 )
-            case riscv.Registers.UNALLOCATED_FLOAT:
+            case riscv.FloatRegisterType():
                 float_type = cast(AnyFloat, op.value.type)
                 match float_type:
                     case Float32Type():

--- a/xdsl/transforms/convert_ptr_to_riscv.py
+++ b/xdsl/transforms/convert_ptr_to_riscv.py
@@ -30,7 +30,7 @@ from xdsl.utils.exceptions import DiagnosticException
 class PtrTypeConversion(TypeConversionPattern):
     @attr_type_rewrite_pattern
     def convert_type(self, typ: ptr.PtrType) -> riscv.IntRegisterType:
-        return riscv.IntRegisterType()
+        return riscv.Registers.UNALLOCATED_INT
 
 
 @dataclass
@@ -48,11 +48,11 @@ class ConvertStoreOp(RewritePattern):
         addr, value = cast_operands_to_regs(rewriter)
 
         match value.type:
-            case riscv.IntRegisterType():
+            case riscv.Registers.UNALLOCATED_INT:
                 new_op = riscv.SwOp(
                     addr, value, 0, comment="store int value to pointer"
                 )
-            case riscv.FloatRegisterType():
+            case riscv.Registers.UNALLOCATED_FLOAT:
                 float_type = cast(AnyFloat, op.value.type)
                 match float_type:
                     case Float32Type():
@@ -112,7 +112,9 @@ class ConvertMemRefToPtrOp(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ptr.ToPtrOp, rewriter: PatternRewriter, /):
         rewriter.replace_matched_op(
-            UnrealizedConversionCastOp.get([op.source], [riscv.IntRegisterType()])
+            UnrealizedConversionCastOp.get(
+                (op.source,), (riscv.Registers.UNALLOCATED_INT,)
+            )
         )
 
 

--- a/xdsl/transforms/inline_snrt.py
+++ b/xdsl/transforms/inline_snrt.py
@@ -109,7 +109,7 @@ class LowerDMAStart1D(RewritePattern):
             return snrt_dma_start_1d_wideptr((size_t)dst, (size_t)src, size);
         }
         """
-        reg_t = riscv.IntRegisterType()
+        reg_t = riscv.Registers.UNALLOCATED_INT
         rewriter.replace_matched_op(
             [
                 zero := riscv.GetRegisterOp(riscv.Registers.ZERO),
@@ -197,7 +197,7 @@ class LowerDMAStart1DWidePtr(RewritePattern):
 
         P.S. We only implement taking the top branch for now.
         """
-        reg_t = riscv.IntRegisterType()
+        reg_t = riscv.Registers.UNALLOCATED_INT
         rewriter.replace_matched_op(
             [
                 # "Take an ui64 and split it in two 32 bit-wide RISC-V registers"
@@ -231,7 +231,7 @@ class LowerDMAStart1DWidePtr(RewritePattern):
 
 
 class LowerDMAStart2DBase(RewritePattern, ABC):
-    any_reg = riscv.IntRegisterType()
+    any_reg = riscv.Registers.UNALLOCATED_INT
 
     def generate_dma_instructions(
         self,


### PR DESCRIPTION
Two related changes:

 - removes the default value of "" for the register name
 - replaces previous unallocated register init calls with no args with the dedicated UNALLOCATED constants

This reduces the users of the init API, which I'm slowly refactoring.