### PR TITLE
dialects (arm): Add NEON ld1 op

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_ops.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops.mlir
@@ -11,13 +11,19 @@
 %v3 = arm_neon.get_register : !arm_neon.reg<v3>
 // CHECK: %v4 = arm_neon.get_register : !arm_neon.reg<v4>
 %v4 = arm_neon.get_register : !arm_neon.reg<v4>
+
 // CHECK: %dss_fmulvec = arm_neon.dss.fmulvec %v1, %v2[0] S {comment = "floating-point vector multiply v1 by v2"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
 // CHECK-ASM: fmul v3.4S, v1.4S, v2.S[0] # floating-point vector multiply v1 by v2
 %dss_fmulvec = arm_neon.dss.fmulvec %v1, %v2[0] S {"comment" = "floating-point vector multiply v1 by v2"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
 
-// CHECK: arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
-// CHECK-ASM: st1 {v1.4S, v2.4S, v3.4S, v4.4S}, [x1] # st1 op
-arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
 // CHECK: %dss_fmla = arm_neon.dss.fmla %v1, %v2[0] S {comment = "Floating-point fused Multiply-Add to accumulator"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
 // CHECK-ASM: fmla v3.4S, v1.4S, v2.S[0] # Floating-point fused Multiply-Add to accumulator
 %dss_fmla = arm_neon.dss.fmla %v1, %v2[0] S {"comment" = "Floating-point fused Multiply-Add to accumulator"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>) -> !arm_neon.reg<v3>
+
+// CHECK: arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
+// CHECK-ASM: st1 {v1.4S, v2.4S, v3.4S, v4.4S}, [x1] # st1 op
+arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
+
+// CHECK: arm_neon.dvars.ld1 %v1, %v2, %v3, %v4 [%x1] S {comment = "ld1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
+// CHECK-ASM: ld1 {v1.4S, v2.4S, v3.4S, v4.4S}, [x1] # ld1 op
+arm_neon.dvars.ld1 %v1, %v2, %v3, %v4 [%x1] S {comment = "ld1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>

--- a/tests/filecheck/dialects/arm_neon/test_ops_invalid.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops_invalid.mlir
@@ -1,6 +1,17 @@
-// RUN: xdsl-opt -t arm-asm %s --verify-diagnostics | filecheck %s
+// RUN: xdsl-opt -t arm-asm %s --verify-diagnostics --split-input-file | filecheck %s
 
-%x1, %v1, %v2, %v3, %v4, %v5 = "test.op"() : () -> (!arm.reg<x1>, !arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>)
-arm_neon.dvars.st1 %v1, %v2, %v3, %v4, %v5 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>) -> !arm.reg<x1>
+builtin.module {
+    %x1, %v1, %v2, %v3, %v4, %v5 = "test.op"() : () -> (!arm.reg<x1>, !arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>)
+    
+    // CHECK:       Operation does not verify: src_regs must contain between 1 and 4 elements, but got 5.
+    arm_neon.dvars.st1 %v1, %v2, %v3, %v4, %v5 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>) -> !arm.reg<x1>
+}
 
-// CHECK:       Operation does not verify: src_regs must contain between 1 and 4 elements, but got 5.
+// -----
+
+builtin.module {
+    %x1, %v1, %v2, %v3, %v4, %v5 = "test.op"() : () -> (!arm.reg<x1>, !arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>)
+
+    // CHECK:       Operation does not verify: dest_regs must contain between 1 and 4 elements, but got 5.
+    arm_neon.dvars.ld1 %v1, %v2, %v3, %v4, %v5 [%x1] S {comment = "ld1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>) -> !arm.reg<x1>
+}

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -338,11 +338,7 @@ class DVarSLd1Op(ARMInstruction):
                 f"dest_regs must contain between 1 and 4 elements, but got {len(self.dest_regs)}."
             )
 
-    def assembly_instruction_name(self) -> str:
-        return "ld1"
-
     def assembly_line_args(self):
-        assert isinstance(self.s.type, IntRegisterType)
         return (
             VariadicNeonRegArg(self.dest_regs, self.arrangement),
             square_brackets_reg(self.s),
@@ -394,11 +390,7 @@ class DVarSSt1Op(ARMInstruction):
                 f"src_regs must contain between 1 and 4 elements, but got {len(self.src_regs)}."
             )
 
-    def assembly_instruction_name(self) -> str:
-        return "st1"
-
     def assembly_line_args(self):
-        assert isinstance(self.d.type, IntRegisterType)
         return (
             VariadicNeonRegArg(self.src_regs, self.arrangement),
             square_brackets_reg(self.d),


### PR DESCRIPTION
 Add ```ld1``` instruction to ARM (NEON) dialect. 

Neon structure load instruction reads data from memory into 64-bit Neon registers.
LD1 loads data from memory into up to four registers, with no interleaving.