### PR TITLE
canonicalize: (arith) Fold cmpf and select on same operands

### DIFF
--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -159,3 +159,29 @@ func.func @test_const_var_const() {
 %11 = arith.constant true
 %12 = arith.addi %11, %11 : i1
 "test.op"(%12) : (i1) -> ()
+
+func.func @test_fold_cmpf_select() {
+  %cst = arith.constant 4.000000e+00 : f64
+  %cst_0 = arith.constant 3.000000e+00 : f64
+  %13 = "test.op"() : () -> f64
+  %14 = arith.cmpf ogt, %13, %cst_0 : f64
+  %15 = arith.select %14, %13, %cst_0 : f64
+  %16 = arith.cmpf olt, %15, %cst : f64
+  %17 = arith.select %16, %15, %cst : f64
+  %18 = arith.cmpf ule, %17, %cst : f64
+  %19 = arith.select %18, %17, %cst : f64
+  %20 = arith.cmpf ule, %19, %cst : f64
+  %21 = arith.select %20, %19, %cst : f64
+  "test.op"(%21) : (f64) -> ()
+  return
+
+  // CHECK-LABEL: @test_fold_cmpf_select
+  // CHECK-NEXT:  %cst = arith.constant 4.000000e+00 : f64
+  // CHECK-NEXT:  %cst_1 = arith.constant 3.000000e+00 : f64
+  // CHECK-NEXT:  %12 = "test.op"() : () -> f64
+  // CHECK-NEXT:  %13 = arith.maximumf %12, %cst_1 : f64
+  // CHECK-NEXT:  %14 = arith.minimumf %13, %cst : f64
+  // CHECK-NEXT:  %15 = arith.minnumf %14, %cst : f64
+  // CHECK-NEXT:  %16 = arith.minnumf %15, %cst : f64
+  // CHECK-NEXT:  "test.op"(%16) : (f64) -> ()
+}

--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -161,9 +161,7 @@ func.func @test_const_var_const() {
 "test.op"(%12) : (i1) -> ()
 
 func.func @test_fold_cmpf_select() {
-  %cst = arith.constant 4.000000e+00 : f64
-  %cst_0 = arith.constant 3.000000e+00 : f64
-  %13 = "test.op"() : () -> f64
+  %cst, %cst_0, %13 = "test.op"() : () -> (f64, f64, f64)
   %14 = arith.cmpf ogt, %13, %cst_0 : f64
   %15 = arith.select %14, %13, %cst_0 : f64
   %16 = arith.cmpf olt, %15, %cst : f64
@@ -176,9 +174,7 @@ func.func @test_fold_cmpf_select() {
   return
 
   // CHECK-LABEL: @test_fold_cmpf_select
-  // CHECK-NEXT:  %cst = arith.constant 4.000000e+00 : f64
-  // CHECK-NEXT:  %cst_1 = arith.constant 3.000000e+00 : f64
-  // CHECK-NEXT:  %12 = "test.op"() : () -> f64
+  // CHECK-NEXT:  %cst, %cst_1, %12 = "test.op"() : () -> (f64, f64, f64)
   // CHECK-NEXT:  %13 = arith.maximumf %12, %cst_1 : f64
   // CHECK-NEXT:  %14 = arith.minimumf %13, %cst : f64
   // CHECK-NEXT:  %15 = arith.minnumf %14, %cst : f64

--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -162,22 +162,22 @@ func.func @test_const_var_const() {
 
 func.func @test_fold_cmpf_select() {
   %cst, %cst_0, %13 = "test.op"() : () -> (f64, f64, f64)
-  %14 = arith.cmpf ogt, %13, %cst_0 : f64
+  %14 = arith.cmpf ogt, %13, %cst_0 fastmath<nnan> : f64
   %15 = arith.select %14, %13, %cst_0 : f64
-  %16 = arith.cmpf olt, %15, %cst : f64
+  %16 = arith.cmpf olt, %15, %cst fastmath<nnan> : f64
   %17 = arith.select %16, %15, %cst : f64
-  %18 = arith.cmpf ule, %17, %cst : f64
+  %18 = arith.cmpf uge, %17, %cst fastmath<nnan> : f64
   %19 = arith.select %18, %17, %cst : f64
-  %20 = arith.cmpf ule, %19, %cst : f64
+  %20 = arith.cmpf ule, %19, %cst fastmath<nnan> : f64
   %21 = arith.select %20, %19, %cst : f64
   "test.op"(%21) : (f64) -> ()
   return
 
   // CHECK-LABEL: @test_fold_cmpf_select
   // CHECK-NEXT:  %cst, %cst_1, %12 = "test.op"() : () -> (f64, f64, f64)
-  // CHECK-NEXT:  %13 = arith.maximumf %12, %cst_1 : f64
-  // CHECK-NEXT:  %14 = arith.minimumf %13, %cst : f64
-  // CHECK-NEXT:  %15 = arith.minnumf %14, %cst : f64
-  // CHECK-NEXT:  %16 = arith.minnumf %15, %cst : f64
+  // CHECK-NEXT:  %13 = arith.maximumf %12, %cst_1 fastmath<nnan> : f64
+  // CHECK-NEXT:  %14 = arith.minimumf %13, %cst fastmath<nnan> : f64
+  // CHECK-NEXT:  %15 = arith.maximumf %14, %cst fastmath<nnan> : f64
+  // CHECK-NEXT:  %16 = arith.minimumf %15, %cst fastmath<nnan> : f64
   // CHECK-NEXT:  "test.op"(%16) : (f64) -> ()
 }

--- a/tests/filecheck/dialects/arith/canonicalize.mlir
+++ b/tests/filecheck/dialects/arith/canonicalize.mlir
@@ -162,22 +162,22 @@ func.func @test_const_var_const() {
 
 func.func @test_fold_cmpf_select() {
   %cst, %cst_0, %13 = "test.op"() : () -> (f64, f64, f64)
-  %14 = arith.cmpf ogt, %13, %cst_0 fastmath<nnan> : f64
+  %14 = arith.cmpf ogt, %13, %cst_0 fastmath<nnan,nsz> : f64
   %15 = arith.select %14, %13, %cst_0 : f64
-  %16 = arith.cmpf olt, %15, %cst fastmath<nnan> : f64
+  %16 = arith.cmpf olt, %15, %cst fastmath<nnan,nsz> : f64
   %17 = arith.select %16, %15, %cst : f64
-  %18 = arith.cmpf uge, %17, %cst fastmath<nnan> : f64
+  %18 = arith.cmpf uge, %17, %cst fastmath<nnan,nsz> : f64
   %19 = arith.select %18, %17, %cst : f64
-  %20 = arith.cmpf ule, %19, %cst fastmath<nnan> : f64
+  %20 = arith.cmpf ule, %19, %cst fastmath<nnan,nsz> : f64
   %21 = arith.select %20, %19, %cst : f64
   "test.op"(%21) : (f64) -> ()
   return
 
   // CHECK-LABEL: @test_fold_cmpf_select
   // CHECK-NEXT:  %cst, %cst_1, %12 = "test.op"() : () -> (f64, f64, f64)
-  // CHECK-NEXT:  %13 = arith.maximumf %12, %cst_1 fastmath<nnan> : f64
-  // CHECK-NEXT:  %14 = arith.minimumf %13, %cst fastmath<nnan> : f64
-  // CHECK-NEXT:  %15 = arith.maximumf %14, %cst fastmath<nnan> : f64
-  // CHECK-NEXT:  %16 = arith.minimumf %15, %cst fastmath<nnan> : f64
+  // CHECK-NEXT:  %13 = arith.maximumf %12, %cst_1 fastmath<nnan,nsz> : f64
+  // CHECK-NEXT:  %14 = arith.minimumf %13, %cst fastmath<nnan,nsz> : f64
+  // CHECK-NEXT:  %15 = arith.maximumf %14, %cst fastmath<nnan,nsz> : f64
+  // CHECK-NEXT:  %16 = arith.minimumf %15, %cst fastmath<nnan,nsz> : f64
   // CHECK-NEXT:  "test.op"(%16) : (f64) -> ()
 }

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -914,6 +914,16 @@ class CmpiOp(ComparisonOperation):
         printer.print_attribute(self.lhs.type)
 
 
+class CmpfOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from xdsl.transforms.canonicalization_patterns.arith import (
+            CmpfOpFoldSelectPattern,
+        )
+
+        return (CmpfOpFoldSelectPattern(),)
+
+
 @irdl_op_definition
 class CmpfOp(ComparisonOperation):
     """
@@ -946,6 +956,8 @@ class CmpfOp(ComparisonOperation):
     rhs = operand_def(floatingPointLike)
     fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
     result = result_def(IntegerType(1))
+
+    traits = traits_def(CmpfOpHasCanonicalizationPatterns(), Pure())
 
     def __init__(
         self,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -914,16 +914,6 @@ class CmpiOp(ComparisonOperation):
         printer.print_attribute(self.lhs.type)
 
 
-class CmpfOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from xdsl.transforms.canonicalization_patterns.arith import (
-            CmpfOpFoldSelectPattern,
-        )
-
-        return (CmpfOpFoldSelectPattern(),)
-
-
 @irdl_op_definition
 class CmpfOp(ComparisonOperation):
     """
@@ -957,7 +947,7 @@ class CmpfOp(ComparisonOperation):
     fastmath = prop_def(FastMathFlagsAttr, default_value=FastMathFlagsAttr("none"))
     result = result_def(IntegerType(1))
 
-    traits = traits_def(CmpfOpHasCanonicalizationPatterns(), Pure())
+    traits = traits_def(Pure())
 
     def __init__(
         self,
@@ -1039,11 +1029,17 @@ class SelectHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from xdsl.transforms.canonicalization_patterns.arith import (
             SelectConstPattern,
+            SelectFoldCmpfPattern,
             SelectSamePattern,
             SelectTrueFalsePattern,
         )
 
-        return (SelectConstPattern(), SelectTrueFalsePattern(), SelectSamePattern())
+        return (
+            SelectConstPattern(),
+            SelectTrueFalsePattern(),
+            SelectSamePattern(),
+            SelectFoldCmpfPattern(),
+        )
 
 
 @irdl_op_definition

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -202,10 +202,7 @@ class SelectFoldCmpfPattern(RewritePattern):
             cmpf := op.cond.op, arith.CmpfOp
         ):
             return
-        if (
-            cmpf.fastmath is None
-            or arith.FastMathFlag.NO_NANS not in cmpf.fastmath.flags
-        ):
+        if arith.FastMathFlag.NO_NANS not in cmpf.fastmath.flags:
             return
         if not (op.lhs == cmpf.lhs and op.rhs == cmpf.rhs):
             return

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -221,7 +221,6 @@ class CmpfOpFoldSelectPattern(RewritePattern):
             case _:
                 return
         rewriter.replace_op(select, target(select.lhs, select.rhs, op.fastmath))
-        rewriter.erase_matched_op()
 
 
 class ApplyCmpiPredicateToEqualOperands(RewritePattern):

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -218,9 +218,10 @@ class CmpfOpFoldSelectPattern(RewritePattern):
             case 11 | 12:
                 # ult | ule
                 target = arith.MinnumfOp
-        if target:
-            rewriter.replace_op(select, target(select.lhs, select.rhs, op.fastmath))
-            rewriter.erase_matched_op()
+            case _:
+                return
+        rewriter.replace_op(select, target(select.lhs, select.rhs, op.fastmath))
+        rewriter.erase_matched_op()
 
 
 class ApplyCmpiPredicateToEqualOperands(RewritePattern):

--- a/xdsl/transforms/canonicalization_patterns/arith.py
+++ b/xdsl/transforms/canonicalization_patterns/arith.py
@@ -202,7 +202,10 @@ class SelectFoldCmpfPattern(RewritePattern):
             cmpf := op.cond.op, arith.CmpfOp
         ):
             return
-        if arith.FastMathFlag.NO_NANS not in cmpf.fastmath.flags:
+        if (
+            arith.FastMathFlag.NO_NANS not in cmpf.fastmath.flags
+            or arith.FastMathFlag.NO_SIGNED_ZEROS not in cmpf.fastmath.flags
+        ):
             return
         if not (op.lhs == cmpf.lhs and op.rhs == cmpf.rhs):
             return


### PR DESCRIPTION
I have encountered a pattern where `arith.cmpf` is immediately followed by `arith.select` on the same operands:

```
    %cst_0 = arith.constant 3.000000e+00 : f64
    %0 = "test.op"() : () -> f64
    %1 = arith.cmpf ogt, %0, %cst_0 : f64
    %2 = arith.select %1, %0, %cst_0 : f64
    "test.op"(%2) : (f64) -> ()
```
This could be simplified to:
```
    %cst_0 = arith.constant 3.000000e+00 : f64
    %0 = "test.op"() : () -> f64
    %1 = arith.maximumf %0, %cst_0 : f64
    "test.op"(%1) : (f64) -> ()
```

The ordered comparisons olt/ole and ogt/oge will produce `minimumf` and `maximumf` ([link](https://mlir.llvm.org/docs/Dialects/ArithOps/#arithmaximumf-arithmaximumfop)), respectively. Similarly, the unordered comparisons ult/ule and ugt/uge will produce a `minnumf` and `maxnumf`, respectively. 

Here, ogt and olt mean "ordered greater than" and "ordered less than", respectively.