### PR TITLE
testing: clean up some filecheck tests

### DIFF
--- a/tests/filecheck/dialects/irdl/cmath_irdl_loading.py
+++ b/tests/filecheck/dialects/irdl/cmath_irdl_loading.py
@@ -1,5 +1,7 @@
 # RUN: python %s | filecheck %s
 
+from pathlib import Path
+
 from xdsl.context import Context
 from xdsl.dialects import get_all_dialects
 from xdsl.dialects.irdl.irdl import DialectOp
@@ -19,7 +21,9 @@ if __name__ == "__main__":
         ctx.register_dialect(n, f)
 
     # Open the IRDL description of cmath, parse it
-    f = open("tests/filecheck/dialects/irdl/cmath.irdl.mlir")
+
+    file_path = Path(__file__).parent / "cmath.irdl.mlir"
+    f = file_path.open()
     parser = Parser(ctx, f.read())
     module = parser.parse_module()
 
@@ -32,7 +36,7 @@ if __name__ == "__main__":
     ctx.register_dialect("cmath", lambda: dialect)
 
     # Roundtrip a cmath file!
-    f = open("tests/filecheck/dialects/cmath/cmath_ops.mlir")
+    f = (Path(__file__).parent.parent / "cmath" / "cmath_ops.mlir").open()
     parser = Parser(ctx, f.read())
     module = parser.parse_module()
     module.verify()

--- a/tests/filecheck/dialects/irdl/cmath_irdl_stub.py
+++ b/tests/filecheck/dialects/irdl/cmath_irdl_stub.py
@@ -1,4 +1,5 @@
 # RUN: python %s | filecheck %s
+from pathlib import Path
 
 from xdsl.context import Context
 from xdsl.dialects import get_all_dialects
@@ -20,7 +21,7 @@ if __name__ == "__main__":
         ctx.register_dialect(n, f)
 
     # Open the IRDL description of cmath, parse it
-    f = open("tests/filecheck/dialects/irdl/cmath.irdl.mlir")
+    f = (Path(__file__).parent / "cmath.irdl.mlir").open()
     parser = Parser(ctx, f.read())
     module = parser.parse_module()
 

--- a/tests/filecheck/transforms/apply-pdl/extra_file.mlir
+++ b/tests/filecheck/transforms/apply-pdl/extra_file.mlir
@@ -1,3 +1,7 @@
+// RUN: true
+
+// Support file for apply_pdl_extra_file.mlir
+
 pdl.pattern : benefit(1) {
     %zero_attr = pdl.attribute = 0
     %root = pdl.operation "test.op" {"attr" = %zero_attr}


### PR DESCRIPTION
These raised errors when removing the `cd ../..` preamble in the lit.cfg. (See #3953)
