### PR TITLE
misc: (makefile) Remove prerequisites for removing hidden ASV directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ asv-preview: uv-installed .asv/html
 	uv run asv preview
 
 .PHONY: asv-clean
-asv-clean: .asv
+asv-clean:
 	rm -rf .asv/
 
 # docs


### PR DESCRIPTION
This PR:

- Removes the `.asv` prerequisite from the `asv-clean` target since there is no production rule for it ATM (and there shouldn't be one as it is a plain clean operation) because otherwise it causes `make asv-clean` and `make clean` to fail