### PR TITLE
backend: add x86-allocate-registers

### DIFF
--- a/tests/filecheck/backend/x86/x86_allocate_registers.mlir
+++ b/tests/filecheck/backend/x86/x86_allocate_registers.mlir
@@ -1,0 +1,29 @@
+// RUN: xdsl-opt -p x86-allocate-registers %s | filecheck %s
+
+// CHECK:       builtin.module {
+
+// CHECK-NEXT:    x86_func.func @external() -> ()
+x86_func.func @external() -> ()
+
+
+// CHECK-NEXT:    x86_func.func @main() {
+// CHECK-NEXT:      %ymm0, %ymm1, %ymm2 = "test.op"() : () -> (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>)
+x86_func.func @main() {
+  %ymm0, %ymm1, %ymm2 = "test.op"() : () -> (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>)
+
+// inout is allocated to same register
+// CHECK-NEXT:      %r0 = x86.rss.vfmadd231pd %ymm0, %ymm1, %ymm2 : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm0>
+  %r0 = x86.rss.vfmadd231pd %ymm0, %ymm1, %ymm2 : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm1>, !x86.avx2reg<ymm2>) -> !x86.avx2reg
+
+// read-only is allocated to new register
+// CHECK-NEXT:      %u0 = "test.op"() : () -> !x86.avx2reg<ymm3>
+// CHECK-NEXT:      %r1 = x86.rss.vfmadd231pd %ymm0, %u0, %ymm2 : (!x86.avx2reg<ymm0>, !x86.avx2reg<ymm3>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm0>
+  %u0 = "test.op"() : () -> !x86.avx2reg
+  %r1 = x86.rss.vfmadd231pd %ymm0, %u0, %ymm2 : (!x86.avx2reg<ymm0>, !x86.avx2reg, !x86.avx2reg<ymm2>) -> !x86.avx2reg
+
+// CHECK-NEXT:      x86_func.ret
+  x86_func.ret
+}
+
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
+++ b/tests/filecheck/projects/libxsmm/x86_matmul_kernel.mlir
@@ -1,85 +1,85 @@
-// RUN: xdsl-opt -t x86-asm %s | filecheck %s
+// RUN: xdsl-opt -p x86-allocate-registers -t x86-asm %s | filecheck %s
 
 // C: 4x4xf32 = A: 4x8xf32 * B: 8x4xf32
 x86_func.func @matmul(%rdi: !x86.reg<rdi>, %rsi: !x86.reg<rsi>, %rcx: !x86.reg<rcx>) {
     // Load rows of A
-    %a_row_0 = x86.dm.vmovups %rdi, 0 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm0>)
-    %a_row_1 = x86.dm.vmovups %rdi, 32 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm1>)
-    %a_row_2 = x86.dm.vmovups %rdi, 64 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm2>)
-    %a_row_3 = x86.dm.vmovups %rdi, 96 : (!x86.reg<rdi>) -> (!x86.avx2reg<ymm3>)
+    %a_row_0 = x86.dm.vmovups %rdi, 0 : (!x86.reg<rdi>) -> (!x86.avx2reg)
+    %a_row_1 = x86.dm.vmovups %rdi, 32 : (!x86.reg<rdi>) -> (!x86.avx2reg)
+    %a_row_2 = x86.dm.vmovups %rdi, 64 : (!x86.reg<rdi>) -> (!x86.avx2reg)
+    %a_row_3 = x86.dm.vmovups %rdi, 96 : (!x86.reg<rdi>) -> (!x86.avx2reg)
     // Initialize the accumulators (rows of C)
-    %c0_tmp0 = x86.dm.vmovups %rcx, 0 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm4>
-    %c1_tmp0 = x86.dm.vmovups %rcx, 32 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm5>
-    %c2_tmp0 = x86.dm.vmovups %rcx, 64 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm6>
-    %c3_tmp0 = x86.dm.vmovups %rcx, 96 : (!x86.reg<rcx>) -> !x86.avx2reg<ymm7>
+    %c0_tmp0 = x86.dm.vmovups %rcx, 0 : (!x86.reg<rcx>) -> !x86.avx2reg
+    %c1_tmp0 = x86.dm.vmovups %rcx, 32 : (!x86.reg<rcx>) -> !x86.avx2reg
+    %c2_tmp0 = x86.dm.vmovups %rcx, 64 : (!x86.reg<rcx>) -> !x86.avx2reg
+    %c3_tmp0 = x86.dm.vmovups %rcx, 96 : (!x86.reg<rcx>) -> !x86.avx2reg
     // Load column 0 of B
