### PR TITLE
dialects (arm): add curly brackets around variadic NeonReg operands t…

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_ops.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops.mlir
@@ -16,7 +16,7 @@
 %dss_fmulvec = arm_neon.dss.fmulvec %v1, %v2[0] S {"comment" = "floating-point vector multiply v1 by v2"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
 
 // CHECK: arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
-// CHECK-ASM: st1 v1.4S, v2.4S, v3.4S, v4.4S, [x1] # st1 op
+// CHECK-ASM: st1 {v1.4S, v2.4S, v3.4S, v4.4S}, [x1] # st1 op
 arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
 // CHECK: %dss_fmla = arm_neon.dss.fmla %v1, %v2[0] S {comment = "Floating-point fused Multiply-Add to accumulator"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
 // CHECK-ASM: fmla v3.4S, v1.4S, v2.S[0] # Floating-point fused Multiply-Add to accumulator


### PR DESCRIPTION
Adding ```{}``` surrounding the variadic NeonReg operands to align with the correct asm format (required by the ```st1``` and ```ld1``` NEON instructions).