### PR TITLE
CI: only collect coverage data for one Python version

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
       MLIR-Version: d401987fe349a87c53fe25829215b080b70c0c1a
+      COLLECT_COVERAGE: ${{ matrix.python-version == '3.10' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -92,15 +93,24 @@ jobs:
     - name: Test with pytest and generate code coverage
       run: |
         cd xdsl
-        uv run pytest -W error --cov
+        if [ "$COLLECT_COVERAGE" = "true" ]; then
+          uv run pytest -W error --cov
+        else
+          uv run pytest -W error
+        fi
 
     - name: Execute lit tests
       run: |
         cd xdsl
         # Add mlir-opt to the path
         export PATH=$PATH:${GITHUB_WORKSPACE}/llvm-project/build/bin/
-        uv run lit -v tests/filecheck/ -DCOVERAGE
-        uv run lit -v docs/Toy/examples/ -DCOVERAGE
+        if [ "$COLLECT_COVERAGE" = "true" ]; then
+          uv run lit -v tests/filecheck/ -DCOVERAGE
+          uv run lit -v docs/Toy/examples/ -DCOVERAGE
+        else
+          uv run lit -v tests/filecheck/
+          uv run lit -v docs/Toy/examples/
+        fi
 
     - name: Test MLIR dependent examples/tutorials
       run: |
@@ -110,6 +120,7 @@ jobs:
         uv run pytest --nbval docs/mlir_interoperation.ipynb --maxfail 1 -vv
 
     - name: Combine coverage data
+      if: matrix.python-version == '3.10'
       run: |
         cd xdsl
         uv run coverage combine --append


### PR DESCRIPTION
It slows down all the tests, even though we only upload the coverage data for 3.10 currently. This will help test both branches of #3953.