### PR TITLE
transformations: vector load to ptr

### DIFF
--- a/tests/filecheck/transforms/convert_vector_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_vector_to_ptr.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-vector-to-ptr %s | filecheck %s
+// RUN: xdsl-opt -p convert-vector-to-ptr --split-input-file %s | filecheck %s
 
 %m = "test.op"(): () -> memref<16xf32>
 %i = arith.constant 0: index
@@ -7,8 +7,25 @@
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %m = "test.op"() : () -> memref<16xf32>
 // CHECK-NEXT:    %i = arith.constant 0 : index
-// CHECK-NEXT:    %v = affine.apply affine_map<(d0) -> (d0)> (%i)
+// CHECK-NEXT:    %v = affine.apply affine_map<(d0) -> ((d0 * 4))> (%i)
 // CHECK-NEXT:    %v_1 = ptr_xdsl.to_ptr %m : memref<16xf32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %v_2 = ptr_xdsl.ptradd %v_1, %v : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %v_3 = ptr_xdsl.load %v_2 : !ptr_xdsl.ptr -> vector<8xf32>
 // CHECK-NEXT:  }
+
+// -----
+
+%m0 = "test.op"(): () -> memref<2x8xf32>
+%i0 = arith.constant 0: index
+%j0 = arith.constant 0: index
+%v0 = vector.load %m0[%i0,%j0]: memref<2x8xf32>, vector<8xf32>
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %m0 = "test.op"() : () -> memref<2x8xf32>
+// CHECK-NEXT:   %i0 = arith.constant 0 : index
+// CHECK-NEXT:   %j0 = arith.constant 0 : index
+// CHECK-NEXT:   %v0 = affine.apply affine_map<(d0, d1) -> (((d0 * 32) + (d1 * 4)))> (%i0, %j0)
+// CHECK-NEXT:   %v0_1 = ptr_xdsl.to_ptr %m0 : memref<2x8xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v0_2 = ptr_xdsl.ptradd %v0_1, %v0 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v0_3 = ptr_xdsl.load %v0_2 : !ptr_xdsl.ptr -> vector<8xf32>
+// CHECK-NEXT: }

--- a/tests/filecheck/transforms/convert_vector_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_vector_to_ptr.mlir
@@ -8,6 +8,6 @@
 // CHECK-NEXT:    %m = "test.op"() : () -> memref<16xf32>
 // CHECK-NEXT:    %i = arith.constant 0 : index
 // CHECK-NEXT:    %v = memref.subview %m[%i] [8] [1] : memref<16xf32> to memref<8xf32>
-// CHECK-NEXT:    %v_1 = builtin.unrealized_conversion_cast %v : memref<8xf32> to !ptr_xdsl.ptr
+// CHECK-NEXT:    %v_1 = ptr_xdsl.to_ptr %v : memref<8xf32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %v_2 = ptr_xdsl.load %v_1 : !ptr_xdsl.ptr -> vector<8xf32>
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/convert_vector_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_vector_to_ptr.mlir
@@ -7,7 +7,8 @@
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %m = "test.op"() : () -> memref<16xf32>
 // CHECK-NEXT:    %i = arith.constant 0 : index
-// CHECK-NEXT:    %v = memref.subview %m[%i] [8] [1] : memref<16xf32> to memref<8xf32>
-// CHECK-NEXT:    %v_1 = ptr_xdsl.to_ptr %v : memref<8xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:    %v_2 = ptr_xdsl.load %v_1 : !ptr_xdsl.ptr -> vector<8xf32>
+// CHECK-NEXT:    %v = affine.apply affine_map<(d0) -> (d0)> (%i)
+// CHECK-NEXT:    %v_1 = ptr_xdsl.to_ptr %m : memref<16xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:    %v_2 = ptr_xdsl.ptradd %v_1, %v : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:    %v_3 = ptr_xdsl.load %v_2 : !ptr_xdsl.ptr -> vector<8xf32>
 // CHECK-NEXT:  }

