### PR TITLE
dialects: (vector) add assembly format to vector ops

### DIFF
--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -104,7 +104,7 @@ def test_vector_store_i32():
 
     store = StoreOp.get(vector_ssa_value, memref_ssa_value, [])
 
-    assert store.memref is memref_ssa_value
+    assert store.base is memref_ssa_value
     assert store.vector is vector_ssa_value
     assert store.indices == ()
 
@@ -117,7 +117,7 @@ def test_vector_store_i32_with_dimensions():
     index2 = TestSSAValue(IndexType())
     store = StoreOp.get(vector_ssa_value, memref_ssa_value, [index1, index2])
 
-    assert store.memref is memref_ssa_value
+    assert store.base is memref_ssa_value
     assert store.vector is vector_ssa_value
     assert store.indices[0] is index1
     assert store.indices[1] is index2
@@ -197,122 +197,6 @@ def test_vector_fma_with_dimensions():
     assert fma.lhs is lhs_vector_ssa_value
     assert fma.rhs is rhs_vector_ssa_value
     assert fma.acc is acc_vector_ssa_value
-
-
-def test_vector_fma_verify_res_lhs_type_matching():
-    i64_vector_type = VectorType(i64, [1])
-
-    i32_vector_ssa_value = get_Vector_SSAVal(i32, [1])
-    i64_vector_ssa_value = get_Vector_SSAVal(i64, [1])
-
-    fma = FMAOp.build(
-        operands=[i32_vector_ssa_value, i64_vector_ssa_value, i64_vector_ssa_value],
-        result_types=[i64_vector_type],
-    )
-
-    message = (
-        "Result vector type must match with all source vectors. Found "
-        "different types for result vector and lhs vector."
-    )
-    with pytest.raises(Exception, match=message):
-        fma.verify()
-
-
-def test_vector_fma_verify_res_rhs_type_matching():
-    i64_vector_type = VectorType(i64, [1])
-
-    i32_vector_ssa_value = get_Vector_SSAVal(i32, [1])
-    i64_vector_ssa_value = get_Vector_SSAVal(i64, [1])
-
-    fma = FMAOp.build(
-        operands=[i64_vector_ssa_value, i32_vector_ssa_value, i64_vector_ssa_value],
-        result_types=[i64_vector_type],
-    )
-
-    message = (
-        "Result vector type must match with all source vectors. "
-        "Found different types for result vector and rhs vector."
-    )
-
-    with pytest.raises(Exception, match=message):
-        fma.verify()
-
-
-def test_vector_fma_verify_res_acc_type_matching():
-    i64_vector_type = VectorType(i64, [1])
-
-    i32_vector_ssa_value = get_Vector_SSAVal(i32, [1])
-    i64_vector_ssa_value = get_Vector_SSAVal(i64, [1])
-
-    fma = FMAOp.build(
-        operands=[i64_vector_ssa_value, i64_vector_ssa_value, i32_vector_ssa_value],
-        result_types=[i64_vector_type],
-    )
-
-    message = (
-        "Result vector type must match with all source vectors. "
-        "Found different types for result vector and acc vector."
-    )
-
-    with pytest.raises(Exception, match=message):
-        fma.verify()
-
-
-def test_vector_fma_verify_res_lhs_shape_matching():
-    i32_vector_type2 = VectorType(i32, [4, 5])
-
-    vector_ssa_value1 = get_Vector_SSAVal(i32, [2, 3])
-    vector_ssa_value2 = get_Vector_SSAVal(i32, [4, 5])
-
-    fma = FMAOp.build(
-        operands=[vector_ssa_value1, vector_ssa_value2, vector_ssa_value2],
-        result_types=[i32_vector_type2],
-    )
-
-    message = (
-        "Result vector shape must match with all source vector shapes. "
-        "Found different shapes for result vector and lhs vector."
-    )
-    with pytest.raises(Exception, match=message):
-        fma.verify()
-
-
-def test_vector_fma_verify_res_rhs_shape_matching():
-    i32_vector_type2 = VectorType(i32, [4, 5])
-
-    vector_ssa_value1 = get_Vector_SSAVal(i32, [2, 3])
-    vector_ssa_value2 = get_Vector_SSAVal(i32, [4, 5])
-
-    fma = FMAOp.build(
-        operands=[vector_ssa_value2, vector_ssa_value1, vector_ssa_value2],
-        result_types=[i32_vector_type2],
-    )
-
-    message = (
-        "Result vector shape must match with all source vector shapes. "
-        "Found different shapes for result vector and rhs vector."
-    )
-    with pytest.raises(Exception, match=message):
-        fma.verify()
-
-
-def test_vector_fma_verify_res_acc_shape_matching():
-    i32_vector_type2 = VectorType(i32, [4, 5])
-
-    vector_ssa_value1 = get_Vector_SSAVal(i32, [2, 3])
-    vector_ssa_value2 = get_Vector_SSAVal(i32, [4, 5])
-
-    fma = FMAOp.build(
-        operands=[vector_ssa_value2, vector_ssa_value2, vector_ssa_value1],
-        result_types=[i32_vector_type2],
-    )
-
-    message = (
-        "Result vector shape must match with all source vector shapes. "
-        "Found different shapes for result vector and acc vector."
-    )
-    with pytest.raises(Exception, match=message):
-        fma.verify()
 
 
 def test_vector_masked_load():
