### PR TITLE
dialects: (builtin) deprecate tensor_from_list

### DIFF
--- a/tests/dialects/test_builtin.py
+++ b/tests/dialects/test_builtin.py
@@ -7,7 +7,6 @@ import pytest
 from xdsl.dialects.arith import ConstantOp
 from xdsl.dialects.builtin import (
     AnyFloat,
-    AnyTensorType,
     ArrayAttr,
     BFloat16Type,
     BoolAttr,
@@ -338,7 +337,7 @@ def test_IntegerType_packing():
 
 
 def test_DenseIntOrFPElementsAttr_fp_type_conversion():
-    check1 = DenseIntOrFPElementsAttr.tensor_from_list([4, 5], f32, [2])
+    check1 = DenseIntOrFPElementsAttr.create_dense_float(TensorType(f64, [2]), [4, 5])
 
     value1 = check1.get_attrs()[0].value.data
     value2 = check1.get_attrs()[1].value.data
@@ -352,7 +351,7 @@ def test_DenseIntOrFPElementsAttr_fp_type_conversion():
     t1 = FloatAttr(4.0, f32)
     t2 = FloatAttr(5.0, f32)
 
-    check2 = DenseIntOrFPElementsAttr.tensor_from_list([t1, t2], f32, [2])
+    check2 = DenseIntOrFPElementsAttr.create_dense_float(TensorType(f32, [2]), [t1, t2])
 
     value3 = check2.get_attrs()[0].value.data
     value4 = check2.get_attrs()[1].value.data
@@ -378,10 +377,10 @@ def test_DenseIntOrFPElementsAttr_splat():
     assert attr_float.is_splat()
 
 
-def test_DenseIntOrFPElementsAttr_from_list():
+def test_DenseIntOrFPElementsAttr_initialization():
     # legal zero-rank tensor
-    attr = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
-    assert attr.type == AnyTensorType(f32, [])
+    attr = DenseIntOrFPElementsAttr.create_dense_float(TensorType(f32, []), [5.5])
+    assert attr.type == TensorType(f32, [])
     assert len(attr) == 1
 
     # illegal zero-rank tensor
@@ -389,27 +388,23 @@ def test_DenseIntOrFPElementsAttr_from_list():
         VerifyException,
         match="A zero-rank tensor can only hold 1 value but 2 were given.",
     ):
-        DenseIntOrFPElementsAttr.tensor_from_list([5.5, 5.6], f32, [])
+        DenseIntOrFPElementsAttr.create_dense_float(TensorType(f32, []), [5.5, 5.6])
 
     # legal 1 element tensor
-    attr = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [1])
-    assert attr.type == AnyTensorType(f32, [1])
+    attr = DenseIntOrFPElementsAttr.create_dense_float(TensorType(f32, [1]), [5.5])
+    assert attr.type == TensorType(f32, [1])
     assert len(attr) == 1
 
     # legal normal tensor
-    attr = DenseIntOrFPElementsAttr.tensor_from_list([5.5, 5.6], f32, [2])
-    assert attr.type == AnyTensorType(f32, [2])
+    attr = DenseIntOrFPElementsAttr.create_dense_float(TensorType(f32, [2]), [5.5, 5.6])
+    assert attr.type == TensorType(f32, [2])
     assert len(attr) == 2
-
-    # splat initialization
-    attr = DenseIntOrFPElementsAttr.tensor_from_list([4], f32, [4])
-    assert attr.type == AnyTensorType(f32, [4])
-    assert tuple(attr.get_values()) == (4, 4, 4, 4)
-    assert len(attr) == 4
 
 
 def test_DenseIntOrFPElementsAttr_values():
-    int_attr = DenseIntOrFPElementsAttr.tensor_from_list([1, 2, 3, 4], i32, [4])
+    int_attr = DenseIntOrFPElementsAttr.create_dense_int(
+        TensorType(i32, [4]), [1, 2, 3, 4]
+    )
     assert tuple(int_attr.get_values()) == (1, 2, 3, 4)
     assert tuple(int_attr.iter_values()) == (1, 2, 3, 4)
     assert tuple(int_attr.get_attrs()) == (
@@ -425,8 +420,8 @@ def test_DenseIntOrFPElementsAttr_values():
         IntegerAttr(4, i32),
     )
 
