### PR TITLE
core: better spans for assembly format error messages

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -713,13 +713,16 @@ def test_unknown_variable():
     with pytest.raises(
         PyRDLOpDefinitionError,
         match="expected variable to refer to an operand, attribute, region, or successor",
-    ):
+    ) as exc_info:
 
         @irdl_op_definition
         class UnknownVarOp(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.unknown_var_op"
 
             assembly_format = "$var attr-dict"
+
+    assert isinstance(exc_info.value.__cause__, ParseError)
+    assert exc_info.value.__cause__.span.text == "$var"
 
 
 ################################################################################

--- a/xdsl/irdl/declarative_assembly_format_parser.py
+++ b/xdsl/irdl/declarative_assembly_format_parser.py
@@ -473,9 +473,11 @@ class FormatParser(BaseParser):
           variable ::= `$` bare-ident
         The variable should refer to an operand or result.
         """
+        start_pos = self.pos
         if self._current_token.text[0] != "$":
             return None
         self._consume_token()
+        end_pos = self._current_token.span.end
         variable_name = self.parse_identifier(" after '$'")
 
         # Check if the variable is an operand
@@ -497,7 +499,11 @@ class FormatParser(BaseParser):
                 case _:
                     return ResultVariable(variable_name, idx)
 
-        self.raise_error("expected typeable variable to refer to an operand or result")
+        self.raise_error(
+            "expected typeable variable to refer to an operand or result",
+            at_position=start_pos,
+            end_position=end_pos,
+        )
 
     def parse_optional_variable(
         self,
@@ -509,7 +515,9 @@ class FormatParser(BaseParser):
         """
         if self._current_token.text[0] != "$":
             return None
+        start_pos = self.pos
         self._consume_token()
+        end_pos = self._current_token.span.end
         variable_name = self.parse_identifier(" after '$'")
 
         # Check if the variable is an operand
@@ -616,7 +624,9 @@ class FormatParser(BaseParser):
                 )
 
         self.raise_error(
-            "expected variable to refer to an operand, attribute, region, or successor"
+            "expected variable to refer to an operand, attribute, region, or successor",
+            at_position=start_pos,
+            end_position=end_pos,
         )
 
     def parse_type_directive(self) -> FormatDirective:


### PR DESCRIPTION
I noticed that we were giving spans of the token after the variable name, this change includes both the $ token and the name.