### PR TITLE
documentation: Fix HTML markup for URL links in docstrings

### DIFF
--- a/xdsl/backend/csl/__init__.py
+++ b/xdsl/backend/csl/__init__.py
@@ -1,5 +1,5 @@
 """
 CSL is the language used to program for the Cerebras Wafer Scale Engine (WSE) a wafer-parallel compute accelerator.
 
-More info here: https://sdk.cerebras.net/
+See external [documentation](https://sdk.cerebras.net/).
 """

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -252,9 +252,9 @@ class CslPrintContext:
                 return ""
             case DenseIntOrFPElementsAttr():
                 data = init.get_attrs()
-                assert (
-                    len(data) == 1
-                ), f"MemRef global initialiser has to have 1 value, got {len(data)}"
+                assert len(data) == 1, (
+                    f"MemRef global initialiser has to have 1 value, got {len(data)}"
+                )
                 return f" = @constants({type}, {self.attribute_value_to_str(data[0])})"
             case other:
                 return f"<unknown memref.global init type {other}>"
@@ -344,9 +344,9 @@ class CslPrintContext:
         """
         type = val.type
         assert isa(type, MemRefType[Attribute])
-        assert isinstance(
-            val, OpResult
-        ), "The value provided to _memref_type_to_string must be an op result"
+        assert isinstance(val, OpResult), (
+            "The value provided to _memref_type_to_string must be an op result"
+        )
         dims: list[str] = []
         idx = 0
         for dim in type.get_shape():

--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -79,7 +79,7 @@ _CSL_KW_SET = {
 The set of CSL language keywords. These should not be used as variable names.
 
 There is no official list of all reserved keywords in CSL, this list was
-compiled using the keywords found here: https://sdk.cerebras.net/csl/language/syntax
+compiled using the keywords found [here](https://sdk.cerebras.net/csl/language/syntax)
 and should be expanded as needed.
 """
 
@@ -252,9 +252,9 @@ class CslPrintContext:
                 return ""
             case DenseIntOrFPElementsAttr():
                 data = init.get_attrs()
-                assert len(data) == 1, (
-                    f"MemRef global initialiser has to have 1 value, got {len(data)}"
-                )
+                assert (
+                    len(data) == 1
+                ), f"MemRef global initialiser has to have 1 value, got {len(data)}"
                 return f" = @constants({type}, {self.attribute_value_to_str(data[0])})"
             case other:
                 return f"<unknown memref.global init type {other}>"
@@ -344,9 +344,9 @@ class CslPrintContext:
         """
         type = val.type
         assert isa(type, MemRefType[Attribute])
-        assert isinstance(val, OpResult), (
-            "The value provided to _memref_type_to_string must be an op result"
-        )
+        assert isinstance(
+            val, OpResult
+        ), "The value provided to _memref_type_to_string must be an op result"
         dims: list[str] = []
         idx = 0
         for dim in type.get_shape():

--- a/xdsl/backend/riscv/traits.py
+++ b/xdsl/backend/riscv/traits.py
@@ -9,7 +9,7 @@ class StaticInsnRepresentation(HasInsnRepresentation):
     """
     Returns the first parameter as an insn template string.
 
