### PR TITLE
backend: add from_index method to register

### DIFF
--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -112,3 +112,10 @@ def test_invalid_index():
 
 def test_name_by_index():
     assert TestRegister.abi_name_by_index() == {0: "a0", 1: "a1"}
+
+
+def test_from_index():
+    assert TestRegister.from_index(0) == TestRegister.from_name("a0")
+    assert TestRegister.from_index(1) == TestRegister.from_name("a1")
+    assert TestRegister.from_index(-1) == TestRegister.infinite_register(0)
+    assert TestRegister.from_index(-2) == TestRegister.infinite_register(1)

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -319,6 +319,20 @@ def test_int_abi_name_by_index():
     }
 
 
+def test_int_from_index():
+    assert riscv.IntRegisterType.from_index(0) == riscv.Registers.ZERO
+    assert riscv.IntRegisterType.from_index(10) == riscv.Registers.A0
+    assert riscv.IntRegisterType.from_index(20) == riscv.Registers.S4
+    assert riscv.IntRegisterType.from_index(30) == riscv.Registers.T5
+
+    with pytest.raises(KeyError):
+        riscv.IntRegisterType.from_index(40)
+
+    assert riscv.IntRegisterType.from_index(
+        -10
+    ) == riscv.IntRegisterType.infinite_register(9)
+
+
 def test_float_abi_name_by_index():
     assert riscv.FloatRegisterType.abi_name_by_index() == {
         0: "ft0",
@@ -354,3 +368,17 @@ def test_float_abi_name_by_index():
         30: "ft10",
         31: "ft11",
     }
+
+
+def test_float_from_index():
+    assert riscv.FloatRegisterType.from_index(0) == riscv.Registers.FT0
+    assert riscv.FloatRegisterType.from_index(10) == riscv.Registers.FA0
+    assert riscv.FloatRegisterType.from_index(20) == riscv.Registers.FS4
+    assert riscv.FloatRegisterType.from_index(30) == riscv.Registers.FT10
+
+    with pytest.raises(KeyError):
+        riscv.FloatRegisterType.from_index(40)
+
+    assert riscv.FloatRegisterType.from_index(
+        -10
+    ) == riscv.FloatRegisterType.infinite_register(9)

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -72,6 +72,13 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
             register_name = StringAttr(register_name)
         return cls(*cls._parameters_from_name(register_name))
 
+    @classmethod
+    def from_index(cls, index: int) -> Self:
+        if index < 0:
+            return cls.infinite_register(~index)
+        name = cls.abi_name_by_index()[index]
+        return cls(IntAttr(index), StringAttr(name))
+
     @property
     def is_allocated(self) -> bool:
         """Returns true if the register is allocated, otherwise false"""


### PR DESCRIPTION
The last PR I have planned for the register types themselves, after this onto the register queue, using this indices to keep track of which registers are reserved or available instead of names.