### PR TITLE
backend: move register type verification from all subclasses to superclass

### DIFF
--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -1,14 +1,14 @@
 import pytest
 
 from xdsl.backend.register_type import RegisterType
+from xdsl.dialects.builtin import IntAttr, NoneAttr, StringAttr
 from xdsl.irdl import irdl_attr_definition
+from xdsl.utils.exceptions import VerifyException
 
 
 @irdl_attr_definition
 class TestRegister(RegisterType):
     name = "test.reg"
-
-    def verify(self) -> None: ...
 
     @classmethod
     def instruction_set_name(cls) -> str:
@@ -16,7 +16,7 @@ class TestRegister(RegisterType):
 
     @classmethod
     def abi_index_by_name(cls) -> dict[str, int]:
-        return {"x0": 0}
+        return {"x0": 0, "y0": 1}
 
     @classmethod
     def infinite_register_prefix(cls):
@@ -34,3 +34,32 @@ def test_register_clashes():
 def test_unallocated_register():
     assert not TestRegister.unallocated().is_allocated
     assert TestRegister.from_name("x0").is_allocated
+
+
+def test_invalid_register_name():
+    with pytest.raises(
+        VerifyException, match="Invalid register name foo for register set TEST."
+    ):
+        TestRegister.from_name("foo")
+
+
+def test_invalid_index():
+    with pytest.raises(
+        AssertionError, match="Infinite index must be positive, got -1."
+    ):
+        TestRegister.infinite_register(-1)
+
+    with pytest.raises(
+        VerifyException, match="Invalid index 1 for unallocated register."
+    ):
+        TestRegister(IntAttr(1), StringAttr(""))
+
+    with pytest.raises(
+        VerifyException, match="Missing index for register y0, expected 1."
+    ):
+        TestRegister(NoneAttr(), StringAttr("y0"))
+
+    with pytest.raises(
+        VerifyException, match="Invalid index for register y0 2, expected 1."
+    ):
+        TestRegister(IntAttr(2), StringAttr("y0"))

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -60,6 +60,6 @@ def test_invalid_index():
         TestRegister(NoneAttr(), StringAttr("y0"))
 
     with pytest.raises(
-        VerifyException, match="Invalid index for register y0 2, expected 1."
+        VerifyException, match="Invalid index 2 for register y0, expected 1."
     ):
         TestRegister(IntAttr(2), StringAttr("y0"))

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -223,9 +223,13 @@ def test_immediate_shift_inst():
 
 
 def test_float_register():
-    with pytest.raises(VerifyException, match="not in"):
+    with pytest.raises(
+        VerifyException, match="Invalid register name ft9 for register set RV32I."
+    ):
         riscv.IntRegisterType.from_name("ft9")
-    with pytest.raises(VerifyException, match="not in"):
+    with pytest.raises(
+        VerifyException, match="Invalid register name a0 for register set RV32F."
+    ):
         riscv.FloatRegisterType.from_name("a0")
 
     a1 = TestSSAValue(riscv.Registers.A1)

--- a/tests/filecheck/dialects/riscv/riscv_registers_invalid.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_registers_invalid.mlir
@@ -1,0 +1,41 @@
+// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s --match-full-lines
+
+// Valid register names as sanity check
+
+"test.op"() : () -> (!riscv.reg<a0>)
+"test.op"() : () -> (!riscv.reg<j_0>)
+"test.op"() : () -> (!riscv.freg<ft0>)
+"test.op"() : () -> (!riscv.freg<fj_0>)
+
+//      CHECK:  %0 = "test.op"() : () -> !riscv.reg<a0>
+// CHECK-NEXT:  %1 = "test.op"() : () -> !riscv.reg<j_0>
+// CHECK-NEXT:  %2 = "test.op"() : () -> !riscv.freg<ft0>
+// CHECK-NEXT:  %3 = "test.op"() : () -> !riscv.freg<fj_0>
+
+// -----
+
+// Invalid integer register name
+"test.op"() : () -> (!riscv.reg<ft0>)
+
+//      CHECK:  Invalid register name ft0 for register set RV32I.
+
+// -----
+
+// Invalid float register name
+"test.op"() : () -> (!riscv.freg<a0>)
+
+//      CHECK:  Invalid register name a0 for register set RV32F.
+
+// -----
+
+// Non-existent integer register name
+"test.op"() : () -> (!riscv.reg<x99>)
+
+//      CHECK:  Invalid register name x99 for register set RV32I.
+
+// -----
+
+// Non-existent float register name
+"test.op"() : () -> (!riscv.freg<ft99>)
+
+//      CHECK:  Invalid register name ft99 for register set RV32F.

--- a/tests/filecheck/dialects/x86/x86_registers_invalid.mlir
+++ b/tests/filecheck/dialects/x86/x86_registers_invalid.mlir
@@ -1,19 +1,19 @@
 // RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
 
-// CHECK: foo not in x86 
+// CHECK: Invalid register name foo for register set x86.
 "test.op"() { reg = !x86.reg<foo> } : () -> ()
 
 // -----
 
-// CHECK: foo not in AVX2
+// CHECK: Invalid register name foo for register set AVX2.
 "test.op"() { reg = !x86.avx2reg<foo> } : () -> ()
 
 // -----
 
-// CHECK: foo not in AVX512
+// CHECK: Invalid register name foo for register set AVX512.
 "test.op"() { reg = !x86.avx512reg<foo> } : () -> ()
 
 // -----
 
-// CHECK: foo not in SSE
+// CHECK: Invalid register name foo for register set SSE.
 "test.op"() { reg = !x86.ssereg<foo> } : () -> ()

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -108,7 +108,7 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
 
         if expected_index != self.index.data:
             raise VerifyException(
-                f"Invalid index for register {name} {self.index.data}, expected {expected_index}."
+                f"Invalid index {self.index.data} for register {name}, expected {expected_index}."
             )
 
     @classmethod

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -11,10 +11,6 @@ class ARMRegisterType(RegisterType, abc.ABC):
     The abstract class for all ARM register types.
     """
 
-    def verify(self):
-        # No verification for now
-        ...
-
 
 ARM_INDEX_BY_NAME = {f"x{i}": i for i in range(0, 31)}
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -86,13 +86,6 @@ class RISCVRegisterType(RegisterType):
     A RISC-V register type.
     """
 
-    def verify(self) -> None:
-        name = self.register_name.data
-        if not self.is_allocated or name.startswith(self.infinite_register_prefix()):
-            return
-        if name not in type(self).abi_index_by_name():
-            raise VerifyException(f"{name} not in {self.instruction_set_name()}")
-
     @classmethod
     @abstractmethod
     def a_register(cls, index: int) -> Self:

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -6,20 +6,12 @@ from xdsl.backend.register_type import RegisterType
 from xdsl.irdl import (
     irdl_attr_definition,
 )
-from xdsl.utils.exceptions import VerifyException
 
 
 class X86RegisterType(RegisterType, ABC):
     """
     The abstract class for all x86 register types.
     """
-
-    def verify(self) -> None:
-        name = self.register_name.data
-        if not self.is_allocated:
-            return
-        if name not in type(self).abi_index_by_name():
-            raise VerifyException(f"{name} not in {self.instruction_set_name()}")
 
 
 # See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
@@ -134,8 +126,6 @@ class X86VectorRegisterType(X86RegisterType):
     """
     The abstract class for all x86 vector register types.
     """
-
-    pass
 
 
 @irdl_attr_definition


### PR DESCRIPTION
Adds more extensive verification that can be shared by all register types.