### PR TITLE
dialects: (ptr) add canonicalization patterns to remove to/from ptr

### DIFF
--- a/tests/filecheck/dialects/ptr/canonicalize.mlir
+++ b/tests/filecheck/dialects/ptr/canonicalize.mlir
@@ -1,0 +1,23 @@
+// RUN: xdsl-opt -p canonicalize %s | filecheck %s
+
+// CHECK-LABEL: @test_from_ptr_0
+// CHECK-SAME: (%mr : memref<f32>)
+func.func @test_from_ptr_0(%mr: memref<f32>) -> memref<f32> {
+  // CHECK-NOT: ptr.to_ptr
+  // CHECK-NOT: ptr.from_ptr
+  // CHECK: return %mr
+  %ptr = ptr_xdsl.to_ptr %mr : memref<f32> -> !ptr_xdsl.ptr
+  %res = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<f32>
+  return %mr : memref<f32>
+}
+
+// CHECK-LABEL: @test_to_ptr_0
+// CHECK-SAME: (%ptr : !ptr_xdsl.ptr)
+func.func @test_to_ptr_0(%ptr: !ptr_xdsl.ptr) -> !ptr_xdsl.ptr {
+  // CHECK-NOT: ptr.to_ptr
+  // CHECK-NOT: ptr.from_ptr
+  // CHECK: return %ptr
+  %mr = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<f32>
+  %res = ptr_xdsl.to_ptr %mr : memref<f32> -> !ptr_xdsl.ptr
+  return %res : !ptr_xdsl.ptr
+}

--- a/tests/filecheck/dialects/ptr/canonicalize.mlir
+++ b/tests/filecheck/dialects/ptr/canonicalize.mlir
@@ -11,6 +11,23 @@ func.func @test_from_ptr_0(%mr: memref<f32>) -> memref<f32> {
   return %res : memref<f32>
 }
 
+// CHECK-LABEL: @test_from_ptr_1
+// CHECK-SAME: (%mr : memref<f32>)
+func.func @test_from_ptr_1(%mr: memref<f32>) -> !ptr_xdsl.ptr {
+  // CHECK: return %ptr
+  %ptr = ptr_xdsl.to_ptr %mr : memref<f32> -> !ptr_xdsl.ptr
+  return %ptr : !ptr_xdsl.ptr
+}
+
+// CHECK-LABEL: @test_from_ptr_2
+// CHECK-SAME: (%mr : memref<2x2xf32>)
+func.func @test_from_ptr_2(%mr: memref<2x2xf32>) -> memref<4xf32> {
+  // CHECK: return %res
+  %ptr = ptr_xdsl.to_ptr %mr : memref<2x2xf32> -> !ptr_xdsl.ptr
+  %res = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<4xf32>
+  return %res : memref<4xf32>
+}
+
 // CHECK-LABEL: @test_to_ptr_0
 // CHECK-SAME: (%ptr : !ptr_xdsl.ptr)
 func.func @test_to_ptr_0(%ptr: !ptr_xdsl.ptr) -> !ptr_xdsl.ptr {
@@ -20,4 +37,12 @@ func.func @test_to_ptr_0(%ptr: !ptr_xdsl.ptr) -> !ptr_xdsl.ptr {
   %mr = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<f32>
   %res = ptr_xdsl.to_ptr %mr : memref<f32> -> !ptr_xdsl.ptr
   return %res : !ptr_xdsl.ptr
+}
+
+// CHECK-LABEL: @test_to_ptr_1
+// CHECK-SAME: (%ptr : !ptr_xdsl.ptr)
+func.func @test_to_ptr_1(%ptr: !ptr_xdsl.ptr) -> memref<f32> {
+  // CHECK: return %mr
+  %mr = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<f32>
+  return %mr : memref<f32>
 }

--- a/tests/filecheck/dialects/ptr/canonicalize.mlir
+++ b/tests/filecheck/dialects/ptr/canonicalize.mlir
@@ -8,7 +8,7 @@ func.func @test_from_ptr_0(%mr: memref<f32>) -> memref<f32> {
   // CHECK: return %mr
   %ptr = ptr_xdsl.to_ptr %mr : memref<f32> -> !ptr_xdsl.ptr
   %res = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<f32>
-  return %mr : memref<f32>
+  return %res : memref<f32>
 }
 
 // CHECK-LABEL: @test_to_ptr_0

--- a/xdsl/transforms/canonicalization_patterns/ptr.py
+++ b/xdsl/transforms/canonicalization_patterns/ptr.py
@@ -1,0 +1,26 @@
+from xdsl.dialects import ptr
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+
+class RedundantFromPtr(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.FromPtrOp, rewriter: PatternRewriter, /):
+        if not isinstance(origin := op.source.owner, ptr.ToPtrOp):
+            return
+
+        if origin.source.type == op.res.type:
+            rewriter.replace_matched_op((), (origin.source,))
+
+
+class RedundantToPtr(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.ToPtrOp, rewriter: PatternRewriter, /):
+        if not isinstance(origin := op.source.owner, ptr.FromPtrOp):
+            return
+
+        if origin.source.type == op.res.type:
+            rewriter.replace_matched_op((), (origin.source,))


### PR DESCRIPTION
Add canonicalization patterns to remove a roundtrip of to/from ptr. These are based on the patterns proposed in [the corresponding MLIR PR](https://github.com/llvm/llvm-project/pull/137469/files), because we don't yet have memory space annotations on `!ptr.ptr`, and will have to be adjusted once that's added.