### PR TITLE
misc: escape code in docstrings

### DIFF
--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -1893,15 +1893,18 @@ class AddressOfOp(IRDLOperation):
     def _verify_memref_addr(self, val_ty: MemRefType[Attribute], res_ty: PtrType):
         """
         Verify that if the address of a memref is taken, the resulting pointer is either:
-            A single pointer to the array type or
-            A many pointer to the array element type
+        - A single pointer to the array type or
+        - A many pointer to the array element type
+
         E.g.
+        ```mlir
             const x: [10]f32;
             const arr_ptr: *[10]f32 = &x;
             const elem_ptr: [*]f32 = &x;
             // const invalid: [*]i32 = &x;
             // const invalid: *f32 = &x;
             // const invalid: [*][10]f32 = &x;
+        ```
         """
 
         # GetDsdOp(DsdType(DsdKind("mem4d_dsd")), self.prev_op.prev_op.results[0],

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -1897,7 +1897,7 @@ class AddressOfOp(IRDLOperation):
         - A many pointer to the array element type
 
         E.g.
-        ```mlir
+        ```zig
             const x: [10]f32;
             const arr_ptr: *[10]f32 = &x;
             const elem_ptr: [*]f32 = &x;

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -2094,7 +2094,7 @@ class StringLitOp(IRDLOperation):
     to Fortran's CHARACTER type, including a LEN.  We support CHARACTER values
     of different KINDs (different constant sizes).
 
-    ```
+    ```mlir
     %1 = fir.string_lit "Hello, World!"(13) : !fir.char<1> // ASCII
     %2 = fir.string_lit [158, 2345](2) : !fir.char<2>      // Wide chars
     ```

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -2094,8 +2094,10 @@ class StringLitOp(IRDLOperation):
     to Fortran's CHARACTER type, including a LEN.  We support CHARACTER values
     of different KINDs (different constant sizes).
 
+    ```
     %1 = fir.string_lit "Hello, World!"(13) : !fir.char<1> // ASCII
     %2 = fir.string_lit [158, 2345](2) : !fir.char<2>      // Wide chars
+    ```
     """
 
     name = "fir.string_lit"


### PR DESCRIPTION
These are currently stopping the docs website from generating correctly.