### PR TITLE
dialects: (irdl) add name properties

### DIFF
--- a/tests/dialects/test_irdl.py
+++ b/tests/dialects/test_irdl.py
@@ -3,7 +3,7 @@ from typing import ClassVar
 
 import pytest
 
-from xdsl.dialects.builtin import ArrayAttr, StringAttr, SymbolRefAttr, i32
+from xdsl.dialects.builtin import StringAttr, SymbolRefAttr, i32
 from xdsl.dialects.irdl import (
     AllOfOp,
     AnyOfOp,
@@ -13,14 +13,10 @@ from xdsl.dialects.irdl import (
     BaseOp,
     DialectOp,
     IsOp,
-    OperandsOp,
     OperationOp,
-    ParametersOp,
     ParametricOp,
-    ResultsOp,
     TypeOp,
 )
-from xdsl.dialects.irdl.irdl import VariadicityArrayAttr, VariadicityAttr
 from xdsl.ir import Block, Region
 from xdsl.irdl import IRDLOperation, irdl_op_definition
 from xdsl.utils.exceptions import PyRDLOpDefinitionError
@@ -45,44 +41,6 @@ def test_named_region_op_init(
 
     assert op.sym_name == StringAttr("cmath")
     assert len(op.body.blocks) == 1
-
-
-def test_parameter_op_init():
-    """
-    Test __init__ of ParametersOp.
-    """
-
-    val1 = create_ssa_value(AttributeType())
-    val2 = create_ssa_value(AttributeType())
-    op = ParametersOp([val1, val2])
-    op2 = ParametersOp.create(operands=[val1, val2])
-
-    assert op.is_structurally_equivalent(op2)
-
-    assert op.args == (val1, val2)
-
-
-@pytest.mark.parametrize("op_type", [OperandsOp, ResultsOp])
-def test_parameters_init(op_type: type[OperandsOp | ResultsOp]):
-    """
-    Test __init__ of OperandsOp, ResultsOp.
-    """
-
-    val1 = create_ssa_value(AttributeType())
-    val2 = create_ssa_value(AttributeType())
-    op = op_type([(VariadicityAttr.SINGLE, val1), (VariadicityAttr.OPTIONAL, val2)])
-    op2 = op_type.create(
-        operands=[val1, val2],
-        attributes={
-            "variadicity": VariadicityArrayAttr(
-                ArrayAttr((VariadicityAttr.SINGLE, VariadicityAttr.OPTIONAL))
-            )
-        },
-    )
-
-    assert op.is_structurally_equivalent(op2)
-
-    assert op.args == (val1, val2)
 
 
 def test_is_init():

--- a/tests/filecheck/dialects/irdl/cmath.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/cmath.irdl.mlir
@@ -8,26 +8,26 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.is f32
     // CHECK-NEXT:   %{{.*}} = irdl.is f64
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(elem: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @complex {
       %0 = irdl.is f32
       %1 = irdl.is f64
       %2 = irdl.any_of(%0, %1)
-      irdl.parameters(%2)
+      irdl.parameters(elem: %2)
     }
 
     // CHECK: irdl.operation @norm {
     // CHECK-NEXT:   %{{.*}} = irdl.any
     // CHECK-NEXT:   %{{.*}} = irdl.parametric @complex<%{{.*}}>
-    // CHECK-NEXT:   irdl.operands(%{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.operands(in: %{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @norm {
       %0 = irdl.any
       %1 = irdl.parametric @complex<%0>
-      irdl.operands(%1)
-      irdl.results(%0)
+      irdl.operands(in: %1)
+      irdl.results(out: %0)
     }
 
     // CHECK: irdl.operation @mul {
@@ -35,16 +35,16 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.is f64
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
     // CHECK-NEXT:   %{{.*}} = irdl.parametric @complex<%{{.*}}>
-    // CHECK-NEXT:   irdl.operands(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.operands(lhs: %{{.*}}, rhs: %{{.*}})
+    // CHECK-NEXT:   irdl.results(res: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @mul {
       %0 = irdl.is f32
       %1 = irdl.is f64
       %2 = irdl.any_of(%0, %1)
       %3 = irdl.parametric @complex<%2>
-      irdl.operands(%3, %3)
-      irdl.results(%3)
+      irdl.operands(lhs: %3, rhs: %3)
+      irdl.results(res: %3)
     }
 
   }

