### PR TITLE
transformations: (convert-vector-to-ptr) cast first then ptr arithmetic

### DIFF
--- a/tests/filecheck/transforms/convert_memref_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_memref_to_ptr.mlir
@@ -3,68 +3,69 @@
 %v, %idx, %arr = "test.op"() : () -> (i32, index, memref<10xi32>)
 memref.store %v, %arr[%idx] {"nontemporal" = false} : memref<10xi32>
 
-// CHECK:       %bytes_per_element = ptr_xdsl.type_offset i32 : index
+// CHECK:       %v, %idx, %arr = "test.op"() : () -> (i32, index, memref<10xi32>)
+// CHECK-NEXT:  %arr_1 = ptr_xdsl.to_ptr %arr : memref<10xi32> -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %bytes_per_element = ptr_xdsl.type_offset i32 : index
 // CHECK-NEXT:  %scaled_pointer_offset = arith.muli %idx, %bytes_per_element : index
-// CHECK-NEXT:  %0 = ptr_xdsl.to_ptr %arr : memref<10xi32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %offset_pointer = ptr_xdsl.ptradd %0, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %offset_pointer = ptr_xdsl.ptradd %arr_1, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 // CHECK-NEXT:  ptr_xdsl.store %v, %offset_pointer : i32, !ptr_xdsl.ptr
 
 %idx1, %idx2, %arr2 = "test.op"() : () -> (index, index, memref<10x10xi32>)
 memref.store %v, %arr2[%idx1, %idx2] {"nontemporal" = false} : memref<10x10xi32>
 
 // CHECK-NEXT:  %idx1, %idx2, %arr2 = "test.op"() : () -> (index, index, memref<10x10xi32>)
+// CHECK-NEXT:  %arr2_1 = ptr_xdsl.to_ptr %arr2 : memref<10x10xi32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %pointer_dim_stride = arith.constant 10 : index
 // CHECK-NEXT:  %pointer_dim_offset = arith.muli %idx1, %pointer_dim_stride : index
 // CHECK-NEXT:  %pointer_dim_stride_1 = arith.addi %pointer_dim_offset, %idx2 : index
 // CHECK-NEXT:  %bytes_per_element_1 = ptr_xdsl.type_offset i32 : index
 // CHECK-NEXT:  %scaled_pointer_offset_1 = arith.muli %pointer_dim_stride_1, %bytes_per_element_1 : index
-// CHECK-NEXT:  %1 = ptr_xdsl.to_ptr %arr2 : memref<10x10xi32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %offset_pointer_1 = ptr_xdsl.ptradd %1, %scaled_pointer_offset_1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %offset_pointer_1 = ptr_xdsl.ptradd %arr2_1, %scaled_pointer_offset_1 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 // CHECK-NEXT:  ptr_xdsl.store %v, %offset_pointer_1 : i32, !ptr_xdsl.ptr
 
 %lv = memref.load %arr[%idx] {"nontemporal" = false} : memref<10xi32>
 
+// CHECK-NEXT:  %arr_2 = ptr_xdsl.to_ptr %arr : memref<10xi32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %bytes_per_element_2 = ptr_xdsl.type_offset i32 : index
 // CHECK-NEXT:  %scaled_pointer_offset_2 = arith.muli %idx, %bytes_per_element_2 : index
-// CHECK-NEXT:  %lv = ptr_xdsl.to_ptr %arr : memref<10xi32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %offset_pointer_2 = ptr_xdsl.ptradd %lv, %scaled_pointer_offset_2 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %lv_1 = ptr_xdsl.load %offset_pointer_2 : !ptr_xdsl.ptr -> i32
+// CHECK-NEXT:  %offset_pointer_2 = ptr_xdsl.ptradd %arr_2, %scaled_pointer_offset_2 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %lv = ptr_xdsl.load %offset_pointer_2 : !ptr_xdsl.ptr -> i32
 
 %lv2 = memref.load %arr2[%idx1, %idx2] {"nontemporal" = false} : memref<10x10xi32>
 
