### PR TITLE
installation: (pre-commit) update versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.0
+    rev: v0.11.6
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]


### PR DESCRIPTION
Updates ruff precommit version and pre-commit-hooks version. Shouldn't renovate do this?