### PR TITLE
bench: add printing benchmarks using existing workloads

### DIFF
--- a/benchmarks/parser.py
+++ b/benchmarks/parser.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Benchmarks for the parser of the xDSL implementation."""
+
+from benchmarks.workloads import WorkloadBuilder
+from xdsl.context import Context
+from xdsl.dialects.arith import Arith
+from xdsl.dialects.builtin import Builtin
+from xdsl.parser import Parser as XdslParser
+
+CTX = Context(allow_unregistered=True)
+CTX.load_dialect(Arith)
+CTX.load_dialect(Builtin)
+
+
+class Parser:
+    """Benchmark the xDSL parser on MLIR files."""
+
+    WORKLOAD_CONSTANT_100 = WorkloadBuilder.constant_folding(100)
+    WORKLOAD_CONSTANT_1000 = WorkloadBuilder.constant_folding(1000)
+    WORKLOAD_LARGE_DENSE_ATTR = WorkloadBuilder.large_dense_attr()
+    WORKLOAD_LARGE_DENSE_ATTR_HEX = WorkloadBuilder.large_dense_attr_hex()
+
+    def time_constant_100(self) -> None:
+        """Time lexing constant folding for 100 items."""
+        XdslParser(CTX, Parser.WORKLOAD_CONSTANT_100).parse_module()
+
+    def time_constant_1000(self) -> None:
+        """Time lexing constant folding for 1000 items."""
+        XdslParser(CTX, Parser.WORKLOAD_CONSTANT_1000).parse_module()
+
+    def ignore_time_dense_attr(self) -> None:
+        """Time lexing a 1024x1024xi8 dense attribute."""
+        XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR).parse_module()
+
+    def ignore_time_dense_attr_hex(self) -> None:
+        """Time lexing a 1024x1024xi8 dense attribute given as a hex string."""
+        XdslParser(CTX, Parser.WORKLOAD_LARGE_DENSE_ATTR_HEX).parse_module()
+
+
+if __name__ == "__main__":
+    from bench_utils import Benchmark, profile
+
+    PARSER = Parser()
+    profile(
+        {
+            "Parser.constant_100": Benchmark(PARSER.time_constant_100),
+            "Parser.constant_1000": Benchmark(PARSER.time_constant_1000),
+            "Parser.dense_attr": Benchmark(PARSER.ignore_time_dense_attr),
+            "Parser.dense_attr_hex": Benchmark(PARSER.ignore_time_dense_attr_hex),
+        }
+    )

--- a/benchmarks/printer.py
+++ b/benchmarks/printer.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Benchmarks for the printer of the xDSL implementation."""
+
+from io import StringIO
+
+from benchmarks.workloads import WorkloadBuilder
+from xdsl.printer import Printer as XdslPrinter
+
+MODULE_PRINTER = XdslPrinter(stream=StringIO())
+
+
+class Printer:
+    """Benchmark the xDSL printer on MLIR files."""
+
+    WORKLOAD_CONSTANT_100 = WorkloadBuilder.constant_folding_module(100)
+    WORKLOAD_CONSTANT_1000 = WorkloadBuilder.constant_folding_module(1000)
+    WORKLOAD_LARGE_DENSE_ATTR = WorkloadBuilder.large_dense_attr_module()
+
+    def time_constant_100(self) -> None:
+        """Time lexing constant folding for 100 items."""
+        MODULE_PRINTER.print_op(Printer.WORKLOAD_CONSTANT_100)
+
+    def time_constant_1000(self) -> None:
+        """Time lexing constant folding for 1000 items."""
+        MODULE_PRINTER.print_op(Printer.WORKLOAD_CONSTANT_1000)
+
+    def time_dense_attr(self) -> None:
+        """Time lexing a 1024x1024xi8 dense attribute given as a hex string."""
+        MODULE_PRINTER.print_op(Printer.WORKLOAD_LARGE_DENSE_ATTR)
+
+
+if __name__ == "__main__":
+    from bench_utils import Benchmark, profile
+
+    PRINTER = Printer()
+    profile(
+        {
+            "Printer.constant_100": Benchmark(PRINTER.time_constant_100),
+            "Printer.constant_1000": Benchmark(PRINTER.time_constant_1000),
+            "Printer.dense_attr": Benchmark(PRINTER.time_dense_attr),
+        }
+    )

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -104,8 +104,11 @@ class WorkloadBuilder:
         assert x >= 0
         assert y >= 0
         random.seed(RANDOM_SEED)
