### PR TITLE
core: TestSSAValue depends on pytest, which is an optional depedency

### DIFF
--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -14,7 +14,6 @@ from xdsl.ir import (
     Region,
     SSAValue,
 )
-from xdsl.utils.test_value import TestSSAValue
 
 
 @dataclass(frozen=True)
@@ -202,8 +201,7 @@ class Rewriter:
                 *args[index + 1 :],
             )
         else:
-            assert isinstance(val, TestSSAValue)
-            new_value = TestSSAValue(new_type)
+            new_value = val.__class__(new_type)
 
         new_value.name_hint = val.name_hint
         val.replace_by(new_value)


### PR DESCRIPTION
Resolves #4203.

I'm not sure if this is a good permanent solution as it removes an `assert` statement and I don't have full context on what the original code was doing, but at the very least this makes it possible to `import xdsl.dialects.arith` with only the core dependencies.