--- a/tests/filecheck/dialects/irdl/cmath_irdl_stub.py
+++ b/tests/filecheck/dialects/irdl/cmath_irdl_stub.py
@@ -50,18 +50,18 @@ if __name__ == "__main__":
 # CHECK-NEXT:  )
 # CHECK-EMPTY:
 # CHECK-NEXT:  class complex(TypeAttribute, ParametrizedAttribute):
-# CHECK-NEXT:      p0 : "Float32Type | Float64Type"
+# CHECK-NEXT:      elem : "Float32Type | Float64Type"
 # CHECK-EMPTY:
 # CHECK-EMPTY:
 # CHECK-NEXT:  class NormOp(IRDLOperation):
-# CHECK-NEXT:      o0 : Operand
-# CHECK-NEXT:      r0 : OpResult
+# CHECK-NEXT:      in_ : Operand
+# CHECK-NEXT:      out : OpResult
 # CHECK-EMPTY:
 # CHECK-EMPTY:
 # CHECK-NEXT:  class MulOp(IRDLOperation):
-# CHECK-NEXT:      o0 : Operand
-# CHECK-NEXT:      o1 : Operand
-# CHECK-NEXT:      r0 : OpResult
+# CHECK-NEXT:      lhs : Operand
+# CHECK-NEXT:      rhs : Operand
+# CHECK-NEXT:      res : OpResult
 # CHECK-EMPTY:
 # CHECK-EMPTY:
 # CHECK-NEXT:  Cmath : Dialect

--- a/tests/filecheck/dialects/irdl/cyclic-types.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/cyclic-types.irdl.mlir
@@ -9,14 +9,14 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.parametric @self_referencing<%{{.*}}>
     // CHECK-NEXT:   %{{.*}} = irdl.is i32
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @self_referencing {
       %0 = irdl.any
       %1 = irdl.parametric @self_referencing<%0>
       %2 = irdl.is i32
       %3 = irdl.any_of(%1, %2)
-      irdl.parameters(%3)
+      irdl.parameters(param: %3)
     }
 
 
@@ -25,14 +25,14 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.parametric @type2<%{{.*}}>
     // CHECK-NEXT:   %{{.*}} = irdl.is i32
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @type1 {
       %0 = irdl.any
       %1 = irdl.parametric @type2<%0>
       %2 = irdl.is i32
       %3 = irdl.any_of(%1, %2)
-      irdl.parameters(%3)
+      irdl.parameters(param: %3)
     }
 
     // CHECK:      irdl.type @type2 {
@@ -40,14 +40,14 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.parametric @type1<%{{.*}}>
     // CHECK-NEXT:   %{{.*}} = irdl.is i32
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @type2 {
         %0 = irdl.any
         %1 = irdl.parametric @type1<%0>
         %2 = irdl.is i32
         %3 = irdl.any_of(%1, %2)
-        irdl.parameters(%3)
+        irdl.parameters(param: %3)
     }
   }
 }

