### PR TITLE
tool: (xdsl-tblgen) fix optional attributes

### DIFF
--- a/tests/xdsl_tblgen/test.json
+++ b/tests/xdsl_tblgen/test.json
@@ -158,9 +158,9 @@
       "args": [
         [
           {
-            "def": "anonymous_338",
+            "def": "anonymous_327",
             "kind": "def",
-            "printable": "anonymous_338"
+            "printable": "anonymous_327"
           },
           "in"
         ]
@@ -171,7 +171,7 @@
         "kind": "def",
         "printable": "ins"
       },
-      "printable": "(ins anonymous_338:$in)"
+      "printable": "(ins anonymous_327:$in)"
     },
     "assemblyFormat": null,
     "opDialect": {
@@ -299,6 +299,14 @@
             "printable": "Test_TestAttr"
           },
           "in"
+        ],
+        [
+          {
+            "def": "anonymous_329",
+            "kind": "def",
+            "printable": "anonymous_329"
+          },
+          "opt"
         ]
       ],
       "kind": "dag",
@@ -307,7 +315,7 @@
         "kind": "def",
         "printable": "ins"
       },
-      "printable": "(ins I16Attr:$int_attr, Test_TestAttr:$in)"
+      "printable": "(ins I16Attr:$int_attr, Test_TestAttr:$in, anonymous_329:$opt)"
     },
     "assemblyFormat": null,
     "opDialect": {
@@ -358,17 +366,17 @@
       "args": [
         [
           {
-            "def": "anonymous_341",
+            "def": "anonymous_331",
             "kind": "def",
-            "printable": "anonymous_341"
+            "printable": "anonymous_331"
           },
           "tensor"
         ],
         [
           {
-            "def": "anonymous_344",
+            "def": "anonymous_334",
             "kind": "def",
-            "printable": "anonymous_344"
+            "printable": "anonymous_334"
           },
           "vector"
         ]
@@ -379,7 +387,7 @@
         "kind": "def",
         "printable": "ins"
       },
-      "printable": "(ins anonymous_341:$tensor, anonymous_344:$vector)"
+      "printable": "(ins anonymous_331:$tensor, anonymous_334:$vector)"
     },
     "assemblyFormat": null,
     "opDialect": {
@@ -510,9 +518,9 @@
       "args": [
         [
           {
-            "def": "anonymous_346",
+            "def": "anonymous_336",
             "kind": "def",
-            "printable": "anonymous_346"
+            "printable": "anonymous_336"
           },
           "in"
         ]
@@ -523,7 +531,7 @@
         "kind": "def",
         "printable": "ins"
       },
-      "printable": "(ins anonymous_346:$in)"
+      "printable": "(ins anonymous_336:$in)"
     },
     "assemblyFormat": null,
     "opDialect": {
@@ -759,9 +767,9 @@
         ],
         [
           {
-            "def": "anonymous_348",
+            "def": "anonymous_338",
             "kind": "def",
-            "printable": "anonymous_348"
+            "printable": "anonymous_338"
           },
           null
         ]
@@ -772,7 +780,7 @@
         "kind": "def",
         "printable": "ins"
       },
-      "printable": "(ins I32:$a, SI64:$b, UI8:$c, Index:$d, F32:$e, NoneType:$f, anonymous_348)"
+      "printable": "(ins I32:$a, SI64:$b, UI8:$c, Index:$d, F32:$e, NoneType:$f, anonymous_338)"
     },
     "assemblyFormat": null,
     "opDialect": {
@@ -823,17 +831,17 @@
       "args": [
         [
           {
-            "def": "anonymous_351",
+            "def": "anonymous_341",
             "kind": "def",
-            "printable": "anonymous_351"
+            "printable": "anonymous_341"
           },
           "variadic"
         ],
         [
           {
-            "def": "anonymous_352",
+            "def": "anonymous_342",
             "kind": "def",
-            "printable": "anonymous_352"
+            "printable": "anonymous_342"
           },
           "optional"
         ],
@@ -852,7 +860,7 @@
         "kind": "def",
         "printable": "ins"
       },
-      "printable": "(ins anonymous_351:$variadic, anonymous_352:$optional, Test_SingletonCType:$required)"
+      "printable": "(ins anonymous_341:$variadic, anonymous_342:$optional, Test_SingletonCType:$required)"
     },
     "assemblyFormat": null,
     "opDialect": {
@@ -905,8 +913,8 @@
     "bitwidth": 8,
     "summary": "8-bit unsigned integer"
   },
