### PR TITLE
core: Allow nesting of optional groups in declarative assembly format

### DIFF
--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1297,3 +1297,8 @@ class OptionalGroupDirective(FormatDirective):
                 *self.then_elements,
             ):
                 element.print(printer, state, op)
+
+    def set_empty(self, state: ParsingState) -> None:
+        self.then_first.set_empty(state)
+        for element in self.then_elements:
+            element.set_empty(state)


### PR DESCRIPTION
Stacked PRs:
 * #4187
 * __->__#4186


--- --- ---

### core: Allow nesting of optional groups in declarative assembly format


Previously, nesting optional groups would raise asserts in the
declarative assembly format generated parser, as nested groups would not
set their operands and results as empty.