### PR TITLE
dialects (arm): add arrangement specifier attribute

### DIFF
--- a/tests/dialects/arm/test_assembly_arg_str.py
+++ b/tests/dialects/arm/test_assembly_arg_str.py
@@ -1,5 +1,18 @@
+from io import StringIO
+
 from xdsl.dialects.arm.register import IntRegisterType
+from xdsl.dialects.arm_neon import NeonArrangement, NeonArrangementAttr
+from xdsl.printer import Printer
 
 
 def test_assembly_arg_str_ARMRegister():
     assert IntRegisterType.from_name("x0").assembly_str() == "x0"
+
+
+def test_gello():
+    assert str(NeonArrangement.S) == "S"
+
+    s = StringIO("")
+    p = Printer(stream=s)
+    p.print_attribute(NeonArrangementAttr(NeonArrangement.S))
+    assert s.getvalue() == "#arm_neon<arrangement S>"

--- a/tests/dialects/arm/test_assembly_arg_str.py
+++ b/tests/dialects/arm/test_assembly_arg_str.py
@@ -1,18 +1,5 @@
-from io import StringIO
-
 from xdsl.dialects.arm.register import IntRegisterType
-from xdsl.dialects.arm_neon import NeonArrangement, NeonArrangementAttr
-from xdsl.printer import Printer
 
 
 def test_assembly_arg_str_ARMRegister():
     assert IntRegisterType.from_name("x0").assembly_str() == "x0"
-
-
-def test_gello():
-    assert str(NeonArrangement.S) == "S"
-
-    s = StringIO("")
-    p = Printer(stream=s)
-    p.print_attribute(NeonArrangementAttr(NeonArrangement.S))
-    assert s.getvalue() == "#arm_neon<arrangement S>"

--- a/tests/filecheck/dialects/arm_neon/test_attrs.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_attrs.mlir
@@ -1,0 +1,26 @@
+// RUN: xdsl-opt %s --parsing-diagnostics --split-input-file | filecheck %s
+
+builtin.module attributes {bla=#arm_neon<arrangement hello>} {}
+
+// CHECK-NEXT:  tests/filecheck/dialects/arm_neon/test_attrs.mlir:3:53
+// CHECK-NEXT:  builtin.module attributes {bla=#arm_neon<arrangement hello>} {}
+// CHECK-NEXT:                                                       ^^^^^
+// CHECK-NEXT:                                                       Expected `D`, `S`, or `H`.
+
+// -----
+
+builtin.module attributes {bla=#arm_neon<arrangement S>} {}
+
+// CHECK:       builtin.module attributes {bla = #arm_neon<arrangement S>} {
+// CHECK-NEXT:  }
+
+builtin.module attributes {bla=#arm_neon<arrangement D>} {}
+
+// CHECK-NEXT:  builtin.module attributes {bla = #arm_neon<arrangement D>} {
+// CHECK-NEXT:  }
+
+
+builtin.module attributes {bla=#arm_neon<arrangement H>} {}
+
+// CHECK-NEXT:  builtin.module attributes {bla = #arm_neon<arrangement H>} {
+// CHECK-NEXT:  }

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -74,14 +74,14 @@ class NeonArrangement(StrEnum):
     """
     The arrangement specifier for NEON instructions determines element size and count.
     We assume full 128-bit registers. Possible arrangements:
-      - H  → 8 half-precision floats
-      - S  → 4 single-precision floats
       - D  → 2 double-precision floats
+      - S  → 4 single-precision floats
+      - H  → 8 half-precision floats
     """
 
     D = "D"
-    H = "H"
     S = "S"
+    H = "H"
 
     def map_to_num_els(self):
         map = {"D": 2, "S": 4, "H": 8}

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 from xdsl.dialects.arm.register import ARMRegisterType
-from xdsl.ir import Dialect
-from xdsl.irdl import irdl_attr_definition
+from xdsl.ir import (
+    Dialect,
+    EnumAttribute,
+    SpacedOpaqueSyntaxAttribute,
+    StrEnum,
+)
+from xdsl.irdl import (
+    irdl_attr_definition,
+)
 
 ARM_NEON_INDEX_BY_NAME = {f"v{i}": i for i in range(0, 32)}
 
@@ -62,10 +69,39 @@ V29 = NEONRegisterType.from_name("v29")
 V30 = NEONRegisterType.from_name("v30")
 V31 = NEONRegisterType.from_name("v31")
 
+
+class NeonArrangement(StrEnum):
+    """
+    The arrangement specifier for NEON instructions determines element size and count.
+    We assume full 128-bit registers. Possible arrangements:
+      - H  → 8 half-precision floats
+      - S  → 4 single-precision floats
+      - D  → 2 double-precision floats
+    """
+
+    D = "D"
+    H = "H"
+    S = "S"
+
+    def map_to_num_els(self):
+        map = {"D": 2, "S": 4, "H": 8}
+        return map[self.name]
+
+
+@irdl_attr_definition
+class NeonArrangementAttr(EnumAttribute[NeonArrangement], SpacedOpaqueSyntaxAttribute):
+    """
+    Attribute containing the arrangement specification.
+    """
+
+    name = "arm_neon.arrangement"
+
+
 ARM_NEON = Dialect(
     "arm_neon",
     [],
     [
+        NeonArrangementAttr,
         NEONRegisterType,
     ],
 )


### PR DESCRIPTION
---
title: dialects (arm): add arrangement specifier attribute

---

Adding an arrangement specifier attribute for ARM NEON instructions, which specifies the number and size of vector lanes. We assume full 128-bit registers.
