### PR TITLE
transforms: (convert-ptr-to-llvm) Enable recursive type rewriting

### DIFF
--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -14,3 +14,7 @@ ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 // CHECK-NEXT: %5 = arith.addi %4, %3 : i64
 // CHECK-NEXT: %6 = "llvm.inttoptr"(%5) : (i64) -> !llvm.ptr
 %3 = ptr_xdsl.ptradd %0, %1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+
+func.func private @example(!ptr_xdsl.ptr) -> !ptr_xdsl.ptr
+
+// CHECK-NEXT: func.func private @example(!llvm.ptr) -> !llvm.ptr

--- a/xdsl/transforms/convert_ptr_to_llvm.py
+++ b/xdsl/transforms/convert_ptr_to_llvm.py
@@ -89,7 +89,7 @@ class ConvertPtrToLLVMPass(ModulePass):
                     ConvertStoreOp(),
                     ConvertLoadOp(),
                     ConvertPtrAddOp(),
-                    RewritePtrTypes(),
+                    RewritePtrTypes(recursive=True),
                 ]
             )
         ).rewrite_module(op)


### PR DESCRIPTION
Enables recursive mode for the `RewritePtrTypes` type conversion pattern.
