### PR TITLE
dialects: (builtin) add generic parameter to DenseIntOrFPElementsAttr

### DIFF
--- a/xdsl/backend/csl/print_csl.py
+++ b/xdsl/backend/csl/print_csl.py
@@ -454,8 +454,8 @@ class CslPrintContext:
                 return str(val.data)
             case StringAttr() as s:
                 return f'"{s.data}"'
-            case DenseIntOrFPElementsAttr(type=typ):
-                return f"{self.mlir_type_to_csl_type(typ)} {{ {', '.join(self.attribute_value_to_str(a) for a in attr.iter_attrs())} }}"  # noqa: E501
+            case DenseIntOrFPElementsAttr():
+                return f"{self.mlir_type_to_csl_type(attr.get_type())} {{ {', '.join(self.attribute_value_to_str(a) for a in attr.iter_attrs())} }}"  # noqa: E501
             case _:
                 return f"<!unknown value {attr}>"
 

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2096,23 +2096,24 @@ RankedStructure: TypeAlias = (
 )
 
 AnyDenseElement: TypeAlias = IntegerType | IndexType | AnyFloat
+DenseElementCovT = TypeVar(
+    "DenseElementCovT", bound=AnyDenseElement, default=AnyDenseElement, covariant=True
+)
 
 
 @irdl_attr_definition
-class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
+class DenseIntOrFPElementsAttr(
+    Generic[DenseElementCovT], TypedAttribute, ContainerType[DenseElementCovT]
+):
     name = "dense"
-    type: ParameterDef[
-        RankedStructure[IntegerType]
-        | RankedStructure[IndexType]
-        | RankedStructure[AnyFloat]
-    ]
+    type: ParameterDef[RankedStructure[DenseElementCovT]]
     data: ParameterDef[BytesAttr]
 
     # The type stores the shape data
     def get_shape(self) -> tuple[int, ...]:
         return self.type.get_shape()
 
-    def get_element_type(self) -> IntegerType | IndexType | AnyFloat:
+    def get_element_type(self) -> DenseElementCovT:
         return self.type.get_element_type()
 
     def __len__(self) -> int:
@@ -2136,7 +2137,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
     def create_dense_index(
         type: RankedStructure[IndexType],
         data: Sequence[int] | Sequence[IntegerAttr[IndexType]],
-    ) -> DenseIntOrFPElementsAttr:
+    ) -> DenseIntOrFPElementsAttr[IndexType]:
         if len(data) and isinstance(data[0], IntegerAttr):
             data = [
                 el.value.data for el in cast(Sequence[IntegerAttr[IndexType]], data)
@@ -2150,7 +2151,7 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
     def create_dense_int(
         type: RankedStructure[IntegerType],
         data: Sequence[int] | Sequence[IntegerAttr[IntegerType]],
-    ) -> DenseIntOrFPElementsAttr:
+    ) -> DenseIntOrFPElementsAttr[IntegerType]:
         if len(data) and isinstance(data[0], IntegerAttr):
             data = [
                 el.value.data for el in cast(Sequence[IntegerAttr[IntegerType]], data)
@@ -2180,8 +2181,8 @@ class DenseIntOrFPElementsAttr(TypedAttribute, ContainerType[AnyDenseElement]):
     @staticmethod
     def create_dense_float(
         type: RankedStructure[AnyFloat],
-        data: Sequence[int | float] | Sequence[FloatAttr],
-    ) -> DenseIntOrFPElementsAttr:
+        data: Sequence[float] | Sequence[FloatAttr],
+    ) -> DenseIntOrFPElementsAttr[AnyFloat]:
         if len(data) and isa(data[0], FloatAttr):
             data = [el.value.data for el in cast(Sequence[FloatAttr], data)]
         else:

--- a/xdsl/interpreters/builtin.py
+++ b/xdsl/interpreters/builtin.py
@@ -86,7 +86,7 @@ class BuiltinFunctions(InterpreterFunctions):
         attr: Attribute,
         type_attr: builtin.MemRefType[Any],
     ) -> ShapedArray[Any]:
