### PR TITLE
transformations: no assembly section when lowering to riscv_func

### DIFF
--- a/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
+++ b/tests/filecheck/backend/riscv/convert_func_to_riscv_func.mlir
@@ -35,83 +35,69 @@ builtin.module {
 }
 
 // CHECK:       builtin.module {
-// CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv_func.func public @main() attributes {p2align = 2 : i8} {
-// CHECK-NEXT:          %0, %1 = "test.op"() : () -> (i32, f32)
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %1 : f32 to !riscv.freg
-// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
-// CHECK-NEXT:          %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
-// CHECK-NEXT:          %{{.*}}, %{{.*}} = riscv_func.call @foo(%{{.*}}, %{{.*}}) : (!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>)
-// CHECK-NEXT:          %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg
-// CHECK-NEXT:          %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i64
-// CHECK-NEXT:          %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f64
-// CHECK-NEXT:          riscv_func.return
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv_func.func public @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>) attributes {p2align = 2 : i8} {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
-// CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %arg1 : (!riscv.freg<fa0>) -> !riscv.freg
-// CHECK-NEXT:        %arg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
-// CHECK-NEXT:        %res0, %res1 = "test.op"(%arg0_1, %arg1_1) : (i32, f32) -> (i64, f64)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0 : i64 to !riscv.reg
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res1 : f64 to !riscv.freg
+// CHECK-NEXT:    riscv_func.func public @main() attributes {p2align = 2 : i8} {
+// CHECK-NEXT:        %0, %1 = "test.op"() : () -> (i32, f32)
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %0 : i32 to !riscv.reg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %1 : f32 to !riscv.freg
 // CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
-// CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.reg<a0>, !riscv.freg<fa0>
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv_func.func public @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) attributes {p2align = 2 : i8} {
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
-// CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg1 : (!riscv.freg<fa1>) -> !riscv.freg
-// CHECK-NEXT:        %farg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
-// CHECK-NEXT:        %fres0, %fres1 = "test.op"(%farg0_1, %farg1_1) : (f32, f32) -> (f32, f32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres1 : f32 to !riscv.freg
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa1>
-// CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.freg<fa1>
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv_func.func public @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
-// CHECK-NEXT:        %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
-// CHECK-NEXT:        %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
-// CHECK-NEXT:        %fres0, %res0 = "test.op"(%arg0_1, %farg0_1) : (i32, f32) -> (f32, i32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %res0 : i32 to !riscv.reg
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
-// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
-// CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv_func.func public @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
-// CHECK-NEXT:        %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:        %{{.*}}, %{{.*}} = riscv_func.call @foo(%{{.*}}, %{{.*}}) : (!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>)
+// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg<a0>) -> !riscv.reg
 // CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i64
 // CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f64
-// CHECK-NEXT:        %{{.*}}, %{{.*}} = "test.op"(%{{.*}}, %{{.*}}) : (i32, f64) -> (f64, i32)
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg
-// CHECK-NEXT:        %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : i32 to !riscv.reg
-// CHECK-NEXT:        %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
-// CHECK-NEXT:        %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
-// CHECK-NEXT:        riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv_func.func private @private_func() attributes {p2align = 2 : i8} {
 // CHECK-NEXT:        riscv_func.return
-// CHECK-NEXT:      }
 // CHECK-NEXT:    }
-// CHECK-NEXT:    riscv.assembly_section ".text" {
-// CHECK-NEXT:      riscv_func.func public @external(!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8}
+// CHECK-NEXT:    riscv_func.func public @foo(%arg0 : !riscv.reg<a0>, %arg1 : !riscv.freg<fa0>) -> (!riscv.reg<a0>, !riscv.freg<fa0>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:      %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.s %arg1 : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:      %arg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:      %res0, %res1 = "test.op"(%arg0_1, %arg1_1) : (i32, f32) -> (i64, f64)
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %res0 : i64 to !riscv.reg
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %res1 : f64 to !riscv.freg
+// CHECK-NEXT:      %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
+// CHECK-NEXT:      riscv_func.return %{{.*}}, %{{.*}} : !riscv.reg<a0>, !riscv.freg<fa0>
 // CHECK-NEXT:    }
+// CHECK-NEXT:    riscv_func.func public @foo_float(%farg0 : !riscv.freg<fa0>, %farg1 : !riscv.freg<fa1>) -> (!riscv.freg<fa0>, !riscv.freg<fa1>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:      %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.s %farg1 : (!riscv.freg<fa1>) -> !riscv.freg
+// CHECK-NEXT:      %farg1_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:      %fres0, %fres1 = "test.op"(%farg0_1, %farg1_1) : (f32, f32) -> (f32, f32)
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %fres1 : f32 to !riscv.freg
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa1>
+// CHECK-NEXT:      riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.freg<fa1>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv_func.func public @foo_int_float(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:      %arg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.s %farg0 : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:      %farg0_1 = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f32
+// CHECK-NEXT:      %fres0, %res0 = "test.op"(%arg0_1, %farg0_1) : (i32, f32) -> (f32, i32)
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %fres0 : f32 to !riscv.freg
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %res0 : i32 to !riscv.reg
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.s %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
+// CHECK-NEXT:      %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:      riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv_func.func public @foo_int_double(%arg0 : !riscv.reg<a0>, %farg0 : !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      %{{.*}} = riscv.mv %arg0 : (!riscv.reg<a0>) -> !riscv.reg
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.reg to i32
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg<fa0>) -> !riscv.freg
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : !riscv.freg to f64
+// CHECK-NEXT:      %{{.*}}, %{{.*}} = "test.op"(%{{.*}}, %{{.*}}) : (i32, f64) -> (f64, i32)
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : f64 to !riscv.freg
+// CHECK-NEXT:      %{{.*}} = builtin.unrealized_conversion_cast %{{.*}} : i32 to !riscv.reg
+// CHECK-NEXT:      %{{.*}} = riscv.fmv.d %{{.*}} : (!riscv.freg) -> !riscv.freg<fa0>
+// CHECK-NEXT:      %{{.*}} = riscv.mv %{{.*}} : (!riscv.reg) -> !riscv.reg<a0>
+// CHECK-NEXT:      riscv_func.return %{{.*}}, %{{.*}} : !riscv.freg<fa0>, !riscv.reg<a0>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv_func.func private @private_func() attributes {p2align = 2 : i8} {
+// CHECK-NEXT:      riscv_func.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    riscv_func.func public @external(!riscv.reg<a0>, !riscv.freg<fa0>) -> (!riscv.freg<fa0>, !riscv.reg<a0>) attributes {p2align = 2 : i8}
 // CHECK-NEXT:  }

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f32.mlir
@@ -20,8 +20,8 @@ func.func public @ssum(
   func.return
 }
 
