### PR TITLE
backend: ptr.store to x86

### DIFF
--- a/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
@@ -1,4 +1,4 @@
-// RUN: xdsl-opt -p convert-ptr-to-x86{arch=avx2} --verify-diagnostics --split-input-file  %s | filecheck %s
+// RUN: xdsl-opt -p convert-ptr-to-x86{arch=avx512} --verify-diagnostics --split-input-file  %s | filecheck %s
 
 %ptr0 = "test.op"(): () -> !ptr_xdsl.ptr
 %v0 = ptr_xdsl.load %ptr0 : !ptr_xdsl.ptr -> vector<8xf32>
@@ -8,6 +8,15 @@
 // CHECK-NEXT:    %v0_1 = x86.rm.vmovups %v0, 0 : (!x86.reg) -> !x86.avx2reg
 // CHECK-NEXT:  }
 
+// -----
+
+%ptr0b = "test.op"(): () -> !ptr_xdsl.ptr
+%v0b = ptr_xdsl.load %ptr0b : !ptr_xdsl.ptr -> vector<16xf32>
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %ptr0b = "test.op"() : () -> !ptr_xdsl.ptr
+// CHECK-NEXT:    %v0b = builtin.unrealized_conversion_cast %ptr0b : !ptr_xdsl.ptr to !x86.reg
+// CHECK-NEXT:    %v0b_1 = x86.rm.vmovups %v0b, 0 : (!x86.reg) -> !x86.avx512reg
+// CHECK-NEXT:  }
 
 // -----
 
@@ -31,7 +40,7 @@
 
 // CHECK: The vector size and target architecture are inconsistent.
 %ptr4 = "test.op"(): () -> !ptr_xdsl.ptr
-%v4 = ptr_xdsl.load %ptr4 : !ptr_xdsl.ptr -> vector<16xf32>
+%v4 = ptr_xdsl.load %ptr4 : !ptr_xdsl.ptr -> vector<32xf32>
 
 // -----
 
@@ -51,6 +60,20 @@ ptr_xdsl.store %v6, %ptr6 : vector<8xf32>, !ptr_xdsl.ptr
 // CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %ptr6 : !ptr_xdsl.ptr to !x86.reg
 // CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %v6 : vector<8xf32> to !x86.avx2reg
 // CHECK-NEXT:   x86.mr.vmovups %0, %1, 0 : (!x86.reg, !x86.avx2reg) -> ()
+// CHECK-NEXT: }
+
+// -----
+
+%ptr6b = "test.op"(): () -> !ptr_xdsl.ptr
+%v6b = "test.op"(): () -> vector<16xf32>
+ptr_xdsl.store %v6b, %ptr6b : vector<16xf32>, !ptr_xdsl.ptr
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %ptr6b = "test.op"() : () -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v6b = "test.op"() : () -> vector<16xf32>
+// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %ptr6b : !ptr_xdsl.ptr to !x86.reg
+// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %v6b : vector<16xf32> to !x86.avx512reg
+// CHECK-NEXT:   x86.mr.vmovups %0, %1, 0 : (!x86.reg, !x86.avx512reg) -> ()
 // CHECK-NEXT: }
 
 // -----
@@ -80,3 +103,10 @@ ptr_xdsl.store %v6, %ptr6 : vector<16xf16>, !ptr_xdsl.ptr
 %ptr6 = "test.op"(): () -> !ptr_xdsl.ptr
 %v6 = "test.op"(): () -> vector<1xf128>
 ptr_xdsl.store %v6, %ptr6 : vector<1xf128>, !ptr_xdsl.ptr
+
+// -----
+
+// CHECK: The lowering of ptr.store is not yet implemented for non-vector types.
+%ptr6 = "test.op"(): () -> !ptr_xdsl.ptr
+%v6 = "test.op"(): () -> f32
+ptr_xdsl.store %v6, %ptr6 : f32, !ptr_xdsl.ptr

--- a/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
+++ b/tests/filecheck/backend/x86/convert_ptr_to_x86.mlir
@@ -31,10 +31,52 @@
 
 // CHECK: The vector size and target architecture are inconsistent.
 %ptr4 = "test.op"(): () -> !ptr_xdsl.ptr