--- a/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/irdl-to-pyrdl/testd.irdl.mlir
@@ -10,42 +10,43 @@ builtin.module {
 
     irdl.type @parametric {
       %0 = irdl.any
-      irdl.parameters(%0)
+      irdl.parameters(elem: %0)
     }
 // CHECK:      @irdl_attr_definition
 // CHECK-NEXT: class parametric(ParametrizedAttribute, TypeAttribute):
 // CHECK-NEXT:     name = "testd.parametric"
-// CHECK-NEXT:     param0: ParameterDef[Attribute]
+// CHECK-NEXT:     elem: ParameterDef[Attribute]
 
 
     irdl.attribute @parametric_attr {
       %0 = irdl.any
-      irdl.parameters(%0)
+      irdl.parameters(elem: %0)
     }
 // CHECK:      @irdl_attr_definition
 // CHECK-NEXT: class parametric_attr(ParametrizedAttribute):
 // CHECK-NEXT:     name = "testd.parametric_attr"
-// CHECK-NEXT:     param0: ParameterDef[Attribute]
+// CHECK-NEXT:     elem: ParameterDef[Attribute]
 
 
     irdl.type @attr_in_type_out {
       %0 = irdl.any
-      irdl.parameters(%0)
+      irdl.parameters(param: %0)
     }
 // CHECK:      @irdl_attr_definition
 // CHECK-NEXT: class attr_in_type_out(ParametrizedAttribute, TypeAttribute):
 // CHECK-NEXT:     name = "testd.attr_in_type_out"
-// CHECK-NEXT:     param0: ParameterDef[Attribute]
+// CHECK-NEXT:     param: ParameterDef[Attribute]
+
 
 
     irdl.operation @my_eq {
       %0 = irdl.is i32
-      irdl.results(%0)
+      irdl.results(out: %0)
     }
 // CHECK:      @irdl_op_definition
 // CHECK-NEXT: class MyEqOp(IRDLOperation):
 // CHECK-NEXT:     name = "testd.my_eq"
-// CHECK-NEXT:     result0 = result_def()
+// CHECK-NEXT:     out = result_def()
 // CHECK-NEXT:     regs = var_region_def()
 // CHECK-NEXT:     succs = var_successor_def()
 
@@ -54,12 +55,12 @@ builtin.module {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
-      irdl.results(%2)
+      irdl.results(out: %2)
     }
 // CHECK:      @irdl_op_definition
 // CHECK-NEXT: class AnyOfOp(IRDLOperation):
 // CHECK-NEXT:     name = "testd.any_of"
-// CHECK-NEXT:     result0 = result_def()
+// CHECK-NEXT:     out = result_def()
 // CHECK-NEXT:     regs = var_region_def()
 // CHECK-NEXT:     succs = var_successor_def()
 
@@ -69,37 +70,37 @@ builtin.module {
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
       %3 = irdl.all_of(%2, %1)
-      irdl.results(%3)
+      irdl.results(out: %3)
     }
 // CHECK:      @irdl_op_definition
 // CHECK-NEXT: class AllOfOp(IRDLOperation):
 // CHECK-NEXT:     name = "testd.all_of"
-// CHECK-NEXT:     result0 = result_def()
+// CHECK-NEXT:     out = result_def()
 // CHECK-NEXT:     regs = var_region_def()
 // CHECK-NEXT:     succs = var_successor_def()
 
 
     irdl.operation @any {
       %0 = irdl.any
-      irdl.results(%0)
+      irdl.results(out: %0)
     }
 // CHECK:      @irdl_op_definition
 // CHECK-NEXT: class AnyOp(IRDLOperation):
 // CHECK-NEXT:     name = "testd.any"
-// CHECK-NEXT:     result0 = result_def()
+// CHECK-NEXT:     out = result_def()
 // CHECK-NEXT:     regs = var_region_def()
 // CHECK-NEXT:     succs = var_successor_def()
 
 
     irdl.operation @dynbase {
       %0 = irdl.any
-      %1 = irdl.parametric @parametric<%0>
-      irdl.results(%1)
+      %1 = irdl.parametric @testd::@parametric<%0>
+      irdl.results(out: %1)
     }
 // CHECK:      @irdl_op_definition
 // CHECK-NEXT: class DynbaseOp(IRDLOperation):
 // CHECK-NEXT:     name = "testd.dynbase"
-// CHECK-NEXT:     result0 = result_def()
+// CHECK-NEXT:     out = result_def()
 // CHECK-NEXT:     regs = var_region_def()
 // CHECK-NEXT:     succs = var_successor_def()
 
@@ -107,13 +108,13 @@ builtin.module {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
-      %3 = irdl.parametric @parametric<%2>
-      irdl.results(%3)
+      %3 = irdl.parametric @testd::@parametric<%2>
+      irdl.results(out: %3)
     }
 // CHECK:      @irdl_op_definition
 // CHECK-NEXT: class DynparamsOp(IRDLOperation):
 // CHECK-NEXT:     name = "testd.dynparams"
-// CHECK-NEXT:     result0 = result_def()
+// CHECK-NEXT:     out = result_def()
 // CHECK-NEXT:     regs = var_region_def()
 // CHECK-NEXT:     succs = var_successor_def()
 
@@ -121,13 +122,13 @@ builtin.module {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
-      irdl.results(%2, %2)
+      irdl.results(out1: %2, out2: %2)
     }
 // CHECK:      @irdl_op_definition
 // CHECK-NEXT: class ConstraintVarsOp(IRDLOperation):
 // CHECK-NEXT:     name = "testd.constraint_vars"
-// CHECK-NEXT:     result0 = result_def()
-// CHECK-NEXT:     result1 = result_def()
+// CHECK-NEXT:     out1 = result_def()
+// CHECK-NEXT:     out2 = result_def()
 // CHECK-NEXT:     regs = var_region_def()
 // CHECK-NEXT:     succs = var_successor_def()
   }