-    See https://sourceware.org/binutils/docs/as/RISC_002dV_002dDirectives.html for more information
+    See external [documentation](https://sourceware.org/binutils/docs/as/RISC_002dV_002dDirectives.html).
     """
 
     insn: str = field(kw_only=True)

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -197,8 +197,7 @@ class Builder(BuilderListener):
 
     @overload
     @staticmethod
-    def region(input: Callable[[Builder], None]) -> Region:
-        ...
+    def region(input: Callable[[Builder], None]) -> Region: ...
 
     @staticmethod
     def region(
@@ -273,8 +272,7 @@ class Builder(BuilderListener):
 
     @overload
     @staticmethod
-    def implicit_region(input: Callable[[], None]) -> Region:
-        ...
+    def implicit_region(input: Callable[[], None]) -> Region: ...
 
     @staticmethod
     def implicit_region(

--- a/xdsl/builder.py
+++ b/xdsl/builder.py
@@ -50,7 +50,7 @@ class Builder(BuilderListener):
     A helper class to construct IRs, by keeping track of where to insert an
     operation. It mimics the OpBuilder class from MLIR.
 
-    https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder.html
+    See external [documentation](https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder.html).
     """
 
     insertion_point: InsertPoint
@@ -197,7 +197,8 @@ class Builder(BuilderListener):
 
     @overload
     @staticmethod
-    def region(input: Callable[[Builder], None]) -> Region: ...
+    def region(input: Callable[[Builder], None]) -> Region:
+        ...
 
     @staticmethod
     def region(
@@ -272,7 +273,8 @@ class Builder(BuilderListener):
 
     @overload
     @staticmethod
-    def implicit_region(input: Callable[[], None]) -> Region: ...
+    def implicit_region(input: Callable[[], None]) -> Region:
+        ...
 
     @staticmethod
     def implicit_region(

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -198,7 +198,7 @@ class ForOp(IRDLOperation):
 @irdl_op_definition
 class IfOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Affine/#affineif-affineaffineifop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Affine/#affineif-affineaffineifop).
     """
 
     name = "affine.if"
@@ -217,7 +217,7 @@ class IfOp(IRDLOperation):
 @irdl_op_definition
 class ParallelOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Affine/#affineparallel-affineaffineparallelop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Affine/#affineparallel-affineaffineparallelop).
     """
 
     name = "affine.parallel"

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -204,7 +204,8 @@ class SignlessIntegerBinaryOperation(IRDLOperation, abc.ABC):
     def is_right_zero(attr: IntegerAttr) -> bool:
         """
         Returns True only when 'attr' is a right zero for the operation
-        https://en.wikipedia.org/wiki/Absorbing_element
+
+        See external [documentation](https://en.wikipedia.org/wiki/Absorbing_element).
 
         Note that this depends on the operation and does *not* imply that
         attr.value.data == 0
@@ -215,7 +216,8 @@ class SignlessIntegerBinaryOperation(IRDLOperation, abc.ABC):
     def is_right_unit(attr: IntegerAttr) -> bool:
         """
         Return True only when 'attr' is a right unit/identity for the operation
-        https://en.wikipedia.org/wiki/Identity_element
+
+        See external [documentation](https://en.wikipedia.org/wiki/Identity_element).
         """
         return False
 

--- a/xdsl/dialects/arm/__init__.py
+++ b/xdsl/dialects/arm/__init__.py
@@ -1,6 +1,5 @@
 """
-ARM dialect, based on the ISA specification in:
-https://developer.arm.com/documentation/102374/0101/Overview
+ARM dialect, based on the ISA [specification](https://developer.arm.com/documentation/102374/0101/Overview).
 """
 
 from typing import IO

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -63,7 +63,7 @@ class DSMovOp(ARMInstruction):
     """
     Copies the value of s into d.
 
-    https://developer.arm.com/documentation/dui0473/m/arm-and-thumb-instructions/mov
+    See external [documentation](https://developer.arm.com/documentation/dui0473/m/arm-and-thumb-instructions/mov).
     """
 
     name = "arm.ds.mov"
@@ -119,7 +119,7 @@ class DSSMulOp(ARMInstruction):
     """
     Multiplies the values in s1 and s2 and stores the result in d.
 
-    https://developer.arm.com/documentation/ddi0597/2024-06/Base-Instructions/MUL--MULS--Multiply-?lang=en
+    See external [documentation](https://developer.arm.com/documentation/ddi0597/2024-06/Base-Instructions/MUL--MULS--Multiply-?lang=en).
     """
 
     name = "arm.dss.mul"
@@ -162,7 +162,8 @@ class LabelOp(ARMOperation):
     """
     The label operation is used to emit text labels (e.g. loop:) that are used
     as branch, unconditional jump targets and symbol offsets.
-    https://developer.arm.com/documentation/dui0801/l/Symbols--Literals--Expressions--and-Operators/Labels
+
+    See external [documentation](https://developer.arm.com/documentation/dui0801/l/Symbols--Literals--Expressions--and-Operators/Labels).
     """
 
     name = "arm.label"
@@ -198,7 +199,8 @@ class CmpRegOp(ARMInstruction):
     """
     Compare (register) subtracts an optionally-shifted register value from a register value.
     It updates the condition flags based on the result, and discards the result.
-    https://developer.arm.com/documentation/ddi0597/2024-12/Base-Instructions/CMP--register---Compare--register--?lang=en
+
+    See external [documentation](https://developer.arm.com/documentation/ddi0597/2024-12/Base-Instructions/CMP--register---Compare--register--?lang=en.
     """
 
     name = "arm.cmp"

--- a/xdsl/dialects/arm/ops.py
+++ b/xdsl/dialects/arm/ops.py
@@ -200,7 +200,7 @@ class CmpRegOp(ARMInstruction):
     Compare (register) subtracts an optionally-shifted register value from a register value.
     It updates the condition flags based on the result, and discards the result.
 
-    See external [documentation](https://developer.arm.com/documentation/ddi0597/2024-12/Base-Instructions/CMP--register---Compare--register--?lang=en.
+    See external [documentation](https://developer.arm.com/documentation/ddi0597/2024-12/Base-Instructions/CMP--register---Compare--register--?lang=en).
     """
 
     name = "arm.cmp"

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -103,10 +103,12 @@ A constant value denoting a dynamic index in a shape.
 
 class ShapedType(Attribute, ABC):
     @abstractmethod
-    def get_num_dims(self) -> int: ...
+    def get_num_dims(self) -> int:
+        ...
 
     @abstractmethod
-    def get_shape(self) -> tuple[int, ...]: ...
+    def get_shape(self) -> tuple[int, ...]:
+        ...
 
     def element_count(self) -> int:
         return prod(self.get_shape())
@@ -477,7 +479,7 @@ class StructPackableType(Generic[_PyT], PackableType[_PyT], ABC):
         """
         Format to be used when decoding and encoding bytes.
 
-        https://docs.python.org/3/library/struct.html
+        See external [documentation](https://docs.python.org/3/library/struct.html).
         """
         raise NotImplementedError()
 
@@ -685,7 +687,8 @@ class IntegerAttr(
         value_type: _IntegerAttrType,
         *,
         truncate_bits: bool = False,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     @overload
     def __init__(
@@ -694,7 +697,8 @@ class IntegerAttr(
         value_type: int,
         *,
         truncate_bits: bool = False,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def __init__(
         self,
@@ -925,10 +929,12 @@ class FloatAttr(Generic[_FloatAttrType], TypedAttribute):
     type: ParameterDef[_FloatAttrType]
 
     @overload
-    def __init__(self, data: float | FloatData, type: _FloatAttrType) -> None: ...
+    def __init__(self, data: float | FloatData, type: _FloatAttrType) -> None:
+        ...
 
     @overload
-    def __init__(self, data: float | FloatData, type: int) -> None: ...
+    def __init__(self, data: float | FloatData, type: int) -> None:
+        ...
 
     def __init__(
         self, data: float | FloatData, type: int | _FloatAttrType | AnyFloat
@@ -1319,13 +1325,15 @@ class DenseArrayBase(ParametrizedAttribute):
     @staticmethod
     def from_list(
         data_type: IntegerType, data: Sequence[int] | Sequence[IntAttr]
-    ) -> DenseArrayBase: ...
+    ) -> DenseArrayBase:
+        ...
 
     @overload
     @staticmethod
     def from_list(
         data_type: Attribute, data: Sequence[int | float] | Sequence[FloatData]
-    ) -> DenseArrayBase: ...
+    ) -> DenseArrayBase:
+        ...
 
     @staticmethod
     def from_list(
@@ -1440,7 +1448,7 @@ class MemRefLayoutAttr(Attribute, ABC):
 class StridedLayoutAttr(MemRefLayoutAttr, ParametrizedAttribute):
     """
     An attribute representing a strided layout of a shaped type.
-    See https://mlir.llvm.org/docs/Dialects/Builtin/#stridedlayoutattr
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Builtin/#stridedlayoutattr).
 
     Contrary to MLIR, we represent dynamic offsets and strides with
     `NoneAttr`, and we do not restrict offsets and strides to 64-bits
@@ -2158,7 +2166,8 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
             | Sequence[IntegerAttr[IndexType]]
             | Sequence[IntegerAttr[IntegerType]]
         ),
-    ) -> DenseIntOrFPElementsAttr: ...
+    ) -> DenseIntOrFPElementsAttr:
+        ...
 
     @overload
     @staticmethod
@@ -2170,7 +2179,8 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
             | RankedStructure[IndexType]
         ),
         data: Sequence[int | float] | Sequence[FloatAttr],
-    ) -> DenseIntOrFPElementsAttr: ...
+    ) -> DenseIntOrFPElementsAttr:
+        ...
 
     @staticmethod
     def from_list(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -103,12 +103,10 @@ A constant value denoting a dynamic index in a shape.
 
 class ShapedType(Attribute, ABC):
     @abstractmethod
-    def get_num_dims(self) -> int:
-        ...
+    def get_num_dims(self) -> int: ...
 
     @abstractmethod
-    def get_shape(self) -> tuple[int, ...]:
-        ...
+    def get_shape(self) -> tuple[int, ...]: ...
 
     def element_count(self) -> int:
         return prod(self.get_shape())
@@ -687,8 +685,7 @@ class IntegerAttr(
         value_type: _IntegerAttrType,
         *,
         truncate_bits: bool = False,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @overload
     def __init__(
@@ -697,8 +694,7 @@ class IntegerAttr(
         value_type: int,
         *,
         truncate_bits: bool = False,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def __init__(
         self,
@@ -929,12 +925,10 @@ class FloatAttr(Generic[_FloatAttrType], TypedAttribute):
     type: ParameterDef[_FloatAttrType]
 
     @overload
-    def __init__(self, data: float | FloatData, type: _FloatAttrType) -> None:
-        ...
+    def __init__(self, data: float | FloatData, type: _FloatAttrType) -> None: ...
 
     @overload
-    def __init__(self, data: float | FloatData, type: int) -> None:
-        ...
+    def __init__(self, data: float | FloatData, type: int) -> None: ...
 
     def __init__(
         self, data: float | FloatData, type: int | _FloatAttrType | AnyFloat
@@ -1325,15 +1319,13 @@ class DenseArrayBase(ParametrizedAttribute):
     @staticmethod
     def from_list(
         data_type: IntegerType, data: Sequence[int] | Sequence[IntAttr]
-    ) -> DenseArrayBase:
-        ...
+    ) -> DenseArrayBase: ...
 
     @overload
     @staticmethod
     def from_list(
         data_type: Attribute, data: Sequence[int | float] | Sequence[FloatData]
-    ) -> DenseArrayBase:
-        ...
+    ) -> DenseArrayBase: ...
 
     @staticmethod
     def from_list(
@@ -2166,8 +2158,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
             | Sequence[IntegerAttr[IndexType]]
             | Sequence[IntegerAttr[IntegerType]]
         ),
-    ) -> DenseIntOrFPElementsAttr:
-        ...
+    ) -> DenseIntOrFPElementsAttr: ...
 
     @overload
     @staticmethod
@@ -2179,8 +2170,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
             | RankedStructure[IndexType]
         ),
         data: Sequence[int | float] | Sequence[FloatAttr],
-    ) -> DenseIntOrFPElementsAttr:
-        ...
+    ) -> DenseIntOrFPElementsAttr: ...
 
     @staticmethod
     def from_list(

--- a/xdsl/dialects/comb.py
+++ b/xdsl/dialects/comb.py
@@ -6,7 +6,7 @@ higher level dialects mixed into it.
 
 Up to date as of CIRCT commit `2e23cda6c2cbedb118b92fab755f1e36d80b13f5`.
 
-[1] https://circt.llvm.org/docs/Dialects/Comb/
+See external [documentation](https://circt.llvm.org/docs/Dialects/Comb/).
 """
 
 from abc import ABC

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -796,9 +796,9 @@ class FuncOp(_FuncBase):
         if res_attrs:
             raise NotImplementedError("res_attrs not implemented in csl FuncOp")
 
-        assert (
-            len(return_types) <= 1
-        ), f"{cls.name} can't have more than one result type!"
+        assert len(return_types) <= 1, (
+            f"{cls.name} can't have more than one result type!"
+        )
 
         func = cls(
             name=name,
@@ -854,9 +854,9 @@ class TaskOp(_FuncBase):
                 id, IntegerType(task_kind.get_color_bits(), Signedness.UNSIGNED)
             )
         if id is not None:
-            assert (
-                id.type.width.data == task_kind.get_color_bits()
-            ), f"{task_kind.data.value} task id has to have {task_kind.get_color_bits()} bits, got {id.type.width.data}"
+            assert id.type.width.data == task_kind.get_color_bits(), (
+                f"{task_kind.data.value} task id has to have {task_kind.get_color_bits()} bits, got {id.type.width.data}"
+            )
 
         properties |= {
             "kind": task_kind,
@@ -923,9 +923,9 @@ class TaskOp(_FuncBase):
                 parser.pos,
             )
 
-        assert (
-            len(return_types) <= 1
-        ), f"{cls.name} can't have more than one result type!"
+        assert len(return_types) <= 1, (
+            f"{cls.name} can't have more than one result type!"
+        )
 
         task = cls(
             name=name,

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -1,10 +1,10 @@
 """
-The CSL dialect models the Cerebras Systems Language. It's meant to be used as a target to do automatic codegen for
-the CS2.
+The CSL dialect models the Cerebras Systems Language.
 
-See https://docs.cerebras.net/en/latest/ for some mediocre documentation on the operations and their semantics.
+It aims to be used as a target (using the `-t cls` commandline option) to do automatic
+codegen for the CS2.
 
-This is meant to be used in conjunction with the `-t csl` printing option to generate CSL code.
+See external [documentation](https://docs.cerebras.net/en/latest/).
 """
 
 from __future__ import annotations
@@ -780,19 +780,25 @@ class FuncOp(_FuncBase):
 
     @classmethod
     def parse(cls, parser: Parser) -> FuncOp:
-        (name, input_types, return_types, region, extra_attrs, arg_attrs, res_attrs) = (
-            parse_func_op_like(
-                parser,
-                reserved_attr_names=("sym_name", "function_type", "sym_visibility"),
-            )
+        (
+            name,
+            input_types,
+            return_types,
+            region,
+            extra_attrs,
+            arg_attrs,
+            res_attrs,
+        ) = parse_func_op_like(
+            parser,
+            reserved_attr_names=("sym_name", "function_type", "sym_visibility"),
         )
 
         if res_attrs:
             raise NotImplementedError("res_attrs not implemented in csl FuncOp")
 
-        assert len(return_types) <= 1, (
-            f"{cls.name} can't have more than one result type!"
-        )
+        assert (
+            len(return_types) <= 1
+        ), f"{cls.name} can't have more than one result type!"
 
         func = cls(
             name=name,
@@ -848,9 +854,9 @@ class TaskOp(_FuncBase):
                 id, IntegerType(task_kind.get_color_bits(), Signedness.UNSIGNED)
             )
         if id is not None:
-            assert id.type.width.data == task_kind.get_color_bits(), (
-                f"{task_kind.data.value} task id has to have {task_kind.get_color_bits()} bits, got {id.type.width.data}"
-            )
+            assert (
+                id.type.width.data == task_kind.get_color_bits()
+            ), f"{task_kind.data.value} task id has to have {task_kind.get_color_bits()} bits, got {id.type.width.data}"
 
         properties |= {
             "kind": task_kind,
@@ -889,11 +895,17 @@ class TaskOp(_FuncBase):
     @classmethod
     def parse(cls, parser: Parser) -> TaskOp:
         pos = parser.pos
-        (name, input_types, return_types, region, extra_attrs, arg_attrs, res_attrs) = (
-            parse_func_op_like(
-                parser,
-                reserved_attr_names=("sym_name", "function_type", "sym_visibility"),
-            )
+        (
+            name,
+            input_types,
+            return_types,
+            region,
+            extra_attrs,
+            arg_attrs,
+            res_attrs,
+        ) = parse_func_op_like(
+            parser,
+            reserved_attr_names=("sym_name", "function_type", "sym_visibility"),
         )
         if res_attrs:
             raise NotImplementedError("res_attrs not implemented in csl TaskOp")
@@ -911,9 +923,9 @@ class TaskOp(_FuncBase):
                 parser.pos,
             )
 
-        assert len(return_types) <= 1, (
-            f"{cls.name} can't have more than one result type!"
-        )
+        assert (
+            len(return_types) <= 1
+        ), f"{cls.name} can't have more than one result type!"
 
         task = cls(
             name=name,

--- a/xdsl/dialects/experimental/fir.py
+++ b/xdsl/dialects/experimental/fir.py
@@ -6,7 +6,7 @@ FIR+HLFIR is the first MLIR representation of a Fortran code in the
 compilation pipeline. Secondly, the HLFIR+FIR is then lowered to FIR
 only, before this is then lowered to LLVM IR.
 
-For more details see https://flang.llvm.org/docs/FortranIR.html
+See external [documentation](https://flang.llvm.org/docs/FortranIR.html).
 """
 
 from __future__ import annotations

--- a/xdsl/dialects/experimental/hlfir.py
+++ b/xdsl/dialects/experimental/hlfir.py
@@ -7,7 +7,7 @@ be materialised and there is a higher level of information about
 the programmer's Fortran code, compared to FIR, available for
 optimisation and lowering.
 
-For more details see https://flang.llvm.org/docs/HighLevelFIR.html
+See external [documentation](https://flang.llvm.org/docs/HighLevelFIR.html).
 """
 
 from __future__ import annotations

--- a/xdsl/dialects/fsm.py
+++ b/xdsl/dialects/fsm.py
@@ -1,3 +1,9 @@
+"""
+Implementation of the FSM dialect by CIRCT
+
+See external [documentation](https://circt.llvm.org/docs/Dialects/FSM/RationaleFSM/).
+"""
+
 from __future__ import annotations
 
 from collections.abc import Sequence
@@ -44,10 +50,6 @@ from xdsl.traits import (
     SymbolTable,
 )
 from xdsl.utils.exceptions import VerifyException
-
-"""
-Implementation of the FSM dialect by CIRCT. Documentation: https://circt.llvm.org/docs/Dialects/FSM/RationaleFSM/
-"""
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -2,8 +2,8 @@
 This is a stub of CIRCT’s hw dialect.
 Follows definitions as of CIRCT commit `f8c7faec1e8447521a1ea9a0836b6923a132c79e`.
 
-[1] https://circt.llvm.org/docs/Dialects/HW/
-[2] https://circt.llvm.org/docs/RationaleSymbols/
+See [rationale](https://circt.llvm.org/docs/RationaleSymbols/) for symbols.
+See external [documentation](https://circt.llvm.org/docs/Dialects/HW/).
 """
 
 import abc
@@ -358,12 +358,14 @@ class InnerSymAttr(
         ...
 
     @overload
-    def __init__(self, syms: str | StringAttr) -> None: ...
+    def __init__(self, syms: str | StringAttr) -> None:
+        ...
 
     @overload
     def __init__(
         self, syms: Sequence[InnerSymPropertiesAttr] | ArrayAttr[InnerSymPropertiesAttr]
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def __init__(
         self,

--- a/xdsl/dialects/hw.py
+++ b/xdsl/dialects/hw.py
@@ -358,14 +358,12 @@ class InnerSymAttr(
         ...
 
     @overload
-    def __init__(self, syms: str | StringAttr) -> None:
-        ...
+    def __init__(self, syms: str | StringAttr) -> None: ...
 
     @overload
     def __init__(
         self, syms: Sequence[InnerSymPropertiesAttr] | ArrayAttr[InnerSymPropertiesAttr]
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def __init__(
         self,

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -554,7 +554,7 @@ class AddOp(NamedOpBase):
     """
     Adds two tensors elementwise.
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgadd-linalgaddop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgadd-linalgaddop).
     """
 
     name = "linalg.add"
@@ -593,7 +593,7 @@ class SubOp(NamedOpBase):
     """
     Subtracts two tensors elementwise.
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgsub-linalgsubop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgsub-linalgsubop).
     """
 
     name = "linalg.sub"
@@ -636,7 +636,7 @@ class FillOp(NamedOpBase):
     only and is thus rank polymorphic. Numeric casting is performed on the value operand,
     promoting it to the same data type as the output.
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgfill-linalgfillop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgfill-linalgfillop).
     """
 
     name = "linalg.fill"
@@ -684,7 +684,7 @@ class MulOp(NamedOpBase):
     """
     Multiplies two tensors elementwise.
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgmul-linalgmulop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgmul-linalgmulop).
     """
 
     name = "linalg.mul"
@@ -723,7 +723,7 @@ class TransposeOp(IRDLOperation):
     """
     Transpose operator
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgtranspose-linalgtransposeop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgtranspose-linalgtransposeop).
     """
 
     name = "linalg.transpose"
@@ -836,8 +836,7 @@ class MatmulOp(NamedOpBase):
     """
     Performs a matrix multiplication of two 2D inputs.
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgmatmul-linalgmatmulop
-
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgmatmul-linalgmatmulop).
     """
 
     name = "linalg.matmul"
@@ -899,8 +898,7 @@ class QuantizedMatmulOp(NamedOpBase):
     """
     Performs a matrix multiplication of two 2D inputs.
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgquantized_matmul-linalgquantizedmatmulop
-
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgquantized_matmul-linalgquantizedmatmulop).
     """
 
     name = "linalg.quantized_matmul"
@@ -972,7 +970,7 @@ class PoolingNchwMaxOp(PoolingOpsBase):
     """
     Performs max pooling
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgpooling_nchw_max-linalgpoolingnchwmaxop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgpooling_nchw_max-linalgpoolingnchwmaxop).
     """
 
     name = "linalg.pooling_nchw_max"
@@ -1053,7 +1051,7 @@ class Conv2DNchwFchwOp(ConvOpsBase):
     """
     Performs 2-D convolution
 
-    See https://mlir.llvm.org/docs/Dialects/Linalg/#linalgconv_2d_nchw_fchw-linalgconv2dnchwfchwop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Linalg/#linalgconv_2d_nchw_fchw-linalgconv2dnchwfchwop).
     """
 
     name = "linalg.conv_2d_nchw_fchw"

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -105,7 +105,7 @@ def parse_optional_llvm_type(parser: AttrParser):
 @irdl_attr_definition
 class LLVMStructType(ParametrizedAttribute, TypeAttribute):
     """
-    https://mlir.llvm.org/docs/Dialects/LLVM/#structure-types
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#structure-types).
     """
 
     name = "llvm.struct"
@@ -242,7 +242,7 @@ class LLVMFunctionType(ParametrizedAttribute, TypeAttribute):
     """
     Currently does not support variadics.
 
-    https://mlir.llvm.org/docs/Dialects/LLVM/#function-types
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#function-types).
     """
 
     name = "llvm.func"
@@ -868,11 +868,12 @@ class GEPOp(IRDLOperation):
     llvm.getelementptr is an instruction to do pointer arithmetic by
     adding/subtracting offsets from a pointer.
 
-    The llvm.getelementptr is documented in various places online:
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmgetelementptr-mlirllvmgepop).
 
-    LLVM documentation: https://www.llvm.org/docs/GetElementPtr.html
-    A good blogpost: https://blog.yossarian.net/2020/09/19/LLVMs-getelementptr-by-example
-    MLIR documentation: https://mlir.llvm.org/docs/Dialects/LLVM/#llvmgetelementptr-mlirllvmgepop
+    GetElementPtr is documented in various places online:
+
+    See the LLVM [documentation](https://www.llvm.org/docs/GetElementPtr.html).
+    A good [blogpost](https://blog.yossarian.net/2020/09/19/LLVMs-getelementptr-by-example).
 
     Note that the first two discuss *LLVM IRs* GEP operation, not the MLIR one.
     The semantics are the same, but the structure used by MLIR is not well
@@ -1116,10 +1117,9 @@ class IntToPtrOp(IRDLOperation):
 @irdl_op_definition
 class InlineAsmOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/LLVM/#llvminline_asm-llvminlineasmop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvminline_asm-llvminlineasmop).
 
-    To see what each field means, have a look at:
-    https://llvm.org/docs/LangRef.html#inline-assembler-expressions
+    To see what each field means, have a look [here](https://llvm.org/docs/LangRef.html#inline-assembler-expressions).
     """
 
     name = "llvm.inline_asm"
@@ -1265,7 +1265,7 @@ class NullOp(IRDLOperation):
 @irdl_op_definition
 class ExtractValueOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/LLVM/#llvmextractvalue-mlirllvmextractvalueop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmextractvalue-mlirllvmextractvalueop).
     """
 
     name = "llvm.extractvalue"
@@ -1295,7 +1295,7 @@ class ExtractValueOp(IRDLOperation):
 @irdl_op_definition
 class InsertValueOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/LLVM/#llvminsertvalue-mlirllvminsertvalueop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvminsertvalue-mlirllvminsertvalueop).
     """
 
     name = "llvm.insertvalue"
@@ -1326,7 +1326,7 @@ class InsertValueOp(IRDLOperation):
 @irdl_op_definition
 class UndefOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/LLVM/#llvmmlirundef-mlirllvmundefop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmmlirundef-mlirllvmundefop).
     """
 
     name = "llvm.mlir.undef"
@@ -1453,9 +1453,8 @@ LLVM_CALLING_CONVS: set[str] = {
     "cfguard_checkcc",
 }
 """
-A list of all valid calling conventions understood by LLVM, see
-https://llvm.org/docs/LangRef.html#calling-conventions
-for more info.
+A list of all valid calling conventions understood by LLVM, see external documentation
+[here](https://llvm.org/docs/LangRef.html#calling-conventions) for more info.
 """
 
 
@@ -1540,7 +1539,7 @@ class FuncOp(IRDLOperation):
 @irdl_op_definition
 class ReturnOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/LLVM/#llvmreturn-mlirllvmreturnop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmreturn-mlirllvmreturnop).
     """
 
     name = "llvm.return"
@@ -1600,7 +1599,7 @@ class FastMathAttr(FastMathAttrBase):
 @irdl_op_definition
 class CallIntrinsicOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/LLVM/#llvmcall_intrinsic-mlirllvmcallintrinsicop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/LLVM/#llvmcall_intrinsic-mlirllvmcallintrinsicop).
     """
 
     name = "llvm.call_intrinsic"

--- a/xdsl/dialects/ltl.py
+++ b/xdsl/dialects/ltl.py
@@ -1,7 +1,7 @@
 """
 Implementation of the LTL dialect by CIRCT.
 
-https://circt.llvm.org/docs/Dialects/LTL/
+See external [documentation](https://circt.llvm.org/docs/Dialects/LTL/).
 """
 
 from __future__ import annotations

--- a/xdsl/dialects/math.py
+++ b/xdsl/dialects/math.py
@@ -2,8 +2,7 @@
 The math dialect is intended to hold mathematical operations on integer and floating
 types beyond simple arithmetics.
 
-
-See https://mlir.llvm.org/docs/Dialects/MathOps/
+See external [documentation](https://mlir.llvm.org/docs/Dialects/MathOps/).
 """
 
 from __future__ import annotations
@@ -209,7 +208,7 @@ class Atan2Op(FloatingPointLikeBinaryMathOperationWithFastMath):
     (x, y).  It is a generalization of the 1-argument arcus tangent which
     returns the angle on the basis of the ratio y/x.
 
-    See also https://en.wikipedia.org/wiki/Atan2
+    See also [wikipedia](https://en.wikipedia.org/wiki/Atan2).
 
     Example:
 

--- a/xdsl/dialects/ml_program.py
+++ b/xdsl/dialects/ml_program.py
@@ -32,7 +32,8 @@ class GlobalOp(IRDLOperation):
     """
     Module level declaration of a global variable
 
-    See https://mlir.llvm.org/docs/Dialects/MLProgramOps/#ml_programglobal-ml_programglobalop
+
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/MLProgramOps/#ml_programglobal-ml_programglobalop).
     """
 
     name = "ml_program.global"
@@ -116,7 +117,8 @@ class GlobalLoadConstantOp(IRDLOperation):
     """
     Direct load a constant value from a global
 
-    See https://mlir.llvm.org/docs/Dialects/MLProgramOps/#ml_programglobal_load_const-ml_programgloballoadconstop
+
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/MLProgramOps/#ml_programglobal_load_const-ml_programgloballoadconstop).
     """
 
     name = "ml_program.global_load_const"

--- a/xdsl/dialects/mpi.py
+++ b/xdsl/dialects/mpi.py
@@ -151,7 +151,8 @@ class MPIBaseOp(IRDLOperation, ABC):
 class ReduceOp(MPIBaseOp):
     """
     This wraps the MPI_Reduce function (blocking reduction)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Reduce.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Reduce.html).
 
     ## The MPI_Reduce Function Docs:
 
@@ -201,7 +202,8 @@ class ReduceOp(MPIBaseOp):
 class AllreduceOp(MPIBaseOp):
     """
     This wraps the MPI_Allreduce function (blocking all reduction)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Allreduce.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Allreduce.html).
 
     ## The MPI_Allreduce Function Docs:
 
@@ -257,7 +259,8 @@ class AllreduceOp(MPIBaseOp):
 class BcastOp(MPIBaseOp):
     """
     This wraps the MPI_Bcast function (blocking broadcast)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Bcast.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Bcast.html).
 
     ## The MPI_Bcast Function Docs:
 
@@ -300,7 +303,8 @@ class BcastOp(MPIBaseOp):
 class IsendOp(MPIBaseOp):
     """
     This wraps the MPI_Isend function (nonblocking send)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Isend.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Isend.html).
 
     ## The MPI_Isend Function Docs:
 
@@ -348,7 +352,8 @@ class IsendOp(MPIBaseOp):
 class SendOp(MPIBaseOp):
     """
     This wraps the MPI_Send function (blocking send)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Send.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Send.html).
 
     ## The MPI_Send Function Docs:
 
@@ -393,7 +398,8 @@ class SendOp(MPIBaseOp):
 class IrecvOp(MPIBaseOp):
     """
     This wraps the MPI_Irecv function (nonblocking receive).
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Irecv.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Irecv.html).
 
     ## The MPI_Irecv Function Docs:
 
@@ -442,7 +448,8 @@ class IrecvOp(MPIBaseOp):
 class RecvOp(MPIBaseOp):
     """
     This wraps the MPI_Recv function (blocking receive).
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Recv.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Recv.html).
 
     ## The MPI_Recv Function Docs:
 
@@ -492,7 +499,8 @@ class RecvOp(MPIBaseOp):
 class TestOp(MPIBaseOp):
     """
     Class for wrapping the MPI_Test function (test for completion of request)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Test.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Test.html).
 
     ## The MPI_Test Function Docs:
 
@@ -518,7 +526,8 @@ class TestOp(MPIBaseOp):
 class WaitOp(MPIBaseOp):
     """
     Class for wrapping the MPI_Wait function (blocking wait for request)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Wait.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Wait.html).
 
     ## The MPI_Test Function Docs:
 
@@ -545,7 +554,8 @@ class WaitOp(MPIBaseOp):
 class WaitallOp(MPIBaseOp):
     """
     Class for wrapping the MPI_Waitall function (blocking wait for requests)
-    https://www.mpich.org/static/docs/v4.1/www3/MPI_Waitall.html
+
+    See external [documentation](https://www.mpich.org/static/docs/v4.1/www3/MPI_Waitall.html).
 
     ## The MPI_Test Function Docs:
 

--- a/xdsl/dialects/pdl.py
+++ b/xdsl/dialects/pdl.py
@@ -181,7 +181,7 @@ class RangeType(Generic[_RangeT], ParametrizedAttribute, TypeAttribute):
 @irdl_op_definition
 class ApplyNativeConstraintOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlapply_native_constraint-mlirpdlapplynativeconstraintop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlapply_native_constraint-mlirpdlapplynativeconstraintop).
     """
 
     name = "pdl.apply_native_constraint"
@@ -212,7 +212,7 @@ class ApplyNativeConstraintOp(IRDLOperation):
 @irdl_op_definition
 class ApplyNativeRewriteOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlapply_native_rewrite-mlirpdlapplynativerewriteop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlapply_native_rewrite-mlirpdlapplynativerewriteop).
     """
 
     name = "pdl.apply_native_rewrite"
@@ -261,7 +261,7 @@ class ApplyNativeRewriteOp(IRDLOperation):
 @irdl_op_definition
 class AttributeOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlattribute-mlirpdlattributeop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlattribute-mlirpdlattributeop).
     """
 
     name = "pdl.attribute"
@@ -317,7 +317,7 @@ class AttributeOp(IRDLOperation):
 @irdl_op_definition
 class EraseOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlerase-mlirpdleraseop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlerase-mlirpdleraseop).
     """
 
     name = "pdl.erase"
@@ -338,7 +338,7 @@ class EraseOp(IRDLOperation):
 @irdl_op_definition
 class OperandOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdloperand-mlirpdloperandop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdloperand-mlirpdloperandop).
     """
 
     name = "pdl.operand"
@@ -367,7 +367,7 @@ class OperandOp(IRDLOperation):
 @irdl_op_definition
 class OperandsOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdloperands-mlirpdloperandsop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdloperands-mlirpdloperandsop).
     """
 
     name = "pdl.operands"
@@ -396,7 +396,7 @@ class OperandsOp(IRDLOperation):
 @irdl_op_definition
 class OperationOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdloperation-mlirpdloperationop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdloperation-mlirpdloperationop).
     """
 
     name = "pdl.operation"
@@ -552,7 +552,7 @@ def _has_user_in_rewrite(op: Operation) -> bool:
 @irdl_op_definition
 class PatternOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlpattern-mlirpdlpatternop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlpattern-mlirpdlpatternop).
     """
 
     name = "pdl.pattern"
@@ -636,7 +636,7 @@ class PatternOp(IRDLOperation):
 @irdl_op_definition
 class RangeOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlrange-mlirpdlrangeop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlrange-mlirpdlrangeop).
     """
 
     name = "pdl.range"
@@ -702,7 +702,7 @@ class RangeOp(IRDLOperation):
 @irdl_op_definition
 class ReplaceOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlreplace-mlirpdlreplaceop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlreplace-mlirpdlreplaceop).
 
     `pdl.replace` operations are used within `pdl.rewrite` regions to specify
     that an input operation should be marked as replaced. The semantics of this
@@ -776,7 +776,7 @@ class ReplaceOp(IRDLOperation):
 @irdl_op_definition
 class ResultOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlresult-mlirpdlresultop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlresult-mlirpdlresultop).
     """
 
     name = "pdl.result"
@@ -805,7 +805,7 @@ class ResultOp(IRDLOperation):
 @irdl_op_definition
 class ResultsOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlresults-mlirpdlresultsop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlresults-mlirpdlresultsop).
     """
 
     name = "pdl.results"
@@ -849,7 +849,7 @@ class ResultsOp(IRDLOperation):
 @irdl_op_definition
 class RewriteOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlrewrite-mlirpdlrewriteop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdlrewrite-mlirpdlrewriteop).
     """
 
     name = "pdl.rewrite"
@@ -935,7 +935,7 @@ class RewriteOp(IRDLOperation):
 @irdl_op_definition
 class TypeOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdltype-mlirpdltypeop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdltype-mlirpdltypeop).
     """
 
     name = "pdl.type"
@@ -965,7 +965,7 @@ class TypeOp(IRDLOperation):
 @irdl_op_definition
 class TypesOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/PDLOps/#pdltypes-mlirpdltypesop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/PDLOps/#pdltypes-mlirpdltypesop).
     """
 
     name = "pdl.types"

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -1461,7 +1461,7 @@ class AddiOp(RdRsImmIntegerOperation):
 
     x[rd] = x[rs1] + sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#addi
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#addi).
     """
 
     name = "riscv.addi"
@@ -1477,7 +1477,7 @@ class SltiOp(RdRsImmIntegerOperation):
 
     x[rd] = x[rs1] <s sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slti
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slti).
     """
 
     name = "riscv.slti"
@@ -1491,7 +1491,7 @@ class SltiuOp(RdRsImmIntegerOperation):
 
     x[rd] = x[rs1] <u sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sltiu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sltiu).
     """
 
     name = "riscv.sltiu"
@@ -1505,7 +1505,7 @@ class AndiOp(RdRsImmIntegerOperation):
 
     x[rd] = x[rs1] & sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#andi
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#andi).
     """
 
     name = "riscv.andi"
@@ -1519,7 +1519,7 @@ class OriOp(RdRsImmIntegerOperation):
 
     x[rd] = x[rs1] | sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#ori
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#ori).
     """
 
     name = "riscv.ori"
@@ -1533,7 +1533,7 @@ class XoriOp(RdRsImmIntegerOperation):
 
     x[rd] = x[rs1] ^ sext(immediate)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#xori
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#xori).
     """
 
     name = "riscv.xori"
@@ -1555,7 +1555,7 @@ class SlliOp(RdRsImmShiftOperation):
 
     x[rd] = x[rs1] << shamt
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slli
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slli).
     """
 
     name = "riscv.slli"
@@ -1571,7 +1571,7 @@ class SrliOp(RdRsImmShiftOperation):
 
     x[rd] = x[rs1] >>u shamt
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srli
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srli).
     """
 
     name = "riscv.srli"
@@ -1585,7 +1585,7 @@ class SraiOp(RdRsImmShiftOperation):
 
     x[rd] = x[rs1] >>s shamt
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srai
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srai).
     """
 
     name = "riscv.srai"
@@ -1599,7 +1599,7 @@ class LuiOp(RdImmIntegerOperation):
 
     x[rd] = sext(immediate[31:12] << 12)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lui
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lui).
     """
 
     name = "riscv.lui"
@@ -1614,7 +1614,7 @@ class AuipcOp(RdImmIntegerOperation):
 
     x[rd] = pc + sext(immediate[31:12] << 12)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#auipc
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#auipc).
     """
 
     name = "riscv.auipc"
@@ -1698,7 +1698,7 @@ class AddOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     x[rd] = x[rs1] + x[rs2]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#add
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#add).
     """
 
     name = "riscv.add"
@@ -1717,7 +1717,7 @@ class SltOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] <s x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slt
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#slt).
     """
 
     name = "riscv.slt"
@@ -1731,7 +1731,7 @@ class SltuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] <u x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sltu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sltu).
     """
 
     name = "riscv.sltu"
@@ -1752,7 +1752,7 @@ class AndOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] & x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#and
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#and).
     """
 
     name = "riscv.and"
@@ -1775,7 +1775,7 @@ class OrOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] | x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#or
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#or).
     """
 
     name = "riscv.or"
@@ -1801,7 +1801,7 @@ class XorOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] ^ x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#xor
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#xor).
     """
 
     name = "riscv.xor"
@@ -1817,7 +1817,7 @@ class SllOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] << x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sll
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sll).
     """
 
     name = "riscv.sll"
@@ -1831,7 +1831,7 @@ class SrlOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] >>u x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srl
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#srl).
     """
 
     name = "riscv.srl"
@@ -1856,7 +1856,7 @@ class SubOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] - x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sub
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sub).
     """
 
     name = "riscv.sub"
@@ -1872,7 +1872,7 @@ class SraOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 
     x[rd] = x[rs1] >>s x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sub
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sub).
     """
 
     name = "riscv.sra"
