### PR TITLE
dialects: (builtin) add `get_{int/float}_values`

### DIFF
--- a/docs/Toy/toy/dialects/toy.py
+++ b/docs/Toy/toy/dialects/toy.py
@@ -117,7 +117,7 @@ class ConstantOp(IRDLOperation):
         return list(self.get_type().get_shape())
 
     def get_data(self) -> list[float]:
-        return list(self.value.get_values())
+        return list(self.value.get_float_values())
 
 
 class InferAddOpShapeTrait(ToyShapeInferenceTrait):

--- a/docs/Toy/toy/rewrites/lower_toy_affine.py
+++ b/docs/Toy/toy/rewrites/lower_toy_affine.py
@@ -364,7 +364,8 @@ class ConstantOpLowering(RewritePattern):
 
         # Scalar constant values for elements of the tensor
         constants: list[arith.ConstantOp] = [
-            arith.ConstantOp(FloatAttr(i, f64)) for i in constant_value.get_values()
+            arith.ConstantOp(FloatAttr(i, f64))
+            for i in constant_value.get_float_values()
         ]
 
         # n-d indices of elements

--- a/docs/Toy/toy/rewrites/optimise_toy.py
+++ b/docs/Toy/toy/rewrites/optimise_toy.py
@@ -73,7 +73,7 @@ class FoldConstantReshapeOpPattern(RewritePattern):
         assert isa(op.res.type, TensorTypeF64)
 
         new_value = DenseIntOrFPElementsAttr.create_dense_float(
-            type=op.res.type, data=reshape_input_op.value.get_values()
+            type=op.res.type, data=reshape_input_op.value.get_float_values()
         )
         new_op = ConstantOp(new_value)
         rewriter.replace_matched_op(new_op)

--- a/tests/filecheck/backend/riscv/memref_to_riscv.mlir
+++ b/tests/filecheck/backend/riscv/memref_to_riscv.mlir
@@ -93,7 +93,7 @@ memref.store %scalar_x_i32, %m_scalar_i32[] {"nontemporal" = false} : memref<i32
 // CHECK-NEXT:       riscv.label "global"
 // CHECK-NEXT:       riscv.directive ".word" "0x0,0x3ff00000,0x0,0x40000000"
 // CHECK-NEXT:   }
-"memref.global"() <{"sym_name" = "global", "sym_visibility" = "public", "type" = memref<2x3xf64>, "initial_value" = dense<[1, 2]> : tensor<2xi32>}> : () -> ()
+"memref.global"() <{"sym_name" = "global", "sym_visibility" = "public", "type" = memref<2xf64>, "initial_value" = dense<[1, 2]> : tensor<2xf64>}> : () -> ()
 
 // CHECK-NEXT:    %global = riscv.li "global" : !riscv.reg
 // CHECK-NEXT:    %global_1 = builtin.unrealized_conversion_cast %global : !riscv.reg to memref<2xi32>

--- a/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
+++ b/xdsl/backend/riscv/lowering/convert_memref_to_riscv.py
@@ -274,16 +274,13 @@ class ConvertMemRefGlobalOp(RewritePattern):
                     raise DiagnosticException(
                         f"Unsupported memref element type for riscv lowering: {element_type}"
                     )
-                ints = initial_value.get_values()
-                for i in ints:
-                    assert isinstance(i, int)
-                ints = cast(list[int], ints)
+                ints = initial_value.get_int_values()
                 ptr = TypedPtr.new_int32(ints).raw
             case Float32Type():
-                floats = initial_value.get_values()
+                floats = initial_value.get_float_values()
                 ptr = TypedPtr.new_float32(floats).raw
             case Float64Type():