-%v4 = ptr_xdsl.load %ptr4 : !ptr_xdsl.ptr -> vector<8xf64>
+%v4 = ptr_xdsl.load %ptr4 : !ptr_xdsl.ptr -> vector<16xf32>
 
 // -----
 
 // CHECK: Float precision must be half, single or double.
 %ptr5 = "test.op"(): () -> !ptr_xdsl.ptr
 %v5 = ptr_xdsl.load %ptr5 : !ptr_xdsl.ptr -> vector<1xf128>
+
+// -----
+
+%ptr6 = "test.op"(): () -> !ptr_xdsl.ptr
+%v6 = "test.op"(): () -> vector<8xf32>
+ptr_xdsl.store %v6, %ptr6 : vector<8xf32>, !ptr_xdsl.ptr
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %ptr6 = "test.op"() : () -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v6 = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %ptr6 : !ptr_xdsl.ptr to !x86.reg
+// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %v6 : vector<8xf32> to !x86.avx2reg
+// CHECK-NEXT:   x86.mr.vmovups %0, %1, 0 : (!x86.reg, !x86.avx2reg) -> ()
+// CHECK-NEXT: }
+
+// -----
+
+%ptr6 = "test.op"(): () -> !ptr_xdsl.ptr
+%v6 = "test.op"(): () -> vector<4xf64>
+ptr_xdsl.store %v6, %ptr6 : vector<4xf64>, !ptr_xdsl.ptr
+
+// CHECK:      builtin.module {
+// CHECK-NEXT:   %ptr6 = "test.op"() : () -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v6 = "test.op"() : () -> vector<4xf64>
+// CHECK-NEXT:   %0 = builtin.unrealized_conversion_cast %ptr6 : !ptr_xdsl.ptr to !x86.reg
+// CHECK-NEXT:   %1 = builtin.unrealized_conversion_cast %v6 : vector<4xf64> to !x86.avx2reg
+// CHECK-NEXT:   x86.mr.vmovapd %0, %1, 0 : (!x86.reg, !x86.avx2reg) -> ()
+// CHECK-NEXT: }
+
+// -----
+
+// CHECK: Half-precision vector load is not implemented yet.
+%ptr6 = "test.op"(): () -> !ptr_xdsl.ptr
+%v6 = "test.op"(): () -> vector<16xf16>
+ptr_xdsl.store %v6, %ptr6 : vector<16xf16>, !ptr_xdsl.ptr
+
+// -----
+
+// CHECK: Float precision must be half, single or double.
+%ptr6 = "test.op"(): () -> !ptr_xdsl.ptr
+%v6 = "test.op"(): () -> vector<1xf128>
+ptr_xdsl.store %v6, %ptr6 : vector<1xf128>, !ptr_xdsl.ptr

--- a/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
+++ b/xdsl/backend/x86/lowering/convert_ptr_to_x86.py
@@ -8,6 +8,7 @@ from xdsl.dialects.builtin import (
     UnrealizedConversionCastOp,
     VectorType,
 )
