### PR TITLE
backend: add RegisterAllocatableOperation abstract base class

### DIFF
--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -1,0 +1,99 @@
+from collections.abc import Sequence
+
+from xdsl.backend.register_allocatable import RegisterAllocatableOperation
+from xdsl.backend.register_type import RegisterType
+from xdsl.builder import Builder
+from xdsl.ir import Attribute, SSAValue
+from xdsl.irdl import (
+    IRDLOperation,
+    irdl_attr_definition,
+    irdl_op_definition,
+    var_operand_def,
+    var_result_def,
+)
+
+
+@irdl_attr_definition
+class TestRegister(RegisterType):
+    name = "test.reg"
+
+    @classmethod
+    def index_by_name(cls) -> dict[str, int]:
+        return {"x0": 0, "x1": 1, "a0": 0, "a1": 1}
+
+    @classmethod
+    def infinite_register_prefix(cls):
+        return "y"
+
+
+@irdl_op_definition
+class TestAllocatableOp(IRDLOperation, RegisterAllocatableOperation):
+    name = "test.allocatable"
+
+    res = var_result_def()
+    ops = var_operand_def()
+
+    def __init__(
+        self, operands: Sequence[SSAValue] = (), result_types: Sequence[Attribute] = ()
+    ):
+        super().__init__(operands=(operands,), result_types=(result_types,))
+
+
+def op(operands: Sequence[SSAValue], *result_types: Attribute):
+    return TestAllocatableOp(operands, result_types).results
+
+
+def test_gather_allocated():
+    u = TestRegister.unallocated()
+    x0 = TestRegister.from_name("x0")
+    x1 = TestRegister.from_name("x0")
+
+    @Builder.implicit_region
+    def no_preallocated_body() -> None:
+        (v1,) = op((), u)
+        (v2,) = op((), u)
+        op((v1, v2), u)
+
+    pa_regs = set(
+        RegisterAllocatableOperation.iter_all_used_registers(no_preallocated_body)
+    )
+
+    assert pa_regs == set()
+
+    @Builder.implicit_region
+    def one_preallocated_body() -> None:
+        (v1,) = op((), u)
+        (v2,) = op((), x0)
+        op((v1, v2), u)
+
+    pa_regs = set(
+        RegisterAllocatableOperation.iter_all_used_registers(one_preallocated_body)
+    )
+
+    assert pa_regs == {x0}
+
+    @Builder.implicit_region
+    def repeated_preallocated_body() -> None:
+        (v1,) = op((), u)
+        (v2,) = op((), x0)
+        (v3,) = op((), x0)
+        op((v1, v2, v3), u)
+
+    pa_regs = set(
+        RegisterAllocatableOperation.iter_all_used_registers(repeated_preallocated_body)
+    )
+
+    assert pa_regs == {x0}
+
+    @Builder.implicit_region
+    def multiple_preallocated_body() -> None:
+        (v1,) = op((), u)
+        (v2,) = op((), x0)
+        (v3,) = op((), x1)
+        op((v1, v2, v3), u)
+
+    pa_regs = set(
+        RegisterAllocatableOperation.iter_all_used_registers(multiple_preallocated_body)
+    )
+
+    assert pa_regs == {x0, x1}

--- a/xdsl/backend/register_allocatable.py
+++ b/xdsl/backend/register_allocatable.py
@@ -1,8 +1,43 @@
 import abc
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import NamedTuple
 
-from xdsl.ir import SSAValue
+from xdsl.backend.register_type import RegisterType
+from xdsl.ir import Operation, Region, SSAValue
+
+
+class RegisterAllocatableOperation(Operation, abc.ABC):
+    """
+    An abstract base class for operations that can be processed during register
+    allocation.
+    """
+
+    def iter_used_registers(self) -> Iterator[RegisterType]:
+        """
+        The registers whose contents may be overwritten when executing this operation.
+        By default returns the types of operands and results that are allocated
+        registers.
+        """
+        return (
+            val.type
+            for vals in (self.operands, self.results)
+            for val in vals
+            if isinstance(val.type, RegisterType) and val.type.is_allocated
+        )
+
+    @staticmethod
+    def iter_all_used_registers(
+        region: Region,
+    ) -> Iterator[RegisterType]:
+        """
+        All used registers of all operations within a region.
+        """
+        return (
+            reg
+            for op in region.walk()
+            if isinstance(op, RegisterAllocatableOperation)
+            for reg in op.iter_used_registers()
+        )
 
 
 class RegisterConstraints(NamedTuple):
