### PR TITLE
dialects (arm): fix NEON ld1 instruction

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_ops.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops.mlir
@@ -24,6 +24,6 @@
 // CHECK-ASM: st1 {v1.4S, v2.4S, v3.4S, v4.4S}, [x1] # st1 op
 arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
 
-// CHECK: arm_neon.dvars.ld1 %v1, %v2, %v3, %v4 [%x1] S {comment = "ld1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
-// CHECK-ASM: ld1 {v1.4S, v2.4S, v3.4S, v4.4S}, [x1] # ld1 op
-arm_neon.dvars.ld1 %v1, %v2, %v3, %v4 [%x1] S {comment = "ld1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>) -> !arm.reg<x1>
+// CHECK: %v11, %v12, %v13, %v14 = arm_neon.dvars.ld1 [%x1] S {comment = "ld1 op"} : !arm.reg<x1> -> (!arm_neon.reg<v11>, !arm_neon.reg<v12>, !arm_neon.reg<v13>, !arm_neon.reg<v14>)
+// CHECK-ASM: ld1 {v11.4S, v12.4S, v13.4S, v14.4S}, [x1] # ld1 op
+%v11, %v12, %v13, %v14 = arm_neon.dvars.ld1 [%x1] S {comment = "ld1 op"} : !arm.reg<x1> -> (!arm_neon.reg<v11>, !arm_neon.reg<v12>, !arm_neon.reg<v13>, !arm_neon.reg<v14>)

--- a/tests/filecheck/dialects/arm_neon/test_ops_invalid.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops_invalid.mlir
@@ -10,8 +10,8 @@ builtin.module {
 // -----
 
 builtin.module {
-    %x1, %v1, %v2, %v3, %v4, %v5 = "test.op"() : () -> (!arm.reg<x1>, !arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>)
+    %x1 = "test.op"() : () -> (!arm.reg<x1>)
 
     // CHECK:       Operation does not verify: dest_regs must contain between 1 and 4 elements, but got 5.
-    arm_neon.dvars.ld1 %v1, %v2, %v3, %v4, %v5 [%x1] S {comment = "ld1 op"} : (!arm_neon.reg<v1>, !arm_neon.reg<v2>, !arm_neon.reg<v3>, !arm_neon.reg<v4>, !arm_neon.reg<v5>) -> !arm.reg<x1>
+    %v11, %v12, %v13, %v14, %v15 = arm_neon.dvars.ld1 [%x1] S {comment = "ld1 op"} : !arm.reg<x1> -> (!arm_neon.reg<v11>, !arm_neon.reg<v12>, !arm_neon.reg<v13>, !arm_neon.reg<v14>, !arm_neon.reg<v15>)
 }

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -7,6 +7,7 @@ from xdsl.dialects.arm.ops import ARMInstruction, ARMOperation
 from xdsl.dialects.arm.register import ARMRegisterType, IntRegisterType
 from xdsl.dialects.builtin import IntegerAttr, StringAttr, i8
 from xdsl.ir import (
+    Attribute,
     Dialect,
     EnumAttribute,
     Operation,
@@ -21,6 +22,7 @@ from xdsl.irdl import (
     operand_def,
     result_def,
     var_operand_def,
+    var_result_def,
 )
 from xdsl.utils.exceptions import VerifyException
 
@@ -302,15 +304,15 @@ class DVarSLd1Op(ARMInstruction):
 
     name = "arm_neon.dvars.ld1"
     s = operand_def(IntRegisterType)
-    dest_regs = var_operand_def(NEONRegisterType)
+    dest_regs = var_result_def(NEONRegisterType)
     arrangement = attr_def(NeonArrangementAttr)
 
-    assembly_format = "$dest_regs ` ` `[` $s `]` $arrangement attr-dict `:` `(` type($dest_regs) `)` `->` type($s)"
+    assembly_format = " ` ` `[` $s `]` $arrangement attr-dict `:` type($s) `->` `(` type($dest_regs) `)`"
 
     def __init__(
         self,
-        s: IntRegisterType,
-        dest_regs: Sequence[SSAValue],
+        s: Operation | SSAValue,
+        result_types: Sequence[Attribute],
         *,
         arrangement: NeonArrangement | NeonArrangementAttr,
         comment: str | StringAttr | None = None,
@@ -324,12 +326,12 @@ class DVarSLd1Op(ARMInstruction):
         if isinstance(arrangement, NeonArrangement):
             arrangement = NeonArrangementAttr(arrangement)
         super().__init__(
-            operands=[*dest_regs],
+            operands=(s,),
             attributes={
                 "comment": comment,
                 "arrangement": arrangement,
             },
-            result_types=(s,),
+            result_types=[result_types],
         )
 
     def verify_(self) -> None:


### PR DESCRIPTION
Fix the representation of the NEON ```ld1``` instruction to have the destination registers as results, not operands.