### PR TITLE
Add linalg.index op

### DIFF
--- a/tests/filecheck/dialects/linalg/linalg_ops.mlir
+++ b/tests/filecheck/dialects/linalg/linalg_ops.mlir
@@ -8,6 +8,15 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
     linalg.yield %arg3 : f32
 }
 
+linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%0 : f32) outs(%1 : memref<1x256xf32>) {
+^bb0(%arg3: f32, %arg4: f32):
+    %index = linalg.index 0 : index
+    %cast_index = arith.index_cast %index : index to i64
+    %convert_index = arith.sitofp %cast_index : i64 to f32
+    %sum = arith.addf %arg3, %convert_index : f32
+    linalg.yield %sum : f32
+}
+
 linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], doc="a_docstring", library_call="a_library_call"} ins(%0 : f32) outs(%1 : memref<1x256xf32>) {
 ^bb0(%arg3: f32, %arg4: f32):
     linalg.yield %arg3 : f32
@@ -19,39 +28,39 @@ linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1)
 }
 
 
-%t1, %t2, %t3 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
-%m1, %m2, %m3 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
-
-%sum = linalg.add ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
-linalg.add ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>) -> ()
-
-%mul = linalg.mul ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
-linalg.mul ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>)
-
-%2, %3 = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
-%4 = "test.op"() : () -> (memref<64x4096xf32>)
-linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs(%4 : memref<64x4096xf32>)
-
-%i2, %i3 = "test.op"() : () -> (memref<64x9216xi32>, memref<9216x4096xi32>)
-%i4 = "test.op"() : () -> (memref<64x4096xi32>)
-linalg.matmul {id} ins(%i2, %i3 : memref<64x9216xi32>, memref<9216x4096xi32>) outs(%i4 : memref<64x4096xi32>)
-
-%fill = linalg.fill ins(%0 : f32) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
-linalg.fill ins(%0 : f32) outs(%m3 : memref<4x16xf32>)
-
-%5, %6 = "test.op"() : () -> (tensor<64x9216xi8>, tensor<9216x4096xi8>)
-%7 = arith.constant 0 : i32
-%8 = arith.constant 0 : i32
-%9 = "test.op"() : () -> (tensor<64x4096xi32>)
-
-linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x4096xi8>, i32, i32) outs(%9 : tensor<64x4096xi32>) -> tensor<64x4096xi32>
-
-%b1 = "test.op"() : () -> tensor<4x16xi1>
-%10 = linalg.select ins(%b1, %t1, %t2 : tensor<4x16xi1>, tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
-"test.op"(%10) : (tensor<4x16xf32>) -> ()
-
-%11 = linalg.max ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
-%12 = linalg.min ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
+ %t1, %t2, %t3 = "test.op"() : () -> (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>)
+ %m1, %m2, %m3 = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
+ 
+ %sum = linalg.add ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+ linalg.add ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>) -> ()
+ 
+ %mul = linalg.mul ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+ linalg.mul ins(%m1, %m2 : memref<4x16xf32>, memref<4x16xf32>) outs(%m3 : memref<4x16xf32>)
+ 
+ %2, %3 = "test.op"() : () -> (memref<64x9216xf32>, memref<9216x4096xf32>)
+ %4 = "test.op"() : () -> (memref<64x4096xf32>)
+ linalg.matmul {id} ins(%2, %3 : memref<64x9216xf32>, memref<9216x4096xf32>) outs(%4 : memref<64x4096xf32>)
+ 
+ %i2, %i3 = "test.op"() : () -> (memref<64x9216xi32>, memref<9216x4096xi32>)
+ %i4 = "test.op"() : () -> (memref<64x4096xi32>)
+ linalg.matmul {id} ins(%i2, %i3 : memref<64x9216xi32>, memref<9216x4096xi32>) outs(%i4 : memref<64x4096xi32>)
+ 
+ %fill = linalg.fill ins(%0 : f32) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+ linalg.fill ins(%0 : f32) outs(%m3 : memref<4x16xf32>)
+ 
+ %5, %6 = "test.op"() : () -> (tensor<64x9216xi8>, tensor<9216x4096xi8>)
+ %7 = arith.constant 0 : i32
+ %8 = arith.constant 0 : i32
+ %9 = "test.op"() : () -> (tensor<64x4096xi32>)
+ 
+ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x4096xi8>, i32, i32) outs(%9 : tensor<64x4096xi32>) -> tensor<64x4096xi32>
+ 
+ %b1 = "test.op"() : () -> tensor<4x16xi1>
+ %10 = linalg.select ins(%b1, %t1, %t2 : tensor<4x16xi1>, tensor<4x16xf32>, tensor<4x16xf32>) outs(%t3 : tensor<4x16xf32>) -> tensor<4x16xf32>
+ "test.op"(%10) : (tensor<4x16xf32>) -> ()
+ 
+ %11 = linalg.max ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
+ %12 = linalg.min ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
 
 // CHECK:        module {
 // CHECK-NEXT:    %{{.*}} %{{.*}} = "test.op"() : () -> (f32, memref<1x256xf32>)
