### PR TITLE
core: Add nicer error messages for RangeOf

### DIFF
--- a/xdsl/irdl/constraints.py
+++ b/xdsl/irdl/constraints.py
@@ -893,7 +893,12 @@ class RangeOf(GenericRangeConstraint[AttributeCovT]):
     ) -> None:
         for a in attrs:
             self.constr.verify(a, constraint_context)
-        self.length.verify(len(attrs), constraint_context)
+        try:
+            self.length.verify(len(attrs), constraint_context)
+        except VerifyException as e:
+            raise VerifyException(
+                "incorrect length for range variable:\n" + str(e)
+            ) from e
 
     def get_length_extractors(self) -> dict[str, VarExtractor[int]]:
         return self.length.get_length_extractors()


### PR DESCRIPTION
This PR adds the following prefix on a verification error for range length constraints:
"incorrect length for range variable:"