### PR TITLE
core: only pass constraints to `isattr`

### DIFF
--- a/tests/test_is_satisfying_hint.py
+++ b/tests/test_is_satisfying_hint.py
@@ -394,8 +394,6 @@ def test_literal():
 
 
 def test_isattr():
-    assert isattr(IntAttr(1), IntAttr)
-    assert not isattr(IntAttr(1), StringAttr)
     assert isattr(IntAttr(1), BaseAttr(IntAttr))
     assert not isattr(IntAttr(1), BaseAttr(StringAttr))
     assert isattr(IntAttr(1), EqAttrConstraint(IntAttr(1)))

--- a/xdsl/dialects/csl/csl.py
+++ b/xdsl/dialects/csl/csl.py
@@ -89,7 +89,6 @@ from xdsl.traits import (
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
-from xdsl.utils.isattr import isattr
 from xdsl.utils.str_enum import StrEnum
 
 Target = Literal["wse2", "wse3"]
@@ -1794,7 +1793,7 @@ class SymbolExportOp(IRDLOperation):
         )
 
         if isinstance(type_or_op, SSAValue):
-            assert isattr(type_or_op.type, PtrType)
+            assert isinstance(type_or_op.type, PtrType)
             sym_type, ops = type_or_op.type, [type_or_op]
         else:
             var_name = SymbolRefAttr(var_name)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -69,7 +69,6 @@ from xdsl.traits import (
 )
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
-from xdsl.utils.isattr import isattr
 from xdsl.utils.str_enum import StrEnum
 
 GEP_USE_SSA_VAL = -2147483648
@@ -1586,7 +1585,7 @@ class ConstantOp(IRDLOperation):
 
     def print(self, printer: Printer) -> None:
         printer.print("(")
-        if isattr(self.value, IntegerAttr) and self.result.type == IntegerType(64):
+        if isa(self.value, IntegerAttr) and self.result.type == IntegerType(64):
             self.value.print_without_type(printer)
         else:
             printer.print(self.value)

--- a/xdsl/transforms/convert_stencil_to_csl_stencil.py
+++ b/xdsl/transforms/convert_stencil_to_csl_stencil.py
@@ -582,7 +582,7 @@ class PromoteCoefficients(RewritePattern):
             return
 
         val = dense.get_attrs()[0]
-        assert isattr(val, FloatAttr)
+        assert isinstance(val, FloatAttr)
         apply.add_coeff(op.offset, val)
         rewriter.replace_op(mulf, [], new_results=[op.result])
 

--- a/xdsl/transforms/lower_csl_stencil.py
+++ b/xdsl/transforms/lower_csl_stencil.py
@@ -43,7 +43,6 @@ from xdsl.transforms.csl_stencil_set_global_coeffs import (
     get_dir_and_distance_ops,
 )
 from xdsl.utils.hints import isa
-from xdsl.utils.isattr import isattr
 
 
 def _get_module_wrapper(op: Operation) -> csl_wrapper.ModuleOp | None:
@@ -358,7 +357,7 @@ class FullStencilAccessImmediateReductionOptimization(RewritePattern):
             return
 
         if (
-            not isattr(accumulator.type, MemRefType)
+            not isa(accumulator.type, MemRefType)
             or not isinstance(op.accumulator, OpResult)
             or not isinstance(alloc := op.accumulator.op, memref.AllocOp)
         ):

--- a/xdsl/transforms/lower_csl_wrapper.py
+++ b/xdsl/transforms/lower_csl_wrapper.py
@@ -55,7 +55,7 @@ class ExtractCslModules(RewritePattern):
 
         params = list[SSAValue]()
         for param in op.params:
-            if isattr(param.value, builtin.IntegerAttr):
+            if isinstance(param.value, builtin.IntegerAttr):
                 value = arith.ConstantOp(param.value)
             else:
                 value = None

--- a/xdsl/utils/isattr.py
+++ b/xdsl/utils/isattr.py
@@ -1,16 +1,12 @@
-from typing import TYPE_CHECKING, Any, TypeGuard
+from typing import Any, TypeGuard
 
 from xdsl.ir import AttributeInvT
 from xdsl.irdl import GenericAttrConstraint
 from xdsl.utils.exceptions import VerifyException
-from xdsl.utils.hints import isa
-
-if TYPE_CHECKING:
-    from typing_extensions import TypeForm
 
 
 def isattr(
-    arg: Any, hint: "TypeForm[AttributeInvT]" | GenericAttrConstraint[AttributeInvT]
+    arg: Any, hint: GenericAttrConstraint[AttributeInvT]
 ) -> TypeGuard[AttributeInvT]:
     """
     A helper method to check whether a given attribute has a given type or conforms to a
@@ -18,11 +14,8 @@ def isattr(
     """
     from xdsl.irdl import ConstraintContext
 
-    if isinstance(hint, GenericAttrConstraint):
-        try:
-            hint.verify(arg, ConstraintContext())
-            return True
-        except VerifyException:
-            return False
-
-    return isa(arg, hint)
+    try:
+        hint.verify(arg, ConstraintContext())
+        return True
+    except VerifyException:
+        return False


### PR DESCRIPTION
Now that `isa` handles `TypeForm`, we don't need duplicated functionality in `isattr`, making the API a bit simpler.