### PR TITLE
Add arith.uitofp and arith.fptoui

### DIFF
--- a/tests/dialects/test_arith.py
+++ b/tests/dialects/test_arith.py
@@ -23,6 +23,7 @@ from xdsl.dialects.arith import (
     FloatingPointLikeBinaryOperation,
     FloorDivSIOp,
     FPToSIOp,
+    FPToUIOp,
     IndexCastOp,
     MaximumfOp,
     MaxSIOp,
@@ -47,6 +48,7 @@ from xdsl.dialects.arith import (
     SubiOp,
     TruncFOp,
     TruncIOp,
+    UIToFPOp,
     XOrIOp,
 )
 from xdsl.dialects.builtin import (
@@ -334,6 +336,17 @@ def test_cast_fp_and_si_ops():
     assert fp.input == a.result
     assert fp.result == si.input
     assert isinstance(si.result.type, IntegerType)
+    assert fp.result.type == f32
+
+
+def test_cast_fp_and_ui_ops():
+    a = ConstantOp.from_int_and_width(0, 32)
+    fp = UIToFPOp(a, f32)
+    ui = FPToUIOp(fp, i32)
+
+    assert fp.input == a.result
+    assert fp.result == ui.input
+    assert isinstance(ui.result.type, IntegerType)
     assert fp.result.type == f32
 
 

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -205,3 +205,15 @@
 %m_const = arith.constant dense<1.678900e-01> : memref<64xf32>
 // CHECK-NEXT: %t_const = arith.constant dense<1.234500e-01> : tensor<16xf32>
 // CHECK-NEXT: %m_const = arith.constant dense<1.678900e-01> : memref<64xf32>
+
+%fp = arith.constant 2.0 : f32
+%to_si = arith.fptosi %fp : f32 to i32
+%from_si_to_fp = arith.sitofp %to_si : i32 to f32
+%to_ui = arith.fptoui %fp : f32 to i32
+%from_ui_to_fp = arith.uitofp %to_ui : i32 to f32
+
+// CHECK-NEXT: %fp = arith.constant 2.000000e+00 : f32
+// CHECK-NEXT: %to_si = arith.fptosi %fp : f32 to i32
+// CHECK-NEXT: %from_si_to_fp = arith.sitofp %to_si : i32 to f32
+// CHECK-NEXT: %to_ui = arith.fptoui %fp : f32 to i32
+// CHECK-NEXT: %from_ui_to_fp = arith.uitofp %to_ui : i32 to f32

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -1329,6 +1329,36 @@ class SIToFPOp(IRDLOperation):
 
 
 @irdl_op_definition
+class FPToUIOp(IRDLOperation):
+    name = "arith.fptoui"
+
+    input = operand_def(AnyFloatConstr)
+    result = result_def(IntegerType)
+
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
+
+    traits = traits_def(Pure())
+
+    def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
+        super().__init__(operands=[op], result_types=[target_type])
+
+
+@irdl_op_definition
+class UIToFPOp(IRDLOperation):
+    name = "arith.uitofp"
+
+    input = operand_def(IntegerType)
+    result = result_def(AnyFloatConstr)
+
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
+
+    traits = traits_def(Pure())
+
+    def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
+        super().__init__(operands=[op], result_types=[target_type])
+
+
+@irdl_op_definition
 class ExtFOp(IRDLOperation):
     name = "arith.extf"
 
@@ -1474,7 +1504,9 @@ Arith = Dialect(
         BitcastOp,
         IndexCastOp,
         FPToSIOp,
+        FPToUIOp,
         SIToFPOp,
+        UIToFPOp,
         ExtFOp,
         TruncFOp,
         TruncIOp,

--- a/xdsl/dialects/arith.py
+++ b/xdsl/dialects/arith.py
@@ -1298,55 +1298,29 @@ class IndexCastOp(IRDLOperation):
             )
 
 
+class FloatingPointToIntegerBaseOp(IRDLOperation, abc.ABC):
+    input = operand_def(AnyFloatConstr)
+    result = result_def(IntegerType)
+
+    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
+
+    traits = traits_def(Pure())
+
+    def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
+        super().__init__(operands=[op], result_types=[target_type])
+
+
 @irdl_op_definition
-class FPToSIOp(IRDLOperation):
+class FPToSIOp(FloatingPointToIntegerBaseOp):
     name = "arith.fptosi"
 
-    input = operand_def(AnyFloatConstr)
-    result = result_def(IntegerType)
-
-    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
-
-    traits = traits_def(Pure())
-
-    def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
-        super().__init__(operands=[op], result_types=[target_type])
-
 
 @irdl_op_definition
-class SIToFPOp(IRDLOperation):
-    name = "arith.sitofp"
-
-    input = operand_def(IntegerType)
-    result = result_def(AnyFloatConstr)
-
-    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
-
-    traits = traits_def(Pure())
-
-    def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
-        super().__init__(operands=[op], result_types=[target_type])
-
-
-@irdl_op_definition
-class FPToUIOp(IRDLOperation):
+class FPToUIOp(FloatingPointToIntegerBaseOp):
     name = "arith.fptoui"
 
-    input = operand_def(AnyFloatConstr)
-    result = result_def(IntegerType)
 
-    assembly_format = "$input attr-dict `:` type($input) `to` type($result)"
-
-    traits = traits_def(Pure())
-
-    def __init__(self, op: SSAValue | Operation, target_type: IntegerType):
-        super().__init__(operands=[op], result_types=[target_type])
-
-
-@irdl_op_definition
-class UIToFPOp(IRDLOperation):
-    name = "arith.uitofp"
-
+class IntegerToFloatingPointBaseOp(IRDLOperation, abc.ABC):
     input = operand_def(IntegerType)
     result = result_def(AnyFloatConstr)
 
@@ -1356,6 +1330,16 @@ class UIToFPOp(IRDLOperation):
 
     def __init__(self, op: SSAValue | Operation, target_type: AnyFloat):
         super().__init__(operands=[op], result_types=[target_type])
+
+
+@irdl_op_definition
+class SIToFPOp(IntegerToFloatingPointBaseOp):
+    name = "arith.sitofp"
+
+
+@irdl_op_definition
+class UIToFPOp(IntegerToFloatingPointBaseOp):
+    name = "arith.uitofp"
 
 
 @irdl_op_definition


### PR DESCRIPTION
It seems we already have `arith.sitofp` and `arith.fptosi`, but not yet their unsigned equivalents.
This PR adds both `arith.uitofp` and `arith.fptoui`.