### PR TITLE
dialects: (cf) simplify switch's use of DenseIntElementAttr

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2347,6 +2347,9 @@ class DenseIntOrFPElementsAttr(
         printer.print_string(">")
 
 
+DenseIntElementsAttr: TypeAlias = DenseIntOrFPElementsAttr[IndexType | IntegerType]
+
+
 Builtin = Dialect(
     "builtin",
     [

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -7,12 +7,13 @@ from typing_extensions import Self
 
 from xdsl.dialects.builtin import (
     DenseArrayBase,
-    DenseIntOrFPElementsAttr,
+    DenseIntElementsAttr,
     IndexType,
     IndexTypeConstr,
     IntegerType,
     SignlessIntegerConstraint,
     StringAttr,
+    VectorType,
     i32,
 )
 from xdsl.ir import Attribute, Block, Dialect, Operation, SSAValue
@@ -21,7 +22,6 @@ from xdsl.irdl import (
     IRDLOperation,
     Successor,
     VarOperand,
-    attr_constr_coercion,
     attr_def,
     irdl_op_definition,
     operand_def,
@@ -180,7 +180,7 @@ class SwitchOp(IRDLOperation):
 
     name = "cf.switch"
 
-    case_values = opt_prop_def(DenseIntOrFPElementsAttr)
+    case_values = opt_prop_def(DenseIntElementsAttr)
 
     flag = operand_def(IndexTypeConstr | SignlessIntegerConstraint)
 
@@ -189,7 +189,7 @@ class SwitchOp(IRDLOperation):
     case_operands = var_operand_def()
 
     # Copied from AttrSizedSegments
-    case_operand_segments = prop_def(attr_constr_coercion(DenseArrayBase))
+    case_operand_segments = prop_def(DenseArrayBase)
 
     default_block = successor_def()
 
@@ -204,7 +204,7 @@ class SwitchOp(IRDLOperation):
         flag: Operation | SSAValue,
         default_block: Successor,
         default_operands: Sequence[Operation | SSAValue],
-        case_values: DenseIntOrFPElementsAttr | None = None,
+        case_values: DenseIntElementsAttr | None = None,
         case_blocks: Sequence[Successor] = [],
         case_operands: Sequence[Sequence[Operation | SSAValue]] = [],
         attr_dict: dict[str, Attribute] | None = None,
@@ -359,7 +359,7 @@ class SwitchOp(IRDLOperation):
         parser.parse_punctuation("[")
         parser.parse_keyword("default")
         (default_block, default_args) = cls._parse_case_body(parser)
-        case_values: DenseIntOrFPElementsAttr | None = None
+        case_values: DenseIntElementsAttr | None = None
         case_blocks: tuple[Block, ...] = ()
         case_operands: tuple[tuple[SSAValue, ...], ...] = ()
         if parser.parse_optional_punctuation(","):
@@ -367,8 +367,9 @@ class SwitchOp(IRDLOperation):
                 Parser.Delimiter.NONE, lambda: cls._parse_case(parser)
             )
             assert isinstance(flag_type, IntegerType | IndexType)
-            case_values = DenseIntOrFPElementsAttr.vector_from_list(
-                [x for (x, _, _) in cases], flag_type
+            data = tuple(x for (x, _, _) in cases)
+            case_values = DenseIntElementsAttr.create_dense_int(
+                VectorType(flag_type, (len(data),)), data
             )
             case_blocks = tuple(x for (_, x, _) in cases)
             case_operands = tuple(tuple(x) for (_, _, x) in cases)

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -4,8 +4,9 @@ from typing import cast
 from xdsl.dialects import arith, cf
 from xdsl.dialects.builtin import (
     BoolAttr,
-    DenseIntOrFPElementsAttr,
+    DenseIntElementsAttr,
     IntegerAttr,
+    VectorType,
 )
 from xdsl.ir import Block, BlockArgument, Operation, SSAValue
 from xdsl.pattern_rewriter import (
@@ -319,8 +320,9 @@ def drop_case_helper(
                 op.flag,
                 op.default_block,
                 op.default_operands,
-                DenseIntOrFPElementsAttr.vector_from_list(
-                    new_case_values, case_values.get_element_type()
+                DenseIntElementsAttr.create_dense_int(
+                    VectorType(case_values.get_element_type(), (len(new_case_values),)),
+                    new_case_values,
                 ),
                 new_case_blocks,
                 new_case_operands,

--- a/xdsl/transforms/convert_scf_to_cf.py
+++ b/xdsl/transforms/convert_scf_to_cf.py
@@ -4,7 +4,11 @@ from typing import cast
 from xdsl.context import Context
 from xdsl.dialects import builtin
 from xdsl.dialects.arith import AddiOp, CmpiOp, IndexCastOp
-from xdsl.dialects.builtin import DenseIntOrFPElementsAttr, i32
+from xdsl.dialects.builtin import (
+    DenseIntElementsAttr,
+    VectorType,
+    i32,
+)
 from xdsl.dialects.cf import BranchOp, ConditionalBranchOp, SwitchOp
 from xdsl.dialects.scf import ForOp, IfOp, IndexSwitchOp, YieldOp
 from xdsl.ir import Block, Region
@@ -209,7 +213,9 @@ class SwitchLowering(RewritePattern):
                 case_value,
                 default_block,
                 (),
-                DenseIntOrFPElementsAttr.vector_from_list(case_values, i32),
+                DenseIntElementsAttr.create_dense_int(
+                    VectorType(i32, (len(case_values),)), case_values
+                ),
                 case_successors,
                 case_operands,
             ),


### PR DESCRIPTION
Creates a `DenseIntElementsAttr` alias (which MLIR also has) and has `cf.switch` use this.

Also switches from `vector_from_list` to `create_dense_int` in preparation for deprecating `vector_from_list`