### PR TITLE
core: Make SSAValue type immutable

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -42,6 +42,7 @@ from xdsl.irdl import (
     var_result_def,
 )
 from xdsl.pattern_rewriter import RewritePattern
+from xdsl.rewriter import Rewriter
 from xdsl.traits import (
     CallableOpInterface,
     HasCanonicalizationPatternsTrait,
@@ -125,7 +126,7 @@ class InferAddOpShapeTrait(ToyShapeInferenceTrait):
         if not isinstance(op, AddOp):
             raise TypeError
         if not (
-            isinstance(op_lhs_type := op.lhs.type, TensorType)
+            isa(op_lhs_type := op.lhs.type, TensorType)
             and isinstance(op_rhs_type := op.rhs.type, TensorType)
         ):
             return
@@ -133,7 +134,7 @@ class InferAddOpShapeTrait(ToyShapeInferenceTrait):
         if isinstance(op_res_type := op.res.type, TensorType):
             assert op_lhs_type.get_shape() == op_res_type.get_shape()
         else:
-            op.res.type = op.lhs.type
+            Rewriter.replace_value_with_new_type(op.res, op_lhs_type)
 
 
 @irdl_op_definition
@@ -303,7 +304,7 @@ class InferMulOpShapeTrait(ToyShapeInferenceTrait):
             raise TypeError
 
         if not (
-            isinstance(op_lhs_type := op.lhs.type, TensorType)
+            isa(op_lhs_type := op.lhs.type, TensorType)
             and isinstance(op_rhs_type := op.rhs.type, TensorType)
         ):
             return
@@ -312,7 +313,7 @@ class InferMulOpShapeTrait(ToyShapeInferenceTrait):
         if isinstance(op_res_type := op.res.type, TensorType):
             assert op_lhs_type.get_shape() == op_res_type.get_shape()
         else:
-            op.res.type = op.lhs.type
+            Rewriter.replace_value_with_new_type(op.res, op_lhs_type)
 
 
 @irdl_op_definition
@@ -461,7 +462,7 @@ class InferTransposeOpShapeTrait(ToyShapeInferenceTrait):
         if isinstance(op_res_type := op.res.type, TensorType):
             assert res_shape == op_res_type.get_shape()
         else:
-            op.res.type = TensorType(f64, res_shape)
+            Rewriter.replace_value_with_new_type(op.res, TensorType(f64, res_shape))
 
 
 class TransposeOpHasCanonicalizationPatternsTrait(HasCanonicalizationPatternsTrait):
@@ -516,7 +517,7 @@ class InferCastOpShapeTrait(ToyShapeInferenceTrait):
         if isinstance(op_res_type := op.res.type, TensorType):
             assert shape == op_res_type.get_shape()
         else:
-            op.res.type = TensorType(f64, shape)
+            Rewriter.replace_value_with_new_type(op.res, TensorType(f64, shape))
 
 
 @irdl_op_definition

--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -10,9 +10,10 @@ from xdsl.backend.riscv.register_allocation import (
 )
 from xdsl.backend.riscv.riscv_register_queue import RiscvRegisterQueue
 from xdsl.dialects import riscv
+from xdsl.dialects.test import TestOp
+from xdsl.ir import SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
 from xdsl.utils.exceptions import DiagnosticException
-from xdsl.utils.test_value import TestSSAValue
 
 
 def test_default_reserved_registers():
@@ -28,33 +29,28 @@ def test_default_reserved_registers():
 
     assert not register_allocator.allocate_same(())
 
-    a = TestSSAValue(unallocated)
-    register_allocator.allocate_same((a,))
+    op_a = TestOp(result_types=[unallocated])
+    register_allocator.allocate_same(op_a.results)
 
-    assert a.type == j(1)
+    assert op_a.results[0].type == j(1)
 
-    register_allocator.allocate_same((a,))
+    register_allocator.allocate_same(op_a.results)
 
-    assert a.type == j(1)
+    assert op_a.results[0].type == j(1)
 
-    b0 = TestSSAValue(unallocated)
-    b1 = TestSSAValue(unallocated)
+    op_b = TestOp(result_types=[unallocated, unallocated])
 
-    register_allocator.allocate_same((b0, b1))
+    register_allocator.allocate_same(op_b.results)
 
-    assert b0.type == j(2)
-    assert b1.type == j(2)
+    assert tuple(op_b.result_types) == (j(2), j(2))
 
-    c0 = TestSSAValue(j(2))
-    c1 = TestSSAValue(unallocated)
+    op_c = TestOp(result_types=[j(2), unallocated])
 
-    register_allocator.allocate_same((c0, c1))
+    register_allocator.allocate_same(op_c.results)
 
-    assert c0.type == j(2)
-    assert c1.type == j(2)
+    assert tuple(op_c.result_types) == (j(2), j(2))
 
-    d0 = TestSSAValue(j(2))
-    d1 = TestSSAValue(j(3))
+    op_d = TestOp(result_types=[j(2), j(3)])
 
     with pytest.raises(
         DiagnosticException,
@@ -62,11 +58,9 @@ def test_default_reserved_registers():
             "Cannot allocate registers to the same register ['!riscv.reg<j_2>', '!riscv.reg<j_3>']"
         ),
     ):
