### PR TITLE
dialects: Raise a parsing error in accfg.setup when result type is invalid

### DIFF
--- a/tests/filecheck/dialects/accfg/invalid.mlir
+++ b/tests/filecheck/dialects/accfg/invalid.mlir
@@ -1,0 +1,7 @@
+// RUN: xdsl-opt --split-input-file --parsing-diagnostics %s | filecheck %s
+
+%one = "test.op"() : () -> i32
+%zero = arith.constant 0 : i32
+%state = accfg.setup "acc1" to ("A" = %one : i32) : !accfg.state<"acc2">
+
+// CHECK: expected !accfg.state<"acc1">, but got !accfg.state<"acc2">

--- a/xdsl/dialects/accfg.py
+++ b/xdsl/dialects/accfg.py
@@ -341,14 +341,19 @@ class SetupOp(IRDLOperation):
             attributes = parser.parse_optional_attr_dict()
 
         parser.parse_punctuation(":")
+        pos = parser.pos
         res_typ = parser.parse_type()
+        if res_typ != StateType(accelerator):
+            parser.raise_error(
+                f"expected {StateType(accelerator)}, but got {res_typ}", pos
+            )
+
         setup_op = cls(
             [val for _, val in args],
             [name for name, _ in args],
             accelerator,
             in_state,
         )
-        setup_op.out_state.type = res_typ
         setup_op.attributes.update(attributes)
         return setup_op
 


### PR DESCRIPTION
Stacked PRs:
 * #3991
 * #3989
 * #3988
 * #3987
 * #4125
 * __->__#3990


--- --- ---

### dialects: Raise a parsing error in accfg.setup when result type is invalid


As there are a redundancy in the assembly format between the first
parsed string and the result type, this should be a parsing error.