@@ -1904,7 +1904,7 @@ class JalOp(RdImmJumpOperation):
 
     x[rd] = pc+4; pc += sext(offset)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#jal
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#jal).
     """
 
     name = "riscv.jal"
@@ -1944,7 +1944,7 @@ class JalrOp(RdRsImmJumpOperation):
     x[rd] = t
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#jalr
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#jalr).
     """
 
     name = "riscv.jalr"
@@ -1975,7 +1975,7 @@ class BeqOp(RsRsOffIntegerOperation):
     if (x[rs1] == x[rs2]) pc += sext(offset)
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#beq
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#beq).
     """
 
     name = "riscv.beq"
@@ -1990,7 +1990,7 @@ class BneOp(RsRsOffIntegerOperation):
     if (x[rs1] != x[rs2]) pc += sext(offset)
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bne
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bne).
     """
 
     name = "riscv.bne"
@@ -2005,7 +2005,7 @@ class BltOp(RsRsOffIntegerOperation):
     if (x[rs1] <s x[rs2]) pc += sext(offset)
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#blt
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#blt).
     """
 
     name = "riscv.blt"
@@ -2020,7 +2020,7 @@ class BgeOp(RsRsOffIntegerOperation):
     if (x[rs1] >=s x[rs2]) pc += sext(offset)
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bge
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bge).
     """
 
     name = "riscv.bge"
@@ -2035,7 +2035,7 @@ class BltuOp(RsRsOffIntegerOperation):
     if (x[rs1] <u x[rs2]) pc += sext(offset)
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bltu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bltu).
     """
 
     name = "riscv.bltu"
@@ -2050,7 +2050,7 @@ class BgeuOp(RsRsOffIntegerOperation):
     if (x[rs1] >=u x[rs2]) pc += sext(offset)
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bgeu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bgeu).
     """
 
     name = "riscv.bgeu"
@@ -2071,7 +2071,7 @@ class LbOp(RdRsImmIntegerOperation):
     x[rd] = sext(M[x[rs1] + sext(offset)][7:0])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lb
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lb).
     """
 
     name = "riscv.lb"
@@ -2087,7 +2087,7 @@ class LbuOp(RdRsImmIntegerOperation):
     x[rd] = M[x[rs1] + sext(offset)][7:0]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lbu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lbu).
     """
 
     name = "riscv.lbu"
@@ -2103,7 +2103,7 @@ class LhOp(RdRsImmIntegerOperation):
     x[rd] = sext(M[x[rs1] + sext(offset)][15:0])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lh
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lh).
     """
 
     name = "riscv.lh"
@@ -2119,7 +2119,7 @@ class LhuOp(RdRsImmIntegerOperation):
     x[rd] = M[x[rs1] + sext(offset)][15:0]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lhu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lhu).
     """
 
     name = "riscv.lhu"
@@ -2145,7 +2145,7 @@ class LwOp(RdRsImmIntegerOperation):
     x[rd] = sext(M[x[rs1] + sext(offset)][31:0])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lw
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#lw).
     """
 
     name = "riscv.lw"
@@ -2171,7 +2171,7 @@ class SbOp(RsRsImmIntegerOperation):
     M[x[rs1] + sext(offset)] = x[rs2][7:0]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sb
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sb).
     """
 
     name = "riscv.sb"
@@ -2186,7 +2186,7 @@ class ShOp(RsRsImmIntegerOperation):
     M[x[rs1] + sext(offset)] = x[rs2][15:0]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sh
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sh).
 
     """
 
@@ -2212,7 +2212,7 @@ class SwOp(RsRsImmIntegerOperation):
     M[x[rs1] + sext(offset)] = x[rs2][31:0]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sw
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#sw).
     """
 
     name = "riscv.sw"
