### PR TITLE
backend: (riscv) allow x0... and f0... register names

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_registers_invalid.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_registers_invalid.mlir
@@ -1,16 +1,20 @@
-// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s --match-full-lines
+// RUN: xdsl-opt --split-input-file --verify-diagnostics %s | filecheck %s
 
 // Valid register names as sanity check
 
 "test.op"() : () -> (!riscv.reg<a0>)
+"test.op"() : () -> (!riscv.reg<x0>)
 "test.op"() : () -> (!riscv.reg<j_0>)
 "test.op"() : () -> (!riscv.freg<ft0>)
+"test.op"() : () -> (!riscv.freg<f0>)
 "test.op"() : () -> (!riscv.freg<fj_0>)
 
-//      CHECK:  %0 = "test.op"() : () -> !riscv.reg<a0>
-// CHECK-NEXT:  %1 = "test.op"() : () -> !riscv.reg<j_0>
-// CHECK-NEXT:  %2 = "test.op"() : () -> !riscv.freg<ft0>
-// CHECK-NEXT:  %3 = "test.op"() : () -> !riscv.freg<fj_0>
+//      CHECK:  "test.op"() : () -> !riscv.reg<a0>
+// CHECK-NEXT:  "test.op"() : () -> !riscv.reg<x0>
+// CHECK-NEXT:  "test.op"() : () -> !riscv.reg<j_0>
+// CHECK-NEXT:  "test.op"() : () -> !riscv.freg<ft0>
+// CHECK-NEXT:  "test.op"() : () -> !riscv.freg<f0>
+// CHECK-NEXT:  "test.op"() : () -> !riscv.freg<fj_0>
 
 // -----
 

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -92,7 +92,7 @@ class RISCVRegisterType(RegisterType):
         raise NotImplementedError()
 
 
-RV32I_INDEX_BY_NAME = {
+_RV32I_NAMED_INDEX_BY_NAME = {
     "zero": 0,
     "ra": 1,
     "sp": 2,
@@ -127,6 +127,8 @@ RV32I_INDEX_BY_NAME = {
     "t5": 30,
     "t6": 31,
 }
+_RV32I_X_INDEX_BY_NAME = {f"x{i}": i for i in range(32)}
+RV32I_INDEX_BY_NAME = _RV32I_NAMED_INDEX_BY_NAME | _RV32I_X_INDEX_BY_NAME
 
 
 @irdl_attr_definition
@@ -154,7 +156,7 @@ class IntRegisterType(RISCVRegisterType):
         return "j_"
 
 
-RV32F_INDEX_BY_NAME = {
+_RV32F_NAMED_INDEX_BY_NAME = {
     "ft0": 0,
     "ft1": 1,
     "ft2": 2,
@@ -188,6 +190,8 @@ RV32F_INDEX_BY_NAME = {
     "ft10": 30,
     "ft11": 31,
 }
+_RV32F_F_INDEX_BY_NAME = {f"f{i}": i for i in range(32)}
+RV32F_INDEX_BY_NAME = _RV32F_NAMED_INDEX_BY_NAME | _RV32F_F_INDEX_BY_NAME
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -92,7 +92,7 @@ class RISCVRegisterType(RegisterType):
         raise NotImplementedError()
 
 
-_RV32I_NAMED_INDEX_BY_NAME = {
+_RV32I_ABI_INDEX_BY_NAME = {
     "zero": 0,
     "ra": 1,
     "sp": 2,
@@ -128,7 +128,7 @@ _RV32I_NAMED_INDEX_BY_NAME = {
     "t6": 31,
 }
 _RV32I_X_INDEX_BY_NAME = {f"x{i}": i for i in range(32)}
-RV32I_INDEX_BY_NAME = _RV32I_NAMED_INDEX_BY_NAME | _RV32I_X_INDEX_BY_NAME
+RV32I_INDEX_BY_NAME = _RV32I_ABI_INDEX_BY_NAME | _RV32I_X_INDEX_BY_NAME
 
 
 @irdl_attr_definition
@@ -156,7 +156,7 @@ class IntRegisterType(RISCVRegisterType):
         return "j_"
 
 
-_RV32F_NAMED_INDEX_BY_NAME = {
+_RV32F_ABI_INDEX_BY_NAME = {
     "ft0": 0,
     "ft1": 1,
     "ft2": 2,
@@ -191,7 +191,7 @@ _RV32F_NAMED_INDEX_BY_NAME = {
     "ft11": 31,
 }
 _RV32F_F_INDEX_BY_NAME = {f"f{i}": i for i in range(32)}
-RV32F_INDEX_BY_NAME = _RV32F_NAMED_INDEX_BY_NAME | _RV32F_F_INDEX_BY_NAME
+RV32F_INDEX_BY_NAME = _RV32F_ABI_INDEX_BY_NAME | _RV32F_F_INDEX_BY_NAME
 
 
 @irdl_attr_definition


### PR DESCRIPTION
RISC-V has at least two ways to indicate the standard integer and floating-point registers, with their ABI names and indexed (x0, x1, ..., f0, f1, ...). With this PR, we support both in the assembly format again.