--- a/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
+++ b/tests/filecheck/dialects/irdl/pyrdl-to-irdl/cmath-conversion.py
@@ -9,22 +9,22 @@ print(dialect_to_irdl(Cmath, "cmath"))
 
 # CHECK-NEXT:   irdl.attribute @complex {
 # CHECK-NEXT:     %{{.*}} = irdl.any
-# CHECK-NEXT:     irdl.parameters(%{{.*}})
+# CHECK-NEXT:     irdl.parameters(elem: %{{.*}})
 # CHECK-NEXT:   }
 
 # CHECK-NEXT:   irdl.operation @norm {
 # CHECK-NEXT:     %{{.*}} = irdl.any
-# CHECK-NEXT:     irdl.operands(%{{.*}})
+# CHECK-NEXT:     irdl.operands(in: %{{.*}})
 # CHECK-NEXT:     %{{.*}} = irdl.any
-# CHECK-NEXT:     irdl.results(%{{.*}})
+# CHECK-NEXT:     irdl.results(out: %{{.*}})
 # CHECK-NEXT:   }
 
 # CHECK-NEXT:   irdl.operation @mul {
 # CHECK-NEXT:     %{{.*}} = irdl.any
 # CHECK-NEXT:     %{{.*}} = irdl.any
-# CHECK-NEXT:     irdl.operands(%{{.*}}, %{{.*}})
+# CHECK-NEXT:     irdl.operands(lhs: %{{.*}}, rhs: %{{.*}})
 # CHECK-NEXT:     %{{.*}} = irdl.any
-# CHECK-NEXT:     irdl.results(%{{.*}})
+# CHECK-NEXT:     irdl.results(res: %{{.*}})
 # CHECK-NEXT:   }
 
 # CHECK-NEXT: }

--- a/tests/filecheck/dialects/irdl/test-type.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/test-type.irdl.mlir
@@ -11,23 +11,23 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.is i32
     // CHECK-NEXT:   %{{.*}} = irdl.is i64
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.parameters(%{{.*}}, %{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param1: %{{.*}}, param2: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @parametrized {
       %0 = irdl.any
       %1 = irdl.is i32
       %2 = irdl.is i64
       %3 = irdl.any_of(%1, %2)
-      irdl.parameters(%0, %3)
+      irdl.parameters(param1: %0, param2: %3)
     }
 
     // CHECK:      irdl.operation @any {
     // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @any {
       %0 = irdl.any
-      irdl.results(%0)
+      irdl.results(out: %0)
     }
   }
 }

