### PR TITLE
dialects: Add vector.insert and vector.extract operations

### DIFF
--- a/tests/filecheck/dialects/vector/vector_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_ops.mlir
@@ -13,8 +13,7 @@ func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %
 }
 
 
-// CHECK:      builtin.module {
-// CHECK-NEXT:   func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %i : index, %fvec : vector<2xf32>) {
+// CHECK:       func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %i : index, %fvec : vector<2xf32>) {
 // CHECK-NEXT:     %load = vector.load %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
 // CHECK-NEXT:     vector.store %load, %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
 // CHECK-NEXT:     %broadcast = vector.broadcast %i : index to vector<1xindex>
@@ -25,4 +24,85 @@ func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %
 // CHECK-NEXT:     %mask = vector.create_mask %i : vector<2xi1>
 // CHECK-NEXT:     func.return
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
+
+// CHECK-LABEL: @extract_const_idx
+func.func @extract_const_idx(%arg0: vector<4x8x16xf32>)
+                             -> (vector<4x8x16xf32>, vector<8x16xf32>, vector<16xf32>, f32) {
+  // CHECK: vector.extract {{.*}}[] : vector<4x8x16xf32> from vector<4x8x16xf32>
+  %0 = vector.extract %arg0[] : vector<4x8x16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract {{.*}}[3] : vector<8x16xf32> from vector<4x8x16xf32>
+  %1 = vector.extract %arg0[3] : vector<8x16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract {{.*}}[3, 3] : vector<16xf32> from vector<4x8x16xf32>
+  %2 = vector.extract %arg0[3, 3] : vector<16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract {{.*}}[3, 3, 3] : f32 from vector<4x8x16xf32>
+  %3 = vector.extract %arg0[3, 3, 3] : f32 from vector<4x8x16xf32>
+  return %0, %1, %2, %3 : vector<4x8x16xf32>, vector<8x16xf32>, vector<16xf32>, f32
+}
+
+// CHECK-LABEL: @extract_val_idx
+func.func @extract_val_idx(%arg0: vector<4x8x16xf32>, %idx: index)
+                           -> (vector<8x16xf32>, vector<16xf32>, f32) {
+  // CHECK: vector.extract %{{.*}}[%{{.*}}] : vector<8x16xf32> from vector<4x8x16xf32>
+  %0 = vector.extract %arg0[%idx] : vector<8x16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract %{{.*}}[%{{.*}}, %{{.*}}] : vector<16xf32> from vector<4x8x16xf32>
+  %1 = vector.extract %arg0[%idx, %idx] : vector<16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract %{{.*}}[%{{.*}}, 5, %{{.*}}] : f32 from vector<4x8x16xf32>
+  %2 = vector.extract %arg0[%idx, 5, %idx] : f32 from vector<4x8x16xf32>
+  return %0, %1, %2 : vector<8x16xf32>, vector<16xf32>, f32
+}
+
+// CHECK-LABEL: @extract_0d
+func.func @extract_0d(%a: vector<f32>) -> f32 {
+  // CHECK-NEXT: vector.extract %{{.*}}[] : f32 from vector<f32>
+  %0 = vector.extract %a[] : f32 from vector<f32>
+  return %0 : f32
+}
+
+// CHECK-LABEL: @extract_poison_idx
+func.func @extract_poison_idx(%a: vector<4x5xf32>) -> f32 {
+  // CHECK-NEXT: vector.extract %{{.*}}[-1, 0] : f32 from vector<4x5xf32>
+  %0 = vector.extract %a[-1, 0] : f32 from vector<4x5xf32>
+  return %0 : f32
+}
+
+// CHECK-LABEL: @insert_const_idx
+func.func @insert_const_idx(%a: f32, %b: vector<16xf32>, %c: vector<8x16xf32>,
+                            %res: vector<4x8x16xf32>) -> vector<4x8x16xf32> {
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[3] : vector<8x16xf32> into vector<4x8x16xf32>
+  %1 = vector.insert %c, %res[3] : vector<8x16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[3, 3] : vector<16xf32> into vector<4x8x16xf32>
+  %2 = vector.insert %b, %res[3, 3] : vector<16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[3, 3, 3] : f32 into vector<4x8x16xf32>
+  %3 = vector.insert %a, %res[3, 3, 3] : f32 into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[] : vector<4x8x16xf32> into vector<4x8x16xf32>
+  %4 = vector.insert %3, %3[] : vector<4x8x16xf32> into vector<4x8x16xf32>
+  return %4 : vector<4x8x16xf32>
+}
+
+// CHECK-LABEL: @insert_val_idx
+func.func @insert_val_idx(%a: f32, %b: vector<16xf32>, %c: vector<8x16xf32>,
+                          %idx: index, %res: vector<4x8x16xf32>) -> vector<4x8x16xf32> {
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[%{{.*}}] : vector<8x16xf32> into vector<4x8x16xf32>
+  %0 = vector.insert %c, %res[%idx] : vector<8x16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : vector<16xf32> into vector<4x8x16xf32>
+  %1 = vector.insert %b, %res[%idx, %idx] : vector<16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[%{{.*}}, 5, %{{.*}}] : f32 into vector<4x8x16xf32>
+  %2 = vector.insert %a, %res[%idx, 5, %idx] : f32 into vector<4x8x16xf32>
+  return %2 : vector<4x8x16xf32>
+}
+
+// CHECK-LABEL: @insert_0d
+func.func @insert_0d(%a: f32, %b: vector<f32>, %c: vector<2x3xf32>) -> (vector<f32>, vector<2x3xf32>) {
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : f32 into vector<f32>
+  %1 = vector.insert %a,  %b[] : f32 into vector<f32>
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<f32> into vector<2x3xf32>
+  %2 = vector.insert %b,  %c[0, 1] : vector<f32> into vector<2x3xf32>
+  return %1, %2 : vector<f32>, vector<2x3xf32>
+}
+
+// CHECK-LABEL: @insert_poison_idx
+func.func @insert_poison_idx(%a: vector<4x5xf32>, %b: f32) {
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[-1, 0] : f32 into vector<4x5xf32>
+  vector.insert %b, %a[-1, 0] : f32 into vector<4x5xf32>
+  return
+}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/vector/extract.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/vector/extract.mlir
@@ -1,0 +1,35 @@
+// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt | filecheck %s
+
+// CHECK-LABEL: @extract_const_idx
+func.func @extract_const_idx(%arg0: vector<4x8x16xf32>)
+                             -> (vector<4x8x16xf32>, vector<8x16xf32>, vector<16xf32>, f32) {
+  // CHECK: vector.extract {{.*}}[] : vector<4x8x16xf32> from vector<4x8x16xf32>
+  %0 = vector.extract %arg0[] : vector<4x8x16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract {{.*}}[3] : vector<8x16xf32> from vector<4x8x16xf32>
+  %1 = vector.extract %arg0[3] : vector<8x16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract {{.*}}[3, 3] : vector<16xf32> from vector<4x8x16xf32>
+  %2 = vector.extract %arg0[3, 3] : vector<16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract {{.*}}[3, 3, 3] : f32 from vector<4x8x16xf32>
+  %3 = vector.extract %arg0[3, 3, 3] : f32 from vector<4x8x16xf32>
+  return %0, %1, %2, %3 : vector<4x8x16xf32>, vector<8x16xf32>, vector<16xf32>, f32
+}
+
+// CHECK-LABEL: @extract_val_idx
+func.func @extract_val_idx(%arg0: vector<4x8x16xf32>, %idx: index)
+                           -> (vector<8x16xf32>, vector<16xf32>, f32) {
+  // CHECK: vector.extract %{{.*}}[%{{.*}}] : vector<8x16xf32> from vector<4x8x16xf32>
+  %0 = vector.extract %arg0[%idx] : vector<8x16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract %{{.*}}[%{{.*}}, %{{.*}}] : vector<16xf32> from vector<4x8x16xf32>
+  %1 = vector.extract %arg0[%idx, %idx] : vector<16xf32> from vector<4x8x16xf32>
+  // CHECK-NEXT: vector.extract %{{.*}}[%{{.*}}, 5, %{{.*}}] : f32 from vector<4x8x16xf32>
+  %2 = vector.extract %arg0[%idx, 5, %idx] : f32 from vector<4x8x16xf32>
+  return %0, %1, %2 : vector<8x16xf32>, vector<16xf32>, f32
+}
+
+// CHECK-LABEL: @extract_0d
+func.func @extract_0d(%a: vector<f32>) -> f32 {
+  // CHECK-NEXT: vector.extract %{{.*}}[] : f32 from vector<f32>
+  %0 = vector.extract %a[] : f32 from vector<f32>
+  return %0 : f32
+}

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/vector/insert.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/vector/insert.mlir
@@ -1,0 +1,37 @@
+// RUN: xdsl-opt --print-op-generic %s | mlir-opt --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt | filecheck %s
+// RUN: xdsl-opt %s | mlir-opt --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt | filecheck %s
+
+// CHECK-LABEL: @insert_const_idx
+func.func @insert_const_idx(%a: f32, %b: vector<16xf32>, %c: vector<8x16xf32>,
+                            %res: vector<4x8x16xf32>) -> vector<4x8x16xf32> {
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[3] : vector<8x16xf32> into vector<4x8x16xf32>
+  %1 = vector.insert %c, %res[3] : vector<8x16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[3, 3] : vector<16xf32> into vector<4x8x16xf32>
+  %2 = vector.insert %b, %res[3, 3] : vector<16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[3, 3, 3] : f32 into vector<4x8x16xf32>
+  %3 = vector.insert %a, %res[3, 3, 3] : f32 into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[] : vector<4x8x16xf32> into vector<4x8x16xf32>
+  %4 = vector.insert %3, %3[] : vector<4x8x16xf32> into vector<4x8x16xf32>
+  return %4 : vector<4x8x16xf32>
+}
+
+// CHECK-LABEL: @insert_val_idx
+func.func @insert_val_idx(%a: f32, %b: vector<16xf32>, %c: vector<8x16xf32>,
+                          %idx: index, %res: vector<4x8x16xf32>) -> vector<4x8x16xf32> {
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[%{{.*}}] : vector<8x16xf32> into vector<4x8x16xf32>
+  %0 = vector.insert %c, %res[%idx] : vector<8x16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : vector<16xf32> into vector<4x8x16xf32>
+  %1 = vector.insert %b, %res[%idx, %idx] : vector<16xf32> into vector<4x8x16xf32>
+  // CHECK: vector.insert %{{.*}}, %{{.*}}[%{{.*}}, 5, %{{.*}}] : f32 into vector<4x8x16xf32>
+  %2 = vector.insert %a, %res[%idx, 5, %idx] : f32 into vector<4x8x16xf32>
+  return %2 : vector<4x8x16xf32>
+}
+
+// CHECK-LABEL: @insert_0d
+func.func @insert_0d(%a: f32, %b: vector<f32>, %c: vector<2x3xf32>) -> (vector<f32>, vector<2x3xf32>) {
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[] : f32 into vector<f32>
+  %1 = vector.insert %a,  %b[] : f32 into vector<f32>
+  // CHECK-NEXT: vector.insert %{{.*}}, %{{.*}}[0, 1] : vector<f32> into vector<2x3xf32>
+  %2 = vector.insert %b,  %c[0, 1] : vector<f32> into vector<2x3xf32>
+  return %1, %2 : vector<f32>, vector<2x3xf32>
+}

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from xdsl.dialects.builtin import (
     AnyFloatConstr,
+    DenseArrayBase,
+    DenseI64ArrayConstr,
     IndexType,
     IndexTypeConstr,
     MemRefType,
@@ -14,21 +16,29 @@ from xdsl.dialects.builtin import (
     VectorRankConstraint,
     VectorType,
     i1,
+    i64,
 )
+from xdsl.dialects.utils import get_dynamic_index_list, split_dynamic_index_list
 from xdsl.ir import Attribute, Dialect, Operation, SSAValue
 from xdsl.irdl import (
+    AnyAttr,
     IRDLOperation,
     VarConstraint,
     irdl_op_definition,
     operand_def,
     opt_operand_def,
+    prop_def,
     result_def,
     traits_def,
     var_operand_def,
 )
+from xdsl.parser import Parser
+from xdsl.printer import Printer
 from xdsl.traits import Pure
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import assert_isa, isa
+
+DYNAMIC_INDEX: int = -(2**63)
 
 
 @irdl_op_definition
@@ -283,6 +293,94 @@ class CreateMaskOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ExtractOp(IRDLOperation):
+    name = "vector.extract"
+
+    _T: ClassVar = VarConstraint("T", AnyAttr())
+    _V: ClassVar = VarConstraint("V", VectorType.constr(_T))
+
+    static_position = prop_def(DenseI64ArrayConstr)
+
+    vector = operand_def(_V)
+    dynamic_position = var_operand_def(IndexTypeConstr)
+
+    result = result_def(VectorType.constr(_T) | _T)
+
+    traits = traits_def(Pure())
+
+    DYNAMIC_INDEX: ClassVar = DYNAMIC_INDEX
+    """This value is used to indicate that a position is a dynamic index."""
+
+    def get_mixed_position(self) -> list[SSAValue | int]:
+        """
+        Returns the list of positions, represented as either an SSAValue or an int
+        """
+        static_positions = self.static_position.get_values()
+        return get_dynamic_index_list(
+            cast(tuple[int, ...], static_positions),
+            self.dynamic_position,
+            ExtractOp.DYNAMIC_INDEX,
+        )
+
+    def __init__(
+        self,
+        vector: SSAValue,
+        positions: Sequence[SSAValue | int],
+        result_type: Attribute,
+    ):
+        static_positions, dynamic_positions = split_dynamic_index_list(
+            positions, ExtractOp.DYNAMIC_INDEX
+        )
+
+        super().__init__(
+            operands=[vector, dynamic_positions],
+            result_types=[result_type],
+            properties={
+                "static_position": DenseArrayBase.from_list(i64, static_positions)
+            },
+        )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> ExtractOp:
+        # Parse the vector operand
+        vector = parser.parse_unresolved_operand()
+
+        def parse_int_or_value() -> SSAValue | int:
+            value = parser.parse_optional_unresolved_operand()
+            if value is not None:
+                return parser.resolve_operand(value, IndexType())
+            value = parser.parse_optional_integer()
+            if value is not None:
+                return value
+            parser.raise_error("Expected dimension as an integer or a value.")
+
+        # Parse the positions
+        positions = parser.parse_comma_separated_list(
+            Parser.Delimiter.SQUARE, parse_int_or_value
+        )
+
+        # parse the attribute dictionary
+        attr_dict = parser.parse_optional_attr_dict()
+
+        parser.parse_punctuation(":")
+        result_type = parser.parse_type()
+        parser.parse_keyword("from")
+        vector_type = parser.parse_type()
+
+        vector = parser.resolve_operand(vector, vector_type)
+
+        op = ExtractOp(vector, positions, result_type)
+        op.attributes = attr_dict
+        return op
+
+    def print(self, printer: Printer) -> None:
+        # Print the vector operand
+        printer.print(" ", self.vector, "[")
+        printer.print_list(self.get_mixed_position(), printer.print)
+        printer.print("] : ", self.result.type, " from ", self.vector.type)
+
+
+@irdl_op_definition
 class ExtractElementOp(IRDLOperation):
     name = "vector.extractelement"
     vector = operand_def(VectorType)
@@ -321,6 +419,104 @@ class ExtractElementOp(IRDLOperation):
             operands=[vector, position],
             result_types=[result_type],
         )
