### PR TITLE
documentation: fix commit hash in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install xdsl
 
 *Note:* This version of xDSL is validated against a specific MLIR version,
 interoperability with other versions may result in problems. The supported
-MLIR version is commit `d401987fe349a87c53fe25829215b080b70c0c1a`.
+MLIR version is commit `cd708029e0b2869e80abe31ddb175f7c35361f90`.
 
 ### Subprojects With Extra Dependencies
 


### PR DESCRIPTION
Missed this in #4055 