### PR TITLE
transformations: preserve visibility when lowering to riscv_func

### DIFF
--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -27,13 +27,16 @@ builtin.module {
         func.return %fres0, %res0 : f64, i32
     }
 
+    func.func private @private_func() {
+        func.return
+    }
+
     func.func @external(%arg0 : i32, %farg0 : f64) -> (f64, i32)
 }
 
 // CHECK:       builtin.module {
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "main"
-// CHECK-NEXT:      riscv_func.func @main() attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      riscv_func.func public @main() attributes {p2align = 2 : i8} {
 // CHECK-NEXT:          %0, %1 = "test.op"() : () -> (i32, f32)
 // CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg
 // CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %1 : f32 to !riscv.freg
@@ -48,8 +51,7 @@ builtin.module {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "foo"
-// CHECK-NEXT:      riscv_func.func @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      riscv_func.func public @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %arg1 : (!riscv.freg<fa0>) -> !riscv.freg
@@ -63,8 +65,7 @@ builtin.module {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "foo_float"
-// CHECK-NEXT:      riscv_func.func @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      riscv_func.func public @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
 // CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg1 : (!riscv.freg<fa1>) -> !riscv.freg
@@ -78,8 +79,7 @@ builtin.module {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "foo_int_float"
-// CHECK-NEXT:      riscv_func.func @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      riscv_func.func public @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
@@ -93,8 +93,7 @@ builtin.module {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "foo_int_double"
-// CHECK-NEXT:      riscv_func.func @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      riscv_func.func public @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg
@@ -108,7 +107,11 @@ builtin.module {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv.directive ".globl" "external"
-// CHECK-NEXT:      riscv_func.func @external(!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8}
+// CHECK-NEXT:      riscv_func.func private @private_func() attributes {p2align = 2 : i8} {
+// CHECK-NEXT:        riscv_func.return
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv.assembly_section ".text" {
+// CHECK-NEXT:      riscv_func.func public @external(!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8}
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
@@ -21,8 +21,8 @@ func.func public @ssum(
 }
 
 // CHECK:       .text
-// CHECK-NEXT:  .globl ssum
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .globl ssum
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  ssum:
 // CHECK-NEXT:      mv t2, a0
@@ -79,9 +79,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     func.return
   }
 
-
-// CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
@@ -158,8 +157,7 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
 
 
   riscv.assembly_section ".text" {
-    riscv.directive ".globl" "reluf32"
-    riscv_func.func @reluf32(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>) attributes {p2align = 2 : i8} {
+    riscv_func.func public @reluf32(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>) attributes {p2align = 2 : i8} {
       %X_1 = riscv.mv %X : (!riscv.reg<a0>) -> !riscv.reg
       %Y_1 = riscv.mv %Y : (!riscv.reg<a1>) -> !riscv.reg
       %zero = riscv.get_register : !riscv.reg<zero>
@@ -184,8 +182,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
     }
   }
 
-// CHECK-NEXT:  .globl reluf32
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
+// CHECK-NEXT:  .globl reluf32
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  reluf32:
 // CHECK-NEXT:      mv t1, a0

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
@@ -35,8 +35,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
 
 
 // CHECK:       .text
-// CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "a4", "a5", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  conv_2d_nchw_fchw_d1_s1_3x3:
 // CHECK-NEXT:      mv t2, a0
@@ -159,8 +159,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK-NEXT:  .globl ddot
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .globl ddot
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  ddot:
 // CHECK-NEXT:      mv t2, a0
@@ -205,8 +205,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     }
 
 
-// CHECK-NEXT:  .globl dsum
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .globl dsum
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  dsum:
 // CHECK-NEXT:      mv t2, a0
@@ -248,8 +248,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK-NEXT:  .globl fill
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["fa0", "ft0", "ft1", "ft2"], "preallocated_int": ["a0", "zero"], "allocated_float": ["fa0", "ft0", "ft3"], "allocated_int": ["a0", "t0", "t1", "zero"]}
+// CHECK-NEXT:  .globl fill
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  fill:
 // CHECK-NEXT:      fmv.d ft3, fa0
@@ -304,8 +304,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
     func.return
 }
 
-// CHECK-NEXT:  .globl matmul
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .globl matmul
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  matmul:
 // CHECK-NEXT:      mv t0, a0
@@ -413,8 +413,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .globl pooling_nchw_max_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_max_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0
@@ -508,8 +508,8 @@ func.func public @pooling_nchw_max_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  .globl reluf64
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3"], "allocated_int": ["a0", "a1", "t0", "t1", "t2", "zero"]}
+// CHECK-NEXT:  .globl reluf64
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  reluf64:
 // CHECK-NEXT:      mv t1, a0
@@ -566,8 +566,8 @@ func.func public @pooling_nchw_sum_d1_s2_3x3(
   }
 
 
-// CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK-NEXT:  .globl pooling_nchw_sum_d1_s2_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  pooling_nchw_sum_d1_s2_3x3:
 // CHECK-NEXT:      mv t1, a0

--- a/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
@@ -11,8 +11,8 @@ func.func @main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1(%
 }
 
 // CHECK:       .text
-// CHECK-NEXT:  .globl main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .globl main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1:
 // CHECK-NEXT:      mv t2, a0

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -180,8 +180,7 @@ async def test_buttons():
             app.output_text_area.text
             == """builtin.module {
   riscv.assembly_section ".text" {
-    riscv.directive ".globl" "hello"
-    riscv_func.func @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
+    riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
       %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
       %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
       %two = riscv.li 2 : !riscv.reg
@@ -219,8 +218,7 @@ async def test_buttons():
             app.output_text_area.text
             == """builtin.module {
   riscv.assembly_section ".text" {
-    riscv.directive ".globl" "hello"
-    riscv_func.func @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
+    riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
       %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
       %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
       %two = arith.constant 2 : index
@@ -405,8 +403,7 @@ async def test_passes():
             app.output_text_area.text
             == """builtin.module {
   riscv.assembly_section ".text" {
-    riscv.directive ".globl" "hello"
-    riscv_func.func @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
+    riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
       %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
       %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
       %two = arith.constant 2 : index
@@ -425,11 +422,11 @@ async def test_passes():
         with ImplicitBuilder(expected_module.body):
             section = riscv.AssemblySectionOp(".text")
             with ImplicitBuilder(section.data):
-                riscv.DirectiveOp(".globl", "hello")
                 function = riscv_func.FuncOp(
                     "hello",
                     Region([Block(arg_types=[riscv.Registers.A0])]),
                     ((riscv.Registers.A0,), (riscv.Registers.A0,)),
+                    "public",
                     p2align=2,
                 )
                 with ImplicitBuilder(function.body) as (n,):


### PR DESCRIPTION
Now that we can print it in riscv_func directly, we might as well print it that way instead of an explicit directive op.