### PR TITLE
tool: (xdsl-tblgen) fix assembly format

### DIFF
--- a/tests/xdsl_tblgen/test.json
+++ b/tests/xdsl_tblgen/test.json
@@ -9,6 +9,8 @@
     "Op": [
       "Test_AndOp",
       "Test_AnyOp",
+      "Test_AssemblyFormat",
+      "Test_AssemblyFormatLong",
       "Test_AttributesOp",
       "Test_ConfinedOp",
       "Test_Integers",
@@ -244,6 +246,116 @@
       "printable": "Test_Dialect"
     },
     "opName": "any",
+    "regions": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "region",
+        "kind": "def",
+        "printable": "region"
+      },
+      "printable": "(region)"
+    },
+    "results": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "outs",
+        "kind": "def",
+        "printable": "outs"
+      },
+      "printable": "(outs)"
+    },
+    "successors": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "successor",
+        "kind": "def",
+        "printable": "successor"
+      },
+      "printable": "(successor)"
+    },
+    "summary": ""
+  },
+  "Test_AssemblyFormat": {
+    "!name": "Test_AssemblyFormat",
+    "!superclasses": [
+      "Op",
+      "Test_Op"
+    ],
+    "arguments": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "ins",
+        "kind": "def",
+        "printable": "ins"
+      },
+      "printable": "(ins)"
+    },
+    "assemblyFormat": "attr-dict",
+    "opDialect": {
+      "def": "Test_Dialect",
+      "kind": "def",
+      "printable": "Test_Dialect"
+    },
+    "opName": "assembly",
+    "regions": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "region",
+        "kind": "def",
+        "printable": "region"
+      },
+      "printable": "(region)"
+    },
+    "results": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "outs",
+        "kind": "def",
+        "printable": "outs"
+      },
+      "printable": "(outs)"
+    },
+    "successors": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "successor",
+        "kind": "def",
+        "printable": "successor"
+      },
+      "printable": "(successor)"
+    },
+    "summary": ""
+  },
+  "Test_AssemblyFormatLong": {
+    "!name": "Test_AssemblyFormatLong",
+    "!superclasses": [
+      "Op",
+      "Test_Op"
+    ],
+    "arguments": {
+      "args": [],
+      "kind": "dag",
+      "operator": {
+        "def": "ins",
+        "kind": "def",
+        "printable": "ins"
+      },
+      "printable": "(ins)"
+    },
+    "assemblyFormat": "\n      `a`\n      `very`\n      `long`\n      `assembly`\n      `format`\n      attr-dict\n  ",
+    "opDialect": {
+      "def": "Test_Dialect",
+      "kind": "def",
+      "printable": "Test_Dialect"
+    },
+    "opName": "assembly_long",
     "regions": {
       "args": [],
       "kind": "dag",

--- a/tests/xdsl_tblgen/test.py
+++ b/tests/xdsl_tblgen/test.py
@@ -46,6 +46,27 @@ class Test_AnyOp(IRDLOperation):
 
 
 @irdl_op_definition
+class Test_AssemblyFormat(IRDLOperation):
+    name = "test.assembly"
+
+    assembly_format = """attr-dict"""
+
+
+@irdl_op_definition
+class Test_AssemblyFormatLong(IRDLOperation):
+    name = "test.assembly_long"
+
+    assembly_format = """
+          `a`
+          `very`
+          `long`
+          `assembly`
+          `format`
+          attr-dict
+      """
+
+
+@irdl_op_definition
 class Test_AttributesOp(IRDLOperation):
     name = "test.attributes"
 
@@ -141,6 +162,8 @@ Test_Dialect = Dialect(
     [
         Test_AndOp,
         Test_AnyOp,
+        Test_AssemblyFormat,
+        Test_AssemblyFormatLong,
         Test_AttributesOp,
         Test_ConfinedOp,
         Test_Integers,

--- a/tests/xdsl_tblgen/test.td
+++ b/tests/xdsl_tblgen/test.td
@@ -39,6 +39,23 @@ def Test_AnyOp : Test_Op<"any"> {
   let arguments = (ins AnyType:$in);
 }
 
+// Check assembly format is converted correctly.
+def Test_AssemblyFormat : Test_Op<"assembly"> {
+  let assemblyFormat = "attr-dict";
+}
+
+// Check assembly format is converted correctly.
+def Test_AssemblyFormatLong : Test_Op<"assembly_long"> {
+  let assemblyFormat = [{
+      `a`
+      `very`
+      `long`
+      `assembly`
+      `format`
+      attr-dict
+  }];
+}
+
 // Check attributes are converted correctly.
 def Test_AttributesOp : Test_Op<"attributes"> {
   let arguments = (ins I16Attr:$int_attr,

--- a/xdsl/tools/xdsl_tblgen.py
+++ b/xdsl/tools/xdsl_tblgen.py
@@ -411,7 +411,7 @@ class TblgenLoader:
 
         assembly = tblgen_op.assembly_format
         if assembly is not None and "custom" not in assembly:
-            fields["assembly_format"] = assembly
+            fields["assembly_format"] = '"""' + assembly + '"""'
 
         for [arg, orig_name] in tblgen_op.arguments:
             name = self._resolve_name(orig_name)
@@ -580,6 +580,9 @@ def tblgen_to_dialect(
         capture_output=True,
         text=True,
     )
+
+    if output.stderr:
+        raise Exception(f"Formatting failed: {output.stderr}")
 
     print(output.stdout, file=output_file, end="")
 


### PR DESCRIPTION
Fixes assembly format printing for xdsl-tblgen by wrapping the string in triple quotes. This is necessary to deal with newlines, an alternative would be to replace all the new lines in the assembly format with spaces, or check if the assembly format has new lines before deciding whether to use single or triple quotes.

@Jimmy2027, I believe this should fix the issues addressed in https://github.com/xdslproject/xdsl/pull/4149 now, would you be able to test this commit to see if it can parse the dialect you were testing.

@erick-xanadu Could you confirm this partially fixes #3787 . At least locally this seem to not crash once the second dialect is removed.