### PR TITLE
core: add custom repr to BaseAttr and ParamAttrConstraint

### DIFF
--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -138,3 +138,18 @@ def test_base_attr_constraint_inference():
 
     data_constr = BaseAttr(DataAttr)
     assert not data_constr.can_infer(set())
+
+
+@pytest.mark.parametrize(
+    "constr, expected",
+    [
+        (BaseAttr(StringAttr), "BaseAttr(StringAttr)"),
+        (
+            ParamAttrConstraint(AttrB, (AnyAttr(),)),
+            "ParamAttrConstraint(AttrB, (AnyAttr(),))",
+        ),
+    ],
+)
+def test_constraint_repr(constr: AttrConstraint, expected: str):
+    assert repr(constr) == expected
+    assert eval(repr(constr)) == constr

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -360,6 +360,9 @@ class BaseAttr(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
     attr: type[AttributeCovT]
     """The expected attribute base type."""
 
+    def __repr__(self):
+        return f"BaseAttr({self.attr.__name__})"
+
     def verify(
         self,
         attr: Attribute,
@@ -568,6 +571,9 @@ class ParamAttrConstraint(
         )
         object.__setattr__(self, "base_attr", base_attr)
         object.__setattr__(self, "param_constrs", constrs)
+
+    def __repr__(self):
+        return f"ParamAttrConstraint({self.base_attr.__name__}, {repr(self.param_constrs)})"
 
     def verify(
         self,


### PR DESCRIPTION
For use in dialect and dialect stub generation. Before this change, the default repr prints the class as `<class xdsl.dialects.builtin.IntegerAttr>` or whatever, and now we just print `IntegerAttr`, which won't work for `eval` if you don't already have the class in your context, but will work for our use-cases for now.