### PR TITLE
dialects: (builtin) Add support for parsing and printing complex types

### DIFF
--- a/tests/filecheck/dialects/builtin/attrs.mlir
+++ b/tests/filecheck/dialects/builtin/attrs.mlir
@@ -45,6 +45,16 @@
     %x20 = "arith.constant"() {"value" = 0 : i64, "test" = dense<true> : tensor<1xi1>} : () -> i64
     // CHECK: test = dense<false>
     %x21 = "arith.constant"() {"value" = 0 : i64, "test" = dense<false> : tensor<1xi1>} : () -> i64
+    // CHECK: test = dense<(1.200000e+00,3.400000e+00)>
+    %x22 = arith.constant {"test" = dense<(1.2,3.4)> : tensor<1xcomplex<f32>>} 0 : i64
+    // CHECK: test = dense<(1.200000e+00,3.400000e+00)>
+    %x23 = arith.constant {"test" = dense<[(1.2,3.4)]> : tensor<1xcomplex<f32>>} 0 : i64
+    // CHECK: test = dense<(1,2)>
+    %x24 = arith.constant {"test" = dense<(1,2)> : tensor<1xcomplex<i32>>} 0 : i64
+    // CHECK: test = dense<(1,2)>
+    %x25 = arith.constant {"test" = dense<[(1,2)]> : tensor<1xcomplex<i32>>} 0 : i64
+    // CHECK: test = dense<(true,false)>
+    %x26 = arith.constant {"test" = dense<[(true,false)]> : tensor<1xcomplex<i1>>} 0 : i64
     "func.return"() : () -> ()
   }) {"function_type" = () -> (), "sym_name" = "builtin"} : () -> ()
   "test.op"() {"value"= {"one"=1 : i64, "two"=2 : i64, "three"="three"}} : () -> ()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/dense_elements.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/builtin/dense_elements.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt %s | xdsl-opt | mlir-opt --allow-unregistered-dialect | filecheck %s
+
+// CHECK: value = dense<[[(1,2), (3,4)], [(5,6), (7,8)]]> : tensor<2x2xcomplex<i32>>
+%complex_tensor_i32 = "test.op"() {"value" = dense<[[(1, 2), (3, 4)], [(5, 6), (7, 8)]]> : tensor<2x2xcomplex<i32>>} : () -> tensor<2x2xcomplex<i32>>
+// CHECK-NEXT: value = dense<[[(1.000000e+00,2.000000e+00), (3.000000e+00,4.000000e+00)], [(5.000000e+00,6.000000e+00), (7.000000e+00,8.000000e+00)]]> : tensor<2x2xcomplex<f32>>
+%complex_tensor_f32 = "test.op"() {"value" = dense<[[(1.0, 2.0), (3.0, 4.0)], [(5.0, 6.0), (7.0, 8.0)]]> : tensor<2x2xcomplex<f32>>} : () -> tensor<2x2xcomplex<f32>>
+// CHECK-NEXT: value = dense<[(true,false), (false,false)]>
+%complex_tensor_i1 = "test.op"() {"value" = dense<[(true, false), (false, false)]> : tensor<2xcomplex<i1>>} : () -> tensor<2xcomplex<i1>>

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2332,6 +2332,13 @@ class DenseIntOrFPElementsAttr(
         data: Sequence[tuple[float, float]],
     ) -> DenseIntOrFPElementsAttr[ComplexType[_FloatAttrTypeInvT]]: ...
 
