### PR TITLE
core: (ParsePropInAttrDict) allow a subset of properties to be parsed in attr-dict

### DIFF
--- a/tests/filecheck/dialects/tosa/ops.mlir
+++ b/tests/filecheck/dialects/tosa/ops.mlir
@@ -7,6 +7,6 @@
 
 // CHECK: builtin.module {
 // CHECK-NEXT:   %0 = "test.op"() : () -> tensor<12x34xi32>
-// CHECK-NEXT:   %1 = tosa.clamp %0 {min_int = 0 : i64, max_int = 1 : i64, min_fp = 0.000000e+00 : f32, max_fp = 1.000000e+00 : f32} : (tensor<12x34xi32>) -> tensor<12x34xi32>
-// CHECK-NEXT:   %2 = tosa.rescale %0 {input_zp = 127 : i32, output_zp = -1 : i32, multiplier = array<i32: 1073741824>, shift = array<i8: 30>, scale32 = true, double_round = false, per_channel = false} : (tensor<12x34xi32>) -> tensor<12x34xi32>
+// CHECK-NEXT:   %1 = tosa.clamp %0 {max_fp = 1.000000e+00 : f32, max_int = 1 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<12x34xi32>) -> tensor<12x34xi32>
+// CHECK-NEXT:   %2 = tosa.rescale %0 {double_round = false, input_zp = 127 : i32, multiplier = array<i32: 1073741824>, output_zp = -1 : i32, per_channel = false, scale32 = true, shift = array<i8: 30>} : (tensor<12x34xi32>) -> tensor<12x34xi32>
 // CHECK-NEXT: }

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -292,6 +292,35 @@ def test_attr_dict_prop_fallack(program: str, generic_program: str):
     check_equivalence(program, generic_program, ctx)
 
 
+@pytest.mark.parametrize(
+    "program, generic_program",
+    [
+        (
+            "test.prop false {prop2 = true}",
+            '"test.prop"() <{prop1 = false, prop2 = true}> : () -> ()',
+        ),
+        (
+            "test.prop false {a = 2 : i32, prop2 = true}",
+            '"test.prop"() <{prop1 = false, prop2 = true}> {a = 2 : i32} : () -> ()',
+        ),
+    ],
+)
+def test_partial_attr_dict_prop_fallack(program: str, generic_program: str):
+    @irdl_op_definition
+    class PropOp(IRDLOperation):
+        name = "test.prop"
+        prop1 = prop_def(Attribute)
+        prop2 = opt_prop_def(Attribute)
+        irdl_options = [ParsePropInAttrDict()]
+        assembly_format = "$prop1 attr-dict"
+
+    ctx = Context()
+    ctx.load_op(PropOp)
+
+    check_roundtrip(program, ctx)
+    check_equivalence(program, generic_program, ctx)
+
+
 ################################################################################
 # Attribute variables                                                          #
 ################################################################################
@@ -1273,7 +1302,7 @@ def test_operands_directive_with_non_variadic_type_directive():
     format_program = FormatProgram(
         (
             OperandsDirective(None),
-            AttrDictDirective(False, set(), False),
+            AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
             TypeDirective(OperandsDirective(None)),
         ),
@@ -1309,7 +1338,7 @@ def test_operands_directive_with_variadic_type_directive():
     format_program = FormatProgram(
         (
             OperandsDirective((False, 1)),
-            AttrDictDirective(False, set(), False),
+            AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
             TypeDirective(OperandsDirective((False, 1))),
         ),
@@ -1718,7 +1747,7 @@ def test_results_directive_with_non_variadic_type_directive():
     # a ResultsDirective, but we can manually make one.
     format_program = FormatProgram(
         (
-            AttrDictDirective(False, set(), False),
+            AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
             TypeDirective(ResultsDirective(None)),
         ),
@@ -1753,7 +1782,7 @@ def test_results_directive_with_variadic_type_directive():
     # a ResultsDirective, but we can manually make one.
     format_program = FormatProgram(
         (
-            AttrDictDirective(False, set(), False),
+            AttrDictDirective(False, set(), set()),
             PunctuationDirective(":"),
             TypeDirective(ResultsDirective((False, 1))),
         ),

--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -277,7 +277,7 @@ def test_attr_dict(program: str, generic_program: str):
         ),
     ],
 )
-def test_attr_dict_prop_fallack(program: str, generic_program: str):
+def test_attr_dict_prop_fallback(program: str, generic_program: str):
     @irdl_op_definition
     class PropOp(IRDLOperation):
         name = "test.prop"
@@ -305,7 +305,7 @@ def test_attr_dict_prop_fallack(program: str, generic_program: str):
         ),
     ],
 )
