### PR TITLE
tool: (xdsl-tblgen) fix tblgen_to_py

### DIFF
--- a/xdsl/tools/tblgen_to_py.py
+++ b/xdsl/tools/tblgen_to_py.py
@@ -68,8 +68,8 @@ class TblgenOp(TblgenRecord):
 
     @property
     def assembly_format(self) -> str | None:
-        if "assemblyFormat" in self.js:
-            assembly = self["assemblyFormat"]
+        if self.js.get("hasCustomAssemblyFormat", False):
+            assembly = '"' + (self["assemblyFormat"] or "null") + '"'
             if isinstance(assembly, str):
                 return assembly
         return None
@@ -310,6 +310,8 @@ class TblgenLoader:
     def _resolve_prop_constraint(self, rec: TblgenRecord | str) -> str:
         if isinstance(rec, str):
             rec = self._get_record(rec)
+        elif isinstance(rec, dict):
+            rec = self._get_record(rec["def"])
 
         if rec.name in self.attributes:
             return f"BaseAttr({rec.name})"
@@ -629,3 +631,7 @@ def main():
             tblgen_to_py(args.input_file, output, cull=args.cull)
     else:
         tblgen_to_py(args.input_file, cull=args.cull)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- fix assembly format print
- fix _resolve_prop_constraint from dict
- fix missing call to main 
Might fix #3787

I'm trying to convert the [emitC](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td) to pyirdl to be able to use it from xDSL.
The `tblgen_to_py` script seemed broken so I added a minimal set of changes to be able to generate something.
Is this the right tool to use actually? Would it be better to convert the EmitC.td to irdl and then import that from xDSL?