### PR TITLE
dialects (arm): Add NEON fmla instruction (mixed: vector/scalar)

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_ops.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops.mlir
@@ -7,3 +7,7 @@
 // CHECK: %dss_fmulvec = arm_neon.dss.fmulvec %v1, %v2[0] S {comment = "floating-point vector multiply v1 by v2"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
 // CHECK-ASM: fmul v3.4S, v1.4S, v2.S[0] # floating-point vector multiply v1 by v2
 %dss_fmulvec = arm_neon.dss.fmulvec %v1, %v2[0] S {"comment" = "floating-point vector multiply v1 by v2"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
+
+// CHECK: %dss_fmla = arm_neon.dss.fmla %v1, %v2[0] S {comment = "Floating-point fused Multiply-Add to accumulator"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
+// CHECK-ASM: fmla v3.4S, v1.4S, v2.S[0] # Floating-point fused Multiply-Add to accumulator
+%dss_fmla = arm_neon.dss.fmla %v1, %v2[0] S {"comment" = "Floating-point fused Multiply-Add to accumulator"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -209,9 +209,69 @@ class DSSFMulVecScalarOp(ARMInstruction):
         )
 
 
+@irdl_op_definition
+class DSSFmlaVecScalarOp(ARMInstruction):
+    """
+    Floating-point fused Multiply-Add to accumulator (mixed: first source operand is a vector, second is a scalar.
+    Destination is a vector)
+    This instruction multiplies the values in the first source operand by the second source operand,
+    adds the accumulated value from the destination operand, and writes the resulting values to the destination.
+    Encoding: FMLA <Vd>.<T>, <Vn>.<T>, <Vm>.<idx>.
+    Vd, Vn, Vm specify the regs. The <T> specifier determines element arrangement (size and count).
+    The <idx> specifier determines the index of Vm at which the second source operand (scalar) can be found,
+    preceded by a size specifier.
+
+    See external [documentation](https://developer.arm.com/documentation/100069/0606/SIMD-Vector-Instructions/FMLA--vector-).
+    """
+
+    name = "arm_neon.dss.fmla"
+    d = result_def(NEONRegisterType)
+    s1 = operand_def(NEONRegisterType)
+    s2 = operand_def(NEONRegisterType)
+    scalar_idx = attr_def(IntegerAttr[i8])
+    arrangement = attr_def(NeonArrangementAttr)
+
+    assembly_format = "$s1 `,` $s2 `[` $scalar_idx `]` $arrangement attr-dict `:` `(` type($s1) `,` type($s2) `)` `->` type($d)"
+
+    def __init__(
+        self,
+        s1: Operation | SSAValue,
+        s2: Operation | SSAValue,
+        *,
+        d: NEONRegisterType,
+        arrangement: NeonArrangement | NeonArrangementAttr,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+        if isinstance(arrangement, NeonArrangement):
+            arrangement = NeonArrangementAttr(arrangement)
+        super().__init__(
+            operands=(s1, s2),
+            attributes={
+                "comment": comment,
+                "arrangement": arrangement,
+            },
+            result_types=(d,),
+        )
+
+    def assembly_instruction_name(self) -> str:
+        return "fmla"
+
+    def assembly_line_args(self):
+        return (
+            VectorWithArrangement(self.d, self.arrangement),
+            VectorWithArrangement(self.s1, self.arrangement),
+            VectorWithArrangement(
+                self.s2, self.arrangement, index=self.scalar_idx.value.data
+            ),
+        )
+
+
 ARM_NEON = Dialect(
     "arm_neon",
     [
+        DSSFmlaVecScalarOp,
         DSSFMulVecScalarOp,
         GetRegisterOp,
     ],


### PR DESCRIPTION
Floating-point fused Multiply-Add to accumulator (mixed: first source operand is a vector, second is a scalar. Destination is a vector)

This instruction multiplies the values in the first source operand by the second source operand, adds the accumulated value from the destination operand, and writes the resulting values to the destination.

This instruction is similar to FMUL and so this PR follows the same approach as https://github.com/xdslproject/xdsl/pull/4122.