### PR TITLE
core: refactor has_trait method to eliminate issubclass checks

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -75,6 +75,7 @@ from xdsl.traits import (
     NoMemoryEffect,
     NoTerminator,
     OptionalSymbolOpInterface,
+    OpTrait,
     SymbolTable,
 )
 from xdsl.utils.comparisons import (
@@ -1705,6 +1706,15 @@ class UnregisteredOp(Operation, ABC):
                 return op
 
         return UnregisteredOpWithNameOp
+
+    @classmethod
+    def has_trait(
+        cls,
+        trait: type[OpTrait] | OpTrait,  # pyright: ignore[reportUnknownParameterType]
+        *,
+        value_if_unregistered: bool = True,
+    ) -> bool:
+        return value_if_unregistered
 
 
 class UnregisteredAttr(ParametrizedAttribute, ABC):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1710,7 +1710,7 @@ class UnregisteredOp(Operation, ABC):
     @classmethod
     def has_trait(
         cls,
-        trait: type[OpTrait] | OpTrait,  # pyright: ignore[reportUnknownParameterType]
+        trait: type[OpTrait] | OpTrait,
         *,
         value_if_unregistered: bool = True,
     ) -> bool:

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -1172,12 +1172,6 @@ class Operation(IRNode):
         Check if the operation implements a trait with the given parameters.
         If the operation is not registered, return value_if_unregisteed instead.
         """
-
-        from xdsl.dialects.builtin import UnregisteredOp
-
-        if issubclass(cls, UnregisteredOp):
-            return value_if_unregistered
-
         return cls.get_trait(trait) is not None
 
     @classmethod


### PR DESCRIPTION
Refactor `has_trait` method to eliminate unnecessary `issubclass` checks for unregistered operations.