@@ -59,8 +68,16 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-NEXT:    ^0(%{{.*}} f32, %{{.*}} f32):
 // CHECK-NEXT:      linalg.yield %{{.*}} : f32
 // CHECK-NEXT:    }
+// CHECK-NEXT:    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%{{.*}} : f32) outs(%{{.*}} : memref<1x256xf32>) {
+// CHECK-NEXT:    ^{{.*}}(%{{.*}} f32, %{{.*}} f32):
+// CHECK-NEXT:      %{{.*}} = linalg.index 0 : index
+// CHECK-NEXT:      %{{.*}} = arith.index_cast %{{.*}} : index to i64
+// CHECK-NEXT:      %{{.*}} = arith.sitofp %{{.*}}: i64 to f32
+// CHECK-NEXT:      %{{.*}} = arith.addf %{{.*}}, %{{.*}}: f32
+// CHECK-NEXT:      linalg.yield %{{.*}} : f32
+// CHECK-NEXT:    }
 // CHECK-NEXT:    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"], doc = "a_docstring", library_call = "a_library_call"} ins(%{{.*}} : f32) outs(%{{.*}} : memref<1x256xf32>) {
-// CHECK-NEXT:    ^1(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32):
 // CHECK-NEXT:      linalg.yield %{{.*}} : f32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    linalg.generic {indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%{{.*}} : f32) outs(%{{.*}} : memref<1x256xf32>) attrs = {hello = "world"} {
@@ -93,12 +110,20 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-NEXT:    %13 = linalg.min ins(%t1, %t2 : tensor<4x16xf32>, tensor<4x16xf32>) outs(%t1 : tensor<4x16xf32>) -> tensor<4x16xf32>
 // CHECK-NEXT:    }
 
-// CHECK-GENERIC:       "linalg.generic"(%{{.*}} %{{.*}} <{indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:  ^0(%{{.*}} f32, %{{.*}} f32):
+// CHECK-GENERIC:       "linalg.generic"(%{{.*}}, %{{.*}}) <{indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-GENERIC-NEXT:  ^{{.*}}(%{{.*}} f32, %{{.*}} f32):
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:  }) : (f32, memref<1x256xf32>) -> ()
-// CHECK-GENERIC-NEXT:  "linalg.generic"(%{{.*}} %{{.*}} <{indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>], doc = "a_docstring", library_call = "a_library_call", operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:  ^1(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:  "linalg.generic"(%{{.*}}, %{{.*}}) <{indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>], operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-GENERIC-NEXT:  ^{{.*}}(%{{.*}}: f32, %{{.*}}: f32):
+// CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.index"() <{dim = 0 : i64}> : () -> index
+// CHECK-GENERIC-NEXT:    %{{.*}} = "arith.index_cast"(%{{.*}}) : (index) -> i64
+// CHECK-GENERIC-NEXT:    %{{.*}} = "arith.sitofp"(%{{.*}}) : (i64) -> f32
+// CHECK-GENERIC-NEXT:    %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}}) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
+// CHECK-GENERIC-NEXT:    "linalg.yield"(%{{.*}}) : (f32) -> ()
+// CHECK-GENERIC-NEXT:  }) : (f32, memref<1x256xf32>) -> ()
+// CHECK-GENERIC-NEXT:  "linalg.generic"(%{{.*}}, %{{.*}}) <{indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>], doc = "a_docstring", library_call = "a_library_call", operandSegmentSizes = array<i32: 1, 1>}> ({
+// CHECK-GENERIC-NEXT:  ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:    "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:  }) : (f32, memref<1x256xf32>) -> ()
 