-    index_attr = DenseIntOrFPElementsAttr.tensor_from_list(
-        [1, 2, 3, 4], IndexType(), [4]
+    index_attr = DenseIntOrFPElementsAttr.create_dense_int(
+        TensorType(IndexType(), [4]), [1, 2, 3, 4]
     )
     assert tuple(index_attr.get_values()) == (1, 2, 3, 4)
     assert tuple(index_attr.iter_values()) == (1, 2, 3, 4)
@@ -443,8 +438,9 @@ def test_DenseIntOrFPElementsAttr_values():
         IntegerAttr(4, IndexType()),
     )
 
-    float_attr = DenseIntOrFPElementsAttr.tensor_from_list(
-        [1.0, 2.0, 3.0, 4.0], f32, [4]
+    float_attr = DenseIntOrFPElementsAttr.create_dense_float(
+        TensorType(f32, [4]),
+        [1.0, 2.0, 3.0, 4.0],
     )
     assert tuple(float_attr.get_values()) == (1.0, 2.0, 3.0, 4.0)
     assert tuple(float_attr.iter_values()) == (1.0, 2.0, 3.0, 4.0)

--- a/tests/dialects/test_math.py
+++ b/tests/dialects/test_math.py
@@ -4,6 +4,7 @@ from xdsl.dialects.arith import ConstantOp, FloatingPointLikeBinaryOperation
 from xdsl.dialects.builtin import (
     DenseIntOrFPElementsAttr,
     FloatAttr,
+    TensorType,
     VectorType,
     f32,
     i32,
@@ -60,7 +61,9 @@ class Test_float_math_binary_construction:
     lhs_vector = TestOp([lhs_vector_ssa_value], result_types=[f32_vector_type])
     rhs_vector = TestOp([rhs_vector_ssa_value], result_types=[f32_vector_type])
 
-    f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
+    f32_tensor_type = DenseIntOrFPElementsAttr.create_dense_float(
+        TensorType(f32, []), [5.5]
+    )
     lhs_tensor_ssa_value = create_ssa_value(f32_tensor_type)
     rhs_tensor_ssa_value = create_ssa_value(f32_tensor_type)
 
@@ -134,7 +137,9 @@ class Test_float_math_unary_constructions:
     test_vector_ssa = create_ssa_value(f32_vector_type)
     test_vec = TestOp([test_vector_ssa], result_types=[f32_vector_type])
 
-    f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
+    f32_tensor_type = DenseIntOrFPElementsAttr.create_dense_float(
+        TensorType(f32, []), [5.5]
+    )
     test_tensor_ssa_value = create_ssa_value(f32_tensor_type)
     test_tensor = TestOp([test_tensor_ssa_value], result_types=[f32_tensor_type])
 
@@ -256,7 +261,9 @@ class Test_fpowi:
     a_vector_ssa_value = create_ssa_value(f32_vector_type)
     a_vector = TestOp([a_vector_ssa_value], result_types=[f32_vector_type])
 
-    f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
+    f32_tensor_type = DenseIntOrFPElementsAttr.create_dense_float(
+        TensorType(f32, []), [5.5]
+    )
     a_tensor_ssa_value = create_ssa_value(f32_tensor_type)
     a_tensor = TestOp([a_tensor_ssa_value], result_types=[f32_tensor_type])
 
@@ -293,7 +300,9 @@ class Test_fma:
     b_vec = TestOp([test_vector_ssa], result_types=[f32_vector_type])
     c_vec = TestOp([test_vector_ssa], result_types=[f32_vector_type])
 
-    f32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5.5], f32, [])
+    f32_tensor_type = DenseIntOrFPElementsAttr.create_dense_float(
+        TensorType(f32, []), [5.5]
+    )
     test_tensor_ssa = create_ssa_value(f32_vector_type)
     a_tensor = TestOp([test_tensor_ssa], result_types=[f32_tensor_type])
     b_tensor = TestOp([test_tensor_ssa], result_types=[f32_tensor_type])
@@ -330,7 +339,9 @@ class Test_int_math_unary_constructions:
     test_vector_ssa = create_ssa_value(i32_vector_type)
     test_vec = TestOp([test_vector_ssa], result_types=[i32_vector_type])
 
