### PR TITLE
interpreter (transform): add semantics for `NamedSequenceOp` and `YieldOp`

### DIFF
--- a/tests/filecheck/dialects/transform/transform_ops.mlir
+++ b/tests/filecheck/dialects/transform/transform_ops.mlir
@@ -17,11 +17,11 @@
 
 // CHECK: "transform.sequence"() <{failure_propagation_mode = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
 // CHECK: ^0(%arg0 : !transform.any_value, %arg1 : !transform.op<"linalg.matmul">):
-// CHECK:   "transform.yield"() : () -> ()
+// CHECK:   transform.yield
 // CHECK: }) : () -> ()
 "transform.sequence"() <{failure_propagation_mode = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
 ^0(%arg0 : !transform.any_value, %arg1 : !transform.op<"linalg.matmul">):
-"transform.yield"() : () -> ()
+  transform.yield
 }) : () -> ()
 
 %input = "test.op"() : () -> !transform.any_value

--- a/tests/filecheck/dialects/transform/transform_types.mlir
+++ b/tests/filecheck/dialects/transform/transform_types.mlir
@@ -3,7 +3,7 @@
 builtin.module attributes  {"transform.with_named_sequence"} {
   "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "foo"}> ({
   ^bb0(%arg0: !transform.any_op):
-    "transform.yield"() : () -> ()
+    transform.yield
   }) : () -> ()
   %0 = "test.op"() : () -> !transform.affine_map
   %1 = "test.op"() : () -> !transform.any_op
@@ -16,13 +16,13 @@ builtin.module attributes  {"transform.with_named_sequence"} {
     %6 = "transform.cast"(%arg1) : (!transform.op<"linalg.quantized_matmul">) -> !transform.any_op
     %7, %8 = "transform.structured.tile_using_forall"(%arg1) <{operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, "static_tile_sizes" = array<i64: 4, 32>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op)
     %9, %10, %11 = "transform.structured.tile_using_for"(%arg1) <{"scalable_sizes" = array<i1: false, false>, "static_sizes" = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-    "transform.yield"() : () -> ()
+    transform.yield
   }) : () -> ()
   "transform.sequence"() <{"failure_propagation_mode" = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
   ^0(%arg0 : !transform.any_op):
     %arg1 = "transform.select"(%arg0) <{"op_name" = "linalg.quantized_matmul"}> : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">
     %6, %7, %8 = "transform.structured.tile_using_for"(%arg1) <{"scalable_sizes" = array<i1: false, false>, "static_sizes" = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-    "transform.yield"() : () -> ()
+    transform.yield
   }) : () -> ()
   %6 = "test.op"() : () -> !transform.any_op
   %7 = "transform.get_producer_of_operand"(%6) <{operand_number = 0 : i64}> : (!transform.any_op) -> !transform.any_op