@@ -111,25 +136,25 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:    %{{.*}} %{{.*}} %{{.*}} = "test.op"() : () -> (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>)
 
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.add"(%{{.*}} %{{.*}} %{{.*}} <{operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^3(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}} %{{.*}} : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
 
 // CHECK-GENERIC-NEXT:    "linalg.add"(%{{.*}} %{{.*}} %{{.*}} <{operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^4(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}} %{{.*}} : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>) -> ()
 
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.mul"(%{{.*}} %{{.*}} %{{.*}} <{operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^5(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.mulf"(%{{.*}} %{{.*}} : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
 
 // CHECK-GENERIC-NEXT:    "linalg.mul"(%{{.*}} %{{.*}} %{{.*}} <{operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^6(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.mulf"(%{{.*}} %{{.*}} : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (memref<4x16xf32>, memref<4x16xf32>, memref<4x16xf32>) -> ()
@@ -138,7 +163,7 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:    %{{.*}} = "test.op"() : () -> memref<64x4096xf32>
 
 // CHECK-GENERIC-NEXT:    "linalg.matmul"(%{{.*}} %{{.*}} %{{.*}} <{indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^7(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.mulf"(%{{.*}}, %{{.*}} : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addf"(%{{.*}}, %{{.*}} : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
@@ -148,19 +173,19 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:    %{{.*}} = "test.op"() : () -> memref<64x4096xi32>
 
 // CHECK-GENERIC-NEXT:    "linalg.matmul"(%{{.*}} %{{.*}} %{{.*}} <{indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^8(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32, %{{.*}} : i32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}} : (i32, i32) -> i32
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}} : (i32, i32) -> i32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (i32) -> ()
 // CHECK-GENERIC-NEXT:    }) {id} : (memref<64x9216xi32>, memref<9216x4096xi32>, memref<64x4096xi32>) -> ()
 
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.fill"(%{{.*}}, %{{.*}} <{operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^9(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (f32, tensor<4x16xf32>) -> tensor<4x16xf32>
 
 // CHECK-GENERIC-NEXT:    "linalg.fill"(%{{.*}}, %{{.*}} <{operandSegmentSizes = array<i32: 1, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^10(%{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}} : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (f32, memref<4x16xf32>) -> ()
 
@@ -170,7 +195,7 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:     %{{.*}} = "test.op"() : () -> tensor<64x4096xi32>
 
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.quantized_matmul"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 4, 1>}> ({
-// CHECK-GENERIC-NEXT:       ^11(%{{.*}}  : i8, %{{.*}}  : i8, %{{.*}}  : i32, %{{.*}}  : i32, %{{.*}}  : i32):
+// CHECK-GENERIC-NEXT:       ^{{.*}}(%{{.*}}  : i8, %{{.*}}  : i8, %{{.*}}  : i32, %{{.*}}  : i32, %{{.*}}  : i32):
 // CHECK-GENERIC-NEXT:         %{{.*}} = "arith.extsi"(%{{.*}}) : (i8) -> i32
 // CHECK-GENERIC-NEXT:         %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
 // CHECK-GENERIC-NEXT:         %{{.*}} = "arith.extsi"(%{{.*}}) : (i8) -> i32
