### PR TITLE
dialects: (vector) Add nontemporal to vector.load and vector.store

### DIFF
--- a/tests/filecheck/dialects/vector/vector_ops.mlir
+++ b/tests/filecheck/dialects/vector/vector_ops.mlir
@@ -3,6 +3,10 @@
 func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %i : index, %fvec : vector<2xf32>) {
   %load = vector.load %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
   vector.store %load, %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+  %load_nontemporal = vector.load %base[%i, %i] {"nontemporal" = false} : memref<4x4xindex>, vector<2xindex>
+  vector.store %load_nontemporal, %base[%i, %i] {"nontemporal" = false} : memref<4x4xindex>, vector<2xindex>
+  %load_nontemporal_1 = vector.load %base[%i, %i] {"nontemporal" = true} : memref<4x4xindex>, vector<2xindex>
+  vector.store %load_nontemporal_1, %base[%i, %i] {"nontemporal" = true} : memref<4x4xindex>, vector<2xindex>
   %broadcast = vector.broadcast %i : index to vector<1xindex>
   %fma = vector.fma %fvec, %fvec, %fvec : vector<2xf32>
   %masked_load = vector.maskedload %base[%i, %i], %vec, %broadcast : memref<4x4xindex>, vector<1xi1>, vector<1xindex> into vector<1xindex>
@@ -19,6 +23,10 @@ func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %
 // CHECK:       func.func private @vector_test(%base : memref<4x4xindex>, %vec : vector<1xi1>, %i : index, %fvec : vector<2xf32>) {
 // CHECK-NEXT:     %load = vector.load %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
 // CHECK-NEXT:     vector.store %load, %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+// CHECK-NEXT:     %load_nontemporal = vector.load %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+// CHECK-NEXT:     vector.store %load_nontemporal, %base[%i, %i] : memref<4x4xindex>, vector<2xindex>
+// CHECK-NEXT:     %load_nontemporal_1 = vector.load %base[%i, %i] {nontemporal = true} : memref<4x4xindex>, vector<2xindex>
+// CHECK-NEXT:     vector.store %load_nontemporal_1, %base[%i, %i] {nontemporal = true} : memref<4x4xindex>, vector<2xindex>
 // CHECK-NEXT:     %broadcast = vector.broadcast %i : index to vector<1xindex>
 // CHECK-NEXT:     %fma = vector.fma %fvec, %fvec, %fvec : vector<2xf32>
 // CHECK-NEXT:     %masked_load = vector.maskedload %base[%i, %i], %vec, %broadcast : memref<4x4xindex>, vector<1xi1>, vector<1xindex> into vector<1xindex>

--- a/xdsl/dialects/vector.py
+++ b/xdsl/dialects/vector.py
@@ -40,6 +40,7 @@ from xdsl.irdl import (
     irdl_op_definition,
     operand_def,
     opt_operand_def,
+    opt_prop_def,
     opt_result_def,
     prop_def,
     result_def,
@@ -62,7 +63,9 @@ class LoadOp(IRDLOperation):
     base = operand_def(MemRefType)
     indices = var_operand_def(IndexType)
     result = result_def(VectorType)
+    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
 
+    irdl_options = [ParsePropInAttrDict()]
     assembly_format = (
         "$base `[` $indices `]` attr-dict `:` type($base) `,` type($result)"
     )
@@ -98,7 +101,9 @@ class StoreOp(IRDLOperation):
     vector = operand_def(VectorType)
     base = operand_def(MemRefType)
     indices = var_operand_def(IndexType)
+    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
 
+    irdl_options = [ParsePropInAttrDict()]
     assembly_format = (
         "$vector `,` $base `[` $indices `]` attr-dict `:` type($base) `,` type($vector)"
     )


### PR DESCRIPTION
Support nontemporal attribute in vector.load and vector.store operations.

Fixes #2606

