### PR TITLE
documentation: ignore markdownlint error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
----
-title: xDSL: A Python-native SSA Compiler Framework
----
+# xDSL: A Python-native SSA Compiler Framework
 
 [![Build Status for the Core backend](https://github.com/xdslproject/xdsl/actions/workflows/ci-core.yml/badge.svg)](https://github.com/xdslproject/xdsl/actions/workflows/ci-core.yml?query=workflow%3A%22CI+-+Python+application%22++)
 [![PyPI version](https://badge.fury.io/py/xdsl.svg)](https://badge.fury.io/py/xdsl)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
+---
+title: xDSL: A Python-native SSA Compiler Framework
+---
+
 [![Build Status for the Core backend](https://github.com/xdslproject/xdsl/actions/workflows/ci-core.yml/badge.svg)](https://github.com/xdslproject/xdsl/actions/workflows/ci-core.yml?query=workflow%3A%22CI+-+Python+application%22++)
 [![PyPI version](https://badge.fury.io/py/xdsl.svg)](https://badge.fury.io/py/xdsl)
 [![Downloads](https://static.pepy.tech/badge/xdsl)](https://www.pepy.tech/projects/xdsl)
 [![Downloads](https://static.pepy.tech/badge/xdsl/week)](https://pepy.tech/project/xdsl)
 [![Code Coverage](https://codecov.io/gh/xdslproject/xdsl/main/graph/badge.svg)](https://codecov.io/gh/xdslproject/xdsl)
 [![Zulip Status](https://img.shields.io/badge/chat-on%20zulip-%2336C5F0)](https://xdsl.zulipchat.com)
-
-# xDSL: A Python-native SSA Compiler Framework
 
 [xDSL](http://www.xdsl.dev) is a Python-native compiler framework built around
 SSA-based intermediate representations (IRs). Users of xDSL build a compiler by

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# xDSL: A Python-native SSA Compiler Framework
-
+<!-- markdownlint-disable-next-line MD041 -->
 [![Build Status for the Core backend](https://github.com/xdslproject/xdsl/actions/workflows/ci-core.yml/badge.svg)](https://github.com/xdslproject/xdsl/actions/workflows/ci-core.yml?query=workflow%3A%22CI+-+Python+application%22++)
 [![PyPI version](https://badge.fury.io/py/xdsl.svg)](https://badge.fury.io/py/xdsl)
 [![Downloads](https://static.pepy.tech/badge/xdsl)](https://www.pepy.tech/projects/xdsl)
 [![Downloads](https://static.pepy.tech/badge/xdsl/week)](https://pepy.tech/project/xdsl)
 [![Code Coverage](https://codecov.io/gh/xdslproject/xdsl/main/graph/badge.svg)](https://codecov.io/gh/xdslproject/xdsl)
 [![Zulip Status](https://img.shields.io/badge/chat-on%20zulip-%2336C5F0)](https://xdsl.zulipchat.com)
+
+# xDSL: A Python-native SSA Compiler Framework
 
 [xDSL](http://www.xdsl.dev) is a Python-native compiler framework built around
 SSA-based intermediate representations (IRs). Users of xDSL build a compiler by


### PR DESCRIPTION
My markdownlint complains when the first thing in a .md file isn't a header, but the badges belong in the first location, so this adds an ignore. I'm not sure that it's worth adding markdownlint as a dependency, I'd like to keep that discussion to the future if possible, and just add the ignores manually.

Check the new README here: https://github.com/xdslproject/xdsl/tree/sasha/misc/mdlint

