### PR TITLE
backend: remove instruction set name from register types

### DIFF
--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -14,10 +14,6 @@ def test_register_clashes():
         def verify(self) -> None: ...
 
         @classmethod
-        def register_set_name(cls) -> str:
-            return "TEST"
-
-        @classmethod
         def index_by_name(cls) -> dict[str, int]:
             return {"x0": 0}
 
@@ -35,10 +31,6 @@ def test_register_clashes():
 @irdl_attr_definition
 class TestRegister(RegisterType):
     name = "test.reg"
-
-    @classmethod
-    def register_set_name(cls) -> str:
-        return "TEST"
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:
@@ -70,20 +62,20 @@ def test_register_from_string():
     # Infinite prefix but not a number
     with pytest.raises(
         VerifyException,
-        match="Invalid register name yy for register set TEST",
+        match="Invalid register name yy for register type test.reg",
     ):
         TestRegister.from_name("yy")
 
     # Incorrect name
     with pytest.raises(
-        VerifyException, match="Invalid register name z0 for register set TEST"
+        VerifyException, match="Invalid register name z0 for register type test.reg"
     ):
         TestRegister.from_name("z0")
 
 
 def test_invalid_register_name():
     with pytest.raises(
-        VerifyException, match="Invalid register name foo for register set TEST."
+        VerifyException, match="Invalid register name foo for register type test.reg."
     ):
         TestRegister.from_name("foo")
 

--- a/tests/backend/test_register.py
+++ b/tests/backend/test_register.py
@@ -14,7 +14,7 @@ def test_register_clashes():
         def verify(self) -> None: ...
 
         @classmethod
-        def instruction_set_name(cls) -> str:
+        def register_set_name(cls) -> str:
             return "TEST"
 
         @classmethod
@@ -37,7 +37,7 @@ class TestRegister(RegisterType):
     name = "test.reg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "TEST"
 
     @classmethod

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -240,11 +240,11 @@ def test_immediate_shift_inst():
 
 def test_float_register():
     with pytest.raises(
-        VerifyException, match="Invalid register name ft9 for register set RV32I."
+        VerifyException, match="Invalid register name ft9 for register type riscv.reg."
     ):
         riscv.IntRegisterType.from_name("ft9")
     with pytest.raises(
-        VerifyException, match="Invalid register name a0 for register set RV32F."
+        VerifyException, match="Invalid register name a0 for register type riscv.freg."
     ):
         riscv.FloatRegisterType.from_name("a0")
 

