### PR TITLE
documentation: Rename traversal example function to @sum_of_squares for clarity

### DIFF
--- a/docs/marimo/traversing_ir.py
+++ b/docs/marimo/traversing_ir.py
@@ -47,7 +47,7 @@ def _(mo):
 @app.cell(hide_code=True)
 def _():
     triangle_text = """\
-    func.func @triangle(%n: index) -> index {
+    func.func @sum_of_squares(%n: index) -> index {
       %zero = arith.constant 0 : index
       %one = arith.constant 1 : index
       %res = scf.for %i = %zero to %n step %one iter_args(%acc_in = %zero) -> (index) {

--- a/docs/marimo/traversing_ir.py
+++ b/docs/marimo/traversing_ir.py
@@ -46,7 +46,7 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _():
-    triangle_text = """\
+    sum_of_squares_text = """\
     func.func @sum_of_squares(%n: index) -> index {
       %zero = arith.constant 0 : index
       %one = arith.constant 1 : index
@@ -58,15 +58,15 @@ def _():
       func.return %res : index
     }\
     """
-    return (triangle_text,)
+    return (sum_of_squares_text,)
 
 
 @app.cell(hide_code=True)
-def _(mo, triangle_text):
+def _(mo, sum_of_squares_text):
     mo.md(fr"""
     In this notebook, we'll be looking at the structure of the following module:
 
-    {mo.ui.code_editor(triangle_text, language="javascript", disabled=True)}
+    {mo.ui.code_editor(sum_of_squares_text, language="javascript", disabled=True)}
     """
     )
     return
@@ -84,12 +84,12 @@ def _(Context, arith, builtin, func, scf):
 
 
 @app.cell
-def _(Parser, ctx, triangle_text, xmo):
-    triangle_module = Parser(ctx, triangle_text).parse_module()
+def _(Parser, ctx, sum_of_squares_text, xmo):
+    sum_of_squares_module = Parser(ctx, sum_of_squares_text).parse_module()
 
     # We can then parse and reprint the same module
-    xmo.module_html(triangle_module)
-    return (triangle_module,)
+    xmo.module_html(sum_of_squares_module)
+    return (sum_of_squares_module,)
 
 
 @app.cell(hide_code=True)
@@ -111,8 +111,8 @@ def _(mo):
 
 
 @app.cell
-def _(triangle_module):
-    print([op.name for op in triangle_module.walk()])
+def _(sum_of_squares_module):
+    print([op.name for op in sum_of_squares_module.walk()])
     return
 
 
@@ -160,9 +160,9 @@ def _(mo):
 
 
 @app.cell(hide_code=True)
-def _(mo, triangle_module, unique_operations):
+def _(mo, sum_of_squares_module, unique_operations):
     try:
-        _sorted = "{" + ", ".join(sorted(unique_operations(triangle_module))) + "}"
+        _sorted = "{" + ", ".join(sorted(unique_operations(sum_of_squares_module))) + "}"
         _res = str(_sorted)
     except Exception as e:
         _res = f"{type(e).__name__}: {e}"
@@ -199,9 +199,9 @@ def _(builtin):
 
 
 @app.cell(hide_code=True)
-def _(mo, operation_counts, triangle_module):
+def _(mo, operation_counts, sum_of_squares_module):
     try:
-        _res = str(operation_counts(triangle_module))
+        _res = str(operation_counts(sum_of_squares_module))
     except Exception as e:
         _res = f"{type(e).__name__}: {e}"
 
@@ -239,9 +239,9 @@ def _(Counter, builtin):
 
 
 @app.cell(hide_code=True)
-def _(mo, operations_by_dialect, triangle_module):
+def _(mo, operations_by_dialect, sum_of_squares_module):
     try:
-        _unsorted = operations_by_dialect(triangle_module)
+        _unsorted = operations_by_dialect(sum_of_squares_module)
         _sorted = {
             k: sorted(_unsorted[k])
             for k in sorted(_unsorted)
@@ -306,12 +306,12 @@ def _(mo):
 
 
 @app.cell(hide_code=True)
-def _(triangle_module):
-    all_operands = set(val.name_hint for op in triangle_module.walk() for val in op.operands)
-    all_results = set(val.name_hint for op in triangle_module.walk() for val in op.results)
+def _(sum_of_squares_module):
+    all_operands = set(val.name_hint for op in sum_of_squares_module.walk() for val in op.operands)
+    all_results = set(val.name_hint for op in sum_of_squares_module.walk() for val in op.results)
     all_block_args = set(
         val.name_hint
-        for op in triangle_module.walk()
+        for op in sum_of_squares_module.walk()
         for region in op.regions
         for block in region.blocks
         for val in block.args
@@ -334,9 +334,9 @@ def _(all_ssa_values, mo):
 
 
 @app.cell(hide_code=True)
-def _(definition_by_use, mo, triangle_module):
+def _(definition_by_use, mo, sum_of_squares_module):
     try:
-        _unsorted = definition_by_use(triangle_module)
+        _unsorted = definition_by_use(sum_of_squares_module)
         _sorted = {
             k: sorted(_unsorted[k])
             for k in sorted(_unsorted)
@@ -391,9 +391,9 @@ def _(OpResult, builtin, defaultdict):
 
 
 @app.cell(hide_code=True)
-def _(mo, triangle_module, uses_by_definition):
+def _(mo, sum_of_squares_module, uses_by_definition):
     try:
-        _unsorted = uses_by_definition(triangle_module)
+        _unsorted = uses_by_definition(sum_of_squares_module)
         _sorted = {
             k: sorted(_unsorted[k])
             for k in sorted(_unsorted)


### PR DESCRIPTION
This PR updates the function name used in the traversal example within the documentation. Previously, the example showed the function named as `@triangle`, which was misleading given the intended functionality of summing squares. With these changes, the function is now correctly labeled as `@sum_of_squares`, aligning with the code's purpose and improving overall readability.

Resolves issue [#4128](https://github.com/xdslproject/xdsl/issues/4128).

---
*Created with [Repobird.ai](https://repobird.ai) 📦🐦*