### PR TITLE
testing: add unregistered dialect flag to new test

### DIFF
--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/transform/transform_generic.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/transform/transform_generic.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic | filecheck %s
+// RUN: xdsl-opt %s --print-op-generic | mlir-opt --mlir-print-op-generic --allow-unregistered-dialect | filecheck %s
 
 %0 = "test.op"() : () -> !transform.op<"builtin.module">
 // CHECK: %1 = "transform.apply_registered_pass"(%0) <{options = "", pass_name = "foo"}> : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">


### PR DESCRIPTION
My local mlir-opt requires this for test operations.