### PR TITLE
misc: Add explicit key check in ScopedDict.

### DIFF
--- a/xdsl/utils/scoped_dict.py
+++ b/xdsl/utils/scoped_dict.py
@@ -53,9 +53,8 @@ class ScopedDict(Generic[_Key, _Value]):
         Fetch key from environment. Attempts to first fetch from current scope,
         then from parent scopes. Raises KeyError error if not found.
         """
-        local = self._local_scope.get(key)
-        if local is not None:
-            return local
+        if key in self._local_scope:
+            return self._local_scope[key]
         if self.parent is None:
             raise KeyError(f"No value for key {key}")
         return self.parent[key]


### PR DESCRIPTION
Due to operations that return `None` when interpreted, a ScopedDict can contain `None` values. For those, the current implicit key check does not suffice. 