### PR TITLE
misc: Fix deprecation message for `TestSSAValue`

### DIFF
--- a/xdsl/utils/test_value.py
+++ b/xdsl/utils/test_value.py
@@ -9,6 +9,6 @@ def create_ssa_value(t: AttributeCovT) -> OpResult[AttributeCovT]:
     return op.results[0]  # pyright: ignore[reportReturnType]
 
 
-@deprecated("Please use `test_ssa_value` instead")
+@deprecated("Please use `create_ssa_value` instead")
 def TestSSAValue(t: AttributeCovT) -> OpResult[AttributeCovT]:
     return create_ssa_value(t)


### PR DESCRIPTION
Fix deprecation message to refer to `create_ssa_value` instead of `test_ssa_value`.