--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -58,7 +58,7 @@ def test_unallocated_register():
 def test_register(register: x86.register.GeneralRegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.instruction_set_name() == "x86"
+    assert register.register_set_name() == "x86"
 
 
 def test_rflags_register():
@@ -107,7 +107,7 @@ def test_rflags_register():
 def test_avx512_register(register: x86.register.AVX512RegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.instruction_set_name() == "AVX512"
+    assert register.register_set_name() == "AVX512"
 
 
 @pytest.mark.parametrize(
@@ -134,7 +134,7 @@ def test_avx512_register(register: x86.register.AVX512RegisterType, name: str):
 def test_avx2_register(register: x86.register.AVX2RegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.instruction_set_name() == "AVX2"
+    assert register.register_set_name() == "AVX2"
 
 
 @pytest.mark.parametrize(
@@ -161,7 +161,7 @@ def test_avx2_register(register: x86.register.AVX2RegisterType, name: str):
 def test_sse_register(register: x86.register.SSERegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.instruction_set_name() == "SSE"
+    assert register.register_set_name() == "SSE"
 
 
 @pytest.mark.parametrize(

--- a/tests/dialects/test_x86.py
+++ b/tests/dialects/test_x86.py
@@ -58,7 +58,6 @@ def test_unallocated_register():
 def test_register(register: x86.register.GeneralRegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.register_set_name() == "x86"
 
 
 def test_rflags_register():
@@ -107,7 +106,6 @@ def test_rflags_register():
 def test_avx512_register(register: x86.register.AVX512RegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.register_set_name() == "AVX512"
 
 
 @pytest.mark.parametrize(
@@ -134,7 +132,6 @@ def test_avx512_register(register: x86.register.AVX512RegisterType, name: str):
 def test_avx2_register(register: x86.register.AVX2RegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.register_set_name() == "AVX2"
 
 
 @pytest.mark.parametrize(
@@ -161,7 +158,6 @@ def test_avx2_register(register: x86.register.AVX2RegisterType, name: str):
 def test_sse_register(register: x86.register.SSERegisterType, name: str):
     assert register.is_allocated
     assert register.register_name.data == name
-    assert register.register_set_name() == "SSE"
 
 
 @pytest.mark.parametrize(

--- a/tests/filecheck/dialects/riscv/riscv_registers_invalid.mlir
+++ b/tests/filecheck/dialects/riscv/riscv_registers_invalid.mlir
@@ -21,39 +21,39 @@
 // Invalid integer register name
 "test.op"() : () -> (!riscv.reg<ft0>)
 
-//      CHECK:  Invalid register name ft0 for register set RV32I.
+//      CHECK:  Invalid register name ft0 for register type riscv.reg.
 
 // -----
 
 // Invalid float register name
 "test.op"() : () -> (!riscv.freg<a0>)
 
-//      CHECK:  Invalid register name a0 for register set RV32F.
+//      CHECK:  Invalid register name a0 for register type riscv.freg.
 
 // -----
 
 // Non-existent integer register name
 "test.op"() : () -> (!riscv.reg<x99>)
 
-//      CHECK:  Invalid register name x99 for register set RV32I.
+//      CHECK:  Invalid register name x99 for register type riscv.reg.
 
 // -----
 
 // Non-existent float register name
 "test.op"() : () -> (!riscv.freg<ft99>)
 
-//      CHECK:  Invalid register name ft99 for register set RV32F.
+//      CHECK:  Invalid register name ft99 for register type riscv.freg.
 
 // -----
 
 // Integer register with non-integer suffix
 "test.op"() : () -> (!riscv.reg<j_j>)
 
-//      CHECK:  Invalid register name j_j for register set RV32I.
+//      CHECK:  Invalid register name j_j for register type riscv.reg.
 
 // -----
 
 // Float register with non-integer suffix
 "test.op"() : () -> (!riscv.freg<fj_bla>)
 
-//      CHECK:  Invalid register name fj_bla for register set RV32F.
+//      CHECK:  Invalid register name fj_bla for register type riscv.freg.

--- a/tests/filecheck/dialects/x86/x86_registers_invalid.mlir
+++ b/tests/filecheck/dialects/x86/x86_registers_invalid.mlir
@@ -1,19 +1,19 @@
 // RUN: xdsl-opt %s --split-input-file --verify-diagnostics | filecheck %s
 
-// CHECK: Invalid register name foo for register set x86.
+// CHECK: Invalid register name foo for register type x86.reg.
 "test.op"() { reg = !x86.reg<foo> } : () -> ()
 
 // -----
 
-// CHECK: Invalid register name foo for register set AVX2.
+// CHECK: Invalid register name foo for register type x86.avx2reg.
 "test.op"() { reg = !x86.avx2reg<foo> } : () -> ()
 
 // -----
 
-// CHECK: Invalid register name foo for register set AVX512.
+// CHECK: Invalid register name foo for register type x86.avx512reg.
 "test.op"() { reg = !x86.avx512reg<foo> } : () -> ()
 
 // -----
 
-// CHECK: Invalid register name foo for register set SSE.
+// CHECK: Invalid register name foo for register type x86.ssereg.
 "test.op"() { reg = !x86.ssereg<foo> } : () -> ()

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -112,7 +112,7 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
             if expected_index is None:
                 raise VerifyException(
                     f"Invalid register name {name} for register set "
-                    f"{self.instruction_set_name()}."
+                    f"{self.register_set_name()}."
                 )
             else:
                 raise VerifyException(
@@ -141,7 +141,7 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
 
     @classmethod
     @abstractmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         raise NotImplementedError()
 
     @classmethod

--- a/xdsl/backend/register_type.py
+++ b/xdsl/backend/register_type.py
@@ -111,8 +111,7 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
 
             if expected_index is None:
                 raise VerifyException(
-                    f"Invalid register name {name} for register set "
-                    f"{self.register_set_name()}."
+                    f"Invalid register name {name} for register type {self.name}."
                 )
             else:
                 raise VerifyException(
@@ -138,11 +137,6 @@ class RegisterType(ParametrizedAttribute, TypeAttribute, ABC):
             return
 
         raise VerifyException(f"Invalid index {self.index.data} for register {name}.")
-
-    @classmethod
-    @abstractmethod
-    def register_set_name(cls) -> str:
-        raise NotImplementedError()
 
     @classmethod
     @abstractmethod

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -29,10 +29,6 @@ class IntRegisterType(ARMRegisterType):
     name = "arm.reg"
 
     @classmethod
-    def register_set_name(cls) -> str:
-        return "arm_int"
-
-    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return ARM_INDEX_BY_NAME
 

--- a/xdsl/dialects/arm/register.py
+++ b/xdsl/dialects/arm/register.py
@@ -29,8 +29,8 @@ class IntRegisterType(ARMRegisterType):
     name = "arm.reg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
-        return "arm"
+    def register_set_name(cls) -> str:
+        return "arm_int"
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -38,10 +38,6 @@ class NEONRegisterType(ARMRegisterType):
     name = "arm_neon.reg"
 
     @classmethod
-    def register_set_name(cls) -> str:
-        return "arm_neon"
-
-    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return ARM_NEON_INDEX_BY_NAME
 

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -38,7 +38,7 @@ class NEONRegisterType(ARMRegisterType):
     name = "arm_neon.reg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "arm_neon"
 
     @classmethod

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -154,10 +154,6 @@ class IntRegisterType(RISCVRegisterType):
     name = "riscv.reg"
 
     @classmethod
-    def register_set_name(cls) -> str:
-        return "RV32I"
-
-    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return RV32I_INDEX_BY_NAME
 
@@ -215,10 +211,6 @@ class FloatRegisterType(RISCVRegisterType):
     """
 
     name = "riscv.freg"
-
-    @classmethod
-    def register_set_name(cls) -> str:
-        return "RV32F"
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:

--- a/xdsl/dialects/riscv.py
+++ b/xdsl/dialects/riscv.py
@@ -154,7 +154,7 @@ class IntRegisterType(RISCVRegisterType):
     name = "riscv.reg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "RV32I"
 
     @classmethod
@@ -217,7 +217,7 @@ class FloatRegisterType(RISCVRegisterType):
     name = "riscv.freg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "RV32F"
 
     @classmethod

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -56,7 +56,7 @@ class GeneralRegisterType(X86RegisterType):
     name = "x86.reg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "x86"
 
     @classmethod
@@ -110,8 +110,8 @@ class RFLAGSRegisterType(X86RegisterType):
     name = "x86.rflags"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
-        return "x86"
+    def register_set_name(cls) -> str:
+        return "x86_rflags"
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:
@@ -141,7 +141,7 @@ class SSERegisterType(X86VectorRegisterType):
     name = "x86.ssereg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "SSE"
 
     @classmethod
@@ -205,7 +205,7 @@ class AVX2RegisterType(X86VectorRegisterType):
     name = "x86.avx2reg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "AVX2"
 
     @classmethod
@@ -269,7 +269,7 @@ class AVX512RegisterType(X86VectorRegisterType):
     name = "x86.avx512reg"
 
     @classmethod
-    def instruction_set_name(cls) -> str:
+    def register_set_name(cls) -> str:
         return "AVX512"
 
     @classmethod

--- a/xdsl/dialects/x86/register.py
+++ b/xdsl/dialects/x86/register.py
@@ -56,10 +56,6 @@ class GeneralRegisterType(X86RegisterType):
     name = "x86.reg"
 
     @classmethod
-    def register_set_name(cls) -> str:
-        return "x86"
-
-    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return X86_INDEX_BY_NAME
 
@@ -110,10 +106,6 @@ class RFLAGSRegisterType(X86RegisterType):
     name = "x86.rflags"
 
     @classmethod
-    def register_set_name(cls) -> str:
-        return "x86_rflags"
-
-    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return RFLAGS_INDEX_BY_NAME
 
@@ -139,10 +131,6 @@ class SSERegisterType(X86VectorRegisterType):
     """
 
     name = "x86.ssereg"
-
-    @classmethod
-    def register_set_name(cls) -> str:
-        return "SSE"
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:
@@ -205,10 +193,6 @@ class AVX2RegisterType(X86VectorRegisterType):
     name = "x86.avx2reg"
 
     @classmethod
-    def register_set_name(cls) -> str:
-        return "AVX2"
-
-    @classmethod
     def index_by_name(cls) -> dict[str, int]:
         return AVX2_INDEX_BY_NAME
 
@@ -267,10 +251,6 @@ class AVX512RegisterType(X86VectorRegisterType):
     """
 
     name = "x86.avx512reg"
-
-    @classmethod
-    def register_set_name(cls) -> str:
-        return "AVX512"
 
     @classmethod
     def index_by_name(cls) -> dict[str, int]:


### PR DESCRIPTION
With this change, a register is uniquely identified by its register set name and index, allowing us to do things like disambiguating registers with multiple register names within a register set, as well as reason about overlapping registers in some simple cases.