### PR TITLE
core: split InferenceContext dictionaries

### DIFF
--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -91,9 +91,19 @@ Possible types that a constraint variable can have.
 
 @dataclass
 class InferenceContext:
-    variables: dict[str, ConstraintVariableType] = field(default_factory=dict)
+    variables: dict[str, Attribute] = field(default_factory=dict)
     """
     A mapping from variable names to the inferred attribute or attribute sequence.
+    """
+
+    range_variables: dict[str, tuple[Attribute, ...]] = field(default_factory=dict)
+    """
+    A mapping from variable names to the inferred attribute sequence.
+    """
+
+    int_variables: dict[str, int] = field(default_factory=dict)
+    """
+    A mapping from variable names to the inferred integer.
     """
 
 
@@ -767,7 +777,7 @@ class IntVarConstraint(IntConstraint):
         self,
         context: InferenceContext,
     ) -> int:
-        v = context.variables[self.name]
+        v = context.int_variables[self.name]
         assert isinstance(v, int)
         return v
 
@@ -872,7 +882,7 @@ class RangeVarConstraint(GenericRangeConstraint[AttributeCovT]):
     def infer(
         self, context: InferenceContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
-        v = context.variables[self.name]
+        v = context.range_variables[self.name]
         return cast(Sequence[AttributeCovT], v)
 
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -168,9 +168,18 @@ class FormatProgram:
         )
 
     def resolve_constraint_variables(self, state: ParsingState):
-        state.context = InferenceContext(
-            {v: r.extract_var(state) for v, r in self.extractors.items()}
-        )
+        ctx = InferenceContext()
+        for k, e in self.extractors.items():
+            v = e.extract_var(state)
+            match v:
+                case Attribute():
+                    ctx.variables[k] = v
+                case int():
+                    ctx.int_variables[k] = v
+                case _:
+                    ctx.range_variables[k] = tuple(v)
+
+        state.context = ctx
 
     def resolve_operand_types(self, state: ParsingState, op_def: OpDef) -> None:
         """


### PR DESCRIPTION
When inferring, we know which dictionary to look into, same for when we construct the InferenceContext, so we might as well split it. PR-1 to using the ConstraintContext during inference.