### PR TITLE
dependencies: update mlir-opt to cd70802

### DIFF
--- a/.github/workflows/ci-mlir.yml
+++ b/.github/workflows/ci-mlir.yml
@@ -20,7 +20,7 @@ jobs:
 
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
-      MLIR-Version: d401987fe349a87c53fe25829215b080b70c0c1a
+      MLIR-Version: cd708029e0b2869e80abe31ddb175f7c35361f90
     steps:
     - uses: actions/checkout@v4
       with:

--- a/docs/guides/mlir_interoperation.md
+++ b/docs/guides/mlir_interoperation.md
@@ -25,4 +25,4 @@ mlir-opt --convert-scf-to-cf --convert-cf-to-llvm --convert-func-to-llvm \
 The generated `tmp.ll` file contains LLVM IR, so it can be directly passed to
 the clang compiler. Notice that a `main` function is required for clang to
 build. The functionality is tested with the MLIR git commit hash:
-d401987fe349a87c53fe25829215b080b70c0c1a
+cd708029e0b2869e80abe31ddb175f7c35361f90

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_putchar.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/print/printf_to_putchar.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p printf-to-putchar %s | mlir-opt --convert-math-to-funcs  --test-lower-to-llvm | mlir-cpu-runner --entry-point-result=void | filecheck %s
+// RUN: xdsl-opt -p printf-to-putchar %s | mlir-opt --convert-math-to-funcs --convert-scf-to-cf --convert-to-llvm | mlir-cpu-runner --entry-point-result=void | filecheck %s
 
 builtin.module{
     "func.func"() ({
@@ -16,7 +16,7 @@ builtin.module{
 	"printf.print_char"(%e) : (i8) -> ()
 	"printf.print_char"(%exclamation) : (i8) -> ()
 	"printf.print_char"(%newline) : (i8) -> ()
-        "printf.print_int"(%integer) : (i32) -> ()
+    "printf.print_int"(%integer) : (i32) -> ()
 	"printf.print_char"(%newline) : (i8) -> ()
 	"func.return"() : () -> ()
     }) {"sym_name" = "main", "function_type" = () -> (), "sym_visibility" = "private"} : () -> ()


### PR DESCRIPTION
This commit corresponds to version 19.1.7, which is the latest version of llvm available in brew.