### PR TITLE
core: Add notify_op_modified to the PatternRewriter

### DIFF
--- a/tests/pattern_rewriter/test_pattern_rewriter.py
+++ b/tests/pattern_rewriter/test_pattern_rewriter.py
@@ -1857,3 +1857,34 @@ def test_pattern_rewriter_erase_op_with_region():
         PatternRewriteWalker(Rewrite(), apply_recursively=False),
         op_removed=1,
     )
+
+
+def test_pattern_rewriter_notify_op_modified():
+    """Test that notifying on op modifications works correctly."""
+    prog = """
+"builtin.module"() ({
+  "test.op"() : () -> ()
+  "test.op"() : () -> ()
+  "test.op"() : () -> ()
+}) : () -> ()"""
+    expected = """
+"builtin.module"() ({
+  "test.op"() {modified} : () -> ()
+  "test.op"() {modified} : () -> ()
+  "test.op"() {modified} : () -> ()
+}) : () -> ()"""
+
+    class Rewrite(RewritePattern):
+        @op_type_rewrite_pattern
+        def match_and_rewrite(self, op: test.TestOp, rewriter: PatternRewriter):
+            if "modified" in op.attributes:
+                return
+            op.attributes["modified"] = UnitAttr()
+            rewriter.notify_op_modified(op)
+
+    rewrite_and_compare(
+        prog,
+        expected,
+        PatternRewriteWalker(Rewrite(), apply_recursively=True),
+        op_modified=3,
+    )

--- a/xdsl/pattern_rewriter.py
+++ b/xdsl/pattern_rewriter.py
@@ -391,6 +391,14 @@ class PatternRewriter(Builder, PatternRewriterListener):
         """Move the region blocks to an existing region."""
         self.inline_region(region, BlockInsertPoint.at_end(target))
 
+    def notify_op_modified(self, op: Operation) -> None:
+        """
+        Notify the rewriter that an operation was modified in the pattern.
+        This will correctly update the rewriter state.
+        """
+        self.has_done_action = True
+        self.handle_operation_modification(op)
+
 
 class RewritePattern(ABC):
     """


### PR DESCRIPTION
`notify_op_modified` should be called whenever an operation is modified so that the pattern rewriter can update its internal state.