### PR TITLE
installation: (nix) include mlir-opt in flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737264083,
-        "narHash": "sha256-6QqSrHPN+ZD+7HuadVLuFNUaM8XnmZF3EO7QViM1b80=",
+        "lastModified": 1746576598,
+        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aa6ae0afa6adeb5c202a168e51eda1d3da571117",
+        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
               buildInputs = [
                 uv
                 nodejs_22
+                llvmPackages_20.mlir
               ];
             };
           }


### PR DESCRIPTION
Adds `mlir-opt` v20.1.4 to the nix flake, allowing all the tests to be run without compiling mlir.

@superlopuh as far as I can tell, `brew` also installs v20.1.4 now (https://formulae.brew.sh/formula/llvm), should we update versions for next release?