### PR TITLE
Add support for optional groups' `else-elements`

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2763,6 +2763,22 @@ def test_optional_else_group(
     check_equivalence(program, generic_program, ctx)
 
 
+def test_impossible_optional_else_group():
+    error = "property 'val' is already bound"
+    with pytest.raises(
+        PyRDLOpDefinitionError,
+        match=error,
+    ):
+
+        @irdl_op_definition
+        class OptionalImpossibleElseGroupOp(IRDLOperation):
+            name = "test.impossible_optional_else_group"
+
+            val = opt_prop_def(IntegerAttr[I32])
+
+            assembly_format = """($val^):($val)? attr-dict"""
+
+
 @pytest.mark.parametrize(
     "program, generic_program",
     [

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2771,7 +2771,7 @@ def test_impossible_optional_else_group():
     ):
 
         @irdl_op_definition
-        class OptionalImpossibleElseGroupOp(IRDLOperation):
+        class _OptionalImpossibleElseGroup(IRDLOperation):
             name = "test.impossible_optional_else_group"
 
             val = opt_prop_def(IntegerAttr[I32])

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -2771,7 +2771,7 @@ def test_impossible_optional_else_group():
     ):
 
         @irdl_op_definition
-        class _OptionalImpossibleElseGroup(IRDLOperation):
+        class OptionalImpossibleElseGroup(IRDLOperation):  # pyright: ignore[reportUnusedClass]
             name = "test.impossible_optional_else_group"
 
             val = opt_prop_def(IntegerAttr[I32])

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -22,6 +22,7 @@ from xdsl.dialects.builtin import (
     ModuleOp,
     StringAttr,
     UnitAttr,
+    i32,
 )
 from xdsl.dialects.test import Test, TestType
 from xdsl.ir import (
@@ -2722,6 +2723,40 @@ def test_optional_group_optional_operand_anchor(
 
     ctx = Context()
     ctx.load_op(OptionalGroupOp)
+    ctx.load_dialect(Test)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            '%0 = "test.op"() : () -> i32\ntest.optional_else_group %0',
+            '%0 = "test.op"() : () -> i32\n"test.optional_else_group"(%0) : (i32) -> ()',
+        ),
+        (
+            "test.optional_else_group 1",
+            '"test.optional_else_group"() <{a = 1 : i32}> : () -> ()',
+        ),
+    ],
+)
+def test_optional_else_group(
+    program: str,
+    generic_program: str,
+):
+    @irdl_op_definition
+    class OptionalElseGroupOp(IRDLOperation):
+        name = "test.optional_else_group"
+
+        v = opt_operand_def(i32)
+        a = opt_prop_def(IntegerAttr[I32])
+
+        assembly_format = """($v^):($a)? attr-dict"""
+
+    ctx = Context()
+    ctx.load_op(OptionalElseGroupOp)
     ctx.load_dialect(Test)
 
     check_roundtrip(program, ctx)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -941,7 +941,7 @@ class OptionalElseGroupOp(IRDLOperation):
     v = opt_operand_def(i32)
     a = opt_prop_def(IntegerAttr[I32])
 
-    assembly_format = """(`value` $v^):($a)? attr-dict"""
+    assembly_format = """($v^):($a)? attr-dict"""
 
 
 def test_optional_else_group():
@@ -953,7 +953,7 @@ def test_optional_else_group():
     assert isinstance(op, OptionalElseGroupOp)
     op.verify()
 