@@ -181,18 +206,18 @@ linalg.quantized_matmul ins(%5, %6, %7, %8 : tensor<64x9216xi8>, tensor<9216x409
 // CHECK-GENERIC-NEXT:       }) {linalg.memoized_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>]} : (tensor<64x9216xi8>, tensor<9216x4096xi8>, i32, i32, tensor<64x4096xi32>) -> tensor<64x4096xi32>
 // CHECK-GENERIC-NEXT:    %{{.*}} = "test.op"() : () -> tensor<4x16xi1>
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.select"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 3, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^12(%{{.*}} : i1, %{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : i1, %{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xi1>, tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
 // CHECK-GENERIC-NEXT:    "test.op"(%{{.*}}) : (tensor<4x16xf32>) -> ()
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.max"(%{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^13(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
 // CHECK-GENERIC-NEXT:      %{{.*}} = "arith.maximumf"(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
 // CHECK-GENERIC-NEXT:    %{{.*}} = "linalg.min"(%{{.*}}, %{{.*}}, %{{.*}}) <{operandSegmentSizes = array<i32: 2, 1>}> ({
-// CHECK-GENERIC-NEXT:    ^14(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
-// CHECK-GENERIC-NEXT:      %67 = "arith.minimumf"(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
+// CHECK-GENERIC-NEXT:    ^{{.*}}(%{{.*}} : f32, %{{.*}} : f32, %{{.*}} : f32):
+// CHECK-GENERIC-NEXT:      %{{.*}} = "arith.minimumf"(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
 // CHECK-GENERIC-NEXT:      "linalg.yield"(%{{.*}}) : (f32) -> ()
 // CHECK-GENERIC-NEXT:    }) : (tensor<4x16xf32>, tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>

--- a/xdsl/dialects/linalg.py
+++ b/xdsl/dialects/linalg.py
@@ -16,6 +16,9 @@ from xdsl.dialects.builtin import (
     ArrayAttr,
     DenseArrayBase,
     DenseIntOrFPElementsAttr,
+    IndexType,
+    IndexTypeConstr,
+    IntegerAttr,
     IntegerType,
     MemRefType,
     ShapedType,
@@ -47,6 +50,7 @@ from xdsl.irdl import (
     opt_prop_def,
     prop_def,
     region_def,
+    result_def,
     traits_def,
     var_operand_def,
     var_result_def,
@@ -386,6 +390,22 @@ class YieldOp(AbstractYieldOperation[Attribute]):
     name = "linalg.yield"
 
     traits = traits_def(IsTerminator())
+
+
+@irdl_op_definition
+class IndexOp(IRDLOperation):
+    name = "linalg.index"
+    dim = prop_def(IntegerAttr[i64])
+    result = result_def(IndexTypeConstr)
+
+    assembly_format = "$dim attr-dict `:` type($result)"
+
+    def __init__(
+        self,
+        dim: int,
+    ):
+        dim_attr = IntegerAttr(dim, i64)
+        super().__init__(properties={"dim": dim_attr}, result_types=[IndexType()])
 
 
 class NamedOpBase(IRDLOperation, ABC):
@@ -1327,6 +1347,7 @@ Linalg = Dialect(
     [
         GenericOp,
         YieldOp,
+        IndexOp,
         AddOp,
         SubOp,
         SelectOp,


### PR DESCRIPTION
This PR adds roundtripping and a constructor for the linalg index op, which is one of those few linalg ops that is not a named op.
Also edited the test a bit to make it less prone to basic block naming and SSAValue name-hint mismatches.

From the docs:
> The linalg.index operation returns the iteration index of the immediately enclosing linalg structured operation for the iteration dimension dim. The dim attribute specifies the position of the accessed dimension in the indexing map domain.

https://mlir.llvm.org/docs/Dialects/Linalg/#linalgindex-linalgindexop

I encountered this op, while trying to canonicalize to linalg generics on https://huggingface.co/roneneldan/TinyStories-1M:
Context:
```mlir
^0(%0 : f32, %1 : f32, %2 : i64):
  %3 = "linalg.index"() <{dim = 3 : i64}> : () -> index
  %4 = arith.index_cast %3 : index to i64
  %5 = arith.maximumf %0, %1 : f32
  %6 = arith.cmpf ogt, %0, %1 : f32
  %7 = arith.select %6, %4, %2 : i64
  linalg.yield %5, %7 : f32, i64
```
![image](https://github.com/user-attachments/assets/8a901e4d-dc6c-4357-b945-a65955ae10c9)


And this one:

```mlir
^0(%0 : i64):
  %1 = "linalg.index"() <{dim = 0 : i64}> : () -> index
  %2 = arith.index_cast %1 : index to i64
  linalg.yield %2 : i64
```
![image](https://github.com/user-attachments/assets/ea04c85c-0a0c-4c95-a91f-59ef379570eb)

Visualizations are a WIP from https://github.com/KULeuven-MICAS/frontend-mess/tree/Josse/visualize-bodies