--- a/tests/filecheck/transforms/convert_vector_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_vector_to_ptr.mlir
@@ -1,0 +1,13 @@
+// RUN: xdsl-opt -p convert-vector-to-ptr %s | filecheck %s
+
+%m = "test.op"(): () -> memref<16xf32>
+%i = arith.constant 0: index
+%v = vector.load %m[%i]: memref<16xf32>, vector<8xf32>
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %m = "test.op"() : () -> memref<16xf32>
+// CHECK-NEXT:    %i = arith.constant 0 : index
+// CHECK-NEXT:    %v = memref.subview %m[%i] [8] [1] : memref<16xf32> to memref<8xf32>
+// CHECK-NEXT:    %v_1 = builtin.unrealized_conversion_cast %v : memref<8xf32> to !ptr_xdsl.ptr
+// CHECK-NEXT:    %v_2 = ptr_xdsl.load %v_1 : !ptr_xdsl.ptr -> vector<8xf32>
+// CHECK-NEXT:  }

--- a/tests/filecheck/transforms/convert_vector_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_vector_to_ptr.mlir
@@ -29,3 +29,37 @@
 // CHECK-NEXT:   %v0_2 = ptr_xdsl.ptradd %v0_1, %v0 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 // CHECK-NEXT:   %v0_3 = ptr_xdsl.load %v0_2 : !ptr_xdsl.ptr -> vector<8xf32>
 // CHECK-NEXT: }
+
+// -----
+
+%m1 = "test.op"(): () -> memref<2x8xf16>
+%i1 = arith.constant 0: index
+%j1 = arith.constant 0: index
+%v1 = vector.load %m1[%i1,%j1]: memref<2x8xf16>, vector<8xf16>
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %m1 = "test.op"() : () -> memref<2x8xf16>
+// CHECK-NEXT:   %i1 = arith.constant 0 : index
+// CHECK-NEXT:   %j1 = arith.constant 0 : index
+// CHECK-NEXT:   %v1 = affine.apply affine_map<(d0, d1) -> (((d0 * 16) + (d1 * 2)))> (%i1, %j1)
+// CHECK-NEXT:   %v1_1 = ptr_xdsl.to_ptr %m1 : memref<2x8xf16> -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v1_2 = ptr_xdsl.ptradd %v1_1, %v1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v1_3 = ptr_xdsl.load %v1_2 : !ptr_xdsl.ptr -> vector<8xf16>
+// CHECK-NEXT: }
+
+// -----
+
+%m2 = "test.op"(): () -> memref<2x32xf32>
+%i2 = arith.constant 0: index
+%j2 = arith.constant 0: index
+%v2 = vector.load %m2[%i2,%j2]: memref<2x32xf32>, vector<8xf32>
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %m2 = "test.op"() : () -> memref<2x32xf32>
+// CHECK-NEXT:   %i2 = arith.constant 0 : index
+// CHECK-NEXT:   %j2 = arith.constant 0 : index
+// CHECK-NEXT:   %v2 = affine.apply affine_map<(d0, d1) -> (((d0 * 128) + (d1 * 4)))> (%i2, %j2)
+// CHECK-NEXT:   %v2_1 = ptr_xdsl.to_ptr %m2 : memref<2x32xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v2_2 = ptr_xdsl.ptradd %v2_1, %v2 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v2_3 = ptr_xdsl.load %v2_2 : !ptr_xdsl.ptr -> vector<8xf32>
+// CHECK-NEXT: }

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -173,6 +173,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return varith_transformations.ConvertVarithToArithPass
 
+    def get_convert_vector_to_ptr():
+        from xdsl.transforms import convert_vector_to_ptr
+
+        return convert_vector_to_ptr.ConvertVectorToPtrPass
+
     def get_jax_use_donated_arguments():
         from xdsl.transforms import jax_use_donated_arguments
 
@@ -539,6 +544,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "convert-stencil-to-csl-stencil": get_convert_stencil_to_csl_stencil,
         "convert-stencil-to-ll-mlir": get_convert_stencil_to_ll_mlir,
         "convert-varith-to-arith": get_convert_varith_to_arith,
+        "convert-vector-to-ptr": get_convert_vector_to_ptr,
         "jax-use-donated-arguments": get_jax_use_donated_arguments,
         "cse": get_cse,
         "csl-stencil-bufferize": get_csl_stencil_bufferize,

