### PR TITLE
backend: (riscv_func) move p2align to property of riscv_func

### DIFF
--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -33,8 +33,7 @@ builtin.module {
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "main"
-// CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @main() {
+// CHECK-NEXT:      riscv_func.func @main() attributes {p2align = 2 : i8} {
 // CHECK-NEXT:          %0, %1 = "test.op"() : () -> (i32, f32)
 // CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg
 // CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %1 : f32 to !riscv.freg
@@ -50,8 +49,7 @@ builtin.module {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "foo"
-// CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>) {
+// CHECK-NEXT:      riscv_func.func @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %arg1 : (!riscv.freg<fa0>) -> !riscv.freg
@@ -66,8 +64,7 @@ builtin.module {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_float"
-// CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) {
+// CHECK-NEXT:      riscv_func.func @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
 // CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg1 : (!riscv.freg<fa1>) -> !riscv.freg
@@ -82,8 +79,7 @@ builtin.module {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_int_float"
-// CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
+// CHECK-NEXT:      riscv_func.func @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
@@ -98,8 +94,7 @@ builtin.module {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "foo_int_double"
-// CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) {
+// CHECK-NEXT:      riscv_func.func @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg
@@ -114,7 +109,6 @@ builtin.module {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
 // CHECK-NEXT:      riscv.directive ".globl" "external"
-// CHECK-NEXT:      riscv.directive ".p2align" "2"
-// CHECK-NEXT:      riscv_func.func @external(!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>)
+// CHECK-NEXT:      riscv_func.func @external(!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8}
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
@@ -22,8 +22,8 @@ func.func public @ssum(
 
 // CHECK:       .text
 // CHECK-NEXT:  .globl ssum
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  ssum:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -82,8 +82,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
@@ -36,8 +36,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
 // CHECK:       .text
 // CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "a4", "a5", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  conv_2d_nchw_fchw_d1_s1_3x3:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -161,8 +161,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
 // CHECK:       .text
 // CHECK-NEXT:  .globl ddot
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  ddot:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -208,8 +208,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
 // CHECK:       .text
 // CHECK-NEXT:  .globl dsum
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  dsum:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1
@@ -252,8 +252,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
 // CHECK:       .text
 // CHECK-NEXT:  .globl fill
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["fa0", "ft0", "ft1", "ft2"], "preallocated_int": ["a0", "zero"], "allocated_float": ["fa0", "ft0", "ft3"], "allocated_int": ["a0", "t0", "t1", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  fill:
 // CHECK-NEXT:      fmv.d ft3, fa0
 // CHECK-NEXT:      mv t0, a0
@@ -309,8 +309,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl matmul
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  matmul:
 // CHECK-NEXT:      mv t0, a0
 // CHECK-NEXT:      mv t1, a1
@@ -419,8 +419,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1
@@ -515,8 +515,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 
 // CHECK:       .text
 // CHECK-NEXT:  .globl reluf64
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  reluf64:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1
@@ -574,8 +574,8 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
 
 // CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_sum_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
 // CHECK-NEXT:      mv t0, a1

--- a/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
@@ -12,8 +12,8 @@ func.func @main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1(%
 
 // CHECK:       .text
 // CHECK-NEXT:  .globl main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1
-// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1:
 // CHECK-NEXT:      mv t2, a0
 // CHECK-NEXT:      mv t1, a1

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from xdsl.backend.assembly_printer import AssemblyPrintable, AssemblyPrinter
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
+    I8,
     FunctionType,
     IntegerAttr,
     IntegerType,
     StringAttr,
     SymbolRefAttr,
+    i8,
 )
 from xdsl.dialects.utils import (
     parse_func_op_like,
@@ -135,7 +138,7 @@ class FuncOpCallableInterface(CallableOpInterface):
 
 
 @irdl_op_definition
-class FuncOp(riscv.RISCVAsmOperation):
+class FuncOp(IRDLOperation, AssemblyPrintable):
     """RISC-V function definition operation"""
 
     name = "riscv_func.func"
@@ -143,6 +146,7 @@ class FuncOp(riscv.RISCVAsmOperation):
     body = region_def()
     function_type = attr_def(FunctionType)
     sym_visibility = opt_attr_def(StringAttr)
+    p2align = opt_attr_def(IntegerAttr[I8])
 
     traits = traits_def(
         SymbolOpInterface(),
@@ -156,16 +160,20 @@ class FuncOp(riscv.RISCVAsmOperation):
         region: Region,
         function_type: FunctionType | tuple[Sequence[Attribute], Sequence[Attribute]],
         visibility: StringAttr | str | None = None,
+        p2align: int | IntegerAttr[I8] | None = None,
     ):
         if isinstance(function_type, tuple):
             inputs, outputs = function_type
             function_type = FunctionType.from_lists(inputs, outputs)
         if isinstance(visibility, str):
             visibility = StringAttr(visibility)
+        if isinstance(p2align, int):
+            p2align = IntegerAttr(p2align, i8)
         attributes: dict[str, Attribute | None] = {
             "sym_name": StringAttr(name),
             "function_type": function_type,
             "sym_visibility": visibility,
+            "p2align": p2align,
         }
 
         super().__init__(attributes=attributes, regions=[region])
@@ -202,11 +210,14 @@ class FuncOp(riscv.RISCVAsmOperation):
             reserved_attr_names=("sym_name", "function_type", "sym_visibility"),
         )
 
-    def assembly_line(self) -> str | None:
-        if self.body.blocks:
-            return f"{self.sym_name.data}:"
-        else:
-            return None
+    def print_assembly(self, printer: AssemblyPrinter) -> None:
+        if not self.body.blocks:
+            # Print nothing for function declaration
+            return
+
+        if self.p2align is not None:
+            printer.print_string(f".p2align {self.p2align.value.data}\n", indent=0)
+        printer.print_string(f"{self.sym_name.data}:\n")
 
 
 @irdl_op_definition


### PR DESCRIPTION
The directives emitted just before a function feel like they should be properties instead. This is the first PR moveing them into the riscv_func.func operation, otherwise preserving current logic as much as possible.