### PR TITLE
testing: use importlib import mode in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ exclude = [
 python_files = ["tests/*test_*.py", "docs/*test_*.py"]
 python_classes = "Test_*"
 python_functions = "test_*"
-addopts = ["--durations=20", "--maxfail=5"]
+addopts = ["--durations=20", "--maxfail=5", "--import-mode=importlib"]
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.versioneer]


### PR DESCRIPTION
This makes the tests behave more like how clients of xDSL would, with the xdsl module in the venv rather than locally available in the current directory.