-  "anonymous_338": {
-    "!name": "anonymous_338",
+  "anonymous_327": {
+    "!name": "anonymous_327",
     "!superclasses": [
       "Constraint",
       "TypeConstraint",
@@ -927,38 +935,44 @@
     ],
     "summary": " and any type"
   },
-  "anonymous_341": {
-    "!name": "anonymous_341",
+  "anonymous_329": {
+    "!name": "anonymous_329",
+    "!superclasses": [
+      "Constraint",
+      "AttrConstraint",
+      "Attr",
+      "OptionalAttr"
+    ],
+    "baseAttr": {
+      "def": "Test_TestAttr",
+      "kind": "def",
+      "printable": "Test_TestAttr"
+    },
+    "summary": "",
+    "valueType": null
+  },
+  "anonymous_331": {
+    "!name": "anonymous_331",
     "!superclasses": [
       "Constraint",
       "TypeConstraint",
       "Type",
       "ConfinedType"
     ],
-    "baseType": {
-      "def": "AnyType",
-      "kind": "def",
-      "printable": "AnyType"
-    },
     "summary": ""
   },
-  "anonymous_344": {
-    "!name": "anonymous_344",
+  "anonymous_334": {
+    "!name": "anonymous_334",
     "!superclasses": [
       "Constraint",
       "TypeConstraint",
       "Type",
       "ConfinedType"
     ],
-    "baseType": {
-      "def": "AnyType",
-      "kind": "def",
-      "printable": "AnyType"
-    },
     "summary": ""
   },
-  "anonymous_346": {
-    "!name": "anonymous_346",
+  "anonymous_336": {
+    "!name": "anonymous_336",
     "!superclasses": [
       "Constraint",
       "TypeConstraint",
@@ -984,8 +998,8 @@
     ],
     "summary": " or  or "
   },
-  "anonymous_348": {
-    "!name": "anonymous_348",
+  "anonymous_338": {
+    "!name": "anonymous_338",
     "!superclasses": [
       "Constraint",
       "TypeConstraint",
@@ -994,11 +1008,6 @@
       "SameBuildabilityAs",
       "Complex"
     ],
-    "baseType": {
-      "def": "AnyComplex",
-      "kind": "def",
-      "printable": "AnyComplex"
-    },
     "elementType": {
       "def": "F8E4M3FN",
       "kind": "def",
@@ -1006,8 +1015,8 @@
     },
     "summary": "complex type with f8E4M3FN type elements"
   },
-  "anonymous_351": {
-    "!name": "anonymous_351",
+  "anonymous_341": {
+    "!name": "anonymous_341",
     "!superclasses": [
       "Constraint",
       "TypeConstraint",
@@ -1020,8 +1029,8 @@
     },
     "summary": "variadic of "
   },
-  "anonymous_352": {
-    "!name": "anonymous_352",
+  "anonymous_342": {
+    "!name": "anonymous_342",
     "!superclasses": [
       "Constraint",
       "TypeConstraint",

--- a/tests/xdsl_tblgen/test.py
+++ b/tests/xdsl_tblgen/test.py
@@ -53,6 +53,8 @@ class Test_AttributesOp(IRDLOperation):
 
     in_ = prop_def(BaseAttr(Test_TestAttr), prop_name="in")
 
+    opt = opt_prop_def(BaseAttr(Test_TestAttr))
+
 
 @irdl_op_definition
 class Test_ConfinedOp(IRDLOperation):

--- a/tests/xdsl_tblgen/test.td
+++ b/tests/xdsl_tblgen/test.td
@@ -42,7 +42,8 @@ def Test_AnyOp : Test_Op<"any"> {
 // Check attributes are converted correctly.
 def Test_AttributesOp : Test_Op<"attributes"> {
   let arguments = (ins I16Attr:$int_attr,
-                       Test_TestAttr:$in);
+                       Test_TestAttr:$in,
+                       OptionalAttr<Test_TestAttr>:$opt);
 }
 
 // Check confined types are converted correctly.

--- a/xdsl/tools/xdsl_tblgen.py
+++ b/xdsl/tools/xdsl_tblgen.py
@@ -396,7 +396,7 @@ class TblgenLoader:
         elif "OptionalAttr" in superclasses:
             return (
                 self._ArgType.OPTIONAL_PROP,
-                self._resolve_prop_constraint(rec["baseAttr"]),
+                self._resolve_prop_constraint(rec["baseAttr"]["def"]),
             )
         else:
             return (self._ArgType.PROP, self._resolve_prop_constraint(rec))


### PR DESCRIPTION
Unsure if the way these were done in tablegen changed since making the tool or if it never worked, but in either case this fixes optional attributes and adds a test.