-def test_partial_attr_dict_prop_fallack(program: str, generic_program: str):
+def test_partial_attr_dict_prop_fallback(program: str, generic_program: str):
     @irdl_op_definition
     class PropOp(IRDLOperation):
         name = "test.prop"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -29,7 +29,7 @@ from xdsl.irdl import (
 )
 from xdsl.parser import Parser
 from xdsl.printer import Printer
-from xdsl.utils.exceptions import ParseError, VerifyException
+from xdsl.utils.exceptions import ParseError
 from xdsl.utils.mlir_lexer import MLIRTokenKind, PunctuationSpelling
 from xdsl.utils.str_enum import StrEnum
 
@@ -884,16 +884,14 @@ def test_properties_retrocompatibility():
     assert op.attributes == retro_op.attributes
     assert op.properties == retro_op.properties
 
-    # We ***do not*** try to be smarter than this. If properties are present, we parse
-    # and verify as-is.
+    # Test partial case
     parser = Parser(ctx, '"test.prop_op"() <{first = "str"}> {second = 42} : () -> ()')
-    wrong_op = parser.parse_op()
-    assert list(wrong_op.properties.keys()) == ["first"]
-    assert list(wrong_op.attributes.keys()) == ["second"]
-    with pytest.raises(
-        VerifyException, match="Operation does not verify: property second expected"
-    ):
-        wrong_op.verify()
+    partial_op = parser.parse_op()
+    assert isinstance(partial_op, PropertyOp)
+    partial_op.verify()
+
+    assert op.attributes == partial_op.attributes
+    assert op.properties == partial_op.properties
 
 
 def test_parse_location():

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -734,7 +734,7 @@ def test_dictionary_attr():
     """Test that a DictionaryAttr can be parsed and then printed."""
 
     prog = """
-"func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr}> {arg_attrs = {key_one = "value_one", key_two = "value_two", key_three = 72 : i64, unit_attr}} : () -> ()
+"func.func"() <{sym_name = "test", function_type = i64, sym_visibility = "private", unit_attr, arg_attrs = {key_one = "value_one", key_two = "value_two", key_three = 72 : i64, unit_attr}}> : () -> ()
     """
 
     ctx = Context()

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -426,13 +426,11 @@ class AttrDictDirective(FormatDirective):
                 "dictionary."
             )
 
-        parsed = bool(res)
-
         props = tuple(k for k in res.keys() if k in self.expected_properties)
         for name in props:
             state.properties[name] = res.pop(name)
         state.attributes |= res
-        return parsed
+        return bool(res) or bool(props)
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
         if not op.attributes.keys().isdisjoint(self.expected_properties):

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -150,19 +150,11 @@ class FormatProgram:
                 "Variadic or optional operand has no type or a single type "
                 operands.append(parser.resolve_operands(uo, ot, parser.pos))
 
-        # Get the properties from the attribute dictionary if no properties are
-        # defined. This is necessary to be compatible with MLIR format, such as
-        # `memref.load`.
-        if state.properties:
-            properties = state.properties
-        else:
-            properties = op_def.split_properties(state.attributes)
-
         return op_type.build(
             result_types=result_types,
             operands=operands,
             attributes=state.attributes,
-            properties=properties,
+            properties=state.properties,
             regions=state.regions,
             successors=state.successors,
         )
