### PR TITLE
bench: Fix issues in benchmark warmed timeit for computers with low precision timers

### DIFF
--- a/benchmarks/bench_utils.py
+++ b/benchmarks/bench_utils.py
@@ -3,6 +3,7 @@
 
 import cProfile
 import gc
+import math
 import subprocess
 import time
 from argparse import ArgumentParser, Namespace
@@ -23,6 +24,7 @@ PROFILERS = (
     "pyinstrument",
     "dis",
 )
+PERF_COUNTER_RESOLUTION = time.get_clock_info("perf_counter").resolution
 
 
 class Benchmark(NamedTuple):
@@ -35,8 +37,8 @@ class Benchmark(NamedTuple):
 def warmed_timeit(
     func: Callable[[], Any],
     setup: Callable[[], Any] | None = None,
-    number: int = 100,
-    warmup: int = 3,
+    repeats: int = 100,
+    warmups: int = 3,
 ) -> tuple[float, float, float]:
     """
     Time the contents of a class method with setup and warmup.
@@ -57,32 +59,65 @@ def warmed_timeit(
     # measurements
     gcold = gc.isenabled()
     gc.disable()
+
     # Pre-populate the arrays to avoid costs of re-sizing them
-    times = [0.0 for _ in range(number)]
-    offset = [0.0 for _ in range(number)]
+    times = [0.0 for _ in range(repeats)]
+    offset = [0.0 for _ in range(repeats)]
 
-    # Run the interleaved setup and function calls to warm up
-    for _ in range(warmup):
+    # Warm up before measuring
+    for _ in range(warmups):
         if setup is not None:
             setup()
         func()
 
-    for i in range(number):
-        # Optionally run setup code (for example resetting mutable state) before
-        # each measurement iteration
-        if setup is not None:
-            setup()
+    # If the function is close to the resolution of the timer, group it into
+    # batches to aim for measurement periods of at least 25x the resolution.
+    if setup is not None:
+        setup()
+    batch_size_func_start = time.perf_counter()
+    func()
+    batch_size_func_end = time.perf_counter()
+    single_func_time = batch_size_func_end - batch_size_func_start
+    if single_func_time > PERF_COUNTER_RESOLUTION * 25:
+        batch_size = 1
+    else:
+        batch_size = math.ceil(
+            (PERF_COUNTER_RESOLUTION * 25 * 1000000000)
+            / (single_func_time * 1000000000)
+        )
+
+    for i in range(repeats):
         # Calculate the base cost of method invocation and timing overhead, so
-        # we can offset our final measurements by it
-        offset_start = time.perf_counter()
-        benchmark_class_empty()
-        offset_end = time.perf_counter()
-        offset[i] = offset_end - offset_start
+        # we can offset our final measurements by it. Setup functions are invoked
+        # in separate clauses despite code duplication to avoid overhead
+        loop = range(batch_size)
+        if setup is not None:
+            offset_start = time.perf_counter()
+            for _ in loop:
+                setup()
+                benchmark_class_empty()
+            offset_end = time.perf_counter()
+        else:
+            offset_start = time.perf_counter()
+            for _ in loop:
+                benchmark_class_empty()
+            offset_end = time.perf_counter()
+        offset[i] = (offset_end - offset_start) / batch_size
+
         # Time the actual function we want to measure
-        func_start = time.perf_counter()
-        func()
-        func_end = time.perf_counter()
-        times[i] = func_end - func_start
+        loop = range(batch_size)
+        if setup is not None:
+            func_start = time.perf_counter()
+            for _ in loop:
+                setup()
+                func()
+            func_end = time.perf_counter()
+        else:
+            func_start = time.perf_counter()
+            for _ in loop:
+                func()
+            func_end = time.perf_counter()
+        times[i] = (func_end - func_start) / batch_size
 
     # Re-enable the garbage collector if it was initially on
     if gcold:

--- a/benchmarks/workloads.py
+++ b/benchmarks/workloads.py
@@ -25,7 +25,8 @@ class WorkloadBuilder:
     @classmethod
     def wrap_module(cls, ops: list[str]) -> str:
         """Wrap a list of operations as a module."""
-        workload = f'"builtin.module"() ({{\n  {"\n  ".join(ops)}\n}}) : () -> ()'
+        joined_ops = "\n  ".join(ops)
+        workload = f'"builtin.module"() ({{\n  {joined_ops}\n}}) : () -> ()'
         return workload
 
     @classmethod


### PR DESCRIPTION
The highest resolution timer on Apple Silicon Macs is `mach_time` at around 40ns, and other computers may have even lower resolution timers. Some microbenchmarks' runtimes are within an order of magnitude of this resolution, reducing the reliability of the results.

This change to the warmed timeit function adds batching for very short microbenchmarks to ensure that their runtimes are 25x greater than this resolution for reliable results.