### PR TITLE
dialects: (llvm) Allow arithmetic operations to accept `vector` types

### DIFF
--- a/tests/filecheck/dialects/llvm/vector.mlir
+++ b/tests/filecheck/dialects/llvm/vector.mlir
@@ -1,0 +1,144 @@
+// RUN: XDSL_ROUNDTRIP
+
+%varg0, %varg1, %vf1 = "test.op"() : () -> (vector<8xi32>, vector<8xi32>, vector<8xf32>)
+
+%vadd_both = llvm.add %varg0, %varg1 {"overflowFlags" = #llvm.overflow<nsw, nuw>} : vector<8xi32>
+// CHECK: %vadd_both = llvm.add %varg0, %varg1 {overflowFlags = #llvm.overflow<nsw,nuw>} : vector<8xi32>
+
+%vadd_both_pretty = llvm.add %varg0, %varg1 overflow<nsw, nuw> : vector<8xi32>
+// CHECK: %vadd_both_pretty = llvm.add %varg0, %varg1 overflow<nsw,nuw> : vector<8xi32>
+
+%vsub = llvm.sub %varg0, %varg1 : vector<8xi32>
+// CHECK: %vsub = llvm.sub %varg0, %varg1 : vector<8xi32>
+
+%vsub_overflow = llvm.sub %varg0, %varg1 overflow<nsw> : vector<8xi32>
+// CHECK: %vsub_overflow = llvm.sub %varg0, %varg1 overflow<nsw> : vector<8xi32>
+
+%vmul = llvm.mul %varg0, %varg1 : vector<8xi32>
+// CHECK: %vmul = llvm.mul %varg0, %varg1 : vector<8xi32>
+
+%vmul_overflow = llvm.mul %varg0, %varg1 overflow<nsw> : vector<8xi32>
+// CHECK: %vmul_overflow = llvm.mul %varg0, %varg1 overflow<nsw> : vector<8xi32>
+
+%vudiv = llvm.udiv %varg0, %varg1 : vector<8xi32>
+// CHECK: %vudiv = llvm.udiv %varg0, %varg1 : vector<8xi32>
+
+%vsdiv = llvm.sdiv %varg0, %varg1 : vector<8xi32>
+// CHECK: %vsdiv = llvm.sdiv %varg0, %varg1 : vector<8xi32>
+
+%vudiv_exact = llvm.udiv exact %varg0, %varg1 : vector<8xi32>
+// CHECK: %vudiv_exact = llvm.udiv exact %varg0, %varg1 : vector<8xi32>
+
+%vsdiv_exact = llvm.sdiv exact %varg0, %varg1 : vector<8xi32>
+// CHECK: %vsdiv_exact = llvm.sdiv exact %varg0, %varg1 : vector<8xi32>
+
+%vurem = llvm.urem %varg0, %varg1 : vector<8xi32>
+// CHECK: %vurem = llvm.urem %varg0, %varg1 : vector<8xi32>
+
+%vsrem = llvm.srem %varg0, %varg1 : vector<8xi32>
+// CHECK: %vsrem = llvm.srem %varg0, %varg1 : vector<8xi32>
+
+%vand = llvm.and %varg0, %varg1 : vector<8xi32>
+// CHECK: %vand = llvm.and %varg0, %varg1 : vector<8xi32>
+
+%vor = llvm.or %varg0, %varg1 : vector<8xi32>
+// CHECK: %vor = llvm.or %varg0, %varg1 : vector<8xi32>
+
+%vor_disjoint = llvm.or disjoint %varg0, %varg1 : vector<8xi32>
+// CHECK: %vor_disjoint = llvm.or disjoint %varg0, %varg1 : vector<8xi32>
+
+%vxor = llvm.xor %varg0, %varg1 : vector<8xi32>
+// CHECK: %vxor = llvm.xor %varg0, %varg1 : vector<8xi32>
+
+%vshl = llvm.shl %varg0, %varg1 : vector<8xi32>
+// CHECK: %vshl = llvm.shl %varg0, %varg1 : vector<8xi32>
+
+%vshl_overflow = llvm.shl %varg0, %varg1 overflow<nsw> : vector<8xi32>
+// CHECK: %vshl_overflow = llvm.shl %varg0, %varg1 overflow<nsw> : vector<8xi32>
+
+%vlshr = llvm.lshr %varg0, %varg1 : vector<8xi32>
+// CHECK: %vlshr = llvm.lshr %varg0, %varg1 : vector<8xi32>
+
+%vashr = llvm.ashr %varg0, %varg1 : vector<8xi32>
+// CHECK: %vashr = llvm.ashr %varg0, %varg1 : vector<8xi32>
+
+%vlshr_exact = llvm.lshr exact %varg0, %varg1 : vector<8xi32>
+// CHECK: %vlshr_exact = llvm.lshr exact %varg0, %varg1 : vector<8xi32>
+
+%vashr_exact = llvm.ashr exact %varg0, %varg1 : vector<8xi32>
+// CHECK: %vashr_exact = llvm.ashr exact %varg0, %varg1 : vector<8xi32>
+
+%vtrunc = llvm.trunc %varg0 : vector<8xi32> to vector<8xi16>
+// CHECK: %vtrunc = llvm.trunc %varg0 : vector<8xi32> to vector<8xi16>
+
+%vtrunc_overflow = llvm.trunc %varg0 overflow<nsw> : vector<8xi32> to vector<8xi16>
+// CHECK: %vtrunc_overflow = llvm.trunc %varg0 overflow<nsw> : vector<8xi32> to vector<8xi16>
+
+%vsext = llvm.sext %varg0 : vector<8xi32> to vector<8xi64>
+// CHECK: %vsext = llvm.sext %varg0 : vector<8xi32> to vector<8xi64>
+
+%vzext = llvm.zext %varg0 : vector<8xi32> to vector<8xi64>
+// CHECK: %vzext = llvm.zext %varg0 : vector<8xi32> to vector<8xi64>
+
+%vzext_nneg = llvm.zext nneg %varg0 : vector<8xi32> to vector<8xi64>
+// CHECK: %vzext_nneg = llvm.zext nneg %varg0 : vector<8xi32> to vector<8xi64>
+
+%vcst1 = llvm.mlir.constant(dense<false> : vector<8xi1>) : vector<8xi1>
+// CHECK: %vcst1 = llvm.mlir.constant(dense<false> : vector<8xi1>) : vector<8xi1>
+
+%vcst64 = llvm.mlir.constant(dense<25> : vector<8xi64>) : vector<8xi64>
+// CHECK: %vcst64 = llvm.mlir.constant(dense<25> : vector<8xi64>) : vector<8xi64>
+
+%vcst32 = llvm.mlir.constant(dense<25> : vector<8xi32>) : vector<8xi32>
+// CHECK: %vcst32 = llvm.mlir.constant(dense<25> : vector<8xi32>) : vector<8xi32>
+
+%vicmp_eq = llvm.icmp "eq" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_eq = llvm.icmp "eq" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_ne = llvm.icmp "ne" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_ne = llvm.icmp "ne" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_slt = llvm.icmp "slt" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_slt = llvm.icmp "slt" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_sle = llvm.icmp "sle" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_sle = llvm.icmp "sle" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_sgt = llvm.icmp "sgt" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_sgt = llvm.icmp "sgt" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_sge = llvm.icmp "sge" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_sge = llvm.icmp "sge" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_ult = llvm.icmp "ult" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_ult = llvm.icmp "ult" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_ule = llvm.icmp "ule" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_ule = llvm.icmp "ule" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_ugt = llvm.icmp "ugt" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_ugt = llvm.icmp "ugt" %varg0, %varg1 : vector<8xi32>
+
+%vicmp_uge = llvm.icmp "uge" %varg0, %varg1 : vector<8xi32>
+// CHECK: %vicmp_uge = llvm.icmp "uge" %varg0, %varg1 : vector<8xi32>
+
+// float arith:
+
+%vfmul = llvm.fmul %vf1, %vf1 : vector<8xf32>
+// CHECK: %vfmul = llvm.fmul %vf1, %vf1 : vector<8xf32>
+
+%vfmul_fast = llvm.fmul %vf1, %vf1 {fastmathFlags = #llvm.fastmath<fast>} : vector<8xf32>
+// CHECK: %vfmul_fast = llvm.fmul %vf1, %vf1 {fastmathFlags = #llvm.fastmath<fast>} : vector<8xf32>
+
+%vfdiv = llvm.fdiv %vf1, %vf1 : vector<8xf32>
+// CHECK: %vfdiv = llvm.fdiv %vf1, %vf1 : vector<8xf32>
+
+%vfadd = llvm.fadd %vf1, %vf1 : vector<8xf32>
+// CHECK: %vfadd = llvm.fadd %vf1, %vf1 : vector<8xf32>
+
+%vfsub = llvm.fsub %vf1, %vf1 : vector<8xf32>
+// CHECK: %vfsub = llvm.fsub %vf1, %vf1 : vector<8xf32>
+
+%vfrem = llvm.frem %vf1, %vf1 : vector<8xf32>
+// CHECK: %vfrem = llvm.frem %vf1, %vf1 : vector<8xf32>
+

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/vector.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/llvm/vector.mlir
@@ -1,0 +1,68 @@
+// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt | filecheck %s
+
+builtin.module {
+    %arg0, %arg1, %f1 = "test.op"() : () -> (vector<8xi32>, vector<8xi32>, vector<8xf32>)
+    // CHECK: [[arg0:%\d+]], [[arg1:%\d+]], [[f1:%\d+]]
+
+    %add = llvm.add %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.add [[arg0]], [[arg1]] : vector<8xi32>
+
+    %add2 = llvm.add %arg0, %arg1 {"nsw"} : vector<8xi32>
+    // CHECK: llvm.add [[arg0]], [[arg1]] {nsw} : vector<8xi32>
+
+    %sub = llvm.sub %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.sub [[arg0]], [[arg1]] : vector<8xi32>
+
+    %mul = llvm.mul %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.mul [[arg0]], [[arg1]] : vector<8xi32>
+
+    %udiv = llvm.udiv %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.udiv [[arg0]], [[arg1]] : vector<8xi32>
+
+    %sdiv = llvm.sdiv %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.sdiv [[arg0]], [[arg1]] : vector<8xi32>
+
+    %urem = llvm.urem %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.urem [[arg0]], [[arg1]] : vector<8xi32>
+
+    %srem = llvm.srem %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.srem [[arg0]], [[arg1]] : vector<8xi32>
+
+    %and = llvm.and %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.and [[arg0]], [[arg1]] : vector<8xi32>
+
+    %or = llvm.or %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.or [[arg0]], [[arg1]] : vector<8xi32>
+
+    %xor = llvm.xor %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.xor [[arg0]], [[arg1]] : vector<8xi32>
+
+    %shl = llvm.shl %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.shl [[arg0]], [[arg1]] : vector<8xi32>
+
+    %lshr = llvm.lshr %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.lshr [[arg0]], [[arg1]] : vector<8xi32>
+
+    %ashr = llvm.ashr %arg0, %arg1 : vector<8xi32>
+    // CHECK: llvm.ashr [[arg0]], [[arg1]] : vector<8xi32>
+
+    // float arith:
+
+    %fmul = llvm.fmul %f1, %f1 : vector<8xf32>
+    // CHECK: llvm.fmul [[f1]], [[f1]] : vector<8xf32>
+
+    %fmul_fast = llvm.fmul %f1, %f1 {test = true, fastmathFlags = #llvm.fastmath<fast>} : vector<8xf32>
+    // CHECK: llvm.fmul [[f1]], [[f1]] {test = true, fastmathFlags = #llvm.fastmath<fast>} : vector<8xf32>
+
+    %fdiv = llvm.fdiv %f1, %f1 : vector<8xf32>
+    // CHECK: llvm.fdiv [[f1]], [[f1]] : vector<8xf32>
+
+    %fadd = llvm.fadd %f1, %f1 : vector<8xf32>
+    // CHECK: llvm.fadd [[f1]], [[f1]] : vector<8xf32>
+
+    %fsub = llvm.fsub %f1, %f1 : vector<8xf32>
+    // CHECK: llvm.fsub [[f1]], [[f1]] : vector<8xf32>
+
+    %frem = llvm.frem %f1, %f1 : vector<8xf32>
+    // CHECK: llvm.frem [[f1]], [[f1]] : vector<8xf32>
+}

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1292,6 +1292,30 @@ class ContainerOf(
             self.elem_constr.verify(attr, constraint_context)
 
 
+class VectorOf(
+    Generic[AttributeCovT],
+    GenericAttrConstraint[VectorType[AttributeCovT] | TensorType[AttributeCovT]],
+):
+    """A type constraint that can be nested in a vector."""
+
+    elem_constr: GenericAttrConstraint[AttributeCovT]
+
+    def __init__(
+        self,
+        elem_constr: (
+            AttributeCovT | type[AttributeCovT] | GenericAttrConstraint[AttributeCovT]
+        ),
+    ) -> None:
+        object.__setattr__(self, "elem_constr", attr_constr_coercion(elem_constr))
+
+    def verify(self, attr: Attribute, constraint_context: ConstraintContext) -> None:
+        if isinstance(attr, VectorType):
+            attr = cast(VectorType[Attribute], attr)
+            self.elem_constr.verify(attr.element_type, constraint_context)
+        else:
+            self.elem_constr.verify(attr, constraint_context)
+
+
 VectorOrTensorOf: TypeAlias = (
     VectorType[AttributeCovT]
     | TensorType[AttributeCovT]

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -4,11 +4,13 @@ from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass
 from types import EllipsisType
-from typing import ClassVar
+from typing import ClassVar, TypeAlias, cast
 
 from xdsl.dialects.builtin import (
     I64,
+    AnyFloat,
     AnyFloatConstr,
+    AnySignlessIntegerType,
     ArrayAttr,
     ContainerType,
     DenseArrayBase,
@@ -19,9 +21,12 @@ from xdsl.dialects.builtin import (
     IntegerAttr,
     IntegerType,
     NoneAttr,
+    SignlessIntegerConstraint,
     StringAttr,
     SymbolRefAttr,
     UnitAttr,
+    VectorOf,
+    VectorType,
     i1,
     i32,
     i64,
@@ -39,8 +44,8 @@ from xdsl.ir import (
     TypeAttribute,
 )
 from xdsl.irdl import (
+    AnyOf,
     AttrSizedOperandSegments,
-    BaseAttr,
     IRDLOperation,
     ParameterDef,
     ParsePropInAttrDict,
@@ -70,6 +75,32 @@ from xdsl.traits import (
 from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
+
+LLVMCompatibleNumericConstraint = AnyOf(
+    [
+        AnyFloatConstr,
+        SignlessIntegerConstraint,
+        VectorOf(AnyFloatConstr),
+        VectorOf(SignlessIntegerConstraint),
+    ]
+)
+
+LLVMCompatibleNumericType: TypeAlias = (
+    AnyFloat
+    | AnySignlessIntegerType
+    | VectorType[AnyFloat]
+    | VectorType[AnySignlessIntegerType]
+)
+
+LLVMCompatibleFloatConstraint = AnyOf(
+    [
+        AnyFloatConstr,
+        VectorOf(AnyFloatConstr),
+    ]
+)
+
+LLVMCompatibleFloatType: TypeAlias = AnyFloat | VectorType[AnyFloat]
+
 
 GEP_USE_SSA_VAL = -2147483648
 """
@@ -372,7 +403,7 @@ class LinkageAttr(ParametrizedAttribute):
 class ArithmeticBinOperation(IRDLOperation, ABC):
     """Class for arithmetic binary operations."""
 
-    T: ClassVar = VarConstraint("T", BaseAttr(IntegerType))
+    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -439,7 +470,7 @@ class OverflowAttr(OverflowAttrBase):
 class ArithmeticBinOpOverflow(IRDLOperation, ABC):
     """Class for arithmetic binary operations that use overflow flags."""
 
-    T: ClassVar = VarConstraint("T", BaseAttr(IntegerType))
+    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -488,7 +519,7 @@ class ArithmeticBinOpOverflow(IRDLOperation, ABC):
 class ArithmeticBinOpExact(IRDLOperation, ABC):
     """Class for arithmetic binary operations that use an exact flag."""
 
-    T: ClassVar = VarConstraint("T", BaseAttr(IntegerType))
+    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -545,7 +576,7 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
 class ArithmeticBinOpDisjoint(IRDLOperation, ABC):
     """Class for arithmetic binary operations that use a disjoint flag."""
 
-    T: ClassVar = VarConstraint("T", BaseAttr(IntegerType))
+    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -576,9 +607,9 @@ class ArithmeticBinOpDisjoint(IRDLOperation, ABC):
 
 
 class IntegerConversionOp(IRDLOperation, ABC):
-    arg = operand_def(IntegerType)
+    arg = operand_def(LLVMCompatibleNumericConstraint)
 
-    res = result_def(IntegerType)
+    res = result_def(LLVMCompatibleNumericConstraint)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -609,8 +640,8 @@ class IntegerConversionOp(IRDLOperation, ABC):
 
 
 class IntegerConversionOpNNeg(IRDLOperation, ABC):
-    arg = operand_def(IntegerType)
-    res = result_def(IntegerType)
+    arg = operand_def(LLVMCompatibleNumericConstraint)
+    res = result_def(LLVMCompatibleNumericConstraint)
     traits = traits_def(NoMemoryEffect())
     non_neg = opt_prop_def(UnitAttr, prop_name="nonNeg")
 
@@ -634,8 +665,8 @@ class IntegerConversionOpNNeg(IRDLOperation, ABC):
 
 
 class IntegerConversionOpOverflow(IRDLOperation, ABC):
-    arg = operand_def(IntegerType)
-    res = result_def(IntegerType)
+    arg = operand_def(LLVMCompatibleNumericConstraint)
+    res = result_def(LLVMCompatibleNumericConstraint)
     overflowFlags = opt_prop_def(OverflowAttr)
     traits = traits_def(NoMemoryEffect())
 
@@ -746,11 +777,22 @@ class TruncOp(IntegerConversionOpOverflow):
     name = "llvm.trunc"
 
     def verify(self, verify_nested_ops: bool = True):
-        assert isinstance(self.arg.type, IntegerType)
-        assert isinstance(self.res.type, IntegerType)
-        if self.arg.type.bitwidth <= self.res.type.bitwidth:
+        if isinstance(self.arg.type, VectorType):
+            arg_type = cast(VectorType[Attribute], self.arg.type).element_type  # pyright: ignore[reportUnknownMemberType]
+        else:
+            arg_type = self.arg.type
+
+        if isinstance(self.res.type, VectorType):
+            res_type = cast(VectorType[Attribute], self.res.type).element_type
+        else:
+            res_type = self.res.type
+
+        assert isinstance(arg_type, IntegerType)
+        assert isinstance(res_type, IntegerType)
+
+        if arg_type.bitwidth <= res_type.bitwidth:
             raise VerifyException(
-                f"invalid cast opcode for cast from {self.arg.type} to {self.res.type}"
+                f"invalid cast opcode for cast from {arg_type} to {res_type}"
             )
         super().verify(verify_nested_ops)
 
@@ -760,11 +802,22 @@ class ZExtOp(IntegerConversionOpNNeg):
     name = "llvm.zext"
 
     def verify(self, verify_nested_ops: bool = True):
-        assert isinstance(self.arg.type, IntegerType)
-        assert isinstance(self.res.type, IntegerType)
-        if self.arg.type.bitwidth >= self.res.type.bitwidth:
+        if isinstance(self.arg.type, VectorType):
+            arg_type = cast(VectorType[Attribute], self.arg.type).element_type  # pyright: ignore[reportUnknownMemberType]
+        else:
+            arg_type = self.arg.type
+
+        if isinstance(self.res.type, VectorType):
+            res_type = cast(VectorType[Attribute], self.res.type).element_type
+        else:
+            res_type = self.res.type
+
+        assert isinstance(arg_type, IntegerType)
+        assert isinstance(res_type, IntegerType)
+
+        if arg_type.bitwidth >= res_type.bitwidth:
             raise VerifyException(
-                f"invalid cast opcode for cast from {self.arg.type} to {self.res.type}"
+                f"invalid cast opcode for cast from {arg_type} to {res_type}"
             )
         super().verify(verify_nested_ops)
 
@@ -774,11 +827,22 @@ class SExtOp(IntegerConversionOp):
     name = "llvm.sext"
 
     def verify(self, verify_nested_ops: bool = True):
-        assert isinstance(self.arg.type, IntegerType)
-        assert isinstance(self.res.type, IntegerType)
-        if self.arg.type.bitwidth >= self.res.type.bitwidth:
+        if isinstance(self.arg.type, VectorType):
+            arg_type = cast(VectorType[Attribute], self.arg.type).element_type  # pyright: ignore[reportUnknownMemberType]
+        else:
+            arg_type = self.arg.type
+
+        if isinstance(self.res.type, VectorType):
+            res_type = cast(VectorType[Attribute], self.res.type).element_type
+        else:
+            res_type = self.res.type
+
+        assert isinstance(arg_type, IntegerType)
+        assert isinstance(res_type, IntegerType)
+
+        if arg_type.bitwidth >= res_type.bitwidth:
             raise VerifyException(
-                f"invalid cast opcode for cast from {self.arg.type} to {self.res.type}"
+                f"invalid cast opcode for cast from {arg_type} to {res_type}"
             )
         super().verify(verify_nested_ops)
 
@@ -810,11 +874,11 @@ ICMP_INDEX_BY_FLAG = {f: i for (i, f) in enumerate(ALL_ICMP_FLAGS)}
 @irdl_op_definition
 class ICmpOp(IRDLOperation):
     name = "llvm.icmp"
-    T: ClassVar = VarConstraint("T", BaseAttr(IntegerType))
+    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
-    res = result_def(i1)
+    res = result_def(AnyOf([i1, VectorOf(i1)]))
     predicate = prop_def(IntegerAttr[i64])
 
     traits = traits_def(NoMemoryEffect())
@@ -826,10 +890,15 @@ class ICmpOp(IRDLOperation):
         predicate: IntegerAttr[IntegerType],
         attributes: dict[str, Attribute] = {},
     ):
+        if isinstance(lhs.type, VectorType):
+            result_type = VectorType(i1, lhs.type.shape)
+        else:
+            result_type = i1
+
         super().__init__(
             operands=[lhs, rhs],
             attributes=attributes,
-            result_types=[i1],
+            result_types=[result_type],
             properties={
                 "predicate": predicate,
             },
@@ -1757,7 +1826,7 @@ class GenericCastOp(IRDLOperation, ABC):
 
 
 class AbstractFloatArithOp(IRDLOperation, ABC):
-    T: ClassVar = VarConstraint("T", AnyFloatConstr)
+    T: ClassVar = VarConstraint("T", LLVMCompatibleFloatConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)

--- a/xdsl/dialects/llvm.py
+++ b/xdsl/dialects/llvm.py
@@ -76,20 +76,15 @@ from xdsl.utils.exceptions import VerifyException
 from xdsl.utils.hints import isa
 from xdsl.utils.str_enum import StrEnum
 
-LLVMCompatibleNumericConstraint = AnyOf(
+LLVMCompatibleSignlessIntegerConstraint = AnyOf(
     [
-        AnyFloatConstr,
         SignlessIntegerConstraint,
-        VectorOf(AnyFloatConstr),
         VectorOf(SignlessIntegerConstraint),
     ]
 )
 
-LLVMCompatibleNumericType: TypeAlias = (
-    AnyFloat
-    | AnySignlessIntegerType
-    | VectorType[AnyFloat]
-    | VectorType[AnySignlessIntegerType]
+LLVMCompatibleSignlessIntegerType: TypeAlias = (
+    AnySignlessIntegerType | VectorType[AnySignlessIntegerType]
 )
 
 LLVMCompatibleFloatConstraint = AnyOf(
@@ -101,6 +96,16 @@ LLVMCompatibleFloatConstraint = AnyOf(
 
 LLVMCompatibleFloatType: TypeAlias = AnyFloat | VectorType[AnyFloat]
 
+LLVMCompatibleNumericConstraint = AnyOf(
+    [
+        LLVMCompatibleSignlessIntegerConstraint,
+        LLVMCompatibleFloatConstraint,
+    ]
+)
+
+LLVMCompatibleNumericType: TypeAlias = (
+    LLVMCompatibleSignlessIntegerType | LLVMCompatibleFloatType
+)
 
 GEP_USE_SSA_VAL = -2147483648
 """
@@ -403,7 +408,7 @@ class LinkageAttr(ParametrizedAttribute):
 class ArithmeticBinOperation(IRDLOperation, ABC):
     """Class for arithmetic binary operations."""
 
-    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
+    T: ClassVar = VarConstraint("T", LLVMCompatibleSignlessIntegerConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -470,7 +475,7 @@ class OverflowAttr(OverflowAttrBase):
 class ArithmeticBinOpOverflow(IRDLOperation, ABC):
     """Class for arithmetic binary operations that use overflow flags."""
 
-    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
+    T: ClassVar = VarConstraint("T", LLVMCompatibleSignlessIntegerConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -519,7 +524,7 @@ class ArithmeticBinOpOverflow(IRDLOperation, ABC):
 class ArithmeticBinOpExact(IRDLOperation, ABC):
     """Class for arithmetic binary operations that use an exact flag."""
 
-    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
+    T: ClassVar = VarConstraint("T", LLVMCompatibleSignlessIntegerConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -576,7 +581,7 @@ class ArithmeticBinOpExact(IRDLOperation, ABC):
 class ArithmeticBinOpDisjoint(IRDLOperation, ABC):
     """Class for arithmetic binary operations that use a disjoint flag."""
 
-    T: ClassVar = VarConstraint("T", LLVMCompatibleNumericConstraint)
+    T: ClassVar = VarConstraint("T", LLVMCompatibleSignlessIntegerConstraint)
 
     lhs = operand_def(T)
     rhs = operand_def(T)
@@ -607,9 +612,9 @@ class ArithmeticBinOpDisjoint(IRDLOperation, ABC):
 
 
 class IntegerConversionOp(IRDLOperation, ABC):
-    arg = operand_def(LLVMCompatibleNumericConstraint)
+    arg = operand_def(LLVMCompatibleSignlessIntegerConstraint)
 
-    res = result_def(LLVMCompatibleNumericConstraint)
+    res = result_def(LLVMCompatibleSignlessIntegerConstraint)
 
     traits = traits_def(NoMemoryEffect())
 
@@ -640,8 +645,8 @@ class IntegerConversionOp(IRDLOperation, ABC):
 
 
 class IntegerConversionOpNNeg(IRDLOperation, ABC):
-    arg = operand_def(LLVMCompatibleNumericConstraint)
-    res = result_def(LLVMCompatibleNumericConstraint)
+    arg = operand_def(LLVMCompatibleSignlessIntegerConstraint)
+    res = result_def(LLVMCompatibleSignlessIntegerConstraint)
     traits = traits_def(NoMemoryEffect())
     non_neg = opt_prop_def(UnitAttr, prop_name="nonNeg")
 
@@ -665,8 +670,8 @@ class IntegerConversionOpNNeg(IRDLOperation, ABC):
 
 
 class IntegerConversionOpOverflow(IRDLOperation, ABC):
-    arg = operand_def(LLVMCompatibleNumericConstraint)
-    res = result_def(LLVMCompatibleNumericConstraint)
+    arg = operand_def(LLVMCompatibleSignlessIntegerConstraint)
+    res = result_def(LLVMCompatibleSignlessIntegerConstraint)
     overflowFlags = opt_prop_def(OverflowAttr)
     traits = traits_def(NoMemoryEffect())
 


### PR DESCRIPTION
Depending on the context, the upstream `llvm` dialect allows many arithmetic operations to accept vectors containing signless integers, floats, or a mixture of the two as inputs.

> Signless integer or LLVM dialect-compatible vector of signless integer

This pull request introduces three constraints:

- `LLVMCompatibleSignlessIntegerConstraint`
- `LLVMCompatibleFloatConstraint`
- `LLVMCompatibleNumericConstraint`

Operations in the dialect are modified to accept these as operand constraints.