### PR TITLE
dialects: (stablehlo) Add support for xor and op operations

### DIFF
--- a/tests/filecheck/dialects/stablehlo/ops.mlir
+++ b/tests/filecheck/dialects/stablehlo/ops.mlir
@@ -36,6 +36,12 @@
 // CHECK: %and = "stablehlo.and"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
 %and = "stablehlo.and"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
 
+// CHECK: %or = "stablehlo.or"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+%or = "stablehlo.or"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+
+// CHECK: %xor = "stablehlo.xor"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+%xor = "stablehlo.xor"(%t0, %t0) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+
 // %bitcast = "stablehlo.bitcast_convert"(%t0) : (tensor<i32>) -> tensor<2xi16>
 %bitcast = "stablehlo.bitcast_convert"(%t0) : (tensor<i32>) -> tensor<2xi16>
 


### PR DESCRIPTION
This PR includes following changes:
1. Add an abstract elementwise binary operations for integer tensor types `IntegerTensorLikeElementwiseBinaryOperation` like https://github.com/xdslproject/xdsl/blob/a072093aa7815d944a6fb97d17d13bcf4777cda4/xdsl/dialects/math.py#L38
2. Replace `AndOp`'s parent class with `IntegerTensorLikeElementwiseBinaryOperation`
3. Add Xor and Or Op 
4. Update on test cases 