### PR TITLE
dialects: (x86) move all abstract operations to one place

### DIFF
--- a/xdsl/dialects/x86/ops.py
+++ b/xdsl/dialects/x86/ops.py
@@ -194,6 +194,9 @@ class X86Instruction(X86AsmOperation):
         return AssemblyPrinter.assembly_line(instruction_name, arg_str, self.comment)
 
 
+# region: Operation Base Classes
+
+
 class R_RR_Operation(
     Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
 ):
@@ -227,6 +230,629 @@ class R_RR_Operation(
 
     def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
         return self.r1, self.r2
+
+
+class R_R_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
+    """
+    A base class for x86 operations that have one register acting as both source and destination.
+    """
+
+    source = operand_def(R1InvT)
+    destination = result_def(R1InvT)
+
+    def __init__(
+        self,
+        source: Operation | SSAValue | None = None,
+        *,
+        comment: str | StringAttr | None = None,
+        destination: R1InvT | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[source],
+            attributes={
+                "comment": comment,
+            },
+            result_types=[destination],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return (self.source,)
+
+
+class R_RM_Operation(
+    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
+):
+    """
+    A base class for x86 operations that have one register and one memory access with an optional offset.
+    """
+
+    r1 = operand_def(R1InvT)
+    r2 = operand_def(R2InvT)
+    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+
+    result = result_def(R1InvT)
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        r2: Operation | SSAValue,
+        offset: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+        result: R1InvT,
+    ):
+        if isinstance(offset, int):
+            offset = IntegerAttr(offset, 64)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1, r2],
+            attributes={
+                "offset": offset,
+                "comment": comment,
+            },
+            result_types=[result],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        memory_access = memory_access_str(self.r2, self.offset)
+        destination = assembly_arg_str(self.r1)
+        return (destination, memory_access)
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        if offset := cls.parse_optional_memory_access_offset(parser):
+            attributes["offset"] = offset
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.offset)
+        return {"offset"}
+
+
+class R_M_Operation(
+    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
+):
+    """
+    A base class for x86 operations that have one register and one memory access with an optional offset.
+    """
+
+    r1 = operand_def(R1InvT)
+    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+
+    result = result_def(R2InvT)
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        offset: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+        result: R2InvT,
+    ):
+        if isinstance(offset, int):
+            offset = IntegerAttr(offset, 64)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1],
+            attributes={
+                "offset": offset,
+                "comment": comment,
+            },
+            result_types=[result],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        memory_access = memory_access_str(self.r1, self.offset)
+        destination = assembly_arg_str(self.result)
+        return (destination, memory_access)
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        if offset := cls.parse_optional_memory_access_offset(parser):
+            attributes["offset"] = offset
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.offset)
+        return {"offset"}
+
+
+class R_RI_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
+    """
+    A base class for x86 operations that have one register and an immediate value.
+    """
+
+    r1 = operand_def(R1InvT)
+    immediate = attr_def(IntegerAttr)
+
+    result = result_def(R1InvT)
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        immediate: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+        result: R1InvT,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(
+                immediate, 32
+            )  # the default immediate size is 32 bits
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1],
+            attributes={
+                "immediate": immediate,
+                "comment": comment,
+            },
+            result_types=[result],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return self.r1, self.immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        temp = parse_optional_immediate_value(
+            parser, IntegerType(32, Signedness.SIGNED)
+        )
+        if temp is not None:
+            attributes["immediate"] = temp
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.immediate)
+        return {"immediate"}
+
+
+class M_MR_Operation(
+    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
+):
+    """
+    A base class for x86 operations that have one memory reference and one register.
+    """
+
+    r1 = operand_def(R1InvT)
+    r2 = operand_def(R2InvT)
+    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        r2: Operation | SSAValue,
+        offset: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(offset, int):
+            offset = IntegerAttr(offset, 64)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1, r2],
+            attributes={
+                "offset": offset,
+                "comment": comment,
+            },
+            result_types=[],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        memory_access = memory_access_str(self.r1, self.offset)
+        return memory_access, self.r2
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        if offset := cls.parse_optional_memory_access_offset(parser):
+            attributes["offset"] = offset
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.offset)
+        return {"offset"}
+
+
+class M_MI_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
+    """
+    A base class for x86 operations that have one memory reference and an immediate value.
+    """
+
+    r1 = operand_def(R1InvT)
+    immediate = attr_def(IntegerAttr)
+    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        offset: int | IntegerAttr,
+        immediate: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(
+                immediate, 32
+            )  # the default immediate size is 32 bits
+        if isinstance(offset, int):
+            offset = IntegerAttr(offset, 64)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1],
+            attributes={
+                "immediate": immediate,
+                "offset": offset,
+                "comment": comment,
+            },
+            result_types=[],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        immediate = assembly_arg_str(self.immediate)
+        memory_access = memory_access_str(self.r1, self.offset)
+        return memory_access, immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        temp = parse_immediate_value(parser, IntegerType(64, Signedness.SIGNED))
+        attributes["immediate"] = temp
+        if parser.parse_optional_punctuation(",") is not None:
+            if offset := cls.parse_optional_memory_access_offset(parser):
+                attributes["offset"] = offset
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.immediate)
+        if self.offset.value.data != 0:
+            printer.print(", ")
+            print_immediate_value(printer, self.offset)
+        return {"immediate", "offset"}
+
+
+class R_RRI_Operation(
+    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
+):
+    """
+    A base class for x86 operations that have one destination register, one source register and an immediate value.
+    """
+
+    r2 = operand_def(R2InvT)
+    immediate = attr_def(IntegerAttr)
+
+    r1 = result_def(R1InvT)
+
+    def __init__(
+        self,
+        r2: Operation | SSAValue,
+        immediate: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+        r1: R1InvT,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(
+                immediate, 32
+            )  # the default immediate size is 32 bits
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r2],
+            attributes={
+                "immediate": immediate,
+                "comment": comment,
+            },
+            result_types=[r1],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return self.r1, self.r2, self.immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        temp = parse_immediate_value(parser, IntegerType(32, Signedness.SIGNED))
+        attributes["immediate"] = temp
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.immediate)
+        return {"immediate"}
+
+
+class R_RMI_Operation(
+    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
+):
+    """
+    A base class for x86 operations that have one source register, one memory reference and an immediate value.
+    """
+
+    r2 = operand_def(R2InvT)
+    immediate = attr_def(IntegerAttr)
+    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+
+    r1 = result_def(R1InvT)
+
+    def __init__(
+        self,
+        r2: Operation | SSAValue,
+        immediate: int | IntegerAttr,
+        offset: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+        r1: R1InvT,
+    ):
+        if isinstance(immediate, int):
+            immediate = IntegerAttr(
+                immediate, 32
+            )  # the default immediate size is 32 bits
+        if isinstance(offset, int):
+            offset = IntegerAttr(offset, 64)
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r2],
+            attributes={
+                "immediate": immediate,
+                "offset": offset,
+                "comment": comment,
+            },
+            result_types=[r1],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        destination = assembly_arg_str(self.r1)
+        immediate = assembly_arg_str(self.immediate)
+        memory_access = memory_access_str(self.r2, self.offset)
+        return destination, memory_access, immediate
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        temp = parse_immediate_value(parser, IntegerType(64, Signedness.SIGNED))
+        attributes["immediate"] = temp
+        if parser.parse_optional_punctuation(",") is not None:
+            if offset := cls.parse_optional_memory_access_offset(parser):
+                attributes["offset"] = offset
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.immediate)
+        if self.offset.value.data != 0:
+            printer.print(", ")
+            print_immediate_value(printer, self.offset)
+        return {"immediate", "offset"}
+
+
+class M_M_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
+    """
+    A base class for x86 operations with a memory reference that's both a source and a
+    destination
+    """
+
+    source = operand_def(R1InvT)
+    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
+
+    def __init__(
+        self,
+        source: Operation | SSAValue,
+        offset: int | IntegerAttr,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+        if isinstance(offset, int):
+            offset = IntegerAttr(offset, 64)
+
+        super().__init__(
+            operands=[source],
+            attributes={
+                "offset": offset,
+                "comment": comment,
+            },
+            result_types=[],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        memory_access = memory_access_str(self.source, self.offset)
+        return (memory_access,)
+
+    @classmethod
+    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
+        attributes = dict[str, Attribute]()
+        if offset := cls.parse_optional_memory_access_offset(parser):
+            attributes["offset"] = offset
+        return attributes
+
+    def custom_print_attributes(self, printer: Printer) -> Set[str]:
+        printer.print(", ")
+        print_immediate_value(printer, self.offset)
+        return {"offset"}
+
+
+class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
+    """
+    A base class for Jcc operations.
+
+    See external [documentation](https://www.felixcloutier.com/x86/jcc).
+    """
+
+    rflags = operand_def(RFLAGSRegisterType)
+
+    then_values = var_operand_def(X86RegisterType)
+    else_values = var_operand_def(X86RegisterType)
+
+    irdl_options = [AttrSizedOperandSegments()]
+
+    then_block = successor_def()
+    else_block = successor_def()
+
+    traits = traits_def(IsTerminator())
+
+    def __init__(
+        self,
+        rflags: Operation | SSAValue,
+        then_values: Sequence[SSAValue],
+        else_values: Sequence[SSAValue],
+        then_block: Successor,
+        else_block: Successor,
+        *,
+        comment: str | StringAttr | None = None,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[rflags, then_values, else_values],
+            attributes={
+                "comment": comment,
+            },
+            successors=(then_block, else_block),
+        )
+
+    def verify_(self) -> None:
+        # The then block must start with a label op
+
+        then_block_first_op = self.then_block.first_op
+
+        if not isinstance(then_block_first_op, LabelOp):
+            raise VerifyException("then block first op must be a label")
+
+        # Types of arguments must match arg types of blocks
+
+        for op_arg, block_arg in zip(self.then_values, self.then_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        for op_arg, block_arg in zip(self.else_values, self.else_block.args):
+            if op_arg.type != block_arg.type:
+                raise VerifyException(
+                    f"Block arg types must match {op_arg.type} {block_arg.type}"
+                )
+
+        # The else block must be the one immediately following this one
+
+        parent_block = self.parent
+        if parent_block is None:
+            return
+
+        parent_region = parent_block.parent
+        if parent_region is None:
+            return
+
+        if parent_block.next_block is not self.else_block:
+            raise VerifyException("else block must be immediately after op")
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
+        then_label = self.then_block.first_op
+        assert isinstance(then_label, LabelOp)
+        return (then_label.label,)
+
+    def print(self, printer: Printer) -> None:
+        printer.print_string(" ")
+        print_type_pair(printer, self.rflags)
+        printer.print_string(", ")
+        printer.print_block_name(self.then_block)
+        printer.print_string("(")
+        printer.print_list(self.then_values, lambda val: print_type_pair(printer, val))
+        printer.print_string("), ")
+        printer.print_block_name(self.else_block)
+        printer.print_string("(")
+        printer.print_list(self.else_values, lambda val: print_type_pair(printer, val))
+        printer.print_string(")")
+        if self.attributes:
+            printer.print_op_attributes(
+                self.attributes,
+                reserved_attr_names="operandSegmentSizes",
+                print_keyword=True,
+            )
+
+    @classmethod
+    def parse(cls, parser: Parser) -> Self:
+        rflags = parse_type_pair(parser)
+        parser.parse_punctuation(",")
+        then_block = parser.parse_successor()
+        then_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: parse_type_pair(parser)
+        )
+        parser.parse_punctuation(",")
+        else_block = parser.parse_successor()
+        else_args = parser.parse_comma_separated_list(
+            parser.Delimiter.PAREN, lambda: parse_type_pair(parser)
+        )
+        attrs = parser.parse_optional_attr_dict_with_keyword()
+        op = cls(rflags, then_args, else_args, then_block, else_block)
+        if attrs is not None:
+            op.attributes |= attrs.data
+        return op
+
+
+class RRROperation(
+    Generic[R1InvT, R2InvT, R3InvT], X86Instruction, X86CustomFormatOperation, ABC
+):
+    """
+    A base class for x86 operations that have three registers.
+    """
+
+    r1 = operand_def(R1InvT)
+    r2 = operand_def(R2InvT)
+    r3 = operand_def(R3InvT)
+
+    result = result_def(R1InvT)
+
+    def __init__(
+        self,
+        r1: Operation | SSAValue,
+        r2: Operation | SSAValue,
+        r3: Operation | SSAValue,
+        *,
+        comment: str | StringAttr | None = None,
+        result: R1InvT,
+    ):
+        if isinstance(comment, str):
+            comment = StringAttr(comment)
+
+        super().__init__(
+            operands=[r1, r2, r3],
+            attributes={
+                "comment": comment,
+            },
+            result_types=[result],
+        )
+
+    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
+        return self.r1, self.r2, self.r3
+
+
+# endregion
 
 
 @irdl_op_definition
@@ -401,36 +1027,6 @@ class R_PopOp(X86Instruction, X86CustomFormatOperation):
         return (self.destination,)
 
 
-class R_R_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
-    """
-    A base class for x86 operations that have one register acting as both source and destination.
-    """
-
-    source = operand_def(R1InvT)
-    destination = result_def(R1InvT)
-
-    def __init__(
-        self,
-        source: Operation | SSAValue | None = None,
-        *,
-        comment: str | StringAttr | None = None,
-        destination: R1InvT | None = None,
-    ):
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[source],
-            attributes={
-                "comment": comment,
-            },
-            result_types=[destination],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        return (self.source,)
-
-
 @irdl_op_definition
 class R_NegOp(R_R_Operation[GeneralRegisterType]):
     """
@@ -572,112 +1168,6 @@ class R_ImulOp(X86Instruction, X86CustomFormatOperation):
         return (self.r1,)
 
 
-class R_RM_Operation(
-    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
-):
-    """
-    A base class for x86 operations that have one register and one memory access with an optional offset.
-    """
-
-    r1 = operand_def(R1InvT)
-    r2 = operand_def(R2InvT)
-    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
-
-    result = result_def(R1InvT)
-
-    def __init__(
-        self,
-        r1: Operation | SSAValue,
-        r2: Operation | SSAValue,
-        offset: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-        result: R1InvT,
-    ):
-        if isinstance(offset, int):
-            offset = IntegerAttr(offset, 64)
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r1, r2],
-            attributes={
-                "offset": offset,
-                "comment": comment,
-            },
-            result_types=[result],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        memory_access = memory_access_str(self.r2, self.offset)
-        destination = assembly_arg_str(self.r1)
-        return (destination, memory_access)
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.offset)
-        return {"offset"}
-
-
-class R_M_Operation(
-    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
-):
-    """
-    A base class for x86 operations that have one register and one memory access with an optional offset.
-    """
-
-    r1 = operand_def(R1InvT)
-    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
-
-    result = result_def(R2InvT)
-
-    def __init__(
-        self,
-        r1: Operation | SSAValue,
-        offset: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-        result: R2InvT,
-    ):
-        if isinstance(offset, int):
-            offset = IntegerAttr(offset, 64)
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r1],
-            attributes={
-                "offset": offset,
-                "comment": comment,
-            },
-            result_types=[result],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        memory_access = memory_access_str(self.r1, self.offset)
-        destination = assembly_arg_str(self.result)
-        return (destination, memory_access)
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.offset)
-        return {"offset"}
-
-
 @irdl_op_definition
 class RM_AddOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
@@ -790,59 +1280,6 @@ class RM_leaOp(R_RM_Operation[GeneralRegisterType, GeneralRegisterType]):
     name = "x86.rm.lea"
 
 
-class R_RI_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
-    """
-    A base class for x86 operations that have one register and an immediate value.
-    """
-
-    r1 = operand_def(R1InvT)
-    immediate = attr_def(IntegerAttr)
-
-    result = result_def(R1InvT)
-
-    def __init__(
-        self,
-        r1: Operation | SSAValue,
-        immediate: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-        result: R1InvT,
-    ):
-        if isinstance(immediate, int):
-            immediate = IntegerAttr(
-                immediate, 32
-            )  # the default immediate size is 32 bits
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r1],
-            attributes={
-                "immediate": immediate,
-                "comment": comment,
-            },
-            result_types=[result],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        return self.r1, self.immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_optional_immediate_value(
-            parser, IntegerType(32, Signedness.SIGNED)
-        )
-        if temp is not None:
-            attributes["immediate"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
-
 @irdl_op_definition
 class RI_AddOp(R_RI_Operation[GeneralRegisterType]):
     """
@@ -927,56 +1364,6 @@ class RI_MovOp(R_RI_Operation[GeneralRegisterType]):
     name = "x86.ri.mov"
 
 
-class M_MR_Operation(
-    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
-):
-    """
-    A base class for x86 operations that have one memory reference and one register.
-    """
-
-    r1 = operand_def(R1InvT)
-    r2 = operand_def(R2InvT)
-    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
-
-    def __init__(
-        self,
-        r1: Operation | SSAValue,
-        r2: Operation | SSAValue,
-        offset: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(offset, int):
-            offset = IntegerAttr(offset, 64)
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r1, r2],
-            attributes={
-                "offset": offset,
-                "comment": comment,
-            },
-            result_types=[],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        memory_access = memory_access_str(self.r1, self.offset)
-        return memory_access, self.r2
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.offset)
-        return {"offset"}
-
-
 @irdl_op_definition
 class MR_AddOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
@@ -1049,66 +1436,6 @@ class MR_MovOp(M_MR_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
 
     name = "x86.mr.mov"
-
-
-class M_MI_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
-    """
-    A base class for x86 operations that have one memory reference and an immediate value.
-    """
-
-    r1 = operand_def(R1InvT)
-    immediate = attr_def(IntegerAttr)
-    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
-
-    def __init__(
-        self,
-        r1: Operation | SSAValue,
-        offset: int | IntegerAttr,
-        immediate: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(immediate, int):
-            immediate = IntegerAttr(
-                immediate, 32
-            )  # the default immediate size is 32 bits
-        if isinstance(offset, int):
-            offset = IntegerAttr(offset, 64)
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r1],
-            attributes={
-                "immediate": immediate,
-                "offset": offset,
-                "comment": comment,
-            },
-            result_types=[],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        immediate = assembly_arg_str(self.immediate)
-        memory_access = memory_access_str(self.r1, self.offset)
-        return memory_access, immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, IntegerType(64, Signedness.SIGNED))
-        attributes["immediate"] = temp
-        if parser.parse_optional_punctuation(",") is not None:
-            if offset := cls.parse_optional_memory_access_offset(parser):
-                attributes["offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.immediate)
-        if self.offset.value.data != 0:
-            printer.print(", ")
-            print_immediate_value(printer, self.offset)
-        return {"immediate", "offset"}
 
 
 @irdl_op_definition
@@ -1189,58 +1516,6 @@ class MI_MovOp(M_MI_Operation[GeneralRegisterType]):
     name = "x86.mi.mov"
 
 
-class R_RRI_Operation(
-    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
-):
-    """
-    A base class for x86 operations that have one destination register, one source register and an immediate value.
-    """
-
-    r2 = operand_def(R2InvT)
-    immediate = attr_def(IntegerAttr)
-
-    r1 = result_def(R1InvT)
-
-    def __init__(
-        self,
-        r2: Operation | SSAValue,
-        immediate: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-        r1: R1InvT,
-    ):
-        if isinstance(immediate, int):
-            immediate = IntegerAttr(
-                immediate, 32
-            )  # the default immediate size is 32 bits
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r2],
-            attributes={
-                "immediate": immediate,
-                "comment": comment,
-            },
-            result_types=[r1],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        return self.r1, self.r2, self.immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, IntegerType(32, Signedness.SIGNED))
-        attributes["immediate"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.immediate)
-        return {"immediate"}
-
-
 @irdl_op_definition
 class RRI_ImulOp(R_RRI_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
@@ -1251,72 +1526,6 @@ class RRI_ImulOp(R_RRI_Operation[GeneralRegisterType, GeneralRegisterType]):
     """
 
     name = "x86.rri.imul"
-
-
-class R_RMI_Operation(
-    Generic[R1InvT, R2InvT], X86Instruction, X86CustomFormatOperation, ABC
-):
-    """
-    A base class for x86 operations that have one source register, one memory reference and an immediate value.
-    """
-
-    r2 = operand_def(R2InvT)
-    immediate = attr_def(IntegerAttr)
-    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
-
-    r1 = result_def(R1InvT)
-
-    def __init__(
-        self,
-        r2: Operation | SSAValue,
-        immediate: int | IntegerAttr,
-        offset: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-        r1: R1InvT,
-    ):
-        if isinstance(immediate, int):
-            immediate = IntegerAttr(
-                immediate, 32
-            )  # the default immediate size is 32 bits
-        if isinstance(offset, int):
-            offset = IntegerAttr(offset, 64)
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r2],
-            attributes={
-                "immediate": immediate,
-                "offset": offset,
-                "comment": comment,
-            },
-            result_types=[r1],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        destination = assembly_arg_str(self.r1)
-        immediate = assembly_arg_str(self.immediate)
-        memory_access = memory_access_str(self.r2, self.offset)
-        return destination, memory_access, immediate
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        temp = parse_immediate_value(parser, IntegerType(64, Signedness.SIGNED))
-        attributes["immediate"] = temp
-        if parser.parse_optional_punctuation(",") is not None:
-            if offset := cls.parse_optional_memory_access_offset(parser):
-                attributes["offset"] = offset
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.immediate)
-        if self.offset.value.data != 0:
-            printer.print(", ")
-            print_immediate_value(printer, self.offset)
-        return {"immediate", "offset"}
 
 
 @irdl_op_definition
@@ -1440,53 +1649,6 @@ class M_PopOp(X86Instruction, X86CustomFormatOperation):
         )
         if temp is not None:
             attributes["offset"] = temp
-        return attributes
-
-    def custom_print_attributes(self, printer: Printer) -> Set[str]:
-        printer.print(", ")
-        print_immediate_value(printer, self.offset)
-        return {"offset"}
-
-
-class M_M_Operation(Generic[R1InvT], X86Instruction, X86CustomFormatOperation, ABC):
-    """
-    A base class for x86 operations with a memory reference that's both a source and a
-    destination
-    """
-
-    source = operand_def(R1InvT)
-    offset = attr_def(IntegerAttr, default_value=IntegerAttr(0, 64))
-
-    def __init__(
-        self,
-        source: Operation | SSAValue,
-        offset: int | IntegerAttr,
-        *,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-        if isinstance(offset, int):
-            offset = IntegerAttr(offset, 64)
-
-        super().__init__(
-            operands=[source],
-            attributes={
-                "offset": offset,
-                "comment": comment,
-            },
-            result_types=[],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        memory_access = memory_access_str(self.source, self.offset)
-        return (memory_access,)
-
-    @classmethod
-    def custom_parse_attributes(cls, parser: Parser) -> dict[str, Attribute]:
-        attributes = dict[str, Attribute]()
-        if offset := cls.parse_optional_memory_access_offset(parser):
-            attributes["offset"] = offset
         return attributes
 
     def custom_print_attributes(self, printer: Printer) -> Set[str]:
@@ -2148,125 +2310,6 @@ class MI_CmpOp(X86Instruction, X86CustomFormatOperation):
         return {"immediate", "offset"}
 
 
-class ConditionalJumpOperation(X86Instruction, X86CustomFormatOperation, ABC):
-    """
-    A base class for Jcc operations.
-
-    See external [documentation](https://www.felixcloutier.com/x86/jcc).
-    """
-
-    rflags = operand_def(RFLAGSRegisterType)
-
-    then_values = var_operand_def(X86RegisterType)
-    else_values = var_operand_def(X86RegisterType)
-
-    irdl_options = [AttrSizedOperandSegments()]
-
-    then_block = successor_def()
-    else_block = successor_def()
-
-    traits = traits_def(IsTerminator())
-
-    def __init__(
-        self,
-        rflags: Operation | SSAValue,
-        then_values: Sequence[SSAValue],
-        else_values: Sequence[SSAValue],
-        then_block: Successor,
-        else_block: Successor,
-        *,
-        comment: str | StringAttr | None = None,
-    ):
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[rflags, then_values, else_values],
-            attributes={
-                "comment": comment,
-            },
-            successors=(then_block, else_block),
-        )
-
-    def verify_(self) -> None:
-        # The then block must start with a label op
-
-        then_block_first_op = self.then_block.first_op
-
-        if not isinstance(then_block_first_op, LabelOp):
-            raise VerifyException("then block first op must be a label")
-
-        # Types of arguments must match arg types of blocks
-
-        for op_arg, block_arg in zip(self.then_values, self.then_block.args):
-            if op_arg.type != block_arg.type:
-                raise VerifyException(
-                    f"Block arg types must match {op_arg.type} {block_arg.type}"
-                )
-
-        for op_arg, block_arg in zip(self.else_values, self.else_block.args):
-            if op_arg.type != block_arg.type:
-                raise VerifyException(
-                    f"Block arg types must match {op_arg.type} {block_arg.type}"
-                )
-
-        # The else block must be the one immediately following this one
-
-        parent_block = self.parent
-        if parent_block is None:
-            return
-
-        parent_region = parent_block.parent
-        if parent_region is None:
-            return
-
-        if parent_block.next_block is not self.else_block:
-            raise VerifyException("else block must be immediately after op")
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg, ...]:
-        then_label = self.then_block.first_op
-        assert isinstance(then_label, LabelOp)
-        return (then_label.label,)
-
-    def print(self, printer: Printer) -> None:
-        printer.print_string(" ")
-        print_type_pair(printer, self.rflags)
-        printer.print_string(", ")
-        printer.print_block_name(self.then_block)
-        printer.print_string("(")
-        printer.print_list(self.then_values, lambda val: print_type_pair(printer, val))
-        printer.print_string("), ")
-        printer.print_block_name(self.else_block)
-        printer.print_string("(")
-        printer.print_list(self.else_values, lambda val: print_type_pair(printer, val))
-        printer.print_string(")")
-        if self.attributes:
-            printer.print_op_attributes(
-                self.attributes,
-                reserved_attr_names="operandSegmentSizes",
-                print_keyword=True,
-            )
-
-    @classmethod
-    def parse(cls, parser: Parser) -> Self:
-        rflags = parse_type_pair(parser)
-        parser.parse_punctuation(",")
-        then_block = parser.parse_successor()
-        then_args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: parse_type_pair(parser)
-        )
-        parser.parse_punctuation(",")
-        else_block = parser.parse_successor()
-        else_args = parser.parse_comma_separated_list(
-            parser.Delimiter.PAREN, lambda: parse_type_pair(parser)
-        )
-        attrs = parser.parse_optional_attr_dict_with_keyword()
-        op = cls(rflags, then_args, else_args, then_block, else_block)
-        if attrs is not None:
-            op.attributes |= attrs.data
-        return op
-
-
 @irdl_op_definition
 class S_JaOp(ConditionalJumpOperation):
     """
@@ -2595,43 +2638,6 @@ class S_JzOp(ConditionalJumpOperation):
     """
 
     name = "x86.s.jz"
-
-
-class RRROperation(
-    Generic[R1InvT, R2InvT, R3InvT], X86Instruction, X86CustomFormatOperation, ABC
-):
-    """
-    A base class for x86 operations that have three registers.
-    """
-
-    r1 = operand_def(R1InvT)
-    r2 = operand_def(R2InvT)
-    r3 = operand_def(R3InvT)
-
-    result = result_def(R1InvT)
-
-    def __init__(
-        self,
-        r1: Operation | SSAValue,
-        r2: Operation | SSAValue,
-        r3: Operation | SSAValue,
-        *,
-        comment: str | StringAttr | None = None,
-        result: R1InvT,
-    ):
-        if isinstance(comment, str):
-            comment = StringAttr(comment)
-
-        super().__init__(
-            operands=[r1, r2, r3],
-            attributes={
-                "comment": comment,
-            },
-            result_types=[result],
-        )
-
-    def assembly_line_args(self) -> tuple[AssemblyInstructionArg | None, ...]:
-        return self.r1, self.r2, self.r3
 
 
 @irdl_op_definition


### PR DESCRIPTION
I would like to change the naming convention we use in this dialect, and putting all the abstract base classes in one place makes this easier. More changes to follow.