-    %b_col_0 = x86.dm.vbroadcastss %rsi, 0 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm8>
+    %b_col_0 = x86.dm.vbroadcastss %rsi, 0 : (!x86.reg<rsi>) -> !x86.avx2reg
     // Reduction
-    %c0_tmp1 = x86.rss.vfmadd231ps %c0_tmp0, %b_col_0, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
-    %c1_tmp1 = x86.rss.vfmadd231ps %c1_tmp0, %b_col_0, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
-    %c2_tmp1 = x86.rss.vfmadd231ps %c2_tmp0, %b_col_0, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
-    %c3_tmp1 = x86.rss.vfmadd231ps %c3_tmp0, %b_col_0, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm8>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
+    %c0_tmp1 = x86.rss.vfmadd231ps %c0_tmp0, %b_col_0, %a_row_0 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+    %c1_tmp1 = x86.rss.vfmadd231ps %c1_tmp0, %b_col_0, %a_row_1 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+    %c2_tmp1 = x86.rss.vfmadd231ps %c2_tmp0, %b_col_0, %a_row_2 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+    %c3_tmp1 = x86.rss.vfmadd231ps %c3_tmp0, %b_col_0, %a_row_3 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
     // Load column 1 of B
-    %b_col_1 = x86.dm.vbroadcastss %rsi, 4 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm9>
+    %b_col_1 = x86.dm.vbroadcastss %rsi, 4 : (!x86.reg<rsi>) -> !x86.avx2reg
     // Reduction
-    %c0_tmp2 = x86.rss.vfmadd231ps %c0_tmp1, %b_col_1, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
-    %c1_tmp2 = x86.rss.vfmadd231ps %c1_tmp1, %b_col_1, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
-    %c2_tmp2 = x86.rss.vfmadd231ps %c2_tmp1, %b_col_1, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
-    %c3_tmp2 = x86.rss.vfmadd231ps %c3_tmp1, %b_col_1, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm9>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
+    %c0_tmp2 = x86.rss.vfmadd231ps %c0_tmp1, %b_col_1, %a_row_0 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+    %c1_tmp2 = x86.rss.vfmadd231ps %c1_tmp1, %b_col_1, %a_row_1 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+    %c2_tmp2 = x86.rss.vfmadd231ps %c2_tmp1, %b_col_1, %a_row_2 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
+    %c3_tmp2 = x86.rss.vfmadd231ps %c3_tmp1, %b_col_1, %a_row_3 : (!x86.avx2reg, !x86.avx2reg, !x86.avx2reg) -> !x86.avx2reg
     // Load column 2 of B
     %b_col_2 = x86.dm.vbroadcastss %rsi, 8 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm10>
     // Reduction
-    %c0_tmp3 = x86.rss.vfmadd231ps %c0_tmp2, %b_col_2, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
-    %c1_tmp3 = x86.rss.vfmadd231ps %c1_tmp2, %b_col_2, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
-    %c2_tmp3 = x86.rss.vfmadd231ps %c2_tmp2, %b_col_2, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
-    %c3_tmp3 = x86.rss.vfmadd231ps %c3_tmp2, %b_col_2, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm10>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
+    %c0_tmp3 = x86.rss.vfmadd231ps %c0_tmp2, %b_col_2, %a_row_0 : (!x86.avx2reg, !x86.avx2reg<ymm10>, !x86.avx2reg) -> !x86.avx2reg
+    %c1_tmp3 = x86.rss.vfmadd231ps %c1_tmp2, %b_col_2, %a_row_1 : (!x86.avx2reg, !x86.avx2reg<ymm10>, !x86.avx2reg) -> !x86.avx2reg
+    %c2_tmp3 = x86.rss.vfmadd231ps %c2_tmp2, %b_col_2, %a_row_2 : (!x86.avx2reg, !x86.avx2reg<ymm10>, !x86.avx2reg) -> !x86.avx2reg
+    %c3_tmp3 = x86.rss.vfmadd231ps %c3_tmp2, %b_col_2, %a_row_3 : (!x86.avx2reg, !x86.avx2reg<ymm10>, !x86.avx2reg) -> !x86.avx2reg
     // Load column 3 of B
     %b_col_3 = x86.dm.vbroadcastss %rsi, 12 : (!x86.reg<rsi>) -> !x86.avx2reg<ymm11>
     // Reduction
