### PR TITLE
core: use bytes internally in Input and Lexer

### DIFF
--- a/docs/Toy/toy/frontend/lexer.py
+++ b/docs/Toy/toy/frontend/lexer.py
@@ -49,7 +49,6 @@ SINGLE_CHAR_TOKENS = {
     "/": ToyTokenKind.OPERATOR,
 }
 
-IDENTIFIER_CHARS = re.compile(r"[\w]|[\d]|_")
 SPECIAL_CHARS = set(",")
 
 
@@ -85,7 +84,7 @@ class ToyLexer(Lexer[ToyTokenKind]):
         """
         self.pos += size
 
-    def _consume_regex(self, regex: re.Pattern[str]) -> re.Match[str] | None:
+    def _consume_regex(self, regex: re.Pattern[bytes]) -> re.Match[bytes] | None:
         """
         Advance the lexer position to the end of the next match of the given
         regular expression.
@@ -96,7 +95,7 @@ class ToyLexer(Lexer[ToyTokenKind]):
         self.pos = match.end()
         return match
 
-    _whitespace_regex = re.compile(r"((#[^\n]*(\n)?)|(\s+))*", re.ASCII)
+    _whitespace_regex = re.compile(rb"((#[^\n]*(\n)?)|(\s+))*", re.ASCII)
 
     def _consume_whitespace(self) -> None:
         """
@@ -132,7 +131,7 @@ class ToyLexer(Lexer[ToyTokenKind]):
             f"Unexpected character: {current_char}",
         )
 
-    IDENTIFIER_SUFFIX = r"[a-zA-Z0-9_$.]*"
+    IDENTIFIER_SUFFIX = rb"[a-zA-Z0-9_$.]*"
     bare_identifier_suffix_regex = re.compile(IDENTIFIER_SUFFIX)
 
     def _lex_bare_identifier(self, start_pos: Position) -> ToyToken:
@@ -146,9 +145,9 @@ class ToyLexer(Lexer[ToyTokenKind]):
 
         return self._form_token(ToyTokenKind.IDENTIFIER, start_pos)
 
-    _hexdigits_star_regex = re.compile(r"[0-9a-fA-F]*")
-    _digits_star_regex = re.compile(r"[0-9]*")
-    _fractional_suffix_regex = re.compile(r"\.[0-9]*([eE][+-]?[0-9]+)?")
+    _hexdigits_star_regex = re.compile(rb"[0-9a-fA-F]*")
+    _digits_star_regex = re.compile(rb"[0-9]*")
+    _fractional_suffix_regex = re.compile(rb"\.[0-9]*([eE][+-]?[0-9]+)?")
 
     def _lex_number(self, start_pos: Position) -> ToyToken:
         """

--- a/docs/Toy/toy/frontend/location.py
+++ b/docs/Toy/toy/frontend/location.py
@@ -29,7 +29,7 @@ def loc(token: Token[Any]) -> Location:
     prev_end = 0
 
     for line, newline_match in enumerate(
-        re.finditer(_NEWLINE, token.span.input.content)
+        re.finditer(_NEWLINE, token.span.input.content.decode())
     ):
         len_line = newline_match.start() - prev_end
         if remaining < len_line:

--- a/xdsl/dialects/stim/stim_parser.py
+++ b/xdsl/dialects/stim/stim_parser.py
@@ -59,19 +59,19 @@ class StimParser:
 
     @property
     def remaining(self) -> str:
-        return self.input.content[self.pos :]
+        return self.input.content[self.pos :].decode()
 
     # region Base parsing functions
 
     def parse_optional_chars(self, chars: str):
-        if self.input.content.startswith(chars, self.pos):
+        if self.input.content.startswith(chars.encode(), self.pos):
             self.pos += len(chars)
             return chars
 
     def parse_optional_pattern(self, pattern: re.Pattern[str]):
-        if (match := pattern.match(self.input.content, self.pos)) is not None:
+        if (match := pattern.match(self.input.content.decode(), self.pos)) is not None:
             self.pos = match.regs[0][1]
