### PR TITLE
dialects: (builtin) remove TensorOrMemRefConstraint

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -31,8 +31,6 @@ from xdsl.dialects.builtin import (
     Signedness,
     StridedLayoutAttr,
     SymbolRefAttr,
-    TensorOrMemRefOf,
-    TensorType,
     UnrealizedConversionCastOp,
     VectorBaseTypeAndRankConstraint,
     VectorBaseTypeConstraint,
@@ -684,27 +682,6 @@ def test_strides():
     assert ShapedType.strides_for_shape((1,), factor=2) == (2,)
     assert ShapedType.strides_for_shape((2, 3)) == (3, 1)
     assert ShapedType.strides_for_shape((4, 5, 6), factor=2) == (60, 12, 2)
-
-
-def test_tensor_or_memref_of_constraint_verify():
-    constraint = TensorOrMemRefOf(i64)
-
-    constraint.verify(MemRefType(i64, [1]), ConstraintContext())
-    constraint.verify(TensorType(i64, [1]), ConstraintContext())
-
-
-def test_tensor_or_memref_of_constraint_attribute_mismatch():
-    constraint = TensorOrMemRefOf(i64)
-
-    with pytest.raises(
-        VerifyException, match=f"Expected tensor or memref type, got {i64}"
-    ):
-        constraint.verify(i64, ConstraintContext())
-
-    with pytest.raises(
-        VerifyException, match=f"Expected attribute {i64} but got {i32}"
-    ):
-        constraint.verify(MemRefType(i32, [1]), ConstraintContext())
 
 
 def test_integer_type_repr():

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -23,7 +23,6 @@ from typing_extensions import Self, TypeVar
 from xdsl.ir import (
     Attribute,
     AttributeCovT,
-    AttributeInvT,
     Block,
     BlockOps,
     BuiltinAttribute,
@@ -2027,52 +2026,6 @@ class MemRefType(
         return ParamAttrConstraint[MemRefType[_MemRefTypeElement]](
             MemRefType, (shape, element_type, layout, memory_space)
         )
-
-
-@dataclass(frozen=True, init=False)
-class TensorOrMemRefOf(
-    GenericAttrConstraint[TensorType[AttributeCovT] | MemRefType[AttributeCovT]]
-):
-    """A type constraint that can be nested once in a memref or a tensor."""
-
-    elem_constr: GenericAttrConstraint[AttributeCovT]
-
-    def __init__(
-        self,
-        elem_constr: (
-            AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT]
-        ),
-    ) -> None:
-        object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
-
-    @dataclass(frozen=True)
-    class _Extractor(
-        VarExtractor[TensorType[AttributeInvT] | MemRefType[AttributeInvT]]
-    ):
-        inner: VarExtractor[AttributeInvT]
-
-        def extract_var(
-            self, a: TensorType[AttributeInvT] | MemRefType[AttributeInvT]
-        ) -> ConstraintVariableType:
-            return self.inner.extract_var(a.element_type)
-
-    def get_resolvers(
-        self,
-    ) -> dict[
-        str,
-        VarExtractor[TensorType[AttributeCovT] | MemRefType[AttributeCovT]],
-    ]:
-        return {
-            v: self._Extractor(r)
-            for v, r in self.elem_constr.get_variable_extractors().items()
-        }
-
-    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
-        if isinstance(attr, MemRefType) or isinstance(attr, TensorType):
-            attr = cast(MemRefType[Attribute] | TensorType[Attribute], attr)
-            self.elem_constr.verify(attr.element_type, constraint_context)
-        else:
-            raise VerifyException(f"Expected tensor or memref type, got {attr}")
 
 
 @irdl_attr_definition

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -16,7 +16,6 @@ from xdsl.dialects.builtin import (
     IndexTypeConstr,
     MemRefType,
     SignlessIntegerConstraint,
-    TensorOrMemRefOf,
     TensorType,
     VectorBaseTypeAndRankConstraint,
     VectorBaseTypeConstraint,
@@ -828,7 +827,7 @@ class TransferReadOp(VectorTransferOperation):
 
     name = "vector.transfer_read"
 
-    source = operand_def(TensorOrMemRefOf(Attribute))
+    source = operand_def(TensorType | MemRefType)
     indices = var_operand_def(IndexType)
     padding = operand_def()
     mask = opt_operand_def(VectorType[I1])
@@ -933,7 +932,7 @@ class TransferWriteOp(VectorTransferOperation):
     name = "vector.transfer_write"
 
     vector = operand_def(VectorType[Attribute])
-    source = operand_def(TensorOrMemRefOf(Attribute))
+    source = operand_def(TensorType | MemRefType)
     indices = var_operand_def(IndexType)
     mask = opt_operand_def(VectorType[I1])
 


### PR DESCRIPTION
This seemed to only be used in two places, both of which could trivially be replaced. Is anyone aware of the reason this exists? (e.g. is it used downstream?)
