### PR TITLE
dialects: (x86) Change RR_MovOp and RI_MovOp to have only one input

### DIFF
--- a/tests/filecheck/backend/x86/convert_func_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_func_to_x86.mlir
@@ -10,8 +10,7 @@ func.func @foo_const() -> i32 {
 // CHECK-NEXT:    x86_func.func @foo_const(%0 : !x86.reg<rsp>) -> !x86.reg<rax> {
 // CHECK-NEXT:      %1 = "test.op"() : () -> i32
 // CHECK-NEXT:      %2 = builtin.unrealized_conversion_cast %1 : i32 to !x86.reg
-// CHECK-NEXT:      %3 = x86.get_register : () -> !x86.reg<rax>
-// CHECK-NEXT:      %4 = x86.rr.mov %2, %3 : (!x86.reg, !x86.reg<rax>) -> !x86.reg<rax>
+// CHECK-NEXT:      %3 = x86.rr.mov %2 : (!x86.reg) -> !x86.reg<rax>
 // CHECK-NEXT:      x86_func.ret
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -50,8 +49,7 @@ func.func public @foo_int(%0: i32, %1: i32, %2: i32, %3: i32, %4: i32, %5: i32, 
 // CHECK-NEXT:      %f = "test.op"(%e, %14) : (i32, i32) -> i32
 // CHECK-NEXT:      %g = "test.op"(%f, %16) : (i32, i32) -> i32
 // CHECK-NEXT:      %17 = builtin.unrealized_conversion_cast %g : i32 to !x86.reg
-// CHECK-NEXT:      %18 = x86.get_register : () -> !x86.reg<rax>
-// CHECK-NEXT:      %19 = x86.rr.mov %17, %18 : (!x86.reg, !x86.reg<rax>) -> !x86.reg<rax>
+// CHECK-NEXT:      %18 = x86.rr.mov %17 : (!x86.reg) -> !x86.reg<rax>
 // CHECK-NEXT:      x86_func.ret
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
+++ b/tests/filecheck/dialects/x86/x86_assembly_emission.mlir
@@ -17,7 +17,7 @@
 // CHECK-NEXT: or rax, rdx
 %rr_xor = x86.rr.xor %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK-NEXT: xor rax, rdx
-%rr_mov = x86.rr.mov %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.reg<rax>
+%rr_mov = x86.rr.mov %1 : (!x86.reg<rdx>) -> !x86.reg<rax>
 // CHECK-NEXT: mov rax, rdx
 %rr_cmp = x86.rr.cmp %0, %1 : (!x86.reg<rax>, !x86.reg<rdx>) -> !x86.rflags<rflags>
 // CHECK-NEXT: cmp rax, rdx
@@ -72,7 +72,7 @@
 // CHECK-NEXT: or rax, 2
 %ri_xor = x86.ri.xor %0, 2 : (!x86.reg<rax>) -> !x86.reg<rax>
 // CHECK-NEXT: xor rax, 2
-%ri_mov = x86.ri.mov %0, 2 : (!x86.reg<rax>) -> !x86.reg<rax>
+%ri_mov = x86.ri.mov 2 : !x86.reg<rax>
 // CHECK-NEXT: mov rax, 2
 %ri_cmp = x86.ri.cmp %0, 2 : (!x86.reg<rax>) -> !x86.rflags<rflags>
 // CHECK-NEXT: cmp rax, 2

--- a/tests/filecheck/dialects/x86/x86_ops.mlir
+++ b/tests/filecheck/dialects/x86/x86_ops.mlir
@@ -19,8 +19,8 @@
 // CHECK-NEXT: %{{.*}} = x86.rr.or %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
 %rr_xor = x86.rr.xor %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
 // CHECK-NEXT: %{{.*}} = x86.rr.xor %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
-%rr_mov = x86.rr.mov %0, %1 : (!x86.reg, !x86.reg) -> !x86.reg
-// CHECK-NEXT: %{{.*}} = x86.rr.mov %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.reg
+%rr_mov = x86.rr.mov %0 : (!x86.reg) -> !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.rr.mov %{{.*}} : (!x86.reg) -> !x86.reg
 %rr_cmp = x86.rr.cmp %0, %1 : (!x86.reg, !x86.reg) -> !x86.rflags<rflags>
 // CHECK: %{{.*}} = x86.rr.cmp %{{.*}}, %{{.*}} : (!x86.reg, !x86.reg) -> !x86.rflags
 
@@ -73,8 +73,8 @@
 // CHECK-NEXT: %{{.*}} = x86.ri.or %{{.*}}, 2 : (!x86.reg) -> !x86.reg
 %ri_xor = x86.ri.xor %0, 2 : (!x86.reg) -> !x86.reg
 // CHECK-NEXT: %{{.*}} = x86.ri.xor %{{.*}}, 2 : (!x86.reg) -> !x86.reg
-%ri_mov = x86.ri.mov %0, 2 : (!x86.reg) -> !x86.reg
-// CHECK-NEXT: %{{.*}} = x86.ri.mov %{{.*}}, 2 : (!x86.reg) -> !x86.reg
+%ri_mov = x86.ri.mov 2 : !x86.reg
+// CHECK-NEXT: %{{.*}} = x86.ri.mov 2 : !x86.reg
 %ri_cmp = x86.ri.cmp %0, 2 : (!x86.reg) -> !x86.rflags<rflags>
 // CHECK-NEXT: %{{.*}} = x86.ri.cmp %{{.*}}, 2 : (!x86.reg) -> !x86.rflags
 

--- a/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
+++ b/xdsl/backend/x86/lowering/convert_func_to_x86_func.py
@@ -145,11 +145,10 @@ class LowerReturnOp(RewritePattern):
         cast_op = builtin.UnrealizedConversionCastOp.get(
             (return_value,), (x86.register.UNALLOCATED_GENERAL,)
         )
-        get_reg_op = x86.ops.GetRegisterOp(return_passing_register)
-        mov_op = x86.ops.RR_MovOp(cast_op, get_reg_op, result=return_passing_register)
+        mov_op = x86.ops.RR_MovOp(cast_op, result=return_passing_register)
         ret_op = x86_func.RetOp()
 
-        rewriter.replace_matched_op([cast_op, get_reg_op, mov_op, ret_op])
+        rewriter.replace_matched_op([cast_op, mov_op, ret_op])
 
 
 class ConvertFuncToX86FuncPass(ModulePass):


### PR DESCRIPTION
Before this change, RR_MovOp and RI_MovOp were subclasses of R_RR_Operation and R_RI_Operation, respectively. These classes are meant for instructions for which, in x86 Intel syntax, the first operand refers to the register which is both the first input register and the output register, and the second operand refers to the second input register or immediate.

The mov instruction with 32-bit or 64-bit registers has only one input because the result register is fully overwritten (in the 32-bit case, the upper half is zeroed). In these cases, there is only one input. With 8-bit or 16-bit registers, only part of the result register is overwritten, so the content of the result register depends on the previous content of it. Partial registers except 32-bit ones are not yet implemented in the x86 dialect, so for now the latter case can be ignored. Therefore, the mov instruction is changed to be modelled with one input register or immediate, and one result register. This change is in line with #3967. There are no existing abstract classes for these kinds of instructions, so RR_MovOp and RI_MovOp were changed to directly subclass X86Instruction.

If the result register is a 64-bit register, R_RI_Operation should be able to take 64-bit immediates. However, supporting this is currently hard because unallocated registers don’t track the size of the register. As R_RI_Operation didn’t support 64-bit immediates, either, this is not a regression. (As a side-note, mov is the only x86 instruction able to take 64-bit immediates.)