### PR TITLE
backend: (riscv) RiscvRegisterQueue makes empty queue, add helper

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -16,9 +16,7 @@ from xdsl.utils.test_value import TestSSAValue
 
 
 def test_default_reserved_registers():
-    register_queue = RiscvRegisterQueue(
-        available_int_registers=[], available_float_registers=[]
-    )
+    register_queue = RiscvRegisterQueue()
 
     unallocated = riscv.Registers.UNALLOCATED_INT
 
@@ -107,9 +105,7 @@ def test_allocate_with_inout_constraints():
                 (self.rs0,), (self.rd0,), ((self.rs1, self.rd1),)
             )
 
-    register_queue = RiscvRegisterQueue(
-        available_int_registers=[], available_float_registers=[]
-    )
+    register_queue = RiscvRegisterQueue()
     register_allocator = RegisterAllocatorLivenessBlockNaive(register_queue)
 
     # All new registers. The result register is reused by the allocator for the operand.

--- a/tests/backend/riscv/test_register_queue.py
+++ b/tests/backend/riscv/test_register_queue.py
@@ -8,7 +8,7 @@ from xdsl.dialects.builtin import IntAttr
 
 
 def test_default_reserved_registers():
-    register_queue = RiscvRegisterQueue()
+    register_queue = RiscvRegisterQueue.default()
 
     for reg in (
         riscv.Registers.ZERO,
@@ -82,7 +82,7 @@ def test_reserve_register():
 
 
 def test_limit():
-    register_queue = RiscvRegisterQueue()
+    register_queue = RiscvRegisterQueue.default()
     register_queue.limit_registers(1)
 
     assert not register_queue.pop(riscv.IntRegisterType).register_name.data.startswith(

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -55,7 +55,7 @@ class RISCVRegisterAllocation(ModulePass):
 
         for inner_op in op.walk():
             if isinstance(inner_op, riscv_func.FuncOp):
-                riscv_register_queue = RiscvRegisterQueue()
+                riscv_register_queue = RiscvRegisterQueue.default()
                 if self.limit_registers is not None:
                     riscv_register_queue.limit_registers(self.limit_registers)
                 allocator = allocator_strategies[self.allocation_strategy](


### PR DESCRIPTION
As a step towards a generic register queue, I wanted to decouple the init from the ABI default available and reserved registers.