### PR TITLE
dialects: (ptr) add FromPtrOp

### DIFF
--- a/tests/filecheck/dialects/ptr/ops.mlir
+++ b/tests/filecheck/dialects/ptr/ops.mlir
@@ -16,3 +16,6 @@ ptr_xdsl.store %v, %p : i32, !ptr_xdsl.ptr
 
 // CHECK-NEXT: %pm = ptr_xdsl.to_ptr %m : memref<10xi32> -> !ptr_xdsl.ptr
 %pm = ptr_xdsl.to_ptr %m : memref<10xi32> -> !ptr_xdsl.ptr
+
+// CHECK-NEXT: %mp = ptr_xdsl.from_ptr %p : !ptr_xdsl.ptr -> memref<10xi32>
+%mp = ptr_xdsl.from_ptr %p : !ptr_xdsl.ptr -> memref<10xi32>

--- a/xdsl/dialects/ptr.py
+++ b/xdsl/dialects/ptr.py
@@ -91,6 +91,16 @@ class ToPtrOp(IRDLOperation):
     assembly_format = "$source attr-dict `:` type($source) `->` type($res)"
 
 
+@irdl_op_definition
+class FromPtrOp(IRDLOperation):
+    name = "ptr_xdsl.from_ptr"
+
+    source = operand_def(PtrType)
+    res = result_def(MemRefType)
+
+    assembly_format = "$source attr-dict `:` type($source) `->` type($res)"
+
+
 Ptr = Dialect(
     "ptr_xdsl",
     [
@@ -99,6 +109,7 @@ Ptr = Dialect(
         StoreOp,
         LoadOp,
         ToPtrOp,
+        FromPtrOp,
     ],
     [
         PtrType,


### PR DESCRIPTION
PR 1/2 adding the canonicalization patterns from [here](https://github.com/llvm/llvm-project/pull/137469/files) that remove chains of to_ptr and from_ptr ops in a simpler way than removing reinterpret casts.