### PR TITLE
core: Create BuiltinAttribute class

### DIFF
--- a/docs/marimo/irdl.py
+++ b/docs/marimo/irdl.py
@@ -439,7 +439,7 @@ def _(Printer, printer):
 
     @irdl_attr_definition
     class MyIntAttr(Data[int]):
-        name = "my_int"
+        name = "test.my_int"
 
         @classmethod
         def parse_parameter(cls, parser: AttrParser) -> int:
@@ -478,7 +478,7 @@ def _(IntAttr, StringAttr, irdl_attr_definition):
     @irdl_attr_definition
     class MyIntegerType(ParametrizedAttribute):
         # Name of the type. This is used for printing and parsing.
-        name = "integer_type"
+        name = "test.integer_type"
 
         # Only parameter of the type, with an `EqAttrConstraint` constraint.
         # Note the use of the attribute constraint coercion.
@@ -697,7 +697,7 @@ def _(
 
     @irdl_op_definition
     class BinaryOp(IRDLOperation):
-        name = "binary_op"
+        name = "test.binary_op"
 
         T: ClassVar = VarConstraint("T", base(IntegerType))
 
@@ -744,7 +744,7 @@ def _(
 
     @irdl_op_definition
     class AddVariadicOp(IRDLOperation):
-        name = "add_variadic"
+        name = "test.add_variadic"
         ops = var_operand_def(i32)
         res = result_def(i32)
 
@@ -791,7 +791,7 @@ def _(
 
     @irdl_op_definition
     class AddVariadic2Op(IRDLOperation):
-        name = "add_variadic"
+        name = "test.add_variadic"
         ops1 = var_operand_def(i32)
         ops2 = var_operand_def(i32)
         res = result_def(i32)
@@ -837,7 +837,7 @@ def _(
 
     @irdl_op_definition
     class AddVariadic2Op2(IRDLOperation):
-        name = "add_optional"
+        name = "test.add_optional"
         ops1 = operand_def(i32)
         ops2 = opt_operand_def(i32)
         res = result_def(i32)
@@ -880,7 +880,7 @@ def _(IRDLOperation, StringAttr, irdl_op_definition, printer):
 
     @irdl_op_definition
     class StringAttrOp(IRDLOperation):
-        name = "string_attr_op"
+        name = "test.string_attr_op"
         value = attr_def(StringAttr)
 
 
@@ -957,7 +957,7 @@ def _(IRDLOperation, i32, irdl_op_definition, printer):
 
     @irdl_op_definition
     class WhileOp(IRDLOperation):
-        name = "while_op"
+        name = "test.while_op"
         value = region_def()
         traits = traits_def(NoTerminator())
 
@@ -1008,7 +1008,7 @@ def _(
 
     @irdl_op_definition
     class MyAddiOp(IRDLOperation):
-        name = "std.addi"
+        name = "test.addi"
         input1 = operand_def(IntegerType)
         input2 = operand_def(IntegerType)
         output = result_def(IntegerType)

--- a/tests/irdl/test_attr_constraint.py
+++ b/tests/irdl/test_attr_constraint.py
@@ -61,7 +61,7 @@ def test_attr_constraint_get_unique_base(
 
 def test_param_attr_constraint_inference():
     class BaseWrapAttr(ParametrizedAttribute):
-        name = "wrap"
+        name = "test.wrap"
 
         inner: ParameterDef[Attribute]
 
@@ -110,17 +110,17 @@ def test_param_attr_constraint_inference():
 
 def test_base_attr_constraint_inference():
     class BaseNoParamAttr(ParametrizedAttribute):
-        name = "no_param"
+        name = "test.no_param"
 
     @irdl_attr_definition
     class WithParamAttr(ParametrizedAttribute):
-        name = "with_param"
+        name = "test.with_param"
 
         inner: ParameterDef[Attribute]
 
     @irdl_attr_definition
     class DataAttr(Data[int]):
-        name = "data"
+        name = "test.data"
 
     @irdl_attr_definition
     class NoParamAttr(BaseNoParamAttr): ...

--- a/tests/irdl/test_attribute_definition.py
+++ b/tests/irdl/test_attribute_definition.py
@@ -23,6 +23,7 @@ from xdsl.dialects.builtin import (
 from xdsl.ir import (
     Attribute,
     BitEnumAttribute,
+    BuiltinAttribute,
     Data,
     EnumAttribute,
     ParametrizedAttribute,
@@ -870,3 +871,47 @@ def test_constraint_var_fail_not_satisfy_constraint():
         ConstraintVarAttr.new(
             [IntegerAttr(42, IndexType()), IntegerAttr(17, IndexType())]
         )
+
+
+################################################################################
+# Names
+################################################################################
+
+
+def test_non_builtin_name_fail():
+    """
+    Test that the name of an attribute is properly checked
+    when it is not a builtin attribute.
+    """
+    with pytest.raises(PyRDLAttrDefinitionError, match="is not a valid attribute name"):
+
+        @irdl_attr_definition
+        class NonBuiltinNameAttr(  # pyright: ignore[reportUnusedClass]
+            ParametrizedAttribute
+        ):
+            name = "vector"
+
+
+def test_non_builtin_name():
+    """
+    Test that the name of an attribute is properly checked
+    when it is not a builtin attribute.
+    """
+
+    @irdl_attr_definition
+    class NonBuiltinNameAttr(  # pyright: ignore[reportUnusedClass]
+        ParametrizedAttribute
+    ):
+        name = "test.vector"
+
+
+def test_builtin_name():
+    """
+    Test that builtin attribute names are not checked.
+    """
+
+    @irdl_attr_definition
+    class BuiltinNameAttr(  # pyright: ignore[reportUnusedClass]
+        ParametrizedAttribute, BuiltinAttribute
+    ):
+        name = "builtin.vector"

--- a/tests/test_frontend_type_conversion.py
+++ b/tests/test_frontend_type_conversion.py
@@ -18,7 +18,7 @@ from xdsl.irdl import irdl_attr_definition
 
 @irdl_attr_definition
 class A(ParametrizedAttribute):
-    name = "a"
+    name = "test.a"
 
 
 class _A(_FrontendType):
@@ -40,7 +40,7 @@ class _C(Generic[T]):
 
 @irdl_attr_definition
 class D(ParametrizedAttribute):
-    name = "d"
+    name = "test.d"
 
 
 class _D(Generic[T], _FrontendType):

--- a/tests/test_pyrdl.py
+++ b/tests/test_pyrdl.py
@@ -27,7 +27,7 @@ from xdsl.utils.exceptions import VerifyException
 class BoolData(Data[bool]):
     """An attribute holding a boolean value."""
 
-    name = "bool"
+    name = "test.bool"
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> bool:
@@ -41,7 +41,7 @@ class BoolData(Data[bool]):
 class IntData(Data[int]):
     """An attribute holding an integer value."""
 
-    name = "int"
+    name = "test.int"
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> int:
@@ -57,7 +57,7 @@ class IntData(Data[int]):
 class DoubleParamAttr(ParametrizedAttribute):
     """An attribute with two unbounded attribute parameters."""
 
-    name = "param"
+    name = "test.param"
 
     param1: ParameterDef[Attribute]
     param2: ParameterDef[Attribute]

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -26,6 +26,7 @@ from xdsl.ir import (
     AttributeInvT,
     Block,
     BlockOps,
+    BuiltinAttribute,
     Data,
     Dialect,
     Operation,
@@ -132,7 +133,7 @@ class ContainerType(Generic[_ContainerElementTypeT], ABC):
 
 
 @irdl_attr_definition
-class NoneAttr(ParametrizedAttribute):
+class NoneAttr(ParametrizedAttribute, BuiltinAttribute):
     """An attribute representing the absence of an attribute."""
 
     name = "none"
@@ -158,7 +159,9 @@ class ArrayOfConstraint(AttrConstraint):
 
 
 @irdl_attr_definition
-class ArrayAttr(GenericData[tuple[AttributeCovT, ...]], Iterable[AttributeCovT]):
+class ArrayAttr(
+    GenericData[tuple[AttributeCovT, ...]], BuiltinAttribute, Iterable[AttributeCovT]
+):
     name = "array"
 
     def __init__(self, param: Iterable[AttributeCovT]) -> None:
@@ -192,7 +195,7 @@ class ArrayAttr(GenericData[tuple[AttributeCovT, ...]], Iterable[AttributeCovT])
 
 
 @irdl_attr_definition
-class StringAttr(Data[str]):
+class StringAttr(Data[str], BuiltinAttribute):
     name = "string"
 
     @classmethod
@@ -205,7 +208,7 @@ class StringAttr(Data[str]):
 
 
 @irdl_attr_definition
-class BytesAttr(Data[bytes]):
+class BytesAttr(Data[bytes], BuiltinAttribute):
     name = "bytes"
 
     @classmethod
@@ -218,7 +221,7 @@ class BytesAttr(Data[bytes]):
 
 
 @irdl_attr_definition
-class SymbolNameAttr(ParametrizedAttribute):
+class SymbolNameAttr(ParametrizedAttribute, BuiltinAttribute):
     name = "symbol_name"
     data: ParameterDef[StringAttr]
 
@@ -229,7 +232,7 @@ class SymbolNameAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class SymbolRefAttr(ParametrizedAttribute):
+class SymbolRefAttr(ParametrizedAttribute, BuiltinAttribute):
     name = "symbol_ref"
     root_reference: ParameterDef[StringAttr]
     nested_references: ParameterDef[ArrayAttr[StringAttr]]
@@ -514,7 +517,9 @@ Bitwidths: `<B`: 1-8, `<H`: 9-16, `<I`: 17-32, `<Q`: 33-64.
 
 
 @irdl_attr_definition
-class IntegerType(ParametrizedAttribute, StructPackableType[int], FixedBitwidthType):
+class IntegerType(
+    ParametrizedAttribute, StructPackableType[int], FixedBitwidthType, BuiltinAttribute
+):
     name = "integer_type"
     width: ParameterDef[IntAttr]
     signedness: ParameterDef[SignednessAttr]
@@ -629,12 +634,12 @@ AnySignlessIntegerType: TypeAlias = Annotated[IntegerType, SignlessIntegerConstr
 
 
 @irdl_attr_definition
-class UnitAttr(ParametrizedAttribute):
+class UnitAttr(ParametrizedAttribute, BuiltinAttribute):
     name = "unit"
 
 
 @irdl_attr_definition
-class LocationAttr(ParametrizedAttribute):
+class LocationAttr(ParametrizedAttribute, BuiltinAttribute):
     """
     An attribute representing source code location.
     Only supports unknown locations for now.
@@ -644,7 +649,7 @@ class LocationAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class IndexType(ParametrizedAttribute, StructPackableType[int]):
+class IndexType(ParametrizedAttribute, BuiltinAttribute, StructPackableType[int]):
     name = "index"
 
     def print_value_without_type(self, value: int, printer: Printer):
@@ -681,6 +686,7 @@ AnySignlessIntegerOrIndexType: TypeAlias = Annotated[
 @irdl_attr_definition
 class IntegerAttr(
     Generic[_IntegerAttrType],
+    BuiltinAttribute,
     TypedAttribute,
 ):
     name = "integer"
@@ -808,7 +814,7 @@ class _FloatType(StructPackableType[float], FixedBitwidthType, ABC):
 
 
 @irdl_attr_definition
-class BFloat16Type(ParametrizedAttribute, _FloatType):
+class BFloat16Type(ParametrizedAttribute, BuiltinAttribute, _FloatType):
     name = "bf16"
 
     @property
@@ -821,7 +827,7 @@ class BFloat16Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float16Type(ParametrizedAttribute, _FloatType):
+class Float16Type(ParametrizedAttribute, BuiltinAttribute, _FloatType):
     name = "f16"
 
     @property
@@ -834,7 +840,7 @@ class Float16Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float32Type(ParametrizedAttribute, _FloatType):
+class Float32Type(ParametrizedAttribute, BuiltinAttribute, _FloatType):
     name = "f32"
 
     @property
@@ -847,7 +853,7 @@ class Float32Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float64Type(ParametrizedAttribute, _FloatType):
+class Float64Type(ParametrizedAttribute, BuiltinAttribute, _FloatType):
     name = "f64"
 
     @property
@@ -860,7 +866,7 @@ class Float64Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float80Type(ParametrizedAttribute, _FloatType):
+class Float80Type(ParametrizedAttribute, BuiltinAttribute, _FloatType):
     name = "f80"
 
     @property
@@ -873,7 +879,7 @@ class Float80Type(ParametrizedAttribute, _FloatType):
 
 
 @irdl_attr_definition
-class Float128Type(ParametrizedAttribute, _FloatType):
+class Float128Type(ParametrizedAttribute, BuiltinAttribute, _FloatType):
     name = "f128"
 
     @property
@@ -900,7 +906,7 @@ AnyFloatConstr = (
 
 @irdl_attr_definition
 class FloatData(Data[float]):
-    name = "float_data"
+    name = "builtin.float_data"
 
     @classmethod
     def parse_parameter(cls, parser: AttrParser) -> float:
@@ -927,7 +933,7 @@ _FloatAttrTypeInvT = TypeVar("_FloatAttrTypeInvT", bound=AnyFloat)
 
 
 @irdl_attr_definition
-class FloatAttr(Generic[_FloatAttrType], TypedAttribute):
+class FloatAttr(Generic[_FloatAttrType], BuiltinAttribute, TypedAttribute):
     name = "float"
 
     value: ParameterDef[FloatData]
@@ -998,7 +1004,7 @@ class FloatAttr(Generic[_FloatAttrType], TypedAttribute):
 
 
 @irdl_attr_definition
-class ComplexType(ParametrizedAttribute, TypeAttribute):
+class ComplexType(ParametrizedAttribute, BuiltinAttribute, TypeAttribute):
     name = "complex"
     element_type: ParameterDef[IntegerType | AnyFloat]
 
@@ -1007,7 +1013,7 @@ class ComplexType(ParametrizedAttribute, TypeAttribute):
 
 
 @irdl_attr_definition
-class DictionaryAttr(GenericData[immutabledict[str, Attribute]]):
+class DictionaryAttr(GenericData[immutabledict[str, Attribute]], BuiltinAttribute):
     name = "dictionary"
 
     def __init__(self, value: Mapping[str, Attribute]):
@@ -1031,7 +1037,7 @@ class DictionaryAttr(GenericData[immutabledict[str, Attribute]]):
 
 
 @irdl_attr_definition
-class TupleType(ParametrizedAttribute):
+class TupleType(ParametrizedAttribute, BuiltinAttribute):
     name = "tuple"
 
     types: ParameterDef[ArrayAttr[Attribute]]
@@ -1045,6 +1051,7 @@ class TupleType(ParametrizedAttribute):
 @irdl_attr_definition
 class VectorType(
     Generic[AttributeCovT],
+    BuiltinAttribute,
     ParametrizedAttribute,
     TypeAttribute,
     ShapedType,
@@ -1123,6 +1130,7 @@ AnyVectorType: TypeAlias = VectorType[Attribute]
 class TensorType(
     Generic[AttributeCovT],
     ParametrizedAttribute,
+    BuiltinAttribute,
     TypeAttribute,
     ShapedType,
     ContainerType[AttributeCovT],
@@ -1162,6 +1170,7 @@ AnyTensorTypeConstr = BaseAttr[TensorType[Attribute]](TensorType)
 class UnrankedTensorType(
     Generic[AttributeCovT],
     ParametrizedAttribute,
+    BuiltinAttribute,
     TypeAttribute,
     ContainerType[AttributeCovT],
 ):
@@ -1193,9 +1202,9 @@ class ContainerOf(
 
     def __init__(
         self,
-        elem_constr: AttributeCovT
-        | type[AttributeCovT]
-        | GenericAttrConstraint[AttributeCovT],
+        elem_constr: (
+            AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT]
+        ),
     ) -> None:
         object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
 
@@ -1275,7 +1284,7 @@ class VectorBaseTypeAndRankConstraint(AttrConstraint):
 
 
 @irdl_attr_definition
-class DenseResourceAttr(ParametrizedAttribute):
+class DenseResourceAttr(ParametrizedAttribute, BuiltinAttribute):
     name = "dense_resource"
 
     resource_handle: ParameterDef[StringAttr]
@@ -1291,7 +1300,7 @@ class DenseResourceAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class DenseArrayBase(ParametrizedAttribute):
+class DenseArrayBase(ParametrizedAttribute, BuiltinAttribute):
     name = "array"
 
     elt_type: ParameterDef[IntegerType | AnyFloat]
@@ -1409,7 +1418,7 @@ DenseI32ArrayConstr = ParamAttrConstraint(DenseArrayBase, [i32, BytesAttr])
 
 
 @irdl_attr_definition
-class FunctionType(ParametrizedAttribute, TypeAttribute):
+class FunctionType(ParametrizedAttribute, BuiltinAttribute, TypeAttribute):
     name = "fun"
 
     inputs: ParameterDef[ArrayAttr[Attribute]]
@@ -1429,7 +1438,7 @@ class FunctionType(ParametrizedAttribute, TypeAttribute):
 
 
 @irdl_attr_definition
-class OpaqueAttr(ParametrizedAttribute):
+class OpaqueAttr(ParametrizedAttribute, BuiltinAttribute):
     name = "opaque"
 
     ident: ParameterDef[StringAttr]
@@ -1473,7 +1482,7 @@ class MemRefLayoutAttr(Attribute, ABC):
 
 
 @irdl_attr_definition
-class StridedLayoutAttr(MemRefLayoutAttr, ParametrizedAttribute):
+class StridedLayoutAttr(MemRefLayoutAttr, BuiltinAttribute, ParametrizedAttribute):
     """
     An attribute representing a strided layout of a shaped type.
     See external [documentation](https://mlir.llvm.org/docs/Dialects/Builtin/#stridedlayoutattr).
@@ -1561,7 +1570,7 @@ class StridedLayoutAttr(MemRefLayoutAttr, ParametrizedAttribute):
 
 
 @irdl_attr_definition
-class AffineMapAttr(MemRefLayoutAttr, Data[AffineMap]):
+class AffineMapAttr(MemRefLayoutAttr, BuiltinAttribute, Data[AffineMap]):
     """An Attribute containing an AffineMap object."""
 
     name = "affine_map"
@@ -1584,7 +1593,7 @@ class AffineMapAttr(MemRefLayoutAttr, Data[AffineMap]):
 
 
 @irdl_attr_definition
-class AffineSetAttr(Data[AffineSet]):
+class AffineSetAttr(Data[AffineSet], BuiltinAttribute):
     """An attribute containing an AffineSet object."""
 
     name = "affine_set"
@@ -1717,7 +1726,7 @@ class UnregisteredOp(Operation, ABC):
         return value_if_unregistered
 
 
-class UnregisteredAttr(ParametrizedAttribute, ABC):
+class UnregisteredAttr(ParametrizedAttribute, BuiltinAttribute, ABC):
     """
     An unregistered attribute or type.
 
@@ -1872,7 +1881,7 @@ _UnrankedMemRefTypeElemsInit = TypeVar("_UnrankedMemRefTypeElemsInit", bound=Att
 
 
 @irdl_attr_definition
-class NoneType(ParametrizedAttribute, TypeAttribute):
+class NoneType(ParametrizedAttribute, BuiltinAttribute, TypeAttribute):
     name = "none_type"
 
 
@@ -1880,6 +1889,7 @@ class NoneType(ParametrizedAttribute, TypeAttribute):
 class MemRefType(
     Generic[_MemRefTypeElement],
     ParametrizedAttribute,
+    BuiltinAttribute,
     TypeAttribute,
     ShapedType,
     ContainerType[_MemRefTypeElement],
@@ -2029,9 +2039,9 @@ class TensorOrMemRefOf(
 
     def __init__(
         self,
-        elem_constr: AttributeCovT
-        | type[AttributeCovT]
-        | GenericAttrConstraint[AttributeCovT],
+        elem_constr: (
+            AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT]
+        ),
     ) -> None:
         object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
 
@@ -2069,6 +2079,7 @@ class TensorOrMemRefOf(
 class UnrankedMemRefType(
     Generic[_UnrankedMemRefTypeElems],
     ParametrizedAttribute,
+    BuiltinAttribute,
     TypeAttribute,
     ContainerType[_UnrankedMemRefTypeElems],
 ):
@@ -2103,7 +2114,10 @@ DenseElementCovT = TypeVar(
 
 @irdl_attr_definition
 class DenseIntOrFPElementsAttr(
-    Generic[DenseElementCovT], TypedAttribute, ContainerType[DenseElementCovT]
+    Generic[DenseElementCovT],
+    TypedAttribute,
+    BuiltinAttribute,
+    ContainerType[DenseElementCovT],
 ):
     name = "dense"
     type: ParameterDef[RankedStructure[DenseElementCovT]]

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -116,10 +116,12 @@ class Attribute(ABC):
         return res.getvalue()
 
 
-class BuiltinAttribute(Attribute):
+class BuiltinAttribute(Attribute, ABC):
     """
-    This class is used to mark builtin attributes. Builtin attributes are handled
-    differently when parsing and printing.
+    This class is used to mark builtin attributes.
+    Unlike other attributes in MLIR, printing and parsing of *Builtin*
+    attributes is handled directly by the parser.
+    Attributes outside of the `builtin` dialect should not inherit from `BuiltinAttribute`.
     """
 
     pass

--- a/xdsl/ir/core.py
+++ b/xdsl/ir/core.py
@@ -116,6 +116,15 @@ class Attribute(ABC):
         return res.getvalue()
 
 
+class BuiltinAttribute(Attribute):
+    """
+    This class is used to mark builtin attributes. Builtin attributes are handled
+    differently when parsing and printing.
+    """
+
+    pass
+
+
 class TypeAttribute(Attribute):
     """
     This class should only be inherited by classes inheriting Attribute.


### PR DESCRIPTION
This class should be used for builtin attributes that are printed differently than "user-defined" attributes. This include for instance `vector`, `integer`, etc...

All non-`BuiltinAttribute` class should have the `dialect.name` syntax for their name