### PR TITLE
dialects: (builtin) remove DenseIntOrFPElementsAttr splat initialisation

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -358,12 +358,6 @@ def test_DenseIntOrFPElementsAttr_from_list():
     assert attr.type == AnyTensorType(f32, [2])
     assert len(attr) == 2
 
-    # splat initialization
-    attr = DenseIntOrFPElementsAttr.tensor_from_list([4], f32, [4])
-    assert attr.type == AnyTensorType(f32, [4])
-    assert tuple(attr.get_values()) == (4, 4, 4, 4)
-    assert len(attr) == 4
-
 
 def test_DenseIntOrFPElementsAttr_values():
     int_attr = DenseIntOrFPElementsAttr.tensor_from_list([1, 2, 3, 4], i32, [4])

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -282,8 +282,8 @@ def test_linalg_pooling_nchw_max():
         (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
         {
-            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-            "strides": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
+            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1, 1], i64, [2]),
+            "strides": DenseIntOrFPElementsAttr.tensor_from_list([1, 1], i64, [2]),
         },
     )
     a = ShapedArray(TypedPtr.new_float32(list(range(1, 17))), [1, 1, 4, 4])
@@ -315,8 +315,8 @@ def test_linalg_pooling_nchw_max_strides_two():
         (create_ssa_value(TensorType(f32, [1, 1, 2, 2])),),
         (TensorType(f32, [1, 1, 2, 2]),),
         {
-            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-            "strides": DenseIntOrFPElementsAttr.tensor_from_list([2], i64, [2]),
+            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1, 1], i64, [2]),
+            "strides": DenseIntOrFPElementsAttr.tensor_from_list([2, 2], i64, [2]),
         },
     )
     a = ShapedArray(
@@ -348,8 +348,8 @@ def test_linalg_conv_2d_nchw_fchw():
         (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
         {
-            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-            "strides": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
+            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1, 1], i64, [2]),
+            "strides": DenseIntOrFPElementsAttr.tensor_from_list([1, 1], i64, [2]),
         },
     )
     a = ShapedArray(TypedPtr.new_float32(list(range(25))), [1, 1, 5, 5])

--- a/tests/interpreters/test_ml_program_interpreter.py
+++ b/tests/interpreters/test_ml_program_interpreter.py
@@ -23,7 +23,7 @@ def test_ml_program_global_load_constant():
             StringAttr("my_global"),
             tensor_type,
             None,
-            DenseIntOrFPElementsAttr.from_list(tensor_type, [4]),
+            DenseIntOrFPElementsAttr.from_list(tensor_type, [4, 4, 4, 4]),
             StringAttr("private"),
         )
         with ImplicitBuilder(func.FuncOp("main", ((), ())).body):

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2216,21 +2216,13 @@ class DenseIntOrFPElementsAttr(
         ),
         data: Sequence[int | float] | Sequence[IntegerAttr] | Sequence[FloatAttr],
     ) -> DenseIntOrFPElementsAttr:
-        # splat value given
-        if len(data) == 1 and prod(type.get_shape()) != 1:
-            new_data = (data[0],) * prod(type.get_shape())
-        else:
-            new_data = data
-
         if isinstance(type.element_type, AnyFloat):
             new_type = cast(RankedStructure[AnyFloat], type)
-            new_data = cast(
-                Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], new_data
-            )
+            new_data = cast(Sequence[int | float] | Sequence[FloatAttr[AnyFloat]], data)
             return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
         else:
             new_type = cast(RankedStructure[IntegerType | IndexType], type)
-            new_data = cast(Sequence[int] | Sequence[IntegerAttr], new_data)
+            new_data = cast(Sequence[int] | Sequence[IntegerAttr], data)
             return DenseIntOrFPElementsAttr.create_dense_int(new_type, new_data)
 
     @staticmethod

--- a/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
+++ b/xdsl/transforms/experimental/stencil_tensorize_z_dimension.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
+from math import prod
 from typing import TypeGuard
 
 from xdsl.context import Context
@@ -205,7 +206,9 @@ class ArithOpTensorize(RewritePattern):
             assert isinstance(float_attr := scalar_op.op.value, FloatAttr)
             scalar_value = float_attr.value.data
             tens_const = ConstantOp(
-                DenseIntOrFPElementsAttr.from_list(dest_typ, [scalar_value])
+                DenseIntOrFPElementsAttr.from_list(
+                    dest_typ, [scalar_value] * prod(dest_typ.get_shape())
+                )
             )
             rewriter.insert_op(tens_const, InsertPoint.before(scalar_op.op))
             return tens_const.result


### PR DESCRIPTION
Remove splat initialisation as it only seems to be used in a couple of tests.

If this has significant use downstream then I'm happy to reinstate this or add something similar to `create_dense_{int/float}`, but I personally think this is slightly confusing behaviour.