### PR TITLE
core: rename AffineMap.compressDims to dropDims

### DIFF
--- a/tests/test_affine_builtins.py
+++ b/tests/test_affine_builtins.py
@@ -219,16 +219,16 @@ def test_inverse_permutation():
     )
 
 
-def test_compress_dims():
+def test_drop_dims():
     # (d0, d1, d2) -> (d1, d2) with [0,1,1] gives (d0, d1) -> (d0, d1)
     # (d0, d1, d2) -> (d2, d2) with [1,0,1] gives (d0, d1) -> (d1, d1)
     t = True
     f = False
-    assert AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)).compress_dims(
-        [f, t, t]
+    assert AffineMap.from_callable(lambda d0, d1, d2: (d1, d2)).drop_dims(
+        [t, f, f]
     ) == AffineMap.from_callable(lambda d0, d1: (d0, d1))
-    assert AffineMap.from_callable(lambda d0, d1, d2: (d2, d2)).compress_dims(
-        [t, f, t]
+    assert AffineMap.from_callable(lambda d0, d1, d2: (d2, d2)).drop_dims(
+        [f, t, f]
     ) == AffineMap.from_callable(lambda d0, d1: (d1, d1))
 
 

--- a/xdsl/ir/affine/affine_map.py
+++ b/xdsl/ir/affine/affine_map.py
@@ -241,29 +241,31 @@ class AffineMap:
         assert len(symbols) == self.num_symbols
         return tuple(expr.eval(dims, symbols) for expr in self.results)
 
-    def compress_dims(self, selectors: Sequence[bool]) -> AffineMap:
+    def drop_dims(self, unused_dims: Sequence[bool]) -> AffineMap:
         """
-        Given a sequence of `selectors` indicating the input dimensions to keep, return a
-        new map only with the new dimensions. The results of `self` must be a subset of
-        the dimensions in `selectors`. The remaining dimensions are remapped to the
-        remaining number.
+        Given a sequence of `unused_dims` indicating the input dimensions to drop,
+        return a new map only with the new dimensions. The results of `self` must be a
+        subset of the dimensions in `selectors`. The remaining dimensions are remapped
+        to the remaining number.
 
         Examples:
         ```
-        (d0, d1, d2) -> (d1, d2) with [0,1,1] gives (d0, d1) -> (d0, d1)
-        (d0, d1, d2) -> (d2, d2) with [1,0,1] gives (d0, d1) -> (d1, d1)
+        (d0, d1, d2) -> (d1, d2) with [1,0,0] gives (d0, d1) -> (d0, d1)
+        (d0, d1, d2) -> (d2, d2) with [0,1,0] gives (d0, d1) -> (d1, d1)
         ```
+
+        Corresponds to MLIR's `compressDims`.
         """
-        if len(selectors) != self.num_dims:
+        if len(unused_dims) != self.num_dims:
             raise ValueError(
-                f"Invalid `selectors`, expected {self.num_dims} `bool` values, got "
-                f"{len(selectors)}"
+                f"Invalid `unused_dims`, expected {self.num_dims} `bool` values, got "
+                f"{len(unused_dims)}"
             )
 
-        result_num_dims = sum(selectors)
+        result_num_dims = sum(not dim for dim in unused_dims)
         new_dims = tuple(
             AffineExpr.dimension(dim)
-            for dim in itertools.accumulate(selectors, initial=0)
+            for dim in itertools.accumulate((not dim for dim in unused_dims), initial=0)
         )
         new_symbols = tuple(AffineExpr.symbol(s) for s in range(self.num_symbols))
 

--- a/xdsl/transforms/loop_nest_lowering_utils.py
+++ b/xdsl/transforms/loop_nest_lowering_utils.py
@@ -44,11 +44,15 @@ def indices_for_map(
             )
             if len(used_dims) != affine_map.num_dims:
                 # Remove unused dims
-                selectors = tuple(
+                # used_dims = affine_map.used_dims_bit_vector()
+                used_dims_vector = tuple(
                     dim in used_dims for dim in range(affine_map.num_dims)
                 )
-                new_index_vals = tuple(compress(new_index_vals, selectors))
-                new_affine_map = new_affine_map.compress_dims(selectors)
+                unused_dims_vector = tuple(
+                    not used_dim for used_dim in used_dims_vector
+                )
+                new_index_vals = tuple(compress(new_index_vals, used_dims_vector))
+                new_affine_map = new_affine_map.drop_dims(unused_dims_vector)
 
             rewriter.insert_op(
                 apply_op := affine.ApplyOp(

--- a/xdsl/transforms/memref_stream_unnest_out_parameters.py
+++ b/xdsl/transforms/memref_stream_unnest_out_parameters.py
@@ -40,13 +40,13 @@ class UnnestOutParametersPattern(RewritePattern):
         if num_parallel == len(op.iterator_types):
             return
 
-        parallel_dims = (True,) * num_parallel + (False,) * num_reduction
+        reduction_dims = (False,) * num_parallel + (True,) * num_reduction
 
         maps = op.indexing_maps.data[num_inputs:]
         new_maps = ArrayAttr(
             (
                 *op.indexing_maps.data[:num_inputs],
-                *(AffineMapAttr(m.data.compress_dims(parallel_dims)) for m in maps),
+                *(AffineMapAttr(m.data.drop_dims(reduction_dims)) for m in maps),
             )
         )
 


### PR DESCRIPTION
Our version of compress dims was more consistent with Python's `itertools.compress`, in that 1 signals to keep an element, than MLIR's `compressDims`, where 1 signals to drop an element. Since there's an inherent confusion in the name here, I propose to make the behaviour consistent with MLIR, while changing the name to be a bit more explicit about the fact that it's dropping the indicated values.

One alternative would be to rename the existing function `keepDims`, and to add a new function called `dropDims`, and have one call the other. It seems that the `keepDims` implementation can be more easily expressed than the dropping version, but it's a very small difference, so I went instead with a smaller API surface.

CC @watermelonwolverine 