### PR TITLE
dialects: (transform) Add custom syntax for `transform.named_sequence`

### DIFF
--- a/tests/filecheck/dialects/transform/transform_interpreter.mlir
+++ b/tests/filecheck/dialects/transform/transform_interpreter.mlir
@@ -5,26 +5,22 @@
 module {
 
   module attributes {transform.with_named_sequence} {
-    "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "__transform_main"}> ({
-    ^bb0(%arg0: !transform.any_op):
+    transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
       transform.yield
-    }) : () -> ()
+    }
   }
 
   module attributes {transform.with_named_sequence} {
-    "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "entry"}> ({
-    ^bb0(%arg0: !transform.any_op):
+    transform.named_sequence @entry(%arg0 : !transform.any_op {transform.readonly}) {
       transform.yield
-    }) : () -> ()
+    }
   }
 }
 
-// CHECK: "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "__transform_main"}> ({
-// CHECK-NEXT: ^0(%arg0 : !transform.any_op):
+// CHECK: transform.named_sequence @__transform_main(%arg0 : !transform.any_op {transform.readonly}) {
 // CHECK-NEXT:   transform.yield
-// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT: }
 
-// CHECK: "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "entry"}> ({
-// CHECK-NEXT: ^0(%arg0 : !transform.any_op):
+// CHECK: transform.named_sequence @entry(%arg0 : !transform.any_op {transform.readonly}) {
 // CHECK-NEXT:   transform.yield
-// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT: }

--- a/tests/filecheck/dialects/transform/transform_types.mlir
+++ b/tests/filecheck/dialects/transform/transform_types.mlir
@@ -1,27 +1,25 @@
 // RUN: XDSL_ROUNDTRIP
 
 builtin.module attributes  {"transform.with_named_sequence"} {
-  "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "foo"}> ({
-  ^bb0(%arg0: !transform.any_op):
+  transform.named_sequence @foo(%arg0 : !transform.any_op {transform.readonly}) {
     transform.yield
-  }) : () -> ()
+  }
   %0 = "test.op"() : () -> !transform.affine_map
   %1 = "test.op"() : () -> !transform.any_op
   %2 = "test.op"() : () -> !transform.any_value
   %3 = "test.op"() : () -> !transform.op<"linalg.quantized_matmul">
   %4 = "test.op"() : () -> !transform.param<i64>
   %5 = "test.op"() : () -> !transform.type