@@ -423,7 +307,7 @@ def test_vector_masked_store():
         memref_ssa_value, [], mask_vector_ssa_value, value_to_store_vector_ssa_value
     )
 
-    assert maskedstore.memref is memref_ssa_value
+    assert maskedstore.base is memref_ssa_value
     assert maskedstore.mask is mask_vector_ssa_value
     assert maskedstore.value_to_store is value_to_store_vector_ssa_value
     assert maskedstore.indices == ()
@@ -444,7 +328,7 @@ def test_vector_masked_store_with_dimensions():
         value_to_store_vector_ssa_value,
     )
 
-    assert maskedstore.memref is memref_ssa_value
+    assert maskedstore.base is memref_ssa_value
     assert maskedstore.mask is mask_vector_ssa_value
     assert maskedstore.value_to_store is value_to_store_vector_ssa_value
     assert maskedstore.indices[0] is index1
@@ -494,7 +378,7 @@ def test_vector_create_mask():
 
     assert type(create_mask.results[0]) is OpResult
     assert type(create_mask.results[0].type) is VectorType
-    assert create_mask.mask_operands == ()
+    assert create_mask.mask_dim_sizes == ()
 
 
 def test_vector_create_mask_with_dimensions():
@@ -505,8 +389,8 @@ def test_vector_create_mask_with_dimensions():
 
     assert type(create_mask.results[0]) is OpResult
     assert type(create_mask.results[0].type) is VectorType
-    assert create_mask.mask_operands[0] is index1
-    assert create_mask.mask_operands[1] is index2
+    assert create_mask.mask_dim_sizes[0] is index1
+    assert create_mask.mask_dim_sizes[1] is index2
 
 
 def test_vector_create_mask_verify_indexing_exception():

--- a/tests/filecheck/dialects/vector/vector_fma_res_acc_shape_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_acc_shape_matching.mlir
@@ -5,6 +5,6 @@
   %0, %1 = "test.op"() : () -> (vector<2xindex>, vector<3xindex>)
 
   %2 = "vector.fma"(%0, %0, %1) : (vector<2xindex>, vector<2xindex>, vector<3xindex>) -> vector<2xindex>
-  // CHECK: Result vector shape must match with all source vector shapes. Found different shapes for result vector and acc vector.
+  // CHECK: attribute vector<2xindex> expected from variable 'T', but got vector<3xindex>
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_fma_res_acc_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_acc_type_matching.mlir
@@ -5,6 +5,6 @@
   %0, %1 = "test.op"() : () -> (vector<2xindex>, vector<2xi32>)
 
   %2 = "vector.fma"(%1, %1, %0) : (vector<2xi32>, vector<2xi32>, vector<2xindex>) -> vector<2xi32>