+    @overload
+    @staticmethod
+    def create_dense_complex(
+        type: RankedStructure[ComplexType[ComplexElementCovT]],
+        data: Sequence[tuple[float, float]] | Sequence[tuple[int, int]],
+    ) -> DenseIntOrFPElementsAttr[ComplexType[ComplexElementCovT]]: ...
+
     @staticmethod
     def create_dense_complex(
         type: RankedStructure[ComplexType[ComplexElementCovT]],
@@ -2544,8 +2551,9 @@ class DenseIntOrFPElementsAttr(
             element_type.print_value_without_type(val, printer)
         elif isinstance(val, float):
             printer.print_float(val, cast(AnyFloat, self.get_element_type()))
-        else:
-            raise NotImplementedError("Next PR")
+        else:  # complex
+            assert isinstance(element_type := self.get_element_type(), ComplexType)
+            printer.print_complex(val, element_type)
 
     def _print_dense_list(
         self,

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -1120,11 +1120,6 @@ class ComplexType(
         self: ComplexType[IntegerType], values: Sequence[tuple[int, int]]
     ) -> bytes: ...
 
-    @overload
-    def pack(
-        self, values: Sequence[tuple[int, int]] | Sequence[tuple[float, float]]
-    ) -> bytes: ...
-
     def pack(self, values: Sequence[tuple[float, float] | tuple[int, int]]) -> bytes:
         return self.element_type.pack(tuple(val for vals in values for val in vals))  # pyright: ignore[reportArgumentType]
 
@@ -2337,7 +2332,7 @@ class DenseIntOrFPElementsAttr(
         type: RankedStructure[ComplexType[ComplexElementCovT]],
         data: Sequence[tuple[float, float]] | Sequence[tuple[int, int]],
     ) -> DenseIntOrFPElementsAttr[ComplexType[ComplexElementCovT]]:
-        return DenseIntOrFPElementsAttr([type, BytesAttr(type.element_type.pack(data))])
+        return DenseIntOrFPElementsAttr([type, BytesAttr(type.element_type.pack(data))])  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportAttributeAccessIssue]
 
     @overload
     @staticmethod

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2332,13 +2332,6 @@ class DenseIntOrFPElementsAttr(
         data: Sequence[tuple[float, float]],
     ) -> DenseIntOrFPElementsAttr[ComplexType[_FloatAttrTypeInvT]]: ...
 
-    @overload
-    @staticmethod
-    def create_dense_complex(
-        type: RankedStructure[ComplexType[ComplexElementCovT]],
-        data: Sequence[tuple[float, float]] | Sequence[tuple[int, int]],
-    ) -> DenseIntOrFPElementsAttr[ComplexType[ComplexElementCovT]]: ...
-
     @staticmethod
     def create_dense_complex(
         type: RankedStructure[ComplexType[ComplexElementCovT]],

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -720,6 +720,7 @@ class AttrParser(BaseParser):
         RankedStructure[IntegerType]
         | RankedStructure[IndexType]
         | RankedStructure[AnyFloat]
+        | RankedStructure[ComplexType]
     ):
         type = self.expect(self.parse_optional_type, "Dense attribute must be typed!")
         # Check that the type is correct.
@@ -727,12 +728,13 @@ class AttrParser(BaseParser):
             base(RankedStructure[IntegerType])
             | base(RankedStructure[IndexType])
             | base(RankedStructure[AnyFloat])
+            | base(RankedStructure[ComplexType])
         ).verifies(
             type,
         ):
             self.raise_error(
                 "Expected memref, vector or tensor type of "
-                "integer, index, or float type"
+                "integer, index, float, or complex type"
             )
 
         # Check for static shapes in type
@@ -822,7 +824,14 @@ class AttrParser(BaseParser):
 
         if isinstance(type.element_type, AnyFloat):
             new_type = cast(RankedStructure[AnyFloat], type)
-            return DenseIntOrFPElementsAttr.create_dense_float(new_type, data_values)
+            new_data = cast(Sequence[int | float], data_values)
+            return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
+        elif isinstance(type.element_type, ComplexType):
+            new_type = cast(RankedStructure[ComplexType], type)
+            new_data = cast(
+                Sequence[tuple[int, int] | tuple[float, float]], data_values
+            )
+            return DenseIntOrFPElementsAttr.create_dense_complex(new_type, new_data)
         else:
             new_type = cast(RankedStructure[IntegerType | IndexType], type)
             new_data = cast(Sequence[int], data_values)
@@ -933,14 +942,14 @@ class AttrParser(BaseParser):
     class _TensorLiteralElement:
         """
         The representation of a tensor literal element used during parsing.
-        It is either an integer, float, or boolean. It also has a check if
+        It is either an integer, float, boolean, or complex. It also has a check if
         the element has a negative sign (it is already applied to the value).
         This class is used to parse a tensor literal before the tensor literal
         type is known
         """
 
         is_negative: bool
-        value: int | float | bool
+        value: int | float | bool | tuple[int, int] | tuple[float, float]
         """
         An integer, float, boolean, integer complex, or float complex value.
         The tuple should be of type `_TensorLiteralElement`, but python does
@@ -976,18 +985,49 @@ class AttrParser(BaseParser):
             Convert the element to a float value. Raises an error if the type
             is compatible.
             """
+            if isinstance(self.value, tuple):
+                raise NotImplementedError()
             return float(self.value)
+
+        def to_complex(
+            self, parser: AttrParser, type: ComplexType
+        ) -> tuple[float, float] | tuple[int, int]:
+            if isinstance(self.value, int) and isinstance(
+                type.element_type, IntegerType
+            ):
+                return (self.value, 0)
+            elif isinstance(self.value, int) and isinstance(
+                type.element_type, AnyFloat
+            ):
+                return (float(self.value), 0.0)
+            elif isinstance(self.value, float) and isinstance(
+                type.element_type, AnyFloat
+            ):
+                return (self.value, 0.0)
+            elif isinstance(self.value, float) and isinstance(
+                type.element_type, IntegerType
+            ):
+                return (int(self.value), 0)
+            elif isinstance(self.value, tuple) and isinstance(
+                type.element_type, IntegerType
+            ):
+                return (int(self.value[0]), int(self.value[1]))
+            elif isinstance(self.value, tuple) and isinstance(
+                type.element_type, AnyFloat
+            ):
+                return (float(self.value[0]), float(self.value[1]))
+            raise NotImplementedError()
 
         def to_type(
             self,
             parser: AttrParser,
             type: AnyFloat | IntegerType | IndexType | ComplexType,
         ):
-            if isinstance(type, ComplexType):
-                raise NotImplementedError("Implemented in follow up PR")
-
             if isinstance(type, AnyFloat):
                 return self.to_float(parser)
+
+            if isinstance(type, ComplexType):
+                return self.to_complex(parser, type)
 
             match type:
                 case IntegerType():
@@ -1083,6 +1123,9 @@ class AttrParser(BaseParser):
         if scalar_span := self._parse_optional_bool_int_or_float():
             value, span = scalar_span
             return self._TensorLiteralElement(value < 0, value, span)
+        elif complex_span := self._parse_optional_complex():
+            value, span = complex_span
+            return self._TensorLiteralElement(False, value, span)
 
         self.raise_error("Expected either a float, integer, or complex literal")
 

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -983,36 +983,21 @@ class AttrParser(BaseParser):
             is compatible.
             """
             if isinstance(self.value, tuple):
-                raise NotImplementedError()
+                parser.raise_error("No conversion from complex to float")
             return float(self.value)
 
         def to_complex(
             self, parser: AttrParser, type: ComplexType
         ) -> tuple[float, float] | tuple[int, int]:
-            if isinstance(self.value, int) and isinstance(
-                type.element_type, IntegerType
-            ):
-                return (self.value, 0)
-            elif isinstance(self.value, int) and isinstance(
-                type.element_type, AnyFloat
-            ):
-                return (float(self.value), 0.0)
-            elif isinstance(self.value, float) and isinstance(
-                type.element_type, AnyFloat
-            ):
-                return (self.value, 0.0)
-            elif isinstance(self.value, float) and isinstance(
-                type.element_type, IntegerType
-            ):
-                return (int(self.value), 0)
-            elif isinstance(self.value, tuple) and isinstance(
-                type.element_type, IntegerType
-            ):
-                return (int(self.value[0]), int(self.value[1]))
-            elif isinstance(self.value, tuple) and isinstance(
-                type.element_type, AnyFloat
-            ):
+            assert isinstance(self.value, tuple)
+
+            if isinstance(type.element_type, AnyFloat):
                 return (float(self.value[0]), float(self.value[1]))
+
+            match type.element_type:
+                case IntegerType():
+                    return (int(self.value[0]), int(self.value[1]))
+
             raise NotImplementedError()
 
         def to_type(

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -828,10 +828,7 @@ class AttrParser(BaseParser):
             return DenseIntOrFPElementsAttr.create_dense_float(new_type, new_data)
         elif isinstance(type.element_type, ComplexType):
             new_type = cast(RankedStructure[ComplexType], type)
-            new_data = cast(
-                Sequence[tuple[int, int] | tuple[float, float]], data_values
-            )
-            return DenseIntOrFPElementsAttr.create_dense_complex(new_type, new_data)
+            return DenseIntOrFPElementsAttr.create_dense_complex(new_type, data_values)  # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType]
         else:
             new_type = cast(RankedStructure[IntegerType | IndexType], type)
             new_data = cast(Sequence[int], data_values)

--- a/xdsl/parser/attribute_parser.py
+++ b/xdsl/parser/attribute_parser.py
@@ -1023,9 +1023,6 @@ class AttrParser(BaseParser):
             if isinstance(type, AnyFloat):
                 return self.to_float(parser)
 
-            if isinstance(type, ComplexType):
-                return self.to_complex(parser, type)
-
             match type:
                 case IntegerType():
                     return self.to_int(
@@ -1037,6 +1034,9 @@ class AttrParser(BaseParser):
                     return self.to_int(
                         parser, allow_negative=True, allow_booleans=False
                     )
+
+                case ComplexType():
+                    return self.to_complex(parser, type)
 
     def _parse_optional_bool_int_or_float(
         self,


### PR DESCRIPTION
Parsing and printing of complex types. 

* adds the `create_dense_complex` method to `DenseIntOrFPElementsAttr`
* adds the `get_dense_values` method `DenseIntOrFPElementsAttr`
* adds the `to_complex` method to `_TensorLiteralElement`
* adds cases to print and parse complex values