### PR TITLE
transformations: (convert-ptr-to-llvm) Add conversions for `ConvertToPtrOp` and `ConvertFromPtrOp` 

### DIFF
--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -14,3 +14,10 @@ ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 // CHECK-NEXT: %5 = arith.addi %4, %3 : i64
 // CHECK-NEXT: %6 = "llvm.inttoptr"(%5) : (i64) -> !llvm.ptr
 %3 = ptr_xdsl.ptradd %0, %1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+
+%4 = "test.op"() : () -> memref<1xf32>
+
+// CHECK-NEXT: "test.op"() : () -> memref<1xf32>
+// CHECK-NEXT: }
+%5 = ptr_xdsl.to_ptr %4 : memref<1xf32> -> !ptr_xdsl.ptr
+%6 = ptr_xdsl.from_ptr %5 : !ptr_xdsl.ptr -> memref<1xf32>

--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -15,10 +15,14 @@ ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 // CHECK-NEXT: %6 = "llvm.inttoptr"(%5) : (i64) -> !llvm.ptr
 %3 = ptr_xdsl.ptradd %0, %1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 
-%memref = "test.op"() : () -> memref<1xf32>
-
 // CHECK-NEXT: "test.op"() : () -> memref<1xf32>
+// CHECK-NEXT: "test.op"() : () -> !llvm.ptr
+%memref = "test.op"() : () -> memref<1xf32>
+%ptr = "test.op"() : () -> !ptr_xdsl.ptr
+
 // CHECK-NEXT: }
 %to_ptr = ptr_xdsl.to_ptr %memref : memref<1xf32> -> !ptr_xdsl.ptr
-%from_ptr = ptr_xdsl.from_ptr %to_ptr : !ptr_xdsl.ptr -> memref<1xf32>
+ptr_xdsl.from_ptr %to_ptr : !ptr_xdsl.ptr -> memref<1xf32>
+
+%from_ptr = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<1xf32>
 ptr_xdsl.to_ptr %from_ptr : memref<1xf32> -> !ptr_xdsl.ptr

--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -18,14 +18,15 @@ ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 // CHECK-NEXT: func.func private @example(!llvm.ptr) -> !llvm.ptr
 func.func private @example(!ptr_xdsl.ptr) -> !ptr_xdsl.ptr
 
-// CHECK-NEXT: "test.op"() : () -> memref<1xf32>
-// CHECK-NEXT: "test.op"() : () -> !llvm.ptr
-%memref = "test.op"() : () -> memref<1xf32>
-%ptr = "test.op"() : () -> !ptr_xdsl.ptr
+// CHECK-NEXT: %memref, %ptr = "test.op"() : () -> (memref<1xf32>, !llvm.ptr)
+%memref, %ptr = "test.op"() : () -> (memref<1xf32>, !llvm.ptr)
+
+// CHECK-NEXT: "test.op"(%memref) : (!llvm.ptr) -> ()
+%to_ptr = ptr_xdsl.to_ptr %memref : memref<1xf32> -> !ptr_xdsl.ptr
+"test.op"(%to_ptr) : (!ptr_xdsl.ptr) -> ()
+
+// CHECK-NEXT: "test.op"(%ptr) : (!llvm.ptr) -> ()
+%from_ptr = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<1xf32>
+"test.op"(%from_ptr) : (!ptr_xdsl.ptr) -> ()
 
 // CHECK-NEXT: }
-%to_ptr = ptr_xdsl.to_ptr %memref : memref<1xf32> -> !ptr_xdsl.ptr
-ptr_xdsl.from_ptr %to_ptr : !ptr_xdsl.ptr -> memref<1xf32>
-
-%from_ptr = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<1xf32>
-ptr_xdsl.to_ptr %from_ptr : memref<1xf32> -> !ptr_xdsl.ptr

--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -15,9 +15,10 @@ ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 // CHECK-NEXT: %6 = "llvm.inttoptr"(%5) : (i64) -> !llvm.ptr
 %3 = ptr_xdsl.ptradd %0, %1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 
-%4 = "test.op"() : () -> memref<1xf32>
+%memref = "test.op"() : () -> memref<1xf32>
 
 // CHECK-NEXT: "test.op"() : () -> memref<1xf32>
 // CHECK-NEXT: }
-%5 = ptr_xdsl.to_ptr %4 : memref<1xf32> -> !ptr_xdsl.ptr
-%6 = ptr_xdsl.from_ptr %5 : !ptr_xdsl.ptr -> memref<1xf32>
+%to_ptr = ptr_xdsl.to_ptr %memref : memref<1xf32> -> !ptr_xdsl.ptr
+%from_ptr = ptr_xdsl.from_ptr %to_ptr : !ptr_xdsl.ptr -> memref<1xf32>
+ptr_xdsl.to_ptr %from_ptr : memref<1xf32> -> !ptr_xdsl.ptr

--- a/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
+++ b/tests/filecheck/transforms/convert_ptr_to_llvm.mlir
@@ -19,14 +19,14 @@ ptr_xdsl.store %2, %0  : i32, !ptr_xdsl.ptr
 func.func private @example(!ptr_xdsl.ptr) -> !ptr_xdsl.ptr
 
 // CHECK-NEXT: %memref, %ptr = "test.op"() : () -> (memref<1xf32>, !llvm.ptr)
-%memref, %ptr = "test.op"() : () -> (memref<1xf32>, !llvm.ptr)
+%memref, %ptr = "test.op"() : () -> (memref<1xf32>, !ptr_xdsl.ptr)
 
-// CHECK-NEXT: "test.op"(%memref) : (!llvm.ptr) -> ()
+// CHECK-NEXT: "test.op"(%memref) : (memref<1xf32>) -> ()
 %to_ptr = ptr_xdsl.to_ptr %memref : memref<1xf32> -> !ptr_xdsl.ptr
 "test.op"(%to_ptr) : (!ptr_xdsl.ptr) -> ()
 
 // CHECK-NEXT: "test.op"(%ptr) : (!llvm.ptr) -> ()
 %from_ptr = ptr_xdsl.from_ptr %ptr : !ptr_xdsl.ptr -> memref<1xf32>
-"test.op"(%from_ptr) : (!ptr_xdsl.ptr) -> ()
+"test.op"(%from_ptr) : (memref<1xf32>) -> ()
 
 // CHECK-NEXT: }

--- a/xdsl/transforms/convert_ptr_to_llvm.py
+++ b/xdsl/transforms/convert_ptr_to_llvm.py
@@ -69,6 +69,18 @@ class ConvertPtrAddOp(RewritePattern):
         )
 
 
+class ConvertToPtrOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.ToPtrOp, rewriter: PatternRewriter, /):
+        rewriter.replace_matched_op((), op.operands)
+
+
+class ConvertFromPtrOp(RewritePattern):
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.FromPtrOp, rewriter: PatternRewriter, /):
+        rewriter.replace_matched_op((), op.operands)
+
+
 class RewritePtrTypes(TypeConversionPattern):
     """
     Replaces `ptr_dxdsl.ptr` with `llvm.ptr`.
@@ -89,6 +101,8 @@ class ConvertPtrToLLVMPass(ModulePass):
                     ConvertStoreOp(),
                     ConvertLoadOp(),
                     ConvertPtrAddOp(),
+                    ConvertToPtrOp(),
+                    ConvertFromPtrOp(),
                     RewritePtrTypes(),
                 ]
             )


### PR DESCRIPTION
Adds conversion patterns for `ToPtrOp` and `FromPtrOp`, added by #4334.