@@ -411,9 +403,9 @@ class AttrDictDirective(FormatDirective):
     printed twice otherwise.
     """
 
-    print_properties: bool
+    expected_properties: set[str]
     """
-    If this is set, also print properties as part of the attribute dictionary.
+    Properties that should be printed and parsed as part of this attr-dict.
     This is used to keep compatibility with MLIR which allows that.
     """
 
@@ -423,7 +415,7 @@ class AttrDictDirective(FormatDirective):
             if res is None:
                 res = {}
             else:
-                res = res.data
+                res = dict(res.data)
         else:
             res = parser.parse_optional_attr_dict()
         defined_reserved_keys = self.reserved_attr_names & res.keys()
@@ -433,23 +425,28 @@ class AttrDictDirective(FormatDirective):
                 "assembly format, and thus should not be defined in the attribute "
                 "dictionary."
             )
+
+        parsed = bool(res)
+
+        props = tuple(k for k in res.keys() if k in self.expected_properties)
+        for name in props:
+            state.properties[name] = res.pop(name)
         state.attributes |= res
-        return bool(res)
+        return parsed
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if self.print_properties:
-            if any(name in op.attributes for name in op.properties):
-                raise ValueError(
-                    "Cannot print attributes and properties with the same name "
-                    "in a single dictionary"
-                )
-            op_def = op.get_irdl_definition()
-            dictionary = op.attributes | op.properties
-            defs = op_def.properties | op_def.attributes
-        else:
-            op_def = op.get_irdl_definition()
-            dictionary = op.attributes
-            defs = op_def.attributes
+        if any(name in op.attributes for name in self.expected_properties):
+            raise ValueError(
+                "Cannot print attributes and properties with the same name "
+                "in a single dictionary"
+            )
+        op_def = op.get_irdl_definition()
+        dictionary = op.attributes | {
+            k: v for k, v in op.properties.items() if k in self.expected_properties
+        }
+        defs = {
+            x: op_def.properties[x] for x in self.expected_properties
+        } | op_def.attributes
 
         reserved_or_default = self.reserved_attr_names.union(
             name

--- a/xdsl/irdl/declarative_assembly_format.py
+++ b/xdsl/irdl/declarative_assembly_format.py
@@ -435,7 +435,7 @@ class AttrDictDirective(FormatDirective):
         return parsed
 
     def print(self, printer: Printer, state: PrintingState, op: IRDLOperation) -> None:
-        if any(name in op.attributes for name in self.expected_properties):
+        if not op.attributes.keys().isdisjoint(self.expected_properties):
             raise ValueError(
                 "Cannot print attributes and properties with the same name "
                 "in a single dictionary"

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -1235,17 +1235,6 @@ class OpDef:
         for trait in self.traits:
             trait.verify(op)
 
-    def split_properties(
-        self, properties: dict[str, Attribute], attr_dict: dict[str, Attribute]
-    ):
-        """
-        Remove all entries of an attribute dictionary that are defined as properties
-        by the operation definition, and return them in a new dictionary.
-        """
-        for property_name in self.properties.keys():
-            if property_name in attr_dict and property_name not in properties:
-                properties[property_name] = attr_dict.pop(property_name)
-
 
 class VarIRConstruct(Enum):
     """

--- a/xdsl/irdl/operations.py
+++ b/xdsl/irdl/operations.py
@@ -309,8 +309,8 @@ class SameVariadicSuccessorSize(SameVariadicSize):
 @dataclass
 class ParsePropInAttrDict(IRDLOption):
     """
-    Parse properties in the attribute dictionary instead of requiring them to
-    be in the assembly format.
+    Allows properties to be omitted from the assembly format, causing them
+    to be parsed as part of the attribute dictionary.
     This should only be used to ensure MLIR compatibility, it is otherwise
     bad design to use it.
     """
