### PR TITLE
transformations: (stencil-shape-minimise) Support missing dims

### DIFF
--- a/tests/filecheck/transforms/stencil-shape-minimize.mlir
+++ b/tests/filecheck/transforms/stencil-shape-minimize.mlir
@@ -1,5 +1,5 @@
 // RUN: xdsl-opt -p stencil-shape-minimize --split-input-file %s | filecheck %s
-// RUN: xdsl-opt -p stencil-shape-minimize{restrict=32} --split-input-file %s | filecheck %s --check-prefix RESTRICT
+// RUN: xdsl-opt -p stencil-shape-minimize{restrict=32} --split-input-file --verify-diagnostics %s | filecheck %s --check-prefix RESTRICT
 
 builtin.module {
   func.func @different_input_offsets(%out : !stencil.field<[-4,68]xf64>, %in : !stencil.field<[-4,68]xf64>) {
@@ -38,3 +38,45 @@ builtin.module {
 // RESTRICT-NEXT:    stencil.store %tout to %out(<[0], [32]>) : !stencil.temp<[0,32]xf64> to !stencil.field<[-1,33]xf64>
 // RESTRICT-NEXT:    func.return
 // RESTRICT-NEXT:  }
+// -----
+
+func.func @stencil_missing_dims(%in : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>, %ybuf : !stencil.field<[-4,68]xf64>, %zbuf : !stencil.field<[-4,68]xf64>, %out : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>) {
+  %intemp = stencil.load %in : !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64> -> !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+  %0 = "dmp.swap"(%intemp) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = [#dmp.exchange<at [0, -1, 0] size [1, 1, 64] source offset [0, 1, 0] to [0, -1, 0]>]} : (!stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>) -> !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+  %ybuf_t = stencil.load %ybuf : !stencil.field<[-4,68]xf64> -> !stencil.temp<[-1,0]xf64>
+  %1 = "dmp.swap"(%ybuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = [#dmp.exchange<at [0, -1, 0] size [1, 1, 64] source offset [0, 1, 0] to [0, -1, 0]>]} : (!stencil.temp<[-1,0]xf64>) -> !stencil.temp<[-1,0]xf64>
+  %zbuf_t = stencil.load %zbuf : !stencil.field<[-4,68]xf64> -> !stencil.temp<[-1,63]xf64>
+  %2 = "dmp.swap"(%zbuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = []} : (!stencil.temp<[-1,63]xf64>) -> !stencil.temp<[-1,63]xf64>
+  %res = stencil.apply(%inarg = %0 : !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>, %ybuf_arg = %1 : !stencil.temp<[-1,0]xf64>, %zbuf_arg = %2 : !stencil.temp<[-1,63]xf64>) -> (!stencil.temp<[0,1]x[0,1]x[0,64]xf64>) {
+    %3 = stencil.access %ybuf_arg[_, -1, _] : !stencil.temp<[-1,0]xf64>
+    %4 = stencil.access %zbuf_arg[_, _, -1] : !stencil.temp<[-1,63]xf64>
+    %5 = stencil.access %inarg[0, -1, -1] : !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+    %6 = arith.addf %3, %4 : f64
+    %7 = arith.addf %5, %6 : f64
+    stencil.return %7 : f64
+  }
+  stencil.store %res to %out(<[0, 0, 0], [1, 1, 64]>) : !stencil.temp<[0,1]x[0,1]x[0,64]xf64> to !stencil.field<[-4,68]x[-4,68]x[-4,68]xf64>
+  func.return
+}
+
+// CHECK:      func.func @stencil_missing_dims(%in : !stencil.field<[0,1]x[-1,1]x[-1,64]xf64>, %ybuf : !stencil.field<[-1,63]xf64>, %zbuf : !stencil.field<[-1,63]xf64>, %out : !stencil.field<[0,1]x[-1,1]x[-1,64]xf64>) {
+// CHECK-NEXT:   %intemp = stencil.load %in : !stencil.field<[0,1]x[-1,1]x[-1,64]xf64> -> !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+// CHECK-NEXT:   %0 = "dmp.swap"(%intemp) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = [#dmp.exchange<at [0, -1, 0] size [1, 1, 64] source offset [0, 1, 0] to [0, -1, 0]>]} : (!stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>) -> !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+// CHECK-NEXT:   %ybuf_t = stencil.load %ybuf : !stencil.field<[-1,63]xf64> -> !stencil.temp<[-1,0]xf64>
+// CHECK-NEXT:   %1 = "dmp.swap"(%ybuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = [#dmp.exchange<at [0, -1, 0] size [1, 1, 64] source offset [0, 1, 0] to [0, -1, 0]>]} : (!stencil.temp<[-1,0]xf64>) -> !stencil.temp<[-1,0]xf64>
+// CHECK-NEXT:   %zbuf_t = stencil.load %zbuf : !stencil.field<[-1,63]xf64> -> !stencil.temp<[-1,63]xf64>
+// CHECK-NEXT:   %2 = "dmp.swap"(%zbuf_t) {strategy = #dmp.grid_slice_2d<#dmp.topo<64x64>, false>, swaps = []} : (!stencil.temp<[-1,63]xf64>) -> !stencil.temp<[-1,63]xf64>
+// CHECK-NEXT:   %res = stencil.apply(%inarg = %0 : !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>, %ybuf_arg = %1 : !stencil.temp<[-1,0]xf64>, %zbuf_arg = %2 : !stencil.temp<[-1,63]xf64>) -> (!stencil.temp<[0,1]x[0,1]x[0,64]xf64>) {
+// CHECK-NEXT:     %3 = stencil.access %ybuf_arg[_, -1, _] : !stencil.temp<[-1,0]xf64>
+// CHECK-NEXT:     %4 = stencil.access %zbuf_arg[_, _, -1] : !stencil.temp<[-1,63]xf64>
+// CHECK-NEXT:     %5 = stencil.access %inarg[0, -1, -1] : !stencil.temp<[0,1]x[-1,0]x[-1,63]xf64>
+// CHECK-NEXT:     %6 = arith.addf %3, %4 : f64
+// CHECK-NEXT:     %7 = arith.addf %5, %6 : f64
+// CHECK-NEXT:     stencil.return %7 : f64
+// CHECK-NEXT:   }
+// CHECK-NEXT:   stencil.store %res to %out(<[0, 0, 0], [1, 1, 64]>) : !stencil.temp<[0,1]x[0,1]x[0,64]xf64> to !stencil.field<[0,1]x[-1,1]x[-1,64]xf64>
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
+
+// RESTRICT:   Cannot restrict stencil programs with different dimensionality

--- a/xdsl/transforms/stencil_shape_minimize.py
+++ b/xdsl/transforms/stencil_shape_minimize.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 from xdsl.context import Context
 from xdsl.dialects import builtin, func, stencil
+from xdsl.dialects.stencil import StencilBoundsAttr
 from xdsl.ir import Attribute
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -14,6 +15,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.transforms.shape_inference import infer_shapes
+from xdsl.utils.exceptions import PassFailedException
 
 
 @dataclass
@@ -33,7 +35,11 @@ class ShapeMinimisation(TypeConversionPattern):
 
     @attr_type_rewrite_pattern
     def convert_type(self, typ: stencil.FieldType[Attribute], /) -> Attribute | None:
-        if typ.bounds != self.shape and self.shape:
+        if (
+            typ.bounds != self.shape
+            and self.shape
+            and len(self.shape.ub) == typ.get_num_dims()
+        ):
             return stencil.FieldType(self.shape, typ.element_type)
 
 
@@ -59,6 +65,8 @@ class RestrictStoreOp(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: stencil.StoreOp, rewriter: PatternRewriter, /):
+        if len(self.restrict) != len(op.bounds.ub):
+            return
         new_bounds = [
             (min(lower_bound, bound_lim), min(upper_bound, bound_lim))
             for lower_bound, upper_bound, bound_lim in zip(
@@ -104,15 +112,28 @@ class StencilShapeMinimize(ModulePass):
         )
         if not bounds:
             return
-        shape: stencil.StencilBoundsAttr = bounds.pop()
+        dim_shapes = dict[int, StencilBoundsAttr]()
         for b in bounds:
-            shape = shape | b
+            dims = len(b.ub)
+            if dims in dim_shapes:
+                dim_shapes[dims] |= b
+            else:
+                dim_shapes[dims] = b
+
+        if self.restrict and len(dim_shapes) != 1:
+            raise PassFailedException(
+                "Cannot restrict stencil programs with different dimensionality"
+            )
+
+        shape_minimisations = [
+            ShapeMinimisation(shape=shape) for shape in dim_shapes.values()
+        ]
 
         PatternRewriteWalker(
             GreedyRewritePatternApplier(
                 [
-                    ShapeMinimisation(shape=shape),
+                    *shape_minimisations,
                     FuncOpShapeUpdate(),
                 ]
-            )
+            ),
         ).rewrite_module(op)

--- a/xdsl/transforms/stencil_shape_minimize.py
+++ b/xdsl/transforms/stencil_shape_minimize.py
@@ -113,6 +113,8 @@ class StencilShapeMinimize(ModulePass):
         if not bounds:
             return
         dim_shapes = dict[int, StencilBoundsAttr]()
+
+        # construct one minimal shape for each number of dimensions
         for b in bounds:
             dims = len(b.ub)
             if dims in dim_shapes:


### PR DESCRIPTION
This PR adds support for stencil types of different dimensionality.

Previously, it used to determine a shape it considers minimal, propagating that throughout the program. Instead, it now builds a separate minimal shape per number of dimensions (e.g. separate for 1-d, 2-d, 3-d, etc).