### PR TITLE
interactive: return structured tuple in get_pass_argument_names_and_types

### DIFF
--- a/tests/test_pass_to_arg_and_types_str.py
+++ b/tests/test_pass_to_arg_and_types_str.py
@@ -5,7 +5,7 @@ import pytest
 
 from xdsl.context import Context
 from xdsl.dialects import builtin
-from xdsl.passes import ModulePass, PassArgOption, get_pass_argument_names_and_types
+from xdsl.passes import ModulePass, PassOptionInfo, get_pass_option_infos
 
 
 @dataclass(frozen=True)
@@ -57,33 +57,33 @@ class SimplePass(ModulePass):
     [
         (
             (
-                PassArgOption("number", "int|float"),
-                PassArgOption("single_number", "int"),
-                PassArgOption("int_list", "tuple[int, ...]"),
-                PassArgOption("non_init_thing", "int"),
-                PassArgOption("str_thing", "str"),
-                PassArgOption("nullable_str", "str|None"),
-                PassArgOption(
+                PassOptionInfo("number", "int|float"),
+                PassOptionInfo("single_number", "int"),
+                PassOptionInfo("int_list", "tuple[int, ...]"),
+                PassOptionInfo("non_init_thing", "int"),
+                PassOptionInfo("str_thing", "str"),
+                PassOptionInfo("nullable_str", "str|None"),
+                PassOptionInfo(
                     "literal",
                     "typing.Literal['yes', 'no', 'maybe']",
                     "no",
                 ),
-                PassArgOption("optional_bool", "bool", "false"),
+                PassOptionInfo("optional_bool", "bool", "false"),
             ),
             CustomPass,
         ),
         ((), EmptyPass),
         (
             (
-                PassArgOption("a", "int|float"),
-                PassArgOption("b", "int|None"),
-                PassArgOption("c", "int", "5"),
+                PassOptionInfo("a", "int|float"),
+                PassOptionInfo("b", "int|None"),
+                PassOptionInfo("c", "int", "5"),
             ),
             SimplePass,
         ),
     ],
 )
 def test_pass_to_arg_and_type_str(
-    arg_options: tuple[PassArgOption, ...], pass_arg: type[ModulePass]
+    arg_options: tuple[PassOptionInfo, ...], pass_arg: type[ModulePass]
 ):
-    assert get_pass_argument_names_and_types(pass_arg) == arg_options
+    assert get_pass_option_infos(pass_arg) == arg_options

--- a/tests/test_pass_to_arg_and_types_str.py
+++ b/tests/test_pass_to_arg_and_types_str.py
@@ -5,7 +5,7 @@ import pytest
 
 from xdsl.context import Context
 from xdsl.dialects import builtin
-from xdsl.passes import ModulePass, get_pass_argument_names_and_types
+from xdsl.passes import ModulePass, PassArgOption, get_pass_argument_names_and_types
 
 
 @dataclass(frozen=True)
@@ -53,17 +53,37 @@ class SimplePass(ModulePass):
 
 
 @pytest.mark.parametrize(
-    "str_arg, pass_arg",
+    "arg_options, pass_arg",
     [
         (
-            "number=int|float single_number=int int_list=tuple[int, ...] "
-            "non_init_thing=int str_thing=str nullable_str=str|None literal=no "
-            "optional_bool=false",
+            (
+                PassArgOption("number", "int|float"),
+                PassArgOption("single_number", "int"),
+                PassArgOption("int_list", "tuple[int, ...]"),
+                PassArgOption("non_init_thing", "int"),
+                PassArgOption("str_thing", "str"),
+                PassArgOption("nullable_str", "str|None"),
+                PassArgOption(
+                    "literal",
+                    "typing.Literal['yes', 'no', 'maybe']",
+                    "no",
+                ),
+                PassArgOption("optional_bool", "bool", "false"),
+            ),
             CustomPass,
         ),
-        ("", EmptyPass),
-        ("""a=int|float b=int|None c=5""", SimplePass),
+        ((), EmptyPass),
+        (
+            (
+                PassArgOption("a", "int|float"),
+                PassArgOption("b", "int|None"),
+                PassArgOption("c", "int", "5"),
+            ),
+            SimplePass,
+        ),
     ],
 )
-def test_pass_to_arg_and_type_str(str_arg: str, pass_arg: type[ModulePass]):
-    assert get_pass_argument_names_and_types(pass_arg) == str_arg
+def test_pass_to_arg_and_type_str(
+    arg_options: tuple[PassArgOption, ...], pass_arg: type[ModulePass]
+):
+    assert get_pass_argument_names_and_types(pass_arg) == arg_options

