### PR TITLE
transformations: (shape-inference) Support stencil offset_mapping

### DIFF
--- a/tests/filecheck/transforms/stencil-shape-inference.mlir
+++ b/tests/filecheck/transforms/stencil-shape-inference.mlir
@@ -327,3 +327,42 @@ func.func @buffer(%arg0 : !stencil.field<?x?x?xf64>, %arg1 : !stencil.field<?x?x
 // CHECK-NEXT:      stencil.store %14 to %2(<[48, 0, 0], [64, 64, 60]>) : !stencil.temp<[48,64]x[0,64]x[0,60]xf64> to !stencil.field<[-3,67]x[-3,67]x[0,60]xf64>
 // CHECK-NEXT:      func.return
 // CHECK-NEXT:    }
+// -----
+
+func.func @stencil_missing_dims(%in : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %ybuf : !stencil.field<[-4,68]xf64>, %zbuf : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+  %intemp = stencil.load %in : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64> -> !stencil.temp<?x?x?xf64>
+  %0 = "dmp.swap"(%intemp) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = []} : (!stencil.temp<?x?x?xf64>) -> !stencil.temp<?x?x?xf64>
+  %ybuf_t = stencil.load %ybuf : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
+  %1 = "dmp.swap"(%ybuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = []} : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+  %zbuf_t = stencil.load %zbuf : !stencil.field<[-4,68]xf64> -> !stencil.temp<?xf64>
+  %2 = "dmp.swap"(%zbuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = []} : (!stencil.temp<?xf64>) -> !stencil.temp<?xf64>
+  %res = stencil.apply(%inarg = %0 : !stencil.temp<?x?x?xf64>, %ybuf_arg = %1 : !stencil.temp<?xf64>, %zbuf_arg = %2 : !stencil.temp<?xf64>) -> (!stencil.temp<?x?x?xf64>) {
+    %3 = stencil.access %ybuf_arg[_, -1, _] : !stencil.temp<?xf64>
+    %4 = stencil.access %zbuf_arg[_, _, -1] : !stencil.temp<?xf64>
+    %5 = stencil.access %inarg[0, -1, -1] : !stencil.temp<?x?x?xf64>
+    %6 = arith.addf %3, %4 : f64
+    %7 = arith.addf %5, %6 : f64
+    stencil.return %7 : f64
+  }
+  stencil.store %res to %out(<[0, 0, 0], [1, 1, 64]>) : !stencil.temp<?x?x?xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+  func.return
+}
+
+// CHECK:       func.func @stencil_missing_dims(%in : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %ybuf : !stencil.field<[-4,68]xf64>, %zbuf : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+// CHECK-NEXT:    %intemp = stencil.load %in : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64> -> !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+// CHECK-NEXT:    %0 = "dmp.swap"(%intemp) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = [#dmp.exchange<at [0, -1, 0] size [1, 1, 64] source offset [0, 1, 0] to [0, -1, 0]>]} : (!stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>) -> !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+// CHECK-NEXT:    %ybuf_t = stencil.load %ybuf : !stencil.field<[-4,68]xf64> -> !stencil.temp<[-1,0]xf64>
+// CHECK-NEXT:    %1 = "dmp.swap"(%ybuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = [#dmp.exchange<at [0, -1, 0] size [1, 1, 64] source offset [0, 1, 0] to [0, -1, 0]>]} : (!stencil.temp<[-1,0]xf64>) -> !stencil.temp<[-1,0]xf64>
+// CHECK-NEXT:    %zbuf_t = stencil.load %zbuf : !stencil.field<[-4,68]xf64> -> !stencil.temp<[-1,63]xf64>
+// CHECK-NEXT:    %2 = "dmp.swap"(%zbuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = []} : (!stencil.temp<[-1,63]xf64>) -> !stencil.temp<[-1,63]xf64>
+// CHECK-NEXT:    %res = stencil.apply(%inarg = %0 : !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>, %ybuf_arg = %1 : !stencil.temp<[-1,0]xf64>, %zbuf_arg = %2 : !stencil.temp<[-1,63]xf64>) -> (!stencil.temp<[0,1]x[0,1]x[0,64]xf64>) {
+// CHECK-NEXT:      %3 = stencil.access %ybuf_arg[_, -1, _] : !stencil.temp<[-1,0]xf64>
+// CHECK-NEXT:      %4 = stencil.access %zbuf_arg[_, _, -1] : !stencil.temp<[-1,63]xf64>
+// CHECK-NEXT:      %5 = stencil.access %inarg[0, -1, -1] : !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+// CHECK-NEXT:      %6 = arith.addf %3, %4 : f64
+// CHECK-NEXT:      %7 = arith.addf %5, %6 : f64
+// CHECK-NEXT:      stencil.return %7 : f64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    stencil.store %res to %out(<[0, 0, 0], [1, 1, 64]>) : !stencil.temp<[0,1]x[0,1]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+// CHECK-NEXT:    func.return
+// CHECK-NEXT:  }

