### PR TITLE
minor: (csl-stencil-handle-async-flow) Provide task ids as list

### DIFF
--- a/tests/filecheck/transforms/csl-stencil-handle-async-flow-no-args.mlir
+++ b/tests/filecheck/transforms/csl-stencil-handle-async-flow-no-args.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p "csl-stencil-handle-async-flow" | filecheck %s
+// RUN: xdsl-opt %s -p "csl-stencil-handle-async-flow{task_ids=1}" | filecheck %s
 
 builtin.module {
   "csl_wrapper.module"() <{height = 4 : i16, params = [#csl_wrapper.param<"z_dim" default=4 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=2 : i16>, #csl_wrapper.param<"padded_z_dim" default=2 : i16>], program_name = "loop_kernel", width = 4 : i16}> ({

--- a/tests/filecheck/transforms/csl-stencil-handle-async-flow.mlir
+++ b/tests/filecheck/transforms/csl-stencil-handle-async-flow.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s -p "csl-stencil-handle-async-flow" | filecheck %s
+// RUN: xdsl-opt %s -p "csl-stencil-handle-async-flow{task_ids=1,2,3,4}" | filecheck %s
 
   "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):

--- a/xdsl/transforms/csl_stencil_handle_async_flow.py
+++ b/xdsl/transforms/csl_stencil_handle_async_flow.py
@@ -148,7 +148,7 @@ class ConvertForLoopToCallGraphPass(RewritePattern):
         if self.task_ids:
             cond_task_id = self.task_ids.pop(0)
         else:
-            raise RuntimeError(
+            raise ValueError(
                 "Insufficient number of task IDs supplied, please provide further IDs to be used."
             )
 

--- a/xdsl/transforms/csl_stencil_handle_async_flow.py
+++ b/xdsl/transforms/csl_stencil_handle_async_flow.py
@@ -103,6 +103,8 @@ class ConvertForLoopToCallGraphPass(RewritePattern):
 
     counter: int
 
+    task_ids: list[int]
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: scf.ForOp, rewriter: PatternRewriter, /):
         if not self._is_inside_wrapper_outside_apply(op):
@@ -143,7 +145,12 @@ class ConvertForLoopToCallGraphPass(RewritePattern):
             )
 
         no_params = FunctionType.from_lists([], [])
-        cond_task_id = self.counter + 1
+        if self.task_ids:
+            cond_task_id = self.task_ids.pop(0)
+        else:
+            raise RuntimeError(
+                "Insufficient number of task IDs supplied, please provide further IDs to be used."
+            )
 
         pre_block = op.parent_block()
         if pre_block is None:
@@ -292,11 +299,16 @@ class CslStencilHandleAsyncControlFlow(ModulePass):
 
     name = "csl-stencil-handle-async-flow"
 
+    task_ids: tuple[int, ...]
+    """
+    Available task IDs that this pass is free to allocate.
+    """
+
     def apply(self, ctx: Context, op: ModuleOp) -> None:
         module_pass = PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
-                    ConvertForLoopToCallGraphPass(0),
+                    ConvertForLoopToCallGraphPass(0, list(self.task_ids)),
                     HandleCslStencilApplyAsyncCF(0),
                 ]
             ),

--- a/xdsl/transforms/csl_stencil_handle_async_flow.py
+++ b/xdsl/transforms/csl_stencil_handle_async_flow.py
@@ -29,6 +29,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
+from xdsl.utils.exceptions import PassFailedException
 from xdsl.utils.hints import isa
 
 
@@ -148,7 +149,7 @@ class ConvertForLoopToCallGraphPass(RewritePattern):
         if self.task_ids:
             cond_task_id = self.task_ids.pop(0)
         else:
-            raise ValueError(
+            raise PassFailedException(
                 "Insufficient number of task IDs supplied, please provide further IDs to be used."
             )
 


### PR DESCRIPTION
Require free task IDs to be provided explicitly as a list.