### PR TITLE
backend: make RegisterQueue non-generic

### DIFF
--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -101,13 +101,13 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
     ```
     """
 
-    available_registers: RegisterQueue[RISCVRegisterType]
+    available_registers: RegisterQueue
     live_ins_per_block: dict[Block, OrderedSet[SSAValue]]
     new_value_by_old_value: dict[SSAValue, SSAValue]
 
     exclude_snitch_reserved: bool = True
 
-    def __init__(self, available_registers: RegisterQueue[RISCVRegisterType]) -> None:
+    def __init__(self, available_registers: RegisterQueue) -> None:
         self.available_registers = available_registers
         self.live_ins_per_block = {}
         self.new_value_by_old_value = {}

--- a/xdsl/backend/riscv/riscv_register_queue.py
+++ b/xdsl/backend/riscv/riscv_register_queue.py
@@ -1,12 +1,11 @@
-from collections.abc import Iterable
 from dataclasses import dataclass
 
 from xdsl.backend.register_queue import LIFORegisterQueue
-from xdsl.dialects.riscv import Registers, RISCVRegisterType
+from xdsl.dialects.riscv import Registers
 
 
 @dataclass
-class RiscvRegisterQueue(LIFORegisterQueue[RISCVRegisterType]):
+class RiscvRegisterQueue(LIFORegisterQueue):
     """
     LIFO queue of RISCV-specific registers.
     """
@@ -28,9 +27,9 @@ class RiscvRegisterQueue(LIFORegisterQueue[RISCVRegisterType]):
     )
 
     @classmethod
-    def default_reserved_registers(cls) -> Iterable[RISCVRegisterType]:
+    def default_reserved_registers(cls):
         return RiscvRegisterQueue.DEFAULT_RESERVED_REGISTERS
 
     @classmethod
-    def default_available_registers(cls) -> Iterable[RISCVRegisterType]:
+    def default_available_registers(cls):
         return RiscvRegisterQueue.DEFAULT_AVAILABLE_REGISTERS


### PR DESCRIPTION
Finally it was too tricky to get the typing to work out with the generics. As you can see in #4314, the plan is to add an abstract method for allocatable operations to implement, and that has to be register-type independent, since that's a thing unknown at runtime.