-        # Each dense attr item is a byte = 2 hex chars
-        dense_attr_hex = "".join(random.choice(HEX_CHARS) for _ in range(x * y * 2))
+        # In order to guarantee the hex value encodes a valid i8 tensor without
+        # significant logic coupled to the hex implementation, we set all values
+        # to zero. Each dense attr item is a byte is 2 hex chars, so we need
+        # x * y * 2 characters.
+        dense_attr_hex = "0" * x * y * 2
         ops = [
             (
                 '%0 = "arith.constant"() '

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -73,7 +73,7 @@ class WorkloadBuilder:
     @classmethod
     def large_dense_attr(cls, x: int = 1024, y: int = 1024) -> str:
         """Get the MLIR text representation of a large dense attr."""
-        return cls.large_dense_attr_module.__str__()
+        return cls.large_dense_attr_module(x=x, y=y).__str__()
 
     @classmethod
     def large_dense_attr_module(cls, x: int = 1024, y: int = 1024) -> ModuleOp:

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -3,6 +3,18 @@
 
 import random
 
+from xdsl.dialects.arith import AddiOp, ConstantOp
+from xdsl.dialects.builtin import (
+    DenseIntOrFPElementsAttr,
+    IntegerAttr,
+    ModuleOp,
+    TensorType,
+    i8,
+    i32,
+)
+from xdsl.dialects.test import TestOp
+from xdsl.ir import Operation
+
 RANDOM_SEED = 0
 HEX_CHARS = "0123456789ABCDEF"
 
@@ -22,11 +34,12 @@ class WorkloadBuilder:
         return WorkloadBuilder.wrap_module([])
 
     @classmethod
-    def constant_folding(cls, size: int = 100) -> str:
+    def constant_folding_module(cls, size: int = 100) -> ModuleOp:
         """Generate a constant folding workload of a given size.
 
-        An example of running `WorkloadBuilder().constant_folding(size=5)`
-        is as follows:
+        The output of running the command
+        `print(WorkloadBuilder().constant_folding_module(size=5))` is shown
+        below:
 
         ```mlir
         "builtin.module"() ({
@@ -42,29 +55,32 @@ class WorkloadBuilder:
         """
         assert size >= 0
         random.seed(RANDOM_SEED)
-        ops: list[str] = []
-        ops.append(
-            '%0 = "arith.constant"() {"value" = '
-            f"{random.randint(1, 1000)} : i32}} : () -> i32"
-        )
+        ops: list[Operation] = []
+        ops.append(ConstantOp(IntegerAttr(random.randint(1, 1000), i32)))
         for i in range(1, size + 1):
             if i % 2 == 0:
-                ops.append(
-                    f'%{i} = "arith.addi"(%{i - 1}, %{i - 2}) : (i32, i32) -> i32'
-                )
+                ops.append(AddiOp(ops[i - 1], ops[i - 2]))
             else:
-                ops.append(
-                    f'%{i} = "arith.constant"() {{"value" = '
-                    f"{random.randint(1, 1000)} : i32}} : () -> i32"
-                )
-        ops.append(f'"test.op"(%{(size // 2) * 2}) : (i32) -> ()')
-        return WorkloadBuilder.wrap_module(ops)
+                ops.append(ConstantOp(IntegerAttr(random.randint(1, 1000), i32)))
+        ops.append(TestOp([ops[(size // 2) * 2]]))
+        return ModuleOp(ops)
+
+    @classmethod
+    def constant_folding(cls, size: int = 100) -> str:
+        """Generate a constant folding workload of a given size."""
+        return cls.constant_folding_module(size=size).__str__()
 
     @classmethod
     def large_dense_attr(cls, x: int = 1024, y: int = 1024) -> str:
+        """Get the MLIR text representation of a large dense attr."""
+        return cls.large_dense_attr_module.__str__()
+
+    @classmethod
+    def large_dense_attr_module(cls, x: int = 1024, y: int = 1024) -> ModuleOp:
         """Get the MLIR text representation of a large dense attr.
 
-        An example of running `WorkloadBuilder().large_dense_attr(x=3, y=3)`
+        An example of running
+        `print(WorkloadBuilder().large_dense_attr_module(x=3, y=3))`
         is as follows:
 
         ```mlir
@@ -77,15 +93,17 @@ class WorkloadBuilder:
         assert x >= 0
         assert y >= 0
         random.seed(RANDOM_SEED)
-        dense_attr = [[random.randint(-128, 128) for _ in range(x)] for _ in range(y)]
-        ops = [
-            (
-                '%0 = "arith.constant"() '
-                f"<{{value = dense<{dense_attr}> "
-                f": tensor<{x}x{y}xi8>}}> : () -> tensor<{x}x{y}xi8>"
-            )
-        ]
-        return WorkloadBuilder.wrap_module(ops)
+        dense_attr = [random.randint(-128, 128) for _ in range(x * y)]
+        tensor_type = TensorType(element_type=i8, shape=[x, y])
+        return ModuleOp(
+            [
+                ConstantOp(
+                    DenseIntOrFPElementsAttr.from_list(
+                        type=tensor_type, data=dense_attr
+                    )
+                )
+            ]
+        )
 
     @classmethod
     def large_dense_attr_hex(cls, x: int = 1024, y: int = 1024) -> str:
@@ -97,7 +115,7 @@ class WorkloadBuilder:
         ```mlir
         "builtin.module"() ({
             %0 = "arith.constant"() <{
-                value = dense<0xCD18FC9FB649438493> : tensor<3x3xi8>
+                value = dense<0x000000000000000000> : tensor<3x3xi8>
             }> : () -> tensor<3x3xi8>
         }) : () -> ()
         """

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -115,7 +115,7 @@ class WorkloadBuilder:
         ```mlir
         "builtin.module"() ({
             %0 = "arith.constant"() <{
-                value = dense<0x000000000000000000> : tensor<3x3xi8>
+                value = dense<0xCD18FC9FB649438493> : tensor<3x3xi8>
             }> : () -> tensor<3x3xi8>
         }) : () -> ()
         """

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -68,12 +68,12 @@ class WorkloadBuilder:
     @classmethod
     def constant_folding(cls, size: int = 100) -> str:
         """Generate a constant folding workload of a given size."""
-        return cls.constant_folding_module(size=size).__str__()
+        return str(cls.constant_folding_module(size=size))
 
     @classmethod
     def large_dense_attr(cls, x: int = 1024, y: int = 1024) -> str:
         """Get the MLIR text representation of a large dense attr."""
-        return cls.large_dense_attr_module(x=x, y=y).__str__()
+        return str(cls.large_dense_attr_module(x=x, y=y))
 
     @classmethod
     def large_dense_attr_module(cls, x: int = 1024, y: int = 1024) -> ModuleOp:

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -3,6 +3,7 @@ import pytest
 from xdsl.dialects.builtin import StringAttr, i32
 from xdsl.ir import Block, BlockArgument, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, result_def
+from xdsl.utils.test_value import TestSSAValue
 
 
 @irdl_op_definition
@@ -59,3 +60,11 @@ def test_invalid_ssa_vals(name: str):
     val = BlockArgument(i32, Block(), 0)
     with pytest.raises(ValueError):
         val.name_hint = name
+
+
+def test_owner():
+    val = TestSSAValue(i32)
+    with pytest.raises(
+        ValueError, match="Attempting to get the owner of a `TestSSAValue`"
+    ):
+        val.owner

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -6,6 +6,4 @@ from xdsl.ir import AttributeCovT, Block, Operation, SSAValue
 class TestSSAValue(Generic[AttributeCovT], SSAValue[AttributeCovT]):
     @property
     def owner(self) -> Operation | Block:
-        import pytest
-
-        pytest.fail("Attempting to get the owner of a `TestSSAValue`")
+        raise ValueError("Attempting to get the owner of a `TestSSAValue`")


### PR DESCRIPTION
Add printing benchmarks using existing workloads, peeled from #4008. This includes changes to workload generation for more efficient setup.