### PR TITLE
dialects: (csl-module-wrapper) Add target arch param

### DIFF
--- a/tests/dialects/test_csl_wrapper.py
+++ b/tests/dialects/test_csl_wrapper.py
@@ -6,7 +6,7 @@ from xdsl.dialects.csl import csl_wrapper
 
 def test_get_layout_arg():
     m_op = csl_wrapper.ModuleOp(
-        7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
+        7, 8, "wse2", params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
     )
     assert m_op.get_layout_param("x") == m_op.layout_module.block.args[0]
     assert m_op.get_layout_param("y") == m_op.layout_module.block.args[1]
@@ -15,22 +15,24 @@ def test_get_layout_arg():
     assert m_op.get_layout_param("one") == m_op.layout_module.block.args[4]
     assert m_op.get_layout_param("two") == m_op.layout_module.block.args[5]
     assert len(m_op.layout_module.block.args) == 6
+    assert m_op.target == "wse2"
 
 
 def test_get_program_arg():
     m_op = csl_wrapper.ModuleOp(
-        7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
+        7, 8, "wse3", params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
     )
     assert m_op.get_program_param("width") == m_op.program_module.block.args[0]
     assert m_op.get_program_param("height") == m_op.program_module.block.args[1]
     assert m_op.get_program_param("one") == m_op.program_module.block.args[2]
     assert m_op.get_program_param("two") == m_op.program_module.block.args[3]
     assert len(m_op.program_module.block.args) == 4
+    assert m_op.target == "wse3"
 
 
 def test_update_program_args():
     m_op = csl_wrapper.ModuleOp(
-        7, 8, params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
+        7, 8, "wse2", params={"one": IntegerAttr(9, 16), "two": IntegerAttr(10, 16)}
     )
     assert len(m_op.program_module.block.args) == 4
     with ImplicitBuilder(m_op.layout_module.block):

--- a/tests/filecheck/transforms/lower-csl-stencil.mlir
+++ b/tests/filecheck/transforms/lower-csl-stencil.mlir
@@ -1,7 +1,7 @@
 // RUN: xdsl-opt %s -p "lower-csl-stencil" --split-input-file | filecheck %s
 
 
