### PR TITLE
dialects: (affine) Fix ApplyOp printing and add test

### DIFF
--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -81,21 +81,3 @@ def test_for_mismatch_blockargs():
 def test_yield():
     yield_ = YieldOp.get()
     assert yield_.arguments == ()
-
-
-def test_affine_apply_map():
-    MODULE_CTX = """
-#map = affine_map<()[s0] -> (s0 * 4)>
-%c0 = arith.constant 2 : index
-%0 = affine.apply #map()[%c0]
-    """
-    ctx = Context()
-    ctx.load_dialect(Tensor)
-    ctx.load_dialect(Arith)
-    ctx.load_dialect(Affine)
-
-    module_op = Parser(ctx, MODULE_CTX).parse_module()
-
-    print(module_op)
-
-    module_op.verify()

--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -1,9 +1,13 @@
 import pytest
 
-from xdsl.dialects.affine import ForOp, YieldOp
+from xdsl.context import Context
+from xdsl.dialects.affine import Affine, ForOp, YieldOp
+from xdsl.dialects.arith import Arith
 from xdsl.dialects.builtin import AffineMapAttr, IndexType, IntegerAttr, IntegerType
+from xdsl.dialects.tensor import Tensor
 from xdsl.ir import Attribute, Block, Region
 from xdsl.ir.affine import AffineExpr
+from xdsl.parser import Parser
 from xdsl.utils.exceptions import VerifyException
 
 
@@ -77,3 +81,21 @@ def test_for_mismatch_blockargs():
 def test_yield():
     yield_ = YieldOp.get()
     assert yield_.arguments == ()
+
+
+def test_affine_apply_map():
+    MODULE_CTX = """
+#map = affine_map<()[s0] -> (s0 * 4)>
+%c0 = arith.constant 2 : index
+%0 = affine.apply #map()[%c0]
+    """
+    ctx = Context()
+    ctx.load_dialect(Tensor)
+    ctx.load_dialect(Arith)
+    ctx.load_dialect(Affine)
+
+    module_op = Parser(ctx, MODULE_CTX).parse_module()
+
+    print(module_op)
+
+    module_op.verify()

--- a/tests/dialects/test_affine.py
+++ b/tests/dialects/test_affine.py
@@ -1,13 +1,9 @@
 import pytest
 
-from xdsl.context import Context
-from xdsl.dialects.affine import Affine, ForOp, YieldOp
-from xdsl.dialects.arith import Arith
+from xdsl.dialects.affine import ForOp, YieldOp
 from xdsl.dialects.builtin import AffineMapAttr, IndexType, IntegerAttr, IntegerType
-from xdsl.dialects.tensor import Tensor
 from xdsl.ir import Attribute, Block, Region
 from xdsl.ir.affine import AffineExpr
-from xdsl.parser import Parser
 from xdsl.utils.exceptions import VerifyException
 
 

--- a/tests/filecheck/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/dialects/affine/affine_ops.mlir
@@ -117,4 +117,11 @@
 // CHECK-NEXT:      func.return %{{.*}} : f32
 // CHECK-NEXT:    }
 
+  // Check that an affine.apply with an affine map is printed correctly.
+
+  %c0 = arith.constant 2 : index
+  %0 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%c0]
+  // CHECK: %{{.*}} = arith.constant 2 : index
+  // CHECK-NEXT: %{{.*}} = affine.apply affine_map<()[{{.*}}] -> (({{.*}} * 4))> ()[%{{.*}}]
+
 }) : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/affine/affine_ops.mlir
@@ -117,4 +117,11 @@
 // CHECK-NEXT:      func.return %{{.*}} : f32
 // CHECK-NEXT:    }
 
+  // Check that an affine.apply with an affine map is printed correctly.
+
+  %c0 = arith.constant 2 : index
+  %0 = affine.apply affine_map<()[s0] -> (s0 * 4)>()[%c0]
+  // CHECK: %{{.*}} = arith.constant 2 : index
+  // CHECK-NEXT: %{{.*}} = affine.apply affine_map<()[{{.*}}] -> (({{.*}} * 4))> ()[%{{.*}}]
+
 }) : () -> ()

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -96,13 +96,13 @@ class ApplyOp(IRDLOperation):
         assert len(operands) == m.num_dims + m.num_symbols, f"{len(operands)} {m}"
         printer.print_string(" ")
         printer.print_attribute(self.map)
-        printer.print_string(" ")
+        printer.print_string("(")
         if m.num_dims:
-            printer.print_string("(")
             printer.print_list(
                 operands[: m.num_dims], lambda el: printer.print_operand(el)
             )
-            printer.print_string(")")
+        printer.print_string(")")
+
         if m.num_symbols:
             printer.print_string("[")
             printer.print_list(

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -96,7 +96,7 @@ class ApplyOp(IRDLOperation):
         assert len(operands) == m.num_dims + m.num_symbols, f"{len(operands)} {m}"
         printer.print_string(" ")
         printer.print_attribute(self.map)
-        printer.print_string("(")
+        printer.print_string(" (")
         if m.num_dims:
             printer.print_list(
                 operands[: m.num_dims], lambda el: printer.print_operand(el)


### PR DESCRIPTION
Without this change the testcase prints this:
```mlir
builtin.module {
  %c0 = arith.constant 2 : index
  %0 = affine.apply affine_map<()[s0] -> ((s0 * 4))> [%c0]
}
```
which results in this error when trying to parse with MLIR:
```
temp.mlir:3:53: error: expected '(' in operand list
  %0 = affine.apply affine_map<()[s0] -> ((s0 * 4))> [%c0]
                                                                                  ^
```

The change should fix the missing parenthesis:
```mlir
builtin.module {
  %c0 = arith.constant 2 : index
  %0 = affine.apply affine_map<()[s0] -> ((s0 * 4))>() [%c0]
}
```

I'm not quite sure how to test the compatibility with MLIR