--- a/tests/filecheck/dialects/irdl/testd.irdl.mlir
+++ b/tests/filecheck/dialects/irdl/testd.irdl.mlir
@@ -6,69 +6,69 @@ builtin.module {
 
     // CHECK:      irdl.type @base_name {
     // CHECK-NEXT:   %{{.*}} = irdl.base "!my_dialect.type_name"
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @base_name {
       %0 = irdl.base "!my_dialect.type_name"
-      irdl.parameters(%0)
+      irdl.parameters(param: %0)
     }
 
     // CHECK:      irdl.type @base_ref {
     // CHECK-NEXT:   %{{.*}} = irdl.base @base_name
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @base_ref {
       %0 = irdl.base @base_name
-      irdl.parameters(%0)
+      irdl.parameters(param: %0)
     }
 
     // CHECK:      irdl.type @parametric {
     // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @parametric {
       %0 = irdl.any
-      irdl.parameters(%0)
+      irdl.parameters(param: %0)
     }
 
     // CHECK:      irdl.attribute @parametric_attr {
     // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.attribute @parametric_attr {
       %0 = irdl.any
-      irdl.parameters(%0)
+      irdl.parameters(param: %0)
     }
 
     // CHECK:      irdl.type @attr_in_type_out {
     // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.parameters(%{{.*}})
+    // CHECK-NEXT:   irdl.parameters(param: %{{.*}})
     // CHECK-NEXT: }
     irdl.type @attr_in_type_out {
       %0 = irdl.any
-      irdl.parameters(%0)
+      irdl.parameters(param: %0)
     }
 
     // CHECK:      irdl.operation @eq {
     // CHECK-NEXT:   %{{.*}} = irdl.is i32
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @eq {
       %0 = irdl.is i32
-      irdl.results(%0)
+      irdl.results(out: %0)
     }
 
     // CHECK:      irdl.operation @anyof {
     // CHECK-NEXT:   %{{.*}} = irdl.is i32
     // CHECK-NEXT:   %{{.*}} = irdl.is i64
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @anyof {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
-      irdl.results(%2)
+      irdl.results(out: %2)
     }
 
     // CHECK:      irdl.operation @all_of {
@@ -76,34 +76,34 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.is i64
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
     // CHECK-NEXT:   %{{.*}} = irdl.all_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @all_of {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
       %3 = irdl.all_of(%2, %1)
-      irdl.results(%3)
+      irdl.results(out: %3)
     }
 
     // CHECK:      irdl.operation @any {
     // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @any {
       %0 = irdl.any
-      irdl.results(%0)
+      irdl.results(out: %0)
     }
 
     // CHECK:      irdl.operation @dynbase {
     // CHECK-NEXT:   %{{.*}} = irdl.any
     // CHECK-NEXT:   %{{.*}} = irdl.parametric @parametric<%{{.*}}>
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @dynbase {
       %0 = irdl.any
       %1 = irdl.parametric @parametric<%0>
-      irdl.results(%1)
+      irdl.results(out: %1)
     }
 
     // CHECK:      irdl.operation @dynparams {
@@ -111,38 +111,38 @@ builtin.module {
     // CHECK-NEXT:   %{{.*}} = irdl.is i64
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
     // CHECK-NEXT:   %{{.*}} = irdl.parametric @parametric<%{{.*}}>
-    // CHECK-NEXT:   irdl.results(%{{.*}})
+    // CHECK-NEXT:   irdl.results(out: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @dynparams {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
       %3 = irdl.parametric @parametric<%2>
-      irdl.results(%3)
+      irdl.results(out: %3)
     }
 
     // CHECK:      irdl.operation @constraint_vars {
     // CHECK-NEXT:   %{{.*}} = irdl.is i32
     // CHECK-NEXT:   %{{.*}} = irdl.is i64
     // CHECK-NEXT:   %{{.*}} = irdl.any_of(%{{.*}}, %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}}, %{{.*}})
+    // CHECK-NEXT:   irdl.results(out1: %{{.*}}, out2: %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @constraint_vars {
       %0 = irdl.is i32
       %1 = irdl.is i64
       %2 = irdl.any_of(%0, %1)