@@ -48,7 +48,7 @@ builtin.module attributes  {"transform.with_named_sequence"} {
 //CHECK: builtin.module attributes  {transform.with_named_sequence} {
 //CHECK-NEXT: "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "foo"}> ({
 //CHECK-NEXT:  ^0(%arg0 : !transform.any_op):
-//CHECK-NEXT:    "transform.yield"() : () -> ()
+//CHECK-NEXT:    transform.yield
 //CHECK-NEXT:  }) : () -> ()
 //CHECK-NEXT:  %0 = "test.op"() : () -> !transform.affine_map
 //CHECK-NEXT:  %1 = "test.op"() : () -> !transform.any_op
@@ -61,13 +61,13 @@ builtin.module attributes  {"transform.with_named_sequence"} {
 //CHECK-NEXT:    %6 = "transform.cast"(%arg1) : (!transform.op<"linalg.quantized_matmul">) -> !transform.any_op
 //CHECK-NEXT:    %7, %8 = "transform.structured.tile_using_forall"(%arg1) <{operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, static_tile_sizes = array<i64: 4, 32>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op)
 //CHECK-NEXT:    %9, %10, %11 = "transform.structured.tile_using_for"(%arg1) <{scalable_sizes = array<i1: false, false>, static_sizes = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-//CHECK-NEXT:    "transform.yield"() : () -> ()
+//CHECK-NEXT:    transform.yield
 //CHECK-NEXT:  }) : () -> ()
 //CHECK-NEXT:  "transform.sequence"() <{failure_propagation_mode = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
 //CHECK-NEXT:  ^0(%arg0 : !transform.any_op):
 //CHECK-NEXT:    %arg1 = "transform.select"(%arg0) <{op_name = "linalg.quantized_matmul"}> : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">
 //CHECK-NEXT:    %6, %7, %8 = "transform.structured.tile_using_for"(%arg1) <{scalable_sizes = array<i1: false, false>, static_sizes = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-//CHECK-NEXT:    "transform.yield"() : () -> ()
+//CHECK-NEXT:    transform.yield
 //CHECK-NEXT:  }) : () -> ()
 //CHECK-NEXT:  %6 = "test.op"() : () -> !transform.any_op
 //CHECK-NEXT:  %7 = "transform.get_producer_of_operand"(%6) <{operand_number = 0 : i64}> : (!transform.any_op) -> !transform.any_op

--- a/tests/interpreters/test_transform_interpreter.py
+++ b/tests/interpreters/test_transform_interpreter.py
@@ -6,9 +6,6 @@ from xdsl.interpreters.transform import TransformFunctions
 from xdsl.ir import Block, Region
 from xdsl.parser import Parser
 
-interpreter = Interpreter(builtin.ModuleOp([]))
-interpreter.register_implementations(TransformFunctions())
-
 
 def test_empty_transform_module():
     payload = """
@@ -22,7 +19,7 @@ def test_empty_transform_module():
     ty = transform.OperationType("builtin.module")
     block = Block(arg_types=[ty])
     with ImplicitBuilder(block):
-        transform.YieldOp()
+        transform.YieldOp(block.args[0])
 
     module = builtin.ModuleOp(
         [], attributes={"transform.with_named_sequence": builtin.UnitAttr()}
@@ -30,17 +27,17 @@ def test_empty_transform_module():
     with ImplicitBuilder(module.body):
         body = Region(block)
         sym_name = "__transform_main"
-        function_type = builtin.FunctionType.from_lists([ty], [])
+        function_type = builtin.FunctionType.from_lists([ty], [ty])
         named_sequence = transform.NamedSequenceOp(sym_name, function_type, body)
+
+    interpreter = Interpreter(module)
+    interpreter.register_implementations(TransformFunctions())
 
     ctx = Context()
     ctx.load_dialect(builtin.Builtin)
     ctx.load_dialect(func.Func)
     ctx.load_dialect(transform.Transform)
 
-    module = Parser(ctx, payload).parse_module()
     expected = Parser(ctx, payload).parse_module()
-    interpreter.call_op(named_sequence, (module,))
-    # No changes because named sequence just contains yield
-    # Compare string as proxy for structure equality.
-    assert str(expected) == str(module)
+    (observed,) = interpreter.call_op(named_sequence, (expected,))
+    assert expected is observed

--- a/tests/interpreters/test_transform_interpreter.py
+++ b/tests/interpreters/test_transform_interpreter.py
@@ -1,0 +1,46 @@
+from xdsl.builder import ImplicitBuilder
+from xdsl.context import Context
+from xdsl.dialects import builtin, func, transform
+from xdsl.interpreter import Interpreter
+from xdsl.interpreters.transform import TransformFunctions
+from xdsl.ir import Block, Region
+from xdsl.parser import Parser
+
+interpreter = Interpreter(builtin.ModuleOp([]))
+interpreter.register_implementations(TransformFunctions())
+
+
+def test_empty_transform_module():
+    payload = """
+    module {
+        func.func @foo() {
+            func.return
+        }
+    }
+    """
+
+    ty = transform.OperationType("builtin.module")
+    block = Block(arg_types=[ty])
+    with ImplicitBuilder(block):
+        transform.YieldOp()
+
+    module = builtin.ModuleOp(
+        [], attributes={"transform.with_named_sequence": builtin.UnitAttr()}
+    )
+    with ImplicitBuilder(module.body):
+        body = Region(block)
+        sym_name = "__transform_main"
+        function_type = builtin.FunctionType.from_lists([ty], [])
+        named_sequence = transform.NamedSequenceOp(sym_name, function_type, body)
+
+    ctx = Context()
+    ctx.load_dialect(builtin.Builtin)
+    ctx.load_dialect(func.Func)
+    ctx.load_dialect(transform.Transform)
+
+    module = Parser(ctx, payload).parse_module()
+    expected = Parser(ctx, payload).parse_module()
+    interpreter.call_op(named_sequence, (module,))
+    # No changes because named sequence just contains yield
+    # Compare string as proxy for structure equality.
+    assert str(expected) == str(module)

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -15,6 +15,7 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     UnitAttr,
 )
+from xdsl.dialects.utils import AbstractYieldOperation
 from xdsl.dialects.func import FuncOpCallableInterface
 from xdsl.ir import (
     Attribute,
@@ -534,7 +535,7 @@ class SplitHandleOp(IRDLOperation):
 
 
 @irdl_op_definition
-class YieldOp(IRDLOperation):
+class YieldOp(AbstractYieldOperation[Attribute]):
     """
     See external [documentation](https://mlir.llvm.org/docs/Dialects/Transform/#transformyield-transformyieldop).
     """

--- a/xdsl/dialects/transform.py
+++ b/xdsl/dialects/transform.py
@@ -15,8 +15,8 @@ from xdsl.dialects.builtin import (
     SymbolRefAttr,
     UnitAttr,
 )
-from xdsl.dialects.utils import AbstractYieldOperation
 from xdsl.dialects.func import FuncOpCallableInterface
+from xdsl.dialects.utils import AbstractYieldOperation
 from xdsl.ir import (
     Attribute,
     Dialect,

--- a/xdsl/interpreters/transform.py
+++ b/xdsl/interpreters/transform.py
@@ -1,0 +1,28 @@
+from xdsl.dialects import transform
+from xdsl.interpreter import (
+    Interpreter,
+    InterpreterFunctions,
+    PythonValues,
+    impl_callable,
+    impl_terminator,
+    register_impls,
+)
+
+
+@register_impls
+class TransformFunctions(InterpreterFunctions):
+    @impl_callable(transform.NamedSequenceOp)
+    def run_named_sequence_op(
+        self,
+        interpreter: Interpreter,
+        op: transform.NamedSequenceOp,
+        args: PythonValues,
+    ) -> PythonValues:
+        return interpreter.run_ssacfg_region(op.body, args, op.sym_name.data)
+
+    @impl_terminator(transform.YieldOp)
+    def run_apply_yield_op(
+        self, interpreter: Interpreter, op: transform.YieldOp, args: PythonValues
+    ) -> PythonValues:
+        # transform.yield does not return anything
+        return (), ()

--- a/xdsl/interpreters/transform.py
+++ b/xdsl/interpreters/transform.py
@@ -3,6 +3,8 @@ from xdsl.interpreter import (
     Interpreter,
     InterpreterFunctions,
     PythonValues,
+    ReturnedValues,
+    TerminatorValue,
     impl_callable,
     impl_terminator,
     register_impls,
@@ -23,6 +25,5 @@ class TransformFunctions(InterpreterFunctions):
     @impl_terminator(transform.YieldOp)
     def run_apply_yield_op(
         self, interpreter: Interpreter, op: transform.YieldOp, args: PythonValues
-    ) -> PythonValues:
-        # transform.yield does not return anything
-        return (), ()
+    ) -> tuple[TerminatorValue, PythonValues]:
+        return ReturnedValues(args), ()


### PR DESCRIPTION
Adds semantics for `NamedSequenceOp` and `YieldOp`.