### PR TITLE
documentation: deploy docs website to readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,7 @@
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
-      - VENV_EXTRAS="--all-extras" make venv
-      - source .venv/bin/activate
+      - VENV_EXTRAS="--all-extras" VENV_DIR="$READTHEDOCS_VIRTUALENV_PATH" make venv
     install:
       - "true"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@
       - asdf install uv latest
       - asdf global uv latest
       - VENV_EXTRAS="--all-extras" make venv
+      - source .venv/bin/activate
     install:
       - "true"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,7 @@
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
+      # https://docs.readthedocs.com/platform/stable/reference/environment-variables.html#envvar-READTHEDOCS_VIRTUALENV_PATH
       - VENV_EXTRAS="--all-extras" VENV_DIR="$READTHEDOCS_VIRTUALENV_PATH" make venv
     install:
       - "true"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+ version: 2
+
+ build:
+   os: "ubuntu-24.04"
+   tools:
+     python: "3.13"
+   # We recommend using a requirements file for reproducible builds.
+   # This is just a quick example to get started.
+   # https://docs.readthedocs.io/page/guides/reproducible-builds.html
+   jobs:
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - VENV_EXTRAS="--all-extras" make venv
+    install:
+      - "true"
+
+ mkdocs:
+   configuration: mkdocs.yml


### PR DESCRIPTION
This PR sets up readthedocs hosting for our mkdocs docs, meaning we get the best of both worlds:
 - docs for each version of xDSL from now on available in a drop-down menu on a platform we don't need to manage (and maybe even for each PR but I haven't tried that yet)
 - we control how the docs are generated and structured in MKDocs's API, which is more flexible and modern than the readthedocs default Sphinx

Check it out here:

https://xdsl.readthedocs.io/en/latest/

We definitely want to clean it up and make it nicer before making public announcements but it seems like a big step forwards.