### PR TITLE
dialects: (memref) Add nontemporal default value.

### DIFF
--- a/tests/filecheck/dialects/memref/memref_ops.mlir
+++ b/tests/filecheck/dialects/memref/memref_ops.mlir
@@ -15,10 +15,12 @@ builtin.module {
     %1 = arith.constant 0 : index
     %2 = "memref.alloca"() {"alignment" = 0 : i64, operandSegmentSizes = array<i32: 0, 0>} : () -> memref<1xindex>
     %3 = arith.constant 42 : index
-    "memref.store"(%3, %2, %1) : (index, memref<1xindex>, index) -> ()
-    "memref.store"(%3, %2, %1) <{"nontemporal" = true}> : (index, memref<1xindex>, index) -> ()
-    %4 = "memref.load"(%2, %1) : (memref<1xindex>, index) -> index
-    %f = "memref.load"(%2, %1) <{"nontemporal" = false}> : (memref<1xindex>, index) -> index
+    memref.store %3, %2[%1] : memref<1xindex>
+    memref.store %3, %2[%1] {nontemporal = true} : memref<1xindex>
+    memref.store %3, %2[%1] {nontemporal = false} : memref<1xindex>
+    %4 = memref.load %2[%1] : memref<1xindex>
+    %f = memref.load %2[%1] {nontemporal = false} : memref<1xindex>
+    %g = memref.load %2[%1] {nontemporal = true} : memref<1xindex>
     %5 = memref.alloc() {"alignment" = 0} : memref<10x2xindex>
     "memref.store"(%3, %5, %3, %4) : (index, memref<10x2xindex>, index, index) -> ()
     %6 = memref.subview %5[0, 0] [1, 1] [1, 1] attributes {"hello" = "world"} : memref<10x2xindex> to memref<1x1xindex>
@@ -67,8 +69,10 @@ builtin.module {
 // CHECK-NEXT:     %{{.*}} = arith.constant 42 : index
 // CHECK-NEXT:     memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<1xindex>
 // CHECK-NEXT:     memref.store %{{.*}}, %{{.*}}[%{{.*}}] {nontemporal = true} : memref<1xindex>
+// CHECK-NEXT:     memref.store %{{.*}}, %{{.*}}[%{{.*}}] : memref<1xindex>
 // CHECK-NEXT:     %{{.*}} = memref.load %{{.*}}[%{{.*}}] : memref<1xindex>
-// CHECK-NEXT:     %{{.*}} = memref.load %{{.*}}[%{{.*}}] {nontemporal = false} : memref<1xindex>
+// CHECK-NEXT:     %{{.*}} = memref.load %{{.*}}[%{{.*}}] : memref<1xindex>
+// CHECK-NEXT:     %{{.*}} = memref.load %{{.*}}[%{{.*}}] {nontemporal = true} : memref<1xindex>
 // CHECK-NEXT:     %{{.*}} = memref.alloc() {alignment = 0 : i64} : memref<10x2xindex>
 // CHECK-NEXT:     memref.store %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<10x2xindex>
 // CHECK-NEXT:     %{{.*}} = memref.subview %{{.*}}[0, 0] [1, 1] [1, 1] attributes {hello = "world"} : memref<10x2xindex> to memref<1x1xindex>

--- a/xdsl/dialects/memref.py
+++ b/xdsl/dialects/memref.py
@@ -76,7 +76,7 @@ class LoadOp(IRDLOperation):
 
     T: ClassVar = VarConstraint("T", AnyAttr())
 
-    nontemporal = opt_prop_def(BoolAttr)
+    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
 
     memref = operand_def(MemRefType.constr(element_type=T))
     indices = var_operand_def(IndexType())
@@ -115,7 +115,7 @@ class StoreOp(IRDLOperation):
 
     name = "memref.store"
 
-    nontemporal = opt_prop_def(BoolAttr)
+    nontemporal = opt_prop_def(BoolAttr, default_value=BoolAttr.from_bool(False))
 
     value = operand_def(T)
     memref = operand_def(MemRefType.constr(element_type=T))


### PR DESCRIPTION
This PR accounts for the default nontemporal value in memref.load and memref.store operations, consistent with [MLIR behavior](https://github.com/llvm/llvm-project/blob/7c366b041cd0effdcf0b7e1f3a7ad4eb39800349/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td#L1209). 