-  "transform.named_sequence"() <{"function_type" = (!transform.any_op, !transform.op<"linalg.quantized_matmul">, !transform.op<"linalg.elemwise_binary">) -> (), "sym_name" = "__transform_main"}> ({
-  ^0(%arg0 : !transform.any_op, %arg1 : !transform.op<"linalg.quantized_matmul">, %arg2 : !transform.op<"linalg.elemwise_binary">):
+  transform.named_sequence @__transform_main(%arg0 : !transform.any_op, %arg1 : !transform.op<"linalg.quantized_matmul">, %arg2 : !transform.op<"linalg.elemwise_binary">) {
     %6 = "transform.cast"(%arg1) : (!transform.op<"linalg.quantized_matmul">) -> !transform.any_op
     %7, %8 = "transform.structured.tile_using_forall"(%arg1) <{operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, "static_tile_sizes" = array<i64: 4, 32>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op)
     %9, %10, %11 = "transform.structured.tile_using_for"(%arg1) <{"scalable_sizes" = array<i1: false, false>, "static_sizes" = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
-  }) : () -> ()
-  "transform.sequence"() <{"failure_propagation_mode" = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
-  ^0(%arg0 : !transform.any_op):
-    %arg1 = "transform.select"(%arg0) <{"op_name" = "linalg.quantized_matmul"}> : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">
-    %6, %7, %8 = "transform.structured.tile_using_for"(%arg1) <{"scalable_sizes" = array<i1: false, false>, "static_sizes" = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+  }
+  "transform.sequence"() <{failure_propagation_mode = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
+    ^0(%arg0 : !transform.any_op):
+      %arg1 = "transform.select"(%arg0) <{"op_name" = "linalg.quantized_matmul"}> : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">
+      %6, %7, %8 = "transform.structured.tile_using_for"(%arg1) <{"scalable_sizes" = array<i1: false, false>, "static_sizes" = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }) : () -> ()
   %6 = "test.op"() : () -> !transform.any_op
@@ -46,23 +44,21 @@ builtin.module attributes  {"transform.with_named_sequence"} {
 
 
 //CHECK: builtin.module attributes  {transform.with_named_sequence} {
-//CHECK-NEXT: "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "foo"}> ({
-//CHECK-NEXT:  ^0(%arg0 : !transform.any_op):
+//CHECK-NEXT:  transform.named_sequence @foo(%arg0 : !transform.any_op {transform.readonly}) {
 //CHECK-NEXT:    transform.yield
-//CHECK-NEXT:  }) : () -> ()
+//CHECK-NEXT:  }
 //CHECK-NEXT:  %0 = "test.op"() : () -> !transform.affine_map
 //CHECK-NEXT:  %1 = "test.op"() : () -> !transform.any_op
 //CHECK-NEXT:  %2 = "test.op"() : () -> !transform.any_value
 //CHECK-NEXT:  %3 = "test.op"() : () -> !transform.op<"linalg.quantized_matmul">
 //CHECK-NEXT:  %4 = "test.op"() : () -> !transform.param<i64>
 //CHECK-NEXT:  %5 = "test.op"() : () -> !transform.type
-//CHECK-NEXT:  "transform.named_sequence"() <{function_type = (!transform.any_op, !transform.op<"linalg.quantized_matmul">, !transform.op<"linalg.elemwise_binary">) -> (), sym_name = "__transform_main"}> ({
-//CHECK-NEXT:  ^0(%arg0 : !transform.any_op, %arg1 : !transform.op<"linalg.quantized_matmul">, %arg2 : !transform.op<"linalg.elemwise_binary">):
+//CHECK-NEXT:  transform.named_sequence @__transform_main(%arg0 : !transform.any_op, %arg1 : !transform.op<"linalg.quantized_matmul">, %arg2 : !transform.op<"linalg.elemwise_binary">) {
 //CHECK-NEXT:    %6 = "transform.cast"(%arg1) : (!transform.op<"linalg.quantized_matmul">) -> !transform.any_op
 //CHECK-NEXT:    %7, %8 = "transform.structured.tile_using_forall"(%arg1) <{operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, static_tile_sizes = array<i64: 4, 32>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op)
 //CHECK-NEXT:    %9, %10, %11 = "transform.structured.tile_using_for"(%arg1) <{scalable_sizes = array<i1: false, false>, static_sizes = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 //CHECK-NEXT:    transform.yield
-//CHECK-NEXT:  }) : () -> ()
+//CHECK-NEXT:  }
 //CHECK-NEXT:  "transform.sequence"() <{failure_propagation_mode = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
 //CHECK-NEXT:  ^0(%arg0 : !transform.any_op):
 //CHECK-NEXT:    %arg1 = "transform.select"(%arg0) <{op_name = "linalg.quantized_matmul"}> : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/transform/transform_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/transform/transform_types.mlir
@@ -1,28 +1,26 @@
 // RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
 
 builtin.module attributes  {"transform.with_named_sequence"} {
-  "transform.named_sequence"() <{arg_attrs = [{transform.readonly}], function_type = (!transform.any_op) -> (), sym_name = "foo"}> ({
-  ^bb0(%arg0: !transform.any_op):
-    "transform.yield"() : () -> ()
-  }) : () -> ()
+  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) {
+    transform.yield
+  }
   %0 = "test.op"() : () -> !transform.affine_map
   %1 = "test.op"() : () -> !transform.any_op
   %3 = "test.op"() : () -> !transform.any_value
   %4 = "test.op"() : () -> !transform.op<"linalg.quantized_matmul">
   %5 = "test.op"() : () -> !transform.param<i64>
   %6 = "test.op"() : () -> !transform.type
-  "transform.named_sequence"() <{"function_type" = (!transform.any_op, !transform.op<"linalg.quantized_matmul">, !transform.op<"linalg.elemwise_binary">) -> (), "sym_name" = "__transform_main"}> ({
-  ^0(%arg0 : !transform.any_op, %arg1 : !transform.op<"linalg.quantized_matmul">, %arg2 : !transform.op<"linalg.elemwise_binary">):
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op, %arg1: !transform.op<"linalg.quantized_matmul">, %arg2: !transform.op<"linalg.elemwise_binary">) {
     %7 = "transform.cast"(%arg1) : (!transform.op<"linalg.quantized_matmul">) -> !transform.any_op
     %8, %9 = "transform.structured.tile_using_forall"(%arg1) <{operandSegmentSizes = array<i32: 1, 0, 0, 0, 0>, "static_tile_sizes" = array<i64: 4, 32>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op)
     %10, %11, %12 = "transform.structured.tile_using_for"(%arg1) <{"scalable_sizes" = array<i1: false, false>, "static_sizes" = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-    "transform.yield"() : () -> ()
-  }) : () -> ()
+    transform.yield
+  }
   "transform.sequence"() <{"failure_propagation_mode" = 1 : i32, operandSegmentSizes = array<i32: 0, 0>}> ({
   ^1(%arg0_1 : !transform.any_op):
     %arg1_1 = "transform.select"(%arg0_1) <{"op_name" = "linalg.quantized_matmul"}> : (!transform.any_op) -> !transform.op<"linalg.quantized_matmul">
     %13, %14, %15 = "transform.structured.tile_using_for"(%arg1_1) <{"scalable_sizes" = array<i1: false, false>, "static_sizes" = array<i64: 8, 8>}> : (!transform.op<"linalg.quantized_matmul">) -> (!transform.any_op, !transform.any_op, !transform.any_op)
-    "transform.yield"() : () -> ()
+    transform.yield
   }) : () -> ()
  %16 = "test.op"() : () -> !transform.any_op
   %17 = "transform.get_producer_of_operand"(%16) <{operand_number = 0 : i64}> : (!transform.any_op) -> !transform.any_op


### PR DESCRIPTION
Also possibly change the name of the operands and properties to match funcOp