+// CHECK-NEXT:  %arr2_2 = ptr_xdsl.to_ptr %arr2 : memref<10x10xi32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %pointer_dim_stride_2 = arith.constant 10 : index
 // CHECK-NEXT:  %pointer_dim_offset_1 = arith.muli %idx1, %pointer_dim_stride_2 : index
 // CHECK-NEXT:  %pointer_dim_stride_3 = arith.addi %pointer_dim_offset_1, %idx2 : index
 // CHECK-NEXT:  %bytes_per_element_3 = ptr_xdsl.type_offset i32 : index
 // CHECK-NEXT:  %scaled_pointer_offset_3 = arith.muli %pointer_dim_stride_3, %bytes_per_element_3 : index
-// CHECK-NEXT:  %lv2 = ptr_xdsl.to_ptr %arr2 : memref<10x10xi32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %offset_pointer_3 = ptr_xdsl.ptradd %lv2, %scaled_pointer_offset_3 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %lv2_1 = ptr_xdsl.load %offset_pointer_3 : !ptr_xdsl.ptr -> i32
+// CHECK-NEXT:  %offset_pointer_3 = ptr_xdsl.ptradd %arr2_2, %scaled_pointer_offset_3 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %lv2 = ptr_xdsl.load %offset_pointer_3 : !ptr_xdsl.ptr -> i32
 
 %fv, %farr = "test.op"() : () -> (f64, memref<10xf64>)
 memref.store %fv, %farr[%idx] {"nontemporal" = false} : memref<10xf64>
 
 // CHECK-NEXT:  %fv, %farr = "test.op"() : () -> (f64, memref<10xf64>)
+// CHECK-NEXT:  %farr_1 = ptr_xdsl.to_ptr %farr : memref<10xf64> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %bytes_per_element_4 = ptr_xdsl.type_offset f64 : index
 // CHECK-NEXT:  %scaled_pointer_offset_4 = arith.muli %idx, %bytes_per_element_4 : index
-// CHECK-NEXT:  %2 = ptr_xdsl.to_ptr %farr : memref<10xf64> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %offset_pointer_4 = ptr_xdsl.ptradd %2, %scaled_pointer_offset_4 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %offset_pointer_4 = ptr_xdsl.ptradd %farr_1, %scaled_pointer_offset_4 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 // CHECK-NEXT:  ptr_xdsl.store %fv, %offset_pointer_4 : f64, !ptr_xdsl.ptr
 
 %flv = memref.load %farr[%idx] {"nontemporal" = false} : memref<10xf64>
 
+// CHECK-NEXT:  %farr_2 = ptr_xdsl.to_ptr %farr : memref<10xf64> -> !ptr_xdsl.ptr
 // CHECK-NEXT:  %bytes_per_element_5 = ptr_xdsl.type_offset f64 : index
 // CHECK-NEXT:  %scaled_pointer_offset_5 = arith.muli %idx, %bytes_per_element_5 : index
-// CHECK-NEXT:  %flv = ptr_xdsl.to_ptr %farr : memref<10xf64> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %offset_pointer_5 = ptr_xdsl.ptradd %flv, %scaled_pointer_offset_5 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %flv_1 = ptr_xdsl.load %offset_pointer_5 : !ptr_xdsl.ptr -> f64
+// CHECK-NEXT:  %offset_pointer_5 = ptr_xdsl.ptradd %farr_2, %scaled_pointer_offset_5 : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %flv = ptr_xdsl.load %offset_pointer_5 : !ptr_xdsl.ptr -> f64
 
 %fmem = "test.op"() : () -> (memref<f64>)
 %flv2 = memref.load %fmem[] {"nontemporal" = false} : memref<f64>
 
 // CHECK-NEXT:  %fmem = "test.op"() : () -> memref<f64>
