### PR TITLE
testing: replace TestSSAValue class with create_ssa_value helper

### DIFF
--- a/tests/backend/riscv/test_func_to_riscv_func.py
+++ b/tests/backend/riscv/test_func_to_riscv_func.py
@@ -8,7 +8,7 @@ from xdsl.context import Context
 from xdsl.dialects import func
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.test import TestType
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 NINE_TYPES = [TestType("misc")] * 9
 THREE_TYPES = [TestType("misc")] * 3
@@ -45,7 +45,7 @@ def test_return_too_many_values_failure():
     @Builder.implicit_region
     def non_empty_return():
         with ImplicitBuilder(func.FuncOp("main", ((), ())).body):
-            func.ReturnOp(*(TestSSAValue(t) for t in THREE_TYPES))
+            func.ReturnOp(*(create_ssa_value(t) for t in THREE_TYPES))
 
     with pytest.raises(
         ValueError, match="Cannot lower func.return with more than 2 arguments"
@@ -58,7 +58,7 @@ def test_call_too_many_operands_failure():
     @Builder.implicit_region
     def non_empty_return():
         with ImplicitBuilder(func.FuncOp("main", ((), ())).body):
-            func.CallOp("foo", [TestSSAValue(t) for t in NINE_TYPES], ())
+            func.CallOp("foo", [create_ssa_value(t) for t in NINE_TYPES], ())
             func.ReturnOp()
 
     with pytest.raises(

--- a/tests/backend/riscv/test_utils.py
+++ b/tests/backend/riscv/test_utils.py
@@ -9,7 +9,7 @@ from xdsl.builder import Builder
 from xdsl.dialects import builtin, memref, riscv, test
 from xdsl.ir import BlockArgument
 from xdsl.pattern_rewriter import PatternRewriter
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 INDEX_TYPE = builtin.IndexType()
 REGISTER_TYPE = riscv.Registers.UNALLOCATED_INT
@@ -158,9 +158,9 @@ def test_a_regs():
     assert list(
         a_regs(
             (
-                TestSSAValue(riscv.Registers.FT0),
-                TestSSAValue(riscv.Registers.FT0),
-                TestSSAValue(riscv.Registers.T0),
+                create_ssa_value(riscv.Registers.FT0),
+                create_ssa_value(riscv.Registers.FT0),
+                create_ssa_value(riscv.Registers.T0),
             )
         )
     ) == [riscv.Registers.FA0, riscv.Registers.FA1, riscv.Registers.A0]

--- a/tests/backend/wgsl/test_wgsl_printer.py
+++ b/tests/backend/wgsl/test_wgsl_printer.py
@@ -3,7 +3,7 @@ from io import StringIO
 from xdsl.backend.wgsl.wgsl_printer import WGSLPrinter
 from xdsl.dialects import arith, gpu, memref, test
 from xdsl.dialects.builtin import IndexType, IntegerAttr, IntegerType, i32
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 lhs_op = test.TestOp(result_types=[IndexType()])
 rhs_op = test.TestOp(result_types=[IndexType()])
@@ -146,7 +146,7 @@ def test_memref_load():
     printer = WGSLPrinter(stream=file)
 
     memref_type = memref.MemRefType(i32, [10, 10])
-    memref_val = TestSSAValue(memref_type)
+    memref_val = create_ssa_value(memref_type)
     load = memref.LoadOp.get(memref_val, [lhs_op.res[0], rhs_op.res[0]])
     printer.print(load)
 
@@ -158,7 +158,7 @@ def test_memref_store():
     printer = WGSLPrinter(stream=file)
 
     memref_type = memref.MemRefType(i32, [10, 10])
-    memref_val = TestSSAValue(memref_type)
+    memref_val = create_ssa_value(memref_type)
     load = memref.LoadOp.get(memref_val, [lhs_op.res[0], rhs_op.res[0]])
     store = memref.StoreOp.get(load.res, memref_val, [lhs_op.res[0], rhs_op.res[0]])
     printer.print(store)

--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -71,7 +71,7 @@ from xdsl.ir import Attribute
 from xdsl.irdl import base
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.isattr import isattr
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 _BinOpArgT = TypeVar("_BinOpArgT", bound=Attribute)
 
@@ -183,8 +183,8 @@ def test_addui_extend(
     sum_type: Attribute | None,
     is_correct: bool,
 ):
-    lhs = TestSSAValue(lhs_type)
-    rhs = TestSSAValue(rhs_type)
+    lhs = create_ssa_value(lhs_type)
+    rhs = create_ssa_value(rhs_type)
 
     attributes = {"foo": i32}
 
@@ -212,8 +212,8 @@ def test_addui_extend(
 
 @pytest.mark.parametrize("op_type", [MulSIExtendedOp, MulUIExtendedOp])
 def test_mul_extended(op_type: type[MulSIExtendedOp | MulUIExtendedOp]):
-    lhs = TestSSAValue(i32)
-    rhs = TestSSAValue(i32)
+    lhs = create_ssa_value(i32)
+    rhs = create_ssa_value(i32)
 
     op = op_type(lhs, rhs)
 
@@ -282,7 +282,7 @@ def test_select_op():
     ],
 )
 def test_bitcast_op(in_type: Attribute, out_type: Attribute):
-    in_arg = TestSSAValue(in_type)
+    in_arg = create_ssa_value(in_type)
     cast = BitcastOp(in_arg, out_type)
 
     cast.verify_()
@@ -310,7 +310,7 @@ BITWIDTH_MISMATCH = "operand and result types must have equal bitwidths or be In
     ],
 )
 def test_bitcast_incorrect(in_type: Attribute, out_type: Attribute, err_msg: str):
-    in_arg = TestSSAValue(in_type)
+    in_arg = create_ssa_value(in_type)
     cast = BitcastOp(in_arg, out_type)
 
     with pytest.raises(VerifyException, match=err_msg):

--- a/tests/dialects/test_comb.py
+++ b/tests/dialects/test_comb.py
@@ -13,12 +13,12 @@ from xdsl.dialects.comb import (
 )
 from xdsl.dialects.test import TestOp, TestType
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_icmp_incorrect_comparison():
-    a = TestSSAValue(i32)
-    b = TestSSAValue(i32)
+    a = create_ssa_value(i32)
+    b = create_ssa_value(i32)
 
     with pytest.raises(VerifyException) as e:
         # 'slet' is an invalid comparison operation
@@ -27,10 +27,10 @@ def test_icmp_incorrect_comparison():
 
 
 def test_comb_concat_builder():
-    a = TestSSAValue(IntegerType(5))
-    b = TestSSAValue(IntegerType(3))
-    c = TestSSAValue(IntegerType(1))
-    foo = TestSSAValue(TestType("foo"))
+    a = create_ssa_value(IntegerType(5))
+    b = create_ssa_value(IntegerType(3))
+    c = create_ssa_value(IntegerType(1))
+    foo = create_ssa_value(TestType("foo"))
 
     concat = ConcatOp.from_int_values([a, b, c])
     assert concat is not None
@@ -63,8 +63,8 @@ def test_comb_concat_verifier():
     ],
 )
 def test_comb_variadic_builder_verifier(ctor: type[VariadicCombOperation]):
-    a = TestSSAValue(IntegerType(5))
-    b = TestSSAValue(IntegerType(6))
+    a = create_ssa_value(IntegerType(5))
+    b = create_ssa_value(IntegerType(6))
 
     ctor([a]).verify()
     ctor([a, a]).verify()

--- a/tests/dialects/test_csl.py
+++ b/tests/dialects/test_csl.py
@@ -3,10 +3,10 @@ import pytest
 from xdsl.dialects.builtin import Float32Type, IntegerType, Signedness, TensorType
 from xdsl.dialects.csl import Add16Op, DsdKind, DsdType, GetMemDsdOp
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
-tensor = TestSSAValue(TensorType(Float32Type(), [4]))
-size_i32 = TestSSAValue(IntegerType(32, Signedness.SIGNED))
+tensor = create_ssa_value(TensorType(Float32Type(), [4]))
+size_i32 = create_ssa_value(IntegerType(32, Signedness.SIGNED))
 dest_dsd = GetMemDsdOp(
     operands=[tensor, size_i32], result_types=[DsdType(DsdKind.mem1d_dsd)]
 )