--- a/xdsl/transforms/convert_vector_to_ptr.py
+++ b/xdsl/transforms/convert_vector_to_ptr.py
@@ -5,7 +5,6 @@ from xdsl.dialects import affine, builtin, memref, ptr, vector
 from xdsl.dialects.builtin import (
     AffineMapAttr,
     FixedBitwidthType,
-    NoneAttr,
 )
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -32,13 +31,10 @@ class VectorLoadToPtr(RewritePattern):
         assert isinstance(memory_ty, memref.MemRefType)
 
         # Build an affine.apply to compute the linearized offset
-        layout_map = memory_ty.layout
-        if isinstance(layout_map, NoneAttr):
-            layout_map = AffineMapAttr(affine.AffineMap.identity(len(op.indices)))
-        assert isinstance(layout_map, AffineMapAttr)
+        layout_map = memory_ty.get_affine_map_in_bytes()
         apply_op = affine.ApplyOp(
             map_operands=op.indices,
-            affine_map=layout_map,
+            affine_map=AffineMapAttr(layout_map),
         )
 
         # Compute the linearized offset

--- a/xdsl/transforms/convert_vector_to_ptr.py
+++ b/xdsl/transforms/convert_vector_to_ptr.py
@@ -4,7 +4,6 @@ from xdsl.context import Context
 from xdsl.dialects import builtin, memref, ptr, vector
 from xdsl.dialects.builtin import (
     FixedBitwidthType,
-    UnrealizedConversionCastOp,
 )
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -48,9 +47,9 @@ class VectorLoadToPtr(RewritePattern):
         )
 
         # Build a pointer from the subview
-        cast_op = UnrealizedConversionCastOp.get((subview_op.result,), (ptr.PtrType(),))
+        cast_op = ptr.ToPtrOp(operands=[subview_op], result_types=[ptr.PtrType()])
         # Load a vector from the pointer
-        load_op = ptr.LoadOp(operands=cast_op.outputs, result_types=[vector_ty])
+        load_op = ptr.LoadOp(operands=cast_op.results, result_types=[vector_ty])
 
         rewriter.replace_matched_op([subview_op, cast_op, load_op])
 

--- a/xdsl/transforms/convert_vector_to_ptr.py
+++ b/xdsl/transforms/convert_vector_to_ptr.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+
+from xdsl.context import Context
+from xdsl.dialects import builtin, memref, ptr, vector
+from xdsl.dialects.builtin import (
+    FixedBitwidthType,
+    UnrealizedConversionCastOp,
+)
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    PatternRewriteWalker,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+@dataclass
+class VectorLoadToPtr(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: vector.LoadOp, rewriter: PatternRewriter):
+        # Output vector description
+        vector_ty = op.result.type
+        vector_int_shape = [i.data for i in vector_ty.shape.data]
+        element_type = vector_ty.get_element_type()
+        assert isinstance(element_type, FixedBitwidthType)
+
+        # Input memref description
+        memory = op.base
+        memory_ty = memory.type
+        assert isinstance(memory_ty, memref.MemRefType)
+
+        # Build a subview of the original memref
+        strides = memory_ty.get_strides()
+        static_strides: list[int] = []
+        if strides:
+            static_strides += [s for s in strides if s is not None]
+        subview_type = memref.MemRefType(
+            element_type=element_type, shape=vector_int_shape
+        )
+        subview_op = memref.SubviewOp.get(
+            source=memory,
+            result_type=subview_type,
+            offsets=op.indices,
+            strides=static_strides,
+            sizes=vector_int_shape,
+        )
+
+        # Build a pointer from the subview
+        cast_op = UnrealizedConversionCastOp.get((subview_op.result,), (ptr.PtrType(),))
+        # Load a vector from the pointer
+        load_op = ptr.LoadOp(operands=cast_op.outputs, result_types=[vector_ty])
+
+        rewriter.replace_matched_op([subview_op, cast_op, load_op])
+
+
+@dataclass(frozen=True)
+class ConvertVectorToPtrPass(ModulePass):
+    name = "convert-vector-to-ptr"
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier([VectorLoadToPtr()]),
+            apply_recursively=False,
+        ).rewrite_module(op)


### PR DESCRIPTION
Lowering of ```vector.load``` to the ```ptr``` dialect. The memory indexing is done in the ```memref``` world (using ```subview```) rather than in the ```ptr``` world. This way, the low-level pointer arithmetic, which is error-prone and implementation-dependent, is confined to the lowering passes of the ```memref``` dialect.
