### PR TITLE
dialects: (arm) Add mov instruction for Neon -> general-purpose register

### DIFF
--- a/tests/filecheck/dialects/arm_neon/test_ops.mlir
+++ b/tests/filecheck/dialects/arm_neon/test_ops.mlir
@@ -31,3 +31,7 @@ arm_neon.dvars.st1 %v1, %v2, %v3, %v4 [%x1] S {comment = "st1 op"} : (!arm_neon.
 // CHECK: %ds_dup = arm_neon.ds.dup %x1 S {comment = "Duplicate general-purpose register to vector"} : !arm.reg<x1> -> (!arm_neon.reg<v1>)
 // CHECK-ASM: dup v1.4S, x1 # Duplicate general-purpose register to vector
 %ds_dup = arm_neon.ds.dup %x1 S {comment = "Duplicate general-purpose register to vector"} : !arm.reg<x1> -> !arm_neon.reg<v1>
+
+// CHECK: %dsvec_mov = arm_neon.dsvec.mov %v3[1] S {comment = "Set X1 to the value of the second single word in V3."} : !arm_neon.reg<v3> -> !arm.reg<x1>
+// CHECK-ASM: mov x1, v3.S[1] # Set X1 to the value of the second single word in V3.
+%dsvec_mov = arm_neon.dsvec.mov %v3[1] S {comment = "Set X1 to the value of the second single word in V3."} : !arm_neon.reg<v3> -> !arm.reg<x1>

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -346,6 +346,54 @@ class DSDupOp(ARMInstruction):
 
 
 @irdl_op_definition
+class DSVecMovOp(ARMInstruction):
+    """
+    Variant of MOV instruction which extracts a value from a specified lane in a NEON register into a general-purpose register.
+    e.g. MOV X0, V3.S[1]
+    Set X0 to the value of the second single word (bits 32-63) in V3.
+    This instruction is an alias of UMOV.
+    """
+
+    name = "arm_neon.dsvec.mov"
+    s = operand_def(NEONRegisterType)
+    d = result_def(IntRegisterType)
+    scalar_idx = prop_def(IntegerAttr[i8])
+    arrangement = prop_def(NeonArrangementAttr)
+    assembly_format = (
+        "$s `[` $scalar_idx `]` $arrangement attr-dict `:` type($s) `->` type($d)"
+    )
+
+    def __init__(
+        self,
+        s: Operation | SSAValue,
+        *,
+        d: IntRegisterType,
+        arrangement: NeonArrangement | NeonArrangementAttr,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+        if isinstance(arrangement, NeonArrangement):
+            arrangement = NeonArrangementAttr(arrangement)
+        super().__init__(
+            operands=(s,),
+            attributes={
+                "comment": comment,
+                "arrangement": arrangement,
+            },
+            result_types=(d,),
+        )
+
+    def assembly_line_args(self):
+        return (
+            reg(self.d),
+            VectorWithArrangement(
+                self.s, self.arrangement, index=self.scalar_idx.value.data
+            ),
+        )
+
+
+@irdl_op_definition
 class DVarSLd1Op(ARMInstruction):
     """
     Neon structure load instruction reads data from memory into 64-bit Neon registers.
@@ -455,6 +503,7 @@ ARM_NEON = Dialect(
         DSSFmlaVecScalarOp,
         DSSFMulVecScalarOp,
         DSDupOp,
+        DSVecMovOp,
         DVarSSt1Op,
         DVarSLd1Op,
         GetRegisterOp,

--- a/xdsl/dialects/arm_neon.py
+++ b/xdsl/dialects/arm_neon.py
@@ -348,7 +348,8 @@ class DSDupOp(ARMInstruction):
 @irdl_op_definition
 class DSVecMovOp(ARMInstruction):
     """
-    Variant of MOV instruction which extracts a value from a specified lane in a NEON register into a general-purpose register.
+    Variant of MOV instruction which extracts a value from a specified lane in a NEON
+    register into a general-purpose register.
     e.g. MOV X0, V3.S[1]
     Set X0 to the value of the second single word (bits 32-63) in V3.
     This instruction is an alias of UMOV.
@@ -369,6 +370,7 @@ class DSVecMovOp(ARMInstruction):
         *,
         d: IntRegisterType,
         arrangement: NeonArrangement | NeonArrangementAttr,
+        scalar_idx: IntegerAttr,
         comment: str | StringAttr | None = None,
     ):
         if isinstance(comment, str):
@@ -379,7 +381,10 @@ class DSVecMovOp(ARMInstruction):
             operands=(s,),
             attributes={
                 "comment": comment,
+            },
+            properties={
                 "arrangement": arrangement,
+                "scalar_idx": scalar_idx,
             },
             result_types=(d,),
         )


### PR DESCRIPTION
Variant of MOV instruction which extracts a value from a specified lane in a NEON register into a general-purpose register.
