### PR TITLE
core: Make SSAValue generic

### DIFF
--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -480,13 +480,13 @@ class IRWithUses(ABC):
 
 
 @dataclass(eq=False)
-class SSAValue(IRWithUses, ABC):
+class SSAValue(Generic[AttributeCovT], IRWithUses, ABC):
     """
     A reference to an SSA variable.
     An SSA variable is either an operation result, or a basic block argument.
     """
 
-    _type: Attribute
+    _type: AttributeCovT
     """Each SSA variable is associated to a type."""
 
     _name: str | None = field(init=False, default=None)
@@ -494,7 +494,7 @@ class SSAValue(IRWithUses, ABC):
     _name_regex: ClassVar[re.Pattern[str]] = re.compile(r"([A-Za-z_$.-][\w$.-]*)")
 
     @property
-    def type(self) -> Attribute:
+    def type(self) -> AttributeCovT:
         return self._type
 
     @property

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -119,6 +119,7 @@ class Printer(BasePrinter):
                 self.print_string(arg)
                 continue
             if isinstance(arg, SSAValue):
+                arg = cast(SSAValue[Attribute], arg)
                 self.print_ssa_value(arg)
                 continue
             if isinstance(arg, Attribute):

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -1,9 +1,11 @@
+from typing import Generic
+
 import pytest
 
-from xdsl.ir import Block, Operation, SSAValue
+from xdsl.ir import AttributeCovT, Block, Operation, SSAValue
 
 
-class TestSSAValue(SSAValue):
+class TestSSAValue(Generic[AttributeCovT], SSAValue[AttributeCovT]):
     @property
     def owner(self) -> Operation | Block:
         pytest.fail("Attempting to get the owner of a `TestSSAValue`")


### PR DESCRIPTION
Stacked PRs:
 * #3991
 * #3989
 * #3988
 * __->__#3987


--- --- ---

### core: Make SSAValue generic


Adds a generic parameter to SSAValue that constrains the type associated
with the SSAValue.
This is useful whenever a function only accepts SSAValue of a given type.
