### PR TITLE
dependencies: make pre-commit version less strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
     "filecheck==1.0.1",
     "lit<19.0.0",
     "marimo==0.11.21",
-    "pre-commit==4.1.0",
+    "pre-commit>=4.0.0,<5.0.0",
     "ruff==0.11.0",
     "nbconvert>=7.7.2,<8.0.0",
     "textual-dev==1.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3085,7 +3085,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'jax'", specifier = "==2.2.4" },
     { name = "ordered-set", specifier = "==4.1.0" },
     { name = "orjson", marker = "extra == 'bench'", specifier = ">=3.10.15" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.1.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0,<5.0.0" },
     { name = "pyclip", marker = "extra == 'gui'", specifier = "==0.7" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.396" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "<8.4" },


### PR DESCRIPTION
Inspired by #4072, I don't think we need to be quite so precise on the pre-commit version.

We might want to revisit the other dependencies.