-// CHECK-NEXT:  %flv2 = ptr_xdsl.to_ptr %fmem : memref<f64> -> !ptr_xdsl.ptr
-// CHECK-NEXT:  %flv2_1 = ptr_xdsl.load %flv2 : !ptr_xdsl.ptr -> f64
+// CHECK-NEXT:  %fmem_1 = ptr_xdsl.to_ptr %fmem : memref<f64> -> !ptr_xdsl.ptr
+// CHECK-NEXT:  %flv2 = ptr_xdsl.load %fmem_1 : !ptr_xdsl.ptr -> f64
 
 // -----
 

--- a/tests/filecheck/transforms/convert_vector_to_ptr.mlir
+++ b/tests/filecheck/transforms/convert_vector_to_ptr.mlir
@@ -7,11 +7,11 @@
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %m = "test.op"() : () -> memref<16xf32>
 // CHECK-NEXT:    %i = arith.constant 0 : index
+// CHECK-NEXT:    %m_1 = ptr_xdsl.to_ptr %m : memref<16xf32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:    %bytes_per_element = ptr_xdsl.type_offset f32 : index
 // CHECK-NEXT:    %scaled_pointer_offset = arith.muli %i, %bytes_per_element : index
-// CHECK-NEXT:    %v = ptr_xdsl.to_ptr %m : memref<16xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:    %offset_pointer = ptr_xdsl.ptradd %v, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:    %v_1 = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf32>
+// CHECK-NEXT:    %offset_pointer = ptr_xdsl.ptradd %m_1, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:    %v = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf32>
 // CHECK-NEXT:  }
 
 // -----
@@ -25,14 +25,14 @@
 // CHECK-NEXT:   %m0 = "test.op"() : () -> memref<2x8xf32>
 // CHECK-NEXT:   %i0 = arith.constant 0 : index
 // CHECK-NEXT:   %j0 = arith.constant 0 : index
+// CHECK-NEXT:   %m0_1 = ptr_xdsl.to_ptr %m0 : memref<2x8xf32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:   %pointer_dim_stride = arith.constant 8 : index
 // CHECK-NEXT:   %pointer_dim_offset = arith.muli %i0, %pointer_dim_stride : index
 // CHECK-NEXT:   %pointer_dim_stride_1 = arith.addi %pointer_dim_offset, %j0 : index
 // CHECK-NEXT:   %bytes_per_element = ptr_xdsl.type_offset f32 : index
 // CHECK-NEXT:   %scaled_pointer_offset = arith.muli %pointer_dim_stride_1, %bytes_per_element : index
-// CHECK-NEXT:   %v0 = ptr_xdsl.to_ptr %m0 : memref<2x8xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %v0, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:   %v0_1 = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf32>
+// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %m0_1, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v0 = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf32>
 // CHECK-NEXT: }
 
 // -----
@@ -46,14 +46,14 @@
 // CHECK-NEXT:   %m1 = "test.op"() : () -> memref<2x8xf16>
 // CHECK-NEXT:   %i1 = arith.constant 0 : index
 // CHECK-NEXT:   %j1 = arith.constant 0 : index
+// CHECK-NEXT:   %m1_1 = ptr_xdsl.to_ptr %m1 : memref<2x8xf16> -> !ptr_xdsl.ptr
 // CHECK-NEXT:   %pointer_dim_stride = arith.constant 8 : index
 // CHECK-NEXT:   %pointer_dim_offset = arith.muli %i1, %pointer_dim_stride : index
 // CHECK-NEXT:   %pointer_dim_stride_1 = arith.addi %pointer_dim_offset, %j1 : index
 // CHECK-NEXT:   %bytes_per_element = ptr_xdsl.type_offset f16 : index
 // CHECK-NEXT:   %scaled_pointer_offset = arith.muli %pointer_dim_stride_1, %bytes_per_element : index
-// CHECK-NEXT:   %v1 = ptr_xdsl.to_ptr %m1 : memref<2x8xf16> -> !ptr_xdsl.ptr
-// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %v1, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:   %v1_1 = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf16>
+// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %m1_1, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v1 = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf16>
 // CHECK-NEXT: }
 
 // -----