-        assert isinstance(attr, builtin.DenseIntOrFPElementsAttr)
+        assert isa(attr, builtin.DenseIntOrFPElementsAttr)
         shape = attr.get_shape()
         data = attr.get_values()
         data_ptr = ptr.TypedPtr[Any].new(

--- a/xdsl/interpreters/memref.py
+++ b/xdsl/interpreters/memref.py
@@ -13,6 +13,7 @@ from xdsl.interpreters.builtin import xtype_for_el_type
 from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.traits import SymbolTable
+from xdsl.utils.hints import isa
 
 
 @register_impls
@@ -71,7 +72,7 @@ class MemRefFunctions(InterpreterFunctions):
         mem = SymbolTable.lookup_symbol(op, op.name_)
         assert isinstance(mem, memref.GlobalOp)
         initial_value = mem.initial_value
-        if not isinstance(initial_value, builtin.DenseIntOrFPElementsAttr):
+        if not isa(initial_value, builtin.DenseIntOrFPElementsAttr):
             raise NotImplementedError(
                 "MemRefs that are not dense int or float arrays are not implemented"
             )

--- a/xdsl/interpreters/ml_program.py
+++ b/xdsl/interpreters/ml_program.py
@@ -12,6 +12,7 @@ from xdsl.interpreters.builtin import xtype_for_el_type
 from xdsl.interpreters.shaped_array import ShapedArray
 from xdsl.interpreters.utils.ptr import TypedPtr
 from xdsl.traits import SymbolTable
+from xdsl.utils.hints import isa
 
 
 @register_impls
@@ -26,7 +27,7 @@ class MLProgramFunctions(InterpreterFunctions):
         global_op = SymbolTable.lookup_symbol(op, op.global_attr)
         assert isinstance(global_op, ml_program.GlobalOp)
         global_value = global_op.value
-        assert isinstance(global_value, DenseIntOrFPElementsAttr)
+        assert isa(global_value, DenseIntOrFPElementsAttr)
         shape = global_value.get_shape()
         xtype = xtype_for_el_type(
             global_value.get_element_type(), interpreter.index_bitwidth

--- a/xdsl/interpreters/riscv.py
+++ b/xdsl/interpreters/riscv.py
@@ -5,6 +5,7 @@ from typing import Any, TypeAlias, TypeVar, cast
 
 from xdsl.dialects import builtin, riscv
 from xdsl.dialects.builtin import (
+    DenseIntOrFPElementsAttr,
     IndexType,
     IntegerAttr,
     IntegerType,
@@ -26,6 +27,7 @@ from xdsl.ir import Attribute, SSAValue
 from xdsl.utils.bitwise_casts import convert_u32_to_f32
 from xdsl.utils.comparisons import to_signed, to_unsigned
 from xdsl.utils.exceptions import InterpretationError
+from xdsl.utils.hints import isa
 
 _T = TypeVar("_T")
 
@@ -639,6 +641,7 @@ class RiscvFunctions(InterpreterFunctions):
             case IntegerAttr():
                 return attr.value.data
             case builtin.DenseIntOrFPElementsAttr():
+                assert isa(attr, DenseIntOrFPElementsAttr)
                 data = attr.get_values()
                 data_ptr = ptr.TypedPtr[Any].new(
                     data,


### PR DESCRIPTION
A much simpler version of #3492 using the default valued typevars. The advantage of this is that you can now represent for example `DenseIntOrFPElementsAttr[AnyFloat]` as a type.

I'm not totally happy with this as there doesn't seem to be a good way to write the extraction methods (`get_attrs`/`iter_attrs`) in a way which actually respects the generic type, so any suggestions would be welcome. 

This PR does not attempt to specialise the use of `DenseIntOrFPElementsAttr` anywhere. I also didn't touch the builder methods `tensor_from_list` or `vector_from_list` or `from_list` as I personally believe it might be possible/best to remove the methods in the future, favouring `create_dense_{float/int/index}`.