### PR TITLE
misc: constrain ConstraintVariableType variadic to be a tuple

### DIFF
--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -239,7 +239,7 @@ class FormatParser(BaseParser):
     class _OperandResultExtractor(VarExtractor[ParsingState]):
         idx: int
         is_operand: bool
-        inner: VarExtractor[Sequence[Attribute]]
+        inner: VarExtractor[tuple[Attribute, ...]]
 
         def extract_var(self, a: ParsingState) -> ConstraintVariableType:
             if self.is_operand:
@@ -249,6 +249,8 @@ class FormatParser(BaseParser):
             assert types is not None
             if isinstance(types, Attribute):
                 types = (types,)
+            else:
+                types = tuple(types)
             return self.inner.extract_var(types)
 
     @dataclass(frozen=True)


### PR DESCRIPTION
Avoids unnecessary copies and exposes a more efficient membership method.