@@ -2246,7 +2246,7 @@ class CsrrwOp(CsrReadWriteOperation):
 
     t = CSRs[csr]; CSRs[csr] = x[rs1]; x[rd] = t
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrw
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrw).
     """
 
     name = "riscv.csrrw"
@@ -2271,7 +2271,7 @@ class CsrrsOp(CsrBitwiseOperation):
 
     t = CSRs[csr]; CSRs[csr] = t | x[rs1]; x[rd] = t
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrs
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrs).
     """
 
     name = "riscv.csrrs"
@@ -2296,7 +2296,7 @@ class CsrrcOp(CsrBitwiseOperation):
 
     t = CSRs[csr]; CSRs[csr] = t &~x[rs1]; x[rd] = t
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrc
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrc).
     """
 
     name = "riscv.csrrc"
@@ -2313,7 +2313,7 @@ class CsrrwiOp(CsrReadWriteImmOperation):
 
     x[rd] = CSRs[csr]; CSRs[csr] = zimm
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrwi
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrwi).
     """
 
     name = "riscv.csrrwi"
@@ -2336,7 +2336,7 @@ class CsrrsiOp(CsrBitwiseImmOperation):
 
     t = CSRs[csr]; CSRs[csr] = t | zimm; x[rd] = t
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrsi
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrsi).
     """
 
     name = "riscv.csrrsi"
@@ -2359,7 +2359,7 @@ class CsrrciOp(CsrBitwiseImmOperation):
 
     t = CSRs[csr]; CSRs[csr] = t &~zimm; x[rd] = t
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrci
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#csrrci).
     """
 
     name = "riscv.csrrci"
@@ -2390,7 +2390,7 @@ class MulOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     and places the lower XLEN bits in the destination register.
     x[rd] = x[rs1] * x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#add
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#add).
     """
 
     name = "riscv.mul"
@@ -2405,7 +2405,7 @@ class MulhOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     and places the upper XLEN bits in the destination register.
     x[rd] = (x[rs1] s×s x[rs2]) >>s XLEN
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulh
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulh).
     """
 
     name = "riscv.mulh"
@@ -2418,7 +2418,7 @@ class MulhsuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     and places the upper XLEN bits in the destination register.
     x[rd] = (x[rs1] s × x[rs2]) >>s XLEN
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulhsu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulhsu).
     """
 
     name = "riscv.mulhsu"
@@ -2431,7 +2431,7 @@ class MulhuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     and places the upper XLEN bits in the destination register.
     x[rd] = (x[rs1] u × x[rs2]) >>u XLEN
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulhu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#mulhu).
     """
 
     name = "riscv.mulhu"
@@ -2445,7 +2445,7 @@ class DivOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     rounding towards zero.
     x[rd] = x[rs1] /s x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#div
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#div).
     """
 
     name = "riscv.div"
@@ -2458,7 +2458,7 @@ class DivuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     rounding towards zero.
     x[rd] = x[rs1] /u x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#divu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#divu).
     """
 
     name = "riscv.divu"
@@ -2470,7 +2470,7 @@ class RemOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     Perform an XLEN bits by XLEN bits signed integer reminder of rs1 by rs2.
     x[rd] = x[rs1] %s x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#rem
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#rem).
     """
 
     name = "riscv.rem"
@@ -2482,7 +2482,7 @@ class RemuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
     Perform an XLEN bits by XLEN bits unsigned integer reminder of rs1 by rs2.
     x[rd] = x[rs1] %u x[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#remu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvm.html#remu).
     """
 
     name = "riscv.remu"
@@ -2491,7 +2491,7 @@ class RemuOp(RdRsRsIntegerOperation[IntRegisterType, IntRegisterType]):
 # endregion
 
 # region Assembler pseudo-instructions
-# https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md
+# See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md).
 
 
 class LiOpHasCanonicalizationPatternTrait(HasCanonicalizationPatternsTrait):
@@ -2511,7 +2511,7 @@ class LiOp(RISCVCustomFormatOperation, RISCVInstruction, ABC):
 
     This is an assembler pseudo-instruction.
 
-    https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#load-immediate
+    See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#load-immediate).
     """
 
     name = "riscv.li"
@@ -2579,7 +2579,7 @@ class EcallOp(NullaryOperation):
     request are passed, but usually these will be in defined locations in the
     integer register file.
 
-    https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf
+    See external [documentation](https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf).
     """
 
     name = "riscv.ecall"
@@ -2591,7 +2591,7 @@ class LabelOp(RISCVCustomFormatOperation, RISCVAsmOperation):
     The label operation is used to emit text labels (e.g. loop:) that are used
     as branch, unconditional jump targets and symbol offsets.
 
-    https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#labels
+    See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#labels).
     """
 
     name = "riscv.label"
@@ -2647,7 +2647,7 @@ class DirectiveOp(RISCVCustomFormatOperation, RISCVAsmOperation):
     without any associated region of assembly code.
     A more complete list of directives can be found here:
 
-    https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudo-ops
+    See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudo-ops).
     """
 
     name = "riscv.directive"
@@ -2717,7 +2717,7 @@ class AssemblySectionOp(IRDLOperation, AssemblyPrintable):
 
     A more complete list of directives can be found here:
 
-    https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudo-ops
+    See external [documentation](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudo-ops).
 
     This operation can have nested operations, corresponding to a section of the assembly.
     """
@@ -2852,7 +2852,7 @@ class EbreakOp(NullaryOperation):
     The EBREAK instruction is used by debuggers to cause control to be
     transferred back to a debugging environment.
 
-    https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf
+    See external [documentation](https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf).
     """
 
     name = "riscv.ebreak"
@@ -2865,7 +2865,7 @@ class WfiOp(NullaryOperation):
     implementation that the current hart can be stalled until an
     interrupt might need servicing.
 
-    https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
+    See external [documentation](https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf).
     """
 
     name = "riscv.wfi"
@@ -3164,7 +3164,7 @@ class FMAddSOp(RdRsRsRsFloatOperation):
     f[rd] = f[rs1]×f[rs2]+f[rs3]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmadd-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmadd-s).
     """
 
     name = "riscv.fmadd.s"
@@ -3179,7 +3179,7 @@ class FMSubSOp(RdRsRsRsFloatOperation):
     f[rd] = f[rs1]×f[rs2]+f[rs3]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmsub-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmsub-s).
     """
 
     name = "riscv.fmsub.s"
@@ -3194,7 +3194,7 @@ class FNMSubSOp(RdRsRsRsFloatOperation):
     f[rd] = -f[rs1]×f[rs2]+f[rs3]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fnmsub-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fnmsub-s).
     """
 
     name = "riscv.fnmsub.s"
@@ -3209,7 +3209,7 @@ class FNMAddSOp(RdRsRsRsFloatOperation):
     f[rd] = -f[rs1]×f[rs2]-f[rs3]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fnmadd-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fnmadd-s).
     """
 
     name = "riscv.fnmadd.s"
@@ -3224,7 +3224,7 @@ class FAddSOp(RdRsRsFloatOperationWithFastMath):
     f[rd] = f[rs1]+f[rs2]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fadd-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fadd-s).
     """
 
     name = "riscv.fadd.s"
@@ -3241,7 +3241,7 @@ class FSubSOp(RdRsRsFloatOperationWithFastMath):
     f[rd] = f[rs1]-f[rs2]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsub-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsub-s).
     """
 
     name = "riscv.fsub.s"
@@ -3256,7 +3256,7 @@ class FMulSOp(RdRsRsFloatOperationWithFastMath):
     f[rd] = f[rs1]×f[rs2]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmul-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmul-s).
     """
 
     name = "riscv.fmul.s"
@@ -3271,7 +3271,7 @@ class FDivSOp(RdRsRsFloatOperationWithFastMath):
     f[rd] = f[rs1] / f[rs2]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fdiv-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fdiv-s).
     """
 
     name = "riscv.fdiv.s"
@@ -3286,7 +3286,7 @@ class FSqrtSOp(RdRsFloatOperation[FloatRegisterType]):
     f[rd] = sqrt(f[rs1])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsqrt-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsqrt-s).
     """
 
     name = "riscv.fsqrt.s"
@@ -3302,7 +3302,7 @@ class FSgnJSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     f[rd] = {f[rs2][31], f[rs1][30:0]}
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsgnj.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsgnj.s).
     """
 
     name = "riscv.fsgnj.s"
@@ -3318,7 +3318,7 @@ class FSgnJNSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     f[rd] = {~f[rs2][31], f[rs1][30:0]}
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsgnjn.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsgnjn.s).
     """
 
     name = "riscv.fsgnjn.s"
@@ -3334,7 +3334,7 @@ class FSgnJXSOp(RdRsRsFloatOperation[FloatRegisterType, FloatRegisterType]):
     f[rd] = {f[rs1][31] ^ f[rs2][31], f[rs1][30:0]}
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsgnjx.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsgnjx.s).
     """
 
     name = "riscv.fsgnjx.s"
@@ -3349,7 +3349,7 @@ class FMinSOp(RdRsRsFloatOperationWithFastMath):
     f[rd] = min(f[rs1], f[rs2])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmin-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmin-s).
     """
 
     name = "riscv.fmin.s"
@@ -3364,7 +3364,7 @@ class FMaxSOp(RdRsRsFloatOperationWithFastMath):
     f[rd] = max(f[rs1], f[rs2])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmax-s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmax-s).
     """
 
     name = "riscv.fmax.s"
@@ -3379,7 +3379,7 @@ class FCvtWSOp(RdRsIntegerOperation[FloatRegisterType]):
     x[rd] = sext(s32_{f32}(f[rs1]))
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.w.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.w.s).
     """
 
     name = "riscv.fcvt.w.s"
@@ -3394,7 +3394,7 @@ class FCvtWuSOp(RdRsIntegerOperation[FloatRegisterType]):
     x[rd] = sext(u32_{f32}(f[rs1]))
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.wu.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.wu.s).
     """
 
     name = "riscv.fcvt.wu.s"
@@ -3410,7 +3410,7 @@ class FMvXWOp(RdRsIntegerOperation[FloatRegisterType]):
     x[rd] = sext(f[rs1][31:0])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmv.x.w
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmv.x.w).
     """
 
     name = "riscv.fmv.x.w"
@@ -3426,7 +3426,7 @@ class FeqSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
 
     x[rd] = f[rs1] == f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#feq.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#feq.s).
     """
 
     name = "riscv.feq.s"
@@ -3442,7 +3442,7 @@ class FltSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
 
     x[rd] = f[rs1] < f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#flt.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#flt.s).
     """
 
     name = "riscv.flt.s"
@@ -3458,7 +3458,7 @@ class FleSOp(RdRsRsFloatFloatIntegerOperationWithFastMath):
 
     x[rd] = f[rs1] <= f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fle.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fle.s).
     """
 
     name = "riscv.fle.s"
@@ -3475,7 +3475,7 @@ class FClassSOp(RdRsIntegerOperation[FloatRegisterType]):
 
     x[rd] = classifys(f[rs1])
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fclass.s
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fclass.s).
     """
 
     name = "riscv.fclass.s"
@@ -3490,7 +3490,7 @@ class FCvtSWOp(RdRsFloatOperation[IntRegisterType]):
     f[rd] = f32_{s32}(x[rs1])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.s.w
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.s.w).
     """
 
     name = "riscv.fcvt.s.w"
@@ -3506,7 +3506,7 @@ class FCvtSWuOp(RdRsFloatOperation[IntRegisterType]):
     f[rd] = f32_{u32}(x[rs1])
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.s.wu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt.s.wu).
     """
 
     name = "riscv.fcvt.s.wu"
@@ -3523,7 +3523,7 @@ class FMvWXOp(RdRsFloatOperation[IntRegisterType]):
     ```
 
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmv.w.x
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmv.w.x).
     """
 
     name = "riscv.fmv.w.x"
@@ -3548,7 +3548,7 @@ class FLwOp(RdRsImmFloatOperation):
     f[rd] = M[x[rs1] + sext(offset)][31:0]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#flw
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#flw).
     """
 
     name = "riscv.flw"
@@ -3582,7 +3582,7 @@ class FSwOp(RsRsImmFloatOperation):
 
     M[x[rs1] + offset] = f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsw
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsw).
     """
 
     name = "riscv.fsw"
@@ -3611,7 +3611,7 @@ class FMAddDOp(RdRsRsRsFloatOperation):
 
     f[rd] = f[rs1]×f[rs2]+f[rs3]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmadd-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmadd-d).
     """
 
     name = "riscv.fmadd.d"
@@ -3626,7 +3626,7 @@ class FMSubDOp(RdRsRsRsFloatOperation):
 
     f[rd] = f[rs1]×f[rs2]+f[rs3]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmsub-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmsub-d).
     """
 
     name = "riscv.fmsub.d"
@@ -3651,7 +3651,7 @@ class FAddDOp(RdRsRsFloatOperationWithFastMath):
 
     f[rd] = f[rs1]+f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fadd-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fadd-d).
     """
 
     name = "riscv.fadd.d"
@@ -3669,7 +3669,7 @@ class FSubDOp(RdRsRsFloatOperationWithFastMath):
 
     f[rd] = f[rs1]-f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsub-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsub-d).
     """
 
     name = "riscv.fsub.d"
@@ -3684,7 +3684,7 @@ class FMulDOp(RdRsRsFloatOperationWithFastMath):
 
     f[rd] = f[rs1]×f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmul-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmul-d).
     """
 
     name = "riscv.fmul.d"
@@ -3699,7 +3699,7 @@ class FDivDOp(RdRsRsFloatOperationWithFastMath):
 
     f[rd] = f[rs1] / f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fdiv-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fdiv-d).
     """
 
     name = "riscv.fdiv.d"
@@ -3722,7 +3722,7 @@ class FMinDOp(RdRsRsFloatOperationWithFastMath):
 
     f[rd] = min(f[rs1], f[rs2])
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmin-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmin-d).
     """
 
     name = "riscv.fmin.d"
@@ -3737,7 +3737,7 @@ class FMaxDOp(RdRsRsFloatOperationWithFastMath):
 
     f[rd] = max(f[rs1], f[rs2])
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmax-d
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fmax-d).
     """
 
     name = "riscv.fmax.d"
@@ -3753,7 +3753,7 @@ class FCvtDWOp(RdRsFloatOperation[IntRegisterType]):
 
     x[rd] = sext(s32_{f64}(f[rs1]))
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt-d-w
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt-d-w).
     """
 
     name = "riscv.fcvt.d.w"
@@ -3769,7 +3769,7 @@ class FCvtDWuOp(RdRsFloatOperation[IntRegisterType]):
 
     f[rd] = f64_{u32}(x[rs1])
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt-d-wu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fcvt-d-wu).
     """
 
     name = "riscv.fcvt.d.wu"
@@ -3786,7 +3786,7 @@ class FLdOp(RdRsImmFloatOperation):
     f[rd] = M[x[rs1] + sext(offset)][63:0]
     ```
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fld
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fld).
     """
 
     name = "riscv.fld"
@@ -3825,7 +3825,7 @@ class FSdOp(RsRsImmFloatOperation):
 
     M[x[rs1] + offset] = f[rs2]
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsw
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvfd.html#fsw).
     """
 
     name = "riscv.fsd"
@@ -3870,7 +3870,7 @@ class FMvDOp(RdRsFloatOperation[FloatRegisterType]):
 
 # region 17 "V" Standard Extension for Vector Operations
 
-# https://riscv.org/wp-content/uploads/2018/05/15.20-15.55-18.05.06.VEXT-bcn-v1.pdf
+# See external documentation https://riscv.org/wp-content/uploads/2018/05/15.20-15.55-18.05.06.VEXT-bcn-v1.pdf
 
 # Vector operations that use standard RISC-V registers are using a non-standard Xfvec
 # extension.