-  // CHECK: Result vector type must match with all source vectors. Found different types for result vector and acc vector.
+  // CHECK: attribute vector<2xi32> expected from variable 'T', but got vector<2xindex>
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_fma_res_lhs_shape_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_lhs_shape_matching.mlir
@@ -5,6 +5,6 @@
   %0, %1 = "test.op"() : () -> (vector<2xindex>, vector<3xindex>)
 
   %2 = "vector.fma"(%1, %0, %0) : (vector<3xindex>, vector<2xindex>, vector<2xindex>) -> vector<2xindex>
-  // CHECK: Result vector shape must match with all source vector shapes. Found different shapes for result vector and lhs vector.
+  // CHECK: attribute vector<3xindex> expected from variable 'T', but got vector<2xindex>
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_fma_res_lhs_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_lhs_type_matching.mlir
@@ -5,6 +5,6 @@
   %0, %1 = "test.op"() : () -> (vector<2xindex>, vector<2xi32>)
 
   %2 = "vector.fma"(%0, %1, %1) : (vector<2xindex>, vector<2xi32>, vector<2xi32>) -> vector<2xi32>
-  // CHECK: Result vector type must match with all source vectors. Found different types for result vector and lhs vector.
+  // CHECK: attribute vector<2xindex> expected from variable 'T', but got vector<2xi32>
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_fma_res_rhs_shape_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_rhs_shape_matching.mlir
@@ -5,6 +5,6 @@
   %0, %1 = "test.op"() : () -> (vector<2xindex>, vector<3xindex>)
 
   %2 = "vector.fma"(%0, %1, %0) : (vector<2xindex>, vector<3xindex>, vector<2xindex>) -> vector<2xindex>
-  // CHECK: Result vector shape must match with all source vector shapes. Found different shapes for result vector and rhs vector.
+  // CHECK: attribute vector<2xindex> expected from variable 'T', but got vector<3xindex>
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_fma_res_rhs_type_matching.mlir
+++ b/tests/filecheck/dialects/vector/vector_fma_res_rhs_type_matching.mlir
@@ -5,6 +5,6 @@
   %0, %1 = "test.op"() : () -> (vector<2xindex>, vector<2xi32>)
 
   %2 = "vector.fma"(%1, %0, %1) : (vector<2xi32>, vector<2xindex>, vector<2xi32>) -> vector<2xi32>
-  // CHECK: Result vector type must match with all source vectors. Found different types for result vector and rhs vector.
+  // CHECK: attribute vector<2xi32> expected from variable 'T', but got vector<2xindex>
 
 }) : () -> ()

--- a/tests/filecheck/dialects/vector/vector_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_ops.mlir
@@ -1,30 +1,28 @@
 // RUN: XDSL_ROUNDTRIP
 
-builtin.module {
-  func.func private @vector_test(%0 : memref<4x4xindex>, %1 : vector<1xi1>, %2 : index) {
-    %3 = "vector.load"(%0, %2, %2) : (memref<4x4xindex>, index, index) -> vector<2xindex>
-    "vector.store"(%3, %0, %2, %2) : (vector<2xindex>, memref<4x4xindex>, index, index) -> ()
-    %4 = "vector.broadcast"(%2) : (index) -> vector<1xindex>
-    %5 = "vector.fma"(%3, %3, %3) : (vector<2xindex>, vector<2xindex>, vector<2xindex>) -> vector<2xindex>
-    %6 = "vector.maskedload"(%0, %2, %2, %1, %4) : (memref<4x4xindex>, index, index, vector<1xi1>, vector<1xindex>) -> vector<1xindex>
-    "vector.maskedstore"(%0, %2, %2, %1, %6) : (memref<4x4xindex>, index, index, vector<1xi1>, vector<1xindex>) -> ()
-    "vector.print"(%6) : (vector<1xindex>) -> ()
-    %7 = "vector.create_mask"(%2) : (index) -> vector<2xi1>
-    func.return
-  }
+func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %i : index) {
+  %load = vector.load %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+  vector.store %load, %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+  %broadcast = vector.broadcast %i : index to vector<1xindex>
+  %fma = vector.fma %load, %load, %load : vector<2xindex>
+  %masked_load = vector.maskedload %base[%i, %i], %vec, %broadcast : memref<4x4xindex>, vector<1xi1>, vector<1xindex> into vector<1xindex>
+  vector.maskedstore %base[%i, %i], %vec, %masked_load : memref<4x4xindex>, vector<1xi1>, vector<1xindex>
+  "vector.print"(%masked_load) : (vector<1xindex>) -> ()
+  %mask = vector.create_mask %i : vector<2xi1>
+  func.return
 }
 
 
 // CHECK:      builtin.module {