-    %c0 = x86.rss.vfmadd231ps %c0_tmp3, %b_col_3, %a_row_0 : (!x86.avx2reg<ymm4>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm0>) -> !x86.avx2reg<ymm4>
-    %c1 = x86.rss.vfmadd231ps %c1_tmp3, %b_col_3, %a_row_1 : (!x86.avx2reg<ymm5>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm1>) -> !x86.avx2reg<ymm5>
-    %c2 = x86.rss.vfmadd231ps %c2_tmp3, %b_col_3, %a_row_2 : (!x86.avx2reg<ymm6>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm2>) -> !x86.avx2reg<ymm6>
-    %c3 = x86.rss.vfmadd231ps %c3_tmp3, %b_col_3, %a_row_3 : (!x86.avx2reg<ymm7>, !x86.avx2reg<ymm11>, !x86.avx2reg<ymm3>) -> !x86.avx2reg<ymm7>
+    %c0 = x86.rss.vfmadd231ps %c0_tmp3, %b_col_3, %a_row_0 : (!x86.avx2reg, !x86.avx2reg<ymm11>, !x86.avx2reg) -> !x86.avx2reg
+    %c1 = x86.rss.vfmadd231ps %c1_tmp3, %b_col_3, %a_row_1 : (!x86.avx2reg, !x86.avx2reg<ymm11>, !x86.avx2reg) -> !x86.avx2reg
+    %c2 = x86.rss.vfmadd231ps %c2_tmp3, %b_col_3, %a_row_2 : (!x86.avx2reg, !x86.avx2reg<ymm11>, !x86.avx2reg) -> !x86.avx2reg
+    %c3 = x86.rss.vfmadd231ps %c3_tmp3, %b_col_3, %a_row_3 : (!x86.avx2reg, !x86.avx2reg<ymm11>, !x86.avx2reg) -> !x86.avx2reg
    // Store the results (rows of C)
-    x86.ms.vmovups %rcx, %c0, 0 : (!x86.reg<rcx>,!x86.avx2reg<ymm4>) -> ()
-    x86.ms.vmovups %rcx, %c1, 32 : (!x86.reg<rcx>,!x86.avx2reg<ymm5>) -> ()
-    x86.ms.vmovups %rcx,%c2,64 : (!x86.reg<rcx>,!x86.avx2reg<ymm6>) -> ()
-    x86.ms.vmovups %rcx,%c3,96 : (!x86.reg<rcx>,!x86.avx2reg<ymm7>) -> ()
+    x86.ms.vmovups %rcx, %c0, 0 : (!x86.reg<rcx>,!x86.avx2reg) -> ()
+    x86.ms.vmovups %rcx, %c1, 32 : (!x86.reg<rcx>,!x86.avx2reg) -> ()
+    x86.ms.vmovups %rcx,%c2,64 : (!x86.reg<rcx>,!x86.avx2reg) -> ()
+    x86.ms.vmovups %rcx,%c3,96 : (!x86.reg<rcx>,!x86.avx2reg) -> ()
 
     x86_func.ret
 }
 
 // CHECK:       matmul:
-// CHECK-NEXT:      vmovups ymm0, [rdi]
-// CHECK-NEXT:      vmovups ymm1, [rdi+32]
-// CHECK-NEXT:      vmovups ymm2, [rdi+64]
-// CHECK-NEXT:      vmovups ymm3, [rdi+96]
-// CHECK-NEXT:      vmovups ymm4, [rcx]
-// CHECK-NEXT:      vmovups ymm5, [rcx+32]
-// CHECK-NEXT:      vmovups ymm6, [rcx+64]
-// CHECK-NEXT:      vmovups ymm7, [rcx+96]
+// CHECK-NEXT:      vmovups ymm7, [rdi]
+// CHECK-NEXT:      vmovups ymm6, [rdi+32]
+// CHECK-NEXT:      vmovups ymm5, [rdi+64]
+// CHECK-NEXT:      vmovups ymm4, [rdi+96]
+// CHECK-NEXT:      vmovups ymm3, [rcx]
+// CHECK-NEXT:      vmovups ymm2, [rcx+32]
+// CHECK-NEXT:      vmovups ymm1, [rcx+64]
+// CHECK-NEXT:      vmovups ymm0, [rcx+96]
 // CHECK-NEXT:      vbroadcastss ymm8, [rsi]
-// CHECK-NEXT:      vfmadd231ps ymm4, ymm8, ymm0
-// CHECK-NEXT:      vfmadd231ps ymm5, ymm8, ymm1
-// CHECK-NEXT:      vfmadd231ps ymm6, ymm8, ymm2
-// CHECK-NEXT:      vfmadd231ps ymm7, ymm8, ymm3
-// CHECK-NEXT:      vbroadcastss ymm9, [rsi+4]
-// CHECK-NEXT:      vfmadd231ps ymm4, ymm9, ymm0
-// CHECK-NEXT:      vfmadd231ps ymm5, ymm9, ymm1
-// CHECK-NEXT:      vfmadd231ps ymm6, ymm9, ymm2
-// CHECK-NEXT:      vfmadd231ps ymm7, ymm9, ymm3
+// CHECK-NEXT:      vfmadd231ps ymm3, ymm8, ymm7
+// CHECK-NEXT:      vfmadd231ps ymm2, ymm8, ymm6
+// CHECK-NEXT:      vfmadd231ps ymm1, ymm8, ymm5
+// CHECK-NEXT:      vfmadd231ps ymm0, ymm8, ymm4
+// CHECK-NEXT:      vbroadcastss ymm8, [rsi+4]
+// CHECK-NEXT:      vfmadd231ps ymm3, ymm8, ymm7
+// CHECK-NEXT:      vfmadd231ps ymm2, ymm8, ymm6
+// CHECK-NEXT:      vfmadd231ps ymm1, ymm8, ymm5
+// CHECK-NEXT:      vfmadd231ps ymm0, ymm8, ymm4
 // CHECK-NEXT:      vbroadcastss ymm10, [rsi+8]
-// CHECK-NEXT:      vfmadd231ps ymm4, ymm10, ymm0
-// CHECK-NEXT:      vfmadd231ps ymm5, ymm10, ymm1
-// CHECK-NEXT:      vfmadd231ps ymm6, ymm10, ymm2
-// CHECK-NEXT:      vfmadd231ps ymm7, ymm10, ymm3
+// CHECK-NEXT:      vfmadd231ps ymm3, ymm10, ymm7
+// CHECK-NEXT:      vfmadd231ps ymm2, ymm10, ymm6
+// CHECK-NEXT:      vfmadd231ps ymm1, ymm10, ymm5
+// CHECK-NEXT:      vfmadd231ps ymm0, ymm10, ymm4
 // CHECK-NEXT:      vbroadcastss ymm11, [rsi+12]