-            return self.input.content[match.pos : self.pos]
+            return self.input.content[match.pos : self.pos].decode()
 
     # endregion
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -222,7 +222,7 @@ def _check_enum_constraints(
         raise TypeError("Only direct inheritance from EnumAttribute is allowed.")
 
     for v in enum_type:
-        if MLIRLexer.bare_identifier_suffix_regex.fullmatch(v) is None:
+        if MLIRLexer.bare_identifier_suffix_regex.fullmatch(v.encode()) is None:
             raise ValueError(
                 "All StrEnum values of an EnumAttribute must be parsable as an identifer."
             )

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -106,7 +106,7 @@ class FormatLexer(MLIRLexer):
         return super().lex()
 
     # Authorize `-` in bare identifier
-    bare_identifier_suffix_regex = re.compile(r"[a-zA-Z0-9_$.\-]*")
+    bare_identifier_suffix_regex = re.compile(rb"[a-zA-Z0-9_$.\-]*")
 
 
 @dataclass(init=False)
@@ -708,7 +708,7 @@ class FormatParser(BaseParser):
         if self.parse_optional_characters("`"):
             whitespace = self.lexer.input.content[
                 start_token.span.end : end_token.span.start
-            ]
+            ].decode()
             if whitespace != " " and whitespace != "":
                 self.raise_error(
                     "unexpected whitespace in directive, only ` ` or `` whitespace is allowed"

--- a/xdsl/printer.py
+++ b/xdsl/printer.py
@@ -317,7 +317,7 @@ class Printer(BasePrinter):
         Prints the provided string as an identifier if it is one,
         and as a string literal otherwise.
         """
-        if MLIRLexer.bare_identifier_regex.fullmatch(string) is None:
+        if MLIRLexer.bare_identifier_regex.fullmatch(string.encode()) is None:
             self.print_string_literal(string)
             return
         self.print_string(string)
@@ -687,7 +687,7 @@ class Printer(BasePrinter):
 
     def _print_attr_string(self, attr_tuple: tuple[str, Attribute]) -> None:
         # Print the name without quotes if it is a bare identifier
-        if MLIRLexer.bare_identifier_regex.fullmatch(attr_tuple[0]):
+        if MLIRLexer.bare_identifier_regex.fullmatch(attr_tuple[0].encode()):
             self.print_string(attr_tuple[0])
         else:
             self.print_string(f'"{attr_tuple[0]}"')

--- a/xdsl/utils/mlir_lexer.py
+++ b/xdsl/utils/mlir_lexer.py
@@ -246,7 +246,7 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
         """
         self.pos += size
 
-    def _consume_regex(self, regex: re.Pattern[str]) -> re.Match[str] | None:
+    def _consume_regex(self, regex: re.Pattern[bytes]) -> re.Match[bytes] | None:
         """
         Advance the lexer position to the end of the next match of the given
         regular expression.
@@ -257,7 +257,7 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
         self.pos = match.end()
         return match
 
-    _whitespace_regex = re.compile(r"((//[^\n]*(\n)?)|(\s+))*", re.ASCII)
+    _whitespace_regex = re.compile(rb"((//[^\n]*(\n)?)|(\s+))*", re.ASCII)
 
     def _consume_whitespace(self) -> None:
         """
@@ -356,8 +356,8 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
             f"Unexpected character: {current_char}",
         )
 
-    IDENTIFIER_SUFFIX = r"[a-zA-Z0-9_$.]*"
-    bare_identifier_regex = re.compile(r"[a-zA-Z_]" + IDENTIFIER_SUFFIX)
+    IDENTIFIER_SUFFIX = rb"[a-zA-Z0-9_$.]*"
+    bare_identifier_regex = re.compile(rb"[a-zA-Z_]" + IDENTIFIER_SUFFIX)
     bare_identifier_suffix_regex = re.compile(IDENTIFIER_SUFFIX)
 
     def _lex_bare_identifier(self, start_pos: Position) -> MLIRToken:
@@ -401,7 +401,7 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
             "@ identifier expected to start with letter, '_', or '\"'.",
         )
 
-    _suffix_id = re.compile(r"([0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*)")
+    _suffix_id = re.compile(rb"([0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*)")
 
     def _lex_prefixed_ident(self, start_pos: Position) -> MLIRToken:
         """
@@ -444,7 +444,7 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
 
         return self._form_token(kind, start_pos)
 
-    _unescaped_characters_regex = re.compile(r'[^"\\\n\v\f]*')
+    _unescaped_characters_regex = re.compile(rb'[^"\\\n\v\f]*')
 
     def _lex_string_literal(self, start_pos: Position) -> MLIRToken:
         """
@@ -496,9 +496,9 @@ class MLIRLexer(Lexer[MLIRTokenKind]):
             "End of file reached before closing string literal.",
         )
 
-    _hexdigits_star_regex = re.compile(r"[0-9a-fA-F]*")
-    _digits_star_regex = re.compile(r"[0-9]*")
-    _fractional_suffix_regex = re.compile(r"\.[0-9]*([eE][+-]?[0-9]+)?")
+    _hexdigits_star_regex = re.compile(rb"[0-9a-fA-F]*")
+    _digits_star_regex = re.compile(rb"[0-9]*")
+    _fractional_suffix_regex = re.compile(rb"\.[0-9]*([eE][+-]?[0-9]+)?")
 
     def _lex_number(self, start_pos: Position) -> MLIRToken:
         """


### PR DESCRIPTION
I'm not sure why it's faster but `make filecheck` runs for 13s on my computer instead of 16s.