### PR TITLE
backend: add ValueAllocator base class for SSAValue allocation

### DIFF
--- a/tests/backend/riscv/test_register_allocation.py
+++ b/tests/backend/riscv/test_register_allocation.py
@@ -27,26 +27,26 @@ def test_default_reserved_registers():
 
     register_allocator = RegisterAllocatorLivenessBlockNaive(register_queue)
 
-    assert not register_allocator.allocate_same(())
+    assert not register_allocator.allocate_values_same_reg(())
 
     op_a = TestOp(result_types=[unallocated])
-    register_allocator.allocate_same(op_a.results)
+    register_allocator.allocate_values_same_reg(op_a.results)
 
     assert op_a.results[0].type == j(1)
 
-    register_allocator.allocate_same(op_a.results)
+    register_allocator.allocate_values_same_reg(op_a.results)
 
     assert op_a.results[0].type == j(1)
 
     op_b = TestOp(result_types=[unallocated, unallocated])
 
-    register_allocator.allocate_same(op_b.results)
+    register_allocator.allocate_values_same_reg(op_b.results)
 
     assert tuple(op_b.result_types) == (j(2), j(2))
 
     op_c = TestOp(result_types=[j(2), unallocated])
 
-    register_allocator.allocate_same(op_c.results)
+    register_allocator.allocate_values_same_reg(op_c.results)
 
     assert tuple(op_c.result_types) == (j(2), j(2))
 
@@ -58,7 +58,7 @@ def test_default_reserved_registers():
             "Cannot allocate registers to the same register ['!riscv.reg<j_2>', '!riscv.reg<j_3>']"
         ),
     ):
-        register_allocator.allocate_same(op_d.results)
+        register_allocator.allocate_values_same_reg(op_d.results)
 
     op_e = TestOp(result_types=[j(2), j(3), unallocated])
 
@@ -68,7 +68,7 @@ def test_default_reserved_registers():
             "Cannot allocate registers to the same register ['!riscv.reg', '!riscv.reg<j_2>', '!riscv.reg<j_3>']"
         ),
     ):
-        register_allocator.allocate_same(op_e.results)
+        register_allocator.allocate_values_same_reg(op_e.results)
 
 
 def test_allocate_with_inout_constraints():

--- a/tests/backend/test_register_allocation.py
+++ b/tests/backend/test_register_allocation.py
@@ -1,10 +1,15 @@
+import re
 from collections.abc import Sequence
+
+import pytest
 
 from xdsl.backend.register_allocatable import (
     HasRegisterConstraints,
     RegisterAllocatableOperation,
     RegisterConstraints,
 )
+from xdsl.backend.register_allocator import ValueAllocator
+from xdsl.backend.register_queue import LIFORegisterQueue
 from xdsl.backend.register_type import RegisterType
 from xdsl.builder import Builder
 from xdsl.ir import Attribute, SSAValue
@@ -17,6 +22,7 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
+from xdsl.utils.exceptions import DiagnosticException
 
 
 @irdl_attr_definition
@@ -127,3 +133,203 @@ def test_gather_allocated():
     )
 
     assert pa_regs == {x0, x1}
