### PR TITLE
dialects: (riscv_func) emit .text in func op

### DIFF
--- a/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_assembly_emission.mlir
@@ -164,7 +164,6 @@
       %inner = riscv.li 5 : !riscv.reg<j_1>
       %nested_addi = riscv.addi %inner, 1 : (!riscv.reg<j_1>) -> !riscv.reg<j_1>
     }
-    // CHECK-NEXT:  .text
     // CHECK-NEXT:  li j_1, 5
     // CHECK-NEXT:  addi j_1, j_1, 1
     riscv.label "label0"

--- a/tests/filecheck/projects/riscv-backend-paper/pres.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/pres.mlir
@@ -3,8 +3,6 @@
 // A test that verifies that we can emit the target assembly for Snitch, below are the
 // versions of ssum (C=A+B where all have fixed size 128xf32) .
 
-riscv.label ".text"
-
 riscv_func.func @pres_1(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.reg<a2>) {
     %zero = riscv.get_register : !riscv.reg<zero>
     %i = riscv.mv %zero : (!riscv.reg<zero>) -> !riscv.reg<a3>
@@ -80,7 +78,7 @@ riscv_func.func @pres_4(%X : !riscv.reg<a0>, %Y : !riscv.reg<a1>, %Z : !riscv.re
     riscv_func.return
 }
 
-// CHECK:        .text:
+// CHECK:        .text
 // CHECK-NEXT:   pres_1:
 // CHECK-NEXT:       mv a3, zero
 // CHECK-NEXT:       addi a4, zero, 512

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -215,6 +215,8 @@ class FuncOp(IRDLOperation, AssemblyPrintable):
             # Print nothing for function declaration
             return
 
+        printer.emit_section(".text")
+
         if self.sym_visibility is not None:
             match self.sym_visibility.data:
                 case "public":


### PR DESCRIPTION
Might as well emit in the func since it's always in a text section.