-// CHECK-NEXT:   func.func private @vector_test(%0 : memref<4x4xindex>, %1 : vector<1xi1>, %2 : index) {
-// CHECK-NEXT:     %3 = "vector.load"(%0, %2, %2) : (memref<4x4xindex>, index, index) -> vector<2xindex>
-// CHECK-NEXT:     "vector.store"(%3, %0, %2, %2) : (vector<2xindex>, memref<4x4xindex>, index, index) -> ()
-// CHECK-NEXT:     %4 = "vector.broadcast"(%2) : (index) -> vector<1xindex>
-// CHECK-NEXT:     %5 = "vector.fma"(%3, %3, %3) : (vector<2xindex>, vector<2xindex>, vector<2xindex>) -> vector<2xindex>
-// CHECK-NEXT:     %6 = "vector.maskedload"(%0, %2, %2, %1, %4) : (memref<4x4xindex>, index, index, vector<1xi1>, vector<1xindex>) -> vector<1xindex>
-// CHECK-NEXT:     "vector.maskedstore"(%0, %2, %2, %1, %6) : (memref<4x4xindex>, index, index, vector<1xi1>, vector<1xindex>) -> ()
-// CHECK-NEXT:     "vector.print"(%6) : (vector<1xindex>) -> ()
-// CHECK-NEXT:     %7 = "vector.create_mask"(%2) : (index) -> vector<2xi1>
+// CHECK-NEXT:   func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %i : index) {
+// CHECK-NEXT:     %load = vector.load %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+// CHECK-NEXT:     vector.store %load, %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+// CHECK-NEXT:     %broadcast = vector.broadcast %i : index to vector<1xindex>
+// CHECK-NEXT:     %fma = vector.fma %load, %load, %load : vector<2xindex>
+// CHECK-NEXT:     %masked_load = vector.maskedload %base[%i, %i], %vec, %broadcast : memref<4x4xindex>, vector<1xi1>, vector<1xindex> into vector<1xindex>
+// CHECK-NEXT:     vector.maskedstore %base[%i, %i], %vec, %masked_load : memref<4x4xindex>, vector<1xi1>, vector<1xindex>
+// CHECK-NEXT:     "vector.print"(%masked_load) : (vector<1xindex>) -> ()
+// CHECK-NEXT:     %mask = vector.create_mask %i : vector<2xi1>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/tests/filecheck/dialects/vector/vector_pure_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_pure_ops.mlir
@@ -1,13 +1,13 @@
-// RUN: xdsl-opt %s --verify-diagnostics -p cse | filecheck %s
+// RUN: xdsl-opt %s -p cse | filecheck %s
 
 %m0, %i0 = "test.op"() : () -> (memref<4x4xindex>, index)