+
+
+def test_new_type_for_value():
+    @irdl_attr_definition
+    class OtherRegister(RegisterType):
+        name = "test.other_reg"
+
+        @classmethod
+        def index_by_name(cls) -> dict[str, int]:
+            return {"x0": 0, "x1": 1, "a0": 0, "a1": 1}
+
+        @classmethod
+        def infinite_register_prefix(cls):
+            return "y"
+
+    u = TestRegister.unallocated()
+    a0 = TestRegister.from_name("a0")
+    a1 = TestRegister.from_name("a1")
+
+    queue = LIFORegisterQueue()
+    queue.push(a0)
+    queue.push(a1)
+    allocator = ValueAllocator(queue, TestRegister)
+
+    r0, r1, r2, r3 = op(
+        (), u, a0, OtherRegister.unallocated(), OtherRegister.from_index(1)
+    ).results
+
+    assert allocator.new_type_for_value(r0) == a1
+    assert allocator.new_type_for_value(r1) is None
+    assert allocator.new_type_for_value(r2) is None
+    assert allocator.new_type_for_value(r3) is None
+
+
+def test_allocate_value():
+    u = TestRegister.unallocated()
+    a0 = TestRegister.from_name("a0")
+    a1 = TestRegister.from_name("a1")
+    y0 = TestRegister.from_name("y0")
+
+    queue = LIFORegisterQueue()
+    queue.push(a0)
+    queue.push(a1)
+    allocator = ValueAllocator(queue, TestRegister)
+
+    op0 = op((), u, u, u, u)
+    r00, r01, r02, _r03 = op0.results
+    op1 = op((r00, r01), u, u, inouts=(r02,))
+    results00 = tuple(op0.results)
+    results10 = tuple(op1.results)
+
+    # Initial state
+    assert queue.available_registers == {"test.reg": [0, 1]}
+    assert allocator.new_value_by_old_value == {}
+    assert op0.result_types == (u, u, u, u)
+    assert op1.result_types == (u, u, u)
+
+    # Allocate first result
+    new_value = allocator.allocate_value(op1.out_results[0])
+    assert new_value is not None
+
+    results11 = tuple(op1.results)
+
+    assert queue.available_registers == {"test.reg": [0]}
+    assert allocator.new_value_by_old_value == {results10[0]: results11[0]}
+    assert op0.result_types == (u, u, u, u)
+    assert op1.result_types == (a1, u, u)
+
+    # Allocate first result again (old value) -> no change of state
+    new_value = allocator.allocate_value(results10[0])
+    assert new_value is None
+    assert queue.available_registers == {"test.reg": [0]}
+    assert allocator.new_value_by_old_value == {results10[0]: results11[0]}
+    assert op0.result_types == (u, u, u, u)
+    assert op1.result_types == (a1, u, u)
+
+    # Allocate first result again (new value) -> no change of state
+    new_value = allocator.allocate_value(op1.out_results[0])
+    assert new_value is None
+    assert queue.available_registers == {"test.reg": [0]}
+    assert allocator.new_value_by_old_value == {results10[0]: results11[0]}
+    assert op0.result_types == (u, u, u, u)
+    assert op1.result_types == (a1, u, u)
+
+    # Allocate second result
+    new_value = allocator.allocate_value(op1.out_results[1])
+    assert new_value is not None
+
+    results12 = tuple(op1.results)
+
+    assert queue.available_registers == {"test.reg": []}
+    assert allocator.new_value_by_old_value == {
+        results10[0]: results11[0],
+        results11[1]: results12[1],
+    }
+    assert op0.result_types == (u, u, u, u)
+    assert op1.result_types == (a1, a0, u)
+
+    # Allocate inout result and operands at the same time
+    new_value = allocator.allocate_values_same_reg(
+        (op1.inout_operands[0], op1.inout_results[0])
+    )
+    results03 = tuple(op0.results)
+    results13 = tuple(op1.results)
+
+    assert queue.available_registers == {"test.reg": []}
+    assert allocator.new_value_by_old_value == {
+        results10[0]: results11[0],
+        results11[1]: results12[1],
+        results12[2]: results13[2],
+        results00[2]: results03[2],
+    }
+    assert op0.result_types == (u, u, y0, u)
+    assert op1.result_types == (a1, a0, y0)
+
+    # Free the allocated result values
+    allocator.free_value(results13[0])
+    allocator.free_value(results13[1])
+
+    assert queue.available_registers == {"test.reg": [1, 0]}
+    assert allocator.new_value_by_old_value == {
+        results10[0]: results11[0],
+        results11[1]: results12[1],
+        results12[2]: results13[2],
+        results00[2]: results03[2],
+    }
+    assert op0.result_types == (u, u, y0, u)
+    assert op1.result_types == (a1, a0, y0)
+
+    # Allocate operand
+    allocator.allocate_value(op1.operands[0])
+    results04 = tuple(op0.results)
+
+    assert queue.available_registers == {"test.reg": [1]}
+    assert allocator.new_value_by_old_value == {
+        results10[0]: results11[0],
+        results11[1]: results12[1],
+        results12[2]: results13[2],
+        results00[2]: results03[2],
+        results00[0]: results04[0],
+    }
+    assert op0.result_types == (a0, u, y0, u)
+    assert op1.result_types == (a1, a0, y0)
+
+
+def test_allocate_values_same_reg():
+    u = TestRegister.unallocated()
+    a0 = TestRegister.from_name("a0")
+    a1 = TestRegister.from_name("a1")
+    y0 = TestRegister.from_name("y0")
+
+    queue = LIFORegisterQueue()
+    queue.push(a0)
+    queue.push(a1)
+    allocator = ValueAllocator(queue, TestRegister)
+
+    # Empty
+    assert not allocator.allocate_values_same_reg(())
+
+    op0 = op((), u, u, u, u, u)
+
+    # 1 unallocated
+    assert allocator.allocate_values_same_reg((op0.results[0],))
+    assert op0.result_types == (a1, u, u, u, u)
+
+    # 1 allocated
+    assert not allocator.allocate_values_same_reg((op0.results[0],))
+    assert op0.result_types == (a1, u, u, u, u)
+
+    # 2 unallocated
+    assert allocator.allocate_values_same_reg((op0.results[1], op0.results[2]))
+    assert op0.result_types == (a1, a0, a0, u, u)
+
+    # 1 allocated 1 unallocated
+    assert allocator.allocate_values_same_reg((op0.results[0], op0.results[3]))
+    assert op0.result_types == (a1, a0, a0, a1, u)
+
+    # 1 unallocated 1 allocated
+    assert allocator.allocate_values_same_reg((op0.results[4], op0.results[0]))
+    assert op0.result_types == (a1, a0, a0, a1, a1)
+
+    with pytest.raises(
+        DiagnosticException,
+        match=re.escape(
+            "Cannot allocate registers to the same register ['!test.reg<a0>', '!test.reg<a1>']"
+        ),
+    ):
+        allocator.allocate_values_same_reg((op0.results[0], op0.results[1]))
+
+    op1 = op((), y0)
+
+    with pytest.raises(
+        DiagnosticException,
+        match=re.escape(
+            "Cannot allocate registers to the same register ['!test.reg<a0>', '!test.reg<a1>', '!test.reg<y0>']"
+        ),
+    ):
+        allocator.allocate_values_same_reg(
+            (op0.results[0], op0.results[1], op1.results[0])
+        )

