### PR TITLE
bench: add parsing benchmarks using existing workloads

### DIFF
--- a/benchmarks/parser.py
+++ b/benchmarks/parser.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Benchmarks for the parser of the xDSL implementation."""
+
+from benchmarks.workloads import WorkloadBuilder
+from xdsl.context import Context
+from xdsl.dialects.arith import Arith
+from xdsl.dialects.builtin import Builtin
+from xdsl.parser import Parser as XdslParser
+
+CTX = Context(allow_unregistered=True)
+CTX.load_dialect(Arith)
+CTX.load_dialect(Builtin)
+
+
+class Parser:
+    """Benchmark the xDSL parser on MLIR files."""
+
+    WORKLOAD_CONSTANT_100 = WorkloadBuilder.constant_folding(100)
+    WORKLOAD_CONSTANT_1000 = WorkloadBuilder.constant_folding(1000)
+    WORKLOAD_LARGE_DENSE_ATTR = WorkloadBuilder.large_dense_attr()
+    WORKLOAD_LARGE_DENSE_ATTR_HEX = WorkloadBuilder.large_dense_attr_hex()
+
+    def time_constant_100(self) -> None:
+        """Time lexing constant folding for 100 items."""
+        XdslParser(CTX, Parser.WORKLOAD_CONSTANT_100).parse_module()
+
+    def time_constant_1000(self) -> None:
+        """Time lexing constant folding for 1000 items."""
+        XdslParser(CTX, Parser.WORKLOAD_CONSTANT_1000).parse_module()
+
+    def ignore_time_dense_attr(self) -> None:
+        """Time lexing a 1024x1024xi8 dense attribute."""
+        XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR).parse_module()
+
+    def ignore_time_dense_attr_hex(self) -> None:
+        """Time lexing a 1024x1024xi8 dense attribute given as a hex string."""
+        XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR_HEX).parse_module()
+
+
+if __name__ == "__main__":
+    from bench_utils import Benchmark, profile
+
+    PARSER = Parser()
+    profile(
+        {
+            "Parser.constant_100": Benchmark(PARSER.time_constant_100),
+            "Parser.constant_1000": Benchmark(PARSER.time_constant_1000),
+            "Parser.dense_attr": Benchmark(PARSER.ignore_time_dense_attr),
+            "Parser.dense_attr_hex": Benchmark(PARSER.ignore_time_dense_attr_hex),
+        }
+    )

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -104,8 +104,11 @@ class WorkloadBuilder:
         assert x >= 0
         assert y >= 0
         random.seed(RANDOM_SEED)
-        # Each dense attr item is a byte = 2 hex chars
-        dense_attr_hex = "".join(random.choice(HEX_CHARS) for _ in range(x * y * 2))
+        # In order to guarantee the hex value encodes a valid i8 tensor without
+        # significant logic coupled to the hex implementation, we set all values
+        # to zero. Each dense attr item is a byte is 2 hex chars, so we need
+        # x * y * 2 characters.
+        dense_attr_hex = "0" * x * y * 2
         ops = [
             (
                 '%0 = "arith.constant"() '

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -104,15 +104,12 @@ class WorkloadBuilder:
         assert x >= 0
         assert y >= 0
         random.seed(RANDOM_SEED)
-        # In order to guarantee the hex value encodes a valid i8 tensor without
-        # significant logic coupled to the hex implementation, we set all values
-        # to zero. Each dense attr item is a byte is 2 hex chars, so we need
-        # x * y * 2 characters.
-        dense_attr_hex = "0" * x * y * 2
+        # Each dense attr item is a byte = 2 hex chars
+        dense_attr_hex = "".join(random.choice(HEX_CHARS) for _ in range(x * y * 2))
         ops = [
             (
                 '%0 = "arith.constant"() '
-                f"<{{value = dense<0x{dense_attr_hex}> "
+                f'<{{value = dense<"0x{dense_attr_hex}"> '
                 f": tensor<{x}x{y}xi8>}}> : () -> tensor<{x}x{y}xi8>"
             )
         ]

--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -39,6 +39,8 @@
     %x17 = "arith.constant"() {"value" = 0 : i64, "test" = 0 : i0} : () -> i64
     // CHECK:  %x18 = arith.constant {array = array<i8: -1>, dense = dense<-1> : vector<i8>, test = -1 : i8} -1 : i8
     %x18 = arith.constant {"array" = array<i8: 255>, "dense" = dense<255> : vector<i8>, "test" = 255 : i8} -1 : i8
+    // CHECK: %x19 = arith.constant dense<[[-51, 24, -4], [-97, -74, 73], [67, -124, -109]]> : tensor<3x3xi8>
+    %x19 = arith.constant dense<"0xCD18FC9FB649438493"> : tensor<3x3xi8>
     "func.return"() : () -> ()
   }) {"function_type" = () -> (), "sym_name" = "builtin"} : () -> ()
   "test.op"() {"value"= {"one"=1 : i64, "two"=2 : i64, "three"="three"}} : () -> ()


### PR DESCRIPTION
Add parsing benchmarks using existing workloads, peeled from #4008