--- a/xdsl/dialects/stencil.py
+++ b/xdsl/dialects/stencil.py
@@ -664,7 +664,10 @@ class ApplyOp(IRDLOperation):
                 # grab the offsets as a tuple[int, ...]
                 offsets = tuple(access.offset)
                 # account for offset_mappings:
-                if access.offset_mapping is not None:
+                if (
+                    access.offset_mapping is not None
+                    and len(offsets) == self.get_rank()
+                ):
                     offsets = tuple(offsets[i] for i in access.offset_mapping)
                 accesses.append(offsets)
             yield AccessPattern(tuple(accesses))

--- a/xdsl/transforms/shape_inference_patterns/dmp.py
+++ b/xdsl/transforms/shape_inference_patterns/dmp.py
@@ -59,6 +59,34 @@ class DmpSwapSwapsInference(RewritePattern):
         if core_lb is None or core_ub is None:
             return
 
+        # if buff_* has fewer dimensions than core_*, we need to find out which dimensions of core_*
+        # those in buff_* map to. This information only exists in the offset_mapping of a stencil.access
+        if len(buff_lb) < len(core_lb):
+            for use in op.swapped_values.uses:
+                if not isinstance(apply_op := use.operation, stencil.ApplyOp):
+                    continue
+                arg_idx = apply_op.operands.index(op.swapped_values)
+                arg = apply_op.region.block.args[arg_idx]
+                for arg_use in arg.uses:
+                    if (
+                        not isinstance(access_op := arg_use.operation, stencil.AccessOp)
+                        or not access_op.offset_mapping
+                    ):
+                        continue
+                    accessed_dims = tuple(access_op.offset_mapping)
+
+                    # reconstruct what dims buff_* maps to
+                    new_lb = [0] * len(core_lb)
+                    new_ub = [0] * len(core_ub)
+                    for idx, dim in enumerate(accessed_dims):
+                        new_lb[dim] = tuple(buff_lb)[idx]
+                        new_ub[dim] = tuple(buff_ub)[idx]
+                    buff_lb = stencil.IndexAttr.get(*new_lb)
+                    buff_ub = stencil.IndexAttr.get(*new_ub)
+
+                    # todo breaking here means we do not verify that all accesses map to the same dimension
+                    break
+
         swaps = builtin.ArrayAttr(
             exchange
             for exchange in op.strategy.halo_exchange_defs(

--- a/xdsl/transforms/shape_inference_patterns/stencil.py
+++ b/xdsl/transforms/shape_inference_patterns/stencil.py
@@ -159,6 +159,12 @@ class AccessOpShapeInference(RewritePattern):
         output_size = apply.res[0].type.bounds
         if not isinstance(output_size, StencilBoundsAttr):
             return
+        if len(op.offset) < apply.res[0].type.get_num_dims() and op.offset_mapping:
+            mapped_offsets = [
+                (output_size.lb.array.data[i], output_size.ub.array.data[i])
+                for i in op.offset_mapping
+            ]
+            output_size = StencilBoundsAttr(mapped_offsets)
 
         update_result_size(
             op.temp, temp_type.bounds | output_size + op.offset, rewriter


### PR DESCRIPTION
Adds support for `stencil.access %buf [_, 0, _] : !stencil.temp<?xf64>` to the `shape-inference` pass for the stencil and dmp dialects.