### PR TITLE
core: (parser) Fix VariadicSuccessorVariable assembly format

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2177,7 +2177,7 @@ def test_successors():
                 "test.op"() ({
                   "test.op"() [^0] : () -> ()
                 ^0:
-                  test.var_successor ^0 ^0
+                  test.var_successor ^0, ^0
                 }) : () -> ()"""
             ),
             textwrap.dedent(

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -1011,7 +1011,9 @@ class VariadicSuccessorVariable(VariadicVariable, SuccessorDirective):
         current_successor = parser.parse_optional_successor()
         while current_successor is not None:
             successors.append(current_successor)
-            current_successor = parser.parse_optional_successor()
+            if not parser.parse_optional_punctuation(","):
+                break
+            current_successor = parser.parse_successor()
 
         state.successors[self.index] = successors
 
@@ -1023,7 +1025,7 @@ class VariadicSuccessorVariable(VariadicVariable, SuccessorDirective):
             return
         if state.should_emit_space or not state.last_was_punctuation:
             printer.print(" ")
-        printer.print_list(successor, printer.print_block_name, delimiter=" ")
+        printer.print_list(successor, printer.print_block_name, delimiter=", ")
         state.last_was_punctuation = False
         state.should_emit_space = True
 


### PR DESCRIPTION
This changes xDSL's interpretation of `VariadicSuccessorVariable` in the assemblyformat string to match MLIR.
Concretely, it now parses and prints a list of the form `^bb1, ^bb2, ^bb3` instead of without the commas.