### PR TITLE
transformations: (convert-memref-to-ptr) use to/from ptr ops for casts

### DIFF
--- a/tests/filecheck/transforms/convert_memref_args_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_memref_args_to_ptr.mlir
@@ -14,15 +14,21 @@ func.func @simple(%arg : memref<2x2xf32>) {
 }
 
 // CHECK-NEXT:    func.func @id(%arg : !ptr_xdsl.ptr) -> !ptr_xdsl.ptr {
-// CHECK-NEXT:      func.return %arg : !ptr_xdsl.ptr
+// CHECK-NEXT:      %arg_1 = ptr_xdsl.from_ptr %arg : !ptr_xdsl.ptr -> memref<2x2xf32>
+// CHECK-NEXT:      %arg_2 = ptr_xdsl.to_ptr %arg_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      func.return %arg_2 : !ptr_xdsl.ptr
 // CHECK-NEXT:    }
 func.func @id(%arg : memref<2x2xf32>) -> memref<2x2xf32> {
     func.return %arg : memref<2x2xf32>
 }
 
 // CHECK-NEXT:    func.func @id2(%arg : !ptr_xdsl.ptr) -> !ptr_xdsl.ptr {
-// CHECK-NEXT:      %res = func.call @id(%arg) : (!ptr_xdsl.ptr) -> !ptr_xdsl.ptr
-// CHECK-NEXT:      func.return %res : !ptr_xdsl.ptr
+// CHECK-NEXT:      %arg_1 = ptr_xdsl.from_ptr %arg : !ptr_xdsl.ptr -> memref<2x2xf32>
+// CHECK-NEXT:      %arg_2 = ptr_xdsl.to_ptr %arg_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %res = func.call @id(%arg_2) : (!ptr_xdsl.ptr) -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %res_1 = ptr_xdsl.from_ptr %res : !ptr_xdsl.ptr -> memref<2x2xf32>
+// CHECK-NEXT:      %res_2 = ptr_xdsl.to_ptr %res_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      func.return %res_2 : !ptr_xdsl.ptr
 // CHECK-NEXT:    }
 func.func @id2(%arg : memref<2x2xf32>) -> memref<2x2xf32> {
     %res = func.call @id(%arg) : (memref<2x2xf32>) -> memref<2x2xf32>
@@ -30,7 +36,9 @@ func.func @id2(%arg : memref<2x2xf32>) -> memref<2x2xf32> {
 }
 
 // CHECK-NEXT:    func.func @first(%arg : !ptr_xdsl.ptr) -> f32 {
-// CHECK-NEXT:      %res = ptr_xdsl.load %arg : !ptr_xdsl.ptr -> f32
+// CHECK-NEXT:      %arg_1 = ptr_xdsl.from_ptr %arg : !ptr_xdsl.ptr -> memref<2x2xf32>
+// CHECK-NEXT:      %pointer = ptr_xdsl.to_ptr %arg_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %res = ptr_xdsl.load %pointer : !ptr_xdsl.ptr -> f32
 // CHECK-NEXT:      func.return %res : f32
 // CHECK-NEXT:    }
 func.func @first(%arg : memref<2x2xf32>) -> f32 {

--- a/tests/filecheck/transforms/convert_memref_args_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_memref_args_to_ptr.mlir
@@ -13,26 +13,32 @@ func.func @simple(%arg : memref<2x2xf32>) {
     func.return
 }
 
-// CHECK-NEXT:    func.func @id(%arg : !ptr_xdsl.ptr) -> !ptr_xdsl.ptr {
-// CHECK-NEXT:      %arg_1 = ptr_xdsl.from_ptr %arg : !ptr_xdsl.ptr -> memref<2x2xf32>
-// CHECK-NEXT:      %arg_2 = ptr_xdsl.to_ptr %arg_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:      func.return %arg_2 : !ptr_xdsl.ptr
+// CHECK-NEXT:    func.func @id(%arg0 : !ptr_xdsl.ptr, %arg1 : !ptr_xdsl.ptr) -> (!ptr_xdsl.ptr, !ptr_xdsl.ptr) {
+// CHECK-NEXT:      %arg0_1 = ptr_xdsl.from_ptr %arg0 : !ptr_xdsl.ptr -> memref<2x2xf32>
+// CHECK-NEXT:      %arg1_1 = ptr_xdsl.from_ptr %arg1 : !ptr_xdsl.ptr -> memref<3x3xf32>
+// CHECK-NEXT:      %arg0_2 = ptr_xdsl.to_ptr %arg0_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %arg1_2 = ptr_xdsl.to_ptr %arg1_1 : memref<3x3xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      func.return %arg0_2, %arg1_2 : !ptr_xdsl.ptr, !ptr_xdsl.ptr
 // CHECK-NEXT:    }
-func.func @id(%arg : memref<2x2xf32>) -> memref<2x2xf32> {
-    func.return %arg : memref<2x2xf32>
+func.func @id(%arg0 : memref<2x2xf32>, %arg1: memref<3x3xf32>) -> (memref<2x2xf32>, memref<3x3xf32>) {
+    func.return %arg0, %arg1 : memref<2x2xf32>, memref<3x3xf32>
 }
 
-// CHECK-NEXT:    func.func @id2(%arg : !ptr_xdsl.ptr) -> !ptr_xdsl.ptr {
-// CHECK-NEXT:      %arg_1 = ptr_xdsl.from_ptr %arg : !ptr_xdsl.ptr -> memref<2x2xf32>
-// CHECK-NEXT:      %arg_2 = ptr_xdsl.to_ptr %arg_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:      %res = func.call @id(%arg_2) : (!ptr_xdsl.ptr) -> !ptr_xdsl.ptr
-// CHECK-NEXT:      %res_1 = ptr_xdsl.from_ptr %res : !ptr_xdsl.ptr -> memref<2x2xf32>
-// CHECK-NEXT:      %res_2 = ptr_xdsl.to_ptr %res_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:      func.return %res_2 : !ptr_xdsl.ptr
+// CHECK-NEXT:    func.func @id2(%arg0 : !ptr_xdsl.ptr, %arg1 : !ptr_xdsl.ptr) -> (!ptr_xdsl.ptr, !ptr_xdsl.ptr) {
+// CHECK-NEXT:      %arg0_1 = ptr_xdsl.from_ptr %arg0 : !ptr_xdsl.ptr -> memref<2x2xf32>
+// CHECK-NEXT:      %arg1_1 = ptr_xdsl.from_ptr %arg1 : !ptr_xdsl.ptr -> memref<3x3xf32>
+// CHECK-NEXT:      %arg0_2 = ptr_xdsl.to_ptr %arg0_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %arg1_2 = ptr_xdsl.to_ptr %arg1_1 : memref<3x3xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %resa, %resb = func.call @id(%arg0_2, %arg1_2) : (!ptr_xdsl.ptr, !ptr_xdsl.ptr) -> (!ptr_xdsl.ptr, !ptr_xdsl.ptr)
+// CHECK-NEXT:      %resa_1 = ptr_xdsl.from_ptr %resa : !ptr_xdsl.ptr -> memref<2x2xf32>
+// CHECK-NEXT:      %resb_1 = ptr_xdsl.from_ptr %resb : !ptr_xdsl.ptr -> memref<3x3xf32>
+// CHECK-NEXT:      %resa_2 = ptr_xdsl.to_ptr %resa_1 : memref<2x2xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      %resb_2 = ptr_xdsl.to_ptr %resb_1 : memref<3x3xf32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:      func.return %resa_2, %resb_2 : !ptr_xdsl.ptr, !ptr_xdsl.ptr
 // CHECK-NEXT:    }
-func.func @id2(%arg : memref<2x2xf32>) -> memref<2x2xf32> {
-    %res = func.call @id(%arg) : (memref<2x2xf32>) -> memref<2x2xf32>
-    func.return %res : memref<2x2xf32>
+func.func @id2(%arg0 : memref<2x2xf32>, %arg1 : memref<3x3xf32>) -> (memref<2x2xf32>, memref<3x3xf32>) {
+    %resa, %resb = func.call @id(%arg0, %arg1) : (memref<2x2xf32>, memref<3x3xf32>) -> (memref<2x2xf32>, memref<3x3xf32>)
+    func.return %resa, %resb : memref<2x2xf32>, memref<3x3xf32>
 }
 
 // CHECK-NEXT:    func.func @first(%arg : !ptr_xdsl.ptr) -> f32 {

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -16,6 +16,7 @@ from xdsl.pattern_rewriter import (
 )
 from xdsl.rewriter import InsertPoint
 from xdsl.utils.exceptions import DiagnosticException
+from xdsl.utils.hints import isa
 
 
 def offset_calculations(
@@ -182,10 +183,10 @@ class LowerMemRefFuncOpPattern(RewritePattern):
                 continue
 
             rewriter.insert_op(
-                cast_op := builtin.UnrealizedConversionCastOp.get([arg], [old_type]),
+                cast_op := ptr.FromPtrOp(arg, old_type),
                 insert_point,
             )
-            arg.replace_by_if(cast_op.results[0], lambda x: x.operation is not cast_op)
+            arg.replace_by_if(cast_op.res, lambda x: x.operation is not cast_op)
 
 
 @dataclass
@@ -199,19 +200,14 @@ class LowerMemRefFuncReturnPattern(RewritePattern):
         if not any(isinstance(arg.type, memref.MemRefType) for arg in op.arguments):
             return
 
-        insert_point = InsertPoint.before(op)
         new_arguments: list[SSAValue] = []
 
         # insert `memref -> ptr` casts for memref return values
         for argument in op.arguments:
             if isinstance(argument.type, memref.MemRefType):
-                rewriter.insert_op(
-                    cast_op := builtin.UnrealizedConversionCastOp.get(
-                        [argument], [ptr.PtrType()]
-                    ),
-                    insert_point,
-                )
-                new_arguments.append(cast_op.results[0])
+                rewriter.insert_op_before_matched_op(cast_op := ptr.ToPtrOp(argument))
+                new_arguments.append(cast_op.res)
+                cast_op.res.name_hint = argument.name_hint
             else:
                 new_arguments.append(argument)
 
@@ -228,37 +224,31 @@ class LowerMemRefFuncCallPattern(RewritePattern):
             return
 
         # rewrite arguments
-        insert_point = InsertPoint.before(op)
         new_arguments: list[SSAValue] = []
 
         # insert `memref -> ptr` casts for memref arguments values
         for argument in op.arguments:
             if isinstance(argument.type, memref.MemRefType):
-                rewriter.insert_op(
-                    cast_op := builtin.UnrealizedConversionCastOp.get(
-                        [argument], [ptr.PtrType()]
-                    ),
-                    insert_point,
+                rewriter.insert_op_before_matched_op(cast_op := ptr.ToPtrOp(argument))
+                new_arguments.append(cast_op.res)
+                cast_op.res.name_hint = argument.name_hint
+                argument.replace_by_if(
+                    cast_op.res, lambda x: x.operation is not cast_op
                 )
-                new_arguments.append(cast_op.results[0])
             else:
                 new_arguments.append(argument)
 
-        insert_point = InsertPoint.after(op)
         new_results: list[SSAValue] = []
 
         #  insert `ptr -> memref` casts for return values
         for result in op.results:
-            if isinstance(result.type, memref.MemRefType):
-                rewriter.insert_op(
-                    cast_op := builtin.UnrealizedConversionCastOp.get(
-                        [result],
-                        # TODO: annoying pyright warnings - Sasha, pls help
-                        [result.type],  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
-                    ),
-                    insert_point,
+            if isa(result.type, memref.MemRefType):
+                rewriter.insert_op_after_matched_op(
+                    cast_op := ptr.FromPtrOp(result, result.type)
                 )
-                new_results.append(cast_op.results[0])
+                new_results.append(cast_op.res)
+                cast_op.res.name_hint = result.name_hint
+                result.replace_by_if(cast_op.res, lambda x: x.operation is not cast_op)
             else:
                 new_results.append(result)
 
@@ -270,49 +260,6 @@ class LowerMemRefFuncCallPattern(RewritePattern):
         rewriter.replace_matched_op(
             func.CallOp(op.callee, new_arguments, new_return_types)
         )
-
-
-class ReconcileUnrealizedPtrCasts(RewritePattern):
-    """
-    Eliminates two variants of unrealized ptr casts:
-    - `ptr_xdsl.ptr -> memref.MemRef -> ptr_xdsl.ptr`;
-    - `ptr_xdsl.ptr -> memref.memref` where all uses are `ToPtrOp` operations.
-    """
-
-    @op_type_rewrite_pattern
-    def match_and_rewrite(
-        self, op: builtin.UnrealizedConversionCastOp, rewriter: PatternRewriter, /
-    ):
-        # preconditions
-        if (
-            len(op.inputs) != 1
-            or len(op.outputs) != 1
-            or not isinstance(op.inputs[0].type, ptr.PtrType)
-            or not isinstance(op.outputs[0].type, memref.MemRefType)
-        ):
-            return
-
-        # erase ptr -> memref -> ptr cast pairs
-        uses = tuple(use for use in op.outputs[0].uses)
-        for use in uses:
-            if (
-                isinstance(use.operation, builtin.UnrealizedConversionCastOp)
-                and isinstance(use.operation.inputs[0].type, memref.MemRefType)
-                and isinstance(use.operation.outputs[0].type, ptr.PtrType)
-            ):
-                use.operation.outputs[0].replace_by(op.inputs[0])
-                rewriter.erase_op(use.operation)
-
-        # erase this cast entirely if all remaining uses are by ToPtr operations
-        cast_ops = [use.operation for use in op.outputs[0].uses]
-        if not all(isinstance(op, ptr.ToPtrOp) for op in cast_ops):
-            return
-
-        for cast_op in cast_ops:
-            cast_op.results[0].replace_by(op.inputs[0])
-            rewriter.erase_op(cast_op)
-
-        rewriter.erase_op(op)
 
 
 @dataclass(frozen=True)
@@ -333,7 +280,6 @@ class ConvertMemRefToPtr(ModulePass):
                         LowerMemRefFuncOpPattern(),
                         LowerMemRefFuncCallPattern(),
                         LowerMemRefFuncReturnPattern(),
-                        ReconcileUnrealizedPtrCasts(),
                     ]
                 )
             ).rewrite_module(op)

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -235,19 +235,14 @@ class LowerMemRefFuncCallPattern(RewritePattern):
             else:
                 new_arguments.append(argument)
 
-        new_results: list[SSAValue] = []
-
         #  insert `ptr -> memref` casts for return values
         for result in op.results:
             if isa(result.type, memref.MemRefType):
                 rewriter.insert_op_after_matched_op(
                     cast_op := ptr.FromPtrOp(result, result.type)
                 )
-                new_results.append(cast_op.res)
                 cast_op.res.name_hint = result.name_hint
                 result.replace_by_if(cast_op.res, lambda x: x.operation is not cast_op)
-            else:
-                new_results.append(result)
 
         new_return_types = [
             ptr.PtrType() if isinstance(type, memref.MemRefType) else type

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -232,9 +232,6 @@ class LowerMemRefFuncCallPattern(RewritePattern):
                 rewriter.insert_op_before_matched_op(cast_op := ptr.ToPtrOp(argument))
                 new_arguments.append(cast_op.res)
                 cast_op.res.name_hint = argument.name_hint
-                argument.replace_by_if(
-                    cast_op.res, lambda x: x.operation is not cast_op
-                )
             else:
                 new_arguments.append(argument)
 


### PR DESCRIPTION
These are a simpler kind of cast to deal with than the unrealized cast, and can trivially be removed by canonicalization. This simplifies #4331.