### PR TITLE
backend: add BlockAllocator base class

### DIFF
--- a/tests/backend/test_live_ins.py
+++ b/tests/backend/test_live_ins.py
@@ -1,6 +1,6 @@
 from ordered_set import OrderedSet
 
-from xdsl.backend.riscv.register_allocation import live_ins_per_block
+from xdsl.backend.register_allocator import live_ins_per_block
 from xdsl.builder import ImplicitBuilder
 from xdsl.dialects.builtin import i32
 from xdsl.dialects.test import TestOp


### PR DESCRIPTION
Moves some logic that is not RISC-V-specific to a new ABC.