### PR TITLE
core: Separate attributes and types in the context

### DIFF
--- a/tests/irdl/test_declarative_assembly_format.py
+++ b/tests/irdl/test_declarative_assembly_format.py
@@ -420,7 +420,7 @@ def test_unqualified_attr(program: str, generic_program: str):
         assembly_format = "$attr attr-dict"
 
     ctx = Context()
-    ctx.load_attr(ParamOne)
+    ctx.load_attr_or_type(ParamOne)
     ctx.load_op(UnqualifiedAttrOp)
 
     check_equivalence(program, generic_program, ctx)
@@ -2348,7 +2348,7 @@ def test_eq_attr_inference():
         assembly_format = "attr-dict $index"
 
     ctx = Context()
-    ctx.load_attr(UnitType)
+    ctx.load_attr_or_type(UnitType)
     ctx.load_op(OneOperandEqTypeOp)
     ctx.load_dialect(Test)
     program = textwrap.dedent(
@@ -2375,7 +2375,7 @@ def test_all_of_attr_inference():
         assembly_format = "attr-dict $index"
 
     ctx = Context()
-    ctx.load_attr(UnitType)
+    ctx.load_attr_or_type(UnitType)
     ctx.load_op(OneOperandEqTypeAllOfNestedOp)
     ctx.load_dialect(Test)
     program = textwrap.dedent(
@@ -2422,7 +2422,7 @@ def test_nested_inference():
 
     ctx = Context()
     ctx.load_op(TwoOperandsNestedVarOp)
-    ctx.load_attr(ParamOne)
+    ctx.load_attr_or_type(ParamOne)
     ctx.load_dialect(Test)
     program = textwrap.dedent(
         """\
@@ -2460,7 +2460,7 @@ def test_nested_inference_variable():
 
     ctx = Context()
     ctx.load_op(ResultTypeIsOperandParamOp)
-    ctx.load_attr(ParamOne)
+    ctx.load_attr_or_type(ParamOne)
     ctx.load_dialect(Test)
     program = textwrap.dedent(
         """\
@@ -2503,7 +2503,7 @@ def test_non_verifying_inference():
 
     ctx = Context()
     ctx.load_op(OneOperandOneResultNestedOp)
-    ctx.load_attr(ParamOne)
+    ctx.load_attr_or_type(ParamOne)
     ctx.load_dialect(Test)
     program = textwrap.dedent(
         """\
@@ -2532,10 +2532,12 @@ def test_variadic_length_inference():
     ctx = Context()
     ctx.load_op(RangeVarOp)
     ctx.load_dialect(Test)
-    program = textwrap.dedent("""\
+    program = textwrap.dedent(
+        """\
     %in0, %in1 = "test.op"() : () -> (index, index)
     %out0, %out1 = test.range_var %in0, %in1 : index, index
-    """)
+    """
+    )
 
     parser = Parser(ctx, program)
     test_op = parser.parse_optional_operation()
@@ -2557,10 +2559,12 @@ def test_int_var_inference():
     ctx = Context()
     ctx.load_op(IntVarOp)
     ctx.load_dialect(Test)
-    program = textwrap.dedent("""\
+    program = textwrap.dedent(
+        """\
     %in0, %in1 = "test.op"() : () -> (index, index)
     %out0, %out1 = test.int_var %in0, %in1
-    """)
+    """
+    )
 
     parser = Parser(ctx, program)
     test_op = parser.parse_optional_operation()
@@ -3240,7 +3244,7 @@ class ParamExtractorOp(IRDLOperation):
 
 def test_param_extraction_fails():
     ctx = Context()
-    ctx.load_attr(DoubleParamAttr)
+    ctx.load_attr_or_type(DoubleParamAttr)
     ctx.load_op(ParamExtractorOp)
     ctx.load_dialect(Test)
     parser = Parser(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -104,7 +104,7 @@ def test_get_attr():
     ctx.load_attr_or_type(DummyAttr)
 
     assert ctx.get_attr("test.dummy_attr") == DummyAttr
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         _ = ctx.get_attr("test.dummy_attr2")
 
     assert ctx.get_optional_attr("test.dummy_attr") == DummyAttr
@@ -118,7 +118,7 @@ def test_get_type():
     ctx.load_attr_or_type(DummyType)
 
     assert ctx.get_type("test.dummy_type") == DummyType
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         _ = ctx.get_type("test.dummy_attr")
 
     assert ctx.get_optional_type("test.dummy_type") == DummyType

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -226,7 +226,7 @@ def test_load_registered_dialect():
     assert list(ctx.loaded_dialects) == [testDialect]
     assert list(ctx.registered_dialect_names) == ["test"]
     assert list(ctx.loaded_types) == [DummyType]
-    assert list(ctx.loaded_attrs) == [DummyOp]
+    assert list(ctx.loaded_attrs) == [DummyAttr]
 
 
 def test_load_registered_dialect_not_registered():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,7 +4,10 @@ from xdsl.context import Context
 from xdsl.dialects.builtin import UnregisteredAttr, UnregisteredOp
 from xdsl.ir import Dialect, ParametrizedAttribute, TypeAttribute
 from xdsl.irdl import IRDLOperation, irdl_attr_definition, irdl_op_definition
-from xdsl.utils.exceptions import UnregisteredConstructException
+from xdsl.utils.exceptions import (
+    AlreadyRegisteredConstructException,
+    UnregisteredConstructException,
+)
 
 
 @irdl_op_definition
@@ -197,14 +200,20 @@ def test_register_dialect_get_op_attr():
 def test_register_dialect_already_registered():
     ctx = Context()
     ctx.register_dialect("test", lambda: testDialect)
-    with pytest.raises(ValueError, match="'test' dialect is already registered"):
+    with pytest.raises(
+        AlreadyRegisteredConstructException,
+        match="'test' dialect is already registered",
+    ):
         ctx.register_dialect("test", lambda: testDialect2)
 
 
 def test_register_dialect_already_loaded():
     ctx = Context()
     ctx.load_dialect(testDialect)
-    with pytest.raises(ValueError, match="'test' dialect is already registered"):
+    with pytest.raises(
+        AlreadyRegisteredConstructException,
+        match="'test' dialect is already registered",
+    ):
         ctx.register_dialect("test", lambda: testDialect2)
 
 
@@ -236,7 +245,10 @@ def test_load_dialect():
 def test_load_dialect_already_loaded():
     ctx = Context()
     ctx.load_dialect(testDialect)
-    with pytest.raises(ValueError, match="'test' dialect is already registered"):
+    with pytest.raises(
+        AlreadyRegisteredConstructException,
+        match="'test' dialect is already registered",
+    ):
         ctx.load_dialect(testDialect)
 
 
@@ -244,7 +256,7 @@ def test_load_dialect_already_registered():
     ctx = Context()
     ctx.register_dialect("test", lambda: testDialect)
     with pytest.raises(
-        ValueError,
+        AlreadyRegisteredConstructException,
         match="'test' dialect is already registered, use "
         "'load_registered_dialect' instead",
     ):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -225,6 +225,8 @@ def test_load_registered_dialect():
     ctx.load_registered_dialect("test")
     assert list(ctx.loaded_dialects) == [testDialect]
     assert list(ctx.registered_dialect_names) == ["test"]
+    assert list(ctx.loaded_types) == [DummyType]
+    assert list(ctx.loaded_attrs) == [DummyOp]
 
 
 def test_load_registered_dialect_not_registered():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -114,7 +114,7 @@ def test_parsing():
     parse attribute arguments without the delimiters.
     """
     ctx = Context()
-    ctx.load_attr(DummyAttr)
+    ctx.load_attr_or_type(DummyAttr)
 
     prog = '#dummy.attr "foo"'
     parser = Parser(ctx, prog)

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -722,7 +722,7 @@ def test_custom_format_attr():
     ctx = Context()
     ctx.load_dialect(Builtin)
     ctx.load_op(AnyOp)
-    ctx.load_attr(CustomFormatAttr)
+    ctx.load_attr_or_type(CustomFormatAttr)
 
     parser = Parser(ctx, prog)
     module = parser.parse_op()

--- a/xdsl/context.py
+++ b/xdsl/context.py
@@ -19,8 +19,8 @@ class Context:
     _loaded_attrs: dict[str, type[Attribute]] = field(
         default_factory=dict[str, type[Attribute]]
     )
-    _loaded_types: dict[str, type[Attribute]] = field(
-        default_factory=dict[str, type[Attribute]]
+    _loaded_types: dict[str, type[TypeAttribute]] = field(
+        default_factory=dict[str, type[TypeAttribute]]
     )
     _registered_dialects: dict[str, Callable[[], Dialect]] = field(
         default_factory=dict[str, Callable[[], Dialect]]
@@ -55,7 +55,7 @@ class Context:
         return self._loaded_attrs.values()
 
     @property
-    def loaded_types(self) -> Iterable[type[Attribute]]:
+    def loaded_types(self) -> Iterable[type[TypeAttribute]]:
         """
         Returns all the loaded types. Not valid across mutations of this object.
         """
@@ -186,7 +186,7 @@ class Context:
             return op_type
         raise Exception(f"Operation {name} is not registered")
 
-    def get_optional_type(self, name: str) -> type[Attribute] | None:
+    def get_optional_type(self, name: str) -> type[TypeAttribute] | None:
         """
         Get a type definition from its name if it exists.
         If the type is not registered, return None unless unregistered types
@@ -213,7 +213,7 @@ class Context:
             self._loaded_types[name] = attr_type
             return attr_type
 
-    def get_type(self, name: str) -> type[Attribute]:
+    def get_type(self, name: str) -> type[TypeAttribute]:
         """
         Get a type definition from its name.
         If the type is not registered, raise an exception unless unregistered

--- a/xdsl/context.py
+++ b/xdsl/context.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from xdsl.ir import Attribute, Dialect, Operation, TypeAttribute
-from xdsl.utils.exceptions import UnregisteredConstructException
+from xdsl.utils.exceptions import (
+    AlreadyRegisteredConstructException,
+    UnregisteredConstructException,
+)
 
 
 @dataclass
@@ -85,7 +88,9 @@ class Context:
         requested with `load_registered_dialect`.
         """
         if name in self._registered_dialects:
-            raise ValueError(f"'{name}' dialect is already registered")
+            raise AlreadyRegisteredConstructException(
+                f"'{name}' dialect is already registered"
+            )
         self._registered_dialects[name] = dialect_factory
 
     def load_registered_dialect(self, name: str) -> None:
@@ -108,7 +113,7 @@ class Context:
         `load_registered_dialect` instead.
         """
         if dialect.name in self._registered_dialects:
-            raise ValueError(
+            raise AlreadyRegisteredConstructException(
                 f"'{dialect.name}' dialect is already registered, use 'load_registered_dialect' instead"
             )
         self.register_dialect(dialect.name, lambda: dialect)
@@ -117,7 +122,9 @@ class Context:
     def load_op(self, op: "type[Operation]") -> None:
         """Load an operation definition. Operation names should be unique."""
         if op.name in self._loaded_ops:
-            raise Exception(f"Operation {op.name} has already been loaded")
+            raise AlreadyRegisteredConstructException(
+                f"Operation {op.name} has already been loaded"
+            )
         self._loaded_ops[op.name] = op
 
     def load_attr_or_type(self, attr: type[Attribute]) -> None:
@@ -128,11 +135,15 @@ class Context:
         """
         if issubclass(attr, TypeAttribute):
             if attr.name in self._loaded_types:
-                raise Exception(f"Type {attr.name} has already been loaded")
+                raise AlreadyRegisteredConstructException(
+                    f"Type {attr.name} has already been loaded"
+                )
             self._loaded_types[attr.name] = attr
         else:
             if attr.name in self._loaded_attrs:
-                raise Exception(f"Attribute {attr.name} has already been loaded")
+                raise AlreadyRegisteredConstructException(
+                    f"Attribute {attr.name} has already been loaded"
+                )
             self._loaded_attrs[attr.name] = attr
 
     def _get_known_op(self, name: str) -> "type[Operation] | None":

--- a/xdsl/context.py
+++ b/xdsl/context.py
@@ -210,6 +210,7 @@ class Context:
             from xdsl.dialects.builtin import UnregisteredAttr
 
             attr_type = UnregisteredAttr.with_name_and_type(name, True)
+            assert issubclass(attr_type, TypeAttribute)
             self._loaded_types[name] = attr_type
             return attr_type
 
@@ -221,7 +222,7 @@ class Context:
         """
         if attr_type := self.get_optional_type(name):
             return attr_type
-        raise Exception(f"Type {name} is not registered")
+        raise ValueError(f"Type {name} is not registered")
 
     def get_optional_attr(
         self,
@@ -277,7 +278,7 @@ class Context:
         """
         if attr_type := self.get_optional_attr(name, create_unregistered_as_type):
             return attr_type
-        raise Exception(f"Attribute {name} is not registered")
+        raise ValueError(f"Attribute {name} is not registered")
 
     def get_dialect(self, name: str) -> "Dialect":
         if (dialect := self.get_optional_dialect(name)) is None:

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1793,9 +1793,9 @@ class UnregisteredAttr(ParametrizedAttribute, BuiltinAttribute, ABC):
                     raise VerifyException("Unregistered attribute is_type mismatch")
 
         if is_type:
-            return UnregisteredAttrWithName
-        else:
             return UnregisteredAttrTypeWithName
+        else:
+            return UnregisteredAttrWithName
 
 
 @irdl_op_definition

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -239,10 +239,14 @@ class AttrParser(BaseParser):
                     MLIRTokenKind.BARE_IDENT, "Expected attribute name."
                 ).text
             )
-        attr_def = self.ctx.get_optional_attr(
-            attr_name,
-            create_unregistered_as_type=is_type,
-        )
+        if is_type:
+            attr_def = self.ctx.get_optional_type(
+                attr_name,
+            )
+        else:
+            attr_def = self.ctx.get_optional_attr(
+                attr_name,
+            )
         if attr_def is None:
             self.raise_error(f"'{attr_name}' is not registered")
         if issubclass(attr_def, UnregisteredAttr):

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -16,7 +16,19 @@ if typing.TYPE_CHECKING:
 
 
 class UnregisteredConstructException(Exception):
-    """An exception raised when an operation, type, or attribute is not registered"""
+    """
+    An exception raised when a dialect, operation, type,
+    or attribute is not registered.
+    """
+
+    pass
+
+
+class AlreadyRegisteredConstructException(Exception):
+    """
+    An exception raised when a dialect, operation, type,
+    or attribute is registered twice.
+    """
 
     pass
 

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -21,16 +21,12 @@ class UnregisteredConstructException(Exception):
     or attribute is not registered.
     """
 
-    pass
-
 
 class AlreadyRegisteredConstructException(Exception):
     """
     An exception raised when a dialect, operation, type,
     or attribute is registered twice.
     """
-
-    pass
 
 
 class DiagnosticException(Exception):

--- a/xdsl/utils/exceptions.py
+++ b/xdsl/utils/exceptions.py
@@ -15,6 +15,12 @@ if typing.TYPE_CHECKING:
     from xdsl.utils.parse_pipeline import Token
 
 
+class UnregisteredConstructException(Exception):
+    """An exception raised when an operation, type, or attribute is not registered"""
+
+    pass
+
+
 class DiagnosticException(Exception):
     pass
 


### PR DESCRIPTION
With this change, it should be possible to have an attribute and a type of the same name, which is necessary to handle the MLIR `emitc` dialect.