### PR TITLE
transformations: (linalg-to-csl) Translate linalg.max

### DIFF
--- a/tests/filecheck/transforms/linalg-to-csl.mlir
+++ b/tests/filecheck/transforms/linalg-to-csl.mlir
@@ -24,6 +24,8 @@ builtin.module {
     %12 = arith.addf %11, %in_1 : f32
     linalg.yield %12 : f32
   }
+
+  linalg.max ins(%1, %0 : memref<16xf32>, memref<16xf32>) outs(%0 : memref<16xf32>)
 }
 
 //CHECK-NEXT: builtin.module {
@@ -43,4 +45,5 @@ builtin.module {
 //CHECK-NEXT:   %c = arith.constant dense<0x4D8EF3C2> : memref<16xf32>
 //CHECK-NEXT:   %13 = arith.constant 0x4D8EF3C2 : f32
 //CHECK-NEXT:   "csl.fmacs"(%0, %2, %0, %13) : (memref<16xf32>, memref<16xf32>, memref<16xf32>, f32) -> ()
+//CHECK-NEXT:   "csl.fmaxs"(%0, %1, %0) : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> ()
 //CHECK-NEXT: }

--- a/xdsl/transforms/linalg_to_csl.py
+++ b/xdsl/transforms/linalg_to_csl.py
@@ -157,6 +157,18 @@ class ConvertLinalgMulPass(ConvertBinaryLinalgOp):
         self.transform_op(op, rewriter, f16=csl.FmulhOp, f32=csl.FmulsOp)
 
 
+class ConvertLinalgMaxPass(ConvertBinaryLinalgOp):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: linalg.MaxOp, rewriter: PatternRewriter, /):
+        self.transform_op(op, rewriter, f16=csl.FmaxhOp, f32=csl.FmaxsOp)
+
+
+class ConvertLinalgMinPass(ConvertBinaryLinalgOp):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: linalg.MinOp, rewriter: PatternRewriter, /):
+        self.transform_op(op, rewriter, f16=csl.FminhOp, f32=csl.FminsOp)
+
+
 @dataclass(frozen=True)
 class LinalgToCsl(ModulePass):
     """
@@ -175,6 +187,8 @@ class LinalgToCsl(ModulePass):
                     ConvertLinalgAddPass(),
                     ConvertLinalgSubPass(),
                     ConvertLinalgMulPass(),
+                    ConvertLinalgMaxPass(),
+                    ConvertLinalgMinPass(),
                 ]
             ),
         )

--- a/xdsl/transforms/linalg_to_csl.py
+++ b/xdsl/transforms/linalg_to_csl.py
@@ -163,12 +163,6 @@ class ConvertLinalgMaxPass(ConvertBinaryLinalgOp):
         self.transform_op(op, rewriter, f16=csl.FmaxhOp, f32=csl.FmaxsOp)
 
 
-class ConvertLinalgMinPass(ConvertBinaryLinalgOp):
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: linalg.MinOp, rewriter: PatternRewriter, /):
-        self.transform_op(op, rewriter, f16=csl.FminhOp, f32=csl.FminsOp)
-
-
 @dataclass(frozen=True)
 class LinalgToCsl(ModulePass):
     """
@@ -188,7 +182,6 @@ class LinalgToCsl(ModulePass):
                     ConvertLinalgSubPass(),
                     ConvertLinalgMulPass(),
                     ConvertLinalgMaxPass(),
-                    ConvertLinalgMinPass(),
                 ]
             ),
         )


### PR DESCRIPTION
It turns out, there are functions for max but not for min. Is there an undocumented one?