### PR TITLE
core: Add support for typed SSA values in isa

### DIFF
--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -9,11 +9,13 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     StringAttr,
+    i32,
 )
-from xdsl.ir import Attribute, ParametrizedAttribute
+from xdsl.ir import Attribute, ParametrizedAttribute, SSAValue
 from xdsl.irdl import BaseAttr, EqAttrConstraint, ParameterDef, irdl_attr_definition
 from xdsl.utils.hints import isa
 from xdsl.utils.isattr import isattr
+from xdsl.utils.test_value import TestSSAValue
 
 
 class Class1:
@@ -398,3 +400,23 @@ def test_isattr():
     assert not isattr(IntAttr(1), BaseAttr(StringAttr))
     assert isattr(IntAttr(1), EqAttrConstraint(IntAttr(1)))
     assert not isattr(IntAttr(1), EqAttrConstraint(IntAttr(2)))
+
+
+################################################################################
+# SSAValue
+################################################################################
+
+
+def test_ssavalue():
+    a = TestSSAValue(i32)
+
+    assert isa(a, SSAValue)
+    assert isa(a, SSAValue[IntegerType])
+    assert not isa(a, SSAValue[StringAttr])
+    assert not isa(a, SSAValue[IntegerAttr[IntegerType]])
+
+    b = TestSSAValue(IntegerAttr(2, i32))
+
+    assert isa(b, SSAValue[IntegerAttr[IntegerType]])
+    assert not isa(b, SSAValue[IntegerAttr[IndexType]])
+    assert not isa(b, SSAValue[IntegerType])

--- a/xdsl/utils/hints.py
+++ b/xdsl/utils/hints.py
@@ -15,7 +15,7 @@ from typing import (
     get_origin,
 )
 
-from xdsl.ir import ParametrizedAttribute
+from xdsl.ir import ParametrizedAttribute, SSAValue
 from xdsl.utils.exceptions import VerifyException
 
 if TYPE_CHECKING:
@@ -101,6 +101,12 @@ def isa(arg: Any, hint: "TypeForm[_T]") -> TypeGuard[_T]:
             return True
         except VerifyException:
             return False
+
+    if origin is SSAValue:
+        if not isinstance(arg, SSAValue):
+            return False
+        arg = cast(SSAValue, arg)
+        return isa(arg.type, get_args(hint)[0])
 
     raise ValueError(f"isa: unsupported type hint '{hint}' {get_origin(hint)}")
 


### PR DESCRIPTION
Stacked PRs:
 * #3991
 * #3989
 * __->__#3988
 * #3987


--- --- ---

### core: Add support for typed SSA values in isa


`isa(arg, SSAValue[T])` will check that `arg` is an SSA value, and that
its type is `T`.