-      irdl.results(%2, %2)
+      irdl.results(out1: %2, out2: %2)
     }
 
     // CHECK:      irdl.operation @variadicity {
     // CHECK-NEXT:   %{{.*}} = irdl.any
-    // CHECK-NEXT:   irdl.operands(%{{.*}}, %{{.*}}, optional %{{.*}}, variadic %{{.*}})
-    // CHECK-NEXT:   irdl.results(%{{.*}}, %{{.*}}, optional %{{.*}}, variadic %{{.*}})
+    // CHECK-NEXT:   irdl.operands(normal: %{{.*}}, sin: %{{.*}}, opt: optional %{{.*}}, var: variadic %{{.*}})
+    // CHECK-NEXT:   irdl.results(normal: %{{.*}}, sin: %{{.*}}, opt: optional %{{.*}}, var: variadic %{{.*}})
     // CHECK-NEXT: }
     irdl.operation @variadicity {
       %0 = irdl.any
-      irdl.operands(%0, single %0, optional %0, variadic %0)
-      irdl.results(%0, single %0, optional %0, variadic %0)
+      irdl.operands(normal: %0, sin: single %0, opt: optional %0, var: variadic %0)
+      irdl.results(normal: %0, sin: single %0, opt: optional %0, var: variadic %0)
     }
 
     // CHECK:      irdl.operation @op_with_regions {
@@ -152,7 +152,7 @@ builtin.module {
     // CHECK-NEXT:    %v1 = irdl.is i64
     // CHECK-NEXT:    %r2 = irdl.region(%v0, %v1)
     // CHECK-NEXT:    %r3 = irdl.region with size 3
-    // CHECK-NEXT:    irdl.regions(%r0, %r1, %r2, %r3)
+    // CHECK-NEXT:    irdl.regions(r0: %r0, r1: %r1, r2: %r2, r3: %r3)
     // CHECK-NEXT:  }
     irdl.operation @op_with_regions {
       %r0 = irdl.region
@@ -162,7 +162,7 @@ builtin.module {
       %r2 = irdl.region(%v0, %v1)
       %r3 = irdl.region with size 3
 
-      irdl.regions(%r0, %r1, %r2, %r3)
+      irdl.regions(r0: %r0, r1: %r1, r2: %r2, r3: %r3)
     }
 
     // CHECK:      irdl.operation @attr_op {

--- a/xdsl/dialects/cmath.irdl
+++ b/xdsl/dialects/cmath.irdl
@@ -4,21 +4,21 @@ builtin.module {
       %0 = irdl.is f32
       %1 = irdl.is f64
       %2 = irdl.any_of(%0, %1)
-      irdl.parameters(%2)
+      irdl.parameters(elem: %2)
     }
     irdl.operation @norm {
       %3 = irdl.any
       %4 = irdl.parametric @complex<%3>
-      irdl.operands(%4)
-      irdl.results(%3)
+      irdl.operands(in: %4)
+      irdl.results(out: %3)
     }
     irdl.operation @mul {
       %5 = irdl.is f32
       %6 = irdl.is f64
       %7 = irdl.any_of(%5, %6)
       %8 = irdl.parametric @complex<%7>
-      irdl.operands(%8, %8)
-      irdl.results(%8)
+      irdl.operands(lhs: %8, rhs: %8)
+      irdl.results(res: %8)
     }
   }
 }