@@ -16,8 +16,8 @@ src_dsd1 = GetMemDsdOp(
 src_dsd2 = GetMemDsdOp(
     operands=[tensor, size_i32], result_types=[DsdType(DsdKind.mem1d_dsd)]
 )
-i16_value = TestSSAValue(IntegerType(16, Signedness.SIGNED))
-u16_value = TestSSAValue(IntegerType(16, Signedness.UNSIGNED))
+i16_value = create_ssa_value(IntegerType(16, Signedness.SIGNED))
+u16_value = create_ssa_value(IntegerType(16, Signedness.UNSIGNED))
 
 
 def test_verify_valid_builtin_signature():

--- a/tests/dialects/test_csl_stencil.py
+++ b/tests/dialects/test_csl_stencil.py
@@ -3,13 +3,13 @@ from xdsl.dialects.builtin import IntegerAttr, IntegerType, MemRefType, TensorTy
 from xdsl.dialects.csl.csl_stencil import AccessOp, ApplyOp
 from xdsl.dialects.stencil import IndexAttr, TempType
 from xdsl.ir import Region, SSAValue
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_access_patterns():
     temp_t = TempType(5, f32)
-    temp = TestSSAValue(temp_t)
-    mref = TestSSAValue(mref_t := MemRefType(tens_t := TensorType(f32, (5,)), (4,)))
+    temp = create_ssa_value(temp_t)
+    mref = create_ssa_value(mref_t := MemRefType(tens_t := TensorType(f32, (5,)), (4,)))
 
     @Builder.implicit_region((mref_t, temp_t))
     def region0(args: tuple[SSAValue, ...]):

--- a/tests/dialects/test_hw.py
+++ b/tests/dialects/test_hw.py
@@ -46,7 +46,7 @@ from xdsl.traits import (
     ensure_terminator,
 )
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_inner_sym_target():
@@ -352,7 +352,7 @@ hw.module @module(in %foo: i32, in %bar: i64, out baz: i32, out qux: i64) {
         inst_op := InstanceOp(
             "test",
             SymbolRefAttr("module"),
-            (("foo", TestSSAValue(i32)), ("bar", TestSSAValue(i64))),
+            (("foo", create_ssa_value(i32)), ("bar", create_ssa_value(i64))),
             (("baz", i32), ("qux", i64)),
         )
     )

--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -24,7 +24,7 @@ from xdsl.dialects.irdl.irdl import VariadicityArrayAttr, VariadicityAttr
 from xdsl.ir import Block, Region
 from xdsl.irdl import IRDLOperation, irdl_op_definition
 from xdsl.utils.exceptions import PyRDLOpDefinitionError
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 @pytest.mark.parametrize("op_type", [DialectOp, TypeOp, AttributeOp, OperationOp])
@@ -52,8 +52,8 @@ def test_parameter_op_init():
     Test __init__ of ParametersOp.
     """
 
-    val1 = TestSSAValue(AttributeType())
-    val2 = TestSSAValue(AttributeType())
+    val1 = create_ssa_value(AttributeType())
+    val2 = create_ssa_value(AttributeType())
     op = ParametersOp([val1, val2])
     op2 = ParametersOp.create(operands=[val1, val2])
 
@@ -68,8 +68,8 @@ def test_parameters_init(op_type: type[OperandsOp | ResultsOp]):
     Test __init__ of OperandsOp, ResultsOp.
     """
 
-    val1 = TestSSAValue(AttributeType())
-    val2 = TestSSAValue(AttributeType())
+    val1 = create_ssa_value(AttributeType())
+    val2 = create_ssa_value(AttributeType())
     op = op_type([(VariadicityAttr.SINGLE, val1), (VariadicityAttr.OPTIONAL, val2)])
     op2 = op_type.create(
         operands=[val1, val2],
@@ -117,8 +117,8 @@ def test_base_init():
 
 def test_parametric_init():
     """Test __init__ of ParametricOp."""
-    val1 = TestSSAValue(AttributeType())
-    val2 = TestSSAValue(AttributeType())
+    val1 = create_ssa_value(AttributeType())
+    val2 = create_ssa_value(AttributeType())
 
     op = ParametricOp("complex", [val1, val2])
     op2 = ParametricOp(StringAttr("complex"), [val1, val2])
@@ -150,8 +150,8 @@ def test_any_init():
 @pytest.mark.parametrize("op_type", [AllOfOp, AnyOfOp])
 def test_any_all_of_init(op_type: type[AllOfOp | AnyOfOp]):
     """Test __init__ of AnyOf and AllOf."""
-    val1 = TestSSAValue(AttributeType())
-    val2 = TestSSAValue(AttributeType())
+    val1 = create_ssa_value(AttributeType())
+    val2 = create_ssa_value(AttributeType())
     op = op_type((val1, val2))
     op2 = op_type.create(operands=[val1, val2], result_types=[AttributeType()])
 

--- a/tests/dialects/test_llvm.py
+++ b/tests/dialects/test_llvm.py
@@ -7,7 +7,7 @@ from xdsl.dialects.builtin import UnitAttr, i32
 from xdsl.ir import Attribute
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 @pytest.mark.parametrize(
@@ -297,9 +297,9 @@ def test_variadic_func():
 
 def test_inline_assembly_op():
     a, b, c = (
-        TestSSAValue(builtin.i32),
-        TestSSAValue(builtin.i32),
-        TestSSAValue(builtin.i32),
+        create_ssa_value(builtin.i32),
+        create_ssa_value(builtin.i32),
+        create_ssa_value(builtin.i32),
     )
 
     op = llvm.InlineAsmOp(

--- a/tests/dialects/test_math.py
+++ b/tests/dialects/test_math.py
@@ -44,7 +44,7 @@ from xdsl.dialects.math import (
 )
 from xdsl.dialects.test import TestOp
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 class Test_float_math_binary_construction:
@@ -54,15 +54,15 @@ class Test_float_math_binary_construction:
 
     f32_vector_type = VectorType(f32, [3])
 
-    lhs_vector_ssa_value = TestSSAValue(f32_vector_type)
-    rhs_vector_ssa_value = TestSSAValue(f32_vector_type)
+    lhs_vector_ssa_value = create_ssa_value(f32_vector_type)
+    rhs_vector_ssa_value = create_ssa_value(f32_vector_type)
 
     lhs_vector = TestOp([lhs_vector_ssa_value], result_types=[f32_vector_type])
     rhs_vector = TestOp([rhs_vector_ssa_value], result_types=[f32_vector_type])
 
     f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
-    lhs_tensor_ssa_value = TestSSAValue(f32_tensor_type)
-    rhs_tensor_ssa_value = TestSSAValue(f32_tensor_type)
+    lhs_tensor_ssa_value = create_ssa_value(f32_tensor_type)
+    rhs_tensor_ssa_value = create_ssa_value(f32_tensor_type)
 
     lhs_tensor = TestOp([lhs_tensor_ssa_value], result_types=[f32_tensor_type])
     rhs_tensor = TestOp([rhs_tensor_ssa_value], result_types=[f32_tensor_type])
@@ -131,11 +131,11 @@ class Test_float_math_unary_constructions:
 
     f32_vector_type = VectorType(f32, [3])
 
-    test_vector_ssa = TestSSAValue(f32_vector_type)
+    test_vector_ssa = create_ssa_value(f32_vector_type)
     test_vec = TestOp([test_vector_ssa], result_types=[f32_vector_type])
 
     f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
-    test_tensor_ssa_value = TestSSAValue(f32_tensor_type)
+    test_tensor_ssa_value = create_ssa_value(f32_tensor_type)
     test_tensor = TestOp([test_tensor_ssa_value], result_types=[f32_tensor_type])
 
     @pytest.mark.parametrize(
@@ -253,11 +253,11 @@ class Test_fpowi:
 
     f32_vector_type = VectorType(f32, [3])
 
-    a_vector_ssa_value = TestSSAValue(f32_vector_type)
+    a_vector_ssa_value = create_ssa_value(f32_vector_type)
     a_vector = TestOp([a_vector_ssa_value], result_types=[f32_vector_type])
 
     f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
-    a_tensor_ssa_value = TestSSAValue(f32_tensor_type)
+    a_tensor_ssa_value = create_ssa_value(f32_tensor_type)
     a_tensor = TestOp([a_tensor_ssa_value], result_types=[f32_tensor_type])
 
     def test_fpowi_constant_construction(self):
@@ -288,13 +288,13 @@ class Test_fma:
     c = ConstantOp(FloatAttr(3.3, f32))
 
     f32_vector_type = VectorType(f32, [3])
-    test_vector_ssa = TestSSAValue(f32_vector_type)
+    test_vector_ssa = create_ssa_value(f32_vector_type)
     a_vec = TestOp([test_vector_ssa], result_types=[f32_vector_type])
     b_vec = TestOp([test_vector_ssa], result_types=[f32_vector_type])
     c_vec = TestOp([test_vector_ssa], result_types=[f32_vector_type])
 
     f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
-    test_tensor_ssa = TestSSAValue(f32_vector_type)
+    test_tensor_ssa = create_ssa_value(f32_vector_type)
     a_tensor = TestOp([test_tensor_ssa], result_types=[f32_tensor_type])
     b_tensor = TestOp([test_tensor_ssa], result_types=[f32_tensor_type])
     c_tensor = TestOp([test_tensor_ssa], result_types=[f32_tensor_type])
@@ -327,11 +327,11 @@ class Test_int_math_unary_constructions:
     a = ConstantOp.from_int_and_width(0, 32)
 
     i32_vector_type = VectorType(i32, [1])
-    test_vector_ssa = TestSSAValue(i32_vector_type)
+    test_vector_ssa = create_ssa_value(i32_vector_type)
     test_vec = TestOp([test_vector_ssa], result_types=[i32_vector_type])
 
     i32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5], i32, [])
-    test_tensor_ssa_value = TestSSAValue(i32_tensor_type)
+    test_tensor_ssa_value = create_ssa_value(i32_tensor_type)
     test_tensor = TestOp([test_tensor_ssa_value], result_types=[i32_tensor_type])
 
     @pytest.mark.parametrize(
@@ -397,11 +397,11 @@ class Test_Trunci:
     a = ConstantOp.from_int_and_width(0, 32)
 
     i32_vector_type = VectorType(i32, [1])
-    test_vector_ssa = TestSSAValue(i32_vector_type)
+    test_vector_ssa = create_ssa_value(i32_vector_type)
     test_vec = TestOp([test_vector_ssa], result_types=[i32_vector_type])
 
     i32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5], i32, [])
-    test_tensor_ssa_value = TestSSAValue(i32_tensor_type)
+    test_tensor_ssa_value = create_ssa_value(i32_tensor_type)
     test_tensor = TestOp([test_tensor_ssa_value], result_types=[i32_tensor_type])
 
     def test_trunci_incorrect_bitwidth(self):

--- a/tests/dialects/test_memref.py
+++ b/tests/dialects/test_memref.py
@@ -35,7 +35,7 @@ from xdsl.ir import Attribute, BlockArgument, OpResult
 from xdsl.ir.affine import AffineMap
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_memreftype():
@@ -54,7 +54,7 @@ def test_memreftype():
 
 def test_memref_load_i32():
     i32_memref_type = MemRefType(i32, [1])
-    memref_ssa_value = TestSSAValue(i32_memref_type)
+    memref_ssa_value = create_ssa_value(i32_memref_type)
     load = LoadOp.get(memref_ssa_value, [])
 
     assert load.memref is memref_ssa_value
@@ -64,9 +64,9 @@ def test_memref_load_i32():
 
 def test_memref_load_i32_with_dimensions():
     i32_memref_type = MemRefType(i32, [2, 3])
-    memref_ssa_value = TestSSAValue(i32_memref_type)
-    index1 = TestSSAValue(IndexType())
-    index2 = TestSSAValue(IndexType())
+    memref_ssa_value = create_ssa_value(i32_memref_type)
+    index1 = create_ssa_value(IndexType())
+    index2 = create_ssa_value(IndexType())
     load = LoadOp.get(memref_ssa_value, [index1, index2])
 
     assert load.memref is memref_ssa_value
@@ -77,8 +77,8 @@ def test_memref_load_i32_with_dimensions():
 
 def test_memref_store_i32():
     i32_memref_type = MemRefType(i32, [1])
-    memref_ssa_value = TestSSAValue(i32_memref_type)
-    i32_ssa_value = TestSSAValue(i32)
+    memref_ssa_value = create_ssa_value(i32_memref_type)
+    i32_ssa_value = create_ssa_value(i32)
     store = StoreOp.get(i32_ssa_value, memref_ssa_value, [])
 
     assert store.memref is memref_ssa_value
@@ -88,10 +88,10 @@ def test_memref_store_i32():
 
 def test_memref_store_i32_with_dimensions():
     i32_memref_type = MemRefType(i32, [2, 3])
-    memref_ssa_value = TestSSAValue(i32_memref_type)
-    i32_ssa_value = TestSSAValue(i32)
-    index1 = TestSSAValue(IndexType())
-    index2 = TestSSAValue(IndexType())
+    memref_ssa_value = create_ssa_value(i32_memref_type)
+    i32_ssa_value = create_ssa_value(i32)
+    index1 = create_ssa_value(IndexType())
+    index2 = create_ssa_value(IndexType())
     store = StoreOp.get(i32_ssa_value, memref_ssa_value, [index1, index2])
 
     assert store.memref is memref_ssa_value
@@ -123,8 +123,8 @@ def test_memref_alloc():
     assert alloc2.results[0].type.layout == my_layout
     assert alloc2.results[0].type.memory_space == my_memspace
 
-    dynamic_sizes_1 = [TestSSAValue(builtin.IndexType()) for _ in range(1)]
-    dynamic_sizes_3 = [TestSSAValue(builtin.IndexType()) for _ in range(3)]
+    dynamic_sizes_1 = [create_ssa_value(builtin.IndexType()) for _ in range(1)]
+    dynamic_sizes_3 = [create_ssa_value(builtin.IndexType()) for _ in range(3)]
 
     alloc4 = AllocOp.get(my_i32, 64, [3, 1, -1], dynamic_sizes=dynamic_sizes_1)
     alloc5 = AllocOp.get(my_i32, 64, [-1, -1, -1], dynamic_sizes=dynamic_sizes_3)
@@ -166,8 +166,8 @@ def test_memref_alloca():
     assert alloc2.results[0].type.layout == my_layout
     assert alloc2.results[0].type.memory_space == my_memspace
 
-    dynamic_sizes_1 = [TestSSAValue(builtin.IndexType()) for _ in range(1)]
-    dynamic_sizes_3 = [TestSSAValue(builtin.IndexType()) for _ in range(3)]
+    dynamic_sizes_1 = [create_ssa_value(builtin.IndexType()) for _ in range(1)]
+    dynamic_sizes_3 = [create_ssa_value(builtin.IndexType()) for _ in range(3)]
 
     alloc4 = AllocaOp.get(my_i32, 64, [3, 1, -1], dynamic_sizes=dynamic_sizes_1)
     alloc5 = AllocaOp.get(my_i32, 64, [-1, -1, -1], dynamic_sizes=dynamic_sizes_3)
@@ -325,7 +325,7 @@ def test_memref_subview_constant_parameters():
 
 def test_memref_cast():
     i32_memref_type = MemRefType(i32, [10, 2])
-    memref_ssa_value = TestSSAValue(i32_memref_type)
+    memref_ssa_value = create_ssa_value(i32_memref_type)
 
     res_type = UnrankedMemRefType.from_type(i32)
 
@@ -337,7 +337,7 @@ def test_memref_cast():
 
 def test_memref_memory_space_cast():
     i32_memref_type = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(1, i32))
-    memref_ssa_value = TestSSAValue(i32_memref_type)
+    memref_ssa_value = create_ssa_value(i32_memref_type)
 
     res_type = MemRefType(i32, [10, 2], memory_space=builtin.IntegerAttr(2, i32))
     res_type_wrong_type = MemRefType(
@@ -380,12 +380,12 @@ def test_dma_start():
 
     tag_type = MemRefType(i32, [4])
 
-    src = TestSSAValue(src_type)
-    dest = TestSSAValue(dest_type)
-    tag = TestSSAValue(tag_type)
+    src = create_ssa_value(src_type)
+    dest = create_ssa_value(dest_type)
+    tag = create_ssa_value(tag_type)
 
-    index = TestSSAValue(IndexType())
-    num_elements = TestSSAValue(IndexType())
+    index = create_ssa_value(IndexType())
+    num_elements = create_ssa_value(IndexType())
 
     dma_start = DmaStartOp.get(
         src, [index, index], dest, [index], num_elements, tag, [index]
@@ -419,7 +419,7 @@ def test_dma_start():
 
     # check that tag element type is verified
     with pytest.raises(VerifyException, match="Expected tag to be a memref of i32"):
-        new_tag = TestSSAValue(src_type)
+        new_tag = create_ssa_value(src_type)
 
         DmaStartOp.get(
             src,
@@ -434,9 +434,9 @@ def test_dma_start():
 
 def test_memref_dma_wait():
     tag_type = MemRefType(i32, [4])
-    tag = TestSSAValue(tag_type)
-    index = TestSSAValue(IndexType())
-    num_elements = TestSSAValue(IndexType())
+    tag = create_ssa_value(tag_type)
+    index = create_ssa_value(IndexType())
+    num_elements = create_ssa_value(IndexType())
 
     dma_wait = DmaWaitOp.get(tag, [index], num_elements)
 
@@ -451,7 +451,7 @@ def test_memref_dma_wait():
     # check that tag element type is verified
     with pytest.raises(VerifyException, match="Expected tag to be a memref of i32"):
         wrong_tag_type = MemRefType(i64, [4])
-        wrong_tag = TestSSAValue(wrong_tag_type)
+        wrong_tag = create_ssa_value(wrong_tag_type)
 
         DmaWaitOp.get(wrong_tag, [index], num_elements).verify()
 
@@ -460,8 +460,8 @@ def test_memref_copy():
     i32type4 = MemRefType(i32, [4])
     i32type3 = MemRefType(i32, [3])
     i64type4 = MemRefType(i64, [4])
-    source = TestSSAValue(i32type4)
-    destination = TestSSAValue(i32type4)
+    source = create_ssa_value(i32type4)
+    destination = create_ssa_value(i32type4)
 
     copy = CopyOp(source, destination)
 
@@ -470,7 +470,7 @@ def test_memref_copy():
     assert copy.source.type == i32type4
     assert copy.destination.type == i32type4
 
-    destination = TestSSAValue(i32type3)
+    destination = create_ssa_value(i32type3)
 
     copy = CopyOp(source, destination)
 
@@ -479,7 +479,7 @@ def test_memref_copy():
     ):
         copy.verify()
 
-    destination = TestSSAValue(i64type4)
+    destination = create_ssa_value(i64type4)
 
     copy = CopyOp(source, destination)
 

--- a/tests/dialects/test_pdl.py
+++ b/tests/dialects/test_pdl.py
@@ -7,7 +7,7 @@ from xdsl.ir import Block
 from xdsl.irdl import IRDLOperation, irdl_op_definition, traits_def
 from xdsl.traits import HasParent, IsTerminator
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 type_type = pdl.TypeType()
 attribute_type = pdl.AttributeType()
@@ -192,9 +192,9 @@ def test_build_operand():
 
 
 def test_range():
-    val1 = TestSSAValue(pdl.ValueType())
-    val2 = TestSSAValue(pdl.RangeType(pdl.ValueType()))
-    val3 = TestSSAValue(pdl.ValueType())
+    val1 = create_ssa_value(pdl.ValueType())
+    val2 = create_ssa_value(pdl.RangeType(pdl.ValueType()))
+    val3 = create_ssa_value(pdl.ValueType())
 
     range_op = pdl.RangeOp((val1, val2, val3))
 

--- a/tests/dialects/test_riscv.py
+++ b/tests/dialects/test_riscv.py
@@ -12,12 +12,12 @@ from xdsl.dialects.builtin import (
 from xdsl.parser import Parser
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
 from xdsl.utils.exceptions import ParseError, VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_add_op():
-    a1 = TestSSAValue(riscv.Registers.A1)
-    a2 = TestSSAValue(riscv.Registers.A2)
+    a1 = create_ssa_value(riscv.Registers.A1)
+    a2 = create_ssa_value(riscv.Registers.A2)
     add_op = riscv.AddOp(a1, a2, rd=riscv.Registers.A0)
     a0 = add_op.rd
 
@@ -55,8 +55,8 @@ def test_is_non_zero():
 
 
 def test_csr_op():
-    a1 = TestSSAValue(riscv.Registers.A1)
-    zero = TestSSAValue(riscv.Registers.ZERO)
+    a1 = create_ssa_value(riscv.Registers.A1)
+    zero = create_ssa_value(riscv.Registers.ZERO)
     csr = IntegerAttr(16, i32)
     # CsrrwOp
     riscv.CsrrwOp(rs1=a1, csr=csr, rd=riscv.Registers.A2).verify()
@@ -152,7 +152,7 @@ def test_return_op():
 def test_immediate_i_inst():
     # I-Type - 12-bits signed immediate
     lb, ub = Signedness.SIGNED.value_range(12)
-    a1 = TestSSAValue(riscv.Registers.A1)
+    a1 = create_ssa_value(riscv.Registers.A1)
 
     with pytest.raises(VerifyException):
         riscv.AddiOp(a1, ub, rd=riscv.Registers.A0)
@@ -167,8 +167,8 @@ def test_immediate_i_inst():
 def test_immediate_s_inst():
     # S-Type - 12-bits signed immediate
     lb, ub = Signedness.SIGNED.value_range(12)
-    a1 = TestSSAValue(riscv.Registers.A1)
-    a2 = TestSSAValue(riscv.Registers.A2)
+    a1 = create_ssa_value(riscv.Registers.A1)
+    a2 = create_ssa_value(riscv.Registers.A2)
 
     with pytest.raises(VerifyException):
         riscv.SwOp(a1, a2, ub)
@@ -198,7 +198,7 @@ def test_immediate_u_j_inst():
 
 def test_immediate_jalr_inst():
     # Jalr - 12-bits immediate
-    a1 = TestSSAValue(riscv.Registers.A1)
+    a1 = create_ssa_value(riscv.Registers.A1)
 
     with pytest.raises(VerifyException):
         riscv.JalrOp(a1, 1 << 12, rd=riscv.Registers.A0)
@@ -227,7 +227,7 @@ def test_immediate_pseudo_inst():
 
 def test_immediate_shift_inst():
     # Shift instructions (SLLI, SRLI, SRAI) - 5-bits immediate
-    a1 = TestSSAValue(riscv.Registers.A1)
+    a1 = create_ssa_value(riscv.Registers.A1)
 
     with pytest.raises(VerifyException):
         riscv.SlliOp(a1, 1 << 5, rd=riscv.Registers.A0)
@@ -248,13 +248,13 @@ def test_float_register():
     ):
         riscv.FloatRegisterType.from_name("a0")
 
-    a1 = TestSSAValue(riscv.Registers.A1)
-    a2 = TestSSAValue(riscv.Registers.A2)
+    a1 = create_ssa_value(riscv.Registers.A1)
+    a2 = create_ssa_value(riscv.Registers.A2)
     with pytest.raises(VerifyException, match="Operation does not verify"):
         riscv.FAddSOp(a1, a2).verify()
 
-    f1 = TestSSAValue(riscv.Registers.FT0)
-    f2 = TestSSAValue(riscv.Registers.FT1)
+    f1 = create_ssa_value(riscv.Registers.FT0)
+    f2 = create_ssa_value(riscv.Registers.FT1)
     riscv.FAddSOp(f1, f2).verify()
 
 

--- a/tests/dialects/test_seq.py
+++ b/tests/dialects/test_seq.py
@@ -12,12 +12,12 @@ from xdsl.dialects.seq import (
     clock,
 )
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_clockdivider_verify():
     clock_div = ClockDividerOp(
-        TestSSAValue(clock),
+        create_ssa_value(clock),
         IntegerAttr(512, i32),
     )
     with pytest.raises(
@@ -28,9 +28,9 @@ def test_clockdivider_verify():
 
 
 def test_compreg_builder():
-    data_val = TestSSAValue(IntegerType(5))
-    bool_val = TestSSAValue(i1)
-    clock_val = TestSSAValue(clock)
+    data_val = create_ssa_value(IntegerType(5))
+    bool_val = create_ssa_value(i1)
+    clock_val = create_ssa_value(clock)
 
     CompRegOp(data_val, clock_val).verify()
 

--- a/tests/dialects/test_snitch.py
+++ b/tests/dialects/test_snitch.py
@@ -3,11 +3,11 @@ import pytest
 from xdsl.dialects import riscv, snitch
 from xdsl.dialects.builtin import IntAttr
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_csr_op():
-    value = TestSSAValue(riscv.Registers.A1)
+    value = create_ssa_value(riscv.Registers.A1)
     stream = IntAttr(0)
     valid = IntAttr(snitch.SnitchResources.dimensions - 1)
     invalid = IntAttr(snitch.SnitchResources.dimensions)

--- a/tests/dialects/test_snitch_runtime.py
+++ b/tests/dialects/test_snitch_runtime.py
@@ -2,11 +2,11 @@ import pytest
 
 from xdsl.dialects import arith, builtin, snitch_runtime
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_ssr_loop_op():
-    data_mover = TestSSAValue(builtin.i32)
+    data_mover = create_ssa_value(builtin.i32)
     ten = arith.ConstantOp.from_int_and_width(10, builtin.IndexType())
     bounds1d = [ten]
     bounds2d = [ten, ten]

--- a/tests/dialects/test_stencil.py
+++ b/tests/dialects/test_stencil.py
@@ -41,7 +41,7 @@ from xdsl.dialects.stencil import (
 from xdsl.ir import Attribute, Block, SSAValue
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_stencilboundsattr_verify():
@@ -62,16 +62,16 @@ def test_stencilboundsattr_verify():
 
 
 def test_stencil_return_single_float():
-    float_val1 = TestSSAValue(FloatAttr(4.0, f32))
+    float_val1 = create_ssa_value(FloatAttr(4.0, f32))
     return_op = ReturnOp.get([float_val1])
 
     assert return_op.arg[0] is float_val1
 
 
 def test_stencil_return_multiple_floats():
-    float_val1 = TestSSAValue(FloatAttr(4.0, f32))
-    float_val2 = TestSSAValue(FloatAttr(5.0, f32))
-    float_val3 = TestSSAValue(FloatAttr(6.0, f32))
+    float_val1 = create_ssa_value(FloatAttr(4.0, f32))
+    float_val2 = create_ssa_value(FloatAttr(5.0, f32))
+    float_val3 = create_ssa_value(FloatAttr(6.0, f32))
 
     return_op = ReturnOp.get([float_val1, float_val2, float_val3])
 
@@ -81,16 +81,16 @@ def test_stencil_return_multiple_floats():
 
 
 def test_stencil_return_single_ResultType():
-    result_type_val1 = TestSSAValue(ResultType(f32))
+    result_type_val1 = create_ssa_value(ResultType(f32))
     return_op = ReturnOp.get([result_type_val1])
 
     assert return_op.arg[0] is result_type_val1
 
 
 def test_stencil_return_multiple_ResultType():
-    result_type_val1 = TestSSAValue(ResultType(f32))
-    result_type_val2 = TestSSAValue(ResultType(f32))
-    result_type_val3 = TestSSAValue(ResultType(f32))
+    result_type_val1 = create_ssa_value(ResultType(f32))
+    result_type_val2 = create_ssa_value(ResultType(f32))
+    result_type_val3 = create_ssa_value(ResultType(f32))
 
     return_op = ReturnOp.get([result_type_val1, result_type_val2, result_type_val3])
 
@@ -101,7 +101,7 @@ def test_stencil_return_multiple_ResultType():
 
 def test_stencil_cast_op_verifier():
     field_type = FieldType(3, f32)
-    field = TestSSAValue(field_type)
+    field = create_ssa_value(field_type)
 
     # check that correct op verifies correctly
     cast = CastOp.get(field, StencilBoundsAttr(((-2, 100), (-2, 100), (-2, 100))))
@@ -131,7 +131,7 @@ def test_stencil_cast_op_verifier():
         cast.verify()
 
     # check that non-dynamic input verifies
-    non_dyn_field = TestSSAValue(FieldType(((-2, 102), (-2, 102), (-2, 102)), f32))
+    non_dyn_field = create_ssa_value(FieldType(((-2, 102), (-2, 102), (-2, 102)), f32))
     cast = CastOp.get(
         non_dyn_field,
         StencilBoundsAttr(((-2, 100), (-2, 100), (-2, 100))),
@@ -152,7 +152,7 @@ def test_stencil_cast_op_verifier():
 
 
 def test_cast_op_constructor():
-    field = TestSSAValue(FieldType(3, f32))
+    field = create_ssa_value(FieldType(3, f32))
 
     cast = CastOp.get(
         field,
@@ -163,7 +163,7 @@ def test_cast_op_constructor():
 
 
 def test_stencil_apply():
-    result_type_val1 = TestSSAValue(ResultType(f32))
+    result_type_val1 = create_ssa_value(ResultType(f32))
 
     stencil_temptype = TempType(2, f32)
     apply_op = ApplyOp.get([result_type_val1], Block([]), [stencil_temptype])
@@ -382,7 +382,7 @@ def test_stencil_fieldtype_constructor_empty_list(
 
 def test_stencil_load():
     field_type = FieldType([(0, 1), (0, 1)], f32)
-    result_type_val1 = TestSSAValue(field_type)
+    result_type_val1 = create_ssa_value(field_type)
 
     load = LoadOp.get(result_type_val1)
 
@@ -397,7 +397,7 @@ def test_stencil_load():
 
 def test_stencil_load_bounds():
     field_type = FieldType([(0, 1), (0, 1)], f32)
-    result_type_val1 = TestSSAValue(field_type)
+    result_type_val1 = create_ssa_value(field_type)
 
     lb = IndexAttr.get(1, 1)
     ub = IndexAttr.get(64, 64)
@@ -484,10 +484,10 @@ def test_stencil_resulttype(float_type: AnyFloat):
 
 def test_stencil_store():
     temp_type = TempType([(0, 5), (0, 5)], f32)
-    temp_type_ssa_val = TestSSAValue(temp_type)
+    temp_type_ssa_val = create_ssa_value(temp_type)
 
     field_type = FieldType([(0, 2), (0, 2)], f32)
-    field_type_ssa_val = TestSSAValue(field_type)
+    field_type_ssa_val = create_ssa_value(field_type)
 
     lb = IndexAttr.get(1, 1)
     ub = IndexAttr.get(64, 64)
@@ -524,7 +524,7 @@ def test_stencil_index():
 
 def test_stencil_access():
     temp_type = TempType([(0, 5), (0, 5)], f32)
-    temp_type_ssa_val = TestSSAValue(temp_type)
+    temp_type_ssa_val = create_ssa_value(temp_type)
 
     offset = [1, 1]
     offset_index_attr = IndexAttr.get(*offset)
@@ -538,11 +538,14 @@ def test_stencil_access():
 
 def test_stencil_dyn_access():
     temp_type = TempType([(0, 5), (0, 5)], f32)
-    temp_type_ssa_val = TestSSAValue(temp_type)
+    temp_type_ssa_val = create_ssa_value(temp_type)
 
     lb = IndexAttr.get(0, 0)
     ub = IndexAttr.get(1, 1)
-    offset = (TestSSAValue(builtin.IndexType()), TestSSAValue(builtin.IndexType()))
+    offset = (
+        create_ssa_value(builtin.IndexType()),
+        create_ssa_value(builtin.IndexType()),
+    )
 
     dyn_access = DynAccessOp(temp_type_ssa_val, offset, lb, ub)
 
@@ -554,7 +557,7 @@ def test_stencil_dyn_access():
 
 def test_stencil_access_offset_mapping():
     temp_type = TempType([(0, 5), (0, 5)], f32)
-    temp_type_ssa_val = TestSSAValue(temp_type)
+    temp_type_ssa_val = create_ssa_value(temp_type)
 
     offset = [1, 1]
     offset_index_attr = IndexAttr.get(*offset)
@@ -573,7 +576,7 @@ def test_stencil_access_offset_mapping():
 
 def test_store_result():
     elem = IndexAttr.get(1)
-    elem_ssa_val = TestSSAValue(elem)
+    elem_ssa_val = create_ssa_value(elem)
     result_type = ResultType(f32)
 
     store_result = StoreResultOp.build(
@@ -586,7 +589,7 @@ def test_store_result():
 
 
 def test_external_load():
-    memref = TestSSAValue(MemRefType(f32, ([5])))
+    memref = create_ssa_value(MemRefType(f32, ([5])))
     field_type = FieldType((5), f32)
 
     external_load = ExternalLoadOp.get(memref, field_type)
@@ -597,8 +600,8 @@ def test_external_load():
 
 
 def test_external_store():
-    field = TestSSAValue(FieldType((5), f32))
-    memref = TestSSAValue(MemRefType(f32, ([5])))
+    field = create_ssa_value(FieldType((5), f32))
+    memref = create_ssa_value(MemRefType(f32, ([5])))
 
     external_store = ExternalStoreOp.build(operands=[field, memref])
 
@@ -608,7 +611,7 @@ def test_external_store():
 
 
 def test_buffer():
-    temp = TestSSAValue(TempType((5), f32))
+    temp = create_ssa_value(TempType((5), f32))
     res_type = TempType((5), f32)
 
     buffer = BufferOp.build(operands=[temp], result_types=[res_type])
@@ -620,7 +623,7 @@ def test_buffer():
 
 def test_access_patterns():
     typ = TempType((5), f32)
-    temp = TestSSAValue(typ)
+    temp = create_ssa_value(typ)
 
     @Builder.implicit_region((typ, typ))
     def apply_op_region(args: tuple[SSAValue, ...]):

--- a/tests/dialects/test_tensor.py
+++ b/tests/dialects/test_tensor.py
@@ -3,7 +3,7 @@ from xdsl.dialects.builtin import DenseArrayBase, TensorType, f64, i64
 from xdsl.dialects.stencil import IndexAttr
 from xdsl.dialects.tensor import ExtractSliceOp, InsertSliceOp
 from xdsl.dialects.test import TestOp
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_extract_slice_static():
@@ -72,13 +72,13 @@ def test_insert_slice_static():
 
 def test_insert_slice_dynamic():
     source_t = TensorType(f64, [10, 20])
-    source_v = TestSSAValue(source_t)
+    source_v = create_ssa_value(source_t)
     dest_t = TensorType(f64, [10, 20, 30])
-    dest_v = TestSSAValue(dest_t)
-    offset1 = TestSSAValue(IndexAttr.get(3))
-    offset2 = TestSSAValue(IndexAttr.get(15))
-    stride1 = TestSSAValue(IndexAttr.get(2))
-    stride2 = TestSSAValue(IndexAttr.get(5))
+    dest_v = create_ssa_value(dest_t)
+    offset1 = create_ssa_value(IndexAttr.get(3))
+    offset2 = create_ssa_value(IndexAttr.get(15))
+    stride1 = create_ssa_value(IndexAttr.get(2))
+    stride2 = create_ssa_value(IndexAttr.get(5))
 
     insert_slice = InsertSliceOp.get(
         source=source_v,

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -23,20 +23,20 @@ from xdsl.dialects.vector import (
     PrintOp,
     StoreOp,
 )
-from xdsl.ir import Attribute, OpResult
+from xdsl.ir import Attribute, OpResult, SSAValue
 from xdsl.utils.test_value import TestSSAValue
 
 
 def get_MemRef_SSAVal(
     referenced_type: Attribute, shape: list[int | IntAttr]
-) -> TestSSAValue:
+) -> SSAValue:
     memref_type = MemRefType(referenced_type, shape)
     return TestSSAValue(memref_type)
 
 
 def get_Vector_SSAVal(
     referenced_type: Attribute, shape: list[int | IntAttr]
-) -> TestSSAValue:
+) -> SSAValue:
     vector_type = VectorType(referenced_type, shape)
     return TestSSAValue(vector_type)
 

--- a/tests/dialects/test_vector.py
+++ b/tests/dialects/test_vector.py
@@ -24,21 +24,21 @@ from xdsl.dialects.vector import (
     StoreOp,
 )
 from xdsl.ir import Attribute, OpResult, SSAValue
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def get_MemRef_SSAVal(
     referenced_type: Attribute, shape: list[int | IntAttr]
 ) -> SSAValue:
     memref_type = MemRefType(referenced_type, shape)
-    return TestSSAValue(memref_type)
+    return create_ssa_value(memref_type)
 
 
 def get_Vector_SSAVal(
     referenced_type: Attribute, shape: list[int | IntAttr]
 ) -> SSAValue:
     vector_type = VectorType(referenced_type, shape)
-    return TestSSAValue(vector_type)
+    return create_ssa_value(vector_type)
 
 
 def test_vectorType():
@@ -68,8 +68,8 @@ def test_vector_load_i32():
 
 def test_vector_load_i32_with_dimensions():
     memref_ssa_value = get_MemRef_SSAVal(i32, [2, 3])
-    index1 = TestSSAValue(IndexType())
-    index2 = TestSSAValue(IndexType())
+    index1 = create_ssa_value(IndexType())
+    index2 = create_ssa_value(IndexType())
     load = LoadOp.get(memref_ssa_value, [index1, index2])
 
     assert type(load.results[0]) is OpResult
@@ -115,8 +115,8 @@ def test_vector_store_i32_with_dimensions():
     vector_ssa_value = get_Vector_SSAVal(i32, [2, 3])
     memref_ssa_value = get_MemRef_SSAVal(i32, [4, 5])
 
-    index1 = TestSSAValue(IndexType())
-    index2 = TestSSAValue(IndexType())
+    index1 = create_ssa_value(IndexType())
+    index2 = create_ssa_value(IndexType())
     store = StoreOp.get(vector_ssa_value, memref_ssa_value, [index1, index2])
 
     assert store.base is memref_ssa_value
@@ -148,7 +148,7 @@ def test_vector_store_verify_indexing_exception():
 
 
 def test_vector_broadcast():
-    index1 = TestSSAValue(IndexType())
+    index1 = create_ssa_value(IndexType())
     broadcast = BroadcastOp.get(index1)
 
     assert type(broadcast.results[0]) is OpResult
@@ -157,7 +157,7 @@ def test_vector_broadcast():
 
 
 def test_vector_broadcast_verify_type_matching():
-    index1 = TestSSAValue(IndexType())
+    index1 = create_ssa_value(IndexType())
     res_vector_type = VectorType(i64, [1])
 
     broadcast = BroadcastOp.build(operands=[index1], result_types=[res_vector_type])
@@ -172,9 +172,9 @@ def test_vector_broadcast_verify_type_matching():
 def test_vector_fma():
     i32_vector_type = VectorType(i32, [1])
 
-    lhs_vector_ssa_value = TestSSAValue(i32_vector_type)
-    rhs_vector_ssa_value = TestSSAValue(i32_vector_type)
-    acc_vector_ssa_value = TestSSAValue(i32_vector_type)
+    lhs_vector_ssa_value = create_ssa_value(i32_vector_type)
+    rhs_vector_ssa_value = create_ssa_value(i32_vector_type)
+    acc_vector_ssa_value = create_ssa_value(i32_vector_type)
 
     fma = FMAOp.get(lhs_vector_ssa_value, rhs_vector_ssa_value, acc_vector_ssa_value)
 
@@ -188,9 +188,9 @@ def test_vector_fma():
 def test_vector_fma_with_dimensions():
     i32_vector_type = VectorType(i32, [2, 3])
 
-    lhs_vector_ssa_value = TestSSAValue(i32_vector_type)
-    rhs_vector_ssa_value = TestSSAValue(i32_vector_type)
-    acc_vector_ssa_value = TestSSAValue(i32_vector_type)
+    lhs_vector_ssa_value = create_ssa_value(i32_vector_type)
+    rhs_vector_ssa_value = create_ssa_value(i32_vector_type)
+    acc_vector_ssa_value = create_ssa_value(i32_vector_type)
 
     fma = FMAOp.get(lhs_vector_ssa_value, rhs_vector_ssa_value, acc_vector_ssa_value)
 
@@ -220,8 +220,8 @@ def test_vector_masked_load_with_dimensions():
     mask_vector_ssa_value = get_Vector_SSAVal(i1, [1])
     passthrough_vector_ssa_value = get_Vector_SSAVal(i32, [1])
 
-    index1 = TestSSAValue(IndexType())
-    index2 = TestSSAValue(IndexType())
+    index1 = create_ssa_value(IndexType())
+    index2 = create_ssa_value(IndexType())
 
     maskedload = MaskedLoadOp.get(
         memref_ssa_value,
@@ -320,8 +320,8 @@ def test_vector_masked_store_with_dimensions():
     mask_vector_ssa_value = get_Vector_SSAVal(i1, [1])
     value_to_store_vector_ssa_value = get_Vector_SSAVal(i32, [1])
 
-    index1 = TestSSAValue(IndexType())
-    index2 = TestSSAValue(IndexType())
+    index1 = create_ssa_value(IndexType())
+    index2 = create_ssa_value(IndexType())
 
     maskedstore = MaskedStoreOp.get(
         memref_ssa_value,
@@ -384,8 +384,8 @@ def test_vector_create_mask():
 
 
 def test_vector_create_mask_with_dimensions():
-    index1 = TestSSAValue(IndexType())
-    index2 = TestSSAValue(IndexType())
+    index1 = create_ssa_value(IndexType())
+    index2 = create_ssa_value(IndexType())
 
     create_mask = CreateMaskOp.get([index1, index2])
 
@@ -410,8 +410,8 @@ def test_vector_create_mask_verify_indexing_exception():
 def test_vector_extract_element_verify_vector_rank_0_or_1():
     vector_type = VectorType(IndexType(), [3, 3])
 
-    vector = TestSSAValue(vector_type)
-    position = TestSSAValue(IndexType())
+    vector = create_ssa_value(vector_type)
+    position = create_ssa_value(IndexType())
     extract_element = ExtractElementOp(vector, position)
 
     with pytest.raises(Exception, match="Unexpected >1 vector rank."):
@@ -421,8 +421,8 @@ def test_vector_extract_element_verify_vector_rank_0_or_1():
 def test_vector_extract_element_construction_1d():
     vector_type = VectorType(IndexType(), [3])
 
-    vector = TestSSAValue(vector_type)
-    position = TestSSAValue(IndexType())
+    vector = create_ssa_value(vector_type)
+    position = create_ssa_value(IndexType())
 
     extract_element = ExtractElementOp(vector, position)
 
@@ -434,7 +434,7 @@ def test_vector_extract_element_construction_1d():
 def test_vector_extract_element_1d_verify_non_empty_position():
     vector_type = VectorType(IndexType(), [3])
 
-    vector = TestSSAValue(vector_type)
+    vector = create_ssa_value(vector_type)
 
     extract_element = ExtractElementOp(vector)
 
@@ -445,7 +445,7 @@ def test_vector_extract_element_1d_verify_non_empty_position():
 def test_vector_extract_element_construction_0d():
     vector_type = VectorType(IndexType(), [])
 
-    vector = TestSSAValue(vector_type)
+    vector = create_ssa_value(vector_type)
 
     extract_element = ExtractElementOp(vector)
 
@@ -457,8 +457,8 @@ def test_vector_extract_element_construction_0d():
 def test_vector_extract_element_0d_verify_empty_position():
     vector_type = VectorType(IndexType(), [])
 
-    vector = TestSSAValue(vector_type)
-    position = TestSSAValue(IndexType())
+    vector = create_ssa_value(vector_type)
+    position = create_ssa_value(IndexType())
 
     extract_element = ExtractElementOp(vector, position)
 
@@ -470,9 +470,9 @@ def test_vector_extract_element_0d_verify_empty_position():
 
 def test_vector_extract():
     vector_type = VectorType(i32, [1, 2, 3, 4])
-    vector = TestSSAValue(vector_type)
-    dim1 = TestSSAValue(i32)
-    dim2 = TestSSAValue(i32)
+    vector = create_ssa_value(vector_type)
+    dim1 = create_ssa_value(i32)
+    dim2 = create_ssa_value(i32)
     dimensions = [0, dim1, 1, dim2]
 
     extract = ExtractOp(vector, dimensions, i32)
@@ -493,9 +493,9 @@ def test_vector_extract():
 def test_vector_insert_element_verify_vector_rank_0_or_1():
     vector_type = VectorType(IndexType(), [3, 3])
 
-    source = TestSSAValue(IndexType())
-    dest = TestSSAValue(vector_type)
-    position = TestSSAValue(IndexType())
+    source = create_ssa_value(IndexType())
+    dest = create_ssa_value(vector_type)
+    position = create_ssa_value(IndexType())
 
     insert_element = InsertElementOp(source, dest, position)
 
@@ -506,9 +506,9 @@ def test_vector_insert_element_verify_vector_rank_0_or_1():
 def test_vector_insert_element_construction_1d():
     vector_type = VectorType(IndexType(), [3])
 
-    source = TestSSAValue(IndexType())
-    dest = TestSSAValue(vector_type)
-    position = TestSSAValue(IndexType())
+    source = create_ssa_value(IndexType())
+    dest = create_ssa_value(vector_type)
+    position = create_ssa_value(IndexType())
 
     insert_element = InsertElementOp(source, dest, position)
 
@@ -521,8 +521,8 @@ def test_vector_insert_element_construction_1d():
 def test_vector_insert_element_1d_verify_non_empty_position():
     vector_type = VectorType(IndexType(), [3])
 
-    source = TestSSAValue(IndexType())
-    dest = TestSSAValue(vector_type)
+    source = create_ssa_value(IndexType())
+    dest = create_ssa_value(vector_type)
 
     insert_element = InsertElementOp(source, dest)
 
@@ -536,8 +536,8 @@ def test_vector_insert_element_1d_verify_non_empty_position():
 def test_vector_insert_element_construction_0d():
     vector_type = VectorType(IndexType(), [])
 
-    source = TestSSAValue(IndexType())
-    dest = TestSSAValue(vector_type)
+    source = create_ssa_value(IndexType())
+    dest = create_ssa_value(vector_type)
 
     insert_element = InsertElementOp(source, dest)
 
@@ -550,9 +550,9 @@ def test_vector_insert_element_construction_0d():
 def test_vector_insert_element_0d_verify_empty_position():
     vector_type = VectorType(IndexType(), [])
 
-    source = TestSSAValue(IndexType())
-    dest = TestSSAValue(vector_type)
-    position = TestSSAValue(IndexType())
+    source = create_ssa_value(IndexType())
+    dest = create_ssa_value(vector_type)
+    position = create_ssa_value(IndexType())
 
     insert_element = InsertElementOp(source, dest, position)
 
@@ -564,10 +564,10 @@ def test_vector_insert_element_0d_verify_empty_position():
 
 
 def test_vector_insert():
-    value = TestSSAValue(VectorType(i32, [5]))
-    dest = TestSSAValue(VectorType(i32, [1, 2, 3, 4, 5]))
-    dim1 = TestSSAValue(i32)
-    dim2 = TestSSAValue(i32)
+    value = create_ssa_value(VectorType(i32, [5]))
+    dest = create_ssa_value(VectorType(i32, [1, 2, 3, 4, 5]))
+    dim1 = create_ssa_value(i32)
+    dim2 = create_ssa_value(i32)
     dimensions = [0, dim1, 1, dim2]
 
     insert = InsertOp(value, dest, dimensions)

--- a/tests/interpreters/test_affine_interpreter.py
+++ b/tests/interpreters/test_affine_interpreter.py
@@ -11,7 +11,7 @@ from xdsl.interpreters.memref import MemRefFunctions
 from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.ir.affine import AffineMap
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 index = IndexType()
 
@@ -97,7 +97,7 @@ def test_apply():
 
     assert interpreter.run_op(
         affine.ApplyOp(
-            (TestSSAValue(index), TestSSAValue(index)),
+            (create_ssa_value(index), create_ssa_value(index)),
             AffineMapAttr(AffineMap.from_callable(lambda d0, d1: (d0 + d1,))),
         ),
         (1, 2),

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -22,7 +22,7 @@ from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.ir import Block, Region
 from xdsl.ir.affine import AffineExpr, AffineMap
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_unimplemented_inputs():
@@ -52,10 +52,10 @@ def test_linalg_generic():
 
     op = linalg.GenericOp(
         (
-            TestSSAValue(MemRefType(i32, [2, 3])),
-            TestSSAValue(MemRefType(i32, [3, 2])),
+            create_ssa_value(MemRefType(i32, [2, 3])),
+            create_ssa_value(MemRefType(i32, [3, 2])),
         ),
-        (TestSSAValue(MemRefType(i32, [1, 6])),),
+        (create_ssa_value(MemRefType(i32, [1, 6])),),
         Region(Block(arg_types=(i32, i32))),
         (
             AffineMapAttr(AffineMap.identity(2)),
@@ -98,10 +98,10 @@ def test_linalg_generic_scalar():
 
     op = linalg.GenericOp(
         (
-            TestSSAValue(MemRefType(i32, [2, 3])),
-            TestSSAValue(i32),
+            create_ssa_value(MemRefType(i32, [2, 3])),
+            create_ssa_value(i32),
         ),
-        (TestSSAValue(MemRefType(i32, [1, 6])),),
+        (create_ssa_value(MemRefType(i32, [1, 6])),),
         Region(Block(arg_types=(i32, i32))),
         (
             AffineMapAttr(AffineMap.identity(2)),
@@ -144,10 +144,10 @@ def test_linalg_generic_reduction():
 
     op = linalg.GenericOp(
         (
-            TestSSAValue(MemRefType(i32, [3])),
-            TestSSAValue(MemRefType(i32, [3])),
+            create_ssa_value(MemRefType(i32, [3])),
+            create_ssa_value(MemRefType(i32, [3])),
         ),
-        (TestSSAValue(MemRefType(i32, [])),),
+        (create_ssa_value(MemRefType(i32, [])),),
         Region(Block(arg_types=(i32, i32, i32))),
         (
             AffineMapAttr(AffineMap.identity(1)),
@@ -176,10 +176,10 @@ def test_linalg_add():
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.AddOp(
         (
-            TestSSAValue(TensorType(f32, [2, 2])),
-            TestSSAValue(TensorType(f32, [2, 2])),
+            create_ssa_value(TensorType(f32, [2, 2])),
+            create_ssa_value(TensorType(f32, [2, 2])),
         ),
-        (TestSSAValue(TensorType(f32, [2, 2])),),
+        (create_ssa_value(TensorType(f32, [2, 2])),),
         (TensorType(f32, [2, 2]),),
     )
 
@@ -198,8 +198,8 @@ def test_fill_op():
     interpreter.register_implementations(LinalgFunctions())
     constant = arith.ConstantOp(FloatAttr(1.0, f32))
     op = linalg.FillOp(
-        (TestSSAValue(constant.result.type),),
-        (TestSSAValue(TensorType(f32, [2, 3])),),
+        (create_ssa_value(constant.result.type),),
+        (create_ssa_value(TensorType(f32, [2, 3])),),
         (TensorType(f32, [2, 3]),),
     )
     a = ShapedArray(TypedPtr.new_float32([1.0]), [1])
@@ -215,10 +215,10 @@ def test_linalg_mul():
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.MulOp(
         (
-            TestSSAValue(TensorType(f32, [2, 2])),
-            TestSSAValue(TensorType(f32, [2, 2])),
+            create_ssa_value(TensorType(f32, [2, 2])),
+            create_ssa_value(TensorType(f32, [2, 2])),
         ),
-        (TestSSAValue(TensorType(f32, [2, 2])),),
+        (create_ssa_value(TensorType(f32, [2, 2])),),
         (TensorType(f32, [2, 2]),),
     )
 
@@ -234,8 +234,8 @@ def test_linalg_transpose():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.TransposeOp(
-        TestSSAValue(TensorType(f32, [3, 2])),
-        TestSSAValue(TensorType(f32, [2, 3])),
+        create_ssa_value(TensorType(f32, [3, 2])),
+        create_ssa_value(TensorType(f32, [2, 3])),
         DenseArrayBase.from_list(i64, [1, 0]),
         TensorType(f32, [2, 3]),
     )
@@ -253,10 +253,10 @@ def test_linalg_matmul():
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.MatmulOp(
         (
-            TestSSAValue(TensorType(f32, [3, 2])),
-            TestSSAValue(TensorType(f32, [2, 3])),
+            create_ssa_value(TensorType(f32, [3, 2])),
+            create_ssa_value(TensorType(f32, [2, 3])),
         ),
-        (TestSSAValue(TensorType(f32, [3, 3])),),
+        (create_ssa_value(TensorType(f32, [3, 3])),),
         (TensorType(f32, [3, 3]),),
     )
 
@@ -276,10 +276,10 @@ def test_linalg_pooling_nchw_max():
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.PoolingNchwMaxOp(
         (
-            TestSSAValue(TensorType(f32, [1, 1, 4, 4])),
-            TestSSAValue(TensorType(f32, [2, 2])),
+            create_ssa_value(TensorType(f32, [1, 1, 4, 4])),
+            create_ssa_value(TensorType(f32, [2, 2])),
         ),
-        (TestSSAValue(TensorType(f32, [1, 1, 3, 3])),),
+        (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
         {
             "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
@@ -309,10 +309,10 @@ def test_linalg_pooling_nchw_max_strides_two():
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.PoolingNchwMaxOp(
         (
-            TestSSAValue(TensorType(f32, [1, 1, 4, 4])),
-            TestSSAValue(TensorType(f32, [2, 2])),
+            create_ssa_value(TensorType(f32, [1, 1, 4, 4])),
+            create_ssa_value(TensorType(f32, [2, 2])),
         ),
-        (TestSSAValue(TensorType(f32, [1, 1, 2, 2])),),
+        (create_ssa_value(TensorType(f32, [1, 1, 2, 2])),),
         (TensorType(f32, [1, 1, 2, 2]),),
         {
             "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
@@ -342,10 +342,10 @@ def test_linalg_conv_2d_nchw_fchw():
     interpreter.register_implementations(LinalgFunctions())
     op = linalg.Conv2DNchwFchwOp(
         (
-            TestSSAValue(TensorType(f32, [1, 1, 5, 5])),
-            TestSSAValue(TensorType(f32, [1, 1, 3, 3])),
+            create_ssa_value(TensorType(f32, [1, 1, 5, 5])),
+            create_ssa_value(TensorType(f32, [1, 1, 3, 3])),
         ),
-        (TestSSAValue(TensorType(f32, [1, 1, 3, 3])),),
+        (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
         {
             "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),

--- a/tests/interpreters/test_memref_stream_interpreter.py
+++ b/tests/interpreters/test_memref_stream_interpreter.py
@@ -20,7 +20,7 @@ from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.ir import Block, Region
 from xdsl.ir.affine import AffineExpr, AffineMap
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 indextype = IndexType()
 
@@ -36,10 +36,10 @@ def test_memref_stream_generic():
 
     op = memref_stream.GenericOp(
         (
-            TestSSAValue(MemRefType(i32, [2, 3])),
-            TestSSAValue(MemRefType(i32, [3, 2])),
+            create_ssa_value(MemRefType(i32, [2, 3])),
+            create_ssa_value(MemRefType(i32, [3, 2])),
         ),
-        (TestSSAValue(MemRefType(i32, [1, 6])),),
+        (create_ssa_value(MemRefType(i32, [1, 6])),),
         (),
         Region(Block(arg_types=(i32, i32, i32))),
         ArrayAttr(
@@ -90,10 +90,10 @@ def test_memref_stream_generic_scalar():
 
     op = memref_stream.GenericOp(
         (
-            TestSSAValue(MemRefType(i32, [2, 3])),
-            TestSSAValue(i32),
+            create_ssa_value(MemRefType(i32, [2, 3])),
+            create_ssa_value(i32),
         ),
-        (TestSSAValue(MemRefType(i32, [1, 6])),),
+        (create_ssa_value(MemRefType(i32, [1, 6])),),
         (),
         Region(Block(arg_types=(i32, i32, i32))),
         ArrayAttr(
@@ -144,10 +144,10 @@ def test_memref_stream_generic_reduction():
 
     op = memref_stream.GenericOp(
         (
-            TestSSAValue(MemRefType(i32, [3])),
-            TestSSAValue(MemRefType(i32, [3])),
+            create_ssa_value(MemRefType(i32, [3])),
+            create_ssa_value(MemRefType(i32, [3])),
         ),
-        (TestSSAValue(MemRefType(i32, [])),),
+        (create_ssa_value(MemRefType(i32, [])),),
         (),
         Region(Block(arg_types=(i32, i32, i32))),
         ArrayAttr(
@@ -187,10 +187,10 @@ def test_memref_stream_generic_imperfect_nesting():
 
     op = memref_stream.GenericOp(
         (
-            TestSSAValue(MemRefType(f32, [3, 2])),
-            TestSSAValue(MemRefType(f32, [2, 3])),
+            create_ssa_value(MemRefType(f32, [3, 2])),
+            create_ssa_value(MemRefType(f32, [2, 3])),
         ),
-        (TestSSAValue(MemRefType(f32, [3, 3])),),
+        (create_ssa_value(MemRefType(f32, [3, 3])),),
         (),
         Region(Block(arg_types=(f32, f32, f32))),
         ArrayAttr(
@@ -238,11 +238,11 @@ def test_memref_stream_generic_reduction_with_initial_value():
 
     op = memref_stream.GenericOp(
         (
-            TestSSAValue(MemRefType(f32, [3, 2])),
-            TestSSAValue(MemRefType(f32, [2, 3])),
+            create_ssa_value(MemRefType(f32, [3, 2])),
+            create_ssa_value(MemRefType(f32, [2, 3])),
         ),
-        (TestSSAValue(MemRefType(f32, [3, 3])),),
-        (TestSSAValue(f32),),
+        (create_ssa_value(MemRefType(f32, [3, 3])),),
+        (create_ssa_value(f32),),
         Region(Block(arg_types=(f32, f32, f32))),
         ArrayAttr(
             (
@@ -289,11 +289,11 @@ def test_memref_stream_interleaved_reduction_with_initial_value():
 
     op = memref_stream.GenericOp(
         (
-            TestSSAValue(MemRefType(f32, [3, 5])),
-            TestSSAValue(MemRefType(f32, [5, 8])),
+            create_ssa_value(MemRefType(f32, [3, 5])),
+            create_ssa_value(MemRefType(f32, [5, 8])),
         ),
-        (TestSSAValue(MemRefType(f32, [3, 8])),),
-        (TestSSAValue(f32),),
+        (create_ssa_value(MemRefType(f32, [3, 8])),),
+        (create_ssa_value(f32),),
         Region(
             Block(
                 arg_types=(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32)

--- a/tests/interpreters/test_pdl_interpreter.py
+++ b/tests/interpreters/test_pdl_interpreter.py
@@ -14,20 +14,20 @@ from xdsl.interpreter import Interpreter
 from xdsl.interpreters.pdl import PDLMatcher, PDLRewriteFunctions, PDLRewritePattern
 from xdsl.ir import Attribute, Block
 from xdsl.pattern_rewriter import PatternRewriteWalker
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_interpreter_functions():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(PDLRewriteFunctions(Context()))
 
-    c0 = TestSSAValue(i32)
-    c1 = TestSSAValue(i32)
+    c0 = create_ssa_value(i32)
+    c1 = create_ssa_value(i32)
     add = arith.AddiOp(c0, c1)
     add_res = add.result
 
     assert interpreter.run_op(
-        pdl.ResultOp(0, TestSSAValue(pdl.OperationType())), (add,)
+        pdl.ResultOp(0, create_ssa_value(pdl.OperationType())), (add,)
     ) == (add_res,)
 
 
@@ -187,7 +187,7 @@ def test_match_operand():
 
     pdl_op = pdl.OperandOp()
     ssa_value = pdl_op.value
-    xdsl_value = TestSSAValue(i32)
+    xdsl_value = create_ssa_value(i32)
 
     # New value
     assert matcher.match_operand(ssa_value, pdl_op, xdsl_value)
@@ -198,14 +198,14 @@ def test_match_operand():
     assert matcher.matching_context == {ssa_value: xdsl_value}
 
     # Other value
-    other_value = TestSSAValue(i32)
+    other_value = create_ssa_value(i32)
     assert not matcher.match_operand(ssa_value, pdl_op, other_value)
     assert matcher.matching_context == {ssa_value: xdsl_value}
 
     # Wrong type
     type_op = pdl.TypeOp(i64)
     new_pdl_op = pdl.OperandOp(type_op.result)
-    new_value = TestSSAValue(i32)
+    new_value = create_ssa_value(i32)
     assert not matcher.match_operand(new_pdl_op.value, new_pdl_op, new_value)
     assert matcher.matching_context == {ssa_value: xdsl_value}
 
@@ -361,8 +361,8 @@ def test_match_operation_with_multiple_constraints():
     matcher = PDLMatcher()
 
     # Create test operation with 2 operands, 2 results, and 2 attributes
-    operand1 = TestSSAValue(i32)
-    operand2 = TestSSAValue(i64)
+    operand1 = create_ssa_value(i32)
+    operand2 = create_ssa_value(i64)
     test_op = test.TestOp(
         operands=[operand1, operand2],
         result_types=[i32, i64],

--- a/tests/interpreters/test_riscv_cf_interpreter.py
+++ b/tests/interpreters/test_riscv_cf_interpreter.py
@@ -3,7 +3,7 @@ from xdsl.dialects.builtin import ModuleOp
 from xdsl.interpreter import Interpreter, Successor
 from xdsl.interpreters.riscv_cf import RiscvCfFunctions
 from xdsl.ir import Block
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 register = riscv.Registers.UNALLOCATED_INT
 module_op = ModuleOp([])
@@ -14,8 +14,8 @@ def test_j_op():
     riscv_cf_functions = RiscvCfFunctions()
     interpreter.register_implementations(riscv_cf_functions)
 
-    a = TestSSAValue(register)
-    b = TestSSAValue(register)
+    a = create_ssa_value(register)
+    b = create_ssa_value(register)
 
     successor = Block(arg_types=(register, register))
 
@@ -35,8 +35,8 @@ def test_branch_op():
     riscv_cf_functions = RiscvCfFunctions()
     interpreter.register_implementations(riscv_cf_functions)
 
-    a = TestSSAValue(register)
-    b = TestSSAValue(register)
+    a = create_ssa_value(register)
+    b = create_ssa_value(register)
 
     successor = Block(arg_types=(register, register))
 
@@ -56,11 +56,11 @@ def test_beq_op():
     riscv_cf_functions = RiscvCfFunctions()
     interpreter.register_implementations(riscv_cf_functions)
 
-    lhs = TestSSAValue(register)
-    rhs = TestSSAValue(register)
-    t0 = TestSSAValue(register)
-    t1 = TestSSAValue(register)
-    e0 = TestSSAValue(register)
+    lhs = create_ssa_value(register)
+    rhs = create_ssa_value(register)
+    t0 = create_ssa_value(register)
+    t1 = create_ssa_value(register)
+    e0 = create_ssa_value(register)
 
     then_block = Block(arg_types=(register, register))
     else_block = Block(arg_types=(register,))

--- a/tests/interpreters/test_riscv_debug_interpreter.py
+++ b/tests/interpreters/test_riscv_debug_interpreter.py
@@ -5,7 +5,7 @@ from xdsl.dialects.builtin import ModuleOp
 from xdsl.interpreter import Interpreter
 from xdsl.interpreters.riscv import RiscvFunctions
 from xdsl.interpreters.riscv_debug import RiscvDebugFunctions
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_riscv_interpreter():
@@ -23,10 +23,10 @@ def test_riscv_interpreter():
             riscv_debug.PrintfOp(
                 "{} {} {} {}",
                 (
-                    TestSSAValue(riscv.Registers.UNALLOCATED_INT),
-                    TestSSAValue(riscv.Registers.UNALLOCATED_INT),
-                    TestSSAValue(riscv.Registers.UNALLOCATED_FLOAT),
-                    TestSSAValue(riscv.Registers.UNALLOCATED_FLOAT),
+                    create_ssa_value(riscv.Registers.UNALLOCATED_INT),
+                    create_ssa_value(riscv.Registers.UNALLOCATED_INT),
+                    create_ssa_value(riscv.Registers.UNALLOCATED_FLOAT),
+                    create_ssa_value(riscv.Registers.UNALLOCATED_FLOAT),
                 ),
             ),
             (1, -1, 2.0, -2.0),

--- a/tests/interpreters/test_riscv_interpreter.py
+++ b/tests/interpreters/test_riscv_interpreter.py
@@ -19,7 +19,7 @@ from xdsl.interpreters.utils.ptr import RawPtr, TypedPtr
 from xdsl.ir import Block, Region
 from xdsl.utils.bitwise_casts import convert_f32_to_u32
 from xdsl.utils.exceptions import InterpretationError
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_riscv_interpreter():
@@ -61,54 +61,66 @@ def test_riscv_interpreter():
     assert interpreter.run_op(riscv.LiOp("label1"), ()) == (
         TypedPtr.new_int32((59,)).raw,
     )
-    assert interpreter.run_op(riscv.MVOp(TestSSAValue(register)), (42,)) == (42,)
+    assert interpreter.run_op(riscv.MVOp(create_ssa_value(register)), (42,)) == (42,)
 
-    assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), 5), (0,)) == (1,)
-    assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), 5), (10,)) == (0,)
-    assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), 5), (-10,)) == (0,)
+    assert interpreter.run_op(riscv.SltiuOp(create_ssa_value(register), 5), (0,)) == (
+        1,
+    )
+    assert interpreter.run_op(riscv.SltiuOp(create_ssa_value(register), 5), (10,)) == (
+        0,
+    )
+    assert interpreter.run_op(riscv.SltiuOp(create_ssa_value(register), 5), (-10,)) == (
+        0,
+    )
 
-    assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), 0), (5,)) == (0,)
-    assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), 10), (5,)) == (1,)
-    assert interpreter.run_op(riscv.SltiuOp(TestSSAValue(register), -10), (5,)) == (1,)
+    assert interpreter.run_op(riscv.SltiuOp(create_ssa_value(register), 0), (5,)) == (
+        0,
+    )
+    assert interpreter.run_op(riscv.SltiuOp(create_ssa_value(register), 10), (5,)) == (
+        1,
+    )
+    assert interpreter.run_op(riscv.SltiuOp(create_ssa_value(register), -10), (5,)) == (
+        1,
+    )
 
     assert interpreter.run_op(
-        riscv.AddOp(TestSSAValue(register), TestSSAValue(register)),
+        riscv.AddOp(create_ssa_value(register), create_ssa_value(register)),
         (1, 2),
     ) == (3,)
 
     assert interpreter.run_op(
-        riscv.AddiOp(TestSSAValue(register), 2),
+        riscv.AddiOp(create_ssa_value(register), 2),
         (1,),
     ) == (3,)
 
     assert interpreter.run_op(
         riscv.SubOp(
-            TestSSAValue(register),
-            TestSSAValue(register),
+            create_ssa_value(register),
+            create_ssa_value(register),
         ),
         (1, 2),
     ) == (-1,)
 
     assert interpreter.run_op(
         riscv.SllOp(
-            TestSSAValue(register),
-            TestSSAValue(register),
+            create_ssa_value(register),
+            create_ssa_value(register),
         ),
         (3, 2),
     ) == (12,)
 
     assert interpreter.run_op(
         riscv.MulOp(
-            TestSSAValue(register),
-            TestSSAValue(register),
+            create_ssa_value(register),
+            create_ssa_value(register),
         ),
         (2, 3),
     ) == (6,)
 
     assert interpreter.run_op(
         riscv.DivOp(
-            TestSSAValue(register),
-            TestSSAValue(register),
+            create_ssa_value(register),
+            create_ssa_value(register),
         ),
         (6, 3),
     ) == (2,)
@@ -120,7 +132,8 @@ def test_riscv_interpreter():
 
     assert (
         interpreter.run_op(
-            riscv.SwOp(TestSSAValue(register), TestSSAValue(register), 0), (buffer, 1)
+            riscv.SwOp(create_ssa_value(register), create_ssa_value(register), 0),
+            (buffer, 1),
         )
         == ()
     )
@@ -130,7 +143,8 @@ def test_riscv_interpreter():
 
     assert (
         interpreter.run_op(
-            riscv.SwOp(TestSSAValue(register), TestSSAValue(register), 4), (buffer, 2)
+            riscv.SwOp(create_ssa_value(register), create_ssa_value(register), 4),
+            (buffer, 2),
         )
         == ()
     )
@@ -138,12 +152,14 @@ def test_riscv_interpreter():
     test_buffer.int32[1] = 2
     assert buffer == test_buffer
 
-    assert interpreter.run_op(riscv.LwOp(TestSSAValue(register), 0), (buffer,)) == (1,)
+    assert interpreter.run_op(riscv.LwOp(create_ssa_value(register), 0), (buffer,)) == (
+        1,
+    )
     assert interpreter.run_op(riscv.LabelOp("label"), ()) == ()
 
     custom_instruction_op = riscv.CustomAssemblyInstructionOp(
         "my_custom_instruction",
-        (TestSSAValue(register), TestSSAValue(register)),
+        (create_ssa_value(register), create_ssa_value(register)),
         (register, register),
     )
 
@@ -151,8 +167,8 @@ def test_riscv_interpreter():
 
     assert interpreter.run_op(
         riscv.FMulSOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (3.0, 4.0),
     ) == (12.0,)
@@ -161,77 +177,77 @@ def test_riscv_interpreter():
 
     assert interpreter.run_op(
         riscv.FMAddDOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (3.0, 4.0, 5.0),
     ) == (17.0,)
 
     assert interpreter.run_op(
         riscv.FAddDOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (3.0, 4.0),
     ) == (7.0,)
 
     assert interpreter.run_op(
         riscv.FSubDOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (3.0, 4.0),
     ) == (-1.0,)
 
     assert interpreter.run_op(
         riscv.FMulDOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (3.0, 4.0),
     ) == (12.0,)
 
     assert interpreter.run_op(
         riscv.FDivDOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (3.0, 4.0),
     ) == (0.75,)
 
     assert interpreter.run_op(
         riscv.FMinDOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (1, 2),
     ) == (1,)
 
     assert interpreter.run_op(
         riscv.FMaxDOp(
-            TestSSAValue(fregister),
-            TestSSAValue(fregister),
+            create_ssa_value(fregister),
+            create_ssa_value(fregister),
         ),
         (1, 2),
     ) == (2,)
 
     assert interpreter.run_op(
-        riscv.FMVOp(TestSSAValue(register)),
+        riscv.FMVOp(create_ssa_value(register)),
         (42.0,),
     ) == (42.0,)
 
     # same behaviour as riscemu currently, but incorrect
     # the top line is the one that should pass, the other is the same as riscemu
-    # assert interpreter.run_op(riscv.FMvWXOp(TestSSAValue(fregister)), (3,)) == (3.0,)
+    # assert interpreter.run_op(riscv.FMvWXOp(test_ssa_value(fregister)), (3,)) == (3.0,)
     assert interpreter.run_op(
-        riscv.FMvWXOp(TestSSAValue(fregister)),
+        riscv.FMvWXOp(create_ssa_value(fregister)),
         (convert_f32_to_u32(3.0),),
     ) == (3.0,)
 
     assert (
         interpreter.run_op(
-            riscv.FSwOp(TestSSAValue(register), TestSSAValue(fregister), 8),
+            riscv.FSwOp(create_ssa_value(register), create_ssa_value(fregister), 8),
             (buffer, 3.0),
         )
         == ()
@@ -241,7 +257,7 @@ def test_riscv_interpreter():
     assert buffer == test_buffer
 
     assert interpreter.run_op(
-        riscv.FLwOp(TestSSAValue(register), 8),
+        riscv.FLwOp(create_ssa_value(register), 8),
         (buffer,),
     ) == (3.0,)
 
@@ -252,25 +268,25 @@ def test_riscv_interpreter():
     test_buffer.float32[3] = 4.0
 
     assert interpreter.run_op(
-        riscv.FLdOp(TestSSAValue(register), 8),
+        riscv.FLdOp(create_ssa_value(register), 8),
         (buffer,),
     ) == (struct.unpack("<d", struct.pack("<ff", 3.0, 4.0))[0],)
 
     assert buffer == test_buffer
 
     assert interpreter.run_op(
-        riscv.FMvDOp(TestSSAValue(register), rd=fregister),
+        riscv.FMvDOp(create_ssa_value(register), rd=fregister),
         (5.0,),
     ) == (5.0,)
 
     assert interpreter.run_op(
-        riscv.FCvtDWOp(TestSSAValue(register)),
+        riscv.FCvtDWOp(create_ssa_value(register)),
         (42,),
     ) == (42.0,)
 
     assert (
         interpreter.run_op(
-            riscv.FSdOp(TestSSAValue(register), TestSSAValue(fregister), 8),
+            riscv.FSdOp(create_ssa_value(register), create_ssa_value(fregister), 8),
             (buffer, struct.unpack("<d", struct.pack("<ff", 5.0, 6.0))[0]),
         )
         == ()

--- a/tests/interpreters/test_riscv_snitch_interpreter.py
+++ b/tests/interpreters/test_riscv_snitch_interpreter.py
@@ -7,7 +7,7 @@ from xdsl.interpreters.riscv import RiscvFunctions
 from xdsl.interpreters.riscv_snitch import RiscvSnitchFunctions
 from xdsl.interpreters.utils.stream import Acc, Nats
 from xdsl.ir import BlockArgument
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_read_write():
@@ -21,18 +21,18 @@ def test_read_write():
     output_stream = Acc()
 
     assert interpreter.run_op(
-        riscv_snitch.ReadOp(TestSSAValue(snitch.ReadableStreamType(a0)), a0),
+        riscv_snitch.ReadOp(create_ssa_value(snitch.ReadableStreamType(a0)), a0),
         (input_stream,),
     ) == (1,)
     assert interpreter.run_op(
-        riscv_snitch.ReadOp(TestSSAValue(snitch.ReadableStreamType(a1)), a1),
+        riscv_snitch.ReadOp(create_ssa_value(snitch.ReadableStreamType(a1)), a1),
         (input_stream,),
     ) == (2,)
 
     assert (
         interpreter.run_op(
             riscv_snitch.WriteOp(
-                TestSSAValue(a0), TestSSAValue(snitch.ReadableStreamType(a0))
+                create_ssa_value(a0), create_ssa_value(snitch.ReadableStreamType(a0))
             ),
             (
                 1,
@@ -45,7 +45,7 @@ def test_read_write():
     assert (
         interpreter.run_op(
             riscv_snitch.WriteOp(
-                TestSSAValue(a1), TestSSAValue(snitch.ReadableStreamType(a1))
+                create_ssa_value(a1), create_ssa_value(snitch.ReadableStreamType(a1))
             ),
             (
                 2,

--- a/tests/interpreters/test_snitch_stream_interpreter.py
+++ b/tests/interpreters/test_snitch_stream_interpreter.py
@@ -9,7 +9,7 @@ from xdsl.interpreters.riscv_snitch import RiscvSnitchFunctions
 from xdsl.interpreters.snitch_stream import SnitchStreamFunctions
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.ir import Block, Region
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 @pytest.mark.parametrize(
@@ -94,8 +94,8 @@ def test_snitch_stream_interpreter():
     assert (
         interpreter.run_op(
             snitch_stream.StreamingRegionOp(
-                (TestSSAValue(register), TestSSAValue(register)),
-                (TestSSAValue(register),),
+                (create_ssa_value(register), create_ssa_value(register)),
+                (create_ssa_value(register),),
                 ArrayAttr(
                     (
                         snitch_stream.StridePattern.from_bounds_and_strides(

--- a/tests/interpreters/test_tensor_interpreter.py
+++ b/tests/interpreters/test_tensor_interpreter.py
@@ -7,7 +7,7 @@ from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.tensor import TensorFunctions
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.utils.exceptions import InterpretationError
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_tensor_empty():
@@ -22,8 +22,8 @@ def test_tensor_reshape():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(TensorFunctions())
     op = tensor.ReshapeOp(
-        TestSSAValue(TensorType(f32, [4, 1])),
-        TestSSAValue(TensorType(i32, [1])),
+        create_ssa_value(TensorType(f32, [4, 1])),
+        create_ssa_value(TensorType(i32, [1])),
         TensorType(f32, [4]),
     )
     a = ShapedArray(TypedPtr.new_float32([1, 2, 3, 4]), [4, 1])
@@ -36,8 +36,8 @@ def test_tensor_reshape_error():
     interpreter = Interpreter(ModuleOp([]))
     interpreter.register_implementations(TensorFunctions())
     op = tensor.ReshapeOp(
-        TestSSAValue(TensorType(f32, [3, 1])),
-        TestSSAValue(TensorType(i32, [1])),
+        create_ssa_value(TensorType(f32, [3, 1])),
+        create_ssa_value(TensorType(i32, [1])),
         TensorType(f32, [3]),
     )
     a = ShapedArray(TypedPtr.new_float32([1, 2, 3]), [3, 1])

--- a/tests/irdl/test_operation_definition.py
+++ b/tests/irdl/test_operation_definition.py
@@ -60,7 +60,7 @@ from xdsl.utils.exceptions import (
     PyRDLOpDefinitionError,
     VerifyException,
 )
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 ################################################################################
 #                              IRDL definition                                 #
@@ -178,8 +178,8 @@ class ConstraintVarOp(IRDLOperation):
 
 
 def test_constraint_var():
-    i32_operand = TestSSAValue(i32)
-    index_operand = TestSSAValue(IndexType())
+    i32_operand = create_ssa_value(i32)
+    index_operand = create_ssa_value(IndexType())
     op = ConstraintVarOp.create(
         operands=[i32_operand], result_types=[i32], attributes={"attribute": i32}
     )
@@ -195,8 +195,8 @@ def test_constraint_var():
 
 def test_constraint_var_fail_non_equal():
     """Check that all uses of a constraint variable are of the same attribute."""
-    i32_operand = TestSSAValue(i32)
-    index_operand = TestSSAValue(IndexType())
+    i32_operand = create_ssa_value(i32)
+    index_operand = create_ssa_value(IndexType())
 
     # Fail because of operand
     op = ConstraintVarOp.create(
@@ -235,7 +235,7 @@ def test_constraint_var_fail_non_equal():
 
 def test_constraint_var_fail_not_satisfy_constraint():
     """Check that all uses of a constraint variable are satisfying the constraint."""
-    test_operand = TestSSAValue(TestType("foo"))
+    test_operand = create_ssa_value(TestType("foo"))
     op = ConstraintVarOp.create(
         operands=[test_operand],
         result_types=[TestType("foo")],
@@ -260,8 +260,8 @@ class GenericConstraintVarOp(IRDLOperation):
 
 
 def test_generic_constraint_var():
-    i32_operand = TestSSAValue(i32)
-    index_operand = TestSSAValue(IndexType())
+    i32_operand = create_ssa_value(i32)
+    index_operand = create_ssa_value(IndexType())
     op = GenericConstraintVarOp.create(
         operands=[i32_operand], result_types=[i32], attributes={"attribute": i32}
     )
@@ -277,8 +277,8 @@ def test_generic_constraint_var():
 
 def test_generic_constraint_var_fail_non_equal():
     """Check that all uses of a constraint variable are of the same attribute."""
-    i32_operand = TestSSAValue(i32)
-    index_operand = TestSSAValue(IndexType())
+    i32_operand = create_ssa_value(i32)
+    index_operand = create_ssa_value(IndexType())
 
     # Fail because of operand
     op = GenericConstraintVarOp.create(
@@ -317,7 +317,7 @@ def test_generic_constraint_var_fail_non_equal():
 
 def test_generic_constraint_var_fail_not_satisfy_constraint():
     """Check that all uses of a constraint variable are satisfying the constraint."""
-    test_operand = TestSSAValue(TestType("foo"))
+    test_operand = create_ssa_value(TestType("foo"))
     op = GenericConstraintVarOp.create(
         operands=[test_operand],
         result_types=[TestType("foo")],
@@ -339,8 +339,8 @@ class ConstraintRangeVarOp(IRDLOperation):
 
 
 def test_range_var():
-    i32_operand = TestSSAValue(i32)
-    index_operand = TestSSAValue(IndexType())
+    i32_operand = create_ssa_value(i32)
+    index_operand = create_ssa_value(IndexType())
     op = ConstraintRangeVarOp.create(operands=[], result_types=[])
     op.verify()
     op = ConstraintRangeVarOp.create(operands=[i32_operand], result_types=[i32])
@@ -358,8 +358,8 @@ def test_range_var():
 
 def test_range_var_fail_non_equal():
     """Check that all uses of a range variable are of the same attribute."""
-    i32_operand = TestSSAValue(i32)
-    index_operand = TestSSAValue(IndexType())
+    i32_operand = create_ssa_value(i32)
+    index_operand = create_ssa_value(IndexType())
 
     op = ConstraintRangeVarOp.create(operands=[index_operand], result_types=[i32])
     with pytest.raises(
@@ -394,7 +394,7 @@ def test_range_var_fail_non_equal():
 
 def test_range_var_fail_not_satisfy_constraint():
     """Check that all uses of a range variable are satisfying the constraint."""
-    test_operand = TestSSAValue(TestType("foo"))
+    test_operand = create_ssa_value(TestType("foo"))
     op = ConstraintRangeVarOp.create(
         operands=[test_operand], result_types=[TestType("foo")]
     )
@@ -475,10 +475,10 @@ class OperandOp(IRDLOperation):
 
 def test_operand_accessors():
     """Test accessors for operands."""
-    operand1 = TestSSAValue(i32)
-    operand2 = TestSSAValue(i32)
-    operand3 = TestSSAValue(i32)
-    operand4 = TestSSAValue(i32)
+    operand1 = create_ssa_value(i32)
+    operand2 = create_ssa_value(i32)
+    operand3 = create_ssa_value(i32)
+    operand4 = create_ssa_value(i32)
 
     op = OperandOp.build(operands=[operand1, [operand2], [operand3, operand4]])
     assert op.operand is op.operands[0]
@@ -729,8 +729,8 @@ class StringFooOp(GenericOp[StringAttr, FooType, FooType]):
 
 def test_generic_op():
     """Test generic operation."""
-    FooOperand = TestSSAValue(TestType("foo"))
-    BarOperand = TestSSAValue(TestType("bar"))
+    FooOperand = create_ssa_value(TestType("foo"))
+    BarOperand = create_ssa_value(TestType("bar"))
     FooResultType = TestType("foo")
     BarResultType = TestType("bar")
 
@@ -777,7 +777,7 @@ class OtherStringFooOp(GenericOp[StringAttr, FooType, FooType], OtherParentOp):
 
 def test_multiple_inheritance_op():
     """Test generic operation."""
-    FooOperand = TestSSAValue(TestType("foo"))
+    FooOperand = create_ssa_value(TestType("foo"))
     FooResultType = TestType("foo")
 
     op = OtherStringFooOp(

--- a/tests/test_dialect_utils.py
+++ b/tests/test_dialect_utils.py
@@ -18,7 +18,7 @@ from xdsl.ir import Dialect, SSAValue
 from xdsl.parser import Parser, UnresolvedOperand
 from xdsl.printer import Printer
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 ctx = Context()
 index = IndexType()
@@ -34,8 +34,8 @@ def test_split_dynamic_index_list():
     assert dynamic == []
 
     # Test case 2: Mix of integers and SSA values
-    val1 = TestSSAValue(IndexType())
-    val2 = TestSSAValue(IndexType())
+    val1 = create_ssa_value(IndexType())
+    val2 = create_ssa_value(IndexType())
     values = [1, 2, val1, 4, val2]
     static, dynamic = split_dynamic_index_list(values, DYNAMIC_INDEX)
     assert static == [1, 2, DYNAMIC_INDEX, 4, DYNAMIC_INDEX]
@@ -60,8 +60,8 @@ def test_get_dynamic_index_list():
     assert result == [1, 2, 3]
 
     # Test case 2: Mix of integers and SSA values
-    val1 = TestSSAValue(IndexType())
-    val2 = TestSSAValue(IndexType())
+    val1 = create_ssa_value(IndexType())
+    val2 = create_ssa_value(IndexType())
     static_values = [1, 2, DYNAMIC_INDEX, 4, DYNAMIC_INDEX]
     dynamic_values = [val1, val2]
     result = get_dynamic_index_list(static_values, dynamic_values, DYNAMIC_INDEX)
@@ -77,7 +77,7 @@ def test_get_dynamic_index_list():
 def test_verify_dynamic_index_list():
     # Test case 1: Valid input
     static_values = [1, 2, DYNAMIC_INDEX]
-    dynamic_values = [TestSSAValue(IndexType())]
+    dynamic_values = [create_ssa_value(IndexType())]
     verify_dynamic_index_list(static_values, dynamic_values, DYNAMIC_INDEX)
 
     # Test case 2: Invalid input (mismatched lengths)
@@ -100,7 +100,7 @@ def test_print_dynamic_index_list():
     # Test case 2: Mix of integers and SSA values
     stream = StringIO()
     printer = Printer(stream)
-    values = [TestSSAValue(IndexType()), TestSSAValue(IndexType())]
+    values = [create_ssa_value(IndexType()), create_ssa_value(IndexType())]
     print_dynamic_index_list(
         printer,
         DYNAMIC_INDEX,
@@ -112,7 +112,7 @@ def test_print_dynamic_index_list():
     # Test case 3: With value types
     stream = StringIO()
     printer = Printer(stream)
-    values = [TestSSAValue(IndexType()), TestSSAValue(IntegerType(32))]
+    values = [create_ssa_value(IndexType()), create_ssa_value(IntegerType(32))]
     value_types = (IndexType(), IntegerType(32))
     print_dynamic_index_list(
         printer,
@@ -184,7 +184,7 @@ def test_parse_dynamic_index_without_type():
 
 def test_parse_dynamic_index_list_with_types():
     dynamic_index = -42
-    test_values = (TestSSAValue(i32), TestSSAValue(index))
+    test_values = (create_ssa_value(i32), create_ssa_value(index))
     parser = Parser(ctx, "[%0 : i32, 42, %1 : index]")
     parser.ssa_values["0"] = (test_values[0],)
     parser.ssa_values["1"] = (test_values[1],)
@@ -213,7 +213,7 @@ def test_parse_dynamic_index_list_without_types():
 
 def test_parse_dynamic_index_list_with_custom_delimiter():
     dynamic_index = -42
-    test_values = (TestSSAValue(i32), TestSSAValue(index))
+    test_values = (create_ssa_value(i32), create_ssa_value(index))
     parser = Parser(ctx, "(%0 : i32, 42, %1 : index)")
     parser.ssa_values["0"] = (test_values[0],)
     parser.ssa_values["1"] = (test_values[1],)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -27,7 +27,7 @@ from xdsl.interpreter import (
 from xdsl.interpreters.builtin import BuiltinFunctions
 from xdsl.ir import Attribute, Operation
 from xdsl.utils.exceptions import InterpretationError
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_import_functions():
@@ -90,7 +90,7 @@ def test_cast():
         integer = interpreter.cast_value(IndexType(), i32, index0)
 
     # Test builtin cast
-    integer_value = TestSSAValue(i32)
+    integer_value = create_ssa_value(i32)
     cast_op = builtin.UnrealizedConversionCastOp.get(
         (integer_value,), result_type=(IndexType(),)
     )
@@ -185,7 +185,7 @@ def test_run_op_interpreter_args():
         interpreter.run_op(test_op, ())
 
     op = test.TestOp(
-        (TestSSAValue(TensorType(f32, [4])),),
+        (create_ssa_value(TensorType(f32, [4])),),
         (
             TensorType(f32, [4]),
             TensorType(f32, [4]),
@@ -206,7 +206,7 @@ def test_run_op_interpreter_args():
     assert interpreter.run_op(test_op_2, ()) == (1,)
 
     op_2 = test.TestOp(
-        (TestSSAValue(TensorType(f32, [4])),),
+        (create_ssa_value(TensorType(f32, [4])),),
         (TensorType(f32, [4]),),
     )
     assert interpreter.run_op(op_2, (1,)) == (1,)

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -23,7 +23,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 @irdl_op_definition
@@ -134,7 +134,7 @@ def test_ops_accessor_III():
 
 def test_op_operands_assign():
     """Test that we can directly assign `op.operands`."""
-    val1, val2 = TestSSAValue(i32), TestSSAValue(i32)
+    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
     op = test.TestOp.create(operands=[val1, val2])
     op.operands = [val2, val1]
     op.verify()
@@ -146,7 +146,7 @@ def test_op_operands_assign():
 
 def test_op_operands_indexing():
     """Test `__getitem__`, `__setitem__`, and `__len__` on `op.operands`."""
-    val1, val2 = TestSSAValue(i32), TestSSAValue(i32)
+    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
     op = test.TestOp.create(operands=[val1, val2])
     op.verify()
 
@@ -165,7 +165,7 @@ def test_op_operands_indexing():
 
 def test_op_operands_comparison():
     """Test `__eq__`, and `__hash__` on `op.operands`."""
-    val1, val2 = TestSSAValue(i32), TestSSAValue(i32)
+    val1, val2 = create_ssa_value(i32), create_ssa_value(i32)
     op1 = test.TestOp.create(operands=[val1, val2])
     op2 = test.TestOp.create(operands=[val1, val2])
     op1.verify()
@@ -740,16 +740,16 @@ def test_is_structurally_equivalent_properties():
 
 
 def test_is_structurally_equivalent_free_operands():
-    val1 = TestSSAValue(i32)
-    val2 = TestSSAValue(i64)
+    val1 = create_ssa_value(i32)
+    val2 = create_ssa_value(i64)
     op1 = test.TestOp.create(operands=[val1, val2])
     op2 = test.TestOp.create(operands=[val1, val2])
     assert op1.is_structurally_equivalent(op2)
 
 
 def test_is_structurally_equivalent_free_operands_fail():
-    val1 = TestSSAValue(i32)
-    val2 = TestSSAValue(i32)
+    val1 = create_ssa_value(i32)
+    val2 = create_ssa_value(i32)
     op1 = test.TestOp.create(operands=[val1])
     op2 = test.TestOp.create(operands=[val2])
     assert not op1.is_structurally_equivalent(op2)
@@ -986,13 +986,13 @@ def test_dialect_name():
 
 
 def test_replace_by_if():
-    a = TestSSAValue(i32)
+    a = create_ssa_value(i32)
     b = test.TestOp((a,))
     c = test.TestOp((a,))
 
     assert set(u.operation for u in a.uses) == {b, c}
 
-    d = TestSSAValue(i32)
+    d = create_ssa_value(i32)
     a.replace_by_if(d, lambda u: u.operation is not c)
 
     assert set(u.operation for u in a.uses) == {c}

--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -15,7 +15,7 @@ from xdsl.ir import Attribute, ParametrizedAttribute, SSAValue
 from xdsl.irdl import BaseAttr, EqAttrConstraint, ParameterDef, irdl_attr_definition
 from xdsl.utils.hints import isa
 from xdsl.utils.isattr import isattr
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 class Class1:
@@ -408,14 +408,14 @@ def test_isattr():
 
 
 def test_ssavalue():
-    a = TestSSAValue(i32)
+    a = create_ssa_value(i32)
 
     assert isa(a, SSAValue)
     assert isa(a, SSAValue[IntegerType])
     assert not isa(a, SSAValue[StringAttr])
     assert not isa(a, SSAValue[IntegerAttr[IntegerType]])
 
-    b = TestSSAValue(IntegerAttr(2, i32))
+    b = create_ssa_value(IntegerAttr(2, i32))
 
     assert isa(b, SSAValue[IntegerAttr[IntegerType]])
     assert not isa(b, SSAValue[IntegerAttr[IndexType]])

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -44,7 +44,7 @@ from xdsl.parser import AttrParser, Parser
 from xdsl.printer import Printer
 from xdsl.utils.diagnostic import Diagnostic
 from xdsl.utils.exceptions import DiagnosticException, ParseError
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_simple_forgotten_op():
@@ -934,7 +934,7 @@ def test_get_printed_name():
     ctx.load_dialect(Builtin)
 
     printer = Printer()
-    val = TestSSAValue(i32)
+    val = create_ssa_value(i32)
 
     # Test printing without constraints
     stream = StringIO()
@@ -949,7 +949,7 @@ def test_get_printed_name():
     assert f"%{picked_name}" == printer.stream.getvalue()
 
     # Test printing with name hint
-    val = TestSSAValue(i32)
+    val = create_ssa_value(i32)
     val.name_hint = "foo"
     printed = StringIO()
     picked_name = Printer(printed).print_ssa_value(val)

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -4,7 +4,7 @@ from xdsl.dialects.builtin import StringAttr, i32, i64
 from xdsl.ir import Block, BlockArgument, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, result_def
 from xdsl.rewriter import Rewriter
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 @irdl_op_definition
@@ -65,7 +65,7 @@ def test_invalid_ssa_vals(name: str):
 
 def test_rewrite_type():
     """We can rewrite the type of a test SSA value."""
-    val = TestSSAValue(i32)
+    val = create_ssa_value(i32)
     rewriter = Rewriter()
     new_val = rewriter.replace_value_with_new_type(val, i64)
     assert val.type == i32

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -3,7 +3,6 @@ import pytest
 from xdsl.dialects.builtin import StringAttr, i32
 from xdsl.ir import Block, BlockArgument, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, result_def
-from xdsl.utils.test_value import TestSSAValue
 
 
 @irdl_op_definition
@@ -60,11 +59,3 @@ def test_invalid_ssa_vals(name: str):
     val = BlockArgument(i32, Block(), 0)
     with pytest.raises(ValueError):
         val.name_hint = name
-
-
-def test_owner():
-    val = TestSSAValue(i32)
-    with pytest.raises(
-        ValueError, match="Attempting to get the owner of a `TestSSAValue`"
-    ):
-        val.owner

--- a/tests/test_ssa_value.py
+++ b/tests/test_ssa_value.py
@@ -1,8 +1,10 @@
 import pytest
 
-from xdsl.dialects.builtin import StringAttr, i32
-from xdsl.ir import Block, BlockArgument, SSAValue
+from xdsl.dialects.builtin import StringAttr, i32, i64
+from xdsl.ir import Block, BlockArgument, Operation, SSAValue
 from xdsl.irdl import IRDLOperation, irdl_op_definition, result_def
+from xdsl.rewriter import Rewriter
+from xdsl.utils.test_value import TestSSAValue
 
 
 @irdl_op_definition
@@ -59,3 +61,33 @@ def test_invalid_ssa_vals(name: str):
     val = BlockArgument(i32, Block(), 0)
     with pytest.raises(ValueError):
         val.name_hint = name
+
+
+def test_rewrite_type():
+    """We can rewrite the type of a test SSA value."""
+    val = TestSSAValue(i32)
+    rewriter = Rewriter()
+    new_val = rewriter.replace_value_with_new_type(val, i64)
+    assert val.type == i32
+    assert new_val.type == i64
+
+
+def test_replace_type():
+    class InvalidValue(SSAValue):
+        @property
+        def owner(self) -> Operation | Block:
+            """
+            An SSA variable is either an operation result, or a basic block argument.
+            This property returns the Operation or Block that currently defines a specific value.
+            """
+            ...
+
+    val = InvalidValue(i32)
+
+    rewriter = Rewriter()
+
+    with pytest.raises(
+        ValueError,
+        match="Expected OpResult or BlockArgument, got InvalidValue",
+    ):
+        rewriter.replace_value_with_new_type(val, i32)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -60,7 +60,7 @@ from xdsl.traits import (
     is_speculatable,
 )
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 @dataclass(frozen=True)
@@ -154,9 +154,9 @@ def test_verifier():
     """
     Check that the traits verifier are correctly called.
     """
-    operand64 = TestSSAValue(i64)
-    operand32 = TestSSAValue(i32)
-    operand1 = TestSSAValue(i1)
+    operand64 = create_ssa_value(i64)
+    operand32 = create_ssa_value(i32)
+    operand1 = create_ssa_value(i1)
     op = TestOp.create(operands=[operand1], result_types=[i32])
 
     message = (
@@ -565,7 +565,7 @@ def test_speculability(
     [
         ([()], [()]),
         ([()], (test.TestType("foo"),)),
-        ((TestSSAValue(test.TestType("foo")),), [()]),
+        ((create_ssa_value(test.TestType("foo")),), [()]),
     ],
 )
 def test_same_operands_and_result_type_trait_for_scalar_types(
@@ -652,7 +652,7 @@ def test_same_operands_and_result_type_trait_for_result_element_type_of_shaped_t
 ):
     op = SameOperandsAndResultTypeOp(
         operands=[
-            TestSSAValue(
+            create_ssa_value(
                 TensorType(operand1_and_result_element_type, operand_and_result_shape1)
             )
         ],
@@ -728,7 +728,7 @@ def test_same_operands_and_result_type_trait_for_element_type_of_shaped_types(
     op = SameOperandsAndResultTypeOp(
         operands=[
             [
-                TestSSAValue(operand_type),
+                create_ssa_value(operand_type),
             ]
             * operands_num,
         ],
@@ -785,7 +785,7 @@ def test_same_operands_and_result_type_trait_for_result_encoding_of_shaped_types
     op = SameOperandsAndResultTypeOp(
         operands=[
             [
-                TestSSAValue(
+                create_ssa_value(
                     TensorType(
                         element_type,
                         shape,
@@ -862,7 +862,7 @@ def test_same_operands_and_result_type_trait_for_encoding_of_shaped_types(
     op = SameOperandsAndResultTypeOp(
         operands=[
             [
-                TestSSAValue(
+                create_ssa_value(
                     TensorType(
                         element_type,
                         shape,
@@ -927,10 +927,10 @@ def test_same_operands_and_result_type_trait_for_ranked_mixed_shapes(
     op = SameOperandsAndResultTypeOp(
         operands=[
             [
-                TestSSAValue(
+                create_ssa_value(
                     TensorType(test.TestType("foo"), operand1_and_result_shape)
                 ),
-                TestSSAValue(TensorType(test.TestType("foo"), operand2_shape)),
+                create_ssa_value(TensorType(test.TestType("foo"), operand2_shape)),
             ]
             * operands_num,
         ],
@@ -967,10 +967,10 @@ def test_same_operands_and_result_type_trait_for_mixed_rank_and_mixed_shapes(
     op = SameOperandsAndResultTypeOp(
         operands=[
             [
-                TestSSAValue(
+                create_ssa_value(
                     TensorType(test.TestType("foo"), operand1_and_result_shape)
                 ),
-                TestSSAValue(UnrankedTensorType(test.TestType("foo"))),
+                create_ssa_value(UnrankedTensorType(test.TestType("foo"))),
             ]
             * operands_num,
         ],

--- a/tests/transforms/test_lower_affine.py
+++ b/tests/transforms/test_lower_affine.py
@@ -5,7 +5,7 @@ from xdsl.dialects.builtin import IndexType, IntegerAttr
 from xdsl.ir import Operation, SSAValue
 from xdsl.ir.affine import AffineBinaryOpExpr, AffineBinaryOpKind, AffineExpr
 from xdsl.transforms.lower_affine import affine_expr_ops
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 @pytest.mark.parametrize(
@@ -20,7 +20,7 @@ from xdsl.utils.test_value import TestSSAValue
         ),
         (
             AffineExpr.dimension(0),
-            [value0 := TestSSAValue(IndexType())],
+            [value0 := create_ssa_value(IndexType())],
             [],
             [],
             value0,
@@ -28,7 +28,7 @@ from xdsl.utils.test_value import TestSSAValue
         (
             AffineExpr.symbol(0),
             [],
-            [value1 := TestSSAValue(IndexType())],
+            [value1 := create_ssa_value(IndexType())],
             [],
             value1,
         ),
@@ -36,7 +36,10 @@ from xdsl.utils.test_value import TestSSAValue
             AffineBinaryOpExpr(
                 AffineBinaryOpKind.Add, AffineExpr.dimension(0), AffineExpr.dimension(1)
             ),
-            [value2 := TestSSAValue(IndexType()), value3 := TestSSAValue(IndexType())],
+            [
+                value2 := create_ssa_value(IndexType()),
+                value3 := create_ssa_value(IndexType()),
+            ],
             [],
             [arith.AddiOp(value2, value3)],
             None,
@@ -45,7 +48,10 @@ from xdsl.utils.test_value import TestSSAValue
             AffineBinaryOpExpr(
                 AffineBinaryOpKind.Mul, AffineExpr.dimension(0), AffineExpr.dimension(1)
             ),
-            [value2 := TestSSAValue(IndexType()), value3 := TestSSAValue(IndexType())],
+            [
+                value2 := create_ssa_value(IndexType()),
+                value3 := create_ssa_value(IndexType()),
+            ],
             [],
             [arith.MuliOp(value2, value3)],
             None,
@@ -54,7 +60,10 @@ from xdsl.utils.test_value import TestSSAValue
             AffineBinaryOpExpr(
                 AffineBinaryOpKind.Mod, AffineExpr.dimension(0), AffineExpr.dimension(1)
             ),
-            [value2 := TestSSAValue(IndexType()), value3 := TestSSAValue(IndexType())],
+            [
+                value2 := create_ssa_value(IndexType()),
+                value3 := create_ssa_value(IndexType()),
+            ],
             [],
             [arith.RemSIOp(value2, value3)],
             None,
@@ -65,7 +74,10 @@ from xdsl.utils.test_value import TestSSAValue
                 AffineExpr.dimension(0),
                 AffineExpr.dimension(1),
             ),
-            [value2 := TestSSAValue(IndexType()), value3 := TestSSAValue(IndexType())],
+            [
+                value2 := create_ssa_value(IndexType()),
+                value3 := create_ssa_value(IndexType()),
+            ],
             [],
             [arith.FloorDivSIOp(value2, value3)],
             None,
@@ -76,7 +88,10 @@ from xdsl.utils.test_value import TestSSAValue
                 AffineExpr.dimension(0),
                 AffineExpr.dimension(1),
             ),
-            [value2 := TestSSAValue(IndexType()), value3 := TestSSAValue(IndexType())],
+            [
+                value2 := create_ssa_value(IndexType()),
+                value3 := create_ssa_value(IndexType()),
+            ],
             [],
             [arith.CeilDivSIOp(value2, value3)],
             None,

--- a/tests/transforms/test_transform_utils.py
+++ b/tests/transforms/test_transform_utils.py
@@ -8,12 +8,12 @@ from xdsl.transforms.loop_hoist_memref import (
     find_same_target_store,
     is_loop_dependent,
 )
-from xdsl.utils.test_value import TestSSAValue
+from xdsl.utils.test_value import create_ssa_value
 
 
 def test_find_same_target_store0():
     i32_memref_type = MemRefType(i32, [1])
-    memref_ssa_value = TestSSAValue(i32_memref_type)
+    memref_ssa_value = create_ssa_value(i32_memref_type)
     load0 = LoadOp.get(memref_ssa_value, [])
 
     assert find_same_target_store(load0) is None
@@ -22,7 +22,7 @@ def test_find_same_target_store0():
 
     assert find_same_target_store(load0) is None
 
-    i32_ssa_value = TestSSAValue(i32)
+    i32_ssa_value = create_ssa_value(i32)
     store0 = StoreOp.get(i32_ssa_value, memref_ssa_value, [])
 
     assert find_same_target_store(load0) is None

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -14,7 +14,6 @@ from xdsl.ir import (
     Region,
     SSAValue,
 )
-from xdsl.utils.test_value import TestSSAValue
 
 
 @dataclass(frozen=True)
@@ -202,8 +201,7 @@ class Rewriter:
                 *args[index + 1 :],
             )
         else:
-            assert isinstance(val, TestSSAValue)
-            new_value = TestSSAValue(new_type)
+            raise ValueError(f"Expected OpResult or BlockArgument, got {val}")
 
         new_value.name_hint = val.name_hint
         val.replace_by(new_value)

--- a/xdsl/rewriter.py
+++ b/xdsl/rewriter.py
@@ -201,7 +201,9 @@ class Rewriter:
                 *args[index + 1 :],
             )
         else:
-            raise ValueError(f"Expected OpResult or BlockArgument, got {val}")
+            raise ValueError(
+                f"Expected OpResult or BlockArgument, got {type(val).__name__}"
+            )
 
         new_value.name_hint = val.name_hint
         val.replace_by(new_value)

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -1,7 +1,14 @@
+from typing_extensions import deprecated
+
 from xdsl.dialects.test import TestOp
 from xdsl.ir import AttributeCovT, OpResult
 
 
-def TestSSAValue(t: AttributeCovT) -> OpResult[AttributeCovT]:
+def create_ssa_value(t: AttributeCovT) -> OpResult[AttributeCovT]:
     op = TestOp(result_types=(t,))
     return op.results[0]  # pyright: ignore[reportReturnType]
+
+
+@deprecated("Please use `test_ssa_value` instead")
+def TestSSAValue(t: AttributeCovT) -> OpResult[AttributeCovT]:
+    return create_ssa_value(t)

--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -1,9 +1,7 @@
-from typing import Generic
+from xdsl.dialects.test import TestOp
+from xdsl.ir import AttributeCovT, OpResult
 
-from xdsl.ir import AttributeCovT, Block, Operation, SSAValue
 
-
-class TestSSAValue(Generic[AttributeCovT], SSAValue[AttributeCovT]):
-    @property
-    def owner(self) -> Operation | Block:
-        raise ValueError("Attempting to get the owner of a `TestSSAValue`")
+def TestSSAValue(t: AttributeCovT) -> OpResult[AttributeCovT]:
+    op = TestOp(result_types=(t,))
+    return op.results[0]  # pyright: ignore[reportReturnType]


### PR DESCRIPTION
As discussed on Zulip, this gets rid of a weird special SSAValue that messed up some core infrastructure.