### PR TITLE
dialects: (builtin) add get_scalable_dims to vector type

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -474,6 +474,10 @@ def test_vector_constructor(
     assert vec.get_num_dims() == len(dims)
     assert vec.get_num_scalable_dims() == num_scalable_dims
     assert vec.get_shape() == dims
+    if scalable_dims is not None:
+        assert vec.get_scalable_dims() == tuple(scalable_dims)
+    else:
+        assert vec.get_scalable_dims() == (False,) * len(dims)
 
 
 @pytest.mark.parametrize(

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1081,6 +1081,9 @@ class VectorType(
     def get_element_type(self) -> AttributeCovT:
         return self.element_type
 
+    def get_scalable_dims(self) -> tuple[bool, ...]:
+        return tuple(bool(i) for i in self.scalable_dims)
+
     def verify(self):
         num_dims = len(self.shape)
         num_scalable_dims = len(self.scalable_dims)


### PR DESCRIPTION
Useful for some upcoming vector op implementations.