### PR TITLE
[WIP] CI: adopt beta dependabot support for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
@@ -14,6 +15,6 @@ updates:
       - "math-fehr"
       - "georgebisbas"
     commit-message:
-      prefix: "pip prod"
-      prefix-development: "pip dev"
+      prefix: "uv prod"
+      prefix-development: "uv dev"
       include: "scope"


### PR DESCRIPTION
Dependabot has [added beta support for uv](https://github.com/dependabot/dependabot-core/issues/10478#issuecomment-2691330949). This PR updates the dependabot configuration to use uv instead of pip.