@@ -17,7 +52,7 @@ class RegisterConstraints(NamedTuple):
     inouts: Sequence[Sequence[SSAValue]]
 
 
-class HasRegisterConstraints(abc.ABC):
+class HasRegisterConstraints(RegisterAllocatableOperation, abc.ABC):
     @abc.abstractmethod
     def get_register_constraints(self) -> RegisterConstraints:
         """

--- a/xdsl/backend/riscv/register_allocation.py
+++ b/xdsl/backend/riscv/register_allocation.py
@@ -2,11 +2,11 @@ import abc
 import json
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
-from itertools import chain
 from typing import cast
 
 from ordered_set import OrderedSet
 
+from xdsl.backend.register_allocatable import RegisterAllocatableOperation
 from xdsl.backend.register_queue import RegisterQueue
 from xdsl.dialects import riscv, riscv_func, riscv_scf, riscv_snitch
 from xdsl.dialects.riscv import Registers, RISCVAsmOperation, RISCVRegisterType
@@ -15,34 +15,6 @@ from xdsl.rewriter import InsertPoint, Rewriter
 from xdsl.transforms.canonicalization_patterns.riscv import get_constant_value
 from xdsl.transforms.snitch_register_allocation import get_snitch_reserved
 from xdsl.utils.exceptions import DiagnosticException
-
-
-def gather_allocated(
-    func: riscv_func.FuncOp,
-) -> set[RISCVRegisterType]:
-    """Utility method to gather already allocated registers"""
-
-    allocated: set[RISCVRegisterType] = set()
-
-    for op in func.walk():
-        if not isinstance(op, RISCVAsmOperation):
-            continue
-
-        if isinstance(op, riscv_func.CallOp):
-            # These registers are not guaranteed to hold the same values when the callee
-            # returns, according to the RISC-V calling convention.
-            # https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf
-            allocated.update(riscv.Registers.A)
-            allocated.update(riscv.Registers.T)
-            allocated.update(riscv.Registers.FA)
-            allocated.update(riscv.Registers.FT)
-
-        for param in chain(op.operands, op.results):
-            if isinstance(param.type, RISCVRegisterType) and param.type.is_allocated:
-                if not param.type.register_name.data.startswith("j"):
-                    allocated.add(param.type)
-
-    return allocated
 
 
 def _uses_snitch_stream(func: riscv_func.FuncOp) -> bool:
@@ -330,7 +302,11 @@ class RegisterAllocatorLivenessBlockNaive(RegisterAllocator):
                 f"Cannot register allocate func with {len(func.body.blocks)} blocks."
             )
 
-        preallocated: set[RISCVRegisterType] = gather_allocated(func)
+        preallocated = {
+            reg
+            for reg in RegisterAllocatableOperation.iter_all_used_registers(func.body)
+            if isinstance(reg, RISCVRegisterType)
+        }
 
         if self.exclude_snitch_reserved and _uses_snitch_stream(func):
             preallocated |= get_snitch_reserved()

--- a/xdsl/dialects/riscv_func.py
+++ b/xdsl/dialects/riscv_func.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 
 from xdsl.backend.assembly_printer import AssemblyPrintable, AssemblyPrinter
+from xdsl.backend.register_type import RegisterType
 from xdsl.dialects import riscv
 from xdsl.dialects.builtin import (
     I8,
@@ -118,6 +119,15 @@ class CallOp(riscv.RISCVInstruction):
 
     def assembly_line_args(self) -> tuple[riscv.AssemblyInstructionArg | None, ...]:
         return (self.callee.string_value(),)
+
+    def iter_used_registers(self) -> Generator[RegisterType, None, None]:
+        # These registers are not guaranteed to hold the same values when the callee
+        # returns, according to the RISC-V calling convention.
+        # https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf
+        yield from riscv.Registers.A
+        yield from riscv.Registers.T
+        yield from riscv.Registers.FA
+        yield from riscv.Registers.FT
 
 
 class FuncOpCallableInterface(CallableOpInterface):


### PR DESCRIPTION
This is half of the class, in a subsequent PR there will actually be an `allocate` method for each subclass to override.