### PR TITLE
misc: catch DiagnosticExceptions thrown in xDSLOptMain targets

### DIFF
--- a/tests/xdsl_opt/test_xdsl_opt.py
+++ b/tests/xdsl_opt/test_xdsl_opt.py
@@ -1,5 +1,6 @@
 from contextlib import redirect_stdout
 from io import StringIO
+from typing import IO
 
 import pytest
 
@@ -156,6 +157,37 @@ def test_diagnostic_exception():
 
     with pytest.raises(DiagnosticException):
         opt.run()
+
+
+def test_verify_diagnostics_output():
+    """
+    Diagnostic exceptions raised when printing output should be redirected to stdout if
+    --verify-diagnostics flag is provided.
+    """
+
+    class TestMain(xDSLOptMain):
+        def register_all_targets(self):
+            def _my_target(prog: builtin.ModuleOp, output: IO[str]):
+                raise DiagnosticException("fail")
+
+            self.available_targets["fail"] = _my_target
+
+        def get_input_stream(self) -> tuple[IO[str], str]:
+            fake_input = StringIO("builtin.module {}")
+            return (fake_input, "mlir")
+
+    opt = TestMain(args=["-t", "fail"])
+    f = StringIO("")
+    with redirect_stdout(f):
+        with pytest.raises(DiagnosticException, match="fail"):
+            opt.run()
+    assert f.getvalue() == ""
+
+    opt = TestMain(args=["--verify-diagnostics", "-t", "fail"])
+    f = StringIO("")
+    with redirect_stdout(f):
+        opt.run()
+    assert f.getvalue() == "fail\n"
 
 
 def test_split_input():

--- a/xdsl/xdsl_opt_main.py
+++ b/xdsl/xdsl_opt_main.py
@@ -359,7 +359,7 @@ class xDSLOptMain(CommandLineTool):
                 print(e)
                 return False
             else:
-                raise e
+                raise
         return True
 
     def output_resulting_program(self, prog: ModuleOp) -> str:
@@ -368,7 +368,13 @@ class xDSLOptMain(CommandLineTool):
         if self.args.target not in self.available_targets:
             raise Exception(f"Unknown target {self.args.target}")
 
-        self.available_targets[self.args.target](prog, output)
+        try:
+            self.available_targets[self.args.target](prog, output)
+        except DiagnosticException as e:
+            if self.args.verify_diagnostics:
+                return f"{e}\n"
+            else:
+                raise
         return output.getvalue()
 
 


### PR DESCRIPTION
This lets us write filecheck tests for exceptions raised during assembly, printing, for example.