### PR TITLE
dialects: (builtin) fix deprecated vector_from_list

### DIFF
--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2247,7 +2247,9 @@ class DenseIntOrFPElementsAttr(
                 VectorType(data_type, shape), data
             )
         else:
-            return DenseIntOrFPElementsAttr.from_list(
+            assert isinstance(data_type, IntegerType | IndexType)
+            data = cast(Sequence[int], data)
+            return DenseIntOrFPElementsAttr.create_dense_int(
                 VectorType(data_type, shape), data
             )
 


### PR DESCRIPTION
Missed a branch of the deprecated function.
Note that although the replacement for this deprecation looks bad, we actually have no cases where this function was used polymorphically across `int` and `float`