--- a/xdsl/dialects/irdl/irdl_to_pyrdl.py
+++ b/xdsl/dialects/irdl/irdl_to_pyrdl.py
@@ -2,6 +2,8 @@
 Translate an IRDL program to a Python program creating the corresponding xDSL dialects.
 """
 
+import keyword
+
 from xdsl.dialects.irdl import (
     AttributeOp,
     DialectOp,
@@ -11,6 +13,13 @@ from xdsl.dialects.irdl import (
     ResultsOp,
     TypeOp,
 )
+from xdsl.dialects.irdl.irdl import VariadicityAttr
+
+
+def python_name(name: str):
+    if keyword.iskeyword(name):
+        return f"{name}_"
+    return name
 
 
 def convert_type_or_attr(op: TypeOp | AttributeOp, dialect_name: str) -> str:
@@ -28,8 +37,8 @@ class {op.sym_name.data}(ParametrizedAttribute{type_addition}):
     for sub_op in op.body.ops:
         if not isinstance(sub_op, ParametersOp):
             continue
-        for idx, _ in enumerate(sub_op.args):
-            res += f"    param{idx}: ParameterDef[Attribute]\n"
+        for name in sub_op.names:
+            res += f"    {python_name(name.data)}: ParameterDef[Attribute]\n"
     return res
 
 
@@ -43,11 +52,30 @@ class {op.get_py_class_name()}(IRDLOperation):
 
     for sub_op in op.body.ops:
         if isinstance(sub_op, OperandsOp):
-            for idx, _ in enumerate(sub_op.args):
-                res += f"    operand{idx} = operand_def()\n"
+            for name, var in zip(sub_op.names, sub_op.variadicity.value):
+                py_name = python_name(name.data)
+                match var:
+                    case VariadicityAttr.SINGLE:
+                        res += f"    {py_name} = operand_def()\n"
+                    case VariadicityAttr.OPTIONAL:
+                        res += f"    {py_name} = opt_operand_def()\n"
+                    case VariadicityAttr.VARIADIC:
+                        res += f"    {py_name} = var_operand_def()\n"
+                    case _:
+                        pass
+
         if isinstance(sub_op, ResultsOp):
-            for idx, _ in enumerate(sub_op.args):
-                res += f"    result{idx} = result_def()\n"
+            for name, var in zip(sub_op.names, sub_op.variadicity.value):
+                py_name = python_name(name.data)
+                match var:
+                    case VariadicityAttr.SINGLE:
+                        res += f"    {py_name} = result_def()\n"
+                    case VariadicityAttr.OPTIONAL:
+                        res += f"    {py_name} = opt_result_def()\n"
+                    case VariadicityAttr.VARIADIC:
+                        res += f"    {py_name} = var_result_def()\n"
+                    case _:
+                        pass
     res += "    regs = var_region_def()\n"
     res += "    succs = var_successor_def()\n"
     return res

--- a/xdsl/interpreters/irdl.py
+++ b/xdsl/interpreters/irdl.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.dialects.irdl import irdl
+from xdsl.dialects.irdl.irdl_to_pyrdl import python_name
 from xdsl.interpreter import (
     Interpreter,
     InterpreterFunctions,
@@ -173,7 +174,7 @@ class IRDLFunctions(InterpreterFunctions):
         op_op = cast(irdl.OperationOp, op.parent_op())
         op_name = op_op.qualified_name
         self._get_op_def(interpreter, op_name).operands = list(
-            (f"o{i}", OperandDef(a)) for i, a in enumerate(args)
+            (python_name(name.data), OperandDef(a)) for name, a in zip(op.names, args)
         )
         return ()
 
@@ -184,7 +185,7 @@ class IRDLFunctions(InterpreterFunctions):
         op_op = cast(irdl.OperationOp, op.parent_op())
         op_name = op_op.qualified_name
         self._get_op_def(interpreter, op_name).results = list(
-            (f"r{i}", ResultDef(a)) for i, a in enumerate(args)
+            (python_name(name.data), ResultDef(a)) for name, a in zip(op.names, args)
         )
         return ()
 
@@ -210,7 +211,7 @@ class IRDLFunctions(InterpreterFunctions):
         attr_op = cast(irdl.AttributeOp | irdl.TypeOp, op.parent_op())
         attr_name = attr_op.qualified_name
         self._get_attr_def(interpreter, attr_name).parameters = list(
-            (f"p{i}", a) for i, a in enumerate(args)
+            (python_name(name.data), a) for name, a in zip(op.names, args)
         )
         return ()
 


### PR DESCRIPTION
Updates irdl to the version in MLIR master.

I think we could benefit from some mlir interop tests here, but xdsl and mlir seems to treat symbols slightly differently which could make this difficult.