### PR TITLE
misc: Fix opt_operand and opt_result printing

### DIFF
--- a/tests/filecheck/utils/codegen/simple.py
+++ b/tests/filecheck/utils/codegen/simple.py
@@ -18,6 +18,7 @@ from xdsl.irdl import (
     EqAttrConstraint,
     OpDef,
     OperandDef,
+    OptOperandDef,
     ParamAttrConstraint,
     ParamAttrDef,
     ResultDef,
@@ -132,6 +133,7 @@ ops = [
         OpDef(
             name="test.variadic",
             operands=[
+                ("opt", OptOperandDef(BaseAttr(SingletonAType))),
                 ("variadic", VarOperandDef(BaseAttr(SingletonAType))),
                 ("required", OperandDef(BaseAttr(SingletonCType))),
             ],
@@ -228,6 +230,7 @@ dump_dialect_pyfile(
 # CHECK:       @irdl_op_definition
 # CHECK-NEXT:  class Test_VariadicityOp(IRDLOperation):
 # CHECK-NEXT:      name = "test.variadic"
+# CHECK-NEXT:      opt = opt_operand_def(BaseAttr(Test_SingletonAType))
 # CHECK-NEXT:      variadic = var_operand_def(BaseAttr(Test_SingletonAType))
 # CHECK-NEXT:      required = operand_def(BaseAttr(Test_SingletonCType))
 

--- a/xdsl/utils/dialect_codegen.py
+++ b/xdsl/utils/dialect_codegen.py
@@ -56,16 +56,16 @@ def get_str_from_operand_or_result(
             )
 
     match operand_or_result:
-        case VarOperandDef():
-            def_str = "var_operand_def"
         case OptOperandDef():
             def_str = "opt_operand_def"
+        case VarOperandDef():
+            def_str = "var_operand_def"
         case OperandDef():
             def_str = "operand_def"
-        case VarResultDef():
-            def_str = "var_result_def"
         case OptResultDef():
             def_str = "opt_result_def"
+        case VarResultDef():
+            def_str = "var_result_def"
         case ResultDef():
             def_str = "result_def"
 


### PR DESCRIPTION
`Opt` check should be before `Var` check since it's a `Var` subclass. In previous order opt variants were never printed.