--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -5,7 +5,7 @@ from textual.reactive import Reactive
 from textual.screen import Screen
 from textual.widgets import Button, TextArea
 
-from xdsl.passes import ModulePass, get_pass_argument_names_and_types
+from xdsl.passes import ModulePass, get_pass_option_infos
 from xdsl.utils.exceptions import PassPipelineParseError
 from xdsl.utils.parse_pipeline import parse_pipeline
 
@@ -26,7 +26,7 @@ class AddArguments(Screen[ModulePass | None]):
         self.argument_text_area = TextArea(
             " ".join(
                 f"{n}={t if d is None else d}"
-                for n, t, d in get_pass_argument_names_and_types(selected_pass_type)
+                for n, t, d in get_pass_option_infos(selected_pass_type)
             ),
             id="argument_text_area",
         )

--- a/xdsl/interactive/add_arguments_screen.py
+++ b/xdsl/interactive/add_arguments_screen.py
@@ -24,7 +24,10 @@ class AddArguments(Screen[ModulePass | None]):
     def __init__(self, selected_pass_type: type[ModulePass]):
         self.selected_pass_type = selected_pass_type
         self.argument_text_area = TextArea(
-            get_pass_argument_names_and_types(selected_pass_type),
+            " ".join(
+                f"{n}={t if d is None else d}"
+                for n, t, d in get_pass_argument_names_and_types(selected_pass_type)
+            ),
             id="argument_text_area",
         )
         self.enter_button = Button("Enter", id="enter_button")

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -3,7 +3,15 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import Field, dataclass, field
 from types import NoneType, UnionType
-from typing import Any, ClassVar, TypeVar, Union, get_args, get_origin
+from typing import (
+    Any,
+    ClassVar,
+    NamedTuple,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from xdsl.context import Context
 from xdsl.dialects import builtin
@@ -151,23 +159,30 @@ class ModulePass(ABC):
         return PipelinePassSpec(self.name, args)
 
 
-# Git Issue: https://github.com/xdslproject/xdsl/issues/1845
-def get_pass_argument_names_and_types(arg: type[ModulePassT]) -> str:
+class PassArgOption(NamedTuple):
+    """ """
+
+    name: str
+    type_str: str
+    default_value_str: str | None = None
+
+
+def get_pass_argument_names_and_types(
+    arg: type[ModulePassT],
+) -> tuple[PassArgOption, ...]:
     """
-    This method takes a type[ModulePassT] and outputs a string containing the names of the
-    pass arguments and their types. If an argument has a default value, it is not
+    This method takes a type[ModulePassT] and outputs a string containing the names of
+    the pass arguments and their types. If an argument has a default value, it is not
     added to the string.
     """
 
-    return " ".join(
-        [
-            (
-                f"{field.name}={type_repr(field.type)}"
-                if not hasattr(arg, field.name)
-                else f"{field.name}={str(getattr(arg, field.name)).lower()}"
-            )
-            for field in dataclasses.fields(arg)
-        ]
+    return tuple(
+        PassArgOption(
+            field.name,
+            type_repr(field.type),
+            str(getattr(arg, field.name)).lower() if hasattr(arg, field.name) else None,
+        )
+        for field in dataclasses.fields(arg)
     )
 
 

--- a/xdsl/passes.py
+++ b/xdsl/passes.py
@@ -159,25 +159,24 @@ class ModulePass(ABC):
         return PipelinePassSpec(self.name, args)
 
 
-class PassArgOption(NamedTuple):
-    """ """
+class PassOptionInfo(NamedTuple):
+    """The name, expected type, and default value for one option of a module pass."""
 
     name: str
-    type_str: str
-    default_value_str: str | None = None
+    expected_type: str
+    default_value: str | None = None
 
 
-def get_pass_argument_names_and_types(
+def get_pass_option_infos(
     arg: type[ModulePassT],
-) -> tuple[PassArgOption, ...]:
+) -> tuple[PassOptionInfo, ...]:
     """
-    This method takes a type[ModulePassT] and outputs a string containing the names of
-    the pass arguments and their types. If an argument has a default value, it is not
-    added to the string.
+    Returns the expected argument names, types, and optional expected values for options
+    for the given pass.
     """
 
     return tuple(
-        PassArgOption(
+        PassOptionInfo(
             field.name,
             type_repr(field.type),
             str(getattr(arg, field.name)).lower() if hasattr(arg, field.name) else None,


### PR DESCRIPTION
We currently return a string, which doesn't allow the caller to choose whether and how to display the options.
Plenty of work to do still when the interactive project picks back up, but I feel like it's a step in the right direction.

Fixes #1845