### PR TITLE
[dialects] arm: Add dup instruction

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_ops.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops.mlir
@@ -27,3 +27,7 @@ arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.
 // CHECK: %v11, %v12, %v13, %v14 = arm_neon.dvars.ld1 [%x1] S {comment = "ld1 op"} : !arm.reg<x1> -> (!arm_neon.reg<v11>, !arm_neon.reg<v12>, !arm_neon.reg<v13>, !arm_neon.reg<v14>)
 // CHECK-ASM: ld1 {v11.4S, v12.4S, v13.4S, v14.4S}, [x1] # ld1 op
 %v11, %v12, %v13, %v14 = arm_neon.dvars.ld1 [%x1] S {comment = "ld1 op"} : !arm.reg<x1> -> (!arm_neon.reg<v11>, !arm_neon.reg<v12>, !arm_neon.reg<v13>, !arm_neon.reg<v14>)
+
+// CHECK: %ds_dup = arm_neon.ds.dup %x1 S {comment = "Duplicate general-purpose register to vector"} : !arm.reg<x1> -> (!arm_neon.reg<v1>)
+// CHECK-ASM: dup v1.4S, x1 # Duplicate general-purpose register to vector
+%ds_dup = arm_neon.ds.dup %x1 S {comment = "Duplicate general-purpose register to vector"} : !arm.reg<x1> -> !arm_neon.reg<v1>

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import ClassVar
 
-from xdsl.dialects.arm.assembly import AssemblyInstructionArg, square_brackets_reg
+from xdsl.dialects.arm.assembly import AssemblyInstructionArg, reg, square_brackets_reg
 from xdsl.dialects.arm.ops import ARMInstruction, ARMOperation
 from xdsl.dialects.arm.register import ARMRegisterType, IntRegisterType
 from xdsl.dialects.builtin import IntegerAttr, StringAttr, i8
@@ -149,9 +149,9 @@ class VariadicNeonRegArg(AssemblyInstructionArg):
     ):
         self.arrangement = arrangement
         vectors: Sequence[VectorWithArrangement] = []
-        for reg in regs:
-            assert isinstance(reg.type, NEONRegisterType)
-            vectors.append(VectorWithArrangement(reg, self.arrangement))
+        for register in regs:
+            assert isinstance(register.type, NEONRegisterType)
+            vectors.append(VectorWithArrangement(register, self.arrangement))
 
         self.regs = vectors
 
@@ -304,6 +304,47 @@ class DSSFmlaVecScalarOp(ARMInstruction):
 
 
 @irdl_op_definition
+class DSDupOp(ARMInstruction):
+    """
+    Duplicate general-purpose register to vector.
+    """
+
+    name = "arm_neon.ds.dup"
+    s = operand_def(IntRegisterType)
+    d = result_def(NEONRegisterType)
+    arrangement = attr_def(NeonArrangementAttr)
+
+    assembly_format = "$s $arrangement attr-dict `:` type($s) `->` `(` type($d) `)`"
+
+    def __init__(
+        self,
+        s: Operation | SSAValue,
+        *,
+        d: NEONRegisterType,
+        arrangement: NeonArrangement | NeonArrangementAttr,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+        if isinstance(arrangement, NeonArrangement):
+            arrangement = NeonArrangementAttr(arrangement)
+        super().__init__(
+            operands=(s,),
+            attributes={
+                "comment": comment,
+                "arrangement": arrangement,
+            },
+            result_types=(d,),
+        )
+
+    def assembly_line_args(self):
+        return (
+            VectorWithArrangement(self.d, self.arrangement),
+            reg(self.s),
+        )
+
+
+@irdl_op_definition
 class DVarSLd1Op(ARMInstruction):
     """
     Neon structure load instruction reads data from memory into 64-bit Neon registers.
@@ -412,6 +453,7 @@ ARM_NEON = Dialect(
     [
         DSSFmlaVecScalarOp,
         DSSFMulVecScalarOp,
+        DSDupOp,
         DVarSSt1Op,
         DVarSLd1Op,
         GetRegisterOp,

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -23,6 +23,7 @@ from xdsl.irdl import (
     irdl_attr_definition,
     irdl_op_definition,
     operand_def,
+    prop_def,
     result_def,
     var_operand_def,
     var_result_def,
@@ -312,7 +313,7 @@ class DSDupOp(ARMInstruction):
     name = "arm_neon.ds.dup"
     s = operand_def(IntRegisterType)
     d = result_def(NEONRegisterType)
-    arrangement = attr_def(NeonArrangementAttr)
+    arrangement = prop_def(NeonArrangementAttr)
 
     assembly_format = "$s $arrangement attr-dict `:` type($s) `->` `(` type($d) `)`"
 


### PR DESCRIPTION
Add ```dup``` instruction to Arm Neon dialect. Duplicate general-purpose register to vector.
