### PR TITLE
backend: vector loads to x86 assembly

### DIFF
--- a/tests/filecheck/backend/x86/convert_vector_load_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_vector_load_to_x86.mlir
@@ -1,0 +1,27 @@
+// RUN: xdsl-opt -p 'convert-vectors-to-x86{arch=avx2}' --verify-diagnostics --split-input-file  %s | filecheck %s
+
+%m = "test.op"(): () -> memref<16xf32>
+%i = arith.constant 0: index
+%v = vector.load %m[%i]: memref<16xf32>, vector<8xf32>
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %m = "test.op"() : () -> memref<16xf32>
+// CHECK-NEXT:    %i = arith.constant 0 : index
+// CHECK-NEXT:    %v = memref.subview %m[%i] [8] [1] : memref<16xf32> to memref<8xf32>
+// CHECK-NEXT:    %v_1 = builtin.unrealized_conversion_cast %v : memref<8xf32> to !x86.reg
+// CHECK-NEXT:    %v_2 = x86.rm.vmovups %v_1, 0 : (!x86.reg) -> !x86.avx2reg
+// CHECK-NEXT:  }
+
+// -----
+
+// CHECK: Half-precision vector load is not implemented yet.
+%m1 = "test.op"(): () -> memref<32xf16>
+%i1 = arith.constant 0: index
+%v1 = vector.load %m1[%i1]: memref<32xf16>, vector<16xf16>
+
+// -----
+
+// CHECK: Double precision vector load is not implemented yet.
+%m1 = "test.op"(): () -> memref<8xf64>
+%i1 = arith.constant 0: index
+%v1 = vector.load %m1[%i1]: memref<8xf64>, vector<4xf64>

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -168,6 +168,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return varith_transformations.ConvertVarithToArithPass
 
+    def get_convert_vectors_to_x86():
+        from xdsl.transforms import convert_vectors_to_x86
+
+        return convert_vectors_to_x86.ConvertVectorsToX86Pass
+
     def get_jax_use_donated_arguments():
         from xdsl.transforms import jax_use_donated_arguments
 
@@ -528,6 +533,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "convert-stencil-to-csl-stencil": get_convert_stencil_to_csl_stencil,
         "convert-stencil-to-ll-mlir": get_convert_stencil_to_ll_mlir,
         "convert-varith-to-arith": get_convert_varith_to_arith,
+        "convert-vectors-to-x86": get_convert_vectors_to_x86,
         "jax-use-donated-arguments": get_jax_use_donated_arguments,
         "cse": get_cse,
         "csl-stencil-bufferize": get_csl_stencil_bufferize,

--- a/xdsl/transforms/convert_vectors_to_x86.py
+++ b/xdsl/transforms/convert_vectors_to_x86.py
@@ -1,0 +1,114 @@
+from dataclasses import dataclass
+from functools import reduce
+
+from xdsl.context import Context
+from xdsl.dialects import builtin, memref, vector, x86
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    FixedBitwidthType,
+    IntAttr,
+    UnrealizedConversionCastOp,
+)
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from xdsl.utils.exceptions import DiagnosticException
+
+
+@dataclass
+class VectorLoadToX86(RewritePattern):
+    arch: str
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: vector.LoadOp, rewriter: PatternRewriter):
+        assert self.arch == "sse" or self.arch == "avx2" or self.arch == "avx512"
+
+        # Output vector description
+        vector = op.result
+        vector_int_shape = [i.data for i in vector.type.shape.data]
+        vector_shape = ArrayAttr(
+            [IntAttr(reduce(lambda x, y: x * y, vector_int_shape))]
+        )
+        vector_num_elements = vector_shape.data[0].data
+        element_type = vector.type.get_element_type()
+        assert isinstance(element_type, FixedBitwidthType)
+        element_size = element_type.bitwidth
+        vector_size = vector_num_elements * element_size
+
+        # Input memref description
+        memory = op.base
+        memory_type = memory.type
+        assert isinstance(memory_type, memref.MemRefType)
+
+        # Build a subview of the original memref
+        strides = memory_type.get_strides()
+        static_strides: list[int] = []
+        if strides:
+            static_strides += [s for s in strides if s is not None]
+        subview_type = memref.MemRefType(
+            element_type=element_type, shape=vector_int_shape
+        )
+        subview_op = memref.SubviewOp.get(
+            source=memory,
+            result_type=subview_type,
+            offsets=op.indices,
+            strides=static_strides,
+            sizes=vector_int_shape,
+        )
+
+        subview = subview_op.result
+        # Build a pointer from the subview
+        x86_reg_type = x86.register.UNALLOCATED_GENERAL
+        cast_op = UnrealizedConversionCastOp.get((subview,), (x86_reg_type,))
+
+        # Choose the x86 vector register according to the
+        # target architecture and the abstract vector size
+        if vector_size == 128:
+            vect_reg_type = x86.register.UNALLOCATED_SSE
+        elif vector_size == 256 and (self.arch == "avx2" or self.arch == "avx512"):
+            vect_reg_type = x86.register.UNALLOCATED_AVX2
+        elif vector_size == 512 and self.arch == "avx512":
+            vect_reg_type = x86.register.UNALLOCATED_AVX512
+        else:
+            vect_reg_type = None
+        assert vect_reg_type is not None
+
+        # Choose the x86 vector instruction according to the
+        # abstract vector element size
+        match element_size:
+            case 16:
+                raise DiagnosticException(
+                    "Half-precision vector load is not implemented yet."
+                )
+            case 32:
+                mov = x86.ops.RM_VmovupsOp
+            case 64:
+                # mov = x86.ops.RM_VmovapdOp
+                raise DiagnosticException(
+                    "Double precision vector load is not implemented yet."
+                )
+            case _:
+                mov = None
+
+        assert mov is not None
+        mov_op = mov(cast_op, offset=0, result=vect_reg_type)
+
+        rewriter.replace_matched_op([subview_op, cast_op, mov_op])
+
+
+@dataclass(frozen=True)
+class ConvertVectorsToX86Pass(ModulePass):
+    name = "convert-vectors-to-x86"
+
+    arch: str
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier([VectorLoadToX86(self.arch)]),
+            apply_recursively=False,
+        ).rewrite_module(op)


### PR DESCRIPTION
These changes implement the lowering of vector.load to x86 vector instructions.