@@ -67,14 +67,14 @@
 // CHECK-NEXT:   %m2 = "test.op"() : () -> memref<2x32xf32>
 // CHECK-NEXT:   %i2 = arith.constant 0 : index
 // CHECK-NEXT:   %j2 = arith.constant 0 : index
+// CHECK-NEXT:   %m2_1 = ptr_xdsl.to_ptr %m2 : memref<2x32xf32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:   %pointer_dim_stride = arith.constant 32 : index
 // CHECK-NEXT:   %pointer_dim_offset = arith.muli %i2, %pointer_dim_stride : index
 // CHECK-NEXT:   %pointer_dim_stride_1 = arith.addi %pointer_dim_offset, %j2 : index
 // CHECK-NEXT:   %bytes_per_element = ptr_xdsl.type_offset f32 : index
 // CHECK-NEXT:   %scaled_pointer_offset = arith.muli %pointer_dim_stride_1, %bytes_per_element : index
-// CHECK-NEXT:   %v2 = ptr_xdsl.to_ptr %m2 : memref<2x32xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %v2, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
-// CHECK-NEXT:   %v2_1 = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf32>
+// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %m2_1, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %v2 = ptr_xdsl.load %offset_pointer : !ptr_xdsl.ptr -> vector<8xf32>
 // CHECK-NEXT: }
 
 // -----
@@ -90,12 +90,12 @@ vector.store %v0, %m0[%i0,%j0]: memref<2x8xf32>, vector<8xf32>
 // CHECK-NEXT:   %i0 = arith.constant 0 : index
 // CHECK-NEXT:   %j0 = arith.constant 0 : index
 // CHECK-NEXT:   %v0 = "test.op"() : () -> vector<8xf32>
+// CHECK-NEXT:   %m0_1 = ptr_xdsl.to_ptr %m0 : memref<2x8xf32> -> !ptr_xdsl.ptr
 // CHECK-NEXT:   %pointer_dim_stride = arith.constant 8 : index
 // CHECK-NEXT:   %pointer_dim_offset = arith.muli %i0, %pointer_dim_stride : index
 // CHECK-NEXT:   %pointer_dim_stride_1 = arith.addi %pointer_dim_offset, %j0 : index
 // CHECK-NEXT:   %bytes_per_element = ptr_xdsl.type_offset f32 : index
 // CHECK-NEXT:   %scaled_pointer_offset = arith.muli %pointer_dim_stride_1, %bytes_per_element : index
-// CHECK-NEXT:   %0 = ptr_xdsl.to_ptr %m0 : memref<2x8xf32> -> !ptr_xdsl.ptr
-// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %0, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
+// CHECK-NEXT:   %offset_pointer = ptr_xdsl.ptradd %m0_1, %scaled_pointer_offset : (!ptr_xdsl.ptr, index) -> !ptr_xdsl.ptr
 // CHECK-NEXT:   ptr_xdsl.store %v0, %offset_pointer : vector<8xf32>, !ptr_xdsl.ptr
 // CHECK-NEXT: }

--- a/xdsl/transforms/convert_memref_to_ptr.py
+++ b/xdsl/transforms/convert_memref_to_ptr.py
@@ -106,12 +106,13 @@ def get_target_ptr(
     """Get operations returning a pointer to an element of a memref referenced by indices."""
 
     ops: list[Operation] = [memref_ptr := ptr.ToPtrOp(target_memref)]
+    memref_ptr.res.name_hint = target_memref.name_hint
 
     if not indices:
         return ops, memref_ptr.res
 
     offset_ops, offset = offset_calculations(memref_type, indices)
-    ops = offset_ops + ops
+    ops.extend(offset_ops)
     ops.append(target_ptr := ptr.PtrAddOp(memref_ptr.res, offset))
 
     target_ptr.result.name_hint = "offset_pointer"


### PR DESCRIPTION
Also fixes the name so that it's the same as the original memref, as opposed to either `%0` in the case of store, or the name of the result value in the case of load.