### PR TITLE
backend: (riscv) use RegisterAllocationOperation for snitch reserved registers

### DIFF
--- a/tests/filecheck/backend/riscv/register-allocation/exclude_snitch.mlir
+++ b/tests/filecheck/backend/riscv/register-allocation/exclude_snitch.mlir
@@ -1,5 +1,4 @@
 // RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive}" %s | filecheck %s
-// RUN: xdsl-opt --split-input-file -p "riscv-allocate-registers{allocation_strategy=LivenessBlockNaive exclude_snitch_reserved=false}" %s | filecheck %s --check-prefix=CHECK-SNITCH-UNRESERVED
 
 riscv_func.func @main() {
   %stream = "test.op"() : () -> (!snitch.readable<!riscv.freg<ft0>>)
@@ -18,16 +17,6 @@ riscv_func.func @main() {
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
-// CHECK-SNITCH-UNRESERVED:       builtin.module {
-// CHECK-SNITCH-UNRESERVED-NEXT:    riscv_func.func @main() {
-// CHECK-SNITCH-UNRESERVED-NEXT:      %stream = "test.op"() : () -> !snitch.readable<!riscv.freg<ft0>>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg)
-// CHECK-SNITCH-UNRESERVED-NEXT:      %read = riscv_snitch.read from %stream : !riscv.freg<ft0>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft1>, !riscv.freg<ft2>) -> !riscv.freg<ft1>
-// CHECK-SNITCH-UNRESERVED-NEXT:      riscv_func.return
-// CHECK-SNITCH-UNRESERVED-NEXT:    }
-// CHECK-SNITCH-UNRESERVED-NEXT:  }
 
 // -----
 
@@ -48,13 +37,3 @@ riscv_func.func @main() {
 // CHECK-NEXT:      riscv_func.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-
-// CHECK-SNITCH-UNRESERVED:       builtin.module {
-// CHECK-SNITCH-UNRESERVED-NEXT:    riscv_func.func @main() {
-// CHECK-SNITCH-UNRESERVED-NEXT:      %stream, %val = "test.op"() : () -> (!snitch.writable<!riscv.freg<ft0>>, !riscv.freg<ft0>)
-// CHECK-SNITCH-UNRESERVED-NEXT:      %v0, %v1, %v2 = "test.op"() : () -> (!riscv.freg<ft1>, !riscv.freg<ft2>, !riscv.freg)
-// CHECK-SNITCH-UNRESERVED-NEXT:      riscv_snitch.write %val to %stream : !riscv.freg<ft0>
-// CHECK-SNITCH-UNRESERVED-NEXT:      %sum1 = riscv.fadd.s %v0, %v1 : (!riscv.freg<ft1>, !riscv.freg<ft2>) -> !riscv.freg<ft1>
-// CHECK-SNITCH-UNRESERVED-NEXT:      riscv_func.return
-// CHECK-SNITCH-UNRESERVED-NEXT:    }
-// CHECK-SNITCH-UNRESERVED-NEXT:  }

--- a/xdsl/dialects/riscv_snitch.py
+++ b/xdsl/dialects/riscv_snitch.py
@@ -181,6 +181,13 @@ class ReadOp(RISCVAsmOperation):
     def assembly_line(self) -> str | None:
         return None
 
+    def iter_used_registers(self):
+        # When streaming, FT0, FT1, and FT2 cannot be used as general-purpose float
+        # registers
+        yield riscv.Registers.FT0
+        yield riscv.Registers.FT1
+        yield riscv.Registers.FT2
+
 
 @irdl_op_definition
 class WriteOp(RISCVAsmOperation):
@@ -198,6 +205,13 @@ class WriteOp(RISCVAsmOperation):
 
     def assembly_line(self) -> str | None:
         return None
+
+    def iter_used_registers(self):
+        # When streaming, FT0, FT1, and FT2 cannot be used as general-purpose float
+        # registers
+        yield riscv.Registers.FT0
+        yield riscv.Registers.FT1
+        yield riscv.Registers.FT2
 
 
 ALLOWED_FREP_OP_TYPES = (

--- a/xdsl/transforms/riscv_register_allocation.py
+++ b/xdsl/transforms/riscv_register_allocation.py
@@ -20,9 +20,6 @@ class RISCVRegisterAllocation(ModulePass):
 
     limit_registers: int | None = None
 
-    exclude_snitch_reserved: bool = True
-    """Excludes floating-point registers that are used by the Snitch ISA extensions."""
-
     add_regalloc_stats: bool = False
     """
     Inserts a comment with register allocation info in the IR.
@@ -53,7 +50,6 @@ class RISCVRegisterAllocation(ModulePass):
                 allocator = allocator_strategies[self.allocation_strategy](
                     riscv_register_queue
                 )
-                allocator.exclude_snitch_reserved = self.exclude_snitch_reserved
                 allocator.allocate_func(
                     inner_op, add_regalloc_stats=self.add_regalloc_stats
                 )

--- a/xdsl/transforms/snitch_register_allocation.py
+++ b/xdsl/transforms/snitch_register_allocation.py
@@ -14,19 +14,6 @@ from xdsl.pattern_rewriter import (
 )
 
 
-def get_snitch_reserved() -> set[riscv.FloatRegisterType]:
-    """
-    Utility method to make explicit the Snitch ISA assumptions wrt the
-    floating-point registers that are considered reserved.
-    Currently, the first 3 floating-point registers are reserved.
-    """
-
-    num_reserved = 3
-    assert len(riscv.Registers.FT) >= num_reserved
-
-    return {riscv.Registers.FT[i] for i in range(0, num_reserved)}
-
-
 class AllocateSnitchStreamingRegionRegisters(RewritePattern):
     """
     Allocates the registers in the body of a `snitch_stream.streaming_region` operation by


### PR DESCRIPTION
Move some of the snitch-specific logic out of the generic RISC-V register allocator, and to the appropriate operations. This preserves the current behaviour of reserving the snitch registers for the whole function if there are any snitch reads or writes.