### PR TITLE
CI: add Dockerfile and CI action for preinstalled LLVM

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -1,0 +1,49 @@
+name: Build LLVM toolchain image
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .github/workflows/toolchain.yml
+  push:
+    branches: [ "main" ]
+    paths:
+      - Dockerfile
+      - .github/workflows/toolchain.yml
+  workflow_dispatch:
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      # Free up disk space on Github-hosted runner
+      - name: Disk usage
+        run: df -h
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+
+      - name: Disk usage after freeing up space
+        run: df -h
+
+      # Actually build the Docker container
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: GHCR Log-in
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: ${{github.workspace}}/runtime/
+          file: ${{github.workspace}}/runtime/toolchain/Dockerfile
+          push: true
+          tags: ghcr.io/xdslproject/xdsl/toolchain:${{ github.head_ref || github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:latest
+
+# Install xz-utils
+RUN apt-get update && apt-get install -y \
+    wget xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download and extract the official LLVM 19.1.7 binary
+WORKDIR /tmp
+RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/LLVM-19.1.7-Linux-X64.tar.xz && \
+    tar xf LLVM-19.1.7-Linux-X64.tar.xz -C /usr/local --strip-components=1 && \
+    rm LLVM-19.1.7-Linux-X64.tar.xz


### PR DESCRIPTION
The main idea here is to provide a base image that would have the necessary LLVM and MLIR binaries to test the interop. 

The toolchain action is lifted from the Quidditch with small modifications.

Having an image like this that we can control would also let us have a base image for GH Codespaces with MLIR preinstalled.

Do you all think that this is a good idea? Is there a better way to set this up?