### PR TITLE
rewriting: make `_replace_all_uses_with` public

### DIFF
--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -163,7 +163,7 @@ class PatternRewriter(Builder, PatternRewriterListener):
         self.handle_operation_removal(op)
         Rewriter.erase_op(op, safe_erase=safe_erase)
 
-    def _replace_all_uses_with(
+    def replace_all_uses_with(
         self, from_: SSAValue, to: SSAValue | None, safe_erase: bool = True
     ):
         """Replace all uses of an SSA value with another SSA value."""
@@ -222,7 +222,7 @@ class PatternRewriter(Builder, PatternRewriterListener):
         # Then, replace the results with new ones
         self.handle_operation_replacement(op, new_results)
         for old_result, new_result in zip(op.results, new_results):
-            self._replace_all_uses_with(old_result, new_result, safe_erase=safe_erase)
+            self.replace_all_uses_with(old_result, new_result, safe_erase=safe_erase)
 
             # Preserve name hints for ops with multiple results
             if new_result is not None and not new_result.name_hint:
@@ -272,7 +272,7 @@ class PatternRewriter(Builder, PatternRewriterListener):
         uses, otherwise, replace it with an ErasedSSAValue.
         """
         self.has_done_action = True
-        self._replace_all_uses_with(arg, None, safe_erase=safe_erase)
+        self.replace_all_uses_with(arg, None, safe_erase=safe_erase)
         arg.block.erase_arg(arg, safe_erase)
 
     def inline_block(


### PR DESCRIPTION
In Zulip, I asked about making this method public and I was told that it should be made public.