+from xdsl.dialects.x86.register import X86VectorRegisterType
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -19,41 +20,85 @@ from xdsl.pattern_rewriter import (
 from xdsl.utils.exceptions import DiagnosticException
 
 
+def vector_type_to_register_type(
+    value_type: VectorType,
+    arch: str,
+) -> X86VectorRegisterType:
+    vector_num_elements = value_type.element_count()
+    element_type = cast(FixedBitwidthType, value_type.get_element_type())
+    element_size = element_type.bitwidth
+    vector_size = vector_num_elements * element_size
+    # Choose the x86 vector register according to the
+    # target architecture and the abstract vector size
+    if vector_size == 128:
+        vect_reg_type = x86.register.UNALLOCATED_SSE
+    elif vector_size == 256 and (arch == "avx2" or arch == "avx512"):
+        vect_reg_type = x86.register.UNALLOCATED_AVX2
+    elif vector_size == 512 and arch == "avx512":
+        vect_reg_type = x86.register.UNALLOCATED_AVX512
+    else:
+        raise DiagnosticException(
+            "The vector size and target architecture are inconsistent."
+        )
+    return vect_reg_type
+
+
+@dataclass
+class PtrStoreToX86(RewritePattern):
+    arch: str
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: ptr.StoreOp, rewriter: PatternRewriter):
+        value_type = op.value.type
+        if not isinstance(value_type, VectorType):
+            raise DiagnosticException(
+                "The lowering of ptr.store is not yet implemented for non-vector types."
+            )
+        value_type = cast(VectorType, value_type)
+        # Pointer casts
+        x86_reg_type = x86.register.UNALLOCATED_GENERAL
+        addr_cast_op = UnrealizedConversionCastOp.get((op.addr,), (x86_reg_type,))
+        x86_vect_type = vector_type_to_register_type(value_type, self.arch)
+        vect_cast_op = UnrealizedConversionCastOp.get((op.value,), (x86_vect_type,))
+        # Choose the x86 vector instruction according to the
+        # abstract vector element size
+        element_size = cast(FixedBitwidthType, value_type.get_element_type()).bitwidth
+        match element_size:
+            case 16:
+                raise DiagnosticException(
+                    "Half-precision vector load is not implemented yet."
+                )
+            case 32:
+                mov = x86.ops.MR_VmovupsOp
+            case 64:
+                mov = x86.ops.MR_VmovapdOp
+            case _:
+                raise DiagnosticException(
+                    "Float precision must be half, single or double."
+                )
+
+        mov_op = mov(addr_cast_op, vect_cast_op, offset=0)
+        rewriter.replace_matched_op([addr_cast_op, vect_cast_op, mov_op])
+
+
 @dataclass
 class PtrLoadToX86(RewritePattern):
     arch: str
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: ptr.LoadOp, rewriter: PatternRewriter):
-        source = op.addr
-        value = op.res
-        value_type = value.type
+        value_type = op.res.type
         if not isinstance(value_type, VectorType):
             raise DiagnosticException(
                 "The lowering of ptr.load is not yet implemented for non-vector types."
             )
+        value_type = cast(VectorType, value_type)
         # Pointer cast
         x86_reg_type = x86.register.UNALLOCATED_GENERAL
-        cast_op = UnrealizedConversionCastOp.get((source,), (x86_reg_type,))
-        # Output vector description
-        vector_num_elements = value_type.element_count()
-        element_type = cast(FixedBitwidthType, value_type.get_element_type())
-        element_size = element_type.bitwidth
-        vector_size = vector_num_elements * element_size
-        # Choose the x86 vector register according to the
-        # target architecture and the abstract vector size
-        if vector_size == 128:
-            vect_reg_type = x86.register.UNALLOCATED_SSE
-        elif vector_size == 256 and (self.arch == "avx2" or self.arch == "avx512"):
-            vect_reg_type = x86.register.UNALLOCATED_AVX2
-        elif vector_size == 512 and self.arch == "avx512":
-            vect_reg_type = x86.register.UNALLOCATED_AVX512
-        else:
-            raise DiagnosticException(
-                "The vector size and target architecture are inconsistent."
-            )
+        cast_op = UnrealizedConversionCastOp.get((op.addr,), (x86_reg_type,))
         # Choose the x86 vector instruction according to the
         # abstract vector element size
+        element_size = cast(FixedBitwidthType, value_type.get_element_type()).bitwidth
         match element_size:
             case 16:
                 raise DiagnosticException(
@@ -62,7 +107,6 @@ class PtrLoadToX86(RewritePattern):
             case 32:
                 mov = x86.ops.RM_VmovupsOp
             case 64:
-                # mov = x86.ops.RM_VmovapdOp
                 raise DiagnosticException(
                     "Double precision vector load is not implemented yet."
                 )
@@ -71,7 +115,11 @@ class PtrLoadToX86(RewritePattern):
                     "Float precision must be half, single or double."
                 )
 
-        mov_op = mov(cast_op, offset=0, result=vect_reg_type)
+        mov_op = mov(
+            cast_op,
+            offset=0,
+            result=vector_type_to_register_type(value_type, self.arch),
+        )
         rewriter.replace_matched_op([cast_op, mov_op])
 
 
@@ -86,6 +134,7 @@ class ConvertPtrToX86Pass(ModulePass):
             GreedyRewritePatternApplier(
                 [
                     PtrLoadToX86(self.arch),
+                    PtrStoreToX86(self.arch),
                 ]
             ),
             apply_recursively=False,


### PR DESCRIPTION
Convert the ```ptr.store``` ops to x86 assembly.