-    assert op.a.value.data == 1
+    assert op.a == IntegerAttr(1, 32)
     assert not op.v
 
     prog = """
@@ -966,7 +966,6 @@ def test_optional_else_group():
     op = list(module.ops)[1]
     assert isinstance(op, OptionalElseGroupOp)
     op.verify()
-
     assert not op.a
     assert op.v
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -935,42 +935,6 @@ def test_parse_number_error(text: str, allow_boolean: bool):
 
 
 @irdl_op_definition
-class OptionalElseGroupOp(IRDLOperation):
-    name = "test.optional_else_group"
-
-    v = opt_operand_def(i32)
-    a = opt_prop_def(IntegerAttr[I32])
-
-    assembly_format = """($v^):($a)? attr-dict"""
-
-
-def test_optional_else_group():
-    ctx = Context()
-    ctx.load_op(OptionalElseGroupOp)
-    ctx.load_dialect(Test)
-    parser = Parser(ctx, '"test.optional_else_group"() <{a = 1 : i32}> : () -> ()')
-    op = parser.parse_op()
-    assert isinstance(op, OptionalElseGroupOp)
-    op.verify()
-
-    assert op.a == IntegerAttr(1, 32)
-    assert not op.v
-
-    prog = """
-    %0 = "test.op"() : () -> (i32)
-    "test.optional_else_group"(%0) : (i32) -> ()
-    """
-
-    parser = Parser(ctx, prog)
-    module = parser.parse_module()
-    op = list(module.ops)[1]
-    assert isinstance(op, OptionalElseGroupOp)
-    op.verify()
-    assert not op.a
-    assert op.v
-
-
-@irdl_op_definition
 class PropertyOp(IRDLOperation):
     name = "test.prop_op"
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,6 @@ import pytest
 from xdsl.context import Context
 from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
-    I32,
     ArrayAttr,
     Builtin,
     DictionaryAttr,
@@ -28,8 +27,6 @@ from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,
     irdl_op_definition,
-    opt_operand_def,
-    opt_prop_def,
     prop_def,
     region_def,
 )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,12 +8,12 @@ import pytest
 from xdsl.context import Context
 from xdsl.dialect_interfaces import OpAsmDialectInterface
 from xdsl.dialects.builtin import (
+    I32,
     ArrayAttr,
     Builtin,
     DictionaryAttr,
     FileLineColLoc,
     FloatAttr,
-    I32,
     IntAttr,
     IntegerAttr,
     IntegerType,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,6 +13,7 @@ from xdsl.dialects.builtin import (
     DictionaryAttr,
     FileLineColLoc,
     FloatAttr,
+    I32,
     IntAttr,
     IntegerAttr,
     IntegerType,
@@ -27,6 +28,8 @@ from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,
     irdl_op_definition,
+    opt_operand_def,
+    opt_prop_def,
     prop_def,
     region_def,
 )
@@ -929,6 +932,43 @@ def test_parse_number_error(text: str, allow_boolean: bool):
     parser = Parser(Context(), text)
     with pytest.raises(ParseError):
         parser.parse_number(allow_boolean=allow_boolean)
+
+
+@irdl_op_definition
+class OptionalElseGroupOp(IRDLOperation):
+    name = "test.optional_else_group"
+
+    v = opt_operand_def(i32)
+    a = opt_prop_def(IntegerAttr[I32])
+
+    assembly_format = """(`value` $v^):($a)? attr-dict"""
+
+
+def test_optional_else_group():
+    ctx = Context()
+    ctx.load_op(OptionalElseGroupOp)
+    ctx.load_dialect(Test)
+    parser = Parser(ctx, '"test.optional_else_group"() <{a = 1 : i32}> : () -> ()')
+    op = parser.parse_op()
+    assert isinstance(op, OptionalElseGroupOp)
+    op.verify()
+
+    assert op.a.value.data == 1
+    assert not op.v
+
+    prog = """
+    %0 = "test.op"() : () -> (i32)
+    "test.optional_else_group"(%0) : (i32) -> ()
+    """
+
+    parser = Parser(ctx, prog)
+    module = parser.parse_module()
+    op = list(module.ops)[1]
+    assert isinstance(op, OptionalElseGroupOp)
+    op.verify()
+
+    assert not op.a
+    assert op.v
 
 
 @irdl_op_definition

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -531,9 +531,6 @@ class OperandVariable(VariableDirective, OperandDirective):
     def get_types(self, op: IRDLOperation) -> Sequence[Attribute]:
         return (getattr(op, self.name).type,)
 
-    def is_anchorable(self):
-        return True
-
 
 @dataclass(frozen=True)
 class VariadicOperandVariable(VariadicVariable, OperandDirective):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -531,6 +531,9 @@ class OperandVariable(VariableDirective, OperandDirective):
     def get_types(self, op: IRDLOperation) -> Sequence[Attribute]:
         return (getattr(op, self.name).type,)
 
+    def is_anchorable(self):
+        return True
+
 
 @dataclass(frozen=True)
 class VariadicOperandVariable(VariadicVariable, OperandDirective):
@@ -1314,17 +1317,20 @@ class OptionalGroupDirective(FormatDirective):
     then_whitespace: tuple[WhitespaceDirective, ...]
     then_first: FormatDirective
     then_elements: tuple[FormatDirective, ...]
+    else_elements: tuple[FormatDirective, ...]
 
     def parse(self, parser: Parser, state: ParsingState) -> bool:
         # If the first element was parsed, parse the then-elements as usual
         if ret := self.then_first.parse(parser, state):
             for element in self.then_elements:
                 element.parse(parser, state)
-        # Otherwise, just explicitly set the variadic/optional variables and
-        # type to empty
+            for element in self.else_elements:
+                element.set_empty(state)
         else:
             for element in self.then_elements:
                 element.set_empty(state)
+            for element in self.else_elements:
+                element.parse(parser, state)
         return ret
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
@@ -1335,8 +1341,13 @@ class OptionalGroupDirective(FormatDirective):
                 *self.then_elements,
             ):
                 element.print(printer, state, op)
+        else:
+            for element in self.else_elements:
+                element.print(printer, state, op)
 
     def set_empty(self, state: ParsingState) -> None:
         self.then_first.set_empty(state)
         for element in self.then_elements:
+            element.set_empty(state)
+        for element in self.else_elements:
             element.set_empty(state)


### PR DESCRIPTION
Note: I'm not too familiar with this part of the code base. Some reviews and direction would be greatly appreciated.

This PR adds support for [optional groups' `else-elements`.](https://mlir.llvm.org/docs/DefiningDialects/Operations/#optional-groups)
