### PR TITLE
core: use ConstraintContext for inference

### DIFF
--- a/tests/dialects/test_bufferization.py
+++ b/tests/dialects/test_bufferization.py
@@ -22,8 +22,8 @@ from xdsl.dialects.builtin import (
 from xdsl.dialects.test import TestOp
 from xdsl.ir import Attribute
 from xdsl.irdl import (
+    ConstraintContext,
     EqAttrConstraint,
-    InferenceContext,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
@@ -40,13 +40,13 @@ def test_tensor_from_memref_inference():
         EqAttrConstraint(MemRefType(f64, [10, 20, 30]))
     )
     assert constr2.can_infer(set())
-    assert constr2.infer(InferenceContext()) == TensorType(f64, [10, 20, 30])
+    assert constr2.infer(ConstraintContext()) == TensorType(f64, [10, 20, 30])
 
     constr3 = TensorFromMemRefConstraint(
         EqAttrConstraint(UnrankedMemRefType.from_type(f64))
     )
     assert constr3.can_infer(set())
-    assert constr3.infer(InferenceContext()) == UnrankedTensorType(f64)
+    assert constr3.infer(ConstraintContext()) == UnrankedTensorType(f64)
 
 
 @irdl_op_definition

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -9,8 +9,8 @@ from xdsl.irdl import (
     AnyAttr,
     AttrConstraint,
     BaseAttr,
+    ConstraintContext,
     EqAttrConstraint,
-    InferenceContext,
     ParamAttrConstraint,
     ParameterDef,
     VarConstraint,
@@ -78,7 +78,7 @@ def test_param_attr_constraint_inference():
     )
 
     assert constr.can_infer(set())
-    assert constr.infer(InferenceContext()) == WrapAttr((StringAttr("Hello"),))
+    assert constr.infer(ConstraintContext()) == WrapAttr((StringAttr("Hello"),))
 
     var_constr = ParamAttrConstraint(
         WrapAttr,
@@ -93,7 +93,7 @@ def test_param_attr_constraint_inference():
     )
 
     assert var_constr.can_infer({"T"})
-    assert var_constr.infer(InferenceContext({"T": StringAttr("Hello")})) == WrapAttr(
+    assert var_constr.infer(ConstraintContext({"T": StringAttr("Hello")})) == WrapAttr(
         (StringAttr("Hello"),)
     )
 
@@ -128,7 +128,7 @@ def test_base_attr_constraint_inference():
     constr = BaseAttr(NoParamAttr)
 
     assert constr.can_infer(set())
-    assert constr.infer(InferenceContext()) == NoParamAttr()
+    assert constr.infer(ConstraintContext()) == NoParamAttr()
 
     base_constr = BaseAttr(BaseNoParamAttr)
     assert not base_constr.can_infer(set())

--- a/xdsl/dialects/bufferization.py
+++ b/xdsl/dialects/bufferization.py
@@ -20,7 +20,6 @@ from xdsl.irdl import (
     AttrSizedOperandSegments,
     ConstraintContext,
     GenericAttrConstraint,
-    InferenceContext,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
@@ -53,7 +52,7 @@ class TensorFromMemRefConstraint(
         return self.memref_constraint.can_infer(var_constraint_names)
 
     def infer(
-        self, context: InferenceContext
+        self, context: ConstraintContext
     ) -> TensorType[Attribute] | UnrankedTensorType[Attribute]:
         memref_type = self.memref_constraint.infer(context)
         if isinstance(memref_type, MemRefType):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -51,7 +51,6 @@ from xdsl.irdl import (
     ConstraintVariableType,
     GenericAttrConstraint,
     GenericData,
-    InferenceContext,
     IntConstraint,
     IRDLAttrConstraint,
     IRDLGenericAttrConstraint,
@@ -329,7 +328,7 @@ class IntAttrConstraint(GenericAttrConstraint[IntAttr]):
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
         return self.int_constraint.can_infer(var_constraint_names)
 
-    def infer(self, context: InferenceContext) -> IntAttr:
+    def infer(self, context: ConstraintContext) -> IntAttr:
         return IntAttr(self.int_constraint.infer(context))
 
     def get_unique_base(self) -> type[Attribute] | None:

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -89,24 +89,6 @@ Possible types that a constraint variable can have.
 """
 
 
-@dataclass
-class InferenceContext:
-    variables: dict[str, Attribute] = field(default_factory=dict)
-    """
-    A mapping from variable names to the inferred attribute or attribute sequence.
-    """
-
-    range_variables: dict[str, tuple[Attribute, ...]] = field(default_factory=dict)
-    """
-    A mapping from variable names to the inferred attribute sequence.
-    """
-
-    int_variables: dict[str, int] = field(default_factory=dict)
-    """
-    A mapping from variable names to the inferred integer.
-    """
-
-
 _T = TypeVar("_T")
 
 
@@ -202,7 +184,7 @@ class GenericAttrConstraint(Generic[AttributeCovT], ABC):
         # By default, we cannot infer anything.
         return False
 
-    def infer(self, context: InferenceContext) -> AttributeCovT:
+    def infer(self, context: ConstraintContext) -> AttributeCovT:
         """
         Infer the attribute given the the values for all variables.
 
@@ -282,7 +264,7 @@ class TypedAttributeConstraint(GenericAttrConstraint[TypedAttributeCovT]):
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
         return self.attr_constraint.can_infer(var_constraint_names)
 
-    def infer(self, context: InferenceContext) -> TypedAttributeCovT:
+    def infer(self, context: ConstraintContext) -> TypedAttributeCovT:
         return self.attr_constraint.infer(context)
 
 
@@ -320,8 +302,8 @@ class VarConstraint(GenericAttrConstraint[AttributeCovT]):
             {self.name: IdExtractor()}, self.constraint.get_variable_extractors()
         )
 
-    def infer(self, context: InferenceContext) -> AttributeCovT:
-        v = context.variables[self.name]
+    def infer(self, context: ConstraintContext) -> AttributeCovT:
+        v = context.get_variable(self.name)
         return cast(AttributeCovT, v)
 
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
@@ -364,7 +346,7 @@ class EqAttrConstraint(Generic[AttributeCovT], GenericAttrConstraint[AttributeCo
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
         return True
 
-    def infer(self, context: InferenceContext) -> AttributeCovT:
+    def infer(self, context: ConstraintContext) -> AttributeCovT:
         return self.attr
 
     def get_unique_base(self) -> type[Attribute] | None:
@@ -395,7 +377,7 @@ class BaseAttr(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
             and not self.attr.get_irdl_definition().parameters
         )
 
-    def infer(self, context: InferenceContext) -> AttributeCovT:
+    def infer(self, context: ConstraintContext) -> AttributeCovT:
         assert issubclass(self.attr, ParametrizedAttribute)
         attr = self.attr.new(())
         return attr
@@ -531,9 +513,9 @@ class AllOf(GenericAttrConstraint[AttributeCovT]):
             constr.can_infer(var_constraint_names) for constr in self.attr_constrs
         )
 
-    def infer(self, context: InferenceContext) -> AttributeCovT:
+    def infer(self, context: ConstraintContext) -> AttributeCovT:
         for constr in self.attr_constrs:
-            if constr.can_infer(context.variables.keys()):
+            if constr.can_infer(context.variables):
                 return constr.infer(context)
         raise ValueError("Cannot infer attribute from constraint")
 
@@ -629,7 +611,7 @@ class ParamAttrConstraint(
             constr.can_infer(var_constraint_names) for constr in self.param_constrs
         )
 
-    def infer(self, context: InferenceContext) -> ParametrizedAttributeCovT:
+    def infer(self, context: ConstraintContext) -> ParametrizedAttributeCovT:
         params = tuple(constr.infer(context) for constr in self.param_constrs)
         attr = self.base_attr.new(params)
         return attr
@@ -682,7 +664,7 @@ class MessageConstraint(GenericAttrConstraint[AttributeCovT]):
     def can_infer(self, var_constraint_names: Set[str]) -> bool:
         return self.constr.can_infer(var_constraint_names)
 
-    def infer(self, context: InferenceContext) -> AttributeCovT:
+    def infer(self, context: ConstraintContext) -> AttributeCovT:
         return self.constr.infer(context)
 
 
@@ -717,7 +699,7 @@ class IntConstraint(ABC):
         # By default, we cannot infer anything.
         return False
 
-    def infer(self, context: InferenceContext) -> int:
+    def infer(self, context: ConstraintContext) -> int:
         """
         Infer the attribute given the the values for all variables.
 
@@ -775,9 +757,9 @@ class IntVarConstraint(IntConstraint):
 
     def infer(
         self,
-        context: InferenceContext,
+        context: ConstraintContext,
     ) -> int:
-        v = context.int_variables[self.name]
+        v = context.get_int_variable(self.name)
         assert isinstance(v, int)
         return v
 
@@ -826,7 +808,7 @@ class GenericRangeConstraint(Generic[AttributeCovT], ABC):
         return False
 
     def infer(
-        self, context: InferenceContext, *, length: int | None
+        self, context: ConstraintContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
         """
         Infer the attribute given the the values for all variables, and possibly
@@ -880,9 +862,9 @@ class RangeVarConstraint(GenericRangeConstraint[AttributeCovT]):
         return self.name in var_constraint_names
 
     def infer(
-        self, context: InferenceContext, *, length: int | None
+        self, context: ConstraintContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
-        v = context.range_variables[self.name]
+        v = context.get_range_variable(self.name)
         return cast(Sequence[AttributeCovT], v)
 
 
@@ -915,7 +897,7 @@ class RangeOf(GenericRangeConstraint[AttributeCovT]):
 
     def infer(
         self,
-        context: InferenceContext,
+        context: ConstraintContext,
         *,
         length: int | None,
     ) -> Sequence[AttributeCovT]:
@@ -963,7 +945,7 @@ class SingleOf(GenericRangeConstraint[AttributeCovT]):
         return self.constr.can_infer(var_constraint_names)
 
     def infer(
-        self, context: InferenceContext, *, length: int | None
+        self, context: ConstraintContext, *, length: int | None
     ) -> Sequence[AttributeCovT]:
         return (self.constr.infer(context),)
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -21,7 +21,7 @@ from xdsl.ir import (
     TypedAttribute,
 )
 from xdsl.irdl import (
-    InferenceContext,
+    ConstraintContext,
     IRDLOperation,
     IRDLOperationInvT,
     OpDef,
@@ -50,7 +50,7 @@ class ParsingState:
     successors: list[Successor | None | Sequence[Successor]]
     attributes: dict[str, Attribute]
     properties: dict[str, Attribute]
-    context: InferenceContext
+    context: ConstraintContext
 
     def __init__(self, op_def: OpDef):
         self.operands = [None] * len(op_def.operands)
@@ -60,7 +60,7 @@ class ParsingState:
         self.successors = [None] * len(op_def.successors)
         self.attributes = {}
         self.properties = {}
-        self.context = InferenceContext()
+        self.context = ConstraintContext()
 
 
 @dataclass
@@ -173,11 +173,11 @@ class FormatProgram:
             v = e.extract_var(state)
             match v:
                 case Attribute():
-                    ctx.variables[k] = v
+                    ctx.set_variable(k, v)
                 case int():
-                    ctx.int_variables[k] = v
+                    ctx.set_int_variable(k, v)
                 case _:
-                    ctx.range_variables[k] = tuple(v)
+                    ctx.set_range_variable(k, tuple(v))
 
         state.context = ctx
 

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -168,7 +168,7 @@ class FormatProgram:
         )
 
     def resolve_constraint_variables(self, state: ParsingState):
-        ctx = InferenceContext()
+        ctx = ConstraintContext()
         for k, e in self.extractors.items():
             v = e.extract_var(state)
             match v:

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -17,8 +17,8 @@ from xdsl.irdl import (
     AttrOrPropDef,
     AttrSizedOperandSegments,
     AttrSizedSegments,
+    ConstraintContext,
     ConstraintVariableType,
-    InferenceContext,
     OpDef,
     OptionalDef,
     OptOperandDef,
@@ -586,7 +586,7 @@ class FormatParser(BaseParser):
                             unique_base.get_type_index()
                         ]
                         if type_constraint.can_infer(set()):
-                            unique_type = type_constraint.infer(InferenceContext())
+                            unique_type = type_constraint.infer(ConstraintContext())
                 if (
                     unique_base is not None
                     and unique_base in Builtin.attributes


### PR DESCRIPTION
In a way, both constraint verification and inference are a matching of a query with data, where we come up with assignments for the variables, and bail if a unique assignment is not found, so it makes sense to me to use the same data structure to represent variable assignment in both cases.