-// CHECK-NEXT:      vfmadd231ps ymm4, ymm11, ymm0
-// CHECK-NEXT:      vfmadd231ps ymm5, ymm11, ymm1
-// CHECK-NEXT:      vfmadd231ps ymm6, ymm11, ymm2
-// CHECK-NEXT:      vfmadd231ps ymm7, ymm11, ymm3
-// CHECK-NEXT:      vmovups [rcx], ymm4
-// CHECK-NEXT:      vmovups [rcx+32], ymm5
-// CHECK-NEXT:      vmovups [rcx+64], ymm6
-// CHECK-NEXT:      vmovups [rcx+96], ymm7
+// CHECK-NEXT:      vfmadd231ps ymm3, ymm11, ymm7
+// CHECK-NEXT:      vfmadd231ps ymm2, ymm11, ymm6
+// CHECK-NEXT:      vfmadd231ps ymm1, ymm11, ymm5
+// CHECK-NEXT:      vfmadd231ps ymm0, ymm11, ymm4
+// CHECK-NEXT:      vmovups [rcx], ymm3
+// CHECK-NEXT:      vmovups [rcx+32], ymm2
+// CHECK-NEXT:      vmovups [rcx+64], ymm1
+// CHECK-NEXT:      vmovups [rcx+96], ymm0
 // CHECK-NEXT:      ret

--- a/xdsl/backend/x86/register_allocation.py
+++ b/xdsl/backend/x86/register_allocation.py
@@ -1,0 +1,43 @@
+from xdsl.backend.block_naive_allocator import BlockNaiveAllocator
+from xdsl.backend.register_allocatable import RegisterAllocatableOperation
+from xdsl.backend.register_allocator import live_ins_per_block
+from xdsl.backend.register_queue import RegisterQueue
+from xdsl.dialects import x86_func
+from xdsl.dialects.x86 import register
+
+
+class X86RegisterAllocator(BlockNaiveAllocator):
+    def __init__(self, available_registers: RegisterQueue) -> None:
+        super().__init__(available_registers, register.X86RegisterType)
+
+    def allocate_func(self, func: x86_func.FuncOp) -> None:
+        """
+        Allocates values in function passed in to registers.
+        The whole function must have been lowered to the relevant x86 dialects
+        and it must contain no unrealized casts.
+        """
+        if not func.body.blocks:
+            # External function declaration
+            return
+
+        if len(func.body.blocks) != 1:
+            raise NotImplementedError(
+                f"Cannot register allocate func with {len(func.body.blocks)} blocks."
+            )
+
+        preallocated = {
+            reg
+            for reg in RegisterAllocatableOperation.iter_all_used_registers(func.body)
+            if isinstance(reg, register.X86RegisterType)
+        }
+
+        for pa_reg in preallocated:
+            self.available_registers.reserve_register(pa_reg)
+            self.available_registers.exclude_register(pa_reg)
+
+        block = func.body.block
+
+        self.live_ins_per_block = live_ins_per_block(block)
+        assert not self.live_ins_per_block[block]
+
+        self.allocate_block(block)

--- a/xdsl/transforms/__init__.py
+++ b/xdsl/transforms/__init__.py
@@ -533,6 +533,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return varith_transformations.VarithFuseRepeatedOperandsPass
 
+    def get_x86_allocate_registers():
+        from xdsl.transforms import x86_allocate_registers
+
+        return x86_allocate_registers.X86AllocateRegisters
+
     # Please insert pass and `get_` function in alphabetical order
 
     return {
@@ -641,4 +646,5 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "test-lower-linalg-to-snitch": get_test_lower_linalg_to_snitch,
         "transform-interpreter": get_transform_interpreter,
         "varith-fuse-repeated-operands": get_varith_fuse_repeated_operands,
+        "x86-allocate-registers": get_x86_allocate_registers,
     }

--- a/xdsl/transforms/x86_allocate_registers.py
+++ b/xdsl/transforms/x86_allocate_registers.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from xdsl.backend.x86.register_allocation import X86RegisterAllocator
+from xdsl.backend.x86.register_queue import X86RegisterQueue
+from xdsl.context import Context
+from xdsl.dialects import x86_func
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.passes import ModulePass
+
+
+@dataclass(frozen=True)
+class X86AllocateRegisters(ModulePass):
+    """
+    Allocates unallocated registers in the module.
+    """
+
+    name = "x86-allocate-registers"
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        for inner_op in op.walk():
+            if isinstance(inner_op, x86_func.FuncOp):
+                register_queue = X86RegisterQueue.default()
+                allocator = X86RegisterAllocator(register_queue)
+                allocator.allocate_func(inner_op)


### PR DESCRIPTION
Adds the pass and a test, and modifies the end-to-end test to include register allocation in the pipeline.