+
+
+@irdl_op_definition
+class InsertOp(IRDLOperation):
+    name = "vector.insert"
+
+    _T: ClassVar = VarConstraint("T", AnyAttr())
+    _V: ClassVar = VarConstraint("V", VectorType.constr(_T))
+
+    static_position = prop_def(DenseI64ArrayConstr)
+
+    source = operand_def(VectorType.constr(_T) | _T)
+    dest = operand_def(_V)
+    dynamic_position = var_operand_def(IndexTypeConstr)
+
+    result = result_def(_V)
+
+    traits = traits_def(Pure())
+
+    DYNAMIC_INDEX: ClassVar = -(2**63)
+    """This value is used to indicate that a position is a dynamic index."""
+
+    def get_mixed_position(self) -> list[SSAValue | int]:
+        """
+        Returns the list of positions, represented as either an SSAValue or an int.
+        """
+        static_positions = self.static_position.get_values()
+        return get_dynamic_index_list(
+            cast(tuple[int, ...], static_positions),
+            self.dynamic_position,
+            InsertOp.DYNAMIC_INDEX,
+        )
+
+    def __init__(
+        self,
+        source: SSAValue,
+        dest: SSAValue,
+        positions: Sequence[SSAValue | int],
+        result_type: Attribute | None = None,
+    ):
+        static_positions, dynamic_positions = split_dynamic_index_list(
+            positions, InsertOp.DYNAMIC_INDEX
+        )
+
+        if result_type is None:
+            result_type = dest.type
+
+        super().__init__(
+            operands=[source, dest, dynamic_positions],
+            result_types=[result_type],
+            properties={
+                "static_position": DenseArrayBase.from_list(i64, static_positions)
+            },
+        )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> InsertOp:
+        # Parse the value to insert
+        source = parser.parse_unresolved_operand()
+        parser.parse_punctuation(",")
+
+        # Parse the vector operand
+        vector = parser.parse_unresolved_operand()
+
+        def parse_int_or_value() -> SSAValue | int:
+            value = parser.parse_optional_unresolved_operand()
+            if value is not None:
+                return parser.resolve_operand(value, IndexType())
+            value = parser.parse_optional_integer()
+            if value is not None:
+                return value
+            parser.raise_error("Expected dimension as an integer or a value.")
+
+        # Parse the positions
+        positions = parser.parse_comma_separated_list(
+            Parser.Delimiter.SQUARE, parse_int_or_value
+        )
+
+        # parse the attribute dictionary
+        attr_dict = parser.parse_optional_attr_dict()
+
+        parser.parse_punctuation(":")
+        source_type = parser.parse_type()
+        parser.parse_keyword("into")
+        vector_type = parser.parse_type()
+
+        source = parser.resolve_operand(source, source_type)
+        vector = parser.resolve_operand(vector, vector_type)
+
+        op = InsertOp(source, vector, positions, vector_type)
+        op.attributes = attr_dict
+        return op
+
+    def print(self, printer: Printer) -> None:
+        # Print the vector operand
+        printer.print(" ", self.source, ", ", self.dest, "[")
+        printer.print_list(self.get_mixed_position(), printer.print)
+        printer.print("] : ", self.source.type, " into ", self.dest.type)
 
 
 @irdl_op_definition
@@ -381,7 +577,9 @@ Vector = Dialect(
         MaskedStoreOp,
         PrintOp,
         CreateMaskOp,
+        ExtractOp,
         ExtractElementOp,
+        InsertOp,
         InsertElementOp,
     ],
     [],


### PR DESCRIPTION
Stacked PRs:
 * #4202
 * __->__#4201


--- --- ---

### dialects: Add vector.insert and vector.extract operations


These operations are defined in MLIR and are meant to replace
vector.insertelement and vector.extractelement.