-        register_allocator.allocate_same((d0, d1))
+        register_allocator.allocate_same(op_d.results)
 
-    e0 = TestSSAValue(j(2))
-    e1 = TestSSAValue(j(3))
-    e2 = TestSSAValue(unallocated)
+    op_e = TestOp(result_types=[j(2), j(3), unallocated])
 
     with pytest.raises(
         DiagnosticException,
@@ -74,7 +68,7 @@ def test_default_reserved_registers():
             "Cannot allocate registers to the same register ['!riscv.reg', '!riscv.reg<j_2>', '!riscv.reg<j_3>']"
         ),
     ):
-        register_allocator.allocate_same((e0, e1, e2))
+        register_allocator.allocate_same(op_e.results)
 
 
 def test_allocate_with_inout_constraints():
@@ -88,12 +82,9 @@ def test_allocate_with_inout_constraints():
         rd1 = result_def()
 
         @classmethod
-        def get(cls, rs0: str, rs1: str, rd0: str, rd1: str) -> Self:
+        def get(cls, rs0: SSAValue, rs1: SSAValue, rd0: str, rd1: str) -> Self:
             return cls.build(
-                operands=(
-                    TestSSAValue(riscv.IntRegisterType.from_name(rs0)),
-                    TestSSAValue(riscv.IntRegisterType.from_name(rs1)),
-                ),
+                operands=(rs0, rs1),
                 result_types=(
                     riscv.IntRegisterType.from_name(rd0),
                     riscv.IntRegisterType.from_name(rd1),
@@ -109,7 +100,13 @@ def test_allocate_with_inout_constraints():
     register_allocator = RegisterAllocatorLivenessBlockNaive(register_queue)
 
     # All new registers. The result register is reused by the allocator for the operand.
-    op0 = MyInstructionOp.get("", "", "", "")
+    rs0, rs1 = TestOp(
+        result_types=[
+            riscv.IntRegisterType.unallocated(),
+            riscv.IntRegisterType.unallocated(),
+        ]
+    ).results
+    op0 = MyInstructionOp.get(rs0, rs1, "", "")
     register_allocator.process_riscv_op(op0)
     assert op0.rs0.type == riscv.IntRegisterType.infinite_register(1)
     assert op0.rs1.type == riscv.IntRegisterType.infinite_register(0)
@@ -118,7 +115,13 @@ def test_allocate_with_inout_constraints():
 
     # One register reserved for inout parameter, the allocator should allocate the output
     # to the same register.
-    op1 = MyInstructionOp.get("", "", "", "a0")
+    rs0, rs1 = TestOp(
+        result_types=[
+            riscv.IntRegisterType.unallocated(),
+            riscv.IntRegisterType.unallocated(),
+        ]
+    ).results
+    op1 = MyInstructionOp.get(rs0, rs1, "", "a0")
     register_allocator.process_riscv_op(op1)
     assert op1.rs0.type == riscv.IntRegisterType.infinite_register(2)
     assert op1.rs1.type == riscv.IntRegisterType.from_name("a0")

--- a/tests/dialects/test_func.py
+++ b/tests/dialects/test_func.py
@@ -18,6 +18,7 @@ from xdsl.irdl import (
     irdl_op_definition,
     traits_def,
 )
+from xdsl.rewriter import Rewriter
 from xdsl.traits import CallableOpInterface, SymbolOpInterface
 from xdsl.utils.exceptions import VerifyException
 
@@ -121,25 +122,26 @@ def test_func_rewriting_helpers():
     with ImplicitBuilder(func.body):
         ReturnOp()
 
-    func.replace_argument_type(2, i64)
+    rewriter = Rewriter()
+    func.replace_argument_type(2, i64, rewriter)
     assert func.function_type.inputs.data[2] is i64
     assert func.args[2].type is i64
 
-    func.replace_argument_type(func.args[0], i64)
+    func.replace_argument_type(func.args[0], i64, rewriter)
     assert func.function_type.inputs.data[0] is i64
     assert func.args[0].type is i64
 
     # check negaitve index
     i8 = IntegerType(8)
-    func.replace_argument_type(-2, i8)
+    func.replace_argument_type(-2, i8, rewriter)
     assert func.function_type.inputs.data[1] is i8
     assert func.args[1].type is i8
 
     with pytest.raises(IndexError):
-        func.replace_argument_type(3, i64)
+        func.replace_argument_type(3, i64, rewriter)
 
     with pytest.raises(IndexError):
-        func.replace_argument_type(-4, i64)
+        func.replace_argument_type(-4, i64, rewriter)
 
     decl = FuncOp.external("external_func", [], [])
     assert decl.is_declaration

--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -697,7 +697,9 @@ def test_block_argument_type_change():
         @op_type_rewrite_pattern
         def match_and_rewrite(self, matched_op: test.TestOp, rewriter: PatternRewriter):
             if matched_op.regs and matched_op.regs[0].blocks:
-                rewriter.modify_value_type(matched_op.regs[0].blocks[0].args[0], i64)
+                rewriter.replace_value_with_new_type(
+                    matched_op.regs[0].blocks[0].args[0], i64
+                )
 
     rewrite_and_compare(
         prog,

--- a/xdsl/dialects/func.py
+++ b/xdsl/dialects/func.py
@@ -34,7 +34,9 @@ from xdsl.irdl import (
     var_result_def,
 )
 from xdsl.parser import Parser
+from xdsl.pattern_rewriter import PatternRewriter
 from xdsl.printer import Printer
+from xdsl.rewriter import Rewriter
 from xdsl.traits import (
     CallableOpInterface,
     HasParent,
@@ -231,7 +233,12 @@ class FuncOp(IRDLOperation):
             visibility=visibility,
         )
 
-    def replace_argument_type(self, arg: int | BlockArgument, new_type: Attribute):
+    def replace_argument_type(
+        self,
+        arg: int | BlockArgument,
+        new_type: Attribute,
+        rewriter: Rewriter | PatternRewriter,
+    ):
         """
         Replaces the type of the argument specified by arg (either the index of the arg,
         or the BlockArgument object itself) with new_type. This also takes care of updating
@@ -248,7 +255,7 @@ class FuncOp(IRDLOperation):
         if arg not in self.args:
             raise ValueError(f"Arg {arg} does not belong to this function")
 
-        arg.type = new_type
+        rewriter.replace_value_with_new_type(arg, new_type)
         self.update_function_type()
 
     def update_function_type(self):

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -486,12 +486,16 @@ class SSAValue(IRWithUses, ABC):
     An SSA variable is either an operation result, or a basic block argument.
     """
 
-    type: Attribute
+    _type: Attribute
     """Each SSA variable is associated to a type."""
 
     _name: str | None = field(init=False, default=None)
 
     _name_regex: ClassVar[re.Pattern[str]] = re.compile(r"([A-Za-z_$.-][\w$.-]*)")
+
+    @property
+    def type(self) -> Attribute:
+        return self._type
 
     @property
     @abstractmethod

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -5,7 +5,16 @@ from dataclasses import dataclass, field
 
 from typing_extensions import deprecated
 
-from xdsl.ir import Block, Operation, Region, SSAValue
+from xdsl.ir import (
+    Attribute,
+    Block,
+    BlockArgument,
+    Operation,
+    OpResult,
+    Region,
+    SSAValue,
+)
+from xdsl.utils.test_value import TestSSAValue
 
 
 @dataclass(frozen=True)
@@ -168,6 +177,37 @@ class Rewriter:
                     res.name_hint = op.results[0].name_hint
 
         block.erase_op(op, safe_erase=safe_erase)
+
+    @staticmethod
+    def replace_value_with_new_type(val: SSAValue, new_type: Attribute) -> SSAValue:
+        """
+        Replace a value with a value of a new type, and return the new value.
+        This will insert the new value in the operation or block, and remove the existing
+        value.
+        """
+        if isinstance(val, OpResult):
+            operation = val.op
+            index = val.index
+            new_value = OpResult(new_type, operation, val.index)
+            results = operation.results
+            operation.results = (*results[:index], new_value, *results[index + 1 :])
+        elif isinstance(val, BlockArgument):
+            block = val.block
+            index = val.index
+            new_value = BlockArgument(new_type, block, index)
+            args = block.args
+            block._args = (  # pyright: ignore[reportPrivateUsage]
+                *args[:index],
+                new_value,
+                *args[index + 1 :],
+            )
+        else:
+            assert isinstance(val, TestSSAValue)
+            new_value = TestSSAValue(new_type)
+
+        new_value.name_hint = val.name_hint
+        val.replace_by(new_value)
+        return new_value
 
     @staticmethod
     def inline_block(

--- a/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
+++ b/xdsl/transforms/convert_memref_stream_to_snitch_stream.py
@@ -188,7 +188,7 @@ class StreamOpLowering(RewritePattern):
             arg.replace_by_if(
                 cast_op.results[0], lambda use: use.operation is not cast_op
             )
-            rewriter.modify_value_type(arg, stream_type)
+            rewriter.replace_value_with_new_type(arg, stream_type)
 
 
 def strides_for_affine_map(

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -190,7 +190,7 @@ class LowerMemRefFuncOpPattern(RewritePattern):
                 continue
 
             old_type = cast(memref.MemRefType[Attribute], arg_type)
-            arg.type = ptr.PtrType()
+            arg = rewriter.replace_value_with_new_type(arg, ptr.PtrType())
 
             if not arg.uses:
                 continue

--- a/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/convert_stencil_to_ll_mlir.py
@@ -553,7 +553,9 @@ class TrivialExternalLoadOpCleanup(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ExternalLoadOp, rewriter: PatternRewriter, /):
         assert isa(op.result.type, FieldType[Attribute])
-        op.result.type = StencilToMemRefType(op.result.type)
+        rewriter.replace_value_with_new_type(
+            op.result, StencilToMemRefType(op.result.type)
+        )
 
         if op.field.type == op.result.type:
             rewriter.replace_matched_op([], [op.field])

--- a/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
+++ b/xdsl/transforms/experimental/hls_convert_stencil_to_ll_mlir.py
@@ -549,7 +549,7 @@ class ApplyOpToHLS(RewritePattern):
 
                 if n_dims == 3:
                     stream = self.shift_streams[current_stream][k]
-                    rewriter.modify_value_type(
+                    rewriter.replace_value_with_new_type(
                         apply_clone.region.block.args[i], stream.results[0].type
                     )
 
@@ -1061,7 +1061,7 @@ class PackData(RewritePattern):
                     [LLVMArrayType.from_size_and_type(8, f64)]
                 )
             )
-            parent_func.replace_argument_type(arg_idx, packed_type)
+            parent_func.replace_argument_type(arg_idx, packed_type, rewriter)
 
             for use in func_arg.uses:
                 if isinstance(use.operation, InsertValueOp):
@@ -1087,15 +1087,21 @@ class PackData(RewritePattern):
                         struct_new_type = LLVMStructType.from_type_list(new_type)
 
                         current_insertvalue = insertvalue
-                        current_insertvalue.res.type = struct_new_type
-                        update_types_insertvalue(current_insertvalue, struct_new_type)
+                        rewriter.replace_value_with_new_type(
+                            current_insertvalue.res, struct_new_type
+                        )
+                        update_types_insertvalue(
+                            current_insertvalue, struct_new_type, rewriter
+                        )
 
 
-def update_types_insertvalue(op: InsertValueOp, new_type: llvm.LLVMStructType):
+def update_types_insertvalue(
+    op: InsertValueOp, new_type: llvm.LLVMStructType, rewriter: PatternRewriter
+):
     for use in op.res.uses:
         if isinstance(use.operation, InsertValueOp):
-            use.operation.res.type = new_type
-            update_types_insertvalue(use.operation, new_type)
+            rewriter.replace_value_with_new_type(use.operation.res, new_type)
+            update_types_insertvalue(use.operation, new_type, rewriter)
 
 
 @dataclass

--- a/xdsl/transforms/experimental/lower_hls.py
+++ b/xdsl/transforms/experimental/lower_hls.py
@@ -239,12 +239,14 @@ class LowerHLSStreamToAlloca(RewritePattern):
         rewriter.replace_matched_op([size, alloca])
 
         for use in uses:
-            use.operation.operands[use.index].type = alloca.res.type
+            rewriter.replace_value_with_new_type(
+                use.operation.operands[use.index], alloca.res.type
+            )
 
             # This is specially important when the stream is an argument of ApplyOp
             if use.operation.regions:
                 block_arg = use.operation.regions[0].block.args[use.index]
-                block_arg.type = alloca.res.type
+                rewriter.replace_value_with_new_type(block_arg, alloca.res.type)
 
 
 @dataclass

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -259,7 +259,9 @@ class FuncOpTensorize(RewritePattern):
         if not op.is_declaration:
             for arg in op.args:
                 if isa(arg.type, FieldType[Attribute]):
-                    op.replace_argument_type(arg, stencil_field_to_tensor(arg.type))
+                    op.replace_argument_type(
+                        arg, stencil_field_to_tensor(arg.type), rewriter
+                    )
 
 
 def is_tensorized(

--- a/xdsl/transforms/memref_stream_legalize.py
+++ b/xdsl/transforms/memref_stream_legalize.py
@@ -171,7 +171,7 @@ class MemRefStreamGenericLegalize(RewritePattern):
         for i, arg in enumerate(new_body.block.args):
             if i not in legalizations:
                 continue
-            rewriter.modify_value_type(arg, legalizations[i])
+            arg = rewriter.replace_value_with_new_type(arg, legalizations[i])
             to_be_legalized.update(use.operation for use in arg.uses)
         # Legalize payload
         _legalize_block(new_body.block, to_be_legalized, rewriter)

--- a/xdsl/transforms/shape_inference_patterns/dmp.py
+++ b/xdsl/transforms/shape_inference_patterns/dmp.py
@@ -19,10 +19,10 @@ class DmpSwapShapeInference(RewritePattern):
         if not op.swapped_values:
             return
         swap_t = op.swapped_values.type
-        if not isinstance(swap_t, stencil.TempType):
+        if not isa(swap_t, stencil.TempType):
             return
         if op.input_stencil.type != swap_t:
-            op.input_stencil.type = swap_t
+            rewrite.replace_value_with_new_type(op.input_stencil, swap_t)
             rewrite.handle_operation_modification(op)
 
 

--- a/xdsl/transforms/snitch_register_allocation.py
+++ b/xdsl/transforms/snitch_register_allocation.py
@@ -40,13 +40,16 @@ class AllocateSnitchStreamingRegionRegisters(RewritePattern):
         block = op.body.block
 
         for index, input_stream in enumerate(block.args):
-            input_stream.type = snitch.ReadableStreamType(riscv.Registers.FT[index])
+            rewriter.replace_value_with_new_type(
+                input_stream, snitch.ReadableStreamType(riscv.Registers.FT[index])
+            )
 
         input_count = len(op.inputs)
 
         for index, output_stream in enumerate(block.args[input_count:]):
-            output_stream.type = snitch.WritableStreamType(
-                riscv.Registers.FT[index + input_count]
+            rewriter.replace_value_with_new_type(
+                output_stream,
+                snitch.WritableStreamType(riscv.Registers.FT[index + input_count]),
             )
 
 
@@ -61,7 +64,7 @@ class AllocateRiscvSnitchReadRegisters(RewritePattern):
         stream_type = cast(
             snitch.ReadableStreamType[riscv.FloatRegisterType], op.stream.type
         )
-        op.res.type = stream_type.element_type
+        rewriter.replace_value_with_new_type(op.res, stream_type.element_type)
 
 
 class AllocateRiscvSnitchWriteRegisters(RewritePattern):
@@ -75,7 +78,7 @@ class AllocateRiscvSnitchWriteRegisters(RewritePattern):
         stream_type = cast(
             snitch.WritableStreamType[riscv.FloatRegisterType], op.stream.type
         )
-        op.value.type = stream_type.element_type
+        rewriter.replace_value_with_new_type(op.value, stream_type.element_type)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Stacked PRs:
 * #3991
 * #3989
 * #3988
 * #3987
 * __->__#4125


--- --- ---

### core: Make SSAValue type immutable


SSAValue can no longer change type after creation.
This ensures that we can have a generic type in values,
as otherwise this would be invalidated by changing the type.
