### PR TITLE
backend: always exclude pre-allocated registers during regalloc

### DIFF
--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -105,7 +105,6 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
     live_ins_per_block: dict[Block, OrderedSet[SSAValue]]
     new_value_by_old_value: dict[SSAValue, SSAValue]
 
-    exclude_preallocated: bool = True
     exclude_snitch_reserved: bool = True
 
     def __init__(self, available_registers: RegisterQueue[RISCVRegisterType]) -> None:
@@ -335,10 +334,7 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 f"Cannot register allocate func with {len(func.body.blocks)} blocks."
             )
 
-        preallocated: set[RISCVRegisterType] = set()
-
-        if self.exclude_preallocated:
-            preallocated |= gather_allocated(func)
+        preallocated: set[RISCVRegisterType] = gather_allocated(func)
 
         if self.exclude_snitch_reserved and _uses_snitch_stream(func):
             preallocated |= get_snitch_reserved()

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -20,14 +20,6 @@ class RISCVRegisterAllocation(ModulePass):
 
     limit_registers: int | None = None
 
-    exclude_preallocated: bool = True
-    """
-    Enables tracking of already allocated registers and excludes them from the
-    available set.
-    This does not keep track of any liveness information and the preallocated registers
-    are excluded completely from any further allocation decisions.
-    """
-
     exclude_snitch_reserved: bool = True
     """Excludes floating-point registers that are used by the Snitch ISA extensions."""
 
@@ -61,7 +53,6 @@ class RISCVRegisterAllocation(ModulePass):
                 allocator = allocator_strategies[self.allocation_strategy](
                     riscv_register_queue
                 )
-                allocator.exclude_preallocated = self.exclude_preallocated
                 allocator.exclude_snitch_reserved = self.exclude_snitch_reserved
                 allocator.allocate_func(
                     inner_op, add_regalloc_stats=self.add_regalloc_stats


### PR DESCRIPTION
In practice I don't think it's ever correct to exclude the preallocated registers, might as well drop this.