### PR TITLE
core: (constraints) remove variance on `get_variable_extractors`

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -85,7 +85,7 @@ from xdsl.utils.comparisons import (
     unsigned_upper_bound,
     unsigned_value_range,
 )
-from xdsl.utils.exceptions import DiagnosticException, VerifyException
+from xdsl.utils.exceptions import DiagnosticException, PyRDLError, VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.isattr import isattr
 
@@ -316,13 +316,15 @@ class IntAttrConstraint(GenericAttrConstraint[IntAttr]):
         self.int_constraint.verify(attr.data, constraint_context)
 
     @dataclass(frozen=True)
-    class _Extractor(VarExtractor[IntAttr]):
+    class _Extractor(VarExtractor[Attribute]):
         inner: VarExtractor[int]
 
-        def extract_var(self, a: IntAttr) -> ConstraintVariableType:
+        def extract_var(self, a: Attribute) -> ConstraintVariableType:
+            if not isinstance(a, IntAttr):
+                raise PyRDLError(f"Inference expected {a} to be an IntAttr")
             return self.inner.extract_var(a.data)
 
-    def get_variable_extractors(self) -> dict[str, VarExtractor[IntAttr]]:
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
         return {
             k: self._Extractor(v)
             for k, v in self.int_constraint.get_length_extractors().items()

--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -12,11 +12,10 @@ from typing_extensions import assert_never
 from xdsl.ir import (
     Attribute,
     AttributeCovT,
-    AttributeInvT,
     ParametrizedAttribute,
     TypedAttribute,
 )
-from xdsl.utils.exceptions import VerifyException
+from xdsl.utils.exceptions import PyRDLError, VerifyException
 from xdsl.utils.runtime_final import is_runtime_final
 
 if TYPE_CHECKING:
@@ -170,7 +169,7 @@ class GenericAttrConstraint(Generic[AttributeCovT], ABC):
         """
         ...
 
-    def get_variable_extractors(self) -> dict[str, VarExtractor[AttributeCovT]]:
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
         """
         Get a dictionary of constraint variables to extractors for these variables,
         which provide a method to obtain the value of each constraint variable from
@@ -248,13 +247,15 @@ class TypedAttributeConstraint(GenericAttrConstraint[TypedAttributeCovT]):
         self.type_constraint.verify(attr.get_type(), constraint_context)
 
     @dataclass(frozen=True)
-    class _Extractor(VarExtractor[TypedAttributeT]):
+    class _Extractor(VarExtractor[Attribute]):
         inner: VarExtractor[Attribute]
 
-        def extract_var(self, a: TypedAttributeT) -> ConstraintVariableType:
+        def extract_var(self, a: Attribute) -> ConstraintVariableType:
+            if not isinstance(a, TypedAttribute):
+                raise PyRDLError(f"Inference expected {a} to be a TypedAttribute")
             return self.inner.extract_var(a.get_type())
 
-    def get_variable_extractors(self) -> dict[str, VarExtractor[TypedAttributeCovT]]:
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
         return merge_extractor_dicts(
             self.attr_constraint.get_variable_extractors(),
             {
@@ -299,7 +300,7 @@ class VarConstraint(GenericAttrConstraint[AttributeCovT]):
             self.constraint.verify(attr, constraint_context)
             constraint_context.set_variable(self.name, attr)
 
-    def get_variable_extractors(self) -> dict[str, VarExtractor[AttributeCovT]]:
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
         return merge_extractor_dicts(
             {self.name: IdExtractor()}, self.constraint.get_variable_extractors()
         )
@@ -467,7 +468,7 @@ class AnyOf(Generic[AttributeCovT], GenericAttrConstraint[AttributeCovT]):
     ) -> AnyOf[AttributeCovT | _AttributeCovT]:
         return AnyOf((*self.attr_constrs, value))
 
-    def get_variable_extractors(self) -> dict[str, VarExtractor[AttributeCovT]]:
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
         if len(self.attr_constrs) == 1:
             return self.attr_constrs[0].get_variable_extractors()
         return dict()
@@ -508,7 +509,7 @@ class AllOf(GenericAttrConstraint[AttributeCovT]):
             exc_msg += "\n".join([str(e) for e in exc_bucket])
             raise VerifyException(exc_msg)
 
-    def get_variable_extractors(self) -> dict[str, VarExtractor[AttributeCovT]]:
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
         return merge_extractor_dicts(
             *(constr.get_variable_extractors() for constr in self.attr_constrs)
         )
@@ -595,17 +596,25 @@ class ParamAttrConstraint(
             param_constr.verify(attr.parameters[idx], constraint_context)
 
     @dataclass(frozen=True)
-    class _Extractor(VarExtractor[ParametrizedAttributeT]):
+    class _Extractor(VarExtractor[Attribute]):
         idx: int
         inner: VarExtractor[Attribute]
 
-        def extract_var(self, a: ParametrizedAttributeT) -> ConstraintVariableType:
+        def extract_var(self, a: Attribute) -> ConstraintVariableType:
+            if not isinstance(a, ParametrizedAttribute):
+                raise PyRDLError(
+                    f"Inference expected {a} to be a ParameterizedAttribute"
+                )
+            if len(a.parameters) <= self.idx:
+                raise PyRDLError(
+                    f"Inference expected {a} to have at least {self.idx + 1} parameters"
+                )
             return self.inner.extract_var(a.parameters[self.idx])
 
     def get_variable_extractors(
         self,
-    ) -> dict[str, VarExtractor[ParametrizedAttributeCovT]]:
-        dicts: Generator[dict[str, VarExtractor[ParametrizedAttributeCovT]]] = (
+    ) -> dict[str, VarExtractor[Attribute]]:
+        dicts: Generator[dict[str, VarExtractor[Attribute]]] = (
             {
                 v: self._Extractor(i, r)
                 for v, r in param_constr.get_variable_extractors().items()
@@ -663,7 +672,7 @@ class MessageConstraint(GenericAttrConstraint[AttributeCovT]):
                 *e.args[1:],
             )
 
-    def get_variable_extractors(self) -> dict[str, VarExtractor[AttributeCovT]]:
+    def get_variable_extractors(self) -> dict[str, VarExtractor[Attribute]]:
         return self.constr.get_variable_extractors()
 
     def get_unique_base(self) -> type[Attribute] | None:
@@ -790,7 +799,7 @@ class GenericRangeConstraint(Generic[AttributeCovT], ABC):
 
     def get_variable_extractors(
         self,
-    ) -> dict[str, VarExtractor[Sequence[AttributeCovT]]]:
+    ) -> dict[str, VarExtractor[Sequence[Attribute]]]:
         """
         Get a dictionary of constraint variables to extractors for these variables,
         which provide a method to obtain the value of each constraint variable from
@@ -863,8 +872,8 @@ class RangeVarConstraint(GenericRangeConstraint[AttributeCovT]):
 
     def get_variable_extractors(
         self,
-    ) -> dict[str, VarExtractor[Sequence[AttributeCovT]]]:
-        return {self.name: IdExtractor[Sequence[AttributeCovT]]()}
+    ) -> dict[str, VarExtractor[Sequence[Attribute]]]:
+        return {self.name: IdExtractor[Sequence[Attribute]]()}
 
     def can_infer(self, var_constraint_names: Set[str], *, length_known: bool) -> bool:
         return self.name in var_constraint_names
@@ -933,15 +942,15 @@ class SingleOf(GenericRangeConstraint[AttributeCovT]):
         self.constr.verify(attrs[0], constraint_context)
 
     @dataclass(frozen=True)
-    class _Extractor(VarExtractor[Sequence[AttributeInvT]]):
-        inner: VarExtractor[AttributeInvT]
+    class _Extractor(VarExtractor[Sequence[Attribute]]):
+        inner: VarExtractor[Attribute]
 
-        def extract_var(self, a: Sequence[AttributeInvT]) -> ConstraintVariableType:
+        def extract_var(self, a: Sequence[Attribute]) -> ConstraintVariableType:
             return self.inner.extract_var(a[0])
 
     def get_variable_extractors(
         self,
-    ) -> dict[str, VarExtractor[Sequence[AttributeCovT]]]:
+    ) -> dict[str, VarExtractor[Sequence[Attribute]]]:
         return {
             v: self._Extractor(r)
             for v, r in self.constr.get_variable_extractors().items()


### PR DESCRIPTION
I'm pretty sure there was some type unsoundness created by having the parameter on `GenericAttrConstraint` be covariant and then having the extractors use this type parameter. This was highlighted by #4238 , where the `TypedAttributeConstraint` extractor encounters an attribute which is not a `TypedAttribute`.

This PR refactors `get_variable_extractors` to remove the variant parameter, adding in some new necessary checks within the extractor.