@@ -1235,16 +1235,16 @@ class OpDef:
         for trait in self.traits:
             trait.verify(op)
 
-    def split_properties(self, attr_dict: dict[str, Attribute]) -> dict[str, Attribute]:
+    def split_properties(
+        self, properties: dict[str, Attribute], attr_dict: dict[str, Attribute]
+    ):
         """
         Remove all entries of an attribute dictionary that are defined as properties
         by the operation definition, and return them in a new dictionary.
         """
-        properties: dict[str, Attribute] = {}
         for property_name in self.properties.keys():
-            if property_name in attr_dict:
+            if property_name in attr_dict and property_name not in properties:
                 properties[property_name] = attr_dict.pop(property_name)
-        return properties
 
 
 class VarIRConstruct(Enum):

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -862,7 +862,7 @@ class Parser(AttrParser):
         regions = self.parse_region_list()
 
         # Parse attribute dictionary
-        attrs = self.parse_optional_attr_dict()
+        attributes = self.parse_optional_attr_dict()
 
         self.parse_punctuation(":", "function type signature expected")
 
@@ -878,13 +878,16 @@ class Parser(AttrParser):
         # Properties retrocompatibility :
         # We extract properties from the attribute dictionary by name.
         if issubclass(op_type, IRDLOperation):
-            op_type.get_irdl_definition().split_properties(properties, attrs)
+            op_def = op_type.get_irdl_definition()
+            for property_name in op_def.properties.keys():
+                if property_name in attributes and property_name not in properties:
+                    properties[property_name] = attributes.pop(property_name)
 
         return op_type.create(
             operands=operands,
             result_types=func_type.outputs.data,
             properties=properties,
-            attributes=attrs,
+            attributes=attributes,
             successors=successors,
             regions=regions,
         )

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -856,7 +856,9 @@ class Parser(AttrParser):
             successors = []
 
         # Parse attribute dictionary
-        properties = self.parse_optional_properties_dict() or {}
+        properties = self.parse_optional_properties_dict()
+        if properties is None:
+            properties = {}
 
         # Parse regions
         regions = self.parse_region_list()

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -857,8 +857,6 @@ class Parser(AttrParser):
 
         # Parse attribute dictionary
         properties = self.parse_optional_properties_dict()
-        if properties is None:
-            properties = {}
 
         # Parse regions
         regions = self.parse_region_list()

--- a/xdsl/parser/core.py
+++ b/xdsl/parser/core.py
@@ -856,7 +856,7 @@ class Parser(AttrParser):
             successors = []
 
         # Parse attribute dictionary
-        properties = self.parse_optional_properties_dict()
+        properties = self.parse_optional_properties_dict() or {}
 
         # Parse regions
         regions = self.parse_region_list()
@@ -875,10 +875,10 @@ class Parser(AttrParser):
 
         operands = self.resolve_operands(args, func_type.inputs.data, func_type_pos)
 
-        # Properties retrocompatibility : if no properties dictionary was present at all,
-        # We extract them from the attribute dictionary by name.
-        if issubclass(op_type, IRDLOperation) and not properties:
-            properties = op_type.get_irdl_definition().split_properties(attrs)
+        # Properties retrocompatibility :
+        # We extract properties from the attribute dictionary by name.
+        if issubclass(op_type, IRDLOperation):
+            op_type.get_irdl_definition().split_properties(properties, attrs)
 
         return op_type.create(
             operands=operands,


### PR DESCRIPTION
Fixes #4306 

I'm not sure this is 100% what MLIR does in every case, but it passes all our tests at seems at least close to mlir behaviour in the cases I tested.

@erick-xanadu can't seem to add you as a reviewer for some reason, but would be good if you could check if this fixes the issues you were having.