### PR TITLE
transformations: (convert-memref-to-ptr) Add lowering for `ReinterpretCastOp`

### DIFF
--- a/tests/filecheck/transforms/convert_memref_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_memref_to_ptr.mlir
@@ -66,6 +66,13 @@ memref.store %fv, %farr[%idx] {"nontemporal" = false} : memref<10xf64>
 // CHECK-NEXT:  %flv2 = ptr_xdsl.to_ptr %fmem : memref<f64> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %flv2_1 = ptr_xdsl.load %flv2 : !ptr_xdsl.ptr -> f64
 
+%fmemcast = "test.op"() : () -> (memref<f64>)
+%fmemcast2 = memref.reinterpret_cast %fmemcast to offset: [0], sizes: [5, 2], strides: [2, 1] : memref<f64> to memref<5x2xf64> 
+
+// CHECK-NEXT:  %fmemcast = "test.op"() : () -> memref<f64>
+// CHECK-NEXT:  %fmemcast2 = ptr_xdsl.to_ptr %fmemcast : memref<f64> -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %fmemcast2_1 = builtin.unrealized_conversion_cast %fmemcast2 : !ptr_xdsl.ptr to memref<5x2xf64>
+
 // -----
 
 %fv, %idx, %mstr = "test.op"() : () -> (f64, index, memref<2xf64, strided<[?]>>)


### PR DESCRIPTION
Adds a rewrite pattern to lower `ReinterpretCastOp`, previously contained in #4331. 