--- a/xdsl/backend/register_allocator.py
+++ b/xdsl/backend/register_allocator.py
@@ -1,0 +1,109 @@
+from collections.abc import Sequence
+from typing import cast
+
+from xdsl.backend.register_queue import RegisterQueue
+from xdsl.backend.register_type import RegisterType
+from xdsl.ir import Attribute, SSAValue
+from xdsl.rewriter import Rewriter
+from xdsl.utils.exceptions import DiagnosticException
+
+
+class ValueAllocator:
+    """
+    Base class for register allocators.
+    """
+
+    available_registers: RegisterQueue
+    register_base_class: type[RegisterType]
+    new_value_by_old_value: dict[SSAValue, SSAValue]
+
+    def __init__(
+        self,
+        available_registers: RegisterQueue,
+        register_base_class: type[RegisterType],
+    ) -> None:
+        self.available_registers = available_registers
+        self.register_base_class = register_base_class
+        self.new_value_by_old_value = {}
+
+    def new_type_for_value(self, reg: SSAValue) -> RegisterType | None:
+        if isinstance(reg.type, self.register_base_class) and not reg.type.is_allocated:
+            return self.available_registers.pop(type(reg.type))
+
+    def _replace_value_with_new_type(
+        self, val: SSAValue, new_type: Attribute
+    ) -> SSAValue:
+        new_val = Rewriter.replace_value_with_new_type(val, new_type)
+        self.new_value_by_old_value[val] = new_val
+        return new_val
+
+    def allocate_value(self, val: SSAValue) -> SSAValue | None:
+        """
+        Allocate a register if not already allocated.
+        """
+        if val in self.new_value_by_old_value:
+            return
+        new_type = self.new_type_for_value(val)
+        if new_type is not None:
+            return self._replace_value_with_new_type(val, new_type)
+
+    def allocate_values_same_reg(self, vals: Sequence[SSAValue]) -> bool:
+        """
+        Allocates the values passed in to the same register.
+        If some of the values are already allocated, they must be allocated to the same
+        register, and unallocated values are then allocated to this register.
+        If the values passed in are already allocated to differing registers, a
+        `DiagnosticException` is raised.
+        """
+        reg_types = set(val.type for val in vals)
+        assert all(
+            isinstance(reg_type, self.register_base_class) for reg_type in reg_types
+        )
+        reg_types = cast(set[RegisterType], reg_types)
+
+        match len(reg_types):
+            case 0:
+                # No inputs, nothing to do
+                return False
+            case 1:
+                # Single input, may already be allocated
+                (reg_type,) = reg_types
+                if reg_type.is_allocated:
+                    return False
+                else:
+                    reg_type = self.available_registers.pop(type(reg_type))
+            case 2:
+                # Two inputs, either one is allocated or two
+                reg_type_0, reg_type_1 = reg_types
+                if reg_type_0.is_allocated:
+                    if reg_type_1.is_allocated:
+                        reg_names = [f"{reg_type}" for reg_type in reg_types]
+                        reg_names.sort()
+                        raise DiagnosticException(
+                            f"Cannot allocate registers to the same register {reg_names}"
+                        )
+                    else:
+                        reg_type = reg_type_0
+                else:
+                    reg_type = reg_type_1
+            case _:
+                # More than one input is allocated, meaning we can't allocate them to be
+                # the same, error.
+                reg_names = [f"{reg_type}" for reg_type in reg_types]
+                reg_names.sort()
+                raise DiagnosticException(
+                    f"Cannot allocate registers to the same register {reg_names}"
+                )
+
+        did_allocate = False
+
+        for val in vals:
+            if val.type != reg_type:
+                self._replace_value_with_new_type(val, reg_type)
+                did_allocate = True
+
+        return did_allocate
+
+    def free_value(self, val: SSAValue) -> None:
+        if isinstance(val.type, self.register_base_class) and val.type.is_allocated:
+            self.available_registers.push(val.type)


### PR DESCRIPTION
This class encapsulates the logic to do with updating the registers for values, whether it's a single value, or multiple values that should all be in the same register.