-    i32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5], i32, [])
+    i32_tensor_type = DenseIntOrFPElementsAttr.create_dense_int(
+        TensorType(i32, []), [5]
+    )
     test_tensor_ssa_value = create_ssa_value(i32_tensor_type)
     test_tensor = TestOp([test_tensor_ssa_value], result_types=[i32_tensor_type])
 
@@ -400,7 +411,9 @@ class Test_Trunci:
     test_vector_ssa = create_ssa_value(i32_vector_type)
     test_vec = TestOp([test_vector_ssa], result_types=[i32_vector_type])
 
-    i32_tensor_type = DenseIntOrFPElementsAttr.tensor_from_list([5], i32, [])
+    i32_tensor_type = DenseIntOrFPElementsAttr.create_dense_int(
+        TensorType(i32, []), [5]
+    )
     test_tensor_ssa_value = create_ssa_value(i32_tensor_type)
     test_tensor = TestOp([test_tensor_ssa_value], result_types=[i32_tensor_type])
 

--- a/tests/interpreters/test_linalg_interpreter.py
+++ b/tests/interpreters/test_linalg_interpreter.py
@@ -282,8 +282,12 @@ def test_linalg_pooling_nchw_max():
         (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
         {
-            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-            "strides": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
+            "dilations": DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(i64, [2]), 1
+            ),
+            "strides": DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(i64, [2]), 1
+            ),
         },
     )
     a = ShapedArray(TypedPtr.new_float32(list(range(1, 17))), [1, 1, 4, 4])
@@ -315,8 +319,12 @@ def test_linalg_pooling_nchw_max_strides_two():
         (create_ssa_value(TensorType(f32, [1, 1, 2, 2])),),
         (TensorType(f32, [1, 1, 2, 2]),),
         {
-            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-            "strides": DenseIntOrFPElementsAttr.tensor_from_list([2], i64, [2]),
+            "dilations": DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(i64, [2]), 1
+            ),
+            "strides": DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(i64, [2]), 2
+            ),
         },
     )
     a = ShapedArray(
@@ -348,8 +356,12 @@ def test_linalg_conv_2d_nchw_fchw():
         (create_ssa_value(TensorType(f32, [1, 1, 3, 3])),),
         (TensorType(f32, [1, 1, 3, 3]),),
         {
-            "dilations": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
-            "strides": DenseIntOrFPElementsAttr.tensor_from_list([1], i64, [2]),
+            "dilations": DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(i64, [2]), 1
+            ),
+            "strides": DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(i64, [2]), 1
+            ),
         },
     )
     a = ShapedArray(TypedPtr.new_float32(list(range(25))), [1, 1, 5, 5])

--- a/xdsl/dialects/builtin.py
+++ b/xdsl/dialects/builtin.py
@@ -2331,6 +2331,7 @@ class DenseIntOrFPElementsAttr(
             )
 
     @staticmethod
+    @deprecated("Please use `create_dense_{int/float}` instead.")
     def tensor_from_list(
         data: (
             Sequence[int]
@@ -2342,8 +2343,20 @@ class DenseIntOrFPElementsAttr(
         data_type: IntegerType | IndexType | AnyFloat,
         shape: Sequence[int],
     ) -> DenseIntOrFPElementsAttr:
-        t = TensorType(data_type, shape)
-        return DenseIntOrFPElementsAttr.from_list(t, data)
+        if isinstance(data_type, AnyFloat):
+            new_data = cast(Sequence[float] | Sequence[FloatAttr], data)
+            if len(new_data) == 1 and prod(shape) != 1:
+                new_data = new_data[0]
+            return DenseIntOrFPElementsAttr.create_dense_float(
+                TensorType(data_type, shape), new_data
+            )
+        else:
+            new_data = cast(Sequence[int] | Sequence[IntegerAttr], data)
+            if len(new_data) == 1 and prod(shape) != 1:
+                new_data = new_data[0]
+            return DenseIntOrFPElementsAttr.create_dense_int(
+                TensorType(data_type, shape), new_data
+            )
 
     def iter_values(self) -> Iterator[int] | Iterator[float]:
         """


### PR DESCRIPTION
Replaces uses of `tensor_from_list` with `create_dense_{int/float}`. Stacked on top of splat initialisation.