-                floats = initial_value.get_values()
+                floats = initial_value.get_float_values()
                 ptr = TypedPtr.new_float64(floats).raw
             case _:
                 raise DiagnosticException(

--- a/xdsl/dialects/affine.py
+++ b/xdsl/dialects/affine.py
@@ -8,7 +8,7 @@ from xdsl.dialects.builtin import (
     AffineSetAttr,
     ArrayAttr,
     ContainerType,
-    DenseIntOrFPElementsAttr,
+    DenseIntElementsAttr,
     IndexType,
     IntegerAttr,
     IntegerType,
@@ -225,9 +225,9 @@ class ParallelOp(IRDLOperation):
 
     reductions = prop_def(ArrayAttr[StringAttr])
     lowerBoundsMap = prop_def(AffineMapAttr)
-    lowerBoundsGroups = prop_def(DenseIntOrFPElementsAttr)
+    lowerBoundsGroups = prop_def(DenseIntElementsAttr)
     upperBoundsMap = prop_def(AffineMapAttr)
-    upperBoundsGroups = prop_def(DenseIntOrFPElementsAttr)
+    upperBoundsGroups = prop_def(DenseIntElementsAttr)
     steps = prop_def(ArrayAttr[IntegerAttr[IntegerType]])
 
     res = var_result_def()
@@ -247,11 +247,11 @@ class ParallelOp(IRDLOperation):
                 "Expected as many operands as results, lower bound args and upper bound args."
             )
 
-        if sum(self.lowerBoundsGroups.get_values()) != len(
+        if sum(self.lowerBoundsGroups.get_int_values()) != len(
             self.lowerBoundsMap.data.results
         ):
             raise VerifyException("Expected a lower bound group for each lower bound")
-        if sum(self.upperBoundsGroups.get_values()) != len(
+        if sum(self.upperBoundsGroups.get_int_values()) != len(
             self.upperBoundsMap.data.results
         ):
             raise VerifyException("Expected an upper bound group for each upper bound")

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2274,6 +2274,24 @@ class DenseIntOrFPElementsAttr(
         """
         return self.get_element_type().iter_unpack(self.data.data)
 
+    def get_int_values(self) -> Sequence[int]:
+        """
+        Return all the values of the elements in this DenseIntOrFPElementsAttr,
+        checking that the elements are integers.
+        """
+        el_type = self.get_element_type()
+        assert isinstance(el_type, IntegerType | IndexType)
+        return el_type.unpack(self.data.data, len(self))
+
+    def get_float_values(self) -> Sequence[float]:
+        """
+        Return all the values of the elements in this DenseIntOrFPElementsAttr,
+        checking that the elements are floats.
+        """
+        el_type = self.get_element_type()
+        assert isinstance(el_type, AnyFloat)
+        return el_type.unpack(self.data.data, len(self))
+
     def get_values(self) -> Sequence[int] | Sequence[float]:
         """
         Return all the values of the elements in this DenseIntOrFPElementsAttr

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2280,7 +2280,7 @@ class DenseIntOrFPElementsAttr(
         checking that the elements are integers.
         """
         el_type = self.get_element_type()
-        assert isinstance(el_type, IntegerType | IndexType)
+        assert isinstance(el_type, IntegerType | IndexType), el_type
         return el_type.unpack(self.data.data, len(self))
 
     def get_float_values(self) -> Sequence[float]:
@@ -2289,7 +2289,7 @@ class DenseIntOrFPElementsAttr(
         checking that the elements are floats.
         """
         el_type = self.get_element_type()
-        assert isinstance(el_type, AnyFloat)
+        assert isinstance(el_type, AnyFloat), el_type
         return el_type.unpack(self.data.data, len(self))
 
     def get_values(self) -> Sequence[int] | Sequence[float]:

--- a/xdsl/dialects/cf.py
+++ b/xdsl/dialects/cf.py
@@ -306,7 +306,7 @@ class SwitchOp(IRDLOperation):
                 cases = cases + [
                     (str(c), block, operands)
                     for (c, block, operands) in zip(
-                        self.case_values.get_values(),
+                        self.case_values.get_int_values(),
                         self.case_blocks,
                         self.case_operand,
                     )

--- a/xdsl/dialects/varith.py
+++ b/xdsl/dialects/varith.py
@@ -182,7 +182,7 @@ class VarithSwitchOp(IRDLOperation):
             cases = [("default", self.default_arg)] + [
                 (str(c), arg)
                 for (c, arg) in zip(
-                    self.case_values.get_values(),
+                    self.case_values.get_int_values(),
                     self.args,
                     strict=True,
                 )

--- a/xdsl/interpreters/linalg.py
+++ b/xdsl/interpreters/linalg.py
@@ -188,7 +188,7 @@ class LinalgFunctions(InterpreterFunctions):
         strides_type = op.strides.type
         assert isinstance(strides_type, TensorType)
         (strides_shape,) = strides_type.get_shape()
-        strides = op.strides.get_values()
+        strides = op.strides.get_int_values()
         if strides_shape != 2:
             raise NotImplementedError("Only 2d max pooling supported")
 
@@ -202,8 +202,8 @@ class LinalgFunctions(InterpreterFunctions):
         ]
 
         output: list[float] = []
-        for k in range(0, m_height - ky + 1, int(strides[0])):
-            for l in range(0, m_width - kx + 1, int(strides[0])):
+        for k in range(0, m_height - ky + 1, strides[0]):
+            for l in range(0, m_width - kx + 1, strides[0]):
                 block_max_value = float("-inf")
                 for i in range(k, k + ky):
                     for j in range(l, l + kx):
@@ -233,7 +233,7 @@ class LinalgFunctions(InterpreterFunctions):
             raise NotImplementedError()
         m_height, m_width = input.shape[2:]
         ky, kx = kernel_filter.shape[2], kernel_filter.shape[3]
-        strides = op.strides.get_values()
+        strides = op.strides.get_int_values()
         # convert input into a numpy like array
         input_data = [
             [input.data[r * m_width + c] for c in range(m_width)]
@@ -248,8 +248,8 @@ class LinalgFunctions(InterpreterFunctions):
             for r in range(kernel_filter.shape[2])
         ]
         output: list[float] = []
-        for k in range(0, m_height - ky + 1, int(strides[0])):
-            for l in range(0, m_width - kx + 1, int(strides[0])):
+        for k in range(0, m_height - ky + 1, strides[0]):
+            for l in range(0, m_width - kx + 1, strides[0]):
                 conv_value: float = 0.0
                 for i in range(k, k + ky):
                     for j in range(l, l + kx):

--- a/xdsl/transforms/canonicalization_patterns/cf.py
+++ b/xdsl/transforms/canonicalization_patterns/cf.py
@@ -535,7 +535,7 @@ class SimplifySwitchFromSwitchOnSameCondition(RewritePattern):
             fold_switch(
                 op,
                 rewriter,
-                cast(int, case_values.get_values()[pred.index - 1]),
+                case_values.get_int_values()[pred.index - 1],
             )
         else:
 


### PR DESCRIPTION
Would like some help with the error here, seems to me that the test has a bug in line 96

Hoping that this will make @erick-xanadu 's life easier for adding complex values. In any case these avoid a few casts. They can be eventually replaced with overloads of `get_values` if https://github.com/microsoft/pyright/issues/10232 is resolved.