### PR TITLE
backend: add emit_section helper to AssemblyPrinter

### DIFF
--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
@@ -80,7 +80,6 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
@@ -186,7 +185,6 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     }
   }
 
-// CHECK:       .text
 // CHECK-NEXT:  .globl reluf32
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
@@ -159,7 +159,6 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK:       .text
 // CHECK-NEXT:  .globl ddot
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
@@ -206,7 +205,6 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     }
 
 
-// CHECK:       .text
 // CHECK-NEXT:  .globl dsum
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
@@ -250,7 +248,6 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK:       .text
 // CHECK-NEXT:  .globl fill
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["fa0", "ft0", "ft1", "ft2"], "preallocated_int": ["a0", "zero"], "allocated_float": ["fa0", "ft0", "ft3"], "allocated_int": ["a0", "t0", "t1", "zero"]}
@@ -307,7 +304,6 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     func.return
 }
 
-// CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl matmul
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
@@ -417,7 +413,6 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
@@ -513,7 +508,6 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK:       .text
 // CHECK-NEXT:  .globl reluf64
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
@@ -572,7 +566,6 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}

--- a/xdsl/backend/assembly_printer.py
+++ b/xdsl/backend/assembly_printer.py
@@ -8,6 +8,15 @@ from xdsl.utils.base_printer import BasePrinter
 
 
 class AssemblyPrinter(BasePrinter):
+    _current_section: str | None = None
+
+    def emit_section(self, new_section: str):
+        if self._current_section == new_section:
+            return
+        self._current_section = new_section
+        self.print_string(new_section, indent=0)
+        self.print_string("\n", indent=0)
+
     @staticmethod
     def append_comment(line: str, comment: StringAttr | None) -> str:
         if comment is None:

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -8,7 +8,11 @@ from typing import IO, Annotated, Generic, Literal, TypeAlias, TypeVar
 
 from typing_extensions import Self, assert_never
 
-from xdsl.backend.assembly_printer import AssemblyPrinter, OneLineAssemblyPrintable
+from xdsl.backend.assembly_printer import (
+    AssemblyPrintable,
+    AssemblyPrinter,
+    OneLineAssemblyPrintable,
+)
 from xdsl.backend.register_allocatable import (
     HasRegisterConstraints,
     RegisterConstraints,
@@ -2706,7 +2710,7 @@ class DirectiveOp(RISCVCustomFormatOperation, RISCVAsmOperation):
 
 
 @irdl_op_definition
-class AssemblySectionOp(RISCVAsmOperation):
+class AssemblySectionOp(IRDLOperation, AssemblyPrintable):
     """
     The directive operation is used to emit assembler directives (e.g. .text; .data; etc.)
     with the scope of a section.
@@ -2765,8 +2769,8 @@ class AssemblySectionOp(RISCVAsmOperation):
         if self.data.block.ops:
             printer.print_region(self.data)
 
-    def assembly_line(self) -> str | None:
-        return AssemblyPrinter.assembly_line(self.directive.data, "", is_indented=False)
+    def print_assembly(self, printer: AssemblyPrinter) -> None:
+        printer.emit_section(self.directive.data)
 
 
 @irdl_op_definition


### PR DESCRIPTION
This lets us avoid a bit of duplication in the emitted assembly, things that belong in the same section now stay in one section as long as they are contiguous.