-  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel_func"}> ({
+  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "gauss_seidel_func", target="wse2"}> ({
   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
     %9 = arith.constant 0 : i16
     %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -60,7 +60,7 @@
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK:       "csl_wrapper.module"() <{width = 1022 : i16, height = 510 : i16, params = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "gauss_seidel_func"}> ({
+// CHECK:        "csl_wrapper.module"() <{width = 1022 : i16, height = 510 : i16, params = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "gauss_seidel_func", target = "wse2"}> ({
 // CHECK-NEXT:   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
 // CHECK-NEXT:     %9 = arith.constant 0 : i16
 // CHECK-NEXT:     %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -127,7 +127,7 @@
 
 // -----
 
-  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "loop", "width" = 1024 : i16}> ({
+  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "loop", "width" = 1024 : i16, target="wse2"}> ({
   ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
     %0 = arith.constant 0 : i16
     %1 = "csl.get_color"(%0) : (i16) -> !csl.color
@@ -235,7 +235,7 @@
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK:       "csl_wrapper.module"() <{height = 512 : i16, params = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "loop", width = 1024 : i16}> ({
+// CHECK:       "csl_wrapper.module"() <{height = 512 : i16, params = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "loop", width = 1024 : i16, target = "wse2"}> ({
 // CHECK-NEXT:  ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
 // CHECK-NEXT:    %0 = arith.constant 0 : i16
 // CHECK-NEXT:    %1 = "csl.get_color"(%0) : (i16) -> !csl.color
@@ -353,7 +353,7 @@
 
 // -----
 
-  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "partial_access"}> ({
+  "csl_wrapper.module"() <{"width" = 1022 : i16, "height" = 510 : i16, "params" = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "partial_access", target="wse2"}> ({
   ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
     %9 = arith.constant 0 : i16
     %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -410,7 +410,7 @@
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK:       "csl_wrapper.module"() <{width = 1022 : i16, height = 510 : i16, params = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "partial_access"}> ({
+// CHECK:       "csl_wrapper.module"() <{width = 1022 : i16, height = 510 : i16, params = [#csl_wrapper.param<"z_dim" default=512 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=2 : i16>, #csl_wrapper.param<"chunk_size" default=255 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "partial_access", target = "wse2"}> ({
 // CHECK-NEXT:  ^0(%0 : i16, %1 : i16, %2 : i16, %3 : i16, %4 : i16, %5 : i16, %6 : i16, %7 : i16, %8 : i16):
 // CHECK-NEXT:    %9 = arith.constant 0 : i16
 // CHECK-NEXT:    %10 = "csl.get_color"(%9) : (i16) -> !csl.color
@@ -483,7 +483,7 @@
 
 // -----
 
-  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=511 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "chunk_reduce_only", "width" = 1024 : i16}> ({
+  "csl_wrapper.module"() <{"height" = 512 : i16, "params" = [#csl_wrapper.param<"z_dim" default=511 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], "program_name" = "chunk_reduce_only", "width" = 1024 : i16, target="wse2"}> ({
   ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
     %0 = arith.constant 1 : i16
     %1 = arith.constant 0 : i16
@@ -585,7 +585,7 @@
     "csl_wrapper.yield"() <{"fields" = []}> : () -> ()
   }) : () -> ()
 
-// CHECK:       "csl_wrapper.module"() <{height = 512 : i16, params = [#csl_wrapper.param<"z_dim" default=511 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "chunk_reduce_only", width = 1024 : i16}> ({
+// CHECK:       "csl_wrapper.module"() <{height = 512 : i16, params = [#csl_wrapper.param<"z_dim" default=511 : i16>, #csl_wrapper.param<"pattern" default=2 : i16>, #csl_wrapper.param<"num_chunks" default=1 : i16>, #csl_wrapper.param<"chunk_size" default=510 : i16>, #csl_wrapper.param<"padded_z_dim" default=510 : i16>], program_name = "chunk_reduce_only", width = 1024 : i16, target = "wse2"}> ({
 // CHECK-NEXT:  ^0(%arg0 : i16, %arg1 : i16, %arg2 : i16, %arg3 : i16, %arg4 : i16, %arg5 : i16, %arg6 : i16, %arg7 : i16, %arg8 : i16):
 // CHECK-NEXT:    %0 = arith.constant 1 : i16
 // CHECK-NEXT:    %1 = arith.constant 0 : i16
@@ -652,33 +652,32 @@
 // CHECK-NEXT:      %33 = "csl.addressof"(%west) : (memref<2xf32>) -> !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:      %34 = "csl.addressof"(%south) : (memref<2xf32>) -> !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:      %35 = "csl.addressof"(%north) : (memref<2xf32>) -> !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>
-// CHECK-NEXT:      %36 = arith.constant false
-// CHECK-NEXT:      "csl.member_call"(%18, %32, %33, %34, %35, %36) <{field = "setCoeffs"}> : (!csl.imported_module, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>, i1) -> ()
-// CHECK-NEXT:      %37 = arith.constant 1 : i16
-// CHECK-NEXT:      %38 = "csl.addressof_fn"() <{fn_name = @receive_chunk_cb0}> : () -> !csl.ptr<(i16) -> (), #csl<ptr_kind single>, #csl<ptr_const const>>
-// CHECK-NEXT:      %39 = "csl.addressof_fn"() <{fn_name = @done_exchange_cb0}> : () -> !csl.ptr<() -> (), #csl<ptr_kind single>, #csl<ptr_const const>>
+// CHECK-NEXT:      "csl.member_call"(%18, %32, %33, %34, %35) <{field = "setCoeffs"}> : (!csl.imported_module, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<memref<2xf32>, #csl<ptr_kind single>, #csl<ptr_const const>>) -> ()
+// CHECK-NEXT:      %36 = arith.constant 1 : i16
+// CHECK-NEXT:      %37 = "csl.addressof_fn"() <{fn_name = @receive_chunk_cb0}> : () -> !csl.ptr<(i16) -> (), #csl<ptr_kind single>, #csl<ptr_const const>>
+// CHECK-NEXT:      %38 = "csl.addressof_fn"() <{fn_name = @done_exchange_cb0}> : () -> !csl.ptr<() -> (), #csl<ptr_kind single>, #csl<ptr_const const>>
 // CHECK-NEXT:      %send_dsd = memref.subview %arg11[0] [510] [1] : memref<511xf32> to memref<510xf32>
-// CHECK-NEXT:      "csl.member_call"(%18, %send_dsd, %37, %38, %39) <{field = "communicate"}> : (!csl.imported_module, memref<510xf32>, i16, !csl.ptr<(i16) -> (), #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<() -> (), #csl<ptr_kind single>, #csl<ptr_const const>>) -> ()
+// CHECK-NEXT:      "csl.member_call"(%18, %send_dsd, %36, %37, %38) <{field = "communicate"}> : (!csl.imported_module, memref<510xf32>, i16, !csl.ptr<(i16) -> (), #csl<ptr_kind single>, #csl<ptr_const const>>, !csl.ptr<() -> (), #csl<ptr_kind single>, #csl<ptr_const const>>) -> ()
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    csl.func @receive_chunk_cb0(%offset : i16) {
 // CHECK-NEXT:      %offset_1 = arith.index_cast %offset : i16 to index
 // CHECK-NEXT:      %arg11_1 = "csl.load_var"(%24) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
-// CHECK-NEXT:      %40 = arith.constant dense<1.234500e-01> : memref<510xf32>
-// CHECK-NEXT:      %41 = arith.constant 1 : i16
-// CHECK-NEXT:      %42 = "csl.get_dir"() <{dir = #csl<dir_kind west>}> : () -> !csl.direction
-// CHECK-NEXT:      %43 = "csl.member_call"(%18, %42, %41) <{field = "getRecvBufDsdByNeighbor"}> : (!csl.imported_module, !csl.direction, i16) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:      %44 = builtin.unrealized_conversion_cast %43 : !csl<dsd mem1d_dsd> to memref<510xf32>
-// CHECK-NEXT:      %45 = memref.subview %arg11_1[1] [510] [1] : memref<511xf32> to memref<510xf32, strided<[1], offset: 1>>
-// CHECK-NEXT:      %46 = arith.constant 1 : i16
-// CHECK-NEXT:      %47 = "csl.get_dir"() <{dir = #csl<dir_kind south>}> : () -> !csl.direction
-// CHECK-NEXT:      %48 = "csl.member_call"(%18, %47, %46) <{field = "getRecvBufDsdByNeighbor"}> : (!csl.imported_module, !csl.direction, i16) -> !csl<dsd mem1d_dsd>
-// CHECK-NEXT:      %49 = builtin.unrealized_conversion_cast %48 : !csl<dsd mem1d_dsd> to memref<510xf32>
-// CHECK-NEXT:      %50 = memref.subview %accumulator[%offset_1] [510] [1] : memref<510xf32> to memref<510xf32, strided<[1], offset: ?>>
-// CHECK-NEXT:      "csl.fadds"(%50, %45, %49) : (memref<510xf32, strided<[1], offset: ?>>, memref<510xf32, strided<[1], offset: 1>>, memref<510xf32>) -> ()
-// CHECK-NEXT:      "csl.fadds"(%50, %50, %44) : (memref<510xf32, strided<[1], offset: ?>>, memref<510xf32, strided<[1], offset: ?>>, memref<510xf32>) -> ()
-// CHECK-NEXT:      %51 = arith.constant 1.234500e-01 : f32
-// CHECK-NEXT:      "csl.fmuls"(%50, %50, %51) : (memref<510xf32, strided<[1], offset: ?>>, memref<510xf32, strided<[1], offset: ?>>, f32) -> ()
+// CHECK-NEXT:      %39 = arith.constant dense<1.234500e-01> : memref<510xf32>
+// CHECK-NEXT:      %40 = arith.constant 1 : i16
+// CHECK-NEXT:      %41 = "csl.get_dir"() <{dir = #csl<dir_kind west>}> : () -> !csl.direction
+// CHECK-NEXT:      %42 = "csl.member_call"(%18, %41, %40) <{field = "getRecvBufDsdByNeighbor"}> : (!csl.imported_module, !csl.direction, i16) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:      %43 = builtin.unrealized_conversion_cast %42 : !csl<dsd mem1d_dsd> to memref<510xf32>
+// CHECK-NEXT:      %44 = memref.subview %arg11_1[1] [510] [1] : memref<511xf32> to memref<510xf32, strided<[1], offset: 1>>
+// CHECK-NEXT:      %45 = arith.constant 1 : i16
+// CHECK-NEXT:      %46 = "csl.get_dir"() <{dir = #csl<dir_kind south>}> : () -> !csl.direction
+// CHECK-NEXT:      %47 = "csl.member_call"(%18, %46, %45) <{field = "getRecvBufDsdByNeighbor"}> : (!csl.imported_module, !csl.direction, i16) -> !csl<dsd mem1d_dsd>
+// CHECK-NEXT:      %48 = builtin.unrealized_conversion_cast %47 : !csl<dsd mem1d_dsd> to memref<510xf32>
+// CHECK-NEXT:      %49 = memref.subview %accumulator[%offset_1] [510] [1] : memref<510xf32> to memref<510xf32, strided<[1], offset: ?>>
+// CHECK-NEXT:      "csl.fadds"(%49, %44, %48) : (memref<510xf32, strided<[1], offset: ?>>, memref<510xf32, strided<[1], offset: 1>>, memref<510xf32>) -> ()
+// CHECK-NEXT:      "csl.fadds"(%49, %49, %43) : (memref<510xf32, strided<[1], offset: ?>>, memref<510xf32, strided<[1], offset: ?>>, memref<510xf32>) -> ()
+// CHECK-NEXT:      %50 = arith.constant 1.234500e-01 : f32
+// CHECK-NEXT:      "csl.fmuls"(%49, %49, %50) : (memref<510xf32, strided<[1], offset: ?>>, memref<510xf32, strided<[1], offset: ?>>, f32) -> ()
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    csl.func @done_exchange_cb0() {
@@ -686,21 +685,21 @@
 // CHECK-NEXT:      %arg11_2 = "csl.load_var"(%24) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
 // CHECK-NEXT:      scf.if %arg9 {
 // CHECK-NEXT:      } else {
-// CHECK-NEXT:        %52 = memref.subview %arg12_1[0] [510] [1] : memref<511xf32> to memref<510xf32>
-// CHECK-NEXT:        "memref.copy"(%accumulator, %52) : (memref<510xf32>, memref<510xf32>) -> ()
+// CHECK-NEXT:        %51 = memref.subview %arg12_1[0] [510] [1] : memref<511xf32> to memref<510xf32>
+// CHECK-NEXT:        "memref.copy"(%accumulator, %51) : (memref<510xf32>, memref<510xf32>) -> ()
 // CHECK-NEXT:      }
 // CHECK-NEXT:      "csl.call"() <{callee = @for_inc0}> : () -> ()
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:    csl.func @for_inc0() {
-// CHECK-NEXT:      %53 = arith.constant 1 : i16
-// CHECK-NEXT:      %54 = "csl.load_var"(%23) : (!csl.var<i16>) -> i16
-// CHECK-NEXT:      %55 = arith.addi %54, %53 : i16
-// CHECK-NEXT:      "csl.store_var"(%23, %55) : (!csl.var<i16>, i16) -> ()
-// CHECK-NEXT:      %56 = "csl.load_var"(%24) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
-// CHECK-NEXT:      %57 = "csl.load_var"(%25) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
-// CHECK-NEXT:      "csl.store_var"(%24, %57) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
-// CHECK-NEXT:      "csl.store_var"(%25, %56) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
+// CHECK-NEXT:      %52 = arith.constant 1 : i16
+// CHECK-NEXT:      %53 = "csl.load_var"(%23) : (!csl.var<i16>) -> i16
+// CHECK-NEXT:      %54 = arith.addi %53, %52 : i16
+// CHECK-NEXT:      "csl.store_var"(%23, %54) : (!csl.var<i16>, i16) -> ()
+// CHECK-NEXT:      %55 = "csl.load_var"(%24) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
+// CHECK-NEXT:      %56 = "csl.load_var"(%25) : (!csl.var<memref<511xf32>>) -> memref<511xf32>
+// CHECK-NEXT:      "csl.store_var"(%24, %56) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
+// CHECK-NEXT:      "csl.store_var"(%25, %55) : (!csl.var<memref<511xf32>>, memref<511xf32>) -> ()
 // CHECK-NEXT:      csl.activate local, 1 : ui6
 // CHECK-NEXT:      csl.return
 // CHECK-NEXT:    }

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass, field
-from typing import Annotated, ClassVar, TypeAlias
+from typing import Annotated, ClassVar, Literal, TypeAlias
 
 from xdsl.dialects import builtin
 from xdsl.dialects.builtin import (
@@ -91,6 +91,8 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.isattr import isattr
 from xdsl.utils.str_enum import StrEnum
+
+target = Literal["wse2", "wse3"]
 
 
 class PtrKind(StrEnum):

--- a/xdsl/dialects/csl/csl_wrapper.py
+++ b/xdsl/dialects/csl/csl_wrapper.py
@@ -162,6 +162,7 @@ class ModuleOp(IRDLOperation):
     width = prop_def(IntegerAttr[IntegerType])
     height = prop_def(IntegerAttr[IntegerType])
     program_name = opt_prop_def(StringAttr)
+    target = prop_def(StringAttr)
     params = prop_def(ArrayAttr[ParamAttribute])
 
     layout_module = region_def("single_block")
@@ -171,6 +172,7 @@ class ModuleOp(IRDLOperation):
         self,
         width: int | IntegerAttr[IntegerType],
         height: int | IntegerAttr[IntegerType],
+        target: csl.target | StringAttr,
         params: (
             dict[str, IntegerAttr[IntegerType]] | Sequence[ParamAttribute] | None
         ) = None,
@@ -179,6 +181,8 @@ class ModuleOp(IRDLOperation):
             width = IntegerAttr(width, i16)
         if not isinstance(height, IntegerAttr):
             height = IntegerAttr(height, i16)
+        if not isinstance(target, StringAttr):
+            target = StringAttr(target)
         if params is None:
             params = []
         elif isinstance(params, dict):
@@ -193,6 +197,7 @@ class ModuleOp(IRDLOperation):
                 "width": width,
                 "height": height,
                 "params": params_attr,
+                "target": target,
             },
             regions=[
                 Region(

--- a/xdsl/transforms/csl_stencil_to_csl_wrapper.py
+++ b/xdsl/transforms/csl_stencil_to_csl_wrapper.py
@@ -60,6 +60,11 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
     to initialise stencil-specific program params and yields them from the layout module.
     """
 
+    target: csl.target
+    """
+    Specifies the target architecture.
+    """
+
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: func.FuncOp, rewriter: PatternRewriter, /):
         # erase timer stubs
@@ -133,6 +138,7 @@ class ConvertStencilFuncToModuleWrappedPattern(RewritePattern):
         module_op = csl_wrapper.ModuleOp(
             width=IntegerAttr(width + (max_distance * 2), 16),
             height=IntegerAttr(height + (max_distance * 2), 16),
+            target=self.target,
             params={
                 "z_dim": IntegerAttr(z_dim, 16),
                 "pattern": IntegerAttr(max_distance + 1, 16),
@@ -449,11 +455,16 @@ class CslStencilToCslWrapperPass(ModulePass):
 
     name = "csl-stencil-to-csl-wrapper"
 
+    target: csl.target
+    """
+    Specifies the target architecture.
+    """
+
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
         module_pass = PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
-                    ConvertStencilFuncToModuleWrappedPattern(),
+                    ConvertStencilFuncToModuleWrappedPattern(self.target),
                     LowerTimerFuncCall(),
                 ]
             ),

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -12,6 +12,7 @@ from xdsl.dialects.builtin import (
     FunctionType,
     IndexType,
     IntegerAttr,
+    IntegerType,
     MemRefType,
     ModuleOp,
     UnrealizedConversionCastOp,
@@ -264,7 +265,14 @@ class GenerateCoeffAPICalls(RewritePattern):
         elem_t = coeffs[0].coeff.type
         pattern = wrapper.get_param_value("pattern").value.data
         neighbours = pattern - 1
-        empty = [FloatAttr(f, elem_t) for f in [0] + neighbours * [1]]
+        is_wse2 = wrapper.target.data == "wse2"
+        if is_wse2:
+            empty = [FloatAttr(f, elem_t) for f in [0] + neighbours * [1]]
+            shape = (pattern,)
+        else:
+            empty = [FloatAttr(f, elem_t) for f in neighbours * [1]]
+            shape = (pattern - 1,)
+
         cmap: dict[csl.Direction, list[FloatAttr]] = {
             csl.Direction.NORTH: empty,
             csl.Direction.SOUTH: empty.copy(),
@@ -274,9 +282,11 @@ class GenerateCoeffAPICalls(RewritePattern):
 
         for c in coeffs:
             direction, distance = get_dir_and_distance(c.offset)
+            if not is_wse2:
+                distance -= 1
             cmap[direction][distance] = c.coeff
 
-        memref_t = memref.MemRefType(Float32Type(), (pattern,))
+        memref_t = memref.MemRefType(Float32Type(), shape)
         ptr_t = csl.PtrType.get(memref_t, is_single=True, is_const=True)
 
         cnsts = {
@@ -291,25 +301,22 @@ class GenerateCoeffAPICalls(RewritePattern):
         for d, c in cnsts.items():
             c.result.name_hint = str(d)
 
+        args: list[Operation] = [
+            addrs[csl.Direction.EAST],
+            addrs[csl.Direction.WEST],
+            addrs[csl.Direction.SOUTH],
+            addrs[csl.Direction.NORTH],
+        ]
+
         rewriter.insert_op(
             [
                 *cnsts.values(),
-                east := addrs[csl.Direction.EAST],
-                west := addrs[csl.Direction.WEST],
-                south := addrs[csl.Direction.SOUTH],
-                north := addrs[csl.Direction.NORTH],
-                flse := arith.ConstantOp(IntegerAttr.from_bool(False)),
+                *args,
                 csl.MemberCallOp(
                     "setCoeffs",
                     None,
                     wrapper.get_program_import("stencil_comms.csl"),
-                    [
-                        east,
-                        west,
-                        south,
-                        north,
-                        flse,
-                    ],
+                    args,
                 ),
             ],
             InsertPoint.before(op),
@@ -457,8 +464,17 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
         direction_count = arith.ConstantOp.from_int_and_width(4, 16)
         pattern = wrapper.get_program_param("pattern")
         chunk_size = wrapper.get_program_param("chunk_size")
+        if wrapper.target.data != "wse2":
+            assert isinstance(pattern.type, IntegerType)
+            one = arith.ConstantOp.from_int_and_width(1, pattern.type)
+            pattern_m_one = arith.SubiOp(pattern, one)
+            new_ops: list[Operation] = [one, pattern_m_one]
+            neighbors = pattern_m_one
+        else:
+            new_ops: list[Operation] = []
+            neighbors = pattern
         acc_dsd = csl.GetMemDsdOp.build(
-            operands=[alloc, [direction_count, pattern, chunk_size]],
+            operands=[alloc, [direction_count, neighbors, chunk_size]],
             result_types=[dsd_t],
             properties={
                 "tensor_access": AffineMapAttr(
@@ -469,7 +485,8 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
         new_acc = acc_dsd
 
         # If the accumulator is a subview at an offset, generate IncrementDsdOffset op (and index_cast).
-        new_ops: list[Operation] = [direction_count, acc_dsd]
+        new_ops.append(direction_count)
+        new_ops.append(acc_dsd)
         if (
             isinstance(accumulator, OpResult)
             and isinstance(subview := accumulator.op, memref.SubviewOp)


### PR DESCRIPTION
- Add a `target` field to the csl module wrapper
- Update coeffs API call and the full stencil access reduction
- Remove bool flag from coeffs API