--- a/xdsl/dialects/riscv_cf.py
+++ b/xdsl/dialects/riscv_cf.py
@@ -197,7 +197,7 @@ class BeqOp(ConditionalBranchOperation):
 
     if (x[rs1] == x[rs2]) pc += sext(offset)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#beq
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#beq).
     """
 
     name = "riscv_cf.beq"
@@ -215,7 +215,7 @@ class BneOp(ConditionalBranchOperation):
 
     if (x[rs1] != x[rs2]) pc += sext(offset)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bne
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bne).
     """
 
     name = "riscv_cf.bne"
@@ -233,7 +233,7 @@ class BltOp(ConditionalBranchOperation):
 
     if (x[rs1] <s x[rs2]) pc += sext(offset)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#blt
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#blt).
     """
 
     name = "riscv_cf.blt"
@@ -251,7 +251,7 @@ class BgeOp(ConditionalBranchOperation):
 
     if (x[rs1] >=s x[rs2]) pc += sext(offset)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bge
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bge).
     """
 
     name = "riscv_cf.bge"
@@ -269,7 +269,7 @@ class BltuOp(ConditionalBranchOperation):
 
     if (x[rs1] <u x[rs2]) pc += sext(offset)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bltu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bltu).
     """
 
     name = "riscv_cf.bltu"
@@ -287,7 +287,7 @@ class BgeuOp(ConditionalBranchOperation):
 
     if (x[rs1] >=u x[rs2]) pc += sext(offset)
 
-    https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bgeu
+    See external [documentation](https://msyksphinz-self.github.io/riscv-isadoc/html/rvi.html#bgeu).
     """
 
     name = "riscv_cf.bgeu"

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -89,7 +89,8 @@ class ScfgwOp(RsRsIntegerOperation):
     location pointed by rs2 in the memory-mapped address space.
 
     This is a RISC-V ISA extension, part of the `Xssr' extension.
-    https://pulp-platform.github.io/snitch/rm/custom_instructions/
+
+    See external [documentation](https://pulp-platform.github.io/snitch/rm/custom_instructions/).
     """
 
     name = "riscv_snitch.scfgw"
@@ -104,7 +105,8 @@ class ScfgwiOp(RISCVCustomFormatOperation, RISCVInstruction):
     immediate value in the memory-mapped address space.
 
     This is a RISC-V ISA extension, part of the `Xssr' extension.