-%load = "vector.load"(%m0, %i0, %i0) : (memref<4x4xindex>, index, index) -> vector<2xindex>
-"vector.store"(%load, %m0, %i0, %i0) : (vector<2xindex>, memref<4x4xindex>, index, index) -> ()
-%broadcast = "vector.broadcast"(%i0) : (index) -> vector<1xindex>
-%fma = "vector.fma"(%load, %load, %load) : (vector<2xindex>, vector<2xindex>, vector<2xindex>) -> vector<2xindex>
+%load = vector.load %m0[%i0, %i0] : memref<4x4xindex>, vector<2xindex>
+vector.store %load, %m0[%i0, %i0] : memref<4x4xindex>, vector<2xindex>
+%broadcast = vector.broadcast %i0 : index to vector<1xindex>
+%fma = vector.fma %load, %load, %load : vector<2xindex>
 %extract_op = "vector.extractelement"(%broadcast, %i0) : (vector<1xindex>, index) -> index
 "vector.insertelement"(%extract_op, %broadcast, %i0) : (index, vector<1xindex>, index) -> vector<1xindex>
 /// Check that unused results from vector.broadcast and vector.fma are eliminated
-// CHECK:       %m0, %i0 = "test.op"() : () -> (memref<4x4xindex>, index) 
-// CHECK-NEXT:  %load = "vector.load"(%m0, %i0, %i0) : (memref<4x4xindex>, index, index) -> vector<2xindex>
-// CHECK-NEXT:  "vector.store"(%load, %m0, %i0, %i0) : (vector<2xindex>, memref<4x4xindex>, index, index) -> ()
+// CHECK:       %m0, %i0 = "test.op"() : () -> (memref<4x4xindex>, index)
+// CHECK-NEXT:  %load = vector.load %m0[%i0, %i0] : memref<4x4xindex>, vector<2xindex>
+// CHECK-NEXT:  vector.store %load, %m0[%i0, %i0] : memref<4x4xindex>, vector<2xindex>

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -138,49 +138,6 @@ class FMAOp(IRDLOperation):
 
     assembly_format = "$lhs `,` $rhs `,` $acc attr-dict `:` type($lhs)"
 
-    def verify_(self):
-        assert isa(self.lhs.type, VectorType[Attribute])
-        assert isa(self.rhs.type, VectorType[Attribute])
-        assert isa(self.acc.type, VectorType[Attribute])
-        assert isa(self.res.type, VectorType[Attribute])
-
-        lhs_shape = self.lhs.type.get_shape()
-        rhs_shape = self.rhs.type.get_shape()
-        acc_shape = self.acc.type.get_shape()
-        res_shape = self.res.type.get_shape()
-
-        if self.res.type.element_type != self.lhs.type.element_type:
-            raise VerifyException(
-                "Result vector type must match with all source vectors. Found "
-                "different types for result vector and lhs vector."
-            )
-        elif self.res.type.element_type != self.rhs.type.element_type:
-            raise VerifyException(
-                "Result vector type must match with all source vectors. Found "
-                "different types for result vector and rhs vector."
-            )
-        elif self.res.type.element_type != self.acc.type.element_type:
-            raise VerifyException(
-                "Result vector type must match with all source vectors. Found "
-                "different types for result vector and acc vector."
-            )
-
-        if res_shape != lhs_shape:
-            raise VerifyException(
-                "Result vector shape must match with all source vector shapes. Found "
-                "different shapes for result vector and lhs vector."
-            )
-        elif res_shape != rhs_shape:
-            raise VerifyException(
-                "Result vector shape must match with all source vector shapes. Found "
-                "different shapes for result vector and rhs vector."
-            )
-        elif res_shape != acc_shape:
-            raise VerifyException(
-                "Result vector shape must match with all source vector shapes. Found "
-                "different shapes for result vector and acc vector."
-            )
-
     @staticmethod
     def get(
         lhs: Operation | SSAValue, rhs: Operation | SSAValue, acc: Operation | SSAValue


### PR DESCRIPTION
Makes IR prettier. Changed some names to conform to MLIR, so most of the assembly format strings match exactly. We don't have operand renaming so I changed camelCase operand names to snake_case in the format strings.

CC @watermelonwolverine 