-// CHECK:       .text
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl ssum
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  ssum:

--- a/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/bottom_up_f64.mlir
@@ -34,8 +34,8 @@ func.func public @conv_2d_nchw_fchw_d1_s1_3x3(
   }
 
 
-// CHECK:       .text
 // CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "a3", "a4", "a5", "t0", "t1", "t2", "t3", "t4", "t5", "t6", "zero"]}
+// CHECK:       .text
 // CHECK-NEXT:  .globl conv_2d_nchw_fchw_d1_s1_3x3
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  conv_2d_nchw_fchw_d1_s1_3x3:

--- a/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
+++ b/tests/filecheck/projects/riscv-backend-paper/nsnet.mlir
@@ -10,8 +10,8 @@ func.func @main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1(%
   return
 }
 
-// CHECK:       .text
-// CHECK-NEXT:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK:  # Regalloc stats: {"preallocated_float": ["ft0", "ft1", "ft2"], "preallocated_int": ["a0", "a1", "a2", "zero"], "allocated_float": ["ft0", "ft1", "ft3", "ft4", "ft5", "ft6", "ft7"], "allocated_int": ["a0", "a1", "a2", "t0", "t1", "t2", "t3", "zero"]}
+// CHECK-NEXT:  .text
 // CHECK-NEXT:  .globl main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1
 // CHECK-NEXT:  .p2align 2
 // CHECK-NEXT:  main$async_dispatch_0_matmul_transpose_b_1x400x161_f64$xdsl_kernel1:

--- a/tests/interactive/test_app.py
+++ b/tests/interactive/test_app.py
@@ -178,21 +178,20 @@ async def test_buttons():
         await pilot.pause()
         assert (
             app.output_text_area.text
-            == """builtin.module {
-  riscv.assembly_section ".text" {
-    riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
-      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
-      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
-      %two = riscv.li 2 : !riscv.reg
-      %two_1 = builtin.unrealized_conversion_cast %two : !riscv.reg to index
-      %res = builtin.unrealized_conversion_cast %n_1 : index to !riscv.reg
-      %res_1 = builtin.unrealized_conversion_cast %two_1 : index to !riscv.reg
-      %res_2 = riscv.mul %res, %res_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
-      %res_3 = builtin.unrealized_conversion_cast %res_2 : !riscv.reg to index
-      %1 = builtin.unrealized_conversion_cast %res_3 : index to !riscv.reg
-      %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
-      riscv_func.return %2 : !riscv.reg<a0>
-    }
+            == """\
+builtin.module {
+  riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
+    %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
+    %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
+    %two = riscv.li 2 : !riscv.reg
+    %two_1 = builtin.unrealized_conversion_cast %two : !riscv.reg to index
+    %res = builtin.unrealized_conversion_cast %n_1 : index to !riscv.reg
+    %res_1 = builtin.unrealized_conversion_cast %two_1 : index to !riscv.reg
+    %res_2 = riscv.mul %res, %res_1 : (!riscv.reg, !riscv.reg) -> !riscv.reg
+    %res_3 = builtin.unrealized_conversion_cast %res_2 : !riscv.reg to index
+    %1 = builtin.unrealized_conversion_cast %res_3 : index to !riscv.reg
+    %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
+    riscv_func.return %2 : !riscv.reg<a0>
   }
 }
 """
@@ -216,17 +215,16 @@ async def test_buttons():
 
         assert (
             app.output_text_area.text
-            == """builtin.module {
-  riscv.assembly_section ".text" {
-    riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
-      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
-      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
-      %two = arith.constant 2 : index
-      %res = arith.muli %n_1, %two : index
-      %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg
-      %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
-      riscv_func.return %2 : !riscv.reg<a0>
-    }
+            == """\
+builtin.module {
+  riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
+    %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
+    %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
+    %two = arith.constant 2 : index
+    %res = arith.muli %n_1, %two : index
+    %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg
+    %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
+    riscv_func.return %2 : !riscv.reg<a0>
   }
 }
 """
@@ -402,16 +400,14 @@ async def test_passes():
         assert (
             app.output_text_area.text
             == """builtin.module {
-  riscv.assembly_section ".text" {
-    riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
-      %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
-      %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
-      %two = arith.constant 2 : index
-      %res = arith.muli %n_1, %two : index
-      %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg
-      %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
-      riscv_func.return %2 : !riscv.reg<a0>
-    }
+  riscv_func.func public @hello(%n : !riscv.reg<a0>) -> !riscv.reg<a0> attributes {p2align = 2 : i8} {
+    %0 = riscv.mv %n : (!riscv.reg<a0>) -> !riscv.reg
+    %n_1 = builtin.unrealized_conversion_cast %0 : !riscv.reg to index
+    %two = arith.constant 2 : index
+    %res = arith.muli %n_1, %two : index
+    %1 = builtin.unrealized_conversion_cast %res : index to !riscv.reg
+    %2 = riscv.mv %1 : (!riscv.reg) -> !riscv.reg<a0>
+    riscv_func.return %2 : !riscv.reg<a0>
   }
 }
 """
@@ -420,25 +416,23 @@ async def test_passes():
         index = IndexType()
         expected_module = ModuleOp(Region([Block()]))
         with ImplicitBuilder(expected_module.body):
-            section = riscv.AssemblySectionOp(".text")
-            with ImplicitBuilder(section.data):
-                function = riscv_func.FuncOp(
-                    "hello",
-                    Region([Block(arg_types=[riscv.Registers.A0])]),
-                    ((riscv.Registers.A0,), (riscv.Registers.A0,)),
-                    "public",
-                    p2align=2,
+            function = riscv_func.FuncOp(
+                "hello",
+                Region([Block(arg_types=[riscv.Registers.A0])]),
+                ((riscv.Registers.A0,), (riscv.Registers.A0,)),
+                "public",
+                p2align=2,
+            )
+            with ImplicitBuilder(function.body) as (n,):
+                zero = riscv.MVOp(n)
+                n_one = UnrealizedConversionCastOp.get([zero.rd], [index])
+                two = arith.ConstantOp(IntegerAttr(2, index)).result
+                res = arith.MuliOp(n_one, two)
+                one = UnrealizedConversionCastOp.get(
+                    [res.result], [riscv.Registers.UNALLOCATED_INT]
                 )
-                with ImplicitBuilder(function.body) as (n,):
-                    zero = riscv.MVOp(n)
-                    n_one = UnrealizedConversionCastOp.get([zero.rd], [index])
-                    two = arith.ConstantOp(IntegerAttr(2, index)).result
-                    res = arith.MuliOp(n_one, two)
-                    one = UnrealizedConversionCastOp.get(
-                        [res.result], [riscv.Registers.UNALLOCATED_INT]
-                    )
-                    two_two = riscv.MVOp(one, rd=riscv.Registers.A0)
-                    riscv_func.ReturnOp(two_two)
+                two_two = riscv.MVOp(one, rd=riscv.Registers.A0)
+                riscv_func.ReturnOp(two_two)
 
         assert isinstance(app.current_module, ModuleOp)
         # Assert that the current module has been changed accordingly

--- a/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
+++ b/xdsl/backend/riscv/lowering/convert_func_to_riscv_func.py
@@ -7,9 +7,8 @@ from xdsl.backend.riscv.lowering.utils import (
     move_to_unallocated_regs,
 )
 from xdsl.context import Context
-from xdsl.dialects import func, riscv, riscv_func
+from xdsl.dialects import func, riscv_func
 from xdsl.dialects.builtin import ModuleOp, StringAttr, UnrealizedConversionCastOp
-from xdsl.ir import Block, Operation, Region
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -52,17 +51,7 @@ class LowerFuncOp(RewritePattern):
             p2align=p2align,
         )
 
-        new_ops: list[Operation] = []
-
-        new_ops.append(new_func)
-
-        # Each function has its own .text: this will tell the assembler to emit
-        # a .text section (if not present) and make it the current one
-        # section = riscv.AssemblySectionOp(".text", Region(Block(result)))
-
-        text_section = riscv.AssemblySectionOp(".text", Region(Block(new_ops)))
-
-        rewriter.replace_matched_op(text_section)
+        rewriter.replace_matched_op(new_func)
 
 
 class LowerFuncCallOp(RewritePattern):


### PR DESCRIPTION
Now that the riscv_func.funcs can emit their own .text section as necessary, we don't need the explicit assembly_section structure. With this change, we can look up the riscv func using the standard SymbolOpInterface, like func.funv.

CC @jumerckx - With this the functions will be ported, but I need to do a similar refactor for global data for the switch to symbols in the interpreter to work.