-    https://pulp-platform.github.io/snitch/rm/custom_instructions/
+
+    See external [documentation](https://pulp-platform.github.io/snitch/rm/custom_instructions/).
     """
 
     name = "riscv_snitch.scfgwi"
@@ -208,12 +210,12 @@ ALLOWED_FREP_OP_TYPES = (
 
 class FRepOperation(RISCVInstruction):
     """
-    From the Snitch paper: https://arxiv.org/abs/2002.10143
-
     The frep instruction marks the beginning of a floating-point kernel which should be
     repeated. It indicates how many subsequent instructions are stored in the sequence
     buffer, how often and how (operand staggering, repetition mode) each instruction is
     going to be repeated.
+
+    Snitch paper: See external [documentation](https://arxiv.org/abs/2002.10143).
     """
 
     max_rep = operand_def(IntRegisterType)

--- a/xdsl/dialects/seq.py
+++ b/xdsl/dialects/seq.py
@@ -1,7 +1,7 @@
 """
-CIRCT’s seq dialect
+CIRCT’s seq dialect.
 
-[1] https://circt.llvm.org/docs/Dialects/Seq/
+See external [documentation](https://circt.llvm.org/docs/Dialects/Seq/).
 """
 
 from enum import Enum

--- a/xdsl/dialects/stablehlo.py
+++ b/xdsl/dialects/stablehlo.py
@@ -1,5 +1,4 @@
 """
-
 [StableHLO](https://github.com/openxla/stablehlo/blob/main/docs/spec.md)
 is an operation set for high-level operations (HLO) in machine learning (ML) models.
 StableHLO works as a portability layer between different ML frameworks and ML compilers:
@@ -208,7 +207,7 @@ class ComparisonDirectionAttr(
 
     For quantized types, performs `dequantize_compare(lhs, rhs, comparison_direction)`
 
-    [See StableHLO specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#compare)
+    See external [documentation](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#compare).
     """
 
     name = "stablehlo.comparison_direction"
@@ -218,7 +217,7 @@ class ComparisonType(StrEnum):
     """
     Together with `comparison_direction` determines the semantics of comparison.
 
-    [See StableHLO's source](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloEnums.td#L152-L156)
+    See StableHLO's [source](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloEnums.td#L152-L156).
     """
 
     NOTYPE = "NOTYPE"
@@ -233,7 +232,7 @@ class ComparisonTypeAttr(EnumAttribute[ComparisonType], SpacedOpaqueSyntaxAttrib
     """
     Together with `comparison_direction` determines the semantics of comparison.
 
-    [See StableHLO specification](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#compare)
+    See external [documentation](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#compare).
     """
 
     name = "stablehlo.comparison_type"
@@ -254,7 +253,7 @@ class PrecisionAttr(EnumAttribute[Precision], SpacedOpaqueSyntaxAttribute):
     """
     XLA precision for an operand. Has backend specific meaning.
 
-    [See StableHLO specification](https://github.com/openxla/stablehlo/blob/b075e948092d8a27ed0be48f4f8dbaa6df7e2e3e/stablehlo/dialect/StablehloEnums.td#L46)
+    See external [documentation](https://github.com/openxla/stablehlo/blob/b075e948092d8a27ed0be48f4f8dbaa6df7e2e3e/stablehlo/dialect/StablehloEnums.td#L46).
     """
 
     name = "stablehlo.precision"
@@ -283,7 +282,7 @@ class DotAttr(ParametrizedAttribute):
     """
     Attribute that models the dimension information for dot.
 
-    [See StableHLO specification](https://github.com/openxla/stablehlo/blob/b075e948092d8a27ed0be48f4f8dbaa6df7e2e3e/stablehlo/dialect/StablehloAttrs.td#L82)
+    See external [documentation](https://github.com/openxla/stablehlo/blob/b075e948092d8a27ed0be48f4f8dbaa6df7e2e3e/stablehlo/dialect/StablehloAttrs.td#L82).
     """
 
     name = "stablehlo.dot"

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -66,7 +66,7 @@ class TransformParamHandleType(TransformHandleType, ABC):
 @irdl_attr_definition
 class AffineMapType(TransformHandleType):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#affinemapparamtype
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#affinemapparamtype).
     """
 
     name = "transform.affine_map"
@@ -75,7 +75,7 @@ class AffineMapType(TransformHandleType):
 @irdl_attr_definition
 class AnyOpType(TransformOpHandleType):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#anyoptype
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#anyoptype).
     """
 
     name = "transform.any_op"
@@ -84,7 +84,7 @@ class AnyOpType(TransformOpHandleType):
 @irdl_attr_definition
 class AnyValueType(TransformValueHandleType):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#anyvaluetype
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#anyvaluetype).
     """
 
     name = "transform.any_value"
@@ -98,7 +98,7 @@ class AnyParamType(TransformParamHandleType):
 @irdl_attr_definition
 class OperationType(TransformOpHandleType):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#operationtype
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#operationtype).
     """
 
     name = "transform.op"
@@ -111,7 +111,7 @@ class OperationType(TransformOpHandleType):
 @irdl_attr_definition
 class ParamType(TransformParamHandleType):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#paramtype
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#paramtype).
     """
 
     name = "transform.param"
@@ -124,7 +124,7 @@ class ParamType(TransformParamHandleType):
 @irdl_attr_definition
 class TypeParamType(TransformParamHandleType):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#typeparamtype
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#typeparamtype).
     """
 
     name = "transform.type"
@@ -150,7 +150,7 @@ AnyIntegerOrFailurePropagationModeAttr: TypeAlias = Annotated[
 @irdl_op_definition
 class GetConsumersOfResultOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformget_consumers_of_result-transformgetconsumersofresult
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformget_consumers_of_result-transformgetconsumersofresult).
     """
 
     name = "transform.get_consumers_of_result"
@@ -174,7 +174,7 @@ class GetConsumersOfResultOp(IRDLOperation):
 @irdl_op_definition
 class GetDefiningOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformget_defining_op-transformgetdefiningop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformget_defining_op-transformgetdefiningop).
     """
 
     name = "transform.get_defining_op"
@@ -189,7 +189,7 @@ class GetDefiningOp(IRDLOperation):
 @irdl_op_definition
 class GetParentOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformget_parent_op-transformgetparentop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformget_parent_op-transformgetparentop).
     """
 
     name = "transform.get_parent_op"
@@ -229,7 +229,7 @@ class GetParentOp(IRDLOperation):
 @irdl_op_definition
 class GetProducerOfOperandOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformget_producer_of_operand-transformgetproducerofoperand
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformget_producer_of_operand-transformgetproducerofoperand).
     """
 
     name = "transform.get_producer_of_operand"
@@ -255,7 +255,7 @@ class GetProducerOfOperandOp(IRDLOperation):
 @irdl_op_definition
 class GetResultOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformget_result-transformgetresultop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformget_result-transformgetresultop).
     """
 
     name = "transform.get_result"
@@ -291,7 +291,7 @@ class GetResultOp(IRDLOperation):
 @irdl_op_definition
 class GetTypeOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformget_type-transformgettypeop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformget_type-transformgettypeop).
     """
 
     name = "transform.get_type"
@@ -311,7 +311,7 @@ class GetTypeOp(IRDLOperation):
 @irdl_op_definition
 class IncludeOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transforminclude-transformincludeop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transforminclude-transformincludeop).
     """
 
     name = "transform.include"
@@ -344,7 +344,7 @@ class IncludeOp(IRDLOperation):
 @irdl_op_definition
 class MatchOperationEmptyOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformmatchoperation_empty-transformmatchoperationemptyop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformmatchoperation_empty-transformmatchoperationemptyop).
     """
 
     name = "transform.match.operation_empty"
@@ -358,7 +358,7 @@ class MatchOperationEmptyOp(IRDLOperation):
 @irdl_op_definition
 class MatchOperationNameOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformmatchoperation_name-transformmatchoperationnameop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformmatchoperation_name-transformmatchoperationnameop).
     """
 
     name = "transform.match.operation_name"
@@ -387,7 +387,7 @@ class MatchOperationNameOp(IRDLOperation):
 @irdl_op_definition
 class MatchParamCmpIOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformmatchparamcmpi-transformmatchparamcmpiop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformmatchparamcmpi-transformmatchparamcmpiop).
     """
 
     name = "transform.match.param.cmpi"
@@ -412,7 +412,7 @@ class MatchParamCmpIOp(IRDLOperation):
 @irdl_op_definition
 class MergeHandlesOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformmerge_handles-transformmergehandlesop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformmerge_handles-transformmergehandlesop).
     """
 
     name = "transform.merge_handles"
@@ -432,7 +432,7 @@ class MergeHandlesOp(IRDLOperation):
 @irdl_op_definition
 class ParamConstantOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformparamconstant-transformparamconstantop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformparamconstant-transformparamconstantop).
     """
 
     name = "transform.param.constant"
@@ -449,7 +449,7 @@ class ParamConstantOp(IRDLOperation):
 @irdl_op_definition
 class SplitHandleOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformsplit_handle-transformsplithandleop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformsplit_handle-transformsplithandleop).
     """
 
     name = "transform.split_handle"
@@ -500,7 +500,7 @@ class SplitHandleOp(IRDLOperation):
 @irdl_op_definition
 class YieldOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformyield-transformyieldop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformyield-transformyieldop).
     """
 
     name = "transform.yield"
@@ -511,7 +511,7 @@ class YieldOp(IRDLOperation):
 @irdl_op_definition
 class SequenceOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformsequence-transformsequenceop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformsequence-transformsequenceop).
     """
 
     name = "transform.sequence"
@@ -556,7 +556,7 @@ class SequenceOp(IRDLOperation):
 @irdl_op_definition
 class TileOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredtile_using_for-transformtileusingforop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredtile_using_for-transformtileusingforop).
     """
 
     name = "transform.structured.tile_using_for"
@@ -617,7 +617,7 @@ class TileOp(IRDLOperation):
 @irdl_op_definition
 class TileToForallOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredtile_using_for-transformtileusingforop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredtile_using_for-transformtileusingforop).
     """
 
     name = "transform.structured.tile_using_forall"
@@ -678,7 +678,7 @@ class TileToForallOp(IRDLOperation):
 @irdl_op_definition
 class SelectOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformselect-transformselectop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformselect-transformselectop).
     """
 
     name = "transform.select"
@@ -700,7 +700,7 @@ class SelectOp(IRDLOperation):
 @irdl_op_definition
 class NamedSequenceOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformnamed_sequence-transformnamedsequenceop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformnamed_sequence-transformnamedsequenceop).
     """
 
     name = "transform.named_sequence"
@@ -744,7 +744,7 @@ class NamedSequenceOp(IRDLOperation):
 @irdl_op_definition
 class CastOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformcast-transformcastop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformcast-transformcastop).
     """
 
     name = "transform.cast"
@@ -759,7 +759,7 @@ class CastOp(IRDLOperation):
 @irdl_op_definition
 class MatchOp(IRDLOperation):
     """
-    https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredmatch-transformmatchop
+    See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformstructuredmatch-transformmatchop).
     """
 
     name = "transform.structured.match"

--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -236,7 +236,8 @@ class RR_AddOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] + x[r2]
     ```
-    https://www.felixcloutier.com/x86/add
+
+    See external [documentation](https://www.felixcloutier.com/x86/add).
     """
 
     name = "x86.rr.add"
@@ -249,7 +250,8 @@ class RR_SubOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] - x[r2]
     ```
-    https://www.felixcloutier.com/x86/sub
+
+    See external [documentation](https://www.felixcloutier.com/x86/sub).
     """
 
     name = "x86.rr.sub"
@@ -262,7 +264,8 @@ class RR_ImulOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] * x[r2]
     ```
-    https://www.felixcloutier.com/x86/imul
+
+    See external [documentation](https://www.felixcloutier.com/x86/imul).
     """
 
     name = "x86.rr.imul"
@@ -275,7 +278,8 @@ class RR_AndOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] & x[r2]
     ```
-    https://www.felixcloutier.com/x86/and
+
+    See external [documentation](https://www.felixcloutier.com/x86/and).
     """
 
     name = "x86.rr.and"
@@ -288,7 +292,8 @@ class RR_OrOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] | x[r2]
     ```
-    https://www.felixcloutier.com/x86/or
+
+    See external [documentation](https://www.felixcloutier.com/x86/or).
     """
 
     name = "x86.rr.or"
@@ -301,7 +306,8 @@ class RR_XorOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] ^ x[r2]
     ```
-    https://www.felixcloutier.com/x86/xor
+
+    See external [documentation](https://www.felixcloutier.com/x86/xor).
     """
 
     name = "x86.rr.xor"
@@ -314,7 +320,8 @@ class RR_MovOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r2]
     ```
-    https://www.felixcloutier..com/x86/mov
+
+    See external [documentation](https://www.felixcloutier..com/x86/mov).
     """
 
     name = "x86.rr.mov"
@@ -324,7 +331,8 @@ class RR_MovOp(R_RR_Operation[GeneralRegisterType, GeneralRegisterType]):
 class R_PushOp(X86Instruction, X86CustomFormatOperation):
     """
     Decreases %rsp and places r1 at the new memory location pointed to by %rsp.
-    https://www.felixcloutier.com/x86/push
+
+    See external [documentation](https://www.felixcloutier.com/x86/push).
     """
 
     name = "x86.r.push"
@@ -360,7 +368,8 @@ class R_PushOp(X86Instruction, X86CustomFormatOperation):
 class R_PopOp(X86Instruction, X86CustomFormatOperation):
     """
     Copies the value at the top of the stack into r1 and increases %rsp.
-    https://www.felixcloutier.com/x86/pop
+
+    See external [documentation](https://www.felixcloutier.com/x86/pop).
     """
 
     name = "x86.r.pop"
@@ -429,7 +438,8 @@ class R_NegOp(R_R_Operation[GeneralRegisterType]):
     ```C
     x[r1] = -x[r1]
     ```
-    https://www.felixcloutier.com/x86/neg
+
+    See external [documentation](https://www.felixcloutier.com/x86/neg).
     """
 
     name = "x86.r.neg"
@@ -442,7 +452,8 @@ class R_NotOp(R_R_Operation[GeneralRegisterType]):
     ```C
     x[r1] = ~x[r1]
     ```
-    https://www.felixcloutier.com/x86/not
+
+    See external [documentation](https://www.felixcloutier.com/x86/not).
     """
 
     name = "x86.r.not"
@@ -455,7 +466,8 @@ class R_IncOp(R_R_Operation[GeneralRegisterType]):
     ```C
     x[r1] = x[r1] + 1
     ```
-    https://www.felixcloutier.com/x86/inc
+
+    See external [documentation](https://www.felixcloutier.com/x86/inc).
     """
 
     name = "x86.r.inc"
@@ -468,7 +480,8 @@ class R_DecOp(R_R_Operation[GeneralRegisterType]):
     ```C
     x[r1] = x[r1] - 1
     ```
-    https://www.felixcloutier.com/x86/dec
+
+    See external [documentation](https://www.felixcloutier.com/x86/dec).
     """
 
     name = "x86.r.dec"
@@ -478,7 +491,8 @@ class R_DecOp(R_R_Operation[GeneralRegisterType]):
 class R_IDivOp(X86Instruction, X86CustomFormatOperation):
     """
     Divides the value in RDX:RAX by r1 and stores the quotient in RAX and the remainder in RDX.
-    https://www.felixcloutier.com/x86/idiv
+
+    See external [documentation](https://www.felixcloutier.com/x86/idiv).
     """
 
     name = "x86.r.idiv"
@@ -522,7 +536,8 @@ class R_ImulOp(X86Instruction, X86CustomFormatOperation):
     ```C
     x[RDX:RAX] = x[RAX] * r1
     ```
-    https://www.felixcloutier.com/x86/imul
+
+    See external [documentation](https://www.felixcloutier.com/x86/imul).
     """
 
     name = "x86.r.imul"
@@ -672,7 +687,8 @@ class RM_AddOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] + [x[r2]]
     ```
-    https://www.felixcloutier.com/x86/add
+
+    See external [documentation](https://www.felixcloutier.com/x86/add).
     """
 
     name = "x86.rm.add"
@@ -685,7 +701,8 @@ class RM_SubOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] - [x[r2]]
     ```
-    https://www.felixcloutier.com/x86/sub
+
+    See external [documentation](https://www.felixcloutier.com/x86/sub).
     """
 
     name = "x86.rm.sub"
@@ -698,7 +715,8 @@ class RM_ImulOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] * [x[r2]]
     ```
-    https://www.felixcloutier.com/x86/imul
+
+    See external [documentation](https://www.felixcloutier.com/x86/imul).
     """
 
     name = "x86.rm.imul"
@@ -711,7 +729,8 @@ class RM_AndOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] & [x[r2]]
     ```
-    https://www.felixcloutier.com/x86/and
+
+    See external [documentation](https://www.felixcloutier.com/x86/and).
     """
 
     name = "x86.rm.and"
@@ -724,7 +743,8 @@ class RM_OrOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] | [x[r2]]
     ```
-    https://www.felixcloutier.com/x86/or
+
+    See external [documentation](https://www.felixcloutier.com/x86/or).
     """
 
     name = "x86.rm.or"
@@ -737,7 +757,8 @@ class RM_XorOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = x[r1] ^ [x[r2]]
     ```
-    https://www.felixcloutier.com/x86/xor
+
+    See external [documentation](https://www.felixcloutier.com/x86/xor).
     """
 
     name = "x86.rm.xor"
@@ -750,7 +771,8 @@ class RM_MovOp(R_M_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r2] = [x[r1]]
     ```
-    https://www.felixcloutier.com/x86/mov
+
+    See external [documentation](https://www.felixcloutier.com/x86/mov).
     """
 
     name = "x86.rm.mov"
@@ -763,7 +785,8 @@ class RM_leaOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     x[r1] = &x[r2]
     ```
-    https://www.felixcloutier.com/x86/lea
+
+    See external [documentation](https://www.felixcloutier.com/x86/lea).
     """
 
     name = "x86.rm.lea"
@@ -829,7 +852,8 @@ class RI_AddOp(R_RI_Operation[GeneralRegisterType]):
     ```C
     x[r1] = x[r1] + immediate
     ```
-    https://www.felixcloutier.com/x86/add
+
+    See external [documentation](https://www.felixcloutier.com/x86/add).
     """
 
     name = "x86.ri.add"
@@ -842,7 +866,8 @@ class RI_SubOp(R_RI_Operation[GeneralRegisterType]):
     ```C
     x[r1] = x[r1] - immediate
     ```
-    https://www.felixcloutier.com/x86/sub
+
+    See external [documentation](https://www.felixcloutier.com/x86/sub).
     """
 
     name = "x86.ri.sub"
@@ -855,7 +880,8 @@ class RI_AndOp(R_RI_Operation[GeneralRegisterType]):
     ```C
     x[r1] = x[r1] & immediate
     ```
-    https://www.felixcloutier.com/x86/and
+
+    See external [documentation](https://www.felixcloutier.com/x86/and).
     """
 
     name = "x86.ri.and"
@@ -868,7 +894,8 @@ class RI_OrOp(R_RI_Operation[GeneralRegisterType]):
     ```C
     x[r1] = x[r1] | immediate
     ```
-    https://www.felixcloutier.com/x86/or
+
+    See external [documentation](https://www.felixcloutier.com/x86/or).
     """
 
     name = "x86.ri.or"
@@ -881,7 +908,8 @@ class RI_XorOp(R_RI_Operation[GeneralRegisterType]):
     ```C
     x[r1] = x[r1] ^ immediate
     ```
-    https://www.felixcloutier.com/x86/xor
+
+    See external [documentation](https://www.felixcloutier.com/x86/xor).
     """
 
     name = "x86.ri.xor"
@@ -894,7 +922,8 @@ class RI_MovOp(R_RI_Operation[GeneralRegisterType]):
     ```C
     x[r1] = immediate
     ```
-    https://www.felixcloutier.com/x86/mov
+
+    See external [documentation](https://www.felixcloutier.com/x86/mov).
     """
 
     name = "x86.ri.mov"
@@ -958,7 +987,8 @@ class MR_AddOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     ```C
     [x[r1]] = [x[r1]] + x[r2]
     ```
-    https://www.felixcloutier.com/x86/add
+
+    See external [documentation](https://www.felixcloutier.com/x86/add).
     """
 
     name = "x86.mr.add"
@@ -969,7 +999,8 @@ class MR_SubOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Subtracts the value from r2 from the memory location pointed to by r1.
     [x[r1]] = [x[r1]] - x[r2]
-    https://www.felixcloutier.com/x86/sub
+
+    See external [documentation](https://www.felixcloutier.com/x86/sub).
     """
 
     name = "x86.mr.sub"
@@ -980,7 +1011,8 @@ class MR_AndOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     bitwise and of [r1] and r2
     [x[r1]] = [x[r1]] & x[r2]
-    https://www.felixcloutier.com/x86/and
+
+    See external [documentation](https://www.felixcloutier.com/x86/and).
     """
 
     name = "x86.mr.and"
@@ -991,7 +1023,8 @@ class MR_OrOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     bitwise or of [r1] and r2
     [x[r1]] = [x[r1]] | x[r2]
-    https://www.felixcloutier.com/x86/or
+
+    See external [documentation](https://www.felixcloutier.com/x86/or).
     """
 
     name = "x86.mr.or"
@@ -1002,7 +1035,8 @@ class MR_XorOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     bitwise xor of [r1] and r2
     [x[r1]] = [x[r1]] ^ x[r2]
-    https://www.felixcloutier.com/x86/xor
+
+    See external [documentation](https://www.felixcloutier.com/x86/xor).
     """
 
     name = "x86.mr.xor"
@@ -1013,7 +1047,8 @@ class MR_MovOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Copies the value from r2 into the memory location pointed to by r1.
     [x[r1]] = x[r2]
-    https://www.felixcloutier.com/x86/mov
+
+    See external [documentation](https://www.felixcloutier.com/x86/mov).
     """
 
     name = "x86.mr.mov"
@@ -1084,7 +1119,8 @@ class MI_AddOp(M_MI_Operation[GeneralRegisterType]):
     """
     Adds the immediate value to the memory location pointed to by r1.
     [x[r1]] = [x[r1]] + immediate
-    https://www.felixcloutier.com/x86/add
+
+    See external [documentation](https://www.felixcloutier.com/x86/add).
     """
 
     name = "x86.mi.add"
@@ -1095,7 +1131,8 @@ class MI_SubOp(M_MI_Operation[GeneralRegisterType]):
     """
     Subtracts the immediate value from the memory location pointed to by r1.
     [x[r1]] = [x[r1]] - immediate
-    https://www.felixcloutier.com/x86/sub
+
+    See external [documentation](https://www.felixcloutier.com/x86/sub).
     """
 
     name = "x86.mi.sub"
@@ -1108,7 +1145,8 @@ class MI_AndOp(M_MI_Operation[GeneralRegisterType]):
     ```C
     [x[r1]] = [x[r1]] & immediate
     ```
-    https://www.felixcloutier.com/x86/and
+
+    See external [documentation](https://www.felixcloutier.com/x86/and).
     """
 
     name = "x86.mi.and"
@@ -1121,7 +1159,8 @@ class MI_OrOp(M_MI_Operation[GeneralRegisterType]):
     ```C
     [x[r1]] = [x[r1]] | immediate
     ```
-    https://www.felixcloutier.com/x86/or
+
+    See external [documentation](https://www.felixcloutier.com/x86/or).
     """
 
     name = "x86.mi.or"
@@ -1134,7 +1173,8 @@ class MI_XorOp(M_MI_Operation[GeneralRegisterType]):
     ```C
     [x[r1]] = [x[r1]] ^ immediate
     ```
-    https://www.felixcloutier.com/x86/xor
+
+    See external [documentation](https://www.felixcloutier.com/x86/xor).
     """
 
     name = "x86.mi.xor"
@@ -1145,7 +1185,8 @@ class MI_MovOp(M_MI_Operation[GeneralRegisterType]):
     """
     Copies the immediate value into the memory location pointed to by r1.
     [x[r1]] = immediate
-    https://www.felixcloutier.com/x86/mov
+
+    See external [documentation](https://www.felixcloutier.com/x86/mov).
     """
 
     name = "x86.mi.mov"
@@ -1208,7 +1249,8 @@ class RRI_ImulOp(R_RRI_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Multiplies the immediate value with the source register and stores the result in the destination register.
     x[r1] = x[r2] * immediate
-    https://www.felixcloutier.com/x86/imul
+
+    See external [documentation](https://www.felixcloutier.com/x86/imul).
     """
 
     name = "x86.rri.imul"
@@ -1285,7 +1327,8 @@ class RMI_ImulOp(R_RMI_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
     Multiplies the immediate value with the memory location pointed to by r2 and stores the result in r1.
     x[r1] = [x[r2]] * immediate
-    https://www.felixcloutier.com/x86/imul
+
+    See external [documentation](https://www.felixcloutier.com/x86/imul).
     """
 
     name = "x86.rmi.imul"
@@ -1295,7 +1338,8 @@ class RMI_ImulOp(R_RMI_Operation[GeneralRegisterType, GeneralRegisterType]):
 class M_PushOp(X86Instruction, X86CustomFormatOperation):
     """
     Decreases %rsp and places [r1] at the new memory location pointed to by %rsp.
-    https://www.felixcloutier.com/x86/push
+
+    See external [documentation](https://www.felixcloutier.com/x86/push).
     """
 
     name = "x86.m.push"
@@ -1353,7 +1397,8 @@ class M_PopOp(X86Instruction, X86CustomFormatOperation):
     Copies the value at the top of the stack into [r1] and increases %rsp.
     The value held by r1 is a pointer to the memory location where the value is stored.
     The only register modified by this operation is %rsp.
-    https://www.felixcloutier.com/x86/pop
+
+    See external [documentation](https://www.felixcloutier.com/x86/pop).
     """
 
     name = "x86.m.pop"
@@ -1463,7 +1508,8 @@ class M_NegOp(M_M_Operation[GeneralRegisterType]):
     ```C
     [x[r1]] = -[x[r1]]
     ```
-    https://www.felixcloutier.com/x86/neg
+
+    See external [documentation](https://www.felixcloutier.com/x86/neg).
     """
 
     name = "x86.m.neg"
@@ -1476,7 +1522,8 @@ class M_NotOp(M_M_Operation[GeneralRegisterType]):
     ```C
     [x[r1]] = ~[x[r1]]
     ```
-    https://www.felixcloutier.com/x86/not
+
+    See external [documentation](https://www.felixcloutier.com/x86/not).
     """
 
     name = "x86.m.not"
@@ -1487,7 +1534,8 @@ class M_IncOp(M_M_Operation[GeneralRegisterType]):
     """
     Increments the value at the memory location pointed to by r1.
     [x[r1]] = [x[r1]] + 1
-    https://www.felixcloutier.com/x86/inc
+
+    See external [documentation](https://www.felixcloutier.com/x86/inc).
     """
 
     name = "x86.m.inc"
@@ -1498,7 +1546,8 @@ class M_DecOp(M_M_Operation[GeneralRegisterType]):
     """
     Decrements the value at the memory location pointed to by r1.
     [x[r1]] = [x[r1]] - 1
-    https://www.felixcloutier.com/x86/dec
+
+    See external [documentation](https://www.felixcloutier.com/x86/dec).
     """
 
     name = "x86.m.dec"
@@ -1508,7 +1557,8 @@ class M_DecOp(M_M_Operation[GeneralRegisterType]):
 class M_IDivOp(X86Instruction, X86CustomFormatOperation):
     """
     Divides the value in RDX:RAX by [r1] and stores the quotient in RAX and the remainder in RDX.
-    https://www.felixcloutier.com/x86/idiv
+
+    See external [documentation](https://www.felixcloutier.com/x86/idiv).
     """
 
     name = "x86.m.idiv"
@@ -1569,7 +1619,8 @@ class M_ImulOp(X86Instruction, X86CustomFormatOperation):
     """
     The source operand is multiplied by the value in the RAX register and the product is stored in the RDX:RAX registers.
     x[RDX:RAX] = x[RAX] * [x[r1]]
-    https://www.felixcloutier.com/x86/imul
+
+    See external [documentation](https://www.felixcloutier.com/x86/imul).
     """
 
     name = "x86.m.imul"
@@ -1749,7 +1800,8 @@ class DirectiveOp(X86AsmOperation, X86CustomFormatOperation):
 class S_JmpOp(X86Instruction, X86CustomFormatOperation):
     """
     Unconditional jump to the label specified in destination.
-    https://www.felixcloutier.com/x86/jmp
+
+    See external [documentation](https://www.felixcloutier.com/x86/jmp).
     """
 
     name = "x86.s.jmp"
@@ -1825,7 +1877,8 @@ class RR_CmpOp(X86Instruction, X86CustomFormatOperation):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
-    https://www.felixcloutier.com/x86/cmp
+
+    See external [documentation](https://www.felixcloutier.com/x86/cmp).
     """
 
     name = "x86.rr.cmp"
@@ -1863,7 +1916,8 @@ class RM_CmpOp(X86Instruction, X86CustomFormatOperation):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
-    https://www.felixcloutier.com/x86/cmp
+
+    See external [documentation](https://www.felixcloutier.com/x86/cmp).
     """
 
     name = "x86.rm.cmp"
@@ -1923,7 +1977,8 @@ class RI_CmpOp(X86Instruction, X86CustomFormatOperation):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
-    https://www.felixcloutier.com/x86/cmp
+
+    See external [documentation](https://www.felixcloutier.com/x86/cmp).
     """
 
     name = "x86.ri.cmp"
@@ -1976,7 +2031,8 @@ class MR_CmpOp(X86Instruction, X86CustomFormatOperation):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
-    https://www.felixcloutier.com/x86/cmp
+
+    See external [documentation](https://www.felixcloutier.com/x86/cmp).
     """
 
     name = "x86.mr.cmp"
@@ -2036,7 +2092,8 @@ class MI_CmpOp(X86Instruction, X86CustomFormatOperation):
     """
     Compares the first source operand with the second source operand and sets the status
     flags in the EFLAGS register according to the results.
-    https://www.felixcloutier.com/x86/cmp
+
+    See external [documentation](https://www.felixcloutier.com/x86/cmp).
     """
 
     name = "x86.mi.cmp"
@@ -2105,7 +2162,8 @@ class MI_CmpOp(X86Instruction, X86CustomFormatOperation):
 class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
     """
     A base class for Jcc operations.
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     rflags = operand_def(RFLAGSRegisterType)
@@ -2224,7 +2282,8 @@ class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
 class S_JaOp(ConditionalJumpOperation):
     """
     Jump if above (CF=0 and ZF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.ja"
@@ -2234,7 +2293,8 @@ class S_JaOp(ConditionalJumpOperation):
 class S_JaeOp(ConditionalJumpOperation):
     """
     Jump if above or equal (CF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jae"
@@ -2244,7 +2304,8 @@ class S_JaeOp(ConditionalJumpOperation):
 class S_JbOp(ConditionalJumpOperation):
     """
     Jump if below (CF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jb"
@@ -2254,7 +2315,8 @@ class S_JbOp(ConditionalJumpOperation):
 class S_JbeOp(ConditionalJumpOperation):
     """
     Jump if below or equal (CF=1 or ZF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jbe"
@@ -2264,7 +2326,8 @@ class S_JbeOp(ConditionalJumpOperation):
 class S_JcOp(ConditionalJumpOperation):
     """
     Jump if carry (CF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jc"
@@ -2274,7 +2337,8 @@ class S_JcOp(ConditionalJumpOperation):
 class S_JeOp(ConditionalJumpOperation):
     """
     Jump if equal (ZF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.je"
@@ -2284,7 +2348,8 @@ class S_JeOp(ConditionalJumpOperation):
 class S_JgOp(ConditionalJumpOperation):
     """
     Jump if greater (ZF=0 and SF=OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jg"
@@ -2294,7 +2359,8 @@ class S_JgOp(ConditionalJumpOperation):
 class S_JgeOp(ConditionalJumpOperation):
     """
     Jump if greater or equal (SF=OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jge"
@@ -2304,7 +2370,8 @@ class S_JgeOp(ConditionalJumpOperation):
 class S_JlOp(ConditionalJumpOperation):
     """
     Jump if less (SF≠OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jl"
@@ -2314,7 +2381,8 @@ class S_JlOp(ConditionalJumpOperation):
 class S_JleOp(ConditionalJumpOperation):
     """
     Jump if less or equal (ZF=1 or SF≠OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jle"
@@ -2324,7 +2392,8 @@ class S_JleOp(ConditionalJumpOperation):
 class S_JnaOp(ConditionalJumpOperation):
     """
     Jump if not above (CF=1 or ZF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jna"
@@ -2334,7 +2403,8 @@ class S_JnaOp(ConditionalJumpOperation):
 class S_JnaeOp(ConditionalJumpOperation):
     """
     Jump if not above or equal (CF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnae"
@@ -2344,7 +2414,8 @@ class S_JnaeOp(ConditionalJumpOperation):
 class S_JnbOp(ConditionalJumpOperation):
     """
     Jump if not below (CF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnb"
@@ -2354,7 +2425,8 @@ class S_JnbOp(ConditionalJumpOperation):
 class S_JnbeOp(ConditionalJumpOperation):
     """
     Jump if not below or equal (CF=0 and ZF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnbe"
@@ -2364,7 +2436,8 @@ class S_JnbeOp(ConditionalJumpOperation):
 class S_JncOp(ConditionalJumpOperation):
     """
     Jump if not carry (CF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnc"
@@ -2374,7 +2447,8 @@ class S_JncOp(ConditionalJumpOperation):
 class S_JneOp(ConditionalJumpOperation):
     """
     Jump if not equal (ZF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jne"
@@ -2384,7 +2458,8 @@ class S_JneOp(ConditionalJumpOperation):
 class S_JngOp(ConditionalJumpOperation):
     """
     Jump if not greater (ZF=1 or SF≠OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jng"
@@ -2394,7 +2469,8 @@ class S_JngOp(ConditionalJumpOperation):
 class S_JngeOp(ConditionalJumpOperation):
     """
     Jump if not greater or equal (SF≠OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnge"
@@ -2404,7 +2480,8 @@ class S_JngeOp(ConditionalJumpOperation):
 class S_JnlOp(ConditionalJumpOperation):
     """
     Jump if not less (SF=OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnl"
@@ -2414,7 +2491,8 @@ class S_JnlOp(ConditionalJumpOperation):
 class S_JnleOp(ConditionalJumpOperation):
     """
     Jump if not less or equal (ZF=0 and SF=OF).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnle"
@@ -2424,7 +2502,8 @@ class S_JnleOp(ConditionalJumpOperation):
 class S_JnoOp(ConditionalJumpOperation):
     """
     Jump if not overflow (OF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jno"
@@ -2434,7 +2513,8 @@ class S_JnoOp(ConditionalJumpOperation):
 class S_JnpOp(ConditionalJumpOperation):
     """
     Jump if not parity (PF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnp"
@@ -2444,7 +2524,8 @@ class S_JnpOp(ConditionalJumpOperation):
 class S_JnsOp(ConditionalJumpOperation):
     """
     Jump if not sign (SF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jns"
@@ -2454,7 +2535,8 @@ class S_JnsOp(ConditionalJumpOperation):
 class S_JnzOp(ConditionalJumpOperation):
     """
     Jump if not zero (ZF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jnz"
@@ -2464,7 +2546,8 @@ class S_JnzOp(ConditionalJumpOperation):
 class S_JoOp(ConditionalJumpOperation):
     """
     Jump if overflow (OF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jo"
@@ -2474,7 +2557,8 @@ class S_JoOp(ConditionalJumpOperation):
 class S_JpOp(ConditionalJumpOperation):
     """
     Jump if parity (PF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jp"
@@ -2484,7 +2568,8 @@ class S_JpOp(ConditionalJumpOperation):
 class S_JpeOp(ConditionalJumpOperation):
     """
     Jump if parity even (PF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jpe"
@@ -2494,7 +2579,8 @@ class S_JpeOp(ConditionalJumpOperation):
 class S_JpoOp(ConditionalJumpOperation):
     """
     Jump if parity odd (PF=0).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jpo"
@@ -2504,7 +2590,8 @@ class S_JpoOp(ConditionalJumpOperation):
 class S_JsOp(ConditionalJumpOperation):
     """
     Jump if sign (SF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.js"
@@ -2514,7 +2601,8 @@ class S_JsOp(ConditionalJumpOperation):
 class S_JzOp(ConditionalJumpOperation):
     """
     Jump if zero (ZF=1).
-    https://www.felixcloutier.com/x86/jcc
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
     """
 
     name = "x86.s.jz"
@@ -2564,7 +2652,8 @@ class RRR_Vfmadd231pdOp(
     """
     Multiply packed double-precision floating-point elements in r2 and r3, add the
     intermediate result to r1, and store the final result in r1.
-    https://www.felixcloutier.com/x86/vfmadd132pd:vfmadd213pd:vfmadd231pd
+
+    See external [documentation](https://www.felixcloutier.com/x86/vfmadd132pd:vfmadd213pd:vfmadd231pd).
     """
 
     name = "x86.rrr.vfmadd231pd"
@@ -2577,7 +2666,8 @@ class RRR_Vfmadd231psOp(
     """
     Multiply packed single-precision floating-point elements in r2 and r3, add the
     intermediate result to r1, and store the final result in r1.
-    https://www.felixcloutier.com/x86/vfmadd132pd:vfmadd213pd:vfmadd231pd
+
+    See external [documentation](https://www.felixcloutier.com/x86/vfmadd132pd:vfmadd213pd:vfmadd231pd).
     """
 
     name = "x86.rrr.vfmadd231ps"
@@ -2588,7 +2678,8 @@ class RR_VmovapdOp(R_RR_Operation[X86VectorRegisterType, X86VectorRegisterType])
     """
     Move aligned packed double precision floating-point values from zmm1 to zmm2 using
     writemask k1
-    https://www.felixcloutier.com/x86/movapd
+
+    See external [documentation](https://www.felixcloutier.com/x86/movapd).
     """
 
     name = "x86.rr.vmovapd"
@@ -2598,7 +2689,8 @@ class RR_VmovapdOp(R_RR_Operation[X86VectorRegisterType, X86VectorRegisterType])
 class MR_VmovapdOp(M_MR_Operation[GeneralRegisterType, X86VectorRegisterType]):
     """
     Move aligned packed double precision floating-point values from zmm1 to m512 using writemask k1
-    https://www.felixcloutier.com/x86/movapd
+
+    See external [documentation](https://www.felixcloutier.com/x86/movapd).
     """
 
     name = "x86.mr.vmovapd"
@@ -2608,7 +2700,8 @@ class MR_VmovapdOp(M_MR_Operation[GeneralRegisterType, X86VectorRegisterType]):
 class MR_VmovupsOp(M_MR_Operation[GeneralRegisterType, X86VectorRegisterType]):
     """
     Move aligned packed single precision floating-point values from vector register to memory
-    https://www.felixcloutier.com/x86/movups
+
+    See external [documentation](https://www.felixcloutier.com/x86/movups).
     """
 
     name = "x86.mr.vmovups"
@@ -2618,7 +2711,8 @@ class MR_VmovupsOp(M_MR_Operation[GeneralRegisterType, X86VectorRegisterType]):
 class RM_VmovupsOp(R_M_Operation[GeneralRegisterType, X86VectorRegisterType]):
     """
     Move aligned packed single precision floating-point values from memory to vector register
-    https://www.felixcloutier.com/x86/movups
+
+    See external [documentation](https://www.felixcloutier.com/x86/movups).
     """
 
     name = "x86.rm.vmovups"
@@ -2628,7 +2722,8 @@ class RM_VmovupsOp(R_M_Operation[GeneralRegisterType, X86VectorRegisterType]):
 class RM_VbroadcastsdOp(R_M_Operation[GeneralRegisterType, X86VectorRegisterType]):
     """
     Broadcast low double precision floating-point element in m64 to eight locations in zmm1 using writemask k1
-    https://www.felixcloutier.com/x86/vbroadcast
+
+    See external [documentation](https://www.felixcloutier.com/x86/vbroadcast).
     """
 
     name = "x86.rm.vbroadcastsd"
@@ -2638,7 +2733,8 @@ class RM_VbroadcastsdOp(R_M_Operation[GeneralRegisterType, X86VectorRegisterType
 class RM_VbroadcastssOp(R_M_Operation[GeneralRegisterType, X86VectorRegisterType]):
     """
     Broadcast single precision floating-point element to eight locations in memory
-    https://www.felixcloutier.com/x86/vbroadcast
+
+    See external [documentation](https://www.felixcloutier.com/x86/vbroadcast).
     """
 
     name = "x86.rm.vbroadcastss"

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -14,7 +14,6 @@ class X86RegisterType(RegisterType, ABC):
     """
 
 
-# See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
 X86_INDEX_BY_NAME = {
     "rax": 0,
     "rcx": 1,
@@ -41,6 +40,11 @@ X86_INDEX_BY_NAME = {
     "r14": 14,
     "r15": 15,
 }
+"""
+Mapping of x86 register names to their indices.
+
+See external [documentation](https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers).
+"""
 
 
 @irdl_attr_definition
@@ -149,7 +153,6 @@ class SSERegisterType(X86VectorRegisterType):
         return "inf_sse_"
 
 
-# See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
 SSE_INDEX_BY_NAME = {
     "xmm0": 0,
     "xmm1": 1,
@@ -168,6 +171,11 @@ SSE_INDEX_BY_NAME = {
     "xmm14": 14,
     "xmm15": 15,
 }
+"""
+Mapping of SSE register names to their indices.
+
+See external # [documentation](https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers).
+"""
 
 UNALLOCATED_SSE = SSERegisterType.unallocated()
 XMM0 = SSERegisterType.from_name("xmm0")
@@ -209,7 +217,6 @@ class AVX2RegisterType(X86VectorRegisterType):
         return "inf_avx2_"
 
 
-# See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
 AVX2_INDEX_BY_NAME = {
     "ymm0": 0,
     "ymm1": 1,
@@ -228,6 +235,11 @@ AVX2_INDEX_BY_NAME = {
     "ymm14": 14,
     "ymm15": 15,
 }
+"""
+Mapping of AVX2 register names to their indices.
+
+See external # [documentation](https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers).
+"""
 
 UNALLOCATED_AVX2 = AVX2RegisterType.unallocated()
 YMM0 = AVX2RegisterType.from_name("ymm0")
@@ -269,7 +281,6 @@ class AVX512RegisterType(X86VectorRegisterType):
         return "inf_avx512_"
 
 
-# See https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers
 X86AVX512_INDEX_BY_NAME = {
     "zmm0": 0,
     "zmm1": 1,
@@ -304,6 +315,11 @@ X86AVX512_INDEX_BY_NAME = {
     "zmm30": 30,
     "zmm31": 31,
 }
+"""
+Mapping of AVX512 register names to their indices.
+
+See external # [documentation](https://wiki.osdev.org/X86-64_Instruction_Encoding#Registers).
+"""
 
 UNALLOCATED_AVX512 = AVX512RegisterType.unallocated()
 ZMM0 = AVX512RegisterType.from_name("zmm0")

--- a/xdsl/ir/affine/affine_expr.py
+++ b/xdsl/ir/affine/affine_expr.py
@@ -301,7 +301,7 @@ class AffineExpr:
         """
         Iterates nodes in depth-first order.
 
-        https://en.wikipedia.org/wiki/Depth-first_search
+        See external [documentation](https://en.wikipedia.org/wiki/Depth-first_search).
         """
         yield self
 

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -129,8 +129,9 @@ class TypeAttribute(Attribute):
 class OpaqueSyntaxAttribute(Attribute):
     """
     This class should only be inherited by classes inheriting Attribute.
-    This class is only used for printing attributes in the opaque form,
-    as described at https://mlir.llvm.org/docs/LangRef/#dialect-attribute-values.
+    This class is only used for printing attributes in the opaque form.
+
+    See external [documentation](https://mlir.llvm.org/docs/LangRef/#dialect-attribute-values.).
     """
 
     pass
@@ -139,8 +140,9 @@ class OpaqueSyntaxAttribute(Attribute):
 class SpacedOpaqueSyntaxAttribute(OpaqueSyntaxAttribute):
     """
     This class should only be inherited by classes inheriting Attribute.
-    This class is only used for printing attributes in the opaque form,
-    as described at https://mlir.llvm.org/docs/LangRef/#dialect-attribute-values.
+    This class is only used for printing attributes in the opaque form.
+
+    See external [documentation](https://mlir.llvm.org/docs/LangRef/#dialect-attribute-values.).
     """
 
     pass
@@ -345,10 +347,10 @@ class BitEnumAttribute(Generic[EnumType], Data[tuple[EnumType, ...]]):
             return {cast(type[EnumType], cls.enum_type)(value)}
 
         with parser.in_angle_brackets():
-            flags: list[set[EnumType]] | None = (
-                parser.parse_optional_undelimited_comma_separated_list(
-                    parse_optional_element, parse_element
-                )
+            flags: list[
+                set[EnumType]
+            ] | None = parser.parse_optional_undelimited_comma_separated_list(
+                parse_optional_element, parse_element
             )
             if flags is None:
                 return tuple()
@@ -430,7 +432,8 @@ class TypedAttribute(ParametrizedAttribute, ABC):
     """
 
     @classmethod
-    def get_type_index(cls) -> int: ...
+    def get_type_index(cls) -> int:
+        ...
 
     def get_type(self) -> Attribute:
         return self.parameters[self.get_type_index()]
@@ -446,7 +449,8 @@ class TypedAttribute(ParametrizedAttribute, ABC):
         ...
 
     @abstractmethod
-    def print_without_type(self, printer: Printer): ...
+    def print_without_type(self, printer: Printer):
+        ...
 
 
 @dataclass(frozen=True)
@@ -658,13 +662,16 @@ class IRNode(ABC):
 
     @property
     @abstractmethod
-    def parent_node(self) -> IRNode | None: ...
+    def parent_node(self) -> IRNode | None:
+        ...
 
     @abstractmethod
-    def __eq__(self, other: object) -> bool: ...
+    def __eq__(self, other: object) -> bool:
+        ...
 
     @abstractmethod
-    def __hash__(self) -> int: ...
+    def __hash__(self) -> int:
+        ...
 
 
 @dataclass
@@ -678,10 +685,12 @@ class OpOperands(Sequence[SSAValue]):
     """The operation owning the operands."""
 
     @overload
-    def __getitem__(self, idx: int) -> SSAValue: ...
+    def __getitem__(self, idx: int) -> SSAValue:
+        ...
 
     @overload
-    def __getitem__(self, idx: slice) -> Sequence[SSAValue]: ...
+    def __getitem__(self, idx: slice) -> Sequence[SSAValue]:
+        ...
 
     def __getitem__(self, idx: int | slice) -> SSAValue | Sequence[SSAValue]:
         return self._op._operands[idx]  # pyright: ignore[reportPrivateUsage]
@@ -1470,7 +1479,8 @@ class Block(IRNode, IRWithUses):
         return self._args
 
     class BlockCallback(Protocol):
-        def __call__(self, *args: BlockArgument) -> list[Operation]: ...
+        def __call__(self, *args: BlockArgument) -> list[Operation]:
+            ...
 
     def insert_arg(self, arg_type: Attribute, index: int) -> BlockArgument:
         """
@@ -1845,10 +1855,12 @@ class OpSuccessors(Sequence[Block]):
     """The operation owning the successors."""
 
     @overload
-    def __getitem__(self, idx: int) -> Block: ...
+    def __getitem__(self, idx: int) -> Block:
+        ...
 
     @overload
-    def __getitem__(self, idx: slice) -> Sequence[Block]: ...
+    def __getitem__(self, idx: slice) -> Sequence[Block]:
+        ...
 
     def __getitem__(self, idx: int | slice) -> Block | Sequence[Block]:
         return self._op._successors[idx]  # pyright: ignore[reportPrivateUsage]
@@ -1910,10 +1922,12 @@ class RegionBlocks(Sequence[Block], Reversible[Block]):
         return _RegionBlocksIterator(self._region.first_block)
 
     @overload
-    def __getitem__(self, idx: int) -> Block: ...
+    def __getitem__(self, idx: int) -> Block:
+        ...
 
     @overload
-    def __getitem__(self, idx: slice) -> Sequence[Block]: ...
+    def __getitem__(self, idx: slice) -> Sequence[Block]:
+        ...
 
     def __getitem__(self, idx: int | slice) -> Block | Sequence[Block]:
         if isinstance(idx, int):

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -347,10 +347,10 @@ class BitEnumAttribute(Generic[EnumType], Data[tuple[EnumType, ...]]):
             return {cast(type[EnumType], cls.enum_type)(value)}
 
         with parser.in_angle_brackets():
-            flags: list[
-                set[EnumType]
-            ] | None = parser.parse_optional_undelimited_comma_separated_list(
-                parse_optional_element, parse_element
+            flags: list[set[EnumType]] | None = (
+                parser.parse_optional_undelimited_comma_separated_list(
+                    parse_optional_element, parse_element
+                )
             )
             if flags is None:
                 return tuple()
@@ -432,8 +432,7 @@ class TypedAttribute(ParametrizedAttribute, ABC):
     """
 
     @classmethod
-    def get_type_index(cls) -> int:
-        ...
+    def get_type_index(cls) -> int: ...
 
     def get_type(self) -> Attribute:
         return self.parameters[self.get_type_index()]
@@ -449,8 +448,7 @@ class TypedAttribute(ParametrizedAttribute, ABC):
         ...
 
     @abstractmethod
-    def print_without_type(self, printer: Printer):
-        ...
+    def print_without_type(self, printer: Printer): ...
 
 
 @dataclass(frozen=True)
@@ -662,16 +660,13 @@ class IRNode(ABC):
 
     @property
     @abstractmethod
-    def parent_node(self) -> IRNode | None:
-        ...
+    def parent_node(self) -> IRNode | None: ...
 
     @abstractmethod
-    def __eq__(self, other: object) -> bool:
-        ...
+    def __eq__(self, other: object) -> bool: ...
 
     @abstractmethod
-    def __hash__(self) -> int:
-        ...
+    def __hash__(self) -> int: ...
 
 
 @dataclass
@@ -685,12 +680,10 @@ class OpOperands(Sequence[SSAValue]):
     """The operation owning the operands."""
 
     @overload
-    def __getitem__(self, idx: int) -> SSAValue:
-        ...
+    def __getitem__(self, idx: int) -> SSAValue: ...
 
     @overload
-    def __getitem__(self, idx: slice) -> Sequence[SSAValue]:
-        ...
+    def __getitem__(self, idx: slice) -> Sequence[SSAValue]: ...
 
     def __getitem__(self, idx: int | slice) -> SSAValue | Sequence[SSAValue]:
         return self._op._operands[idx]  # pyright: ignore[reportPrivateUsage]
@@ -1479,8 +1472,7 @@ class Block(IRNode, IRWithUses):
         return self._args
 
     class BlockCallback(Protocol):
-        def __call__(self, *args: BlockArgument) -> list[Operation]:
-            ...
+        def __call__(self, *args: BlockArgument) -> list[Operation]: ...
 
     def insert_arg(self, arg_type: Attribute, index: int) -> BlockArgument:
         """
@@ -1855,12 +1847,10 @@ class OpSuccessors(Sequence[Block]):
     """The operation owning the successors."""
 
     @overload
-    def __getitem__(self, idx: int) -> Block:
-        ...
+    def __getitem__(self, idx: int) -> Block: ...
 
     @overload
-    def __getitem__(self, idx: slice) -> Sequence[Block]:
-        ...
+    def __getitem__(self, idx: slice) -> Sequence[Block]: ...
 
     def __getitem__(self, idx: int | slice) -> Block | Sequence[Block]:
         return self._op._successors[idx]  # pyright: ignore[reportPrivateUsage]
@@ -1922,12 +1912,10 @@ class RegionBlocks(Sequence[Block], Reversible[Block]):
         return _RegionBlocksIterator(self._region.first_block)
 
     @overload
-    def __getitem__(self, idx: int) -> Block:
-        ...
+    def __getitem__(self, idx: int) -> Block: ...
 
     @overload
-    def __getitem__(self, idx: slice) -> Sequence[Block]:
-        ...
+    def __getitem__(self, idx: slice) -> Sequence[Block]: ...
 
     def __getitem__(self, idx: int | slice) -> Block | Sequence[Block]:
         if isinstance(idx, int):

--- a/xdsl/irdl/dominance.py
+++ b/xdsl/irdl/dominance.py
@@ -5,7 +5,7 @@ class DominanceInfo:
     """
     Computes and exposes the dominance relation amongst blocks of a region.
 
-    https://en.wikipedia.org/w/index.php?title=Dominator_(graph_theory)&oldid=1189814332
+    See external [documentation](https://en.wikipedia.org/w/index.php?title=Dominator_(graph_theory)&oldid=1189814332).
     """
 
     _dominance: dict[Block, set[Block]]
@@ -14,7 +14,7 @@ class DominanceInfo:
         """
         Compute (improper) dominance.
 
-        https://en.wikipedia.org/w/index.php?title=Dominator_(graph_theory)&oldid=1189814332
+        See external [documentation](https://en.wikipedia.org/w/index.php?title=Dominator_(graph_theory)&oldid=1189814332).
         """
 
         self._dominance = {}

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -14,7 +14,7 @@ class InsertPoint:
     An insert point.
     It is either a point before an operation, or at the end of a block.
 
-    https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder_1_1InsertPoint.html
+    See external [documentation](https://mlir.llvm.org/doxygen/classmlir_1_1OpBuilder_1_1InsertPoint.html).
     """
 
     block: Block

--- a/xdsl/traits.py
+++ b/xdsl/traits.py
@@ -35,7 +35,7 @@ class ConstantLike(OpTrait):
     """
     Operation known to be constant-like.
 
-    https://mlir.llvm.org/doxygen/classmlir_1_1OpTrait_1_1ConstantLike.html
+    See external [documentation](https://mlir.llvm.org/doxygen/classmlir_1_1OpTrait_1_1ConstantLike.html).
     """
 
 
@@ -104,7 +104,7 @@ class IsTerminator(OpTrait):
     This trait provides verification and functionality for operations that are
     known to be terminators.
 
-    https://mlir.llvm.org/docs/Traits/#terminator
+    See external [documentation](https://mlir.llvm.org/docs/Traits/#terminator).
     """
 
     def verify(self, op: Operation) -> None:
@@ -119,7 +119,7 @@ class NoTerminator(OpTrait):
     """
     Allow an operation to have single block regions with no terminator.
 
-    https://mlir.llvm.org/docs/Traits/#terminator
+    See external [documentation](https://mlir.llvm.org/docs/Traits/#terminator).
     """
 
     def verify(self, op: Operation) -> None:
@@ -138,8 +138,9 @@ class SingleBlockImplicitTerminator(OpTrait):
     The conditions for the implicit creation of the terminator depend on the operation
     and occur during its creation using the `ensure_terminator` method.
 
-    This should be fully compatible with MLIR's Trait:
-    https://mlir.llvm.org/docs/Traits/#single-block-with-implicit-terminator
+    This should be fully compatible with MLIR's Trait.
+
+    See external [documentation](https://mlir.llvm.org/docs/Traits/#single-block-with-implicit-terminator).
     """
 
     op_type: type[Operation]
@@ -209,8 +210,9 @@ class IsolatedFromAbove(OpTrait):
     Constrains the contained operations to use only values defined inside this
     operation.
 
-    This should be fully compatible with MLIR's Trait:
-    https://mlir.llvm.org/docs/Traits/#isolatedfromabove
+    This should be fully compatible with MLIR's Trait.
+
+    See external [documentation](https://mlir.llvm.org/docs/Traits/#isolatedfromabove).
     """
 
     def verify(self, op: Operation) -> None:
@@ -245,7 +247,7 @@ class SymbolUserOpInterface(OpTrait, abc.ABC):
     ability to perform safe and efficient verification of symbol uses, as well as
     additional functionality.
 
-    https://mlir.llvm.org/docs/Interfaces/#symbolinterfaces
+    See external [documentation](https://mlir.llvm.org/docs/Interfaces/#symbolinterfaces).
     """
 
     @abc.abstractmethod
@@ -377,7 +379,7 @@ class SymbolOpInterface(OpTrait):
     More requirements are defined in MLIR; Please see MLIR documentation for Symbol and
     SymbolTable for the requirements that are upcoming in xDSL.
 
-    https://mlir.llvm.org/docs/SymbolsAndSymbolTables/#symbol
+    See external [documentation](https://mlir.llvm.org/docs/SymbolsAndSymbolTables/#symbol).
     """
 
     def get_sym_attr_name(self, op: Operation) -> StringAttr | None:
@@ -427,7 +429,7 @@ class CallableOpInterface(OpTrait, abc.ABC):
     Please see MLIR documentation for CallOpInterface and CallableOpInterface for more
     information.
 
-    https://mlir.llvm.org/docs/Interfaces/#callinterfaces
+    See external [documentation](https://mlir.llvm.org/docs/Interfaces/#callinterfaces).
     """
 
     @classmethod
@@ -720,7 +722,7 @@ class HasInsnRepresentation(OpTrait, abc.ABC):
     The returned string contains python string.format placeholders where formatted operands are inserted during
     printing.
 
-    See https://sourceware.org/binutils/docs/as/RISC_002dV_002dDirectives.html for more information.
+    See external [documentation](https://sourceware.org/binutils/docs/as/RISC_002dV_002dDirectives.html for more information.).
     """
 
     @abc.abstractmethod

--- a/xdsl/transforms/loop_invariant_code_motion.py
+++ b/xdsl/transforms/loop_invariant_code_motion.py
@@ -1,9 +1,7 @@
 """
 This pass hoists operation that are invariant to the loops.
 
-Similar to MLIR's loop invariant code motion:
-
-https://mlir.llvm.org/doxygen/LoopInvariantCodeMotion_8cpp_source.html
+Similar to MLIR's loop invariant code motion: see external [documentation](https://mlir.llvm.org/doxygen/LoopInvariantCodeMotion_8cpp_source.html).
 
 An operation is loop-invariant if it depends only of values defined outside of the loop.
 LICM moves these operations out of the loop body so that they are not computed more than

--- a/xdsl/utils/comparisons.py
+++ b/xdsl/utils/comparisons.py
@@ -15,11 +15,11 @@ the sign. Here's a table of values for a three-bit two's complement integer type
 |  111 |     7    |   -1   | +7 or -1 |
 |------|----------|--------|----------|
 
-https://en.wikipedia.org/wiki/Two%27s_complement
+See [wikipedia](https://en.wikipedia.org/wiki/Two%27s_complement).
 
-We follow LLVM and MLIR in having a concept of signless integers:
+We follow LLVM and MLIR in having a concept of signless integers.
 
-https://mlir.llvm.org/docs/Rationale/Rationale/#integer-signedness-semantics
+See external [documentation](https://mlir.llvm.org/docs/Rationale/Rationale/#integer-signedness-semantics).
 
 The main idea is to not have the signedness be a property of the type of the value,
 and rather be a property of the operation. That means that a signless value can be

--- a/xdsl/utils/disjoint_set.py
+++ b/xdsl/utils/disjoint_set.py
@@ -1,7 +1,7 @@
 """
 Generic implementation of a disjoint set data structure.
 
-https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+See external [documentation](https://en.wikipedia.org/wiki/Disjoint-set_data_structure).
 """
 
 from collections.abc import Hashable, Sequence


### PR DESCRIPTION
This PR:

- Fixes the HTML markup for URL links in docstrings.

Brought to you by the power of ripgrep and vim macros (with some minor manual fiddling).

Example change [here](https://xdsl--4115.org.readthedocs.build/4115/reference/dialects/riscv/?readthedocs-diff=true#xdsl.dialects.riscv.SltiuOp)