### PR TITLE
dialects: (emitc) Add EmitC dialect with the EmitC_ArrayType

### DIFF
--- a/tests/dialects/test_emitc.py
+++ b/tests/dialects/test_emitc.py
@@ -1,0 +1,10 @@
+import pytest
+
+from xdsl.dialects.builtin import i32
+from xdsl.dialects.emitc import EmitC_ArrayType
+from xdsl.utils.exceptions import VerifyException
+
+
+def test_emitc_array_empty_shape():
+    with pytest.raises(VerifyException, match="EmitC array shape must not be empty"):
+        EmitC_ArrayType([], i32)

--- a/tests/filecheck/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types.mlir
@@ -1,0 +1,12 @@
+// RUN: XDSL_ROUNDTRIP
+
+// CHECK: f32_2D = !emitc.array<4x2xf32>
+// CHECK-SAME: i32_1D = !emitc.array<10xi32>
+// CHECK-SAME: f64_1D = !emitc.array<5xf64>
+// CHECK-SAME: i1_3D = !emitc.array<3x4x5xi1>
+"test.op"() {
+  f32_2D = !emitc.array<4x2xf32>,
+  i32_1D = !emitc.array<10xi32>,
+  f64_1D = !emitc.array<5xf64>,
+  i1_3D = !emitc.array<3x4x5xi1>
+}: ()->()

--- a/tests/filecheck/dialects/emitc/emitc_types_invalid_parsing.mlir
+++ b/tests/filecheck/dialects/emitc/emitc_types_invalid_parsing.mlir
@@ -1,0 +1,8 @@
+// RUN: xdsl-opt %s --split-input-file --parsing-diagnostics | filecheck %s
+
+// Check that the right diagnostics are emitted when parsing EmitC types with invalid definition.
+
+// CHECK: EmitC array shape must not be empty
+"test.op"() {
+  empty = !emitc.array<f32>
+}: ()->()

--- a/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
+++ b/tests/filecheck/mlir-conversion/with-mlir/dialects/emitc/emitc_types.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt %s --mlir-print-op-generic --allow-unregistered-dialect | xdsl-opt --print-op-generic | filecheck %s
+
+// CHECK: f32_2D = !emitc.array<4x2xf32>
+// CHECK-SAME: f64_1D = !emitc.array<5xf64>
+// CHECK-SAME: i1_3D = !emitc.array<3x4x5xi1>
+// CHECK-SAME: i32_1D = !emitc.array<10xi32>
+"test.op"() {
+  f32_2D = !emitc.array<4x2xf32>,
+  i32_1D = !emitc.array<10xi32>,
+  f64_1D = !emitc.array<5xf64>,
+  i1_3D = !emitc.array<3x4x5xi1>
+}: ()->()

--- a/xdsl/dialects/__init__.py
+++ b/xdsl/dialects/__init__.py
@@ -93,6 +93,11 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
 
         return DMP
 
+    def get_emitc():
+        from xdsl.dialects.emitc import EmitC
+
+        return EmitC
+
     def get_eqsat():
         from xdsl.dialects.eqsat import EqSat
 
@@ -351,6 +356,7 @@ def get_all_dialects() -> dict[str, Callable[[], Dialect]]:
         "csl_stencil": get_csl_stencil,
         "csl_wrapper": get_csl_wrapper,
         "dmp": get_dmp,
+        "emitc": get_emitc,
         "eqsat": get_eqsat,
         "fir": get_fir,
         "fsm": get_fsm,

--- a/xdsl/dialects/emitc.py
+++ b/xdsl/dialects/emitc.py
@@ -1,0 +1,90 @@
+"""
+Dialect to generate C/C++ from MLIR.
+
+The EmitC dialect allows to convert operations from other MLIR dialects to EmitC ops.
+Those can be translated to C/C++ via the Cpp emitter.
+
+See external [documentation](https://mlir.llvm.org/docs/Dialects/EmitC/).
+"""
+
+from collections.abc import Iterable
+
+from xdsl.dialects.builtin import (
+    ArrayAttr,
+    ContainerType,
+    IntAttr,
+    ShapedType,
+)
+from xdsl.ir import (
+    AttributeCovT,
+    Dialect,
+    ParametrizedAttribute,
+    TypeAttribute,
+)
+from xdsl.irdl import (
+    ParameterDef,
+    irdl_attr_definition,
+)
+from xdsl.parser import AttrParser
+from xdsl.printer import Printer
+from xdsl.utils.exceptions import VerifyException
+
+
+@irdl_attr_definition
+class EmitC_ArrayType(
+    ParametrizedAttribute, TypeAttribute, ShapedType, ContainerType[AttributeCovT]
+):
+    """EmitC array type"""
+
+    name = "emitc.array"
+
+    shape: ParameterDef[ArrayAttr[IntAttr]]
+    element_type: ParameterDef[AttributeCovT]
+
+    def __init__(
+        self,
+        shape: Iterable[int | IntAttr],
+        element_type: AttributeCovT,
+    ):
+        shape = ArrayAttr(
+            [IntAttr(dim) if isinstance(dim, int) else dim for dim in shape]
+        )
+        super().__init__([shape, element_type])
+
+    def verify(self) -> None:
+        if not self.shape.data:
+            raise VerifyException("EmitC array shape must not be empty")
+
+    def get_num_dims(self) -> int:
+        return len(self.shape.data)
+
+    def get_shape(self) -> tuple[int, ...]:
+        return tuple(i.data for i in self.shape.data)
+
+    def get_element_type(self) -> AttributeCovT:
+        return self.element_type
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser):
+        with parser.in_angle_brackets():
+            shape, type = parser.parse_ranked_shape()
+            if not shape:
+                raise parser.raise_error("EmitC array shape must not be empty")
+            return ArrayAttr(IntAttr(dim) for dim in shape), type
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_list(
+                self.shape, lambda dim: printer.print_string(f"{dim.data}"), "x"
+            )
+            printer.print_string("x")
+            printer.print_attribute(self.element_type)
+
+
+EmitC = Dialect(
+    "emitc",
+    [],
+    [
+        EmitC_ArrayType,
+    ],
+)


### PR DESCRIPTION
Register the emitc dialect in xdsl/dialects/__init__.py and add the EmitC Array Type as a first step towards adding the full [emitc dialect](https://mlir.llvm.org/docs/Dialects/EmitC/)

 